### PR TITLE
[core] Fix license entity reference

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Material-UI SAS
+Copyright (c) 2021 Material-UI SAS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Material-UI
+Copyright (c) 2020 Material-UI SAS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 Material-UI SAS
+Copyright (c) 2019 Material-UI SAS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I noticed this in https://github.com/mui/pigment-css/pull/1#discussion_r1560772919. I'm changing this to replicate what we did in MUI X, and then Toolpad. See https://www.notion.so/mui-org/Legal-Public-company-info-e215ee76047940f48717b3c4ec9769b9?pvs=4#efcfb7aeda4f4feb961ee91ee43413b3 for why.