### PR TITLE
Improve performance of `mergeReactProps`

### DIFF
--- a/packages/mui-base/src/utils/mergeReactProps.ts
+++ b/packages/mui-base/src/utils/mergeReactProps.ts
@@ -17,7 +17,14 @@ export function mergeReactProps<T extends React.ElementType>(
 ): WithBaseUIEvent<React.ComponentPropsWithRef<T>> {
   return Object.entries(externalProps).reduce(
     (acc, [key, value]) => {
-      if (/^on[A-Z]/.test(key) && typeof value === 'function') {
+      if (
+        // This approach is more efficient than using a regex.
+        key[0] === 'o' &&
+        key[1] === 'n' &&
+        key.charCodeAt(2) >= 65 /* A */ &&
+        key.charCodeAt(2) <= 90 /* Z */ &&
+        typeof value === 'function'
+      ) {
         acc[key] = (event: React.SyntheticEvent) => {
           let isPrevented = false;
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `mergeReactProps` function uses a regex to identify event handlers and invoke them all. Since it is a low-level utility, I believe it should be optimized for performance, even at the expense of some readability. 

Just suggesting an alternative approach that doesn't rely on using a regex.
