### PR TITLE
[menu] Correct the MenuGroupLabel's role attribute

### DIFF
--- a/packages/mui-base/src/Menu/GroupLabel/MenuGroupLabel.test.tsx
+++ b/packages/mui-base/src/Menu/GroupLabel/MenuGroupLabel.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { Menu } from '@base_ui/react/Menu';
 import { createRenderer, describeConformance } from '#test-utils';
 import { MenuGroupContext } from '../Group/MenuGroupContext';
@@ -18,4 +19,59 @@ describe('<Menu.GroupLabel />', () => {
     },
     refInstanceof: window.HTMLDivElement,
   }));
+
+  describe('a11y attributes', () => {
+    it('should have the role `presentation`', async () => {
+      const { getByText } = await render(
+        <Menu.Root open>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Group>
+                <Menu.GroupLabel>Test group</Menu.GroupLabel>
+              </Menu.Group>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Root>,
+      );
+
+      const groupLabel = getByText('Test group');
+      expect(groupLabel).to.have.attribute('role', 'presentation');
+    });
+
+    it("should reference the generated id in Group's `aria-labelledby`", async () => {
+      const { getByText, getByRole } = await render(
+        <Menu.Root open>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Group>
+                <Menu.GroupLabel>Test group</Menu.GroupLabel>
+              </Menu.Group>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Root>,
+      );
+
+      const group = getByRole('group');
+      const groupLabel = getByText('Test group');
+
+      expect(group).to.have.attribute('aria-labelledby', groupLabel.id);
+    });
+
+    it("should reference the provided id in Group's `aria-labelledby`", async () => {
+      const { getByRole } = await render(
+        <Menu.Root open>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Group>
+                <Menu.GroupLabel id="test-group">Test group</Menu.GroupLabel>
+              </Menu.Group>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Root>,
+      );
+
+      const group = getByRole('group');
+      expect(group).to.have.attribute('aria-labelledby', 'test-group');
+    });
+  });
 });

--- a/packages/mui-base/src/Menu/GroupLabel/MenuGroupLabel.tsx
+++ b/packages/mui-base/src/Menu/GroupLabel/MenuGroupLabel.tsx
@@ -40,7 +40,7 @@ const MenuGroupLabel = React.forwardRef(function MenuGroupLabelComponent(
     render: render ?? 'div',
     className,
     ownerState,
-    extraProps: { role: 'group', id, ...other },
+    extraProps: { role: 'presentation', id, ...other },
     ref: forwardedRef,
   });
 


### PR DESCRIPTION
The MenuGroupLabel rendered an incorrect `group` role. This PR changes it to `presentation`.