### PR TITLE
[test] Clean up and unify test code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,5 +57,15 @@ module.exports = {
         'no-console': 'off',
       },
     },
+    {
+      files: ['packages/**/*.test{.tsx,.js}'],
+      excludedFiles: 'packages/mui-base/src/legacy/**/*.*',
+      extends: ['plugin:testing-library/react'],
+      rules: {
+        'testing-library/prefer-screen-queries': 'off', // TODO: enable and fix
+        'testing-library/no-container': 'off', // TODO: enable and fix
+        'testing-library/render-result-naming-convention': 'off', // False positives
+      },
+    },
   ],
 };

--- a/docs/package.json
+++ b/docs/package.json
@@ -76,7 +76,7 @@
     "@babel/plugin-transform-react-constant-elements": "^7.25.1",
     "@babel/preset-typescript": "^7.24.7",
     "@mui/internal-docs-utils": "^1.0.8",
-    "@mui/internal-test-utils": "https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils",
+    "@mui/internal-test-utils": "1.0.6-dev.20240805-092432-9f940a61d6",
     "@types/autosuggest-highlight": "^3.2.3",
     "@types/chai": "^4.3.17",
     "@types/node": "^18.19.42",

--- a/docs/package.json
+++ b/docs/package.json
@@ -76,7 +76,7 @@
     "@babel/plugin-transform-react-constant-elements": "^7.25.1",
     "@babel/preset-typescript": "^7.24.7",
     "@mui/internal-docs-utils": "^1.0.8",
-    "@mui/internal-test-utils": "1.0.6",
+    "@mui/internal-test-utils": "https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils",
     "@types/autosuggest-highlight": "^3.2.3",
     "@types/chai": "^4.3.17",
     "@types/node": "^18.19.42",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@mui/internal-docs-utils": "^1.0.8",
     "@mui/internal-markdown": "^1.0.8",
     "@mui/internal-scripts": "^1.0.14",
-    "@mui/internal-test-utils": "https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils",
+    "@mui/internal-test-utils": "1.0.6-dev.20240805-092432-9f940a61d6",
     "@mui/material": "6.0.0-beta.4",
     "@mui/monorepo": "github:mui/material-ui#v6.0.0-beta.4",
     "@mui/utils": "6.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@mui/internal-docs-utils": "^1.0.8",
     "@mui/internal-markdown": "^1.0.8",
     "@mui/internal-scripts": "^1.0.14",
-    "@mui/internal-test-utils": "1.0.6",
+    "@mui/internal-test-utils": "https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils",
     "@mui/material": "6.0.0-beta.4",
     "@mui/monorepo": "github:mui/material-ui#v6.0.0-beta.4",
     "@mui/utils": "6.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "eslint-plugin-mocha": "^10.4.3",
     "eslint-plugin-react": "^7.34.2",
     "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-testing-library": "^6.2.2",
     "execa": "^8.0.1",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",

--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@mui/internal-babel-macros": "^1.0.1",
-    "@mui/internal-test-utils": "https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils",
+    "@mui/internal-test-utils": "1.0.6-dev.20240805-092432-9f940a61d6",
     "@testing-library/react": "^15.0.7",
     "@testing-library/user-event": "^14.5.2",
     "@types/chai": "^4.3.17",

--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@mui/internal-babel-macros": "^1.0.1",
-    "@mui/internal-test-utils": "1.0.6",
+    "@mui/internal-test-utils": "https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils",
     "@testing-library/react": "^15.0.7",
     "@testing-library/user-event": "^14.5.2",
     "@types/chai": "^4.3.17",

--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -26,6 +26,9 @@
     "type": "opencollective",
     "url": "https://opencollective.com/mui-org"
   },
+  "imports": {
+    "#test-utils": "./test/index.ts"
+  },
   "scripts": {
     "build": "pnpm build:node && pnpm build:stable && pnpm build:types && pnpm build:copy-files",
     "build:node": "node ../../scripts/build.mjs node",

--- a/packages/mui-base/src/AlertDialog/Backdrop/AlertDialogBackdrop.test.tsx
+++ b/packages/mui-base/src/AlertDialog/Backdrop/AlertDialogBackdrop.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import * as AlertDialog from '@base_ui/react/AlertDialog';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<AlertDialog.Backdrop />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/AlertDialog/Close/AlertDialogClose.test.tsx
+++ b/packages/mui-base/src/AlertDialog/Close/AlertDialogClose.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as AlertDialog from '@base_ui/react/AlertDialog';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<AlertDialog.Close />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/AlertDialog/Description/AlertDialogDescription.test.tsx
+++ b/packages/mui-base/src/AlertDialog/Description/AlertDialogDescription.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as AlertDialog from '@base_ui/react/AlertDialog';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<AlertDialog.Description />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/AlertDialog/Popup/AlertDialogPopup.test.tsx
+++ b/packages/mui-base/src/AlertDialog/Popup/AlertDialogPopup.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import * as AlertDialog from '@base_ui/react/AlertDialog';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<AlertDialog.Popup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/AlertDialog/Title/AlertDialogTitle.test.tsx
+++ b/packages/mui-base/src/AlertDialog/Title/AlertDialogTitle.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as AlertDialog from '@base_ui/react/AlertDialog';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<AlertDialog.Title />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/AlertDialog/Trigger/AlertDialogTrigger.test.tsx
+++ b/packages/mui-base/src/AlertDialog/Trigger/AlertDialogTrigger.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as AlertDialog from '@base_ui/react/AlertDialog';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<AlertDialog.Trigger />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Checkbox/Indicator/CheckboxIndicator.test.tsx
+++ b/packages/mui-base/src/Checkbox/Indicator/CheckboxIndicator.test.tsx
@@ -17,7 +17,6 @@ describe('<Checkbox.Indicator />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Checkbox.Indicator />, () => ({
-    inheritComponent: 'span',
     refInstanceof: window.HTMLSpanElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/Checkbox/Indicator/CheckboxIndicator.test.tsx
+++ b/packages/mui-base/src/Checkbox/Indicator/CheckboxIndicator.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import * as Checkbox from '@base_ui/react/Checkbox';
 import { CheckboxContext } from '@base_ui/react/Checkbox';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const testContext = {
   checked: true,

--- a/packages/mui-base/src/Checkbox/Indicator/CheckboxIndicator.test.tsx
+++ b/packages/mui-base/src/Checkbox/Indicator/CheckboxIndicator.test.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Checkbox from '@base_ui/react/Checkbox';
 import { CheckboxContext } from '@base_ui/react/Checkbox';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const testContext = {
   checked: true,
@@ -25,8 +24,8 @@ describe('<Checkbox.Indicator />', () => {
     },
   }));
 
-  it('should not render indicator by default', () => {
-    const { container } = render(
+  it('should not render indicator by default', async () => {
+    const { container } = await render(
       <Checkbox.Root>
         <Checkbox.Indicator />
       </Checkbox.Root>,
@@ -35,8 +34,8 @@ describe('<Checkbox.Indicator />', () => {
     expect(indicator).to.equal(null);
   });
 
-  it('should render indicator when checked', () => {
-    const { container } = render(
+  it('should render indicator when checked', async () => {
+    const { container } = await render(
       <Checkbox.Root checked>
         <Checkbox.Indicator />
       </Checkbox.Root>,
@@ -45,8 +44,8 @@ describe('<Checkbox.Indicator />', () => {
     expect(indicator).not.to.equal(null);
   });
 
-  it('should spread extra props', () => {
-    const { container } = render(
+  it('should spread extra props', async () => {
+    const { container } = await render(
       <Checkbox.Root defaultChecked>
         <Checkbox.Indicator data-extra-prop="Lorem ipsum" />
       </Checkbox.Root>,
@@ -56,8 +55,8 @@ describe('<Checkbox.Indicator />', () => {
   });
 
   describe('keepMounted prop', () => {
-    it('should keep indicator mounted when unchecked', () => {
-      const { container } = render(
+    it('should keep indicator mounted when unchecked', async () => {
+      const { container } = await render(
         <Checkbox.Root>
           <Checkbox.Indicator keepMounted />
         </Checkbox.Root>,
@@ -66,8 +65,8 @@ describe('<Checkbox.Indicator />', () => {
       expect(indicator).not.to.equal(null);
     });
 
-    it('should keep indicator mounted when checked', () => {
-      const { container } = render(
+    it('should keep indicator mounted when checked', async () => {
+      const { container } = await render(
         <Checkbox.Root checked>
           <Checkbox.Indicator keepMounted />
         </Checkbox.Root>,
@@ -76,8 +75,8 @@ describe('<Checkbox.Indicator />', () => {
       expect(indicator).not.to.equal(null);
     });
 
-    it('should keep indicator mounted when indeterminate', () => {
-      const { container } = render(
+    it('should keep indicator mounted when indeterminate', async () => {
+      const { container } = await render(
         <Checkbox.Root indeterminate>
           <Checkbox.Indicator keepMounted />
         </Checkbox.Root>,

--- a/packages/mui-base/src/Checkbox/Root/CheckboxRoot.test.tsx
+++ b/packages/mui-base/src/Checkbox/Root/CheckboxRoot.test.tsx
@@ -11,7 +11,6 @@ describe('<Checkbox.Root />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Checkbox.Root />, () => ({
-    inheritComponent: 'button',
     refInstanceof: window.HTMLButtonElement,
     render,
   }));
@@ -23,7 +22,7 @@ describe('<Checkbox.Root />', () => {
     });
   });
 
-  it('should change its state when clicked', () => {
+  it('should change its state when clicked', async () => {
     const { getAllByRole, container } = render(<Checkbox.Root />);
     const [checkbox] = getAllByRole('checkbox');
     const input = container.querySelector('input[type=checkbox]') as HTMLInputElement;
@@ -31,14 +30,14 @@ describe('<Checkbox.Root />', () => {
     expect(checkbox).to.have.attribute('aria-checked', 'false');
     expect(input.checked).to.equal(false);
 
-    act(() => {
+    await act(() => {
       checkbox.click();
     });
 
     expect(checkbox).to.have.attribute('aria-checked', 'true');
     expect(input.checked).to.equal(true);
 
-    act(() => {
+    await act(() => {
       checkbox.click();
     });
 
@@ -46,7 +45,7 @@ describe('<Checkbox.Root />', () => {
     expect(input.checked).to.equal(false);
   });
 
-  it('should update its state when changed from outside', () => {
+  it('should update its state when changed from outside', async () => {
     function Test() {
       const [checked, setChecked] = React.useState(false);
       return (
@@ -62,25 +61,25 @@ describe('<Checkbox.Root />', () => {
     const button = getByText('Toggle');
 
     expect(checkbox).to.have.attribute('aria-checked', 'false');
-    act(() => {
+    await act(() => {
       button.click();
     });
 
     expect(checkbox).to.have.attribute('aria-checked', 'true');
 
-    act(() => {
+    await act(() => {
       button.click();
     });
 
     expect(checkbox).to.have.attribute('aria-checked', 'false');
   });
 
-  it('should call onChange when clicked', () => {
+  it('should call onChange when clicked', async () => {
     const handleChange = spy();
     const { getAllByRole } = render(<Checkbox.Root onCheckedChange={handleChange} />);
     const [checkbox] = getAllByRole('checkbox');
 
-    act(() => {
+    await act(() => {
       checkbox.click();
     });
 
@@ -99,13 +98,13 @@ describe('<Checkbox.Root />', () => {
       expect(getAllByRole('checkbox')[0]).not.to.have.attribute('aria-disabled');
     });
 
-    it('should not change its state when clicked', () => {
+    it('should not change its state when clicked', async () => {
       const { getAllByRole } = render(<Checkbox.Root disabled />);
       const [checkbox] = getAllByRole('checkbox');
 
       expect(checkbox).to.have.attribute('aria-checked', 'false');
 
-      act(() => {
+      await act(() => {
         checkbox.click();
       });
 
@@ -124,13 +123,13 @@ describe('<Checkbox.Root />', () => {
       expect(getAllByRole('checkbox')[0]).not.to.have.attribute('aria-readonly');
     });
 
-    it('should not change its state when clicked', () => {
+    it('should not change its state when clicked', async () => {
       const { getAllByRole } = render(<Checkbox.Root readOnly />);
       const [checkbox] = getAllByRole('checkbox');
 
       expect(checkbox).to.have.attribute('aria-checked', 'false');
 
-      act(() => {
+      await act(() => {
         checkbox.click();
       });
 
@@ -144,13 +143,13 @@ describe('<Checkbox.Root />', () => {
       expect(getAllByRole('checkbox')[0]).to.have.attribute('aria-checked', 'mixed');
     });
 
-    it('should not change its state when clicked', () => {
+    it('should not change its state when clicked', async () => {
       const { getAllByRole } = render(<Checkbox.Root indeterminate />);
       const [checkbox] = getAllByRole('checkbox');
 
       expect(checkbox).to.have.attribute('aria-checked', 'mixed');
 
-      act(() => {
+      await act(() => {
         checkbox.click();
       });
 
@@ -173,12 +172,12 @@ describe('<Checkbox.Root />', () => {
     });
   });
 
-  it('should update its state if the underlying input is toggled', () => {
+  it('should update its state if the underlying input is toggled', async () => {
     const { getAllByRole, container } = render(<Checkbox.Root />);
     const [checkbox] = getAllByRole('checkbox');
     const input = container.querySelector('input[type=checkbox]') as HTMLInputElement;
 
-    act(() => {
+    await act(() => {
       input.click();
     });
 
@@ -214,7 +213,7 @@ describe('<Checkbox.Root />', () => {
   });
 
   describe('form handling', () => {
-    it('should toggle the checkbox when a parent label is clicked', function test() {
+    it('should toggle the checkbox when a parent label is clicked', async function test() {
       // Clicking the label causes unrelated browser tests to fail.
       if (!isJSDOM) {
         this.skip();
@@ -232,14 +231,14 @@ describe('<Checkbox.Root />', () => {
 
       expect(checkbox).to.have.attribute('aria-checked', 'false');
 
-      act(() => {
+      await act(() => {
         label.click();
       });
 
       expect(checkbox).to.have.attribute('aria-checked', 'true');
     });
 
-    it('should toggle the checkbox when a linked label is clicked', function test() {
+    it('should toggle the checkbox when a linked label is clicked', async function test() {
       // Clicking the label causes unrelated browser tests to fail.
       if (!isJSDOM) {
         this.skip();
@@ -259,7 +258,7 @@ describe('<Checkbox.Root />', () => {
 
       expect(checkbox).to.have.attribute('aria-checked', 'false');
 
-      act(() => {
+      await act(() => {
         label.click();
       });
 
@@ -267,7 +266,7 @@ describe('<Checkbox.Root />', () => {
     });
   });
 
-  it('should include the checkbox value in the form submission', function test() {
+  it('should include the checkbox value in the form submission', async function test() {
     if (isJSDOM) {
       // FormData is not available in JSDOM
       this.skip();
@@ -295,7 +294,7 @@ describe('<Checkbox.Root />', () => {
 
     expect(stringifiedFormData).to.equal('test-checkbox=off');
 
-    act(() => {
+    await act(() => {
       checkbox.click();
     });
 

--- a/packages/mui-base/src/Checkbox/Root/CheckboxRoot.test.tsx
+++ b/packages/mui-base/src/Checkbox/Root/CheckboxRoot.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, fireEvent } from '@mui/internal-test-utils';
 import * as Checkbox from '@base_ui/react/Checkbox';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 

--- a/packages/mui-base/src/Checkbox/Root/CheckboxRoot.test.tsx
+++ b/packages/mui-base/src/Checkbox/Root/CheckboxRoot.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, act, fireEvent } from '@mui/internal-test-utils';
+import { act, fireEvent } from '@mui/internal-test-utils';
 import * as Checkbox from '@base_ui/react/Checkbox';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
@@ -16,14 +16,14 @@ describe('<Checkbox.Root />', () => {
   }));
 
   describe('extra props', () => {
-    it('can override the built-in attributes', () => {
-      const { container } = render(<Checkbox.Root data-state="checked" role="switch" />);
+    it('can override the built-in attributes', async () => {
+      const { container } = await render(<Checkbox.Root data-state="checked" role="switch" />);
       expect(container.firstElementChild as HTMLElement).to.have.attribute('role', 'switch');
     });
   });
 
   it('should change its state when clicked', async () => {
-    const { getAllByRole, container } = render(<Checkbox.Root />);
+    const { getAllByRole, container } = await render(<Checkbox.Root />);
     const [checkbox] = getAllByRole('checkbox');
     const input = container.querySelector('input[type=checkbox]') as HTMLInputElement;
 
@@ -56,7 +56,7 @@ describe('<Checkbox.Root />', () => {
       );
     }
 
-    const { getAllByRole, getByText } = render(<Test />);
+    const { getAllByRole, getByText } = await render(<Test />);
     const [checkbox] = getAllByRole('checkbox');
     const button = getByText('Toggle');
 
@@ -76,7 +76,7 @@ describe('<Checkbox.Root />', () => {
 
   it('should call onChange when clicked', async () => {
     const handleChange = spy();
-    const { getAllByRole } = render(<Checkbox.Root onCheckedChange={handleChange} />);
+    const { getAllByRole } = await render(<Checkbox.Root onCheckedChange={handleChange} />);
     const [checkbox] = getAllByRole('checkbox');
 
     await act(() => {
@@ -88,18 +88,18 @@ describe('<Checkbox.Root />', () => {
   });
 
   describe('prop: disabled', () => {
-    it('should have the `aria-disabled` attribute', () => {
-      const { getAllByRole } = render(<Checkbox.Root disabled />);
+    it('should have the `aria-disabled` attribute', async () => {
+      const { getAllByRole } = await render(<Checkbox.Root disabled />);
       expect(getAllByRole('checkbox')[0]).to.have.attribute('aria-disabled', 'true');
     });
 
-    it('should not have the aria attribute when `disabled` is not set', () => {
-      const { getAllByRole } = render(<Checkbox.Root />);
+    it('should not have the aria attribute when `disabled` is not set', async () => {
+      const { getAllByRole } = await render(<Checkbox.Root />);
       expect(getAllByRole('checkbox')[0]).not.to.have.attribute('aria-disabled');
     });
 
     it('should not change its state when clicked', async () => {
-      const { getAllByRole } = render(<Checkbox.Root disabled />);
+      const { getAllByRole } = await render(<Checkbox.Root disabled />);
       const [checkbox] = getAllByRole('checkbox');
 
       expect(checkbox).to.have.attribute('aria-checked', 'false');
@@ -113,18 +113,18 @@ describe('<Checkbox.Root />', () => {
   });
 
   describe('prop: readOnly', () => {
-    it('should have the `aria-readonly` attribute', () => {
-      const { getAllByRole } = render(<Checkbox.Root readOnly />);
+    it('should have the `aria-readonly` attribute', async () => {
+      const { getAllByRole } = await render(<Checkbox.Root readOnly />);
       expect(getAllByRole('checkbox')[0]).to.have.attribute('aria-readonly', 'true');
     });
 
-    it('should not have the aria attribute when `readOnly` is not set', () => {
-      const { getAllByRole } = render(<Checkbox.Root />);
+    it('should not have the aria attribute when `readOnly` is not set', async () => {
+      const { getAllByRole } = await render(<Checkbox.Root />);
       expect(getAllByRole('checkbox')[0]).not.to.have.attribute('aria-readonly');
     });
 
     it('should not change its state when clicked', async () => {
-      const { getAllByRole } = render(<Checkbox.Root readOnly />);
+      const { getAllByRole } = await render(<Checkbox.Root readOnly />);
       const [checkbox] = getAllByRole('checkbox');
 
       expect(checkbox).to.have.attribute('aria-checked', 'false');
@@ -138,13 +138,13 @@ describe('<Checkbox.Root />', () => {
   });
 
   describe('prop: indeterminate', () => {
-    it('should set the `aria-checked` attribute as "mixed"', () => {
-      const { getAllByRole } = render(<Checkbox.Root indeterminate />);
+    it('should set the `aria-checked` attribute as "mixed"', async () => {
+      const { getAllByRole } = await render(<Checkbox.Root indeterminate />);
       expect(getAllByRole('checkbox')[0]).to.have.attribute('aria-checked', 'mixed');
     });
 
     it('should not change its state when clicked', async () => {
-      const { getAllByRole } = render(<Checkbox.Root indeterminate />);
+      const { getAllByRole } = await render(<Checkbox.Root indeterminate />);
       const [checkbox] = getAllByRole('checkbox');
 
       expect(checkbox).to.have.attribute('aria-checked', 'mixed');
@@ -156,24 +156,24 @@ describe('<Checkbox.Root />', () => {
       expect(checkbox).to.have.attribute('aria-checked', 'mixed');
     });
 
-    it('should not set the `data-indeterminate` attribute', () => {
-      const { getAllByRole } = render(<Checkbox.Root indeterminate />);
+    it('should not set the `data-indeterminate` attribute', async () => {
+      const { getAllByRole } = await render(<Checkbox.Root indeterminate />);
       expect(getAllByRole('checkbox')[0]).to.not.have.attribute('data-indeterminate', 'true');
     });
 
-    it('should not have the aria attribute when `indeterminate` is not set', () => {
-      const { getAllByRole } = render(<Checkbox.Root />);
+    it('should not have the aria attribute when `indeterminate` is not set', async () => {
+      const { getAllByRole } = await render(<Checkbox.Root />);
       expect(getAllByRole('checkbox')[0]).not.to.have.attribute('aria-checked', 'mixed');
     });
 
-    it('should not be overridden by `checked` prop', () => {
-      const { getAllByRole } = render(<Checkbox.Root indeterminate checked />);
+    it('should not be overridden by `checked` prop', async () => {
+      const { getAllByRole } = await render(<Checkbox.Root indeterminate checked />);
       expect(getAllByRole('checkbox')[0]).to.have.attribute('aria-checked', 'mixed');
     });
   });
 
   it('should update its state if the underlying input is toggled', async () => {
-    const { getAllByRole, container } = render(<Checkbox.Root />);
+    const { getAllByRole, container } = await render(<Checkbox.Root />);
     const [checkbox] = getAllByRole('checkbox');
     const input = container.querySelector('input[type=checkbox]') as HTMLInputElement;
 
@@ -184,8 +184,8 @@ describe('<Checkbox.Root />', () => {
     expect(checkbox).to.have.attribute('aria-checked', 'true');
   });
 
-  it('should place the style hooks on the root and the indicator', () => {
-    const { getAllByRole } = render(
+  it('should place the style hooks on the root and the indicator', async () => {
+    const { getAllByRole } = await render(
       <Checkbox.Root defaultChecked disabled readOnly required>
         <Checkbox.Indicator />
       </Checkbox.Root>,
@@ -205,8 +205,8 @@ describe('<Checkbox.Root />', () => {
     expect(indicator).to.have.attribute('data-required', 'true');
   });
 
-  it('should set the name attribute on the input', () => {
-    const { container } = render(<Checkbox.Root name="checkbox-name" />);
+  it('should set the name attribute on the input', async () => {
+    const { container } = await render(<Checkbox.Root name="checkbox-name" />);
     const input = container.querySelector('input[type="checkbox"]')! as HTMLInputElement;
 
     expect(input).to.have.attribute('name', 'checkbox-name');
@@ -219,7 +219,7 @@ describe('<Checkbox.Root />', () => {
         this.skip();
       }
 
-      const { getByTestId, getAllByRole } = render(
+      const { getByTestId, getAllByRole } = await render(
         <label data-testid="label">
           <Checkbox.Root />
           Toggle
@@ -244,7 +244,7 @@ describe('<Checkbox.Root />', () => {
         this.skip();
       }
 
-      const { getByTestId, getAllByRole } = render(
+      const { getByTestId, getAllByRole } = await render(
         <div>
           <label htmlFor="test-checkbox" data-testid="label">
             Toggle
@@ -274,7 +274,7 @@ describe('<Checkbox.Root />', () => {
 
     let stringifiedFormData = '';
 
-    const { getAllByRole, getByRole } = render(
+    const { getAllByRole, getByRole } = await render(
       <form
         onSubmit={(event) => {
           event.preventDefault();
@@ -303,8 +303,8 @@ describe('<Checkbox.Root />', () => {
     expect(stringifiedFormData).to.equal('test-checkbox=on');
   });
 
-  it('should change state when clicking the checkbox if it has a wrapping label', () => {
-    const { getAllByRole } = render(
+  it('should change state when clicking the checkbox if it has a wrapping label', async () => {
+    const { getAllByRole } = await render(
       <label data-testid="label">
         <Checkbox.Root />
         Toggle

--- a/packages/mui-base/src/Dialog/Backdrop/DialogBackdrop.test.tsx
+++ b/packages/mui-base/src/Dialog/Backdrop/DialogBackdrop.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Dialog from '@base_ui/react/Dialog';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Dialog.Backdrop />', () => {
   const { render } = createRenderer();
@@ -18,8 +17,8 @@ describe('<Dialog.Backdrop />', () => {
     },
   }));
 
-  it('has role="presentation"', () => {
-    const { getByTestId } = render(
+  it('has role="presentation"', async () => {
+    const { getByTestId } = await render(
       <Dialog.Root open animated={false}>
         <Dialog.Backdrop data-testid="backdrop" />
       </Dialog.Root>,

--- a/packages/mui-base/src/Dialog/Backdrop/DialogBackdrop.test.tsx
+++ b/packages/mui-base/src/Dialog/Backdrop/DialogBackdrop.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import * as Dialog from '@base_ui/react/Dialog';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Dialog.Backdrop />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Dialog/Close/DialogClose.test.tsx
+++ b/packages/mui-base/src/Dialog/Close/DialogClose.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Dialog from '@base_ui/react/Dialog';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Dialog.Close />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Dialog/Close/DialogClose.test.tsx
+++ b/packages/mui-base/src/Dialog/Close/DialogClose.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Dialog from '@base_ui/react/Dialog';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Dialog.Close />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Dialog/Description/DialogDescription.test.tsx
+++ b/packages/mui-base/src/Dialog/Description/DialogDescription.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Dialog from '@base_ui/react/Dialog';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Dialog.Description />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Dialog/Description/DialogDescription.test.tsx
+++ b/packages/mui-base/src/Dialog/Description/DialogDescription.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Dialog from '@base_ui/react/Dialog';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Dialog.Description />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Dialog/Popup/DialogPopup.test.tsx
+++ b/packages/mui-base/src/Dialog/Popup/DialogPopup.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import * as Dialog from '@base_ui/react/Dialog';
-import { describeConformance, createRenderer } from '../../../test';
+import { describeConformance, createRenderer } from '#test-utils';
 
 describe('<Dialog.Popup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Dialog/Root/DialogRoot.test.tsx
+++ b/packages/mui-base/src/Dialog/Root/DialogRoot.test.tsx
@@ -28,7 +28,7 @@ describe('<Dialog.Root />', () => {
       const button = getByRole('button');
       expect(queryByRole('dialog')).to.equal(null);
 
-      act(() => {
+      await act(() => {
         button.click();
       });
 
@@ -199,7 +199,7 @@ describe('<Dialog.Root />', () => {
       );
 
       const trigger = getByText('Open');
-      act(() => {
+      await act(() => {
         trigger.click();
       });
 

--- a/packages/mui-base/src/Dialog/Root/DialogRoot.test.tsx
+++ b/packages/mui-base/src/Dialog/Root/DialogRoot.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, fireEvent } from '@mui/internal-test-utils';
 import * as Dialog from '@base_ui/react/Dialog';
-import { createRenderer } from '../../../test';
+import { createRenderer } from '#test-utils';
 
 async function wait(timeout: number) {
   return new Promise<void>((resolve) => {

--- a/packages/mui-base/src/Dialog/Title/DialogTitle.test.tsx
+++ b/packages/mui-base/src/Dialog/Title/DialogTitle.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Dialog from '@base_ui/react/Dialog';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Dialog.Title />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Dialog/Title/DialogTitle.test.tsx
+++ b/packages/mui-base/src/Dialog/Title/DialogTitle.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Dialog from '@base_ui/react/Dialog';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Dialog.Title />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Dialog/Trigger/DialogTrigger.test.tsx
+++ b/packages/mui-base/src/Dialog/Trigger/DialogTrigger.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Dialog from '@base_ui/react/Dialog';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Dialog.Trigger />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Dialog/Trigger/DialogTrigger.test.tsx
+++ b/packages/mui-base/src/Dialog/Trigger/DialogTrigger.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Dialog from '@base_ui/react/Dialog';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Dialog.Trigger />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Menu/Arrow/MenuArrow.test.tsx
+++ b/packages/mui-base/src/Menu/Arrow/MenuArrow.test.tsx
@@ -6,7 +6,6 @@ describe('<Menu.Arrow />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Menu.Arrow />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/Menu/Arrow/MenuArrow.test.tsx
+++ b/packages/mui-base/src/Menu/Arrow/MenuArrow.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Menu from '@base_ui/react/Menu';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Menu.Arrow />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Menu/Item/MenuItem.test.tsx
+++ b/packages/mui-base/src/Menu/Item/MenuItem.test.tsx
@@ -6,7 +6,7 @@ import { fireEvent, act, waitFor } from '@mui/internal-test-utils';
 import { FloatingRootContext, FloatingTree } from '@floating-ui/react';
 import * as Menu from '@base_ui/react/Menu';
 import { MenuRootContext } from '@base_ui/react/Menu';
-import { describeConformance, createRenderer } from '../../../test';
+import { describeConformance, createRenderer } from '#test-utils';
 
 const testRootContext: MenuRootContext = {
   floatingRootContext: {} as FloatingRootContext,

--- a/packages/mui-base/src/Menu/Item/MenuItem.test.tsx
+++ b/packages/mui-base/src/Menu/Item/MenuItem.test.tsx
@@ -101,6 +101,8 @@ describe('<Menu.Item />', () => {
 
     await waitFor(() => {
       expect(renderItem1Spy.callCount).to.equal(4); // '1' rerenders as it loses highlight
+    });
+    await waitFor(() => {
       expect(renderItem2Spy.callCount).to.equal(4); // '2' rerenders as it receives highlight
     });
 

--- a/packages/mui-base/src/Menu/Popup/MenuPopup.test.tsx
+++ b/packages/mui-base/src/Menu/Popup/MenuPopup.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Menu from '@base_ui/react/Menu';
 import { MenuRootContext } from '@base_ui/react/Menu';
 import { FloatingRootContext, FloatingTree } from '@floating-ui/react';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 import { MenuPositionerContext } from '../Positioner/MenuPositionerContext';
 
 const testRootContext: MenuRootContext = {

--- a/packages/mui-base/src/Menu/Popup/MenuPopup.test.tsx
+++ b/packages/mui-base/src/Menu/Popup/MenuPopup.test.tsx
@@ -40,7 +40,6 @@ describe('<Menu.Popup />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Menu.Popup />, () => ({
-    inheritComponent: 'div',
     render: (node) => {
       return render(
         <FloatingTree>

--- a/packages/mui-base/src/Menu/Positioner/MenuPositioner.test.tsx
+++ b/packages/mui-base/src/Menu/Positioner/MenuPositioner.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { flushMicrotasks } from '@mui/internal-test-utils';
 import * as Menu from '@base_ui/react/Menu';
 import { MenuRootContext } from '@base_ui/react/Menu';
-import { describeConformance, createRenderer } from '../../../test';
+import { describeConformance, createRenderer } from '#test-utils';
 
 const testRootContext: MenuRootContext = {
   floatingRootContext: undefined as unknown as FloatingRootContext,

--- a/packages/mui-base/src/Menu/Root/MenuRoot.test.tsx
+++ b/packages/mui-base/src/Menu/Root/MenuRoot.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, waitFor } from '@mui/internal-test-utils';
+import { act, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
 import * as Menu from '@base_ui/react/Menu';
 import userEvent from '@testing-library/user-event';
 import { createRenderer } from '../../../test';
@@ -552,7 +552,7 @@ describe('<Menu.Root />', () => {
       });
 
       await user.keyboard('[Escape]');
-      await act(async () => {});
+      await flushMicrotasks();
 
       expect(queryByRole('menu', { hidden: false })).to.equal(null);
     });

--- a/packages/mui-base/src/Menu/Root/MenuRoot.test.tsx
+++ b/packages/mui-base/src/Menu/Root/MenuRoot.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { act, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
 import * as Menu from '@base_ui/react/Menu';
 import userEvent from '@testing-library/user-event';
-import { createRenderer } from '../../../test';
+import { createRenderer } from '#test-utils';
 
 describe('<Menu.Root />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Menu/Root/MenuRoot.test.tsx
+++ b/packages/mui-base/src/Menu/Root/MenuRoot.test.tsx
@@ -191,6 +191,7 @@ describe('<Menu.Root />', () => {
         await user.click(trigger);
 
         const items = getAllByRole('menuitem');
+        await flushMicrotasks();
 
         await user.keyboard('b');
         await waitFor(() => {

--- a/packages/mui-base/src/Menu/Root/MenuRoot.test.tsx
+++ b/packages/mui-base/src/Menu/Root/MenuRoot.test.tsx
@@ -126,8 +126,9 @@ describe('<Menu.Root />', () => {
 
       await waitFor(() => {
         expect(item2).toHaveFocus();
-        expect(item2).to.have.attribute('aria-disabled', 'true');
       });
+
+      expect(item2).to.have.attribute('aria-disabled', 'true');
     });
 
     describe('text navigation', () => {
@@ -161,15 +162,17 @@ describe('<Menu.Root />', () => {
 
         await user.keyboard('c');
         await waitFor(() => {
-          expect(document.activeElement).to.equal(getByText('Ca'));
-          expect(getByText('Ca')).to.have.attribute('tabindex', '0');
+          expect(getByText('Ca')).toHaveFocus();
         });
+
+        expect(getByText('Ca')).to.have.attribute('tabindex', '0');
 
         await user.keyboard('d');
         await waitFor(() => {
-          expect(document.activeElement).to.equal(getByText('Cd'));
-          expect(getByText('Cd')).to.have.attribute('tabindex', '0');
+          expect(getByText('Cd')).toHaveFocus();
         });
+
+        expect(getByText('Cd')).to.have.attribute('tabindex', '0');
       });
 
       it('changes the highlighted item using text navigation on label prop', async () => {
@@ -196,20 +199,23 @@ describe('<Menu.Root />', () => {
         await user.keyboard('b');
         await waitFor(() => {
           expect(items[1]).toHaveFocus();
+        });
+
+        await waitFor(() => {
           expect(items[1]).to.have.attribute('tabindex', '0');
         });
 
         await user.keyboard('b');
         await waitFor(() => {
           expect(items[2]).toHaveFocus();
-          expect(items[2]).to.have.attribute('tabindex', '0');
         });
+        expect(items[2]).to.have.attribute('tabindex', '0');
 
         await user.keyboard('b');
         await waitFor(() => {
           expect(items[2]).toHaveFocus();
-          expect(items[2]).to.have.attribute('tabindex', '0');
         });
+        expect(items[2]).to.have.attribute('tabindex', '0');
       });
 
       it('skips the non-stringifiable items', async function test() {
@@ -246,14 +252,14 @@ describe('<Menu.Root />', () => {
         await user.keyboard('b');
         await waitFor(() => {
           expect(getByText('Ba')).toHaveFocus();
-          expect(getByText('Ba')).to.have.attribute('tabindex', '0');
         });
+        expect(getByText('Ba')).to.have.attribute('tabindex', '0');
 
         await user.keyboard('c');
         await waitFor(() => {
           expect(getByText('Bc')).toHaveFocus();
-          expect(getByText('Bc')).to.have.attribute('tabindex', '0');
         });
+        expect(getByText('Bc')).to.have.attribute('tabindex', '0');
       });
 
       it('navigate to options with diacritic characters', async function test() {
@@ -285,14 +291,14 @@ describe('<Menu.Root />', () => {
         await user.keyboard('b');
         await waitFor(() => {
           expect(getByText('Ba')).toHaveFocus();
-          expect(getByText('Ba')).to.have.attribute('tabindex', '0');
         });
+        expect(getByText('Ba')).to.have.attribute('tabindex', '0');
 
         await user.keyboard('ą');
         await waitFor(() => {
           expect(getByText('Bą')).toHaveFocus();
-          expect(getByText('Bą')).to.have.attribute('tabindex', '0');
         });
+        expect(getByText('Bą')).to.have.attribute('tabindex', '0');
       });
 
       it('navigate to next options beginning with diacritic characters', async function test() {
@@ -324,8 +330,8 @@ describe('<Menu.Root />', () => {
         await user.keyboard('ą');
         await waitFor(() => {
           expect(getByText('ąa')).toHaveFocus();
-          expect(getByText('ąa')).to.have.attribute('tabindex', '0');
         });
+        expect(getByText('ąa')).to.have.attribute('tabindex', '0');
       });
     });
   });
@@ -600,11 +606,13 @@ describe('<Menu.Root />', () => {
       });
 
       await user.keyboard('[Escape]');
+
+      const menus = queryAllByRole('menu', { hidden: false });
       await waitFor(() => {
-        const menus = queryAllByRole('menu', { hidden: false });
         expect(menus.length).to.equal(1);
-        expect(menus[0].id).to.equal('parent-menu');
       });
+
+      expect(menus[0].id).to.equal('parent-menu');
     });
   });
 });

--- a/packages/mui-base/src/Menu/Trigger/MenuTrigger.test.tsx
+++ b/packages/mui-base/src/Menu/Trigger/MenuTrigger.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { act } from '@mui/internal-test-utils';
 import * as Menu from '@base_ui/react/Menu';
 import { MenuRootContext } from '@base_ui/react/Menu';
-import { describeConformance, createRenderer } from '../../../test';
+import { describeConformance, createRenderer } from '#test-utils';
 
 const testRootContext: MenuRootContext = {
   floatingRootContext: {} as FloatingRootContext,

--- a/packages/mui-base/src/NumberField/Decrement/NumberFieldDecrement.test.tsx
+++ b/packages/mui-base/src/NumberField/Decrement/NumberFieldDecrement.test.tsx
@@ -4,7 +4,7 @@ import { screen, fireEvent } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
 import { CHANGE_VALUE_TICK_DELAY, START_AUTO_CHANGE_DELAY } from '../utils/constants';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const testContext = {
   getDecrementButtonProps: (externalProps) => externalProps,

--- a/packages/mui-base/src/NumberField/Decrement/NumberFieldDecrement.test.tsx
+++ b/packages/mui-base/src/NumberField/Decrement/NumberFieldDecrement.test.tsx
@@ -3,8 +3,8 @@ import { expect } from 'chai';
 import { screen, fireEvent } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
-import { CHANGE_VALUE_TICK_DELAY, START_AUTO_CHANGE_DELAY } from '../utils/constants';
 import { createRenderer, describeConformance } from '#test-utils';
+import { CHANGE_VALUE_TICK_DELAY, START_AUTO_CHANGE_DELAY } from '../utils/constants';
 
 const testContext = {
   getDecrementButtonProps: (externalProps) => externalProps,

--- a/packages/mui-base/src/NumberField/Decrement/NumberFieldDecrement.test.tsx
+++ b/packages/mui-base/src/NumberField/Decrement/NumberFieldDecrement.test.tsx
@@ -21,7 +21,6 @@ describe('<NumberField.Decrement />', () => {
   const { render, clock } = createRenderer();
 
   describeConformance(<NumberField.Decrement />, () => ({
-    inheritComponent: 'button',
     refInstanceof: window.HTMLButtonElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/NumberField/Decrement/NumberFieldDecrement.test.tsx
+++ b/packages/mui-base/src/NumberField/Decrement/NumberFieldDecrement.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
+import { screen, fireEvent } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
 import { CHANGE_VALUE_TICK_DELAY, START_AUTO_CHANGE_DELAY } from '../utils/constants';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const testContext = {
   getDecrementButtonProps: (externalProps) => externalProps,
@@ -29,8 +29,8 @@ describe('<NumberField.Decrement />', () => {
     },
   }));
 
-  it('has decrease label', () => {
-    render(
+  it('has decrease label', async () => {
+    await render(
       <NumberField.Root>
         <NumberField.Decrement />
       </NumberField.Root>,
@@ -38,8 +38,8 @@ describe('<NumberField.Decrement />', () => {
     expect(screen.queryByLabelText('Decrease')).not.to.equal(null);
   });
 
-  it('decrements starting from 0 click', () => {
-    render(
+  it('decrements starting from 0 click', async () => {
+    await render(
       <NumberField.Root>
         <NumberField.Decrement />
         <NumberField.Input />
@@ -51,8 +51,8 @@ describe('<NumberField.Decrement />', () => {
     expect(screen.getByRole('textbox')).to.have.value('0');
   });
 
-  it('decrements to -1 starting from defaultValue=0 click', () => {
-    render(
+  it('decrements to -1 starting from defaultValue=0 click', async () => {
+    await render(
       <NumberField.Root defaultValue={0}>
         <NumberField.Decrement />
         <NumberField.Input />
@@ -67,8 +67,8 @@ describe('<NumberField.Decrement />', () => {
   describe('press and hold', () => {
     clock.withFakeTimers();
 
-    it('decrements continuously when holding pointerdown', () => {
-      render(
+    it('decrements continuously when holding pointerdown', async () => {
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Decrement />
           <NumberField.Input />
@@ -97,8 +97,8 @@ describe('<NumberField.Decrement />', () => {
       expect(input).to.have.value('-4');
     });
 
-    it('does not decrement twice with pointerdown and click', () => {
-      render(
+    it('does not decrement twice with pointerdown and click', async () => {
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Decrement />
           <NumberField.Input />
@@ -115,8 +115,8 @@ describe('<NumberField.Decrement />', () => {
       expect(input).to.have.value('-1');
     });
 
-    it('should stop decrementing after mouseleave', () => {
-      render(
+    it('should stop decrementing after mouseleave', async () => {
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Decrement />
           <NumberField.Input />
@@ -145,8 +145,8 @@ describe('<NumberField.Decrement />', () => {
       expect(input).to.have.value('-4');
     });
 
-    it('should start decrementing again after mouseleave then mouseenter', () => {
-      render(
+    it('should start decrementing again after mouseleave then mouseenter', async () => {
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Decrement />
           <NumberField.Input />
@@ -181,8 +181,8 @@ describe('<NumberField.Decrement />', () => {
       expect(input).to.have.value('-5');
     });
 
-    it('should not start decrementing again after mouseleave then mouseenter after pointerup', () => {
-      render(
+    it('should not start decrementing again after mouseleave then mouseenter after pointerup', async () => {
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Decrement />
           <NumberField.Input />
@@ -224,8 +224,8 @@ describe('<NumberField.Decrement />', () => {
     });
   });
 
-  it('should not decrement when disabled', () => {
-    render(
+  it('should not decrement when disabled', async () => {
+    await render(
       <NumberField.Root disabled>
         <NumberField.Decrement />
         <NumberField.Input />
@@ -237,8 +237,8 @@ describe('<NumberField.Decrement />', () => {
     expect(screen.getByRole('textbox')).to.have.value('');
   });
 
-  it('should not decrement when readOnly', () => {
-    render(
+  it('should not decrement when readOnly', async () => {
+    await render(
       <NumberField.Root readOnly>
         <NumberField.Decrement />
         <NumberField.Input />

--- a/packages/mui-base/src/NumberField/Group/NumberFieldGroup.test.tsx
+++ b/packages/mui-base/src/NumberField/Group/NumberFieldGroup.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, screen } from '@mui/internal-test-utils';
+import { screen } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const testContext = {
   getGroupProps: (externalProps) => ({ role: 'group', ...externalProps }),
@@ -28,8 +28,8 @@ describe('<NumberField.Group />', () => {
     },
   }));
 
-  it('has role prop', () => {
-    render(
+  it('has role prop', async () => {
+    await render(
       <NumberField.Root>
         <NumberField.Group />
       </NumberField.Root>,

--- a/packages/mui-base/src/NumberField/Group/NumberFieldGroup.test.tsx
+++ b/packages/mui-base/src/NumberField/Group/NumberFieldGroup.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { screen } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const testContext = {
   getGroupProps: (externalProps) => ({ role: 'group', ...externalProps }),

--- a/packages/mui-base/src/NumberField/Group/NumberFieldGroup.test.tsx
+++ b/packages/mui-base/src/NumberField/Group/NumberFieldGroup.test.tsx
@@ -20,7 +20,6 @@ describe('<NumberField.Group />', () => {
   const { render } = createRenderer();
 
   describeConformance(<NumberField.Group />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/NumberField/Increment/NumberFieldIncrement.test.tsx
+++ b/packages/mui-base/src/NumberField/Increment/NumberFieldIncrement.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
+import { screen, fireEvent } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
 import { CHANGE_VALUE_TICK_DELAY, START_AUTO_CHANGE_DELAY } from '../utils/constants';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const testContext = {
   getIncrementButtonProps: (externalProps) => externalProps,
@@ -29,8 +29,8 @@ describe('<NumberField.Increment />', () => {
     },
   }));
 
-  it('has increase label', () => {
-    render(
+  it('has increase label', async () => {
+    await render(
       <NumberField.Root>
         <NumberField.Increment />
       </NumberField.Root>,
@@ -38,8 +38,8 @@ describe('<NumberField.Increment />', () => {
     expect(screen.queryByLabelText('Increase')).not.to.equal(null);
   });
 
-  it('increments starting from 0 click', () => {
-    render(
+  it('increments starting from 0 click', async () => {
+    await render(
       <NumberField.Root>
         <NumberField.Increment />
         <NumberField.Input />
@@ -51,8 +51,8 @@ describe('<NumberField.Increment />', () => {
     expect(screen.getByRole('textbox')).to.have.value('0');
   });
 
-  it('increments to 1 starting from defaultValue=0 click', () => {
-    render(
+  it('increments to 1 starting from defaultValue=0 click', async () => {
+    await render(
       <NumberField.Root defaultValue={0}>
         <NumberField.Increment />
         <NumberField.Input />
@@ -67,8 +67,8 @@ describe('<NumberField.Increment />', () => {
   describe('press and hold', () => {
     clock.withFakeTimers();
 
-    it('increments continuously when holding pointerdown', () => {
-      render(
+    it('increments continuously when holding pointerdown', async () => {
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Increment />
           <NumberField.Input />
@@ -97,8 +97,8 @@ describe('<NumberField.Increment />', () => {
       expect(input).to.have.value('4');
     });
 
-    it('does not increment twice with pointerdown and click', () => {
-      render(
+    it('does not increment twice with pointerdown and click', async () => {
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Increment />
           <NumberField.Input />
@@ -115,8 +115,8 @@ describe('<NumberField.Increment />', () => {
       expect(input).to.have.value('1');
     });
 
-    it('should stop incrementing after mouseleave', () => {
-      render(
+    it('should stop incrementing after mouseleave', async () => {
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Increment />
           <NumberField.Input />
@@ -145,8 +145,8 @@ describe('<NumberField.Increment />', () => {
       expect(input).to.have.value('4');
     });
 
-    it('should start incrementing again after mouseleave then mouseenter', () => {
-      render(
+    it('should start incrementing again after mouseleave then mouseenter', async () => {
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Increment />
           <NumberField.Input />
@@ -181,8 +181,8 @@ describe('<NumberField.Increment />', () => {
       expect(input).to.have.value('5');
     });
 
-    it('should not start incrementing again after mouseleave then mouseenter after pointerup', () => {
-      render(
+    it('should not start incrementing again after mouseleave then mouseenter after pointerup', async () => {
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Increment />
           <NumberField.Input />
@@ -224,8 +224,8 @@ describe('<NumberField.Increment />', () => {
     });
   });
 
-  it('should not increment when disabled', () => {
-    render(
+  it('should not increment when disabled', async () => {
+    await render(
       <NumberField.Root disabled>
         <NumberField.Increment />
         <NumberField.Input />
@@ -237,8 +237,8 @@ describe('<NumberField.Increment />', () => {
     expect(screen.getByRole('textbox')).to.have.value('');
   });
 
-  it('should not increment when readOnly', () => {
-    render(
+  it('should not increment when readOnly', async () => {
+    await render(
       <NumberField.Root readOnly>
         <NumberField.Increment />
         <NumberField.Input />

--- a/packages/mui-base/src/NumberField/Increment/NumberFieldIncrement.test.tsx
+++ b/packages/mui-base/src/NumberField/Increment/NumberFieldIncrement.test.tsx
@@ -21,7 +21,6 @@ describe('<NumberField.Increment />', () => {
   const { render, clock } = createRenderer();
 
   describeConformance(<NumberField.Increment />, () => ({
-    inheritComponent: 'button',
     refInstanceof: window.HTMLButtonElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/NumberField/Increment/NumberFieldIncrement.test.tsx
+++ b/packages/mui-base/src/NumberField/Increment/NumberFieldIncrement.test.tsx
@@ -3,8 +3,8 @@ import { expect } from 'chai';
 import { screen, fireEvent } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
-import { CHANGE_VALUE_TICK_DELAY, START_AUTO_CHANGE_DELAY } from '../utils/constants';
 import { createRenderer, describeConformance } from '#test-utils';
+import { CHANGE_VALUE_TICK_DELAY, START_AUTO_CHANGE_DELAY } from '../utils/constants';
 
 const testContext = {
   getIncrementButtonProps: (externalProps) => externalProps,

--- a/packages/mui-base/src/NumberField/Increment/NumberFieldIncrement.test.tsx
+++ b/packages/mui-base/src/NumberField/Increment/NumberFieldIncrement.test.tsx
@@ -4,7 +4,7 @@ import { screen, fireEvent } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
 import { CHANGE_VALUE_TICK_DELAY, START_AUTO_CHANGE_DELAY } from '../utils/constants';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const testContext = {
   getIncrementButtonProps: (externalProps) => externalProps,

--- a/packages/mui-base/src/NumberField/Input/NumberFieldInput.test.tsx
+++ b/packages/mui-base/src/NumberField/Input/NumberFieldInput.test.tsx
@@ -20,7 +20,6 @@ describe('<NumberField.Input />', () => {
   const { render } = createRenderer();
 
   describeConformance(<NumberField.Input />, () => ({
-    inheritComponent: 'input',
     refInstanceof: window.HTMLInputElement,
     render(node) {
       return render(
@@ -38,154 +37,154 @@ describe('<NumberField.Input />', () => {
     expect(screen.queryByRole('textbox')).not.to.equal(null);
   });
 
-  it('should not allow non-numeric characters on change', () => {
+  it('should not allow non-numeric characters on change', async () => {
     render(
       <NumberField.Root>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.change(input, { target: { value: 'abc' } });
     expect(input).to.have.value('');
   });
 
-  it('should not allow non-numeric characters on keydown', () => {
+  it('should not allow non-numeric characters on keydown', async () => {
     render(
       <NumberField.Root>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.keyDown(input, { key: 'a' });
     expect(input).to.have.value('');
   });
 
-  it('should allow numeric characters on change', () => {
+  it('should allow numeric characters on change', async () => {
     render(
       <NumberField.Root>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.change(input, { target: { value: '123' } });
     expect(input).to.have.value('123');
   });
 
-  it('should increment on keydown ArrowUp', () => {
+  it('should increment on keydown ArrowUp', async () => {
     render(
       <NumberField.Root defaultValue={0}>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.keyDown(input, { key: 'ArrowUp' });
     expect(input).to.have.value('1');
   });
 
-  it('should decrement on keydown ArrowDown', () => {
+  it('should decrement on keydown ArrowDown', async () => {
     render(
       <NumberField.Root defaultValue={0}>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.keyDown(input, { key: 'ArrowDown' });
     expect(input).to.have.value('-1');
   });
 
-  it('should increment to min on keydown Home', () => {
+  it('should increment to min on keydown Home', async () => {
     render(
       <NumberField.Root min={-10} max={10}>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.keyDown(input, { key: 'Home' });
     expect(input).to.have.value('-10');
   });
 
-  it('should decrement to max on keydown End', () => {
+  it('should decrement to max on keydown End', async () => {
     render(
       <NumberField.Root min={-10} max={10}>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.keyDown(input, { key: 'End' });
     expect(input).to.have.value('10');
   });
 
-  it('commits formatted value only on blur', () => {
+  it('commits formatted value only on blur', async () => {
     render(
       <NumberField.Root>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.change(input, { target: { value: '1234' } });
     expect(input).to.have.value('1234');
     fireEvent.blur(input);
     expect(input).to.have.value((1234).toLocaleString());
   });
 
-  it('should commit validated number on blur (min)', () => {
+  it('should commit validated number on blur (min)', async () => {
     render(
       <NumberField.Root min={0}>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.change(input, { target: { value: '-1' } });
     expect(input).to.have.value('-1');
     fireEvent.blur(input);
     expect(input).to.have.value('0');
   });
 
-  it('should commit validated number on blur (max)', () => {
+  it('should commit validated number on blur (max)', async () => {
     render(
       <NumberField.Root max={0}>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.change(input, { target: { value: '1' } });
     expect(input).to.have.value('1');
     fireEvent.blur(input);
     expect(input).to.have.value('0');
   });
 
-  it('should commit validated number on blur (step)', () => {
+  it('should commit validated number on blur (step)', async () => {
     render(
       <NumberField.Root step={0.5}>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.change(input, { target: { value: '1.1' } });
     expect(input).to.have.value('1.1');
     fireEvent.blur(input);
     expect(input).to.have.value('1');
   });
 
-  it('should commit validated number on blur (step and min)', () => {
+  it('should commit validated number on blur (step and min)', async () => {
     render(
       <NumberField.Root min={2} step={2}>
         <NumberField.Input />
       </NumberField.Root>,
     );
     const input = screen.getByRole('textbox');
-    act(() => input.focus());
+    await act(() => input.focus());
     fireEvent.change(input, { target: { value: '3' } });
     expect(input).to.have.value('3');
     fireEvent.blur(input);

--- a/packages/mui-base/src/NumberField/Input/NumberFieldInput.test.tsx
+++ b/packages/mui-base/src/NumberField/Input/NumberFieldInput.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { act, screen, fireEvent } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const testContext = {
   getInputProps: (externalProps) => externalProps,

--- a/packages/mui-base/src/NumberField/Input/NumberFieldInput.test.tsx
+++ b/packages/mui-base/src/NumberField/Input/NumberFieldInput.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
+import { act, screen, fireEvent } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const testContext = {
   getInputProps: (externalProps) => externalProps,
@@ -28,8 +28,8 @@ describe('<NumberField.Input />', () => {
     },
   }));
 
-  it('has textbox role', () => {
-    render(
+  it('has textbox role', async () => {
+    await render(
       <NumberField.Root>
         <NumberField.Input />
       </NumberField.Root>,
@@ -38,7 +38,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('should not allow non-numeric characters on change', async () => {
-    render(
+    await render(
       <NumberField.Root>
         <NumberField.Input />
       </NumberField.Root>,
@@ -50,7 +50,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('should not allow non-numeric characters on keydown', async () => {
-    render(
+    await render(
       <NumberField.Root>
         <NumberField.Input />
       </NumberField.Root>,
@@ -62,7 +62,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('should allow numeric characters on change', async () => {
-    render(
+    await render(
       <NumberField.Root>
         <NumberField.Input />
       </NumberField.Root>,
@@ -74,7 +74,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('should increment on keydown ArrowUp', async () => {
-    render(
+    await render(
       <NumberField.Root defaultValue={0}>
         <NumberField.Input />
       </NumberField.Root>,
@@ -86,7 +86,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('should decrement on keydown ArrowDown', async () => {
-    render(
+    await render(
       <NumberField.Root defaultValue={0}>
         <NumberField.Input />
       </NumberField.Root>,
@@ -98,7 +98,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('should increment to min on keydown Home', async () => {
-    render(
+    await render(
       <NumberField.Root min={-10} max={10}>
         <NumberField.Input />
       </NumberField.Root>,
@@ -110,7 +110,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('should decrement to max on keydown End', async () => {
-    render(
+    await render(
       <NumberField.Root min={-10} max={10}>
         <NumberField.Input />
       </NumberField.Root>,
@@ -122,7 +122,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('commits formatted value only on blur', async () => {
-    render(
+    await render(
       <NumberField.Root>
         <NumberField.Input />
       </NumberField.Root>,
@@ -136,7 +136,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('should commit validated number on blur (min)', async () => {
-    render(
+    await render(
       <NumberField.Root min={0}>
         <NumberField.Input />
       </NumberField.Root>,
@@ -150,7 +150,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('should commit validated number on blur (max)', async () => {
-    render(
+    await render(
       <NumberField.Root max={0}>
         <NumberField.Input />
       </NumberField.Root>,
@@ -164,7 +164,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('should commit validated number on blur (step)', async () => {
-    render(
+    await render(
       <NumberField.Root step={0.5}>
         <NumberField.Input />
       </NumberField.Root>,
@@ -178,7 +178,7 @@ describe('<NumberField.Input />', () => {
   });
 
   it('should commit validated number on blur (step and min)', async () => {
-    render(
+    await render(
       <NumberField.Root min={2} step={2}>
         <NumberField.Input />
       </NumberField.Root>,

--- a/packages/mui-base/src/NumberField/Root/NumberFieldRoot.test.tsx
+++ b/packages/mui-base/src/NumberField/Root/NumberFieldRoot.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { act, createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
+import { act, screen, fireEvent } from '@mui/internal-test-utils';
 import * as NumberFieldBase from '@base_ui/react/NumberField';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<NumberField />', () => {
   const { render } = createRenderer();
@@ -27,43 +27,43 @@ describe('<NumberField />', () => {
   }
 
   describe('prop: defaultValue', () => {
-    it('should accept a number value', () => {
-      render(<NumberField defaultValue={1} />);
+    it('should accept a number value', async () => {
+      await render(<NumberField defaultValue={1} />);
       const input = screen.getByRole('textbox');
       expect(input).to.have.value('1');
     });
 
-    it('should accept an `undefined` value', () => {
-      render(<NumberField />);
+    it('should accept an `undefined` value', async () => {
+      await render(<NumberField />);
       const input = screen.getByRole('textbox');
       expect(input).to.have.value('');
     });
   });
 
   describe('prop: value', () => {
-    it('should accept a number value that can change over time', () => {
-      const { rerender } = render(<NumberField value={1} />);
+    it('should accept a number value that can change over time', async () => {
+      const { rerender } = await render(<NumberField value={1} />);
       const input = screen.getByRole('textbox');
       expect(input).to.have.value('1');
       rerender(<NumberField value={2} />);
       expect(input).to.have.value('2');
     });
 
-    it('should accept an `undefined` value', () => {
-      render(<NumberField />);
+    it('should accept an `undefined` value', async () => {
+      await render(<NumberField />);
       const input = screen.getByRole('textbox');
       expect(input).to.have.value('');
     });
 
-    it('should accept a `null` value', () => {
-      render(<NumberField value={null} />);
+    it('should accept a `null` value', async () => {
+      await render(<NumberField value={null} />);
       const input = screen.getByRole('textbox');
       expect(input).to.have.value('');
     });
 
-    it('should be `null` when the input is empty but not trimmed', () => {
+    it('should be `null` when the input is empty but not trimmed', async () => {
       const onValueChange = spy();
-      render(<NumberField value={1} onValueChange={onValueChange} />);
+      await render(<NumberField value={1} onValueChange={onValueChange} />);
       const input = screen.getByRole('textbox');
       fireEvent.change(input, { target: { value: '  ' } });
       expect(onValueChange.firstCall.args[0]).to.equal(null);
@@ -71,7 +71,7 @@ describe('<NumberField />', () => {
   });
 
   describe('prop: onValueChange', () => {
-    it('should be called when the value changes', () => {
+    it('should be called when the value changes', async () => {
       const onValueChange = spy();
       function App() {
         const [value, setValue] = React.useState<number | null>(1);
@@ -85,14 +85,14 @@ describe('<NumberField />', () => {
           />
         );
       }
-      render(<App />);
+      await render(<App />);
       const input = screen.getByRole('textbox');
       fireEvent.change(input, { target: { value: '2' } });
       expect(onValueChange.callCount).to.equal(1);
       expect(onValueChange.firstCall.args[0]).to.equal(2);
     });
 
-    it('should be called with a number when transitioning from `null`', () => {
+    it('should be called with a number when transitioning from `null`', async () => {
       const onValueChange = spy();
       function App() {
         const [value, setValue] = React.useState<number | null>(null);
@@ -106,14 +106,14 @@ describe('<NumberField />', () => {
           />
         );
       }
-      render(<App />);
+      await render(<App />);
       const input = screen.getByRole('textbox');
       fireEvent.change(input, { target: { value: '5' } });
       expect(onValueChange.callCount).to.equal(1);
       expect(onValueChange.firstCall.args[0]).to.equal(5);
     });
 
-    it('should be called with `null` when empty and transitioning from a number', () => {
+    it('should be called with `null` when empty and transitioning from a number', async () => {
       const onValueChange = spy();
       function App() {
         const [value, setValue] = React.useState<number | null>(5);
@@ -127,7 +127,7 @@ describe('<NumberField />', () => {
           />
         );
       }
-      render(<App />);
+      await render(<App />);
       const input = screen.getByRole('textbox');
       fireEvent.change(input, { target: { value: '' } });
       expect(onValueChange.callCount).to.equal(1);
@@ -136,55 +136,55 @@ describe('<NumberField />', () => {
   });
 
   describe('prop: disabled', () => {
-    it('should disable the input', () => {
-      render(<NumberField disabled />);
+    it('should disable the input', async () => {
+      await render(<NumberField disabled />);
       const input = screen.getByRole('textbox');
       expect(input).to.have.attribute('disabled');
     });
   });
 
   describe('prop: readOnly', () => {
-    it('should mark the input as readOnly', () => {
-      render(<NumberField readOnly />);
+    it('should mark the input as readOnly', async () => {
+      await render(<NumberField readOnly />);
       const input = screen.getByRole('textbox');
       expect(input).to.have.attribute('readonly');
     });
   });
 
   describe('prop: autoFocus', () => {
-    it('should focus the input', () => {
-      render(<NumberField autoFocus />);
+    it('should focus the input', async () => {
+      await render(<NumberField autoFocus />);
       const input = screen.getByRole('textbox');
       expect(document.activeElement).to.equal(input);
     });
   });
 
   describe('prop: required', () => {
-    it('should mark the input as required', () => {
-      render(<NumberField required />);
+    it('should mark the input as required', async () => {
+      await render(<NumberField required />);
       const input = screen.getByRole('textbox');
       expect(input).to.have.attribute('required');
     });
   });
 
   describe('prop: invalid', () => {
-    it('sets `aria-invalid` on the input', () => {
-      render(<NumberField invalid />);
+    it('sets `aria-invalid` on the input', async () => {
+      await render(<NumberField invalid />);
       const input = screen.getByRole('textbox');
       expect(input).to.have.attribute('aria-invalid', 'true');
     });
   });
 
   describe('prop: name', () => {
-    it('should set the name attribute on the input', () => {
-      render(<NumberField name="test" />);
+    it('should set the name attribute on the input', async () => {
+      await render(<NumberField name="test" />);
       const input = screen.getByRole('textbox');
       expect(input).to.have.attribute('name', 'test');
     });
   });
 
   describe('prop: min', () => {
-    it('prevents the raw value from going below the `min` prop', () => {
+    it('prevents the raw value from going below the `min` prop', async () => {
       const fn = spy();
 
       function App() {
@@ -201,7 +201,7 @@ describe('<NumberField />', () => {
         );
       }
 
-      render(<App />);
+      await render(<App />);
 
       const input = screen.getByRole('textbox');
       fireEvent.change(input, { target: { value: '4' } });
@@ -210,7 +210,7 @@ describe('<NumberField />', () => {
       expect(fn.firstCall.args[0]).to.equal(5);
     });
 
-    it('allows the value to go above the `min` prop', () => {
+    it('allows the value to go above the `min` prop', async () => {
       const fn = spy();
 
       function App() {
@@ -227,7 +227,7 @@ describe('<NumberField />', () => {
         );
       }
 
-      render(<App />);
+      await render(<App />);
 
       const input = screen.getByRole('textbox');
       fireEvent.change(input, { target: { value: '6' } });
@@ -237,7 +237,7 @@ describe('<NumberField />', () => {
   });
 
   describe('prop: max', () => {
-    it('prevents the value from going above the `max` prop', () => {
+    it('prevents the value from going above the `max` prop', async () => {
       const fn = spy();
 
       function App() {
@@ -254,7 +254,7 @@ describe('<NumberField />', () => {
         );
       }
 
-      render(<App />);
+      await render(<App />);
 
       const input = screen.getByRole('textbox');
       fireEvent.change(input, { target: { value: '6' } });
@@ -263,7 +263,7 @@ describe('<NumberField />', () => {
       expect(fn.firstCall.args[0]).to.equal(5);
     });
 
-    it('allows the value to go below the `max` prop', () => {
+    it('allows the value to go below the `max` prop', async () => {
       const fn = spy();
 
       function App() {
@@ -280,7 +280,7 @@ describe('<NumberField />', () => {
         );
       }
 
-      render(<App />);
+      await render(<App />);
 
       const input = screen.getByRole('textbox');
       fireEvent.change(input, { target: { value: '4' } });
@@ -291,37 +291,37 @@ describe('<NumberField />', () => {
   });
 
   describe('prop: step', () => {
-    it('defaults to 1', () => {
-      render(<NumberField defaultValue={5} />);
+    it('defaults to 1', async () => {
+      await render(<NumberField defaultValue={5} />);
       const input = screen.getByRole('textbox');
       fireEvent.click(screen.getByLabelText('Increase'));
       expect(input).to.have.value('6');
     });
 
-    it('should increment the value by the `step` prop', () => {
-      render(<NumberField defaultValue={4} step={2} />);
+    it('should increment the value by the `step` prop', async () => {
+      await render(<NumberField defaultValue={4} step={2} />);
       const input = screen.getByRole('textbox');
       fireEvent.click(screen.getByLabelText('Increase'));
       expect(input).to.have.value('6');
     });
 
-    it('should snap when incrementing to the nearest multiple of the `step` prop', () => {
-      render(<NumberField defaultValue={5} step={2} />);
+    it('should snap when incrementing to the nearest multiple of the `step` prop', async () => {
+      await render(<NumberField defaultValue={5} step={2} />);
       const input = screen.getByRole('textbox');
       fireEvent.change(input, { target: { value: '6' } });
       fireEvent.blur(input);
       expect(input).to.have.value('6');
     });
 
-    it('should decrement the value by the `step` prop', () => {
-      render(<NumberField defaultValue={6} step={2} />);
+    it('should decrement the value by the `step` prop', async () => {
+      await render(<NumberField defaultValue={6} step={2} />);
       const input = screen.getByRole('textbox');
       fireEvent.click(screen.getByLabelText('Decrease'));
       expect(input).to.have.value('4');
     });
 
-    it('should snap when decrementing to the nearest multiple of the `step` prop', () => {
-      render(<NumberField defaultValue={5} step={2} />);
+    it('should snap when decrementing to the nearest multiple of the `step` prop', async () => {
+      await render(<NumberField defaultValue={5} step={2} />);
       const input = screen.getByRole('textbox');
       fireEvent.change(input, { target: { value: '4' } });
       fireEvent.blur(input);
@@ -330,32 +330,32 @@ describe('<NumberField />', () => {
   });
 
   describe('prop: largeStep', () => {
-    it('should increment the value by the default `largeStep` prop of 10 while holding the shift key', () => {
-      render(<NumberField defaultValue={5} />);
+    it('should increment the value by the default `largeStep` prop of 10 while holding the shift key', async () => {
+      await render(<NumberField defaultValue={5} />);
       const input = screen.getByRole('textbox');
       fireEvent.keyDown(document.body, { shiftKey: true });
       fireEvent.pointerDown(screen.getByLabelText('Increase'));
       expect(input).to.have.value('20');
     });
 
-    it('should decrement the value by the default `largeStep` prop of 10 while holding the shift key', () => {
-      render(<NumberField defaultValue={6} />);
+    it('should decrement the value by the default `largeStep` prop of 10 while holding the shift key', async () => {
+      await render(<NumberField defaultValue={6} />);
       const input = screen.getByRole('textbox');
       fireEvent.keyDown(document.body, { shiftKey: true });
       fireEvent.pointerDown(screen.getByLabelText('Decrease'));
       expect(input).to.have.value('0');
     });
 
-    it('should use explicit `largeStep` value if provided while holding the shift key', () => {
-      render(<NumberField defaultValue={5} largeStep={5} />);
+    it('should use explicit `largeStep` value if provided while holding the shift key', async () => {
+      await render(<NumberField defaultValue={5} largeStep={5} />);
       const input = screen.getByRole('textbox');
       fireEvent.keyDown(document.body, { shiftKey: true });
       fireEvent.pointerDown(screen.getByLabelText('Increase'));
       expect(input).to.have.value('10');
     });
 
-    it('should not use the `largeStep` prop if no longer holding the shift key', () => {
-      render(<NumberField defaultValue={5} largeStep={5} />);
+    it('should not use the `largeStep` prop if no longer holding the shift key', async () => {
+      await render(<NumberField defaultValue={5} largeStep={5} />);
       const input = screen.getByRole('textbox');
       fireEvent.keyDown(document.body, { shiftKey: true });
       fireEvent.pointerDown(screen.getByLabelText('Increase'));
@@ -367,32 +367,32 @@ describe('<NumberField />', () => {
   });
 
   describe('prop: smallStep', () => {
-    it('should increment the value by the default `smallStep` prop of 0.1 while holding the alt key', () => {
-      render(<NumberField defaultValue={5} />);
+    it('should increment the value by the default `smallStep` prop of 0.1 while holding the alt key', async () => {
+      await render(<NumberField defaultValue={5} />);
       const input = screen.getByRole('textbox');
       fireEvent.keyDown(document.body, { altKey: true });
       fireEvent.pointerDown(screen.getByLabelText('Increase'));
       expect(input).to.have.value((5.1).toLocaleString());
     });
 
-    it('should decrement the value by the default `smallStep` prop of 0.1 while holding the alt key', () => {
-      render(<NumberField defaultValue={6} />);
+    it('should decrement the value by the default `smallStep` prop of 0.1 while holding the alt key', async () => {
+      await render(<NumberField defaultValue={6} />);
       const input = screen.getByRole('textbox');
       fireEvent.keyDown(document.body, { altKey: true });
       fireEvent.pointerDown(screen.getByLabelText('Decrease'));
       expect(input).to.have.value((5.9).toLocaleString());
     });
 
-    it('should use explicit `smallStep` value if provided while holding the alt key', () => {
-      render(<NumberField defaultValue={5} smallStep={0.5} />);
+    it('should use explicit `smallStep` value if provided while holding the alt key', async () => {
+      await render(<NumberField defaultValue={5} smallStep={0.5} />);
       const input = screen.getByRole('textbox');
       fireEvent.keyDown(document.body, { altKey: true });
       fireEvent.pointerDown(screen.getByLabelText('Increase'));
       expect(input).to.have.value((5.5).toLocaleString());
     });
 
-    it('should not use the `smallStep` prop if no longer holding the alt key', () => {
-      render(<NumberField defaultValue={5} smallStep={0.5} />);
+    it('should not use the `smallStep` prop if no longer holding the alt key', async () => {
+      await render(<NumberField defaultValue={5} smallStep={0.5} />);
       const input = screen.getByRole('textbox');
       const button = screen.getByLabelText('Increase');
       fireEvent.keyDown(document.body, { altKey: true });
@@ -405,8 +405,10 @@ describe('<NumberField />', () => {
   });
 
   describe('prop: format', () => {
-    it('should format the value using the provided options', () => {
-      render(<NumberField defaultValue={1000} format={{ style: 'currency', currency: 'USD' }} />);
+    it('should format the value using the provided options', async () => {
+      await render(
+        <NumberField defaultValue={1000} format={{ style: 'currency', currency: 'USD' }} />,
+      );
       const input = screen.getByRole('textbox');
       const expectedValue = new Intl.NumberFormat(undefined, {
         style: 'currency',
@@ -418,7 +420,7 @@ describe('<NumberField />', () => {
 
   describe('prop: allowWheelScrub', () => {
     it('should allow the user to scrub the input value with the mouse wheel', async () => {
-      render(<NumberField defaultValue={5} allowWheelScrub />);
+      await render(<NumberField defaultValue={5} allowWheelScrub />);
       const input = screen.getByRole('textbox');
       await act(() => input.focus());
       fireEvent.wheel(input, { deltaY: 1 });
@@ -428,7 +430,7 @@ describe('<NumberField />', () => {
     });
 
     it('should not allow the user to scrub the input value with the mouse wheel if `allowWheelScrub` is `false`', async () => {
-      render(<NumberField defaultValue={5} allowWheelScrub={false} />);
+      await render(<NumberField defaultValue={5} allowWheelScrub={false} />);
       const input = screen.getByRole('textbox');
       await act(() => input.focus());
       fireEvent.wheel(input, { deltaY: 1 });
@@ -447,7 +449,7 @@ describe('<NumberField />', () => {
 
       let stringifiedFormData = '';
 
-      render(
+      await render(
         <form
           onSubmit={(event) => {
             event.preventDefault();
@@ -478,8 +480,8 @@ describe('<NumberField />', () => {
   });
 
   describe('inputMode', () => {
-    it('should set the inputMode to numeric', () => {
-      render(<NumberField />);
+    it('should set the inputMode to numeric', async () => {
+      await render(<NumberField />);
       const input = screen.getByRole('textbox');
       expect(input).to.have.attribute('inputmode', 'numeric');
     });
@@ -491,8 +493,8 @@ describe('<NumberField />', () => {
       return;
     }
 
-    it('should allow pasting a valid number', () => {
-      render(<NumberField />);
+    it('should allow pasting a valid number', async () => {
+      await render(<NumberField />);
       const input = screen.getByRole('textbox');
 
       const dataTransfer = new DataTransfer();
@@ -503,8 +505,8 @@ describe('<NumberField />', () => {
       expect(input).to.have.value('123');
     });
 
-    it('should not allow pasting an invalid number', () => {
-      render(<NumberField />);
+    it('should not allow pasting an invalid number', async () => {
+      await render(<NumberField />);
       const input = screen.getByRole('textbox');
 
       const dataTransfer = new DataTransfer();
@@ -518,8 +520,8 @@ describe('<NumberField />', () => {
     });
   });
 
-  it('should allow navigation keys and not prevent their default behavior', () => {
-    render(<NumberField />);
+  it('should allow navigation keys and not prevent their default behavior', async () => {
+    await render(<NumberField />);
     const input = screen.getByRole('textbox') as HTMLInputElement;
     input.focus();
     fireEvent.change(input, { target: { value: '123' } });

--- a/packages/mui-base/src/NumberField/Root/NumberFieldRoot.test.tsx
+++ b/packages/mui-base/src/NumberField/Root/NumberFieldRoot.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, screen, fireEvent } from '@mui/internal-test-utils';
 import * as NumberFieldBase from '@base_ui/react/NumberField';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<NumberField />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/NumberField/Root/NumberFieldRoot.test.tsx
+++ b/packages/mui-base/src/NumberField/Root/NumberFieldRoot.test.tsx
@@ -9,7 +9,6 @@ describe('<NumberField />', () => {
   const { render } = createRenderer();
 
   describeConformance(<NumberFieldBase.Root />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render,
   }));
@@ -418,20 +417,20 @@ describe('<NumberField />', () => {
   });
 
   describe('prop: allowWheelScrub', () => {
-    it('should allow the user to scrub the input value with the mouse wheel', () => {
+    it('should allow the user to scrub the input value with the mouse wheel', async () => {
       render(<NumberField defaultValue={5} allowWheelScrub />);
       const input = screen.getByRole('textbox');
-      act(() => input.focus());
+      await act(() => input.focus());
       fireEvent.wheel(input, { deltaY: 1 });
       expect(input).to.have.value('4');
       fireEvent.wheel(input, { deltaY: -1 });
       expect(input).to.have.value('5');
     });
 
-    it('should not allow the user to scrub the input value with the mouse wheel if `allowWheelScrub` is `false`', () => {
+    it('should not allow the user to scrub the input value with the mouse wheel if `allowWheelScrub` is `false`', async () => {
       render(<NumberField defaultValue={5} allowWheelScrub={false} />);
       const input = screen.getByRole('textbox');
-      act(() => input.focus());
+      await act(() => input.focus());
       fireEvent.wheel(input, { deltaY: 1 });
       expect(input).to.have.value('5');
       fireEvent.wheel(input, { deltaY: -5 });
@@ -440,7 +439,7 @@ describe('<NumberField />', () => {
   });
 
   describe('form handling', () => {
-    it('should include the input value in the form submission', function test() {
+    it('should include the input value in the form submission', async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // FormData is not available in JSDOM
         this.skip();
@@ -466,13 +465,13 @@ describe('<NumberField />', () => {
       const numberField = screen.getByRole('textbox');
       const submitButton = screen.getByTestId('submit');
 
-      act(() => submitButton.click());
+      await act(() => submitButton.click());
 
       expect(stringifiedFormData).to.equal('test-number-field=');
 
       fireEvent.change(numberField, { target: { value: '5' } });
 
-      act(() => submitButton.click());
+      await act(() => submitButton.click());
 
       expect(stringifiedFormData).to.equal('test-number-field=5');
     });

--- a/packages/mui-base/src/NumberField/ScrubArea/NumberFieldScrubArea.test.tsx
+++ b/packages/mui-base/src/NumberField/ScrubArea/NumberFieldScrubArea.test.tsx
@@ -3,8 +3,8 @@ import { expect } from 'chai';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
-import { isWebKit } from '../../utils/detectBrowser';
 import { createRenderer, describeConformance } from '#test-utils';
+import { isWebKit } from '../../utils/detectBrowser';
 
 function createPointerMoveEvent({ movementX = 0, movementY = 0 }) {
   return new PointerEvent('pointermove', {

--- a/packages/mui-base/src/NumberField/ScrubArea/NumberFieldScrubArea.test.tsx
+++ b/packages/mui-base/src/NumberField/ScrubArea/NumberFieldScrubArea.test.tsx
@@ -29,7 +29,6 @@ describe('<NumberField.ScrubArea />', () => {
   const { render } = createRenderer();
 
   describeConformance(<NumberField.ScrubArea />, () => ({
-    inheritComponent: 'span',
     refInstanceof: window.HTMLSpanElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/NumberField/ScrubArea/NumberFieldScrubArea.test.tsx
+++ b/packages/mui-base/src/NumberField/ScrubArea/NumberFieldScrubArea.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, screen, waitFor } from '@mui/internal-test-utils';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
 import { isWebKit } from '../../utils/detectBrowser';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 function createPointerMoveEvent({ movementX = 0, movementY = 0 }) {
   return new PointerEvent('pointermove', {
@@ -37,8 +37,8 @@ describe('<NumberField.ScrubArea />', () => {
     },
   }));
 
-  it('has presentation role', () => {
-    render(
+  it('has presentation role', async () => {
+    await render(
       <NumberField.Root>
         <NumberField.ScrubArea />
       </NumberField.Root>,
@@ -59,7 +59,7 @@ describe('<NumberField.ScrubArea />', () => {
   });
 
   it('should increment or decrement the value when scrubbing with the pointer', async () => {
-    render(
+    await render(
       <NumberField.Root defaultValue={0}>
         <NumberField.Input />
         <NumberField.ScrubArea data-testid="scrub-area">
@@ -87,7 +87,7 @@ describe('<NumberField.ScrubArea />', () => {
 
   describe('prop: pixelSensitivity', () => {
     it('should only increment if the pointer movement was greater than or equal to the value', async () => {
-      render(
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Input />
           <NumberField.ScrubArea data-testid="scrub-area" pixelSensitivity={5}>
@@ -139,7 +139,7 @@ describe('<NumberField.ScrubArea />', () => {
 
   describe('prop: direction', () => {
     it('should only scrub if the pointer moved in the given direction', async () => {
-      render(
+      await render(
         <NumberField.Root defaultValue={0}>
           <NumberField.Input />
           <NumberField.ScrubArea data-testid="scrub-area" direction="horizontal">

--- a/packages/mui-base/src/NumberField/ScrubArea/NumberFieldScrubArea.test.tsx
+++ b/packages/mui-base/src/NumberField/ScrubArea/NumberFieldScrubArea.test.tsx
@@ -4,7 +4,7 @@ import { screen, waitFor } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
 import { isWebKit } from '../../utils/detectBrowser';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 function createPointerMoveEvent({ movementX = 0, movementY = 0 }) {
   return new PointerEvent('pointermove', {

--- a/packages/mui-base/src/NumberField/ScrubAreaCursor/NumberFieldScrubAreaCursor.test.tsx
+++ b/packages/mui-base/src/NumberField/ScrubAreaCursor/NumberFieldScrubAreaCursor.test.tsx
@@ -27,7 +27,6 @@ describe('<NumberField.ScrubAreaCursor />', () => {
   }
 
   describeConformance(<NumberField.ScrubAreaCursor />, () => ({
-    inheritComponent: 'span',
     refInstanceof: window.HTMLSpanElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/NumberField/ScrubAreaCursor/NumberFieldScrubAreaCursor.test.tsx
+++ b/packages/mui-base/src/NumberField/ScrubAreaCursor/NumberFieldScrubAreaCursor.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, screen } from '@mui/internal-test-utils';
+import { screen } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
 import { isWebKit } from '../../utils/detectBrowser';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const testContext = {
   getScrubAreaCursorProps: (externalProps) => externalProps,
@@ -35,8 +35,8 @@ describe('<NumberField.ScrubAreaCursor />', () => {
     },
   }));
 
-  it('has presentation role', () => {
-    render(
+  it('has presentation role', async () => {
+    await render(
       <NumberField.Root>
         <NumberField.ScrubArea />
       </NumberField.Root>,

--- a/packages/mui-base/src/NumberField/ScrubAreaCursor/NumberFieldScrubAreaCursor.test.tsx
+++ b/packages/mui-base/src/NumberField/ScrubAreaCursor/NumberFieldScrubAreaCursor.test.tsx
@@ -3,8 +3,8 @@ import { expect } from 'chai';
 import { screen } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
-import { isWebKit } from '../../utils/detectBrowser';
 import { createRenderer, describeConformance } from '#test-utils';
+import { isWebKit } from '../../utils/detectBrowser';
 
 const testContext = {
   getScrubAreaCursorProps: (externalProps) => externalProps,

--- a/packages/mui-base/src/NumberField/ScrubAreaCursor/NumberFieldScrubAreaCursor.test.tsx
+++ b/packages/mui-base/src/NumberField/ScrubAreaCursor/NumberFieldScrubAreaCursor.test.tsx
@@ -4,7 +4,7 @@ import { screen } from '@mui/internal-test-utils';
 import * as NumberField from '@base_ui/react/NumberField';
 import { NumberFieldContext, type NumberFieldContextValue } from '@base_ui/react/NumberField';
 import { isWebKit } from '../../utils/detectBrowser';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const testContext = {
   getScrubAreaCursorProps: (externalProps) => externalProps,

--- a/packages/mui-base/src/Popover/Arrow/PopoverArrow.test.tsx
+++ b/packages/mui-base/src/Popover/Arrow/PopoverArrow.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
-import { describeConformance } from '../../../test/describeConformance';
-import { createRenderer } from '../../../test';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Popover.Arrow />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Arrow/PopoverArrow.test.tsx
+++ b/packages/mui-base/src/Popover/Arrow/PopoverArrow.test.tsx
@@ -7,7 +7,6 @@ describe('<Popover.Arrow />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Popover.Arrow />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/Popover/Arrow/PopoverArrow.test.tsx
+++ b/packages/mui-base/src/Popover/Arrow/PopoverArrow.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Popover.Arrow />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Backdrop/PopoverBackdrop.test.tsx
+++ b/packages/mui-base/src/Popover/Backdrop/PopoverBackdrop.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Popover.Backdrop />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Backdrop/PopoverBackdrop.test.tsx
+++ b/packages/mui-base/src/Popover/Backdrop/PopoverBackdrop.test.tsx
@@ -7,7 +7,6 @@ describe('<Popover.Backdrop />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Popover.Backdrop />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/Popover/Backdrop/PopoverBackdrop.test.tsx
+++ b/packages/mui-base/src/Popover/Backdrop/PopoverBackdrop.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
-import { describeConformance } from '../../../test/describeConformance';
-import { createRenderer } from '../../../test';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Popover.Backdrop />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Close/PopoverClose.test.tsx
+++ b/packages/mui-base/src/Popover/Close/PopoverClose.test.tsx
@@ -9,7 +9,6 @@ describe('<Popover.Close />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Popover.Close />, () => ({
-    inheritComponent: 'button',
     refInstanceof: window.HTMLButtonElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/Popover/Close/PopoverClose.test.tsx
+++ b/packages/mui-base/src/Popover/Close/PopoverClose.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
 import { fireEvent, screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Popover.Close />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Close/PopoverClose.test.tsx
+++ b/packages/mui-base/src/Popover/Close/PopoverClose.test.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
 import { fireEvent, screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { createRenderer } from '../../../test';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Popover.Close />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Description/PopoverDescription.test.tsx
+++ b/packages/mui-base/src/Popover/Description/PopoverDescription.test.tsx
@@ -9,7 +9,6 @@ describe('<Popover.Description />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Popover.Description />, () => ({
-    inheritComponent: 'p',
     refInstanceof: window.HTMLParagraphElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/Popover/Description/PopoverDescription.test.tsx
+++ b/packages/mui-base/src/Popover/Description/PopoverDescription.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
 import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Popover.Description />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Description/PopoverDescription.test.tsx
+++ b/packages/mui-base/src/Popover/Description/PopoverDescription.test.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
 import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { describeConformance } from '../../../test/describeConformance';
-import { createRenderer } from '../../../test';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Popover.Description />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Popup/PopoverPopup.test.tsx
+++ b/packages/mui-base/src/Popover/Popup/PopoverPopup.test.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
 import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { describeConformance } from '../../../test/describeConformance';
-import { createRenderer } from '../../../test';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Popover.Popup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Popup/PopoverPopup.test.tsx
+++ b/packages/mui-base/src/Popover/Popup/PopoverPopup.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
 import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Popover.Popup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Popup/PopoverPopup.test.tsx
+++ b/packages/mui-base/src/Popover/Popup/PopoverPopup.test.tsx
@@ -9,7 +9,6 @@ describe('<Popover.Popup />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Popover.Popup />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/Popover/Positioner/PopoverPositioner.test.tsx
+++ b/packages/mui-base/src/Popover/Positioner/PopoverPositioner.test.tsx
@@ -7,7 +7,6 @@ describe('<Popover.Positioner />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Popover.Positioner />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/Popover/Positioner/PopoverPositioner.test.tsx
+++ b/packages/mui-base/src/Popover/Positioner/PopoverPositioner.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
-import { createRenderer } from '../../../test';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Popover.Positioner />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Positioner/PopoverPositioner.test.tsx
+++ b/packages/mui-base/src/Popover/Positioner/PopoverPositioner.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Popover.Positioner />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Root/PopoverRoot.test.tsx
+++ b/packages/mui-base/src/Popover/Root/PopoverRoot.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-
 import userEvent from '@testing-library/user-event';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer } from '../../../test';
+import { createRenderer } from '#test-utils';
 import { OPEN_DELAY } from '../utils/constants';
 
 const user = userEvent.setup();

--- a/packages/mui-base/src/Popover/Title/PopoverTitle.test.tsx
+++ b/packages/mui-base/src/Popover/Title/PopoverTitle.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
 import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Popover.Title />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Title/PopoverTitle.test.tsx
+++ b/packages/mui-base/src/Popover/Title/PopoverTitle.test.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
 import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { describeConformance } from '../../../test/describeConformance';
-import { createRenderer } from '../../../test';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Popover.Title />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Title/PopoverTitle.test.tsx
+++ b/packages/mui-base/src/Popover/Title/PopoverTitle.test.tsx
@@ -9,7 +9,6 @@ describe('<Popover.Title />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Popover.Title />, () => ({
-    inheritComponent: 'h2',
     refInstanceof: window.HTMLHeadingElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/Popover/Trigger/PopoverTrigger.test.tsx
+++ b/packages/mui-base/src/Popover/Trigger/PopoverTrigger.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
-import { describeConformance } from '../../../test/describeConformance';
-import { createRenderer } from '../../../test';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Popover.Trigger />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Popover/Trigger/PopoverTrigger.test.tsx
+++ b/packages/mui-base/src/Popover/Trigger/PopoverTrigger.test.tsx
@@ -7,7 +7,6 @@ describe('<Popover.Trigger />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Popover.Trigger />, () => ({
-    inheritComponent: 'button',
     refInstanceof: window.HTMLButtonElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/Popover/Trigger/PopoverTrigger.test.tsx
+++ b/packages/mui-base/src/Popover/Trigger/PopoverTrigger.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Popover from '@base_ui/react/Popover';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Popover.Trigger />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/PreviewCard/Arrow/PreviewCardArrow.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Arrow/PreviewCardArrow.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PreviewCard from '@base_ui/react/PreviewCard';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<PreviewCard.Arrow />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/PreviewCard/Arrow/PreviewCardArrow.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Arrow/PreviewCardArrow.test.tsx
@@ -7,7 +7,6 @@ describe('<PreviewCard.Arrow />', () => {
   const { render } = createRenderer();
 
   describeConformance(<PreviewCard.Arrow />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/PreviewCard/Arrow/PreviewCardArrow.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Arrow/PreviewCardArrow.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as PreviewCard from '@base_ui/react/PreviewCard';
-import { describeConformance } from '../../../test/describeConformance';
-import { createRenderer } from '../../../test';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<PreviewCard.Arrow />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/PreviewCard/Backdrop/PreviewCardBackdrop.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Backdrop/PreviewCardBackdrop.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PreviewCard from '@base_ui/react/PreviewCard';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<PreviewCard.Backdrop />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/PreviewCard/Backdrop/PreviewCardBackdrop.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Backdrop/PreviewCardBackdrop.test.tsx
@@ -7,7 +7,6 @@ describe('<PreviewCard.Backdrop />', () => {
   const { render } = createRenderer();
 
   describeConformance(<PreviewCard.Backdrop />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/PreviewCard/Backdrop/PreviewCardBackdrop.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Backdrop/PreviewCardBackdrop.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as PreviewCard from '@base_ui/react/PreviewCard';
-import { describeConformance } from '../../../test/describeConformance';
-import { createRenderer } from '../../../test';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<PreviewCard.Backdrop />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/PreviewCard/Popup/PreviewCardPopup.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Popup/PreviewCardPopup.test.tsx
@@ -9,7 +9,6 @@ describe('<Popover.Popup />', () => {
   const { render } = createRenderer();
 
   describeConformance(<PreviewCard.Popup />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/PreviewCard/Popup/PreviewCardPopup.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Popup/PreviewCardPopup.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PreviewCard from '@base_ui/react/PreviewCard';
 import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Popover.Popup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/PreviewCard/Popup/PreviewCardPopup.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Popup/PreviewCardPopup.test.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import * as PreviewCard from '@base_ui/react/PreviewCard';
 import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { describeConformance } from '../../../test/describeConformance';
-import { createRenderer } from '../../../test';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Popover.Popup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/PreviewCard/Positioner/PreviewCardPositioner.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Positioner/PreviewCardPositioner.test.tsx
@@ -7,7 +7,6 @@ describe('<PreviewCard.Positioner />', () => {
   const { render } = createRenderer();
 
   describeConformance(<PreviewCard.Positioner />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/PreviewCard/Positioner/PreviewCardPositioner.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Positioner/PreviewCardPositioner.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PreviewCard from '@base_ui/react/PreviewCard';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<PreviewCard.Positioner />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/PreviewCard/Positioner/PreviewCardPositioner.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Positioner/PreviewCardPositioner.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as PreviewCard from '@base_ui/react/PreviewCard';
-import { createRenderer } from '../../../test';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<PreviewCard.Positioner />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
@@ -3,8 +3,8 @@ import * as PreviewCard from '@base_ui/react/PreviewCard';
 import { act, fireEvent, screen, flushMicrotasks } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { CLOSE_DELAY, OPEN_DELAY } from '../utils/constants';
 import { createRenderer } from '#test-utils';
+import { CLOSE_DELAY, OPEN_DELAY } from '../utils/constants';
 
 function Root(props: PreviewCard.RootProps) {
   return <PreviewCard.Root animated={false} {...props} />;

--- a/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
@@ -112,15 +112,11 @@ describe('<PreviewCard.Root />', () => {
 
       const trigger = screen.getByRole('link');
 
-      await act(() => trigger.focus());
-
+      await act(async () => trigger.focus());
       clock.tick(OPEN_DELAY);
+      await flushMicrotasks();
 
-      await act(async () => {});
-      // flushMicrotasks();
-
-      await act(() => trigger.blur());
-
+      await act(async () => trigger.blur());
       clock.tick(CLOSE_DELAY);
 
       expect(screen.queryByText('Content')).to.equal(null);

--- a/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
@@ -100,7 +100,7 @@ describe('<PreviewCard.Root />', () => {
       expect(screen.getByText('Content')).not.to.equal(null);
     });
 
-    it.only('should close when the trigger is blurred', async () => {
+    it('should close when the trigger is blurred', async () => {
       await render(
         <Root>
           <Trigger />

--- a/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
@@ -91,7 +91,7 @@ describe('<PreviewCard.Root />', () => {
 
       const trigger = screen.getByRole('link');
 
-      act(() => trigger.focus());
+      await act(() => trigger.focus());
 
       clock.tick(OPEN_DELAY);
 
@@ -100,7 +100,7 @@ describe('<PreviewCard.Root />', () => {
       expect(screen.getByText('Content')).not.to.equal(null);
     });
 
-    it('should close when the trigger is blurred', async () => {
+    it.only('should close when the trigger is blurred', async () => {
       await render(
         <Root>
           <Trigger />
@@ -112,13 +112,14 @@ describe('<PreviewCard.Root />', () => {
 
       const trigger = screen.getByRole('link');
 
-      act(() => trigger.focus());
+      await act(() => trigger.focus());
 
       clock.tick(OPEN_DELAY);
 
-      await flushMicrotasks();
+      await act(async () => {});
+      // flushMicrotasks();
 
-      act(() => trigger.blur());
+      await act(() => trigger.blur());
 
       clock.tick(CLOSE_DELAY);
 

--- a/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, screen, flushMicrotasks } from '@mui/internal-test-util
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { CLOSE_DELAY, OPEN_DELAY } from '../utils/constants';
-import { createRenderer } from '../../../test';
+import { createRenderer } from '#test-utils';
 
 function Root(props: PreviewCard.RootProps) {
   return <PreviewCard.Root animated={false} {...props} />;

--- a/packages/mui-base/src/PreviewCard/Trigger/PreviewCardTrigger.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Trigger/PreviewCardTrigger.test.tsx
@@ -7,7 +7,6 @@ describe('<PreviewCard.Trigger />', () => {
   const { render } = createRenderer();
 
   describeConformance(<PreviewCard.Trigger />, () => ({
-    inheritComponent: 'a',
     refInstanceof: window.HTMLAnchorElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/PreviewCard/Trigger/PreviewCardTrigger.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Trigger/PreviewCardTrigger.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as PreviewCard from '@base_ui/react/PreviewCard';
-import { describeConformance } from '../../../test/describeConformance';
-import { createRenderer } from '../../../test';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<PreviewCard.Trigger />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/PreviewCard/Trigger/PreviewCardTrigger.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Trigger/PreviewCardTrigger.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PreviewCard from '@base_ui/react/PreviewCard';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<PreviewCard.Trigger />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Progress/Indicator/ProgressIndicator.test.tsx
+++ b/packages/mui-base/src/Progress/Indicator/ProgressIndicator.test.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Progress from '@base_ui/react/Progress';
 import { ProgressContext } from '@base_ui/react/Progress';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 import type { ProgressContextValue } from '../Root/ProgressRoot.types';
 
 const contextValue: ProgressContextValue = {
@@ -24,22 +23,20 @@ describe('<Progress.Indicator />', () => {
 
   describeConformance(<Progress.Indicator />, () => ({
     render: (node) => {
-      const { container, ...other } = render(
+      return render(
         <ProgressContext.Provider value={contextValue}>{node}</ProgressContext.Provider>,
       );
-
-      return { container, ...other };
     },
     refInstanceof: window.HTMLSpanElement,
   }));
 
   describe('internal styles', () => {
-    it('determinate', function test() {
+    it('determinate', async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
 
-      const { getByTestId } = render(
+      const { getByTestId } = await render(
         <Progress.Root value={33}>
           <Progress.Track>
             <Progress.Indicator data-testid="indicator" />
@@ -55,12 +52,12 @@ describe('<Progress.Indicator />', () => {
       });
     });
 
-    it('indeterminate', function test() {
+    it('indeterminate', async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
 
-      const { getByTestId } = render(
+      const { getByTestId } = await render(
         <Progress.Root value={null}>
           <Progress.Track>
             <Progress.Indicator data-testid="indicator" />

--- a/packages/mui-base/src/Progress/Indicator/ProgressIndicator.test.tsx
+++ b/packages/mui-base/src/Progress/Indicator/ProgressIndicator.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import * as Progress from '@base_ui/react/Progress';
 import { ProgressContext } from '@base_ui/react/Progress';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 import type { ProgressContextValue } from '../Root/ProgressRoot.types';
 
 const contextValue: ProgressContextValue = {

--- a/packages/mui-base/src/Progress/Indicator/ProgressIndicator.test.tsx
+++ b/packages/mui-base/src/Progress/Indicator/ProgressIndicator.test.tsx
@@ -23,7 +23,6 @@ describe('<Progress.Indicator />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Progress.Indicator />, () => ({
-    inheritComponent: 'span',
     render: (node) => {
       const { container, ...other } = render(
         <ProgressContext.Provider value={contextValue}>{node}</ProgressContext.Provider>,

--- a/packages/mui-base/src/Progress/Root/ProgressRoot.test.tsx
+++ b/packages/mui-base/src/Progress/Root/ProgressRoot.test.tsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as React from 'react';
 import * as Progress from '@base_ui/react/Progress';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 import type { ProgressRootProps } from './ProgressRoot.types';
 
 function TestProgress(props: ProgressRootProps) {

--- a/packages/mui-base/src/Progress/Root/ProgressRoot.test.tsx
+++ b/packages/mui-base/src/Progress/Root/ProgressRoot.test.tsx
@@ -19,7 +19,6 @@ describe('<Progress.Root />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Progress.Root value={50} />, () => ({
-    inheritComponent: 'div',
     render,
     refInstanceof: window.HTMLDivElement,
   }));

--- a/packages/mui-base/src/Progress/Root/ProgressRoot.test.tsx
+++ b/packages/mui-base/src/Progress/Root/ProgressRoot.test.tsx
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Progress from '@base_ui/react/Progress';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 import type { ProgressRootProps } from './ProgressRoot.types';
 
 function TestProgress(props: ProgressRootProps) {
@@ -23,8 +22,8 @@ describe('<Progress.Root />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
-  it('renders a progressbar', () => {
-    const { getByRole } = render(
+  it('renders a progressbar', async () => {
+    const { getByRole } = await render(
       <Progress.Root value={30}>
         <Progress.Track>
           <Progress.Indicator />
@@ -36,8 +35,8 @@ describe('<Progress.Root />', () => {
   });
 
   describe('ARIA attributes', () => {
-    it('sets the correct aria attributes', () => {
-      const { getByRole } = render(
+    it('sets the correct aria attributes', async () => {
+      const { getByRole } = await render(
         <Progress.Root value={30}>
           <Progress.Track>
             <Progress.Indicator />
@@ -53,8 +52,8 @@ describe('<Progress.Root />', () => {
       expect(progressbar).to.have.attribute('aria-valuetext', '30%');
     });
 
-    it('should update aria-valuenow when value changes', () => {
-      const { getByRole, setProps } = render(<TestProgress value={50} />);
+    it('should update aria-valuenow when value changes', async () => {
+      const { getByRole, setProps } = await render(<TestProgress value={50} />);
       const progressbar = getByRole('progressbar');
       setProps({ value: 77 });
       expect(progressbar).to.have.attribute('aria-valuenow', '77');

--- a/packages/mui-base/src/Progress/Track/ProgressTrack.test.tsx
+++ b/packages/mui-base/src/Progress/Track/ProgressTrack.test.tsx
@@ -22,7 +22,6 @@ describe('<Progress.Track />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Progress.Track />, () => ({
-    inheritComponent: 'span',
     render: (node) => {
       const { container, ...other } = render(
         <ProgressContext.Provider value={contextValue}>{node}</ProgressContext.Provider>,

--- a/packages/mui-base/src/Progress/Track/ProgressTrack.test.tsx
+++ b/packages/mui-base/src/Progress/Track/ProgressTrack.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Progress from '@base_ui/react/Progress';
 import { ProgressContext } from '@base_ui/react/Progress';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 import type { ProgressContextValue } from '../Root/ProgressRoot.types';
 
 const contextValue: ProgressContextValue = {
@@ -23,11 +22,9 @@ describe('<Progress.Track />', () => {
 
   describeConformance(<Progress.Track />, () => ({
     render: (node) => {
-      const { container, ...other } = render(
+      return render(
         <ProgressContext.Provider value={contextValue}>{node}</ProgressContext.Provider>,
       );
-
-      return { container, ...other };
     },
     refInstanceof: window.HTMLSpanElement,
   }));

--- a/packages/mui-base/src/Progress/Track/ProgressTrack.test.tsx
+++ b/packages/mui-base/src/Progress/Track/ProgressTrack.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Progress from '@base_ui/react/Progress';
 import { ProgressContext } from '@base_ui/react/Progress';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 import type { ProgressContextValue } from '../Root/ProgressRoot.types';
 
 const contextValue: ProgressContextValue = {

--- a/packages/mui-base/src/Slider/Control/SliderControl.test.tsx
+++ b/packages/mui-base/src/Slider/Control/SliderControl.test.tsx
@@ -56,7 +56,6 @@ describe('<Slider.Control />', () => {
   };
 
   describeConformance(<Slider.Control />, () => ({
-    inheritComponent: 'span',
     render: (node) => {
       const { container, ...other } = render(
         <SliderProvider value={testProviderValue}>{node}</SliderProvider>,

--- a/packages/mui-base/src/Slider/Control/SliderControl.test.tsx
+++ b/packages/mui-base/src/Slider/Control/SliderControl.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Slider from '@base_ui/react/Slider';
 import { SliderProvider, type SliderProviderValue } from '@base_ui/react/Slider';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const NOOP = () => {};
 
@@ -57,11 +56,7 @@ describe('<Slider.Control />', () => {
 
   describeConformance(<Slider.Control />, () => ({
     render: (node) => {
-      const { container, ...other } = render(
-        <SliderProvider value={testProviderValue}>{node}</SliderProvider>,
-      );
-
-      return { container, ...other };
+      return render(<SliderProvider value={testProviderValue}>{node}</SliderProvider>);
     },
     refInstanceof: window.HTMLSpanElement,
   }));

--- a/packages/mui-base/src/Slider/Control/SliderControl.test.tsx
+++ b/packages/mui-base/src/Slider/Control/SliderControl.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Slider from '@base_ui/react/Slider';
 import { SliderProvider, type SliderProviderValue } from '@base_ui/react/Slider';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const NOOP = () => {};
 

--- a/packages/mui-base/src/Slider/Indicator/SliderIndicator.test.tsx
+++ b/packages/mui-base/src/Slider/Indicator/SliderIndicator.test.tsx
@@ -56,7 +56,6 @@ describe('<Slider.Indicator />', () => {
   };
 
   describeConformance(<Slider.Indicator />, () => ({
-    inheritComponent: 'span',
     render: (node) => {
       const { container, ...other } = render(
         <SliderProvider value={testProviderValue}>{node}</SliderProvider>,

--- a/packages/mui-base/src/Slider/Indicator/SliderIndicator.test.tsx
+++ b/packages/mui-base/src/Slider/Indicator/SliderIndicator.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Slider from '@base_ui/react/Slider';
 import { SliderProvider, type SliderProviderValue } from '@base_ui/react/Slider';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const NOOP = () => {};
 
@@ -57,11 +56,7 @@ describe('<Slider.Indicator />', () => {
 
   describeConformance(<Slider.Indicator />, () => ({
     render: (node) => {
-      const { container, ...other } = render(
-        <SliderProvider value={testProviderValue}>{node}</SliderProvider>,
-      );
-
-      return { container, ...other };
+      return render(<SliderProvider value={testProviderValue}>{node}</SliderProvider>);
     },
     refInstanceof: window.HTMLSpanElement,
   }));

--- a/packages/mui-base/src/Slider/Indicator/SliderIndicator.test.tsx
+++ b/packages/mui-base/src/Slider/Indicator/SliderIndicator.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Slider from '@base_ui/react/Slider';
 import { SliderProvider, type SliderProviderValue } from '@base_ui/react/Slider';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const NOOP = () => {};
 

--- a/packages/mui-base/src/Slider/Output/SliderOutput.test.tsx
+++ b/packages/mui-base/src/Slider/Output/SliderOutput.test.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Slider from '@base_ui/react/Slider';
 import { SliderProvider, type SliderProviderValue } from '@base_ui/react/Slider';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const NOOP = () => {};
 
@@ -58,17 +57,13 @@ describe('<Slider.Output />', () => {
 
   describeConformance(<Slider.Output />, () => ({
     render: (node) => {
-      const { container, ...other } = render(
-        <SliderProvider value={testProviderValue}>{node}</SliderProvider>,
-      );
-
-      return { container, ...other };
+      return render(<SliderProvider value={testProviderValue}>{node}</SliderProvider>);
     },
     refInstanceof: window.HTMLOutputElement,
   }));
 
-  it('renders a single value', () => {
-    const { getByTestId } = render(
+  it('renders a single value', async () => {
+    const { getByTestId } = await render(
       <Slider.Root defaultValue={40}>
         <Slider.Output data-testid="output" />
       </Slider.Root>,
@@ -78,8 +73,8 @@ describe('<Slider.Output />', () => {
     expect(sliderOutput).to.have.text('40');
   });
 
-  it('renders a range', () => {
-    const { getByTestId } = render(
+  it('renders a range', async () => {
+    const { getByTestId } = await render(
       <Slider.Root defaultValue={[40, 65]}>
         <Slider.Output data-testid="output" />
       </Slider.Root>,
@@ -89,8 +84,8 @@ describe('<Slider.Output />', () => {
     expect(sliderOutput).to.have.text('40 – 65');
   });
 
-  it('renders all thumb values', () => {
-    const { getByTestId } = render(
+  it('renders all thumb values', async () => {
+    const { getByTestId } = await render(
       <Slider.Root defaultValue={[40, 60, 80, 95]}>
         <Slider.Output data-testid="output" />
       </Slider.Root>,

--- a/packages/mui-base/src/Slider/Output/SliderOutput.test.tsx
+++ b/packages/mui-base/src/Slider/Output/SliderOutput.test.tsx
@@ -57,7 +57,6 @@ describe('<Slider.Output />', () => {
   };
 
   describeConformance(<Slider.Output />, () => ({
-    inheritComponent: 'output',
     render: (node) => {
       const { container, ...other } = render(
         <SliderProvider value={testProviderValue}>{node}</SliderProvider>,

--- a/packages/mui-base/src/Slider/Output/SliderOutput.test.tsx
+++ b/packages/mui-base/src/Slider/Output/SliderOutput.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import * as Slider from '@base_ui/react/Slider';
 import { SliderProvider, type SliderProviderValue } from '@base_ui/react/Slider';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const NOOP = () => {};
 

--- a/packages/mui-base/src/Slider/Root/SliderRoot.test.tsx
+++ b/packages/mui-base/src/Slider/Root/SliderRoot.test.tsx
@@ -76,7 +76,6 @@ describe('<Slider.Root />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Slider.Root defaultValue={50} />, () => ({
-    inheritComponent: 'div',
     render,
     refInstanceof: window.HTMLDivElement,
   }));
@@ -143,10 +142,10 @@ describe('<Slider.Root />', () => {
       expect(input).to.have.attribute('aria-valuenow', '30');
     });
 
-    it('should update aria-valuenow', () => {
+    it('should update aria-valuenow', async () => {
       const { getByRole } = render(<TestSlider defaultValue={50} />);
       const slider = getByRole('slider');
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -197,7 +196,7 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.equal(78);
     });
 
-    it('increments on ArrowUp', () => {
+    it('increments on ArrowUp', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
@@ -207,7 +206,7 @@ describe('<Slider.Root />', () => {
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
 
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -220,7 +219,7 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.deep.equal(31);
     });
 
-    it('increments on ArrowLeft', () => {
+    it('increments on ArrowLeft', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
@@ -230,7 +229,7 @@ describe('<Slider.Root />', () => {
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
 
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -243,7 +242,7 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.deep.equal(31);
     });
 
-    it('decrements on ArrowDown', () => {
+    it('decrements on ArrowDown', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
@@ -253,7 +252,7 @@ describe('<Slider.Root />', () => {
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
 
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -266,7 +265,7 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.deep.equal(9);
     });
 
-    it('decrements on ArrowRight', () => {
+    it('decrements on ArrowRight', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
@@ -276,7 +275,7 @@ describe('<Slider.Root />', () => {
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
 
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -459,13 +458,13 @@ describe('<Slider.Root />', () => {
   });
 
   describe('prop: step', () => {
-    it('supports non-integer values', () => {
+    it('supports non-integer values', async () => {
       const { getByRole } = render(
         <TestSlider defaultValue={0.2} min={-100} max={100} step={0.00000001} />,
       );
       const slider = getByRole('slider');
 
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -479,13 +478,13 @@ describe('<Slider.Root />', () => {
       expect(slider).to.have.attribute('aria-valuenow', '1e-7');
     });
 
-    it('should round value to step precision', () => {
+    it('should round value to step precision', async () => {
       const { getByRole, getByTestId } = render(
         <TestSlider defaultValue={0.2} min={0} max={1} step={0.1} />,
       );
       const slider = getByRole('slider');
 
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -494,7 +493,7 @@ describe('<Slider.Root />', () => {
         () => GETBOUNDINGCLIENTRECT_HORIZONTAL_SLIDER_RETURN_VAL,
       );
 
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -518,13 +517,13 @@ describe('<Slider.Root />', () => {
       expect(slider).to.have.attribute('aria-valuenow', '0.4');
     });
 
-    it('should not fail to round value to step precision when step is very small', () => {
+    it('should not fail to round value to step precision when step is very small', async () => {
       const { getByRole, getByTestId } = render(
         <TestSlider defaultValue={0.00000002} min={0} max={0.0000001} step={0.00000001} />,
       );
       const slider = getByRole('slider');
 
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -533,7 +532,7 @@ describe('<Slider.Root />', () => {
         () => GETBOUNDINGCLIENTRECT_HORIZONTAL_SLIDER_RETURN_VAL,
       );
 
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -551,13 +550,13 @@ describe('<Slider.Root />', () => {
       expect(slider).to.have.attribute('aria-valuenow', '8e-8');
     });
 
-    it('should not fail to round value to step precision when step is very small and negative', () => {
+    it('should not fail to round value to step precision when step is very small and negative', async () => {
       const { getByRole, getByTestId } = render(
         <TestSlider defaultValue={-0.00000002} min={-0.0000001} max={0} step={0.00000001} />,
       );
       const slider = getByRole('slider');
 
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -566,7 +565,7 @@ describe('<Slider.Root />', () => {
         () => GETBOUNDINGCLIENTRECT_HORIZONTAL_SLIDER_RETURN_VAL,
       );
 
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -598,13 +597,13 @@ describe('<Slider.Root />', () => {
       expect(slider).to.have.attribute('max', String(MAX));
     });
 
-    it('should not go more than the max', () => {
+    it('should not go more than the max', async () => {
       const { getByRole } = render(
         <TestSlider defaultValue={150} step={100} max={MAX} min={150} />,
       );
 
       const slider = getByRole('slider');
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -612,7 +611,7 @@ describe('<Slider.Root />', () => {
       expect(slider).to.have.attribute('aria-valuenow', String(MAX));
     });
 
-    it('should reach right edge value', () => {
+    it('should reach right edge value', async () => {
       const { getByRole, getByTestId } = render(
         <TestSlider defaultValue={90} min={6} max={108} step={10} />,
       );
@@ -624,7 +623,7 @@ describe('<Slider.Root />', () => {
       );
 
       const slider = getByRole('slider');
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -674,24 +673,24 @@ describe('<Slider.Root />', () => {
       expect(slider).to.have.attribute('min', String(MIN));
     });
 
-    it('should use min as the step origin', () => {
+    it('should use min as the step origin', async () => {
       const { getByRole } = render(
         <TestSlider defaultValue={150} step={100} max={750} min={MIN} />,
       );
       const slider = getByRole('slider');
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
       expect(slider).to.have.attribute('aria-valuenow', String(MIN));
     });
 
-    it('should not go less than the min', () => {
+    it('should not go less than the min', async () => {
       const { getByRole } = render(
         <TestSlider defaultValue={150} step={100} max={750} min={MIN} />,
       );
       const slider = getByRole('slider');
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -701,7 +700,7 @@ describe('<Slider.Root />', () => {
   });
 
   describe('prop: minStepsBetweenValues', () => {
-    it('should enforce a minimum difference between range slider values', () => {
+    it('should enforce a minimum difference between range slider values', async () => {
       const handleValueChange = spy();
 
       const { getByTestId } = render(
@@ -716,7 +715,7 @@ describe('<Slider.Root />', () => {
       const thumbOne = getByTestId('thumb-0');
       const thumbTwo = getByTestId('thumb-1');
 
-      act(() => {
+      await act(() => {
         thumbOne.focus();
       });
 
@@ -726,7 +725,7 @@ describe('<Slider.Root />', () => {
       fireEvent.keyDown(thumbOne, { key: 'ArrowUp' });
       expect(handleValueChange.callCount).to.equal(1);
 
-      act(() => {
+      await act(() => {
         thumbTwo.focus();
       });
 
@@ -741,7 +740,7 @@ describe('<Slider.Root />', () => {
   });
 
   describe('events', () => {
-    it('should call handlers', () => {
+    it('should call handlers', async () => {
       const handleValueChange = spy();
       const handleValueCommitted = spy();
 
@@ -775,7 +774,7 @@ describe('<Slider.Root />', () => {
       expect(handleValueCommitted.callCount).to.equal(1);
       expect(handleValueCommitted.args[0][0]).to.equal(10);
 
-      act(() => {
+      await act(() => {
         slider.focus();
       });
 
@@ -1095,7 +1094,7 @@ describe('<Slider.Root />', () => {
 
   describe('form submission', () => {
     // doesn't work with two `<input type="range" />` elements with the same name attribute
-    it('includes the slider value in formData when the `name` attribute is provided', function test() {
+    it('includes the slider value in formData when the `name` attribute is provided', async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // FormData is not available in JSDOM
         this.skip();
@@ -1119,7 +1118,7 @@ describe('<Slider.Root />', () => {
       );
 
       const button = getByText('Submit');
-      act(() => {
+      await act(() => {
         button.click();
       });
     });
@@ -1232,8 +1231,8 @@ describe('<Slider.Root />', () => {
         // pixel:  0   20  40  60  80  100
         // slider: |---|---|---|---|---|
         // values: 0   1   2   3   4   5
-        // value:      ¡ü   ¡ü
-        // mouse:           ¡ü
+        // value:      ï¿½ï¿½   ï¿½ï¿½
+        // mouse:           ï¿½ï¿½
 
         fireEvent.pointerDown(sliderControl, {
           buttons: 1,
@@ -1246,7 +1245,7 @@ describe('<Slider.Root />', () => {
       });
     });
 
-    it('should pass "name" and "value" as part of the event.target for onValueChange', () => {
+    it('should pass "name" and "value" as part of the event.target for onValueChange', async () => {
       const handleValueChange = stub().callsFake((newValue, thumbIndex, event) => event.target);
 
       const { getByRole } = render(
@@ -1254,7 +1253,7 @@ describe('<Slider.Root />', () => {
       );
       const slider = getByRole('slider');
 
-      act(() => {
+      await act(() => {
         slider.focus();
       });
       fireEvent.change(slider, {
@@ -1273,7 +1272,7 @@ describe('<Slider.Root />', () => {
   });
 
   describe('keyboard interactions', () => {
-    it('increments on ArrowUp', () => {
+    it('increments on ArrowUp', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
@@ -1283,7 +1282,7 @@ describe('<Slider.Root />', () => {
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
 
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -1296,7 +1295,7 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.deep.equal(31);
     });
 
-    it('increments on ArrowRight', () => {
+    it('increments on ArrowRight', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
@@ -1306,7 +1305,7 @@ describe('<Slider.Root />', () => {
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
 
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -1319,7 +1318,7 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.deep.equal(31);
     });
 
-    it('decrements on ArrowDown', () => {
+    it('decrements on ArrowDown', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
@@ -1329,7 +1328,7 @@ describe('<Slider.Root />', () => {
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
 
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -1342,7 +1341,7 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.deep.equal(9);
     });
 
-    it('decrements on ArrowLeft', () => {
+    it('decrements on ArrowLeft', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
@@ -1352,7 +1351,7 @@ describe('<Slider.Root />', () => {
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
 
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -1366,7 +1365,7 @@ describe('<Slider.Root />', () => {
     });
 
     describe('key: Home', () => {
-      it('sets value to max in a single value slider', () => {
+      it('sets value to max in a single value slider', async () => {
         const handleValueChange = spy();
         const { container } = render(
           <TestSlider defaultValue={20} onValueChange={handleValueChange} max={77} />,
@@ -1376,7 +1375,7 @@ describe('<Slider.Root />', () => {
 
         fireEvent.keyDown(document.body, { key: 'TAB' });
 
-        act(() => {
+        await act(() => {
           (input as HTMLInputElement).focus();
         });
 
@@ -1385,7 +1384,7 @@ describe('<Slider.Root />', () => {
         expect(handleValueChange.args[0][0]).to.deep.equal(77);
       });
 
-      it('sets value to the maximum possible value in a range slider', () => {
+      it('sets value to the maximum possible value in a range slider', async () => {
         const handleValueChange = spy();
         const { getByTestId } = render(
           <TestRangeSlider defaultValue={[20, 50]} onValueChange={handleValueChange} max={77} />,
@@ -1394,7 +1393,7 @@ describe('<Slider.Root />', () => {
         const thumbOne = getByTestId('thumb-0');
         const thumbTwo = getByTestId('thumb-1');
 
-        act(() => {
+        await act(() => {
           thumbOne.focus();
         });
 
@@ -1404,7 +1403,7 @@ describe('<Slider.Root />', () => {
         fireEvent.keyDown(thumbOne, { key: 'Home' });
         expect(handleValueChange.callCount).to.equal(1);
 
-        act(() => {
+        await act(() => {
           thumbTwo.focus();
         });
 
@@ -1415,7 +1414,7 @@ describe('<Slider.Root />', () => {
     });
 
     describe('key: End', () => {
-      it('sets value to min on End', () => {
+      it('sets value to min on End', async () => {
         const handleValueChange = spy();
         const { container } = render(
           <TestSlider defaultValue={55} onValueChange={handleValueChange} min={17} />,
@@ -1425,7 +1424,7 @@ describe('<Slider.Root />', () => {
 
         fireEvent.keyDown(document.body, { key: 'TAB' });
 
-        act(() => {
+        await act(() => {
           (input as HTMLInputElement).focus();
         });
 
@@ -1434,7 +1433,7 @@ describe('<Slider.Root />', () => {
         expect(handleValueChange.args[0][0]).to.deep.equal(17);
       });
 
-      it('sets value to the minimum possible value in a range slider', () => {
+      it('sets value to the minimum possible value in a range slider', async () => {
         const handleValueChange = spy();
         const { getByTestId } = render(
           <TestRangeSlider defaultValue={[20, 50]} onValueChange={handleValueChange} min={7} />,
@@ -1443,7 +1442,7 @@ describe('<Slider.Root />', () => {
         const thumbOne = getByTestId('thumb-0');
         const thumbTwo = getByTestId('thumb-1');
 
-        act(() => {
+        await act(() => {
           thumbTwo.focus();
         });
 
@@ -1453,7 +1452,7 @@ describe('<Slider.Root />', () => {
         fireEvent.keyDown(thumbTwo, { key: 'End' });
         expect(handleValueChange.callCount).to.equal(1);
 
-        act(() => {
+        await act(() => {
           thumbOne.focus();
         });
 
@@ -1463,7 +1462,7 @@ describe('<Slider.Root />', () => {
       });
     });
 
-    it('should support Shift + Left Arrow / Right Arrow keys', () => {
+    it('should support Shift + Left Arrow / Right Arrow keys', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
@@ -1473,7 +1472,7 @@ describe('<Slider.Root />', () => {
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
 
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -1486,7 +1485,7 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.deep.equal(20);
     });
 
-    it('should support Shift + Up Arrow / Down Arrow keys', () => {
+    it('should support Shift + Up Arrow / Down Arrow keys', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
@@ -1495,7 +1494,7 @@ describe('<Slider.Root />', () => {
       const input = container.querySelector('input');
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -1508,7 +1507,7 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.deep.equal(20);
     });
 
-    it('should support PageUp / PageDown keys', () => {
+    it('should support PageUp / PageDown keys', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
@@ -1517,7 +1516,7 @@ describe('<Slider.Root />', () => {
       const input = container.querySelector('input');
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -1530,7 +1529,7 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.deep.equal(20);
     });
 
-    it('should support Shift + Left Arrow / Right Arrow keys by taking acount step and largeStep', () => {
+    it('should support Shift + Left Arrow / Right Arrow keys by taking acount step and largeStep', async () => {
       const handleValueChange = spy();
       const DEFAULT_VALUE = 20;
       const LARGE_STEP = 15;
@@ -1547,7 +1546,7 @@ describe('<Slider.Root />', () => {
       const input = container.querySelector('input');
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 
@@ -1562,7 +1561,7 @@ describe('<Slider.Root />', () => {
       expect(input).to.have.attribute('aria-valuenow', `${DEFAULT_VALUE}`);
     });
 
-    it('should stop at max/min when using Shift + Left Arrow / Right Arrow keys', () => {
+    it('should stop at max/min when using Shift + Left Arrow / Right Arrow keys', async () => {
       const handleValueChange = spy();
       const { container } = render(
         <TestSlider defaultValue={5} max={8} onValueChange={handleValueChange} />,
@@ -1571,7 +1570,7 @@ describe('<Slider.Root />', () => {
       const input = container.querySelector('input');
 
       fireEvent.keyDown(document.body, { key: 'TAB' });
-      act(() => {
+      await act(() => {
         (input as HTMLInputElement).focus();
       });
 

--- a/packages/mui-base/src/Slider/Root/SliderRoot.test.tsx
+++ b/packages/mui-base/src/Slider/Root/SliderRoot.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { spy, stub } from 'sinon';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import * as Slider from '@base_ui/react/Slider';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 import type { SliderRootProps } from './SliderRoot.types';
 
 type Touches = Array<Pick<Touch, 'identifier' | 'clientX' | 'clientY'>>;

--- a/packages/mui-base/src/Slider/Root/SliderRoot.test.tsx
+++ b/packages/mui-base/src/Slider/Root/SliderRoot.test.tsx
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import * as React from 'react';
 import { spy, stub } from 'sinon';
-import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import * as Slider from '@base_ui/react/Slider';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 import type { SliderRootProps } from './SliderRoot.types';
 
 type Touches = Array<Pick<Touch, 'identifier' | 'clientX' | 'clientY'>>;
@@ -80,8 +80,8 @@ describe('<Slider.Root />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
-  it('renders a slider', () => {
-    render(
+  it('renders a slider', async () => {
+    await render(
       <Slider.Root defaultValue={30}>
         <Slider.Output />
         <Slider.Control>
@@ -96,8 +96,8 @@ describe('<Slider.Root />', () => {
     expect(screen.getByRole('slider')).to.have.attribute('aria-valuenow', '30');
   });
 
-  it('should not break when initial value is out of range', () => {
-    const { getByTestId } = render(<TestRangeSlider value={[19, 41]} min={20} max={40} />);
+  it('should not break when initial value is out of range', async () => {
+    const { getByTestId } = await render(<TestRangeSlider value={[19, 41]} min={20} max={40} />);
 
     const sliderControl = getByTestId('control');
 
@@ -114,8 +114,8 @@ describe('<Slider.Root />', () => {
   });
 
   describe('ARIA attributes', () => {
-    it('it has the correct aria attributes', () => {
-      const { container, getByRole, getByTestId } = render(
+    it('it has the correct aria attributes', async () => {
+      const { container, getByRole, getByTestId } = await render(
         <Slider.Root defaultValue={30} aria-labelledby="labelId" data-testid="root">
           <Slider.Output />
           <Slider.Control>
@@ -143,7 +143,7 @@ describe('<Slider.Root />', () => {
     });
 
     it('should update aria-valuenow', async () => {
-      const { getByRole } = render(<TestSlider defaultValue={50} />);
+      const { getByRole } = await render(<TestSlider defaultValue={50} />);
       const slider = getByRole('slider');
       await act(() => {
         slider.focus();
@@ -156,8 +156,8 @@ describe('<Slider.Root />', () => {
       expect(slider).to.have.attribute('aria-valuenow', '52');
     });
 
-    it('should set default aria-valuetext on range slider thumbs', () => {
-      const { getByTestId } = render(<TestRangeSlider defaultValue={[44, 50]} />);
+    it('should set default aria-valuetext on range slider thumbs', async () => {
+      const { getByTestId } = await render(<TestRangeSlider defaultValue={[44, 50]} />);
 
       const thumbOne = getByTestId('thumb-0');
       const thumbTwo = getByTestId('thumb-1');
@@ -168,9 +168,9 @@ describe('<Slider.Root />', () => {
   });
 
   describe('rtl', () => {
-    it('should handle RTL', () => {
+    it('should handle RTL', async () => {
       const handleValueChange = spy();
-      const { getByTestId } = render(
+      const { getByTestId } = await render(
         <TestSlider direction="rtl" value={30} onValueChange={handleValueChange} />,
       );
       const sliderControl = getByTestId('control');
@@ -198,7 +198,7 @@ describe('<Slider.Root />', () => {
 
     it('increments on ArrowUp', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
       );
 
@@ -221,7 +221,7 @@ describe('<Slider.Root />', () => {
 
     it('increments on ArrowLeft', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
       );
 
@@ -244,7 +244,7 @@ describe('<Slider.Root />', () => {
 
     it('decrements on ArrowDown', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
       );
 
@@ -267,7 +267,7 @@ describe('<Slider.Root />', () => {
 
     it('decrements on ArrowRight', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
       );
 
@@ -290,8 +290,8 @@ describe('<Slider.Root />', () => {
   });
 
   describe('prop: disabled', () => {
-    it('should render data-disabled on all subcomponents', () => {
-      const { getByTestId } = render(
+    it('should render data-disabled on all subcomponents', async () => {
+      const { getByTestId } = await render(
         <Slider.Root defaultValue={30} disabled data-testid="root">
           <Slider.Output data-testid="output" />
           <Slider.Control data-testid="control">
@@ -315,13 +315,13 @@ describe('<Slider.Root />', () => {
       });
     });
 
-    it('should not respond to drag events after becoming disabled', function test() {
+    it('should not respond to drag events after becoming disabled', async function test() {
       // TODO: Don't skip once a fix for https://github.com/jsdom/jsdom/issues/3029 is released.
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
 
-      const { getByRole, setProps, getByTestId } = render(
+      const { getByRole, setProps, getByTestId } = await render(
         <TestSlider defaultValue={0} data-testid="slider-root" />,
       );
 
@@ -352,13 +352,13 @@ describe('<Slider.Root />', () => {
       expect(thumb).to.have.attribute('aria-valuenow', '21');
     });
 
-    it('should not respond to drag events if disabled', function test() {
+    it('should not respond to drag events if disabled', async function test() {
       // TODO: Don't skip once a fix for https://github.com/jsdom/jsdom/issues/3029 is released.
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
 
-      const { getByRole, getByTestId } = render(
+      const { getByRole, getByTestId } = await render(
         <TestSlider defaultValue={21} data-testid="slider-root" disabled />,
       );
 
@@ -389,15 +389,15 @@ describe('<Slider.Root />', () => {
   });
 
   describe('prop: orientation', () => {
-    it('sets the orientation via ARIA', () => {
-      render(<TestSlider orientation="vertical" />);
+    it('sets the orientation via ARIA', async () => {
+      await render(<TestSlider orientation="vertical" />);
 
       const sliderRoot = screen.getByRole('slider');
       expect(sliderRoot).to.have.attribute('aria-orientation', 'vertical');
     });
 
-    it('sets the data-orientation attribute', () => {
-      const { getByTestId } = render(<TestSlider />);
+    it('sets the data-orientation attribute', async () => {
+      const { getByTestId } = await render(<TestSlider />);
 
       const sliderRoot = screen.getByRole('group');
       expect(sliderRoot).to.have.attribute('data-orientation', 'horizontal');
@@ -407,12 +407,12 @@ describe('<Slider.Root />', () => {
       expect(sliderOutput).to.have.attribute('data-orientation', 'horizontal');
     });
 
-    it('does not set the orientation via appearance for WebKit browsers', function test() {
+    it('does not set the orientation via appearance for WebKit browsers', async function test() {
       if (/jsdom/.test(window.navigator.userAgent) || !/WebKit/.test(window.navigator.userAgent)) {
         this.skip();
       }
 
-      render(<TestSlider orientation="vertical" />);
+      await render(<TestSlider orientation="vertical" />);
 
       const slider = screen.getByRole('slider');
 
@@ -423,9 +423,9 @@ describe('<Slider.Root />', () => {
       expect(slider).not.toHaveComputedStyle({ webkitAppearance: 'slider-vertical' });
     });
 
-    it('should report the right position', () => {
+    it('should report the right position', async () => {
       const handleValueChange = spy();
-      const { getByTestId } = render(
+      const { getByTestId } = await render(
         <TestSlider orientation="vertical" defaultValue={20} onValueChange={handleValueChange} />,
       );
 
@@ -459,7 +459,7 @@ describe('<Slider.Root />', () => {
 
   describe('prop: step', () => {
     it('supports non-integer values', async () => {
-      const { getByRole } = render(
+      const { getByRole } = await render(
         <TestSlider defaultValue={0.2} min={-100} max={100} step={0.00000001} />,
       );
       const slider = getByRole('slider');
@@ -479,7 +479,7 @@ describe('<Slider.Root />', () => {
     });
 
     it('should round value to step precision', async () => {
-      const { getByRole, getByTestId } = render(
+      const { getByRole, getByTestId } = await render(
         <TestSlider defaultValue={0.2} min={0} max={1} step={0.1} />,
       );
       const slider = getByRole('slider');
@@ -518,7 +518,7 @@ describe('<Slider.Root />', () => {
     });
 
     it('should not fail to round value to step precision when step is very small', async () => {
-      const { getByRole, getByTestId } = render(
+      const { getByRole, getByTestId } = await render(
         <TestSlider defaultValue={0.00000002} min={0} max={0.0000001} step={0.00000001} />,
       );
       const slider = getByRole('slider');
@@ -551,7 +551,7 @@ describe('<Slider.Root />', () => {
     });
 
     it('should not fail to round value to step precision when step is very small and negative', async () => {
-      const { getByRole, getByTestId } = render(
+      const { getByRole, getByTestId } = await render(
         <TestSlider defaultValue={-0.00000002} min={-0.0000001} max={0} step={0.00000001} />,
       );
       const slider = getByRole('slider');
@@ -587,8 +587,8 @@ describe('<Slider.Root />', () => {
   describe('prop: max', () => {
     const MAX = 750;
 
-    it('should set the max and aria-valuemax on the input', () => {
-      const { getByRole } = render(
+    it('should set the max and aria-valuemax on the input', async () => {
+      const { getByRole } = await render(
         <TestSlider defaultValue={150} step={100} max={MAX} min={150} />,
       );
       const slider = getByRole('slider');
@@ -598,7 +598,7 @@ describe('<Slider.Root />', () => {
     });
 
     it('should not go more than the max', async () => {
-      const { getByRole } = render(
+      const { getByRole } = await render(
         <TestSlider defaultValue={150} step={100} max={MAX} min={150} />,
       );
 
@@ -612,7 +612,7 @@ describe('<Slider.Root />', () => {
     });
 
     it('should reach right edge value', async () => {
-      const { getByRole, getByTestId } = render(
+      const { getByRole, getByTestId } = await render(
         <TestSlider defaultValue={90} min={6} max={108} step={10} />,
       );
 
@@ -663,8 +663,8 @@ describe('<Slider.Root />', () => {
   describe('prop: min', () => {
     const MIN = 150;
 
-    it('should set the min and aria-valuemin on the input', () => {
-      const { getByRole } = render(
+    it('should set the min and aria-valuemin on the input', async () => {
+      const { getByRole } = await render(
         <TestSlider defaultValue={150} step={100} max={750} min={MIN} />,
       );
       const slider = getByRole('slider');
@@ -674,7 +674,7 @@ describe('<Slider.Root />', () => {
     });
 
     it('should use min as the step origin', async () => {
-      const { getByRole } = render(
+      const { getByRole } = await render(
         <TestSlider defaultValue={150} step={100} max={750} min={MIN} />,
       );
       const slider = getByRole('slider');
@@ -686,7 +686,7 @@ describe('<Slider.Root />', () => {
     });
 
     it('should not go less than the min', async () => {
-      const { getByRole } = render(
+      const { getByRole } = await render(
         <TestSlider defaultValue={150} step={100} max={750} min={MIN} />,
       );
       const slider = getByRole('slider');
@@ -703,7 +703,7 @@ describe('<Slider.Root />', () => {
     it('should enforce a minimum difference between range slider values', async () => {
       const handleValueChange = spy();
 
-      const { getByTestId } = render(
+      const { getByTestId } = await render(
         <TestRangeSlider
           onValueChange={handleValueChange}
           defaultValue={[44, 50]}
@@ -744,7 +744,7 @@ describe('<Slider.Root />', () => {
       const handleValueChange = spy();
       const handleValueCommitted = spy();
 
-      const { getByRole, getByTestId } = render(
+      const { getByRole, getByTestId } = await render(
         <TestSlider
           onValueChange={handleValueChange}
           onValueCommitted={handleValueCommitted}
@@ -783,9 +783,9 @@ describe('<Slider.Root />', () => {
       expect(handleValueCommitted.callCount).to.equal(2);
     });
 
-    it('should support touch events', () => {
+    it('should support touch events', async () => {
       const handleValueChange = spy();
-      const { getByTestId } = render(
+      const { getByTestId } = await render(
         <TestRangeSlider defaultValue={[20, 30]} onValueChange={handleValueChange} />,
       );
       const sliderControl = getByTestId('control');
@@ -843,11 +843,11 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.deep.equal([22, 30]);
     });
 
-    it('should only listen to changes from the same touchpoint', () => {
+    it('should only listen to changes from the same touchpoint', async () => {
       const handleValueChange = spy();
       const handleValueCommitted = spy();
 
-      const { getByTestId } = render(
+      const { getByTestId } = await render(
         <TestSlider
           onValueChange={handleValueChange}
           onValueCommitted={handleValueCommitted}
@@ -894,10 +894,12 @@ describe('<Slider.Root />', () => {
       expect(handleValueCommitted.callCount).to.equal(1);
     });
 
-    it('should hedge against a dropped mouseup event', () => {
+    it('should hedge against a dropped mouseup event', async () => {
       const handleValueChange = spy();
 
-      const { getByTestId } = render(<TestSlider onValueChange={handleValueChange} value={0} />);
+      const { getByTestId } = await render(
+        <TestSlider onValueChange={handleValueChange} value={0} />,
+      );
 
       const sliderControl = getByTestId('control');
 
@@ -927,8 +929,8 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.callCount).to.equal(2);
     });
 
-    it('should focus the slider when touching', () => {
-      const { getByRole, getByTestId } = render(<TestSlider defaultValue={30} />);
+    it('should focus the slider when touching', async () => {
+      const { getByRole, getByTestId } = await render(<TestSlider defaultValue={30} />);
       const slider = getByRole('slider');
       const sliderControl = getByTestId('control');
 
@@ -944,8 +946,8 @@ describe('<Slider.Root />', () => {
       expect(slider).toHaveFocus();
     });
 
-    it('should focus the slider when dragging', () => {
-      const { getByRole, getByTestId } = render(<TestSlider defaultValue={30} step={10} />);
+    it('should focus the slider when dragging', async () => {
+      const { getByRole, getByTestId } = await render(<TestSlider defaultValue={30} step={10} />);
       const slider = getByRole('slider');
       const sliderThumb = getByTestId('thumb');
       const sliderControl = getByTestId('control');
@@ -962,7 +964,7 @@ describe('<Slider.Root />', () => {
       expect(slider).toHaveFocus();
     });
 
-    it('should not override the event.target on touch events', () => {
+    it('should not override the event.target on touch events', async () => {
       const handleValueChange = spy();
       const handleNativeEvent = spy();
       const handleEvent = spy();
@@ -981,7 +983,7 @@ describe('<Slider.Root />', () => {
         );
       }
 
-      const { getByTestId } = render(<Test />);
+      const { getByTestId } = await render(<Test />);
       const sliderControl = getByTestId('control');
 
       stub(sliderControl, 'getBoundingClientRect').callsFake(
@@ -1000,7 +1002,7 @@ describe('<Slider.Root />', () => {
       expect(handleEvent.firstCall.args[0]).to.have.property('target', sliderControl);
     });
 
-    it('should not override the event.target on mouse events', () => {
+    it('should not override the event.target on mouse events', async () => {
       const handleValueChange = spy();
       const handleNativeEvent = spy();
       const handleEvent = spy();
@@ -1018,7 +1020,7 @@ describe('<Slider.Root />', () => {
           </div>
         );
       }
-      const { getByTestId } = render(<Test />);
+      const { getByTestId } = await render(<Test />);
       const sliderControl = getByTestId('control');
 
       stub(sliderControl, 'getBoundingClientRect').callsFake(
@@ -1036,8 +1038,8 @@ describe('<Slider.Root />', () => {
   });
 
   describe('dragging state', () => {
-    it('should not apply data-dragging for click modality', () => {
-      const { getByTestId } = render(<TestSlider defaultValue={90} />);
+    it('should not apply data-dragging for click modality', async () => {
+      const { getByTestId } = await render(<TestSlider defaultValue={90} />);
 
       const sliderControl = getByTestId('control');
 
@@ -1057,8 +1059,8 @@ describe('<Slider.Root />', () => {
       fireEvent.touchEnd(document.body, createTouches([{ identifier: 1, clientX: 0, clientY: 0 }]));
     });
 
-    it('should apply data-dragging for dragging modality', () => {
-      const { getByTestId } = render(<TestSlider defaultValue={90} />);
+    it('should apply data-dragging for dragging modality', async () => {
+      const { getByTestId } = await render(<TestSlider defaultValue={90} />);
 
       const sliderControl = getByTestId('control');
 
@@ -1110,7 +1112,7 @@ describe('<Slider.Root />', () => {
         expect(Object.keys(formDataAsObject).length).to.equal(1);
       };
 
-      const { getByText } = render(
+      const { getByText } = await render(
         <form onSubmit={handleSubmit}>
           <TestSlider defaultValue={51} name="sliderField" />
           <button type="submit">Submit</button>
@@ -1125,9 +1127,9 @@ describe('<Slider.Root />', () => {
   });
 
   describe('prop: onValueChange', () => {
-    it('is called when clicking on the control', () => {
+    it('is called when clicking on the control', async () => {
       const handleValueChange = spy();
-      render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
+      await render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
 
       const sliderControl = screen.getByTestId('control');
 
@@ -1143,9 +1145,9 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.callCount).to.equal(1);
     });
 
-    it('is not called when clicking on the thumb', () => {
+    it('is not called when clicking on the thumb', async () => {
       const handleValueChange = spy();
-      render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
+      await render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
 
       const sliderControl = screen.getByTestId('control');
       const sliderThumb = screen.getByTestId('thumb');
@@ -1162,9 +1164,9 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.callCount).to.equal(0);
     });
 
-    it('should not react to right clicks', () => {
+    it('should not react to right clicks', async () => {
       const handleValueChange = spy();
-      render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
+      await render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
 
       const sliderControl = screen.getByTestId('control');
 
@@ -1180,9 +1182,9 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.callCount).to.equal(0);
     });
 
-    it('should fire only when the value changes', () => {
+    it('should fire only when the value changes', async () => {
       const handleValueChange = spy();
-      render(<TestSlider defaultValue={20} onValueChange={handleValueChange} />);
+      await render(<TestSlider defaultValue={20} onValueChange={handleValueChange} />);
 
       const sliderControl = screen.getByTestId('control');
 
@@ -1217,10 +1219,12 @@ describe('<Slider.Root />', () => {
       ['range', [2, 1]],
     ] as Values;
     values.forEach(([valueLabel, value]) => {
-      it(`is called even if the ${valueLabel} did not change`, () => {
+      it(`is called even if the ${valueLabel} did not change`, async () => {
         const handleValueChange = spy();
 
-        render(<TestRangeSlider min={0} max={5} onValueChange={handleValueChange} value={value} />);
+        await render(
+          <TestRangeSlider min={0} max={5} onValueChange={handleValueChange} value={value} />,
+        );
 
         const sliderControl = screen.getByTestId('control');
 
@@ -1248,7 +1252,7 @@ describe('<Slider.Root />', () => {
     it('should pass "name" and "value" as part of the event.target for onValueChange', async () => {
       const handleValueChange = stub().callsFake((newValue, thumbIndex, event) => event.target);
 
-      const { getByRole } = render(
+      const { getByRole } = await render(
         <TestSlider onValueChange={handleValueChange} name="change-testing" value={3} />,
       );
       const slider = getByRole('slider');
@@ -1274,7 +1278,7 @@ describe('<Slider.Root />', () => {
   describe('keyboard interactions', () => {
     it('increments on ArrowUp', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
       );
 
@@ -1297,7 +1301,7 @@ describe('<Slider.Root />', () => {
 
     it('increments on ArrowRight', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
       );
 
@@ -1320,7 +1324,7 @@ describe('<Slider.Root />', () => {
 
     it('decrements on ArrowDown', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
       );
 
@@ -1343,7 +1347,7 @@ describe('<Slider.Root />', () => {
 
     it('decrements on ArrowLeft', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
       );
 
@@ -1367,7 +1371,7 @@ describe('<Slider.Root />', () => {
     describe('key: Home', () => {
       it('sets value to max in a single value slider', async () => {
         const handleValueChange = spy();
-        const { container } = render(
+        const { container } = await render(
           <TestSlider defaultValue={20} onValueChange={handleValueChange} max={77} />,
         );
 
@@ -1386,7 +1390,7 @@ describe('<Slider.Root />', () => {
 
       it('sets value to the maximum possible value in a range slider', async () => {
         const handleValueChange = spy();
-        const { getByTestId } = render(
+        const { getByTestId } = await render(
           <TestRangeSlider defaultValue={[20, 50]} onValueChange={handleValueChange} max={77} />,
         );
 
@@ -1416,7 +1420,7 @@ describe('<Slider.Root />', () => {
     describe('key: End', () => {
       it('sets value to min on End', async () => {
         const handleValueChange = spy();
-        const { container } = render(
+        const { container } = await render(
           <TestSlider defaultValue={55} onValueChange={handleValueChange} min={17} />,
         );
 
@@ -1435,7 +1439,7 @@ describe('<Slider.Root />', () => {
 
       it('sets value to the minimum possible value in a range slider', async () => {
         const handleValueChange = spy();
-        const { getByTestId } = render(
+        const { getByTestId } = await render(
           <TestRangeSlider defaultValue={[20, 50]} onValueChange={handleValueChange} min={7} />,
         );
 
@@ -1464,7 +1468,7 @@ describe('<Slider.Root />', () => {
 
     it('should support Shift + Left Arrow / Right Arrow keys', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
       );
 
@@ -1487,7 +1491,7 @@ describe('<Slider.Root />', () => {
 
     it('should support Shift + Up Arrow / Down Arrow keys', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
       );
 
@@ -1509,7 +1513,7 @@ describe('<Slider.Root />', () => {
 
     it('should support PageUp / PageDown keys', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={20} onValueChange={handleValueChange} />,
       );
 
@@ -1534,7 +1538,7 @@ describe('<Slider.Root />', () => {
       const DEFAULT_VALUE = 20;
       const LARGE_STEP = 15;
       const STEP = 5;
-      const { container } = render(
+      const { container } = await render(
         <TestSlider
           defaultValue={DEFAULT_VALUE}
           onValueChange={handleValueChange}
@@ -1563,7 +1567,7 @@ describe('<Slider.Root />', () => {
 
     it('should stop at max/min when using Shift + Left Arrow / Right Arrow keys', async () => {
       const handleValueChange = spy();
-      const { container } = render(
+      const { container } = await render(
         <TestSlider defaultValue={5} max={8} onValueChange={handleValueChange} />,
       );
 
@@ -1583,8 +1587,8 @@ describe('<Slider.Root />', () => {
       expect(handleValueChange.args[1][0]).to.deep.equal(8);
     });
 
-    it('can be removed from the tab sequence', () => {
-      render(<TestSlider tabIndex={-1} value={30} />);
+    it('can be removed from the tab sequence', async () => {
+      await render(<TestSlider tabIndex={-1} value={30} />);
       expect(screen.getByRole('slider')).to.have.property('tabIndex', -1);
     });
   });

--- a/packages/mui-base/src/Slider/Thumb/SliderThumb.test.tsx
+++ b/packages/mui-base/src/Slider/Thumb/SliderThumb.test.tsx
@@ -56,7 +56,6 @@ describe('<Slider.Thumb />', () => {
   };
 
   describeConformance(<Slider.Thumb />, () => ({
-    inheritComponent: 'span',
     render: (node) => {
       const { container, ...other } = render(
         <SliderProvider value={testProviderValue}>{node}</SliderProvider>,

--- a/packages/mui-base/src/Slider/Thumb/SliderThumb.test.tsx
+++ b/packages/mui-base/src/Slider/Thumb/SliderThumb.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Slider from '@base_ui/react/Slider';
 import { SliderProvider, type SliderProviderValue } from '@base_ui/react/Slider';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const NOOP = () => {};
 
@@ -57,11 +56,7 @@ describe('<Slider.Thumb />', () => {
 
   describeConformance(<Slider.Thumb />, () => ({
     render: (node) => {
-      const { container, ...other } = render(
-        <SliderProvider value={testProviderValue}>{node}</SliderProvider>,
-      );
-
-      return { container, ...other };
+      return render(<SliderProvider value={testProviderValue}>{node}</SliderProvider>);
     },
     refInstanceof: window.HTMLSpanElement,
   }));

--- a/packages/mui-base/src/Slider/Thumb/SliderThumb.test.tsx
+++ b/packages/mui-base/src/Slider/Thumb/SliderThumb.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Slider from '@base_ui/react/Slider';
 import { SliderProvider, type SliderProviderValue } from '@base_ui/react/Slider';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const NOOP = () => {};
 

--- a/packages/mui-base/src/Slider/Track/SliderTrack.test.tsx
+++ b/packages/mui-base/src/Slider/Track/SliderTrack.test.tsx
@@ -56,7 +56,6 @@ describe('<Slider.Track />', () => {
   };
 
   describeConformance(<Slider.Track />, () => ({
-    inheritComponent: 'span',
     render: (node) => {
       const { container, ...other } = render(
         <SliderProvider value={testProviderValue}>{node}</SliderProvider>,

--- a/packages/mui-base/src/Slider/Track/SliderTrack.test.tsx
+++ b/packages/mui-base/src/Slider/Track/SliderTrack.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Slider from '@base_ui/react/Slider';
 import { SliderProvider, type SliderProviderValue } from '@base_ui/react/Slider';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const NOOP = () => {};
 

--- a/packages/mui-base/src/Slider/Track/SliderTrack.test.tsx
+++ b/packages/mui-base/src/Slider/Track/SliderTrack.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Slider from '@base_ui/react/Slider';
 import { SliderProvider, type SliderProviderValue } from '@base_ui/react/Slider';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const NOOP = () => {};
 
@@ -57,11 +56,7 @@ describe('<Slider.Track />', () => {
 
   describeConformance(<Slider.Track />, () => ({
     render: (node) => {
-      const { container, ...other } = render(
-        <SliderProvider value={testProviderValue}>{node}</SliderProvider>,
-      );
-
-      return { container, ...other };
+      return render(<SliderProvider value={testProviderValue}>{node}</SliderProvider>);
     },
     refInstanceof: window.HTMLSpanElement,
   }));

--- a/packages/mui-base/src/Switch/Root/SwitchRoot.test.tsx
+++ b/packages/mui-base/src/Switch/Root/SwitchRoot.test.tsx
@@ -10,7 +10,6 @@ describe('<Switch.Root />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Switch.Root />, () => ({
-    inheritComponent: 'button',
     refInstanceof: window.HTMLButtonElement,
     render,
   }));

--- a/packages/mui-base/src/Switch/Root/SwitchRoot.test.tsx
+++ b/packages/mui-base/src/Switch/Root/SwitchRoot.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { act } from '@mui/internal-test-utils';
+import { act, screen } from '@mui/internal-test-utils';
 import * as Switch from '@base_ui/react/Switch';
 import { userEvent } from '@testing-library/user-event';
 import { describeConformance, createRenderer } from '#test-utils';
@@ -58,9 +58,9 @@ describe('<Switch.Root />', () => {
     });
 
     it('should update its state if the underlying input is toggled', async () => {
-      const { getByRole, container } = await render(<Switch.Root />);
-      const switchElement = getByRole('switch');
-      const internalInput = container.querySelector('input[type="checkbox"]')! as HTMLInputElement;
+      await render(<Switch.Root />);
+      const switchElement = screen.getByRole('switch');
+      const internalInput = screen.getByRole('checkbox', { hidden: true });
 
       await act(() => {
         internalInput.click();
@@ -72,9 +72,9 @@ describe('<Switch.Root />', () => {
 
   describe('extra props', () => {
     it('should override the built-in attributes', async () => {
-      const { container } = await render(<Switch.Root data-state="checked" role="checkbox" />);
-      expect(container.firstElementChild as HTMLElement).to.have.attribute('role', 'checkbox');
-      expect(container.firstElementChild as HTMLElement).to.have.attribute('data-state', 'checked');
+      await render(<Switch.Root data-state="checked" role="checkbox" data-testid="switch" />);
+      expect(screen.getByTestId('switch')).to.have.attribute('role', 'checkbox');
+      expect(screen.getByTestId('switch')).to.have.attribute('data-state', 'checked');
     });
   });
 
@@ -160,8 +160,8 @@ describe('<Switch.Root />', () => {
   describe('prop: inputRef', () => {
     it('should be able to access the native input', async () => {
       const inputRef = React.createRef<HTMLInputElement>();
-      const { container } = await render(<Switch.Root inputRef={inputRef} />);
-      const internalInput = container.querySelector('input[type="checkbox"]')!;
+      await render(<Switch.Root inputRef={inputRef} />);
+      const internalInput = screen.getByRole('checkbox', { hidden: true });
 
       expect(inputRef.current).to.equal(internalInput);
     });
@@ -247,14 +247,14 @@ describe('<Switch.Root />', () => {
   });
 
   it('should place the style hooks on the root and the thumb', async () => {
-    const { getByRole } = await render(
+    await render(
       <Switch.Root defaultChecked disabled readOnly required>
-        <Switch.Thumb />
+        <Switch.Thumb data-testid="thumb" />
       </Switch.Root>,
     );
 
-    const switchElement = getByRole('switch');
-    const thumb = switchElement.querySelector('span');
+    const switchElement = screen.getByRole('switch');
+    const thumb = screen.getByTestId('thumb');
 
     expect(switchElement).to.have.attribute('data-state', 'checked');
     expect(switchElement).to.have.attribute('data-disabled', 'true');
@@ -268,9 +268,8 @@ describe('<Switch.Root />', () => {
   });
 
   it('should set the name attribute on the input', async () => {
-    const { container } = await render(<Switch.Root name="switch-name" />);
-    const internalInput = container.querySelector('input[type="checkbox"]')! as HTMLInputElement;
-
+    await render(<Switch.Root name="switch-name" />);
+    const internalInput = screen.getByRole('checkbox', { hidden: true });
     expect(internalInput).to.have.attribute('name', 'switch-name');
   });
 });

--- a/packages/mui-base/src/Switch/Root/SwitchRoot.test.tsx
+++ b/packages/mui-base/src/Switch/Root/SwitchRoot.test.tsx
@@ -4,7 +4,7 @@ import { spy } from 'sinon';
 import { act } from '@mui/internal-test-utils';
 import * as Switch from '@base_ui/react/Switch';
 import { userEvent } from '@testing-library/user-event';
-import { describeConformance, createRenderer } from '../../../test';
+import { describeConformance, createRenderer } from '#test-utils';
 
 describe('<Switch.Root />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Switch/Thumb/SwitchThumb.test.tsx
+++ b/packages/mui-base/src/Switch/Thumb/SwitchThumb.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Switch from '@base_ui/react/Switch';
 import { SwitchContext } from '../Root/SwitchContext';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 const testContext = {
   checked: false,

--- a/packages/mui-base/src/Switch/Thumb/SwitchThumb.test.tsx
+++ b/packages/mui-base/src/Switch/Thumb/SwitchThumb.test.tsx
@@ -15,7 +15,6 @@ describe('<Switch.Thumb />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Switch.Thumb />, () => ({
-    inheritComponent: 'span',
     refInstanceof: window.HTMLSpanElement,
     render: (node) => {
       return render(<SwitchContext.Provider value={testContext}>{node}</SwitchContext.Provider>);

--- a/packages/mui-base/src/Switch/Thumb/SwitchThumb.test.tsx
+++ b/packages/mui-base/src/Switch/Thumb/SwitchThumb.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Switch from '@base_ui/react/Switch';
 import { SwitchContext } from '../Root/SwitchContext';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 const testContext = {
   checked: false,

--- a/packages/mui-base/src/Switch/Thumb/SwitchThumb.test.tsx
+++ b/packages/mui-base/src/Switch/Thumb/SwitchThumb.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Switch from '@base_ui/react/Switch';
-import { SwitchContext } from '../Root/SwitchContext';
 import { createRenderer, describeConformance } from '#test-utils';
+import { SwitchContext } from '../Root/SwitchContext';
 
 const testContext = {
   checked: false,

--- a/packages/mui-base/src/Tabs/Root/TabsRoot.test.tsx
+++ b/packages/mui-base/src/Tabs/Root/TabsRoot.test.tsx
@@ -21,7 +21,6 @@ describe('<Tabs.Root />', () => {
   });
 
   describeConformance(<Tabs.Root value={0} />, () => ({
-    inheritComponent: 'div',
     render,
     refInstanceof: window.HTMLDivElement,
   }));
@@ -128,7 +127,7 @@ describe('<Tabs.Root />', () => {
       expect(tabElements[1]).to.have.attribute('aria-selected', 'true');
     });
 
-    it('should support values of different types', () => {
+    it('should support values of different types', async () => {
       const tabValues = [0, '1', { value: 2 }, () => 3, Symbol('4'), /5/];
 
       const { getAllByRole } = render(
@@ -147,10 +146,10 @@ describe('<Tabs.Root />', () => {
       const tabElements = getAllByRole('tab');
       const tabPanelElements = getAllByRole('tabpanel', { hidden: true });
 
-      tabValues.forEach((value, index) => {
+      tabValues.forEach(async (value, index) => {
         expect(tabPanelElements[index]).to.have.attribute('aria-labelledby', tabElements[index].id);
 
-        act(() => {
+        await act(() => {
           tabElements[index].click();
         });
 
@@ -191,7 +190,7 @@ describe('<Tabs.Root />', () => {
       expect(handleChange.callCount).to.equal(0);
     });
 
-    it('should call onValueChange if an unselected tab gets focused', () => {
+    it('should call onValueChange if an unselected tab gets focused', async () => {
       const handleChange = spy();
       const { getAllByRole } = render(
         <Tabs.Root value={0} onValueChange={handleChange}>
@@ -203,7 +202,7 @@ describe('<Tabs.Root />', () => {
       );
       const [firstTab] = getAllByRole('tab');
 
-      act(() => {
+      await act(() => {
         firstTab.focus();
       });
 
@@ -213,7 +212,7 @@ describe('<Tabs.Root />', () => {
       expect(handleChange.firstCall.args[0]).to.equal(1);
     });
 
-    it('when `activateOnFocus = false` should not call onValueChange if an unselected tab gets focused', () => {
+    it('when `activateOnFocus = false` should not call onValueChange if an unselected tab gets focused', async () => {
       const handleChange = spy();
       const { getAllByRole } = render(
         <Tabs.Root value={1} onValueChange={handleChange}>
@@ -226,7 +225,7 @@ describe('<Tabs.Root />', () => {
 
       const [firstTab] = getAllByRole('tab');
 
-      act(() => {
+      await act(() => {
         firstTab.focus();
       });
 
@@ -271,7 +270,7 @@ describe('<Tabs.Root />', () => {
       describe(`when focus is on a tab element in a ${orientation} ${direction} tablist`, () => {
         describe(previousItemKey ?? '', () => {
           describe('with `activateOnFocus = false`', () => {
-            it('moves focus to the last tab without activating it if focus is on the first tab', () => {
+            it('moves focus to the last tab without activating it if focus is on the first tab', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
               const { getAllByRole } = render(
@@ -290,7 +289,7 @@ describe('<Tabs.Root />', () => {
                 </Tabs.Root>,
               );
               const [firstTab, , lastTab] = getAllByRole('tab');
-              act(() => {
+              await act(() => {
                 firstTab.focus();
               });
 
@@ -302,7 +301,7 @@ describe('<Tabs.Root />', () => {
               expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
             });
 
-            it('moves focus to the previous tab without activating it', () => {
+            it('moves focus to the previous tab without activating it', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
               const { getAllByRole } = render(
@@ -321,7 +320,7 @@ describe('<Tabs.Root />', () => {
                 </Tabs.Root>,
               );
               const [firstTab, secondTab] = getAllByRole('tab');
-              act(() => {
+              await act(() => {
                 secondTab.focus();
               });
 
@@ -335,7 +334,7 @@ describe('<Tabs.Root />', () => {
           });
 
           describe('with `activateOnFocus = true`', () => {
-            it('moves focus to the last tab while activating it if focus is on the first tab', () => {
+            it('moves focus to the last tab while activating it if focus is on the first tab', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
               const { getAllByRole } = render(
@@ -354,7 +353,7 @@ describe('<Tabs.Root />', () => {
                 </Tabs.Root>,
               );
               const [firstTab, , lastTab] = getAllByRole('tab');
-              act(() => {
+              await act(() => {
                 firstTab.focus();
               });
 
@@ -367,7 +366,7 @@ describe('<Tabs.Root />', () => {
               expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
             });
 
-            it('moves focus to the previous tab while activating it', () => {
+            it('moves focus to the previous tab while activating it', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
               const { getAllByRole } = render(
@@ -386,7 +385,7 @@ describe('<Tabs.Root />', () => {
                 </Tabs.Root>,
               );
               const [firstTab, secondTab] = getAllByRole('tab');
-              act(() => {
+              await act(() => {
                 secondTab.focus();
               });
 
@@ -400,7 +399,7 @@ describe('<Tabs.Root />', () => {
             });
           });
 
-          it('skips over disabled tabs', () => {
+          it('skips over disabled tabs', async () => {
             const handleKeyDown = spy();
             const { getAllByRole } = render(
               <Tabs.Root
@@ -417,7 +416,7 @@ describe('<Tabs.Root />', () => {
               </Tabs.Root>,
             );
             const [firstTab, , lastTab] = getAllByRole('tab');
-            act(() => {
+            await act(() => {
               lastTab.focus();
             });
 
@@ -431,7 +430,7 @@ describe('<Tabs.Root />', () => {
 
         describe(nextItemKey ?? '', () => {
           describe('with `activateOnFocus = false`', () => {
-            it('moves focus to the first tab without activating it if focus is on the last tab', () => {
+            it('moves focus to the first tab without activating it if focus is on the last tab', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
               const { getAllByRole } = render(
@@ -450,7 +449,7 @@ describe('<Tabs.Root />', () => {
                 </Tabs.Root>,
               );
               const [firstTab, , lastTab] = getAllByRole('tab');
-              act(() => {
+              await act(() => {
                 lastTab.focus();
               });
 
@@ -462,7 +461,7 @@ describe('<Tabs.Root />', () => {
               expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
             });
 
-            it('moves focus to the next tab without activating it', () => {
+            it('moves focus to the next tab without activating it', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
               const { getAllByRole } = render(
@@ -481,7 +480,7 @@ describe('<Tabs.Root />', () => {
                 </Tabs.Root>,
               );
               const [, secondTab, lastTab] = getAllByRole('tab');
-              act(() => {
+              await act(() => {
                 secondTab.focus();
               });
 
@@ -495,7 +494,7 @@ describe('<Tabs.Root />', () => {
           });
 
           describe('with `activateOnFocus = true`', () => {
-            it('moves focus to the first tab while activating it if focus is on the last tab', () => {
+            it('moves focus to the first tab while activating it if focus is on the last tab', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
               const { getAllByRole } = render(
@@ -514,7 +513,7 @@ describe('<Tabs.Root />', () => {
                 </Tabs.Root>,
               );
               const [firstTab, , lastTab] = getAllByRole('tab');
-              act(() => {
+              await act(() => {
                 lastTab.focus();
               });
 
@@ -527,7 +526,7 @@ describe('<Tabs.Root />', () => {
               expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
             });
 
-            it('moves focus to the next tab while activating it', () => {
+            it('moves focus to the next tab while activating it', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
               const { getAllByRole } = render(
@@ -546,7 +545,7 @@ describe('<Tabs.Root />', () => {
                 </Tabs.Root>,
               );
               const [, secondTab, lastTab] = getAllByRole('tab');
-              act(() => {
+              await act(() => {
                 secondTab.focus();
               });
 
@@ -560,7 +559,7 @@ describe('<Tabs.Root />', () => {
             });
           });
 
-          it('skips over disabled tabs', () => {
+          it('skips over disabled tabs', async () => {
             const handleKeyDown = spy();
             const { getAllByRole } = render(
               <Tabs.Root
@@ -577,7 +576,7 @@ describe('<Tabs.Root />', () => {
               </Tabs.Root>,
             );
             const [firstTab, , lastTab] = getAllByRole('tab');
-            act(() => {
+            await act(() => {
               firstTab.focus();
             });
 
@@ -593,7 +592,7 @@ describe('<Tabs.Root />', () => {
 
     describe('when focus is on a tab regardless of orientation', () => {
       describe('Home', () => {
-        it('when `activateOnFocus = false`, moves focus to the first tab without activating it', () => {
+        it('when `activateOnFocus = false`, moves focus to the first tab without activating it', async () => {
           const handleChange = spy();
           const handleKeyDown = spy();
           const { getAllByRole } = render(
@@ -606,7 +605,7 @@ describe('<Tabs.Root />', () => {
             </Tabs.Root>,
           );
           const [firstTab, , lastTab] = getAllByRole('tab');
-          act(() => {
+          await act(() => {
             lastTab.focus();
           });
 
@@ -618,7 +617,7 @@ describe('<Tabs.Root />', () => {
           expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
         });
 
-        it('when `activateOnFocus = true`, moves focus to the first tab while activating it', () => {
+        it('when `activateOnFocus = true`, moves focus to the first tab while activating it', async () => {
           const handleChange = spy();
           const handleKeyDown = spy();
           const { getAllByRole } = render(
@@ -631,7 +630,7 @@ describe('<Tabs.Root />', () => {
             </Tabs.Root>,
           );
           const [firstTab, , lastTab] = getAllByRole('tab');
-          act(() => {
+          await act(() => {
             lastTab.focus();
           });
 
@@ -644,7 +643,7 @@ describe('<Tabs.Root />', () => {
           expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
         });
 
-        it('moves focus to first non-disabled tab', () => {
+        it('moves focus to first non-disabled tab', async () => {
           const handleKeyDown = spy();
           const { getAllByRole } = render(
             <Tabs.Root onKeyDown={handleKeyDown} value={2}>
@@ -656,7 +655,7 @@ describe('<Tabs.Root />', () => {
             </Tabs.Root>,
           );
           const [, secondTab, lastTab] = getAllByRole('tab');
-          act(() => {
+          await act(() => {
             lastTab.focus();
           });
 
@@ -669,7 +668,7 @@ describe('<Tabs.Root />', () => {
       });
 
       describe('End', () => {
-        it('when `activateOnFocus = false`, moves focus to the last tab without activating it', () => {
+        it('when `activateOnFocus = false`, moves focus to the last tab without activating it', async () => {
           const handleChange = spy();
           const handleKeyDown = spy();
           const { getAllByRole } = render(
@@ -682,7 +681,7 @@ describe('<Tabs.Root />', () => {
             </Tabs.Root>,
           );
           const [firstTab, , lastTab] = getAllByRole('tab');
-          act(() => {
+          await act(() => {
             firstTab.focus();
           });
 
@@ -694,7 +693,7 @@ describe('<Tabs.Root />', () => {
           expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
         });
 
-        it('when `activateOnFocus = true`, moves focus to the last tab while activating it', () => {
+        it('when `activateOnFocus = true`, moves focus to the last tab while activating it', async () => {
           const handleChange = spy();
           const handleKeyDown = spy();
           const { getAllByRole } = render(
@@ -707,7 +706,7 @@ describe('<Tabs.Root />', () => {
             </Tabs.Root>,
           );
           const [firstTab, , lastTab] = getAllByRole('tab');
-          act(() => {
+          await act(() => {
             firstTab.focus();
           });
 
@@ -720,7 +719,7 @@ describe('<Tabs.Root />', () => {
           expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
         });
 
-        it('moves focus to first non-disabled tab', () => {
+        it('moves focus to first non-disabled tab', async () => {
           const handleKeyDown = spy();
           const { getAllByRole } = render(
             <Tabs.Root onKeyDown={handleKeyDown} value={0}>
@@ -732,7 +731,7 @@ describe('<Tabs.Root />', () => {
             </Tabs.Root>,
           );
           const [firstTab, secondTab] = getAllByRole('tab');
-          act(() => {
+          await act(() => {
             firstTab.focus();
           });
 
@@ -769,7 +768,7 @@ describe('<Tabs.Root />', () => {
       }
     });
 
-    it('should set the `data-activation-direction` attribute on the tabs root with orientation=horizontal', () => {
+    it('should set the `data-activation-direction` attribute on the tabs root with orientation=horizontal', async () => {
       const { getAllByRole, getByTestId } = render(
         <Tabs.Root data-testid="root">
           <Tabs.List>
@@ -783,20 +782,20 @@ describe('<Tabs.Root />', () => {
       const tabs = getAllByRole('tab');
 
       expect(root).to.have.attribute('data-activation-direction', 'none');
-      act(() => {
+      await act(() => {
         tabs[1].click();
       });
 
       expect(root).to.have.attribute('data-activation-direction', 'right');
 
-      act(() => {
+      await act(() => {
         tabs[0].click();
       });
 
       expect(root).to.have.attribute('data-activation-direction', 'left');
     });
 
-    it('should set the `data-activation-direction` attribute on the tabs root with orientation=vertical', () => {
+    it('should set the `data-activation-direction` attribute on the tabs root with orientation=vertical', async () => {
       const { getAllByRole, getByTestId } = render(
         <Tabs.Root data-testid="root" orientation="vertical">
           <Tabs.List>
@@ -810,13 +809,13 @@ describe('<Tabs.Root />', () => {
       const tabs = getAllByRole('tab');
 
       expect(root).to.have.attribute('data-activation-direction', 'none');
-      act(() => {
+      await act(() => {
         tabs[1].click();
       });
 
       expect(root).to.have.attribute('data-activation-direction', 'down');
 
-      act(() => {
+      await act(() => {
         tabs[0].click();
       });
 

--- a/packages/mui-base/src/Tabs/Root/TabsRoot.test.tsx
+++ b/packages/mui-base/src/Tabs/Root/TabsRoot.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import * as Tabs from '@base_ui/react/Tabs';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Tabs.Root />', () => {
   const { render } = createRenderer();
@@ -26,8 +26,8 @@ describe('<Tabs.Root />', () => {
   }));
 
   describe('prop: children', () => {
-    it('should accept a null child', () => {
-      const { getAllByRole } = render(
+    it('should accept a null child', async () => {
+      const { getAllByRole } = await render(
         <Tabs.Root value={0}>
           {null}
           <Tabs.List>
@@ -38,12 +38,12 @@ describe('<Tabs.Root />', () => {
       expect(getAllByRole('tab')).to.have.lengthOf(1);
     });
 
-    it('should support empty children', () => {
-      render(<Tabs.Root value={1} />);
+    it('should support empty children', async () => {
+      await render(<Tabs.Root value={1} />);
     });
 
-    it('puts the selected child in tab order', () => {
-      const { getAllByRole, setProps } = render(
+    it('puts the selected child in tab order', async () => {
+      const { getAllByRole, setProps } = await render(
         <Tabs.Root value={1}>
           <Tabs.List>
             <Tabs.Tab value={0} />
@@ -59,8 +59,8 @@ describe('<Tabs.Root />', () => {
       expect(getAllByRole('tab').map((tab) => tab.tabIndex)).to.have.ordered.members([0, -1]);
     });
 
-    it('sets the aria-labelledby attribute on tab panels to the corresponding tab id', () => {
-      const { getAllByRole } = render(
+    it('sets the aria-labelledby attribute on tab panels to the corresponding tab id', async () => {
+      const { getAllByRole } = await render(
         <Tabs.Root defaultValue="tab-0">
           <Tabs.List>
             <Tabs.Tab value="tab-0" />
@@ -84,8 +84,8 @@ describe('<Tabs.Root />', () => {
       expect(tabPanels[3]).to.have.attribute('aria-labelledby', tabs[3].id);
     });
 
-    it('sets the aria-controls attribute on tabs to the corresponding tab panel id', () => {
-      const { getAllByRole } = render(
+    it('sets the aria-controls attribute on tabs to the corresponding tab panel id', async () => {
+      const { getAllByRole } = await render(
         <Tabs.Root defaultValue="tab-0">
           <Tabs.List>
             <Tabs.Tab value="tab-0" />
@@ -111,7 +111,7 @@ describe('<Tabs.Root />', () => {
   });
 
   describe('prop: value', () => {
-    it('should pass selected prop to children', () => {
+    it('should pass selected prop to children', async () => {
       const tabs = (
         <Tabs.Root value={1}>
           <Tabs.List>
@@ -121,7 +121,7 @@ describe('<Tabs.Root />', () => {
         </Tabs.Root>
       );
 
-      const { getAllByRole } = render(tabs);
+      const { getAllByRole } = await render(tabs);
       const tabElements = getAllByRole('tab');
       expect(tabElements[0]).to.have.attribute('aria-selected', 'false');
       expect(tabElements[1]).to.have.attribute('aria-selected', 'true');
@@ -130,7 +130,7 @@ describe('<Tabs.Root />', () => {
     it('should support values of different types', async () => {
       const tabValues = [0, '1', { value: 2 }, () => 3, Symbol('4'), /5/];
 
-      const { getAllByRole } = render(
+      const { getAllByRole } = await render(
         <Tabs.Root>
           <Tabs.List>
             {tabValues.map((value, index) => (
@@ -146,22 +146,27 @@ describe('<Tabs.Root />', () => {
       const tabElements = getAllByRole('tab');
       const tabPanelElements = getAllByRole('tabpanel', { hidden: true });
 
-      tabValues.forEach(async (value, index) => {
-        expect(tabPanelElements[index]).to.have.attribute('aria-labelledby', tabElements[index].id);
+      await Promise.allSettled(
+        tabValues.map(async (value, index) => {
+          expect(tabPanelElements[index]).to.have.attribute(
+            'aria-labelledby',
+            tabElements[index].id,
+          );
 
-        await act(() => {
-          tabElements[index].click();
-        });
+          await act(() => {
+            tabElements[index].click();
+          });
 
-        expect(tabPanelElements[index]).not.to.have.attribute('hidden');
-      });
+          expect(tabPanelElements[index]).not.to.have.attribute('hidden');
+        }),
+      );
     });
   });
 
   describe('prop: onValueChange', () => {
-    it('should call onValueChange when clicking', () => {
+    it('should call onValueChange when clicking', async () => {
       const handleChange = spy();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await render(
         <Tabs.Root value={0} onValueChange={handleChange}>
           <Tabs.List>
             <Tabs.Tab value={0} />
@@ -175,9 +180,9 @@ describe('<Tabs.Root />', () => {
       expect(handleChange.firstCall.args[0]).to.equal(1);
     });
 
-    it('should not call onValueChange when already selected', () => {
+    it('should not call onValueChange when already selected', async () => {
       const handleChange = spy();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await render(
         <Tabs.Root value={0} onValueChange={handleChange}>
           <Tabs.List>
             <Tabs.Tab value={0} />
@@ -192,7 +197,7 @@ describe('<Tabs.Root />', () => {
 
     it('should call onValueChange if an unselected tab gets focused', async () => {
       const handleChange = spy();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await render(
         <Tabs.Root value={0} onValueChange={handleChange}>
           <Tabs.List>
             <Tabs.Tab value={0} />
@@ -214,7 +219,7 @@ describe('<Tabs.Root />', () => {
 
     it('when `activateOnFocus = false` should not call onValueChange if an unselected tab gets focused', async () => {
       const handleChange = spy();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await render(
         <Tabs.Root value={1} onValueChange={handleChange}>
           <Tabs.List activateOnFocus={false}>
             <Tabs.Tab value={0} />
@@ -234,8 +239,8 @@ describe('<Tabs.Root />', () => {
   });
 
   describe('prop: orientation', () => {
-    it('does not add aria-orientation by default', () => {
-      render(
+    it('does not add aria-orientation by default', async () => {
+      await render(
         <Tabs.Root value={0}>
           <Tabs.List>
             <Tabs.Root />
@@ -246,8 +251,8 @@ describe('<Tabs.Root />', () => {
       expect(screen.getByRole('tablist')).not.to.have.attribute('aria-orientation');
     });
 
-    it('adds the proper aria-orientation when vertical', () => {
-      render(
+    it('adds the proper aria-orientation when vertical', async () => {
+      await render(
         <Tabs.Root value={0} orientation="vertical">
           <Tabs.List>
             <Tabs.Root />
@@ -273,7 +278,7 @@ describe('<Tabs.Root />', () => {
             it('moves focus to the last tab without activating it if focus is on the first tab', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
-              const { getAllByRole } = render(
+              const { getAllByRole } = await render(
                 <Tabs.Root
                   direction={direction as Tabs.RootProps['direction']}
                   onValueChange={handleChange}
@@ -304,7 +309,7 @@ describe('<Tabs.Root />', () => {
             it('moves focus to the previous tab without activating it', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
-              const { getAllByRole } = render(
+              const { getAllByRole } = await render(
                 <Tabs.Root
                   direction={direction as Tabs.RootProps['direction']}
                   onValueChange={handleChange}
@@ -337,7 +342,7 @@ describe('<Tabs.Root />', () => {
             it('moves focus to the last tab while activating it if focus is on the first tab', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
-              const { getAllByRole } = render(
+              const { getAllByRole } = await render(
                 <Tabs.Root
                   direction={direction as Tabs.RootProps['direction']}
                   onValueChange={handleChange}
@@ -369,7 +374,7 @@ describe('<Tabs.Root />', () => {
             it('moves focus to the previous tab while activating it', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
-              const { getAllByRole } = render(
+              const { getAllByRole } = await render(
                 <Tabs.Root
                   direction={direction as Tabs.RootProps['direction']}
                   onValueChange={handleChange}
@@ -401,7 +406,7 @@ describe('<Tabs.Root />', () => {
 
           it('skips over disabled tabs', async () => {
             const handleKeyDown = spy();
-            const { getAllByRole } = render(
+            const { getAllByRole } = await render(
               <Tabs.Root
                 direction={direction as Tabs.RootProps['direction']}
                 onKeyDown={handleKeyDown}
@@ -433,7 +438,7 @@ describe('<Tabs.Root />', () => {
             it('moves focus to the first tab without activating it if focus is on the last tab', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
-              const { getAllByRole } = render(
+              const { getAllByRole } = await render(
                 <Tabs.Root
                   direction={direction as Tabs.RootProps['direction']}
                   onValueChange={handleChange}
@@ -464,7 +469,7 @@ describe('<Tabs.Root />', () => {
             it('moves focus to the next tab without activating it', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
-              const { getAllByRole } = render(
+              const { getAllByRole } = await render(
                 <Tabs.Root
                   direction={direction as Tabs.RootProps['direction']}
                   onValueChange={handleChange}
@@ -497,7 +502,7 @@ describe('<Tabs.Root />', () => {
             it('moves focus to the first tab while activating it if focus is on the last tab', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
-              const { getAllByRole } = render(
+              const { getAllByRole } = await render(
                 <Tabs.Root
                   direction={direction as Tabs.RootProps['direction']}
                   onValueChange={handleChange}
@@ -529,7 +534,7 @@ describe('<Tabs.Root />', () => {
             it('moves focus to the next tab while activating it', async () => {
               const handleChange = spy();
               const handleKeyDown = spy();
-              const { getAllByRole } = render(
+              const { getAllByRole } = await render(
                 <Tabs.Root
                   direction={direction as Tabs.RootProps['direction']}
                   onValueChange={handleChange}
@@ -561,7 +566,7 @@ describe('<Tabs.Root />', () => {
 
           it('skips over disabled tabs', async () => {
             const handleKeyDown = spy();
-            const { getAllByRole } = render(
+            const { getAllByRole } = await render(
               <Tabs.Root
                 direction={direction as Tabs.RootProps['direction']}
                 onKeyDown={handleKeyDown}
@@ -595,7 +600,7 @@ describe('<Tabs.Root />', () => {
         it('when `activateOnFocus = false`, moves focus to the first tab without activating it', async () => {
           const handleChange = spy();
           const handleKeyDown = spy();
-          const { getAllByRole } = render(
+          const { getAllByRole } = await render(
             <Tabs.Root onValueChange={handleChange} onKeyDown={handleKeyDown} value={2}>
               <Tabs.List activateOnFocus={false}>
                 <Tabs.Tab value={0} />
@@ -620,7 +625,7 @@ describe('<Tabs.Root />', () => {
         it('when `activateOnFocus = true`, moves focus to the first tab while activating it', async () => {
           const handleChange = spy();
           const handleKeyDown = spy();
-          const { getAllByRole } = render(
+          const { getAllByRole } = await render(
             <Tabs.Root onValueChange={handleChange} onKeyDown={handleKeyDown} value={2}>
               <Tabs.List>
                 <Tabs.Tab value={0} />
@@ -645,7 +650,7 @@ describe('<Tabs.Root />', () => {
 
         it('moves focus to first non-disabled tab', async () => {
           const handleKeyDown = spy();
-          const { getAllByRole } = render(
+          const { getAllByRole } = await render(
             <Tabs.Root onKeyDown={handleKeyDown} value={2}>
               <Tabs.List>
                 <Tabs.Tab value={0} disabled />
@@ -671,7 +676,7 @@ describe('<Tabs.Root />', () => {
         it('when `activateOnFocus = false`, moves focus to the last tab without activating it', async () => {
           const handleChange = spy();
           const handleKeyDown = spy();
-          const { getAllByRole } = render(
+          const { getAllByRole } = await render(
             <Tabs.Root onValueChange={handleChange} onKeyDown={handleKeyDown} value={0}>
               <Tabs.List activateOnFocus={false}>
                 <Tabs.Tab value={0} />
@@ -696,7 +701,7 @@ describe('<Tabs.Root />', () => {
         it('when `activateOnFocus = true`, moves focus to the last tab while activating it', async () => {
           const handleChange = spy();
           const handleKeyDown = spy();
-          const { getAllByRole } = render(
+          const { getAllByRole } = await render(
             <Tabs.Root onValueChange={handleChange} onKeyDown={handleKeyDown} value={0}>
               <Tabs.List>
                 <Tabs.Tab value={0} />
@@ -721,7 +726,7 @@ describe('<Tabs.Root />', () => {
 
         it('moves focus to first non-disabled tab', async () => {
           const handleKeyDown = spy();
-          const { getAllByRole } = render(
+          const { getAllByRole } = await render(
             <Tabs.Root onKeyDown={handleKeyDown} value={0}>
               <Tabs.List>
                 <Tabs.Tab value={0} />
@@ -744,8 +749,8 @@ describe('<Tabs.Root />', () => {
       });
     });
 
-    it('should allow to focus first tab when there are no active tabs', () => {
-      const { getAllByRole } = render(
+    it('should allow to focus first tab when there are no active tabs', async () => {
+      const { getAllByRole } = await render(
         <Tabs.Root defaultValue={0}>
           <Tabs.List>
             <Tabs.Tab value={0} />
@@ -769,7 +774,7 @@ describe('<Tabs.Root />', () => {
     });
 
     it('should set the `data-activation-direction` attribute on the tabs root with orientation=horizontal', async () => {
-      const { getAllByRole, getByTestId } = render(
+      const { getAllByRole, getByTestId } = await render(
         <Tabs.Root data-testid="root">
           <Tabs.List>
             <Tabs.Tab />
@@ -796,7 +801,7 @@ describe('<Tabs.Root />', () => {
     });
 
     it('should set the `data-activation-direction` attribute on the tabs root with orientation=vertical', async () => {
-      const { getAllByRole, getByTestId } = render(
+      const { getAllByRole, getByTestId } = await render(
         <Tabs.Root data-testid="root" orientation="vertical">
           <Tabs.List>
             <Tabs.Tab style={{ display: 'block' }} />

--- a/packages/mui-base/src/Tabs/Root/TabsRoot.test.tsx
+++ b/packages/mui-base/src/Tabs/Root/TabsRoot.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import * as Tabs from '@base_ui/react/Tabs';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Tabs.Root />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Tabs/Tab/Tab.test.tsx
+++ b/packages/mui-base/src/Tabs/Tab/Tab.test.tsx
@@ -39,7 +39,6 @@ describe('<Tabs.Tab />', () => {
   };
 
   describeConformance(<Tabs.Tab value="1" />, () => ({
-    inheritComponent: 'div',
     render: (node) => {
       const { container, ...other } = render(
         <TabsContext.Provider value={testTabsContext}>

--- a/packages/mui-base/src/Tabs/Tab/Tab.test.tsx
+++ b/packages/mui-base/src/Tabs/Tab/Tab.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Tabs from '@base_ui/react/Tabs';
 import {
   TabsListProvider,
@@ -7,7 +6,7 @@ import {
   TabsContext,
   TabsContextValue,
 } from '@base_ui/react/Tabs';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Tabs.Tab />', () => {
   const { render } = createRenderer();
@@ -40,13 +39,11 @@ describe('<Tabs.Tab />', () => {
 
   describeConformance(<Tabs.Tab value="1" />, () => ({
     render: (node) => {
-      const { container, ...other } = render(
+      return render(
         <TabsContext.Provider value={testTabsContext}>
           <TabsListProvider value={testTabsListContext}>{node}</TabsListProvider>
         </TabsContext.Provider>,
       );
-
-      return { container, ...other };
     },
     refInstanceof: window.HTMLButtonElement,
   }));

--- a/packages/mui-base/src/Tabs/Tab/Tab.test.tsx
+++ b/packages/mui-base/src/Tabs/Tab/Tab.test.tsx
@@ -6,7 +6,7 @@ import {
   TabsContext,
   TabsContextValue,
 } from '@base_ui/react/Tabs';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Tabs.Tab />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Tabs/TabIndicator/TabIndicator.test.tsx
+++ b/packages/mui-base/src/Tabs/TabIndicator/TabIndicator.test.tsx
@@ -16,7 +16,6 @@ describe('<Tabs.Indicator />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Tabs.Indicator />, () => ({
-    inheritComponent: 'span',
     render: (node) => {
       const { container, ...other } = render(
         <Tabs.Root defaultValue={1}>

--- a/packages/mui-base/src/Tabs/TabIndicator/TabIndicator.test.tsx
+++ b/packages/mui-base/src/Tabs/TabIndicator/TabIndicator.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import * as Tabs from '@base_ui/react/Tabs';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 async function wait(timeout: number) {
   return new Promise<void>((resolve) => {

--- a/packages/mui-base/src/Tabs/TabIndicator/TabIndicator.test.tsx
+++ b/packages/mui-base/src/Tabs/TabIndicator/TabIndicator.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Tabs from '@base_ui/react/Tabs';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 async function wait(timeout: number) {
   return new Promise<void>((resolve) => {
@@ -17,7 +16,7 @@ describe('<Tabs.Indicator />', () => {
 
   describeConformance(<Tabs.Indicator />, () => ({
     render: (node) => {
-      const { container, ...other } = render(
+      return render(
         <Tabs.Root defaultValue={1}>
           <Tabs.List>
             <Tabs.Tab value={1} />
@@ -25,8 +24,6 @@ describe('<Tabs.Indicator />', () => {
           </Tabs.List>
         </Tabs.Root>,
       );
-
-      return { container, ...other };
     },
     refInstanceof: window.HTMLSpanElement,
     testRenderPropWith: 'div',
@@ -39,8 +36,8 @@ describe('<Tabs.Indicator />', () => {
       }
     });
 
-    it('should not render when no tab is selected', () => {
-      const { queryByTestId } = render(
+    it('should not render when no tab is selected', async () => {
+      const { queryByTestId } = await render(
         <Tabs.Root value={null}>
           <Tabs.List>
             <Tabs.Indicator data-testid="bubble" />
@@ -92,8 +89,8 @@ describe('<Tabs.Indicator />', () => {
       assertSize(actualBottom, relativeBottom);
     }
 
-    it('should set CSS variables corresponding to the active tab', () => {
-      const { getByTestId, getByRole, getAllByRole } = render(
+    it('should set CSS variables corresponding to the active tab', async () => {
+      const { getByTestId, getByRole, getAllByRole } = await render(
         <Tabs.Root value={2}>
           <Tabs.List>
             <Tabs.Tab value={1}>One</Tabs.Tab>
@@ -112,8 +109,8 @@ describe('<Tabs.Indicator />', () => {
       assertBubblePositionVariables(bubble, tabList, activeTab);
     });
 
-    it('should update the position and movement variables when the active tab changes', () => {
-      const { getByTestId, getByRole, getAllByRole, setProps } = render(
+    it('should update the position and movement variables when the active tab changes', async () => {
+      const { getByTestId, getByRole, getAllByRole, setProps } = await render(
         <Tabs.Root value={2}>
           <Tabs.List>
             <Tabs.Tab value={1}>One</Tabs.Tab>
@@ -139,7 +136,7 @@ describe('<Tabs.Indicator />', () => {
     });
 
     it('should update the position variables when the tab list is resized', async () => {
-      const { getByTestId, getByRole, getAllByRole, setProps } = render(
+      const { getByTestId, getByRole, getAllByRole, setProps } = await render(
         <Tabs.Root value={1} style={{ width: '400px' }}>
           <Tabs.List style={{ display: 'flex' }}>
             <Tabs.Tab value={1} style={{ flex: '1 1 auto' }}>

--- a/packages/mui-base/src/Tabs/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-base/src/Tabs/TabPanel/TabPanel.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Tabs from '@base_ui/react/Tabs';
 import { TabsProvider, TabsProviderValue } from '@base_ui/react/Tabs';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Tabs.Panel />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Tabs/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-base/src/Tabs/TabPanel/TabPanel.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils';
 import * as Tabs from '@base_ui/react/Tabs';
 import { TabsProvider, TabsProviderValue } from '@base_ui/react/Tabs';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Tabs.Panel />', () => {
   const { render } = createRenderer();
@@ -23,11 +22,7 @@ describe('<Tabs.Panel />', () => {
 
   describeConformance(<Tabs.Panel value="1" />, () => ({
     render: (node) => {
-      const { container, ...other } = render(
-        <TabsProvider value={tabsProviderDefaultValue}>{node}</TabsProvider>,
-      );
-
-      return { container, ...other };
+      return render(<TabsProvider value={tabsProviderDefaultValue}>{node}</TabsProvider>);
     },
     refInstanceof: window.HTMLDivElement,
   }));

--- a/packages/mui-base/src/Tabs/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-base/src/Tabs/TabPanel/TabPanel.test.tsx
@@ -22,7 +22,6 @@ describe('<Tabs.Panel />', () => {
   };
 
   describeConformance(<Tabs.Panel value="1" />, () => ({
-    inheritComponent: 'div',
     render: (node) => {
       const { container, ...other } = render(
         <TabsProvider value={tabsProviderDefaultValue}>{node}</TabsProvider>,

--- a/packages/mui-base/src/Tabs/TabsList/TabsList.test.tsx
+++ b/packages/mui-base/src/Tabs/TabsList/TabsList.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { act } from '@mui/internal-test-utils';
 import * as Tabs from '@base_ui/react/Tabs';
 import { TabsContext } from '@base_ui/react/Tabs';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Tabs.List />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Tabs/TabsList/TabsList.test.tsx
+++ b/packages/mui-base/src/Tabs/TabsList/TabsList.test.tsx
@@ -9,7 +9,6 @@ describe('<Tabs.List />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Tabs.List />, () => ({
-    inheritComponent: 'div',
     render: (node) => {
       const { container, ...other } = render(
         <TabsContext.Provider
@@ -34,7 +33,7 @@ describe('<Tabs.List />', () => {
   }));
 
   describe('accessibility attributes', () => {
-    it('sets the aria-selected attribute on the selected tab', () => {
+    it('sets the aria-selected attribute on the selected tab', async () => {
       const { getByText } = render(
         <Tabs.Root defaultValue={1}>
           <Tabs.List>
@@ -53,7 +52,7 @@ describe('<Tabs.List />', () => {
       expect(tab2).to.have.attribute('aria-selected', 'false');
       expect(tab3).to.have.attribute('aria-selected', 'false');
 
-      act(() => {
+      await act(() => {
         tab2.click();
       });
 
@@ -61,7 +60,7 @@ describe('<Tabs.List />', () => {
       expect(tab2).to.have.attribute('aria-selected', 'true');
       expect(tab3).to.have.attribute('aria-selected', 'false');
 
-      act(() => {
+      await act(() => {
         tab3.click();
       });
 
@@ -69,7 +68,7 @@ describe('<Tabs.List />', () => {
       expect(tab2).to.have.attribute('aria-selected', 'false');
       expect(tab3).to.have.attribute('aria-selected', 'true');
 
-      act(() => {
+      await act(() => {
         tab1.click();
       });
 

--- a/packages/mui-base/src/Tabs/TabsList/TabsList.test.tsx
+++ b/packages/mui-base/src/Tabs/TabsList/TabsList.test.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, createRenderer } from '@mui/internal-test-utils';
+import { act } from '@mui/internal-test-utils';
 import * as Tabs from '@base_ui/react/Tabs';
 import { TabsContext } from '@base_ui/react/Tabs';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Tabs.List />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Tabs.List />, () => ({
     render: (node) => {
-      const { container, ...other } = render(
+      return render(
         <TabsContext.Provider
           value={{
             value: '1',
@@ -26,15 +26,13 @@ describe('<Tabs.List />', () => {
           {node}
         </TabsContext.Provider>,
       );
-
-      return { container, ...other };
     },
     refInstanceof: window.HTMLDivElement,
   }));
 
   describe('accessibility attributes', () => {
     it('sets the aria-selected attribute on the selected tab', async () => {
-      const { getByText } = render(
+      const { getByText } = await render(
         <Tabs.Root defaultValue={1}>
           <Tabs.List>
             <Tabs.Tab value={1}>Tab 1</Tabs.Tab>
@@ -78,8 +76,8 @@ describe('<Tabs.List />', () => {
     });
   });
 
-  it('can be named via `aria-label`', () => {
-    const { getByRole } = render(
+  it('can be named via `aria-label`', async () => {
+    const { getByRole } = await render(
       <Tabs.Root defaultValue={0}>
         <Tabs.List aria-label="string label">
           <Tabs.Tab value={0} />
@@ -90,8 +88,8 @@ describe('<Tabs.List />', () => {
     expect(getByRole('tablist')).toHaveAccessibleName('string label');
   });
 
-  it('can be named via `aria-labelledby`', () => {
-    const { getByRole } = render(
+  it('can be named via `aria-labelledby`', async () => {
+    const { getByRole } = await render(
       <React.Fragment>
         <h3 id="label-id">complex name</h3>
         <Tabs.Root defaultValue={0}>

--- a/packages/mui-base/src/Tooltip/Arrow/TooltipArrow.test.tsx
+++ b/packages/mui-base/src/Tooltip/Arrow/TooltipArrow.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Tooltip from '@base_ui/react/Tooltip';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Tooltip.Arrow />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Tooltip/Arrow/TooltipArrow.test.tsx
+++ b/packages/mui-base/src/Tooltip/Arrow/TooltipArrow.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as Tooltip from '@base_ui/react/Tooltip';
-import { createRenderer } from '@mui/internal-test-utils';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Tooltip.Arrow />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Tooltip/Popup/TooltipPopup.test.tsx
+++ b/packages/mui-base/src/Tooltip/Popup/TooltipPopup.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Tooltip from '@base_ui/react/Tooltip';
 import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Tooltip.Popup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Tooltip/Popup/TooltipPopup.test.tsx
+++ b/packages/mui-base/src/Tooltip/Popup/TooltipPopup.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as Tooltip from '@base_ui/react/Tooltip';
-import { createRenderer, screen } from '@mui/internal-test-utils';
+import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Tooltip.Popup />', () => {
   const { render } = createRenderer();
@@ -18,8 +18,8 @@ describe('<Tooltip.Popup />', () => {
     },
   }));
 
-  it('should render the children', () => {
-    render(
+  it('should render the children', async () => {
+    await render(
       <Tooltip.Root open>
         <Tooltip.Positioner>
           <Tooltip.Popup>Content</Tooltip.Popup>

--- a/packages/mui-base/src/Tooltip/Popup/TooltipPopup.test.tsx
+++ b/packages/mui-base/src/Tooltip/Popup/TooltipPopup.test.tsx
@@ -8,7 +8,6 @@ describe('<Tooltip.Popup />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Tooltip.Popup />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(

--- a/packages/mui-base/src/Tooltip/Positioner/TooltipPositioner.test.tsx
+++ b/packages/mui-base/src/Tooltip/Positioner/TooltipPositioner.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Tooltip from '@base_ui/react/Tooltip';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Tooltip.Positioner />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Tooltip/Positioner/TooltipPositioner.test.tsx
+++ b/packages/mui-base/src/Tooltip/Positioner/TooltipPositioner.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as Tooltip from '@base_ui/react/Tooltip';
-import { createRenderer } from '@mui/internal-test-utils';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Tooltip.Positioner />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Tooltip/Positioner/TooltipPositioner.test.tsx
+++ b/packages/mui-base/src/Tooltip/Positioner/TooltipPositioner.test.tsx
@@ -7,7 +7,6 @@ describe('<Tooltip.Positioner />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Tooltip.Positioner />, () => ({
-    inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(<Tooltip.Root open>{node}</Tooltip.Root>);

--- a/packages/mui-base/src/Tooltip/Provider/TooltipProvider.test.tsx
+++ b/packages/mui-base/src/Tooltip/Provider/TooltipProvider.test.tsx
@@ -3,7 +3,7 @@ import * as Tooltip from '@base_ui/react/Tooltip';
 import { screen, fireEvent, flushMicrotasks } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { OPEN_DELAY } from '../utils/constants';
-import { createRenderer } from '../../../test';
+import { createRenderer } from '#test-utils';
 
 describe('<Tooltip.Provider />', () => {
   const { render, clock } = createRenderer();

--- a/packages/mui-base/src/Tooltip/Provider/TooltipProvider.test.tsx
+++ b/packages/mui-base/src/Tooltip/Provider/TooltipProvider.test.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import * as Tooltip from '@base_ui/react/Tooltip';
 import { screen, fireEvent, flushMicrotasks } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { OPEN_DELAY } from '../utils/constants';
 import { createRenderer } from '#test-utils';
+import { OPEN_DELAY } from '../utils/constants';
 
 describe('<Tooltip.Provider />', () => {
   const { render, clock } = createRenderer();

--- a/packages/mui-base/src/Tooltip/Root/TooltipRoot.test.tsx
+++ b/packages/mui-base/src/Tooltip/Root/TooltipRoot.test.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-util
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { OPEN_DELAY } from '../utils/constants';
-import { createRenderer } from '../../../test';
+import { createRenderer } from '#test-utils';
 
 function Root(props: Tooltip.RootProps) {
   return <Tooltip.Root animated={false} {...props} />;

--- a/packages/mui-base/src/Tooltip/Root/TooltipRoot.test.tsx
+++ b/packages/mui-base/src/Tooltip/Root/TooltipRoot.test.tsx
@@ -3,8 +3,8 @@ import * as Tooltip from '@base_ui/react/Tooltip';
 import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { OPEN_DELAY } from '../utils/constants';
 import { createRenderer } from '#test-utils';
+import { OPEN_DELAY } from '../utils/constants';
 
 function Root(props: Tooltip.RootProps) {
   return <Tooltip.Root animated={false} {...props} />;

--- a/packages/mui-base/src/Tooltip/Root/TooltipRoot.test.tsx
+++ b/packages/mui-base/src/Tooltip/Root/TooltipRoot.test.tsx
@@ -100,13 +100,16 @@ describe('<Tooltip.Root />', () => {
 
       const trigger = screen.getByRole('button');
 
-      await act(() => trigger.focus());
+      await act(async () => {
+        trigger.focus();
+      });
 
       clock.tick(OPEN_DELAY);
-
       await flushMicrotasks();
 
-      await act(() => trigger.blur());
+      await act(async () => {
+        trigger.blur();
+      });
 
       clock.tick(OPEN_DELAY);
 

--- a/packages/mui-base/src/Tooltip/Root/TooltipRoot.test.tsx
+++ b/packages/mui-base/src/Tooltip/Root/TooltipRoot.test.tsx
@@ -81,7 +81,7 @@ describe('<Tooltip.Root />', () => {
 
       const trigger = screen.getByRole('button');
 
-      act(() => trigger.focus());
+      await act(() => trigger.focus());
 
       await flushMicrotasks();
 
@@ -100,13 +100,13 @@ describe('<Tooltip.Root />', () => {
 
       const trigger = screen.getByRole('button');
 
-      act(() => trigger.focus());
+      await act(() => trigger.focus());
 
       clock.tick(OPEN_DELAY);
 
       await flushMicrotasks();
 
-      act(() => trigger.blur());
+      await act(() => trigger.blur());
 
       clock.tick(OPEN_DELAY);
 

--- a/packages/mui-base/src/Tooltip/Trigger/TooltipTrigger.test.tsx
+++ b/packages/mui-base/src/Tooltip/Trigger/TooltipTrigger.test.tsx
@@ -7,7 +7,6 @@ describe('<Tooltip.Trigger />', () => {
   const { render } = createRenderer();
 
   describeConformance(<Tooltip.Trigger />, () => ({
-    inheritComponent: 'button',
     refInstanceof: window.HTMLButtonElement,
     render(node) {
       return render(<Tooltip.Root>{node}</Tooltip.Root>);

--- a/packages/mui-base/src/Tooltip/Trigger/TooltipTrigger.test.tsx
+++ b/packages/mui-base/src/Tooltip/Trigger/TooltipTrigger.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Tooltip from '@base_ui/react/Tooltip';
-import { createRenderer, describeConformance } from '../../../test';
+import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Tooltip.Trigger />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Tooltip/Trigger/TooltipTrigger.test.tsx
+++ b/packages/mui-base/src/Tooltip/Trigger/TooltipTrigger.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as Tooltip from '@base_ui/react/Tooltip';
-import { createRenderer } from '@mui/internal-test-utils';
-import { describeConformance } from '../../../test/describeConformance';
+import { createRenderer, describeConformance } from '../../../test';
 
 describe('<Tooltip.Trigger />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/legacy/FormControl/FormControl.test.tsx
+++ b/packages/mui-base/src/legacy/FormControl/FormControl.test.tsx
@@ -13,7 +13,6 @@ describe('<FormControl />', () => {
   const { render } = createRenderer();
 
   describeConformanceUnstyled(<FormControl />, () => ({
-    inheritComponent: 'div',
     render,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'div',

--- a/packages/mui-base/src/legacy/Option/Option.test.tsx
+++ b/packages/mui-base/src/legacy/Option/Option.test.tsx
@@ -15,7 +15,6 @@ describe('<Option />', () => {
   const { render } = createRenderer();
 
   describeConformanceUnstyled(<Option value={42} />, () => ({
-    inheritComponent: 'li',
     render: (node) => {
       return render(
         <SelectProvider

--- a/packages/mui-base/src/legacy/OptionGroup/OptionGroup.test.tsx
+++ b/packages/mui-base/src/legacy/OptionGroup/OptionGroup.test.tsx
@@ -7,7 +7,6 @@ describe('<OptionGroup />', () => {
   const { render } = createRenderer();
 
   describeConformanceUnstyled(<OptionGroup />, () => ({
-    inheritComponent: 'li',
     render,
     refInstanceof: window.HTMLLIElement,
     testComponentPropWith: 'span',

--- a/packages/mui-base/src/legacy/Select/Select.test.tsx
+++ b/packages/mui-base/src/legacy/Select/Select.test.tsx
@@ -43,7 +43,6 @@ describe('<Select />', () => {
   );
 
   describeConformanceUnstyled(componentToTest, () => ({
-    inheritComponent: 'button',
     render,
     refInstanceof: window.HTMLButtonElement,
     testComponentPropWith: 'span',

--- a/packages/mui-base/src/legacy/Snackbar/Snackbar.test.tsx
+++ b/packages/mui-base/src/legacy/Snackbar/Snackbar.test.tsx
@@ -29,7 +29,6 @@ describe('<Snackbar />', () => {
     </Snackbar>,
     () => ({
       classes,
-      inheritComponent: 'div',
       render,
       refInstanceof: window.HTMLDivElement,
       slots: {

--- a/packages/mui-base/src/legacy/TablePagination/TablePagination.test.tsx
+++ b/packages/mui-base/src/legacy/TablePagination/TablePagination.test.tsx
@@ -27,7 +27,6 @@ describe('<TablePagination />', () => {
   describeConformanceUnstyled(
     <TablePagination count={1} onPageChange={noop} page={0} rowsPerPage={10} />,
     () => ({
-      inheritComponent: 'td',
       render: (node) => {
         const { container, ...other } = render(
           <table>

--- a/packages/mui-base/src/legacy/TextareaAutosize/TextareaAutosize.test.tsx
+++ b/packages/mui-base/src/legacy/TextareaAutosize/TextareaAutosize.test.tsx
@@ -37,7 +37,6 @@ describe('<TextareaAutosize />', () => {
 
   describeConformanceUnstyled(<TextareaAutosize />, () => ({
     render,
-    inheritComponent: 'textarea',
     refInstanceof: window.HTMLTextAreaElement,
     slots: {},
     skip: [

--- a/packages/mui-base/src/legacy/Unstable_Popup/Popup.test.tsx
+++ b/packages/mui-base/src/legacy/Unstable_Popup/Popup.test.tsx
@@ -52,7 +52,6 @@ describe('<Popup />', () => {
   };
 
   describeConformanceUnstyled(<Popup {...defaultProps} />, () => ({
-    inheritComponent: 'div',
     render: async (...renderArgs) => {
       const result = render(...renderArgs);
       await flushMicrotasks();

--- a/packages/mui-base/src/legacy/Unstable_Popup/Popup.test.tsx
+++ b/packages/mui-base/src/legacy/Unstable_Popup/Popup.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
+import { act, createRenderer, screen, fireEvent, flushMicrotasks } from '@mui/internal-test-utils';
 import {
   Unstable_Popup as Popup,
   popupClasses,
@@ -45,14 +45,6 @@ function FakeTransition(props: React.PropsWithChildren<{}>) {
 describe('<Popup />', () => {
   const { clock, render } = createRenderer();
 
-  // https://floating-ui.com/docs/react#testing
-  async function waitForPosition() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // This is only needed for JSDOM and causes issues in real browsers
-      await act(() => async () => {});
-    }
-  }
-
   const defaultProps: PopupProps = {
     anchor: () => createAnchor(),
     children: <span>Hello World</span>,
@@ -63,7 +55,7 @@ describe('<Popup />', () => {
     inheritComponent: 'div',
     render: async (...renderArgs) => {
       const result = render(...renderArgs);
-      await waitForPosition();
+      await flushMicrotasks();
 
       return result;
     },
@@ -89,12 +81,14 @@ describe('<Popup />', () => {
 
     it('should have top placement', async () => {
       render(
-        <Popup {...defaultProps} placement="top">
-          <PlacementTester />
-        </Popup>,
+        <div style={{ margin: '100px' }}>
+          <Popup {...defaultProps} placement="top">
+            <PlacementTester />
+          </Popup>
+        </div>,
       );
 
-      await waitForPosition();
+      await flushMicrotasks();
 
       expect(screen.getByTestId('placement-tester')).to.have.text('top');
     });
@@ -131,7 +125,7 @@ describe('<Popup />', () => {
       }
 
       render(<RtlTest />);
-      await waitForPosition();
+      await flushMicrotasks();
 
       await new Promise((resolve) => {
         requestAnimationFrame(resolve);
@@ -149,7 +143,7 @@ describe('<Popup />', () => {
         anchor.click();
       });
 
-      await waitForPosition();
+      await flushMicrotasks();
       expect(popup.getBoundingClientRect().right).to.equal(popup.getBoundingClientRect().right);
       expect(popup.getBoundingClientRect().left).not.to.equal(anchor.getBoundingClientRect().left);
     });
@@ -260,22 +254,22 @@ describe('<Popup />', () => {
     it('should open without any issues', async () => {
       const { queryByRole, getByRole, setProps } = render(<Popup {...defaultProps} open={false} />);
 
-      await waitForPosition();
+      await flushMicrotasks();
       expect(queryByRole('tooltip')).to.equal(null);
 
       setProps({ open: true });
-      await waitForPosition();
+      await flushMicrotasks();
       expect(getByRole('tooltip')).to.have.text('Hello World');
     });
 
     it('should close without any issues', async () => {
       const { queryByRole, getByRole, setProps } = render(<Popup {...defaultProps} />);
 
-      await waitForPosition();
+      await flushMicrotasks();
       expect(getByRole('tooltip')).to.have.text('Hello World');
 
       setProps({ open: false });
-      await waitForPosition();
+      await flushMicrotasks();
       expect(queryByRole('tooltip')).to.equal(null);
     });
   });
@@ -283,7 +277,7 @@ describe('<Popup />', () => {
   describe('prop: keepMounted', () => {
     it('should keep the children mounted in the DOM', async () => {
       render(<Popup {...defaultProps} keepMounted open={false} />);
-      await waitForPosition();
+      await flushMicrotasks();
 
       const tooltip = document.querySelector('[role="tooltip"]') as HTMLElement;
       expect(tooltip).to.have.text('Hello World');
@@ -303,11 +297,11 @@ describe('<Popup />', () => {
         </Popup>,
       );
 
-      await waitForPosition();
+      await flushMicrotasks();
       expect(getByRole('tooltip')).to.have.text('Hello World');
 
       setProps({ open: false });
-      await waitForPosition();
+      await flushMicrotasks();
       clock.tick(TRANSITION_DURATION);
 
       expect(queryByRole('tooltip')).to.equal(null);
@@ -343,11 +337,11 @@ describe('<Popup />', () => {
       }
 
       const { getByRole } = render(<OpenClose />);
-      await waitForPosition();
+      await flushMicrotasks();
       expect(document.querySelector('p')).to.equal(null);
 
       fireEvent.click(getByRole('button'));
-      await waitForPosition();
+      await flushMicrotasks();
       expect(document.querySelector('p')).to.equal(null);
     });
   });
@@ -360,7 +354,7 @@ describe('<Popup />', () => {
         </div>,
       );
 
-      await waitForPosition();
+      await flushMicrotasks();
 
       const tooltip = getByRole('tooltip');
       const parent = getByTestId('parent');
@@ -376,7 +370,7 @@ describe('<Popup />', () => {
         </div>,
       );
 
-      await waitForPosition();
+      await flushMicrotasks();
 
       const tooltip = getByRole('tooltip');
       expect(tooltip.parentNode).to.equal(document.body);
@@ -395,15 +389,15 @@ describe('<Popup />', () => {
         </Popup>,
       );
 
-      await waitForPosition();
+      await flushMicrotasks();
       expect(getByRole('tooltip', { hidden: true }).style.visibility).to.equal('hidden');
 
       setProps({ open: true });
-      await waitForPosition();
+      await flushMicrotasks();
       clock.tick(TRANSITION_DURATION);
 
       setProps({ open: false });
-      await waitForPosition();
+      await flushMicrotasks();
       clock.tick(TRANSITION_DURATION);
       expect(getByRole('tooltip', { hidden: true }).style.visibility).to.equal('hidden');
     });

--- a/packages/mui-base/test/conformanceTests/propForwarding.tsx
+++ b/packages/mui-base/test/conformanceTests/propForwarding.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, randomStringValue } from '@mui/internal-test-utils';
+import { flushMicrotasks, randomStringValue } from '@mui/internal-test-utils';
 import { throwMissingPropError } from './utils';
 import { type BaseUiConformanceTestsOptions } from '../describeConformance';
 
@@ -25,7 +25,7 @@ export function testPropForwarding(
         React.cloneElement(element, { 'data-testid': 'root', ...otherProps }),
       );
 
-      await act(async () => {});
+      await flushMicrotasks();
 
       const customRoot = getByTestId('root');
       expect(customRoot).to.have.attribute('lang', otherProps.lang);
@@ -45,7 +45,7 @@ export function testPropForwarding(
         }),
       );
 
-      await act(async () => {});
+      await flushMicrotasks();
 
       const customRoot = getByTestId('custom-root');
       expect(customRoot).to.have.attribute('lang', otherProps.lang);

--- a/packages/mui-base/test/describeConformanceUnstyled.tsx
+++ b/packages/mui-base/test/describeConformanceUnstyled.tsx
@@ -92,7 +92,7 @@ function testPropForwarding(
     expect(customRoot).to.have.attribute('data-foobar', otherProps.fooBar);
   });
 
-  it('does forward standard props to the root element if an intrinsic element is provided', () => {
+  it('does forward standard props to the root element if an intrinsic element is provided', async () => {
     const otherProps = {
       lang: 'fr',
       'data-foobar': randomStringValue(),
@@ -100,7 +100,7 @@ function testPropForwarding(
       ...(rootElementNameMustMatchComponentProp ? { rootElementName: Element } : {}),
     };
 
-    render(React.cloneElement(element, { slots: { root: Element }, ...otherProps }));
+    await render(React.cloneElement(element, { slots: { root: Element }, ...otherProps }));
 
     const customRoot = screen.getByTestId('custom-root');
     expect(customRoot).to.have.attribute('lang', otherProps.lang);
@@ -324,7 +324,7 @@ function testOwnerStatePropagation(
   }
 
   forEachSlot(slots, (slotName) => {
-    it(`sets the ownerState prop on the ${slotName} slot's component`, () => {
+    it(`sets the ownerState prop on the ${slotName} slot's component`, async () => {
       let componentOwnerState;
       const TestComponent = React.forwardRef(
         ({ ownerState }: WithOwnerState, ref: React.Ref<any>) => {
@@ -343,7 +343,7 @@ function testOwnerStatePropagation(
         id: 'foo',
       };
 
-      render(
+      await render(
         React.cloneElement(element, {
           slots: slotOverrides,
           id: 'foo',
@@ -366,8 +366,8 @@ function testDisablingClassGeneration(
     throwMissingPropError('render');
   }
 
-  it(`does not generate any class names if placed within a ClassNameConfigurator`, () => {
-    render(<ClassNameConfigurator disableDefaultClasses>{element}</ClassNameConfigurator>);
+  it(`does not generate any class names if placed within a ClassNameConfigurator`, async () => {
+    await render(<ClassNameConfigurator disableDefaultClasses>{element}</ClassNameConfigurator>);
 
     const elementsWithClasses = document.querySelectorAll(`[class]`);
 

--- a/packages/mui-base/tsconfig.build.json
+++ b/packages/mui-base/tsconfig.build.json
@@ -6,6 +6,8 @@
     "composite": true,
     "declaration": true,
     "emitDeclarationOnly": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "noEmit": false,
     "rootDir": "./src",
     "outDir": "build"

--- a/packages/mui-base/tsconfig.test.json
+++ b/packages/mui-base/tsconfig.test.json
@@ -5,6 +5,8 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "noEmit": false,
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "rootDir": ".",
     "outDir": "build-tests"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^4.6.2
         version: 4.6.2(eslint@8.57.0)
+      eslint-plugin-testing-library:
+        specifier: ^6.2.2
+        version: 6.2.2(eslint@8.57.0)(typescript@5.4.5)
       execa:
         specifier: ^8.0.1
         version: 8.0.1
@@ -4534,6 +4537,12 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+
+  eslint-plugin-testing-library@6.2.2:
+    resolution: {integrity: sha512-1E94YOTUDnOjSLyvOwmbVDzQi/WkKm3WVrMXu6SmBr6DN95xTGZmI6HJ/eOkSXh/DlheRsxaPsJvZByDBhWLVQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
+    peerDependencies:
+      eslint: ^7.5.0 || ^8.0.0
 
   eslint-rule-composer@0.3.0:
     resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
@@ -11428,6 +11437,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
+      eslint: 8.57.0
+      eslint-scope: 5.1.1
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/utils@5.62.0(eslint@9.8.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.8.0)
@@ -13225,6 +13249,14 @@ snapshots:
       resolve: 2.0.0-next.5
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
+
+  eslint-plugin-testing-library@6.2.2(eslint@8.57.0)(typescript@5.4.5):
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint-rule-composer@0.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         specifier: ^1.0.14
         version: 1.0.14
       '@mui/internal-test-utils':
-        specifier: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils
-        version: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.0.6-dev.20240805-092432-9f940a61d6
+        version: 1.0.6-dev.20240805-092432-9f940a61d6(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/material':
         specifier: 6.0.0-beta.4
         version: 6.0.0-beta.4(@emotion/react@11.13.0(@types/react@18.3.1)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.13.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -492,8 +492,8 @@ importers:
         specifier: ^1.0.8
         version: 1.0.8
       '@mui/internal-test-utils':
-        specifier: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils
-        version: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.0.6-dev.20240805-092432-9f940a61d6
+        version: 1.0.6-dev.20240805-092432-9f940a61d6(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/autosuggest-highlight':
         specifier: ^3.2.3
         version: 3.2.3
@@ -586,8 +586,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1(@mui/utils@5.16.6(@types/react@18.3.1)(react@18.3.1))
       '@mui/internal-test-utils':
-        specifier: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils
-        version: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.0.6-dev.20240805-092432-9f940a61d6
+        version: 1.0.6-dev.20240805-092432-9f940a61d6(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/react':
         specifier: ^15.0.7
         version: 15.0.7(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -650,8 +650,8 @@ importers:
         specifier: ^11.11.4
         version: 11.13.0(@types/react@18.3.1)(react@18.3.1)
       '@mui/internal-test-utils':
-        specifier: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils
-        version: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.0.6-dev.20240805-092432-9f940a61d6
+        version: 1.0.6-dev.20240805-092432-9f940a61d6(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/joy':
         specifier: 5.0.0-beta.48
         version: 5.0.0-beta.48(@emotion/react@11.13.0(@types/react@18.3.1)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.13.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2077,9 +2077,8 @@ packages:
   '@mui/internal-scripts@1.0.14':
     resolution: {integrity: sha512-v2HQWzssX8l+WAZh4JpgAtnxvwi4ZEm7+spi3e/1zxTXz/k3aWlcc50lpfeAtD6TGbegN2/j0OCORfDHTDQdbQ==}
 
-  '@mui/internal-test-utils@https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils':
-    resolution: {tarball: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils}
-    version: 1.0.6
+  '@mui/internal-test-utils@1.0.6-dev.20240805-092432-9f940a61d6':
+    resolution: {integrity: sha512-bagoSVQFWUJaHK2iJkTLGSUxTchucNEpQorfFNjv0Ep2I/LBnmnLWJZG0vhKq0dljgZj5Y9UYaCjClfLrjTvCA==}
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -10217,7 +10216,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mui/internal-test-utils@https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/internal-test-utils@1.0.6-dev.20240805-092432-9f940a61d6(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.25.2)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.25.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         specifier: ^1.0.14
         version: 1.0.14
       '@mui/internal-test-utils':
-        specifier: 1.0.6
-        version: 1.0.6(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils
+        version: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/material':
         specifier: 6.0.0-beta.4
         version: 6.0.0-beta.4(@emotion/react@11.13.0(@types/react@18.3.1)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.13.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -240,7 +240,7 @@ importers:
         version: 0.13.0
       mocha:
         specifier: ^10.4.0
-        version: 10.6.0
+        version: 10.7.0
       nx:
         specifier: ^18.3.5
         version: 18.3.5
@@ -492,8 +492,8 @@ importers:
         specifier: ^1.0.8
         version: 1.0.8
       '@mui/internal-test-utils':
-        specifier: 1.0.6
-        version: 1.0.6(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils
+        version: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/autosuggest-highlight':
         specifier: ^3.2.3
         version: 3.2.3
@@ -586,8 +586,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1(@mui/utils@5.16.6(@types/react@18.3.1)(react@18.3.1))
       '@mui/internal-test-utils':
-        specifier: 1.0.6
-        version: 1.0.6(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils
+        version: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/react':
         specifier: ^15.0.7
         version: 15.0.7(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -650,8 +650,8 @@ importers:
         specifier: ^11.11.4
         version: 11.13.0(@types/react@18.3.1)(react@18.3.1)
       '@mui/internal-test-utils':
-        specifier: 1.0.6
-        version: 1.0.6(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils
+        version: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/joy':
         specifier: 5.0.0-beta.48
         version: 5.0.0-beta.48(@emotion/react@11.13.0(@types/react@18.3.1)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.13.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2077,8 +2077,9 @@ packages:
   '@mui/internal-scripts@1.0.14':
     resolution: {integrity: sha512-v2HQWzssX8l+WAZh4JpgAtnxvwi4ZEm7+spi3e/1zxTXz/k3aWlcc50lpfeAtD6TGbegN2/j0OCORfDHTDQdbQ==}
 
-  '@mui/internal-test-utils@1.0.6':
-    resolution: {integrity: sha512-S2I9ytriELHH3kr+RNRQ9On0wRMVTNTSQagD7H6/rwoQC8BDs1J72etjamjItagEFXAyuUXX2FzWwhUTZFJHlg==}
+  '@mui/internal-test-utils@https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils':
+    resolution: {tarball: https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils}
+    version: 1.0.6
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -4232,8 +4233,8 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
-  dom-accessibility-api@0.6.3:
-    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+  dom-accessibility-api@0.7.0:
+    resolution: {integrity: sha512-LjjdFmd9AITAet3Hy6Y6rwB7Sq1+x5NiwbOpnkLHC1bCXJqJKiV9DyppSSWobuSKvjKXt9G2u3hW402MPt6m+g==}
 
   dom-converter@0.2.0:
     resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
@@ -6293,8 +6294,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  mocha@10.6.0:
-    resolution: {integrity: sha512-hxjt4+EEB0SA0ZDygSS015t65lJw/I2yRCS3Ae+SJ5FrbzrXgfYwJr96f0OvIXdj7h4lv/vLCrH3rkiuizFSvw==}
+  mocha@10.7.0:
+    resolution: {integrity: sha512-v8/rBWr2VO5YkspYINnvu81inSz2y3ODJrhO175/Exzor1RcEZZkizgE2A+w/CAXXoESS8Kys5E62dOHGHzULA==}
     engines: {node: '>= 14.0.0'}
     hasBin: true
 
@@ -10216,7 +10217,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mui/internal-test-utils@1.0.6(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/internal-test-utils@https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils(@babel/core@7.25.2)(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.25.2)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.25.2)
@@ -10229,12 +10230,12 @@ snapshots:
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       chai: 4.5.0
       chai-dom: 1.12.0(chai@4.5.0)
-      dom-accessibility-api: 0.6.3
+      dom-accessibility-api: 0.7.0
       format-util: 1.0.5
       fs-extra: 11.2.0
       jsdom: 24.0.0
       lodash: 4.17.21
-      mocha: 10.6.0
+      mocha: 10.7.0
       playwright: 1.45.3
       prop-types: 15.8.1
       react: 18.3.1
@@ -12777,7 +12778,7 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
-  dom-accessibility-api@0.6.3: {}
+  dom-accessibility-api@0.7.0: {}
 
   dom-converter@0.2.0:
     dependencies:
@@ -15347,7 +15348,7 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  mocha@10.6.0:
+  mocha@10.7.0:
     dependencies:
       ansi-colors: 4.1.3
       browser-stdout: 1.3.1

--- a/test/package.json
+++ b/test/package.json
@@ -10,7 +10,7 @@
     "@base_ui/react": "workspace:*",
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.4",
-    "@mui/internal-test-utils": "https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils",
+    "@mui/internal-test-utils": "1.0.6-dev.20240805-092432-9f940a61d6",
     "@mui/joy": "5.0.0-beta.48",
     "@mui/material": "6.0.0-beta.4",
     "@playwright/test": "1.45.3",

--- a/test/package.json
+++ b/test/package.json
@@ -10,7 +10,7 @@
     "@base_ui/react": "workspace:*",
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.4",
-    "@mui/internal-test-utils": "1.0.6",
+    "@mui/internal-test-utils": "https://pkg.csb.dev/mui/material-ui/commit/a09cbe73/@mui/internal-test-utils",
     "@mui/joy": "5.0.0-beta.48",
     "@mui/material": "6.0.0-beta.4",
     "@playwright/test": "1.45.3",


### PR DESCRIPTION
- Added `await` to all `act` and `render` calls
- Using our version of `createRenderer` (it flushes the microtask queue after rendering)
- Removed the unused `inheritComponent` field from conformance tests
- Updated the test-utils (fixing `flushMicrotasks` in Karma tests) and fixed a few newly failing tests
- Introduced the `#test-utils` subpath import in package.json to avoid importing from `../../../test`.
- Configured ESList with React Testing Library plugin