### PR TITLE
[core] Allow Renovate to update pnpm

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -88,6 +88,7 @@
     },
     {
       "matchDepTypes": ["engines"],
+      "matchFileNames": ["packages/*/package.json"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Our current Renovate settings prevented it from updating pnpm. This PR (hopefully) fixes it.