### PR TITLE
[typescript] Add `type` to export statements

### DIFF
--- a/packages/mui-base/src/Progress/index.ts
+++ b/packages/mui-base/src/Progress/index.ts
@@ -1,5 +1,5 @@
 export { ProgressRoot as Root } from './Root/ProgressRoot';
-export {
+export type {
   ProgressRootOwnerState as ProgressOwnerState,
   ProgressRootProps as RootProps,
   UseProgressRootParameters,

--- a/packages/mui-base/src/Slider/index.ts
+++ b/packages/mui-base/src/Slider/index.ts
@@ -1,5 +1,5 @@
 export { SliderRoot as Root } from './Root/SliderRoot';
-export {
+export type {
   SliderRootOwnerState as SliderOwnerState,
   SliderRootProps as RootProps,
   UseSliderParameters,


### PR DESCRIPTION
Next.js build complains about several exports (see https://app.netlify.com/sites/base-ui/deploys/66c2fdcd3b18260008132343).
Explicitly marking them as types solves the issue.