### PR TITLE
[core] Add DirectionProvider

### DIFF
--- a/docs/data/api/direction-provider.json
+++ b/docs/data/api/direction-provider.json
@@ -1,11 +1,16 @@
 {
-  "props": {},
+  "props": {
+    "direction": {
+      "type": { "name": "enum", "description": "'ltr'<br>&#124;&nbsp;'rtl'" },
+      "default": "'ltr'"
+    }
+  },
   "name": "DirectionProvider",
   "imports": ["import { DirectionProvider } from '@base-ui-components/react/direction-provider';"],
   "classes": [],
   "muiName": "DirectionProvider",
   "filename": "/packages/react/src/direction-provider/DirectionProvider.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/components/react-direction-provider/\">Progress</a></li></ul>",
+  "demos": "<ul><li><a href=\"/components/react-direction-provider/\">Direction Provider</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/data/api/direction-provider.json
+++ b/docs/data/api/direction-provider.json
@@ -1,0 +1,11 @@
+{
+  "props": {},
+  "name": "DirectionProvider",
+  "imports": ["import { DirectionProvider } from '@base-ui-components/react/direction-provider';"],
+  "classes": [],
+  "muiName": "DirectionProvider",
+  "filename": "/packages/react/src/direction-provider/DirectionProvider.tsx",
+  "inheritance": null,
+  "demos": "<ul><li><a href=\"/components/react-direction-provider/\">Progress</a></li></ul>",
+  "cssComponent": false
+}

--- a/docs/data/api/menu-root.json
+++ b/docs/data/api/menu-root.json
@@ -3,10 +3,6 @@
     "closeParentOnEsc": { "type": { "name": "bool" }, "default": "true" },
     "defaultOpen": { "type": { "name": "bool" }, "default": "false" },
     "delay": { "type": { "name": "number" }, "default": "100" },
-    "dir": {
-      "type": { "name": "enum", "description": "'ltr'<br>&#124;&nbsp;'rtl'" },
-      "default": "'ltr'"
-    },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
     "loop": { "type": { "name": "bool" }, "default": "true" },
     "onOpenChange": { "type": { "name": "func" } },

--- a/docs/data/api/slider-root.json
+++ b/docs/data/api/slider-root.json
@@ -5,10 +5,6 @@
     "defaultValue": {
       "type": { "name": "union", "description": "Array&lt;number&gt;<br>&#124;&nbsp;number" }
     },
-    "direction": {
-      "type": { "name": "enum", "description": "'ltr'<br>&#124;&nbsp;'rtl'" },
-      "default": "'ltr'"
-    },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
     "largeStep": { "type": { "name": "number" }, "default": "10" },
     "minStepsBetweenValues": { "type": { "name": "number" }, "default": "0" },

--- a/docs/data/api/slider-root.json
+++ b/docs/data/api/slider-root.json
@@ -7,7 +7,10 @@
     },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
     "largeStep": { "type": { "name": "number" }, "default": "10" },
+    "max": { "type": { "name": "number" }, "default": "100" },
+    "min": { "type": { "name": "number" }, "default": "0" },
     "minStepsBetweenValues": { "type": { "name": "number" }, "default": "0" },
+    "name": { "type": { "name": "string" } },
     "onValueChange": {
       "type": { "name": "func" },
       "signature": {
@@ -27,6 +30,7 @@
       "default": "'horizontal'"
     },
     "render": { "type": { "name": "union", "description": "element<br>&#124;&nbsp;func" } },
+    "step": { "type": { "name": "number" }, "default": "1" },
     "value": {
       "type": { "name": "union", "description": "Array&lt;number&gt;<br>&#124;&nbsp;number" }
     }

--- a/docs/data/components/accordion/accordion.mdx
+++ b/docs/data/components/accordion/accordion.mdx
@@ -176,7 +176,7 @@ Use the `orientation` prop to configure a horizontal accordion. In a horizontal 
 
 ## RTL
 
-To change direction for right-to-left languages, place the accordion in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place the accordion in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop to configure RTL behavior, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/accordion/accordion.mdx
+++ b/docs/data/components/accordion/accordion.mdx
@@ -176,13 +176,19 @@ Use the `orientation` prop to configure a horizontal accordion. In a horizontal 
 
 ## RTL
 
-Use the `direction` prop to configure a RTL accordion:
+To change direction for right-to-left languages, place the accordion in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
-<Accordion.Root direction="rtl">{/* subcomponents */}</Accordion.Root>
+<html dir="rtl">
+  <body>
+    <DirectionProvider direction="rtl">
+      <Accordion.Root>{/* Subcomponents */}</Accordion.Root>
+    </DirectionProvider>
+  </body>
+</html>
 ```
 
-When a horizontal accordion is set to `direction="rtl"`, keyboard actions are reversed accordingly - <kbd className="key">Left Arrow</kbd> moves focus to the next trigger and <kbd className="key">Right Arrow</kbd> moves focus to the previous trigger.
+When RTL, keyboard actions for horizontal accordions are reversed - <kbd className="key">Left Arrow</kbd> moves focus to the next trigger and <kbd className="key">Right Arrow</kbd> moves focus to the previous trigger.
 
 ## Hidden state
 

--- a/docs/data/components/direction-provider/direction-provider.mdx
+++ b/docs/data/components/direction-provider/direction-provider.mdx
@@ -1,0 +1,17 @@
+---
+productId: base-ui
+title: Direction Provider React component
+description: Direction provider configures RTL/LTR for part of or the whole app
+components: DirectionProvider
+packageName: '@base-ui-components/react'
+---
+
+# Progress
+
+<Description />
+
+<ComponentLinkHeader design={false} />
+
+## Installation
+
+<InstallationInstructions componentName="Progress" />

--- a/docs/data/components/direction-provider/direction-provider.mdx
+++ b/docs/data/components/direction-provider/direction-provider.mdx
@@ -6,7 +6,7 @@ components: DirectionProvider
 packageName: '@base-ui-components/react'
 ---
 
-# Progress
+# Direction Provider
 
 <Description />
 
@@ -14,4 +14,19 @@ packageName: '@base-ui-components/react'
 
 ## Installation
 
-<InstallationInstructions componentName="Progress" />
+<InstallationInstructions componentName="DirectionProvider" />
+
+## Usage
+
+Use DirectionProvider to configure RTL keyboard behavior for an app or a group
+of components:
+
+```jsx
+<html dir="rtl">
+  <body>
+    <DirectionProvider direction="rtl">{/* Your React app */}</DirectionProvider>
+  </body>
+</html>
+```
+
+Additionally, you must set the `dir="rtl"` attribute in your HTML to affect styling.

--- a/docs/data/components/menu/menu.mdx
+++ b/docs/data/components/menu/menu.mdx
@@ -279,6 +279,22 @@ To visually separate items, use the `Menu.Separator` component:
 The Menu.Separator is a re-exported Separator component.
 See the [Separator docs](/components/react-separator) to learn about its API.
 
+## RTL
+
+To change direction for right-to-left languages, place the menu in `DirectionProvider` with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
+
+```jsx
+<html dir="rtl">
+  <body>
+    <DirectionProvider direction="rtl">
+      <Menu.Root>{/* Subcomponents */}</Menu.Root>
+    </DirectionProvider>
+  </body>
+</html>
+```
+
+In a RTL menu, <kbd>Left Arrow</kbd> opens submenus while <kbd>Right Arrow</kbd> closes them.
+
 ## Animations
 
 The menu can animate when opening or closing with either:

--- a/docs/data/components/menu/menu.mdx
+++ b/docs/data/components/menu/menu.mdx
@@ -281,7 +281,7 @@ See the [Separator docs](/components/react-separator) to learn about its API.
 
 ## RTL
 
-To change direction for right-to-left languages, place the menu in `DirectionProvider` with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place the menu in [`DirectionProvider`](/components/react-direction-provider) with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/menu/menu.mdx
+++ b/docs/data/components/menu/menu.mdx
@@ -281,7 +281,7 @@ See the [Separator docs](/components/react-separator) to learn about its API.
 
 ## RTL
 
-To change direction for right-to-left languages, place the menu in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place the menu in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop to configure RTL behavior, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/menu/menu.mdx
+++ b/docs/data/components/menu/menu.mdx
@@ -281,7 +281,7 @@ See the [Separator docs](/components/react-separator) to learn about its API.
 
 ## RTL
 
-To change direction for right-to-left languages, place the menu in [`DirectionProvider`](/components/react-direction-provider) with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place the menu in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/radio-group/radio-group.mdx
+++ b/docs/data/components/radio-group/radio-group.mdx
@@ -112,7 +112,7 @@ The `Radio` components have a `[data-checked]` or `[data-unchecked]` attribute t
 
 ## RTL
 
-To change direction for right-to-left languages, place the component in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place the component in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop to configure RTL behavior, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/radio-group/radio-group.mdx
+++ b/docs/data/components/radio-group/radio-group.mdx
@@ -112,12 +112,14 @@ The `Radio` components have a `[data-checked]` or `[data-unchecked]` attribute t
 
 ## RTL
 
-Place the component inside an HTML element or component with the HTML `dir="rtl"` attribute to reverse arrow key navigation for right-to-left languages:
+To change direction for right-to-left languages, place the component in `DirectionProvider` with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">
   <body>
-    <RadioGroup.Root /> {/* RTL keyboard behavior */}
+    <DirectionProvider direction="rtl">
+      <RadioGroup.Root /> {/* RTL keyboard behavior */}
+    </DirectionProvider>
   </body>
 </html>
 ```

--- a/docs/data/components/radio-group/radio-group.mdx
+++ b/docs/data/components/radio-group/radio-group.mdx
@@ -112,7 +112,7 @@ The `Radio` components have a `[data-checked]` or `[data-unchecked]` attribute t
 
 ## RTL
 
-To change direction for right-to-left languages, place the component in [`DirectionProvider`](/components/react-direction-provider) with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place the component in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/radio-group/radio-group.mdx
+++ b/docs/data/components/radio-group/radio-group.mdx
@@ -112,7 +112,7 @@ The `Radio` components have a `[data-checked]` or `[data-unchecked]` attribute t
 
 ## RTL
 
-To change direction for right-to-left languages, place the component in `DirectionProvider` with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place the component in [`DirectionProvider`](/components/react-direction-provider) with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/slider/RtlSlider.js
+++ b/docs/data/components/slider/RtlSlider.js
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { DirectionProvider } from '@base-ui-components/react/direction-provider';
 import { Slider } from '@base-ui-components/react/slider';
 import { useTheme } from '@mui/system';
 import classes from './styles.module.css';
@@ -9,32 +10,33 @@ export default function RtlSlider() {
   // Replace this with your app logic for determining dark mode
   const isDarkMode = useIsDarkMode();
   return (
-    <div className={isDarkMode ? 'dark' : ''} style={{ width: 320, margin: 32 }}>
-      <Slider.Root
-        defaultValue={50}
-        aria-labelledby="VolumeSliderLabel"
-        direction="rtl"
-        className={classes.slider}
-      >
-        <Label
-          id="VolumeSliderLabel"
-          htmlFor=":slider-thumb-input-rtl:"
-          className={classes.label}
+    <DirectionProvider direction="rtl">
+      <div className={isDarkMode ? 'dark' : ''} style={{ width: 320, margin: 32 }}>
+        <Slider.Root
+          defaultValue={50}
+          aria-labelledby="VolumeSliderLabel"
+          className={classes.slider}
         >
-          Volume (RTL)
-        </Label>
-        <Slider.Output className={classes.output} />
-        <Slider.Control className={classes.control}>
-          <Slider.Track className={classes.track}>
-            <Slider.Indicator className={classes.indicator} />
-            <Slider.Thumb
-              className={classes.thumb}
-              inputId=":slider-thumb-input-rtl:"
-            />
-          </Slider.Track>
-        </Slider.Control>
-      </Slider.Root>
-    </div>
+          <Label
+            id="VolumeSliderLabel"
+            htmlFor=":slider-thumb-input-rtl:"
+            className={classes.label}
+          >
+            Volume (RTL)
+          </Label>
+          <Slider.Output className={classes.output} />
+          <Slider.Control className={classes.control}>
+            <Slider.Track className={classes.track}>
+              <Slider.Indicator className={classes.indicator} />
+              <Slider.Thumb
+                className={classes.thumb}
+                inputId=":slider-thumb-input-rtl:"
+              />
+            </Slider.Track>
+          </Slider.Control>
+        </Slider.Root>
+      </div>
+    </DirectionProvider>
   );
 }
 

--- a/docs/data/components/slider/RtlSlider.tsx
+++ b/docs/data/components/slider/RtlSlider.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { DirectionProvider } from '@base-ui-components/react/direction-provider';
 import { Slider } from '@base-ui-components/react/slider';
 import { useTheme } from '@mui/system';
 import classes from './styles.module.css';
@@ -8,32 +9,33 @@ export default function RtlSlider() {
   // Replace this with your app logic for determining dark mode
   const isDarkMode = useIsDarkMode();
   return (
-    <div className={isDarkMode ? 'dark' : ''} style={{ width: 320, margin: 32 }}>
-      <Slider.Root
-        defaultValue={50}
-        aria-labelledby="VolumeSliderLabel"
-        direction="rtl"
-        className={classes.slider}
-      >
-        <Label
-          id="VolumeSliderLabel"
-          htmlFor=":slider-thumb-input-rtl:"
-          className={classes.label}
+    <DirectionProvider direction="rtl">
+      <div className={isDarkMode ? 'dark' : ''} style={{ width: 320, margin: 32 }}>
+        <Slider.Root
+          defaultValue={50}
+          aria-labelledby="VolumeSliderLabel"
+          className={classes.slider}
         >
-          Volume (RTL)
-        </Label>
-        <Slider.Output className={classes.output} />
-        <Slider.Control className={classes.control}>
-          <Slider.Track className={classes.track}>
-            <Slider.Indicator className={classes.indicator} />
-            <Slider.Thumb
-              className={classes.thumb}
-              inputId=":slider-thumb-input-rtl:"
-            />
-          </Slider.Track>
-        </Slider.Control>
-      </Slider.Root>
-    </div>
+          <Label
+            id="VolumeSliderLabel"
+            htmlFor=":slider-thumb-input-rtl:"
+            className={classes.label}
+          >
+            Volume (RTL)
+          </Label>
+          <Slider.Output className={classes.output} />
+          <Slider.Control className={classes.control}>
+            <Slider.Track className={classes.track}>
+              <Slider.Indicator className={classes.indicator} />
+              <Slider.Thumb
+                className={classes.thumb}
+                inputId=":slider-thumb-input-rtl:"
+              />
+            </Slider.Track>
+          </Slider.Control>
+        </Slider.Root>
+      </div>
+    </DirectionProvider>
   );
 }
 

--- a/docs/data/components/slider/slider.mdx
+++ b/docs/data/components/slider/slider.mdx
@@ -185,7 +185,7 @@ To create vertical sliders, set the `orientation` prop to `"vertical"`. This wil
 
 ## RTL
 
-To change direction for right-to-left languages, place the slider in `DirectionProvider` with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place the slider in [`DirectionProvider`](/components/react-direction-provider) with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/slider/slider.mdx
+++ b/docs/data/components/slider/slider.mdx
@@ -185,10 +185,16 @@ To create vertical sliders, set the `orientation` prop to `"vertical"`. This wil
 
 ## RTL
 
-Set the `direction` prop to `'rtl'` to change the slider's direction for right-to-left languages:
+To change direction for right-to-left languages, place the slider in `DirectionProvider` with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
-<Slider.Root direction="rtl">{/* Subcomponents */}</Slider.Root>
+<html dir="rtl">
+  <body>
+    <DirectionProvider direction="rtl">
+      <Slider.Root>{/* Subcomponents */}</Slider.Root>
+    </DirectionProvider>
+  </body>
+</html>
 ```
 
 In a RTL Slider, <kbd>Left Arrow</kbd> increases the value while <kbd>Right Arrow</kbd> decreases the value.

--- a/docs/data/components/slider/slider.mdx
+++ b/docs/data/components/slider/slider.mdx
@@ -185,7 +185,7 @@ To create vertical sliders, set the `orientation` prop to `"vertical"`. This wil
 
 ## RTL
 
-To change direction for right-to-left languages, place the slider in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place the slider in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop to configure RTL behavior, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/slider/slider.mdx
+++ b/docs/data/components/slider/slider.mdx
@@ -185,7 +185,7 @@ To create vertical sliders, set the `orientation` prop to `"vertical"`. This wil
 
 ## RTL
 
-To change direction for right-to-left languages, place the slider in [`DirectionProvider`](/components/react-direction-provider) with the `direction` prop to `'rtl'`, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place the slider in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/tabs/tabs.mdx
+++ b/docs/data/components/tabs/tabs.mdx
@@ -156,7 +156,7 @@ Base UI Tabs follow the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/A
 
 ## RTL
 
-To change direction for right-to-left languages, place horizontal tabs in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place horizontal tabs in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop to configure RTL behavior, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/tabs/tabs.mdx
+++ b/docs/data/components/tabs/tabs.mdx
@@ -156,12 +156,14 @@ Base UI Tabs follow the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/A
 
 ## RTL
 
-Place horizontal tabs inside an HTML element or component with the HTML `dir="rtl"` attribute to reverse arrow key navigation for right-to-left languages:
+To change direction for right-to-left languages, place horizontal tabs in `DirectionProvider` with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">
   <body>
-    <Tabs.Root orientation="horizontal" /> {/* RTL keyboard behavior */}
+    <DirectionProvider direction="rtl">
+      <Tabs.Root orientation="horizontal" /> {/* RTL keyboard behavior */}
+    </DirectionProvider>
   </body>
 </html>
 ```

--- a/docs/data/components/tabs/tabs.mdx
+++ b/docs/data/components/tabs/tabs.mdx
@@ -156,7 +156,7 @@ Base UI Tabs follow the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/A
 
 ## RTL
 
-To change direction for right-to-left languages, place horizontal tabs in `DirectionProvider` with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
+To change direction for right-to-left languages, place horizontal tabs in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop, and set the `dir` attribute accordingly in your HTML to affect styling:
 
 ```jsx
 <html dir="rtl">

--- a/docs/data/components/toggle-group/toggle-group.mdx
+++ b/docs/data/components/toggle-group/toggle-group.mdx
@@ -114,6 +114,22 @@ return (
 );
 ```
 
+## RTL
+
+To change direction for right-to-left languages, place the component in [`DirectionProvider`](/components/react-direction-provider) with the `direction="rtl"` prop to configure RTL behavior, and set the `dir` attribute accordingly in your HTML to affect styling:
+
+```jsx
+<html dir="rtl">
+  <body>
+    <DirectionProvider direction="rtl">
+      <ToggleGroup>{/* Subcomponents */}</ToggleGroup>
+    </DirectionProvider>
+  </body>
+</html>
+```
+
+When RTL, the behavior of the left and right arrow keys are reversed - <kbd className="key">Left Arrow</kbd> moves focus to the next toggle and <kbd className="key">Right Arrow</kbd> moves focus to the previous toggle.
+
 ## Accessibility
 
 - The `ToggleGroup` component, and every `Toggle` within must be given must be given an accessible name with `aria-label` or `aria-labelledby`.

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -28,6 +28,7 @@ const pages: readonly RouteMetadata[] = [
       { pathname: '/components/react-checkbox-group', title: 'Checkbox Group' },
       { pathname: '/components/react-collapsible', title: 'Collapsible' },
       { pathname: '/components/react-dialog', title: 'Dialog' },
+      { pathname: '/components/react-direction-provider', title: 'Direction Provider' },
       { pathname: '/components/react-field', title: 'Field' },
       { pathname: '/components/react-fieldset', title: 'Fieldset' },
       { pathname: '/components/react-form', title: 'Form' },

--- a/docs/data/translations/api-docs/direction-provider/direction-provider.json
+++ b/docs/data/translations/api-docs/direction-provider/direction-provider.json
@@ -1,5 +1,5 @@
 {
   "componentDescription": "A provider that configures RTL/LTR behavior for part of an app or a whole app.",
-  "propDescriptions": {},
+  "propDescriptions": { "direction": { "description": "The reading direction of the text" } },
   "classDescriptions": {}
 }

--- a/docs/data/translations/api-docs/direction-provider/direction-provider.json
+++ b/docs/data/translations/api-docs/direction-provider/direction-provider.json
@@ -1,0 +1,5 @@
+{
+  "componentDescription": "A provider that configures RTL/LTR behavior for part of an app or a whole app.",
+  "propDescriptions": {},
+  "classDescriptions": {}
+}

--- a/docs/data/translations/api-docs/menu-root/menu-root.json
+++ b/docs/data/translations/api-docs/menu-root/menu-root.json
@@ -8,7 +8,6 @@
     "delay": {
       "description": "The delay in milliseconds until the menu popup is opened when <code>openOnHover</code> is <code>true</code>."
     },
-    "dir": { "description": "The direction of the Menu (left-to-right or right-to-left)." },
     "disabled": { "description": "If <code>true</code>, the Menu is disabled." },
     "loop": {
       "description": "If <code>true</code>, using keyboard navigation will wrap focus to the other end of the list once the end is reached."

--- a/docs/data/translations/api-docs/slider-root/slider-root.json
+++ b/docs/data/translations/api-docs/slider-root/slider-root.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "aria-labelledby": {
-      "description": "The id of the element containing a label for the slider."
+      "description": "Identifies the element (or elements) that labels the current element."
     },
     "className": {
       "description": "Class names applied to the element or a function that returns them based on the component&#39;s state."
@@ -14,9 +14,16 @@
     "largeStep": {
       "description": "The granularity with which the slider can step through values when using Page Up/Page Down or Shift + Arrow Up/Arrow Down."
     },
+    "max": {
+      "description": "The maximum allowed value of the slider. Should not be equal to min."
+    },
+    "min": {
+      "description": "The minimum allowed value of the slider. Should not be equal to max."
+    },
     "minStepsBetweenValues": {
       "description": "The minimum steps between values in a range slider."
     },
+    "name": { "description": "Name attribute of the hidden <code>input</code> element." },
     "onValueChange": {
       "description": "Callback function that is fired when the slider&#39;s value changed.",
       "typeDescriptions": {
@@ -34,6 +41,9 @@
     },
     "orientation": { "description": "The component orientation." },
     "render": { "description": "A function to customize rendering of the component." },
+    "step": {
+      "description": "The granularity with which the slider can step through values. (A &quot;discrete&quot; slider.) The <code>min</code> prop serves as the origin for the valid values. We recommend (max - min) to be evenly divisible by the step."
+    },
     "value": {
       "description": "The value of the slider. For ranged sliders, provide an array with two values."
     }

--- a/docs/data/translations/api-docs/slider-root/slider-root.json
+++ b/docs/data/translations/api-docs/slider-root/slider-root.json
@@ -10,9 +10,6 @@
     "defaultValue": {
       "description": "The default value of the slider. Use when the component is not controlled."
     },
-    "direction": {
-      "description": "Sets the direction. For right-to-left languages, the lowest value is on the right-hand side."
-    },
     "disabled": { "description": "If <code>true</code>, the component is disabled." },
     "largeStep": {
       "description": "The granularity with which the slider can step through values when using Page Up/Page Down or Shift + Arrow Up/Arrow Down."

--- a/docs/data/translations/api-docs/toggle-group-root/toggle-group-root.json
+++ b/docs/data/translations/api-docs/toggle-group-root/toggle-group-root.json
@@ -5,7 +5,7 @@
       "description": "Class names applied to the element or a function that returns them based on the component&#39;s state."
     },
     "defaultValue": {
-      "description": "The open state of the ToggleGroup represented by an array of the values of all pressed <code>&lt;ToggleGroup.Item/&gt;</code>s This is the uncontrolled counterpart of <code>value</code>."
+      "description": "The open state of the ToggleGroup represented by an array of the values of all pressed <code>&lt;ToggleGroup.Item/&gt;</code>s. This is the uncontrolled counterpart of <code>value</code>."
     },
     "onValueChange": {
       "description": "Callback fired when the pressed states of the ToggleGroup changes.",

--- a/docs/data/translations/api-docs/toggle-root/toggle-root.json
+++ b/docs/data/translations/api-docs/toggle-root/toggle-root.json
@@ -22,7 +22,7 @@
     "pressed": { "description": "If <code>true</code>, the component is pressed." },
     "render": { "description": "A function to customize rendering of the component." },
     "value": {
-      "description": "A unique string that identifies the component when used inside a ToggleGroup"
+      "description": "A unique string that identifies the component when used inside a ToggleGroup."
     }
   },
   "classDescriptions": {}

--- a/docs/reference/generated/direction-provider.json
+++ b/docs/reference/generated/direction-provider.json
@@ -1,0 +1,5 @@
+{
+  "name": "DirectionProvider",
+  "description": "A provider that configures RTL/LTR behavior for part of an app or a whole app.",
+  "props": {}
+}

--- a/docs/reference/generated/direction-provider.json
+++ b/docs/reference/generated/direction-provider.json
@@ -1,5 +1,11 @@
 {
   "name": "DirectionProvider",
   "description": "A provider that configures RTL/LTR behavior for part of an app or a whole app.",
-  "props": {}
+  "props": {
+    "direction": {
+      "type": "'ltr' | 'rtl'",
+      "default": "'ltr'",
+      "description": "The reading direction of the text"
+    }
+  }
 }

--- a/docs/reference/generated/menu-root.json
+++ b/docs/reference/generated/menu-root.json
@@ -17,11 +17,6 @@
       "default": "100",
       "description": "The delay in milliseconds until the menu popup is opened when `openOnHover` is `true`."
     },
-    "dir": {
-      "type": "'ltr' | 'rtl'",
-      "default": "'ltr'",
-      "description": "The direction of the Menu (left-to-right or right-to-left)."
-    },
     "disabled": {
       "type": "boolean",
       "default": "false",

--- a/docs/reference/generated/slider-root.json
+++ b/docs/reference/generated/slider-root.json
@@ -14,11 +14,6 @@
       "type": "Array<number> | number",
       "description": "The default value of the slider. Use when the component is not controlled."
     },
-    "direction": {
-      "type": "'ltr' | 'rtl'",
-      "default": "'ltr'",
-      "description": "Sets the direction. For right-to-left languages, the lowest value is on the right-hand side."
-    },
     "disabled": {
       "type": "boolean",
       "default": "false",

--- a/docs/reference/generated/slider-root.json
+++ b/docs/reference/generated/slider-root.json
@@ -4,7 +4,7 @@
   "props": {
     "aria-labelledby": {
       "type": "string",
-      "description": "The id of the element containing a label for the slider."
+      "description": "Identifies the element (or elements) that labels the current element."
     },
     "className": {
       "type": "string | (state) => string",
@@ -24,10 +24,24 @@
       "default": "10",
       "description": "The granularity with which the slider can step through values when using Page Up/Page Down or Shift + Arrow Up/Arrow Down."
     },
+    "max": {
+      "type": "number",
+      "default": "100",
+      "description": "The maximum allowed value of the slider.\nShould not be equal to min."
+    },
+    "min": {
+      "type": "number",
+      "default": "0",
+      "description": "The minimum allowed value of the slider.\nShould not be equal to max."
+    },
     "minStepsBetweenValues": {
       "type": "number",
       "default": "0",
       "description": "The minimum steps between values in a range slider."
+    },
+    "name": {
+      "type": "string",
+      "description": "Name attribute of the hidden `input` element."
     },
     "onValueChange": {
       "type": "(value, event, activeThumbIndex) => void",
@@ -45,6 +59,11 @@
     "render": {
       "type": "React.ReactElement | (props, state) => React.ReactElement",
       "description": "A function to customize rendering of the component."
+    },
+    "step": {
+      "type": "number",
+      "default": "1",
+      "description": "The granularity with which the slider can step through values. (A \"discrete\" slider.)\nThe `min` prop serves as the origin for the valid values.\nWe recommend (max - min) to be evenly divisible by the step."
     },
     "value": {
       "type": "Array<number> | number",

--- a/docs/reference/generated/toggle-group-root.json
+++ b/docs/reference/generated/toggle-group-root.json
@@ -8,7 +8,7 @@
     },
     "defaultValue": {
       "type": "array",
-      "description": "The open state of the ToggleGroup represented by an array of\nthe values of all pressed `<ToggleGroup.Item/>`s\nThis is the uncontrolled counterpart of `value`."
+      "description": "The open state of the ToggleGroup represented by an array of\nthe values of all pressed `<ToggleGroup.Item/>`s.\nThis is the uncontrolled counterpart of `value`."
     },
     "onValueChange": {
       "type": "function(groupValue: Array<any>, event: Event) => void",

--- a/docs/reference/generated/toggle-root.json
+++ b/docs/reference/generated/toggle-root.json
@@ -38,7 +38,7 @@
     },
     "value": {
       "type": "string",
-      "description": "A unique string that identifies the component when used\ninside a ToggleGroup"
+      "description": "A unique string that identifies the component when used\ninside a ToggleGroup."
     }
   }
 }

--- a/docs/src/app/experiments/accordion-horizontal.tsx
+++ b/docs/src/app/experiments/accordion-horizontal.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { DirectionProvider } from '@base-ui-components/react/direction-provider';
 import { Accordion } from '@base-ui-components/react/accordion';
 import classes from './accordion.horizontal.module.css';
 
@@ -16,7 +17,6 @@ export default function App() {
         className={classes.root}
         aria-label="Uncontrolled Horizontal Accordion"
         openMultiple={false}
-        orientation="horizontal"
       >
         {['one', 'two', 'three'].map((value, index) => (
           <Accordion.Item className={classes.item} key={value}>
@@ -39,35 +39,36 @@ export default function App() {
         <h2>Horizontal RTL</h2>
         <p>one section must remain open</p>
       </span>
-      <Accordion.Root
-        className={classes.root}
-        aria-label="Controlled Horizontal RTL Accordion"
-        openMultiple={false}
-        orientation="horizontal"
-        direction="rtl"
-        value={val}
-        onValueChange={(newValue: Accordion.Root.Props['value']) => {
-          if (Array.isArray(newValue) && newValue.length > 0) {
-            setVal(newValue);
-          }
-        }}
-      >
-        {['one', 'two', 'three'].map((value, index) => (
-          <Accordion.Item className={classes.item} key={value} value={value}>
-            <Accordion.Header className={classes.header}>
-              <Accordion.Trigger
-                className={classNames(classes.trigger, classes[value])}
-              >
-                <span className={classes.triggerText}>{index + 1}</span>
-                <span className={classes.triggerLabel}>{value}</span>
-              </Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Panel className={classes.panel}>
-              This is the contents of Accordion.Panel {index + 1}
-            </Accordion.Panel>
-          </Accordion.Item>
-        ))}
-      </Accordion.Root>
+      <DirectionProvider direction="rtl">
+        <Accordion.Root
+          className={classes.root}
+          aria-label="Controlled Horizontal RTL Accordion"
+          openMultiple={false}
+          orientation="horizontal"
+          value={val}
+          onValueChange={(newValue: Accordion.Root.Props['value']) => {
+            if (Array.isArray(newValue) && newValue.length > 0) {
+              setVal(newValue);
+            }
+          }}
+        >
+          {['one', 'two', 'three'].map((value, index) => (
+            <Accordion.Item className={classes.item} key={value} value={value}>
+              <Accordion.Header className={classes.header}>
+                <Accordion.Trigger
+                  className={classNames(classes.trigger, classes[value])}
+                >
+                  <span className={classes.triggerText}>{index + 1}</span>
+                  <span className={classes.triggerLabel}>{value}</span>
+                </Accordion.Trigger>
+              </Accordion.Header>
+              <Accordion.Panel className={classes.panel}>
+                This is the contents of Accordion.Panel {index + 1}
+              </Accordion.Panel>
+            </Accordion.Item>
+          ))}
+        </Accordion.Root>
+      </DirectionProvider>
     </div>
   );
 }

--- a/docs/src/app/experiments/slider-marks.tsx
+++ b/docs/src/app/experiments/slider-marks.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { DirectionProvider } from '@base-ui-components/react/direction-provider';
 import { Slider } from '@base-ui-components/react/slider';
 import { useSliderRootContext } from '../../../../packages/react/src/slider/root/SliderRootContext';
 
@@ -99,27 +100,29 @@ export default function App() {
         </Slider.Control>
       </Slider.Root>
 
-      <Slider.Root className="TempSlider" defaultValue={40} direction="rtl">
-        <pre>RTL</pre>
-        <Slider.Output className="TempSlider-output" />
-        <Slider.Control className="TempSlider-control">
-          <Slider.Track className="TempSlider-track">
-            {STOPS.map((mark, index) => (
-              <MarkWithLabel
-                key={`mark-${index}`}
-                index={index}
-                label={mark.label}
-                value={mark.value}
+      <DirectionProvider direction="rtl">
+        <Slider.Root className="TempSlider" defaultValue={40}>
+          <pre>RTL</pre>
+          <Slider.Output className="TempSlider-output" />
+          <Slider.Control className="TempSlider-control">
+            <Slider.Track className="TempSlider-track">
+              {STOPS.map((mark, index) => (
+                <MarkWithLabel
+                  key={`mark-${index}`}
+                  index={index}
+                  label={mark.label}
+                  value={mark.value}
+                />
+              ))}
+              <Slider.Indicator className="TempSlider-indicator" />
+              <Slider.Thumb
+                className="TempSlider-thumb"
+                getAriaValueText={getSliderThumbAriaValueText}
               />
-            ))}
-            <Slider.Indicator className="TempSlider-indicator" />
-            <Slider.Thumb
-              className="TempSlider-thumb"
-              getAriaValueText={getSliderThumbAriaValueText}
-            />
-          </Slider.Track>
-        </Slider.Control>
-      </Slider.Root>
+            </Slider.Track>
+          </Slider.Control>
+        </Slider.Root>
+      </DirectionProvider>
       <BrandingStyles />
     </div>
   );

--- a/packages/react/src/accordion/root/AccordionRoot.test.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.test.tsx
@@ -621,7 +621,7 @@ describe('<Accordion.Root />', () => {
       it('ArrowLeft/Right is reversed for horizontal accordions in RTL mode', async () => {
         const { getAllByRole, user } = await render(
           <DirectionProvider direction="rtl">
-            <Accordion.Root orientation="horizontal" direction="rtl">
+            <Accordion.Root orientation="horizontal">
               <Accordion.Item>
                 <Accordion.Header>
                   <Accordion.Trigger>Trigger 1</Accordion.Trigger>

--- a/packages/react/src/accordion/root/AccordionRoot.test.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { describeSkipIf, flushMicrotasks } from '@mui/internal-test-utils';
+import { DirectionProvider } from '@base-ui-components/react/direction-provider';
 import { Accordion } from '@base-ui-components/react/accordion';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -619,20 +620,22 @@ describe('<Accordion.Root />', () => {
     describeSkipIf(isJSDOM)('RTL', () => {
       it('ArrowLeft/Right is reversed for horizontal accordions in RTL mode', async () => {
         const { getAllByRole, user } = await render(
-          <Accordion.Root orientation="horizontal" direction="rtl">
-            <Accordion.Item>
-              <Accordion.Header>
-                <Accordion.Trigger>Trigger 1</Accordion.Trigger>
-              </Accordion.Header>
-              <Accordion.Panel>1</Accordion.Panel>
-            </Accordion.Item>
-            <Accordion.Item>
-              <Accordion.Header>
-                <Accordion.Trigger>Trigger 2</Accordion.Trigger>
-              </Accordion.Header>
-              <Accordion.Panel>2</Accordion.Panel>
-            </Accordion.Item>
-          </Accordion.Root>,
+          <DirectionProvider direction="rtl">
+            <Accordion.Root orientation="horizontal" direction="rtl">
+              <Accordion.Item>
+                <Accordion.Header>
+                  <Accordion.Trigger>Trigger 1</Accordion.Trigger>
+                </Accordion.Header>
+                <Accordion.Panel>1</Accordion.Panel>
+              </Accordion.Item>
+              <Accordion.Item>
+                <Accordion.Header>
+                  <Accordion.Trigger>Trigger 2</Accordion.Trigger>
+                </Accordion.Header>
+                <Accordion.Panel>2</Accordion.Panel>
+              </Accordion.Item>
+            </Accordion.Root>
+          </DirectionProvider>,
         );
 
         const [trigger1, trigger2] = getAllByRole('button');

--- a/packages/react/src/accordion/root/AccordionRoot.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.tsx
@@ -131,7 +131,6 @@ export namespace AccordionRoot {
           useAccordionRoot.Parameters,
           | 'value'
           | 'defaultValue'
-          | 'animated'
           | 'disabled'
           | 'loop'
           | 'onValueChange'

--- a/packages/react/src/accordion/root/AccordionRoot.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.tsx
@@ -7,7 +7,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 import { warn } from '../../utils/warn';
 import { CompositeList } from '../../composite/list/CompositeList';
-import { useDirectionContext } from '../../direction-provider/DirectionContext';
+import { useDirection } from '../../direction-provider/DirectionContext';
 import {
   useAccordionRoot,
   type AccordionOrientation,
@@ -48,8 +48,7 @@ const AccordionRoot = React.forwardRef(function AccordionRoot(
     ...otherProps
   } = props;
 
-  const directionContext = useDirectionContext();
-  const direction = directionContext?.direction ?? 'ltr';
+  const direction = useDirection();
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/react/src/accordion/root/AccordionRoot.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.tsx
@@ -7,6 +7,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 import { warn } from '../../utils/warn';
 import { CompositeList } from '../../composite/list/CompositeList';
+import { useDirectionContext } from '../../direction-provider/DirectionContext';
 import {
   useAccordionRoot,
   type AccordionOrientation,
@@ -34,7 +35,6 @@ const AccordionRoot = React.forwardRef(function AccordionRoot(
 ) {
   const {
     className,
-    direction = 'ltr',
     disabled = false,
     hiddenUntilFound: hiddenUntilFoundProp,
     keepMounted: keepMountedProp,
@@ -47,6 +47,9 @@ const AccordionRoot = React.forwardRef(function AccordionRoot(
     render,
     ...otherProps
   } = props;
+
+  const directionContext = useDirectionContext();
+  const direction = directionContext?.direction ?? 'ltr';
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -124,7 +127,19 @@ export namespace AccordionRoot {
   }
 
   export interface Props
-    extends Partial<useAccordionRoot.Parameters>,
+    extends Partial<
+        Pick<
+          useAccordionRoot.Parameters,
+          | 'value'
+          | 'defaultValue'
+          | 'animated'
+          | 'disabled'
+          | 'loop'
+          | 'onValueChange'
+          | 'openMultiple'
+          | 'orientation'
+        >
+      >,
       Omit<BaseUIComponentProps<'div', State>, 'defaultValue'> {
     /**
      * If `true`, sets `hidden="until-found"` when closed. Accordion panels
@@ -163,10 +178,6 @@ AccordionRoot.propTypes /* remove-proptypes */ = {
    * This is the uncontrolled counterpart of `value`.
    */
   defaultValue: PropTypes.array,
-  /**
-   * @ignore
-   */
-  direction: PropTypes.oneOf(['ltr', 'rtl']),
   /**
    * If `true`, the component is disabled.
    * @default false

--- a/packages/react/src/composite/composite.ts
+++ b/packages/react/src/composite/composite.ts
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { hasComputedStyleMapSupport } from '../utils/hasComputedStyleMapSupport';
 import { ownerWindow } from '../utils/owner';
-
-export type TextDirection = 'ltr' | 'rtl';
+import type { TextDirection } from '../direction-provider/DirectionContext';
 
 export interface Dimensions {
   width: number;

--- a/packages/react/src/composite/root/CompositeRoot.tsx
+++ b/packages/react/src/composite/root/CompositeRoot.tsx
@@ -114,6 +114,10 @@ CompositeRoot.propTypes /* remove-proptypes */ = {
   /**
    * @ignore
    */
+  direction: PropTypes.oneOf(['ltr', 'rtl']),
+  /**
+   * @ignore
+   */
   enableHomeAndEndKeys: PropTypes.bool,
   /**
    * @ignore

--- a/packages/react/src/composite/root/CompositeRoot.tsx
+++ b/packages/react/src/composite/root/CompositeRoot.tsx
@@ -1,12 +1,13 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { CompositeList, type CompositeMetadata } from '../list/CompositeList';
 import { useCompositeRoot } from './useCompositeRoot';
 import { CompositeRootContext } from './CompositeRootContext';
 import { refType } from '../../utils/proptypes';
+import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
+import type { TextDirection } from '../../direction-provider/DirectionContext';
 import type { Dimensions } from '../composite';
 
 /**
@@ -23,6 +24,7 @@ function CompositeRoot<Metadata extends {}>(props: CompositeRoot.Props<Metadata>
     itemSizes,
     loop,
     cols,
+    direction,
     enableHomeAndEndKeys,
     onMapChange,
     stopEventPropagation,
@@ -42,6 +44,7 @@ function CompositeRoot<Metadata extends {}>(props: CompositeRoot.Props<Metadata>
       rootRef,
       stopEventPropagation,
       enableHomeAndEndKeys,
+      direction,
     });
 
   const { renderElement } = useComponentRenderer({
@@ -77,6 +80,7 @@ namespace CompositeRoot {
     onHighlightedIndexChange?: (index: number) => void;
     itemSizes?: Dimensions[];
     dense?: boolean;
+    direction?: TextDirection;
     enableHomeAndEndKeys?: boolean;
     onMapChange?: (newMap: Map<Node, CompositeMetadata<Metadata> | null>) => void;
     stopEventPropagation?: boolean;

--- a/packages/react/src/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/composite/root/useCompositeRoot.ts
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import type { TextDirection } from '../../direction-provider/DirectionContext';
 import { mergeReactProps } from '../../utils/mergeReactProps';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useForkRef } from '../../utils/useForkRef';
@@ -27,7 +28,6 @@ import {
   VERTICAL_KEYS,
   VERTICAL_KEYS_WITH_EXTRA_KEYS,
   type Dimensions,
-  type TextDirection,
 } from '../composite';
 
 export interface UseCompositeRootParameters {

--- a/packages/react/src/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/composite/root/useCompositeRoot.ts
@@ -37,6 +37,7 @@ export interface UseCompositeRootParameters {
   highlightedIndex?: number;
   onHighlightedIndexChange?: (index: number) => void;
   dense?: boolean;
+  direction?: TextDirection;
   itemSizes?: Array<Dimensions>;
   rootRef?: React.Ref<Element>;
   /**
@@ -66,6 +67,7 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
     loop = true,
     dense = false,
     orientation = 'both',
+    direction,
     highlightedIndex: externalHighlightedIndex,
     onHighlightedIndexChange: externalSetHighlightedIndex,
     rootRef: externalRef,
@@ -82,7 +84,7 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
     externalSetHighlightedIndex ?? internalSetHighlightedIndex,
   );
 
-  const textDirectionRef = React.useRef<TextDirection | null>(null);
+  const textDirectionRef = React.useRef<TextDirection | null>(direction ?? null);
 
   const rootRef = React.useRef<HTMLElement | null>(null);
   const mergedRef = useForkRef(rootRef, externalRef);

--- a/packages/react/src/direction-provider/DirectionContext.tsx
+++ b/packages/react/src/direction-provider/DirectionContext.tsx
@@ -16,11 +16,11 @@ if (process.env.NODE_ENV !== 'production') {
   DirectionContext.displayName = 'DirectionContext';
 }
 
-export function useDirectionContext(optional = true) {
+export function useDirection(optional = true) {
   const context = React.useContext(DirectionContext);
   if (context === undefined && !optional) {
     throw new Error('Base UI: DirectionContext is missing.');
   }
 
-  return context;
+  return context?.direction ?? 'ltr';
 }

--- a/packages/react/src/direction-provider/DirectionContext.tsx
+++ b/packages/react/src/direction-provider/DirectionContext.tsx
@@ -1,0 +1,25 @@
+'use client';
+import * as React from 'react';
+import type { TextDirection } from '../composite/composite';
+
+export type DirectionContext = {
+  direction: TextDirection;
+};
+
+/**
+ * @ignore - internal component.
+ */
+export const DirectionContext = React.createContext<DirectionContext | undefined>(undefined);
+
+if (process.env.NODE_ENV !== 'production') {
+  DirectionContext.displayName = 'DirectionContext';
+}
+
+export function useDirectionContext(optional = true) {
+  const context = React.useContext(DirectionContext);
+  if (context === undefined && !optional) {
+    throw new Error('Base UI: DirectionContext is missing.');
+  }
+
+  return context;
+}

--- a/packages/react/src/direction-provider/DirectionContext.tsx
+++ b/packages/react/src/direction-provider/DirectionContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
-import type { TextDirection } from '../composite/composite';
+
+export type TextDirection = 'ltr' | 'rtl';
 
 export type DirectionContext = {
   direction: TextDirection;

--- a/packages/react/src/direction-provider/DirectionProvider.tsx
+++ b/packages/react/src/direction-provider/DirectionProvider.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { DirectionContext, type TextDirection } from './DirectionContext';
 
 /**
@@ -7,16 +8,18 @@ import { DirectionContext, type TextDirection } from './DirectionContext';
  *
  * Demos:
  *
- * - [Progress](https://base-ui.com/components/react-direction-provider/)
+ * - [Direction Provider](https://base-ui.com/components/react-direction-provider/)
  *
  * API:
  *
  * - [DirectionProvider API](https://base-ui.com/components/react-direction-provider/#api-reference-DirectionProvider)
  */
 const DirectionProvider: React.FC<DirectionProvider.Props> = function DirectionProvider(props) {
-  const { direction = 'ltr', children } = props;
+  const { direction = 'ltr' } = props;
   const contextValue = React.useMemo(() => ({ direction }), [direction]);
-  return <DirectionContext.Provider value={contextValue}>{children}</DirectionContext.Provider>;
+  return (
+    <DirectionContext.Provider value={contextValue}>{props.children}</DirectionContext.Provider>
+  );
 };
 
 namespace DirectionProvider {
@@ -31,3 +34,19 @@ namespace DirectionProvider {
 }
 
 export { DirectionProvider };
+
+DirectionProvider.propTypes /* remove-proptypes */ = {
+  // ┌────────────────────────────── Warning ──────────────────────────────┐
+  // │ These PropTypes are generated from the TypeScript type definitions. │
+  // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
+  // └─────────────────────────────────────────────────────────────────────┘
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * The reading direction of the text
+   * @default 'ltr'
+   */
+  direction: PropTypes.oneOf(['ltr', 'rtl']),
+} as any;

--- a/packages/react/src/direction-provider/DirectionProvider.tsx
+++ b/packages/react/src/direction-provider/DirectionProvider.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
-import type { TextDirection } from '../composite/composite';
-import { DirectionContext } from './DirectionContext';
+import { DirectionContext, type TextDirection } from './DirectionContext';
 
 /**
  * A provider that configures RTL/LTR behavior for part of an app or a whole app.

--- a/packages/react/src/direction-provider/DirectionProvider.tsx
+++ b/packages/react/src/direction-provider/DirectionProvider.tsx
@@ -1,0 +1,34 @@
+'use client';
+import * as React from 'react';
+import type { TextDirection } from '../composite/composite';
+import { DirectionContext } from './DirectionContext';
+
+/**
+ * A provider that configures RTL/LTR behavior for part of an app or a whole app.
+ *
+ * Demos:
+ *
+ * - [Progress](https://base-ui.com/components/react-direction-provider/)
+ *
+ * API:
+ *
+ * - [DirectionProvider API](https://base-ui.com/components/react-direction-provider/#api-reference-DirectionProvider)
+ */
+const DirectionProvider: React.FC<DirectionProvider.Props> = function DirectionProvider(props) {
+  const { direction = 'ltr', children } = props;
+  const contextValue = React.useMemo(() => ({ direction }), [direction]);
+  return <DirectionContext.Provider value={contextValue}>{children}</DirectionContext.Provider>;
+};
+
+namespace DirectionProvider {
+  export interface Props {
+    children?: React.ReactNode;
+    /**
+     * The reading direction of the text
+     * @default 'ltr'
+     */
+    direction?: TextDirection;
+  }
+}
+
+export { DirectionProvider };

--- a/packages/react/src/direction-provider/index.parts.ts
+++ b/packages/react/src/direction-provider/index.parts.ts
@@ -1,0 +1,3 @@
+export { DirectionProvider as Provider } from './DirectionProvider';
+
+export type { TextDirection } from './DirectionContext';

--- a/packages/react/src/direction-provider/index.ts
+++ b/packages/react/src/direction-provider/index.ts
@@ -1,0 +1,1 @@
+export { DirectionProvider } from './DirectionProvider';

--- a/packages/react/src/direction-provider/index.ts
+++ b/packages/react/src/direction-provider/index.ts
@@ -1,1 +1,3 @@
 export { DirectionProvider } from './DirectionProvider';
+
+export type { TextDirection } from './DirectionContext';

--- a/packages/react/src/direction-provider/index.ts
+++ b/packages/react/src/direction-provider/index.ts
@@ -1,3 +1,1 @@
-export { DirectionProvider } from './DirectionProvider';
-
-export type { TextDirection } from './DirectionContext';
+export { Provider as DirectionProvider, type TextDirection } from './index.parts';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,7 @@ export * from './checkbox';
 export * from './checkbox-group';
 export * from './collapsible';
 export * from './dialog';
+export * from './direction-provider';
 export * from './field';
 export * from './fieldset';
 export * from './form';

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { act, flushMicrotasks, waitFor, screen } from '@mui/internal-test-utils';
+import { DirectionProvider } from '@base-ui-components/react/direction-provider';
 import { Menu } from '@base-ui-components/react/menu';
 import userEvent from '@testing-library/user-event';
 import { spy } from 'sinon';
@@ -406,22 +407,24 @@ describe('<Menu.Root />', () => {
     ).forEach(([orientation, direction, openKey, closeKey]) => {
       it(`opens a nested menu of a ${orientation} ${direction.toUpperCase()} menu with ${openKey} key and closes it with ${closeKey}`, async () => {
         const { getByTestId, queryByTestId } = await render(
-          <Menu.Root open orientation={orientation} dir={direction}>
-            <Menu.Positioner>
-              <Menu.Popup>
-                <Menu.Item>1</Menu.Item>
-                <Menu.Root orientation={orientation} dir={direction}>
-                  <Menu.SubmenuTrigger data-testid="submenu-trigger">2</Menu.SubmenuTrigger>
-                  <Menu.Positioner>
-                    <Menu.Popup data-testid="submenu">
-                      <Menu.Item data-testid="submenu-item-1">2.1</Menu.Item>
-                      <Menu.Item>2.2</Menu.Item>
-                    </Menu.Popup>
-                  </Menu.Positioner>
-                </Menu.Root>
-              </Menu.Popup>
-            </Menu.Positioner>
-          </Menu.Root>,
+          <DirectionProvider direction={direction}>
+            <Menu.Root open orientation={orientation} dir={direction}>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item>1</Menu.Item>
+                  <Menu.Root orientation={orientation} dir={direction}>
+                    <Menu.SubmenuTrigger data-testid="submenu-trigger">2</Menu.SubmenuTrigger>
+                    <Menu.Positioner>
+                      <Menu.Popup data-testid="submenu">
+                        <Menu.Item data-testid="submenu-item-1">2.1</Menu.Item>
+                        <Menu.Item>2.2</Menu.Item>
+                      </Menu.Popup>
+                    </Menu.Positioner>
+                  </Menu.Root>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Root>
+          </DirectionProvider>,
         );
 
         const submenuTrigger = getByTestId('submenu-trigger');

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -408,11 +408,11 @@ describe('<Menu.Root />', () => {
       it(`opens a nested menu of a ${orientation} ${direction.toUpperCase()} menu with ${openKey} key and closes it with ${closeKey}`, async () => {
         const { getByTestId, queryByTestId } = await render(
           <DirectionProvider direction={direction}>
-            <Menu.Root open orientation={orientation} dir={direction}>
+            <Menu.Root open orientation={orientation}>
               <Menu.Positioner>
                 <Menu.Popup>
                   <Menu.Item>1</Menu.Item>
-                  <Menu.Root orientation={orientation} dir={direction}>
+                  <Menu.Root orientation={orientation}>
                     <Menu.SubmenuTrigger data-testid="submenu-trigger">2</Menu.SubmenuTrigger>
                     <Menu.Positioner>
                       <Menu.Popup data-testid="submenu">

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -2,8 +2,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { FloatingTree } from '@floating-ui/react';
+import { useDirectionContext } from '../../direction-provider/DirectionContext';
 import { MenuRootContext, useMenuRootContext } from './MenuRootContext';
-import { MenuDirection, MenuOrientation, useMenuRoot } from './useMenuRoot';
+import { MenuOrientation, useMenuRoot } from './useMenuRoot';
 
 /**
  *
@@ -19,7 +20,6 @@ const MenuRoot: React.FC<MenuRoot.Props> = function MenuRoot(props) {
   const {
     children,
     defaultOpen = false,
-    dir: direction = 'ltr',
     disabled = false,
     closeParentOnEsc = true,
     loop = true,
@@ -29,6 +29,9 @@ const MenuRoot: React.FC<MenuRoot.Props> = function MenuRoot(props) {
     delay = 100,
     openOnHover: openOnHoverProp,
   } = props;
+
+  const directionContext = useDirectionContext();
+  const direction = directionContext?.direction ?? 'ltr';
 
   const parentContext = useMenuRootContext(true);
   const nested = parentContext != null;
@@ -119,12 +122,6 @@ namespace MenuRoot {
      */
     orientation?: MenuOrientation;
     /**
-     * The direction of the Menu (left-to-right or right-to-left).
-     *
-     * @default 'ltr'
-     */
-    dir?: MenuDirection;
-    /**
      * If `true`, the Menu is disabled.
      *
      * @default false
@@ -183,12 +180,6 @@ MenuRoot.propTypes /* remove-proptypes */ = {
    * @default 100
    */
   delay: PropTypes.number,
-  /**
-   * The direction of the Menu (left-to-right or right-to-left).
-   *
-   * @default 'ltr'
-   */
-  dir: PropTypes.oneOf(['ltr', 'rtl']),
   /**
    * If `true`, the Menu is disabled.
    *

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { FloatingTree } from '@floating-ui/react';
-import { useDirectionContext } from '../../direction-provider/DirectionContext';
+import { useDirection } from '../../direction-provider/DirectionContext';
 import { MenuRootContext, useMenuRootContext } from './MenuRootContext';
 import { MenuOrientation, useMenuRoot } from './useMenuRoot';
 
@@ -30,8 +30,7 @@ const MenuRoot: React.FC<MenuRoot.Props> = function MenuRoot(props) {
     openOnHover: openOnHoverProp,
   } = props;
 
-  const directionContext = useDirectionContext();
-  const direction = directionContext?.direction ?? 'ltr';
+  const direction = useDirection();
 
   const parentContext = useMenuRootContext(true);
   const nested = parentContext != null;

--- a/packages/react/src/menu/root/useMenuRoot.ts
+++ b/packages/react/src/menu/root/useMenuRoot.ts
@@ -19,6 +19,7 @@ import { useEventCallback } from '../../utils/useEventCallback';
 import { useControlled } from '../../utils/useControlled';
 import { TYPEAHEAD_RESET_MS } from '../../utils/constants';
 import { useAfterExitAnimation } from '../../utils/useAfterExitAnimation';
+import type { TextDirection } from '../../direction-provider/DirectionContext';
 
 const EMPTY_ARRAY: never[] = [];
 
@@ -190,8 +191,6 @@ export function useMenuRoot(parameters: useMenuRoot.Parameters): useMenuRoot.Ret
 
 export type MenuOrientation = 'horizontal' | 'vertical';
 
-export type MenuDirection = 'ltr' | 'rtl';
-
 export namespace useMenuRoot {
   export interface Parameters {
     /**
@@ -222,7 +221,7 @@ export namespace useMenuRoot {
     /**
      * The direction of the Menu (left-to-right or right-to-left).
      */
-    direction: MenuDirection;
+    direction: TextDirection;
     /**
      * If `true`, the Menu is disabled.
      */

--- a/packages/react/src/radio-group/root/RadioGroupRoot.test.tsx
+++ b/packages/react/src/radio-group/root/RadioGroupRoot.test.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { RadioGroup } from '@base-ui-components/react/radio-group';
 import { Radio } from '@base-ui-components/react/radio';
+import {
+  DirectionProvider,
+  type TextDirection,
+} from '@base-ui-components/react/direction-provider';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, act, screen, fireEvent, describeSkipIf } from '@mui/internal-test-utils';
@@ -226,7 +230,7 @@ describe('<RadioGroup.Root />', () => {
       describeSkipIf(isJSDOM && direction === 'rtl')(direction, () => {
         it(direction, async () => {
           const { user } = await render(
-            <div dir={direction}>
+            <DirectionProvider direction={direction as TextDirection}>
               <button data-testid="before" />
               <RadioGroup.Root>
                 <Radio.Root value="a" data-testid="a" />
@@ -234,7 +238,7 @@ describe('<RadioGroup.Root />', () => {
                 <Radio.Root value="c" data-testid="c" />
               </RadioGroup.Root>
               <button data-testid="after" />
-            </div>,
+            </DirectionProvider>,
           );
 
           const a = screen.getByTestId('a');

--- a/packages/react/src/radio-group/root/RadioGroupRoot.tsx
+++ b/packages/react/src/radio-group/root/RadioGroupRoot.tsx
@@ -5,7 +5,7 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import { CompositeRoot } from '../../composite/root/CompositeRoot';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useEventCallback } from '../../utils/useEventCallback';
-import { useDirectionContext } from '../../direction-provider/DirectionContext';
+import { useDirection } from '../../direction-provider/DirectionContext';
 import { useRadioGroupRoot } from './useRadioGroupRoot';
 import { RadioGroupRootContext } from './RadioGroupRootContext';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
@@ -34,8 +34,7 @@ const RadioGroupRoot = React.forwardRef(function RadioGroupRoot(
     ...otherProps
   } = props;
 
-  const directionContext = useDirectionContext();
-  const direction = directionContext?.direction ?? 'ltr';
+  const direction = useDirection();
 
   const { getRootProps, getInputProps, checkedValue, setCheckedValue, touched, setTouched } =
     useRadioGroupRoot(props);

--- a/packages/react/src/radio-group/root/RadioGroupRoot.tsx
+++ b/packages/react/src/radio-group/root/RadioGroupRoot.tsx
@@ -5,6 +5,7 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import { CompositeRoot } from '../../composite/root/CompositeRoot';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useEventCallback } from '../../utils/useEventCallback';
+import { useDirectionContext } from '../../direction-provider/DirectionContext';
 import { useRadioGroupRoot } from './useRadioGroupRoot';
 import { RadioGroupRootContext } from './RadioGroupRootContext';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
@@ -32,6 +33,9 @@ const RadioGroupRoot = React.forwardRef(function RadioGroupRoot(
     name,
     ...otherProps
   } = props;
+
+  const directionContext = useDirectionContext();
+  const direction = directionContext?.direction ?? 'ltr';
 
   const { getRootProps, getInputProps, checkedValue, setCheckedValue, touched, setTouched } =
     useRadioGroupRoot(props);
@@ -86,7 +90,7 @@ const RadioGroupRoot = React.forwardRef(function RadioGroupRoot(
 
   return (
     <RadioGroupRootContext.Provider value={contextValue}>
-      <CompositeRoot enableHomeAndEndKeys={false} render={renderElement()} />
+      <CompositeRoot direction={direction} enableHomeAndEndKeys={false} render={renderElement()} />
       <input {...getInputProps()} />
     </RadioGroupRootContext.Provider>
   );

--- a/packages/react/src/slider/control/SliderControl.test.tsx
+++ b/packages/react/src/slider/control/SliderControl.test.tsx
@@ -28,7 +28,6 @@ const testRootContext: SliderRootContext = {
     activeThumbIndex: -1,
     disabled: false,
     dragging: false,
-    direction: 'ltr',
     max: 100,
     min: 0,
     minStepsBetweenValues: 0,

--- a/packages/react/src/slider/indicator/SliderIndicator.test.tsx
+++ b/packages/react/src/slider/indicator/SliderIndicator.test.tsx
@@ -28,7 +28,6 @@ const testRootContext: SliderRootContext = {
     activeThumbIndex: -1,
     disabled: false,
     dragging: false,
-    direction: 'ltr',
     max: 100,
     min: 0,
     minStepsBetweenValues: 0,

--- a/packages/react/src/slider/output/SliderOutput.test.tsx
+++ b/packages/react/src/slider/output/SliderOutput.test.tsx
@@ -29,7 +29,6 @@ const testRootContext: SliderRootContext = {
     activeThumbIndex: -1,
     disabled: false,
     dragging: false,
-    direction: 'ltr',
     max: 100,
     min: 0,
     minStepsBetweenValues: 0,

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import * as React from 'react';
 import { spy, stub } from 'sinon';
 import { act, describeSkipIf, fireEvent, screen } from '@mui/internal-test-utils';
+import { DirectionProvider } from '@base-ui-components/react/direction-provider';
 import { Slider } from '@base-ui-components/react/slider';
 import { createRenderer, describeConformance } from '#test-utils';
 import type { SliderRoot } from './SliderRoot';
@@ -168,7 +169,9 @@ describeSkipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     it('should handle RTL', async () => {
       const handleValueChange = spy();
       const { getByTestId } = await render(
-        <TestSlider direction="rtl" value={30} onValueChange={handleValueChange} />,
+        <DirectionProvider direction="rtl">
+          <TestSlider value={30} onValueChange={handleValueChange} />
+        </DirectionProvider>,
       );
       const sliderControl = getByTestId('control');
       const sliderThumb = getByTestId('thumb');
@@ -196,7 +199,9 @@ describeSkipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     it('increments on ArrowUp', async () => {
       const handleValueChange = spy();
       const { container } = await render(
-        <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
+        <DirectionProvider direction="rtl">
+          <TestSlider defaultValue={20} onValueChange={handleValueChange} />
+        </DirectionProvider>,
       );
 
       const input = container.querySelector('input');
@@ -219,7 +224,9 @@ describeSkipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     it('increments on ArrowLeft', async () => {
       const handleValueChange = spy();
       const { container } = await render(
-        <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
+        <DirectionProvider direction="rtl">
+          <TestSlider defaultValue={20} onValueChange={handleValueChange} />
+        </DirectionProvider>,
       );
 
       const input = container.querySelector('input');
@@ -242,7 +249,9 @@ describeSkipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     it('decrements on ArrowDown', async () => {
       const handleValueChange = spy();
       const { container } = await render(
-        <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
+        <DirectionProvider direction="rtl">
+          <TestSlider defaultValue={20} onValueChange={handleValueChange} />
+        </DirectionProvider>,
       );
 
       const input = container.querySelector('input');
@@ -265,7 +274,9 @@ describeSkipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     it('decrements on ArrowRight', async () => {
       const handleValueChange = spy();
       const { container } = await render(
-        <TestSlider defaultValue={20} onValueChange={handleValueChange} direction="rtl" />,
+        <DirectionProvider direction="rtl">
+          <TestSlider defaultValue={20} onValueChange={handleValueChange} />
+        </DirectionProvider>,
       );
 
       const input = container.querySelector('input');

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -5,6 +5,7 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { FieldRoot } from '../../field/root/FieldRoot';
 import { CompositeList } from '../../composite/list/CompositeList';
+import { useDirectionContext } from '../../direction-provider/DirectionContext';
 import { sliderStyleHookMapping } from './styleHooks';
 import { useSliderRoot } from './useSliderRoot';
 import { SliderRootContext } from './SliderRootContext';
@@ -28,17 +29,25 @@ const SliderRoot = React.forwardRef(function SliderRoot(
     'aria-labelledby': ariaLabelledby,
     className,
     defaultValue,
-    direction = 'ltr',
     disabled: disabledProp = false,
+    id,
     largeStep,
     render,
+    max,
+    min,
     minStepsBetweenValues,
+    name,
     onValueChange,
     onValueCommitted,
     orientation = 'horizontal',
+    step,
+    tabIndex,
     value,
     ...otherProps
   } = props;
+
+  const directionContext = useDirectionContext();
+  const direction = directionContext?.direction ?? 'ltr';
 
   const { labelId, state: fieldState, disabled: fieldDisabled } = useFieldRootContext();
   const disabled = fieldDisabled || disabledProp;
@@ -46,23 +55,27 @@ const SliderRoot = React.forwardRef(function SliderRoot(
   const { getRootProps, ...slider } = useSliderRoot({
     'aria-labelledby': ariaLabelledby ?? labelId,
     defaultValue,
-    disabled,
     direction,
+    disabled,
+    id,
     largeStep,
+    max,
+    min,
     minStepsBetweenValues,
+    name,
     onValueChange,
     onValueCommitted,
     orientation,
     rootRef: forwardedRef,
+    step,
+    tabIndex,
     value,
-    ...otherProps,
   });
 
   const state: SliderRoot.State = React.useMemo(
     () => ({
       ...fieldState,
       activeThumbIndex: slider.active,
-      direction,
       disabled,
       dragging: slider.dragging,
       orientation,
@@ -74,7 +87,6 @@ const SliderRoot = React.forwardRef(function SliderRoot(
     }),
     [
       fieldState,
-      direction,
       disabled,
       orientation,
       slider.active,
@@ -125,7 +137,6 @@ export namespace SliderRoot {
      * If `true`, a thumb is being dragged by a pointer.
      */
     dragging: boolean;
-    direction: useSliderRoot.Direction;
     max: number;
     min: number;
     /**
@@ -150,7 +161,20 @@ export namespace SliderRoot {
   }
 
   export interface Props
-    extends Omit<useSliderRoot.Parameters, 'rootRef'>,
+    extends Pick<
+        useSliderRoot.Parameters,
+        | 'disabled'
+        | 'max'
+        | 'min'
+        | 'minStepsBetweenValues'
+        | 'name'
+        | 'onValueChange'
+        | 'onValueCommitted'
+        | 'orientation'
+        | 'largeStep'
+        | 'step'
+        | 'value'
+      >,
       Omit<BaseUIComponentProps<'span', State>, 'defaultValue' | 'onChange' | 'values'> {
     /**
      * The default value of the slider. Use when the component is not controlled.
@@ -192,11 +216,6 @@ SliderRoot.propTypes /* remove-proptypes */ = {
    * The default value of the slider. Use when the component is not controlled.
    */
   defaultValue: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.number]),
-  /**
-   * Sets the direction. For right-to-left languages, the lowest value is on the right-hand side.
-   * @default 'ltr'
-   */
-  direction: PropTypes.oneOf(['ltr', 'rtl']),
   /**
    * If `true`, the component is disabled.
    * @default false

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -5,7 +5,7 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { FieldRoot } from '../../field/root/FieldRoot';
 import { CompositeList } from '../../composite/list/CompositeList';
-import { useDirectionContext } from '../../direction-provider/DirectionContext';
+import { useDirection } from '../../direction-provider/DirectionContext';
 import { sliderStyleHookMapping } from './styleHooks';
 import { useSliderRoot } from './useSliderRoot';
 import { SliderRootContext } from './SliderRootContext';
@@ -46,8 +46,7 @@ const SliderRoot = React.forwardRef(function SliderRoot(
     ...otherProps
   } = props;
 
-  const directionContext = useDirectionContext();
-  const direction = directionContext?.direction ?? 'ltr';
+  const direction = useDirection();
 
   const { labelId, state: fieldState, disabled: fieldDisabled } = useFieldRootContext();
   const disabled = fieldDisabled || disabledProp;

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -201,7 +201,8 @@ SliderRoot.propTypes /* remove-proptypes */ = {
   // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
   // └─────────────────────────────────────────────────────────────────────┘
   /**
-   * The id of the element containing a label for the slider.
+   * Identifies the element (or elements) that labels the current element.
+   * @see aria-describedby.
    */
   'aria-labelledby': PropTypes.string,
   /**
@@ -222,15 +223,35 @@ SliderRoot.propTypes /* remove-proptypes */ = {
    */
   disabled: PropTypes.bool,
   /**
+   * @ignore
+   */
+  id: PropTypes.string,
+  /**
    * The granularity with which the slider can step through values when using Page Up/Page Down or Shift + Arrow Up/Arrow Down.
    * @default 10
    */
   largeStep: PropTypes.number,
   /**
+   * The maximum allowed value of the slider.
+   * Should not be equal to min.
+   * @default 100
+   */
+  max: PropTypes.number,
+  /**
+   * The minimum allowed value of the slider.
+   * Should not be equal to max.
+   * @default 0
+   */
+  min: PropTypes.number,
+  /**
    * The minimum steps between values in a range slider.
    * @default 0
    */
   minStepsBetweenValues: PropTypes.number,
+  /**
+   * Name attribute of the hidden `input` element.
+   */
+  name: PropTypes.string,
   /**
    * Callback function that is fired when the slider's value changed.
    *
@@ -257,6 +278,17 @@ SliderRoot.propTypes /* remove-proptypes */ = {
    * A function to customize rendering of the component.
    */
   render: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
+  /**
+   * The granularity with which the slider can step through values. (A "discrete" slider.)
+   * The `min` prop serves as the origin for the valid values.
+   * We recommend (max - min) to be evenly divisible by the step.
+   * @default 1
+   */
+  step: PropTypes.number,
+  /**
+   * @ignore
+   */
+  tabIndex: PropTypes.number,
   /**
    * The value of the slider.
    * For ranged sliders, provide an array with two values.

--- a/packages/react/src/slider/root/styleHooks.ts
+++ b/packages/react/src/slider/root/styleHooks.ts
@@ -3,7 +3,6 @@ import type { SliderRoot } from './SliderRoot';
 
 export const sliderStyleHookMapping: CustomStyleHookMapping<SliderRoot.State> = {
   activeThumbIndex: () => null,
-  direction: () => null,
   max: () => null,
   min: () => null,
   minStepsBetweenValues: () => null,

--- a/packages/react/src/slider/root/useSliderRoot.ts
+++ b/packages/react/src/slider/root/useSliderRoot.ts
@@ -6,16 +6,17 @@ import { clamp } from '../../utils/clamp';
 import { mergeReactProps } from '../../utils/mergeReactProps';
 import { ownerDocument } from '../../utils/owner';
 import { useControlled } from '../../utils/useControlled';
-import { useForkRef } from '../../utils/useForkRef';
 import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
-import { percentToValue, roundValueToStep, valueToPercent } from '../utils';
-import { useFieldRootContext } from '../../field/root/FieldRootContext';
+import { useForkRef } from '../../utils/useForkRef';
 import { useBaseUiId } from '../../utils/useBaseUiId';
+import type { TextDirection } from '../../direction-provider/DirectionContext';
+import { useField } from '../../field/useField';
+import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
+import { percentToValue, roundValueToStep, valueToPercent } from '../utils';
 import { asc } from '../utils/asc';
 import { setValueIndex } from '../utils/setValueIndex';
 import { getSliderValue } from '../utils/getSliderValue';
-import { useField } from '../../field/useField';
 
 function findClosest(values: number[], currentValue: number) {
   const { index: closestIndex } =
@@ -121,15 +122,15 @@ export function trackFinger(
 export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRoot.ReturnValue {
   const {
     'aria-labelledby': ariaLabelledby,
-    id: idProp,
-    name,
     defaultValue,
     direction = 'ltr',
     disabled = false,
+    id: idProp,
     largeStep = 10,
     max = 100,
     min = 0,
     minStepsBetweenValues = 0,
+    name,
     onValueChange,
     onValueCommitted,
     orientation = 'horizontal',
@@ -415,10 +416,11 @@ export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRo
       mergeReactProps(getValidationProps(externalProps), {
         'aria-labelledby': ariaLabelledby,
         dir: direction,
+        id,
         ref: handleRootRef,
         role: 'group',
       }),
-    [ariaLabelledby, direction, getValidationProps, handleRootRef],
+    [ariaLabelledby, direction, getValidationProps, handleRootRef, id],
   );
 
   return React.useMemo(
@@ -489,8 +491,6 @@ export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRo
 }
 
 export namespace useSliderRoot {
-  export type Direction = 'ltr' | 'rtl';
-
   export type Orientation = 'horizontal' | 'vertical';
 
   export interface Parameters {
@@ -510,7 +510,7 @@ export namespace useSliderRoot {
      * Sets the direction. For right-to-left languages, the lowest value is on the right-hand side.
      * @default 'ltr'
      */
-    direction?: Direction;
+    direction: TextDirection;
     /**
      * If `true`, the component is disabled.
      * @default false
@@ -610,7 +610,7 @@ export namespace useSliderRoot {
       event: React.KeyboardEvent | React.ChangeEvent,
     ) => void;
     dragging: boolean;
-    direction: Direction;
+    direction: TextDirection;
     disabled: boolean;
     getFingerNewValue: (args: {
       finger: { x: number; y: number };

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -28,7 +28,6 @@ const testRootContext: SliderRootContext = {
     activeThumbIndex: -1,
     disabled: false,
     dragging: false,
-    direction: 'ltr',
     max: 100,
     min: 0,
     minStepsBetweenValues: 0,

--- a/packages/react/src/slider/track/SliderTrack.test.tsx
+++ b/packages/react/src/slider/track/SliderTrack.test.tsx
@@ -28,7 +28,6 @@ const testRootContext: SliderRootContext = {
     activeThumbIndex: -1,
     disabled: false,
     dragging: false,
-    direction: 'ltr',
     max: 100,
     min: 0,
     minStepsBetweenValues: 0,

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -2,6 +2,10 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, describeSkipIf, flushMicrotasks, fireEvent, screen } from '@mui/internal-test-utils';
+import {
+  DirectionProvider,
+  type TextDirection,
+} from '@base-ui-components/react/direction-provider';
 import { Tabs } from '@base-ui-components/react/tabs';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -286,7 +290,7 @@ describe('<Tabs.Root />', () => {
                 const handleChange = spy();
                 const handleKeyDown = spy();
                 const { getAllByRole } = await render(
-                  <div dir={direction}>
+                  <DirectionProvider direction={direction as TextDirection}>
                     <Tabs.Root
                       onValueChange={handleChange}
                       onKeyDown={handleKeyDown}
@@ -299,7 +303,7 @@ describe('<Tabs.Root />', () => {
                         <Tabs.Tab value={2} />
                       </Tabs.List>
                     </Tabs.Root>
-                  </div>,
+                  </DirectionProvider>,
                 );
                 const [firstTab, , lastTab] = getAllByRole('tab');
                 await act(async () => {
@@ -319,7 +323,7 @@ describe('<Tabs.Root />', () => {
                 const handleChange = spy();
                 const handleKeyDown = spy();
                 const { getAllByRole } = await render(
-                  <div dir={direction}>
+                  <DirectionProvider direction={direction as TextDirection}>
                     <Tabs.Root
                       onValueChange={handleChange}
                       onKeyDown={handleKeyDown}
@@ -332,7 +336,7 @@ describe('<Tabs.Root />', () => {
                         <Tabs.Tab value={2} />
                       </Tabs.List>
                     </Tabs.Root>
-                  </div>,
+                  </DirectionProvider>,
                 );
                 const [firstTab, secondTab] = getAllByRole('tab');
                 await act(async () => {
@@ -354,7 +358,7 @@ describe('<Tabs.Root />', () => {
                 const handleChange = spy();
                 const handleKeyDown = spy();
                 const { getAllByRole } = await render(
-                  <div dir={direction}>
+                  <DirectionProvider direction={direction as TextDirection}>
                     <Tabs.Root
                       onValueChange={handleChange}
                       onKeyDown={handleKeyDown}
@@ -367,7 +371,7 @@ describe('<Tabs.Root />', () => {
                         <Tabs.Tab value={2} />
                       </Tabs.List>
                     </Tabs.Root>
-                  </div>,
+                  </DirectionProvider>,
                 );
                 const [firstTab, , lastTab] = getAllByRole('tab');
                 await act(async () => {
@@ -388,7 +392,7 @@ describe('<Tabs.Root />', () => {
                 const handleChange = spy();
                 const handleKeyDown = spy();
                 const { getAllByRole } = await render(
-                  <div dir={direction}>
+                  <DirectionProvider direction={direction as TextDirection}>
                     <Tabs.Root
                       onValueChange={handleChange}
                       onKeyDown={handleKeyDown}
@@ -401,7 +405,7 @@ describe('<Tabs.Root />', () => {
                         <Tabs.Tab value={2} />
                       </Tabs.List>
                     </Tabs.Root>
-                  </div>,
+                  </DirectionProvider>,
                 );
                 const [firstTab, secondTab] = getAllByRole('tab');
                 await act(async () => {
@@ -422,7 +426,7 @@ describe('<Tabs.Root />', () => {
             it('skips over disabled tabs', async () => {
               const handleKeyDown = spy();
               const { getAllByRole } = await render(
-                <div dir={direction}>
+                <DirectionProvider direction={direction as TextDirection}>
                   <Tabs.Root
                     onKeyDown={handleKeyDown}
                     orientation={orientation as Tabs.Root.Props['orientation']}
@@ -434,7 +438,7 @@ describe('<Tabs.Root />', () => {
                       <Tabs.Tab value={2} />
                     </Tabs.List>
                   </Tabs.Root>
-                </div>,
+                </DirectionProvider>,
               );
               const [firstTab, , lastTab] = getAllByRole('tab');
               await act(async () => {
@@ -456,7 +460,7 @@ describe('<Tabs.Root />', () => {
                 const handleChange = spy();
                 const handleKeyDown = spy();
                 const { getAllByRole } = await render(
-                  <div dir={direction}>
+                  <DirectionProvider direction={direction as TextDirection}>
                     <Tabs.Root
                       onValueChange={handleChange}
                       onKeyDown={handleKeyDown}
@@ -469,7 +473,7 @@ describe('<Tabs.Root />', () => {
                         <Tabs.Tab value={2} />
                       </Tabs.List>
                     </Tabs.Root>
-                  </div>,
+                  </DirectionProvider>,
                 );
                 const [firstTab, , lastTab] = getAllByRole('tab');
                 await act(async () => {
@@ -489,7 +493,7 @@ describe('<Tabs.Root />', () => {
                 const handleChange = spy();
                 const handleKeyDown = spy();
                 const { getAllByRole } = await render(
-                  <div dir={direction}>
+                  <DirectionProvider direction={direction as TextDirection}>
                     <Tabs.Root
                       onValueChange={handleChange}
                       onKeyDown={handleKeyDown}
@@ -502,7 +506,7 @@ describe('<Tabs.Root />', () => {
                         <Tabs.Tab value={2} />
                       </Tabs.List>
                     </Tabs.Root>
-                  </div>,
+                  </DirectionProvider>,
                 );
                 const [, secondTab, lastTab] = getAllByRole('tab');
                 await act(async () => {
@@ -524,7 +528,7 @@ describe('<Tabs.Root />', () => {
                 const handleChange = spy();
                 const handleKeyDown = spy();
                 const { getAllByRole } = await render(
-                  <div dir={direction}>
+                  <DirectionProvider direction={direction as TextDirection}>
                     <Tabs.Root
                       onValueChange={handleChange}
                       onKeyDown={handleKeyDown}
@@ -537,7 +541,7 @@ describe('<Tabs.Root />', () => {
                         <Tabs.Tab value={2} />
                       </Tabs.List>
                     </Tabs.Root>
-                  </div>,
+                  </DirectionProvider>,
                 );
                 const [firstTab, , lastTab] = getAllByRole('tab');
                 await act(async () => {
@@ -558,7 +562,7 @@ describe('<Tabs.Root />', () => {
                 const handleChange = spy();
                 const handleKeyDown = spy();
                 const { getAllByRole } = await render(
-                  <div dir={direction}>
+                  <DirectionProvider direction={direction as TextDirection}>
                     <Tabs.Root
                       onValueChange={handleChange}
                       onKeyDown={handleKeyDown}
@@ -571,7 +575,7 @@ describe('<Tabs.Root />', () => {
                         <Tabs.Tab value={2} />
                       </Tabs.List>
                     </Tabs.Root>
-                  </div>,
+                  </DirectionProvider>,
                 );
                 const [, secondTab, lastTab] = getAllByRole('tab');
                 await act(async () => {
@@ -592,7 +596,7 @@ describe('<Tabs.Root />', () => {
             it('skips over disabled tabs', async () => {
               const handleKeyDown = spy();
               const { getAllByRole } = await render(
-                <div dir={direction}>
+                <DirectionProvider direction={direction as TextDirection}>
                   <Tabs.Root
                     onKeyDown={handleKeyDown}
                     orientation={orientation as Tabs.Root.Props['orientation']}
@@ -604,7 +608,7 @@ describe('<Tabs.Root />', () => {
                       <Tabs.Tab value={2} />
                     </Tabs.List>
                   </Tabs.Root>
-                </div>,
+                </DirectionProvider>,
               );
               const [firstTab, , lastTab] = getAllByRole('tab');
               await act(async () => {

--- a/packages/react/src/tabs/root/TabsRoot.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { CompositeList } from '../../composite/list/CompositeList';
-import { useDirectionContext, type TextDirection } from '../../direction-provider/DirectionContext';
+import { useDirectionContext } from '../../direction-provider/DirectionContext';
 import { useTabsRoot } from './useTabsRoot';
 import { TabsRootContext } from './TabsRootContext';
 import { tabsStyleHookMapping } from './styleHooks';
@@ -123,11 +123,6 @@ namespace TabsRoot {
      * @default 0
      */
     defaultValue?: TabValue;
-    /**
-     * Sets ArrowLeft and ArrowRight behavior based on text direction.
-     * @default 'ltr'
-     */
-    direction?: TextDirection;
     /**
      * The component orientation (layout flow direction).
      * @default 'horizontal'

--- a/packages/react/src/tabs/root/TabsRoot.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { CompositeList } from '../../composite/list/CompositeList';
-import { useDirectionContext } from '../../direction-provider/DirectionContext';
+import { useDirection } from '../../direction-provider/DirectionContext';
 import { useTabsRoot } from './useTabsRoot';
 import { TabsRootContext } from './TabsRootContext';
 import { tabsStyleHookMapping } from './styleHooks';
@@ -34,8 +34,7 @@ const TabsRoot = React.forwardRef(function TabsRoot(
     ...other
   } = props;
 
-  const directionContext = useDirectionContext();
-  const direction = directionContext?.direction ?? 'ltr';
+  const direction = useDirection();
 
   const {
     getTabElementBySelectedValue,

--- a/packages/react/src/tabs/root/TabsRoot.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.tsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { CompositeList } from '../../composite/list/CompositeList';
+import { useDirectionContext, type TextDirection } from '../../direction-provider/DirectionContext';
 import { useTabsRoot } from './useTabsRoot';
 import { TabsRootContext } from './TabsRootContext';
 import { tabsStyleHookMapping } from './styleHooks';
@@ -33,6 +34,9 @@ const TabsRoot = React.forwardRef(function TabsRoot(
     ...other
   } = props;
 
+  const directionContext = useDirectionContext();
+  const direction = directionContext?.direction ?? 'ltr';
+
   const {
     getTabElementBySelectedValue,
     getTabIdByPanelValueOrIndex,
@@ -51,6 +55,7 @@ const TabsRoot = React.forwardRef(function TabsRoot(
 
   const tabsContextValue: TabsRootContext = React.useMemo(
     () => ({
+      direction,
       getTabElementBySelectedValue,
       getTabIdByPanelValueOrIndex,
       getTabPanelIdByTabValueOrIndex,
@@ -61,6 +66,7 @@ const TabsRoot = React.forwardRef(function TabsRoot(
       value,
     }),
     [
+      direction,
       getTabElementBySelectedValue,
       getTabIdByPanelValueOrIndex,
       getTabPanelIdByTabValueOrIndex,
@@ -117,6 +123,11 @@ namespace TabsRoot {
      * @default 0
      */
     defaultValue?: TabValue;
+    /**
+     * Sets ArrowLeft and ArrowRight behavior based on text direction.
+     * @default 'ltr'
+     */
+    direction?: TextDirection;
     /**
      * The component orientation (layout flow direction).
      * @default 'horizontal'

--- a/packages/react/src/tabs/root/TabsRootContext.ts
+++ b/packages/react/src/tabs/root/TabsRootContext.ts
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import type { TextDirection } from '../../direction-provider/DirectionContext';
 import { type TabMetadata } from '../tab/useTab';
 import type { TabActivationDirection, TabValue } from './TabsRoot';
 
@@ -16,6 +17,11 @@ export interface TabsRootContext {
     activationDirection: TabActivationDirection,
     event: Event,
   ) => void;
+  /**
+   * Sets ArrowLeft and ArrowRight behavior based on text direction.
+   * @default 'ltr'
+   */
+  direction: TextDirection;
   /**
    * The component orientation (layout flow direction).
    */

--- a/packages/react/src/tabs/tab-panel/TabPanel.test.tsx
+++ b/packages/react/src/tabs/tab-panel/TabPanel.test.tsx
@@ -13,6 +13,7 @@ describe('<Tabs.Panel />', () => {
     getTabElementBySelectedValue: () => null,
     getTabIdByPanelValueOrIndex: () => '',
     getTabPanelIdByTabValueOrIndex: () => '',
+    direction: 'ltr',
     orientation: 'horizontal',
     tabActivationDirection: 'none',
   };

--- a/packages/react/src/tabs/tab/Tab.test.tsx
+++ b/packages/react/src/tabs/tab/Tab.test.tsx
@@ -31,6 +31,7 @@ describe('<Tabs.Tab />', () => {
     getTabElementBySelectedValue: () => null,
     getTabIdByPanelValueOrIndex: () => '',
     getTabPanelIdByTabValueOrIndex: () => '',
+    direction: 'ltr',
     orientation: 'horizontal',
     tabActivationDirection: 'none',
   };

--- a/packages/react/src/tabs/tabs-list/TabsList.test.tsx
+++ b/packages/react/src/tabs/tabs-list/TabsList.test.tsx
@@ -19,6 +19,7 @@ describe('<Tabs.List />', () => {
             getTabElementBySelectedValue: () => null,
             getTabIdByPanelValueOrIndex: () => '',
             getTabPanelIdByTabValueOrIndex: () => '',
+            direction: 'ltr',
             orientation: 'horizontal',
             tabActivationDirection: 'none',
           }}

--- a/packages/react/src/tabs/tabs-list/TabsList.tsx
+++ b/packages/react/src/tabs/tabs-list/TabsList.tsx
@@ -28,9 +28,10 @@ const TabsList = React.forwardRef(function TabsList(
   const { activateOnFocus = true, className, loop = true, render, ...other } = props;
 
   const {
+    direction,
     getTabElementBySelectedValue,
     onValueChange,
-    orientation = 'horizontal',
+    orientation,
     value,
     setTabMap,
     tabActivationDirection,
@@ -92,6 +93,7 @@ const TabsList = React.forwardRef(function TabsList(
         highlightedIndex={highlightedTabIndex}
         enableHomeAndEndKeys
         loop={loop}
+        direction={direction}
         orientation={orientation}
         onHighlightedIndexChange={setHighlightedTabIndex}
         onMapChange={setTabMap}

--- a/packages/react/src/toggle-group/root/ToggleGroupRoot.test.tsx
+++ b/packages/react/src/toggle-group/root/ToggleGroupRoot.test.tsx
@@ -2,6 +2,10 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, describeSkipIf, flushMicrotasks } from '@mui/internal-test-utils';
+import {
+  DirectionProvider,
+  type TextDirection,
+} from '@base-ui-components/react/direction-provider';
 import { ToggleGroup } from '@base-ui-components/react/toggle-group';
 import { Toggle } from '@base-ui-components/react/toggle';
 import { createRenderer, describeConformance } from '#test-utils';
@@ -215,88 +219,68 @@ describe('<ToggleGroup />', () => {
   });
 
   describeSkipIf(isJSDOM)('keyboard interactions', () => {
-    it('ltr', async () => {
-      const { getAllByRole, user } = await render(
-        <ToggleGroup>
-          <Toggle value="one" />
-          <Toggle value="two" />
-        </ToggleGroup>,
-      );
+    [
+      ['ltr', 'ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp'],
+      ['rtl', 'ArrowLeft', 'ArrowDown', 'ArrowRight', 'ArrowUp'],
+    ].forEach((entry) => {
+      const [direction, horizontalNextKey, verticalNextKey, horizontalPrevKey, verticalPrevKey] =
+        entry;
 
-      const [button1, button2] = getAllByRole('button');
+      it(direction, async () => {
+        const { getAllByRole, user } = await render(
+          <DirectionProvider direction={direction as TextDirection}>
+            <ToggleGroup>
+              <Toggle value="one" />
+              <Toggle value="two" />
+              <Toggle value="three" />
+            </ToggleGroup>
+          </DirectionProvider>,
+        );
 
-      await user.keyboard('[Tab]');
+        const [button1, button2, button3] = getAllByRole('button');
 
-      expect(button1).to.have.attribute('data-highlighted');
-      expect(button1).to.have.attribute('tabindex', '0');
-      expect(button1).toHaveFocus();
+        await user.keyboard('[Tab]');
 
-      await user.keyboard('[ArrowRight]');
+        expect(button1).to.have.attribute('data-highlighted');
+        expect(button1).to.have.attribute('tabindex', '0');
+        expect(button1).toHaveFocus();
 
-      expect(button2).to.have.attribute('data-highlighted');
-      expect(button2).to.have.attribute('tabindex', '0');
-      expect(button2).toHaveFocus();
+        await user.keyboard(`[${horizontalNextKey}]`);
 
-      await user.keyboard('[ArrowRight]');
+        expect(button2).to.have.attribute('data-highlighted');
+        expect(button2).to.have.attribute('tabindex', '0');
+        expect(button2).toHaveFocus();
 
-      expect(button1).to.have.attribute('data-highlighted');
-      expect(button1).to.have.attribute('tabindex', '0');
-      expect(button1).toHaveFocus();
+        await user.keyboard(`[${horizontalNextKey}]`);
 
-      await user.keyboard('[ArrowDown]');
+        expect(button3).to.have.attribute('data-highlighted');
+        expect(button3).to.have.attribute('tabindex', '0');
+        expect(button3).toHaveFocus();
 
-      expect(button2).to.have.attribute('data-highlighted');
-      expect(button2).to.have.attribute('tabindex', '0');
-      expect(button2).toHaveFocus();
+        await user.keyboard(`[${verticalNextKey}]`);
 
-      await user.keyboard('[ArrowDown]');
+        expect(button1).to.have.attribute('data-highlighted');
+        expect(button1).to.have.attribute('tabindex', '0');
+        expect(button1).toHaveFocus();
 
-      expect(button1).to.have.attribute('data-highlighted');
-      expect(button1).to.have.attribute('tabindex', '0');
-      expect(button1).toHaveFocus();
-    });
+        await user.keyboard(`[${verticalNextKey}]`);
 
-    it('rtl', async () => {
-      const { getAllByRole, user } = await render(
-        <div dir="rtl">
-          <ToggleGroup>
-            <Toggle value="one" />
-            <Toggle value="two" />
-          </ToggleGroup>
-        </div>,
-      );
+        expect(button2).to.have.attribute('data-highlighted');
+        expect(button2).to.have.attribute('tabindex', '0');
+        expect(button2).toHaveFocus();
 
-      const [button1, button2] = getAllByRole('button');
+        await user.keyboard(`[${horizontalPrevKey}]`);
 
-      await user.keyboard('[Tab]');
+        expect(button1).to.have.attribute('data-highlighted');
+        expect(button1).to.have.attribute('tabindex', '0');
+        expect(button1).toHaveFocus();
 
-      expect(button1).to.have.attribute('data-highlighted');
-      expect(button1).to.have.attribute('tabindex', '0');
-      expect(button1).toHaveFocus();
+        await user.keyboard(`[${verticalPrevKey}]`);
 
-      await user.keyboard('[ArrowLeft]');
-
-      expect(button2).to.have.attribute('data-highlighted');
-      expect(button2).to.have.attribute('tabindex', '0');
-      expect(button2).toHaveFocus();
-
-      await user.keyboard('[ArrowLeft]');
-
-      expect(button1).to.have.attribute('data-highlighted');
-      expect(button1).to.have.attribute('tabindex', '0');
-      expect(button1).toHaveFocus();
-
-      await user.keyboard('[ArrowDown]');
-
-      expect(button2).to.have.attribute('data-highlighted');
-      expect(button2).to.have.attribute('tabindex', '0');
-      expect(button2).toHaveFocus();
-
-      await user.keyboard('[ArrowDown]');
-
-      expect(button1).to.have.attribute('data-highlighted');
-      expect(button1).to.have.attribute('tabindex', '0');
-      expect(button1).toHaveFocus();
+        expect(button3).to.have.attribute('data-highlighted');
+        expect(button3).to.have.attribute('tabindex', '0');
+        expect(button3).toHaveFocus();
+      });
     });
 
     ['Enter', 'Space'].forEach((key) => {

--- a/packages/react/src/toggle-group/root/ToggleGroupRoot.tsx
+++ b/packages/react/src/toggle-group/root/ToggleGroupRoot.tsx
@@ -5,7 +5,7 @@ import { NOOP } from '../../utils/noop';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { CompositeRoot } from '../../composite/root/CompositeRoot';
-import { useDirectionContext } from '../../direction-provider/DirectionContext';
+import { useDirection } from '../../direction-provider/DirectionContext';
 import { useToggleGroupRoot, type UseToggleGroupRoot } from './useToggleGroupRoot';
 import { ToggleGroupRootContext } from './ToggleGroupRootContext';
 
@@ -44,8 +44,7 @@ const ToggleGroupRoot = React.forwardRef(function ToggleGroupRoot(
     ...otherProps
   } = props;
 
-  const directionContext = useDirectionContext();
-  const direction = directionContext?.direction ?? 'ltr';
+  const direction = useDirection();
 
   const defaultValue = React.useMemo(() => {
     if (valueProp === undefined) {

--- a/packages/react/src/toggle-group/root/ToggleGroupRoot.tsx
+++ b/packages/react/src/toggle-group/root/ToggleGroupRoot.tsx
@@ -5,6 +5,7 @@ import { NOOP } from '../../utils/noop';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { CompositeRoot } from '../../composite/root/CompositeRoot';
+import { useDirectionContext } from '../../direction-provider/DirectionContext';
 import { useToggleGroupRoot, type UseToggleGroupRoot } from './useToggleGroupRoot';
 import { ToggleGroupRootContext } from './ToggleGroupRootContext';
 
@@ -42,6 +43,9 @@ const ToggleGroupRoot = React.forwardRef(function ToggleGroupRoot(
     render,
     ...otherProps
   } = props;
+
+  const directionContext = useDirectionContext();
+  const direction = directionContext?.direction ?? 'ltr';
 
   const defaultValue = React.useMemo(() => {
     if (valueProp === undefined) {
@@ -91,7 +95,7 @@ const ToggleGroupRoot = React.forwardRef(function ToggleGroupRoot(
 
   return (
     <ToggleGroupRootContext.Provider value={contextValue}>
-      <CompositeRoot loop={loop} render={renderElement()} />
+      <CompositeRoot direction={direction} loop={loop} render={renderElement()} />
     </ToggleGroupRootContext.Provider>
   );
 });

--- a/packages/react/src/toggle-group/root/ToggleGroupRoot.tsx
+++ b/packages/react/src/toggle-group/root/ToggleGroupRoot.tsx
@@ -143,7 +143,7 @@ ToggleGroupRoot.propTypes /* remove-proptypes */ = {
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   /**
    * The open state of the ToggleGroup represented by an array of
-   * the values of all pressed `<ToggleGroup.Item/>`s
+   * the values of all pressed `<ToggleGroup.Item/>`s.
    * This is the uncontrolled counterpart of `value`.
    */
   defaultValue: PropTypes.array,

--- a/packages/react/src/toggle-group/root/useToggleGroupRoot.ts
+++ b/packages/react/src/toggle-group/root/useToggleGroupRoot.ts
@@ -66,7 +66,7 @@ export namespace UseToggleGroupRoot {
     value?: readonly any[];
     /**
      * The open state of the ToggleGroup represented by an array of
-     * the values of all pressed `<ToggleGroup.Item/>`s
+     * the values of all pressed `<ToggleGroup.Item/>`s.
      * This is the uncontrolled counterpart of `value`.
      */
     defaultValue?: readonly any[];
@@ -94,7 +94,7 @@ export namespace UseToggleGroupRoot {
   export interface ReturnValue {
     getRootProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
     /**
-     * When `true` the component is disabled
+     * When `true` the component is disabled.
      * @false
      */
     disabled: boolean;
@@ -104,7 +104,7 @@ export namespace UseToggleGroupRoot {
     setGroupValue: (newValue: string, nextPressed: boolean, event: Event) => void;
     /**
      * The value of the ToggleGroup represented by an array of values
-     * of the items that are pressed
+     * of the items that are pressed.
      */
     value: readonly any[];
   }

--- a/packages/react/src/toggle/root/ToggleRoot.tsx
+++ b/packages/react/src/toggle/root/ToggleRoot.tsx
@@ -156,7 +156,7 @@ ToggleRoot.propTypes /* remove-proptypes */ = {
   type: PropTypes.oneOf(['button', 'reset', 'submit']),
   /**
    * A unique string that identifies the component when used
-   * inside a ToggleGroup
+   * inside a ToggleGroup.
    */
   value: PropTypes.string,
 } as any;

--- a/packages/react/src/toggle/root/useToggleRoot.ts
+++ b/packages/react/src/toggle/root/useToggleRoot.ts
@@ -95,7 +95,7 @@ export namespace useToggleRoot {
     setGroupValue: (newValue: string, nextPressed: boolean, event: Event) => void;
     /**
      * A unique string that identifies the component when used
-     * inside a ToggleGroup
+     * inside a ToggleGroup.
      */
     value: string;
     // TODO: a prop to indicate `aria-pressed='mixed'` is supported
@@ -104,8 +104,8 @@ export namespace useToggleRoot {
   export interface ReturnValue {
     /**
      * Resolver for the root slot's props.
-     * @param externalProps props for the root slot
-     * @returns props that should be spread on the root slot
+     * @param externalProps props for the root slot.
+     * @returns props that should be spread on the root slot.
      */
     getRootProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
     /**


### PR DESCRIPTION
Closes https://github.com/mui/base-ui/issues/831
Closes https://github.com/mui/base-ui/issues/59

- Docs: https://deploy-preview-931--base-ui.netlify.app/components/react-direction-provider
- Updates [Menu](https://deploy-preview-931--base-ui.netlify.app/components/react-menu#rtl), [RadioGroup](https://deploy-preview-931--base-ui.netlify.app/components/react-radio-group#rtl), [Slider](https://deploy-preview-931--base-ui.netlify.app/components/react-slider#rtl), [Tabs](https://deploy-preview-931--base-ui.netlify.app/components/react-tabs#rtl), [Accordion](https://deploy-preview-931--base-ui.netlify.app/components/react-accordion#rtl), [ToggleGroup](https://deploy-preview-931--base-ui.netlify.app/components/react-toggle-group#rtl)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
