### PR TITLE
[popups] Use `data-uncentered` attribute for arrows

### DIFF
--- a/docs/data/api/menu-arrow.json
+++ b/docs/data/api/menu-arrow.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "className": { "type": { "name": "union", "description": "func<br>&#124;&nbsp;string" } },
-    "hideWhenUncentered": { "type": { "name": "bool" }, "default": "false" },
     "render": { "type": { "name": "union", "description": "element<br>&#124;&nbsp;func" } }
   },
   "name": "MenuArrow",

--- a/docs/data/api/popover-arrow.json
+++ b/docs/data/api/popover-arrow.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "className": { "type": { "name": "union", "description": "func<br>&#124;&nbsp;string" } },
-    "hideWhenUncentered": { "type": { "name": "bool" }, "default": "false" },
     "render": { "type": { "name": "union", "description": "element<br>&#124;&nbsp;func" } }
   },
   "name": "PopoverArrow",

--- a/docs/data/api/preview-card-arrow.json
+++ b/docs/data/api/preview-card-arrow.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "className": { "type": { "name": "union", "description": "func<br>&#124;&nbsp;string" } },
-    "hideWhenUncentered": { "type": { "name": "bool" }, "default": "false" },
     "render": { "type": { "name": "union", "description": "element<br>&#124;&nbsp;func" } }
   },
   "name": "PreviewCardArrow",

--- a/docs/data/api/select-arrow.json
+++ b/docs/data/api/select-arrow.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "className": { "type": { "name": "union", "description": "func<br>&#124;&nbsp;string" } },
-    "hideWhenUncentered": { "type": { "name": "bool" }, "default": "false" },
     "render": { "type": { "name": "union", "description": "element<br>&#124;&nbsp;func" } }
   },
   "name": "SelectArrow",

--- a/docs/data/api/tooltip-arrow.json
+++ b/docs/data/api/tooltip-arrow.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "className": { "type": { "name": "union", "description": "func<br>&#124;&nbsp;string" } },
-    "hideWhenUncentered": { "type": { "name": "bool" }, "default": "false" },
     "render": { "type": { "name": "union", "description": "element<br>&#124;&nbsp;func" } }
   },
   "name": "TooltipArrow",

--- a/docs/data/translations/api-docs/menu-arrow/menu-arrow.json
+++ b/docs/data/translations/api-docs/menu-arrow/menu-arrow.json
@@ -4,9 +4,6 @@
     "className": {
       "description": "Class names applied to the element or a function that returns them based on the component&#39;s state."
     },
-    "hideWhenUncentered": {
-      "description": "If <code>true</code>, the arrow is hidden when it can&#39;t point to the center of the anchor element."
-    },
     "render": { "description": "A function to customize rendering of the component." }
   },
   "classDescriptions": {}

--- a/docs/data/translations/api-docs/popover-arrow/popover-arrow.json
+++ b/docs/data/translations/api-docs/popover-arrow/popover-arrow.json
@@ -4,9 +4,6 @@
     "className": {
       "description": "Class names applied to the element or a function that returns them based on the component&#39;s state."
     },
-    "hideWhenUncentered": {
-      "description": "If <code>true</code>, the arrow is hidden when it can&#39;t point to the center of the anchor element."
-    },
     "render": { "description": "A function to customize rendering of the component." }
   },
   "classDescriptions": {}

--- a/docs/data/translations/api-docs/preview-card-arrow/preview-card-arrow.json
+++ b/docs/data/translations/api-docs/preview-card-arrow/preview-card-arrow.json
@@ -4,9 +4,6 @@
     "className": {
       "description": "Class names applied to the element or a function that returns them based on the component&#39;s state."
     },
-    "hideWhenUncentered": {
-      "description": "Whether the <code>Arrow</code> is hidden when it can&#39;t point to the center of the anchor element."
-    },
     "render": { "description": "A function to customize rendering of the component." }
   },
   "classDescriptions": {}

--- a/docs/data/translations/api-docs/select-arrow/select-arrow.json
+++ b/docs/data/translations/api-docs/select-arrow/select-arrow.json
@@ -4,9 +4,6 @@
     "className": {
       "description": "Class names applied to the element or a function that returns them based on the component&#39;s state."
     },
-    "hideWhenUncentered": {
-      "description": "If <code>true</code>, the arrow is hidden when it can&#39;t point to the center of the anchor element."
-    },
     "render": { "description": "A function to customize rendering of the component." }
   },
   "classDescriptions": {}

--- a/docs/data/translations/api-docs/tooltip-arrow/tooltip-arrow.json
+++ b/docs/data/translations/api-docs/tooltip-arrow/tooltip-arrow.json
@@ -4,9 +4,6 @@
     "className": {
       "description": "Class names applied to the element or a function that returns them based on the component&#39;s state."
     },
-    "hideWhenUncentered": {
-      "description": "If <code>true</code>, the arrow will be hidden when it can&#39;t point to the center of the anchor element."
-    },
     "render": { "description": "A function to customize rendering of the component." }
   },
   "classDescriptions": {}

--- a/docs/reference/generated/menu-arrow.json
+++ b/docs/reference/generated/menu-arrow.json
@@ -6,11 +6,6 @@
       "type": "string | (state) => string",
       "description": "Class names applied to the element or a function that returns them based on the component's state."
     },
-    "hideWhenUncentered": {
-      "type": "boolean",
-      "default": "false",
-      "description": "If `true`, the arrow is hidden when it can't point to the center of the anchor element."
-    },
     "render": {
       "type": "React.ReactElement | (props, state) => React.ReactElement",
       "description": "A function to customize rendering of the component."

--- a/docs/reference/generated/popover-arrow.json
+++ b/docs/reference/generated/popover-arrow.json
@@ -6,11 +6,6 @@
       "type": "string | (state) => string",
       "description": "Class names applied to the element or a function that returns them based on the component's state."
     },
-    "hideWhenUncentered": {
-      "type": "boolean",
-      "default": "false",
-      "description": "If `true`, the arrow is hidden when it can't point to the center of the anchor element."
-    },
     "render": {
       "type": "React.ReactElement | (props, state) => React.ReactElement",
       "description": "A function to customize rendering of the component."

--- a/docs/reference/generated/preview-card-arrow.json
+++ b/docs/reference/generated/preview-card-arrow.json
@@ -6,11 +6,6 @@
       "type": "string | (state) => string",
       "description": "Class names applied to the element or a function that returns them based on the component's state."
     },
-    "hideWhenUncentered": {
-      "type": "boolean",
-      "default": "false",
-      "description": "Whether the `Arrow` is hidden when it can't point to the center of the anchor element."
-    },
     "render": {
       "type": "React.ReactElement | (props, state) => React.ReactElement",
       "description": "A function to customize rendering of the component."

--- a/docs/reference/generated/select-arrow.json
+++ b/docs/reference/generated/select-arrow.json
@@ -6,11 +6,6 @@
       "type": "string | (state) => string",
       "description": "Class names applied to the element or a function that returns them based on the component's state."
     },
-    "hideWhenUncentered": {
-      "type": "boolean",
-      "default": "false",
-      "description": "If `true`, the arrow is hidden when it can't point to the center of the anchor element."
-    },
     "render": {
       "type": "React.ReactElement | (props, state) => React.ReactElement",
       "description": "A function to customize rendering of the component."

--- a/docs/reference/generated/tooltip-arrow.json
+++ b/docs/reference/generated/tooltip-arrow.json
@@ -6,11 +6,6 @@
       "type": "string | (state) => string",
       "description": "Class names applied to the element or a function that returns them based on the component's state."
     },
-    "hideWhenUncentered": {
-      "type": "boolean",
-      "default": "false",
-      "description": "If `true`, the arrow will be hidden when it can't point to the center of the anchor element."
-    },
     "render": {
       "type": "React.ReactElement | (props, state) => React.ReactElement",
       "description": "A function to customize rendering of the component."

--- a/packages/react/src/menu/arrow/MenuArrow.tsx
+++ b/packages/react/src/menu/arrow/MenuArrow.tsx
@@ -25,14 +25,13 @@ const MenuArrow = React.forwardRef(function MenuArrow(
   props: MenuArrow.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { className, render, hideWhenUncentered = false, ...otherProps } = props;
+  const { className, render, ...otherProps } = props;
 
   const { open } = useMenuRootContext();
   const { arrowRef, side, align, arrowUncentered, arrowStyles } = useMenuPositionerContext();
 
   const { getArrowProps } = useMenuArrow({
     arrowStyles,
-    hidden: hideWhenUncentered && arrowUncentered,
   });
 
   const state: MenuArrow.State = React.useMemo(
@@ -40,7 +39,7 @@ const MenuArrow = React.forwardRef(function MenuArrow(
       open,
       side,
       align,
-      arrowUncentered,
+      uncentered: arrowUncentered,
     }),
     [open, side, align, arrowUncentered],
   );
@@ -65,16 +64,10 @@ namespace MenuArrow {
     open: boolean;
     side: Side;
     align: Align;
-    arrowUncentered: boolean;
+    uncentered: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<'div', State> {
-    /**
-     * If `true`, the arrow is hidden when it can't point to the center of the anchor element.
-     * @default false
-     */
-    hideWhenUncentered?: boolean;
-  }
+  export interface Props extends BaseUIComponentProps<'div', State> {}
 }
 
 MenuArrow.propTypes /* remove-proptypes */ = {
@@ -90,11 +83,6 @@ MenuArrow.propTypes /* remove-proptypes */ = {
    * Class names applied to the element or a function that returns them based on the component's state.
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /**
-   * If `true`, the arrow is hidden when it can't point to the center of the anchor element.
-   * @default false
-   */
-  hideWhenUncentered: PropTypes.bool,
   /**
    * A function to customize rendering of the component.
    */

--- a/packages/react/src/menu/arrow/useMenuArrow.ts
+++ b/packages/react/src/menu/arrow/useMenuArrow.ts
@@ -26,7 +26,6 @@ export function useMenuArrow(params: useMenuArrow.Parameters): useMenuArrow.Retu
 export namespace useMenuArrow {
   export interface Parameters {
     arrowStyles: React.CSSProperties;
-    hidden?: boolean;
   }
 
   export interface ReturnValue {

--- a/packages/react/src/popover/arrow/PopoverArrow.tsx
+++ b/packages/react/src/popover/arrow/PopoverArrow.tsx
@@ -25,14 +25,13 @@ const PopoverArrow = React.forwardRef(function PopoverArrow(
   props: PopoverArrow.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { className, render, hideWhenUncentered = false, ...otherProps } = props;
+  const { className, render, ...otherProps } = props;
 
   const { open } = usePopoverRootContext();
   const { arrowRef, side, align, arrowUncentered, arrowStyles } = usePopoverPositionerContext();
 
   const { getArrowProps } = usePopoverArrow({
     arrowStyles,
-    hidden: hideWhenUncentered && arrowUncentered,
   });
 
   const state: PopoverArrow.State = React.useMemo(
@@ -40,7 +39,7 @@ const PopoverArrow = React.forwardRef(function PopoverArrow(
       open,
       side,
       align,
-      arrowUncentered,
+      uncentered: arrowUncentered,
     }),
     [open, side, align, arrowUncentered],
   );
@@ -65,16 +64,10 @@ namespace PopoverArrow {
     open: boolean;
     side: Side;
     align: Align;
-    arrowUncentered: boolean;
+    uncentered: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<'div', State> {
-    /**
-     * If `true`, the arrow is hidden when it can't point to the center of the anchor element.
-     * @default false
-     */
-    hideWhenUncentered?: boolean;
-  }
+  export interface Props extends BaseUIComponentProps<'div', State> {}
 }
 
 PopoverArrow.propTypes /* remove-proptypes */ = {
@@ -90,11 +83,6 @@ PopoverArrow.propTypes /* remove-proptypes */ = {
    * Class names applied to the element or a function that returns them based on the component's state.
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /**
-   * If `true`, the arrow is hidden when it can't point to the center of the anchor element.
-   * @default false
-   */
-  hideWhenUncentered: PropTypes.bool,
   /**
    * A function to customize rendering of the component.
    */

--- a/packages/react/src/popover/arrow/usePopoverArrow.ts
+++ b/packages/react/src/popover/arrow/usePopoverArrow.ts
@@ -3,18 +3,15 @@ import { mergeReactProps } from '../../utils/mergeReactProps';
 import type { GenericHTMLProps } from '../../utils/types';
 
 export function usePopoverArrow(params: usePopoverArrow.Parameters): usePopoverArrow.ReturnValue {
-  const { arrowStyles, hidden } = params;
+  const { arrowStyles } = params;
 
   const getArrowProps = React.useCallback(
     (externalProps = {}) => {
       return mergeReactProps<'div'>(externalProps, {
-        style: {
-          ...arrowStyles,
-          ...(hidden && { visibility: 'hidden' }),
-        },
+        style: arrowStyles,
       });
     },
-    [arrowStyles, hidden],
+    [arrowStyles],
   );
 
   return React.useMemo(
@@ -28,8 +25,8 @@ export function usePopoverArrow(params: usePopoverArrow.Parameters): usePopoverA
 namespace usePopoverArrow {
   export interface Parameters {
     arrowStyles: React.CSSProperties;
-    hidden?: boolean;
   }
+
   export interface ReturnValue {
     getArrowProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
   }

--- a/packages/react/src/preview-card/arrow/PreviewCardArrow.tsx
+++ b/packages/react/src/preview-card/arrow/PreviewCardArrow.tsx
@@ -24,14 +24,13 @@ const PreviewCardArrow = React.forwardRef(function PreviewCardArrow(
   props: PreviewCardArrow.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { render, className, hideWhenUncentered, ...otherProps } = props;
+  const { render, className, ...otherProps } = props;
 
   const { open } = usePreviewCardRootContext();
   const { arrowRef, side, align, arrowUncentered, arrowStyles } = usePreviewCardPositionerContext();
 
   const { getArrowProps } = usePreviewCardArrow({
     arrowStyles,
-    hidden: hideWhenUncentered && arrowUncentered,
   });
 
   const state: PreviewCardArrow.State = React.useMemo(
@@ -39,8 +38,9 @@ const PreviewCardArrow = React.forwardRef(function PreviewCardArrow(
       open,
       side,
       align,
+      uncentered: arrowUncentered,
     }),
-    [open, side, align],
+    [open, side, align, arrowUncentered],
   );
 
   const mergedRef = useForkRef(arrowRef, forwardedRef);
@@ -63,15 +63,10 @@ namespace PreviewCardArrow {
     open: boolean;
     side: Side;
     align: Align;
+    uncentered: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<'div', State> {
-    /**
-     * Whether the `Arrow` is hidden when it can't point to the center of the anchor element.
-     * @default false
-     */
-    hideWhenUncentered?: boolean;
-  }
+  export interface Props extends BaseUIComponentProps<'div', State> {}
 }
 
 PreviewCardArrow.propTypes /* remove-proptypes */ = {
@@ -87,11 +82,6 @@ PreviewCardArrow.propTypes /* remove-proptypes */ = {
    * Class names applied to the element or a function that returns them based on the component's state.
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /**
-   * Whether the `Arrow` is hidden when it can't point to the center of the anchor element.
-   * @default false
-   */
-  hideWhenUncentered: PropTypes.bool,
   /**
    * A function to customize rendering of the component.
    */

--- a/packages/react/src/preview-card/arrow/usePreviewCardArrow.ts
+++ b/packages/react/src/preview-card/arrow/usePreviewCardArrow.ts
@@ -4,18 +4,15 @@ import { mergeReactProps } from '../../utils/mergeReactProps';
 export function usePreviewCardArrow(
   params: usePreviewCardArrow.Parameters,
 ): usePreviewCardArrow.ReturnValue {
-  const { arrowStyles, hidden } = params;
+  const { arrowStyles } = params;
 
   const getArrowProps = React.useCallback(
     (externalProps = {}) => {
       return mergeReactProps<'div'>(externalProps, {
-        style: {
-          ...arrowStyles,
-          ...(hidden && { visibility: 'hidden' }),
-        },
+        style: arrowStyles,
       });
     },
-    [arrowStyles, hidden],
+    [arrowStyles],
   );
 
   return React.useMemo(

--- a/packages/react/src/select/arrow/SelectArrow.tsx
+++ b/packages/react/src/select/arrow/SelectArrow.tsx
@@ -24,7 +24,7 @@ const SelectArrow = React.forwardRef(function SelectArrow(
   props: SelectArrow.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { className, render, hideWhenUncentered = false, ...otherProps } = props;
+  const { className, render, ...otherProps } = props;
 
   const { open, alignOptionToTrigger } = useSelectRootContext();
   const { arrowRef, side, align, arrowUncentered, arrowStyles } = useSelectPositionerContext();
@@ -32,12 +32,9 @@ const SelectArrow = React.forwardRef(function SelectArrow(
   const getArrowProps = React.useCallback(
     (externalProps = {}) =>
       mergeReactProps<'div'>(externalProps, {
-        style: {
-          ...arrowStyles,
-          ...(hideWhenUncentered && arrowUncentered ? { visibility: 'hidden' } : {}),
-        },
+        style: arrowStyles,
       }),
-    [arrowStyles, hideWhenUncentered, arrowUncentered],
+    [arrowStyles],
   );
 
   const state: SelectArrow.State = React.useMemo(
@@ -45,7 +42,7 @@ const SelectArrow = React.forwardRef(function SelectArrow(
       open,
       side,
       align,
-      arrowUncentered,
+      uncentered: arrowUncentered,
     }),
     [open, side, align, arrowUncentered],
   );
@@ -74,16 +71,10 @@ namespace SelectArrow {
     open: boolean;
     side: Side | 'none';
     align: Align;
-    arrowUncentered: boolean;
+    uncentered: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<'div', State> {
-    /**
-     * If `true`, the arrow is hidden when it can't point to the center of the anchor element.
-     * @default false
-     */
-    hideWhenUncentered?: boolean;
-  }
+  export interface Props extends BaseUIComponentProps<'div', State> {}
 }
 
 SelectArrow.propTypes /* remove-proptypes */ = {
@@ -99,11 +90,6 @@ SelectArrow.propTypes /* remove-proptypes */ = {
    * Class names applied to the element or a function that returns them based on the component's state.
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /**
-   * If `true`, the arrow is hidden when it can't point to the center of the anchor element.
-   * @default false
-   */
-  hideWhenUncentered: PropTypes.bool,
   /**
    * A function to customize rendering of the component.
    */

--- a/packages/react/src/tooltip/arrow/TooltipArrow.tsx
+++ b/packages/react/src/tooltip/arrow/TooltipArrow.tsx
@@ -24,14 +24,13 @@ const TooltipArrow = React.forwardRef(function TooltipArrow(
   props: TooltipArrow.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { className, render, hideWhenUncentered = false, ...otherProps } = props;
+  const { className, render, ...otherProps } = props;
 
   const { open, arrowRef, side, align, arrowUncentered, arrowStyles } =
     useTooltipPositionerContext();
 
   const { getArrowProps } = useTooltipArrow({
     arrowStyles,
-    hidden: hideWhenUncentered && arrowUncentered,
   });
 
   const state: TooltipArrow.State = React.useMemo(
@@ -39,8 +38,9 @@ const TooltipArrow = React.forwardRef(function TooltipArrow(
       open,
       side,
       align,
+      uncentered: arrowUncentered,
     }),
-    [open, side, align],
+    [open, side, align, arrowUncentered],
   );
 
   const mergedRef = useForkRef(arrowRef, forwardedRef);
@@ -63,15 +63,10 @@ namespace TooltipArrow {
     open: boolean;
     side: Side;
     align: Align;
+    uncentered: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<'div', State> {
-    /**
-     * If `true`, the arrow will be hidden when it can't point to the center of the anchor element.
-     * @default false
-     */
-    hideWhenUncentered?: boolean;
-  }
+  export interface Props extends BaseUIComponentProps<'div', State> {}
 }
 
 TooltipArrow.propTypes /* remove-proptypes */ = {
@@ -87,11 +82,6 @@ TooltipArrow.propTypes /* remove-proptypes */ = {
    * Class names applied to the element or a function that returns them based on the component's state.
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /**
-   * If `true`, the arrow will be hidden when it can't point to the center of the anchor element.
-   * @default false
-   */
-  hideWhenUncentered: PropTypes.bool,
   /**
    * A function to customize rendering of the component.
    */

--- a/packages/react/src/tooltip/arrow/useTooltipArrow.ts
+++ b/packages/react/src/tooltip/arrow/useTooltipArrow.ts
@@ -3,18 +3,15 @@ import { mergeReactProps } from '../../utils/mergeReactProps';
 import type { GenericHTMLProps } from '../../utils/types';
 
 export function useTooltipArrow(params: useTooltipArrow.Parameters): useTooltipArrow.ReturnValue {
-  const { arrowStyles, hidden } = params;
+  const { arrowStyles } = params;
 
   const getArrowProps = React.useCallback(
     (externalProps = {}) => {
       return mergeReactProps<'div'>(externalProps, {
-        style: {
-          ...arrowStyles,
-          ...(hidden && { visibility: 'hidden' }),
-        },
+        style: arrowStyles,
       });
     },
-    [arrowStyles, hidden],
+    [arrowStyles],
   );
 
   return React.useMemo(
@@ -28,7 +25,6 @@ export function useTooltipArrow(params: useTooltipArrow.Parameters): useTooltipA
 namespace useTooltipArrow {
   export interface Parameters {
     arrowStyles: React.CSSProperties;
-    hidden?: boolean;
   }
 
   export interface ReturnValue {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Same as with `hideWhenDetached`, let them use a hook