### PR TITLE
[core] Group MUI package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,10 +26,6 @@
       "matchPackagePatterns": "@emotion/*"
     },
     {
-      "groupName": "Font awesome SVG icons",
-      "matchPackagePatterns": "@fortawesome/*"
-    },
-    {
       "groupName": "core-js",
       "matchPackageNames": ["core-js"],
       "allowedVersions": "< 2.0.0"
@@ -59,8 +55,17 @@
       ]
     },
     {
+      "groupName": "MUI Core",
+      "matchPackagePatterns": ["@mui/*"],
+      "excludePackagePatterns": ["@mui/x-*", "@mui/internal-*"]
+    },
+    {
       "groupName": "MUI X",
       "matchPackagePatterns": ["@mui/x-*"]
+    },
+    {
+      "groupName": "MUI Infra",
+      "matchPackagePatterns": ["@mui/internal-*"]
     },
     {
       "groupName": "React",
@@ -105,12 +110,6 @@
     {
       "groupName": "@definitelytyped tools",
       "matchPackagePatterns": ["@definitelytyped/*"]
-    },
-    {
-      "groupName": "envinfo tests",
-      "matchPaths": ["packages/mui-envinfo/test/package.json"],
-      "matchPackagePatterns": ["@mui/*"],
-      "enabled": false
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"],


### PR DESCRIPTION
Instruct Renovate to batch MUI packages' updates instead of creating a separate PR for each one.

Also removed the unnecessary rule regarding Font Awesome packages (we don't use them in this repo).