### PR TITLE
[Tooltip][docs] Use the correct version of ComponentLinkHeader

### DIFF
--- a/docs/data/base/components/tooltip/tooltip.md
+++ b/docs/data/base/components/tooltip/tooltip.md
@@ -11,7 +11,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
 
 <p class="description">Tooltips are visual-only floating elements that display information about a trigger element when a user hovers or focuses it.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 


### PR DESCRIPTION
After https://github.com/mui/base-ui/pull/378 was merged, we have to use @mui/docs/ComponentLinkHeader for the docs. Without it, building the docs fails.