### PR TITLE
[popups] Look for animations when `open` is set to `false` externally

### DIFF
--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.tsx
@@ -16,11 +16,12 @@ import { useDialogRoot } from '../../dialog/root/useDialogRoot';
  * - [AlertDialogRoot API](https://base-ui.com/components/react-alert-dialog/#api-reference-AlertDialogRoot)
  */
 const AlertDialogRoot: React.FC<AlertDialogRoot.Props> = function AlertDialogRoot(props) {
-  const { animated = true, children, defaultOpen, onOpenChange, open } = props;
+  const { animated = true, children, defaultOpen = false, onOpenChange, open } = props;
 
   const parentDialogRootContext = React.useContext(AlertDialogRootContext);
 
   const dialogRoot = useDialogRoot({
+    animated,
     open,
     defaultOpen,
     onOpenChange,

--- a/packages/react/src/dialog/popup/useDialogPopup.tsx
+++ b/packages/react/src/dialog/popup/useDialogPopup.tsx
@@ -74,7 +74,6 @@ export function useDialogPopup(parameters: useDialogPopup.Parameters): useDialog
     mergeReactProps<'div'>(externalProps, {
       'aria-labelledby': titleElementId ?? undefined,
       'aria-describedby': descriptionElementId ?? undefined,
-      'aria-hidden': !open || undefined,
       'aria-modal': open && modal ? true : undefined,
       role: 'dialog',
       tabIndex: -1,

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { act, describeSkipIf, fireEvent } from '@mui/internal-test-utils';
+import { act, describeSkipIf, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Dialog } from '@base-ui-components/react/dialog';
 import { createRenderer } from '#test-utils';
 
@@ -44,43 +44,96 @@ describe('<Dialog.Root />', () => {
       setProps({ open: false });
       expect(queryByRole('dialog')).to.equal(null);
     });
-  });
 
-  // toWarnDev doesn't work reliably with async rendering. To re-eanble after it's fixed in the test-utils.
-  // eslint-disable-next-line mocha/no-skipped-tests
-  describe.skip('prop: modal', () => {
-    it('warns when the dialog is modal but no backdrop is present', async () => {
-      await expect(() =>
-        render(
-          <Dialog.Root modal animated={false}>
-            <Dialog.Popup />
-          </Dialog.Root>,
-        ),
-      ).toWarnDev([
-        'Base UI: The Dialog is modal but no backdrop is present. Add the backdrop component to prevent interacting with the rest of the page.',
-        'Base UI: The Dialog is modal but no backdrop is present. Add the backdrop component to prevent interacting with the rest of the page.',
-      ]);
+    it('should remove the popup when animated=true and there is no exit animation defined', async function test(t = {}) {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // @ts-expect-error to support mocha and vitest
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        this?.skip?.() || t?.skip();
+      }
+
+      function Test() {
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <div>
+            <button onClick={() => setOpen(false)}>Close</button>
+            <Dialog.Root open={open}>
+              <Dialog.Popup />
+            </Dialog.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const closeButton = screen.getByText('Close');
+
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).to.equal(null);
+      });
     });
 
-    it('does not warn when the dialog is not modal and no backdrop is present', () => {
-      expect(() =>
-        render(
-          <Dialog.Root modal={false} animated={false}>
-            <Dialog.Popup />
-          </Dialog.Root>,
-        ),
-      ).not.toWarnDev();
-    });
+    it('should remove the popup when animated=true and the animation finishes', async function test(t = {}) {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // @ts-expect-error to support mocha and vitest
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        this?.skip?.() || t?.skip();
+      }
 
-    it('does not warn when the dialog is modal and backdrop is present', () => {
-      expect(() =>
-        render(
-          <Dialog.Root modal animated={false}>
-            <Dialog.Backdrop />
-            <Dialog.Popup />
-          </Dialog.Root>,
-        ),
-      ).not.toWarnDev();
+      let animationFinished = false;
+      const notifyAnimationFinished = () => {
+        animationFinished = true;
+      };
+
+      function Test() {
+        const style = `
+          @keyframes test-anim {
+            to {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-popup[data-open] {
+            opacity: 1;
+          }
+
+          .animation-test-popup[data-exiting] {
+            animation: test-anim 50ms;
+          }
+        `;
+
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <div>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            <button onClick={() => setOpen(false)}>Close</button>
+            <Dialog.Root open={open}>
+              <Dialog.Popup
+                className="animation-test-popup"
+                onAnimationEnd={notifyAnimationFinished}
+              />
+            </Dialog.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      expect(screen.queryByRole('dialog')).not.to.equal(null);
+
+      const closeButton = screen.getByText('Close');
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).to.equal(null);
+      });
+
+      expect(animationFinished).to.equal(true);
     });
   });
 
@@ -136,16 +189,24 @@ describe('<Dialog.Root />', () => {
   `;
 
     it('when `true`, waits for the exit transition to finish before unmounting', async () => {
+      const notifyTransitionEnd = spy();
+
       const { setProps, queryByRole } = await render(
         <Dialog.Root open modal={false} animated>
           {/* eslint-disable-next-line react/no-danger */}
           <style dangerouslySetInnerHTML={{ __html: css }} />
-          <Dialog.Popup className="dialog" />
+          <Dialog.Popup className="dialog" onTransitionEnd={notifyTransitionEnd} />
         </Dialog.Root>,
       );
 
       setProps({ open: false });
-      expect(queryByRole('dialog', { hidden: true })).not.to.equal(null);
+      expect(queryByRole('dialog')).not.to.equal(null);
+
+      await waitFor(() => {
+        expect(queryByRole('dialog')).to.equal(null);
+      });
+
+      expect(notifyTransitionEnd.callCount).to.equal(1);
     });
 
     it('when `false`, unmounts the popup immediately', async () => {

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -68,7 +68,6 @@ describe('<Dialog.Root />', () => {
       const { user } = await render(<Test />);
 
       const closeButton = screen.getByText('Close');
-
       await user.click(closeButton);
 
       await waitFor(() => {
@@ -123,8 +122,6 @@ describe('<Dialog.Root />', () => {
       }
 
       const { user } = await render(<Test />);
-
-      expect(screen.queryByRole('dialog')).not.to.equal(null);
 
       const closeButton = screen.getByText('Close');
       await user.click(closeButton);

--- a/packages/react/src/dialog/root/DialogRoot.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.tsx
@@ -29,6 +29,7 @@ const DialogRoot = function DialogRoot(props: DialogRoot.Props) {
   const parentDialogRootContext = React.useContext(DialogRootContext);
 
   const dialogRoot = useDialogRoot({
+    animated,
     open,
     defaultOpen,
     onOpenChange,

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -16,6 +16,7 @@ import { type GenericHTMLProps } from '../../utils/types';
 import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
 import { mergeReactProps } from '../../utils/mergeReactProps';
 import { useLatestRef } from '../../utils/useLatestRef';
+import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 
 export function useDialogRoot(parameters: useDialogRoot.Parameters): useDialogRoot.ReturnValue {
   const {
@@ -56,8 +57,10 @@ export function useDialogRoot(parameters: useDialogRoot.Parameters): useDialogRo
   const setOpen = useEventCallback((nextOpen: boolean, event?: Event) => {
     onOpenChange?.(nextOpen, event);
     setOpenUnwrapped(nextOpen);
+  });
 
-    if (!keepMounted && !nextOpen) {
+  useEnhancedEffect(() => {
+    if (!keepMounted && !open) {
       if (animated) {
         runOnceAnimationsFinish(() => {
           if (!openRef.current) {
@@ -68,7 +71,7 @@ export function useDialogRoot(parameters: useDialogRoot.Parameters): useDialogRo
         setMounted(false);
       }
     }
-  });
+  }, [keepMounted, animated, open, openRef, runOnceAnimationsFinish, setMounted]);
 
   const context = useFloatingRootContext({
     elements: { reference: triggerElement, floating: popupElement },

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -11,17 +11,17 @@ import { useControlled } from '../../utils/useControlled';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useTransitionStatus, type TransitionStatus } from '../../utils/useTransitionStatus';
 import { type InteractionType } from '../../utils/useEnhancedClickHandler';
-import { type GenericHTMLProps } from '../../utils/types';
+import type { RequiredExcept, GenericHTMLProps } from '../../utils/types';
 import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
 import { mergeReactProps } from '../../utils/mergeReactProps';
 import { useUnmountAfterExitAnimation } from '../../utils/useUnmountAfterCloseAnimation';
 
 export function useDialogRoot(parameters: useDialogRoot.Parameters): useDialogRoot.ReturnValue {
   const {
-    animated = true,
-    defaultOpen = false,
-    dismissible = true,
-    modal = true,
+    animated,
+    defaultOpen,
+    dismissible,
+    modal,
     onNestedDialogClose,
     onNestedDialogOpen,
     onOpenChange,
@@ -190,7 +190,7 @@ export interface CommonParameters {
 }
 
 export namespace useDialogRoot {
-  export interface Parameters extends CommonParameters {
+  export interface Parameters extends RequiredExcept<CommonParameters, 'open' | 'onOpenChange'> {
     /**
      * Callback to invoke when a nested dialog is opened.
      */

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -10,13 +10,11 @@ import {
 import { useControlled } from '../../utils/useControlled';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useTransitionStatus, type TransitionStatus } from '../../utils/useTransitionStatus';
-import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
 import { type InteractionType } from '../../utils/useEnhancedClickHandler';
 import { type GenericHTMLProps } from '../../utils/types';
 import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
 import { mergeReactProps } from '../../utils/mergeReactProps';
-import { useLatestRef } from '../../utils/useLatestRef';
-import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
+import { useUnmountAfterExitAnimation } from '../../utils/useUnmountAfterCloseAnimation';
 
 export function useDialogRoot(parameters: useDialogRoot.Parameters): useDialogRoot.ReturnValue {
   const {
@@ -49,28 +47,17 @@ export function useDialogRoot(parameters: useDialogRoot.Parameters): useDialogRo
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
 
-  const runOnceAnimationsFinish = useAnimationsFinished(popupRef);
-
-  const openRef = useLatestRef(open);
-
   const setOpen = useEventCallback((nextOpen: boolean, event?: Event) => {
     onOpenChange?.(nextOpen, event);
     setOpenUnwrapped(nextOpen);
   });
 
-  useEnhancedEffect(() => {
-    if (!open) {
-      if (animated) {
-        runOnceAnimationsFinish(() => {
-          if (!openRef.current) {
-            setMounted(false);
-          }
-        });
-      } else {
-        setMounted(false);
-      }
-    }
-  }, [animated, open, openRef, runOnceAnimationsFinish, setMounted]);
+  useUnmountAfterExitAnimation({
+    open,
+    animated,
+    animatedElementRef: popupRef,
+    setMounted,
+  });
 
   const context = useFloatingRootContext({
     elements: { reference: triggerElement, floating: popupElement },

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -23,7 +23,6 @@ export function useDialogRoot(parameters: useDialogRoot.Parameters): useDialogRo
     animated = true,
     defaultOpen = false,
     dismissible = true,
-    keepMounted = false,
     modal = true,
     onNestedDialogClose,
     onNestedDialogOpen,
@@ -60,7 +59,7 @@ export function useDialogRoot(parameters: useDialogRoot.Parameters): useDialogRo
   });
 
   useEnhancedEffect(() => {
-    if (!keepMounted && !open) {
+    if (!open) {
       if (animated) {
         runOnceAnimationsFinish(() => {
           if (!openRef.current) {
@@ -71,7 +70,7 @@ export function useDialogRoot(parameters: useDialogRoot.Parameters): useDialogRo
         setMounted(false);
       }
     }
-  }, [keepMounted, animated, open, openRef, runOnceAnimationsFinish, setMounted]);
+  }, [animated, open, openRef, runOnceAnimationsFinish, setMounted]);
 
   const context = useFloatingRootContext({
     elements: { reference: triggerElement, floating: popupElement },
@@ -201,11 +200,6 @@ export interface CommonParameters {
    * @default true
    */
   dismissible?: boolean;
-  /**
-   * Whether the dialog element stays mounted in the DOM when closed.
-   * @default false
-   */
-  keepMounted?: boolean;
 }
 
 export namespace useDialogRoot {

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
+import { act, flushMicrotasks, waitFor, screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui-components/react/menu';
 import userEvent from '@testing-library/user-event';
 import { spy } from 'sinon';
@@ -683,6 +683,100 @@ describe('<Menu.Root />', () => {
       });
 
       expect(menus[0].id).to.equal('parent-menu');
+    });
+  });
+
+  describe('controlled mode', () => {
+    it('should remove the popup when animated=true and there is no exit animation defined', async function test(t = {}) {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // @ts-expect-error to support mocha and vitest
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        this?.skip?.() || t?.skip();
+      }
+
+      function Test() {
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <div>
+            <button onClick={() => setOpen(false)}>Close</button>
+            <Menu.Root open={open}>
+              <Menu.Positioner>
+                <Menu.Popup />
+              </Menu.Positioner>
+            </Menu.Root>
+          </div>
+        );
+      }
+
+      await render(<Test />);
+
+      const closeButton = screen.getByText('Close');
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).to.equal(null);
+      });
+    });
+
+    it('should remove the popup when animated=true and the animation finishes', async function test(t = {}) {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // @ts-expect-error to support mocha and vitest
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        this?.skip?.() || t?.skip();
+      }
+
+      let animationFinished = false;
+      const notifyAnimationFinished = () => {
+        animationFinished = true;
+      };
+
+      function Test() {
+        const style = `
+          @keyframes test-anim {
+            to {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-popup[data-open] {
+            opacity: 1;
+          }
+
+          .animation-test-popup[data-exiting] {
+            animation: test-anim 50ms;
+          }
+        `;
+
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <div>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            <button onClick={() => setOpen(false)}>Close</button>
+            <Menu.Root open={open}>
+              <Menu.Positioner>
+                <Menu.Popup
+                  className="animation-test-popup"
+                  onAnimationEnd={notifyAnimationFinished}
+                />
+              </Menu.Positioner>
+            </Menu.Root>
+          </div>
+        );
+      }
+
+      await render(<Test />);
+
+      const closeButton = screen.getByText('Close');
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).to.equal(null);
+      });
+
+      expect(animationFinished).to.equal(true);
     });
   });
 });

--- a/packages/react/src/menu/root/useMenuRoot.ts
+++ b/packages/react/src/menu/root/useMenuRoot.ts
@@ -16,11 +16,9 @@ import { mergeReactProps } from '../../utils/mergeReactProps';
 import { GenericHTMLProps } from '../../utils/types';
 import { useTransitionStatus } from '../../utils/useTransitionStatus';
 import { useEventCallback } from '../../utils/useEventCallback';
-import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
 import { useControlled } from '../../utils/useControlled';
 import { TYPEAHEAD_RESET_MS } from '../../utils/constants';
-import { useLatestRef } from '../../utils/useLatestRef';
-import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
+import { useUnmountAfterExitAnimation } from '../../utils/useUnmountAfterCloseAnimation';
 
 const EMPTY_ARRAY: never[] = [];
 
@@ -56,28 +54,17 @@ export function useMenuRoot(parameters: useMenuRoot.Parameters): useMenuRoot.Ret
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open, animated);
 
-  const runOnceAnimationsFinish = useAnimationsFinished(popupRef);
-
-  const openRef = useLatestRef(open);
-
   const setOpen = useEventCallback((nextOpen: boolean, event?: Event) => {
     onOpenChange?.(nextOpen, event);
     setOpenUnwrapped(nextOpen);
   });
 
-  useEnhancedEffect(() => {
-    if (!open) {
-      if (animated) {
-        runOnceAnimationsFinish(() => {
-          if (!openRef.current) {
-            setMounted(false);
-          }
-        });
-      } else {
-        setMounted(false);
-      }
-    }
-  }, [animated, open, openRef, runOnceAnimationsFinish, setMounted]);
+  useUnmountAfterExitAnimation({
+    open,
+    animated,
+    animatedElementRef: popupRef,
+    setMounted,
+  });
 
   const floatingRootContext = useFloatingRootContext({
     elements: {

--- a/packages/react/src/menu/root/useMenuRoot.ts
+++ b/packages/react/src/menu/root/useMenuRoot.ts
@@ -20,6 +20,7 @@ import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
 import { useControlled } from '../../utils/useControlled';
 import { TYPEAHEAD_RESET_MS } from '../../utils/constants';
 import { useLatestRef } from '../../utils/useLatestRef';
+import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 
 const EMPTY_ARRAY: never[] = [];
 
@@ -62,7 +63,10 @@ export function useMenuRoot(parameters: useMenuRoot.Parameters): useMenuRoot.Ret
   const setOpen = useEventCallback((nextOpen: boolean, event?: Event) => {
     onOpenChange?.(nextOpen, event);
     setOpenUnwrapped(nextOpen);
-    if (!nextOpen) {
+  });
+
+  useEnhancedEffect(() => {
+    if (!open) {
       if (animated) {
         runOnceAnimationsFinish(() => {
           if (!openRef.current) {
@@ -73,7 +77,7 @@ export function useMenuRoot(parameters: useMenuRoot.Parameters): useMenuRoot.Ret
         setMounted(false);
       }
     }
-  });
+  }, [animated, open, openRef, runOnceAnimationsFinish, setMounted]);
 
   const floatingRootContext = useFloatingRootContext({
     elements: {

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -173,6 +173,99 @@ describe('<Popover.Root />', () => {
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.firstCall.args[0]).to.equal(false);
     });
+
+    it('should remove the popup when animated=true and there is no exit animation defined', async function test(t = {}) {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // @ts-expect-error to support mocha and vitest
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        this?.skip?.() || t?.skip();
+      }
+
+      function Test() {
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <div>
+            <button onClick={() => setOpen(false)}>Close</button>
+            <Popover.Root open={open}>
+              <Popover.Positioner>
+                <Popover.Popup />
+              </Popover.Positioner>
+            </Popover.Root>
+          </div>
+        );
+      }
+
+      await render(<Test />);
+
+      const closeButton = screen.getByText('Close');
+
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).to.equal(null);
+      });
+    });
+
+    it('should remove the popup when animated=true and the animation finishes', async function test(t = {}) {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // @ts-expect-error to support mocha and vitest
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        this?.skip?.() || t?.skip();
+      }
+
+      let animationFinished = false;
+      const notifyAnimationFinished = () => {
+        animationFinished = true;
+      };
+
+      function Test() {
+        const style = `
+          @keyframes test-anim {
+            to {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-popup[data-open] {
+            opacity: 1;
+          }
+
+          .animation-test-popup[data-exiting] {
+            animation: test-anim 50ms;
+          }
+        `;
+
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <div>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            <button onClick={() => setOpen(false)}>Close</button>
+            <Popover.Root open={open}>
+              <Popover.Positioner>
+                <Popover.Popup
+                  className="animation-test-popup"
+                  onAnimationEnd={notifyAnimationFinished}
+                />
+              </Popover.Positioner>
+            </Popover.Root>
+          </div>
+        );
+      }
+
+      await render(<Test />);
+
+      const closeButton = screen.getByText('Close');
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).to.equal(null);
+      });
+
+      expect(animationFinished).to.equal(true);
+    });
   });
 
   describe('prop: defaultOpen', () => {

--- a/packages/react/src/popover/root/usePopoverRoot.ts
+++ b/packages/react/src/popover/root/usePopoverRoot.ts
@@ -13,19 +13,17 @@ import {
 import { useControlled } from '../../utils/useControlled';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useTransitionStatus } from '../../utils/useTransitionStatus';
-import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
 import { OPEN_DELAY } from '../utils/constants';
 import type { GenericHTMLProps } from '../../utils/types';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { type InteractionType } from '../../utils/useEnhancedClickHandler';
 import { mergeReactProps } from '../../utils/mergeReactProps';
 import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
-import { useLatestRef } from '../../utils/useLatestRef';
 import {
   translateOpenChangeReason,
   type OpenChangeReason,
 } from '../../utils/translateOpenChangeReason';
-import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
+import { useUnmountAfterExitAnimation } from '../../utils/useUnmountAfterCloseAnimation';
 
 export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoot.ReturnValue {
   const {
@@ -61,10 +59,6 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
 
-  const runOnceAnimationsFinish = useAnimationsFinished(popupRef);
-
-  const openRef = useLatestRef(open);
-
   const setOpen = useEventCallback(
     (nextOpen: boolean, event?: Event, reason?: OpenChangeReason) => {
       onOpenChange(nextOpen, event, reason);
@@ -78,19 +72,12 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
     },
   );
 
-  useEnhancedEffect(() => {
-    if (!open) {
-      if (animated) {
-        runOnceAnimationsFinish(() => {
-          if (!openRef.current) {
-            setMounted(false);
-          }
-        });
-      } else {
-        setMounted(false);
-      }
-    }
-  }, [animated, open, openRef, runOnceAnimationsFinish, setMounted]);
+  useUnmountAfterExitAnimation({
+    open,
+    animated,
+    animatedElementRef: popupRef,
+    setMounted,
+  });
 
   const context = useFloatingRootContext({
     elements: { reference: triggerElement, floating: positionerElement },

--- a/packages/react/src/popover/root/usePopoverRoot.ts
+++ b/packages/react/src/popover/root/usePopoverRoot.ts
@@ -25,6 +25,7 @@ import {
   translateOpenChangeReason,
   type OpenChangeReason,
 } from '../../utils/translateOpenChangeReason';
+import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 
 export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoot.ReturnValue {
   const {
@@ -69,23 +70,27 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
       onOpenChange(nextOpen, event, reason);
       setOpenUnwrapped(nextOpen);
 
-      if (!nextOpen) {
-        if (animated) {
-          runOnceAnimationsFinish(() => {
-            if (!openRef.current) {
-              setMounted(false);
-              setOpenReason(null);
-            }
-          });
-        } else {
-          setMounted(false);
-          setOpenReason(null);
-        }
-      } else {
+      if (nextOpen) {
         setOpenReason(reason ?? null);
       }
     },
   );
+
+  useEnhancedEffect(() => {
+    if (!open) {
+      if (animated) {
+        runOnceAnimationsFinish(() => {
+          if (!openRef.current) {
+            setMounted(false);
+            setOpenReason(null);
+          }
+        });
+      } else {
+        setMounted(false);
+        setOpenReason(null);
+      }
+    }
+  }, [animated, open, openRef, runOnceAnimationsFinish, setMounted]);
 
   const context = useFloatingRootContext({
     elements: { reference: triggerElement, floating: positionerElement },

--- a/packages/react/src/popover/root/usePopoverRoot.ts
+++ b/packages/react/src/popover/root/usePopoverRoot.ts
@@ -72,6 +72,8 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
 
       if (nextOpen) {
         setOpenReason(reason ?? null);
+      } else {
+        setOpenReason(null);
       }
     },
   );
@@ -82,12 +84,10 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
         runOnceAnimationsFinish(() => {
           if (!openRef.current) {
             setMounted(false);
-            setOpenReason(null);
           }
         });
       } else {
         setMounted(false);
-        setOpenReason(null);
       }
     }
   }, [animated, open, openRef, runOnceAnimationsFinish, setMounted]);

--- a/packages/react/src/preview-card/root/usePreviewCardRoot.ts
+++ b/packages/react/src/preview-card/root/usePreviewCardRoot.ts
@@ -10,18 +10,16 @@ import {
 } from '@floating-ui/react';
 import { useControlled } from '../../utils/useControlled';
 import { useTransitionStatus } from '../../utils/useTransitionStatus';
-import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useFocusExtended } from '../utils/useFocusExtended';
 import { OPEN_DELAY, CLOSE_DELAY } from '../utils/constants';
 import type { GenericHTMLProps } from '../../utils/types';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
-import { useLatestRef } from '../../utils/useLatestRef';
 import {
   translateOpenChangeReason,
   type OpenChangeReason,
 } from '../../utils/translateOpenChangeReason';
-import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
+import { useUnmountAfterExitAnimation } from '../../utils/useUnmountAfterCloseAnimation';
 
 export function usePreviewCardRoot(
   params: usePreviewCardRoot.Parameters,
@@ -55,10 +53,6 @@ export function usePreviewCardRoot(
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open, animated);
 
-  const runOnceAnimationsFinish = useAnimationsFinished(popupRef);
-
-  const openRef = useLatestRef(open);
-
   const setOpen = useEventCallback(
     (nextOpen: boolean, event?: Event, reason?: OpenChangeReason) => {
       onOpenChange(nextOpen, event, reason);
@@ -66,19 +60,12 @@ export function usePreviewCardRoot(
     },
   );
 
-  useEnhancedEffect(() => {
-    if (!open) {
-      if (animated) {
-        runOnceAnimationsFinish(() => {
-          if (!openRef.current) {
-            setMounted(false);
-          }
-        });
-      } else {
-        setMounted(false);
-      }
-    }
-  }, [animated, open, openRef, runOnceAnimationsFinish, setMounted]);
+  useUnmountAfterExitAnimation({
+    open,
+    animated,
+    animatedElementRef: popupRef,
+    setMounted,
+  });
 
   const context = useFloatingRootContext({
     elements: { reference: triggerElement, floating: positionerElement },

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -98,7 +98,9 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
   const setOpen = useEventCallback((nextOpen: boolean, event?: Event) => {
     params.onOpenChange?.(nextOpen, event);
     setOpenUnwrapped(nextOpen);
+  });
 
+  useEnhancedEffect(() => {
     function handleUnmounted() {
       ReactDOM.flushSync(() => {
         if (!openRef.current) {
@@ -107,14 +109,14 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
       });
     }
 
-    if (!nextOpen) {
+    if (!open) {
       if (params.animated) {
         runOnceAnimationsFinish(handleUnmounted);
       } else {
         handleUnmounted();
       }
     }
-  });
+  }, [open, openRef, params.animated, runOnceAnimationsFinish, setMounted]);
 
   const setValue = useEventCallback((nextValue: any, event?: Event) => {
     params.onValueChange?.(nextValue, event);

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -99,7 +99,6 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     animated: params.animated || true,
     animatedElementRef: popupRef,
     setMounted,
-    flushUpdatesSynchronously: true,
   });
 
   const setValue = useEventCallback((nextValue: any, event?: Event) => {

--- a/packages/react/src/utils/types.ts
+++ b/packages/react/src/utils/types.ts
@@ -60,3 +60,5 @@ export type BaseUIComponentProps<
  * Taken from https://effectivetypescript.com/2022/02/25/gentips-4-display/
  */
 export type Simplify<T> = T extends Function ? T : { [K in keyof T]: T[K] };
+
+export type RequiredExcept<T, K extends keyof T> = Required<Omit<T, K>> & Pick<T, K>;

--- a/packages/react/src/utils/useUnmountAfterCloseAnimation.tsx
+++ b/packages/react/src/utils/useUnmountAfterCloseAnimation.tsx
@@ -1,0 +1,50 @@
+import * as ReactDOM from 'react-dom';
+import { useAnimationsFinished } from './useAnimationsFinished';
+import { useEnhancedEffect } from './useEnhancedEffect';
+import { useLatestRef } from './useLatestRef';
+
+export function useUnmountAfterExitAnimation(parameters: useUnmountAfterExitAnimation.Parameters) {
+  const {
+    open,
+    animated,
+    animatedElementRef,
+    setMounted,
+    flushUpdatesSynchronously = false,
+  } = parameters;
+
+  const runOnceAnimationsFinish = useAnimationsFinished(animatedElementRef);
+
+  const openRef = useLatestRef(open);
+
+  useEnhancedEffect(() => {
+    function unmount() {
+      if (flushUpdatesSynchronously) {
+        ReactDOM.flushSync(() => {
+          if (!openRef.current) {
+            setMounted(false);
+          }
+        });
+      } else if (!openRef.current) {
+        setMounted(false);
+      }
+    }
+
+    if (!open) {
+      if (animated) {
+        runOnceAnimationsFinish(unmount);
+      } else {
+        unmount();
+      }
+    }
+  }, [animated, open, openRef, runOnceAnimationsFinish, setMounted, flushUpdatesSynchronously]);
+}
+
+export namespace useUnmountAfterExitAnimation {
+  export interface Parameters {
+    open: boolean;
+    animated: boolean;
+    animatedElementRef: React.RefObject<HTMLElement | null>;
+    setMounted: (mounted: boolean) => void;
+    flushUpdatesSynchronously?: boolean;
+  }
+}

--- a/packages/react/src/utils/useUnmountAfterCloseAnimation.tsx
+++ b/packages/react/src/utils/useUnmountAfterCloseAnimation.tsx
@@ -1,4 +1,3 @@
-import * as ReactDOM from 'react-dom';
 import { useAnimationsFinished } from './useAnimationsFinished';
 import { useEnhancedEffect } from './useEnhancedEffect';
 import { useLatestRef } from './useLatestRef';
@@ -7,27 +6,14 @@ import { useLatestRef } from './useLatestRef';
  * Unmounts a component (by calling the provided `setMounted` function) when its CSS animation or transition completes.
  */
 export function useUnmountAfterExitAnimation(parameters: useUnmountAfterExitAnimation.Parameters) {
-  const {
-    open,
-    animated,
-    animatedElementRef,
-    setMounted,
-    flushUpdatesSynchronously = false,
-  } = parameters;
+  const { open, animated, animatedElementRef, setMounted } = parameters;
 
   const runOnceAnimationsFinish = useAnimationsFinished(animatedElementRef);
-
   const openRef = useLatestRef(open);
 
   useEnhancedEffect(() => {
     function unmount() {
-      if (flushUpdatesSynchronously) {
-        ReactDOM.flushSync(() => {
-          if (!openRef.current) {
-            setMounted(false);
-          }
-        });
-      } else if (!openRef.current) {
+      if (!openRef.current) {
         setMounted(false);
       }
     }
@@ -39,7 +25,7 @@ export function useUnmountAfterExitAnimation(parameters: useUnmountAfterExitAnim
         unmount();
       }
     }
-  }, [animated, open, openRef, runOnceAnimationsFinish, setMounted, flushUpdatesSynchronously]);
+  }, [animated, open, openRef, runOnceAnimationsFinish, setMounted]);
 }
 
 export namespace useUnmountAfterExitAnimation {
@@ -63,10 +49,5 @@ export namespace useUnmountAfterExitAnimation {
      * It is always called with a single parameter: `false`.
      */
     setMounted: (mounted: boolean) => void;
-    /**
-     * If `true`, forces React to flush all updates immediately after calling `setMounted`
-     * by using `flushSync` function.
-     */
-    flushUpdatesSynchronously?: boolean;
   }
 }

--- a/packages/react/src/utils/useUnmountAfterCloseAnimation.tsx
+++ b/packages/react/src/utils/useUnmountAfterCloseAnimation.tsx
@@ -3,6 +3,9 @@ import { useAnimationsFinished } from './useAnimationsFinished';
 import { useEnhancedEffect } from './useEnhancedEffect';
 import { useLatestRef } from './useLatestRef';
 
+/**
+ * Unmounts a component (by calling the provided `setMounted` function) when its CSS animation or transition completes.
+ */
 export function useUnmountAfterExitAnimation(parameters: useUnmountAfterExitAnimation.Parameters) {
   const {
     open,
@@ -41,10 +44,29 @@ export function useUnmountAfterExitAnimation(parameters: useUnmountAfterExitAnim
 
 export namespace useUnmountAfterExitAnimation {
   export interface Parameters {
+    /**
+     * Determines if the component is open.
+     * The logic runs when the component goes from open to closed.
+     */
     open: boolean;
+    /**
+     * Determines if the animations are enabled.
+     * If set to `false`, `setMounted(false)` is set immediately after `open` turns `false` (in the next layout effect).
+     */
     animated: boolean;
+    /**
+     * Ref to the element being closed.
+     */
     animatedElementRef: React.RefObject<HTMLElement | null>;
+    /**
+     * Function to call when the element should be unmounted.
+     * It is always called with a single parameter: `false`.
+     */
     setMounted: (mounted: boolean) => void;
+    /**
+     * If `true`, forces React to flush all updates immediately after calling `setMounted`
+     * by using `flushSync` function.
+     */
     flushUpdatesSynchronously?: boolean;
   }
 }


### PR DESCRIPTION
When popups are closed programatically, the code that unmounts them after their exit animations finish wasn't run. 
In this PR I moved the exit animation detection to an effect, so it runs whenever the state changes. Added tests in all affected components (and fixed few other issues with the Dialog: `animated` prop not being propagated to `useDialogRoot` and `aria-hidden` being applied next to `inert`)