### PR TITLE
[core] Do not hoist the @mui/base package on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
 
 [build.environment]
   NODE_VERSION = "18"
-  PNPM_FLAGS = "--shamefully-hoist"
+  PNPM_FLAGS = "--public-hoist-pattern=* --public-hoist-pattern=!@mui/base"
 
 [[plugins]]
   package = "./node_modules/@mui/monorepo/packages/netlify-plugin-cache-docs"


### PR DESCRIPTION
Netlify requires its Next.js apps to have hoisted dependencies (https://docs.netlify.com/frameworks/next-js/overview/#pnpm-support). In our case, however, hoisting the @mui/base package causes unintended behavior, as we have two different versions in the workspace (one as a dependency of @mui/material, the other - the version we develop). 
When the `shamefully-hoist` setting is used, the docs package ends up using the npm version of @mui/base, not the workspace one. Excluding this package from hoisting fixes the issue.
