### PR TITLE
[popups] Use `data-anchor-hidden` attribute

### DIFF
--- a/docs/data/api/menu-positioner.json
+++ b/docs/data/api/menu-positioner.json
@@ -31,7 +31,6 @@
       "default": "5"
     },
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
-    "hideWhenDetached": { "type": { "name": "bool" }, "default": "false" },
     "keepMounted": { "type": { "name": "bool" }, "default": "false" },
     "positionMethod": {
       "type": { "name": "enum", "description": "'absolute'<br>&#124;&nbsp;'fixed'" },

--- a/docs/data/api/popover-positioner.json
+++ b/docs/data/api/popover-positioner.json
@@ -31,7 +31,6 @@
       "default": "5"
     },
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
-    "hideWhenDetached": { "type": { "name": "bool" }, "default": "false" },
     "keepMounted": { "type": { "name": "bool" }, "default": "false" },
     "positionMethod": {
       "type": { "name": "enum", "description": "'absolute'<br>&#124;&nbsp;'fixed'" },

--- a/docs/data/api/preview-card-positioner.json
+++ b/docs/data/api/preview-card-positioner.json
@@ -31,7 +31,6 @@
       "default": "5"
     },
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
-    "hideWhenDetached": { "type": { "name": "bool" }, "default": "false" },
     "keepMounted": { "type": { "name": "bool" }, "default": "false" },
     "positionMethod": {
       "type": { "name": "enum", "description": "'absolute'<br>&#124;&nbsp;'fixed'" },

--- a/docs/data/api/select-positioner.json
+++ b/docs/data/api/select-positioner.json
@@ -36,7 +36,6 @@
         "description": "(props, propName) => {\n  if (props[propName] == null) {\n    return new Error(`Prop '${propName}' is required but wasn't specified`);\n  }\n  if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {\n    return new Error(`Expected prop '${propName}' to be of type Element`);\n  }\n  return null;\n}<br>&#124;&nbsp;{ current?: (props, propName) => {\n  if (props[propName] == null) {\n    return null;\n  }\n  if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {\n    return new Error(`Expected prop '${propName}' to be of type Element`);\n  }\n  return null;\n} }"
       }
     },
-    "hideWhenDetached": { "type": { "name": "bool" }, "default": "false" },
     "positionMethod": {
       "type": { "name": "enum", "description": "'absolute'<br>&#124;&nbsp;'fixed'" },
       "default": "'absolute'"

--- a/docs/data/api/tooltip-positioner.json
+++ b/docs/data/api/tooltip-positioner.json
@@ -31,7 +31,6 @@
       "default": "5"
     },
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
-    "hideWhenDetached": { "type": { "name": "bool" }, "default": "false" },
     "keepMounted": { "type": { "name": "bool" }, "default": "false" },
     "positionMethod": {
       "type": { "name": "enum", "description": "'absolute'<br>&#124;&nbsp;'fixed'" },

--- a/docs/data/translations/api-docs/menu-positioner/menu-positioner.json
+++ b/docs/data/translations/api-docs/menu-positioner/menu-positioner.json
@@ -19,9 +19,6 @@
     "container": {
       "description": "The container element to which the Menu popup will be appended to."
     },
-    "hideWhenDetached": {
-      "description": "If <code>true</code>, the Menu will be hidden if it is detached from its anchor element due to differing clipping contexts."
-    },
     "keepMounted": {
       "description": "Whether the menu popup remains mounted in the DOM while closed."
     },

--- a/docs/data/translations/api-docs/popover-positioner/popover-positioner.json
+++ b/docs/data/translations/api-docs/popover-positioner/popover-positioner.json
@@ -19,9 +19,6 @@
       "description": "The padding between the popover element and the edges of the collision boundary to add whitespace between them to prevent them from touching."
     },
     "container": { "description": "The element the popover positioner element is appended to." },
-    "hideWhenDetached": {
-      "description": "Whether the popover element is hidden if it appears detached from its anchor element due to the anchor element being clipped (or hidden) from view."
-    },
     "keepMounted": {
       "description": "Whether the popover remains mounted in the DOM while closed."
     },

--- a/docs/data/translations/api-docs/preview-card-positioner/preview-card-positioner.json
+++ b/docs/data/translations/api-docs/preview-card-positioner/preview-card-positioner.json
@@ -23,9 +23,6 @@
     "container": {
       "description": "The container element to which the preview card popup will be appended to."
     },
-    "hideWhenDetached": {
-      "description": "If <code>true</code>, the preview card will be hidden if it is detached from its anchor element due to differing clipping contexts."
-    },
     "keepMounted": {
       "description": "If <code>true</code>, preview card stays mounted in the DOM when closed."
     },

--- a/docs/data/translations/api-docs/select-positioner/select-positioner.json
+++ b/docs/data/translations/api-docs/select-positioner/select-positioner.json
@@ -19,9 +19,6 @@
     "container": {
       "description": "The container element to which the Select popup will be appended to."
     },
-    "hideWhenDetached": {
-      "description": "If <code>true</code>, the Select will be hidden if it is detached from its anchor element due to differing clipping contexts."
-    },
     "positionMethod": {
       "description": "The CSS position method for positioning the Select popup element."
     },

--- a/docs/data/translations/api-docs/tooltip-positioner/tooltip-positioner.json
+++ b/docs/data/translations/api-docs/tooltip-positioner/tooltip-positioner.json
@@ -19,9 +19,6 @@
       "description": "The padding between the tooltip element and the edges of the collision boundary to add whitespace between them to prevent them from touching."
     },
     "container": { "description": "The container element the tooltip positioner is appended to." },
-    "hideWhenDetached": {
-      "description": "Whether the tooltip element is hidden if it appears detached from its anchor element due to the anchor element being clipped (or hidden) from view."
-    },
     "keepMounted": {
       "description": "Whether the tooltip remains mounted in the DOM while closed."
     },

--- a/docs/reference/generated/menu-positioner.json
+++ b/docs/reference/generated/menu-positioner.json
@@ -39,11 +39,6 @@
       "type": "React.Ref | HTMLElement | null",
       "description": "The container element to which the Menu popup will be appended to."
     },
-    "hideWhenDetached": {
-      "type": "boolean",
-      "default": "false",
-      "description": "If `true`, the Menu will be hidden if it is detached from its anchor element due to\ndiffering clipping contexts."
-    },
     "keepMounted": {
       "type": "boolean",
       "default": "false",

--- a/docs/reference/generated/popover-positioner.json
+++ b/docs/reference/generated/popover-positioner.json
@@ -39,11 +39,6 @@
       "type": "React.Ref | HTMLElement | null",
       "description": "The element the popover positioner element is appended to."
     },
-    "hideWhenDetached": {
-      "type": "boolean",
-      "default": "false",
-      "description": "Whether the popover element is hidden if it appears detached from its anchor element due\nto the anchor element being clipped (or hidden) from view."
-    },
     "keepMounted": {
       "type": "boolean",
       "default": "false",

--- a/docs/reference/generated/preview-card-positioner.json
+++ b/docs/reference/generated/preview-card-positioner.json
@@ -39,11 +39,6 @@
       "type": "React.Ref | HTMLElement | null",
       "description": "The container element to which the preview card popup will be appended to."
     },
-    "hideWhenDetached": {
-      "type": "boolean",
-      "default": "false",
-      "description": "If `true`, the preview card will be hidden if it is detached from its anchor element due to\ndiffering clipping contexts."
-    },
     "keepMounted": {
       "type": "boolean",
       "default": "false",

--- a/docs/reference/generated/select-positioner.json
+++ b/docs/reference/generated/select-positioner.json
@@ -39,11 +39,6 @@
       "type": "React.Ref | HTMLElement | null",
       "description": "The container element to which the Select popup will be appended to."
     },
-    "hideWhenDetached": {
-      "type": "boolean",
-      "default": "false",
-      "description": "If `true`, the Select will be hidden if it is detached from its anchor element due to\ndiffering clipping contexts."
-    },
     "positionMethod": {
       "type": "'absolute' | 'fixed'",
       "default": "'absolute'",

--- a/docs/reference/generated/tooltip-positioner.json
+++ b/docs/reference/generated/tooltip-positioner.json
@@ -39,11 +39,6 @@
       "type": "React.Ref | HTMLElement | null",
       "description": "The container element the tooltip positioner is appended to."
     },
-    "hideWhenDetached": {
-      "type": "boolean",
-      "default": "false",
-      "description": "Whether the tooltip element is hidden if it appears detached from its anchor element due\nto the anchor element being clipped (or hidden) from view."
-    },
     "keepMounted": {
       "type": "boolean",
       "default": "false",

--- a/docs/src/app/experiments/anchor-positioning.tsx
+++ b/docs/src/app/experiments/anchor-positioning.tsx
@@ -22,7 +22,6 @@ export default function AnchorPositioning() {
   const [alignOffset, setAlignOffset] = React.useState(0);
   const [collisionPadding, setCollisionPadding] = React.useState(5);
   const [arrowPadding, setArrowPadding] = React.useState(5);
-  const [hideWhenDetached, setHideWhenDetached] = React.useState(false);
   const [arrow, setArrow] = React.useState(true);
   const [hideArrowWhenUncentered, setHideArrowWhenUncentered] =
     React.useState(false);
@@ -44,7 +43,6 @@ export default function AnchorPositioning() {
     sideOffset,
     alignOffset,
     collisionPadding,
-    hideWhenDetached,
     sticky,
     arrowPadding,
     trackAnchor,
@@ -270,15 +268,6 @@ export default function AnchorPositioning() {
               onChange={() => setConstrainSize((prev) => !prev)}
             />
             Constrain size
-          </label>
-
-          <label>
-            <input
-              type="checkbox"
-              checked={hideWhenDetached}
-              onChange={() => setHideWhenDetached((prev) => !prev)}
-            />
-            Hide when detached
           </label>
 
           <label>

--- a/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
+++ b/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
@@ -8,7 +8,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 
 const customStyleHookMapping: CustomStyleHookMapping<AlertDialogBackdrop.State> = {
   ...baseMapping,

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -9,7 +9,7 @@ import { refType, HTMLElementType } from '../../utils/proptypes';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import { useForkRef } from '../../utils/useForkRef';
 import { InteractionType } from '../../utils/useEnhancedClickHandler';
 

--- a/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
+++ b/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
@@ -5,7 +5,7 @@ import { useAlertDialogRootContext } from '../root/AlertDialogRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 
 /**
  *

--- a/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
+++ b/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
@@ -8,7 +8,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { type TransitionStatus } from '../../utils/useTransitionStatus';
 import { type BaseUIComponentProps } from '../../utils/types';
 import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 
 const customStyleHookMapping: CustomStyleHookMapping<DialogBackdrop.State> = {
   ...baseMapping,

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -9,7 +9,7 @@ import { refType, HTMLElementType } from '../../utils/proptypes';
 import { type BaseUIComponentProps } from '../../utils/types';
 import { type TransitionStatus } from '../../utils/useTransitionStatus';
 import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import { useForkRef } from '../../utils/useForkRef';
 import { InteractionType } from '../../utils/useEnhancedClickHandler';
 

--- a/packages/react/src/dialog/trigger/DialogTrigger.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.tsx
@@ -5,7 +5,7 @@ import { useDialogRootContext } from '../root/DialogRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 
 /**
  * A button that opens the dialog. Renders a `<button>` element.

--- a/packages/react/src/menu/arrow/MenuArrow.tsx
+++ b/packages/react/src/menu/arrow/MenuArrow.tsx
@@ -8,7 +8,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { Side, Align } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 
 /**
  * Renders an arrow that points to the center of the anchor element.
@@ -54,7 +54,7 @@ const MenuArrow = React.forwardRef(function MenuArrow(
     state,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping: popupStateMapping,
   });
 
   return renderElement();

--- a/packages/react/src/menu/popup/MenuPopup.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.tsx
@@ -10,7 +10,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
-import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 
 const customStyleHookMapping: CustomStyleHookMapping<MenuPopup.State> = {
   ...baseMapping,

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -46,7 +46,6 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     collisionBoundary = 'clipping-ancestors',
     collisionPadding = 5,
     arrowPadding = 5,
-    hideWhenDetached = false,
     sticky = false,
     container,
     ...otherProps
@@ -79,7 +78,6 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     arrowPadding,
     collisionBoundary,
     collisionPadding,
-    hideWhenDetached,
     sticky,
     nodeId,
   });
@@ -89,8 +87,9 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
       open,
       side: positioner.side,
       align: positioner.align,
+      anchorHidden: positioner.anchorHidden,
     }),
-    [open, positioner.side, positioner.align],
+    [open, positioner.side, positioner.align, positioner.anchorHidden],
   );
 
   const contextValue: MenuPositionerContext = React.useMemo(
@@ -237,12 +236,6 @@ MenuPositioner.propTypes /* remove-proptypes */ = {
     HTMLElementType,
     PropTypes.func,
   ]),
-  /**
-   * If `true`, the Menu will be hidden if it is detached from its anchor element due to
-   * differing clipping contexts.
-   * @default false
-   */
-  hideWhenDetached: PropTypes.bool,
   /**
    * Whether the menu popup remains mounted in the DOM while closed.
    * @default false

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -16,7 +16,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import { useMenuPositioner } from './useMenuPositioner';
 import { HTMLElementType } from '../../utils/proptypes';
 import { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 
 /**
  * Renders the element that positions the Menu popup.
@@ -119,7 +119,7 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     render: render ?? 'div',
     className,
     state,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping: popupStateMapping,
     ref: mergedRef,
     extraProps: otherProps,
   });

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -150,14 +150,13 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
   );
 });
 
-export { MenuPositioner };
-
 export namespace MenuPositioner {
-  export type State = {
+  export interface State {
     open: boolean;
     side: Side;
     align: 'start' | 'end' | 'center';
-  };
+    anchorHidden: boolean;
+  }
 
   export interface Props
     extends useMenuPositioner.SharedParameters,
@@ -267,3 +266,5 @@ MenuPositioner.propTypes /* remove-proptypes */ = {
    */
   sticky: PropTypes.bool,
 } as any;
+
+export { MenuPositioner };

--- a/packages/react/src/menu/positioner/useMenuPositioner.ts
+++ b/packages/react/src/menu/positioner/useMenuPositioner.ts
@@ -22,7 +22,7 @@ export function useMenuPositioner(
   const {
     positionerStyles,
     arrowStyles,
-    hidden,
+    anchorHidden,
     arrowRef,
     arrowUncentered,
     renderedSide,
@@ -34,7 +34,7 @@ export function useMenuPositioner(
     (externalProps = {}) => {
       const hiddenStyles: React.CSSProperties = {};
 
-      if ((keepMounted && !open) || hidden) {
+      if ((keepMounted && !open) || anchorHidden) {
         hiddenStyles.pointerEvents = 'none';
       }
 
@@ -47,7 +47,7 @@ export function useMenuPositioner(
         },
       });
     },
-    [keepMounted, open, hidden, positionerStyles, mounted],
+    [keepMounted, open, anchorHidden, positionerStyles, mounted],
   );
 
   return React.useMemo(
@@ -59,6 +59,7 @@ export function useMenuPositioner(
       side: renderedSide,
       align: renderedAlign,
       floatingContext,
+      anchorHidden,
     }),
     [
       getPositionerProps,
@@ -68,6 +69,7 @@ export function useMenuPositioner(
       renderedSide,
       renderedAlign,
       floatingContext,
+      anchorHidden,
     ],
   );
 }
@@ -126,12 +128,6 @@ export namespace useMenuPositioner {
      * @default 5
      */
     collisionPadding?: Padding;
-    /**
-     * If `true`, the Menu will be hidden if it is detached from its anchor element due to
-     * differing clipping contexts.
-     * @default false
-     */
-    hideWhenDetached?: boolean;
     /**
      * Whether the menu popup remains mounted in the DOM while closed.
      * @default false
@@ -195,5 +191,9 @@ export namespace useMenuPositioner {
      * The floating context.
      */
     floatingContext: FloatingContext;
+    /**
+     * Determines if the anchor element is hidden.
+     */
+    anchorHidden: boolean;
   }
 }

--- a/packages/react/src/menu/positioner/useMenuPositioner.ts
+++ b/packages/react/src/menu/positioner/useMenuPositioner.ts
@@ -47,7 +47,7 @@ export function useMenuPositioner(
         },
       });
     },
-    [keepMounted, open, anchorHidden, positionerStyles, mounted],
+    [keepMounted, open, positionerStyles, mounted],
   );
 
   return React.useMemo(

--- a/packages/react/src/menu/positioner/useMenuPositioner.ts
+++ b/packages/react/src/menu/positioner/useMenuPositioner.ts
@@ -34,7 +34,7 @@ export function useMenuPositioner(
     (externalProps = {}) => {
       const hiddenStyles: React.CSSProperties = {};
 
-      if ((keepMounted && !open) || anchorHidden) {
+      if (keepMounted && !open) {
         hiddenStyles.pointerEvents = 'none';
       }
 

--- a/packages/react/src/menu/submenu-trigger/SubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/SubmenuTrigger.tsx
@@ -8,7 +8,7 @@ import { useId } from '../../utils/useId';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useSubmenuTrigger } from './useSubmenuTrigger';
 import { useForkRef } from '../../utils/useForkRef';
-import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 
 /**
  *

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useFloatingTree } from '@floating-ui/react';
 import { useMenuTrigger } from './useMenuTrigger';
 import { useMenuRootContext } from '../root/MenuRootContext';
-import { pressableTriggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { pressableTriggerOpenStateMapping } from '../../utils/popupStateMapping';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { BaseUIComponentProps } from '../../utils/types';
 

--- a/packages/react/src/popover/arrow/PopoverArrow.tsx
+++ b/packages/react/src/popover/arrow/PopoverArrow.tsx
@@ -8,7 +8,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import { usePopoverArrow } from './usePopoverArrow';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 
 /**
  * Renders an arrow that points to the center of the anchor element.
@@ -54,7 +54,7 @@ const PopoverArrow = React.forwardRef(function PopoverArrow(
     state,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping: popupStateMapping,
   });
 
   return renderElement();

--- a/packages/react/src/popover/backdrop/PopoverBackdrop.tsx
+++ b/packages/react/src/popover/backdrop/PopoverBackdrop.tsx
@@ -8,7 +8,7 @@ import { HTMLElementType } from '../../utils/proptypes';
 import { usePopoverBackdrop } from './usePopoverBackdrop';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 
 const customStyleHookMapping: CustomStyleHookMapping<PopoverBackdrop.State> = {

--- a/packages/react/src/popover/popup/PopoverPopup.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.tsx
@@ -11,7 +11,7 @@ import type { Side, Align } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
-import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import { InteractionType } from '../../utils/useEnhancedClickHandler';
 import { refType } from '../../utils/proptypes';
 

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -10,7 +10,7 @@ import { PopoverPositionerContext } from './PopoverPositionerContext';
 import { HTMLElementType } from '../../utils/proptypes';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Side, Align } from '../../utils/useAnchorPositioning';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 
 /**
  * The popover positioner element.
@@ -86,7 +86,7 @@ const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     state,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping: popupStateMapping,
   });
 
   const shouldRender = keepMounted || mounted;

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -106,6 +106,7 @@ namespace PopoverPositioner {
     open: boolean;
     side: Side;
     align: Align;
+    anchorHidden: boolean;
   }
 
   export interface Props

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -41,7 +41,6 @@ const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     collisionBoundary = 'clipping-ancestors',
     collisionPadding = 5,
     arrowPadding = 5,
-    hideWhenDetached = false,
     sticky = false,
     ...otherProps
   } = props;
@@ -63,7 +62,6 @@ const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     arrowPadding,
     collisionBoundary,
     collisionPadding,
-    hideWhenDetached,
     sticky,
     popupRef,
     openMethod,
@@ -74,8 +72,9 @@ const PopoverPositioner = React.forwardRef(function PopoverPositioner(
       open,
       side: positioner.side,
       align: positioner.align,
+      anchorHidden: positioner.anchorHidden,
     }),
-    [open, positioner.side, positioner.align],
+    [open, positioner.side, positioner.align, positioner.anchorHidden],
   );
 
   const mergedRef = useForkRef(forwardedRef, setPositionerElement);
@@ -192,12 +191,6 @@ PopoverPositioner.propTypes /* remove-proptypes */ = {
     HTMLElementType,
     PropTypes.func,
   ]),
-  /**
-   * Whether the popover element is hidden if it appears detached from its anchor element due
-   * to the anchor element being clipped (or hidden) from view.
-   * @default false
-   */
-  hideWhenDetached: PropTypes.bool,
   /**
    * Whether the popover remains mounted in the DOM while closed.
    * @default false

--- a/packages/react/src/popover/positioner/usePopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/usePopoverPositioner.tsx
@@ -18,7 +18,7 @@ export function usePopoverPositioner(
   const {
     positionerStyles,
     arrowStyles,
-    hidden,
+    anchorHidden,
     arrowRef,
     arrowUncentered,
     renderedSide,
@@ -31,7 +31,7 @@ export function usePopoverPositioner(
       (externalProps = {}) => {
         const hiddenStyles: React.CSSProperties = {};
 
-        if ((keepMounted && !open) || hidden) {
+        if ((keepMounted && !open) || anchorHidden) {
           hiddenStyles.pointerEvents = 'none';
         }
 
@@ -44,7 +44,7 @@ export function usePopoverPositioner(
           },
         });
       },
-      [keepMounted, open, hidden, mounted, positionerStyles],
+      [keepMounted, open, anchorHidden, mounted, positionerStyles],
     );
 
   return React.useMemo(
@@ -56,6 +56,7 @@ export function usePopoverPositioner(
       side: renderedSide,
       align: renderedAlign,
       positionerContext,
+      anchorHidden,
     }),
     [
       getPositionerProps,
@@ -65,6 +66,7 @@ export function usePopoverPositioner(
       renderedSide,
       renderedAlign,
       positionerContext,
+      anchorHidden,
     ],
   );
 }
@@ -116,12 +118,6 @@ export namespace usePopoverPositioner {
      * @default 5
      */
     collisionPadding?: Padding;
-    /**
-     * Whether the popover element is hidden if it appears detached from its anchor element due
-     * to the anchor element being clipped (or hidden) from view.
-     * @default false
-     */
-    hideWhenDetached?: boolean;
     /**
      * Whether to allow the popover to remain stuck in view while the anchor element is scrolled out
      * of view.
@@ -199,5 +195,9 @@ export namespace usePopoverPositioner {
      * The floating context.
      */
     positionerContext: FloatingContext;
+    /**
+     * Determines if the anchor element is hidden.
+     */
+    anchorHidden: boolean;
   }
 }

--- a/packages/react/src/popover/positioner/usePopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/usePopoverPositioner.tsx
@@ -31,7 +31,7 @@ export function usePopoverPositioner(
       (externalProps = {}) => {
         const hiddenStyles: React.CSSProperties = {};
 
-        if ((keepMounted && !open) || anchorHidden) {
+        if (keepMounted && !open) {
           hiddenStyles.pointerEvents = 'none';
         }
 
@@ -44,7 +44,7 @@ export function usePopoverPositioner(
           },
         });
       },
-      [keepMounted, open, anchorHidden, mounted, positionerStyles],
+      [keepMounted, open, mounted, positionerStyles],
     );
 
   return React.useMemo(

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -8,7 +8,7 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import {
   triggerOpenStateMapping,
   pressableTriggerOpenStateMapping,
-} from '../../utils/popupOpenStateMapping';
+} from '../../utils/popupStateMapping';
 import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 
 /**

--- a/packages/react/src/preview-card/arrow/PreviewCardArrow.tsx
+++ b/packages/react/src/preview-card/arrow/PreviewCardArrow.tsx
@@ -8,7 +8,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import { usePreviewCardRootContext } from '../root/PreviewCardContext';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 
 /**
  *
@@ -52,7 +52,7 @@ const PreviewCardArrow = React.forwardRef(function PreviewCardArrow(
     state,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping: popupStateMapping,
   });
 
   return renderElement();

--- a/packages/react/src/preview-card/backdrop/PreviewCardBackdrop.tsx
+++ b/packages/react/src/preview-card/backdrop/PreviewCardBackdrop.tsx
@@ -8,7 +8,7 @@ import { usePreviewCardBackdrop } from './usePreviewCardBackdrop';
 import { HTMLElementType } from '../../utils/proptypes';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 
 const customStyleHookMapping: CustomStyleHookMapping<PreviewCardBackdrop.State> = {

--- a/packages/react/src/preview-card/popup/PreviewCardPopup.tsx
+++ b/packages/react/src/preview-card/popup/PreviewCardPopup.tsx
@@ -9,7 +9,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 
 const customStyleHookMapping: CustomStyleHookMapping<PreviewCardPopup.State> = {

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
@@ -10,7 +10,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import { HTMLElementType } from '../../utils/proptypes';
 import type { Side, Align } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 
 /**
  *
@@ -100,7 +100,7 @@ const PreviewCardPositioner = React.forwardRef(function PreviewCardPositioner(
     state,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping: popupStateMapping,
   });
 
   const shouldRender = keepMounted || mounted;

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
@@ -38,7 +38,6 @@ const PreviewCardPositioner = React.forwardRef(function PreviewCardPositioner(
     collisionBoundary = 'clipping-ancestors',
     collisionPadding = 5,
     arrowPadding = 5,
-    hideWhenDetached = false,
     sticky = false,
     keepMounted = false,
     container,
@@ -62,7 +61,6 @@ const PreviewCardPositioner = React.forwardRef(function PreviewCardPositioner(
     arrowPadding,
     collisionBoundary,
     collisionPadding,
-    hideWhenDetached,
     sticky,
   });
 
@@ -71,8 +69,9 @@ const PreviewCardPositioner = React.forwardRef(function PreviewCardPositioner(
       open,
       side: positioner.side,
       align: positioner.align,
+      anchorHidden: positioner.anchorHidden,
     }),
-    [open, positioner.side, positioner.align],
+    [open, positioner.side, positioner.align, positioner.anchorHidden],
   );
 
   const contextValue: PreviewCardPositionerContext = React.useMemo(
@@ -200,12 +199,6 @@ PreviewCardPositioner.propTypes /* remove-proptypes */ = {
     HTMLElementType,
     PropTypes.func,
   ]),
-  /**
-   * If `true`, the preview card will be hidden if it is detached from its anchor element due to
-   * differing clipping contexts.
-   * @default false
-   */
-  hideWhenDetached: PropTypes.bool,
   /**
    * If `true`, preview card stays mounted in the DOM when closed.
    * @default false

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
@@ -120,6 +120,7 @@ namespace PreviewCardPositioner {
     open: boolean;
     side: Side;
     align: Align;
+    anchorHidden: boolean;
   }
 
   export interface Props

--- a/packages/react/src/preview-card/positioner/usePreviewCardPositioner.ts
+++ b/packages/react/src/preview-card/positioner/usePreviewCardPositioner.ts
@@ -20,7 +20,7 @@ export function usePreviewCardPositioner(
   const {
     positionerStyles,
     arrowStyles,
-    hidden,
+    anchorHidden,
     arrowRef,
     arrowUncentered,
     renderedSide,
@@ -33,7 +33,7 @@ export function usePreviewCardPositioner(
       (externalProps = {}) => {
         const hiddenStyles: React.CSSProperties = {};
 
-        if ((keepMounted && !open) || hidden) {
+        if ((keepMounted && !open) || anchorHidden) {
           hiddenStyles.pointerEvents = 'none';
         }
 
@@ -46,7 +46,7 @@ export function usePreviewCardPositioner(
           },
         });
       },
-      [positionerStyles, open, keepMounted, hidden, mounted],
+      [positionerStyles, open, keepMounted, anchorHidden, mounted],
     );
 
   return React.useMemo(
@@ -58,6 +58,7 @@ export function usePreviewCardPositioner(
       side: renderedSide,
       align: renderedAlign,
       positionerContext,
+      anchorHidden,
     }),
     [
       getPositionerProps,
@@ -67,6 +68,7 @@ export function usePreviewCardPositioner(
       renderedSide,
       renderedAlign,
       positionerContext,
+      anchorHidden,
     ],
   );
 }
@@ -121,12 +123,6 @@ export namespace usePreviewCardPositioner {
      * @default 5
      */
     collisionPadding?: Padding;
-    /**
-     * If `true`, the preview card will be hidden if it is detached from its anchor element due to
-     * differing clipping contexts.
-     * @default false
-     */
-    hideWhenDetached?: boolean;
     /**
      * If `true`, allow the preview card to remain in stuck view while the anchor element is scrolled
      * out of view.
@@ -196,5 +192,9 @@ export namespace usePreviewCardPositioner {
      * The floating context.
      */
     positionerContext: FloatingContext;
+    /**
+     * Determines if the anchor element is hidden.
+     */
+    anchorHidden: boolean;
   }
 }

--- a/packages/react/src/preview-card/positioner/usePreviewCardPositioner.ts
+++ b/packages/react/src/preview-card/positioner/usePreviewCardPositioner.ts
@@ -33,7 +33,7 @@ export function usePreviewCardPositioner(
       (externalProps = {}) => {
         const hiddenStyles: React.CSSProperties = {};
 
-        if ((keepMounted && !open) || anchorHidden) {
+        if (keepMounted && !open) {
           hiddenStyles.pointerEvents = 'none';
         }
 
@@ -46,7 +46,7 @@ export function usePreviewCardPositioner(
           },
         });
       },
-      [positionerStyles, open, keepMounted, anchorHidden, mounted],
+      [positionerStyles, open, keepMounted, mounted],
     );
 
   return React.useMemo(

--- a/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
+++ b/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
@@ -5,7 +5,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { usePreviewCardRootContext } from '../root/PreviewCardContext';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 
 /**
  *

--- a/packages/react/src/select/arrow/SelectArrow.tsx
+++ b/packages/react/src/select/arrow/SelectArrow.tsx
@@ -7,7 +7,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import { mergeReactProps } from '../../utils/mergeReactProps';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
 
 /**
@@ -59,7 +59,7 @@ const SelectArrow = React.forwardRef(function SelectArrow(
     state,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping: popupStateMapping,
   });
 
   if (alignOptionToTrigger) {

--- a/packages/react/src/select/backdrop/SelectBackdrop.tsx
+++ b/packages/react/src/select/backdrop/SelectBackdrop.tsx
@@ -7,12 +7,12 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { HTMLElementType } from '../../utils/proptypes';
 import { useSelectRootContext } from '../root/SelectRootContext';
 import { useSelectBackdrop } from './useSelectBackdrop';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 
 const customStyleHookMapping: CustomStyleHookMapping<SelectBackdrop.State> = {
-  ...popupOpenStateMapping,
+  ...popupStateMapping,
   transitionStatus(value): Record<string, string> | null {
     if (value === 'entering') {
       return { 'data-starting-style': '' };

--- a/packages/react/src/select/popup/SelectPopup.tsx
+++ b/packages/react/src/select/popup/SelectPopup.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { FloatingFocusManager, type Side } from '@floating-ui/react';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useSelectRootContext } from '../root/SelectRootContext';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
@@ -13,7 +13,7 @@ import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { useSelectPositionerContext } from '../positioner/SelectPositionerContext';
 
 const customStyleHookMapping: CustomStyleHookMapping<SelectPopup.State> = {
-  ...popupOpenStateMapping,
+  ...popupStateMapping,
   transitionStatus(value): Record<string, string> | null {
     if (value === 'entering') {
       return { 'data-starting-style': '' };

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -7,7 +7,7 @@ import { useSelectRootContext } from '../root/SelectRootContext';
 import { CompositeList } from '../../composite/list/CompositeList';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 import { useSelectPositioner } from './useSelectPositioner';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
 import { SelectPositionerContext } from './SelectPositionerContext';
@@ -83,7 +83,7 @@ const SelectPositioner = React.forwardRef(function SelectPositioner(
     ref: mergedRef,
     className,
     state,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping: popupStateMapping,
     extraProps: otherProps,
   });
 

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -103,6 +103,7 @@ namespace SelectPositioner {
     open: boolean;
     side: Side | 'none';
     align: Align;
+    anchorHidden: boolean;
   }
 
   export interface Props

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -38,7 +38,6 @@ const SelectPositioner = React.forwardRef(function SelectPositioner(
     collisionBoundary = 'clipping-ancestors',
     collisionPadding,
     arrowPadding = 5,
-    hideWhenDetached = false,
     sticky = false,
     trackAnchor = true,
     container,
@@ -61,7 +60,6 @@ const SelectPositioner = React.forwardRef(function SelectPositioner(
     arrowPadding,
     collisionBoundary,
     collisionPadding,
-    hideWhenDetached,
     sticky,
     trackAnchor,
     allowAxisFlip: false,
@@ -74,8 +72,9 @@ const SelectPositioner = React.forwardRef(function SelectPositioner(
       open,
       side: positioner.side,
       align: positioner.align,
+      anchorHidden: positioner.anchorHidden,
     }),
-    [open, positioner.side, positioner.align],
+    [open, positioner.side, positioner.align, positioner.anchorHidden],
   );
 
   const { renderElement } = useComponentRenderer({
@@ -248,12 +247,6 @@ SelectPositioner.propTypes /* remove-proptypes */ = {
       },
     }),
   ]),
-  /**
-   * If `true`, the Select will be hidden if it is detached from its anchor element due to
-   * differing clipping contexts.
-   * @default false
-   */
-  hideWhenDetached: PropTypes.bool,
   /**
    * The CSS position method for positioning the Select popup element.
    * @default 'absolute'

--- a/packages/react/src/select/positioner/useSelectPositioner.ts
+++ b/packages/react/src/select/positioner/useSelectPositioner.ts
@@ -29,7 +29,7 @@ export function useSelectPositioner(
   const {
     positionerStyles: enabledPositionerStyles,
     arrowStyles,
-    hidden,
+    anchorHidden,
     arrowRef,
     arrowUncentered,
     renderedSide,
@@ -53,7 +53,7 @@ export function useSelectPositioner(
       (externalProps = {}) => {
         const hiddenStyles: React.CSSProperties = {};
 
-        if (!open || hidden) {
+        if (!open || anchorHidden) {
           hiddenStyles.pointerEvents = 'none';
         }
 
@@ -66,7 +66,7 @@ export function useSelectPositioner(
           },
         });
       },
-      [open, hidden, mounted, positionerStyles],
+      [open, anchorHidden, mounted, positionerStyles],
     );
 
   const positioner = React.useMemo(
@@ -79,6 +79,7 @@ export function useSelectPositioner(
         align: renderedAlign,
         positionerContext,
         isPositioned,
+        anchorHidden,
       }) as const,
     [
       alignOptionToTrigger,
@@ -89,6 +90,7 @@ export function useSelectPositioner(
       positionerContext,
       renderedAlign,
       renderedSide,
+      anchorHidden,
     ],
   );
 
@@ -151,12 +153,6 @@ export namespace useSelectPositioner {
      * @default 5
      */
     collisionPadding?: Padding;
-    /**
-     * If `true`, the Select will be hidden if it is detached from its anchor element due to
-     * differing clipping contexts.
-     * @default false
-     */
-    hideWhenDetached?: boolean;
     /**
      * Whether the select popup remains mounted in the DOM while closed.
      * @default true
@@ -258,6 +254,10 @@ export namespace useSelectPositioner {
        * Whether the Select popup has been positioned.
        */
       isPositioned: boolean;
+      /**
+       * Determines if the anchor element is hidden.
+       */
+      anchorHidden: boolean;
     };
   }
 }

--- a/packages/react/src/select/positioner/useSelectPositioner.ts
+++ b/packages/react/src/select/positioner/useSelectPositioner.ts
@@ -53,7 +53,7 @@ export function useSelectPositioner(
       (externalProps = {}) => {
         const hiddenStyles: React.CSSProperties = {};
 
-        if (!open || anchorHidden) {
+        if (!open) {
           hiddenStyles.pointerEvents = 'none';
         }
 
@@ -66,7 +66,7 @@ export function useSelectPositioner(
           },
         });
       },
-      [open, anchorHidden, mounted, positionerStyles],
+      [open, mounted, positionerStyles],
     );
 
   const positioner = React.useMemo(

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -6,7 +6,7 @@ import { useSelectRootContext } from '../root/SelectRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
-import { pressableTriggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { pressableTriggerOpenStateMapping } from '../../utils/popupStateMapping';
 
 /**
  *

--- a/packages/react/src/tooltip/arrow/TooltipArrow.tsx
+++ b/packages/react/src/tooltip/arrow/TooltipArrow.tsx
@@ -7,7 +7,7 @@ import { useTooltipPositionerContext } from '../positioner/TooltipPositionerCont
 import { useTooltipArrow } from './useTooltipArrow';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Side, Align } from '../../utils/useAnchorPositioning';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 
 /**
  * Renders an arrow that points to the center of the anchor element.
@@ -52,7 +52,7 @@ const TooltipArrow = React.forwardRef(function TooltipArrow(
     className,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping: popupStateMapping,
   });
 
   return renderElement();

--- a/packages/react/src/tooltip/popup/TooltipPopup.tsx
+++ b/packages/react/src/tooltip/popup/TooltipPopup.tsx
@@ -8,7 +8,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import { popupOpenStateMapping as baseMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 
 const customStyleHookMapping: CustomStyleHookMapping<TooltipPopup.State> = {

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
@@ -10,7 +10,7 @@ import { TooltipPositionerContext } from './TooltipPositionerContext';
 import { useTooltipPositioner } from './useTooltipPositioner';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Side, Align } from '../../utils/useAnchorPositioning';
-import { popupOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
 
 /**
  * The tooltip positioner element.
@@ -95,7 +95,7 @@ const TooltipPositioner = React.forwardRef(function TooltipPositioner(
     state,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupOpenStateMapping,
+    customStyleHookMapping: popupStateMapping,
   });
 
   const shouldRender = keepMounted || mounted;

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
@@ -115,6 +115,7 @@ namespace TooltipPositioner {
     open: boolean;
     side: Side;
     align: Align;
+    anchorHidden: boolean;
   }
 
   export interface Props

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
@@ -41,7 +41,6 @@ const TooltipPositioner = React.forwardRef(function TooltipPositioner(
     collisionBoundary = 'clipping-ancestors',
     collisionPadding = 5,
     arrowPadding = 5,
-    hideWhenDetached = false,
     sticky = false,
     ...otherProps
   } = props;
@@ -62,7 +61,6 @@ const TooltipPositioner = React.forwardRef(function TooltipPositioner(
     alignOffset,
     collisionBoundary,
     collisionPadding,
-    hideWhenDetached,
     sticky,
     trackCursorAxis,
     arrowPadding,
@@ -75,8 +73,9 @@ const TooltipPositioner = React.forwardRef(function TooltipPositioner(
       open,
       side: positioner.side,
       align: positioner.align,
+      anchorHidden: positioner.anchorHidden,
     }),
-    [open, positioner.side, positioner.align],
+    [open, positioner.side, positioner.align, positioner.anchorHidden],
   );
 
   const contextValue: TooltipPositionerContext = React.useMemo(
@@ -201,12 +200,6 @@ TooltipPositioner.propTypes /* remove-proptypes */ = {
     HTMLElementType,
     PropTypes.func,
   ]),
-  /**
-   * Whether the tooltip element is hidden if it appears detached from its anchor element due
-   * to the anchor element being clipped (or hidden) from view.
-   * @default false
-   */
-  hideWhenDetached: PropTypes.bool,
   /**
    * Whether the tooltip remains mounted in the DOM while closed.
    * @default false

--- a/packages/react/src/tooltip/positioner/useTooltipPositioner.ts
+++ b/packages/react/src/tooltip/positioner/useTooltipPositioner.ts
@@ -27,7 +27,7 @@ export function useTooltipPositioner(
       (externalProps = {}) => {
         const hiddenStyles: React.CSSProperties = {};
 
-        if ((keepMounted && !open) || anchorHidden) {
+        if (keepMounted && !open) {
           hiddenStyles.pointerEvents = 'none';
         }
 
@@ -44,7 +44,7 @@ export function useTooltipPositioner(
           },
         });
       },
-      [keepMounted, open, anchorHidden, trackCursorAxis, mounted, positionerStyles],
+      [keepMounted, open, trackCursorAxis, mounted, positionerStyles],
     );
 
   return React.useMemo(

--- a/packages/react/src/tooltip/positioner/useTooltipPositioner.ts
+++ b/packages/react/src/tooltip/positioner/useTooltipPositioner.ts
@@ -15,7 +15,7 @@ export function useTooltipPositioner(
   const {
     positionerStyles,
     arrowStyles,
-    hidden,
+    anchorHidden,
     arrowRef,
     arrowUncentered,
     renderedSide,
@@ -27,7 +27,7 @@ export function useTooltipPositioner(
       (externalProps = {}) => {
         const hiddenStyles: React.CSSProperties = {};
 
-        if ((keepMounted && !open) || hidden) {
+        if ((keepMounted && !open) || anchorHidden) {
           hiddenStyles.pointerEvents = 'none';
         }
 
@@ -44,7 +44,7 @@ export function useTooltipPositioner(
           },
         });
       },
-      [keepMounted, open, hidden, trackCursorAxis, mounted, positionerStyles],
+      [keepMounted, open, anchorHidden, trackCursorAxis, mounted, positionerStyles],
     );
 
   return React.useMemo(
@@ -55,8 +55,17 @@ export function useTooltipPositioner(
       arrowUncentered,
       side: renderedSide,
       align: renderedAlign,
+      anchorHidden,
     }),
-    [getPositionerProps, arrowRef, arrowUncentered, renderedSide, renderedAlign, arrowStyles],
+    [
+      getPositionerProps,
+      arrowStyles,
+      arrowRef,
+      arrowUncentered,
+      renderedSide,
+      renderedAlign,
+      anchorHidden,
+    ],
   );
 }
 
@@ -112,12 +121,6 @@ export namespace useTooltipPositioner {
      * @default 5
      */
     collisionPadding?: Padding;
-    /**
-     * Whether the tooltip element is hidden if it appears detached from its anchor element due
-     * to the anchor element being clipped (or hidden) from view.
-     * @default false
-     */
-    hideWhenDetached?: boolean;
     /**
      * Whether to allow the tooltip to remain stuck in view while the anchor element is scrolled out
      * of view.
@@ -193,5 +196,9 @@ export namespace useTooltipPositioner {
      * The rendered align of the tooltip element.
      */
     align: 'start' | 'end' | 'center';
+    /**
+     * Determines if the anchor element is hidden.
+     */
+    anchorHidden: boolean;
   }
 }

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -5,7 +5,7 @@ import { useTooltipRootContext } from '../root/TooltipRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { triggerOpenStateMapping } from '../../utils/popupOpenStateMapping';
+import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 
 /**
  * Renders a trigger element that opens the tooltip.

--- a/packages/react/src/utils/popupStateMapping.ts
+++ b/packages/react/src/utils/popupStateMapping.ts
@@ -13,6 +13,10 @@ const POPUP_HOOK = {
   'data-open': '',
 };
 
+const ANCHOR_HIDDEN_HOOK = {
+  'data-anchor-hidden': '',
+};
+
 export const triggerOpenStateMapping = {
   open(value) {
     if (value) {
@@ -31,11 +35,17 @@ export const pressableTriggerOpenStateMapping = {
   },
 } satisfies CustomStyleHookMapping<{ open: boolean }>;
 
-export const popupOpenStateMapping = {
+export const popupStateMapping = {
   open(value) {
     if (value) {
       return POPUP_HOOK;
     }
     return null;
   },
-} satisfies CustomStyleHookMapping<{ open: boolean }>;
+  anchorHidden(value) {
+    if (value) {
+      return ANCHOR_HIDDEN_HOOK;
+    }
+    return null;
+  },
+} satisfies CustomStyleHookMapping<{ open: boolean; anchorHidden: boolean }>;

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -39,7 +39,6 @@ interface UseAnchorPositioningParameters {
   fallbackAxisSideDirection?: 'start' | 'end' | 'none';
   collisionBoundary?: Boundary;
   collisionPadding?: Padding;
-  hideWhenDetached?: boolean;
   sticky?: boolean;
   keepMounted?: boolean;
   arrowPadding?: number;
@@ -57,7 +56,7 @@ interface UseAnchorPositioningReturnValue {
   arrowUncentered: boolean;
   renderedSide: Side;
   renderedAlign: Align;
-  hidden: boolean;
+  anchorHidden: boolean;
   refs: ReturnType<typeof useFloating>['refs'];
   positionerContext: FloatingContext;
   isPositioned: boolean;
@@ -81,7 +80,6 @@ export function useAnchorPositioning(
     alignOffset = 0,
     collisionBoundary,
     collisionPadding = 5,
-    hideWhenDetached = false,
     fallbackAxisSideDirection = 'none',
     sticky = false,
     keepMounted = false,
@@ -162,7 +160,7 @@ export function useAnchorPositioning(
       }),
       [arrowPadding],
     ),
-    hideWhenDetached && hide(),
+    hide(),
     {
       name: 'transformOrigin',
       fn({ elements, middlewareData, placement: renderedPlacement }) {
@@ -272,15 +270,7 @@ export function useAnchorPositioning(
 
   const renderedSide = getSide(renderedPlacement);
   const renderedAlign = getAlignment(renderedPlacement) || 'center';
-  const hidden = Boolean(hideWhenDetached && middlewareData.hide?.referenceHidden);
-
-  const positionerStyles = React.useMemo(
-    () => ({
-      ...floatingStyles,
-      ...(hidden && { visibility: 'hidden' as const }),
-    }),
-    [floatingStyles, hidden],
-  );
+  const anchorHidden = Boolean(middlewareData.hide?.referenceHidden);
 
   const arrowStyles = React.useMemo(
     () => ({
@@ -295,25 +285,25 @@ export function useAnchorPositioning(
 
   return React.useMemo(
     () => ({
-      positionerStyles,
+      positionerStyles: floatingStyles,
       arrowStyles,
       arrowRef,
       arrowUncentered,
       renderedSide,
       renderedAlign,
-      hidden,
+      anchorHidden,
       refs,
       positionerContext,
       isPositioned,
     }),
     [
-      positionerStyles,
+      floatingStyles,
       arrowStyles,
       arrowRef,
       arrowUncentered,
       renderedSide,
       renderedAlign,
-      hidden,
+      anchorHidden,
       refs,
       positionerContext,
       isPositioned,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

`hideWhenDetached` -> always-present `data-anchor-hidden` attribute