### PR TITLE
[docs-infra] Add mdx support to vale lint

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -9,7 +9,13 @@ MinAlertLevel = warning
 # 4. You can test locally by replacing the url with the file path of the generated zip
 Packages = Google, https://github.com/mui/material-ui/raw/HEAD/docs/mui-vale.zip
 
+[formats]
+mdx = md
+
 [*.md]
+# Ignore React component calls
+TokenIgnores = (<\/?[A-Z].+>)
+
 # Ignore code injections that start with {{...
 BlockIgnores = {{.*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ A big thanks to the 7 contributors who made this release possible. Here are some
 - [docs] Avoid dead links in demos (#610) @oliviertassinari
 - [docs] Fix rel attribute on edit GitHub links (#614) @oliviertassinari
 - [docs] Fix pnpm docs:link-check script (#552) @oliviertassinari
-- [docs] Fix Stack Overflow issue canned response @oliviertassinari
+- [docs] Fix Stack Overflow issue canned response @oliviertassinari
 - [docs] Fix outdated link to support page @oliviertassinari
 - [docs] Clarify contribution guide references @oliviertassinari
 
@@ -54,19 +54,19 @@ A big thanks to the 7 contributors who made this release possible. Here are some
 - [code-infra] Remove custom playwright installation steps (#646) @Janpot
 - [core] Fix 301 link to Next.js and git diff @oliviertassinari
 - [core] Fix package.json repository rule @oliviertassinari
-- [core] MUI X repository moved to a new location @oliviertassinari
+- [core] MUI X repository moved to a new location @oliviertassinari
 - [core] React 19 compatibility (#605) @michaldudak
 - [core] Reference `ownerDocument` (#660) @atomiks
 - [core] Remove 'use client' from index files (#331) @michaldudak
 - [core] Remove /.yarn (#596) @oliviertassinari
-- [core] Remove Material UI dependency (#585) @michaldudak
+- [core] Remove Material UI dependency (#585) @michaldudak
 - [core] Remove the legacy components from the repo (#584) @michaldudak
 - [core] Rename positionStrategy to positionMethod (#704) @michaldudak
 - [docs-infra] Fix double // (#613) @oliviertassinari
 - [docs-infra] Strengthen CSP (#595) @oliviertassinari
 - [infra] Adds reusable workflow for closing message on issues (#598) @michelengelen
 - [infra] Adds reusable workflow for issue cleanup (#597) @michelengelen
-- [infra] Fix line break in Stack Overflow message @oliviertassinari
+- [infra] Fix line break in Stack Overflow message @oliviertassinari
 - [test] Fix tests on Safari (#546) @michaldudak
 - [test] Fix the test_types_next CI job (#703) @michaldudak
 - [test] Improve visual screenshot canva (#708)
@@ -74,7 +74,7 @@ A big thanks to the 7 contributors who made this release possible. Here are some
 - [test] Run Browserstack tests on master only (#578) @michaldudak
 - [test] Use `waitFor` instead of fixed timeout in tests (#632) @michaldudak
 - [website] Improve utm_source strategy @oliviertassinari
-- [website] Modernize the Base UI website (#538) @michaldudak
+- [website] Modernize the Base UI website (#538) @michaldudak
 
 All contributors of this release in alphabetical order: @atomiks, @Janpot, @michaldudak, @michelengelen, @mj12albert, @oliviertassinari, @sai6855
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ A big thanks to the 10 contributors who made this release possible. Here are som
 
 ### Docs
 
-- [docs] Add badges like in Material UI @oliviertassinari
+- [docs] Add badges like in Material UI @oliviertassinari
 - [docs] Add the logo to the README (#448) @danilo-leal
 - [docs] Convert alpha component docs to new docs template (#392) @colmtuite
 - [docs] Correct Bundlephobia links (#419) @michaldudak

--- a/docs/data/components/accordion/accordion.mdx
+++ b/docs/data/components/accordion/accordion.mdx
@@ -290,7 +290,7 @@ When using CSS transitions, styles for the `Panel` must be applied to three stat
 
 ### JavaScript Animations
 
-When using external libraries for animation, for example `framer-motion`, be aware that `Accordion.Item`s hides content using the html `hidden` attribute in the closed state, and does not unmount from the DOM.
+When using external libraries for animation, for example `framer-motion`, be aware that `Accordion.Item`s hides content using the HTML `hidden` attribute in the closed state, and does not unmount from the DOM.
 
 ```js
 function App() {

--- a/docs/data/components/collapsible/collapsible.mdx
+++ b/docs/data/components/collapsible/collapsible.mdx
@@ -147,7 +147,7 @@ When using CSS transitions, styles for the `Panel` must be applied to three stat
 
 ### JavaScript Animations
 
-When using external libraries for animation, for example `framer-motion`, be aware that Collapsible hides content using the html `hidden` attribute in the closed state, and does not unmount the `Collapsible.Panel` subcomponent.
+When using external libraries for animation, for example `framer-motion`, be aware that Collapsible hides content using the HTML `hidden` attribute in the closed state, and does not unmount the `Collapsible.Panel` subcomponent.
 
 ```js
 function App() {

--- a/docs/data/components/menu/menu.mdx
+++ b/docs/data/components/menu/menu.mdx
@@ -161,7 +161,7 @@ Menu items can be used as radio buttons. To group them together, use the `Menu.R
 <Demo demo="RadioItems" />
 
 <Callout type="warning">
-  If you rely on the RadioItem to manage its state (e.g., you use the `defaultChecked` and `onCheckedChange` props), ensure that the item is not unmounted when its parent menu is closed.
+  If you rely on the RadioItem to manage its state (for example, you use the `defaultChecked` and `onCheckedChange` props), ensure that the item is not unmounted when its parent menu is closed.
   Unmounting the component resets its state.
 
 To do this, add the `keepMounted` prop to the `Menu.Positioner` the checkbox item is in (and all parent positioners, in the case of a nested menu):
@@ -194,7 +194,7 @@ Menu items can act as checkboxes.
 <Demo demo="CheckboxItems" />
 
 <Callout type="warning">
-  If you rely on the CheckboxItem to manage its state (e.g., you use the `defaultChecked` and `onCheckedChange` props), ensure that the item is not unmounted when its parent menu is closed.
+  If you rely on the CheckboxItem to manage its state (for example, you use the `defaultChecked` and `onCheckedChange` props), ensure that the item is not unmounted when its parent menu is closed.
   Unmounting the component resets its state.
 
 To do this, add the `keepMounted` prop to the `Menu.Positioner` the checkbox item is in (and all parent positioners, in the case of a nested menu):


### PR DESCRIPTION
A quick fix for a regression that I noticed while fixing https://github.com/mui/material-ui/pull/44277. We were no longer linting the docs. This got broken with #538.

Ideally, we could use https://github.com/errata-ai/vale/issues/841, but it's not there. Instead, there are a bunch of examples online on how this can be done https://github.com/search?q=%5Bformats%5D+mdx+%3D+md&type=code.

We will need to propagate this to the other repositories. But unclear if we should do it just yet, we might want to wait.
Point 20. of https://github.com/mui/base-ui/issues/588 doesn't make it super clear that MDX is compatible with a great UX for developers. I imagine that it's solvable, but it's it's not it seems to mean that we need to remove MDX and go back to the previous approach that yields better performance.