### PR TITLE
[core] Remove unused dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -56,7 +56,6 @@
     "react-is": "19.0.0-rc-fb9a90fa48-20240614",
     "react-router-dom": "^6.28.0",
     "react-runner": "^1.0.5",
-    "react-simple-code-editor": "^0.13.1",
     "rehype-pretty-code": "^0.14.0",
     "remark": "^15.0.1",
     "remark-frontmatter": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,9 +482,6 @@ importers:
       react-runner:
         specifier: ^1.0.5
         version: 1.0.5(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
-      react-simple-code-editor:
-        specifier: ^0.13.1
-        version: 0.13.1(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
       rehype-pretty-code:
         specifier: ^0.14.0
         version: 0.14.0(shiki@1.24.0)
@@ -8036,12 +8033,6 @@ packages:
     peerDependencies:
       react: ^16.0.0 || ^17 || ^18
       react-dom: ^16.0.0 || ^17 || ^18
-
-  react-simple-code-editor@0.13.1:
-    resolution: {integrity: sha512-XYeVwRZwgyKtjNIYcAEgg2FaQcCZwhbarnkJIV20U2wkCU9q/CPFBo8nRXrK4GXUz3AvbqZFsZRrpUTkqqEYyQ==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
 
   react@19.0.0-rc-fb9a90fa48-20240614:
     resolution: {integrity: sha512-nvE3Gy+IOIfH/DXhkyxFVQSrITarFcQz4+shzC/McxQXEUSonpw2oDy/Wi9hdDtV3hlP12VYuDL95iiBREedNQ==}
@@ -18338,11 +18329,6 @@ snapshots:
       react: 19.0.0-rc-fb9a90fa48-20240614
       react-dom: 19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614)
       sucrase: 3.35.0
-
-  react-simple-code-editor@0.13.1(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614):
-    dependencies:
-      react: 19.0.0-rc-fb9a90fa48-20240614
-      react-dom: 19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614)
 
   react@19.0.0-rc-fb9a90fa48-20240614: {}
 


### PR DESCRIPTION
We don't use the dependency, I noticed it as renovate was trying to upgrade it: https://github.com/mui/base-ui/pull/926. I suppose we stopped using when we removed the editable demos feature, but the dependency was never removed.