### PR TITLE
[code-infra] Fix pnpm version in package.json engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,9 @@
     "yargs": "^17.7.2"
   },
   "packageManager": "pnpm@9.0.6",
+  "engines": {
+    "pnpm": "9.0.6"
+  },
   "resolutions": {
     "@babel/core": "^7.24.5",
     "@babel/code-frame": "^7.24.2",


### PR DESCRIPTION
As per https://github.com/mui/material-ui/pull/42331