### PR TITLE
[docs] Remove trailing slash from link

### DIFF
--- a/docs/data/components/text-input/text-input.mdx
+++ b/docs/data/components/text-input/text-input.mdx
@@ -21,7 +21,7 @@ packageName: '@base_ui/react'
 
 ## Anatomy
 
-`<TextInput />` renders an `<input>`, enhanced with field context when placed inside a [`Field`](/components/react-field/).
+`<TextInput />` renders an `<input>`, enhanced with field context when placed inside a [`Field`](/components/react-field).
 
 ```tsx
 <TextInput />


### PR DESCRIPTION
Removed a trailing slash from a link that was triggering a failure in https://app.circleci.com/pipelines/github/mui/base-ui/4430/workflows/ef320ba1-f2dd-4d6a-a306-116d7a862ccd/jobs/29845