### PR TITLE
[core] Adjust conformance tests to support portals

### DIFF
--- a/packages/mui-base/test/conformanceTests/className.tsx
+++ b/packages/mui-base/test/conformanceTests/className.tsx
@@ -15,8 +15,8 @@ export function testClassName(
     }
 
     it('should apply the className when passed as a string', async () => {
-      const { container } = await render(React.cloneElement(element, { className: 'test-class' }));
-      expect(container.firstElementChild?.className).to.contain('test-class');
+      await render(React.cloneElement(element, { className: 'test-class' }));
+      expect(document.querySelector('.test-class')).not.to.equal(null);
     });
   });
 }

--- a/packages/mui-base/test/conformanceTests/renderProp.tsx
+++ b/packages/mui-base/test/conformanceTests/renderProp.tsx
@@ -16,7 +16,7 @@ export function testRenderProp(
   const Wrapper = React.forwardRef<any, { children?: React.ReactNode }>(
     function Wrapper(props, forwardedRef) {
       return (
-        <div data-testid="wrapper">
+        <div data-testid="base-ui-wrapper">
           {/* @ts-ignore */}
           <Element ref={forwardedRef} {...props} />
         </div>
@@ -26,13 +26,13 @@ export function testRenderProp(
 
   describe('prop: render', () => {
     it('renders a customized root element', async () => {
-      const { container, getByTestId } = await render(
+      await render(
         React.cloneElement(element, {
           render: (props: any) => <Wrapper {...props} />,
         }),
       );
 
-      expect(container.firstElementChild).to.equal(getByTestId('wrapper'));
+      expect(document.querySelector('[data-testid="base-ui-wrapper"]')).to.not.equal(null);
     });
 
     it('should pass the ref to the custom component', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Taken from https://github.com/mui/base-ui/pull/186 into this individual PR.