### PR TITLE
[docs] Consistent arrow style

### DIFF
--- a/docs/data/base/components/tabs/tabs.md
+++ b/docs/data/base/components/tabs/tabs.md
@@ -170,10 +170,10 @@ Base UI Tabs follow the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/AR
 
 | Key                                                        | Function                                                                                                        |
 | :--------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- |
-| <kbd class="key">Left arrow</kbd>                          | Moves focus to the previous tab (when `orientation="horizontal"`) and activates it if `activateOnFocus` is set. |
-| <kbd class="key">Right arrow</kbd>                         | Moves focus to the next tab (when `orientation="horizontal"`) and activates it if `activateOnFocus` is set.     |
-| <kbd class="key">Up arrow</kbd>                            | Moves focus to the previous tab (when `orientation="vertical"`) and activates it if `activateOnFocus` is set.   |
-| <kbd class="key">Down arrow</kbd>                          | Moves focus to the next tab (when `orientation="vertical"`) and activates it if `activateOnFocus` is set.       |
+| <kbd class="key">Left Arrow</kbd>                          | Moves focus to the previous tab (when `orientation="horizontal"`) and activates it if `activateOnFocus` is set. |
+| <kbd class="key">Right Arrow</kbd>                         | Moves focus to the next tab (when `orientation="horizontal"`) and activates it if `activateOnFocus` is set.     |
+| <kbd class="key">Up Arrow</kbd>                            | Moves focus to the previous tab (when `orientation="vertical"`) and activates it if `activateOnFocus` is set.   |
+| <kbd class="key">Down Arrow</kbd>                          | Moves focus to the next tab (when `orientation="vertical"`) and activates it if `activateOnFocus` is set.       |
 | <kbd class="key">Space</kbd>, <kbd class="key">Enter</kbd> | Activates the focused tab.                                                                                      |
 
 ### Labeling

--- a/docs/data/base/components/tabs/tabs.md
+++ b/docs/data/base/components/tabs/tabs.md
@@ -19,7 +19,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
 
 ## Installation
 
-Base UI components are all available as a single package.
+Base UI components are all available as a single package.
 
 <codeblock storageKey="package-manager">
 
@@ -164,16 +164,16 @@ Alternatively, you can set `activateOnFocus={false}` on `<Tabs.List>` so tabs ar
 
 ## Accessibility
 
-Base UI Tabs follow the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).
+Base UI Tabs follow the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).
 
 ### Keyboard navigation
 
-| Key                                                        | Function                                                                                                        |
-| :--------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- |
-| <kbd class="key">Left Arrow</kbd>                          | Moves focus to the previous tab (when `orientation="horizontal"`) and activates it if `activateOnFocus` is set. |
-| <kbd class="key">Right Arrow</kbd>                         | Moves focus to the next tab (when `orientation="horizontal"`) and activates it if `activateOnFocus` is set.     |
-| <kbd class="key">Up Arrow</kbd>                            | Moves focus to the previous tab (when `orientation="vertical"`) and activates it if `activateOnFocus` is set.   |
-| <kbd class="key">Down Arrow</kbd>                          | Moves focus to the next tab (when `orientation="vertical"`) and activates it if `activateOnFocus` is set.       |
+|                                                       Keys | Descriptions                                                                                                    |
+| ---------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------- |
+|                          <kbd class="key">Left Arrow</kbd> | Moves focus to the previous tab (when `orientation="horizontal"`) and activates it if `activateOnFocus` is set. |
+|                         <kbd class="key">Right Arrow</kbd> | Moves focus to the next tab (when `orientation="horizontal"`) and activates it if `activateOnFocus` is set.     |
+|                            <kbd class="key">Up Arrow</kbd> | Moves focus to the previous tab (when `orientation="vertical"`) and activates it if `activateOnFocus` is set.   |
+|                          <kbd class="key">Down Arrow</kbd> | Moves focus to the next tab (when `orientation="vertical"`) and activates it if `activateOnFocus` is set.       |
 | <kbd class="key">Space</kbd>, <kbd class="key">Enter</kbd> | Activates the focused tab.                                                                                      |
 
 ### Labeling


### PR DESCRIPTION
Match with https://mui.com/x/react-data-grid/accessibility/#navigation.

Why upper case? We copied https://www.w3.org/WAI/ARIA/apg/patterns/listbox/. MDN uses a different style https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role#examples but 🤷‍♂️

Why right aligned? I guess it's simpler to scan?

Preview: https://deploy-preview-397--base-ui.netlify.app/base-ui/react-tabs/#accessibility