### PR TITLE
[docs] Place Quick Nav after the main demo in the DOM

### DIFF
--- a/docs/src/components/demo/Demo.css
+++ b/docs/src/components/demo/Demo.css
@@ -3,6 +3,15 @@
     background-color: var(--color-content);
     border: 1px solid var(--color-gray-200);
     border-radius: var(--radius-md);
+
+    /* Coordinate the placement of Quick Nav that follows the main Demo */
+    &[data-before-quick-nav] {
+      float: left;
+      width: 100%;
+      & + * + * {
+        clear: left;
+      }
+    }
   }
 
   .DemoPlayground {

--- a/docs/src/components/quick-nav/rehypeQuickNav.mjs
+++ b/docs/src/components/quick-nav/rehypeQuickNav.mjs
@@ -1,5 +1,9 @@
 // @ts-check
+/**
+ * @import {Nodes} from 'hast'
+ */
 import { createMdxElement } from 'docs/src/mdx/createMdxElement.mjs';
+import { toString } from 'hast-util-to-string';
 
 const ROOT = 'QuickNav.Root';
 const TITLE = 'QuickNav.Title';
@@ -29,7 +33,7 @@ export function rehypeQuickNav() {
       children: toc.flatMap(getNodeFromEntry).filter(Boolean),
     });
 
-    if (!toc.length) {
+    if (!toc?.length) {
       return;
     }
 
@@ -37,13 +41,12 @@ export function rehypeQuickNav() {
 
     /** @type {{ tagName?: string; name?: string; attributes?: Record<string, string>[] }[]} */
     const contentNodes = tree.children.filter(
-      /** @param {{ type?: string; value?: string;  }} child */
+      /** @param {Nodes} child */
       (child) => {
         return (
-          // Filter out import statements
-          child.type !== 'mdxjsEsm' &&
-          // Filter out plain line breaks
-          child.value !== '\n'
+          // Filter out nodes that don't produce text
+          (('children' in child || 'value' in child) && toString(child).trim()) ||
+          ('name' in child && child.name === 'Demo')
         );
       },
     );

--- a/docs/src/components/quick-nav/rehypeQuickNav.mjs
+++ b/docs/src/components/quick-nav/rehypeQuickNav.mjs
@@ -43,11 +43,11 @@ export function rehypeQuickNav() {
     const contentNodes = tree.children.filter(
       /** @param {Nodes} child */
       (child) => {
-        return (
-          // Filter out nodes that don't produce text
-          (('children' in child || 'value' in child) && toString(child).trim()) ||
-          ('name' in child && child.name === 'Demo')
-        );
+        // Filter out nodes that don't produce texts
+        const hasChildren = 'children' in child && child.children?.length;
+        const isText = child.type === 'text';
+        const isDemo = 'name' in child && child.name === 'Demo';
+        return ((hasChildren || isText) && toString(child).trim()) || isDemo;
       },
     );
 

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -66,7 +66,9 @@ export const mdxComponents: MDXComponents = {
   td: Table.Cell,
 
   // Custom components
-  Demo: (props) => <DemoLoader className="mt-5 mb-8" {...props} />,
+  Demo: (props) => (
+    <DemoLoader className={'data-before-quick-nav' in props ? 'mb-10' : 'mt-5 mb-8'} {...props} />
+  ),
   QuickNav,
   AttributesTable: (props) => <AttributesTable className="mt-5 mb-6" {...props} />,
   CssVariablesTable: (props) => <CssVariablesTable className="mt-5 mb-6" {...props} />,


### PR DESCRIPTION
Place Quick Nav after the main demo in the DOM so that keyboard focus follows the reading order

https://deploy-preview-845--base-ui.netlify.app/new/components/dialog
