### PR TITLE
[docs] Fix rel attribute on edit GitHub links

### DIFF
--- a/docs/src/components/EditPageGithubLink.tsx
+++ b/docs/src/components/EditPageGithubLink.tsx
@@ -15,7 +15,7 @@ export function EditPageGithubLink(props: EditPageGithubLinkProps) {
 
   const url = `${REPO_ROOT}/edit/${DEFAULT_BRANCH}/docs/data/${category}/${slug}/${slug}.mdx`;
   return (
-    <a href={url} target="_blank" rel="noopener noreferrer" className={classes.root}>
+    <a href={url} target="_blank" rel="noopener nofollow" className={classes.root}>
       Edit this page on GitHub
     </a>
   );


### PR DESCRIPTION
Quick-win I saw on #613. It's a regression from previous docs-infra:

- We don't need to add `noreferrer` anymore: https://github.com/mui/material-ui/pull/40447.
- However, I don't think we want to waste SEO crawling budget and page rank on those links, so added `nofollow` to keep the juice for our internal links.