### PR TITLE
[Composite] Support RTL navigation, Home/End keys

### DIFF
--- a/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, createRenderer, describeSkipIf, fireEvent } from '@mui/internal-test-utils';
+import {
+  act,
+  createRenderer,
+  describeSkipIf,
+  fireEvent,
+  flushMicrotasks,
+} from '@mui/internal-test-utils';
 import { CompositeItem } from '../Item/CompositeItem';
 import { CompositeRoot } from './CompositeRoot';
 
@@ -33,21 +39,25 @@ describe('Composite', () => {
       expect(item1).to.have.attribute('data-active');
 
       fireEvent.keyDown(item1, { key: 'ArrowDown' });
+      await flushMicrotasks();
       expect(item2).to.have.attribute('data-active');
       expect(item2).to.have.attribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowDown' });
+      await flushMicrotasks();
       expect(item3).to.have.attribute('data-active');
       expect(item3).to.have.attribute('tabindex', '0');
       expect(item3).toHaveFocus();
 
       fireEvent.keyDown(item3, { key: 'ArrowUp' });
+      await flushMicrotasks();
       expect(item2).to.have.attribute('data-active');
       expect(item2).to.have.attribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowUp' });
+      await flushMicrotasks();
       expect(item1).to.have.attribute('data-active');
       expect(item1).to.have.attribute('tabindex', '0');
       expect(item1).toHaveFocus();
@@ -71,21 +81,25 @@ describe('Composite', () => {
       expect(item1).to.have.attribute('data-active');
 
       fireEvent.keyDown(item1, { key: 'ArrowDown' });
+      await flushMicrotasks();
       expect(item2).to.have.attribute('data-active');
       expect(item2).to.have.attribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowDown' });
+      await flushMicrotasks();
       expect(item3).to.have.attribute('data-active');
       expect(item3).to.have.attribute('tabindex', '0');
       expect(item3).toHaveFocus();
 
       fireEvent.keyDown(item3, { key: 'ArrowUp' });
+      await flushMicrotasks();
       expect(item2).to.have.attribute('data-active');
       expect(item2).to.have.attribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowUp' });
+      await flushMicrotasks();
       expect(item1).to.have.attribute('data-active');
       expect(item1).to.have.attribute('tabindex', '0');
       expect(item1).toHaveFocus();
@@ -156,30 +170,36 @@ describe('Composite', () => {
         expect(item1).to.have.attribute('data-active');
 
         fireEvent.keyDown(item1, { key: 'ArrowDown' });
+        await flushMicrotasks();
         expect(item1).to.have.attribute('data-active');
 
         fireEvent.keyDown(item1, { key: 'ArrowLeft' });
+        await flushMicrotasks();
         expect(item2).to.have.attribute('data-active');
         expect(item2).to.have.attribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowLeft' });
+        await flushMicrotasks();
         expect(item3).to.have.attribute('data-active');
         expect(item3).to.have.attribute('tabindex', '0');
         expect(item3).toHaveFocus();
 
         fireEvent.keyDown(item3, { key: 'ArrowRight' });
+        await flushMicrotasks();
         expect(item2).to.have.attribute('data-active');
         expect(item2).to.have.attribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowRight' });
+        await flushMicrotasks();
         expect(item1).to.have.attribute('data-active');
         expect(item1).to.have.attribute('tabindex', '0');
         expect(item1).toHaveFocus();
 
         // loop backward
         fireEvent.keyDown(item1, { key: 'ArrowRight' });
+        await flushMicrotasks();
         expect(item3).to.have.attribute('data-active');
         expect(item3).to.have.attribute('tabindex', '0');
         expect(item3).toHaveFocus();
@@ -205,31 +225,37 @@ describe('Composite', () => {
         expect(item1).to.have.attribute('data-active');
 
         fireEvent.keyDown(item1, { key: 'ArrowLeft' });
+        await flushMicrotasks();
         expect(item2).to.have.attribute('data-active');
         expect(item2).to.have.attribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowLeft' });
+        await flushMicrotasks();
         expect(item3).to.have.attribute('data-active');
         expect(item3).to.have.attribute('tabindex', '0');
         expect(item3).toHaveFocus();
 
         fireEvent.keyDown(item3, { key: 'ArrowRight' });
+        await flushMicrotasks();
         expect(item2).to.have.attribute('data-active');
         expect(item2).to.have.attribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowRight' });
+        await flushMicrotasks();
         expect(item1).to.have.attribute('data-active');
         expect(item1).to.have.attribute('tabindex', '0');
         expect(item1).toHaveFocus();
 
         fireEvent.keyDown(item1, { key: 'ArrowDown' });
+        await flushMicrotasks();
         expect(item2).to.have.attribute('data-active');
         expect(item2).to.have.attribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowDown' });
+        await flushMicrotasks();
         expect(item3).to.have.attribute('data-active');
         expect(item3).to.have.attribute('tabindex', '0');
         expect(item3).toHaveFocus();
@@ -258,31 +284,37 @@ describe('Composite', () => {
       expect(getByTestId('1')).to.have.attribute('data-active');
 
       fireEvent.keyDown(getByTestId('1'), { key: 'ArrowDown' });
+      await flushMicrotasks();
       expect(getByTestId('4')).to.have.attribute('data-active');
       expect(getByTestId('4')).to.have.attribute('tabindex', '0');
       expect(getByTestId('4')).toHaveFocus();
 
       fireEvent.keyDown(getByTestId('4'), { key: 'ArrowRight' });
+      await flushMicrotasks();
       expect(getByTestId('5')).to.have.attribute('data-active');
       expect(getByTestId('5')).to.have.attribute('tabindex', '0');
       expect(getByTestId('5')).toHaveFocus();
 
       fireEvent.keyDown(getByTestId('5'), { key: 'ArrowDown' });
+      await flushMicrotasks();
       expect(getByTestId('8')).to.have.attribute('data-active');
       expect(getByTestId('8')).to.have.attribute('tabindex', '0');
       expect(getByTestId('8')).toHaveFocus();
 
       fireEvent.keyDown(getByTestId('8'), { key: 'ArrowLeft' });
+      await flushMicrotasks();
       expect(getByTestId('7')).to.have.attribute('data-active');
       expect(getByTestId('7')).to.have.attribute('tabindex', '0');
       expect(getByTestId('7')).toHaveFocus();
 
       fireEvent.keyDown(getByTestId('7'), { key: 'ArrowUp' });
+      await flushMicrotasks();
       expect(getByTestId('4')).to.have.attribute('data-active');
       expect(getByTestId('4')).to.have.attribute('tabindex', '0');
       expect(getByTestId('4')).toHaveFocus();
 
       act(() => getByTestId('9').focus());
+      await flushMicrotasks();
       expect(getByTestId('9')).to.have.attribute('data-active');
       expect(getByTestId('9')).to.have.attribute('tabindex', '0');
 

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
@@ -111,7 +111,7 @@ describe('Composite', () => {
         expect(item1).to.have.attribute('data-active');
         expect(item1).to.have.attribute('tabindex', '0');
         expect(item1).toHaveFocus();
-      })
+      });
 
       it('End key moves focus to the last item', async () => {
         const { getByTestId } = render(
@@ -132,8 +132,8 @@ describe('Composite', () => {
         expect(item3).to.have.attribute('data-active');
         expect(item3).to.have.attribute('tabindex', '0');
         expect(item3).toHaveFocus();
-      })
-    })
+      });
+    });
 
     describeSkipIf(isJSDOM)('rtl', () => {
       it('horizontal orientation', async () => {
@@ -293,6 +293,107 @@ describe('Composite', () => {
       fireEvent.keyDown(getByTestId('1'), { key: 'End' });
       expect(getByTestId('9')).to.have.attribute('data-active');
       expect(getByTestId('9')).to.have.attribute('tabindex', '0');
+    });
+
+    describeSkipIf(isJSDOM)('rtl', () => {
+      it('horizontal orientation', async () => {
+        const { getByTestId } = render(
+          <div dir="rtl">
+            <CompositeRoot cols={3} orientation="horizontal" enableHomeAndEndKeys>
+              {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map((i) => (
+                <CompositeItem key={i} data-testid={i}>
+                  {i}
+                </CompositeItem>
+              ))}
+            </CompositeRoot>
+          </div>,
+        );
+
+        act(() => getByTestId('1').focus());
+        expect(getByTestId('1')).to.have.attribute('data-active');
+
+        fireEvent.keyDown(getByTestId('1'), { key: 'ArrowLeft' });
+        expect(getByTestId('2')).to.have.attribute('data-active');
+        expect(getByTestId('2')).to.have.attribute('tabindex', '0');
+        expect(getByTestId('2')).toHaveFocus();
+
+        fireEvent.keyDown(getByTestId('2'), { key: 'ArrowLeft' });
+        expect(getByTestId('3')).to.have.attribute('data-active');
+        expect(getByTestId('3')).to.have.attribute('tabindex', '0');
+        expect(getByTestId('3')).toHaveFocus();
+
+        fireEvent.keyDown(getByTestId('3'), { key: 'ArrowLeft' });
+        expect(getByTestId('4')).to.have.attribute('data-active');
+        expect(getByTestId('4')).to.have.attribute('tabindex', '0');
+        expect(getByTestId('4')).toHaveFocus();
+
+        fireEvent.keyDown(getByTestId('4'), { key: 'ArrowLeft' });
+        expect(getByTestId('5')).to.have.attribute('data-active');
+        expect(getByTestId('5')).to.have.attribute('tabindex', '0');
+        expect(getByTestId('5')).toHaveFocus();
+
+        fireEvent.keyDown(getByTestId('5'), { key: 'Home' });
+        expect(getByTestId('1')).to.have.attribute('data-active');
+        expect(getByTestId('1')).to.have.attribute('tabindex', '0');
+
+        fireEvent.keyDown(getByTestId('1'), { key: 'End' });
+        expect(getByTestId('9')).to.have.attribute('data-active');
+        expect(getByTestId('9')).to.have.attribute('tabindex', '0');
+      });
+
+      it('both horizontal and vertical orientation', async () => {
+        const { getByTestId } = await render(
+          <div dir="rtl">
+            <CompositeRoot cols={3} orientation="both" enableHomeAndEndKeys>
+              {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map((i) => (
+                <CompositeItem key={i} data-testid={i} style={{ width: 32, height: 32 }}>
+                  {i}
+                </CompositeItem>
+              ))}
+            </CompositeRoot>
+          </div>,
+        );
+
+        act(() => getByTestId('1').focus());
+        expect(getByTestId('1')).to.have.attribute('data-active');
+
+        fireEvent.keyDown(getByTestId('1'), { key: 'ArrowDown' });
+        expect(getByTestId('4')).to.have.attribute('data-active');
+        expect(getByTestId('4')).to.have.attribute('tabindex', '0');
+        expect(getByTestId('4')).toHaveFocus();
+
+        fireEvent.keyDown(getByTestId('4'), { key: 'ArrowLeft' });
+        expect(getByTestId('5')).to.have.attribute('data-active');
+        expect(getByTestId('5')).to.have.attribute('tabindex', '0');
+        expect(getByTestId('5')).toHaveFocus();
+
+        fireEvent.keyDown(getByTestId('5'), { key: 'ArrowDown' });
+        expect(getByTestId('8')).to.have.attribute('data-active');
+        expect(getByTestId('8')).to.have.attribute('tabindex', '0');
+        expect(getByTestId('8')).toHaveFocus();
+
+        fireEvent.keyDown(getByTestId('8'), { key: 'ArrowRight' });
+        expect(getByTestId('7')).to.have.attribute('data-active');
+        expect(getByTestId('7')).to.have.attribute('tabindex', '0');
+        expect(getByTestId('7')).toHaveFocus();
+
+        fireEvent.keyDown(getByTestId('7'), { key: 'ArrowUp' });
+        expect(getByTestId('4')).to.have.attribute('data-active');
+        expect(getByTestId('4')).to.have.attribute('tabindex', '0');
+        expect(getByTestId('4')).toHaveFocus();
+
+        act(() => getByTestId('9').focus());
+        expect(getByTestId('9')).to.have.attribute('data-active');
+        expect(getByTestId('9')).to.have.attribute('tabindex', '0');
+
+        fireEvent.keyDown(getByTestId('9'), { key: 'Home' });
+        expect(getByTestId('1')).to.have.attribute('data-active');
+        expect(getByTestId('1')).to.have.attribute('tabindex', '0');
+
+        fireEvent.keyDown(getByTestId('1'), { key: 'End' });
+        expect(getByTestId('9')).to.have.attribute('data-active');
+        expect(getByTestId('9')).to.have.attribute('tabindex', '0');
+      });
     });
   });
 });

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
@@ -388,7 +388,7 @@ describe('Composite', () => {
           <div dir="rtl">
             <CompositeRoot cols={3} orientation="both" enableHomeAndEndKeys>
               {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map((i) => (
-                <CompositeItem key={i} data-testid={i} style={{ width: 32, height: 32 }}>
+                <CompositeItem key={i} data-testid={i}>
                   {i}
                 </CompositeItem>
               ))}

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, createRenderer, fireEvent, flushMicrotasks } from '@mui/internal-test-utils';
+import { act, createRenderer, fireEvent } from '@mui/internal-test-utils';
 import { CompositeItem } from '../Item/CompositeItem';
 import { CompositeRoot } from './CompositeRoot';
 
@@ -31,25 +31,21 @@ describe('Composite', () => {
       expect(item1).to.have.attribute('data-active');
 
       fireEvent.keyDown(item1, { key: 'ArrowDown' });
-      await flushMicrotasks();
       expect(item2).to.have.attribute('data-active');
       expect(item2).to.have.attribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowDown' });
-      await flushMicrotasks();
       expect(item3).to.have.attribute('data-active');
       expect(item3).to.have.attribute('tabindex', '0');
       expect(item3).toHaveFocus();
 
       fireEvent.keyDown(item3, { key: 'ArrowUp' });
-      await flushMicrotasks();
       expect(item2).to.have.attribute('data-active');
       expect(item2).to.have.attribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowUp' });
-      await flushMicrotasks();
       expect(item1).to.have.attribute('data-active');
       expect(item1).to.have.attribute('tabindex', '0');
       expect(item1).toHaveFocus();
@@ -73,25 +69,21 @@ describe('Composite', () => {
       expect(item1).to.have.attribute('data-active');
 
       fireEvent.keyDown(item1, { key: 'ArrowDown' });
-      await flushMicrotasks();
       expect(item2).to.have.attribute('data-active');
       expect(item2).to.have.attribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowDown' });
-      await flushMicrotasks();
       expect(item3).to.have.attribute('data-active');
       expect(item3).to.have.attribute('tabindex', '0');
       expect(item3).toHaveFocus();
 
       fireEvent.keyDown(item3, { key: 'ArrowUp' });
-      await flushMicrotasks();
       expect(item2).to.have.attribute('data-active');
       expect(item2).to.have.attribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowUp' });
-      await flushMicrotasks();
       expect(item1).to.have.attribute('data-active');
       expect(item1).to.have.attribute('tabindex', '0');
       expect(item1).toHaveFocus();
@@ -116,36 +108,30 @@ describe('Composite', () => {
         expect(item1).to.have.attribute('data-active');
 
         fireEvent.keyDown(item1, { key: 'ArrowDown' });
-        await flushMicrotasks();
         expect(item1).to.have.attribute('data-active');
 
         fireEvent.keyDown(item1, { key: 'ArrowLeft' });
-        await flushMicrotasks();
         expect(item2).to.have.attribute('data-active');
         expect(item2).to.have.attribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowLeft' });
-        await flushMicrotasks();
         expect(item3).to.have.attribute('data-active');
         expect(item3).to.have.attribute('tabindex', '0');
         expect(item3).toHaveFocus();
 
         fireEvent.keyDown(item3, { key: 'ArrowRight' });
-        await flushMicrotasks();
         expect(item2).to.have.attribute('data-active');
         expect(item2).to.have.attribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowRight' });
-        await flushMicrotasks();
         expect(item1).to.have.attribute('data-active');
         expect(item1).to.have.attribute('tabindex', '0');
         expect(item1).toHaveFocus();
 
         // loop backward
         fireEvent.keyDown(item1, { key: 'ArrowRight' });
-        await flushMicrotasks();
         expect(item3).to.have.attribute('data-active');
         expect(item3).to.have.attribute('tabindex', '0');
         expect(item3).toHaveFocus();
@@ -169,37 +155,31 @@ describe('Composite', () => {
         expect(item1).to.have.attribute('data-active');
 
         fireEvent.keyDown(item1, { key: 'ArrowLeft' });
-        await flushMicrotasks();
         expect(item2).to.have.attribute('data-active');
         expect(item2).to.have.attribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowLeft' });
-        await flushMicrotasks();
         expect(item3).to.have.attribute('data-active');
         expect(item3).to.have.attribute('tabindex', '0');
         expect(item3).toHaveFocus();
 
         fireEvent.keyDown(item3, { key: 'ArrowRight' });
-        await flushMicrotasks();
         expect(item2).to.have.attribute('data-active');
         expect(item2).to.have.attribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowRight' });
-        await flushMicrotasks();
         expect(item1).to.have.attribute('data-active');
         expect(item1).to.have.attribute('tabindex', '0');
         expect(item1).toHaveFocus();
 
         fireEvent.keyDown(item1, { key: 'ArrowDown' });
-        await flushMicrotasks();
         expect(item2).to.have.attribute('data-active');
         expect(item2).to.have.attribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowDown' });
-        await flushMicrotasks();
         expect(item3).to.have.attribute('data-active');
         expect(item3).to.have.attribute('tabindex', '0');
         expect(item3).toHaveFocus();
@@ -228,37 +208,31 @@ describe('Composite', () => {
       expect(getByTestId('1')).to.have.attribute('data-active');
 
       fireEvent.keyDown(getByTestId('1'), { key: 'ArrowDown' });
-      await flushMicrotasks();
       expect(getByTestId('4')).to.have.attribute('data-active');
       expect(getByTestId('4')).to.have.attribute('tabindex', '0');
       expect(getByTestId('4')).toHaveFocus();
 
       fireEvent.keyDown(getByTestId('4'), { key: 'ArrowRight' });
-      await flushMicrotasks();
       expect(getByTestId('5')).to.have.attribute('data-active');
       expect(getByTestId('5')).to.have.attribute('tabindex', '0');
       expect(getByTestId('5')).toHaveFocus();
 
       fireEvent.keyDown(getByTestId('5'), { key: 'ArrowDown' });
-      await flushMicrotasks();
       expect(getByTestId('8')).to.have.attribute('data-active');
       expect(getByTestId('8')).to.have.attribute('tabindex', '0');
       expect(getByTestId('8')).toHaveFocus();
 
       fireEvent.keyDown(getByTestId('8'), { key: 'ArrowLeft' });
-      await flushMicrotasks();
       expect(getByTestId('7')).to.have.attribute('data-active');
       expect(getByTestId('7')).to.have.attribute('tabindex', '0');
       expect(getByTestId('7')).toHaveFocus();
 
       fireEvent.keyDown(getByTestId('7'), { key: 'ArrowUp' });
-      await flushMicrotasks();
       expect(getByTestId('4')).to.have.attribute('data-active');
       expect(getByTestId('4')).to.have.attribute('tabindex', '0');
       expect(getByTestId('4')).toHaveFocus();
 
       act(() => getByTestId('9').focus());
-      await flushMicrotasks();
       expect(getByTestId('9')).to.have.attribute('data-active');
       expect(getByTestId('9')).to.have.attribute('tabindex', '0');
     });

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, createRenderer, fireEvent } from '@mui/internal-test-utils';
+import { act, createRenderer, describeSkipIf, fireEvent } from '@mui/internal-test-utils';
 import { CompositeItem } from '../Item/CompositeItem';
 import { CompositeRoot } from './CompositeRoot';
+
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('Composite', () => {
   const { render } = createRenderer();
@@ -89,14 +91,16 @@ describe('Composite', () => {
       expect(item1).toHaveFocus();
     });
 
-    describe('prop: isRtl', () => {
+    describeSkipIf(isJSDOM)('rtl', () => {
       it('horizontal orientation', async () => {
         const { getByTestId } = render(
-          <CompositeRoot isRtl orientation="horizontal">
-            <CompositeItem data-testid="1">1</CompositeItem>
-            <CompositeItem data-testid="2">2</CompositeItem>
-            <CompositeItem data-testid="3">3</CompositeItem>
-          </CompositeRoot>,
+          <div dir="rtl">
+            <CompositeRoot orientation="horizontal">
+              <CompositeItem data-testid="1">1</CompositeItem>
+              <CompositeItem data-testid="2">2</CompositeItem>
+              <CompositeItem data-testid="3">3</CompositeItem>
+            </CompositeRoot>
+          </div>,
         );
 
         const item1 = getByTestId('1');
@@ -139,11 +143,13 @@ describe('Composite', () => {
 
       it('both horizontal and vertical orientation', async () => {
         const { getByTestId } = render(
-          <CompositeRoot isRtl orientation="both">
-            <CompositeItem data-testid="1">1</CompositeItem>
-            <CompositeItem data-testid="2">2</CompositeItem>
-            <CompositeItem data-testid="3">3</CompositeItem>
-          </CompositeRoot>,
+          <div dir="rtl">
+            <CompositeRoot orientation="both">
+              <CompositeItem data-testid="1">1</CompositeItem>
+              <CompositeItem data-testid="2">2</CompositeItem>
+              <CompositeItem data-testid="3">3</CompositeItem>
+            </CompositeRoot>
+          </div>,
         );
 
         const item1 = getByTestId('1');

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
@@ -122,6 +122,7 @@ describe('Composite', () => {
         expect(item3).to.have.attribute('data-active');
 
         fireEvent.keyDown(item3, { key: 'Home' });
+        await flushMicrotasks();
         expect(item1).to.have.attribute('data-active');
         expect(item1).to.have.attribute('tabindex', '0');
         expect(item1).toHaveFocus();
@@ -143,6 +144,7 @@ describe('Composite', () => {
         expect(item1).to.have.attribute('data-active');
 
         fireEvent.keyDown(item1, { key: 'End' });
+        await flushMicrotasks();
         expect(item3).to.have.attribute('data-active');
         expect(item3).to.have.attribute('tabindex', '0');
         expect(item3).toHaveFocus();
@@ -319,10 +321,12 @@ describe('Composite', () => {
       expect(getByTestId('9')).to.have.attribute('tabindex', '0');
 
       fireEvent.keyDown(getByTestId('9'), { key: 'Home' });
+      await flushMicrotasks();
       expect(getByTestId('1')).to.have.attribute('data-active');
       expect(getByTestId('1')).to.have.attribute('tabindex', '0');
 
       fireEvent.keyDown(getByTestId('1'), { key: 'End' });
+      await flushMicrotasks();
       expect(getByTestId('9')).to.have.attribute('data-active');
       expect(getByTestId('9')).to.have.attribute('tabindex', '0');
     });
@@ -345,30 +349,36 @@ describe('Composite', () => {
         expect(getByTestId('1')).to.have.attribute('data-active');
 
         fireEvent.keyDown(getByTestId('1'), { key: 'ArrowLeft' });
+        await flushMicrotasks();
         expect(getByTestId('2')).to.have.attribute('data-active');
         expect(getByTestId('2')).to.have.attribute('tabindex', '0');
         expect(getByTestId('2')).toHaveFocus();
 
         fireEvent.keyDown(getByTestId('2'), { key: 'ArrowLeft' });
+        await flushMicrotasks();
         expect(getByTestId('3')).to.have.attribute('data-active');
         expect(getByTestId('3')).to.have.attribute('tabindex', '0');
         expect(getByTestId('3')).toHaveFocus();
 
         fireEvent.keyDown(getByTestId('3'), { key: 'ArrowLeft' });
+        await flushMicrotasks();
         expect(getByTestId('4')).to.have.attribute('data-active');
         expect(getByTestId('4')).to.have.attribute('tabindex', '0');
         expect(getByTestId('4')).toHaveFocus();
 
         fireEvent.keyDown(getByTestId('4'), { key: 'ArrowLeft' });
+        await flushMicrotasks();
         expect(getByTestId('5')).to.have.attribute('data-active');
         expect(getByTestId('5')).to.have.attribute('tabindex', '0');
         expect(getByTestId('5')).toHaveFocus();
 
         fireEvent.keyDown(getByTestId('5'), { key: 'Home' });
+        await flushMicrotasks();
         expect(getByTestId('1')).to.have.attribute('data-active');
         expect(getByTestId('1')).to.have.attribute('tabindex', '0');
 
         fireEvent.keyDown(getByTestId('1'), { key: 'End' });
+        await flushMicrotasks();
         expect(getByTestId('9')).to.have.attribute('data-active');
         expect(getByTestId('9')).to.have.attribute('tabindex', '0');
       });
@@ -390,41 +400,44 @@ describe('Composite', () => {
         expect(getByTestId('1')).to.have.attribute('data-active');
 
         fireEvent.keyDown(getByTestId('1'), { key: 'ArrowDown' });
+        await flushMicrotasks();
         expect(getByTestId('4')).to.have.attribute('data-active');
         expect(getByTestId('4')).to.have.attribute('tabindex', '0');
         expect(getByTestId('4')).toHaveFocus();
 
         fireEvent.keyDown(getByTestId('4'), { key: 'ArrowLeft' });
+        await flushMicrotasks();
         expect(getByTestId('5')).to.have.attribute('data-active');
         expect(getByTestId('5')).to.have.attribute('tabindex', '0');
         expect(getByTestId('5')).toHaveFocus();
 
         fireEvent.keyDown(getByTestId('5'), { key: 'ArrowDown' });
+        await flushMicrotasks();
         expect(getByTestId('8')).to.have.attribute('data-active');
         expect(getByTestId('8')).to.have.attribute('tabindex', '0');
         expect(getByTestId('8')).toHaveFocus();
 
         fireEvent.keyDown(getByTestId('8'), { key: 'ArrowRight' });
+        await flushMicrotasks();
         expect(getByTestId('7')).to.have.attribute('data-active');
         expect(getByTestId('7')).to.have.attribute('tabindex', '0');
         expect(getByTestId('7')).toHaveFocus();
 
         fireEvent.keyDown(getByTestId('7'), { key: 'ArrowUp' });
+        await flushMicrotasks();
         expect(getByTestId('4')).to.have.attribute('data-active');
         expect(getByTestId('4')).to.have.attribute('tabindex', '0');
         expect(getByTestId('4')).toHaveFocus();
 
-        act(() => getByTestId('9').focus());
+        fireEvent.keyDown(getByTestId('4'), { key: 'End' });
+        await flushMicrotasks();
         expect(getByTestId('9')).to.have.attribute('data-active');
         expect(getByTestId('9')).to.have.attribute('tabindex', '0');
 
         fireEvent.keyDown(getByTestId('9'), { key: 'Home' });
+        await flushMicrotasks();
         expect(getByTestId('1')).to.have.attribute('data-active');
         expect(getByTestId('1')).to.have.attribute('tabindex', '0');
-
-        fireEvent.keyDown(getByTestId('1'), { key: 'End' });
-        expect(getByTestId('9')).to.have.attribute('data-active');
-        expect(getByTestId('9')).to.have.attribute('tabindex', '0');
       });
     });
   });

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
@@ -96,5 +96,171 @@ describe('Composite', () => {
       expect(item1).to.have.attribute('tabindex', '0');
       expect(item1).toHaveFocus();
     });
+
+    describe('prop: isRtl', () => {
+      it('horizontal orientation', async () => {
+        const { getByTestId } = render(
+          <CompositeRoot isRtl orientation="horizontal">
+            <CompositeItem data-testid="1">1</CompositeItem>
+            <CompositeItem data-testid="2">2</CompositeItem>
+            <CompositeItem data-testid="3">3</CompositeItem>
+          </CompositeRoot>,
+        );
+
+        const item1 = getByTestId('1');
+        const item2 = getByTestId('2');
+        const item3 = getByTestId('3');
+
+        act(() => item1.focus());
+
+        expect(item1).to.have.attribute('data-active');
+
+        fireEvent.keyDown(item1, { key: 'ArrowDown' });
+        await flushMicrotasks();
+        expect(item1).to.have.attribute('data-active');
+
+        fireEvent.keyDown(item1, { key: 'ArrowLeft' });
+        await flushMicrotasks();
+        expect(item2).to.have.attribute('data-active');
+        expect(item2).to.have.attribute('tabindex', '0');
+        expect(item2).toHaveFocus();
+
+        fireEvent.keyDown(item2, { key: 'ArrowLeft' });
+        await flushMicrotasks();
+        expect(item3).to.have.attribute('data-active');
+        expect(item3).to.have.attribute('tabindex', '0');
+        expect(item3).toHaveFocus();
+
+        fireEvent.keyDown(item3, { key: 'ArrowRight' });
+        await flushMicrotasks();
+        expect(item2).to.have.attribute('data-active');
+        expect(item2).to.have.attribute('tabindex', '0');
+        expect(item2).toHaveFocus();
+
+        fireEvent.keyDown(item2, { key: 'ArrowRight' });
+        await flushMicrotasks();
+        expect(item1).to.have.attribute('data-active');
+        expect(item1).to.have.attribute('tabindex', '0');
+        expect(item1).toHaveFocus();
+
+        // loop backward
+        fireEvent.keyDown(item1, { key: 'ArrowRight' });
+        await flushMicrotasks();
+        expect(item3).to.have.attribute('data-active');
+        expect(item3).to.have.attribute('tabindex', '0');
+        expect(item3).toHaveFocus();
+      });
+
+      it('both horizontal and vertical orientation', async () => {
+        const { getByTestId } = render(
+          <CompositeRoot isRtl orientation="both">
+            <CompositeItem data-testid="1">1</CompositeItem>
+            <CompositeItem data-testid="2">2</CompositeItem>
+            <CompositeItem data-testid="3">3</CompositeItem>
+          </CompositeRoot>,
+        );
+
+        const item1 = getByTestId('1');
+        const item2 = getByTestId('2');
+        const item3 = getByTestId('3');
+
+        act(() => item1.focus());
+
+        expect(item1).to.have.attribute('data-active');
+
+        fireEvent.keyDown(item1, { key: 'ArrowLeft' });
+        await flushMicrotasks();
+        expect(item2).to.have.attribute('data-active');
+        expect(item2).to.have.attribute('tabindex', '0');
+        expect(item2).toHaveFocus();
+
+        fireEvent.keyDown(item2, { key: 'ArrowLeft' });
+        await flushMicrotasks();
+        expect(item3).to.have.attribute('data-active');
+        expect(item3).to.have.attribute('tabindex', '0');
+        expect(item3).toHaveFocus();
+
+        fireEvent.keyDown(item3, { key: 'ArrowRight' });
+        await flushMicrotasks();
+        expect(item2).to.have.attribute('data-active');
+        expect(item2).to.have.attribute('tabindex', '0');
+        expect(item2).toHaveFocus();
+
+        fireEvent.keyDown(item2, { key: 'ArrowRight' });
+        await flushMicrotasks();
+        expect(item1).to.have.attribute('data-active');
+        expect(item1).to.have.attribute('tabindex', '0');
+        expect(item1).toHaveFocus();
+
+        fireEvent.keyDown(item1, { key: 'ArrowDown' });
+        await flushMicrotasks();
+        expect(item2).to.have.attribute('data-active');
+        expect(item2).to.have.attribute('tabindex', '0');
+        expect(item2).toHaveFocus();
+
+        fireEvent.keyDown(item2, { key: 'ArrowDown' });
+        await flushMicrotasks();
+        expect(item3).to.have.attribute('data-active');
+        expect(item3).to.have.attribute('tabindex', '0');
+        expect(item3).toHaveFocus();
+      });
+    });
+  });
+
+  describe('grid', () => {
+    it('uniform 1x1 items', async () => {
+      function App() {
+        return (
+          // 1 to 9 numpad
+          <CompositeRoot cols={3}>
+            {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map((i) => (
+              <CompositeItem key={i} data-testid={i}>
+                {i}
+              </CompositeItem>
+            ))}
+          </CompositeRoot>
+        );
+      }
+
+      const { getByTestId } = await render(<App />);
+
+      act(() => getByTestId('1').focus());
+      expect(getByTestId('1')).to.have.attribute('data-active');
+
+      fireEvent.keyDown(getByTestId('1'), { key: 'ArrowDown' });
+      await flushMicrotasks();
+      expect(getByTestId('4')).to.have.attribute('data-active');
+      expect(getByTestId('4')).to.have.attribute('tabindex', '0');
+      expect(getByTestId('4')).toHaveFocus();
+
+      fireEvent.keyDown(getByTestId('4'), { key: 'ArrowRight' });
+      await flushMicrotasks();
+      expect(getByTestId('5')).to.have.attribute('data-active');
+      expect(getByTestId('5')).to.have.attribute('tabindex', '0');
+      expect(getByTestId('5')).toHaveFocus();
+
+      fireEvent.keyDown(getByTestId('5'), { key: 'ArrowDown' });
+      await flushMicrotasks();
+      expect(getByTestId('8')).to.have.attribute('data-active');
+      expect(getByTestId('8')).to.have.attribute('tabindex', '0');
+      expect(getByTestId('8')).toHaveFocus();
+
+      fireEvent.keyDown(getByTestId('8'), { key: 'ArrowLeft' });
+      await flushMicrotasks();
+      expect(getByTestId('7')).to.have.attribute('data-active');
+      expect(getByTestId('7')).to.have.attribute('tabindex', '0');
+      expect(getByTestId('7')).toHaveFocus();
+
+      fireEvent.keyDown(getByTestId('7'), { key: 'ArrowUp' });
+      await flushMicrotasks();
+      expect(getByTestId('4')).to.have.attribute('data-active');
+      expect(getByTestId('4')).to.have.attribute('tabindex', '0');
+      expect(getByTestId('4')).toHaveFocus();
+
+      act(() => getByTestId('9').focus());
+      await flushMicrotasks();
+      expect(getByTestId('9')).to.have.attribute('data-active');
+      expect(getByTestId('9')).to.have.attribute('tabindex', '0');
+    });
   });
 });

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
@@ -91,6 +91,50 @@ describe('Composite', () => {
       expect(item1).toHaveFocus();
     });
 
+    describe('Home and End keys', () => {
+      it('Home key moves focus to the first item', async () => {
+        const { getByTestId } = render(
+          <CompositeRoot enableHomeAndEndKeys>
+            <CompositeItem data-testid="1">1</CompositeItem>
+            <CompositeItem data-testid="2">2</CompositeItem>
+            <CompositeItem data-testid="3">3</CompositeItem>
+          </CompositeRoot>,
+        );
+
+        const item1 = getByTestId('1');
+        const item3 = getByTestId('3');
+
+        act(() => item3.focus());
+        expect(item3).to.have.attribute('data-active');
+
+        fireEvent.keyDown(item3, { key: 'Home' });
+        expect(item1).to.have.attribute('data-active');
+        expect(item1).to.have.attribute('tabindex', '0');
+        expect(item1).toHaveFocus();
+      })
+
+      it('End key moves focus to the last item', async () => {
+        const { getByTestId } = render(
+          <CompositeRoot enableHomeAndEndKeys>
+            <CompositeItem data-testid="1">1</CompositeItem>
+            <CompositeItem data-testid="2">2</CompositeItem>
+            <CompositeItem data-testid="3">3</CompositeItem>
+          </CompositeRoot>,
+        );
+
+        const item1 = getByTestId('1');
+        const item3 = getByTestId('3');
+
+        act(() => item1.focus());
+        expect(item1).to.have.attribute('data-active');
+
+        fireEvent.keyDown(item1, { key: 'End' });
+        expect(item3).to.have.attribute('data-active');
+        expect(item3).to.have.attribute('tabindex', '0');
+        expect(item3).toHaveFocus();
+      })
+    })
+
     describeSkipIf(isJSDOM)('rtl', () => {
       it('horizontal orientation', async () => {
         const { getByTestId } = render(
@@ -198,7 +242,7 @@ describe('Composite', () => {
       function App() {
         return (
           // 1 to 9 numpad
-          <CompositeRoot cols={3}>
+          <CompositeRoot cols={3} enableHomeAndEndKeys>
             {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map((i) => (
               <CompositeItem key={i} data-testid={i}>
                 {i}
@@ -239,6 +283,14 @@ describe('Composite', () => {
       expect(getByTestId('4')).toHaveFocus();
 
       act(() => getByTestId('9').focus());
+      expect(getByTestId('9')).to.have.attribute('data-active');
+      expect(getByTestId('9')).to.have.attribute('tabindex', '0');
+
+      fireEvent.keyDown(getByTestId('9'), { key: 'Home' });
+      expect(getByTestId('1')).to.have.attribute('data-active');
+      expect(getByTestId('1')).to.have.attribute('tabindex', '0');
+
+      fireEvent.keyDown(getByTestId('1'), { key: 'End' });
       expect(getByTestId('9')).to.have.attribute('data-active');
       expect(getByTestId('9')).to.have.attribute('tabindex', '0');
     });

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.test.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { act, createRenderer, fireEvent, flushMicrotasks } from '@mui/internal-test-utils';
+import { CompositeItem } from '../Item/CompositeItem';
+import { CompositeRoot } from './CompositeRoot';
+
+describe('Composite', () => {
+  const { render } = createRenderer();
+
+  describe('list', () => {
+    it('controlled mode', async () => {
+      function App() {
+        const [activeIndex, setActiveIndex] = React.useState(0);
+        return (
+          <CompositeRoot activeIndex={activeIndex} onActiveIndexChange={setActiveIndex}>
+            <CompositeItem data-testid="1">1</CompositeItem>
+            <CompositeItem data-testid="2">2</CompositeItem>
+            <CompositeItem data-testid="3">3</CompositeItem>
+          </CompositeRoot>
+        );
+      }
+
+      const { getByTestId } = render(<App />);
+
+      const item1 = getByTestId('1');
+      const item2 = getByTestId('2');
+      const item3 = getByTestId('3');
+
+      act(() => item1.focus());
+
+      expect(item1).to.have.attribute('data-active');
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown' });
+      await flushMicrotasks();
+      expect(item2).to.have.attribute('data-active');
+      expect(item2).to.have.attribute('tabindex', '0');
+      expect(item2).toHaveFocus();
+
+      fireEvent.keyDown(item2, { key: 'ArrowDown' });
+      await flushMicrotasks();
+      expect(item3).to.have.attribute('data-active');
+      expect(item3).to.have.attribute('tabindex', '0');
+      expect(item3).toHaveFocus();
+
+      fireEvent.keyDown(item3, { key: 'ArrowUp' });
+      await flushMicrotasks();
+      expect(item2).to.have.attribute('data-active');
+      expect(item2).to.have.attribute('tabindex', '0');
+      expect(item2).toHaveFocus();
+
+      fireEvent.keyDown(item2, { key: 'ArrowUp' });
+      await flushMicrotasks();
+      expect(item1).to.have.attribute('data-active');
+      expect(item1).to.have.attribute('tabindex', '0');
+      expect(item1).toHaveFocus();
+    });
+
+    it('uncontrolled mode', async () => {
+      const { getByTestId } = render(
+        <CompositeRoot>
+          <CompositeItem data-testid="1">1</CompositeItem>
+          <CompositeItem data-testid="2">2</CompositeItem>
+          <CompositeItem data-testid="3">3</CompositeItem>
+        </CompositeRoot>,
+      );
+
+      const item1 = getByTestId('1');
+      const item2 = getByTestId('2');
+      const item3 = getByTestId('3');
+
+      act(() => item1.focus());
+
+      expect(item1).to.have.attribute('data-active');
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown' });
+      await flushMicrotasks();
+      expect(item2).to.have.attribute('data-active');
+      expect(item2).to.have.attribute('tabindex', '0');
+      expect(item2).toHaveFocus();
+
+      fireEvent.keyDown(item2, { key: 'ArrowDown' });
+      await flushMicrotasks();
+      expect(item3).to.have.attribute('data-active');
+      expect(item3).to.have.attribute('tabindex', '0');
+      expect(item3).toHaveFocus();
+
+      fireEvent.keyDown(item3, { key: 'ArrowUp' });
+      await flushMicrotasks();
+      expect(item2).to.have.attribute('data-active');
+      expect(item2).to.have.attribute('tabindex', '0');
+      expect(item2).toHaveFocus();
+
+      fireEvent.keyDown(item2, { key: 'ArrowUp' });
+      await flushMicrotasks();
+      expect(item1).to.have.attribute('data-active');
+      expect(item1).to.have.attribute('tabindex', '0');
+      expect(item1).toHaveFocus();
+    });
+  });
+});

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.tsx
@@ -105,6 +105,10 @@ CompositeRoot.propTypes /* remove-proptypes */ = {
   /**
    * @ignore
    */
+  enableHomeAndEndKeys: PropTypes.bool,
+  /**
+   * @ignore
+   */
   itemSizes: PropTypes.arrayOf(
     PropTypes.shape({
       height: PropTypes.number.isRequired,

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.tsx
@@ -25,6 +25,7 @@ const CompositeRoot = React.forwardRef(function CompositeRoot(
     itemSizes,
     loop,
     cols,
+    enableHomeAndEndKeys,
     ...otherProps
   } = props;
 
@@ -37,6 +38,7 @@ const CompositeRoot = React.forwardRef(function CompositeRoot(
     activeIndex: activeIndexProp,
     onActiveIndexChange: onActiveIndexChangeProp,
     rootRef: forwardedRef,
+    enableHomeAndEndKeys,
   });
 
   const { renderElement } = useComponentRenderer({
@@ -71,6 +73,7 @@ namespace CompositeRoot {
     onActiveIndexChange?: (index: number) => void;
     itemSizes?: Dimensions[];
     dense?: boolean;
+    enableHomeAndEndKeys?: boolean;
   }
 }
 

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.tsx
@@ -25,11 +25,19 @@ const CompositeRoot = React.forwardRef(function CompositeRoot(
     itemSizes,
     loop,
     cols,
-    isRtl,
     ...otherProps
   } = props;
 
-  const { getRootProps, activeIndex, onActiveIndexChange, elementsRef } = useCompositeRoot(props);
+  const { getRootProps, activeIndex, onActiveIndexChange, elementsRef } = useCompositeRoot({
+    itemSizes,
+    cols,
+    loop,
+    dense,
+    orientation,
+    activeIndex: activeIndexProp,
+    onActiveIndexChange: onActiveIndexChangeProp,
+    rootRef: forwardedRef,
+  });
 
   const { renderElement } = useComponentRenderer({
     propGetter: getRootProps,
@@ -59,7 +67,6 @@ namespace CompositeRoot {
     orientation?: 'horizontal' | 'vertical' | 'both';
     cols?: number;
     loop?: boolean;
-    isRtl?: boolean;
     activeIndex?: number;
     onActiveIndexChange?: (index: number) => void;
     itemSizes?: Dimensions[];
@@ -92,10 +99,6 @@ CompositeRoot.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   dense: PropTypes.bool,
-  /**
-   * @ignore
-   */
-  isRtl: PropTypes.bool,
   /**
    * @ignore
    */

--- a/packages/mui-base/src/Composite/Root/CompositeRoot.tsx
+++ b/packages/mui-base/src/Composite/Root/CompositeRoot.tsx
@@ -25,6 +25,7 @@ const CompositeRoot = React.forwardRef(function CompositeRoot(
     itemSizes,
     loop,
     cols,
+    isRtl,
     ...otherProps
   } = props;
 
@@ -58,6 +59,7 @@ namespace CompositeRoot {
     orientation?: 'horizontal' | 'vertical' | 'both';
     cols?: number;
     loop?: boolean;
+    isRtl?: boolean;
     activeIndex?: number;
     onActiveIndexChange?: (index: number) => void;
     itemSizes?: Dimensions[];
@@ -90,6 +92,10 @@ CompositeRoot.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   dense: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  isRtl: PropTypes.bool,
   /**
    * @ignore
    */

--- a/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
+++ b/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
@@ -172,29 +172,19 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
             ] as number; // navigated cell will never be nullish
           }
 
-          const toEndKeys = isRtl
-            ? {
-                horizontal: [ARROW_LEFT],
-                vertical: [ARROW_DOWN],
-                both: [ARROW_LEFT, ARROW_DOWN],
-              }[orientation]
-            : {
-                horizontal: [ARROW_RIGHT],
-                vertical: [ARROW_DOWN],
-                both: [ARROW_RIGHT, ARROW_DOWN],
-              }[orientation];
+          const horizontalEndKey = isRtl ? ARROW_LEFT : ARROW_RIGHT;
+          const toEndKeys = {
+            horizontal: [horizontalEndKey],
+            vertical: [ARROW_DOWN],
+            both: [horizontalEndKey, ARROW_DOWN],
+          }[orientation];
 
-          const toStartKeys = isRtl
-            ? {
-                horizontal: [ARROW_RIGHT],
-                vertical: [ARROW_UP],
-                both: [ARROW_RIGHT, ARROW_UP],
-              }[orientation]
-            : {
-                horizontal: [ARROW_LEFT],
-                vertical: [ARROW_UP],
-                both: [ARROW_LEFT, ARROW_UP],
-              }[orientation];
+          const horizontalStartKey = isRtl ? ARROW_RIGHT : ARROW_LEFT;
+          const toStartKeys = {
+            horizontal: [horizontalStartKey],
+            vertical: [ARROW_UP],
+            both: [horizontalStartKey, ARROW_UP],
+          }[orientation];
 
           const preventedKeys = isGrid
             ? RELEVANT_KEYS

--- a/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
+++ b/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
@@ -193,10 +193,7 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
 
             onActiveIndexChange(nextIndex);
 
-            // Wait for FocusManager `returnFocus` to execute.
-            queueMicrotask(() => {
-              elementsRef.current[nextIndex]?.focus();
-            });
+            elementsRef.current[nextIndex]?.focus();
           }
         },
       }),

--- a/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
+++ b/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
@@ -1,13 +1,11 @@
 'use client';
 import * as React from 'react';
-import { hasComputedStyleMapSupport } from '../../utils/hasComputedStyleMapSupport';
 import { mergeReactProps } from '../../utils/mergeReactProps';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useForkRef } from '../../utils/useForkRef';
-import { ownerWindow } from '../../utils/owner';
 import {
   ALL_KEYS,
-  ALL_KEYS_WITH_EXTRA_KEYS,
+  ARROW_KEYS,
   ARROW_DOWN,
   ARROW_LEFT,
   ARROW_RIGHT,
@@ -21,6 +19,7 @@ import {
   getGridNavigatedIndex,
   getMaxIndex,
   getMinIndex,
+  getTextDirection,
   HORIZONTAL_KEYS,
   HORIZONTAL_KEYS_WITH_EXTRA_KEYS,
   isDisabled,
@@ -40,17 +39,12 @@ export interface UseCompositeRootParameters {
   dense?: boolean;
   itemSizes?: Array<Dimensions>;
   rootRef?: React.Ref<Element>;
+  /**
+   * When `true`, pressing the Home key moves focus to the first item,
+   * and pressing the End key moves focus to the last item.
+   * @default false
+   */
   enableHomeAndEndKeys?: boolean;
-}
-
-function getTextDirection(element: HTMLElement): TextDirection {
-  if (hasComputedStyleMapSupport()) {
-    const direction = element.computedStyleMap().get('direction');
-
-    return (direction as CSSKeywordValue)?.value as TextDirection;
-  }
-
-  return ownerWindow(element).getComputedStyle(element).direction as TextDirection;
 }
 
 // Advanced options of Composite, to be implemented later if needed.
@@ -101,9 +95,9 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
         'aria-orientation': orientation === 'both' ? undefined : orientation,
         ref: mergedRef,
         onKeyDown(event) {
-          const ALL_RELEVANT_KEYS = enableHomeAndEndKeys ? ALL_KEYS_WITH_EXTRA_KEYS : ALL_KEYS;
+          const RELEVANT_KEYS = enableHomeAndEndKeys ? ALL_KEYS : ARROW_KEYS;
 
-          if (!ALL_RELEVANT_KEYS.includes(event.key)) {
+          if (!RELEVANT_KEYS.includes(event.key)) {
             return;
           }
 
@@ -203,13 +197,13 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
               }[orientation];
 
           const preventedKeys = isGrid
-            ? ALL_RELEVANT_KEYS
+            ? RELEVANT_KEYS
             : {
                 horizontal: enableHomeAndEndKeys
                   ? HORIZONTAL_KEYS_WITH_EXTRA_KEYS
                   : HORIZONTAL_KEYS,
                 vertical: enableHomeAndEndKeys ? VERTICAL_KEYS_WITH_EXTRA_KEYS : VERTICAL_KEYS,
-                both: ALL_RELEVANT_KEYS,
+                both: RELEVANT_KEYS,
               }[orientation];
 
           if (enableHomeAndEndKeys) {

--- a/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
+++ b/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
@@ -28,6 +28,7 @@ import {
   VERTICAL_KEYS,
   VERTICAL_KEYS_WITH_EXTRA_KEYS,
   type Dimensions,
+  type TextDirection,
 } from '../composite';
 
 export interface UseCompositeRootParameters {
@@ -41,8 +42,6 @@ export interface UseCompositeRootParameters {
   rootRef?: React.Ref<Element>;
   enableHomeAndEndKeys?: boolean;
 }
-
-type TextDirection = 'ltr' | 'rtl';
 
 function getTextDirection(element: HTMLElement): TextDirection {
   if (hasComputedStyleMapSupport()) {
@@ -108,9 +107,7 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
             return;
           }
 
-          // isRtl not yet supported for grids (cols > 1)
           const isRtl = textDirectionRef?.current === 'rtl';
-          // console.log('isRtl', isRtl);
 
           let nextIndex = activeIndex;
           const minIndex = getMinIndex(elementsRef, disabledIndices);
@@ -175,6 +172,7 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
                     // eslint-disable-next-line no-nested-ternary
                     event.key === ARROW_DOWN ? 'bl' : event.key === ARROW_RIGHT ? 'tr' : 'tl',
                   ),
+                  rtl: isRtl,
                 },
               )
             ] as number; // navigated cell will never be nullish
@@ -207,7 +205,9 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
           const preventedKeys = isGrid
             ? ALL_RELEVANT_KEYS
             : {
-                horizontal: enableHomeAndEndKeys ? HORIZONTAL_KEYS_WITH_EXTRA_KEYS : HORIZONTAL_KEYS,
+                horizontal: enableHomeAndEndKeys
+                  ? HORIZONTAL_KEYS_WITH_EXTRA_KEYS
+                  : HORIZONTAL_KEYS,
                 vertical: enableHomeAndEndKeys ? VERTICAL_KEYS_WITH_EXTRA_KEYS : VERTICAL_KEYS,
                 both: ALL_RELEVANT_KEYS,
               }[orientation];

--- a/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
+++ b/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
@@ -237,7 +237,10 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
 
             onActiveIndexChange(nextIndex);
 
-            elementsRef.current[nextIndex]?.focus();
+            // Wait for FocusManager `returnFocus` to execute.
+            queueMicrotask(() => {
+              elementsRef.current[nextIndex]?.focus();
+            });
           }
         },
       }),

--- a/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
+++ b/packages/mui-base/src/Composite/Root/useCompositeRoot.ts
@@ -25,6 +25,8 @@ import {
 export interface UseCompositeRootParameters {
   orientation?: 'horizontal' | 'vertical' | 'both';
   cols?: number;
+  // isRtl not yet supported for grids (cols > 1)
+  isRtl?: boolean;
   loop?: boolean;
   activeIndex?: number;
   onActiveIndexChange?: (index: number) => void;
@@ -42,6 +44,7 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
   const {
     itemSizes,
     cols = 1,
+    isRtl = false,
     loop = true,
     dense = false,
     orientation = 'both',
@@ -135,17 +138,29 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
             ] as number; // navigated cell will never be nullish
           }
 
-          const toEndKeys = {
-            horizontal: [ARROW_RIGHT],
-            vertical: [ARROW_DOWN],
-            both: [ARROW_RIGHT, ARROW_DOWN],
-          }[orientation];
+          const toEndKeys = isRtl
+            ? {
+                horizontal: [ARROW_LEFT],
+                vertical: [ARROW_DOWN],
+                both: [ARROW_LEFT, ARROW_DOWN],
+              }[orientation]
+            : {
+                horizontal: [ARROW_RIGHT],
+                vertical: [ARROW_DOWN],
+                both: [ARROW_RIGHT, ARROW_DOWN],
+              }[orientation];
 
-          const toStartKeys = {
-            horizontal: [ARROW_LEFT],
-            vertical: [ARROW_UP],
-            both: [ARROW_LEFT, ARROW_UP],
-          }[orientation];
+          const toStartKeys = isRtl
+            ? {
+                horizontal: [ARROW_RIGHT],
+                vertical: [ARROW_UP],
+                both: [ARROW_RIGHT, ARROW_UP],
+              }[orientation]
+            : {
+                horizontal: [ARROW_LEFT],
+                vertical: [ARROW_UP],
+                both: [ARROW_LEFT, ARROW_UP],
+              }[orientation];
 
           const preventedKeys = isGrid
             ? ALL_KEYS
@@ -191,6 +206,7 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
       dense,
       elementsRef,
       isGrid,
+      isRtl,
       itemSizes,
       loop,
       onActiveIndexChange,

--- a/packages/mui-base/src/Composite/composite.ts
+++ b/packages/mui-base/src/Composite/composite.ts
@@ -9,10 +9,15 @@ export const ARROW_UP = 'ArrowUp';
 export const ARROW_DOWN = 'ArrowDown';
 export const ARROW_LEFT = 'ArrowLeft';
 export const ARROW_RIGHT = 'ArrowRight';
+export const HOME = 'Home';
+export const END = 'End';
 
 export const HORIZONTAL_KEYS = [ARROW_LEFT, ARROW_RIGHT];
+export const HORIZONTAL_KEYS_WITH_EXTRA_KEYS = [ARROW_LEFT, ARROW_RIGHT, HOME, END];
 export const VERTICAL_KEYS = [ARROW_UP, ARROW_DOWN];
+export const VERTICAL_KEYS_WITH_EXTRA_KEYS = [ARROW_UP, ARROW_DOWN, HOME, END];
 export const ALL_KEYS = [...HORIZONTAL_KEYS, ...VERTICAL_KEYS];
+export const ALL_KEYS_WITH_EXTRA_KEYS = [...ALL_KEYS, HOME, END];
 
 function stopEvent(event: Event | React.SyntheticEvent) {
   event.preventDefault();

--- a/packages/mui-base/src/Composite/composite.ts
+++ b/packages/mui-base/src/Composite/composite.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+export type TextDirection = 'ltr' | 'rtl';
+
 export interface Dimensions {
   width: number;
   height: number;
@@ -88,6 +90,7 @@ export function getGridNavigatedIndex(
     minIndex,
     maxIndex,
     prevIndex,
+    rtl,
     stopEvent: stop = false,
   }: {
     event: React.KeyboardEvent;
@@ -98,6 +101,7 @@ export function getGridNavigatedIndex(
     minIndex: number;
     maxIndex: number;
     prevIndex: number;
+    rtl: boolean;
     stopEvent?: boolean;
   },
 ) {
@@ -166,9 +170,12 @@ export function getGridNavigatedIndex(
 
   // Remains on the same row/column.
   if (orientation === 'both') {
+    const nextKey = rtl ? ARROW_LEFT : ARROW_RIGHT;
+    const prevKey = rtl ? ARROW_RIGHT : ARROW_LEFT;
+
     const prevRow = Math.floor(prevIndex / cols);
 
-    if (event.key === ARROW_RIGHT) {
+    if (event.key === nextKey) {
       if (stop) {
         stopEvent(event);
       }
@@ -197,7 +204,7 @@ export function getGridNavigatedIndex(
       }
     }
 
-    if (event.key === ARROW_LEFT) {
+    if (event.key === prevKey) {
       if (stop) {
         stopEvent(event);
       }
@@ -234,7 +241,7 @@ export function getGridNavigatedIndex(
     if (isIndexOutOfBounds(elementsRef, nextIndex)) {
       if (loop && lastRow) {
         nextIndex =
-          event.key === ARROW_LEFT
+          event.key === prevKey
             ? maxIndex
             : findNonDisabledIndex(elementsRef, {
                 startingIndex: prevIndex - (prevIndex % cols) - 1,

--- a/packages/mui-base/src/Composite/composite.ts
+++ b/packages/mui-base/src/Composite/composite.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { hasComputedStyleMapSupport } from '../utils/hasComputedStyleMapSupport';
+import { ownerWindow } from '../utils/owner';
 
 export type TextDirection = 'ltr' | 'rtl';
 
@@ -18,8 +20,8 @@ export const HORIZONTAL_KEYS = [ARROW_LEFT, ARROW_RIGHT];
 export const HORIZONTAL_KEYS_WITH_EXTRA_KEYS = [ARROW_LEFT, ARROW_RIGHT, HOME, END];
 export const VERTICAL_KEYS = [ARROW_UP, ARROW_DOWN];
 export const VERTICAL_KEYS_WITH_EXTRA_KEYS = [ARROW_UP, ARROW_DOWN, HOME, END];
-export const ALL_KEYS = [...HORIZONTAL_KEYS, ...VERTICAL_KEYS];
-export const ALL_KEYS_WITH_EXTRA_KEYS = [...ALL_KEYS, HOME, END];
+export const ARROW_KEYS = [...HORIZONTAL_KEYS, ...VERTICAL_KEYS];
+export const ALL_KEYS = [...ARROW_KEYS, HOME, END];
 
 function stopEvent(event: Event | React.SyntheticEvent) {
   event.preventDefault();
@@ -358,4 +360,14 @@ export function isDisabled(
     element.hasAttribute('disabled') ||
     element.getAttribute('aria-disabled') === 'true'
   );
+}
+
+export function getTextDirection(element: HTMLElement): TextDirection {
+  if (hasComputedStyleMapSupport()) {
+    const direction = element.computedStyleMap().get('direction');
+
+    return (direction as CSSKeywordValue)?.value as TextDirection;
+  }
+
+  return ownerWindow(element).getComputedStyle(element).direction as TextDirection;
 }

--- a/packages/mui-base/src/RadioGroup/Root/RadioGroupRoot.test.tsx
+++ b/packages/mui-base/src/RadioGroup/Root/RadioGroupRoot.test.tsx
@@ -197,7 +197,8 @@ describe('<RadioGroup.Root />', () => {
     expect(stringifiedFormData).to.equal('group=a');
   });
 
-  it('should automatically select radio upon navigation', async () => {
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('should automatically select radio upon navigation', async () => {
     render(
       <RadioGroup.Root>
         <Radio.Root value="a" data-testid="a" />

--- a/packages/mui-base/src/RadioGroup/Root/RadioGroupRoot.test.tsx
+++ b/packages/mui-base/src/RadioGroup/Root/RadioGroupRoot.test.tsx
@@ -197,8 +197,7 @@ describe('<RadioGroup.Root />', () => {
     expect(stringifiedFormData).to.equal('group=a');
   });
 
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('should automatically select radio upon navigation', async () => {
+  it('should automatically select radio upon navigation', async () => {
     render(
       <RadioGroup.Root>
         <Radio.Root value="a" data-testid="a" />

--- a/packages/mui-base/src/RadioGroup/Root/RadioGroupRoot.tsx
+++ b/packages/mui-base/src/RadioGroup/Root/RadioGroupRoot.tsx
@@ -86,7 +86,7 @@ const RadioGroupRoot = React.forwardRef(function RadioGroupRoot(
 
   return (
     <RadioGroupRootContext.Provider value={contextValue}>
-      <CompositeRoot render={renderElement()} />
+      <CompositeRoot enableHomeAndEndKeys={false} render={renderElement()} />
       <input {...getInputProps()} />
     </RadioGroupRootContext.Provider>
   );

--- a/packages/mui-base/src/utils/hasComputedStyleMapSupport.ts
+++ b/packages/mui-base/src/utils/hasComputedStyleMapSupport.ts
@@ -1,0 +1,22 @@
+'use client';
+
+let node: HTMLElement | null = null;
+
+let cachedHasComputedStyleMapSupport: boolean | undefined;
+
+/**
+ * Detect if Element: computedStyleMap() is supported as a more performant
+ * alternative to getComputedStyles()
+ * Only Firefox does not have support as of Nov 2024.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Element/computedStyleMap
+ */
+export function hasComputedStyleMapSupport() {
+  if (node == null) {
+    node = document.createElement('div');
+  }
+
+  if (cachedHasComputedStyleMapSupport === undefined) {
+    cachedHasComputedStyleMapSupport = node.computedStyleMap !== undefined;
+  }
+  return cachedHasComputedStyleMapSupport;
+}


### PR DESCRIPTION
Split from https://github.com/mui/base-ui/pull/763 to unblock https://github.com/mui/base-ui/pull/751
Closes https://github.com/mui/base-ui/issues/824

- Adds support for RTL navigation with arrow keys by detecting the CSS `direction` property that could be inherited from the HTML `dir` attribute
- Adds support for navigating to the first/last items with Home/End keys, enable-able with the `enableHomeAndEndKeys` prop
