### PR TITLE
[core] Simplify build scripts

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -13,7 +13,7 @@ const productionPlugins = [
 ];
 
 module.exports = function getBabelConfig(api) {
-  const useESModules = api.env(['regressions', 'legacy', 'modern', 'stable', 'rollup']);
+  const useESModules = api.env(['regressions', 'stable', 'rollup']);
 
   const defaultAlias = {
     '@mui/base': resolveAliasPath('./packages/mui-base/src'),
@@ -32,7 +32,6 @@ module.exports = function getBabelConfig(api) {
         browserslistEnv: process.env.BABEL_ENV || process.env.NODE_ENV,
         debug: process.env.MUI_BUILD_VERBOSE === 'true',
         modules: useESModules ? false : 'commonjs',
-        shippedProposals: api.env('modern'),
       },
     ],
     [
@@ -80,15 +79,6 @@ module.exports = function getBabelConfig(api) {
   if (process.env.NODE_ENV === 'production') {
     plugins.push(...productionPlugins);
   }
-  if (process.env.NODE_ENV === 'test') {
-    plugins.push([
-      'babel-plugin-module-resolver',
-      {
-        alias: defaultAlias,
-        root: ['./'],
-      },
-    ]);
-  }
 
   return {
     assumptions: {
@@ -121,11 +111,8 @@ module.exports = function getBabelConfig(api) {
           [
             'babel-plugin-module-resolver',
             {
-              alias: {
-                ...defaultAlias,
-                modules: './modules',
-              },
               root: ['./'],
+              alias: defaultAlias,
             },
           ],
         ],
@@ -138,12 +125,6 @@ module.exports = function getBabelConfig(api) {
               alias: defaultAlias,
             },
           ],
-        ],
-      },
-      legacy: {
-        plugins: [
-          // IE11 support
-          '@babel/plugin-transform-object-assign',
         ],
       },
       test: {

--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -27,13 +27,11 @@
     "url": "https://opencollective.com/mui-org"
   },
   "scripts": {
-    "build": "pnpm build:legacy && pnpm build:modern && pnpm build:node && pnpm build:stable && pnpm build:types && pnpm build:copy-files",
-    "build:legacy": "node ../../scripts/build.mjs legacy",
-    "build:modern": "node ../../scripts/build.mjs modern",
+    "build": "pnpm build:node && pnpm build:stable && pnpm build:types && pnpm build:copy-files",
     "build:node": "node ../../scripts/build.mjs node",
     "build:stable": "node ../../scripts/build.mjs stable",
     "build:copy-files": "node ../../scripts/copyFiles.mjs",
-    "build:types": "node ../../scripts/buildTypes.mjs",
+    "build:types": "tsc -b tsconfig.build.json",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "release": "pnpm build && pnpm publish",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-base/**/*.test.{js,ts,tsx}'",
@@ -65,7 +63,8 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sinon": "^17.0.1"
+    "sinon": "^17.0.1",
+    "typescript": "^5.3.3"
   },
   "peerDependencies": {
     "@types/react": "^17.0.0 || ^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,7 +688,7 @@ importers:
         version: 17.0.1
       typescript:
         specifier: ^5.3.3
-        version: 5.3.3
+        version: 5.4.2
     publishDirectory: build
 
   test:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,6 +686,9 @@ importers:
       sinon:
         specifier: ^17.0.1
         version: 17.0.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.3.3
     publishDirectory: build
 
   test:

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -8,10 +8,6 @@ import { getWorkspaceRoot } from './utils.mjs';
 const exec = promisify(childProcess.exec);
 
 const validBundles = [
-  // legacy build using ES6 modules
-  'legacy',
-  // modern build with a rolling target using ES6 modules
-  'modern',
   // build for node using commonJS modules
   'node',
   // build with a hardcoded target using ES6 modules
@@ -63,9 +59,7 @@ async function run(argv) {
     // TODO v6: Switch to `exports` field.
     {
       node: topLevelPathImportsCanBePackages ? './node' : './',
-      modern: './modern',
       stable: topLevelPathImportsCanBePackages ? './' : './esm',
-      legacy: './legacy',
     }[bundle],
   );
 

--- a/scripts/copyFiles.mjs
+++ b/scripts/copyFiles.mjs
@@ -22,24 +22,19 @@ async function addLicense(packageData) {
  */
 `;
   await Promise.all(
-    [
-      './index.js',
-      './legacy/index.js',
-      './modern/index.js',
-      './node/index.js',
-      './umd/material-ui.development.js',
-      './umd/material-ui.production.min.js',
-    ].map(async (file) => {
-      try {
-        await prepend(path.resolve(buildPath, file), license);
-      } catch (err) {
-        if (err.code === 'ENOENT') {
-          console.log(`Skipped license for ${file}`);
-        } else {
-          throw err;
+    ['./index.js', './legacy/index.js', './modern/index.js', './node/index.js'].map(
+      async (file) => {
+        try {
+          await prepend(path.resolve(buildPath, file), license);
+        } catch (err) {
+          if (err.code === 'ENOENT') {
+            console.log(`Skipped license for ${file}`);
+          } else {
+            throw err;
+          }
         }
-      }
-    }),
+      },
+    ),
   );
 }
 


### PR DESCRIPTION
Removed the `legacy` and `modern` build targets. We'll ship standard ESM (once https://github.com/mui/material-ui/pull/41102 is complete and ready to be ported to Base UI) and CommonJS for Node.

Also removed the custom TS build script, as the issue it works around has been resolved.