### PR TITLE
[core] Simplify isReactVersionAtLeast()

### DIFF
--- a/packages/react/src/utils/reactVersion.ts
+++ b/packages/react/src/utils/reactVersion.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-const majorVersion = parseInt(React.version.split('.')[0], 10);
+const majorVersion = parseInt(React.version, 10);
 
 type SupportedVersions = 17 | 18 | 19;
 


### PR DESCRIPTION
Same as https://github.com/mui/material-ui/pull/43820

```js
parseInt('19.0.0-rc.12131', 10); // returns 19
```

---

**Off topic**. I could see us creating an internal helper and exposing fit from Base UI, this duplication feels off:

- https://github.com/mui/mui-x/blob/46c46ff829ed601387048d5da99d156967226980/packages/x-internals/src/reactMajor.ts#L3
- https://github.com/mui/material-ui/blob/6b5d751b0c7f46919cca75238b3da7ee751ac8a6/packages/mui-utils/src/getReactElementRef/getReactElementRef.ts#L12
- https://github.com/mui/material-ui/blob/6b5d751b0c7f46919cca75238b3da7ee751ac8a6/packages/mui-base/src/Input/Input.test.tsx#L285
- MUI X and Material UI tests use `reactMajor } from '@mui/internal-test-utils';` but the source use something different? Doesn't make much sense.

A possible path:

- We remove `isReactVersionAtLeast()` no need for an abstraction of: `>=`.
- We expose `majorVersion` from `@base-ui-components/internal/majorVersion`
- Everything else starts to use it. 

The value is then only about abstracting `parseInt(React.version, 10)` into something simpler.

If we are worried about the coupling of Base UI / Material UI / MUI X (I don't understand this as I think it's a great thing, it forces Base UI to be anchored into its product purpose) but ok, we could replicate the same structure. I see no reason for this to be different.