### PR TITLE
[popover] Better handle impatient clicks

### DIFF
--- a/packages/react/src/popover/root/usePopoverRoot.ts
+++ b/packages/react/src/popover/root/usePopoverRoot.ts
@@ -13,7 +13,7 @@ import {
 import { useControlled } from '../../utils/useControlled';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useTransitionStatus } from '../../utils/useTransitionStatus';
-import { OPEN_DELAY } from '../utils/constants';
+import { IMPATIENT_CLICK_THRESHOLD, OPEN_DELAY } from '../utils/constants';
 import type { GenericHTMLProps } from '../../utils/types';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { type InteractionType } from '../../utils/useEnhancedClickHandler';
@@ -108,7 +108,7 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
         clearTimeout(clickEnabledTimeoutRef.current);
         clickEnabledTimeoutRef.current = window.setTimeout(() => {
           setClickEnabled(true);
-        }, 300);
+        }, IMPATIENT_CLICK_THRESHOLD);
 
         ReactDOM.flushSync(changeState);
       } else {

--- a/packages/react/src/popover/root/usePopoverRoot.ts
+++ b/packages/react/src/popover/root/usePopoverRoot.ts
@@ -13,7 +13,7 @@ import {
 import { useControlled } from '../../utils/useControlled';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useTransitionStatus } from '../../utils/useTransitionStatus';
-import { IMPATIENT_CLICK_THRESHOLD, OPEN_DELAY } from '../utils/constants';
+import { PATIENT_CLICK_THRESHOLD, OPEN_DELAY } from '../utils/constants';
 import type { GenericHTMLProps } from '../../utils/types';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { type InteractionType } from '../../utils/useEnhancedClickHandler';
@@ -108,7 +108,7 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
         clearTimeout(clickEnabledTimeoutRef.current);
         clickEnabledTimeoutRef.current = window.setTimeout(() => {
           setClickEnabled(true);
-        }, IMPATIENT_CLICK_THRESHOLD);
+        }, PATIENT_CLICK_THRESHOLD);
 
         ReactDOM.flushSync(changeState);
       } else {

--- a/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
@@ -3,7 +3,7 @@ import { Popover } from '@base-ui-components/react/popover';
 import { createRenderer, describeConformance } from '#test-utils';
 import { expect } from 'chai';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
-import { IMPATIENT_CLICK_THRESHOLD } from '../utils/constants';
+import { PATIENT_CLICK_THRESHOLD } from '../utils/constants';
 
 describe('<Popover.Trigger />', () => {
   const { render } = createRenderer();
@@ -85,7 +85,7 @@ describe('<Popover.Trigger />', () => {
     });
   });
 
-  describe('impatient clicks', () => {
+  describe('impatient clicks with `openOnHover=true`', () => {
     const { clock, render: renderFakeTimers } = createRenderer();
 
     clock.withFakeTimers();
@@ -101,7 +101,7 @@ describe('<Popover.Trigger />', () => {
 
       fireEvent.mouseEnter(trigger);
 
-      clock.tick(IMPATIENT_CLICK_THRESHOLD - 1);
+      clock.tick(PATIENT_CLICK_THRESHOLD - 1);
 
       await act(async () => {
         trigger.click();
@@ -121,7 +121,7 @@ describe('<Popover.Trigger />', () => {
 
       fireEvent.mouseEnter(trigger);
 
-      clock.tick(IMPATIENT_CLICK_THRESHOLD);
+      clock.tick(PATIENT_CLICK_THRESHOLD);
 
       await act(async () => {
         trigger.click();

--- a/packages/react/src/popover/utils/constants.ts
+++ b/packages/react/src/popover/utils/constants.ts
@@ -1,2 +1,2 @@
 export const OPEN_DELAY = 300;
-export const IMPATIENT_CLICK_THRESHOLD = 500;
+export const PATIENT_CLICK_THRESHOLD = 500;

--- a/packages/react/src/popover/utils/constants.ts
+++ b/packages/react/src/popover/utils/constants.ts
@@ -1,1 +1,2 @@
 export const OPEN_DELAY = 300;
+export const IMPATIENT_CLICK_THRESHOLD = 500;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #955

Currently if you click right as the popover opens it unexpectedly closes. The alternative, leaving it stay "stuck open" if it was already open for a while also feels off. This blends the two modes so that if they 'impatiently' clicked within 500ms after it opened on hover, it simply ignores the click entirely. This doesn't make it feel sticky, and it doesn't unexpectedly close, feeling the most natural. If it was open for >500ms, it does close though, making it feel responsive to clicks.