### PR TITLE
[test] Update karma config

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -43,7 +43,7 @@ In addition to the core matchers from `chai` we also use matchers from [`chai-do
 
 Deciding where to put a test is (like naming things) a hard problem:
 
-- When in doubt, put the new test case directly in the unit test file for that component e.g. `packages/mui-material/src/Button/Button.test.js`.
+- When in doubt, put the new test case directly in the unit test file for that component e.g. `packages/mui-base/src/Button/Button.test.tsx`.
 - If your test requires multiple components from the library create a new integration test.
 - If you find yourself using a lot of `data-testid` attributes or you're accessing
   a lot of styles consider adding a component (that doesn't require any interaction)
@@ -173,7 +173,7 @@ For example, you've opened a PR with the number 64209 and now after everything i
 
 ```bash
 curl --request POST \
-  --url https://circleci.com/api/v2/project/gh/mui/material-ui/pipeline \
+  --url https://circleci.com/api/v2/project/gh/mui/base-ui/pipeline \
   --header 'content-type: application/json' \
   --header 'Circle-Token: $CIRCLE_TOKEN' \
   --data-raw '{"branch":"pull/64209/head","parameters":{"browserstack-force":true}}'
@@ -229,7 +229,7 @@ The following command triggers the `profile` workflow for the pull request #2428
 
 ```bash
 curl --request POST \
-  --url https://circleci.com/api/v2/project/gh/mui/material-ui/pipeline \
+  --url https://circleci.com/api/v2/project/gh/mui/base-ui/pipeline \
   --header 'content-type: application/json' \
   --header 'Circle-Token: $CIRCLE_TOKEN' \
   --data-raw '{"branch":"pull/24289/head","parameters":{"workflow":"profile"}}'
@@ -238,10 +238,10 @@ curl --request POST \
 To analyze this profile run you can use https://mui-dashboard.netlify.app/test-profile/:job-number.
 
 To find out the job number you can start with the response of the previous CircleCI API request which includes the created pipeline id.
-You then have to search in the [CircleCI UI](https://app.circleci.com/pipelines/github/mui/material-ui) for the job number of `test_profile` that is part of the started pipeline.
+You then have to search in the [CircleCI UI](https://app.circleci.com/pipelines/github/mui/base-ui) for the job number of `test_profile` that is part of the started pipeline.
 The job number can be extracted from the URL of a particular CircleCI job.
 
-For example, in https://app.circleci.com/pipelines/github/mui/material-ui/32796/workflows/23f946de-328e-49b7-9c94-bfe0a0248a12/jobs/211258 `jobs/211258` points to the job number which is in this case `211258` which means you want to visit https://mui-dashboard.netlify.app/test-profile/211258 to analyze the profile.
+For example, in https://app.circleci.com/pipelines/github/mui/base-ui/32796/workflows/23f946de-328e-49b7-9c94-bfe0a0248a12/jobs/211258 `jobs/211258` points to the job number which is in this case `211258` which means you want to visit https://mui-dashboard.netlify.app/test-profile/211258 to analyze the profile.
 
 ### Testing multiple versions of React
 
@@ -262,7 +262,7 @@ PR #24289 for `react@next`
 
 ```bash
 curl --request POST \
-  --url https://circleci.com/api/v2/project/gh/mui/material-ui/pipeline \
+  --url https://circleci.com/api/v2/project/gh/mui/base-ui/pipeline \
   --header 'content-type: application/json' \
   --header 'Circle-Token: $CIRCLE_TOKEN' \
   --data-raw '{"branch":"pull/24289/head","parameters":{"react-version":"next"}}'

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -186,7 +186,7 @@ module.exports = function setKarmaConfig(config) {
         chrome: {
           base: 'BrowserStack',
           os: 'OS X',
-          os_version: 'Catalina',
+          os_version: 'Monterey',
           browser: 'chrome',
           // We support Chrome 109.x per .browserslistrc
           browser_version: '109.0',
@@ -194,7 +194,7 @@ module.exports = function setKarmaConfig(config) {
         safari: {
           base: 'BrowserStack',
           os: 'OS X',
-          os_version: 'Catalina',
+          os_version: 'Monterey',
           browser: 'safari',
           browser_version: '15.6',
         },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -188,26 +188,22 @@ module.exports = function setKarmaConfig(config) {
           os: 'OS X',
           os_version: 'Catalina',
           browser: 'chrome',
-          // We support Chrome 90.x
-          // However, >=88 fails on seemingly all focus-related tests.
-          // TODO: Investigate why.
-          browser_version: '87.0',
+          // We support Chrome 109.x per .browserslistrc
+          browser_version: '109.0',
         },
         safari: {
           base: 'BrowserStack',
           os: 'OS X',
           os_version: 'Catalina',
           browser: 'safari',
-          // We support 12.5 on iOS.
-          // However, 12.x is very flaky on desktop (mobile is always flaky).
-          browser_version: '13.0',
+          browser_version: '15.6',
         },
         edge: {
           base: 'BrowserStack',
           os: 'Windows',
           os_version: '10',
           browser: 'edge',
-          browser_version: '91.0',
+          browser_version: '120.0',
         },
       },
     };

--- a/test/karma.conf.profile.js
+++ b/test/karma.conf.profile.js
@@ -144,10 +144,8 @@ module.exports = function setKarmaConfig(config) {
           os: 'OS X',
           os_version: 'Catalina',
           browser: 'chrome',
-          // We support Chrome 90.x
-          // However, >=88 fails on seemingly all focus-related tests.
-          // TODO: Investigate why.
-          browser_version: '87.0',
+          // We support Chrome 109.x per .browserslistrc
+          browser_version: '109.0',
         },
         // No accurate performance timings (integer precision instead of double).
         firefox: {
@@ -155,7 +153,7 @@ module.exports = function setKarmaConfig(config) {
           os: 'Windows',
           os_version: '10',
           browser: 'firefox',
-          browser_version: '78.0',
+          browser_version: '15.0',
         },
         // No accurate performance timings (integer precision instead of double).
         safari: {
@@ -163,16 +161,14 @@ module.exports = function setKarmaConfig(config) {
           os: 'OS X',
           os_version: 'Catalina',
           browser: 'safari',
-          // We support 12.5 on iOS.
-          // However, 12.x is very flaky on desktop (mobile is always flaky).
-          browser_version: '13.0',
+          browser_version: '15.6',
         },
         edge: {
           base: 'BrowserStack',
           os: 'Windows',
           os_version: '10',
           browser: 'edge',
-          browser_version: '91.0',
+          browser_version: '120.0',
         },
       },
     };

--- a/test/karma.conf.profile.js
+++ b/test/karma.conf.profile.js
@@ -159,7 +159,7 @@ module.exports = function setKarmaConfig(config) {
         safari: {
           base: 'BrowserStack',
           os: 'OS X',
-          os_version: 'Catalina',
+          os_version: 'Monterey',
           browser: 'safari',
           browser_version: '15.6',
         },


### PR DESCRIPTION
This PR updates browser versions in the BrowserStack config to match `.browserslistrc`:
- I've added the BrowserStack access token (from [here](https://www.notion.so/mui-org/BrowserStack-72953eaebde6421faf4644d3bd1641a5?pvs=4)) to the project in CircleCI, it wasn't there before (new repo!)
- Here's a successful job running all the updated browsers with `browserstack-force`: https://app.circleci.com/pipelines/github/mui/base-ui/387/workflows/b5119fff-1815-47f4-a481-7792f82727a9/jobs/2154/parallel-runs/0/steps/0-111

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
