### PR TITLE
[test] Fix correct box-sizing reset in visual tests

### DIFF
--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -53,7 +53,7 @@ function TestViewer(props) {
     }
 
     *, *::before, *::after {
-      boxSizing: inherit;
+      box-sizing: inherit;
       /* Disable transitions to avoid flaky screenshots */
       transition: none !important;
       animation: none !important;


### PR DESCRIPTION
This wasn't correctly migrated from emotion style: https://github.com/mui/material-ui/blob/860ccd0e5a8f38e8149977ba4bb46c71ae7e894c/test/regressions/TestViewer.js#L68

I noticed this by chance from #665.