### PR TITLE
[core] Merge render prop's className with component's className

### DIFF
--- a/packages/react/src/utils/mergeReactProps.ts
+++ b/packages/react/src/utils/mergeReactProps.ts
@@ -65,6 +65,17 @@ function merge<T extends React.ElementType>(
         if (value || internalProps.style) {
           acc[key] = { ...internalProps.style, ...(value || {}) };
         }
+      } else if (key === 'className') {
+        if (value) {
+          if (internalProps.className) {
+            // eslint-disable-next-line prefer-template
+            acc[key] = value + ' ' + internalProps.className;
+          } else {
+            acc[key] = value;
+          }
+        } else {
+          acc[key] = internalProps.className;
+        }
       } else {
         acc[key] = value;
       }

--- a/packages/react/src/utils/useComponentRenderer.ts
+++ b/packages/react/src/utils/useComponentRenderer.ts
@@ -73,10 +73,6 @@ export function useComponentRenderer<
     ...extraProps,
   };
 
-  if (className) {
-    ownProps.className = className;
-  }
-
   let resolvedRenderProp:
     | ComponentRenderFn<React.HTMLAttributes<any>, OwnerState>
     | React.ReactElement<Record<string, unknown>>;
@@ -91,6 +87,7 @@ export function useComponentRenderer<
   const propsWithRef = {
     ...renderedElementProps,
     ref: useRenderPropForkRef(resolvedRenderProp, ref as React.Ref<any>, renderedElementProps.ref),
+    className,
   };
 
   const renderElement = () => evaluateRenderProp(resolvedRenderProp, propsWithRef, ownerState);

--- a/packages/react/test/conformanceTests/renderProp.tsx
+++ b/packages/react/test/conformanceTests/renderProp.tsx
@@ -112,5 +112,37 @@ export function testRenderProp(
       expect(refB!.tagName).to.equal(Element.toUpperCase());
       expect(refB!).to.have.attribute('data-testid', 'wrapped');
     });
+
+    it('should merge the rendering element className with the custom component className', async () => {
+      function Test() {
+        return React.cloneElement(element, {
+          className: 'component-classname',
+          render: <div className="render-prop-classname" />,
+          'data-testid': 'test-component',
+        });
+      }
+
+      const { getByTestId } = await render(<Test />);
+
+      const component = getByTestId('test-component');
+      expect(component.classList.contains('component-classname')).to.equal(true);
+      expect(component.classList.contains('render-prop-classname')).to.equal(true);
+    });
+
+    it('should merge the rendering element resolved className with the custom component className', async () => {
+      function Test() {
+        return React.cloneElement(element, {
+          className: () => 'conditional-component-classname',
+          render: <div className="render-prop-classname" />,
+          'data-testid': 'test-component',
+        });
+      }
+
+      const { getByTestId } = await render(<Test />);
+
+      const component = getByTestId('test-component');
+      expect(component.classList.contains('conditional-component-classname')).to.equal(true);
+      expect(component.classList.contains('render-prop-classname')).to.equal(true);
+    });
   });
 }

--- a/packages/react/test/describeConformance.tsx
+++ b/packages/react/test/describeConformance.tsx
@@ -14,7 +14,7 @@ export type ConformantComponentProps = {
   render?: React.ReactElement<unknown> | ((props: Record<string, unknown>) => React.ReactNode);
   ref?: React.Ref<unknown>;
   'data-testid'?: string;
-  className?: string;
+  className?: string | ((state: unknown) => string);
   style?: React.CSSProperties;
 };
 


### PR DESCRIPTION
Merges the `className` present in render prop (when using the short form) with the original component's `className`.