### PR TITLE
[internal] Refactor popup component style hooks to `data-popup-open`, `data-open`

### DIFF
--- a/docs/app/experiments/dialog.module.css
+++ b/docs/app/experiments/dialog.module.css
@@ -88,7 +88,7 @@
       opacity var(--transition-duration) ease-in,
       visibility var(--transition-duration) step-end;
 
-    &[data-state='open'] {
+    &[data-open] {
       @starting-style {
         & {
           transform: translate(-50%, -35%) scale(0.8) translateY(0);
@@ -112,7 +112,7 @@
     visibility: hidden;
     opacity: 0;
 
-    &[data-state='open'] {
+    &[data-open] {
       animation:
         dialog-opening-transform var(--transition-duration) ease-out,
         dialog-opening-opacity var(--transition-duration) ease-out forwards;
@@ -149,7 +149,7 @@
       opacity 300ms ease-in,
       visibility 300ms step-end;
 
-    &[data-state='open'] {
+    &[data-open] {
       @starting-style {
         & {
           opacity: 0;
@@ -167,7 +167,7 @@
   }
 
   &.withAnimations {
-    &[data-state='open'] {
+    &[data-open] {
       animation: backdrop-opening 500ms ease-out forwards;
     }
 

--- a/docs/app/experiments/tooltip.tsx
+++ b/docs/app/experiments/tooltip.tsx
@@ -40,7 +40,7 @@ export const TooltipPopup = styled(Tooltip.Popup)`
   }
 
   &[data-type='css-animation'] {
-    &[data-state='open'] {
+    &[data-open] {
       visibility: visible;
       animation: ${scaleIn} 0.2s forwards;
     }
@@ -53,7 +53,7 @@ export const TooltipPopup = styled(Tooltip.Popup)`
   &[data-type='css-animation-keep-mounted'] {
     visibility: hidden;
 
-    &[data-state='open'] {
+    &[data-open] {
       visibility: visible;
       animation: ${scaleIn} 0.2s forwards;
     }
@@ -70,7 +70,7 @@ export const TooltipPopup = styled(Tooltip.Popup)`
     opacity: 0;
     transform: scale(0);
 
-    &[data-state='open'] {
+    &[data-open] {
       opacity: 1;
       transform: scale(1);
     }
@@ -88,7 +88,7 @@ export const TooltipPopup = styled(Tooltip.Popup)`
     transform: scale(0.8);
     visibility: hidden;
 
-    &[data-state='open'] {
+    &[data-open] {
       opacity: 1;
       transform: scale(1);
       visibility: visible;
@@ -106,13 +106,13 @@ export const TooltipPopup = styled(Tooltip.Popup)`
     opacity: 0;
     transform: scale(0);
 
-    &[data-state='open'] {
+    &[data-open] {
       opacity: 1;
       transform: scale(1);
     }
 
     @starting-style {
-      &[data-state='open'] {
+      &[data-open] {
         opacity: 0;
         transform: scale(0.8);
       }
@@ -134,7 +134,7 @@ export const AnchorButton = styled(Tooltip.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 `;

--- a/docs/data/components/alert-dialog/AlertDialogWithTransitions.js
+++ b/docs/data/components/alert-dialog/AlertDialogWithTransitions.js
@@ -51,7 +51,7 @@ const Popup = styled(BaseAlertDialog.Popup)(
   opacity: 0;
   transform: translate(-50%, -35%) scale(0.8);
 
-  &[data-state='open'] {
+  &[data-open] {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
     transition-timing-function: ease-out;
@@ -75,7 +75,7 @@ const Backdrop = styled(BaseAlertDialog.Backdrop)`
   transition-duration: 250ms;
   transition-timing-function: ease-in;
 
-  &[data-state='open'] {
+  &[data-open] {
     backdrop-filter: blur(6px);
     opacity: 1;
     transition-timing-function: ease-out;

--- a/docs/data/components/alert-dialog/AlertDialogWithTransitions.tsx
+++ b/docs/data/components/alert-dialog/AlertDialogWithTransitions.tsx
@@ -51,7 +51,7 @@ const Popup = styled(BaseAlertDialog.Popup)(
   opacity: 0;
   transform: translate(-50%, -35%) scale(0.8);
 
-  &[data-state='open'] {
+  &[data-open] {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
     transition-timing-function: ease-out;
@@ -75,7 +75,7 @@ const Backdrop = styled(BaseAlertDialog.Backdrop)`
   transition-duration: 250ms;
   transition-timing-function: ease-in;
 
-  &[data-state='open'] {
+  &[data-open] {
     backdrop-filter: blur(6px);
     opacity: 1;
     transition-timing-function: ease-out;

--- a/docs/data/components/alert-dialog/NestedAlertDialogs.js
+++ b/docs/data/components/alert-dialog/NestedAlertDialogs.js
@@ -72,7 +72,7 @@ const Popup = styled(BaseAlertDialog.Popup)(
     opacity var(--transition-duration) ease-in,
     visibility var(--transition-duration) step-end;
 
-  &[data-state='open'] {
+  &[data-open] {
     @starting-style {
       & {
         transform: translate(-50%, -35%) scale(0.8) translateY(0);
@@ -124,7 +124,7 @@ const Backdrop = styled(BaseAlertDialog.Backdrop)`
   transition-duration: 250ms;
   transition-timing-function: ease-in;
 
-  &[data-state='open'] {
+  &[data-open] {
     backdrop-filter: blur(6px);
     opacity: 1;
     transition-timing-function: ease-out;

--- a/docs/data/components/alert-dialog/NestedAlertDialogs.tsx
+++ b/docs/data/components/alert-dialog/NestedAlertDialogs.tsx
@@ -72,7 +72,7 @@ const Popup = styled(BaseAlertDialog.Popup)(
     opacity var(--transition-duration) ease-in,
     visibility var(--transition-duration) step-end;
 
-  &[data-state='open'] {
+  &[data-open] {
     @starting-style {
       & {
         transform: translate(-50%, -35%) scale(0.8) translateY(0);
@@ -124,7 +124,7 @@ const Backdrop = styled(BaseAlertDialog.Backdrop)`
   transition-duration: 250ms;
   transition-timing-function: ease-in;
 
-  &[data-state='open'] {
+  &[data-open] {
     backdrop-filter: blur(6px);
     opacity: 1;
     transition-timing-function: ease-out;

--- a/docs/data/components/alert-dialog/alert-dialog.mdx
+++ b/docs/data/components/alert-dialog/alert-dialog.mdx
@@ -129,7 +129,7 @@ Here is an example of how to apply a symmetric scale and fade transition with th
 }
 
 /* Represents the final styles once entered */
-.AlertDialogPopup[data-state='open'] {
+.AlertDialogPopup[data-open] {
   opacity: 1;
   transform: translate(-50%, -50%) scale(1);
 }
@@ -160,7 +160,7 @@ In newer browsers, there is a feature called `@starting-style` which allows tran
 
 /* Official Browser API - no Firefox support as of May 2024 */
 @starting-style {
-  .AlertDialogPopup[data-state='open'] {
+  .AlertDialogPopup[data-open] {
     opacity: 0;
     transform: translate(-50%, -35%) scale(0.8);
   }

--- a/docs/data/components/dialog/DialogWithTransitions.js
+++ b/docs/data/components/dialog/DialogWithTransitions.js
@@ -51,7 +51,7 @@ const Popup = styled(BaseDialog.Popup)(
   opacity: 0;
   transform: translate(-50%, -35%) scale(0.8);
 
-  &[data-state='open'] {
+  &[data-open] {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
     transition-timing-function: ease-out;
@@ -75,7 +75,7 @@ const Backdrop = styled(BaseDialog.Backdrop)`
   transition-duration: 250ms;
   transition-timing-function: ease-in;
 
-  &[data-state='open'] {
+  &[data-open] {
     backdrop-filter: blur(6px);
     opacity: 1;
     transition-timing-function: ease-out;

--- a/docs/data/components/dialog/DialogWithTransitions.tsx
+++ b/docs/data/components/dialog/DialogWithTransitions.tsx
@@ -51,7 +51,7 @@ const Popup = styled(BaseDialog.Popup)(
   opacity: 0;
   transform: translate(-50%, -35%) scale(0.8);
 
-  &[data-state='open'] {
+  &[data-open] {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
     transition-timing-function: ease-out;
@@ -75,7 +75,7 @@ const Backdrop = styled(BaseDialog.Backdrop)`
   transition-duration: 250ms;
   transition-timing-function: ease-in;
 
-  &[data-state='open'] {
+  &[data-open] {
     backdrop-filter: blur(6px);
     opacity: 1;
     transition-timing-function: ease-out;

--- a/docs/data/components/dialog/NestedDialogs.js
+++ b/docs/data/components/dialog/NestedDialogs.js
@@ -72,7 +72,7 @@ const Popup = styled(BaseDialog.Popup)(
     opacity var(--transition-duration) ease-in,
     visibility var(--transition-duration) step-end;
 
-  &[data-state='open'] {
+  &[data-open] {
     @starting-style {
       & {
         transform: translate(-50%, -35%) scale(0.8) translateY(0);
@@ -140,7 +140,7 @@ const Backdrop = styled(BaseDialog.Backdrop)`
   transition-duration: 250ms;
   transition-timing-function: ease-in;
 
-  &[data-state='open'] {
+  &[data-open] {
     backdrop-filter: blur(6px);
     opacity: 1;
     transition-timing-function: ease-out;

--- a/docs/data/components/dialog/NestedDialogs.tsx
+++ b/docs/data/components/dialog/NestedDialogs.tsx
@@ -72,7 +72,7 @@ const Popup = styled(BaseDialog.Popup)(
     opacity var(--transition-duration) ease-in,
     visibility var(--transition-duration) step-end;
 
-  &[data-state='open'] {
+  &[data-open] {
     @starting-style {
       & {
         transform: translate(-50%, -35%) scale(0.8) translateY(0);
@@ -140,7 +140,7 @@ const Backdrop = styled(BaseDialog.Backdrop)`
   transition-duration: 250ms;
   transition-timing-function: ease-in;
 
-  &[data-state='open'] {
+  &[data-open] {
     backdrop-filter: blur(6px);
     opacity: 1;
     transition-timing-function: ease-out;

--- a/docs/data/components/dialog/dialog.mdx
+++ b/docs/data/components/dialog/dialog.mdx
@@ -152,7 +152,7 @@ Here is an example of how to apply a symmetric scale and fade transition with th
 }
 
 /* Represents the final styles once entered */
-.DialogPopup[data-state='open'] {
+.DialogPopup[data-open] {
   opacity: 1;
   transform: translate(-50%, -50%) scale(1);
 }
@@ -183,7 +183,7 @@ In newer browsers, there is a feature called `@starting-style` which allows tran
 
 /* Official Browser API - no Firefox support as of May 2024 */
 @starting-style {
-  .DialogPopup[data-state='open'] {
+  .DialogPopup[data-open] {
     opacity: 0;
     transform: translate(-50%, -35%) scale(0.8);
   }

--- a/docs/data/components/menu/CheckboxItems.js
+++ b/docs/data/components/menu/CheckboxItems.js
@@ -150,7 +150,7 @@ const Indicator = styled(Menu.CheckboxItemIndicator)(
   border-radius: 2px;
 
 
-  &[data-checkbox-item-checked] {
+  &[data-checked] {
     background: ${theme.palette.mode === 'dark' ? grey[800] : grey[700]};
     box-shadow: 0 0 0 2px ${theme.palette.mode === 'dark' ? grey[900] : '#fff'} inset;
   }

--- a/docs/data/components/menu/CheckboxItems.js
+++ b/docs/data/components/menu/CheckboxItems.js
@@ -150,7 +150,7 @@ const Indicator = styled(Menu.CheckboxItemIndicator)(
   border-radius: 2px;
 
 
-  &[data-checkboxitem=checked] {
+  &[data-checkbox-item-checked] {
     background: ${theme.palette.mode === 'dark' ? grey[800] : grey[700]};
     box-shadow: 0 0 0 2px ${theme.palette.mode === 'dark' ? grey[900] : '#fff'} inset;
   }

--- a/docs/data/components/menu/CheckboxItems.tsx
+++ b/docs/data/components/menu/CheckboxItems.tsx
@@ -150,7 +150,7 @@ const Indicator = styled(Menu.CheckboxItemIndicator)(
   border-radius: 2px;
 
 
-  &[data-checkbox-item-checked] {
+  &[data-checked] {
     background: ${theme.palette.mode === 'dark' ? grey[800] : grey[700]};
     box-shadow: 0 0 0 2px ${theme.palette.mode === 'dark' ? grey[900] : '#fff'} inset;
   }

--- a/docs/data/components/menu/CheckboxItems.tsx
+++ b/docs/data/components/menu/CheckboxItems.tsx
@@ -150,7 +150,7 @@ const Indicator = styled(Menu.CheckboxItemIndicator)(
   border-radius: 2px;
 
 
-  &[data-checkboxitem=checked] {
+  &[data-checkbox-item-checked] {
     background: ${theme.palette.mode === 'dark' ? grey[800] : grey[700]};
     box-shadow: 0 0 0 2px ${theme.palette.mode === 'dark' ? grey[900] : '#fff'} inset;
   }

--- a/docs/data/components/menu/MenuIntroduction/css-modules/Menu.module.css
+++ b/docs/data/components/menu/MenuIntroduction/css-modules/Menu.module.css
@@ -41,7 +41,7 @@
       transform 200ms ease-in;
   }
 
-  &[data-state='open'] {
+  &[data-open] {
     opacity: 1;
     transform: scale(1, 1);
     transition:

--- a/docs/data/components/menu/NestedMenu.js
+++ b/docs/data/components/menu/NestedMenu.js
@@ -208,7 +208,7 @@ const SubmenuTrigger = styled(Menu.SubmenuTrigger)(
     float: right;
   }
 
-  &[data-state='open'] {
+  &[data-popup-open] {
     background-color: ${theme.palette.mode === 'dark' ? grey[900] : grey[50]};
     color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
   }

--- a/docs/data/components/menu/NestedMenu.tsx
+++ b/docs/data/components/menu/NestedMenu.tsx
@@ -208,7 +208,7 @@ const SubmenuTrigger = styled(Menu.SubmenuTrigger)(
     float: right;
   }
 
-  &[data-state='open'] {
+  &[data-popup-open] {
     background-color: ${theme.palette.mode === 'dark' ? grey[900] : grey[50]};
     color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
   }

--- a/docs/data/components/menu/RadioItems.js
+++ b/docs/data/components/menu/RadioItems.js
@@ -143,7 +143,7 @@ const Indicator = styled(Menu.RadioItemIndicator)(
   box-sizing: border-box;
   border-radius: 50%;
 
-  &[data-radio-item-checked] {
+  &[data-checked] {
     background: ${theme.palette.mode === 'dark' ? grey[800] : grey[700]};
     box-shadow: 0 0 0 2px ${theme.palette.mode === 'dark' ? grey[900] : '#fff'} inset;
   }

--- a/docs/data/components/menu/RadioItems.js
+++ b/docs/data/components/menu/RadioItems.js
@@ -143,7 +143,7 @@ const Indicator = styled(Menu.RadioItemIndicator)(
   box-sizing: border-box;
   border-radius: 50%;
 
-  &[data-radioitem=checked] {
+  &[data-radio-item-checked] {
     background: ${theme.palette.mode === 'dark' ? grey[800] : grey[700]};
     box-shadow: 0 0 0 2px ${theme.palette.mode === 'dark' ? grey[900] : '#fff'} inset;
   }

--- a/docs/data/components/menu/RadioItems.tsx
+++ b/docs/data/components/menu/RadioItems.tsx
@@ -143,7 +143,7 @@ const Indicator = styled(Menu.RadioItemIndicator)(
   box-sizing: border-box;
   border-radius: 50%;
 
-  &[data-radio-item-checked] {
+  &[data-checked] {
     background: ${theme.palette.mode === 'dark' ? grey[800] : grey[700]};
     box-shadow: 0 0 0 2px ${theme.palette.mode === 'dark' ? grey[900] : '#fff'} inset;
   }

--- a/docs/data/components/menu/RadioItems.tsx
+++ b/docs/data/components/menu/RadioItems.tsx
@@ -143,7 +143,7 @@ const Indicator = styled(Menu.RadioItemIndicator)(
   box-sizing: border-box;
   border-radius: 50%;
 
-  &[data-radioitem=checked] {
+  &[data-radio-item-checked] {
     background: ${theme.palette.mode === 'dark' ? grey[800] : grey[700]};
     box-shadow: 0 0 0 2px ${theme.palette.mode === 'dark' ? grey[900] : '#fff'} inset;
   }

--- a/docs/data/components/menu/menu.mdx
+++ b/docs/data/components/menu/menu.mdx
@@ -308,7 +308,7 @@ Here is an example of how to apply a symmetric scale and fade transition with th
 }
 
 /* Represents the final styles once entered */
-.MenuPopup[data-state='open'] {
+.MenuPopup[data-open] {
   opacity: 1;
   transform: scale(1);
 }
@@ -337,7 +337,7 @@ In newer browsers, there is a feature called `@starting-style` which allows tran
 
 /* Official Browser API - no Firefox support as of May 2024 */
 @starting-style {
-  .MenuPopup[data-state='open'] {
+  .MenuPopup[data-open] {
     opacity: 0;
     transform: scale(0.9);
   }

--- a/docs/data/components/popover/UnstyledPopoverIntroduction/system/index.js
+++ b/docs/data/components/popover/UnstyledPopoverIntroduction/system/index.js
@@ -58,7 +58,7 @@ export const AnchorButton = styled(Popover.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 `;

--- a/docs/data/components/popover/UnstyledPopoverIntroduction/system/index.tsx
+++ b/docs/data/components/popover/UnstyledPopoverIntroduction/system/index.tsx
@@ -58,7 +58,7 @@ export const AnchorButton = styled(Popover.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 `;

--- a/docs/data/components/popover/UnstyledPopoverTransition.js
+++ b/docs/data/components/popover/UnstyledPopoverTransition.js
@@ -40,7 +40,7 @@ export const PopoverPopup = styled(Popover.Popup)`
   transform: scale(0.9);
   transform-origin: var(--transform-origin);
 
-  &[data-state='open'] {
+  &[data-open] {
     opacity: 1;
     transform: scale(1);
   }
@@ -75,7 +75,7 @@ export const AnchorButton = styled(Popover.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 `;

--- a/docs/data/components/popover/UnstyledPopoverTransition.tsx
+++ b/docs/data/components/popover/UnstyledPopoverTransition.tsx
@@ -40,7 +40,7 @@ export const PopoverPopup = styled(Popover.Popup)`
   transform: scale(0.9);
   transform-origin: var(--transform-origin);
 
-  &[data-state='open'] {
+  &[data-open] {
     opacity: 1;
     transform: scale(1);
   }
@@ -75,7 +75,7 @@ export const AnchorButton = styled(Popover.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 `;

--- a/docs/data/components/popover/popover.mdx
+++ b/docs/data/components/popover/popover.mdx
@@ -309,7 +309,7 @@ Here is an example of how to apply a symmetric scale and fade transition with th
 }
 
 /* Represents the final styles once entered */
-.PopoverPopup[data-state='open'] {
+.PopoverPopup[data-open] {
   opacity: 1;
   transform: scale(1);
 }
@@ -340,7 +340,7 @@ In newer browsers, there is a feature called `@starting-style` which allows tran
 
 /* Official Browser API - no Firefox support as of May 2024 */
 @starting-style {
-  .PopoverPopup[data-state='open'] {
+  .PopoverPopup[data-open] {
     opacity: 0;
     transform: scale(0.9);
   }

--- a/docs/data/components/preview-card/UnstyledPreviewCardTransition.js
+++ b/docs/data/components/preview-card/UnstyledPreviewCardTransition.js
@@ -54,7 +54,7 @@ export const PreviewCardPopup = styled(PreviewCard.Popup)`
   opacity: 0;
   transform-origin: var(--transform-origin);
 
-  &[data-state='open'] {
+  &[data-open] {
     opacity: 1;
     transform: scale(1);
   }

--- a/docs/data/components/preview-card/UnstyledPreviewCardTransition.tsx
+++ b/docs/data/components/preview-card/UnstyledPreviewCardTransition.tsx
@@ -54,7 +54,7 @@ export const PreviewCardPopup = styled(PreviewCard.Popup)`
   opacity: 0;
   transform-origin: var(--transform-origin);
 
-  &[data-state='open'] {
+  &[data-open] {
     opacity: 1;
     transform: scale(1);
   }

--- a/docs/data/components/preview-card/preview-card.mdx
+++ b/docs/data/components/preview-card/preview-card.mdx
@@ -259,7 +259,7 @@ Here is an example of how to apply a symmetric scale and fade transition with th
 }
 
 /* Represents the final styles once entered */
-.PreviewCardPopup[data-state='open'] {
+.PreviewCardPopup[data-open] {
   opacity: 1;
   transform: scale(1);
 }
@@ -290,7 +290,7 @@ In newer browsers, there is a feature called `@starting-style` which allows tran
 
 /* Official Browser API - no Firefox support as of May 2024 */
 @starting-style {
-  .PreviewCardPopup[data-state='open'] {
+  .PreviewCardPopup[data-open] {
     opacity: 0;
     transform: scale(0.9);
   }

--- a/docs/data/components/tooltip/UnstyledTooltipDelayGroup.js
+++ b/docs/data/components/tooltip/UnstyledTooltipDelayGroup.js
@@ -55,7 +55,7 @@ export const AnchorButton = styled(Tooltip.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 `;

--- a/docs/data/components/tooltip/UnstyledTooltipDelayGroup.tsx
+++ b/docs/data/components/tooltip/UnstyledTooltipDelayGroup.tsx
@@ -55,7 +55,7 @@ export const AnchorButton = styled(Tooltip.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 `;

--- a/docs/data/components/tooltip/UnstyledTooltipFollowCursor.js
+++ b/docs/data/components/tooltip/UnstyledTooltipFollowCursor.js
@@ -47,7 +47,7 @@ export const AnchorButton = styled(Tooltip.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 `;

--- a/docs/data/components/tooltip/UnstyledTooltipFollowCursor.tsx
+++ b/docs/data/components/tooltip/UnstyledTooltipFollowCursor.tsx
@@ -47,7 +47,7 @@ export const AnchorButton = styled(Tooltip.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 `;

--- a/docs/data/components/tooltip/UnstyledTooltipIntroduction/system/index.js
+++ b/docs/data/components/tooltip/UnstyledTooltipIntroduction/system/index.js
@@ -70,7 +70,7 @@ export const AnchorButton = styled(Tooltip.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 

--- a/docs/data/components/tooltip/UnstyledTooltipIntroduction/system/index.tsx
+++ b/docs/data/components/tooltip/UnstyledTooltipIntroduction/system/index.tsx
@@ -70,7 +70,7 @@ export const AnchorButton = styled(Tooltip.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 

--- a/docs/data/components/tooltip/UnstyledTooltipTransition.js
+++ b/docs/data/components/tooltip/UnstyledTooltipTransition.js
@@ -36,7 +36,7 @@ export const TooltipPopup = styled(Tooltip.Popup)`
     transform: scale(0.9);
     transform-origin: var(--transform-origin);
 
-    &[data-state='open'] {
+    &[data-open] {
       opacity: 1;
       transform: scale(1);
     }
@@ -62,7 +62,7 @@ export const AnchorButton = styled(Tooltip.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 `;

--- a/docs/data/components/tooltip/UnstyledTooltipTransition.tsx
+++ b/docs/data/components/tooltip/UnstyledTooltipTransition.tsx
@@ -36,7 +36,7 @@ export const TooltipPopup = styled(Tooltip.Popup)`
     transform: scale(0.9);
     transform-origin: var(--transform-origin);
 
-    &[data-state='open'] {
+    &[data-open] {
       opacity: 1;
       transform: scale(1);
     }
@@ -62,7 +62,7 @@ export const AnchorButton = styled(Tooltip.Trigger)`
   }
 
   &:hover,
-  &[data-state='open'] {
+  &[data-popup-open] {
     background: ${blue[800]};
   }
 `;

--- a/docs/data/components/tooltip/tooltip.mdx
+++ b/docs/data/components/tooltip/tooltip.mdx
@@ -237,7 +237,7 @@ Here is an example of how to apply a symmetric scale and fade transition with th
 }
 
 /* Represents the final styles once entered */
-.TooltipPopup[data-state='open'] {
+.TooltipPopup[data-open] {
   opacity: 1;
   transform: scale(1);
 }
@@ -268,7 +268,7 @@ In newer browsers, there is a feature called `@starting-style` which allows tran
 
 /* Official Browser API - no Firefox support as of May 2024 */
 @starting-style {
-  .TooltipPopup[data-state='open'] {
+  .TooltipPopup[data-open] {
     opacity: 0;
     transform: scale(0.9);
   }

--- a/packages/mui-base/src/AlertDialog/Backdrop/AlertDialogBackdrop.tsx
+++ b/packages/mui-base/src/AlertDialog/Backdrop/AlertDialogBackdrop.tsx
@@ -7,6 +7,21 @@ import { useDialogBackdrop } from '../../Dialog/Backdrop/useDialogBackdrop';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import type { BaseUIComponentProps } from '../../utils/types';
+import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+
+const customStyleHookMapping: CustomStyleHookMapping<AlertDialogBackdrop.OwnerState> = {
+  ...baseMapping,
+  transitionStatus: (value) => {
+    if (value === 'entering') {
+      return { 'data-entering': '' } as Record<string, string>;
+    }
+    if (value === 'exiting') {
+      return { 'data-exiting': '' };
+    }
+    return null;
+  },
+};
 
 /**
  *
@@ -44,18 +59,7 @@ const AlertDialogBackdrop = React.forwardRef(function AlertDialogBackdrop(
     ownerState,
     propGetter: getRootProps,
     extraProps: other,
-    customStyleHookMapping: {
-      open: (value) => ({ 'data-state': value ? 'open' : 'closed' }),
-      transitionStatus: (value) => {
-        if (value === 'entering') {
-          return { 'data-entering': '' } as Record<string, string>;
-        }
-        if (value === 'exiting') {
-          return { 'data-exiting': '' };
-        }
-        return null;
-      },
-    },
+    customStyleHookMapping,
   });
 
   if (!mounted && !keepMounted) {

--- a/packages/mui-base/src/AlertDialog/Close/AlertDialogClose.tsx
+++ b/packages/mui-base/src/AlertDialog/Close/AlertDialogClose.tsx
@@ -6,6 +6,8 @@ import { useDialogClose } from '../../Dialog/Close/useDialogClose';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 
+const ownerState = {};
+
 /**
  *
  * Demos:
@@ -24,10 +26,6 @@ const AlertDialogClose = React.forwardRef(function AlertDialogClose(
   const { open, onOpenChange } = useAlertDialogRootContext();
   const { getRootProps } = useDialogClose({ open, onOpenChange });
 
-  const ownerState: AlertDialogClose.OwnerState = {
-    open,
-  };
-
   const { renderElement } = useComponentRenderer({
     render: render ?? 'button',
     className,
@@ -43,9 +41,7 @@ const AlertDialogClose = React.forwardRef(function AlertDialogClose(
 namespace AlertDialogClose {
   export interface Props extends BaseUIComponentProps<'button', OwnerState> {}
 
-  export interface OwnerState {
-    open: boolean;
-  }
+  export interface OwnerState {}
 }
 
 AlertDialogClose.propTypes /* remove-proptypes */ = {

--- a/packages/mui-base/src/AlertDialog/Description/AlertDialogDescription.tsx
+++ b/packages/mui-base/src/AlertDialog/Description/AlertDialogDescription.tsx
@@ -7,6 +7,8 @@ import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 import { useId } from '../../utils/useId';
 import type { BaseUIComponentProps } from '../../utils/types';
 
+const ownerState = {};
+
 /**
  *
  * Demos:
@@ -22,11 +24,7 @@ const AlertDialogDescription = React.forwardRef(function AlertDialogDescription(
   forwardedRef: React.ForwardedRef<HTMLParagraphElement>,
 ) {
   const { render, className, id: idProp, ...other } = props;
-  const { setDescriptionElementId, open } = useAlertDialogRootContext();
-
-  const ownerState: AlertDialogDescription.OwnerState = {
-    open,
-  };
+  const { setDescriptionElementId } = useAlertDialogRootContext();
 
   const id = useId(idProp);
 
@@ -51,9 +49,7 @@ const AlertDialogDescription = React.forwardRef(function AlertDialogDescription(
 namespace AlertDialogDescription {
   export interface Props extends BaseUIComponentProps<'p', OwnerState> {}
 
-  export interface OwnerState {
-    open: boolean;
-  }
+  export interface OwnerState {}
 }
 
 AlertDialogDescription.propTypes /* remove-proptypes */ = {

--- a/packages/mui-base/src/AlertDialog/Popup/AlertDialogPopup.tsx
+++ b/packages/mui-base/src/AlertDialog/Popup/AlertDialogPopup.tsx
@@ -8,6 +8,22 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { refType, HTMLElementType } from '../../utils/proptypes';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
+import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+
+const customStyleHookMapping: CustomStyleHookMapping<AlertDialogPopup.OwnerState> = {
+  ...baseMapping,
+  nestedOpenDialogCount: (value) => ({ 'data-nested-dialogs': value.toString() }),
+  transitionStatus: (value) => {
+    if (value === 'entering') {
+      return { 'data-entering': '' } as Record<string, string>;
+    }
+    if (value === 'exiting') {
+      return { 'data-exiting': '' };
+    }
+    return null;
+  },
+};
 
 /**
  *
@@ -36,11 +52,14 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
     ...rootContext,
   });
 
-  const ownerState: AlertDialogPopup.OwnerState = {
-    open,
-    nestedOpenDialogCount,
-    transitionStatus,
-  };
+  const ownerState: AlertDialogPopup.OwnerState = React.useMemo(
+    () => ({
+      open,
+      nestedOpenDialogCount,
+      transitionStatus,
+    }),
+    [open, nestedOpenDialogCount, transitionStatus],
+  );
 
   const { renderElement } = useComponentRenderer({
     render: render ?? 'div',
@@ -52,19 +71,7 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
       style: { ...other.style, '--nested-dialogs': nestedOpenDialogCount },
       role: 'alertdialog',
     },
-    customStyleHookMapping: {
-      open: (value) => ({ 'data-state': value ? 'open' : 'closed' }),
-      nestedOpenDialogCount: (value) => ({ 'data-nested-dialogs': value.toString() }),
-      transitionStatus: (value) => {
-        if (value === 'entering') {
-          return { 'data-entering': '' } as Record<string, string>;
-        }
-        if (value === 'exiting') {
-          return { 'data-exiting': '' };
-        }
-        return null;
-      },
-    },
+    customStyleHookMapping,
   });
 
   if (!keepMounted && !mounted) {

--- a/packages/mui-base/src/AlertDialog/Title/AlertDialogTitle.tsx
+++ b/packages/mui-base/src/AlertDialog/Title/AlertDialogTitle.tsx
@@ -7,6 +7,8 @@ import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 import { useId } from '../../utils/useId';
 import type { BaseUIComponentProps } from '../../utils/types';
 
+const ownerState = {};
+
 /**
  *
  * Demos:
@@ -22,11 +24,7 @@ const AlertDialogTitle = React.forwardRef(function AlertDialogTitle(
   forwardedRef: React.ForwardedRef<HTMLParagraphElement>,
 ) {
   const { render, className, id: idProp, ...other } = props;
-  const { setTitleElementId, open } = useAlertDialogRootContext();
-
-  const ownerState: AlertDialogTitle.OwnerState = {
-    open,
-  };
+  const { setTitleElementId } = useAlertDialogRootContext();
 
   const id = useId(idProp);
 
@@ -51,9 +49,7 @@ const AlertDialogTitle = React.forwardRef(function AlertDialogTitle(
 namespace AlertDialogTitle {
   export interface Props extends BaseUIComponentProps<'h2', OwnerState> {}
 
-  export interface OwnerState {
-    open: boolean;
-  }
+  export interface OwnerState {}
 }
 
 AlertDialogTitle.propTypes /* remove-proptypes */ = {

--- a/packages/mui-base/src/AlertDialog/Trigger/AlertDialogTrigger.tsx
+++ b/packages/mui-base/src/AlertDialog/Trigger/AlertDialogTrigger.tsx
@@ -5,6 +5,7 @@ import { useDialogTrigger } from '../../Dialog/Trigger/useDialogTrigger';
 import { useAlertDialogRootContext } from '../Root/AlertDialogRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
+import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  *
@@ -37,9 +38,7 @@ const AlertDialogTrigger = React.forwardRef(function AlertDialogTrigger(
     ownerState,
     propGetter: getRootProps,
     extraProps: other,
-    customStyleHookMapping: {
-      open: (value) => ({ 'data-state': value ? 'open' : 'closed' }),
-    },
+    customStyleHookMapping: triggerOpenStateMapping,
     ref: forwardedRef,
   });
 

--- a/packages/mui-base/src/Dialog/Backdrop/DialogBackdrop.tsx
+++ b/packages/mui-base/src/Dialog/Backdrop/DialogBackdrop.tsx
@@ -7,6 +7,21 @@ import { useDialogRootContext } from '../Root/DialogRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { type TransitionStatus } from '../../utils/useTransitionStatus';
 import { type BaseUIComponentProps } from '../../utils/types';
+import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+
+const customStyleHookMapping: CustomStyleHookMapping<DialogBackdrop.OwnerState> = {
+  ...baseMapping,
+  transitionStatus: (value) => {
+    if (value === 'entering') {
+      return { 'data-entering': '' } as Record<string, string>;
+    }
+    if (value === 'exiting') {
+      return { 'data-exiting': '' };
+    }
+    return null;
+  },
+};
 
 /**
  *
@@ -47,18 +62,7 @@ const DialogBackdrop = React.forwardRef(function DialogBackdrop(
     ownerState,
     propGetter: getRootProps,
     extraProps: other,
-    customStyleHookMapping: {
-      open: (value) => ({ 'data-state': value ? 'open' : 'closed' }),
-      transitionStatus: (value) => {
-        if (value === 'entering') {
-          return { 'data-entering': '' } as Record<string, string>;
-        }
-        if (value === 'exiting') {
-          return { 'data-exiting': '' };
-        }
-        return null;
-      },
-    },
+    customStyleHookMapping,
   });
 
   if (!mounted && !keepMounted) {

--- a/packages/mui-base/src/Dialog/Close/DialogClose.tsx
+++ b/packages/mui-base/src/Dialog/Close/DialogClose.tsx
@@ -6,6 +6,8 @@ import { useDialogRootContext } from '../Root/DialogRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 
+const ownerState = {};
+
 /**
  *
  * Demos:
@@ -21,13 +23,8 @@ const DialogClose = React.forwardRef(function DialogClose(
   forwardedRef: React.ForwardedRef<HTMLButtonElement>,
 ) {
   const { render, className, ...other } = props;
-  const { open, onOpenChange, modal } = useDialogRootContext();
+  const { open, onOpenChange } = useDialogRootContext();
   const { getRootProps } = useDialogClose({ open, onOpenChange });
-
-  const ownerState: DialogClose.OwnerState = {
-    open,
-    modal,
-  };
 
   const { renderElement } = useComponentRenderer({
     render: render ?? 'button',
@@ -44,10 +41,7 @@ const DialogClose = React.forwardRef(function DialogClose(
 namespace DialogClose {
   export interface Props extends BaseUIComponentProps<'button', OwnerState> {}
 
-  export interface OwnerState {
-    open: boolean;
-    modal: boolean;
-  }
+  export interface OwnerState {}
 }
 
 DialogClose.propTypes /* remove-proptypes */ = {

--- a/packages/mui-base/src/Dialog/Description/DialogDescription.tsx
+++ b/packages/mui-base/src/Dialog/Description/DialogDescription.tsx
@@ -7,6 +7,8 @@ import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 import { useId } from '../../utils/useId';
 import type { BaseUIComponentProps } from '../../utils/types';
 
+const ownerState = {};
+
 /**
  *
  * Demos:
@@ -22,12 +24,7 @@ const DialogDescription = React.forwardRef(function DialogDescription(
   forwardedRef: React.ForwardedRef<HTMLParagraphElement>,
 ) {
   const { render, className, id: idProp, ...other } = props;
-  const { setDescriptionElementId, open, modal } = useDialogRootContext();
-
-  const ownerState = {
-    open,
-    modal,
-  };
+  const { setDescriptionElementId } = useDialogRootContext();
 
   const id = useId(idProp);
 
@@ -52,10 +49,7 @@ const DialogDescription = React.forwardRef(function DialogDescription(
 namespace DialogDescription {
   export interface Props extends BaseUIComponentProps<'p', OwnerState> {}
 
-  export interface OwnerState {
-    open: boolean;
-    modal: boolean;
-  }
+  export interface OwnerState {}
 }
 
 DialogDescription.propTypes /* remove-proptypes */ = {

--- a/packages/mui-base/src/Dialog/Popup/DialogPopup.tsx
+++ b/packages/mui-base/src/Dialog/Popup/DialogPopup.tsx
@@ -8,6 +8,22 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { refType, HTMLElementType } from '../../utils/proptypes';
 import { type BaseUIComponentProps } from '../../utils/types';
 import { type TransitionStatus } from '../../utils/useTransitionStatus';
+import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+
+const customStyleHookMapping: CustomStyleHookMapping<DialogPopup.OwnerState> = {
+  ...baseMapping,
+  nestedOpenDialogCount: (value) => ({ 'data-nested-dialogs': value.toString() }),
+  transitionStatus: (value) => {
+    if (value === 'entering') {
+      return { 'data-entering': '' } as Record<string, string>;
+    }
+    if (value === 'exiting') {
+      return { 'data-exiting': '' };
+    }
+    return null;
+  },
+};
 
 /**
  *
@@ -50,19 +66,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
       ...other,
       style: { ...other.style, '--nested-dialogs': nestedOpenDialogCount },
     },
-    customStyleHookMapping: {
-      open: (value) => ({ 'data-state': value ? 'open' : 'closed' }),
-      nestedOpenDialogCount: (value) => ({ 'data-nested-dialogs': value.toString() }),
-      transitionStatus: (value) => {
-        if (value === 'entering') {
-          return { 'data-entering': '' } as Record<string, string>;
-        }
-        if (value === 'exiting') {
-          return { 'data-exiting': '' };
-        }
-        return null;
-      },
-    },
+    customStyleHookMapping,
   });
 
   if (!keepMounted && !mounted) {

--- a/packages/mui-base/src/Dialog/Root/DialogRoot.test.tsx
+++ b/packages/mui-base/src/Dialog/Root/DialogRoot.test.tsx
@@ -136,7 +136,7 @@ describe('<Dialog.Root />', () => {
       transition: opacity 200ms;
     }
 
-    .dialog[data-state='open'] {
+    .dialog[data-open] {
       opacity: 1;
     }
   `;

--- a/packages/mui-base/src/Dialog/Title/DialogTitle.tsx
+++ b/packages/mui-base/src/Dialog/Title/DialogTitle.tsx
@@ -6,6 +6,9 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 import { useId } from '../../utils/useId';
 import { type BaseUIComponentProps } from '../../utils/types';
+import { customStyleHookMapping } from '../../utils/popupOpenStateMapping';
+
+const ownerState = {};
 
 /**
  *
@@ -22,12 +25,7 @@ const DialogTitle = React.forwardRef(function DialogTitle(
   forwardedRef: React.ForwardedRef<HTMLParagraphElement>,
 ) {
   const { render, className, id: idProp, ...other } = props;
-  const { setTitleElementId, open, modal } = useDialogRootContext();
-
-  const ownerState = {
-    open,
-    modal,
-  };
+  const { setTitleElementId } = useDialogRootContext();
 
   const id = useId(idProp);
 
@@ -44,6 +42,7 @@ const DialogTitle = React.forwardRef(function DialogTitle(
     ownerState,
     ref: forwardedRef,
     extraProps: other,
+    customStyleHookMapping,
   });
 
   return renderElement();
@@ -52,10 +51,7 @@ const DialogTitle = React.forwardRef(function DialogTitle(
 namespace DialogTitle {
   export interface Props extends BaseUIComponentProps<'h2', OwnerState> {}
 
-  export interface OwnerState {
-    open: boolean;
-    modal: boolean;
-  }
+  export interface OwnerState {}
 }
 
 DialogTitle.propTypes /* remove-proptypes */ = {

--- a/packages/mui-base/src/Dialog/Title/DialogTitle.tsx
+++ b/packages/mui-base/src/Dialog/Title/DialogTitle.tsx
@@ -6,7 +6,6 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 import { useId } from '../../utils/useId';
 import { type BaseUIComponentProps } from '../../utils/types';
-import { customStyleHookMapping } from '../../utils/popupOpenStateMapping';
 
 const ownerState = {};
 
@@ -42,7 +41,6 @@ const DialogTitle = React.forwardRef(function DialogTitle(
     ownerState,
     ref: forwardedRef,
     extraProps: other,
-    customStyleHookMapping,
   });
 
   return renderElement();

--- a/packages/mui-base/src/Dialog/Trigger/DialogTrigger.tsx
+++ b/packages/mui-base/src/Dialog/Trigger/DialogTrigger.tsx
@@ -5,6 +5,7 @@ import { useDialogTrigger } from './useDialogTrigger';
 import { useDialogRootContext } from '../Root/DialogRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
+import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  *
@@ -40,9 +41,7 @@ const DialogTrigger = React.forwardRef(function DialogTrigger(
     ownerState,
     propGetter: getRootProps,
     extraProps: other,
-    customStyleHookMapping: {
-      open: (value) => ({ 'data-state': value ? 'open' : 'closed' }),
-    },
+    customStyleHookMapping: triggerOpenStateMapping,
     ref: forwardedRef,
   });
 

--- a/packages/mui-base/src/Menu/Arrow/MenuArrow.tsx
+++ b/packages/mui-base/src/Menu/Arrow/MenuArrow.tsx
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types';
 import { useMenuArrow } from './useMenuArrow';
 import { useMenuPositionerContext } from '../Positioner/MenuPositionerContext';
 import { useMenuRootContext } from '../Root/MenuRootContext';
-import { commonStyleHooks } from '../utils/commonStyleHooks';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { Side, Alignment } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
+import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  * Renders an arrow that points to the center of the anchor element.
@@ -54,19 +54,19 @@ const MenuArrow = React.forwardRef(function MenuArrow(
     ownerState,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: commonStyleHooks,
+    customStyleHookMapping: popupOpenStateMapping,
   });
 
   return renderElement();
 });
 
 namespace MenuArrow {
-  export type OwnerState = {
+  export interface OwnerState {
     open: boolean;
     side: Side;
     alignment: Alignment;
     arrowUncentered: boolean;
-  };
+  }
 
   export interface Props extends BaseUIComponentProps<'div', OwnerState> {
     /**

--- a/packages/mui-base/src/Menu/CheckboxItem/MenuCheckboxItem.test.tsx
+++ b/packages/mui-base/src/Menu/CheckboxItem/MenuCheckboxItem.test.tsx
@@ -147,7 +147,7 @@ describe('<Menu.CheckboxItem />', () => {
 
         const item = getByRole('menuitemcheckbox');
         expect(item).to.have.attribute('aria-checked', ariaChecked);
-        expect(item).to.have.attribute('data-checkboxitem', dataState);
+        expect(item).to.have.attribute(`data-checkbox-item-${dataState}`, '');
       }),
     );
 
@@ -170,12 +170,12 @@ describe('<Menu.CheckboxItem />', () => {
       await user.click(item);
 
       expect(item).to.have.attribute('aria-checked', 'true');
-      expect(item).to.have.attribute('data-checkboxitem', 'checked');
+      expect(item).to.have.attribute('data-checkbox-item-checked', '');
 
       await user.click(item);
 
       expect(item).to.have.attribute('aria-checked', 'false');
-      expect(item).to.have.attribute('data-checkboxitem', 'unchecked');
+      expect(item).to.have.attribute('data-checkbox-item-unchecked', '');
     });
 
     it(`toggles the checked state when Space is pressed`, async () => {
@@ -202,10 +202,10 @@ describe('<Menu.CheckboxItem />', () => {
       });
 
       await user.keyboard(`[Space]`);
-      expect(item).to.have.attribute('data-checkboxitem', 'checked');
+      expect(item).to.have.attribute('data-checkbox-item-checked', '');
 
       await user.keyboard(`[Space]`);
-      expect(item).to.have.attribute('data-checkboxitem', 'unchecked');
+      expect(item).to.have.attribute('data-checkbox-item-unchecked', '');
     });
 
     it(`toggles the checked state and closes the menu when Enter is pressed`, async () => {
@@ -236,7 +236,7 @@ describe('<Menu.CheckboxItem />', () => {
 
       expect(queryByRole('menu', { hidden: false })).to.equal(null);
       await user.click(trigger);
-      expect(item).to.have.attribute('data-checkboxitem', 'checked');
+      expect(item).to.have.attribute('data-checkbox-item-checked', '');
     });
 
     it('calls `onCheckedChange` when the item is clicked', async () => {
@@ -291,7 +291,7 @@ describe('<Menu.CheckboxItem />', () => {
 
       const itemAfterReopen = getByRole('menuitemcheckbox');
       expect(itemAfterReopen).to.have.attribute('aria-checked', 'true');
-      expect(itemAfterReopen).to.have.attribute('data-checkboxitem', 'checked');
+      expect(itemAfterReopen).to.have.attribute('data-checkbox-item-checked');
     });
   });
 

--- a/packages/mui-base/src/Menu/CheckboxItem/MenuCheckboxItem.test.tsx
+++ b/packages/mui-base/src/Menu/CheckboxItem/MenuCheckboxItem.test.tsx
@@ -147,7 +147,7 @@ describe('<Menu.CheckboxItem />', () => {
 
         const item = getByRole('menuitemcheckbox');
         expect(item).to.have.attribute('aria-checked', ariaChecked);
-        expect(item).to.have.attribute(`data-checkbox-item-${dataState}`, '');
+        expect(item).to.have.attribute(`data-${dataState}`, '');
       }),
     );
 
@@ -170,12 +170,12 @@ describe('<Menu.CheckboxItem />', () => {
       await user.click(item);
 
       expect(item).to.have.attribute('aria-checked', 'true');
-      expect(item).to.have.attribute('data-checkbox-item-checked', '');
+      expect(item).to.have.attribute('data-checked', '');
 
       await user.click(item);
 
       expect(item).to.have.attribute('aria-checked', 'false');
-      expect(item).to.have.attribute('data-checkbox-item-unchecked', '');
+      expect(item).to.have.attribute('data-unchecked', '');
     });
 
     it(`toggles the checked state when Space is pressed`, async () => {
@@ -202,10 +202,10 @@ describe('<Menu.CheckboxItem />', () => {
       });
 
       await user.keyboard(`[Space]`);
-      expect(item).to.have.attribute('data-checkbox-item-checked', '');
+      expect(item).to.have.attribute('data-checked', '');
 
       await user.keyboard(`[Space]`);
-      expect(item).to.have.attribute('data-checkbox-item-unchecked', '');
+      expect(item).to.have.attribute('data-unchecked', '');
     });
 
     it(`toggles the checked state and closes the menu when Enter is pressed`, async () => {
@@ -236,7 +236,7 @@ describe('<Menu.CheckboxItem />', () => {
 
       expect(queryByRole('menu', { hidden: false })).to.equal(null);
       await user.click(trigger);
-      expect(item).to.have.attribute('data-checkbox-item-checked', '');
+      expect(item).to.have.attribute('data-checked', '');
     });
 
     it('calls `onCheckedChange` when the item is clicked', async () => {
@@ -291,7 +291,7 @@ describe('<Menu.CheckboxItem />', () => {
 
       const itemAfterReopen = getByRole('menuitemcheckbox');
       expect(itemAfterReopen).to.have.attribute('aria-checked', 'true');
-      expect(itemAfterReopen).to.have.attribute('data-checkbox-item-checked');
+      expect(itemAfterReopen).to.have.attribute('data-checked');
     });
   });
 

--- a/packages/mui-base/src/Menu/CheckboxItem/MenuCheckboxItem.tsx
+++ b/packages/mui-base/src/Menu/CheckboxItem/MenuCheckboxItem.tsx
@@ -9,7 +9,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useId } from '../../utils/useId';
 import type { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
 import { useForkRef } from '../../utils/useForkRef';
-import { checkboxItemMapping } from '../utils/styleHookMapping';
+import { itemMapping } from '../utils/styleHookMapping';
 
 const InnerMenuCheckboxItem = React.memo(
   React.forwardRef(function InnerMenuItem(
@@ -57,7 +57,7 @@ const InnerMenuCheckboxItem = React.memo(
       className,
       ownerState,
       propGetter: (externalProps) => propGetter(getRootProps(externalProps)),
-      customStyleHookMapping: checkboxItemMapping,
+      customStyleHookMapping: itemMapping,
       extraProps: other,
     });
 

--- a/packages/mui-base/src/Menu/CheckboxItem/MenuCheckboxItem.tsx
+++ b/packages/mui-base/src/Menu/CheckboxItem/MenuCheckboxItem.tsx
@@ -6,14 +6,10 @@ import { useMenuCheckboxItem } from './useMenuCheckboxItem';
 import { MenuCheckboxItemContext } from './MenuCheckboxItemContext';
 import { useMenuRootContext } from '../Root/MenuRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
-import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import { useId } from '../../utils/useId';
 import type { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
 import { useForkRef } from '../../utils/useForkRef';
-
-const customStyleHookMapping: CustomStyleHookMapping<MenuCheckboxItem.OwnerState> = {
-  checked: (value: boolean) => ({ 'data-checkboxitem': value ? 'checked' : 'unchecked' }),
-};
+import { checkboxItemMapping } from '../utils/styleHookMapping';
 
 const InnerMenuCheckboxItem = React.memo(
   React.forwardRef(function InnerMenuItem(
@@ -61,7 +57,7 @@ const InnerMenuCheckboxItem = React.memo(
       className,
       ownerState,
       propGetter: (externalProps) => propGetter(getRootProps(externalProps)),
-      customStyleHookMapping,
+      customStyleHookMapping: checkboxItemMapping,
       extraProps: other,
     });
 

--- a/packages/mui-base/src/Menu/CheckboxItemIndicator/MenuCheckboxItemIndicator.tsx
+++ b/packages/mui-base/src/Menu/CheckboxItemIndicator/MenuCheckboxItemIndicator.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useMenuCheckboxItemContext } from '../CheckboxItem/MenuCheckboxItemContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { BaseUIComponentProps } from '../../utils/types';
-import { checkboxItemMapping } from '../utils/styleHookMapping';
+import { itemMapping } from '../utils/styleHookMapping';
 
 /**
  *
@@ -28,7 +28,7 @@ const MenuCheckboxItemIndicator = React.forwardRef(function MenuCheckboxItemIndi
     render: render || 'span',
     className,
     ownerState,
-    customStyleHookMapping: checkboxItemMapping,
+    customStyleHookMapping: itemMapping,
     extraProps: other,
     ref: forwardedRef,
   });

--- a/packages/mui-base/src/Menu/CheckboxItemIndicator/MenuCheckboxItemIndicator.tsx
+++ b/packages/mui-base/src/Menu/CheckboxItemIndicator/MenuCheckboxItemIndicator.tsx
@@ -1,14 +1,10 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { MenuCheckboxItem } from '../CheckboxItem/MenuCheckboxItem';
 import { useMenuCheckboxItemContext } from '../CheckboxItem/MenuCheckboxItemContext';
-import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { BaseUIComponentProps } from '../../utils/types';
-
-const customStyleHookMapping: CustomStyleHookMapping<MenuCheckboxItem.OwnerState> = {
-  checked: (value: boolean) => ({ 'data-checkboxitem': value ? 'checked' : 'unchecked' }),
-};
+import { checkboxItemMapping } from '../utils/styleHookMapping';
 
 /**
  *
@@ -32,7 +28,7 @@ const MenuCheckboxItemIndicator = React.forwardRef(function MenuCheckboxItemIndi
     render: render || 'span',
     className,
     ownerState,
-    customStyleHookMapping,
+    customStyleHookMapping: checkboxItemMapping,
     extraProps: other,
     ref: forwardedRef,
   });

--- a/packages/mui-base/src/Menu/Group/MenuGroup.tsx
+++ b/packages/mui-base/src/Menu/Group/MenuGroup.tsx
@@ -1,10 +1,11 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { MenuGroupContext } from './MenuGroupContext';
 
-const EMPTY_OBJECT = {};
+const ownerState = {};
 
 /**
  *
@@ -23,12 +24,13 @@ const MenuGroup = React.forwardRef(function MenuGroup(
   const { render, className, ...other } = props;
 
   const [labelId, setLabelId] = React.useState<string | undefined>(undefined);
+
   const context = React.useMemo(() => ({ setLabelId }), [setLabelId]);
 
   const { renderElement } = useComponentRenderer({
     render: render || 'div',
     className,
-    ownerState: EMPTY_OBJECT,
+    ownerState,
     extraProps: {
       role: 'group',
       'aria-labelledby': labelId,

--- a/packages/mui-base/src/Menu/GroupLabel/MenuGroupLabel.tsx
+++ b/packages/mui-base/src/Menu/GroupLabel/MenuGroupLabel.tsx
@@ -7,7 +7,7 @@ import { useId } from '../../utils/useId';
 import { useMenuGroupRootContext } from '../Group/MenuGroupContext';
 import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 
-const EMPTY_OBJECT = {};
+const ownerState = {};
 
 /**
  *
@@ -31,7 +31,6 @@ const MenuGroupLabel = React.forwardRef(function MenuGroupLabelComponent(
 
   useEnhancedEffect(() => {
     setLabelId(id);
-
     return () => {
       setLabelId(undefined);
     };
@@ -40,7 +39,7 @@ const MenuGroupLabel = React.forwardRef(function MenuGroupLabelComponent(
   const { renderElement } = useComponentRenderer({
     render: render ?? 'div',
     className,
-    ownerState: EMPTY_OBJECT,
+    ownerState,
     extraProps: { role: 'group', id, ...other },
     ref: forwardedRef,
   });

--- a/packages/mui-base/src/Menu/Item/MenuItem.tsx
+++ b/packages/mui-base/src/Menu/Item/MenuItem.tsx
@@ -39,7 +39,10 @@ const InnerMenuItem = React.memo(
       typingRef,
     });
 
-    const ownerState: MenuItem.OwnerState = { disabled, highlighted };
+    const ownerState: MenuItem.OwnerState = React.useMemo(
+      () => ({ disabled, highlighted }),
+      [disabled, highlighted],
+    );
 
     const { renderElement } = useComponentRenderer({
       render: render || 'div',

--- a/packages/mui-base/src/Menu/Popup/MenuPopup.tsx
+++ b/packages/mui-base/src/Menu/Popup/MenuPopup.tsx
@@ -5,19 +5,19 @@ import { Side, useFloatingTree } from '@floating-ui/react';
 import { useMenuPopup } from './useMenuPopup';
 import { useMenuRootContext } from '../Root/MenuRootContext';
 import { useMenuPositionerContext } from '../Positioner/MenuPositionerContext';
-import { commonStyleHooks } from '../utils/commonStyleHooks';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
-import { BaseUIComponentProps } from '../../utils/types';
-import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { BaseUIComponentProps } from '../../utils/types';
+import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
 
 const customStyleHookMapping: CustomStyleHookMapping<MenuPopup.OwnerState> = {
-  ...commonStyleHooks,
+  ...baseMapping,
   entering(value) {
-    return value ? { 'data-menu-entering': '' } : null;
+    return value ? { 'data-entering': '' } : null;
   },
   exiting(value) {
-    return value ? { 'data-menu-exiting': '' } : null;
+    return value ? { 'data-exiting': '' } : null;
   },
 };
 
@@ -47,13 +47,16 @@ const MenuPopup = React.forwardRef(function MenuPopup(
 
   const mergedRef = useForkRef(forwardedRef, popupRef);
 
-  const ownerState: MenuPopup.OwnerState = {
-    entering: transitionStatus === 'entering',
-    exiting: transitionStatus === 'exiting',
-    side,
-    alignment,
-    open,
-  };
+  const ownerState: MenuPopup.OwnerState = React.useMemo(
+    () => ({
+      entering: transitionStatus === 'entering',
+      exiting: transitionStatus === 'exiting',
+      side,
+      alignment,
+      open,
+    }),
+    [transitionStatus, side, alignment, open],
+  );
 
   const { renderElement } = useComponentRenderer({
     render: render || 'div',

--- a/packages/mui-base/src/Menu/Popup/MenuPopup.tsx
+++ b/packages/mui-base/src/Menu/Popup/MenuPopup.tsx
@@ -9,15 +9,19 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
 
 const customStyleHookMapping: CustomStyleHookMapping<MenuPopup.OwnerState> = {
   ...baseMapping,
-  entering(value) {
-    return value ? { 'data-entering': '' } : null;
-  },
-  exiting(value) {
-    return value ? { 'data-exiting': '' } : null;
+  transitionStatus(value) {
+    if (value === 'entering') {
+      return { 'data-entering': '' } as Record<string, string>;
+    }
+    if (value === 'exiting') {
+      return { 'data-exiting': '' };
+    }
+    return null;
   },
 };
 
@@ -49,8 +53,7 @@ const MenuPopup = React.forwardRef(function MenuPopup(
 
   const ownerState: MenuPopup.OwnerState = React.useMemo(
     () => ({
-      entering: transitionStatus === 'entering',
-      exiting: transitionStatus === 'exiting',
+      transitionStatus,
       side,
       alignment,
       open,
@@ -80,8 +83,7 @@ namespace MenuPopup {
   }
 
   export type OwnerState = {
-    entering: boolean;
-    exiting: boolean;
+    transitionStatus: TransitionStatus;
     side: Side;
     alignment: 'start' | 'end' | 'center';
     open: boolean;

--- a/packages/mui-base/src/Menu/Positioner/MenuPositioner.tsx
+++ b/packages/mui-base/src/Menu/Positioner/MenuPositioner.tsx
@@ -11,12 +11,12 @@ import {
 } from '@floating-ui/react';
 import { MenuPositionerContext } from './MenuPositionerContext';
 import { useMenuRootContext } from '../Root/MenuRootContext';
-import { commonStyleHooks } from '../utils/commonStyleHooks';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import { useMenuPositioner } from './useMenuPositioner';
 import { HTMLElementType } from '../../utils/proptypes';
 import { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
+import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  * Renders the element that positions the Menu popup.
@@ -121,7 +121,7 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     render: render ?? 'div',
     className,
     ownerState,
-    customStyleHookMapping: commonStyleHooks,
+    customStyleHookMapping: popupOpenStateMapping,
     ref: mergedRef,
     extraProps: otherProps,
   });

--- a/packages/mui-base/src/Menu/RadioItem/MenuRadioItem.test.tsx
+++ b/packages/mui-base/src/Menu/RadioItem/MenuRadioItem.test.tsx
@@ -173,7 +173,7 @@ describe('<Menu.RadioItem />', () => {
       await user.click(item);
 
       expect(item).to.have.attribute('aria-checked', 'true');
-      expect(item).to.have.attribute('data-radioitem', 'checked');
+      expect(item).to.have.attribute('data-radio-item-checked', '');
     });
 
     ['Space', 'Enter'].forEach((key) => {
@@ -201,7 +201,7 @@ describe('<Menu.RadioItem />', () => {
         });
 
         await user.keyboard(`[${key}]`);
-        expect(item).to.have.attribute('data-radioitem', 'checked');
+        expect(item).to.have.attribute('data-radio-item-checked', '');
       });
     });
 
@@ -256,7 +256,7 @@ describe('<Menu.RadioItem />', () => {
 
       const itemAfterReopen = getByRole('menuitemradio');
       expect(itemAfterReopen).to.have.attribute('aria-checked', 'true');
-      expect(itemAfterReopen).to.have.attribute('data-radioitem', 'checked');
+      expect(itemAfterReopen).to.have.attribute('data-radio-item-checked', '');
     });
   });
 

--- a/packages/mui-base/src/Menu/RadioItem/MenuRadioItem.test.tsx
+++ b/packages/mui-base/src/Menu/RadioItem/MenuRadioItem.test.tsx
@@ -173,7 +173,7 @@ describe('<Menu.RadioItem />', () => {
       await user.click(item);
 
       expect(item).to.have.attribute('aria-checked', 'true');
-      expect(item).to.have.attribute('data-radio-item-checked', '');
+      expect(item).to.have.attribute('data-checked', '');
     });
 
     ['Space', 'Enter'].forEach((key) => {
@@ -201,7 +201,7 @@ describe('<Menu.RadioItem />', () => {
         });
 
         await user.keyboard(`[${key}]`);
-        expect(item).to.have.attribute('data-radio-item-checked', '');
+        expect(item).to.have.attribute('data-checked', '');
       });
     });
 
@@ -256,7 +256,7 @@ describe('<Menu.RadioItem />', () => {
 
       const itemAfterReopen = getByRole('menuitemradio');
       expect(itemAfterReopen).to.have.attribute('aria-checked', 'true');
-      expect(itemAfterReopen).to.have.attribute('data-radio-item-checked', '');
+      expect(itemAfterReopen).to.have.attribute('data-checked', '');
     });
   });
 

--- a/packages/mui-base/src/Menu/RadioItem/MenuRadioItem.tsx
+++ b/packages/mui-base/src/Menu/RadioItem/MenuRadioItem.tsx
@@ -10,7 +10,7 @@ import type { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
 import { useForkRef } from '../../utils/useForkRef';
 import { useMenuRadioGroupContext } from '../RadioGroup/MenuRadioGroupContext';
 import { MenuRadioItemContext } from './MenuRadioItemContext';
-import { radioItemMapping } from '../utils/styleHookMapping';
+import { itemMapping } from '../utils/styleHookMapping';
 
 const InnerMenuRadioItem = React.memo(
   React.forwardRef(function InnerMenuItem(
@@ -53,7 +53,7 @@ const InnerMenuRadioItem = React.memo(
       className,
       ownerState,
       propGetter: (externalProps) => propGetter(getRootProps(externalProps)),
-      customStyleHookMapping: radioItemMapping,
+      customStyleHookMapping: itemMapping,
       extraProps: other,
     });
 

--- a/packages/mui-base/src/Menu/RadioItem/MenuRadioItem.tsx
+++ b/packages/mui-base/src/Menu/RadioItem/MenuRadioItem.tsx
@@ -5,16 +5,12 @@ import { FloatingEvents, useFloatingTree, useListItem } from '@floating-ui/react
 import { useMenuRadioItem } from './useMenuRadioItem';
 import { useMenuRootContext } from '../Root/MenuRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
-import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import { useId } from '../../utils/useId';
 import type { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
 import { useForkRef } from '../../utils/useForkRef';
 import { useMenuRadioGroupContext } from '../RadioGroup/MenuRadioGroupContext';
 import { MenuRadioItemContext } from './MenuRadioItemContext';
-
-const customStyleHookMapping: CustomStyleHookMapping<MenuRadioItem.OwnerState> = {
-  checked: (value: boolean) => ({ 'data-radioitem': value ? 'checked' : 'unchecked' }),
-};
+import { radioItemMapping } from '../utils/styleHookMapping';
 
 const InnerMenuRadioItem = React.memo(
   React.forwardRef(function InnerMenuItem(
@@ -57,7 +53,7 @@ const InnerMenuRadioItem = React.memo(
       className,
       ownerState,
       propGetter: (externalProps) => propGetter(getRootProps(externalProps)),
-      customStyleHookMapping,
+      customStyleHookMapping: radioItemMapping,
       extraProps: other,
     });
 

--- a/packages/mui-base/src/Menu/RadioItemIndicator/MenuRadioItemIndicator.tsx
+++ b/packages/mui-base/src/Menu/RadioItemIndicator/MenuRadioItemIndicator.tsx
@@ -1,14 +1,10 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { MenuRadioItem } from '../RadioItem/MenuRadioItem';
 import { useMenuRadioItemContext } from '../RadioItem/MenuRadioItemContext';
-import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { BaseUIComponentProps } from '../../utils/types';
-
-const customStyleHookMapping: CustomStyleHookMapping<MenuRadioItem.OwnerState> = {
-  checked: (value: boolean) => ({ 'data-radioitem': value ? 'checked' : 'unchecked' }),
-};
+import { radioItemMapping } from '../utils/styleHookMapping';
 
 /**
  *
@@ -32,7 +28,7 @@ const MenuRadioItemIndicator = React.forwardRef(function MenuRadioItemIndicatorC
     render: render || 'span',
     className,
     ownerState,
-    customStyleHookMapping,
+    customStyleHookMapping: radioItemMapping,
     extraProps: other,
     ref: forwardedRef,
   });

--- a/packages/mui-base/src/Menu/RadioItemIndicator/MenuRadioItemIndicator.tsx
+++ b/packages/mui-base/src/Menu/RadioItemIndicator/MenuRadioItemIndicator.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useMenuRadioItemContext } from '../RadioItem/MenuRadioItemContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { BaseUIComponentProps } from '../../utils/types';
-import { radioItemMapping } from '../utils/styleHookMapping';
+import { itemMapping } from '../utils/styleHookMapping';
 
 /**
  *
@@ -28,7 +28,7 @@ const MenuRadioItemIndicator = React.forwardRef(function MenuRadioItemIndicatorC
     render: render || 'span',
     className,
     ownerState,
-    customStyleHookMapping: radioItemMapping,
+    customStyleHookMapping: itemMapping,
     extraProps: other,
     ref: forwardedRef,
   });

--- a/packages/mui-base/src/Menu/SubmenuTrigger/SubmenuTrigger.tsx
+++ b/packages/mui-base/src/Menu/SubmenuTrigger/SubmenuTrigger.tsx
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types';
 import { useFloatingTree, useListItem } from '@floating-ui/react';
 import { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
 import { useMenuRootContext } from '../Root/MenuRootContext';
-import { commonStyleHooks } from '../utils/commonStyleHooks';
 import { useId } from '../../utils/useId';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useSubmenuTrigger } from './useSubmenuTrigger';
 import { useForkRef } from '../../utils/useForkRef';
+import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  *
@@ -60,7 +60,10 @@ const SubmenuTrigger = React.forwardRef(function SubmenuTriggerComponent(
     typingRef,
   });
 
-  const ownerState: SubmenuTrigger.OwnerState = { disabled, highlighted, open };
+  const ownerState: SubmenuTrigger.OwnerState = React.useMemo(
+    () => ({ disabled, highlighted, open }),
+    [disabled, highlighted, open],
+  );
 
   const { renderElement } = useComponentRenderer({
     render: render || 'div',
@@ -68,7 +71,7 @@ const SubmenuTrigger = React.forwardRef(function SubmenuTriggerComponent(
     ownerState,
     propGetter: (externalProps: GenericHTMLProps) =>
       getTriggerProps(getItemProps(getRootProps(externalProps))),
-    customStyleHookMapping: commonStyleHooks,
+    customStyleHookMapping: triggerOpenStateMapping,
     extraProps: other,
   });
 

--- a/packages/mui-base/src/Menu/Trigger/MenuTrigger.test.tsx
+++ b/packages/mui-base/src/Menu/Trigger/MenuTrigger.test.tsx
@@ -91,7 +91,7 @@ describe('<Menu.Trigger />', () => {
     const menuPopup = queryByRole('menu', { hidden: false });
     expect(menuPopup).not.to.equal(null);
 
-    expect(menuPopup).to.have.attribute('data-menu', 'open');
+    expect(menuPopup).to.have.attribute('data-open', '');
   });
 
   describe('keyboard navigation', () => {

--- a/packages/mui-base/src/Menu/Trigger/MenuTrigger.tsx
+++ b/packages/mui-base/src/Menu/Trigger/MenuTrigger.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useFloatingTree } from '@floating-ui/react';
 import { useMenuTrigger } from './useMenuTrigger';
 import { useMenuRootContext } from '../Root/MenuRootContext';
-import { commonStyleHooks } from '../utils/commonStyleHooks';
+import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { BaseUIComponentProps } from '../../utils/types';
 
@@ -45,16 +45,14 @@ const MenuTrigger = React.forwardRef(function MenuTrigger(
     setClickAndDragEnabled,
   });
 
-  const ownerState: MenuTrigger.OwnerState = {
-    open,
-  };
+  const ownerState: MenuTrigger.OwnerState = React.useMemo(() => ({ open }), [open]);
 
   const { renderElement } = useComponentRenderer({
     render: render || 'button',
     className,
     ownerState,
     propGetter: (externalProps) => getTriggerProps(getRootProps(externalProps)),
-    customStyleHookMapping: commonStyleHooks,
+    customStyleHookMapping: triggerOpenStateMapping,
     extraProps: other,
   });
 

--- a/packages/mui-base/src/Menu/utils/commonStyleHooks.ts
+++ b/packages/mui-base/src/Menu/utils/commonStyleHooks.ts
@@ -1,3 +1,0 @@
-export const commonStyleHooks = {
-  open: (value: boolean) => ({ 'data-menu': value ? 'open' : 'closed' }),
-};

--- a/packages/mui-base/src/Menu/utils/styleHookMapping.ts
+++ b/packages/mui-base/src/Menu/utils/styleHookMapping.ts
@@ -1,27 +1,14 @@
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 
-export const radioItemMapping: CustomStyleHookMapping<{ checked: boolean }> = {
+export const itemMapping: CustomStyleHookMapping<{ checked: boolean }> = {
   checked(value): Record<string, string> {
     if (value) {
       return {
-        'data-radio-item-checked': '',
+        'data-checked': '',
       };
     }
     return {
-      'data-radio-item-unchecked': '',
-    };
-  },
-};
-
-export const checkboxItemMapping: CustomStyleHookMapping<{ checked: boolean }> = {
-  checked(value): Record<string, string> {
-    if (value) {
-      return {
-        'data-checkbox-item-checked': '',
-      };
-    }
-    return {
-      'data-checkbox-item-unchecked': '',
+      'data-unchecked': '',
     };
   },
 };

--- a/packages/mui-base/src/Menu/utils/styleHookMapping.ts
+++ b/packages/mui-base/src/Menu/utils/styleHookMapping.ts
@@ -1,0 +1,27 @@
+import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+
+export const radioItemMapping: CustomStyleHookMapping<{ checked: boolean }> = {
+  checked(value): Record<string, string> {
+    if (value) {
+      return {
+        'data-radio-item-checked': '',
+      };
+    }
+    return {
+      'data-radio-item-unchecked': '',
+    };
+  },
+};
+
+export const checkboxItemMapping: CustomStyleHookMapping<{ checked: boolean }> = {
+  checked(value): Record<string, string> {
+    if (value) {
+      return {
+        'data-checkbox-item-checked': '',
+      };
+    }
+    return {
+      'data-checkbox-item-unchecked': '',
+    };
+  },
+};

--- a/packages/mui-base/src/Popover/Arrow/PopoverArrow.tsx
+++ b/packages/mui-base/src/Popover/Arrow/PopoverArrow.tsx
@@ -8,15 +8,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import { usePopoverArrow } from './usePopoverArrow';
 import type { Alignment, Side } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-
-const customStyleHookMapping: CustomStyleHookMapping<PopoverArrow.OwnerState> = {
-  open(value) {
-    return {
-      'data-state': value ? 'open' : 'closed',
-    };
-  },
-};
+import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  * Renders an arrow that points to the center of the anchor element.
@@ -62,7 +54,7 @@ const PopoverArrow = React.forwardRef(function PopoverArrow(
     ownerState,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping,
+    customStyleHookMapping: popupOpenStateMapping,
   });
 
   return renderElement();

--- a/packages/mui-base/src/Popover/Backdrop/PopoverBackdrop.tsx
+++ b/packages/mui-base/src/Popover/Backdrop/PopoverBackdrop.tsx
@@ -7,7 +7,22 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { HTMLElementType } from '../../utils/proptypes';
 import { usePopoverBackdrop } from './usePopoverBackdrop';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import type { TransitionStatus } from '../../utils/useTransitionStatus';
+
+const customStyleHookMapping: CustomStyleHookMapping<PopoverBackdrop.OwnerState> = {
+  ...baseMapping,
+  transitionStatus(value) {
+    if (value === 'entering') {
+      return { 'data-entering': '' } as Record<string, string>;
+    }
+    if (value === 'exiting') {
+      return { 'data-exiting': '' };
+    }
+    return null;
+  },
+};
 
 /**
  * Renders a backdrop for the popover.
@@ -26,11 +41,17 @@ const PopoverBackdrop = React.forwardRef(function PopoverBackdrop(
 ) {
   const { className, render, keepMounted = false, container, ...otherProps } = props;
 
-  const { open, mounted } = usePopoverRootContext();
+  const { open, mounted, transitionStatus } = usePopoverRootContext();
 
   const { getBackdropProps } = usePopoverBackdrop();
 
-  const ownerState = React.useMemo(() => ({ open }), [open]);
+  const ownerState = React.useMemo(
+    () => ({
+      open,
+      transitionStatus,
+    }),
+    [open, transitionStatus],
+  );
 
   const { renderElement } = useComponentRenderer({
     propGetter: getBackdropProps,
@@ -39,7 +60,7 @@ const PopoverBackdrop = React.forwardRef(function PopoverBackdrop(
     ownerState,
     ref: forwardedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping,
   });
 
   const shouldRender = keepMounted || mounted;
@@ -53,6 +74,7 @@ const PopoverBackdrop = React.forwardRef(function PopoverBackdrop(
 namespace PopoverBackdrop {
   export interface OwnerState {
     open: boolean;
+    transitionStatus: TransitionStatus;
   }
 
   export interface Props extends BaseUIComponentProps<'div', OwnerState> {

--- a/packages/mui-base/src/Popover/Backdrop/PopoverBackdrop.tsx
+++ b/packages/mui-base/src/Popover/Backdrop/PopoverBackdrop.tsx
@@ -7,6 +7,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { HTMLElementType } from '../../utils/proptypes';
 import { usePopoverBackdrop } from './usePopoverBackdrop';
 import type { BaseUIComponentProps } from '../../utils/types';
+import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  * Renders a backdrop for the popover.
@@ -38,6 +39,7 @@ const PopoverBackdrop = React.forwardRef(function PopoverBackdrop(
     ownerState,
     ref: forwardedRef,
     extraProps: otherProps,
+    customStyleHookMapping: popupOpenStateMapping,
   });
 
   const shouldRender = keepMounted || mounted;

--- a/packages/mui-base/src/Popover/Popup/PopoverPopup.tsx
+++ b/packages/mui-base/src/Popover/Popup/PopoverPopup.tsx
@@ -9,15 +9,19 @@ import { useForkRef } from '../../utils/useForkRef';
 import type { Side, Alignment } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
 
 const customStyleHookMapping: CustomStyleHookMapping<PopoverPopup.OwnerState> = {
   ...baseMapping,
-  entering(value) {
-    return value ? { 'data-entering': '' } : null;
-  },
-  exiting(value) {
-    return value ? { 'data-exiting': '' } : null;
+  transitionStatus(value) {
+    if (value === 'entering') {
+      return { 'data-entering': '' } as Record<string, string>;
+    }
+    if (value === 'exiting') {
+      return { 'data-exiting': '' };
+    }
+    return null;
   },
 };
 
@@ -61,8 +65,7 @@ const PopoverPopup = React.forwardRef(function PopoverPopup(
       side,
       alignment,
       instant: instantType,
-      entering: transitionStatus === 'entering',
-      exiting: transitionStatus === 'exiting',
+      transitionStatus,
     }),
     [open, side, alignment, instantType, transitionStatus],
   );
@@ -87,8 +90,7 @@ namespace PopoverPopup {
     open: boolean;
     side: Side;
     alignment: Alignment;
-    entering: boolean;
-    exiting: boolean;
+    transitionStatus: TransitionStatus;
   }
 
   export interface Props extends BaseUIComponentProps<'div', OwnerState> {}

--- a/packages/mui-base/src/Popover/Popup/PopoverPopup.tsx
+++ b/packages/mui-base/src/Popover/Popup/PopoverPopup.tsx
@@ -9,18 +9,15 @@ import { useForkRef } from '../../utils/useForkRef';
 import type { Side, Alignment } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
 
 const customStyleHookMapping: CustomStyleHookMapping<PopoverPopup.OwnerState> = {
+  ...baseMapping,
   entering(value) {
     return value ? { 'data-entering': '' } : null;
   },
   exiting(value) {
     return value ? { 'data-exiting': '' } : null;
-  },
-  open(value) {
-    return {
-      'data-state': value ? 'open' : 'closed',
-    };
   },
 };
 

--- a/packages/mui-base/src/Popover/Positioner/PopoverPositioner.tsx
+++ b/packages/mui-base/src/Popover/Positioner/PopoverPositioner.tsx
@@ -10,6 +10,7 @@ import { PopoverPositionerContext } from './PopoverPositionerContext';
 import { HTMLElementType } from '../../utils/proptypes';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Side, Alignment } from '../../utils/useAnchorPositioning';
+import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  * The popover positioner element.
@@ -93,6 +94,7 @@ const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     ownerState,
     ref: mergedRef,
     extraProps: otherProps,
+    customStyleHookMapping: popupOpenStateMapping,
   });
 
   const shouldRender = keepMounted || mounted;

--- a/packages/mui-base/src/Popover/Trigger/PopoverTrigger.tsx
+++ b/packages/mui-base/src/Popover/Trigger/PopoverTrigger.tsx
@@ -5,15 +5,7 @@ import { usePopoverRootContext } from '../Root/PopoverRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-
-const customStyleHookMapping: CustomStyleHookMapping<PopoverTrigger.OwnerState> = {
-  open(value) {
-    return {
-      'data-state': value ? 'open' : 'closed',
-    };
-  },
-};
+import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  * Renders a trigger element that opens the popover.
@@ -45,7 +37,7 @@ const PopoverTrigger = React.forwardRef(function PopoverTrigger(
     ownerState,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping,
+    customStyleHookMapping: triggerOpenStateMapping,
   });
 
   return renderElement();

--- a/packages/mui-base/src/PreviewCard/Arrow/PreviewCardArrow.tsx
+++ b/packages/mui-base/src/PreviewCard/Arrow/PreviewCardArrow.tsx
@@ -8,6 +8,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import { usePreviewCardRootContext } from '../Root/PreviewCardContext';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Alignment, Side } from '../../utils/useAnchorPositioning';
+import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  *
@@ -52,6 +53,7 @@ const PreviewCardArrow = React.forwardRef(function PreviewCardArrow(
     ownerState,
     ref: mergedRef,
     extraProps: otherProps,
+    customStyleHookMapping: popupOpenStateMapping,
   });
 
   return renderElement();

--- a/packages/mui-base/src/PreviewCard/Backdrop/PreviewCardBackdrop.tsx
+++ b/packages/mui-base/src/PreviewCard/Backdrop/PreviewCardBackdrop.tsx
@@ -7,7 +7,22 @@ import { usePreviewCardRootContext } from '../Root/PreviewCardContext';
 import { usePreviewCardBackdrop } from './usePreviewCardBackdrop';
 import { HTMLElementType } from '../../utils/proptypes';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import type { TransitionStatus } from '../../utils/useTransitionStatus';
+
+const customStyleHookMapping: CustomStyleHookMapping<PreviewCardBackdrop.OwnerState> = {
+  ...baseMapping,
+  transitionStatus(value) {
+    if (value === 'entering') {
+      return { 'data-entering': '' } as Record<string, string>;
+    }
+    if (value === 'exiting') {
+      return { 'data-exiting': '' };
+    }
+    return null;
+  },
+};
 
 /**
  *
@@ -25,10 +40,16 @@ const PreviewCardBackdrop = React.forwardRef(function PreviewCardBackdrop(
 ) {
   const { render, className, keepMounted = false, container, ...otherProps } = props;
 
-  const { open, mounted } = usePreviewCardRootContext();
+  const { open, mounted, transitionStatus } = usePreviewCardRootContext();
   const { getBackdropProps } = usePreviewCardBackdrop();
 
-  const ownerState: PreviewCardBackdrop.OwnerState = React.useMemo(() => ({ open }), [open]);
+  const ownerState: PreviewCardBackdrop.OwnerState = React.useMemo(
+    () => ({
+      open,
+      transitionStatus,
+    }),
+    [open, transitionStatus],
+  );
 
   const { renderElement } = useComponentRenderer({
     propGetter: getBackdropProps,
@@ -37,7 +58,7 @@ const PreviewCardBackdrop = React.forwardRef(function PreviewCardBackdrop(
     ownerState,
     ref: forwardedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping,
   });
 
   const shouldRender = keepMounted || mounted;
@@ -51,6 +72,7 @@ const PreviewCardBackdrop = React.forwardRef(function PreviewCardBackdrop(
 namespace PreviewCardBackdrop {
   export interface OwnerState {
     open: boolean;
+    transitionStatus: TransitionStatus;
   }
 
   export interface Props extends BaseUIComponentProps<'div', OwnerState> {

--- a/packages/mui-base/src/PreviewCard/Backdrop/PreviewCardBackdrop.tsx
+++ b/packages/mui-base/src/PreviewCard/Backdrop/PreviewCardBackdrop.tsx
@@ -7,6 +7,7 @@ import { usePreviewCardRootContext } from '../Root/PreviewCardContext';
 import { usePreviewCardBackdrop } from './usePreviewCardBackdrop';
 import { HTMLElementType } from '../../utils/proptypes';
 import type { BaseUIComponentProps } from '../../utils/types';
+import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  *
@@ -36,6 +37,7 @@ const PreviewCardBackdrop = React.forwardRef(function PreviewCardBackdrop(
     ownerState,
     ref: forwardedRef,
     extraProps: otherProps,
+    customStyleHookMapping: popupOpenStateMapping,
   });
 
   const shouldRender = keepMounted || mounted;

--- a/packages/mui-base/src/PreviewCard/Popup/PreviewCardPopup.tsx
+++ b/packages/mui-base/src/PreviewCard/Popup/PreviewCardPopup.tsx
@@ -9,18 +9,15 @@ import { useForkRef } from '../../utils/useForkRef';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import type { Alignment, Side } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
+import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
 
 const customStyleHookMapping: CustomStyleHookMapping<PreviewCardPopup.OwnerState> = {
+  ...baseMapping,
   entering(value) {
     return value ? { 'data-entering': '' } : null;
   },
   exiting(value) {
     return value ? { 'data-exiting': '' } : null;
-  },
-  open(value) {
-    return {
-      'data-state': value ? 'open' : 'closed',
-    };
   },
 };
 

--- a/packages/mui-base/src/PreviewCard/Popup/PreviewCardPopup.tsx
+++ b/packages/mui-base/src/PreviewCard/Popup/PreviewCardPopup.tsx
@@ -10,14 +10,18 @@ import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import type { Alignment, Side } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import type { TransitionStatus } from '../../utils/useTransitionStatus';
 
 const customStyleHookMapping: CustomStyleHookMapping<PreviewCardPopup.OwnerState> = {
   ...baseMapping,
-  entering(value) {
-    return value ? { 'data-entering': '' } : null;
-  },
-  exiting(value) {
-    return value ? { 'data-exiting': '' } : null;
+  transitionStatus(value) {
+    if (value === 'entering') {
+      return { 'data-entering': '' } as Record<string, string>;
+    }
+    if (value === 'exiting') {
+      return { 'data-exiting': '' };
+    }
+    return null;
   },
 };
 
@@ -49,8 +53,7 @@ const PreviewCardPopup = React.forwardRef(function PreviewCardPopup(
       open,
       side,
       alignment,
-      entering: transitionStatus === 'entering',
-      exiting: transitionStatus === 'exiting',
+      transitionStatus,
     }),
     [open, side, alignment, transitionStatus],
   );
@@ -75,8 +78,7 @@ namespace PreviewCardPopup {
     open: boolean;
     side: Side;
     alignment: Alignment;
-    entering: boolean;
-    exiting: boolean;
+    transitionStatus: TransitionStatus;
   }
 
   export interface Props extends BaseUIComponentProps<'div', OwnerState> {}

--- a/packages/mui-base/src/PreviewCard/Positioner/PreviewCardPositioner.tsx
+++ b/packages/mui-base/src/PreviewCard/Positioner/PreviewCardPositioner.tsx
@@ -10,6 +10,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import { HTMLElementType } from '../../utils/proptypes';
 import type { Side, Alignment } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
+import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  *
@@ -101,6 +102,7 @@ const PreviewCardPositioner = React.forwardRef(function PreviewCardPositioner(
     ownerState,
     ref: mergedRef,
     extraProps: otherProps,
+    customStyleHookMapping: popupOpenStateMapping,
   });
 
   const shouldRender = keepMounted || mounted;

--- a/packages/mui-base/src/PreviewCard/Trigger/PreviewCardTrigger.tsx
+++ b/packages/mui-base/src/PreviewCard/Trigger/PreviewCardTrigger.tsx
@@ -5,6 +5,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { usePreviewCardRootContext } from '../Root/PreviewCardContext';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
+import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  *
@@ -35,6 +36,7 @@ const PreviewCardTrigger = React.forwardRef(function PreviewCardTrigger(
     ownerState,
     ref: mergedRef,
     extraProps: otherProps,
+    customStyleHookMapping: triggerOpenStateMapping,
   });
 
   return renderElement();

--- a/packages/mui-base/src/Tooltip/Arrow/TooltipArrow.tsx
+++ b/packages/mui-base/src/Tooltip/Arrow/TooltipArrow.tsx
@@ -5,17 +5,9 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import { useTooltipPositionerContext } from '../Positioner/TooltipPositionerContext';
 import { useTooltipArrow } from './useTooltipArrow';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Side, Alignment } from '../../utils/useAnchorPositioning';
-
-const customStyleHookMapping: CustomStyleHookMapping<TooltipArrow.OwnerState> = {
-  open(value) {
-    return {
-      'data-state': value ? 'open' : 'closed',
-    };
-  },
-};
+import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  * Renders an arrow that points to the center of the anchor element.
@@ -60,7 +52,7 @@ const TooltipArrow = React.forwardRef(function TooltipArrow(
     className,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping,
+    customStyleHookMapping: popupOpenStateMapping,
   });
 
   return renderElement();

--- a/packages/mui-base/src/Tooltip/Popup/TooltipPopup.tsx
+++ b/packages/mui-base/src/Tooltip/Popup/TooltipPopup.tsx
@@ -8,18 +8,15 @@ import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Alignment, Side } from '../../utils/useAnchorPositioning';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
 
 const customStyleHookMapping: CustomStyleHookMapping<TooltipPopup.OwnerState> = {
+  ...baseMapping,
   entering(value) {
     return value ? { 'data-entering': '' } : null;
   },
   exiting(value) {
     return value ? { 'data-exiting': '' } : null;
-  },
-  open(value) {
-    return {
-      'data-state': value ? 'open' : 'closed',
-    };
   },
 };
 

--- a/packages/mui-base/src/Tooltip/Popup/TooltipPopup.tsx
+++ b/packages/mui-base/src/Tooltip/Popup/TooltipPopup.tsx
@@ -9,14 +9,18 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import type { Alignment, Side } from '../../utils/useAnchorPositioning';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import type { TransitionStatus } from '../../utils/useTransitionStatus';
 
 const customStyleHookMapping: CustomStyleHookMapping<TooltipPopup.OwnerState> = {
   ...baseMapping,
-  entering(value) {
-    return value ? { 'data-entering': '' } : null;
-  },
-  exiting(value) {
-    return value ? { 'data-exiting': '' } : null;
+  transitionStatus(value) {
+    if (value === 'entering') {
+      return { 'data-entering': '' } as Record<string, string>;
+    }
+    if (value === 'exiting') {
+      return { 'data-exiting': '' };
+    }
+    return null;
   },
 };
 
@@ -47,8 +51,7 @@ const TooltipPopup = React.forwardRef(function TooltipPopup(
       side,
       alignment,
       instant: instantType,
-      entering: transitionStatus === 'entering',
-      exiting: transitionStatus === 'exiting',
+      transitionStatus,
     }),
     [open, side, alignment, instantType, transitionStatus],
   );
@@ -76,8 +79,7 @@ namespace TooltipPopup {
     side: Side;
     alignment: Alignment;
     instant: 'delay' | 'focus' | 'dismiss' | undefined;
-    entering: boolean;
-    exiting: boolean;
+    transitionStatus: TransitionStatus;
   }
 
   export interface Props extends BaseUIComponentProps<'div', OwnerState> {}

--- a/packages/mui-base/src/Tooltip/Positioner/TooltipPositioner.tsx
+++ b/packages/mui-base/src/Tooltip/Positioner/TooltipPositioner.tsx
@@ -10,6 +10,7 @@ import { TooltipPositionerContext } from './TooltipPositionerContext';
 import { useTooltipPositioner } from './useTooltipPositioner';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Side, Alignment } from '../../utils/useAnchorPositioning';
+import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  * The tooltip positioner element.
@@ -100,6 +101,7 @@ const TooltipPositioner = React.forwardRef(function TooltipPositioner(
     ownerState,
     ref: mergedRef,
     extraProps: otherProps,
+    customStyleHookMapping: popupOpenStateMapping,
   });
 
   const shouldRender = keepMounted || mounted;

--- a/packages/mui-base/src/Tooltip/Trigger/TooltipTrigger.tsx
+++ b/packages/mui-base/src/Tooltip/Trigger/TooltipTrigger.tsx
@@ -5,15 +5,7 @@ import { useTooltipRootContext } from '../Root/TooltipRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-
-const customStyleHookMapping: CustomStyleHookMapping<TooltipTrigger.OwnerState> = {
-  open(value: boolean) {
-    return {
-      'data-state': value ? 'open' : 'closed',
-    };
-  },
-};
+import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
 
 /**
  * Renders a trigger element that opens the tooltip.
@@ -45,7 +37,7 @@ const TooltipTrigger = React.forwardRef(function TooltipTrigger(
     ownerState,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping,
+    customStyleHookMapping: triggerOpenStateMapping,
   });
 
   return renderElement();

--- a/packages/mui-base/src/utils/popupOpenStateMapping.ts
+++ b/packages/mui-base/src/utils/popupOpenStateMapping.ts
@@ -1,0 +1,23 @@
+import type { CustomStyleHookMapping } from './getStyleHookProps';
+
+export const triggerOpenStateMapping: CustomStyleHookMapping<{ open: boolean }> = {
+  open(value: boolean): Record<string, string> {
+    if (value) {
+      return {
+        'data-popup-open': '',
+      };
+    }
+    return {};
+  },
+};
+
+export const popupOpenStateMapping: CustomStyleHookMapping<{ open: boolean }> = {
+  open(value: boolean): Record<string, string> {
+    if (value) {
+      return {
+        'data-open': '',
+      };
+    }
+    return {};
+  },
+};

--- a/packages/mui-base/src/utils/popupOpenStateMapping.ts
+++ b/packages/mui-base/src/utils/popupOpenStateMapping.ts
@@ -1,23 +1,23 @@
 import type { CustomStyleHookMapping } from './getStyleHookProps';
 
 export const triggerOpenStateMapping: CustomStyleHookMapping<{ open: boolean }> = {
-  open(value: boolean): Record<string, string> {
+  open(value) {
     if (value) {
       return {
         'data-popup-open': '',
       };
     }
-    return {};
+    return null;
   },
 };
 
 export const popupOpenStateMapping: CustomStyleHookMapping<{ open: boolean }> = {
-  open(value: boolean): Record<string, string> {
+  open(value) {
     if (value) {
       return {
         'data-open': '',
       };
     }
-    return {};
+    return null;
   },
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/base-ui/issues/717

Style hooks refer to themselves or closely related components:

- `Trigger` receives `data-popup-open`
- `Backdrop`, `Popup`, `Positioner` and child components receive `data-open`
- Menu `data-radioitem` -> `data-{checked,unchecked}`
- Menu `data-checkboxitem` -> `data-{checked,unchecked}`
- Components that don't need to read open remove the state
- `React.useMemo` the ownerState for missing components
- Make `data-entering`/`data-exiting` consistent