### PR TITLE
[code-infra] Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,7 @@
     },
     {
       "groupName": "eslint",
-      "matchPackagePatterns": ["eslint", "eslint-*"],
+      "matchPackagePatterns": ["eslint", "eslint-*", "@typescript-eslint/*"],
       "automerge": true
     },
     {
@@ -66,10 +66,6 @@
         "@types/react-dom",
         "@types/react-is"
       ]
-    },
-    {
-      "groupName": "typescript-eslint",
-      "matchPackagePatterns": "@typescript-eslint/*"
     },
     {
       "groupName": "Node.js",

--- a/renovate.json
+++ b/renovate.json
@@ -31,39 +31,29 @@
       "allowedVersions": "< 2.0.0"
     },
     {
-      "groupName": "JSS",
-      "matchPackageNames": [
-        "css-jss",
-        "jss-plugin-cache",
-        "jss-plugin-camel-case",
-        "jss-plugin-compose",
-        "jss-plugin-default-unit",
-        "jss-plugin-expand",
-        "jss-plugin-extend",
-        "jss-plugin-global",
-        "jss-plugin-isolate",
-        "jss-plugin-nested",
-        "jss-plugin-props-sort",
-        "jss-plugin-rule-value-function",
-        "jss-plugin-rule-value-observable",
-        "jss-plugin-template",
-        "jss-plugin-vendor-prefixer",
-        "jss-preset-default",
-        "jss-starter-kit",
-        "jss",
-        "react-jss"
-      ]
+      "groupName": "eslint",
+      "matchPackagePatterns": ["eslint", "eslint-*"],
+      "automerge": true
+    },
+    {
+      "automerge": true,
+      "matchPackageNames": ["@types/**"]
     },
     {
       "groupName": "MUI",
-      "matchPackagePatterns": ["@mui/*"],
+      "matchPackagePatterns": [
+        "@mui/*",
+        "playwright",
+        "@playwright/test",
+        "mcr.microsoft.com/playwright"
+      ],
       "allowedVersions": "!/-dev/",
       "schedule": "before 6:00am on Wednesday"
     },
     {
       "groupName": "Public packages' dependencies",
       "matchFileNames": ["packages/*/package.json"],
-      "matchDepTypes": ["dependencies"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
       "schedule": "before 6:00am on Wednesday"
     },
     {
@@ -92,18 +82,9 @@
       "enabled": false
     },
     {
-      "groupName": "bundling fixtures",
-      "matchPaths": ["test/bundling/fixtures/**/package.json"],
-      "schedule": "every 6 months on the first day of the month"
-    },
-    {
       "groupName": "examples",
       "matchPaths": ["examples/**/package.json"],
       "enabled": false
-    },
-    {
-      "groupName": "Playwright",
-      "matchPackageNames": ["playwright", "@playwright/test", "mcr.microsoft.com/playwright"]
     },
     {
       "matchDepTypes": ["action"],


### PR DESCRIPTION
Updated Renovate config:
- included (previously omitted by mistake) devDependencies of public packages
- grouped ESLint plugins together and enabled automerge to reduce the number of PRs
- enabled automerge for `@types/*` packages
- bundled MUI packages with Playwright, as they usually have to be updated together
- removed JSS group as it's unused in this repo
