### PR TITLE
[Slider] Detect text direction instead of using `direction` prop

### DIFF
--- a/docs/data/components/slider/RtlSlider.js
+++ b/docs/data/components/slider/RtlSlider.js
@@ -9,11 +9,14 @@ export default function RtlSlider() {
   // Replace this with your app logic for determining dark mode
   const isDarkMode = useIsDarkMode();
   return (
-    <div className={isDarkMode ? 'dark' : ''} style={{ width: 320, margin: 32 }}>
+    <div
+      className={isDarkMode ? 'dark' : ''}
+      style={{ width: 320, margin: 32 }}
+      dir="rtl"
+    >
       <Slider.Root
         defaultValue={50}
         aria-labelledby="VolumeSliderLabel"
-        direction="rtl"
         className={classes.slider}
       >
         <Label

--- a/docs/data/components/slider/RtlSlider.tsx
+++ b/docs/data/components/slider/RtlSlider.tsx
@@ -8,11 +8,14 @@ export default function RtlSlider() {
   // Replace this with your app logic for determining dark mode
   const isDarkMode = useIsDarkMode();
   return (
-    <div className={isDarkMode ? 'dark' : ''} style={{ width: 320, margin: 32 }}>
+    <div
+      className={isDarkMode ? 'dark' : ''}
+      style={{ width: 320, margin: 32 }}
+      dir="rtl"
+    >
       <Slider.Root
         defaultValue={50}
         aria-labelledby="VolumeSliderLabel"
-        direction="rtl"
         className={classes.slider}
       >
         <Label

--- a/docs/data/components/slider/slider.mdx
+++ b/docs/data/components/slider/slider.mdx
@@ -185,10 +185,14 @@ To create vertical sliders, set the `orientation` prop to `"vertical"`. This wil
 
 ## RTL
 
-Set the `direction` prop to `'rtl'` to change the slider's direction for right-to-left languages:
+Place the slider inside any HTML element or component with the HTML `dir="rtl"` attribute to change the direction for right-to-left languages:
 
 ```jsx
-<Slider.Root direction="rtl">{/* Subcomponents */}</Slider.Root>
+<html dir="rtl">
+  <body>
+    <Slider.Root /> {/* RTL keyboard behavior*/}
+  </body>
+</html>
 ```
 
 In a RTL Slider, <kbd>Left Arrow</kbd> increases the value while <kbd>Right Arrow</kbd> decreases the value.

--- a/docs/src/app/experiments/slider-marks.tsx
+++ b/docs/src/app/experiments/slider-marks.tsx
@@ -38,8 +38,8 @@ function MarkWithLabel(props: {
   inverted?: boolean;
 }) {
   const { index, value, label, inverted = false } = props;
-  const { direction, values } = useSliderRootContext();
-  const isRtl = direction === 'rtl';
+  const { dir, values } = useSliderRootContext();
+  const isRtl = dir === 'rtl';
   const isFilled = inverted ? value >= values[0] : values[0] >= value;
   return (
     <React.Fragment>
@@ -99,7 +99,7 @@ export default function App() {
         </Slider.Control>
       </Slider.Root>
 
-      <Slider.Root className="TempSlider" defaultValue={40} direction="rtl">
+      <Slider.Root className="TempSlider" defaultValue={40} dir="rtl">
         <pre>RTL</pre>
         <Slider.Output className="TempSlider-output" />
         <Slider.Control className="TempSlider-control">

--- a/packages/react/src/composite/composite.ts
+++ b/packages/react/src/composite/composite.ts
@@ -1,8 +1,4 @@
 import * as React from 'react';
-import { hasComputedStyleMapSupport } from '../utils/hasComputedStyleMapSupport';
-import { ownerWindow } from '../utils/owner';
-
-export type TextDirection = 'ltr' | 'rtl';
 
 export interface Dimensions {
   width: number;
@@ -360,14 +356,4 @@ export function isDisabled(
     element.hasAttribute('disabled') ||
     element.getAttribute('aria-disabled') === 'true'
   );
-}
-
-export function getTextDirection(element: HTMLElement): TextDirection {
-  if (hasComputedStyleMapSupport()) {
-    const direction = element.computedStyleMap().get('direction');
-
-    return (direction as CSSKeywordValue)?.value as TextDirection;
-  }
-
-  return ownerWindow(element).getComputedStyle(element).direction as TextDirection;
 }

--- a/packages/react/src/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/composite/root/useCompositeRoot.ts
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { getTextDirection, type TextDirection } from '../../utils/getTextDirection';
 import { mergeReactProps } from '../../utils/mergeReactProps';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useForkRef } from '../../utils/useForkRef';
@@ -19,7 +20,6 @@ import {
   getGridNavigatedIndex,
   getMaxIndex,
   getMinIndex,
-  getTextDirection,
   HORIZONTAL_KEYS,
   HORIZONTAL_KEYS_WITH_EXTRA_KEYS,
   isDisabled,
@@ -27,7 +27,6 @@ import {
   VERTICAL_KEYS,
   VERTICAL_KEYS_WITH_EXTRA_KEYS,
   type Dimensions,
-  type TextDirection,
 } from '../composite';
 
 export interface UseCompositeRootParameters {

--- a/packages/react/src/scroll-area/root/useScrollAreaRoot.ts
+++ b/packages/react/src/scroll-area/root/useScrollAreaRoot.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useEventCallback } from '../../utils/useEventCallback';
-import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 import { mergeReactProps } from '../../utils/mergeReactProps';
 import { useId } from '../../utils/useId';
+import { useDir } from '../../utils/useDir';
 import { SCROLL_TIMEOUT } from '../constants';
 
 interface Size {
@@ -42,14 +42,7 @@ export function useScrollAreaRoot(params: useScrollAreaRoot.Parameters) {
     cornerHidden: false,
   });
 
-  const [autoDir, setAutoDir] = React.useState(dirParam);
-  const dir = dirParam ?? autoDir;
-
-  useEnhancedEffect(() => {
-    if (dirParam === undefined && viewportRef.current) {
-      setAutoDir(getComputedStyle(viewportRef.current).direction);
-    }
-  }, [dirParam]);
+  const dir = useDir(dirParam, viewportRef.current);
 
   React.useEffect(() => {
     return () => {

--- a/packages/react/src/slider/control/SliderControl.test.tsx
+++ b/packages/react/src/slider/control/SliderControl.test.tsx
@@ -7,9 +7,8 @@ import { NOOP } from '../../utils/noop';
 const testRootContext: SliderRootContext = {
   active: -1,
   areValuesEqual: () => true,
-  axis: 'horizontal',
   changeValue: NOOP,
-  direction: 'ltr',
+  dir: 'ltr',
   dragging: false,
   disabled: false,
   getFingerNewValue: () => ({
@@ -28,7 +27,7 @@ const testRootContext: SliderRootContext = {
     activeThumbIndex: -1,
     disabled: false,
     dragging: false,
-    direction: 'ltr',
+    dir: 'ltr',
     max: 100,
     min: 0,
     minStepsBetweenValues: 0,

--- a/packages/react/src/slider/indicator/SliderIndicator.test.tsx
+++ b/packages/react/src/slider/indicator/SliderIndicator.test.tsx
@@ -7,9 +7,8 @@ import { NOOP } from '../../utils/noop';
 const testRootContext: SliderRootContext = {
   active: -1,
   areValuesEqual: () => true,
-  axis: 'horizontal',
   changeValue: NOOP,
-  direction: 'ltr',
+  dir: 'ltr',
   dragging: false,
   disabled: false,
   getFingerNewValue: () => ({
@@ -28,7 +27,7 @@ const testRootContext: SliderRootContext = {
     activeThumbIndex: -1,
     disabled: false,
     dragging: false,
-    direction: 'ltr',
+    dir: 'ltr',
     max: 100,
     min: 0,
     minStepsBetweenValues: 0,

--- a/packages/react/src/slider/indicator/SliderIndicator.tsx
+++ b/packages/react/src/slider/indicator/SliderIndicator.tsx
@@ -23,12 +23,9 @@ const SliderIndicator = React.forwardRef(function SliderIndicator(
 ) {
   const { render, className, ...otherProps } = props;
 
-  const { axis, direction, disabled, orientation, state, percentageValues } =
-    useSliderRootContext();
+  const { disabled, orientation, state, percentageValues } = useSliderRootContext();
 
   const { getRootProps } = useSliderIndicator({
-    axis,
-    direction,
     disabled,
     orientation,
     percentageValues,

--- a/packages/react/src/slider/indicator/useSliderIndicator.ts
+++ b/packages/react/src/slider/indicator/useSliderIndicator.ts
@@ -4,16 +4,23 @@ import { mergeReactProps } from '../../utils/mergeReactProps';
 import type { GenericHTMLProps } from '../../utils/types';
 import type { useSliderRoot } from '../root/useSliderRoot';
 
-const rangeStyles = {
-  horizontal: {
-    offset: (percent: number) => ({ insetInlineStart: `${percent}%` }),
-    leap: (percent: number) => ({ width: `${percent}%`, height: 'inherit' }),
-  },
-  vertical: {
-    offset: (percent: number) => ({ bottom: `${percent}%` }),
-    leap: (percent: number) => ({ height: `${percent}%`, width: 'inherit' }),
-  },
-};
+function getRangeStyles(orientation: useSliderRoot.Orientation, offset: number, leap: number) {
+  if (orientation === 'vertical') {
+    return {
+      position: 'absolute',
+      bottom: `${offset}%`,
+      height: `${leap}%`,
+      width: 'inherit',
+    };
+  }
+
+  return {
+    position: 'absolute',
+    insetInlineStart: `${offset}%`,
+    width: `${leap}%`,
+    height: 'inherit',
+  };
+}
 
 /**
  *
@@ -30,19 +37,13 @@ export function useSliderIndicator(
 ): useSliderIndicator.ReturnValue {
   const { orientation, percentageValues } = parameters;
 
-  const isRange = percentageValues.length > 1;
-
   let internalStyles;
 
-  if (isRange) {
+  if (percentageValues.length > 1) {
     const trackOffset = percentageValues[0];
     const trackLeap = percentageValues[percentageValues.length - 1] - trackOffset;
 
-    internalStyles = {
-      position: 'absolute',
-      ...rangeStyles[orientation].offset(trackOffset),
-      ...rangeStyles[orientation].leap(trackLeap),
-    };
+    internalStyles = getRangeStyles(orientation, trackOffset, trackLeap);
   } else if (orientation === 'vertical') {
     internalStyles = {
       position: 'absolute',

--- a/packages/react/src/slider/indicator/useSliderIndicator.ts
+++ b/packages/react/src/slider/indicator/useSliderIndicator.ts
@@ -4,13 +4,9 @@ import { mergeReactProps } from '../../utils/mergeReactProps';
 import type { GenericHTMLProps } from '../../utils/types';
 import type { useSliderRoot } from '../root/useSliderRoot';
 
-const axisProps = {
+const rangeStyles = {
   horizontal: {
-    offset: (percent: number) => ({ left: `${percent}%` }),
-    leap: (percent: number) => ({ width: `${percent}%`, height: 'inherit' }),
-  },
-  'horizontal-reverse': {
-    offset: (percent: number) => ({ right: `${percent}%` }),
+    offset: (percent: number) => ({ insetInlineStart: `${percent}%` }),
     leap: (percent: number) => ({ width: `${percent}%`, height: 'inherit' }),
   },
   vertical: {
@@ -32,11 +28,9 @@ const axisProps = {
 export function useSliderIndicator(
   parameters: useSliderIndicator.Parameters,
 ): useSliderIndicator.ReturnValue {
-  const { axis, direction, orientation, percentageValues } = parameters;
+  const { orientation, percentageValues } = parameters;
 
   const isRange = percentageValues.length > 1;
-
-  const isRtl = direction === 'rtl';
 
   let internalStyles;
 
@@ -46,8 +40,8 @@ export function useSliderIndicator(
 
     internalStyles = {
       position: 'absolute',
-      ...axisProps[axis].offset(trackOffset),
-      ...axisProps[axis].leap(trackLeap),
+      ...rangeStyles[orientation].offset(trackOffset),
+      ...rangeStyles[orientation].leap(trackLeap),
     };
   } else if (orientation === 'vertical') {
     internalStyles = {
@@ -59,7 +53,7 @@ export function useSliderIndicator(
   } else {
     internalStyles = {
       position: 'absolute',
-      [isRtl ? 'right' : 'left']: 0,
+      insetInlineStart: 0,
       width: `${percentageValues[0]}%`,
       height: 'inherit',
     };
@@ -84,10 +78,7 @@ export function useSliderIndicator(
 
 export namespace useSliderIndicator {
   export interface Parameters
-    extends Pick<
-      useSliderRoot.ReturnValue,
-      'axis' | 'direction' | 'disabled' | 'orientation' | 'percentageValues'
-    > {}
+    extends Pick<useSliderRoot.ReturnValue, 'disabled' | 'orientation' | 'percentageValues'> {}
 
   export interface ReturnValue {
     getRootProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;

--- a/packages/react/src/slider/output/SliderOutput.test.tsx
+++ b/packages/react/src/slider/output/SliderOutput.test.tsx
@@ -8,9 +8,8 @@ import { NOOP } from '../../utils/noop';
 const testRootContext: SliderRootContext = {
   active: -1,
   areValuesEqual: () => true,
-  axis: 'horizontal',
   changeValue: NOOP,
-  direction: 'ltr',
+  dir: 'ltr',
   dragging: false,
   disabled: false,
   getFingerNewValue: () => ({
@@ -29,7 +28,7 @@ const testRootContext: SliderRootContext = {
     activeThumbIndex: -1,
     disabled: false,
     dragging: false,
-    direction: 'ltr',
+    dir: 'ltr',
     max: 100,
     min: 0,
     minStepsBetweenValues: 0,

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -8,6 +8,8 @@ import type { SliderRoot } from './SliderRoot';
 
 type Touches = Array<Pick<Touch, 'identifier' | 'clientX' | 'clientY'>>;
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 const GETBOUNDINGCLIENTRECT_HORIZONTAL_SLIDER_RETURN_VAL = {
   width: 100,
   height: 10,
@@ -164,15 +166,17 @@ describeSkipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     });
   });
 
-  describe('rtl', () => {
+  describeSkipIf(isJSDOM)('rtl', () => {
     it('should handle RTL', async () => {
       const handleValueChange = spy();
       const { getByTestId } = await render(
-        <TestSlider direction="rtl" value={30} onValueChange={handleValueChange} />,
+        <div dir="rtl">
+          <TestSlider value={30} onValueChange={handleValueChange} />
+        </div>,
       );
       const sliderControl = getByTestId('control');
       const sliderThumb = getByTestId('thumb');
-      expect(sliderThumb.style.right).to.equal('30%');
+      expect(sliderThumb.style.insetInlineStart).to.equal('30%');
 
       stub(sliderControl, 'getBoundingClientRect').callsFake(
         () => GETBOUNDINGCLIENTRECT_HORIZONTAL_SLIDER_RETURN_VAL,
@@ -196,7 +200,9 @@ describeSkipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     it('increments on ArrowUp', async () => {
       const handleValueChange = spy();
       const { container } = await render(
-        <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
+        <div dir="rtl">
+          <TestSlider defaultValue={20} onValueChange={handleValueChange} />
+        </div>,
       );
 
       const input = container.querySelector('input');
@@ -219,7 +225,9 @@ describeSkipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     it('increments on ArrowLeft', async () => {
       const handleValueChange = spy();
       const { container } = await render(
-        <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
+        <div dir="rtl">
+          <TestSlider defaultValue={20} onValueChange={handleValueChange} />
+        </div>,
       );
 
       const input = container.querySelector('input');
@@ -242,7 +250,9 @@ describeSkipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     it('decrements on ArrowDown', async () => {
       const handleValueChange = spy();
       const { container } = await render(
-        <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
+        <div dir="rtl">
+          <TestSlider defaultValue={20} onValueChange={handleValueChange} />
+        </div>,
       );
 
       const input = container.querySelector('input');
@@ -265,7 +275,9 @@ describeSkipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     it('decrements on ArrowRight', async () => {
       const handleValueChange = spy();
       const { container } = await render(
-        <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
+        <div dir="rtl">
+          <TestSlider defaultValue={20} onValueChange={handleValueChange} />
+        </div>,
       );
 
       const input = container.querySelector('input');

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -28,7 +28,7 @@ const SliderRoot = React.forwardRef(function SliderRoot(
     'aria-labelledby': ariaLabelledby,
     className,
     defaultValue,
-    direction = 'ltr',
+    dir: dirAttribute,
     disabled: disabledProp = false,
     largeStep,
     render,
@@ -47,7 +47,7 @@ const SliderRoot = React.forwardRef(function SliderRoot(
     'aria-labelledby': ariaLabelledby ?? labelId,
     defaultValue,
     disabled,
-    direction,
+    dir: dirAttribute,
     largeStep,
     minStepsBetweenValues,
     onValueChange,
@@ -62,7 +62,7 @@ const SliderRoot = React.forwardRef(function SliderRoot(
     () => ({
       ...fieldState,
       activeThumbIndex: slider.active,
-      direction,
+      dir: slider.dir,
       disabled,
       dragging: slider.dragging,
       orientation,
@@ -74,10 +74,10 @@ const SliderRoot = React.forwardRef(function SliderRoot(
     }),
     [
       fieldState,
-      direction,
       disabled,
       orientation,
       slider.active,
+      slider.dir,
       slider.dragging,
       slider.max,
       slider.min,
@@ -125,7 +125,7 @@ export namespace SliderRoot {
      * If `true`, a thumb is being dragged by a pointer.
      */
     dragging: boolean;
-    direction: useSliderRoot.Direction;
+    dir: string | undefined;
     max: number;
     min: number;
     /**

--- a/packages/react/src/slider/root/styleHooks.ts
+++ b/packages/react/src/slider/root/styleHooks.ts
@@ -3,7 +3,7 @@ import type { SliderRoot } from './SliderRoot';
 
 export const sliderStyleHookMapping: CustomStyleHookMapping<SliderRoot.State> = {
   activeThumbIndex: () => null,
-  direction: () => null,
+  dir: () => null,
   max: () => null,
   min: () => null,
   minStepsBetweenValues: () => null,

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -7,9 +7,8 @@ import { NOOP } from '../../utils/noop';
 const testRootContext: SliderRootContext = {
   active: -1,
   areValuesEqual: () => true,
-  axis: 'horizontal',
   changeValue: NOOP,
-  direction: 'ltr',
+  dir: 'ltr',
   dragging: false,
   disabled: false,
   getFingerNewValue: () => ({
@@ -28,7 +27,7 @@ const testRootContext: SliderRootContext = {
     activeThumbIndex: -1,
     disabled: false,
     dragging: false,
-    direction: 'ltr',
+    dir: 'ltr',
     max: 100,
     min: 0,
     minStepsBetweenValues: 0,

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -46,6 +46,7 @@ const SliderThumb = React.forwardRef(function SliderThumb(
     getAriaLabel,
     getAriaValueText,
     id,
+    inputId,
     ...otherProps
   } = props;
 
@@ -54,9 +55,8 @@ const SliderThumb = React.forwardRef(function SliderThumb(
   const {
     active: activeIndex,
     'aria-labelledby': ariaLabelledby,
-    axis,
     changeValue,
-    direction,
+    dir,
     disabled: contextDisabled,
     largeStep,
     max,
@@ -84,13 +84,13 @@ const SliderThumb = React.forwardRef(function SliderThumb(
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledby,
     'aria-valuetext': ariaValuetext,
-    axis,
     changeValue,
-    direction,
+    dir,
     disabled: disabledProp || contextDisabled,
     getAriaLabel,
     getAriaValueText,
     id,
+    inputId,
     largeStep,
     max,
     min,

--- a/packages/react/src/slider/thumb/useSliderThumb.ts
+++ b/packages/react/src/slider/thumb/useSliderThumb.ts
@@ -44,9 +44,8 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledby,
     'aria-valuetext': ariaValuetext,
-    axis,
     changeValue,
-    direction,
+    dir,
     disabled,
     getAriaLabel,
     getAriaValueText,
@@ -98,7 +97,7 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
   // for SSR, don't wait for the index if there's only one thumb
   const percent = percentageValues.length === 1 ? percentageValues[0] : percentageValues[index];
 
-  const isRtl = direction === 'rtl';
+  const isRtl = dir === 'rtl';
 
   const getThumbStyle = React.useCallback(() => {
     const isVertical = orientation === 'vertical';
@@ -110,17 +109,16 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
     return {
       position: 'absolute',
       [{
-        horizontal: 'left',
-        'horizontal-reverse': 'right',
+        horizontal: 'insetInlineStart',
         vertical: 'bottom',
-      }[axis]]: `${percent}%`,
+      }[orientation]]: `${percent}%`,
       [isVertical ? 'left' : 'top']: '50%',
       transform: `translate(${(isVertical || !isRtl ? -1 : 1) * 50}%, ${(isVertical ? 1 : -1) * 50}%)`,
       // So the non active thumb doesn't show its label on hover.
       pointerEvents: activeIndex !== -1 && activeIndex !== index ? 'none' : undefined,
       zIndex: activeIndex === index ? 1 : undefined,
     };
-  }, [activeIndex, axis, isRtl, orientation, percent, index]);
+  }, [activeIndex, isRtl, orientation, percent, index]);
 
   const getRootProps: useSliderThumb.ReturnValue['getRootProps'] = React.useCallback(
     (externalProps = {}) => {
@@ -262,7 +260,6 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
         step,
         style: {
           ...visuallyHidden,
-          direction: isRtl ? 'rtl' : 'ltr',
           // So that VoiceOver's focus indicator matches the thumb's dimensions
           width: '100%',
           height: '100%',
@@ -313,9 +310,8 @@ export namespace useSliderThumb {
       useSliderRoot.ReturnValue,
       | 'active'
       | 'aria-labelledby'
-      | 'axis'
       | 'changeValue'
-      | 'direction'
+      | 'dir'
       | 'largeStep'
       | 'max'
       | 'min'

--- a/packages/react/src/slider/track/SliderTrack.test.tsx
+++ b/packages/react/src/slider/track/SliderTrack.test.tsx
@@ -7,9 +7,8 @@ import { NOOP } from '../../utils/noop';
 const testRootContext: SliderRootContext = {
   active: -1,
   areValuesEqual: () => true,
-  axis: 'horizontal',
   changeValue: NOOP,
-  direction: 'ltr',
+  dir: 'ltr',
   dragging: false,
   disabled: false,
   getFingerNewValue: () => ({
@@ -28,7 +27,7 @@ const testRootContext: SliderRootContext = {
     activeThumbIndex: -1,
     disabled: false,
     dragging: false,
-    direction: 'ltr',
+    dir: 'ltr',
     max: 100,
     min: 0,
     minStepsBetweenValues: 0,

--- a/packages/react/src/utils/getTextDirection.ts
+++ b/packages/react/src/utils/getTextDirection.ts
@@ -1,0 +1,14 @@
+import { hasComputedStyleMapSupport } from './hasComputedStyleMapSupport';
+import { ownerWindow } from './owner';
+
+export type TextDirection = 'ltr' | 'rtl';
+
+export function getTextDirection(element: HTMLElement): TextDirection {
+  if (hasComputedStyleMapSupport()) {
+    const direction = element.computedStyleMap().get('direction');
+
+    return (direction as CSSKeywordValue)?.value as TextDirection;
+  }
+
+  return ownerWindow(element).getComputedStyle(element).direction as TextDirection;
+}

--- a/packages/react/src/utils/useDir.ts
+++ b/packages/react/src/utils/useDir.ts
@@ -1,0 +1,20 @@
+'use client';
+import * as React from 'react';
+import { getTextDirection } from './getTextDirection';
+import { useEnhancedEffect } from './useEnhancedEffect';
+
+/**
+ * Detect the inherited CSS `direction` if a `dir` param is not provided
+ * @ignore - internal
+ */
+export function useDir(dirParam: string | undefined, element: HTMLElement | null) {
+  const [autoDir, setAutoDir] = React.useState(dirParam);
+
+  useEnhancedEffect(() => {
+    if (dirParam === undefined && element) {
+      setAutoDir(getTextDirection(element));
+    }
+  }, [dirParam, element]);
+
+  return dirParam ?? autoDir;
+}


### PR DESCRIPTION
Part of https://github.com/mui/base-ui/issues/831

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
