### PR TITLE
[test] Run Browserstack tests on master only

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -5,6 +5,7 @@ const webpack = require('webpack');
 const CI = Boolean(process.env.CI);
 // renovate PRs are based off of  upstream branches.
 // Their CI run will be a branch based run not PR run and therefore won't have a CIRCLE_PR_NUMBER
+const isPR = Boolean(process.env.CIRCLE_PULL_REQUEST);
 
 let build = `Base UI local ${new Date().toISOString()}`;
 
@@ -21,7 +22,7 @@ const browserStack = {
   // Since we have limited resources on BrowserStack we often time out on PRs.
   // However, BrowserStack rarely fails with a true-positive so we use it as a stop gap for release not merge.
   // But always enable it locally since people usually have to explicitly have to expose their BrowserStack access key anyway.
-  enabled: true,
+  enabled: !CI || !isPR || process.env.BROWSERSTACK_FORCE === 'true',
   username: process.env.BROWSERSTACK_USERNAME,
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,


### PR DESCRIPTION
Revert the change made in https://github.com/mui/base-ui/pull/546 as Browserstack often times out due to limited resources.