### PR TITLE
[internal] Remove `delayType` prop across hoverable popup components

### DIFF
--- a/docs/data/api/popover-root.json
+++ b/docs/data/api/popover-root.json
@@ -4,10 +4,6 @@
     "closeDelay": { "type": { "name": "number" }, "default": "0" },
     "defaultOpen": { "type": { "name": "bool" }, "default": "false" },
     "delay": { "type": { "name": "number" }, "default": "300" },
-    "delayType": {
-      "type": { "name": "enum", "description": "'hover'<br>&#124;&nbsp;'rest'" },
-      "default": "'rest'"
-    },
     "onOpenChange": { "type": { "name": "func" } },
     "open": { "type": { "name": "bool" }, "default": "false" },
     "openOnHover": { "type": { "name": "bool" }, "default": "false" }

--- a/docs/data/api/preview-card-root.json
+++ b/docs/data/api/preview-card-root.json
@@ -4,10 +4,6 @@
     "closeDelay": { "type": { "name": "number" }, "default": "300" },
     "defaultOpen": { "type": { "name": "bool" }, "default": "false" },
     "delay": { "type": { "name": "number" }, "default": "600" },
-    "delayType": {
-      "type": { "name": "enum", "description": "'hover'<br>&#124;&nbsp;'rest'" },
-      "default": "'rest'"
-    },
     "onOpenChange": { "type": { "name": "func" } },
     "open": { "type": { "name": "bool" }, "default": "false" }
   },

--- a/docs/data/api/tooltip-root.json
+++ b/docs/data/api/tooltip-root.json
@@ -4,10 +4,6 @@
     "closeDelay": { "type": { "name": "number" }, "default": "0" },
     "defaultOpen": { "type": { "name": "bool" }, "default": "false" },
     "delay": { "type": { "name": "number" }, "default": "600" },
-    "delayType": {
-      "type": { "name": "enum", "description": "'hover'<br>&#124;&nbsp;'rest'" },
-      "default": "'rest'"
-    },
     "hoverable": { "type": { "name": "bool" }, "default": "true" },
     "onOpenChange": { "type": { "name": "func" } },
     "open": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/data/components/popover/popover.mdx
+++ b/docs/data/components/popover/popover.mdx
@@ -111,12 +111,6 @@ To change how long the popover waits until it opens or closes when `openOnHover`
 <Popover.Root openOnHover delay={200} closeDelay={200}>
 ```
 
-The delay type can be changed from `"rest"` (user's cursor is static over the trigger for the given timeout in milliseconds) to `"hover"` (the user's cursor has entered the trigger):
-
-```jsx
-<Popover.Root openOnHover delayType="hover">
-```
-
 ## Controlled
 
 To control the popover with external state, use the `open` and `onOpenChange` props:

--- a/docs/data/components/preview-card/preview-card.mdx
+++ b/docs/data/components/preview-card/preview-card.mdx
@@ -104,12 +104,6 @@ To change how long the Preview Card waits until it opens or closes, use the `del
 <PreviewCard.Root delay={200} closeDelay={200}>
 ```
 
-The delay type can be changed from `"rest"` (user's cursor is static over the trigger for the given timeout in milliseconds) to `"hover"` (the user's cursor has entered the trigger):
-
-```jsx
-<PreviewCard.Root delayType="hover">
-```
-
 ## Controlled
 
 To control the Preview Card with external state, use the `open` and `onOpenChange` props:

--- a/docs/data/components/tooltip/tooltip.mdx
+++ b/docs/data/components/tooltip/tooltip.mdx
@@ -126,12 +126,6 @@ To change how long the tooltip waits until it opens or closes, use the `delay` a
 <Tooltip.Root delay={200} closeDelay={200}>
 ```
 
-The delay type can be changed from `"rest"` (user's cursor is static over the trigger for the given timeout in milliseconds) to `"hover"` (the user's cursor has entered the trigger):
-
-```jsx
-<Tooltip.Root delayType="hover">
-```
-
 ## Controlled
 
 To control the tooltip with external state, use the `open` and `onOpenChange` props:

--- a/docs/data/translations/api-docs/popover-root/popover-root.json
+++ b/docs/data/translations/api-docs/popover-root/popover-root.json
@@ -13,9 +13,6 @@
     "delay": {
       "description": "The delay in milliseconds until the popover popup is opened when <code>openOnHover</code> is <code>true</code>."
     },
-    "delayType": {
-      "description": "The delay type to use when <code>openOnHover</code> is <code>true</code>. <code>rest</code> means the <code>delay</code> represents how long the user&#39;s cursor must rest on the trigger before the popover popup is opened. <code>hover</code> means the <code>delay</code> represents how long to wait as soon as the user&#39;s cursor has entered the trigger."
-    },
     "onOpenChange": {
       "description": "Callback fired when the popover popup is requested to be opened or closed. Use when controlled."
     },

--- a/docs/data/translations/api-docs/preview-card-root/preview-card-root.json
+++ b/docs/data/translations/api-docs/preview-card-root/preview-card-root.json
@@ -13,9 +13,6 @@
     "delay": {
       "description": "The delay in milliseconds until the preview card popup is opened when <code>openOnHover</code> is <code>true</code>."
     },
-    "delayType": {
-      "description": "The delay type to use when the preview card is triggered by hover. <code>rest</code> means the <code>delay</code> represents how long the user&#39;s cursor must rest on the trigger before the preview card popup is opened. <code>hover</code> means the <code>delay</code> represents how long to wait as soon as the user&#39;s cursor has entered the trigger."
-    },
     "onOpenChange": {
       "description": "Callback fired when the preview card popup is requested to be opened or closed. Use when controlled."
     },

--- a/docs/data/translations/api-docs/tooltip-root/tooltip-root.json
+++ b/docs/data/translations/api-docs/tooltip-root/tooltip-root.json
@@ -9,9 +9,6 @@
       "description": "Whether the tooltip popup is open by default. Use when uncontrolled."
     },
     "delay": { "description": "The delay in milliseconds until the tooltip popup is opened." },
-    "delayType": {
-      "description": "The delay type to use. <code>rest</code> means the <code>delay</code> represents how long the user&#39;s cursor must rest on the trigger before the tooltip popup is opened. <code>hover</code> means the <code>delay</code> represents how long to wait as soon as the user&#39;s cursor has entered the trigger."
-    },
     "hoverable": {
       "description": "Whether the user can move their cursor from the trigger element toward the tooltip popup element without it closing using a &quot;safe polygon&quot; technique."
     },

--- a/packages/mui-base/src/Popover/Root/PopoverRoot.test.tsx
+++ b/packages/mui-base/src/Popover/Root/PopoverRoot.test.tsx
@@ -263,32 +263,6 @@ describe('<Popover.Root />', () => {
 
       expect(screen.getByText('Content')).not.to.equal(null);
     });
-
-    it('should open after delay with hover type', async () => {
-      await render(
-        <Root openOnHover delayType="hover">
-          <Popover.Trigger />
-          <Popover.Positioner>
-            <Popover.Popup>Content</Popover.Popup>
-          </Popover.Positioner>
-        </Root>,
-      );
-
-      const anchor = screen.getByRole('button');
-
-      fireEvent.mouseEnter(anchor);
-      clock.tick(OPEN_DELAY / 2);
-
-      await flushMicrotasks();
-
-      expect(screen.queryByText('Content')).to.equal(null);
-
-      clock.tick(OPEN_DELAY / 2);
-
-      await flushMicrotasks();
-
-      expect(screen.getByText('Content')).not.to.equal(null);
-    });
   });
 
   describe('prop: closeDelay', () => {

--- a/packages/mui-base/src/Popover/Root/PopoverRoot.tsx
+++ b/packages/mui-base/src/Popover/Root/PopoverRoot.tsx
@@ -17,7 +17,7 @@ import { OPEN_DELAY } from '../utils/constants';
  * - [PopoverRoot API](https://base-ui.netlify.app/components/react-popover/#api-reference-PopoverRoot)
  */
 function PopoverRoot(props: PopoverRoot.Props) {
-  const { openOnHover = false, delayType = 'rest', delay, closeDelay = 0, animated = true } = props;
+  const { openOnHover = false, delay, closeDelay = 0, animated = true } = props;
 
   const delayWithDefault = delay ?? OPEN_DELAY;
 
@@ -43,7 +43,6 @@ function PopoverRoot(props: PopoverRoot.Props) {
   } = usePopoverRoot({
     openOnHover,
     delay: delayWithDefault,
-    delayType,
     closeDelay,
     animated,
     open: props.open,
@@ -55,7 +54,6 @@ function PopoverRoot(props: PopoverRoot.Props) {
     () => ({
       openOnHover,
       delay: delayWithDefault,
-      delayType,
       closeDelay,
       open,
       setOpen,
@@ -79,7 +77,6 @@ function PopoverRoot(props: PopoverRoot.Props) {
     [
       openOnHover,
       delayWithDefault,
-      delayType,
       closeDelay,
       open,
       setOpen,
@@ -145,14 +142,6 @@ PopoverRoot.propTypes /* remove-proptypes */ = {
    * @default 300
    */
   delay: PropTypes.number,
-  /**
-   * The delay type to use when `openOnHover` is `true`. `rest` means the `delay` represents how
-   * long the user's cursor must rest on the trigger before the popover popup is opened. `hover`
-   * means the `delay` represents how long to wait as soon as the user's cursor has entered the
-   * trigger.
-   * @default 'rest'
-   */
-  delayType: PropTypes.oneOf(['hover', 'rest']),
   /**
    * Callback fired when the popover popup is requested to be opened or closed. Use when
    * controlled.

--- a/packages/mui-base/src/Popover/Root/PopoverRootContext.ts
+++ b/packages/mui-base/src/Popover/Root/PopoverRootContext.ts
@@ -15,7 +15,6 @@ export interface PopoverRootContext {
   popupRef: React.RefObject<HTMLElement | null>;
   delay: number;
   closeDelay: number;
-  delayType: 'rest' | 'hover';
   instantType: 'dismiss' | 'click' | undefined;
   mounted: boolean;
   setMounted: React.Dispatch<React.SetStateAction<boolean>>;

--- a/packages/mui-base/src/Popover/Root/usePopoverRoot.ts
+++ b/packages/mui-base/src/Popover/Root/usePopoverRoot.ts
@@ -25,7 +25,6 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
     onOpenChange: onOpenChangeProp = () => {},
     defaultOpen = false,
     keepMounted = false,
-    delayType = 'rest',
     delay,
     closeDelay,
     openOnHover = false,
@@ -96,12 +95,7 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
     },
   });
 
-  const computedRestMs = delayType === 'rest' ? delayWithDefault : undefined;
-  let computedOpenDelay: number | undefined = delayType === 'hover' ? delayWithDefault : undefined;
-
-  if (delayType === 'hover') {
-    computedOpenDelay = delay == null ? delayWithDefault : delay;
-  }
+  const computedRestMs = delayWithDefault;
 
   const hover = useHover(context, {
     enabled: openOnHover,
@@ -110,7 +104,6 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
     handleClose: safePolygon(),
     restMs: computedRestMs,
     delay: {
-      open: computedOpenDelay,
       close: closeDelayWithDefault,
     },
   });
@@ -191,14 +184,6 @@ export namespace usePopoverRoot {
      * @default 0
      */
     closeDelay?: number;
-    /**
-     * The delay type to use when `openOnHover` is `true`. `rest` means the `delay` represents how
-     * long the user's cursor must rest on the trigger before the popover popup is opened. `hover`
-     * means the `delay` represents how long to wait as soon as the user's cursor has entered the
-     * trigger.
-     * @default 'rest'
-     */
-    delayType?: 'rest' | 'hover';
     /**
      * Whether the popover popup element stays mounted in the DOM when closed.
      * @default false

--- a/packages/mui-base/src/PreviewCard/Root/PreviewCardContext.ts
+++ b/packages/mui-base/src/PreviewCard/Root/PreviewCardContext.ts
@@ -13,7 +13,6 @@ export interface PreviewCardRootContext {
   setPositionerElement: (el: HTMLElement | null) => void;
   delay: number;
   closeDelay: number;
-  delayType: 'rest' | 'hover';
   mounted: boolean;
   setMounted: React.Dispatch<React.SetStateAction<boolean>>;
   getRootTriggerProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;

--- a/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
+++ b/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.test.tsx
@@ -330,32 +330,6 @@ describe('<PreviewCard.Root />', () => {
 
       expect(screen.getByText('Content')).not.to.equal(null);
     });
-
-    it('should open after delay with hover type', async () => {
-      await render(
-        <Root delayType="hover">
-          <Trigger />
-          <PreviewCard.Positioner>
-            <PreviewCard.Popup>Content</PreviewCard.Popup>
-          </PreviewCard.Positioner>
-        </Root>,
-      );
-
-      const trigger = screen.getByRole('link');
-
-      fireEvent.mouseEnter(trigger);
-      clock.tick(OPEN_DELAY - 100);
-
-      await flushMicrotasks();
-
-      expect(screen.queryByText('Content')).to.equal(null);
-
-      clock.tick(100);
-
-      await flushMicrotasks();
-
-      expect(screen.getByText('Content')).not.to.equal(null);
-    });
   });
 
   describe('prop: closeDelay', () => {

--- a/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.tsx
+++ b/packages/mui-base/src/PreviewCard/Root/PreviewCardRoot.tsx
@@ -16,7 +16,7 @@ import { CLOSE_DELAY, OPEN_DELAY } from '../utils/constants';
  * - [PreviewCardRoot API](https://base-ui.netlify.app/components/react-preview-card/#api-reference-PreviewCardRoot)
  */
 function PreviewCardRoot(props: PreviewCardRoot.Props) {
-  const { delayType = 'rest', delay, closeDelay, animated = true } = props;
+  const { delay, closeDelay, animated = true } = props;
 
   const delayWithDefault = delay ?? OPEN_DELAY;
   const closeDelayWithDefault = closeDelay ?? CLOSE_DELAY;
@@ -39,7 +39,6 @@ function PreviewCardRoot(props: PreviewCardRoot.Props) {
   } = usePreviewCardRoot({
     animated,
     delay,
-    delayType,
     closeDelay,
     open: props.open,
     onOpenChange: props.onOpenChange,
@@ -49,7 +48,6 @@ function PreviewCardRoot(props: PreviewCardRoot.Props) {
   const contextValue = React.useMemo(
     () => ({
       delay: delayWithDefault,
-      delayType,
       closeDelay: closeDelayWithDefault,
       open,
       setOpen,
@@ -68,7 +66,6 @@ function PreviewCardRoot(props: PreviewCardRoot.Props) {
     }),
     [
       delayWithDefault,
-      delayType,
       closeDelayWithDefault,
       open,
       setOpen,
@@ -132,14 +129,6 @@ PreviewCardRoot.propTypes /* remove-proptypes */ = {
    * @default 600
    */
   delay: PropTypes.number,
-  /**
-   * The delay type to use when the preview card is triggered by hover. `rest` means the `delay`
-   * represents how long the user's cursor must rest on the trigger before the preview card popup is
-   * opened. `hover` means the `delay` represents how long to wait as soon as the user's cursor has
-   * entered the trigger.
-   * @default 'rest'
-   */
-  delayType: PropTypes.oneOf(['hover', 'rest']),
   /**
    * Callback fired when the preview card popup is requested to be opened or closed. Use when
    * controlled.

--- a/packages/mui-base/src/PreviewCard/Root/usePreviewCardRoot.ts
+++ b/packages/mui-base/src/PreviewCard/Root/usePreviewCardRoot.ts
@@ -27,7 +27,6 @@ export function usePreviewCardRoot(
     defaultOpen = false,
     keepMounted = false,
     animated = true,
-    delayType = 'rest',
     delay,
     closeDelay,
   } = params;
@@ -98,12 +97,7 @@ export function usePreviewCardRoot(
   });
 
   const instantType = instantTypeState;
-  const computedRestMs = delayType === 'rest' ? delayWithDefault : undefined;
-  let computedOpenDelay: number | undefined = delayType === 'hover' ? delayWithDefault : undefined;
-
-  if (delayType === 'hover') {
-    computedOpenDelay = delay == null ? delayWithDefault : delay;
-  }
+  const computedRestMs = delayWithDefault;
 
   const hover = useHover(context, {
     mouseOnly: true,
@@ -111,7 +105,6 @@ export function usePreviewCardRoot(
     handleClose: safePolygon(),
     restMs: computedRestMs,
     delay: {
-      open: computedOpenDelay,
       close: closeDelayWithDefault,
     },
   });
@@ -186,14 +179,6 @@ export namespace usePreviewCardRoot {
      * @default 300
      */
     closeDelay?: number;
-    /**
-     * The delay type to use when the preview card is triggered by hover. `rest` means the `delay`
-     * represents how long the user's cursor must rest on the trigger before the preview card popup is
-     * opened. `hover` means the `delay` represents how long to wait as soon as the user's cursor has
-     * entered the trigger.
-     * @default 'rest'
-     */
-    delayType?: 'rest' | 'hover';
     /**
      * Whether the preview card popup element stays mounted in the DOM when closed.
      * @default false

--- a/packages/mui-base/src/Tooltip/Root/TooltipRoot.test.tsx
+++ b/packages/mui-base/src/Tooltip/Root/TooltipRoot.test.tsx
@@ -328,32 +328,6 @@ describe('<Tooltip.Root />', () => {
 
       expect(screen.getByText('Content')).not.to.equal(null);
     });
-
-    it('should open after delay with hover type', async () => {
-      await render(
-        <Root delayType="hover">
-          <Tooltip.Trigger />
-          <Tooltip.Positioner>
-            <Tooltip.Popup>Content</Tooltip.Popup>
-          </Tooltip.Positioner>
-        </Root>,
-      );
-
-      const trigger = screen.getByRole('button');
-
-      fireEvent.mouseEnter(trigger);
-      clock.tick(OPEN_DELAY - 100);
-
-      await flushMicrotasks();
-
-      expect(screen.queryByText('Content')).to.equal(null);
-
-      clock.tick(100);
-
-      await flushMicrotasks();
-
-      expect(screen.getByText('Content')).not.to.equal(null);
-    });
   });
 
   describe('prop: closeDelay', () => {

--- a/packages/mui-base/src/Tooltip/Root/TooltipRoot.tsx
+++ b/packages/mui-base/src/Tooltip/Root/TooltipRoot.tsx
@@ -17,14 +17,7 @@ import { OPEN_DELAY } from '../utils/constants';
  * - [TooltipRoot API](https://base-ui.netlify.app/components/react-tooltip/#api-reference-TooltipRoot)
  */
 function TooltipRoot(props: TooltipRoot.Props) {
-  const {
-    delayType = 'rest',
-    delay,
-    closeDelay,
-    hoverable = true,
-    animated = true,
-    trackCursorAxis = 'none',
-  } = props;
+  const { delay, closeDelay, hoverable = true, animated = true, trackCursorAxis = 'none' } = props;
 
   const delayWithDefault = delay ?? OPEN_DELAY;
   const closeDelayWithDefault = closeDelay ?? 0;
@@ -49,7 +42,6 @@ function TooltipRoot(props: TooltipRoot.Props) {
     animated,
     trackCursorAxis,
     delay,
-    delayType,
     closeDelay,
     open: props.open,
     onOpenChange: props.onOpenChange,
@@ -59,7 +51,6 @@ function TooltipRoot(props: TooltipRoot.Props) {
   const contextValue = React.useMemo(
     () => ({
       delay: delayWithDefault,
-      delayType,
       closeDelay: closeDelayWithDefault,
       open,
       setOpen,
@@ -79,7 +70,6 @@ function TooltipRoot(props: TooltipRoot.Props) {
     }),
     [
       delayWithDefault,
-      delayType,
       closeDelayWithDefault,
       open,
       setOpen,
@@ -142,13 +132,6 @@ TooltipRoot.propTypes /* remove-proptypes */ = {
    * @default 600
    */
   delay: PropTypes.number,
-  /**
-   * The delay type to use. `rest` means the `delay` represents how long the user's cursor must
-   * rest on the trigger before the tooltip popup is opened. `hover` means the `delay` represents
-   * how long to wait as soon as the user's cursor has entered the trigger.
-   * @default 'rest'
-   */
-  delayType: PropTypes.oneOf(['hover', 'rest']),
   /**
    * Whether the user can move their cursor from the trigger element toward the tooltip popup element
    * without it closing using a "safe polygon" technique.

--- a/packages/mui-base/src/Tooltip/Root/TooltipRootContext.ts
+++ b/packages/mui-base/src/Tooltip/Root/TooltipRootContext.ts
@@ -14,7 +14,6 @@ export interface TooltipRootContext {
   popupRef: React.RefObject<HTMLElement | null>;
   delay: number;
   closeDelay: number;
-  delayType: 'rest' | 'hover';
   mounted: boolean;
   setMounted: React.Dispatch<React.SetStateAction<boolean>>;
   getRootTriggerProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;

--- a/packages/mui-base/src/Tooltip/Root/useTooltipRoot.ts
+++ b/packages/mui-base/src/Tooltip/Root/useTooltipRoot.ts
@@ -29,7 +29,6 @@ export function useTooltipRoot(params: useTooltipRoot.Parameters): useTooltipRoo
     hoverable = true,
     animated = true,
     trackCursorAxis = 'none',
-    delayType = 'rest',
     delay,
     closeDelay,
   } = params;
@@ -110,22 +109,8 @@ export function useTooltipRoot(params: useTooltipRoot.Parameters): useTooltipRoo
     instantType = instantTypeState;
   }
 
-  const computedRestMs = delayType === 'rest' ? openGroupDelay || delayWithDefault : undefined;
-  let computedOpenDelay: number | undefined = delayType === 'hover' ? delayWithDefault : undefined;
+  const computedRestMs = openGroupDelay || delayWithDefault;
   let computedCloseDelay: number | undefined = closeDelayWithDefault;
-
-  if (delayType === 'hover') {
-    if (delay == null) {
-      computedOpenDelay =
-        groupDelay === 0
-          ? // A provider is not present.
-            delayWithDefault
-          : // A provider is present.
-            openGroupDelay;
-    } else {
-      computedOpenDelay = delay;
-    }
-  }
 
   // A provider is present and the close delay is not set.
   if (closeDelay == null && groupDelay !== 0) {
@@ -138,7 +123,6 @@ export function useTooltipRoot(params: useTooltipRoot.Parameters): useTooltipRoo
     handleClose: hoverable && trackCursorAxis !== 'both' ? safePolygon() : null,
     restMs: computedRestMs,
     delay: {
-      open: computedOpenDelay,
       close: computedCloseDelay,
     },
   });
@@ -228,13 +212,6 @@ export namespace useTooltipRoot {
      * @default 0
      */
     closeDelay?: number;
-    /**
-     * The delay type to use. `rest` means the `delay` represents how long the user's cursor must
-     * rest on the trigger before the tooltip popup is opened. `hover` means the `delay` represents
-     * how long to wait as soon as the user's cursor has entered the trigger.
-     * @default 'rest'
-     */
-    delayType?: 'rest' | 'hover';
     /**
      * Whether the tooltip popup element stays mounted in the DOM when closed.
      * @default false


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #654. Now all hoverable popups only open once the cursor is at "rest". As before with `rest`, they can never open when scrolling and the cursor happens to land on a trigger, since `mousemove` isn't triggered in that case.

- `@floating-ui/react@0.26.25` will ignore insignficant movements for `restMs` once it's released (allows small 1px movements to handle tremors that are also considered to be "at rest"), but is not tied to this PR.