### PR TITLE
[Field] Update APIs

### DIFF
--- a/docs/data/api/field-error.json
+++ b/docs/data/api/field-error.json
@@ -2,13 +2,13 @@
   "props": {
     "className": { "type": { "name": "union", "description": "func<br>&#124;&nbsp;string" } },
     "forceShow": { "type": { "name": "bool" } },
-    "render": { "type": { "name": "union", "description": "element<br>&#124;&nbsp;func" } },
-    "show": {
+    "match": {
       "type": {
         "name": "enum",
         "description": "'badInput'<br>&#124;&nbsp;'customError'<br>&#124;&nbsp;'patternMismatch'<br>&#124;&nbsp;'rangeOverflow'<br>&#124;&nbsp;'rangeUnderflow'<br>&#124;&nbsp;'stepMismatch'<br>&#124;&nbsp;'tooLong'<br>&#124;&nbsp;'tooShort'<br>&#124;&nbsp;'typeMismatch'<br>&#124;&nbsp;'valid'<br>&#124;&nbsp;'valueMissing'"
       }
-    }
+    },
+    "render": { "type": { "name": "union", "description": "element<br>&#124;&nbsp;func" } }
   },
   "name": "FieldError",
   "imports": ["import * as Field from '@base_ui/react/Field';\nconst FieldError = Field.Error;"],

--- a/docs/data/api/field-root.json
+++ b/docs/data/api/field-root.json
@@ -6,8 +6,11 @@
     "name": { "type": { "name": "string" } },
     "render": { "type": { "name": "union", "description": "element<br>&#124;&nbsp;func" } },
     "validate": { "type": { "name": "func" } },
-    "validateDebounceTime": { "type": { "name": "number" }, "default": "0" },
-    "validateOnChange": { "type": { "name": "bool" }, "default": "false" }
+    "validationDebounceTime": { "type": { "name": "number" }, "default": "0" },
+    "validationMode": {
+      "type": { "name": "enum", "description": "'onBlur'<br>&#124;&nbsp;'onChange'" },
+      "default": "'onBlur'"
+    }
   },
   "name": "FieldRoot",
   "imports": ["import * as Field from '@base_ui/react/Field';\nconst FieldRoot = Field.Root;"],

--- a/docs/data/components/field/UnstyledFieldAsync.js
+++ b/docs/data/components/field/UnstyledFieldAsync.js
@@ -48,8 +48,8 @@ export default function UnstyledFieldAsync() {
       <h3>Handle availability checker</h3>
       <FieldRoot
         validate={handleValidate}
-        validateOnChange
-        validateDebounceTime={300}
+        validationMode="onChange"
+        validationDebounceTime={300}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Field.Label>@</Field.Label>
@@ -83,7 +83,7 @@ export default function UnstyledFieldAsync() {
               );
             }
 
-            return <FieldError show="customError" />;
+            return <FieldError match="customError" />;
           }}
         </Field.Validity>
       </FieldRoot>

--- a/docs/data/components/field/UnstyledFieldAsync.tsx
+++ b/docs/data/components/field/UnstyledFieldAsync.tsx
@@ -48,8 +48,8 @@ export default function UnstyledFieldAsync() {
       <h3>Handle availability checker</h3>
       <FieldRoot
         validate={handleValidate}
-        validateOnChange
-        validateDebounceTime={300}
+        validationMode="onChange"
+        validationDebounceTime={300}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Field.Label>@</Field.Label>
@@ -83,7 +83,7 @@ export default function UnstyledFieldAsync() {
               );
             }
 
-            return <FieldError show="customError" />;
+            return <FieldError match="customError" />;
           }}
         </Field.Validity>
       </FieldRoot>

--- a/docs/data/components/field/UnstyledFieldIntroduction/system/index.js
+++ b/docs/data/components/field/UnstyledFieldIntroduction/system/index.js
@@ -27,9 +27,9 @@ export default function UnstyledFieldIntroduction() {
           );
         }}
       </Field.Validity>
-      <FieldError show="customError" />
-      <FieldError show="valueMissing" />
-      <FieldError show="patternMismatch">
+      <FieldError match="customError" />
+      <FieldError match="valueMissing" />
+      <FieldError match="patternMismatch">
         Only alphanumeric characters are allowed (a-z, A-Z, 0-9).
       </FieldError>
     </FieldRoot>

--- a/docs/data/components/field/UnstyledFieldIntroduction/system/index.tsx
+++ b/docs/data/components/field/UnstyledFieldIntroduction/system/index.tsx
@@ -27,9 +27,9 @@ export default function UnstyledFieldIntroduction() {
           );
         }}
       </Field.Validity>
-      <FieldError show="customError" />
-      <FieldError show="valueMissing" />
-      <FieldError show="patternMismatch">
+      <FieldError match="customError" />
+      <FieldError match="valueMissing" />
+      <FieldError match="patternMismatch">
         Only alphanumeric characters are allowed (a-z, A-Z, 0-9).
       </FieldError>
     </FieldRoot>

--- a/docs/data/components/field/field.mdx
+++ b/docs/data/components/field/field.mdx
@@ -93,17 +93,17 @@ The `children` by default is the browser's native message, which is automaticall
 
 ### Individual constraint validation failures
 
-When there are multiple HTML validation props, you can target individual validity state failures using the `show` prop to render custom messages:
+When there are multiple HTML validation props, you can target individual validity state failures using the `match` prop to render custom messages:
 
 ```jsx
 <Field.Root>
   <Field.Control required pattern="[a-zA-Z0-9]+" />
-  <Field.Error show="valueMissing">Field is required</Field.Error>
-  <Field.Error show="patternMismatch">Only alphanumeric characters allowed</Field.Error>
+  <Field.Error match="valueMissing">Field is required</Field.Error>
+  <Field.Error match="patternMismatch">Only alphanumeric characters allowed</Field.Error>
 </Field.Root>
 ```
 
-For the list of supported `show` strings, visit [`ValidityState` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState#instance_properties).
+For the list of supported `match` strings, visit [`ValidityState` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState#instance_properties).
 
 ### Custom validation
 
@@ -179,8 +179,8 @@ const [serverErrors, setServerErrors] = React.useState({
 return (
   <Field.Root invalid={serverErrors.email}>
     <Field.Control type="email" required />
-    <Field.Error show="valueMissing">Client-side only error message</Field.Error>
-    <Field.Error show="typeMismatch" forceShow={serverErrors.email}>
+    <Field.Error match="valueMissing">Client-side only error message</Field.Error>
+    <Field.Error match="typeMismatch" forceShow={serverErrors.email}>
       Client + server-side error message
     </Field.Error>
     <Field.Error forceShow={serverErrors.email}>Server-side only message</Field.Error>

--- a/docs/data/components/field/field.mdx
+++ b/docs/data/components/field/field.mdx
@@ -200,10 +200,10 @@ Errors shown initially for password validation:
 
 ### Realtime and async validation
 
-`validateOnChange` reports the validity of the control on every `change` event, such as a keypress:
+`validationMode="onChange"` reports the validity of the control on every `change` event instead of `blur`:
 
 ```jsx
-<Field.Root validateOnChange>
+<Field.Root validationMode="onChange">
 ```
 
 The `validate` function can also be async by returning a promise, enabling inline server-side validation through network requests.
@@ -212,10 +212,10 @@ In the demo below, the taken names are `admin`, `root`, and `superuser` — ever
 
 <Demo demo="UnstyledFieldAsync" defaultCodeOpen="false" />
 
-The `change` validation is debounced by 500ms to avoid firing a network request on every keystroke by specifying the `validateDebounceTime` prop:
+The `onChange` validation is debounced by 500ms to avoid firing a network request on every keystroke by specifying the `validationDebounceTime` prop:
 
 ```jsx
-<Field.Root validateOnChange validateDebounceTime={500}>
+<Field.Root validationMode="onChange" validationDebounceTime={500}>
 ```
 
 ## Styling

--- a/docs/data/translations/api-docs/field-error/field-error.json
+++ b/docs/data/translations/api-docs/field-error/field-error.json
@@ -7,10 +7,10 @@
     "forceShow": {
       "description": "Determines whether the error message should be shown regardless of the field&#39;s client validity."
     },
-    "render": { "description": "A function to customize rendering of the component." },
-    "show": {
+    "match": {
       "description": "Determines whether the error message should be shown when it matches a given property of the field&#39;s <code>ValidityState</code>."
-    }
+    },
+    "render": { "description": "A function to customize rendering of the component." }
   },
   "classDescriptions": {}
 }

--- a/docs/data/translations/api-docs/field-root/field-root.json
+++ b/docs/data/translations/api-docs/field-root/field-root.json
@@ -15,12 +15,10 @@
     "validate": {
       "description": "Function to custom-validate the field&#39;s value. Return a string or array of strings with error messages if the value is invalid, or <code>null</code> if the value is valid. The function can also return a promise that resolves to a string, array of strings, or <code>null</code>."
     },
-    "validateDebounceTime": {
-      "description": "The debounce time in milliseconds for the <code>validate</code> function in the <code>change</code> phase."
+    "validationDebounceTime": {
+      "description": "The debounce time in milliseconds for the <code>validate</code> function in <code>onChange</code> phase."
     },
-    "validateOnChange": {
-      "description": "Determines if validation should be triggered on the <code>change</code> event, rather than only on commit (blur)."
-    }
+    "validationMode": { "description": "Determines when validation should be triggered." }
   },
   "classDescriptions": {}
 }

--- a/packages/mui-base/src/Field/Control/useFieldControlValidation.ts
+++ b/packages/mui-base/src/Field/Control/useFieldControlValidation.ts
@@ -15,8 +15,8 @@ export function useFieldControlValidation() {
     validate,
     messageIds,
     validityData,
-    validateOnChange,
-    validateDebounceTime,
+    validationMode,
+    validationDebounceTime,
     invalid,
     markedDirtyRef,
     controlId,
@@ -125,7 +125,7 @@ export function useFieldControlValidation() {
             return;
           }
 
-          if (invalid || !validateOnChange) {
+          if (invalid || validationMode !== 'onChange') {
             return;
           }
 
@@ -139,16 +139,16 @@ export function useFieldControlValidation() {
 
           window.clearTimeout(timeoutRef.current);
 
-          if (validateDebounceTime) {
+          if (validationDebounceTime) {
             timeoutRef.current = window.setTimeout(() => {
               commitValidation(element.value);
-            }, validateDebounceTime);
+            }, validationDebounceTime);
           } else {
             commitValidation(element.value);
           }
         },
       }),
-    [getValidationProps, invalid, validateOnChange, validateDebounceTime, commitValidation],
+    [getValidationProps, invalid, validationMode, validationDebounceTime, commitValidation],
   );
 
   return React.useMemo(

--- a/packages/mui-base/src/Field/Error/FieldError.test.tsx
+++ b/packages/mui-base/src/Field/Error/FieldError.test.tsx
@@ -53,7 +53,7 @@ describe('<Field.Error />', () => {
       render(
         <Field.Root>
           <Field.Control required />
-          <Field.Error show="valueMissing">Message</Field.Error>
+          <Field.Error match="valueMissing">Message</Field.Error>
         </Field.Root>,
       );
 
@@ -73,7 +73,7 @@ describe('<Field.Error />', () => {
       render(
         <Field.Root validate={() => 'error'}>
           <Field.Control />
-          <Field.Error show="customError">Message</Field.Error>
+          <Field.Error match="customError">Message</Field.Error>
         </Field.Root>,
       );
 

--- a/packages/mui-base/src/Field/Error/FieldError.tsx
+++ b/packages/mui-base/src/Field/Error/FieldError.tsx
@@ -24,7 +24,7 @@ const FieldError = React.forwardRef(function FieldError(
   props: FieldError.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { render, id, className, show, forceShow, ...otherProps } = props;
+  const { render, id, className, match, forceShow, ...otherProps } = props;
 
   const { validityData, ownerState, name } = useFieldRootContext(false);
 
@@ -35,8 +35,8 @@ const FieldError = React.forwardRef(function FieldError(
   let rendered = false;
   if (formError || forceShow) {
     rendered = true;
-  } else if (show) {
-    rendered = Boolean(validityData.state[show]);
+  } else if (match) {
+    rendered = Boolean(validityData.state[match]);
   } else if (forceShow == null) {
     rendered = validityData.state.valid === false;
   }
@@ -68,7 +68,7 @@ namespace FieldError {
      * Determines whether the error message should be shown when it matches a given property of the
      * field's `ValidityState`.
      */
-    show?: keyof ValidityState;
+    match?: keyof ValidityState;
     /**
      * Determines whether the error message should be shown regardless of the field's client validity.
      */
@@ -98,14 +98,10 @@ FieldError.propTypes /* remove-proptypes */ = {
    */
   id: PropTypes.string,
   /**
-   * A function to customize rendering of the component.
-   */
-  render: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-  /**
    * Determines whether the error message should be shown when it matches a given property of the
    * field's `ValidityState`.
    */
-  show: PropTypes.oneOf([
+  match: PropTypes.oneOf([
     'badInput',
     'customError',
     'patternMismatch',
@@ -118,6 +114,10 @@ FieldError.propTypes /* remove-proptypes */ = {
     'valid',
     'valueMissing',
   ]),
+  /**
+   * A function to customize rendering of the component.
+   */
+  render: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
 } as any;
 
 export { FieldError };

--- a/packages/mui-base/src/Field/Root/FieldRoot.test.tsx
+++ b/packages/mui-base/src/Field/Root/FieldRoot.test.tsx
@@ -259,11 +259,11 @@ describe('<Field.Root />', () => {
     });
   });
 
-  describe('prop: validateOnChange', () => {
+  describe('prop: validationMode', () => {
     it('should validate the field on change', async () => {
       render(
         <Field.Root
-          validateOnChange
+          validationMode="onChange"
           validate={(value) => {
             const str = value as string;
             return str.length < 3 ? 'error' : null;
@@ -294,8 +294,8 @@ describe('<Field.Root />', () => {
     it('should debounce validation', async () => {
       renderFakeTimers(
         <Field.Root
-          validateDebounceTime={100}
-          validateOnChange
+          validationDebounceTime={100}
+          validationMode="onChange"
           validate={(value) => {
             const str = value as string;
             return str.length < 3 ? 'error' : null;

--- a/packages/mui-base/src/Field/Root/FieldRoot.tsx
+++ b/packages/mui-base/src/Field/Root/FieldRoot.tsx
@@ -28,8 +28,8 @@ const FieldRoot = React.forwardRef(function FieldRoot(
     render,
     className,
     validate: validateProp,
-    validateDebounceTime = 0,
-    validateOnChange = false,
+    validationDebounceTime = 0,
+    validationMode = 'onBlur',
     name,
     disabled: disabledProp = false,
     invalid: invalidProp,
@@ -100,8 +100,8 @@ const FieldRoot = React.forwardRef(function FieldRoot(
       dirty,
       setDirty,
       validate,
-      validateOnChange,
-      validateDebounceTime,
+      validationMode,
+      validationDebounceTime,
       ownerState,
       markedDirtyRef,
     }),
@@ -117,8 +117,8 @@ const FieldRoot = React.forwardRef(function FieldRoot(
       dirty,
       setDirty,
       validate,
-      validateOnChange,
-      validateDebounceTime,
+      validationMode,
+      validationDebounceTime,
       ownerState,
     ],
   );
@@ -183,16 +183,15 @@ namespace FieldRoot {
      */
     validate?: (value: unknown) => string | string[] | null | Promise<string | string[] | null>;
     /**
-     * Determines if validation should be triggered on the `change` event, rather than only on commit
-     * (blur).
-     * @default false
+     * Determines when validation should be triggered.
+     * @default 'onBlur'
      */
-    validateOnChange?: boolean;
+    validationMode?: 'onBlur' | 'onChange';
     /**
-     * The debounce time in milliseconds for the `validate` function in the `change` phase.
+     * The debounce time in milliseconds for the `validate` function in `onChange` phase.
      * @default 0
      */
-    validateDebounceTime?: number;
+    validationDebounceTime?: number;
     /**
      * Determines if the field is forcefully marked as invalid.
      */
@@ -238,16 +237,15 @@ FieldRoot.propTypes /* remove-proptypes */ = {
    */
   validate: PropTypes.func,
   /**
-   * The debounce time in milliseconds for the `validate` function in the `change` phase.
+   * The debounce time in milliseconds for the `validate` function in `onChange` phase.
    * @default 0
    */
-  validateDebounceTime: PropTypes.number,
+  validationDebounceTime: PropTypes.number,
   /**
-   * Determines if validation should be triggered on the `change` event, rather than only on commit
-   * (blur).
-   * @default false
+   * Determines when validation should be triggered.
+   * @default 'onBlur'
    */
-  validateOnChange: PropTypes.bool,
+  validationMode: PropTypes.oneOf(['onBlur', 'onChange']),
 } as any;
 
 export { FieldRoot };

--- a/packages/mui-base/src/Field/Root/FieldRootContext.ts
+++ b/packages/mui-base/src/Field/Root/FieldRootContext.ts
@@ -22,8 +22,8 @@ export interface FieldRootContext {
   dirty: boolean;
   setDirty: React.Dispatch<React.SetStateAction<boolean>>;
   validate: (value: unknown) => string | string[] | null | Promise<string | string[] | null>;
-  validateOnChange: boolean;
-  validateDebounceTime: number;
+  validationMode: 'onBlur' | 'onChange';
+  validationDebounceTime: number;
   ownerState: FieldRoot.OwnerState;
   markedDirtyRef: React.MutableRefObject<boolean>;
 }
@@ -51,8 +51,8 @@ export const FieldRootContext = React.createContext<FieldRootContext>({
   dirty: false,
   setDirty: NOOP,
   validate: () => null,
-  validateOnChange: false,
-  validateDebounceTime: 0,
+  validationMode: 'onBlur',
+  validationDebounceTime: 0,
   ownerState: {
     disabled: false,
     valid: null,

--- a/packages/mui-base/src/NumberField/Root/useNumberFieldRoot.ts
+++ b/packages/mui-base/src/NumberField/Root/useNumberFieldRoot.ts
@@ -59,7 +59,7 @@ export function useNumberFieldRoot(
   const {
     labelId,
     setControlId,
-    validateOnChange,
+    validationMode,
     setTouched,
     setDirty,
     validityData,
@@ -182,7 +182,7 @@ export function useNumberFieldRoot(
     setValueUnwrapped(validatedValue);
     setDirty(validatedValue !== validityData.initialValue);
 
-    if (validateOnChange) {
+    if (validationMode === 'onChange') {
       commitValidation(validatedValue);
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

- `Field.Error`: `show` -> `match`
- `Field.Root`: `validateOnChange` -> `validationMode: 'onChange'` (`onBlur` default)
- `Field.Root`: `validateDebounceTime` -> `validationDebounceTime`

Unhandled: `validationMode: 'all'` for both simultaneously. The docs demos don't seem to need this - wait until a use case appears?