### PR TITLE
[NumberField] Fix tests on non-English locale machines

### DIFF
--- a/packages/mui-base/src/NumberField/Input/NumberFieldInput.test.tsx
+++ b/packages/mui-base/src/NumberField/Input/NumberFieldInput.test.tsx
@@ -133,7 +133,7 @@ describe('<NumberField.Input />', () => {
     fireEvent.change(input, { target: { value: '1234' } });
     expect(input).to.have.value('1234');
     fireEvent.blur(input);
-    expect(input).to.have.value('1,234');
+    expect(input).to.have.value((1234).toLocaleString());
   });
 
   it('should commit validated number on blur (min)', () => {

--- a/packages/mui-base/src/NumberField/Root/NumberFieldRoot.test.tsx
+++ b/packages/mui-base/src/NumberField/Root/NumberFieldRoot.test.tsx
@@ -373,7 +373,7 @@ describe('<NumberField />', () => {
       const input = screen.getByRole('textbox');
       fireEvent.keyDown(document.body, { altKey: true });
       fireEvent.pointerDown(screen.getByLabelText('Increase'));
-      expect(input).to.have.value('5.1');
+      expect(input).to.have.value((5.1).toLocaleString());
     });
 
     it('should decrement the value by the default `smallStep` prop of 0.1 while holding the alt key', () => {
@@ -381,7 +381,7 @@ describe('<NumberField />', () => {
       const input = screen.getByRole('textbox');
       fireEvent.keyDown(document.body, { altKey: true });
       fireEvent.pointerDown(screen.getByLabelText('Decrease'));
-      expect(input).to.have.value('5.9');
+      expect(input).to.have.value((5.9).toLocaleString());
     });
 
     it('should use explicit `smallStep` value if provided while holding the alt key', () => {
@@ -389,7 +389,7 @@ describe('<NumberField />', () => {
       const input = screen.getByRole('textbox');
       fireEvent.keyDown(document.body, { altKey: true });
       fireEvent.pointerDown(screen.getByLabelText('Increase'));
-      expect(input).to.have.value('5.5');
+      expect(input).to.have.value((5.5).toLocaleString());
     });
 
     it('should not use the `smallStep` prop if no longer holding the alt key', () => {
@@ -398,10 +398,10 @@ describe('<NumberField />', () => {
       const button = screen.getByLabelText('Increase');
       fireEvent.keyDown(document.body, { altKey: true });
       fireEvent.pointerDown(button);
-      expect(input).to.have.value('5.5');
+      expect(input).to.have.value((5.5).toLocaleString());
       fireEvent.keyUp(input, { altKey: false });
       fireEvent.pointerDown(button);
-      expect(input).to.have.value('6.5');
+      expect(input).to.have.value((6.5).toLocaleString());
     });
   });
 
@@ -409,7 +409,11 @@ describe('<NumberField />', () => {
     it('should format the value using the provided options', () => {
       render(<NumberField defaultValue={1000} format={{ style: 'currency', currency: 'USD' }} />);
       const input = screen.getByRole('textbox');
-      expect(input).to.have.value('$1,000.00');
+      const expectedValue = new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: 'USD',
+      }).format(1000);
+      expect(input).to.have.value(expectedValue);
     });
   });
 

--- a/packages/mui-base/src/NumberField/utils/format.test.ts
+++ b/packages/mui-base/src/NumberField/utils/format.test.ts
@@ -19,7 +19,11 @@ describe('NumberField format', () => {
 
   describe('formatNumber', () => {
     it('formats a number', () => {
-      expect(getFormatter(undefined, getOptions()).format(1234.56)).to.equal('$1,234.56');
+      const expected = new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: 'USD',
+      }).format(1234.56);
+      expect(getFormatter(undefined, getOptions()).format(1234.56)).to.equal(expected);
     });
 
     it('formats a number with different options', () => {

--- a/packages/mui-base/src/NumberField/utils/parse.test.ts
+++ b/packages/mui-base/src/NumberField/utils/parse.test.ts
@@ -4,7 +4,7 @@ import { getNumberLocaleDetails, parseNumber } from './parse';
 describe('NumberField parse', () => {
   describe('getNumberLocaleDetails', () => {
     it('returns the number locale details', () => {
-      const details = getNumberLocaleDetails();
+      const details = getNumberLocaleDetails('en-US');
       expect(details.decimal).to.equal('.');
       expect(details.group).to.equal(',');
       expect(details.currency).to.equal(undefined);
@@ -16,7 +16,8 @@ describe('NumberField parse', () => {
 
   describe('parseNumber', () => {
     it('parses a number', () => {
-      expect(parseNumber('1,234.56')).to.equal(1234.56);
+      const numberString = new Intl.NumberFormat().format(1234.56);
+      expect(parseNumber(numberString)).to.equal(1234.56);
     });
 
     it('parses a number with different options', () => {


### PR DESCRIPTION
Fixed the NumberInput tests failing on machines with non-English locales.
Tested on my local Windows PC with Polish regional settings.

Fixes #516 