### PR TITLE
[core][Slider] Ref immutable consistency

### DIFF
--- a/packages/mui-base/src/useSlider/useSlider.ts
+++ b/packages/mui-base/src/useSlider/useSlider.ts
@@ -273,7 +273,7 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
   } = useIsFocusVisible();
   const [focusedThumbIndex, setFocusedThumbIndex] = React.useState(-1);
 
-  const sliderRef = React.useRef<HTMLSpanElement>();
+  const sliderRef = React.useRef<HTMLSpanElement>(null);
   const handleFocusRef = useForkRef(focusVisibleRef, sliderRef);
   const handleRef = useForkRef(ref, handleFocusRef);
 


### PR DESCRIPTION
Make it trigger as an immutable ref, for consistency with the rest of the codebase.

To be fair, I don't know if this PR (Option A) is the right long-term decision. We have two other options:

Option B
```diff
-const sliderRef = React.useRef<HTMLSpanElement>(null);
+const sliderRef = React.useRef<HTMLSpanElement>() as React.RefObject<HTMLSpanElement>;
```

Option C
```diff
-const sliderRef = React.useRef<HTMLSpanElement>(null);
+const sliderRef = React.useRef<HTMLSpanElement>();
```

I started a bit this with @romgrk in https://github.com/mui/mui-x/pull/11847#pullrequestreview-1847598552.

- Option A leads to more bundle size, but is consistent with how React sets null when unmounting. It also prevents reassignment mistakes. What's documented in https://react.dev/reference/react/useRef.
- Option B reduces bundle size, avoids reassignment mistakes, and treats null/undefined as equivalent
- Option C doesn't have the type of safety benefit.

In any case, for now, I'm going with the consistency path, defaulting to what the rest of the codebase is doing. It makes it easier to learn and update things at scale. It feels to me that:

- We shouldn't care about null/undefined accuracy, we can treat them as equivalent
- We should care about type reassignment
- We should care about bundle size, maintainers should pay the cost, not developers or end-users.

So I land on going with https://github.com/mui/mui-x/pull/11847#issuecomment-1914751915 for the none refs because who cares about the null/undefiend difference. Going with Option A for DOM refs to things simple for the rest. If this is OK, I can open an issue. It probably doesn't matter much what we pick, as long as it's consistent. 