### PR TITLE
[core] Config cleanup

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -56,7 +56,3 @@ node 18.0
 # same as `node`
 [test]
 node 18.0
-
-# same as `node`
-[benchmark]
-node 18.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,22 +392,6 @@ jobs:
       - run:
           name: Upload screenshots to Argos CI
           command: pnpm test:argos
-  test_benchmark:
-    <<: *default-job
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.43.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
-    steps:
-      - checkout
-      - install_js:
-          react-version: << parameters.react-version >>
-          browsers: true
-      - run: pnpm benchmark:browser
-      - store_artifacts:
-          name: Publish benchmark results as a pipeline artifact.
-          path: tmp/benchmarks
-          destination: benchmarks
 workflows:
   version: 2
   pipeline:
@@ -493,10 +477,4 @@ workflows:
                 - master
     jobs:
       - test_types_next:
-          <<: *default-context
-  benchmark:
-    when:
-      equal: [benchmark, << pipeline.parameters.workflow >>]
-    jobs:
-      - test_benchmark:
           <<: *default-context

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 /.git
 /.yarn
-/benchmark/**/dist
 /coverage
 /docs/export
 /docs/pages/playground/

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 *.tsbuildinfo
 /.eslintcache
 /.nyc_output
-/benchmark/**/dist
 /coverage
 /docs/.env.local
 /docs/export

--- a/babel.config.js
+++ b/babel.config.js
@@ -121,16 +121,6 @@ module.exports = function getBabelConfig(api) {
           ],
         ],
       },
-      rollup: {
-        plugins: [
-          [
-            'babel-plugin-module-resolver',
-            {
-              alias: defaultAlias,
-            },
-          ],
-        ],
-      },
       test: {
         sourceMaps: 'both',
         plugins: [
@@ -138,17 +128,6 @@ module.exports = function getBabelConfig(api) {
             'babel-plugin-module-resolver',
             {
               root: ['./'],
-              alias: defaultAlias,
-            },
-          ],
-        ],
-      },
-      benchmark: {
-        plugins: [
-          ...productionPlugins,
-          [
-            'babel-plugin-module-resolver',
-            {
               alias: defaultAlias,
             },
           ],

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -3,11 +3,6 @@ const fse = require('fs-extra');
 
 const errorCodesPath = path.resolve(__dirname, './public/static/error-codes.json');
 
-const alias = {
-  docs: '../node_modules/@mui/monorepo/docs',
-  'docs-base': './',
-};
-
 const { version: transformRuntimeVersion } = fse.readJSONSync(
   require.resolve('@babel/runtime-corejs2/package.json'),
 );
@@ -34,13 +29,6 @@ module.exports = {
         muiError: {
           errorCodesPath,
         },
-      },
-    ],
-    [
-      'babel-plugin-module-resolver',
-      {
-        alias,
-        transformFunctions: ['require', 'require.context'],
       },
     ],
     'babel-plugin-optimize-clsx',

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -8,10 +8,9 @@ const { version: transformRuntimeVersion } = fse.readJSONSync(
 );
 
 module.exports = {
-  // TODO: Enable once nextjs uses babel 7.13
-  // assumptions: {
-  //   noDocumentAll: true,
-  // },
+  assumptions: {
+    noDocumentAll: true,
+  },
   presets: [
     // backport of https://github.com/vercel/next.js/pull/9511
     [

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -2,7 +2,6 @@
 import * as path from 'path';
 import * as url from 'url';
 import * as fs from 'fs';
-import { createRequire } from 'module';
 // eslint-disable-next-line no-restricted-imports
 import withDocsInfra from '@mui/monorepo/docs/nextConfigDocsInfra.js';
 import { findPages } from './src/utils/findPages.mjs';
@@ -14,35 +13,31 @@ import {
 } from './config.js';
 
 const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
-const require = createRequire(import.meta.url);
-
-const workspaceRoot = path.join(currentDirectory, '../');
+const workspaceRoot = path.resolve(currentDirectory, '../');
 
 /**
- * @param {string} pkgPath
  * @returns {{version: string}}
  */
-function loadPkg(pkgPath) {
-  const pkgContent = fs.readFileSync(path.resolve(workspaceRoot, pkgPath, 'package.json'), 'utf8');
+function loadPackageJson() {
+  const pkgContent = fs.readFileSync(path.resolve(workspaceRoot, 'package.json'), 'utf8');
   return JSON.parse(pkgContent);
 }
 
-const pkg = loadPkg('.');
+const rootPackage = loadPackageJson();
 
-export default withDocsInfra({
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   // Avoid conflicts with the other Next.js apps hosted under https://mui.com/
   assetPrefix: process.env.DEPLOY_ENV === 'development' ? undefined : '/base-ui/',
   env: {
     // docs-infra
-    LIB_VERSION: pkg.version,
+    LIB_VERSION: rootPackage.version,
     SOURCE_CODE_REPO: 'https://github.com/mui/base-ui',
     SOURCE_GITHUB_BRANCH: 'master',
     GITHUB_TEMPLATE_DOCS_FEEDBACK: '6.docs-feedback.yml',
   },
-  // @ts-ignore
   webpack: (config, options) => {
     const plugins = config.plugins.slice();
-
     const includesMonorepo = [/(@mui[\\/]monorepo)$/, /(@mui[\\/]monorepo)[\\/](?!.*node_modules)/];
 
     return {
@@ -52,8 +47,8 @@ export default withDocsInfra({
         ...config.resolve,
         alias: {
           ...config.resolve.alias,
-          'docs-base': path.resolve(currentDirectory, '../docs'),
-          docs: path.resolve(currentDirectory, '../node_modules/@mui/monorepo/docs'),
+          'docs-base': path.resolve(workspaceRoot, 'docs'),
+          docs: path.resolve(workspaceRoot, 'node_modules/@mui/monorepo/docs'),
         },
       },
       module: {
@@ -61,42 +56,32 @@ export default withDocsInfra({
         rules: config.module.rules.concat([
           {
             test: /\.md$/,
-            oneOf: [
+            resourceQuery: /@mui\/markdown/,
+            use: [
+              options.defaultLoaders.babel,
               {
-                resourceQuery: /@mui\/markdown/,
-                use: [
-                  options.defaultLoaders.babel,
-                  {
-                    loader: require.resolve('@mui/internal-markdown/loader'),
-                    options: {
-                      workspaceRoot,
-                      ignoreLanguagePages: LANGUAGES_IGNORE_PAGES,
-                      languagesInProgress: LANGUAGES_IN_PROGRESS,
-                      packages: [
-                        {
-                          productId: 'base-ui',
-                          paths: [path.join(workspaceRoot, 'packages/mui-base/src')],
-                        },
-                      ],
-                      env: {
-                        SOURCE_CODE_REPO: options.config.env.SOURCE_CODE_REPO,
-                        LIB_VERSION: options.config.env.LIB_VERSION,
-                      },
+                loader: '@mui/internal-markdown/loader',
+                options: {
+                  workspaceRoot,
+                  ignoreLanguagePages: LANGUAGES_IGNORE_PAGES,
+                  languagesInProgress: LANGUAGES_IN_PROGRESS,
+                  packages: [
+                    {
+                      productId: 'base-ui',
+                      paths: [path.join(workspaceRoot, 'packages/mui-base/src')],
                     },
+                  ],
+                  env: {
+                    SOURCE_CODE_REPO: options.config.env.SOURCE_CODE_REPO,
+                    LIB_VERSION: options.config.env.LIB_VERSION,
                   },
-                ],
+                },
               },
             ],
           },
           {
             test: /\.+(js|jsx|mjs|ts|tsx)$/,
             include: includesMonorepo,
-            use: options.defaultLoaders.babel,
-          },
-          {
-            test: /\.(js|mjs|ts|tsx)$/,
-            include: [workspaceRoot],
-            exclude: /node_modules/,
             use: options.defaultLoaders.babel,
           },
         ]),
@@ -106,52 +91,8 @@ export default withDocsInfra({
   distDir: 'export',
   // Next.js provides a `defaultPathMap` argument, we could simplify the logic.
   // However, we don't in order to prevent any regression in the `findPages()` method.
-  exportPathMap: () => {
-    const pages = findPages();
-    const map = {};
-
-    // @ts-ignore
-    function traverse(pages2, userLanguage) {
-      const prefix = userLanguage === 'en' ? '' : `/${userLanguage}`;
-
-      // @ts-ignore
-      pages2.forEach((page) => {
-        // The experiments pages are only meant for experiments, they shouldn't leak to production.
-        if (page.pathname.includes('/experiments/') && process.env.DEPLOY_ENV === 'production') {
-          return;
-        }
-
-        if (!page.children) {
-          // @ts-ignore
-          map[`${prefix}${page.pathname.replace(/^\/api-docs\/(.*)/, '/api/$1')}`] = {
-            page: page.pathname,
-            query: {
-              userLanguage,
-            },
-          };
-          return;
-        }
-
-        traverse(page.children, userLanguage);
-      });
-    }
-
-    // We want to speed-up the build of pull requests.
-    if (process.env.PULL_REQUEST === 'true') {
-      // eslint-disable-next-line no-console
-      console.log('Considering only English for SSR');
-      traverse(pages, 'en');
-    } else {
-      // eslint-disable-next-line no-console
-      console.log('Considering various locales for SSR');
-      LANGUAGES_SSR.forEach((userLanguage) => {
-        traverse(pages, userLanguage);
-      });
-    }
-
-    return map;
-  },
-  transpilePackages: ['@mui/docs'],
+  exportPathMap,
+  transpilePackages: ['@mui/docs', '@mui/monorepo'],
   ...(process.env.NODE_ENV === 'production'
     ? {
         output: 'export',
@@ -172,4 +113,56 @@ export default withDocsInfra({
           },
         ],
       }),
-});
+};
+
+function exportPathMap() {
+  const allPages = findPages();
+  /**
+   * @type {Record<string, {page: string, query: {userLanguage: string}}>}
+   */
+  const map = {};
+
+  /**
+   * @param {import('./src/utils/findPages.mjs').NextJSPage[]} pages
+   * @param {string} userLanguage
+   */
+  function traverse(pages, userLanguage) {
+    const prefix = userLanguage === 'en' ? '' : `/${userLanguage}`;
+
+    pages.forEach((page) => {
+      // The experiments pages are only meant for experiments, they shouldn't leak to production.
+      if (page.pathname.includes('/experiments/') && process.env.DEPLOY_ENV === 'production') {
+        return;
+      }
+
+      if (!page.children) {
+        map[`${prefix}${page.pathname.replace(/^\/api-docs\/(.*)/, '/api/$1')}`] = {
+          page: page.pathname,
+          query: {
+            userLanguage,
+          },
+        };
+        return;
+      }
+
+      traverse(page.children, userLanguage);
+    });
+  }
+
+  // We want to speed-up the build of pull requests.
+  if (process.env.PULL_REQUEST === 'true') {
+    // eslint-disable-next-line no-console
+    console.log('Considering only English for SSR');
+    traverse(allPages, 'en');
+  } else {
+    // eslint-disable-next-line no-console
+    console.log('Considering various locales for SSR');
+    LANGUAGES_SSR.forEach((userLanguage) => {
+      traverse(allPages, userLanguage);
+    });
+  }
+
+  return map;
+}
+
+export default withDocsInfra(nextConfig);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 packages:
-  - 'benchmark'
   - 'packages/*'
   - 'docs'
   - 'test'


### PR DESCRIPTION
Removed aliases from docs' Babel config, following up on https://github.com/mui/material-ui/pull/40792.
Also cleaned up the Babel and Next configs, removing `@ts-ignore`s and references to benchmark tests (we don't have them in this repo).