### PR TITLE
[popover] Wait for focus to settle in tests

### DIFF
--- a/packages/mui-base/src/Popover/Root/PopoverRoot.test.tsx
+++ b/packages/mui-base/src/Popover/Root/PopoverRoot.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
-import { fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
+import { fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import userEvent from '@testing-library/user-event';
 import { expect } from 'chai';
 import { spy } from 'sinon';
@@ -352,6 +352,8 @@ describe('<Popover.Root />', () => {
 
     await user.click(close);
 
-    expect(toggle).toHaveFocus();
+    await waitFor(() => {
+      expect(toggle).toHaveFocus();
+    });
   });
 });


### PR DESCRIPTION
Add `waitFor` around focus check to give the browser more time to set focus.