### PR TITLE
[core] Create `mergeReactProps` utility

### DIFF
--- a/docs/pages/base-ui/api/use-switch.json
+++ b/docs/pages/base-ui/api/use-switch.json
@@ -23,15 +23,15 @@
     "checked": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
     "getButtonProps": {
       "type": {
-        "name": "(externalProps?: React.HTMLAttributes&lt;HTMLButtonElement&gt;) =&gt; UseSwitchButtonElementProps",
-        "description": "(externalProps?: React.HTMLAttributes&lt;HTMLButtonElement&gt;) =&gt; UseSwitchButtonElementProps"
+        "name": "(externalProps?: React.ComponentPropsWithRef&lt;&#39;button&#39;&gt;) =&gt; React.ComponentPropsWithRef&lt;&#39;button&#39;&gt;",
+        "description": "(externalProps?: React.ComponentPropsWithRef&lt;&#39;button&#39;&gt;) =&gt; React.ComponentPropsWithRef&lt;&#39;button&#39;&gt;"
       },
       "required": true
     },
     "getInputProps": {
       "type": {
-        "name": "(externalProps?: React.HTMLAttributes&lt;HTMLInputElement&gt;) =&gt; UseSwitchInputElementProps",
-        "description": "(externalProps?: React.HTMLAttributes&lt;HTMLInputElement&gt;) =&gt; UseSwitchInputElementProps"
+        "name": "(externalProps?: React.ComponentPropsWithRef&lt;&#39;input&#39;&gt;) =&gt; React.ComponentPropsWithRef&lt;&#39;input&#39;&gt;",
+        "description": "(externalProps?: React.ComponentPropsWithRef&lt;&#39;input&#39;&gt;) =&gt; React.ComponentPropsWithRef&lt;&#39;input&#39;&gt;"
       },
       "required": true
     }

--- a/packages/mui-base/src/Switch/Switch.tsx
+++ b/packages/mui-base/src/Switch/Switch.tsx
@@ -3,14 +3,13 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import refType from '@mui/utils/refType';
 import { useSwitch } from '../useSwitch';
-import { SwitchProps, SwitchOwnerState } from './Switch.types';
+import type { SwitchProps, SwitchOwnerState } from './Switch.types';
 import { resolveClassName } from '../utils/resolveClassName';
 import { SwitchContext } from './SwitchContext';
 import { useSwitchStyleHooks } from './useSwitchStyleHooks';
 
 function defaultRender(props: React.ComponentPropsWithRef<'button'>) {
-  // eslint-disable-next-line react/button-has-type
-  return <button {...props} />;
+  return <button type="button" {...props} />;
 }
 
 /**
@@ -37,9 +36,10 @@ const Switch = React.forwardRef(function Switch(
     onChange,
     readOnly = false,
     required = false,
-    render = defaultRender,
+    render: renderProp,
     ...other
   } = props;
+  const render = renderProp ?? defaultRender;
 
   const { getInputProps, getButtonProps, checked } = useSwitch(props);
 

--- a/packages/mui-base/src/Switch/Switch.types.ts
+++ b/packages/mui-base/src/Switch/Switch.types.ts
@@ -1,4 +1,4 @@
-import { BaseUiComponentCommonProps } from '../utils/BaseUiComponentCommonProps';
+import type { BaseUIComponentProps } from '../utils/BaseUI.types';
 import { UseSwitchParameters } from '../useSwitch';
 
 export type SwitchOwnerState = {
@@ -10,6 +10,6 @@ export type SwitchOwnerState = {
 
 export interface SwitchProps
   extends UseSwitchParameters,
-    Omit<BaseUiComponentCommonProps<'button', SwitchOwnerState>, 'onChange'> {}
+    Omit<BaseUIComponentProps<'button', SwitchOwnerState>, 'onChange'> {}
 
-export interface SwitchThumbProps extends BaseUiComponentCommonProps<'span', SwitchOwnerState> {}
+export interface SwitchThumbProps extends BaseUIComponentProps<'span', SwitchOwnerState> {}

--- a/packages/mui-base/src/useSwitch/useSwitch.ts
+++ b/packages/mui-base/src/useSwitch/useSwitch.ts
@@ -4,6 +4,7 @@ import { useControlled } from '../utils/useControlled';
 import { UseSwitchParameters, UseSwitchReturnValue } from './useSwitch.types';
 import { useForkRef } from '../utils/useForkRef';
 import { visuallyHidden } from '../utils/visuallyHidden';
+import { mergeReactProps } from '../utils/mergeReactProps';
 
 /**
  * The basic building block for creating custom switches.
@@ -38,49 +39,47 @@ export function useSwitch(params: UseSwitchParameters): UseSwitchReturnValue {
     state: 'checked',
   });
 
-  const getButtonProps: UseSwitchReturnValue['getButtonProps'] = React.useCallback(
-    (otherProps = {}) => ({
-      type: 'button',
-      role: 'switch',
-      'aria-checked': checked,
-      'aria-disabled': disabled,
-      'aria-readonly': readOnly,
-      ...otherProps,
-      onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
-        otherProps.onClick?.(event);
-        if (event.defaultPrevented || readOnly) {
-          return;
-        }
+  const getButtonProps = React.useCallback(
+    (otherProps = {}) =>
+      mergeReactProps<'button'>(otherProps, {
+        type: 'button',
+        role: 'switch',
+        'aria-checked': checked,
+        'aria-disabled': disabled,
+        'aria-readonly': readOnly,
+        onClick(event) {
+          if (event.defaultPrevented || readOnly) {
+            return;
+          }
 
-        inputRef.current?.click();
-      },
-    }),
+          inputRef.current?.click();
+        },
+      }),
     [checked, disabled, readOnly],
   );
 
-  const getInputProps: UseSwitchReturnValue['getInputProps'] = React.useCallback(
-    (otherProps = {}) => ({
-      checked,
-      disabled,
-      name,
-      required,
-      style: visuallyHidden,
-      tabIndex: -1,
-      type: 'checkbox',
-      'aria-hidden': true,
-      ...otherProps,
-      ref: handleInputRef,
-      onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
-        // Workaround for https://github.com/facebook/react/issues/9023
-        if (event.nativeEvent.defaultPrevented) {
-          return;
-        }
+  const getInputProps = React.useCallback(
+    (otherProps = {}) =>
+      mergeReactProps<'input'>(otherProps, {
+        checked,
+        disabled,
+        name,
+        required,
+        style: visuallyHidden,
+        tabIndex: -1,
+        type: 'checkbox',
+        'aria-hidden': true,
+        ref: handleInputRef,
+        onChange(event) {
+          // Workaround for https://github.com/facebook/react/issues/9023
+          if (event.nativeEvent.defaultPrevented) {
+            return;
+          }
 
-        setCheckedState(event.target.checked);
-        onChange?.(event);
-        otherProps.onChange?.(event);
-      },
-    }),
+          setCheckedState(event.target.checked);
+          onChange?.(event);
+        },
+      }),
     [checked, disabled, name, required, handleInputRef, onChange, setCheckedState],
   );
 

--- a/packages/mui-base/src/useSwitch/useSwitch.types.ts
+++ b/packages/mui-base/src/useSwitch/useSwitch.types.ts
@@ -96,14 +96,14 @@ export interface UseSwitchReturnValue {
    * @returns Props that should be spread on the input element
    */
   getInputProps: (
-    externalProps?: React.HTMLAttributes<HTMLInputElement>,
-  ) => UseSwitchInputElementProps;
+    externalProps?: React.ComponentPropsWithRef<'input'>,
+  ) => React.ComponentPropsWithRef<'input'>;
   /**
    * Resolver for the button element's props.
    * @param externalProps Additional props for the input element
    * @returns Props that should be spread on the button element
    */
   getButtonProps: (
-    externalProps?: React.HTMLAttributes<HTMLButtonElement>,
-  ) => UseSwitchButtonElementProps;
+    externalProps?: React.ComponentPropsWithRef<'button'>,
+  ) => React.ComponentPropsWithRef<'button'>;
 }

--- a/packages/mui-base/src/utils/BaseUI.types.ts
+++ b/packages/mui-base/src/utils/BaseUI.types.ts
@@ -1,3 +1,19 @@
+export type BaseUIEvent<E extends React.SyntheticEvent<Element, Event>> = E & {
+  preventBaseUIHandler: () => void;
+};
+
+type WithPreventBaseUIHandler<T> = T extends (event: infer E) => any
+  ? E extends React.SyntheticEvent<Element, Event>
+    ? (event: BaseUIEvent<E>) => ReturnType<T>
+    : never
+  : T extends undefined
+    ? undefined
+    : T;
+
+export type BaseUIProps<T> = {
+  [K in keyof T]: WithPreventBaseUIHandler<T[K]>;
+};
+
 /**
  * Shape of the render prop: a function that takes props to be spread on the element and component's state and returns a React element.
  *
@@ -9,10 +25,9 @@ export type ComponentRenderFn<Props, State> = (props: Props, state: State) => Re
 /**
  * Props shared by all Base UI components.
  * Contains `className` (string or callback taking the component's state as an argument) and `render` (function to customize rendering).
- 
  */
-export type BaseUiComponentCommonProps<ElementType extends React.ElementType, OwnerState> = Omit<
-  React.ComponentPropsWithoutRef<ElementType>,
+export type BaseUIComponentProps<ElementType extends React.ElementType, OwnerState> = Omit<
+  BaseUIProps<React.ComponentPropsWithoutRef<ElementType>>,
   'className'
 > & {
   /**

--- a/packages/mui-base/src/utils/BaseUI.types.ts
+++ b/packages/mui-base/src/utils/BaseUI.types.ts
@@ -10,7 +10,10 @@ type WithPreventBaseUIHandler<T> = T extends (event: infer E) => any
     ? undefined
     : T;
 
-export type BaseUIProps<T> = {
+/**
+ * Adds a `preventBaseUIHandler` method to all event handlers.
+ */
+export type WithBaseUIEvent<T> = {
   [K in keyof T]: WithPreventBaseUIHandler<T[K]>;
 };
 
@@ -27,7 +30,7 @@ export type ComponentRenderFn<Props, State> = (props: Props, state: State) => Re
  * Contains `className` (string or callback taking the component's state as an argument) and `render` (function to customize rendering).
  */
 export type BaseUIComponentProps<ElementType extends React.ElementType, OwnerState> = Omit<
-  BaseUIProps<React.ComponentPropsWithoutRef<ElementType>>,
+  WithBaseUIEvent<React.ComponentPropsWithoutRef<ElementType>>,
   'className'
 > & {
   /**

--- a/packages/mui-base/src/utils/mergeReactProps.test.ts
+++ b/packages/mui-base/src/utils/mergeReactProps.test.ts
@@ -1,0 +1,108 @@
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { mergeReactProps } from './mergeReactProps';
+
+describe('mergeReactProps', () => {
+  it('merges event handlers', () => {
+    const theirProps = {
+      onClick: spy(),
+      onKeyDown: spy(),
+    };
+    const ourProps = {
+      onClick: spy(),
+      onPaste: spy(),
+    };
+    const mergedProps = mergeReactProps<'button'>(theirProps, ourProps);
+
+    mergedProps.onClick?.({} as any);
+    mergedProps.onKeyDown?.({} as any);
+    mergedProps.onPaste?.({} as any);
+
+    expect(theirProps.onClick.calledBefore(ourProps.onClick)).to.equal(true);
+    expect(theirProps.onClick.callCount).to.equal(1);
+    expect(ourProps.onClick.callCount).to.equal(1);
+    expect(theirProps.onKeyDown.callCount).to.equal(1);
+    expect(ourProps.onPaste.callCount).to.equal(1);
+  });
+
+  it('merges styles', () => {
+    const theirProps = {
+      style: { color: 'red' },
+    };
+    const ourProps = {
+      style: { color: 'blue', backgroundColor: 'blue' },
+    };
+    const mergedProps = mergeReactProps<'div'>(theirProps, ourProps);
+
+    expect(mergedProps.style).to.deep.equal({
+      color: 'red',
+      backgroundColor: 'blue',
+    });
+  });
+
+  it('merges styles with undefined', () => {
+    const theirProps = {
+      style: { color: 'red' },
+    };
+    const ourProps = {
+      style: undefined,
+    };
+    const mergedProps = mergeReactProps<'button'>(theirProps, ourProps);
+
+    expect(mergedProps.style).to.deep.equal({
+      color: 'red',
+    });
+  });
+
+  it('does not merge styles if both are undefined', () => {
+    const theirProps = {
+      style: undefined,
+    };
+    const ourProps = {
+      style: undefined,
+    };
+    const mergedProps = mergeReactProps<'button'>(theirProps, ourProps);
+
+    expect(mergedProps.style).to.equal(undefined);
+  });
+
+  it('does not prevent internal handler if event.preventBaseUIHandler() is not called', () => {
+    let ran = false;
+
+    const mergedProps = mergeReactProps<'button'>(
+      {
+        onClick() {},
+      },
+      {
+        onClick() {
+          ran = true;
+        },
+      },
+    );
+
+    mergedProps.onClick?.({} as any);
+
+    expect(ran).to.equal(true);
+  });
+
+  it('prevents internal handler if event.preventBaseUIHandler() is called', () => {
+    let ran = false;
+
+    const mergedProps = mergeReactProps<'button'>(
+      {
+        onClick(event) {
+          event.preventBaseUIHandler();
+        },
+      },
+      {
+        onClick() {
+          ran = true;
+        },
+      },
+    );
+
+    mergedProps.onClick?.({} as any);
+
+    expect(ran).to.equal(false);
+  });
+});

--- a/packages/mui-base/src/utils/mergeReactProps.ts
+++ b/packages/mui-base/src/utils/mergeReactProps.ts
@@ -1,0 +1,53 @@
+import type * as React from 'react';
+import type { BaseUIEvent, BaseUIProps } from './BaseUI.types';
+
+/**
+ * Merges two sets of React props such that their event handlers are called in sequence (the user's
+ * before our internal ones), and allows the user to prevent the internal event handlers from being
+ * executed by attaching a `preventBaseUIHandler` method. It also merges the `style` prop, whereby
+ * the user's styles overwrite the internal ones.
+ * @important **`className` and `ref` are not merged.**
+ * @param externalProps the user's external props.
+ * @param internalProps our own internal props.
+ * @returns the merged props.
+ */
+export function mergeReactProps<T extends React.ElementType>(
+  externalProps: BaseUIProps<React.ComponentPropsWithRef<T>>,
+  internalProps: React.ComponentPropsWithRef<T>,
+): BaseUIProps<React.ComponentPropsWithRef<T>> {
+  return Object.entries(externalProps).reduce(
+    (acc, [key, value]) => {
+      if (/^on[A-Z]/.test(key) && typeof value === 'function') {
+        acc[key] = (event: React.SyntheticEvent) => {
+          let isPrevented = false;
+
+          const theirHandler = value;
+          const ourHandler = internalProps[key];
+
+          const baseUIEvent = event as BaseUIEvent<typeof event>;
+
+          baseUIEvent.preventBaseUIHandler = () => {
+            isPrevented = true;
+          };
+
+          const result = theirHandler(baseUIEvent);
+
+          if (!isPrevented) {
+            ourHandler?.(baseUIEvent);
+          }
+
+          return result;
+        };
+      } else if (key === 'style') {
+        if (value || internalProps.style) {
+          acc[key] = { ...internalProps.style, ...(value || {}) };
+        }
+      } else {
+        acc[key] = value;
+      }
+
+      return acc;
+    },
+    { ...internalProps },
+  );
+}

--- a/packages/mui-base/src/utils/mergeReactProps.ts
+++ b/packages/mui-base/src/utils/mergeReactProps.ts
@@ -1,5 +1,5 @@
 import type * as React from 'react';
-import type { BaseUIEvent, BaseUIProps } from './BaseUI.types';
+import type { BaseUIEvent, WithBaseUIEvent } from './BaseUI.types';
 
 /**
  * Merges two sets of React props such that their event handlers are called in sequence (the user's
@@ -12,9 +12,9 @@ import type { BaseUIEvent, BaseUIProps } from './BaseUI.types';
  * @returns the merged props.
  */
 export function mergeReactProps<T extends React.ElementType>(
-  externalProps: BaseUIProps<React.ComponentPropsWithRef<T>>,
+  externalProps: WithBaseUIEvent<React.ComponentPropsWithRef<T>>,
   internalProps: React.ComponentPropsWithRef<T>,
-): BaseUIProps<React.ComponentPropsWithRef<T>> {
+): WithBaseUIEvent<React.ComponentPropsWithRef<T>> {
   return Object.entries(externalProps).reduce(
     (acc, [key, value]) => {
       if (/^on[A-Z]/.test(key) && typeof value === 'function') {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This is an alternative to https://github.com/mui/base-ui/pull/209, which merges a user's external event handlers with our components' internal event handlers. Instead of needing to define every event handler with `mergeEventHandlers`, you just pass props normally through the function, and things get merged (including `style`) as expected. The other "mergeable" prop `className` is not considered, however.

One important part though is allowing to disambiguate preventing the browser's default behavior from preventing the library's logic.

## Usage

React Event types are preserved here.

```js
mergeReactProps({
  onPointerDown(event) {
    // event is typed correctly + has this method:
    event.preventBaseUIHandler();
  } 
}, {
  onPointerDown(event) {
    console.log('this never runs');
  }
})
```

We don't need a `defaultBaseUIPrevented` property, since it uses the closure variable.

## Component example

```js
<NumberField.Input 
  onKeyDown={(event) => {
    event.preventBaseUIHandler();
    // Base UI's logic now never runs, but the browser's default does still.
  }}
/>
```

The `MergedProps` (`WithPreventComponentHandler`) event type will need to be added to all component definitions.

## Other possible names for `.preventBaseUIHandler()`

- `.preventComponentDefault()`
- `.preventComponentHandler()`
- `.preventBaseUIDefault()`
- `.preventInternalDefault()`

## Considerations

### Pros

- Always provides an escape hatch when the user needs to stop the library's event handler from running internally, which is useful for a low-level headless library like Base UI.
- Handles future event handlers that we add, always allowing users to start preventing them after updating.

### Cons 

- Not granular. Stops all logic inside the event handler, even if the user wants to stop only part of it, resulting in them having to re-implement the whole event handler. @michaldudak suggested exposing a reducer pattern to let the user granularly change how state updates internally for complex components.
- Non-standard. Creates a complex typing situation to add the `preventBaseUIHandler()` function to every `Event`.

## Alternatives

Allow users to turn behaviors on or off via props, allowing granular prevention, instead of wholesale-stopping a given event handler. Could potentially lead to a propocalypse.

Furthermore, there are certain behaviors where simply checking `event.defaultPrevented` is fine when it matches the browser's behavior. It calls into question how often users need to stop the library's event handler at all, compared to when `event.preventDefault()` works for both cases (browser and library). We could avoid checking `event.defaultPrevented` unless we're certain it matches how the browser does something natively and makes sense.

Either way, this utility is still useful for merging props, even if we decide to remove the `preventBaseUIHandler` part of it.