### PR TITLE
Add  default value as `clippingAncestors` to collisionBoundary prop

### DIFF
--- a/packages/mui-base/src/Menu/Positioner/MenuPositioner.tsx
+++ b/packages/mui-base/src/Menu/Positioner/MenuPositioner.tsx
@@ -43,7 +43,7 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     alignment = 'center',
     sideOffset = 0,
     alignmentOffset = 0,
-    collisionBoundary,
+    collisionBoundary = 'clippingAncestors',
     collisionPadding = 5,
     arrowPadding = 5,
     hideWhenDetached = false,

--- a/packages/mui-base/src/Popover/Positioner/PopoverPositioner.tsx
+++ b/packages/mui-base/src/Popover/Positioner/PopoverPositioner.tsx
@@ -40,7 +40,7 @@ const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     alignment = 'center',
     sideOffset = 0,
     alignmentOffset = 0,
-    collisionBoundary,
+    collisionBoundary = 'clippingAncestors',
     collisionPadding = 5,
     arrowPadding = 5,
     hideWhenDetached = false,

--- a/packages/mui-base/src/PreviewCard/Positioner/PreviewCardPositioner.tsx
+++ b/packages/mui-base/src/PreviewCard/Positioner/PreviewCardPositioner.tsx
@@ -27,7 +27,7 @@ const PreviewCardPositioner = React.forwardRef(function PreviewCardPositioner(
     alignment = 'center',
     sideOffset = 0,
     alignmentOffset = 0,
-    collisionBoundary,
+    collisionBoundary = 'clippingAncestors',
     collisionPadding = 5,
     arrowPadding = 5,
     hideWhenDetached = false,

--- a/packages/mui-base/src/Tooltip/Positioner/TooltipPositioner.tsx
+++ b/packages/mui-base/src/Tooltip/Positioner/TooltipPositioner.tsx
@@ -40,7 +40,7 @@ const TooltipPositioner = React.forwardRef(function TooltipPositioner(
     alignment = 'center',
     sideOffset = 0,
     alignmentOffset = 0,
-    collisionBoundary,
+    collisionBoundary = 'clippingAncestors',
     collisionPadding = 5,
     arrowPadding = 5,
     hideWhenDetached = false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

[Docs says ](https://deploy-preview-580--base-ui.netlify.app/base-ui/react-menu/components-api/#menu-positioner-props)default value of `collsionBoundary` prop is `clippingAncestors` but it's not defined anywhere. This PR adds  missing default values. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
