### PR TITLE
[useAfterExitAnimation] `flushSync` the `onFinished` call

### DIFF
--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { hasComputedStyleMapSupport } from '../../utils/hasComputedStyleMapSupport';
 import { mergeReactProps } from '../../utils/mergeReactProps';
 import { ownerWindow } from '../../utils/owner';
@@ -179,17 +178,15 @@ export function useCollapsiblePanel(
         : (originalTransitionDuration ?? '');
 
       runOnceAnimationsFinish(() => {
-        ReactDOM.flushSync(() => {
-          setContextMounted(open);
-          if (isBeforeMatch) {
-            isBeforeMatchRef.current = false;
-            frame1 = requestAnimationFrame(() => {
-              frame2 = requestAnimationFrame(() => {
-                element.style.transitionDuration = originalTransitionDurationStyleRef.current ?? '';
-              });
+        setContextMounted(open);
+        if (isBeforeMatch) {
+          isBeforeMatchRef.current = false;
+          frame1 = requestAnimationFrame(() => {
+            frame2 = requestAnimationFrame(() => {
+              element.style.transitionDuration = originalTransitionDurationStyleRef.current ?? '';
             });
-          }
-        });
+          });
+        }
       });
     }
 

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -6,6 +6,10 @@ import { Dialog } from '@base-ui-components/react/dialog';
 import { createRenderer } from '#test-utils';
 
 describe('<Dialog.Root />', () => {
+  beforeEach(() => {
+    (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = true;
+  });
+
   const { render } = createRenderer();
 
   describe('uncontrolled mode', () => {
@@ -45,7 +49,7 @@ describe('<Dialog.Root />', () => {
       expect(queryByRole('dialog')).to.equal(null);
     });
 
-    it('should remove the popup when animated=true and there is no exit animation defined', async function test(t = {}) {
+    it('should remove the popup when there is no exit animation defined', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -75,7 +79,7 @@ describe('<Dialog.Root />', () => {
       });
     });
 
-    it('should remove the popup when animated=true and the animation finishes', async function test(t = {}) {
+    it('should remove the popup when the animation finishes', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -116,7 +120,9 @@ describe('<Dialog.Root />', () => {
             <Dialog.Root open={open}>
               <Dialog.Popup
                 className="animation-test-popup"
+                data-testid="popup"
                 onAnimationEnd={notifyAnimationFinished}
+                keepMounted
               />
             </Dialog.Root>
           </div>
@@ -129,12 +135,10 @@ describe('<Dialog.Root />', () => {
       await user.click(closeButton);
 
       await waitFor(() => {
-        expect(screen.queryByRole('dialog')).to.equal(null);
+        expect(screen.getByTestId('popup')).to.have.attribute('hidden');
       });
 
       expect(animationFinished).to.equal(true);
-
-      (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = true;
     });
   });
 
@@ -201,7 +205,7 @@ describe('<Dialog.Root />', () => {
       <Dialog.Root open modal={false}>
         {/* eslint-disable-next-line react/no-danger */}
         <style dangerouslySetInnerHTML={{ __html: css }} />
-        <Dialog.Popup className="dialog" onTransitionEnd={notifyTransitionEnd} />
+        <Dialog.Popup className="dialog" onTransitionEnd={notifyTransitionEnd} keepMounted />
       </Dialog.Root>,
     );
 
@@ -213,7 +217,5 @@ describe('<Dialog.Root />', () => {
     });
 
     expect(notifyTransitionEnd.callCount).to.equal(1);
-
-    (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = true;
   });
 });

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -726,7 +726,7 @@ describe('<Menu.Root />', () => {
       });
     });
 
-    it('should remove the popup and the animation finishes', async function test(t = {}) {
+    it('should remove the popup when the animation finishes', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -694,7 +694,7 @@ describe('<Menu.Root />', () => {
   });
 
   describe('controlled mode', () => {
-    it('should remove the popup when animated=true and there is no exit animation defined', async function test(t = {}) {
+    it('should remove the popup when and there is no exit animation defined', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -726,7 +726,7 @@ describe('<Menu.Root />', () => {
       });
     });
 
-    it('should remove the popup when animated=true and the animation finishes', async function test(t = {}) {
+    it('should remove the popup and the animation finishes', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -8,6 +8,10 @@ import { spy } from 'sinon';
 import { createRenderer } from '#test-utils';
 
 describe('<Menu.Root />', () => {
+  beforeEach(() => {
+    (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = true;
+  });
+
   const { render } = createRenderer();
   const user = userEvent.setup();
 
@@ -761,7 +765,7 @@ describe('<Menu.Root />', () => {
             <style dangerouslySetInnerHTML={{ __html: style }} />
             <button onClick={() => setOpen(false)}>Close</button>
             <Menu.Root open={open}>
-              <Menu.Positioner>
+              <Menu.Positioner keepMounted>
                 <Menu.Popup
                   className="animation-test-popup"
                   onAnimationEnd={notifyAnimationFinished}
@@ -782,8 +786,6 @@ describe('<Menu.Root />', () => {
       });
 
       expect(animationFinished).to.equal(true);
-
-      (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = true;
     });
   });
 });

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -14,6 +14,10 @@ function Root(props: Popover.Root.Props) {
 }
 
 describe('<Popover.Root />', () => {
+  beforeEach(() => {
+    (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = true;
+  });
+
   const { render, clock } = createRenderer();
 
   it('should render the children', async () => {
@@ -188,7 +192,7 @@ describe('<Popover.Root />', () => {
           <div>
             <button onClick={() => setOpen(false)}>Close</button>
             <Popover.Root open={open}>
-              <Popover.Positioner>
+              <Popover.Positioner keepMounted>
                 <Popover.Popup />
               </Popover.Positioner>
             </Popover.Root>
@@ -207,7 +211,7 @@ describe('<Popover.Root />', () => {
       });
     });
 
-    it('should remove the popup when animated=true and the animation finishes', async function test(t = {}) {
+    it('should remove the popup when the animation finishes', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -246,7 +250,7 @@ describe('<Popover.Root />', () => {
             <style dangerouslySetInnerHTML={{ __html: style }} />
             <button onClick={() => setOpen(false)}>Close</button>
             <Popover.Root open={open}>
-              <Popover.Positioner>
+              <Popover.Positioner keepMounted data-testid="positioner">
                 <Popover.Popup
                   className="animation-test-popup"
                   onAnimationEnd={notifyAnimationFinished}
@@ -263,12 +267,10 @@ describe('<Popover.Root />', () => {
       await user.click(closeButton);
 
       await waitFor(() => {
-        expect(screen.queryByRole('dialog')).to.equal(null);
+        expect(screen.getByTestId('positioner')).to.have.attribute('hidden');
       });
 
       expect(animationFinished).to.equal(true);
-
-      (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = true;
     });
   });
 

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -178,7 +178,7 @@ describe('<Popover.Root />', () => {
       expect(handleChange.firstCall.args[0]).to.equal(false);
     });
 
-    it('should remove the popup and there is no exit animation defined', async function test(t = {}) {
+    it('should remove the popup when there is no exit animation defined', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -178,7 +178,7 @@ describe('<Popover.Root />', () => {
       expect(handleChange.firstCall.args[0]).to.equal(false);
     });
 
-    it('should remove the popup when animated=true and there is no exit animation defined', async function test(t = {}) {
+    it('should remove the popup and there is no exit animation defined', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions

--- a/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
@@ -19,6 +19,10 @@ function Trigger(props: PreviewCard.Trigger.Props) {
 }
 
 describe('<PreviewCard.Root />', () => {
+  beforeEach(() => {
+    (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = true;
+  });
+
   const { render, clock } = createRenderer();
 
   describe('uncontrolled open', () => {
@@ -148,7 +152,7 @@ describe('<PreviewCard.Root />', () => {
       expect(screen.queryByText('Content')).to.equal(null);
     });
 
-    it('should remove the popup when animated=true and there is no exit animation defined', async function test(t = {}) {
+    it('should remove the popup when there is no exit animation defined', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -180,7 +184,7 @@ describe('<PreviewCard.Root />', () => {
       });
     });
 
-    it('should remove the popup when animated=true and the animation finishes', async function test(t = {}) {
+    it('should remove the popup when the animation finishes', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -219,7 +223,7 @@ describe('<PreviewCard.Root />', () => {
             <style dangerouslySetInnerHTML={{ __html: style }} />
             <button onClick={() => setOpen(false)}>Close</button>
             <PreviewCard.Root open={open}>
-              <PreviewCard.Positioner>
+              <PreviewCard.Positioner keepMounted data-testid="positioner">
                 <PreviewCard.Popup
                   className="animation-test-popup"
                   onAnimationEnd={notifyAnimationFinished}
@@ -238,12 +242,10 @@ describe('<PreviewCard.Root />', () => {
       await user.click(closeButton);
 
       await waitFor(() => {
-        expect(screen.queryByText('Content')).to.equal(null);
+        expect(screen.getByTestId('positioner')).to.have.attribute('hidden');
       });
 
       expect(animationFinished).to.equal(true);
-
-      (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = true;
     });
   });
 

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -195,7 +195,7 @@ describe('<Select.Root />', () => {
       expect(screen.queryByRole('listbox')).not.to.equal(null);
     });
 
-    it('when `false`, should remove the popup when animated=true and there is no exit animation defined', async function test(t = {}) {
+    it('when `false`, should remove the popup when there is no exit animation defined', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -227,7 +227,7 @@ describe('<Select.Root />', () => {
       });
     });
 
-    it('when `false`, should remove the popup when animated=true and the animation finishes', async function test(t = {}) {
+    it('when `false`, should remove the popup when the animation finishes', async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions

--- a/packages/react/src/utils/useAfterExitAnimation.tsx
+++ b/packages/react/src/utils/useAfterExitAnimation.tsx
@@ -18,9 +18,7 @@ export function useAfterExitAnimation(parameters: useAfterExitAnimation.Paramete
   useEnhancedEffect(() => {
     function callOnFinished() {
       if (!openRef.current) {
-        // Synchronously flush the unmounting of the component so that the browser doesn't
-        // paint: https://github.com/mui/base-ui/issues/979
-        ReactDOM.flushSync(onFinished);
+        onFinished();
       }
     }
 

--- a/packages/react/src/utils/useAfterExitAnimation.tsx
+++ b/packages/react/src/utils/useAfterExitAnimation.tsx
@@ -1,3 +1,4 @@
+import * as ReactDOM from 'react-dom';
 import { useAnimationsFinished } from './useAnimationsFinished';
 import { useEnhancedEffect } from './useEnhancedEffect';
 import { useEventCallback } from './useEventCallback';
@@ -17,7 +18,9 @@ export function useAfterExitAnimation(parameters: useAfterExitAnimation.Paramete
   useEnhancedEffect(() => {
     function callOnFinished() {
       if (!openRef.current) {
-        onFinished();
+        // Synchronously flush the unmounting of the component so that the browser doesn't
+        // paint: https://github.com/mui/base-ui/issues/979
+        ReactDOM.flushSync(onFinished);
       }
     }
 

--- a/packages/react/src/utils/useAfterExitAnimation.tsx
+++ b/packages/react/src/utils/useAfterExitAnimation.tsx
@@ -1,4 +1,3 @@
-import * as ReactDOM from 'react-dom';
 import { useAnimationsFinished } from './useAnimationsFinished';
 import { useEnhancedEffect } from './useEnhancedEffect';
 import { useEventCallback } from './useEventCallback';

--- a/packages/react/src/utils/useAnimationsFinished.ts
+++ b/packages/react/src/utils/useAnimationsFinished.ts
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { useEventCallback } from './useEventCallback';
 
 /**
@@ -31,7 +32,11 @@ export function useAnimationsFinished(ref: React.RefObject<HTMLElement | null>) 
       fnToExecute();
     } else {
       frameRef.current = requestAnimationFrame(() => {
-        Promise.allSettled(element.getAnimations().map((anim) => anim.finished)).then(fnToExecute);
+        Promise.allSettled(element.getAnimations().map((anim) => anim.finished)).then(() => {
+          // Synchronously flush the unmounting of the component so that the browser doesn't
+          // paint: https://github.com/mui/base-ui/issues/979
+          ReactDOM.flushSync(fnToExecute);
+        });
       });
     }
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #979
Addresses the `alignOptionToTrigger` non-animated use case of #965

`runOnceAnimationsFinish` is wrapped in a `requestAnimationFrame` (to know the ending styles) and then a microtask. By flushing the `setMounted` state update synchronously, the browser won't paint, leading to no flicker.