### PR TITLE
[docs-infra] Fix a stylelint issue

### DIFF
--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/css/index.js
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/css/index.js
@@ -278,7 +278,7 @@ function Styles() {
         width: 100%;
         border-radius: 12px;
         overflow: auto;
-        outline: 0px;
+        outline: 0;
         max-height: 300px;
         z-index: 1;
         position: absolute;

--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/css/index.tsx
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/css/index.tsx
@@ -255,7 +255,7 @@ function Styles() {
         width: 100%;
         border-radius: 12px;
         overflow: auto;
-        outline: 0px;
+        outline: 0;
         max-height: 300px;
         z-index: 1;
         position: absolute;

--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/system/index.js
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/system/index.js
@@ -205,7 +205,7 @@ const StyledListbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   max-height: 300px;
   z-index: 1;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};

--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/system/index.tsx
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/system/index.tsx
@@ -191,7 +191,7 @@ const StyledListbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   max-height: 300px;
   z-index: 1;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};

--- a/docs/data/base/components/autocomplete/ControlledStates.js
+++ b/docs/data/base/components/autocomplete/ControlledStates.js
@@ -136,7 +136,7 @@ const Listbox = styled('ul')(
   max-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   max-height: 300px;
   z-index: 1;
   position: absolute;

--- a/docs/data/base/components/autocomplete/ControlledStates.tsx
+++ b/docs/data/base/components/autocomplete/ControlledStates.tsx
@@ -136,7 +136,7 @@ const Listbox = styled('ul')(
   max-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   max-height: 300px;
   z-index: 1;
   position: absolute;

--- a/docs/data/base/components/autocomplete/UseAutocomplete.js
+++ b/docs/data/base/components/autocomplete/UseAutocomplete.js
@@ -127,7 +127,7 @@ const Listbox = styled('ul')(
   width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   max-height: 300px;
   z-index: 1;
   position: absolute;

--- a/docs/data/base/components/autocomplete/UseAutocomplete.tsx
+++ b/docs/data/base/components/autocomplete/UseAutocomplete.tsx
@@ -129,7 +129,7 @@ const Listbox = styled('ul')(
   width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   max-height: 300px;
   z-index: 1;
   position: absolute;

--- a/docs/data/base/components/autocomplete/UseAutocompletePopper.js
+++ b/docs/data/base/components/autocomplete/UseAutocompletePopper.js
@@ -152,7 +152,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   max-height: 300px;
   z-index: 1;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};

--- a/docs/data/base/components/autocomplete/UseAutocompletePopper.tsx
+++ b/docs/data/base/components/autocomplete/UseAutocompletePopper.tsx
@@ -163,7 +163,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   max-height: 300px;
   z-index: 1;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};

--- a/docs/data/base/components/menu/MenuIntroduction/css/index.js
+++ b/docs/data/base/components/menu/MenuIntroduction/css/index.js
@@ -125,7 +125,7 @@ function Styles() {
       min-width: 200px;
       border-radius: 12px;
       overflow: auto;
-      outline: 0px;
+      outline: 0;
       background: ${isDarkMode ? grey[900] : '#fff'};
       border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
       color: ${isDarkMode ? grey[300] : grey[900]};

--- a/docs/data/base/components/menu/MenuIntroduction/css/index.tsx
+++ b/docs/data/base/components/menu/MenuIntroduction/css/index.tsx
@@ -123,7 +123,7 @@ function Styles() {
       min-width: 200px;
       border-radius: 12px;
       overflow: auto;
-      outline: 0px;
+      outline: 0;
       background: ${isDarkMode ? grey[900] : '#fff'};
       border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
       color: ${isDarkMode ? grey[300] : grey[900]};

--- a/docs/data/base/components/menu/MenuIntroduction/system/index.js
+++ b/docs/data/base/components/menu/MenuIntroduction/system/index.js
@@ -65,7 +65,7 @@ const Listbox = styled('ul')(
   min-width: 200px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/menu/MenuIntroduction/system/index.tsx
+++ b/docs/data/base/components/menu/MenuIntroduction/system/index.tsx
@@ -64,7 +64,7 @@ const Listbox = styled('ul')(
   min-width: 200px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/menu/MenuSimple/css/index.js
+++ b/docs/data/base/components/menu/MenuSimple/css/index.js
@@ -92,7 +92,7 @@ function Styles() {
       min-width: 200px;
       border-radius: 12px;
       overflow: auto;
-      outline: 0px;
+      outline: 0;
       background: ${isDarkMode ? grey[900] : '#fff'};
       border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
       color: ${isDarkMode ? grey[300] : grey[900]};

--- a/docs/data/base/components/menu/MenuSimple/css/index.tsx
+++ b/docs/data/base/components/menu/MenuSimple/css/index.tsx
@@ -92,7 +92,7 @@ function Styles() {
       min-width: 200px;
       border-radius: 12px;
       overflow: auto;
-      outline: 0px;
+      outline: 0;
       background: ${isDarkMode ? grey[900] : '#fff'};
       border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
       color: ${isDarkMode ? grey[300] : grey[900]};

--- a/docs/data/base/components/menu/MenuSimple/system/index.js
+++ b/docs/data/base/components/menu/MenuSimple/system/index.js
@@ -62,7 +62,7 @@ const Listbox = styled('ul')(
   min-width: 200px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/menu/MenuSimple/system/index.tsx
+++ b/docs/data/base/components/menu/MenuSimple/system/index.tsx
@@ -62,7 +62,7 @@ const Listbox = styled('ul')(
   min-width: 200px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/menu/MenuTransitions.js
+++ b/docs/data/base/components/menu/MenuTransitions.js
@@ -65,7 +65,7 @@ const Listbox = styled('ul')(
   min-width: 200px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/menu/MenuTransitions.tsx
+++ b/docs/data/base/components/menu/MenuTransitions.tsx
@@ -64,7 +64,7 @@ const Listbox = styled('ul')(
   min-width: 200px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/menu/UseMenu.js
+++ b/docs/data/base/components/menu/UseMenu.js
@@ -137,7 +137,7 @@ function Styles() {
       border-radius: 0.75em;
       color: ${grey[900]};
       overflow: auto;
-      outline: 0px;
+      outline: 0;
       box-shadow: 0 4px 6px 0 rgba(0, 0, 0, 0.05);
     }
 

--- a/docs/data/base/components/menu/UseMenu.tsx
+++ b/docs/data/base/components/menu/UseMenu.tsx
@@ -136,7 +136,7 @@ function Styles() {
       border-radius: 0.75em;
       color: ${grey[900]};
       overflow: auto;
-      outline: 0px;
+      outline: 0;
       box-shadow: 0 4px 6px 0 rgba(0, 0, 0, 0.05);
     }
 

--- a/docs/data/base/components/menu/WrappedMenuItems.js
+++ b/docs/data/base/components/menu/WrappedMenuItems.js
@@ -90,7 +90,7 @@ const Listbox = styled('ul')(
   min-width: 200px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/menu/WrappedMenuItems.tsx
+++ b/docs/data/base/components/menu/WrappedMenuItems.tsx
@@ -84,7 +84,7 @@ const Listbox = styled('ul')(
   min-width: 200px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectBasic/css/index.js
+++ b/docs/data/base/components/select/UnstyledSelectBasic/css/index.js
@@ -135,7 +135,7 @@ function Styles() {
         min-width: 320px;
         border-radius: 12px;
         overflow: auto;
-        outline: 0px;
+        outline: 0;
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         color: ${isDarkMode ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectBasic/css/index.tsx
+++ b/docs/data/base/components/select/UnstyledSelectBasic/css/index.tsx
@@ -135,7 +135,7 @@ function Styles() {
         min-width: 320px;
         border-radius: 12px;
         overflow: auto;
-        outline: 0px;
+        outline: 0;
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         color: ${isDarkMode ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectBasic/system/index.js
+++ b/docs/data/base/components/select/UnstyledSelectBasic/system/index.js
@@ -117,7 +117,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectBasic/system/index.tsx
+++ b/docs/data/base/components/select/UnstyledSelectBasic/system/index.tsx
@@ -127,7 +127,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectControlled.js
+++ b/docs/data/base/components/select/UnstyledSelectControlled.js
@@ -138,7 +138,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectControlled.tsx
+++ b/docs/data/base/components/select/UnstyledSelectControlled.tsx
@@ -127,7 +127,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectCustomRenderValue.js
+++ b/docs/data/base/components/select/UnstyledSelectCustomRenderValue.js
@@ -140,7 +140,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectCustomRenderValue.tsx
+++ b/docs/data/base/components/select/UnstyledSelectCustomRenderValue.tsx
@@ -132,7 +132,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectForm.js
+++ b/docs/data/base/components/select/UnstyledSelectForm.js
@@ -132,7 +132,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectForm.tsx
+++ b/docs/data/base/components/select/UnstyledSelectForm.tsx
@@ -142,7 +142,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectGrouping.js
+++ b/docs/data/base/components/select/UnstyledSelectGrouping.js
@@ -161,7 +161,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectGrouping.tsx
+++ b/docs/data/base/components/select/UnstyledSelectGrouping.tsx
@@ -146,7 +146,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectIntroduction/css/index.js
+++ b/docs/data/base/components/select/UnstyledSelectIntroduction/css/index.js
@@ -165,7 +165,7 @@ function Styles() {
         min-width: 320px;
         border-radius: 12px;
         overflow: auto;
-        outline: 0px;
+        outline: 0;
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         color: ${isDarkMode ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectIntroduction/css/index.tsx
+++ b/docs/data/base/components/select/UnstyledSelectIntroduction/css/index.tsx
@@ -172,7 +172,7 @@ function Styles() {
         min-width: 320px;
         border-radius: 12px;
         overflow: auto;
-        outline: 0px;
+        outline: 0;
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         color: ${isDarkMode ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectIntroduction/system/index.js
+++ b/docs/data/base/components/select/UnstyledSelectIntroduction/system/index.js
@@ -132,7 +132,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectIntroduction/system/index.tsx
+++ b/docs/data/base/components/select/UnstyledSelectIntroduction/system/index.tsx
@@ -128,7 +128,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectMultiple.js
+++ b/docs/data/base/components/select/UnstyledSelectMultiple.js
@@ -129,7 +129,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectMultiple.tsx
+++ b/docs/data/base/components/select/UnstyledSelectMultiple.tsx
@@ -124,7 +124,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectObjectValues.js
+++ b/docs/data/base/components/select/UnstyledSelectObjectValues.js
@@ -145,7 +145,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectObjectValues.tsx
+++ b/docs/data/base/components/select/UnstyledSelectObjectValues.tsx
@@ -144,7 +144,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectObjectValuesForm.js
+++ b/docs/data/base/components/select/UnstyledSelectObjectValuesForm.js
@@ -209,7 +209,7 @@ const Listbox = styled('ul')(
   border-radius: 8px;
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   box-shadow: 0px 2px 6px ${
     theme.palette.mode === 'dark' ? 'rgba(0,0,0, 0.50)' : 'rgba(0,0,0, 0.05)'
   };

--- a/docs/data/base/components/select/UnstyledSelectObjectValuesForm.tsx
+++ b/docs/data/base/components/select/UnstyledSelectObjectValuesForm.tsx
@@ -208,7 +208,7 @@ const Listbox = styled('ul')(
   border-radius: 8px;
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   box-shadow: 0px 2px 6px ${
     theme.palette.mode === 'dark' ? 'rgba(0,0,0, 0.50)' : 'rgba(0,0,0, 0.05)'
   };

--- a/docs/data/base/components/select/UnstyledSelectRichOptions.js
+++ b/docs/data/base/components/select/UnstyledSelectRichOptions.js
@@ -138,7 +138,7 @@ const Listbox = styled('ul')(
   max-height: 400px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectRichOptions.tsx
+++ b/docs/data/base/components/select/UnstyledSelectRichOptions.tsx
@@ -133,7 +133,7 @@ const Listbox = styled('ul')(
   max-height: 400px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectTransitions.js
+++ b/docs/data/base/components/select/UnstyledSelectTransitions.js
@@ -135,7 +135,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UnstyledSelectTransitions.tsx
+++ b/docs/data/base/components/select/UnstyledSelectTransitions.tsx
@@ -131,7 +131,7 @@ const Listbox = styled('ul')(
   min-width: 320px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/components/select/UseSelect.js
+++ b/docs/data/base/components/select/UseSelect.js
@@ -99,7 +99,7 @@ const Listbox = styled('ul')(
   width: 100%;
   overflow: auto;
   z-index: 1;
-  outline: 0px;
+  outline: 0;
   list-style: none;
   box-shadow: 0px 2px 6px ${
     theme.palette.mode === 'dark' ? 'rgba(0,0,0, 0.50)' : 'rgba(0,0,0, 0.05)'

--- a/docs/data/base/components/select/UseSelect.tsx
+++ b/docs/data/base/components/select/UseSelect.tsx
@@ -102,7 +102,7 @@ const Listbox = styled('ul')(
   width: 100%;
   overflow: auto;
   z-index: 1;
-  outline: 0px;
+  outline: 0;
   list-style: none;
   box-shadow: 0px 2px 6px ${
     theme.palette.mode === 'dark' ? 'rgba(0,0,0, 0.50)' : 'rgba(0,0,0, 0.05)'

--- a/docs/data/base/getting-started/accessibility/KeyboardNavigation.js
+++ b/docs/data/base/getting-started/accessibility/KeyboardNavigation.js
@@ -139,7 +139,7 @@ const Listbox = styled('ul')(
   min-width: 200px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[800] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/data/base/getting-started/accessibility/KeyboardNavigation.tsx
+++ b/docs/data/base/getting-started/accessibility/KeyboardNavigation.tsx
@@ -149,7 +149,7 @@ const Listbox = styled('ul')(
   min-width: 200px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[800] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};

--- a/docs/public/static/components-gallery/base-theme.css
+++ b/docs/public/static/components-gallery/base-theme.css
@@ -410,7 +410,7 @@
   min-width: 200px;
   border-radius: var(--border-radius-lg);
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: var(--bg-default);
   border: var(--border-soft);
   box-shadow: var(--shadow-elevation-2);
@@ -620,7 +620,7 @@
   margin: 12px 0;
   border-radius: var(--border-radius-lg);
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background: var(--bg-default);
   border: var(--border-soft);
   box-shadow: var(--shadow-elevation-2);

--- a/docs/src/modules/home/BaseUIThemesDemo.tsx
+++ b/docs/src/modules/home/BaseUIThemesDemo.tsx
@@ -589,7 +589,7 @@ const StyledMenuListbox = styled('ul')(`
   min-width: 230px;
   border-radius: 12px;
   overflow: auto;
-  outline: 0px;
+  outline: 0;
   background-color: var(--muidocs-palette-background-default);
   border-radius: min(var(--border-radius), 16px);
   border: var(--border-width) solid;


### PR DESCRIPTION
This is not detected by our stylelint rules everywhere (yet?), I created an issue for them: https://github.com/hudochenkov/postcss-styled-syntax/issues/31.

<img width="600" alt="SCR-20240528-rgpl" src="https://github.com/mui/material-ui/assets/3165635/9732883d-788b-45aa-a175-28096114d2aa">

As for why this rule, it's in the default: https://github.com/stylelint/stylelint-config-standard/blob/08b6e948de94189c1d3ce376e50f2c42dc94580e/index.js#L76, so why not 🤷‍♂️