### PR TITLE
[test] Enable the hanging process reporter for tests

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,7 +6,7 @@ const CI = process.env.CI === 'true';
 
 export default defineConfig({
   test: {
-    reporters: ['basic'],
+    reporters: ['basic', 'hanging-process'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
Enabled the vitest's hanging-process reporter to debug the flaky browser tests