### PR TITLE
[docs] Correct Bundlephobia links

### DIFF
--- a/docs/data/base/components/checkbox/checkbox.md
+++ b/docs/data/base/components/checkbox/checkbox.md
@@ -5,6 +5,7 @@ components: CheckboxRoot, CheckboxIndicator
 hooks: useCheckboxRoot
 githubLabel: 'component: checkbox'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
+packageName: '@base_ui/react'
 ---
 
 # Checkbox

--- a/docs/data/base/components/number-field/number-field.md
+++ b/docs/data/base/components/number-field/number-field.md
@@ -5,6 +5,7 @@ githubLabel: 'component: number-field'
 components: NumberFieldRoot, NumberFieldGroup, NumberFieldInput, NumberFieldIncrement, NumberFieldDecrement, NumberFieldScrubArea, NumberFieldScrubAreaCursor
 hooks: useNumberFieldRoot
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/
+packageName: '@base_ui/react'
 ---
 
 # Number Field

--- a/docs/data/base/components/switch/switch.md
+++ b/docs/data/base/components/switch/switch.md
@@ -5,6 +5,7 @@ components: SwitchRoot, SwitchThumb
 hooks: useSwitchRoot
 githubLabel: 'component: switch'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/switch/
+packageName: '@base_ui/react'
 ---
 
 # Switch

--- a/docs/data/base/components/tabs/tabs.md
+++ b/docs/data/base/components/tabs/tabs.md
@@ -5,6 +5,7 @@ components: TabsRoot, TabPanel, Tab, TabsList, TabIndicator
 hooks: useTabsRoot, useTabPanel, useTab, useTabsList, useTabIndicator
 githubLabel: 'component: tabs'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+packageName: '@base_ui/react'
 ---
 
 # Tabs


### PR DESCRIPTION
The Bundlephobia links in the components docs' headers (the "Bundle size" pill under the header) incorrectly pointed to `@mui/base`. Once we have just one docs site for Base UI, we'll be able to change the package name globally, in a shared package #422, but for the time being, we have to update each page manually.

https://github.com/mui/material-ui/blob/a55cd51ab4312fd2864dbd59e78a2ed8b5aae3dc/packages/mui-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx#L34

Preview: https://deploy-preview-419--base-ui.netlify.app/base-ui/react-checkbox