### PR TITLE
[docs] Display API docs of "foreign" parts

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/menu/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/menu/page.mdx
@@ -44,6 +44,5 @@ import { Menu } from '@base-ui-components/react/menu';
 
 <Reference
   component="Menu"
-  parts="Root, Trigger, Positioner, Popup, Arrow, Item,  Group, GroupLabel, RadioGroup, RadioItem, RadioItemIndicator, CheckboxItem, CheckboxItemIndicator, SubmenuTrigger"
+  parts="Root, Trigger, Positioner, Popup, Arrow, Item, Group, GroupLabel, RadioGroup, RadioItem, RadioItemIndicator, CheckboxItem, CheckboxItemIndicator, SubmenuTrigger, Separator"
 />
-{/* TODO: Separator is missing */}

--- a/docs/src/app/(public)/(content)/react/components/select/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/select/page.mdx
@@ -42,7 +42,5 @@ import { Select } from '@base-ui-components/react/select';
 
 <Reference
   component="Select"
-  parts="Root, Trigger, Value, Icon, Backdrop, Positioner, Popup, Arrow, Item, ItemText, ItemIndicator, Group, GroupLabel, ScrollUpArrow, ScrollDownArrow"
+  parts="Root, Trigger, Value, Icon, Backdrop, Positioner, Popup, Arrow, Item, ItemText, ItemIndicator, Group, GroupLabel, ScrollUpArrow, ScrollDownArrow, Separator"
 />
-
-{/* TODO: Separator is missing */}


### PR DESCRIPTION
Displays the API reference of parts that are defined outside of the main component directory, such as the Separator (being a part of a Menu and Select).

@atomiks, this should also cover the standalone Portal component.

Fixes #1000