### PR TITLE
[core] Use Base UI repo in the release changelog script

### DIFF
--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -200,7 +200,7 @@ yargs(process.argv.slice(2))
           type: 'string',
         })
         .option('repo', {
-          default: 'material-ui',
+          default: 'base-ui',
           describe: 'Repository to generate a changelog for',
           type: 'string',
         });

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -140,15 +140,8 @@ async function main(argv) {
     return aTags.localeCompare(bTags);
   });
   const changes = commitsItems.map((commitsItem) => {
-    // Helps changelog author keeping track of order when grouping commits under headings.
-    // &#8203; is a zero-width-space that ensures that the content of the listitem is formatted properly
-    const dateSortMarker = `&#8203;<!-- ${(commitsItems.length - commitsItems.indexOf(commitsItem))
-      .toString()
-      // Padding them with a zero means we can just feed a list into online sorting tools like https://www.online-utility.org/text/sort.jsp
-      // i.e. we can sort the lines alphanumerically
-      .padStart(Math.floor(Math.log10(commitsItemsByDateDesc.length)) + 1, '0')} -->`;
     const shortMessage = commitsItem.commit.message.split('\n')[0];
-    return `- ${dateSortMarker}${shortMessage} @${getAuthor(commitsItem)}`;
+    return `- ${shortMessage} @${getAuthor(commitsItem)}`;
   });
   const nowFormatted = new Date().toLocaleDateString('en-US', {
     month: 'short',


### PR DESCRIPTION
Changed material-ui to base-ui as the default repo in the release changelog script.
Also removed the unused date sort markers.