### PR TITLE
[core] Update Codesandbox preview to use the dev packages

### DIFF
--- a/docs/src/modules/sandbox/Dependencies.test.js
+++ b/docs/src/modules/sandbox/Dependencies.test.js
@@ -3,7 +3,7 @@ import SandboxDependencies from './Dependencies';
 
 describe('Dependencies', () => {
   before(() => {
-    process.env.SOURCE_CODE_REPO = 'https://github.com/mui/material-ui';
+    process.env.SOURCE_CODE_REPO = 'https://github.com/mui/base-ui';
   });
 
   after(() => {
@@ -167,7 +167,6 @@ import 'exceljs';
       'react-dom': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
-      '@mui/material': 'latest',
       '@types/react-dom': 'latest',
       '@types/react': 'latest',
       typescript: 'latest',
@@ -244,14 +243,13 @@ import * as Utils from '@mui/utils';
       'react-dom': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
-      '@mui/material': 'https://pkg.csb.dev/mui/material-ui/commit/2d0e8b4d/@mui/material',
-      '@mui/icons-material':
-        'https://pkg.csb.dev/mui/material-ui/commit/2d0e8b4d/@mui/icons-material',
-      '@mui/lab': 'https://pkg.csb.dev/mui/material-ui/commit/2d0e8b4d/@mui/lab',
-      '@mui/styles': 'https://pkg.csb.dev/mui/material-ui/commit/2d0e8b4d/@mui/styles',
-      '@mui/system': 'https://pkg.csb.dev/mui/material-ui/commit/2d0e8b4d/@mui/system',
-      '@mui/utils': 'https://pkg.csb.dev/mui/material-ui/commit/2d0e8b4d/@mui/utils',
-      '@mui/base': 'https://pkg.csb.dev/mui/material-ui/commit/2d0e8b4d/@mui/base',
+      '@mui/material': 'latest',
+      '@mui/icons-material': 'latest',
+      '@mui/lab': 'latest',
+      '@mui/styles': 'latest',
+      '@mui/system': 'latest',
+      '@mui/utils': 'latest',
+      '@mui/base': 'https://pkg.csb.dev/mui/base-ui/commit/2d0e8b4d/@mui/base',
     });
   });
 

--- a/docs/src/modules/sandbox/Dependencies.ts
+++ b/docs/src/modules/sandbox/Dependencies.ts
@@ -46,13 +46,13 @@ export default function SandboxDependencies(
   function getMuiPackageVersion(packageName: string): string {
     if (
       commitRef === undefined ||
-      process.env.SOURCE_CODE_REPO !== 'https://github.com/mui/material-ui'
+      process.env.SOURCE_CODE_REPO !== 'https://github.com/mui/base-ui'
     ) {
       // #default-branch-switch
       return 'latest';
     }
     const shortSha = commitRef.slice(0, 8);
-    return `https://pkg.csb.dev/mui/material-ui/commit/${shortSha}/@mui/${packageName}`;
+    return `https://pkg.csb.dev/mui/base-ui/commit/${shortSha}/@mui/${packageName}`;
   }
 
   function extractDependencies(raw: string) {
@@ -71,11 +71,11 @@ export default function SandboxDependencies(
       };
 
       if (newDeps['@mui/lab'] || newDeps['@mui/icons-material']) {
-        newDeps['@mui/material'] = versions['@mui/material'];
+        newDeps['@mui/material'] = 'latest';
       }
 
       if (newDeps['@mui/x-data-grid']) {
-        newDeps['@mui/material'] = versions['@mui/material'];
+        newDeps['@mui/material'] = 'latest';
       }
 
       // TODO: consider if this configuration could be injected in a "cleaner" way.
@@ -93,19 +93,7 @@ export default function SandboxDependencies(
       'react-dom': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
-      '@mui/material': getMuiPackageVersion('material'),
-      '@mui/icons-material': getMuiPackageVersion('icons-material'),
-      '@mui/lab': getMuiPackageVersion('lab'),
-      '@mui/styled-engine': getMuiPackageVersion('styled-engine'),
-      '@mui/styles': getMuiPackageVersion('styles'),
-      '@mui/system': getMuiPackageVersion('system'),
-      '@mui/private-theming': getMuiPackageVersion('theming'),
-      '@mui/private-classnames': getMuiPackageVersion('classnames'),
       '@mui/base': getMuiPackageVersion('base'),
-      '@mui/utils': getMuiPackageVersion('utils'),
-      '@mui/material-next': getMuiPackageVersion('material-next'),
-      '@mui/material-nextjs': getMuiPackageVersion('material-nextjs'),
-      '@mui/joy': getMuiPackageVersion('joy'),
     };
 
     // TODO: consider if this configuration could be injected in a "cleaner" way.
@@ -144,15 +132,6 @@ export default function SandboxDependencies(
   if (demo.codeVariant === CODE_VARIANTS.TS) {
     addTypeDeps(dependencies);
     dependencies.typescript = 'latest';
-  }
-
-  if (!demo.productId && !dependencies['@mui/material']) {
-    // The `index.js` imports StyledEngineProvider from '@mui/material', so we need to make sure we have it as a dependency
-    const name = '@mui/material';
-    const versions = {
-      [name]: getMuiPackageVersion('material'),
-    };
-    dependencies[name] = versions[name] ? versions[name] : 'latest';
   }
 
   const devDependencies = {


### PR DESCRIPTION
Changed the demo codesandbox generator to correctly reference the @mui/base package built in a PR and use npm-published versions of other MUI packages.

Before: https://codesandbox.io/p/sandbox/recursing-burnell-km9sz4?file=%2Fpackage.json
After: https://codesandbox.io/p/sandbox/peaceful-goldwasser-mn5v9x?file=%2Fpackage.json