### PR TITLE
[TextareaAutosize] Fix inline style not getting applied

### DIFF
--- a/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.tsx
+++ b/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.tsx
@@ -458,4 +458,17 @@ describe('<TextareaAutosize />', () => {
       expect(input.style).to.have.property('height', `${lineHeight * 2}px`);
     });
   });
+
+  it('should apply the inline styles using the "style" prop', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    render(<TextareaAutosize style={{ backgroundColor: 'yellow' }} />);
+    const input = document.querySelector<HTMLTextAreaElement>('textarea');
+
+    expect(input).toHaveComputedStyle({
+      backgroundColor: 'rgb(255, 255, 0)',
+    });
+  });
 });

--- a/packages/mui-base/src/TextareaAutosize/TextareaAutosize.tsx
+++ b/packages/mui-base/src/TextareaAutosize/TextareaAutosize.tsx
@@ -197,6 +197,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
         ref={handleRef}
         // Apply the rows prop to get a "correct" first SSR paint
         rows={minRows as number}
+        style={style}
         {...other}
       />
       <textarea


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Same as https://github.com/mui/material-ui/pull/41369. Applied it here. Fixes part of https://github.com/mui/base-ui/issues/168.
