### PR TITLE
[docs] Fix Vale errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://master--material-ui.netlify.app/static/base-ui/base-ui-logo-dark.svg">
       <source media="(prefers-color-scheme: light)" srcset="https://master--material-ui.netlify.app/static/base-ui/base-ui-logo-light.svg">
-      <img alt="Base UI" src="https://master--material-ui.netlify.app/static/base-ui/base-ui-logo-light.svg" width="257" height="70">
+      <img alt="Base UI" src="https://master--material-ui.netlify.app/static/base-ui/base-ui-logo-light.svg" width="257" height="70">
     </picture>
   </a>
 </p>
 
 <p align="center">
-Base UI is an unstyled UI component library for building accessible user interfaces while maintaining complete control over styling.
+Base UI is an unstyled UI component library for building accessible user interfaces while maintaining complete control over styling.
 </p>
 
 <div align="center">

--- a/docs/data/base/components/alert-dialog/alert-dialog.md
+++ b/docs/data/base/components/alert-dialog/alert-dialog.md
@@ -18,7 +18,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/
 
 ## Installation
 
-Base UI components are all available as a single package.
+Base UI components are all available as a single package.
 
 <codeblock storageKey="package-manager">
 
@@ -131,7 +131,7 @@ If a component has a transition or animation applied to it when it closes, it wi
 As this detection of exit animations requires an extra render, you may opt out of it by setting the `animated` prop on Popup and Backdrop to `false`.
 We also recommend doing so in automated tests, to avoid asynchronous behavior and make testing easier.
 
-Alternatively, you can use JS-based animations with a library like framer-motion, React Spring, or similar.
+Alternatively, you can use JavaScript-based animations with a library like framer-motion, React Spring, or similar.
 With this approach set the `keepMounted` to `true` and let the animation library control mounting and unmounting.
 
 ### CSS transitions

--- a/docs/data/base/components/checkbox/checkbox.md
+++ b/docs/data/base/components/checkbox/checkbox.md
@@ -20,7 +20,7 @@ packageName: '@base_ui/react'
 
 ## Installation
 
-Base UI components are all available as a single package.
+Base UI components are all available as a single package.
 
 <codeblock storageKey="package-manager">
 

--- a/docs/data/base/components/dialog/dialog.md
+++ b/docs/data/base/components/dialog/dialog.md
@@ -19,7 +19,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
 
 ## Installation
 
-Base UI components are all available as a single package.
+Base UI components are all available as a single package.
 
 <codeblock storageKey="package-manager">
 
@@ -153,7 +153,7 @@ If a component has a transition or animation applied to it when it closes, it wi
 As this detection of exit animations requires an extra render, you may opt out of it by setting the `animated` prop on Root to `false`.
 We also recommend doing so in automated tests, to avoid asynchronous behavior and make testing easier.
 
-Alternatively, you can use JS-based animations with a library like framer-motion, React Spring, or similar.
+Alternatively, you can use JavaScript-based animations with a library like framer-motion, React Spring, or similar.
 With this approach set the `keepMounted` to `true` and let the animation library control mounting and unmounting.
 
 ### CSS transitions

--- a/docs/data/base/components/number-field/number-field.md
+++ b/docs/data/base/components/number-field/number-field.md
@@ -20,7 +20,7 @@ packageName: '@base_ui/react'
 
 ## Installation
 
-Base UI components are all available as a single package.
+Base UI components are all available as a single package.
 
 <codeblock storageKey="package-manager">
 

--- a/docs/data/base/components/switch/switch.md
+++ b/docs/data/base/components/switch/switch.md
@@ -20,7 +20,7 @@ packageName: '@base_ui/react'
 
 ## Installation
 
-Base UI components are all available as a single package.
+Base UI components are all available as a single package.
 
 <codeblock storageKey="package-manager">
 

--- a/packages/mui-base/src/legacy/README.md
+++ b/packages/mui-base/src/legacy/README.md
@@ -1,4 +1,4 @@
-# Legacy Base UI components
+# Legacy Base UI components
 
 The components and hooks in this directory expose an older version of the customization API.
 They are kept in the repository to maintain history, but they are not published in the npm package.


### PR DESCRIPTION
Those errors can be seen by running

`vale sync && git ls-files | grep -h ".md$" | xargs vale --filter='.Level=="error"'`

It's not in the CI yet because we share the config with the monorepo HEAD, which could mean breaking the CI in Base UI as soon as a PR is merged in the monorepo.

https://github.com/mui/base-ui/blob/25eb16b271c6e704bb261bb4df71b6951c0a5585/.vale.ini#L10

We will need to change this.