### PR TITLE
[docs] Bordered popups and arrows

### DIFF
--- a/docs/src/app/experiments/popup-arrow.module.css
+++ b/docs/src/app/experiments/popup-arrow.module.css
@@ -1,0 +1,84 @@
+.popup {
+  background: white;
+  border: 1px solid #ccc;
+  padding: 20px;
+  width: 200px;
+}
+
+.arrow {
+  --arrow-size: 10px;
+  --stroke-size: 1px;
+
+  width: 0;
+  height: 0;
+}
+
+.arrow::before {
+  --size: calc(var(--arrow-size) + var(--stroke-size) * 2);
+
+  content: '';
+  position: absolute;
+  width: 0;
+  height: 0;
+  z-index: -1;
+}
+
+.arrow[data-side='bottom'] {
+  top: calc((var(--arrow-size) - 1px) * -1);
+  border-left: var(--arrow-size) solid transparent;
+  border-right: var(--arrow-size) solid transparent;
+  border-bottom: var(--arrow-size) solid white;
+}
+
+.arrow[data-side='bottom']::before {
+  top: calc(var(--stroke-size) * -1);
+  left: calc(var(--size) * -1);
+  border-left: var(--size) solid transparent;
+  border-right: var(--size) solid transparent;
+  border-bottom: var(--size) solid #ccc;
+}
+
+.arrow[data-side='top'] {
+  bottom: calc((var(--arrow-size) - 1px) * -1);
+  border-left: var(--arrow-size) solid transparent;
+  border-right: var(--arrow-size) solid transparent;
+  border-top: var(--arrow-size) solid white;
+}
+
+.arrow[data-side='top']::before {
+  bottom: calc(var(--stroke-size) * -1);
+  left: calc(var(--size) * -1);
+  border-left: var(--size) solid transparent;
+  border-right: var(--size) solid transparent;
+  border-top: var(--size) solid #ccc;
+}
+
+.arrow[data-side='left'] {
+  right: calc((var(--arrow-size) - 1px) * -1);
+  border-top: var(--arrow-size) solid transparent;
+  border-bottom: var(--arrow-size) solid transparent;
+  border-left: var(--arrow-size) solid white;
+}
+
+.arrow[data-side='left']::before {
+  right: calc(var(--stroke-size) * -1);
+  top: calc(var(--size) * -1);
+  border-top: var(--size) solid transparent;
+  border-bottom: var(--size) solid transparent;
+  border-left: var(--size) solid #ccc;
+}
+
+.arrow[data-side='right'] {
+  left: calc((var(--arrow-size) - 1px) * -1);
+  border-top: var(--arrow-size) solid transparent;
+  border-bottom: var(--arrow-size) solid transparent;
+  border-right: var(--arrow-size) solid white;
+}
+
+.arrow[data-side='right']::before {
+  left: calc(var(--stroke-size) * -1);
+  top: calc(var(--size) * -1);
+  border-top: var(--size) solid transparent;
+  border-bottom: var(--size) solid transparent;
+  border-right: var(--size) solid #ccc;
+}

--- a/docs/src/app/experiments/popup-arrow.tsx
+++ b/docs/src/app/experiments/popup-arrow.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Popover } from '@base-ui-components/react/Popover';
+import classes from './popup-arrow.module.css';
+
+export default function PopupArrow() {
+  return (
+    <Popover.Root>
+      <Popover.Trigger>Trigger</Popover.Trigger>
+      <Popover.Positioner sideOffset={10}>
+        <Popover.Popup className={classes.popup}>Popup</Popover.Popup>
+        <Popover.Arrow className={classes.arrow} />
+      </Popover.Positioner>
+    </Popover.Root>
+  );
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

There are various ways to create arrows, including bordered ones.

This demo uses CSS `border` and places `Arrow` inside `Positioner` instead of `Popup`. This is recommended as it prevents it from being cut off if `Popup` is scrollable. 

The calculations to position the arrow correctly can get complex with small 1px or 2px differences, which the demo uses CSS variables for.

Floating UI has a rule that the [layout box of the arrow](https://floating-ui.com/docs/arrow) should be a square with equal width and height, which this particular demo doesn't follow. However, the rule exists only for when the side axis flips from x to y or vice-versa, because the width or height of the arrow changing causes its position to be wrong on the very first update. However, this is rarely seen in practice when scrolling or resizing since more updates typically occur after the axis flip. Plus, given we likely don't want a popover or tooltip to flip its side axis when scrolling (which will be the case when https://github.com/mui/base-ui/pull/817 is merged), this won't be seen by default - if the side axis is only changed based on the available viewport width, it's unlikely for this to be seen in practice as well.

I also think we should make demos for [SVG arrows](https://floating-ui.com/docs/FloatingArrow). 