### PR TITLE
[useScrollLock] Avoid scrollbar layout shift issues

### DIFF
--- a/docs/app/experiments/scroll-lock.tsx
+++ b/docs/app/experiments/scroll-lock.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import * as React from 'react';
+import { useScrollLock } from '../../../packages/mui-base/src/utils/useScrollLock';
+
+export default function ScrollLock() {
+  const [enabled, setEnabled] = React.useState(false);
+  const [bodyScrollY, setBodyScrollY] = React.useState(false);
+  const [longContent, setLongContent] = React.useState(true);
+
+  useScrollLock(enabled);
+
+  React.useEffect(() => {
+    document.body.style.overflowY = bodyScrollY ? 'auto' : '';
+  }, [bodyScrollY]);
+
+  return (
+    <div>
+      <h2>Enable Show scroll bar: Always</h2>
+      <div style={{ display: 'flex', gap: 10 }}>
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+            />
+            Scroll lock
+          </label>
+        </div>
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={bodyScrollY}
+              onChange={(e) => setBodyScrollY(e.target.checked)}
+            />
+            body `overflow`
+          </label>
+        </div>
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={longContent}
+              onChange={(e) => setLongContent(e.target.checked)}
+            />
+            Long content
+          </label>
+        </div>
+      </div>
+      {[...Array(longContent ? 100 : 10)].map(() => (
+        <p>Scroll locking text content</p>
+      ))}
+    </div>
+  );
+}

--- a/docs/app/experiments/scroll-lock.tsx
+++ b/docs/app/experiments/scroll-lock.tsx
@@ -11,7 +11,7 @@ export default function ScrollLock() {
   useScrollLock(enabled);
 
   React.useEffect(() => {
-    document.body.style.overflowY = bodyScrollY ? 'auto' : '';
+    document.body.style.overflowY = bodyScrollY ? 'scroll' : '';
   }, [bodyScrollY]);
 
   return (
@@ -59,8 +59,8 @@ export default function ScrollLock() {
           </label>
         </div>
       </div>
-      {[...Array(longContent ? 100 : 10)].map(() => (
-        <p>Scroll locking text content</p>
+      {[...Array(longContent ? 100 : 10)].map((_, i) => (
+        <p key={i}>Scroll locking text content</p>
       ))}
     </div>
   );

--- a/docs/app/experiments/scroll-lock.tsx
+++ b/docs/app/experiments/scroll-lock.tsx
@@ -16,8 +16,18 @@ export default function ScrollLock() {
 
   return (
     <div>
-      <h2>Enable Show scroll bar: Always</h2>
-      <div style={{ display: 'flex', gap: 10 }}>
+      <h1>useScrollLock</h1>
+      <p>On macOS, enable `Show scroll bars: Always` in `Appearance` Settings.</p>
+      <div
+        style={{
+          position: 'fixed',
+          top: 15,
+          display: 'flex',
+          gap: 10,
+          background: 'white',
+          padding: 20,
+        }}
+      >
         <div>
           <label>
             <input

--- a/docs/app/experiments/scroll-lock.tsx
+++ b/docs/app/experiments/scroll-lock.tsx
@@ -1,5 +1,4 @@
 'use client';
-
 import * as React from 'react';
 import { useScrollLock } from '../../../packages/mui-base/src/utils/useScrollLock';
 

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -24,8 +24,8 @@ function preventScrollStandard() {
   function lockScroll() {
     const offsetLeft = window.visualViewport?.offsetLeft || 0;
     const offsetTop = window.visualViewport?.offsetTop || 0;
-    const hasConstantOverflowY = rootStyle.overflowY === 'scroll';
-    const hasConstantOverflowX = rootStyle.overflowX === 'scroll';
+    const hasConstantOverflowY = getComputedStyle(html).overflowY === 'scroll';
+    const hasConstantOverflowX = getComputedStyle(html).overflowX === 'scroll';
 
     scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;
     scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -47,7 +47,7 @@ export function useScrollLock(enabled: boolean = true) {
           overflowY: '',
         });
 
-        if ('scrollTo' in window) {
+        if (window.scrollTo.toString().includes('[native code]')) {
           window.scrollTo(scrollX, scrollY);
         }
       }

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -1,6 +1,5 @@
 import { isIOS } from './detectBrowser';
 import { useEnhancedEffect } from './useEnhancedEffect';
-import { useId } from './useId';
 
 let originalStyles = {};
 
@@ -78,10 +77,8 @@ function preventScrollStandard() {
  * @param enabled - Whether to enable the scroll lock.
  */
 export function useScrollLock(enabled: boolean = true) {
-  const id = useId();
-
   useEnhancedEffect(() => {
-    if (!enabled || !id) {
+    if (!enabled) {
       return undefined;
     }
 
@@ -96,5 +93,5 @@ export function useScrollLock(enabled: boolean = true) {
         restore();
       }
     };
-  }, [enabled, id]);
+  }, [enabled]);
 }

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -30,6 +30,7 @@ export function useScrollLock(enabled: boolean = true) {
       const scrollbarWidth = window.innerWidth - html.clientWidth;
       const offsetLeft = window.visualViewport?.offsetLeft || 0;
       const offsetTop = window.visualViewport?.offsetTop || 0;
+
       scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;
       scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;
 
@@ -57,10 +58,13 @@ export function useScrollLock(enabled: boolean = true) {
       bodyStyle.overflow = 'hidden';
 
       Object.assign(rootStyle, {
+        // Handle `scrollbar-gutter` in Chrome when there is no scrollable content.
         position: html.scrollHeight > html.clientHeight ? 'fixed' : '',
         top: `${-(scrollY - Math.floor(offsetTop))}px`,
         left: `${-(scrollX - Math.floor(offsetLeft))}px`,
         right: '0',
+        // On iOS, the html can't be scrollable at it allows "pull-to-refresh" to still work. This
+        // is only necessary when scrollbars are present.
         ...(scrollbarWidth && {
           overflowY: html.scrollHeight > html.clientHeight ? 'scroll' : 'hidden',
           overflowX: html.scrollWidth > html.clientWidth ? 'scroll' : 'hidden',
@@ -87,11 +91,11 @@ export function useScrollLock(enabled: boolean = true) {
       }
     }
 
-    const handleResize = () => {
+    function handleResize() {
       cleanup();
       cancelAnimationFrame(resizeRaf);
       resizeRaf = requestAnimationFrame(lockScroll);
-    };
+    }
 
     lockScroll();
     window.addEventListener('resize', handleResize);

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -3,6 +3,7 @@ import { useId } from './useId';
 
 const activeLocks = new Set<string>();
 let originalStyles = {};
+let originalBodyOverflow = '';
 
 /**
  * Locks the scroll of the document when enabled.
@@ -18,13 +19,56 @@ export function useScrollLock(enabled: boolean = true) {
     }
 
     const html = document.documentElement;
-    const body = document.body;
-    const rootStyle = body.style;
+    const rootStyle = html.style;
+    const bodyStyle = document.body.style;
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
 
-    const scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;
-    const scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;
-    const offsetLeft = window.visualViewport?.offsetLeft || 0;
-    const offsetTop = window.visualViewport?.offsetTop || 0;
+    let resizeRaf: number;
+    let scrollX: number;
+    let scrollY: number;
+
+    function lockScroll() {
+      const offsetLeft = window.visualViewport?.offsetLeft || 0;
+      const offsetTop = window.visualViewport?.offsetTop || 0;
+      scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;
+      scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;
+
+      activeLocks.add(lockId!);
+
+      // We don't need to lock the scroll if there's already an active lock. However, it's possible
+      // that the one that originally locked it doesn't get cleaned up last. In that case, one of the
+      // newer locks needs to perform the style and scroll restoration.
+      if (activeLocks.size > 1) {
+        return cleanup;
+      }
+
+      originalStyles = {
+        position: rootStyle.position,
+        top: rootStyle.top,
+        left: rootStyle.left,
+        right: rootStyle.right,
+        ...(scrollbarWidth && {
+          overflowX: rootStyle.overflowX,
+          overflowY: rootStyle.overflowY,
+        }),
+      };
+      originalBodyOverflow = bodyStyle.overflow;
+
+      bodyStyle.overflow = 'hidden';
+
+      Object.assign(rootStyle, {
+        position: html.scrollHeight > html.clientHeight ? 'fixed' : '',
+        top: `${-(scrollY - Math.floor(offsetTop))}px`,
+        left: `${-(scrollX - Math.floor(offsetLeft))}px`,
+        right: '0',
+        ...(scrollbarWidth && {
+          overflowY: html.scrollHeight > html.clientHeight ? 'scroll' : 'hidden',
+          overflowX: html.scrollWidth > html.clientWidth ? 'scroll' : 'hidden',
+        }),
+      });
+
+      return undefined;
+    }
 
     function cleanup() {
       if (!lockId) {
@@ -35,6 +79,7 @@ export function useScrollLock(enabled: boolean = true) {
 
       if (activeLocks.size === 0) {
         Object.assign(rootStyle, originalStyles);
+        bodyStyle.overflow = originalBodyOverflow;
 
         if (window.scrollTo.toString().includes('[native code]')) {
           window.scrollTo(scrollX, scrollY);
@@ -42,33 +87,18 @@ export function useScrollLock(enabled: boolean = true) {
       }
     }
 
-    activeLocks.add(lockId);
-
-    // We don't need to lock the scroll if there's already an active lock. However, it's possible
-    // that the one that originally locked it doesn't get cleaned up last. In that case, one of the
-    // newer locks needs to perform the style and scroll restoration.
-    if (activeLocks.size > 1) {
-      return cleanup;
-    }
-
-    originalStyles = {
-      position: rootStyle.position,
-      top: rootStyle.top,
-      left: rootStyle.left,
-      right: rootStyle.right,
-      overflowX: rootStyle.overflowX,
-      overflowY: rootStyle.overflowY,
+    const handleResize = () => {
+      cleanup();
+      cancelAnimationFrame(resizeRaf);
+      resizeRaf = requestAnimationFrame(lockScroll);
     };
 
-    Object.assign(rootStyle, {
-      position: html.scrollHeight > html.clientHeight ? 'fixed' : '',
-      top: `${-(scrollY - Math.floor(offsetTop))}px`,
-      left: `${-(scrollX - Math.floor(offsetLeft))}px`,
-      right: '0',
-      overflowY: html.scrollHeight > html.clientHeight ? 'scroll' : 'hidden',
-      overflowX: html.scrollWidth > html.clientWidth ? 'scroll' : 'hidden',
-    });
+    lockScroll();
+    window.addEventListener('resize', handleResize);
 
-    return cleanup;
+    return () => {
+      cleanup();
+      window.removeEventListener('resize', handleResize);
+    };
   }, [lockId, enabled]);
 }

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -45,7 +45,7 @@ function preventScrollStandard() {
     const isScrollableY = html.scrollHeight > html.clientHeight;
     const isScrollableX = html.scrollWidth > html.clientWidth;
 
-    if (isScrollableY) {
+    if (isScrollableY || isScrollableX) {
       Object.assign(rootStyle, {
         position: 'fixed',
         top: `${-scrollY}px`,

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -41,7 +41,8 @@ function preventScrollStandard() {
       overflowY: htmlStyle.overflowY,
     };
     originalBodyStyles = {
-      overflow: bodyStyle.overflow,
+      overflowX: bodyStyle.overflowX,
+      overflowY: bodyStyle.overflowY,
     };
 
     // Handle `scrollbar-gutter` in Chrome when there is no scrollable content.
@@ -64,7 +65,12 @@ function preventScrollStandard() {
 
     // Ensure two scrollbars can't appear since `<html>` now has a forced scrollbar, but the
     // `<body>` may have one too.
-    bodyStyle.overflow = 'hidden';
+    if (isScrollableY || hasConstantOverflowY) {
+      bodyStyle.overflowY = 'hidden';
+    }
+    if (isScrollableX || hasConstantOverflowX) {
+      bodyStyle.overflowX = 'hidden';
+    }
   }
 
   function cleanup() {

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -7,8 +7,36 @@ let preventScrollCount = 0;
 let restore: () => void = () => {};
 
 function preventScrollIOS() {
-  // To implement
-  return () => {};
+  const body = document.body;
+  const bodyStyle = body.style;
+
+  // iOS 12 does not support `visualViewport`.
+  const offsetLeft = window.visualViewport?.offsetLeft || 0;
+  const offsetTop = window.visualViewport?.offsetTop || 0;
+  const scrollX = bodyStyle.left ? parseFloat(bodyStyle.left) : window.scrollX;
+  const scrollY = bodyStyle.top ? parseFloat(bodyStyle.top) : window.scrollY;
+
+  originalBodyStyles = {
+    position: bodyStyle.position,
+    top: bodyStyle.top,
+    left: bodyStyle.left,
+    right: bodyStyle.right,
+    overflowX: bodyStyle.overflowX,
+    overflowY: bodyStyle.overflowY,
+  };
+
+  Object.assign(bodyStyle, {
+    position: 'fixed',
+    top: `${-(scrollY - Math.floor(offsetTop))}px`,
+    left: `${-(scrollX - Math.floor(offsetLeft))}px`,
+    right: '0',
+    overflow: 'hidden',
+  });
+
+  return () => {
+    Object.assign(bodyStyle, originalBodyStyles);
+    window.scrollTo(scrollX, scrollY);
+  };
 }
 
 function preventScrollStandard() {

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -45,11 +45,13 @@ function preventScrollStandard() {
       overflowY: bodyStyle.overflowY,
     };
 
-    // Handle `scrollbar-gutter` in Chrome when there is no scrollable content.
     const isScrollableY = html.scrollHeight > html.clientHeight;
     const isScrollableX = html.scrollWidth > html.clientWidth;
 
-    if (isScrollableY || isScrollableX) {
+    // Handle `scrollbar-gutter` in Chrome when there is no scrollable content.
+    const hasScrollbarGutterStable = htmlComputedStyles.scrollbarGutter?.includes('stable');
+
+    if (!hasScrollbarGutterStable) {
       Object.assign(htmlStyle, {
         position: 'fixed',
         top: `${-scrollY}px`,
@@ -59,8 +61,10 @@ function preventScrollStandard() {
     }
 
     Object.assign(htmlStyle, {
-      overflowY: isScrollableY || hasConstantOverflowY ? 'scroll' : 'hidden',
-      overflowX: isScrollableX || hasConstantOverflowX ? 'scroll' : 'hidden',
+      overflowY:
+        !hasScrollbarGutterStable && (isScrollableY || hasConstantOverflowY) ? 'scroll' : 'hidden',
+      overflowX:
+        !hasScrollbarGutterStable && (isScrollableX || hasConstantOverflowX) ? 'scroll' : 'hidden',
     });
 
     // Ensure two scrollbars can't appear since `<html>` now has a forced scrollbar, but the

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -35,7 +35,7 @@ export function useScrollLock(enabled: boolean = true) {
     };
 
     Object.assign(rootStyle, {
-      position: 'fixed',
+      position: html.scrollHeight > html.clientHeight ? 'fixed' : '',
       top: `${-(scrollY - Math.floor(offsetTop))}px`,
       left: `${-(scrollX - Math.floor(offsetLeft))}px`,
       right: '0',

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -1,17 +1,3 @@
-/*
- * LICENSE: https://github.com/adobe/react-spectrum/blob/main/LICENSE
- * Copyright 2020 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
- * -------------------------------------------------------------------------------------------------
- * This code has been modified by Base UI contributors and does not reflect the original version.
- */
 import { isIOS } from './detectBrowser';
 import { useEnhancedEffect } from './useEnhancedEffect';
 import { useId } from './useId';
@@ -19,262 +5,12 @@ import { useId } from './useId';
 let originalStyles = {};
 let originalBodyOverflow = '';
 
-function chain(...fns: any[]) {
-  return () => {
-    fns.forEach((fn) => {
-      if (typeof fn === 'function') {
-        fn();
-      }
-    });
-  };
-}
-
-function isScrollable(node: Element, checkForOverflow?: boolean) {
-  const style = window.getComputedStyle(node);
-  let value = /(auto|scroll)/.test(style.overflow + style.overflowX + style.overflowY);
-
-  if (value && checkForOverflow) {
-    value = node.scrollHeight !== node.clientHeight || node.scrollWidth !== node.clientWidth;
-  }
-
-  return value;
-}
-
-function getScrollParent(node: Element, checkForOverflow?: boolean) {
-  let scrollableNode: Element | null = node;
-
-  if (isScrollable(scrollableNode, checkForOverflow)) {
-    scrollableNode = scrollableNode.parentElement;
-  }
-
-  while (scrollableNode && !isScrollable(scrollableNode, checkForOverflow)) {
-    scrollableNode = scrollableNode.parentElement;
-  }
-
-  return scrollableNode || document.scrollingElement || document.documentElement;
-}
-
-// @ts-ignore
-const visualViewport = typeof document !== 'undefined' && window.visualViewport;
-
-// HTML input types that do not cause the software keyboard to appear.
-const nonTextInputTypes = new Set([
-  'checkbox',
-  'radio',
-  'range',
-  'color',
-  'file',
-  'image',
-  'button',
-  'submit',
-  'reset',
-]);
-
-// The number of active usePreventScroll calls. Used to determine whether to revert back to the original page style/scroll position
 let preventScrollCount = 0;
 let restore: () => void = () => {};
 
 function preventScrollIOS() {
-  let scrollable: Element;
-  let restoreScrollableStyles: () => void;
-
-  function onTouchStart(event: TouchEvent) {
-    // Store the nearest scrollable parent element from the element that the user touched.
-    scrollable = getScrollParent(event.target as Element, true);
-    if (scrollable === document.documentElement && scrollable === document.body) {
-      return;
-    }
-
-    // Prevent scrolling up when at the top and scrolling down when at the bottom
-    // of a nested scrollable area, otherwise mobile Safari will start scrolling
-    // the window instead.
-    if (
-      scrollable instanceof HTMLElement &&
-      window.getComputedStyle(scrollable).overscrollBehavior === 'auto'
-    ) {
-      restoreScrollableStyles = setStyle(scrollable, 'overscrollBehavior', 'contain');
-    }
-  }
-
-  function onTouchMove(e: TouchEvent) {
-    // Prevent scrolling the window.
-    if (!scrollable || scrollable === document.documentElement || scrollable === document.body) {
-      e.preventDefault();
-      return;
-    }
-
-    // overscroll-behavior should prevent scroll chaining, but currently does not
-    // if the element doesn't actually overflow. https://bugs.webkit.org/show_bug.cgi?id=243452
-    // This checks that both the width and height do not overflow, otherwise we might
-    // block horizontal scrolling too. In that case, adding `touch-action: pan-x` to
-    // the element will prevent vertical page scrolling. We can't add that automatically
-    // because it must be set before the touchstart event.
-    if (
-      scrollable.scrollHeight === scrollable.clientHeight &&
-      scrollable.scrollWidth === scrollable.clientWidth
-    ) {
-      e.preventDefault();
-    }
-  }
-
-  function onTouchEnd(event: TouchEvent) {
-    const target = event.target as HTMLElement;
-
-    // Apply this change if we're not already focused on the target element
-    if (willOpenKeyboard(target) && target !== document.activeElement) {
-      event.preventDefault();
-      setupStyles();
-
-      // Apply a transform to trick Safari into thinking the input is at the top of the page
-      // so it doesn't try to scroll it into view. When tapping on an input, this needs to
-      // be done before the "focus" event, so we have to focus the element ourselves.
-      target.style.transform = 'translateY(-2000px)';
-      target.focus();
-      requestAnimationFrame(() => {
-        target.style.transform = '';
-      });
-    }
-
-    if (restoreScrollableStyles) {
-      restoreScrollableStyles();
-    }
-  }
-
-  function onFocus(event: FocusEvent) {
-    const target = event.target as HTMLElement;
-
-    if (willOpenKeyboard(target)) {
-      setupStyles();
-
-      // Transform also needs to be applied in the focus event in cases where focus moves
-      // other than tapping on an input directly, e.g. the next/previous buttons in the
-      // software keyboard. In these cases, it seems applying the transform in the focus event
-      // is good enough, whereas when tapping an input, it must be done before the focus event. 🤷‍♂️
-      target.style.transform = 'translateY(-2000px)';
-      requestAnimationFrame(() => {
-        target.style.transform = '';
-
-        // This will have prevented the browser from scrolling the focused element into view,
-        // so we need to do this ourselves in a way that doesn't cause the whole page to scroll.
-        if (visualViewport) {
-          if (visualViewport.height < window.innerHeight) {
-            // If the keyboard is already visible, do this after one additional frame
-            // to wait for the transform to be removed.
-            requestAnimationFrame(() => {
-              scrollIntoView(target);
-            });
-          } else {
-            // Otherwise, wait for the visual viewport to resize before scrolling so we can
-            // measure the correct position to scroll to.
-            visualViewport.addEventListener('resize', () => scrollIntoView(target), { once: true });
-          }
-        }
-      });
-    }
-  }
-
-  let restoreStyles: null | (() => void) = null;
-
-  function setupStyles() {
-    if (restoreStyles) {
-      return;
-    }
-
-    function onWindowScroll() {
-      // Last resort. If the window scrolled, scroll it back to the top.
-      // It should always be at the top because the body will have a negative margin (see below).
-      window.scrollTo(0, 0);
-    }
-
-    // Record the original scroll position so we can restore it.
-    // Then apply a negative margin to the body to offset it by the scroll position. This will
-    // enable us to scroll the window to the top, which is required for the rest of this to work.
-    const scrollX = window.scrollX;
-    const scrollY = window.scrollY;
-
-    restoreStyles = chain(
-      addEvent(window, 'scroll', onWindowScroll),
-      setStyle(
-        document.documentElement,
-        'paddingRight',
-        `${window.innerWidth - document.documentElement.clientWidth}px`,
-      ),
-      setStyle(document.documentElement, 'overflow', 'hidden'),
-      setStyle(document.body, 'marginTop', `-${scrollY}px`),
-      () => {
-        window.scrollTo(scrollX, scrollY);
-      },
-    );
-
-    // Scroll to the top. The negative margin on the body will make this appear the same.
-    window.scrollTo(0, 0);
-  }
-
-  const removeEvents = chain(
-    addEvent(document, 'touchstart', onTouchStart, { passive: false, capture: true }),
-    addEvent(document, 'touchmove', onTouchMove, { passive: false, capture: true }),
-    addEvent(document, 'touchend', onTouchEnd, { passive: false, capture: true }),
-    addEvent(document, 'focus', onFocus, true),
-  );
-
-  return () => {
-    // Restore styles and scroll the page back to where it was.
-    restoreScrollableStyles?.();
-    restoreStyles?.();
-    removeEvents();
-  };
-}
-
-// Sets a CSS property on an element, and returns a function to revert it to the previous value.
-function setStyle(element: HTMLElement, style: any, value: string) {
-  const cur = element.style[style];
-  element.style[style] = value;
-  return () => {
-    element.style[style] = cur;
-  };
-}
-
-// Adds an event listener to an element, and returns a function to remove it.
-function addEvent<K extends keyof GlobalEventHandlersEventMap>(
-  target: EventTarget,
-  event: K,
-  handler: any,
-  options?: boolean | AddEventListenerOptions,
-) {
-  target.addEventListener(event, handler, options);
-  return () => {
-    target.removeEventListener(event, handler, options);
-  };
-}
-
-function scrollIntoView(target: Element | null) {
-  const root = document.scrollingElement || document.documentElement;
-
-  while (target && target !== root) {
-    // Find the parent scrollable element and adjust the scroll position if the target is not already in view.
-    const scrollable = getScrollParent(target);
-    if (
-      scrollable !== document.documentElement &&
-      scrollable !== document.body &&
-      scrollable !== target
-    ) {
-      const scrollableTop = scrollable.getBoundingClientRect().top;
-      const targetTop = target.getBoundingClientRect().top;
-      if (targetTop > scrollableTop + target.clientHeight) {
-        scrollable.scrollTop += targetTop - scrollableTop;
-      }
-    }
-
-    target = scrollable.parentElement;
-  }
-}
-
-function willOpenKeyboard(target: Element) {
-  return (
-    (target instanceof HTMLInputElement && !nonTextInputTypes.has(target.type)) ||
-    target instanceof HTMLTextAreaElement ||
-    (target instanceof HTMLElement && target.isContentEditable)
-  );
+  // To implement
+  return () => {};
 }
 
 function preventScrollStandard() {
@@ -287,29 +23,19 @@ function preventScrollStandard() {
   let scrollY: number;
 
   function lockScroll() {
-    const scrollbarWidth = window.innerWidth - html.clientWidth;
     const offsetLeft = window.visualViewport?.offsetLeft || 0;
     const offsetTop = window.visualViewport?.offsetTop || 0;
 
     scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;
     scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;
 
-    // We don't need to lock the scroll if there's already an active lock. However, it's possible
-    // that the one that originally locked it doesn't get cleaned up last. In that case, one of the
-    // newer locks needs to perform the style and scroll restoration.
-    if (preventScrollCount > 1) {
-      return cleanup;
-    }
-
     originalStyles = {
       position: rootStyle.position,
       top: rootStyle.top,
       left: rootStyle.left,
       right: rootStyle.right,
-      ...(scrollbarWidth && {
-        overflowX: rootStyle.overflowX,
-        overflowY: rootStyle.overflowY,
-      }),
+      overflowX: rootStyle.overflowX,
+      overflowY: rootStyle.overflowY,
     };
     originalBodyOverflow = bodyStyle.overflow;
 
@@ -321,12 +47,8 @@ function preventScrollStandard() {
       top: `${-(scrollY - Math.floor(offsetTop))}px`,
       left: `${-(scrollX - Math.floor(offsetLeft))}px`,
       right: '0',
-      // On iOS, the html can't be scrollable as it allows "pull-to-refresh" to still work. This
-      // is only necessary when scrollbars are present.
-      ...(scrollbarWidth && {
-        overflowY: html.scrollHeight > html.clientHeight ? 'scroll' : 'hidden',
-        overflowX: html.scrollWidth > html.clientWidth ? 'scroll' : 'hidden',
-      }),
+      overflowY: html.scrollHeight > html.clientHeight ? 'scroll' : 'hidden',
+      overflowX: html.scrollWidth > html.clientWidth ? 'scroll' : 'hidden',
     });
 
     return undefined;

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -22,6 +22,8 @@ function preventScrollStandard() {
   function lockScroll() {
     const offsetLeft = window.visualViewport?.offsetLeft || 0;
     const offsetTop = window.visualViewport?.offsetTop || 0;
+    const hasConstantOverflowY = rootStyle.overflowY === 'scroll';
+    const hasConstantOverflowX = rootStyle.overflowX === 'scroll';
 
     scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;
     scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;
@@ -41,8 +43,9 @@ function preventScrollStandard() {
       top: `${-(scrollY - Math.floor(offsetTop))}px`,
       left: `${-(scrollX - Math.floor(offsetLeft))}px`,
       right: '0',
-      overflowY: html.scrollHeight > html.clientHeight ? 'scroll' : 'hidden',
-      overflowX: html.scrollWidth > html.clientWidth ? 'scroll' : 'hidden',
+      overflowY:
+        html.scrollHeight > html.clientHeight || hasConstantOverflowY ? 'scroll' : 'hidden',
+      overflowX: html.scrollWidth > html.clientWidth || hasConstantOverflowX ? 'scroll' : 'hidden',
     });
 
     return undefined;

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -21,13 +21,13 @@ export function useScrollLock(enabled: boolean = true) {
     const html = document.documentElement;
     const rootStyle = html.style;
     const bodyStyle = document.body.style;
-    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
 
     let resizeRaf: number;
     let scrollX: number;
     let scrollY: number;
 
     function lockScroll() {
+      const scrollbarWidth = window.innerWidth - html.clientWidth;
       const offsetLeft = window.visualViewport?.offsetLeft || 0;
       const offsetTop = window.visualViewport?.offsetTop || 0;
       scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -12,11 +12,11 @@ export function useScrollLock(enabled: boolean = true) {
   const lockId = useId();
 
   useEnhancedEffect(() => {
-    if (!enabled) {
+    if (!enabled || !lockId || activeLocks.size > 0) {
       return undefined;
     }
 
-    activeLocks.add(lockId!);
+    activeLocks.add(lockId);
 
     const html = document.documentElement;
     const rootStyle = html.style;
@@ -24,6 +24,15 @@ export function useScrollLock(enabled: boolean = true) {
     const scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;
     const offsetLeft = window.visualViewport?.offsetLeft || 0;
     const offsetTop = window.visualViewport?.offsetTop || 0;
+
+    const originalStyles = {
+      position: rootStyle.position,
+      top: rootStyle.top,
+      left: rootStyle.left,
+      right: rootStyle.right,
+      overflowX: rootStyle.overflowX,
+      overflowY: rootStyle.overflowY,
+    };
 
     Object.assign(rootStyle, {
       position: 'fixed',
@@ -35,17 +44,10 @@ export function useScrollLock(enabled: boolean = true) {
     });
 
     return () => {
-      activeLocks.delete(lockId!);
+      activeLocks.delete(lockId);
 
       if (activeLocks.size === 0) {
-        Object.assign(rootStyle, {
-          position: '',
-          top: '',
-          left: '',
-          right: '',
-          overflowX: '',
-          overflowY: '',
-        });
+        Object.assign(rootStyle, originalStyles);
 
         if (window.scrollTo.toString().includes('[native code]')) {
           window.scrollTo(scrollX, scrollY);

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -1,7 +1,7 @@
 import { isIOS } from './detectBrowser';
 import { useEnhancedEffect } from './useEnhancedEffect';
 
-let originalRootStyles = {};
+let originalHtmlStyles = {};
 let originalBodyStyles = {};
 let preventScrollCount = 0;
 let restore: () => void = () => {};
@@ -14,7 +14,7 @@ function preventScrollIOS() {
 function preventScrollStandard() {
   const html = document.documentElement;
   const body = document.body;
-  const rootStyle = html.style;
+  const htmlStyle = html.style;
   const bodyStyle = body.style;
 
   let resizeRaf: number;
@@ -23,19 +23,22 @@ function preventScrollStandard() {
 
   function lockScroll() {
     const htmlComputedStyles = getComputedStyle(html);
-    const hasConstantOverflowY = htmlComputedStyles.overflowY === 'scroll';
-    const hasConstantOverflowX = htmlComputedStyles.overflowX === 'scroll';
+    const bodyComputedStyles = getComputedStyle(body);
+    const hasConstantOverflowY =
+      htmlComputedStyles.overflowY === 'scroll' || bodyComputedStyles.overflowY === 'scroll';
+    const hasConstantOverflowX =
+      htmlComputedStyles.overflowX === 'scroll' || bodyComputedStyles.overflowX === 'scroll';
 
-    scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;
-    scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;
+    scrollX = htmlStyle.left ? parseFloat(htmlStyle.left) : window.scrollX;
+    scrollY = htmlStyle.top ? parseFloat(htmlStyle.top) : window.scrollY;
 
-    originalRootStyles = {
-      position: rootStyle.position,
-      top: rootStyle.top,
-      left: rootStyle.left,
-      right: rootStyle.right,
-      overflowX: rootStyle.overflowX,
-      overflowY: rootStyle.overflowY,
+    originalHtmlStyles = {
+      position: htmlStyle.position,
+      top: htmlStyle.top,
+      left: htmlStyle.left,
+      right: htmlStyle.right,
+      overflowX: htmlStyle.overflowX,
+      overflowY: htmlStyle.overflowY,
     };
     originalBodyStyles = {
       overflow: bodyStyle.overflow,
@@ -46,7 +49,7 @@ function preventScrollStandard() {
     const isScrollableX = html.scrollWidth > html.clientWidth;
 
     if (isScrollableY || isScrollableX) {
-      Object.assign(rootStyle, {
+      Object.assign(htmlStyle, {
         position: 'fixed',
         top: `${-scrollY}px`,
         left: `${-scrollX}px`,
@@ -54,7 +57,7 @@ function preventScrollStandard() {
       });
     }
 
-    Object.assign(rootStyle, {
+    Object.assign(htmlStyle, {
       overflowY: isScrollableY || hasConstantOverflowY ? 'scroll' : 'hidden',
       overflowX: isScrollableX || hasConstantOverflowX ? 'scroll' : 'hidden',
     });
@@ -65,7 +68,7 @@ function preventScrollStandard() {
   }
 
   function cleanup() {
-    Object.assign(rootStyle, originalRootStyles);
+    Object.assign(htmlStyle, originalHtmlStyles);
     Object.assign(bodyStyle, originalBodyStyles);
 
     if (window.scrollTo.toString().includes('[native code]')) {

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -46,7 +46,10 @@ export function useScrollLock(enabled: boolean = true) {
           overflowX: '',
           overflowY: '',
         });
-        window.scrollTo?.(scrollX, scrollY);
+
+        if ('scrollTo' in window) {
+          window.scrollTo(scrollX, scrollY);
+        }
       }
     };
   }, [lockId, enabled]);

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -57,8 +57,6 @@ function preventScrollStandard() {
     // Ensure two scrollbars can't appear since `<html>` now has a forced scrollbar, but the
     // `<body>` may have one too.
     bodyStyle.overflow = 'hidden';
-
-    return undefined;
   }
 
   function cleanup() {

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -24,8 +24,9 @@ function preventScrollStandard() {
   function lockScroll() {
     const offsetLeft = window.visualViewport?.offsetLeft || 0;
     const offsetTop = window.visualViewport?.offsetTop || 0;
-    const hasConstantOverflowY = getComputedStyle(html).overflowY === 'scroll';
-    const hasConstantOverflowX = getComputedStyle(html).overflowX === 'scroll';
+    const htmlComputedStyles = getComputedStyle(html);
+    const hasConstantOverflowY = htmlComputedStyles.overflowY === 'scroll';
+    const hasConstantOverflowX = htmlComputedStyles.overflowX === 'scroll';
 
     scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;
     scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -1,3 +1,18 @@
+/*
+ * LICENSE: https://github.com/adobe/react-spectrum/blob/main/LICENSE
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * -------------------------------------------------------------------------------------------------
+ * This code has been modified by Base UI contributors and does not reflect the original version.
+ */
+import { isIOS } from './detectBrowser';
 import { useEnhancedEffect } from './useEnhancedEffect';
 import { useId } from './useId';
 
@@ -5,104 +20,376 @@ const activeLocks = new Set<string>();
 let originalStyles = {};
 let originalBodyOverflow = '';
 
+function chain(...fns: any[]) {
+  return () => {
+    fns.forEach((fn) => {
+      if (typeof fn === 'function') {
+        fn();
+      }
+    });
+  };
+}
+
+function isScrollable(node: Element, checkForOverflow?: boolean) {
+  const style = window.getComputedStyle(node);
+  let value = /(auto|scroll)/.test(style.overflow + style.overflowX + style.overflowY);
+
+  if (value && checkForOverflow) {
+    value = node.scrollHeight !== node.clientHeight || node.scrollWidth !== node.clientWidth;
+  }
+
+  return value;
+}
+
+function getScrollParent(node: Element, checkForOverflow?: boolean) {
+  let scrollableNode: Element | null = node;
+
+  if (isScrollable(scrollableNode, checkForOverflow)) {
+    scrollableNode = scrollableNode.parentElement;
+  }
+
+  while (scrollableNode && !isScrollable(scrollableNode, checkForOverflow)) {
+    scrollableNode = scrollableNode.parentElement;
+  }
+
+  return scrollableNode || document.scrollingElement || document.documentElement;
+}
+
+// @ts-ignore
+const visualViewport = typeof document !== 'undefined' && window.visualViewport;
+
+// HTML input types that do not cause the software keyboard to appear.
+const nonTextInputTypes = new Set([
+  'checkbox',
+  'radio',
+  'range',
+  'color',
+  'file',
+  'image',
+  'button',
+  'submit',
+  'reset',
+]);
+
+// The number of active usePreventScroll calls. Used to determine whether to revert back to the original page style/scroll position
+let preventScrollCount = 0;
+let restore: () => void = () => {};
+
+function preventScrollIOS() {
+  let scrollable: Element;
+  let restoreScrollableStyles: () => void;
+
+  function onTouchStart(event: TouchEvent) {
+    // Store the nearest scrollable parent element from the element that the user touched.
+    scrollable = getScrollParent(event.target as Element, true);
+    if (scrollable === document.documentElement && scrollable === document.body) {
+      return;
+    }
+
+    // Prevent scrolling up when at the top and scrolling down when at the bottom
+    // of a nested scrollable area, otherwise mobile Safari will start scrolling
+    // the window instead.
+    if (
+      scrollable instanceof HTMLElement &&
+      window.getComputedStyle(scrollable).overscrollBehavior === 'auto'
+    ) {
+      restoreScrollableStyles = setStyle(scrollable, 'overscrollBehavior', 'contain');
+    }
+  }
+
+  function onTouchMove(e: TouchEvent) {
+    // Prevent scrolling the window.
+    if (!scrollable || scrollable === document.documentElement || scrollable === document.body) {
+      e.preventDefault();
+      return;
+    }
+
+    // overscroll-behavior should prevent scroll chaining, but currently does not
+    // if the element doesn't actually overflow. https://bugs.webkit.org/show_bug.cgi?id=243452
+    // This checks that both the width and height do not overflow, otherwise we might
+    // block horizontal scrolling too. In that case, adding `touch-action: pan-x` to
+    // the element will prevent vertical page scrolling. We can't add that automatically
+    // because it must be set before the touchstart event.
+    if (
+      scrollable.scrollHeight === scrollable.clientHeight &&
+      scrollable.scrollWidth === scrollable.clientWidth
+    ) {
+      e.preventDefault();
+    }
+  }
+
+  function onTouchEnd(event: TouchEvent) {
+    const target = event.target as HTMLElement;
+
+    // Apply this change if we're not already focused on the target element
+    if (willOpenKeyboard(target) && target !== document.activeElement) {
+      event.preventDefault();
+      setupStyles();
+
+      // Apply a transform to trick Safari into thinking the input is at the top of the page
+      // so it doesn't try to scroll it into view. When tapping on an input, this needs to
+      // be done before the "focus" event, so we have to focus the element ourselves.
+      target.style.transform = 'translateY(-2000px)';
+      target.focus();
+      requestAnimationFrame(() => {
+        target.style.transform = '';
+      });
+    }
+
+    if (restoreScrollableStyles) {
+      restoreScrollableStyles();
+    }
+  }
+
+  function onFocus(event: FocusEvent) {
+    const target = event.target as HTMLElement;
+
+    if (willOpenKeyboard(target)) {
+      setupStyles();
+
+      // Transform also needs to be applied in the focus event in cases where focus moves
+      // other than tapping on an input directly, e.g. the next/previous buttons in the
+      // software keyboard. In these cases, it seems applying the transform in the focus event
+      // is good enough, whereas when tapping an input, it must be done before the focus event. 🤷‍♂️
+      target.style.transform = 'translateY(-2000px)';
+      requestAnimationFrame(() => {
+        target.style.transform = '';
+
+        // This will have prevented the browser from scrolling the focused element into view,
+        // so we need to do this ourselves in a way that doesn't cause the whole page to scroll.
+        if (visualViewport) {
+          if (visualViewport.height < window.innerHeight) {
+            // If the keyboard is already visible, do this after one additional frame
+            // to wait for the transform to be removed.
+            requestAnimationFrame(() => {
+              scrollIntoView(target);
+            });
+          } else {
+            // Otherwise, wait for the visual viewport to resize before scrolling so we can
+            // measure the correct position to scroll to.
+            visualViewport.addEventListener('resize', () => scrollIntoView(target), { once: true });
+          }
+        }
+      });
+    }
+  }
+
+  let restoreStyles: null | (() => void) = null;
+
+  function setupStyles() {
+    if (restoreStyles) {
+      return;
+    }
+
+    function onWindowScroll() {
+      // Last resort. If the window scrolled, scroll it back to the top.
+      // It should always be at the top because the body will have a negative margin (see below).
+      window.scrollTo(0, 0);
+    }
+
+    // Record the original scroll position so we can restore it.
+    // Then apply a negative margin to the body to offset it by the scroll position. This will
+    // enable us to scroll the window to the top, which is required for the rest of this to work.
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
+
+    restoreStyles = chain(
+      addEvent(window, 'scroll', onWindowScroll),
+      setStyle(
+        document.documentElement,
+        'paddingRight',
+        `${window.innerWidth - document.documentElement.clientWidth}px`,
+      ),
+      setStyle(document.documentElement, 'overflow', 'hidden'),
+      setStyle(document.body, 'marginTop', `-${scrollY}px`),
+      () => {
+        window.scrollTo(scrollX, scrollY);
+      },
+    );
+
+    // Scroll to the top. The negative margin on the body will make this appear the same.
+    window.scrollTo(0, 0);
+  }
+
+  const removeEvents = chain(
+    addEvent(document, 'touchstart', onTouchStart, { passive: false, capture: true }),
+    addEvent(document, 'touchmove', onTouchMove, { passive: false, capture: true }),
+    addEvent(document, 'touchend', onTouchEnd, { passive: false, capture: true }),
+    addEvent(document, 'focus', onFocus, true),
+  );
+
+  return () => {
+    // Restore styles and scroll the page back to where it was.
+    restoreScrollableStyles?.();
+    restoreStyles?.();
+    removeEvents();
+  };
+}
+
+// Sets a CSS property on an element, and returns a function to revert it to the previous value.
+function setStyle(element: HTMLElement, style: any, value: string) {
+  const cur = element.style[style];
+  element.style[style] = value;
+  return () => {
+    element.style[style] = cur;
+  };
+}
+
+// Adds an event listener to an element, and returns a function to remove it.
+function addEvent<K extends keyof GlobalEventHandlersEventMap>(
+  target: EventTarget,
+  event: K,
+  handler: any,
+  options?: boolean | AddEventListenerOptions,
+) {
+  target.addEventListener(event, handler, options);
+  return () => {
+    target.removeEventListener(event, handler, options);
+  };
+}
+
+function scrollIntoView(target: Element | null) {
+  const root = document.scrollingElement || document.documentElement;
+
+  while (target && target !== root) {
+    // Find the parent scrollable element and adjust the scroll position if the target is not already in view.
+    const scrollable = getScrollParent(target);
+    if (
+      scrollable !== document.documentElement &&
+      scrollable !== document.body &&
+      scrollable !== target
+    ) {
+      const scrollableTop = scrollable.getBoundingClientRect().top;
+      const targetTop = target.getBoundingClientRect().top;
+      if (targetTop > scrollableTop + target.clientHeight) {
+        scrollable.scrollTop += targetTop - scrollableTop;
+      }
+    }
+
+    target = scrollable.parentElement;
+  }
+}
+
+function willOpenKeyboard(target: Element) {
+  return (
+    (target instanceof HTMLInputElement && !nonTextInputTypes.has(target.type)) ||
+    target instanceof HTMLTextAreaElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+  );
+}
+
+function preventScrollStandard(lockId: string) {
+  const html = document.documentElement;
+  const rootStyle = html.style;
+  const bodyStyle = document.body.style;
+
+  let resizeRaf: number;
+  let scrollX: number;
+  let scrollY: number;
+
+  function lockScroll() {
+    const scrollbarWidth = window.innerWidth - html.clientWidth;
+    const offsetLeft = window.visualViewport?.offsetLeft || 0;
+    const offsetTop = window.visualViewport?.offsetTop || 0;
+
+    scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;
+    scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;
+
+    activeLocks.add(lockId!);
+
+    // We don't need to lock the scroll if there's already an active lock. However, it's possible
+    // that the one that originally locked it doesn't get cleaned up last. In that case, one of the
+    // newer locks needs to perform the style and scroll restoration.
+    if (activeLocks.size > 1) {
+      return cleanup;
+    }
+
+    originalStyles = {
+      position: rootStyle.position,
+      top: rootStyle.top,
+      left: rootStyle.left,
+      right: rootStyle.right,
+      ...(scrollbarWidth && {
+        overflowX: rootStyle.overflowX,
+        overflowY: rootStyle.overflowY,
+      }),
+    };
+    originalBodyOverflow = bodyStyle.overflow;
+
+    bodyStyle.overflow = 'hidden';
+
+    Object.assign(rootStyle, {
+      // Handle `scrollbar-gutter` in Chrome when there is no scrollable content.
+      position: html.scrollHeight > html.clientHeight ? 'fixed' : '',
+      top: `${-(scrollY - Math.floor(offsetTop))}px`,
+      left: `${-(scrollX - Math.floor(offsetLeft))}px`,
+      right: '0',
+      // On iOS, the html can't be scrollable as it allows "pull-to-refresh" to still work. This
+      // is only necessary when scrollbars are present.
+      ...(scrollbarWidth && {
+        overflowY: html.scrollHeight > html.clientHeight ? 'scroll' : 'hidden',
+        overflowX: html.scrollWidth > html.clientWidth ? 'scroll' : 'hidden',
+      }),
+    });
+
+    return undefined;
+  }
+
+  function cleanup() {
+    if (!lockId) {
+      return;
+    }
+
+    activeLocks.delete(lockId);
+
+    if (activeLocks.size === 0) {
+      Object.assign(rootStyle, originalStyles);
+      bodyStyle.overflow = originalBodyOverflow;
+
+      if (window.scrollTo.toString().includes('[native code]')) {
+        window.scrollTo(scrollX, scrollY);
+      }
+    }
+  }
+
+  function handleResize() {
+    cleanup();
+    cancelAnimationFrame(resizeRaf);
+    resizeRaf = requestAnimationFrame(lockScroll);
+  }
+
+  lockScroll();
+  window.addEventListener('resize', handleResize);
+
+  return () => {
+    cleanup();
+    window.removeEventListener('resize', handleResize);
+  };
+}
+
 /**
  * Locks the scroll of the document when enabled.
  *
  * @param enabled - Whether to enable the scroll lock.
  */
 export function useScrollLock(enabled: boolean = true) {
-  const lockId = useId();
+  const id = useId();
 
   useEnhancedEffect(() => {
-    if (!enabled || !lockId) {
+    if (!enabled || !id) {
       return undefined;
     }
 
-    const html = document.documentElement;
-    const rootStyle = html.style;
-    const bodyStyle = document.body.style;
-
-    let resizeRaf: number;
-    let scrollX: number;
-    let scrollY: number;
-
-    function lockScroll() {
-      const scrollbarWidth = window.innerWidth - html.clientWidth;
-      const offsetLeft = window.visualViewport?.offsetLeft || 0;
-      const offsetTop = window.visualViewport?.offsetTop || 0;
-
-      scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;
-      scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;
-
-      activeLocks.add(lockId!);
-
-      // We don't need to lock the scroll if there's already an active lock. However, it's possible
-      // that the one that originally locked it doesn't get cleaned up last. In that case, one of the
-      // newer locks needs to perform the style and scroll restoration.
-      if (activeLocks.size > 1) {
-        return cleanup;
-      }
-
-      originalStyles = {
-        position: rootStyle.position,
-        top: rootStyle.top,
-        left: rootStyle.left,
-        right: rootStyle.right,
-        ...(scrollbarWidth && {
-          overflowX: rootStyle.overflowX,
-          overflowY: rootStyle.overflowY,
-        }),
-      };
-      originalBodyOverflow = bodyStyle.overflow;
-
-      bodyStyle.overflow = 'hidden';
-
-      Object.assign(rootStyle, {
-        // Handle `scrollbar-gutter` in Chrome when there is no scrollable content.
-        position: html.scrollHeight > html.clientHeight ? 'fixed' : '',
-        top: `${-(scrollY - Math.floor(offsetTop))}px`,
-        left: `${-(scrollX - Math.floor(offsetLeft))}px`,
-        right: '0',
-        // On iOS, the html can't be scrollable as it allows "pull-to-refresh" to still work. This
-        // is only necessary when scrollbars are present.
-        ...(scrollbarWidth && {
-          overflowY: html.scrollHeight > html.clientHeight ? 'scroll' : 'hidden',
-          overflowX: html.scrollWidth > html.clientWidth ? 'scroll' : 'hidden',
-        }),
-      });
-
-      return undefined;
+    preventScrollCount += 1;
+    if (preventScrollCount === 1) {
+      restore = isIOS() ? preventScrollIOS() : preventScrollStandard(id);
     }
-
-    function cleanup() {
-      if (!lockId) {
-        return;
-      }
-
-      activeLocks.delete(lockId);
-
-      if (activeLocks.size === 0) {
-        Object.assign(rootStyle, originalStyles);
-        bodyStyle.overflow = originalBodyOverflow;
-
-        if (window.scrollTo.toString().includes('[native code]')) {
-          window.scrollTo(scrollX, scrollY);
-        }
-      }
-    }
-
-    function handleResize() {
-      cleanup();
-      cancelAnimationFrame(resizeRaf);
-      resizeRaf = requestAnimationFrame(lockScroll);
-    }
-
-    lockScroll();
-    window.addEventListener('resize', handleResize);
 
     return () => {
-      cleanup();
-      window.removeEventListener('resize', handleResize);
+      preventScrollCount -= 1;
+      if (preventScrollCount === 0) {
+        restore();
+      }
     };
-  }, [lockId, enabled]);
+  }, [enabled, id]);
 }

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -42,9 +42,10 @@ function preventScrollStandard() {
     };
 
     // Handle `scrollbar-gutter` in Chrome when there is no scrollable content.
-    const isFixed = html.scrollHeight > html.clientHeight;
+    const isScrollableY = html.scrollHeight > html.clientHeight;
+    const isScrollableX = html.scrollWidth > html.clientWidth;
 
-    if (isFixed) {
+    if (isScrollableY) {
       Object.assign(rootStyle, {
         position: 'fixed',
         top: `${-scrollY}px`,
@@ -54,9 +55,8 @@ function preventScrollStandard() {
     }
 
     Object.assign(rootStyle, {
-      overflowY:
-        html.scrollHeight > html.clientHeight || hasConstantOverflowY ? 'scroll' : 'hidden',
-      overflowX: html.scrollWidth > html.clientWidth || hasConstantOverflowX ? 'scroll' : 'hidden',
+      overflowY: isScrollableY || hasConstantOverflowY ? 'scroll' : 'hidden',
+      overflowX: isScrollableX || hasConstantOverflowX ? 'scroll' : 'hidden',
     });
 
     // Ensure two scrollbars can't appear since `<html>` now has a forced scrollbar, but the

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -22,8 +22,6 @@ function preventScrollStandard() {
   let scrollY: number;
 
   function lockScroll() {
-    const offsetLeft = window.visualViewport?.offsetLeft || 0;
-    const offsetTop = window.visualViewport?.offsetTop || 0;
     const htmlComputedStyles = getComputedStyle(html);
     const hasConstantOverflowY = htmlComputedStyles.overflowY === 'scroll';
     const hasConstantOverflowX = htmlComputedStyles.overflowX === 'scroll';
@@ -43,12 +41,19 @@ function preventScrollStandard() {
       overflow: bodyStyle.overflow,
     };
 
+    // Handle `scrollbar-gutter` in Chrome when there is no scrollable content.
+    const isFixed = html.scrollHeight > html.clientHeight;
+
+    if (isFixed) {
+      Object.assign(rootStyle, {
+        position: 'fixed',
+        top: `${-scrollY}px`,
+        left: `${-scrollX}px`,
+        right: '0',
+      });
+    }
+
     Object.assign(rootStyle, {
-      // Handle `scrollbar-gutter` in Chrome when there is no scrollable content.
-      position: html.scrollHeight > html.clientHeight ? 'fixed' : '',
-      top: `${-(scrollY - Math.floor(offsetTop))}px`,
-      left: `${-(scrollX - Math.floor(offsetLeft))}px`,
-      right: '0',
       overflowY:
         html.scrollHeight > html.clientHeight || hasConstantOverflowY ? 'scroll' : 'hidden',
       overflowX: html.scrollWidth > html.clientWidth || hasConstantOverflowX ? 'scroll' : 'hidden',

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -63,7 +63,7 @@ export function useScrollLock(enabled: boolean = true) {
         top: `${-(scrollY - Math.floor(offsetTop))}px`,
         left: `${-(scrollX - Math.floor(offsetLeft))}px`,
         right: '0',
-        // On iOS, the html can't be scrollable at it allows "pull-to-refresh" to still work. This
+        // On iOS, the html can't be scrollable as it allows "pull-to-refresh" to still work. This
         // is only necessary when scrollbars are present.
         ...(scrollbarWidth && {
           overflowY: html.scrollHeight > html.clientHeight ? 'scroll' : 'hidden',

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -3,7 +3,6 @@ import { useEnhancedEffect } from './useEnhancedEffect';
 import { useId } from './useId';
 
 let originalStyles = {};
-let originalBodyOverflow = '';
 
 let preventScrollCount = 0;
 let restore: () => void = () => {};
@@ -16,7 +15,6 @@ function preventScrollIOS() {
 function preventScrollStandard() {
   const html = document.documentElement;
   const rootStyle = html.style;
-  const bodyStyle = document.body.style;
 
   let resizeRaf: number;
   let scrollX: number;
@@ -37,9 +35,6 @@ function preventScrollStandard() {
       overflowX: rootStyle.overflowX,
       overflowY: rootStyle.overflowY,
     };
-    originalBodyOverflow = bodyStyle.overflow;
-
-    bodyStyle.overflow = 'hidden';
 
     Object.assign(rootStyle, {
       // Handle `scrollbar-gutter` in Chrome when there is no scrollable content.
@@ -56,7 +51,6 @@ function preventScrollStandard() {
 
   function cleanup() {
     Object.assign(rootStyle, originalStyles);
-    bodyStyle.overflow = originalBodyOverflow;
 
     if (window.scrollTo.toString().includes('[native code]')) {
       window.scrollTo(scrollX, scrollY);

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -18,7 +18,9 @@ export function useScrollLock(enabled: boolean = true) {
     }
 
     const html = document.documentElement;
-    const rootStyle = html.style;
+    const body = document.body;
+    const rootStyle = body.style;
+
     const scrollX = rootStyle.left ? parseFloat(rootStyle.left) : window.scrollX;
     const scrollY = rootStyle.top ? parseFloat(rootStyle.top) : window.scrollY;
     const offsetLeft = window.visualViewport?.offsetLeft || 0;

--- a/packages/mui-base/src/utils/useScrollLock.ts
+++ b/packages/mui-base/src/utils/useScrollLock.ts
@@ -46,7 +46,7 @@ export function useScrollLock(enabled: boolean = true) {
           overflowX: '',
           overflowY: '',
         });
-        window.scrollTo(scrollX, scrollY);
+        window.scrollTo?.(scrollX, scrollY);
       }
     };
   }, [lockId, enabled]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #603

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

- This applies the internal iOS technique to all browsers _aside_ from iOS, removing the need for scrollbar compensation.
- iOS implementation is pending


## Problem 1

This currently breaks the positioning of (anchored) floating elements. **Edit: works if using the `fixed` positioning strategy instead of `absolute` + fixed in latest Floating UI version.**

This raises some minor interoperability concerns with extensions and third party widgets that use outdated versions of Floating UI, Popper (assuming it's broken there) or custom positioning methods that don't handle this edge case (where `html` has an offset).

## Problem 2

The forced overflow of the `<html>` scrollbar appears on top of backdrops, which looks a bit unsightly if it's not a custom scrollbar

<img width="757" alt="Screenshot 2024-09-12 at 4 29 06 PM" src="https://github.com/user-attachments/assets/51ef9c44-4ac8-4137-868b-266e93d5a25a">