### PR TITLE
[Select, Radio] Unify conditional component transitions

### DIFF
--- a/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
@@ -17,6 +17,10 @@ const testContext = {
 };
 
 describe('<Checkbox.Indicator />', () => {
+  beforeEach(() => {
+    (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = true;
+  });
+
   const { render } = createRenderer();
 
   describeConformance(<Checkbox.Indicator />, () => ({

--- a/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { Checkbox } from '@base-ui-components/react/checkbox';
 import { createRenderer, describeConformance } from '#test-utils';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { CheckboxRootContext } from '../root/CheckboxRootContext';
 
 const testContext = {
@@ -90,5 +91,97 @@ describe('<Checkbox.Indicator />', () => {
       expect(indicator).not.to.equal(null);
       expect(indicator).not.to.have.attribute('hidden');
     });
+  });
+
+  it('should remove the indicator when there is no exit animation defined', async function test(t = {}) {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // @ts-expect-error to support mocha and vitest
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      this?.skip?.() || t?.skip();
+    }
+
+    function Test() {
+      const [checked, setChecked] = React.useState(true);
+      return (
+        <div>
+          <button onClick={() => setChecked(false)}>Close</button>
+          <Checkbox.Root checked={checked}>
+            <Checkbox.Indicator data-testid="indicator" keepMounted />
+          </Checkbox.Root>
+        </div>
+      );
+    }
+
+    const { user } = await render(<Test />);
+
+    expect(screen.getByTestId('indicator')).not.to.have.attribute('hidden');
+
+    const closeButton = screen.getByText('Close');
+
+    await user.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('indicator')).to.have.attribute('hidden');
+    });
+  });
+
+  it('should remove the indicator when the animation finishes', async function test(t = {}) {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // @ts-expect-error to support mocha and vitest
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      this?.skip?.() || t?.skip();
+    }
+
+    (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = false;
+
+    let animationFinished = false;
+    const notifyAnimationFinished = () => {
+      animationFinished = true;
+    };
+
+    function Test() {
+      const style = `
+        @keyframes test-anim {
+          to {
+            opacity: 0;
+          }
+        }
+
+        .animation-test-indicator[data-ending-style] {
+          animation: test-anim 50ms;
+        }
+      `;
+
+      const [checked, setChecked] = React.useState(true);
+
+      return (
+        <div>
+          {/* eslint-disable-next-line react/no-danger */}
+          <style dangerouslySetInnerHTML={{ __html: style }} />
+          <button onClick={() => setChecked(false)}>Close</button>
+          <Checkbox.Root checked={checked}>
+            <Checkbox.Indicator
+              className="animation-test-indicator"
+              data-testid="indicator"
+              onAnimationEnd={notifyAnimationFinished}
+              keepMounted
+            />
+          </Checkbox.Root>
+        </div>
+      );
+    }
+
+    const { user } = await render(<Test />);
+
+    expect(screen.getByTestId('indicator')).not.to.have.attribute('hidden');
+
+    const closeButton = screen.getByText('Close');
+    await user.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('indicator')).to.have.attribute('hidden');
+    });
+
+    expect(animationFinished).to.equal(true);
   });
 });

--- a/packages/react/src/checkbox/indicator/CheckboxIndicator.tsx
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicator.tsx
@@ -76,7 +76,7 @@ const CheckboxIndicator = React.forwardRef(function CheckboxIndicator(
     },
   });
 
-  const shouldRender = keepMounted || state.checked || state.indeterminate;
+  const shouldRender = keepMounted || rendered;
   if (!shouldRender) {
     return null;
   }

--- a/packages/react/src/radio/indicator/RadioIndicator.test.tsx
+++ b/packages/react/src/radio/indicator/RadioIndicator.test.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 import { Radio } from '@base-ui-components/react/radio';
+import { expect } from 'chai';
+import { RadioGroup } from '@base-ui-components/react/radio-group';
 
 describe('<Radio.Indicator />', () => {
+  beforeEach(() => {
+    (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = true;
+  });
+
   const { render } = createRenderer();
 
   describeConformance(<Radio.Indicator />, () => ({
@@ -11,4 +18,110 @@ describe('<Radio.Indicator />', () => {
       return render(<Radio.Root value="">{node}</Radio.Root>);
     },
   }));
+
+  it('should remove the indicator when there is no exit animation defined', async function test(t = {}) {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // @ts-expect-error to support mocha and vitest
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      this?.skip?.() || t?.skip();
+    }
+
+    function Test() {
+      const [value, setValue] = React.useState('a');
+      return (
+        <div>
+          <button onClick={() => setValue('b')}>Close</button>
+          <RadioGroup value={value}>
+            <Radio.Root value="a">
+              <Radio.Indicator
+                className="animation-test-indicator"
+                keepMounted
+                data-testid="indicator-a"
+              />
+            </Radio.Root>
+            <Radio.Root value="a">
+              <Radio.Indicator className="animation-test-indicator" keepMounted />
+            </Radio.Root>
+          </RadioGroup>
+        </div>
+      );
+    }
+
+    const { user } = await render(<Test />);
+
+    expect(screen.getByTestId('indicator-a')).not.to.have.attribute('hidden');
+
+    const closeButton = screen.getByText('Close');
+
+    await user.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('indicator-a')).to.have.attribute('hidden');
+    });
+  });
+
+  it('should remove the indicator when the animation finishes', async function test(t = {}) {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // @ts-expect-error to support mocha and vitest
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      this?.skip?.() || t?.skip();
+    }
+
+    (globalThis as any).BASE_UI_ANIMATIONS_DISABLED = false;
+
+    let animationFinished = false;
+    const notifyAnimationFinished = () => {
+      animationFinished = true;
+    };
+
+    function Test() {
+      const style = `
+        @keyframes test-anim {
+          to {
+            opacity: 0;
+          }
+        }
+
+        .animation-test-indicator[data-ending-style] {
+          animation: test-anim 50ms;
+        }
+      `;
+
+      const [value, setValue] = React.useState('a');
+
+      return (
+        <div>
+          {/* eslint-disable-next-line react/no-danger */}
+          <style dangerouslySetInnerHTML={{ __html: style }} />
+          <button onClick={() => setValue('b')}>Close</button>
+          <RadioGroup value={value}>
+            <Radio.Root value="a">
+              <Radio.Indicator
+                className="animation-test-indicator"
+                keepMounted
+                onAnimationEnd={notifyAnimationFinished}
+                data-testid="indicator-a"
+              />
+            </Radio.Root>
+            <Radio.Root value="a">
+              <Radio.Indicator className="animation-test-indicator" keepMounted />
+            </Radio.Root>
+          </RadioGroup>
+        </div>
+      );
+    }
+
+    const { user } = await render(<Test />);
+
+    expect(screen.getByTestId('indicator-a')).not.to.have.attribute('hidden');
+
+    const closeButton = screen.getByText('Close');
+    await user.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('indicator-a')).to.have.attribute('hidden');
+    });
+
+    expect(animationFinished).to.equal(true);
+  });
 });

--- a/packages/react/src/radio/indicator/RadioIndicator.tsx
+++ b/packages/react/src/radio/indicator/RadioIndicator.tsx
@@ -48,8 +48,8 @@ const RadioIndicator = React.forwardRef(function RadioIndicator(
     className,
     state,
     extraProps: {
-      ...otherProps,
       hidden: !mounted,
+      ...otherProps,
     },
     customStyleHookMapping,
   });

--- a/packages/react/src/radio/indicator/RadioIndicator.tsx
+++ b/packages/react/src/radio/indicator/RadioIndicator.tsx
@@ -7,7 +7,7 @@ import { useRadioRootContext } from '../root/RadioRootContext';
 import { customStyleHookMapping } from '../utils/customStyleHookMapping';
 import { useAfterExitAnimation } from '../../utils/useAfterExitAnimation';
 import { useForkRef } from '../../utils/useForkRef';
-import { useTransitionStatus } from '../../utils/useTransitionStatus';
+import { type TransitionStatus, useTransitionStatus } from '../../utils/useTransitionStatus';
 
 /**
  *
@@ -62,7 +62,7 @@ const RadioIndicator = React.forwardRef(function RadioIndicator(
     },
   });
 
-  const shouldRender = keepMounted || state.checked;
+  const shouldRender = keepMounted || rendered;
   if (!shouldRender) {
     return null;
   }
@@ -81,6 +81,7 @@ namespace RadioIndicator {
 
   export interface State {
     checked: boolean;
+    transitionStatus: TransitionStatus;
   }
 }
 

--- a/packages/react/src/radio/utils/customStyleHookMapping.ts
+++ b/packages/react/src/radio/utils/customStyleHookMapping.ts
@@ -1,4 +1,6 @@
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { TransitionStatus } from '../../utils/useTransitionStatus';
+import { transitionStatusMapping } from '../../utils/styleHookMapping';
 
 export const customStyleHookMapping = {
   checked(value): Record<string, string> {
@@ -7,4 +9,8 @@ export const customStyleHookMapping = {
     }
     return { 'data-unchecked': '' };
   },
-} satisfies CustomStyleHookMapping<{ checked: boolean }>;
+  ...transitionStatusMapping,
+} satisfies CustomStyleHookMapping<{
+  checked: boolean;
+  transitionStatus: TransitionStatus;
+}>;

--- a/packages/react/src/select/item-indicator/SelectItemIndicator.tsx
+++ b/packages/react/src/select/item-indicator/SelectItemIndicator.tsx
@@ -5,9 +5,7 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useSelectItemContext } from '../item/SelectItemContext';
 import { mergeReactProps } from '../../utils/mergeReactProps';
-import { useAfterExitAnimation } from '../../utils/useAfterExitAnimation';
 import { useForkRef } from '../../utils/useForkRef';
-import { type TransitionStatus, useTransitionStatus } from '../../utils/useTransitionStatus';
 
 /**
  *
@@ -27,8 +25,6 @@ const SelectItemIndicator = React.forwardRef(function SelectItemIndicator(
 
   const { selected } = useSelectItemContext();
 
-  const { mounted, transitionStatus, setMounted } = useTransitionStatus(selected);
-
   const indicatorRef = React.useRef<HTMLSpanElement | null>(null);
   const mergedRef = useForkRef(forwardedRef, indicatorRef);
 
@@ -37,25 +33,15 @@ const SelectItemIndicator = React.forwardRef(function SelectItemIndicator(
       mergeReactProps(externalProps, {
         'aria-hidden': true,
         children: '✔️',
-        hidden: !mounted,
       }),
-    [mounted],
+    [],
   );
-
-  useAfterExitAnimation({
-    open: selected,
-    animatedElementRef: indicatorRef,
-    onFinished() {
-      setMounted(false);
-    },
-  });
 
   const state: SelectItemIndicator.State = React.useMemo(
     () => ({
       selected,
-      transitionStatus,
     }),
-    [selected, transitionStatus],
+    [selected],
   );
 
   const { renderElement } = useComponentRenderer({
@@ -88,7 +74,6 @@ namespace SelectItemIndicator {
 
   export interface State {
     selected: boolean;
-    transitionStatus: TransitionStatus;
   }
 }
 

--- a/packages/react/src/select/item-indicator/SelectItemIndicator.tsx
+++ b/packages/react/src/select/item-indicator/SelectItemIndicator.tsx
@@ -5,6 +5,9 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useSelectItemContext } from '../item/SelectItemContext';
 import { mergeReactProps } from '../../utils/mergeReactProps';
+import { useAfterExitAnimation } from '../../utils/useAfterExitAnimation';
+import { useForkRef } from '../../utils/useForkRef';
+import { type TransitionStatus, useTransitionStatus } from '../../utils/useTransitionStatus';
 
 /**
  *
@@ -24,26 +27,41 @@ const SelectItemIndicator = React.forwardRef(function SelectItemIndicator(
 
   const { selected } = useSelectItemContext();
 
+  const { mounted, transitionStatus, setMounted } = useTransitionStatus(selected);
+
+  const indicatorRef = React.useRef<HTMLSpanElement | null>(null);
+  const mergedRef = useForkRef(forwardedRef, indicatorRef);
+
   const getItemProps = React.useCallback(
     (externalProps = {}) =>
       mergeReactProps(externalProps, {
         'aria-hidden': true,
         children: '✔️',
+        hidden: !mounted,
       }),
-    [],
+    [mounted],
   );
+
+  useAfterExitAnimation({
+    open: selected,
+    animatedElementRef: indicatorRef,
+    onFinished() {
+      setMounted(false);
+    },
+  });
 
   const state: SelectItemIndicator.State = React.useMemo(
     () => ({
       selected,
+      transitionStatus,
     }),
-    [selected],
+    [selected, transitionStatus],
   );
 
   const { renderElement } = useComponentRenderer({
     propGetter: getItemProps,
     render: render ?? 'span',
-    ref: forwardedRef,
+    ref: mergedRef,
     className,
     state,
     extraProps: otherProps,
@@ -70,6 +88,7 @@ namespace SelectItemIndicator {
 
   export interface State {
     selected: boolean;
+    transitionStatus: TransitionStatus;
   }
 }
 

--- a/packages/react/src/select/scroll-arrow/SelectScrollArrow.tsx
+++ b/packages/react/src/select/scroll-arrow/SelectScrollArrow.tsx
@@ -132,8 +132,8 @@ const SelectScrollArrow = React.forwardRef(function SelectScrollArrow(
     className,
     state,
     extraProps: {
-      ...otherProps,
       hidden: !mounted,
+      ...otherProps,
     },
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Continues #936 - anything that can be conditionally rendered has `transitionStatus` state to apply animations when `keepMounted=false`, and for consistency `hidden=true` when `keepMounted=true` but not rendered/open.

Applies to:

- `Select.Scroll{Up,Down}Arrow`
- `Select.ItemIndicator`
- `Radio.Indicator`