### PR TITLE
[number field] Add `UseNumberFieldParameters` type

### DIFF
--- a/docs/pages/base-ui/api/number-field.json
+++ b/docs/pages/base-ui/api/number-field.json
@@ -3,11 +3,16 @@
     "allowWheelScrub": { "type": { "name": "bool" }, "default": "false" },
     "className": { "type": { "name": "union", "description": "func<br>&#124;&nbsp;string" } },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "id": { "type": { "name": "string" } },
     "invalid": { "type": { "name": "bool" }, "default": "false" },
     "largeStep": { "type": { "name": "number" }, "default": "10" },
     "max": { "type": { "name": "number" } },
     "min": { "type": { "name": "number" } },
     "name": { "type": { "name": "string" } },
+    "onChange": {
+      "type": { "name": "func" },
+      "signature": { "type": "function(value: number | null) => void", "describedArgs": ["value"] }
+    },
     "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "render": { "type": { "name": "func" } },
     "required": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/base-ui/api/number-field.json
+++ b/docs/pages/base-ui/api/number-field.json
@@ -1,17 +1,8 @@
 {
   "props": {
     "allowWheelScrub": { "type": { "name": "bool" }, "default": "false" },
-    "autoFocus": { "type": { "name": "bool" }, "default": "false" },
     "className": { "type": { "name": "union", "description": "func<br>&#124;&nbsp;string" } },
-    "defaultValue": { "type": { "name": "number" } },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
-    "format": {
-      "type": {
-        "name": "shape",
-        "description": "{ compactDisplay?: 'long'<br>&#124;&nbsp;'short', currency?: string, currencyDisplay?: string, currencySign?: string, localeMatcher?: string, maximumFractionDigits?: number, maximumSignificantDigits?: number, minimumFractionDigits?: number, minimumIntegerDigits?: number, minimumSignificantDigits?: number, notation?: 'compact'<br>&#124;&nbsp;'engineering'<br>&#124;&nbsp;'scientific'<br>&#124;&nbsp;'standard', signDisplay?: 'always'<br>&#124;&nbsp;'auto'<br>&#124;&nbsp;'exceptZero'<br>&#124;&nbsp;'never', style?: string, unit?: string, unitDisplay?: 'long'<br>&#124;&nbsp;'narrow'<br>&#124;&nbsp;'short', useGrouping?: bool }"
-      }
-    },
-    "id": { "type": { "name": "string" } },
     "invalid": { "type": { "name": "bool" }, "default": "false" },
     "largeStep": { "type": { "name": "number" }, "default": "10" },
     "max": { "type": { "name": "number" } },

--- a/docs/pages/base-ui/api/use-number-field.json
+++ b/docs/pages/base-ui/api/use-number-field.json
@@ -1,5 +1,33 @@
 {
-  "parameters": {},
+  "parameters": {
+    "allowWheelScrub": {
+      "type": { "name": "boolean", "description": "boolean" },
+      "default": "false"
+    },
+    "autoFocus": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
+    "defaultValue": { "type": { "name": "number", "description": "number" } },
+    "disabled": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
+    "format": {
+      "type": { "name": "Intl.NumberFormatOptions", "description": "Intl.NumberFormatOptions" }
+    },
+    "id": { "type": { "name": "string", "description": "string" } },
+    "invalid": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
+    "largeStep": { "type": { "name": "number", "description": "number" }, "default": "10" },
+    "max": { "type": { "name": "number", "description": "number" } },
+    "min": { "type": { "name": "number", "description": "number" } },
+    "name": { "type": { "name": "string", "description": "string" } },
+    "onChange": {
+      "type": {
+        "name": "(value: number | null) =&gt; void",
+        "description": "(value: number | null) =&gt; void"
+      }
+    },
+    "readOnly": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
+    "required": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
+    "smallStep": { "type": { "name": "number", "description": "number" }, "default": "0.1" },
+    "step": { "type": { "name": "number", "description": "number" } },
+    "value": { "type": { "name": "number | null", "description": "number | null" } }
+  },
   "returnValue": {
     "getDecrementButtonProps": {
       "type": {

--- a/docs/translations/api-docs-base/number-field/number-field.json
+++ b/docs/translations/api-docs-base/number-field/number-field.json
@@ -8,6 +8,7 @@
       "description": "Class names applied to the element or a function that returns them based on the component&#39;s state."
     },
     "disabled": { "description": "If <code>true</code>, the input element is disabled." },
+    "id": { "description": "The id of the input element." },
     "invalid": { "description": "If <code>true</code>, the input element is invalid." },
     "largeStep": {
       "description": "The large step value of the input element when incrementing while the shift key is held. Snaps to multiples of this value."
@@ -15,6 +16,10 @@
     "max": { "description": "The maximum value of the input element." },
     "min": { "description": "The minimum value of the input element." },
     "name": { "description": "The name of the input element." },
+    "onChange": {
+      "description": "Callback fired when the number value changes.",
+      "typeDescriptions": { "value": "The new value." }
+    },
     "readOnly": { "description": "If <code>true</code>, the input element is read only." },
     "render": { "description": "A function to customize rendering of the component." },
     "required": { "description": "If <code>true</code>, the input element is required." },

--- a/docs/translations/api-docs-base/number-field/number-field.json
+++ b/docs/translations/api-docs-base/number-field/number-field.json
@@ -4,16 +4,10 @@
     "allowWheelScrub": {
       "description": "Whether to allow the user to scrub the input value with the mouse wheel while focused and hovering over the input."
     },
-    "autoFocus": { "description": "If <code>true</code>, the input element is focused on mount." },
     "className": {
       "description": "Class names applied to the element or a function that returns them based on the component&#39;s state."
     },
-    "defaultValue": {
-      "description": "The default value of the input element. Use when the component is not controlled."
-    },
     "disabled": { "description": "If <code>true</code>, the input element is disabled." },
-    "format": { "description": "Options to format the input value." },
-    "id": { "description": "The id of the input element." },
     "invalid": { "description": "If <code>true</code>, the input element is invalid." },
     "largeStep": {
       "description": "The large step value of the input element when incrementing while the shift key is held. Snaps to multiples of this value."

--- a/docs/translations/api-docs/use-number-field/use-number-field.json
+++ b/docs/translations/api-docs/use-number-field/use-number-field.json
@@ -1,5 +1,32 @@
 {
   "hookDescription": "The basic building block for creating custom number fields.",
-  "parametersDescriptions": {},
+  "parametersDescriptions": {
+    "allowWheelScrub": {
+      "description": "Whether to allow the user to scrub the input value with the mouse wheel while focused and hovering over the input."
+    },
+    "autoFocus": { "description": "If <code>true</code>, the input element is focused on mount." },
+    "defaultValue": {
+      "description": "The default value of the input element. Use when the component is not controlled."
+    },
+    "disabled": { "description": "If <code>true</code>, the input element is disabled." },
+    "format": { "description": "Options to format the input value." },
+    "id": { "description": "The id of the input element." },
+    "invalid": { "description": "If <code>true</code>, the input element is invalid." },
+    "largeStep": {
+      "description": "The large step value of the input element when incrementing while the shift key is held. Snaps to multiples of this value."
+    },
+    "max": { "description": "The maximum value of the input element." },
+    "min": { "description": "The minimum value of the input element." },
+    "name": { "description": "The name of the input element." },
+    "readOnly": { "description": "If <code>true</code>, the input element is read only." },
+    "required": { "description": "If <code>true</code>, the input element is required." },
+    "smallStep": {
+      "description": "The small step value of the input element when incrementing while the meta key is held. Snaps to multiples of this value."
+    },
+    "step": {
+      "description": "The step value of the input element when incrementing, decrementing, or scrubbing. It will snap to multiples of this value. When unspecified, decimal values are allowed, but the stepper buttons will increment or decrement by <code>1</code>."
+    },
+    "value": { "description": "The raw number value of the input element." }
+  },
   "returnValueDescriptions": {}
 }

--- a/docs/translations/api-docs/use-number-field/use-number-field.json
+++ b/docs/translations/api-docs/use-number-field/use-number-field.json
@@ -18,6 +18,7 @@
     "max": { "description": "The maximum value of the input element." },
     "min": { "description": "The minimum value of the input element." },
     "name": { "description": "The name of the input element." },
+    "onChange": { "description": "Callback fired when the number value changes." },
     "readOnly": { "description": "If <code>true</code>, the input element is read only." },
     "required": { "description": "If <code>true</code>, the input element is required." },
     "smallStep": {

--- a/packages/mui-base/src/NumberField/NumberField.tsx
+++ b/packages/mui-base/src/NumberField/NumberField.tsx
@@ -114,7 +114,7 @@ NumberField.propTypes /* remove-proptypes */ = {
    */
   disabled: PropTypes.bool,
   /**
-   * @ignore
+   * The id of the input element.
    */
   id: PropTypes.string,
   /**
@@ -141,7 +141,8 @@ NumberField.propTypes /* remove-proptypes */ = {
    */
   name: PropTypes.string,
   /**
-   * @param value the raw number value of the input element.
+   * Callback fired when the number value changes.
+   * @param {number | null} value The new value.
    */
   onChange: PropTypes.func,
   /**

--- a/packages/mui-base/src/NumberField/NumberField.tsx
+++ b/packages/mui-base/src/NumberField/NumberField.tsx
@@ -101,11 +101,6 @@ NumberField.propTypes /* remove-proptypes */ = {
    */
   allowWheelScrub: PropTypes.bool,
   /**
-   * If `true`, the input element is focused on mount.
-   * @default false
-   */
-  autoFocus: PropTypes.bool,
-  /**
    * @ignore
    */
   children: PropTypes.node,
@@ -114,37 +109,12 @@ NumberField.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   /**
-   * The default value of the input element. Use when the component is not controlled.
-   */
-  defaultValue: PropTypes.number,
-  /**
    * If `true`, the input element is disabled.
    * @default false
    */
   disabled: PropTypes.bool,
   /**
-   * Options to format the input value.
-   */
-  format: PropTypes.shape({
-    compactDisplay: PropTypes.oneOf(['long', 'short']),
-    currency: PropTypes.string,
-    currencyDisplay: PropTypes.string,
-    currencySign: PropTypes.string,
-    localeMatcher: PropTypes.string,
-    maximumFractionDigits: PropTypes.number,
-    maximumSignificantDigits: PropTypes.number,
-    minimumFractionDigits: PropTypes.number,
-    minimumIntegerDigits: PropTypes.number,
-    minimumSignificantDigits: PropTypes.number,
-    notation: PropTypes.oneOf(['compact', 'engineering', 'scientific', 'standard']),
-    signDisplay: PropTypes.oneOf(['always', 'auto', 'exceptZero', 'never']),
-    style: PropTypes.string,
-    unit: PropTypes.string,
-    unitDisplay: PropTypes.oneOf(['long', 'narrow', 'short']),
-    useGrouping: PropTypes.bool,
-  }),
-  /**
-   * The id of the input element.
+   * @ignore
    */
   id: PropTypes.string,
   /**

--- a/packages/mui-base/src/NumberField/NumberField.types.ts
+++ b/packages/mui-base/src/NumberField/NumberField.types.ts
@@ -1,7 +1,7 @@
 import type { UseNumberFieldParameters } from '../useNumberField';
 import type { BaseUIComponentProps } from '../utils/BaseUI.types';
 
-export interface NumberFieldOwnerState {
+export type NumberFieldOwnerState = {
   /**
    * The raw number value of the input element.
    */
@@ -30,11 +30,11 @@ export interface NumberFieldOwnerState {
    * If `true`, the value is being scrubbed.
    */
   scrubbing: boolean;
-}
+};
 
 export interface NumberFieldProps
-  extends Omit<BaseUIComponentProps<'div', NumberFieldOwnerState>, 'onChange' | 'defaultValue'>,
-    UseNumberFieldParameters {}
+  extends UseNumberFieldParameters,
+    Omit<BaseUIComponentProps<'div', NumberFieldOwnerState>, 'onChange' | 'defaultValue'> {}
 
 export interface NumberFieldGroupProps extends BaseUIComponentProps<'div', NumberFieldOwnerState> {}
 

--- a/packages/mui-base/src/NumberField/NumberField.types.ts
+++ b/packages/mui-base/src/NumberField/NumberField.types.ts
@@ -1,3 +1,4 @@
+import type { UseNumberFieldParameters } from '../useNumberField';
 import type { BaseUIComponentProps } from '../utils/BaseUI.types';
 
 export interface NumberFieldOwnerState {
@@ -32,89 +33,8 @@ export interface NumberFieldOwnerState {
 }
 
 export interface NumberFieldProps
-  extends Omit<BaseUIComponentProps<'div', NumberFieldOwnerState>, 'onChange'> {
-  /**
-   * The id of the input element.
-   */
-  id?: string;
-  /**
-   * The minimum value of the input element.
-   */
-  min?: number;
-  /**
-   * The maximum value of the input element.
-   */
-  max?: number;
-  /**
-   * The small step value of the input element when incrementing while the meta key is held. Snaps
-   * to multiples of this value.
-   * @default 0.1
-   */
-  smallStep?: number;
-  /**
-   * The step value of the input element when incrementing, decrementing, or scrubbing. It will snap
-   * to multiples of this value. When unspecified, decimal values are allowed, but the stepper
-   * buttons will increment or decrement by `1`.
-   */
-  step?: number;
-  /**
-   * The large step value of the input element when incrementing while the shift key is held. Snaps
-   * to multiples of this value.
-   * @default 10
-   */
-  largeStep?: number;
-  /**
-   * If `true`, the input element is required.
-   * @default false
-   */
-  required?: boolean;
-  /**
-   * If `true`, the input element is disabled.
-   * @default false
-   */
-  disabled?: boolean;
-  /**
-   * If `true`, the input element is invalid.
-   * @default false
-   */
-  invalid?: boolean;
-  /**
-   * If `true`, the input element is focused on mount.
-   * @default false
-   */
-  autoFocus?: boolean;
-  /**
-   * If `true`, the input element is read only.
-   * @default false
-   */
-  readOnly?: boolean;
-  /**
-   * The name of the input element.
-   */
-  name?: string;
-  /**
-   * The raw number value of the input element.
-   */
-  value?: number | null;
-  /**
-   * The default value of the input element. Use when the component is not controlled.
-   */
-  defaultValue?: number;
-  /**
-   * Whether to allow the user to scrub the input value with the mouse wheel while focused and
-   * hovering over the input.
-   * @default false
-   */
-  allowWheelScrub?: boolean;
-  /**
-   * Options to format the input value.
-   */
-  format?: Intl.NumberFormatOptions;
-  /**
-   * @param value the raw number value of the input element.
-   */
-  onChange?: (value: number | null) => void;
-}
+  extends Omit<BaseUIComponentProps<'div', NumberFieldOwnerState>, 'onChange' | 'defaultValue'>,
+    UseNumberFieldParameters {}
 
 export interface NumberFieldGroupProps extends BaseUIComponentProps<'div', NumberFieldOwnerState> {}
 

--- a/packages/mui-base/src/useNumberField/useNumberField.ts
+++ b/packages/mui-base/src/useNumberField/useNumberField.ts
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { useEventCallback } from '../utils/useEventCallback';
 import { useControlled } from '../utils/useControlled';
-import type { NumberFieldProps } from '../NumberField';
 import { useLatestRef } from '../utils/useLatestRef';
-import type { UseNumberFieldReturnValue } from './useNumberField.types';
+import type { UseNumberFieldParameters, UseNumberFieldReturnValue } from './useNumberField.types';
 import { ownerDocument, ownerWindow } from '../utils/owner';
 import { useId } from '../utils/useId';
 import { isIOS } from '../utils/detectBrowser';
@@ -40,7 +39,7 @@ import { mergeReactProps } from '../utils/mergeReactProps';
  *
  * - [useNumberField API](https://mui.com/base-ui/react-number-field/hooks-api/#use-number-field)
  */
-export function useNumberField(params: NumberFieldProps): UseNumberFieldReturnValue {
+export function useNumberField(params: UseNumberFieldParameters): UseNumberFieldReturnValue {
   const {
     id: idProp,
     name,

--- a/packages/mui-base/src/useNumberField/useNumberField.types.ts
+++ b/packages/mui-base/src/useNumberField/useNumberField.types.ts
@@ -1,5 +1,89 @@
 import type { ScrubHandle } from './useScrub.types';
 
+export interface UseNumberFieldParameters {
+  /**
+   * The id of the input element.
+   */
+  id?: string;
+  /**
+   * The minimum value of the input element.
+   */
+  min?: number;
+  /**
+   * The maximum value of the input element.
+   */
+  max?: number;
+  /**
+   * The small step value of the input element when incrementing while the meta key is held. Snaps
+   * to multiples of this value.
+   * @default 0.1
+   */
+  smallStep?: number;
+  /**
+   * The step value of the input element when incrementing, decrementing, or scrubbing. It will snap
+   * to multiples of this value. When unspecified, decimal values are allowed, but the stepper
+   * buttons will increment or decrement by `1`.
+   */
+  step?: number;
+  /**
+   * The large step value of the input element when incrementing while the shift key is held. Snaps
+   * to multiples of this value.
+   * @default 10
+   */
+  largeStep?: number;
+  /**
+   * If `true`, the input element is required.
+   * @default false
+   */
+  required?: boolean;
+  /**
+   * If `true`, the input element is disabled.
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, the input element is invalid.
+   * @default false
+   */
+  invalid?: boolean;
+  /**
+   * If `true`, the input element is focused on mount.
+   * @default false
+   */
+  autoFocus?: boolean;
+  /**
+   * If `true`, the input element is read only.
+   * @default false
+   */
+  readOnly?: boolean;
+  /**
+   * The name of the input element.
+   */
+  name?: string;
+  /**
+   * The raw number value of the input element.
+   */
+  value?: number | null;
+  /**
+   * The default value of the input element. Use when the component is not controlled.
+   */
+  defaultValue?: number;
+  /**
+   * Whether to allow the user to scrub the input value with the mouse wheel while focused and
+   * hovering over the input.
+   * @default false
+   */
+  allowWheelScrub?: boolean;
+  /**
+   * Options to format the input value.
+   */
+  format?: Intl.NumberFormatOptions;
+  /**
+   * @param value the raw number value of the input element.
+   */
+  onChange?: (value: number | null) => void;
+}
+
 export interface UseNumberFieldReturnValue {
   getGroupProps: (
     externalProps?: React.ComponentPropsWithRef<'div'>,

--- a/packages/mui-base/src/useNumberField/useNumberField.types.ts
+++ b/packages/mui-base/src/useNumberField/useNumberField.types.ts
@@ -79,7 +79,8 @@ export interface UseNumberFieldParameters {
    */
   format?: Intl.NumberFormatOptions;
   /**
-   * @param value the raw number value of the input element.
+   * Callback fired when the number value changes.
+   * @param {number | null} value The new value.
    */
   onChange?: (value: number | null) => void;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `useNumberField` Hook should have a `Parameters` type. This also fixes the `onChange` doc.

https://github.com/mui/base-ui/pull/294#discussion_r1562141527