### PR TITLE
[core] Adapt proptypes generator to project needs

### DIFF
--- a/packages/mui-base/src/Input/Input.tsx
+++ b/packages/mui-base/src/Input/Input.tsx
@@ -242,15 +242,6 @@ Input.propTypes /* remove-proptypes */ = {
    */
   id: PropTypes.string,
   /**
-   * @ignore
-   */
-  inputRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.object,
-    }),
-  ]),
-  /**
    * Maximum number of rows to display when multiline option is set to true.
    */
   maxRows: PropTypes.number,

--- a/packages/mui-base/src/TablePagination/TablePaginationActions.tsx
+++ b/packages/mui-base/src/TablePagination/TablePaginationActions.tsx
@@ -201,11 +201,11 @@ TablePaginationActions.propTypes /* remove-proptypes */ = {
   /**
    * @ignore
    */
-  showFirstButton: PropTypes.bool.isRequired,
+  showFirstButton: PropTypes.bool,
   /**
    * @ignore
    */
-  showLastButton: PropTypes.bool.isRequired,
+  showLastButton: PropTypes.bool,
   /**
    * The props used for each slot inside the TablePagination.
    * @default {}

--- a/packages/mui-base/src/TablePagination/TablePaginationActions.tsx
+++ b/packages/mui-base/src/TablePagination/TablePaginationActions.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { PolymorphicComponent, useSlotProps, WithOptionalOwnerState } from '../utils';
 import {
   TablePaginationActionsButtonSlotProps,
@@ -146,6 +147,7 @@ const TablePaginationActions = React.forwardRef(function TablePaginationActions<
           {direction === 'rtl' ? <LastPageIcon /> : <FirstPageIcon />}
         </FirstButton>
       )}
+
       <BackButton {...backButtonProps}>
         {direction === 'rtl' ? <NextPageIcon /> : <BackPageIcon />}
       </BackButton>
@@ -160,5 +162,77 @@ const TablePaginationActions = React.forwardRef(function TablePaginationActions<
     </Root>
   );
 }) as PolymorphicComponent<TablePaginationActionsTypeMap>;
+
+TablePaginationActions.propTypes /* remove-proptypes */ = {
+  // ┌────────────────────────────── Warning ──────────────────────────────┐
+  // │ These PropTypes are generated from the TypeScript type definitions. │
+  // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
+  // └─────────────────────────────────────────────────────────────────────┘
+  /**
+   * @ignore
+   */
+  count: PropTypes.number.isRequired,
+  /**
+   * Direction of the text.
+   * @default 'ltr'
+   */
+  direction: PropTypes.oneOf(['ltr', 'rtl']),
+  /**
+   * Accepts a function which returns a string value that provides a user-friendly name for the current page.
+   * This is important for screen reader users.
+   *
+   * For localization purposes, you can use the provided [translations](/material-ui/guides/localization/).
+   * @param {string} type The link or button type to format ('first' | 'last' | 'next' | 'previous').
+   * @returns {string}
+   */
+  getItemAriaLabel: PropTypes.func.isRequired,
+  /**
+   * @ignore
+   */
+  onPageChange: PropTypes.func.isRequired,
+  /**
+   * @ignore
+   */
+  page: PropTypes.number.isRequired,
+  /**
+   * @ignore
+   */
+  rowsPerPage: PropTypes.number.isRequired,
+  /**
+   * @ignore
+   */
+  showFirstButton: PropTypes.bool.isRequired,
+  /**
+   * @ignore
+   */
+  showLastButton: PropTypes.bool.isRequired,
+  /**
+   * The props used for each slot inside the TablePagination.
+   * @default {}
+   */
+  slotProps: PropTypes.shape({
+    backButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    firstButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    lastButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    nextButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  }),
+  /**
+   * The components used for each slot inside the TablePagination.
+   * Either a string to use a HTML element or a component.
+   * @default {}
+   */
+  slots: PropTypes.shape({
+    backButton: PropTypes.elementType,
+    backPageIcon: PropTypes.elementType,
+    firstButton: PropTypes.elementType,
+    firstPageIcon: PropTypes.elementType,
+    lastButton: PropTypes.elementType,
+    lastPageIcon: PropTypes.elementType,
+    nextButton: PropTypes.elementType,
+    nextPageIcon: PropTypes.elementType,
+    root: PropTypes.elementType,
+  }),
+} as any;
 
 export { TablePaginationActions };

--- a/packages/mui-base/src/TablePagination/TablePaginationActions.types.ts
+++ b/packages/mui-base/src/TablePagination/TablePaginationActions.types.ts
@@ -63,8 +63,8 @@ export interface TablePaginationActionsOwnProps {
   onPageChange: (event: React.MouseEvent<HTMLButtonElement> | null, page: number) => void;
   page: number;
   rowsPerPage: number;
-  showFirstButton: boolean;
-  showLastButton: boolean;
+  showFirstButton?: boolean;
+  showLastButton?: boolean;
 }
 
 export interface TablePaginationActionsSlots {

--- a/packages/mui-base/src/Transitions/CssAnimation.tsx
+++ b/packages/mui-base/src/Transitions/CssAnimation.tsx
@@ -83,12 +83,38 @@ function CssAnimation(props: CssAnimationProps) {
   );
 }
 
-CssAnimation.propTypes = {
+CssAnimation.propTypes /* remove-proptypes */ = {
+  // ┌────────────────────────────── Warning ──────────────────────────────┐
+  // │ These PropTypes are generated from the TypeScript type definitions. │
+  // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
+  // └─────────────────────────────────────────────────────────────────────┘
+  /**
+   * @ignore
+   */
   children: PropTypes.node,
+  /**
+   * @ignore
+   */
   className: PropTypes.string,
+  /**
+   * The name of the CSS animation (the `animation-name` CSS property) applied to the component when
+   * the transition is requested to enter.
+   */
   enterAnimationName: PropTypes.string,
+  /**
+   * The name of the CSS class applied to the component when the transition
+   * is requested to enter.
+   */
   enterClassName: PropTypes.string,
+  /**
+   * The name of the CSS animation (the `animation-name` CSS property) applied to the component when
+   * the transition is requested to exit.
+   */
   exitAnimationName: PropTypes.string,
+  /**
+   * The name of the CSS class applied to the component when the transition
+   * is requested to exit.
+   */
   exitClassName: PropTypes.string,
 } as any;
 

--- a/packages/mui-base/src/Transitions/CssTransition.tsx
+++ b/packages/mui-base/src/Transitions/CssTransition.tsx
@@ -94,12 +94,35 @@ const CssTransition = React.forwardRef(function CssTransition(
   );
 });
 
-CssTransition.propTypes = {
+CssTransition.propTypes /* remove-proptypes */ = {
+  // ┌────────────────────────────── Warning ──────────────────────────────┐
+  // │ These PropTypes are generated from the TypeScript type definitions. │
+  // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
+  // └─────────────────────────────────────────────────────────────────────┘
+  /**
+   * @ignore
+   */
   children: PropTypes.node,
+  /**
+   * @ignore
+   */
   className: PropTypes.string,
+  /**
+   * The name of the CSS class applied to the component when the transition
+   * is requested to enter.
+   */
   enterClassName: PropTypes.string,
+  /**
+   * The name of the CSS class applied to the component when the transition
+   * is requested to exit.
+   */
   exitClassName: PropTypes.string,
-  lastTransitionedPropertyOnEnter: PropTypes.string,
+  /**
+   * The name of the CSS property that is transitioned the longest (has the largest `transition-duration`) on exit.
+   * This is used to determine when the transition has ended.
+   * If not specified, the transition will be considered finished end when the first property is transitioned.
+   * If all properties have the same `transition-duration` (or there is just one transitioned property), this can be omitted.
+   */
   lastTransitionedPropertyOnExit: PropTypes.string,
 } as any;
 

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -6,11 +6,7 @@ import glob from 'fast-glob';
 import * as _ from 'lodash';
 import * as yargs from 'yargs';
 import * as ts from 'typescript';
-import {
-  fixBabelGeneratorIssues,
-  fixLineEndings,
-  getUnstyledFilename,
-} from '@mui/internal-docs-utils';
+import { fixBabelGeneratorIssues, fixLineEndings } from '@mui/internal-docs-utils';
 import {
   getPropTypesFromFile,
   injectPropTypesInFile,
@@ -22,114 +18,6 @@ import {
 } from '@mui-internal/api-docs-builder/utils/createTypeScriptProject';
 
 import CORE_TYPESCRIPT_PROJECTS from './coreTypeScriptProjects';
-
-const useExternalPropsFromInputBase = [
-  'autoComplete',
-  'autoFocus',
-  'color',
-  'defaultValue',
-  'disabled',
-  'endAdornment',
-  'error',
-  'id',
-  'inputProps',
-  'inputRef',
-  'margin',
-  'maxRows',
-  'minRows',
-  'name',
-  'onChange',
-  'placeholder',
-  'readOnly',
-  'required',
-  'rows',
-  'startAdornment',
-  'value',
-];
-
-/**
- * A map of components and their props that should be documented
- * but are not used directly in their implementation.
- *
- * TODO: In the future we want to remove them from the API docs in favor
- * of dynamically loading them. At that point this list should be removed.
- * TODO: typecheck values
- */
-const useExternalDocumentation: Record<string, '*' | readonly string[]> = {
-  Button: ['disableRipple'],
-  Box: ['component', 'sx'],
-  // `classes` is always external since it is applied from a HOC
-  // In DialogContentText we pass it through
-  // Therefore it's considered "unused" in the actual component but we still want to document it.
-  DialogContentText: ['classes'],
-  FilledInput: useExternalPropsFromInputBase,
-  IconButton: ['disableRipple'],
-  Input: useExternalPropsFromInputBase,
-  MenuItem: ['dense'],
-  OutlinedInput: useExternalPropsFromInputBase,
-  Radio: ['disableRipple', 'id', 'inputProps', 'inputRef', 'required'],
-  Checkbox: ['defaultChecked'],
-  Container: ['component'],
-  Stack: ['component'],
-  Switch: [
-    'checked',
-    'defaultChecked',
-    'disabled',
-    'disableRipple',
-    'edge',
-    'id',
-    'inputProps',
-    'inputRef',
-    'onChange',
-    'required',
-    'value',
-  ],
-  SwipeableDrawer: [
-    'anchor',
-    'hideBackdrop',
-    'ModalProps',
-    'PaperProps',
-    'transitionDuration',
-    'variant',
-  ],
-  Tab: ['disableRipple'],
-  TextField: ['margin'],
-  ToggleButton: ['disableRipple'],
-};
-const transitionCallbacks = [
-  'onEnter',
-  'onEntered',
-  'onEntering',
-  'onExit',
-  'onExiting',
-  'onExited',
-];
-/**
- * These are components that use props implemented by external components.
- * Those props have their own JSDoc which we don't want to emit in our docs
- * but do want them to have JSDoc in IntelliSense
- * TODO: In the future we want to ignore external docs on the initial load anyway
- * since they will be fetched dynamically.
- */
-const ignoreExternalDocumentation: Record<string, readonly string[]> = {
-  Button: ['focusVisibleClassName', 'type'],
-  Collapse: transitionCallbacks,
-  CardActionArea: ['focusVisibleClassName'],
-  AccordionSummary: ['onFocusVisible'],
-  Dialog: ['BackdropProps'],
-  Drawer: ['BackdropProps'],
-  Fab: ['focusVisibleClassName'],
-  Fade: transitionCallbacks,
-  Grow: transitionCallbacks,
-  ListItem: ['focusVisibleClassName'],
-  InputBase: ['aria-describedby'],
-  Menu: ['PaperProps'],
-  MenuItem: ['disabled'],
-  Slide: transitionCallbacks,
-  SwipeableDrawer: ['anchor', 'hideBackdrop', 'ModalProps', 'PaperProps', 'variant'],
-  TextField: ['hiddenLabel'],
-  Zoom: transitionCallbacks,
-};
 
 function sortBreakpointsLiteralByViewportAscending(a: ts.LiteralType, b: ts.LiteralType) {
   // default breakpoints ordered by their size ascending
@@ -162,25 +50,10 @@ const getSortLiteralUnions: InjectPropTypesInFileOptions['getSortLiteralUnions']
   return undefined;
 };
 
-async function generateProptypes(
-  project: TypeScriptProject,
-  sourceFile: string,
-  tsFile: string,
-): Promise<void> {
+async function generateProptypes(project: TypeScriptProject, sourceFile: string): Promise<void> {
   const components = getPropTypesFromFile({
-    filePath: tsFile,
+    filePath: sourceFile,
     project,
-    shouldResolveObject: ({ name }) => {
-      if (
-        name.toLowerCase().endsWith('classes') ||
-        name === 'theme' ||
-        name === 'ownerState' ||
-        (name.endsWith('Props') && name !== 'componentsProps' && name !== 'slotProps')
-      ) {
-        return false;
-      }
-      return undefined;
-    },
     checkDeclarations: true,
   });
 
@@ -188,26 +61,9 @@ async function generateProptypes(
     return;
   }
 
-  // exclude internal slot components, for example ButtonRoot
-  const cleanComponents = components.filter((component) => {
-    if (component.propsFilename?.endsWith('.tsx')) {
-      // only check for .tsx
-      const match = component.propsFilename.match(/.*\/([A-Z][a-zA-Z]+)\.tsx/);
-      if (match) {
-        return component.name === match[1];
-      }
-    }
-    return true;
-  });
-
-  cleanComponents.forEach((component) => {
+  components.forEach((component) => {
     component.types.forEach((prop) => {
-      if (
-        !prop.jsDoc ||
-        (project.name !== 'base' &&
-          ignoreExternalDocumentation[component.name] &&
-          ignoreExternalDocumentation[component.name].includes(prop.name))
-      ) {
+      if (!prop.jsDoc) {
         prop.jsDoc = '@ignore';
       }
     });
@@ -215,20 +71,13 @@ async function generateProptypes(
 
   const sourceContent = await fse.readFile(sourceFile, 'utf8');
   const isTsFile = /(\.(ts|tsx))/.test(sourceFile);
-  // If the component inherits the props from some unstyled components
-  // we don't want to add those propTypes again in the Material UI/Joy UI propTypes
-  const unstyledFile = getUnstyledFilename(tsFile, true);
-  const unstyledPropsFile = unstyledFile.replace('.d.ts', '.types.ts');
+  const propsFile = sourceFile.replace(/(\.d\.ts|\.tsx|\.ts)/g, '.types.ts');
 
-  // TODO remove, should only have .types.ts
-  const propsFile = tsFile.replace(/(\.d\.ts|\.tsx|\.ts)/g, 'Props.ts');
-  const propsFileAlternative = tsFile.replace(/(\.d\.ts|\.tsx|\.ts)/g, '.types.ts');
-  const generatedForTypeScriptFile = sourceFile === tsFile;
   const result = injectPropTypesInFile({
     components,
     target: sourceContent,
     options: {
-      disablePropTypesTypeChecking: generatedForTypeScriptFile,
+      disablePropTypesTypeChecking: true,
       babelOptions: {
         filename: sourceFile,
       },
@@ -267,31 +116,20 @@ async function generateProptypes(
 
         return generated;
       },
-      shouldInclude: ({ component, prop }) => {
+      shouldInclude: ({ prop }) => {
         if (prop.name === 'children') {
           return true;
         }
         let shouldDocument;
-        const { name: componentName } = component;
 
         prop.filenames.forEach((filename) => {
-          const isExternal = filename !== tsFile;
-          const implementedByUnstyledVariant =
-            filename === unstyledFile || filename === unstyledPropsFile;
-          const implementedBySelfPropsFile =
-            filename === propsFile || filename === propsFileAlternative;
-          if (!isExternal || implementedByUnstyledVariant || implementedBySelfPropsFile) {
+          const isExternal = filename !== sourceFile;
+
+          const implementedBySelfPropsFile = filename === propsFile;
+          if (!isExternal || implementedBySelfPropsFile) {
             shouldDocument = true;
           }
         });
-
-        if (
-          useExternalDocumentation[componentName] &&
-          (useExternalDocumentation[componentName] === '*' ||
-            useExternalDocumentation[componentName].includes(prop.name))
-        ) {
-          shouldDocument = true;
-        }
 
         return shouldDocument;
       },
@@ -329,14 +167,7 @@ async function run(argv: HandlerArgv) {
   // Matches files where the folder and file both start with uppercase letters
   // Example: AppBar/AppBar.d.ts
   const allFiles = await Promise.all(
-    [
-      path.resolve(__dirname, '../packages/mui-system/src'),
-      path.resolve(__dirname, '../packages/mui-base/src'),
-      path.resolve(__dirname, '../packages/mui-material/src'),
-      path.resolve(__dirname, '../packages/mui-lab/src'),
-      path.resolve(__dirname, '../packages/mui-material-next/src'),
-      path.resolve(__dirname, '../packages/mui-joy/src'),
-    ].map((folderPath) =>
+    [path.resolve(__dirname, '../packages/mui-base/src')].map((folderPath) =>
       glob('+([A-Z])*/+([A-Z])*.*@(d.ts|ts|tsx)', {
         absolute: true,
         cwd: folderPath,
@@ -346,31 +177,21 @@ async function run(argv: HandlerArgv) {
 
   const files = _.flatten(allFiles)
     .filter((filePath) => {
-      // Filter out files where the directory name and filename doesn't match
-      // Example: Modal/ModalManager.d.ts
-      let folderName = path.basename(path.dirname(filePath));
-      const fileName = path.basename(filePath).replace(/(\.d\.ts|\.tsx|\.ts)/g, '');
-
-      // An exception is if the folder name starts with Unstable_/unstable_
-      // Example: Unstable_Grid2/Grid2.tsx
-      if (/(u|U)nstable_/g.test(folderName)) {
-        folderName = folderName.slice(9);
-      }
-
-      return fileName === folderName;
+      return !(
+        filePath.includes('.test.') ||
+        filePath.includes('.spec.') ||
+        filePath.includes('.types.')
+      );
     })
     .filter((filePath) => filePattern.test(filePath));
 
-  const promises = files.map<Promise<void>>(async (tsFile) => {
-    const sourceFile = tsFile.includes('.d.ts') ? tsFile.replace('.d.ts', '.js') : tsFile;
+  const promises = files.map<Promise<void>>(async (sourceFile) => {
     try {
-      const projectName = tsFile.match(
-        /packages\/mui-([a-zA-Z-]+)\/src/,
-      )![1] as CoreTypeScriptProjects;
+      const projectName = sourceFile.match(/packages\/mui-([a-zA-Z-]+)\/src/)![1];
       const project = buildProject(projectName);
-      await generateProptypes(project, sourceFile, tsFile);
+      await generateProptypes(project, sourceFile);
     } catch (error: any) {
-      error.message = `${tsFile}: ${error.message}`;
+      error.message = `${sourceFile}: ${error.message}`;
       throw error;
     }
   });


### PR DESCRIPTION
Removed code unrelated to Base UI from the proptypes generator. Specifically, the most problematic part was a requirement to have a filename equal to the directory name (so TablePagination/TablePagination.tsx was picked up, but TablePagination/TablePaginationActions.tsx wasn't).
Also removed code specific to JS sources since the whole Base UI codebase is in TS.

These changes caused a couple of previously excluded components to have proptypes generated. This, in turn, caused a failing test in TablePaginationActions, where two mandatory props were not provided. As the props had their default value set in the code, I made them optional.