### PR TITLE
[docs] Work around iOS Safari flicker

### DIFF
--- a/docs/src/components/CodeBlock.css
+++ b/docs/src/components/CodeBlock.css
@@ -30,6 +30,11 @@
       display: none;
     }
 
+    /* iOS Safari appears to flicker the scroll containers during tasking animations */
+    [data-mobile-nav-open] & {
+      overflow: hidden;
+    }
+
     /* Scroll containers may be focusable */
     &:focus-visible {
       position: relative;
@@ -58,6 +63,11 @@
     overflow: auto;
     overscroll-behavior-x: contain;
     scrollbar-width: thin;
+
+    /* iOS Safari appears to flicker the scroll containers during tasking animations */
+    [data-mobile-nav-open] & {
+      overflow: hidden;
+    }
 
     /* Scroll containers may be focusable */
     &:focus-visible {

--- a/docs/src/components/MobileNav.tsx
+++ b/docs/src/components/MobileNav.tsx
@@ -35,6 +35,7 @@ export function Popup({ children, className, ...props }: Dialog.Popup.Props) {
 
   return (
     <Dialog.Popup className={clsx('MobileNavPopup', className)} {...props}>
+      <MountEffect />
       <div className="MobileNavBottomOverscroll" />
       <div
         className="MobileNavViewport"
@@ -117,6 +118,28 @@ export function Popup({ children, className, ...props }: Dialog.Popup.Props) {
       </div>
     </Dialog.Popup>
   );
+}
+
+// iOS Safari appears to flicker the scroll containers during tasking animations
+// As a workaround, we set an attribute on body to know when the nav is mounted
+function MountEffect() {
+  const timeout = React.useRef(0);
+
+  React.useLayoutEffect(() => {
+    window.clearTimeout(timeout.current);
+    document.body.setAttribute('data-mobile-nav-open', '');
+
+    return () => {
+      window.clearTimeout(timeout.current);
+      timeout.current = window.setTimeout(() => {
+        document.body.removeAttribute('data-mobile-nav-open');
+        // Safari seems to need some arbitrary time to be done with whatever causes the flicker
+        // Using setTimeout 0, RAFs, or even double RAFs doesn't work reliably
+      }, 100);
+    };
+  }, []);
+
+  return null;
 }
 
 export function Section({ className, ...props }: React.ComponentProps<'div'>) {

--- a/docs/src/components/MobileNav.tsx
+++ b/docs/src/components/MobileNav.tsx
@@ -5,17 +5,16 @@ import NextLink from 'next/link';
 import { Dialog } from '@base-ui-components/react/dialog';
 import { HEADER_HEIGHT } from './Header';
 
-type MobileNavState = [boolean, (open: boolean) => void];
-const MobileNavState = React.createContext<MobileNavState>([false, () => undefined]);
+const MobileNavStateCallback = React.createContext<(open: boolean) => void>(() => undefined);
 
 export function Root(props: Dialog.Root.Props) {
   const state = React.useState(false);
   const [open, setOpen] = state;
 
   return (
-    <MobileNavState.Provider value={state}>
+    <MobileNavStateCallback.Provider value={setOpen}>
       <Dialog.Root open={open} onOpenChange={setOpen} {...props} />
-    </MobileNavState.Provider>
+    </MobileNavStateCallback.Provider>
   );
 }
 
@@ -26,7 +25,7 @@ export function Backdrop({ className, ...props }: Dialog.Backdrop.Props) {
 }
 
 export function Popup({ children, className, ...props }: Dialog.Popup.Props) {
-  const [, setOpen] = React.useContext(MobileNavState);
+  const setOpen = React.useContext(MobileNavStateCallback);
   const rem = React.useRef(16);
 
   React.useEffect(() => {
@@ -165,7 +164,7 @@ interface ItemProps extends React.ComponentPropsWithoutRef<'li'> {
 }
 
 export function Item({ active, children, className, href, rel, ...props }: ItemProps) {
-  const [, setOpen] = React.useContext(MobileNavState);
+  const setOpen = React.useContext(MobileNavStateCallback);
   return (
     <li className={clsx('MobileNavItem', className)} {...props}>
       <NextLink

--- a/docs/src/components/Table.css
+++ b/docs/src/components/Table.css
@@ -78,5 +78,10 @@
     &::-webkit-scrollbar {
       display: none;
     }
+
+    /* iOS Safari appears to flicker the scroll containers during tasking animations */
+    [data-mobile-nav-open] & {
+      overflow: hidden;
+    }
   }
 }

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -215,12 +215,6 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
-  svg {
-    /* Safari messes up geometry of many basic SVGs, such as check icons in checkboxes or chevrons on menus */
-    /* Putting them on the GPU fixes that */
-    transform: translateZ(0);
-  }
-
   /* Debugging red text? You just forgot to set or inherit color in your demo. */
   [data-demo] {
     &,


### PR DESCRIPTION
Fixes the flicker on some scroll containers in iOS Safari when the mobile nav is opened

Before


https://github.com/user-attachments/assets/1f252424-0f1f-4ae7-b65e-f45df0b36383



After

https://github.com/user-attachments/assets/17cbc01e-0a18-4c23-98d9-f3badbc506f6

