### PR TITLE
[test] Improve visual screenshot canva

### DIFF
--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -70,11 +70,7 @@ function TestViewer(props) {
       {/* eslint-disable-next-line react/no-danger */}
       <style dangerouslySetInnerHTML={{ __html: globalStyles }} />
       <React.Suspense fallback={<div aria-busy />}>
-        <div
-          aria-busy={!ready}
-          data-testid="testcase"
-          style={{ backgroundColor: '#fff', display: 'inline-block', padding: '8px' }}
-        >
+        <div aria-busy={!ready} data-testid="testcase" style={{ display: 'block', padding: '8px' }}>
           {children}
         </div>
       </React.Suspense>


### PR DESCRIPTION
Propagate https://github.com/mui/material-ui/pull/43656, one small iteration on https://github.com/mui/mui-public/issues/199

I noticed this by chance from #707.

What's the value? For example, it surfaces how this demo https://master--base-ui.netlify.app/components/react-number-field/ is broken once exported to codesandbox. Meaning, once a developer copy & paste it in its project.