### PR TITLE
[docs] Various fixes and cleanup

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/switch/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/switch/demos/hero/css-modules/index.module.css
@@ -1,4 +1,5 @@
 .Switch {
+  position: relative;
   display: flex;
   appearance: none;
   border: 0;
@@ -48,6 +49,17 @@
       box-shadow: none;
     }
   }
+
+  &:focus-visible {
+    &::before {
+      content: '';
+      inset: 0;
+      position: absolute;
+      border-radius: inherit;
+      outline: 2px solid var(--color-blue);
+      outline-offset: 2px;
+    }
+  }
 }
 
 .Thumb {
@@ -56,10 +68,6 @@
   border-radius: 100%;
   background-color: white;
   transition: translate 150ms ease;
-
-  &:focus-visible {
-    outline: 2px solid var(--color-blue);
-  }
 
   &[data-checked] {
     translate: 1rem 0;

--- a/docs/src/app/(public)/(content)/react/components/switch/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/switch/demos/hero/tailwind/index.tsx
@@ -5,7 +5,7 @@ export default function ExampleSwitch() {
   return (
     <Switch.Root
       defaultChecked
-      className="flex h-6 w-10 rounded-full bg-gradient-to-r from-gray-700 from-35% to-gray-200 to-65% bg-[length:6.5rem_100%] bg-[100%_0%] bg-no-repeat p-px shadow-[inset_0_1.5px_2px] shadow-gray-200 outline -outline-offset-1 outline-gray-200 transition-[background-position,box-shadow] duration-[125ms] ease-[cubic-bezier(0.26,0.75,0.38,0.45)] active:bg-gray-100 data-[checked]:bg-[0%_0%] data-[checked]:active:bg-gray-500 dark:from-gray-500 dark:shadow-black/75 dark:outline-white/15 dark:data-[checked]:shadow-none"
+      className="relative flex h-6 w-10 rounded-full bg-gradient-to-r from-gray-700 from-35% to-gray-200 to-65% bg-[length:6.5rem_100%] bg-[100%_0%] bg-no-repeat p-px shadow-[inset_0_1.5px_2px] shadow-gray-200 outline -outline-offset-1 outline-gray-200 transition-[background-position,box-shadow] duration-[125ms] ease-[cubic-bezier(0.26,0.75,0.38,0.45)] before:absolute before:rounded-full before:outline-offset-2 before:outline-blue-800 focus-visible:before:inset-0 focus-visible:before:outline-2 active:bg-gray-100 data-[checked]:bg-[0%_0%] data-[checked]:active:bg-gray-500 dark:from-gray-500 dark:shadow-black/75 dark:outline-white/15 dark:data-[checked]:shadow-none"
     >
       <Switch.Thumb className="aspect-square h-full rounded-full bg-white shadow-[0_0_1px_1px,0_1px_1px,1px_2px_4px_-1px] shadow-gray-100 transition-transform duration-150 data-[checked]:translate-x-4 dark:shadow-black/25" />
     </Switch.Root>

--- a/docs/src/app/(public)/layout.css
+++ b/docs/src/app/(public)/layout.css
@@ -9,7 +9,7 @@
   }
 
   body {
-    min-width: 360px;
+    min-width: 320px;
     line-height: 1.5;
     background-color: var(--color-background);
     color: var(--color-foreground);

--- a/docs/src/components/Header.css
+++ b/docs/src/components/Header.css
@@ -2,6 +2,7 @@
   .Header {
     @apply text-sm;
     position: absolute;
+    left: 0;
     top: 0;
     height: var(--header-height);
     width: 100%;

--- a/docs/src/components/Select.tsx
+++ b/docs/src/components/Select.tsx
@@ -14,7 +14,8 @@ interface TriggerProps extends Select.Trigger.Props {
 
 export function Trigger({ className, ssrFallback, placeholder, ...props }: TriggerProps) {
   return (
-    <Select.Trigger {...props}>
+    // Implicitly relying on <GhostButton>, keep it in sync
+    <Select.Trigger data-layout="text" className="GhostButton" {...props}>
       <Select.Value placeholder={placeholder}>{(value) => value || ssrFallback}</Select.Value>
       <Select.Icon render={<ChevronDownIcon className="-ml-0.5" />} />
     </Select.Trigger>

--- a/docs/src/components/SideNav.tsx
+++ b/docs/src/components/SideNav.tsx
@@ -105,7 +105,7 @@ export function Item({ children, className, href, ...props }: ItemProps) {
             // We are scrolling into view, update upstream state
             setScrollingIntoView(true);
             // Sync flag removal with ScrollArea's own scrolling state timeout
-            setTimeout(() => setScrollingIntoView(false), SCROLL_TIMEOUT);
+            setTimeout(() => setScrollingIntoView(false), SCROLL_TIMEOUT + 50);
           }
           actions.forEach(({ top }) => {
             const dir = viewport.scrollTop > top ? -1 : 1;

--- a/docs/src/components/demo/Demo.css
+++ b/docs/src/components/demo/Demo.css
@@ -152,9 +152,18 @@
       display: flex;
       cursor: text;
 
-      /* Closed state */
-      overflow: hidden;
-      max-height: calc(8.6lh + 0.5rem); /* Show 8.6 of code lines and account for top padding */
+      /* Scroll */
+      overflow: auto;
+      overscroll-behavior-x: contain;
+      scrollbar-width: thin;
+
+      /* Scroll containers may be focusable */
+      &:focus-visible {
+        position: relative;
+        outline: 2px solid var(--color-blue);
+        outline-offset: -1px;
+        z-index: 1;
+      }
 
       /* Add a border radius when there is no collapse button */
       &:not(.DemoCollapseButton + &) {
@@ -163,57 +172,35 @@
       }
     }
 
-    /* Scroll containers may be focusable */
-    & pre:focus-visible {
-      position: relative;
-      outline: 2px solid var(--color-blue);
-      outline-offset: -1px;
-      z-index: 1;
-    }
-
-    &::before {
-      content: '';
-      position: absolute;
-      pointer-events: none;
-      height: 7.5rem;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: linear-gradient(to bottom, rgb(255 255 255 / 0), rgb(255 255 255 / 60%));
-    }
-    @media (prefers-color-scheme: dark) {
-      &::before {
-        background: linear-gradient(to bottom, rgb(0 0 0 / 0), rgb(0 0 0 / 60%));
-      }
-    }
-
-    &[data-open] {
-      & pre {
-        max-height: none;
-
-        /* Scroll */
-        overflow: auto;
-        overscroll-behavior-x: contain;
-        scrollbar-width: thin;
-
-        /* Scroll containers may be focusable */
-        &:focus-visible {
-          position: relative;
-          outline: 2px solid var(--color-blue);
-          outline-offset: -1px;
-          z-index: 1;
-        }
-      }
-      &::before {
-        content: none;
-      }
-    }
-
     & code {
       /* Different fonts may introduce vertical align issues */
       display: block;
       /* Make sure selection highlight spans full container width in Safari */
       flex-grow: 1;
+    }
+
+    &[data-closed] {
+      & pre {
+        overflow: hidden;
+        max-height: calc(8.6lh + 0.5rem); /* Show 8.6 of code lines and account for top padding */
+      }
+
+      &::before {
+        content: '';
+        position: absolute;
+        pointer-events: none;
+        height: 7.5rem;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: linear-gradient(to bottom, rgb(255 255 255 / 0), rgb(255 255 255 / 60%));
+      }
+
+      @media (prefers-color-scheme: dark) {
+        &::before {
+          background: linear-gradient(to bottom, rgb(0 0 0 / 0), rgb(0 0 0 / 60%));
+        }
+      }
     }
   }
 

--- a/docs/src/components/demo/DemoSourceBrowser.tsx
+++ b/docs/src/components/demo/DemoSourceBrowser.tsx
@@ -23,7 +23,13 @@ export function DemoSourceBrowser({
   const lineBreaks = selectedFile.content.match(/\n/g) ?? [];
 
   if (lineBreaks.length < collapsibleLinesThreshold) {
-    return <DemoCodeBlock data-open />;
+    return (
+      <BaseDemo.SourceBrowser
+        tabIndex={-1}
+        onKeyDown={handleSelectAll}
+        className="DemoCodeBlockContainer"
+      />
+    );
   }
 
   return (
@@ -36,31 +42,19 @@ export function DemoSourceBrowser({
       <Collapsible.Panel
         keepMounted
         hidden={false}
-        aria-hidden={!collapsibleOpen}
-        render={<DemoCodeBlock />}
-      />
+        tabIndex={-1}
+        onKeyDown={handleSelectAll}
+        className="DemoCodeBlockContainer"
+      >
+        <BaseDemo.SourceBrowser aria-hidden={!collapsibleOpen} />
+      </Collapsible.Panel>
     </div>
   );
 }
 
-function DemoCodeBlock(props: React.ComponentProps<typeof BaseDemo.SourceBrowser>) {
-  return (
-    <BaseDemo.SourceBrowser
-      {...props}
-      className="DemoCodeBlockContainer"
-      // Select code block contents on Ctrl/Cmd + A
-      tabIndex={-1}
-      onKeyDown={(event) => {
-        if (
-          event.key === 'a' &&
-          (event.metaKey || event.ctrlKey) &&
-          !event.shiftKey &&
-          !event.altKey
-        ) {
-          event.preventDefault();
-          window.getSelection()?.selectAllChildren(event.currentTarget);
-        }
-      }}
-    />
-  );
+function handleSelectAll(event: React.KeyboardEvent) {
+  if (event.key === 'a' && (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey) {
+    event.preventDefault();
+    window.getSelection()?.selectAllChildren(event.currentTarget);
+  }
 }


### PR DESCRIPTION
- Add focus outline to the switch demo
- Fix the demo code block accessibility violation
- Fix horizontal space on mobile
- Fix a screen reader issue with the docs select component
- Reduce docs min width to `320px`
- Bump up the timeout to force hide the scrollbar after the programmatic scroll in side nav