### PR TITLE
[core] Increase the minimum Node.js version support to 14.0.0

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -43,16 +43,16 @@ samsung 22
 # snapshot of `npx browserslist "maintained node versions"`
 # On update check all #stable-snapshot markers
 [node]
-node 18.0
+node 14.0
 
 # same as `node`
 [coverage]
-node 18.0
+node 14.0
 
 # same as `node`
 [development]
-node 18.0
+node 14.0
 
 # same as `node`
 [test]
-node 18.0
+node 14.0

--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -86,6 +86,6 @@
     "directory": "build"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
Same minimum version increase as in https://github.com/mui/material-ui/pull/42920, from v12.0.0 to v14.0.0. No reason for the version to be different.