### PR TITLE
[core] Disable updating packages to incompatible versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -110,12 +110,27 @@
     {
       "groupName": "@definitelytyped tools",
       "matchPackagePatterns": ["@definitelytyped/*"]
+    },
+    {
+      "groupName": "unist-util-visit - incompatible versions",
+      "matchPackageNames": ["unist-util-visit"],
+      "allowedVersions": "< 3.0.0"
+    },
+    {
+      "groupName": "remark - incompatible versions",
+      "matchPackageNames": ["remark"],
+      "allowedVersions": "< 14.0.0"
+    },
+    {
+      "groupName": "chai - incompatible versions",
+      "matchPackageNames": ["chai"],
+      "allowedVersions": "< 5.0.0"
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"],
   "prConcurrentLimit": 30,
   "prHourlyLimit": 0,
   "rangeStrategy": "bump",
-  "schedule": "on sunday before 6:00am",
+  "schedule": "on sunday before 6:00pm",
   "timezone": "UTC"
 }


### PR DESCRIPTION
Do not attempt to upgrade packages to incompatible versions:
- chai >= 5.0 - requires tests in ESM (https://github.com/mui/base-ui/pull/118)
- unist-util-visit >= 3.0.0 - requires ESM (https://github.com/mui/base-ui/pull/129), can be removed once API docs builder is distributed through npm
- remark >= 14.0.0 - requires ESM (https://github.com/mui/base-ui/pull/123), can be removed once API docs builder is distributed through npm

Additionally moved the dependency update time window later, so it doesn't occur at the same time as the Core's.
