### PR TITLE
[core] Disable updating packages to incompatible versions (part 2)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,17 +55,8 @@
       ]
     },
     {
-      "groupName": "MUI Core",
-      "matchPackagePatterns": ["@mui/*"],
-      "excludePackagePatterns": ["@mui/x-*", "@mui/internal-*"]
-    },
-    {
-      "groupName": "MUI X",
-      "matchPackagePatterns": ["@mui/x-*"]
-    },
-    {
-      "groupName": "MUI Infra",
-      "matchPackagePatterns": ["@mui/internal-*"]
+      "groupName": "MUI",
+      "matchPackagePatterns": ["@mui/*"]
     },
     {
       "groupName": "React",
@@ -76,19 +67,14 @@
       "matchPackagePatterns": "@typescript-eslint/*"
     },
     {
-      "groupName": "@types/node",
-      "matchPackageNames": ["@types/node"],
+      "groupName": "Node.js",
+      "matchPackageNames": ["node", "@types/node", "cimg/node"],
       "allowedVersions": "< 19.0.0"
     },
     {
       "groupName": "bundling fixtures",
       "matchPaths": ["test/bundling/fixtures/**/package.json"],
       "schedule": "every 6 months on the first day of the month"
-    },
-    {
-      "groupName": "node",
-      "matchPackageNames": ["node"],
-      "enabled": false
     },
     {
       "groupName": "examples",
@@ -125,6 +111,11 @@
       "groupName": "chai - incompatible versions",
       "matchPackageNames": ["chai"],
       "allowedVersions": "< 5.0.0"
+    },
+    {
+      "groupName": "react-docgen - incompatible versions",
+      "matchPackageNames": ["react-docgen"],
+      "allowedVersions": "< 6.0.0"
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"],


### PR DESCRIPTION
This is a follow-up to #208, as I did not include all the dependencies.

- react-docgen - must be the same version as in api-docs-builder. Can be removed once this package is distributed through npm
- cimg/node (CircleCI docker image) - it should be consistent with the other Node.js packages

Also grouped all the MUI packages together as updating them separately doesn't make sense.