### PR TITLE
[docs] API reference fixes/improvements

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/css-modules/index.module.css
@@ -20,6 +20,7 @@
   box-sizing: border-box;
   display: flex;
   width: 100%;
+  gap: 1rem;
   align-items: baseline;
   justify-content: space-between;
   padding: 0.5rem 0;
@@ -32,6 +33,7 @@
   border: none;
   outline: none;
   cursor: pointer;
+  text-align: left;
 
   &:focus-visible {
     outline: 2px solid var(--color-blue);

--- a/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/css-modules/index.tsx
@@ -38,7 +38,7 @@ export default function ExampleAccordion() {
       <Accordion.Item className={styles.Item}>
         <Accordion.Header className={styles.Header}>
           <Accordion.Trigger className={styles.Trigger}>
-            Can I use it for my next project?
+            Can I use it for my project?
             <PlusIcon className={styles.TriggerIcon} />
           </Accordion.Trigger>
         </Accordion.Header>

--- a/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/tailwind/index.tsx
@@ -6,7 +6,7 @@ export default function ExampleAccordion() {
     <Accordion.Root className="flex w-96 max-w-[calc(100vw-8rem)] flex-col justify-center text-gray-900">
       <Accordion.Item className="border-b border-gray-200">
         <Accordion.Header>
-          <Accordion.Trigger className="group flex w-full cursor-pointer items-baseline justify-between py-2 font-medium focus-visible:outline-2 focus-visible:outline-blue-800">
+          <Accordion.Trigger className="group flex w-full cursor-pointer items-baseline justify-between gap-4 py-2 text-left font-medium focus-visible:outline-2 focus-visible:outline-blue-800">
             What is Base UI?
             <PlusIcon className="mr-2 size-3 transition-all ease-out group-data-[panel-open]:scale-110 group-data-[panel-open]:rotate-45" />
           </Accordion.Trigger>
@@ -21,7 +21,7 @@ export default function ExampleAccordion() {
 
       <Accordion.Item className="border-b border-gray-200">
         <Accordion.Header>
-          <Accordion.Trigger className="group flex w-full cursor-pointer items-baseline justify-between py-2 font-medium focus-visible:outline-2 focus-visible:outline-blue-800">
+          <Accordion.Trigger className="group flex w-full cursor-pointer items-baseline justify-between gap-4 py-2 text-left font-medium focus-visible:outline-2 focus-visible:outline-blue-800">
             How do I get started?
             <PlusIcon className="mr-2 size-3 transition-all ease-out group-data-[panel-open]:scale-110 group-data-[panel-open]:rotate-45" />
           </Accordion.Trigger>
@@ -36,8 +36,8 @@ export default function ExampleAccordion() {
 
       <Accordion.Item className="border-b border-gray-200">
         <Accordion.Header>
-          <Accordion.Trigger className="group flex w-full cursor-pointer items-baseline justify-between py-2 font-medium focus-visible:outline-2 focus-visible:outline-blue-800">
-            Can I use it for my next project?
+          <Accordion.Trigger className="group flex w-full cursor-pointer items-baseline justify-between gap-4 py-2 text-left font-medium focus-visible:outline-2 focus-visible:outline-blue-800">
+            Can I use it for my project?
             <PlusIcon className="mr-2 size-3 transition-all ease-out group-data-[panel-open]:scale-110 group-data-[panel-open]:rotate-45" />
           </Accordion.Trigger>
         </Accordion.Header>

--- a/docs/src/components/Popup.css
+++ b/docs/src/components/Popup.css
@@ -4,7 +4,6 @@
     max-height: var(--available-height, none);
     border-radius: var(--radius-md);
     background-color: var(--color-popup);
-    overflow: hidden;
     box-shadow:
       0px 154px 62px 0px rgb(36 40 52 / 1%),
       0px 87px 52px 0px rgb(36 40 52 / 3%),
@@ -33,6 +32,13 @@
 
     &[data-ending-style] {
       transition-timing-function: var(--ease-in-slow);
+    }
+
+    overflow: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+      display: none;
     }
   }
 }

--- a/docs/src/components/Select.tsx
+++ b/docs/src/components/Select.tsx
@@ -7,7 +7,6 @@ import { ThickCheckIcon } from './icons/ThickCheckIcon';
 export const Root = Select.Root;
 
 interface TriggerProps extends Select.Trigger.Props {
-  render: NonNullable<Select.Trigger.Props['render']>;
   ssrFallback?: string;
   placeholder?: Select.Value.Props['placeholder'];
 }

--- a/docs/src/components/Table.css
+++ b/docs/src/components/Table.css
@@ -50,7 +50,7 @@
         pointer-events: none;
         top: 1px;
         bottom: 1px;
-        right: 0;
+        right: -1px; /* Browsers may miss half a pixel due to subpixel table cell widths */
         width: 1.25rem;
         background-image: linear-gradient(to right, transparent, var(--color-content));
         animation: table-cell-overscroll-overlay 500ms;

--- a/docs/src/components/TableCode.tsx
+++ b/docs/src/components/TableCode.tsx
@@ -57,5 +57,9 @@ export function TableCode({ children, printWidth = 40, ...props }: TableCodeProp
     children = unionGroups.flat();
   }
 
-  return <Code {...props}>{children}</Code>;
+  return (
+    <Code data-table-code="" {...props}>
+      {children}
+    </Code>
+  );
 }

--- a/docs/src/components/demo/DemoVariantSelector.tsx
+++ b/docs/src/components/demo/DemoVariantSelector.tsx
@@ -4,7 +4,6 @@ import { type DemoVariant } from 'docs/src/blocks/Demo';
 import { useDemoContext } from 'docs/src/blocks/Demo/DemoContext';
 import * as Select from 'docs/src/components/Select';
 import { useDemoVariantSelectorContext } from './DemoVariantSelectorProvider';
-import { GhostButton } from '../GhostButton';
 
 const translations = {
   variants: {

--- a/docs/src/components/demo/DemoVariantSelector.tsx
+++ b/docs/src/components/demo/DemoVariantSelector.tsx
@@ -127,7 +127,6 @@ export function DemoVariantSelector({
       {renderLanguageSelector && (
         <Select.Root value={selectedLocalVariant.language} onValueChange={handleLanguageChange}>
           <Select.Trigger
-            render={<GhostButton />}
             ssrFallback={
               currentVariantLanguages.find((item) => item.value === selectedLocalVariant.language)
                 ?.label
@@ -145,10 +144,7 @@ export function DemoVariantSelector({
 
       {renderVariantSelector && (
         <Select.Root value={selectedLocalVariant.name} onValueChange={handleVariantChange}>
-          <Select.Trigger
-            render={<GhostButton />}
-            ssrFallback={translations.variants[selectedLocalVariant.name]}
-          />
+          <Select.Trigger ssrFallback={translations.variants[selectedLocalVariant.name]} />
           <Select.Popup>
             {Object.keys(variantsMap).map((variantName) => (
               <Select.Item key={variantName} value={variantName}>

--- a/docs/src/components/reference/AttributesTable.tsx
+++ b/docs/src/components/reference/AttributesTable.tsx
@@ -16,8 +16,8 @@ export async function AttributesTable({ data, ...props }: AttributesTableProps) 
     <Table.Root {...props}>
       <Table.Head>
         <Table.Row>
-          <Table.ColumnHeader className="w-1/2 xs:w-5/8 md:w-1/4">Attribute</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-1/2 xs:w-3/8 md:w-3/4">Type</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-1/2 xs:w-5/8 md:w-1/3">Attribute</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-1/2 xs:w-3/8 md:w-2/3">Type</Table.ColumnHeader>
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>

--- a/docs/src/components/reference/AttributesTable.tsx
+++ b/docs/src/components/reference/AttributesTable.tsx
@@ -16,8 +16,8 @@ export async function AttributesTable({ data, ...props }: AttributesTableProps) 
     <Table.Root {...props}>
       <Table.Head>
         <Table.Row>
-          <Table.ColumnHeader className="w-1/2 xs:w-5/8 md:w-1/3">Attribute</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-1/2 xs:w-3/8 md:w-2/3">Type</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-full md:w-1/3">Attribute</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-2/3 max-md:hidden">Type</Table.ColumnHeader>
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>
@@ -43,12 +43,18 @@ export async function AttributesTable({ data, ...props }: AttributesTableProps) 
               <Table.RowHeader>
                 <Code className="text-navy">{name}</Code>
               </Table.RowHeader>
-              <Table.Cell>
+              <Table.Cell className="w-2/3 max-md:hidden">
                 <AttributeType />
               </Table.Cell>
               <Table.Cell>
                 <ReferenceTablePopover>
                   <AttributeDescription />
+                  <div className="flex flex-col gap-2 text-xs md:hidden">
+                    <div className="border-t border-gray-200 pt-2">
+                      <div className="mb-1 font-bold">Type</div>
+                      <AttributeType />
+                    </div>
+                  </div>
                 </ReferenceTablePopover>
               </Table.Cell>
             </Table.Row>

--- a/docs/src/components/reference/AttributesTable.tsx
+++ b/docs/src/components/reference/AttributesTable.tsx
@@ -16,8 +16,10 @@ export async function AttributesTable({ data, ...props }: AttributesTableProps) 
     <Table.Root {...props}>
       <Table.Head>
         <Table.Row>
-          <Table.ColumnHeader className="w-full md:w-1/3">Attribute</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-2/3 max-md:hidden">Type</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-full xs:w-48 sm:w-56 md:w-1/3">
+            Attribute
+          </Table.ColumnHeader>
+          <Table.ColumnHeader className="max-xs:hidden xs:w-full md:w-2/3">Type</Table.ColumnHeader>
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>
@@ -43,13 +45,13 @@ export async function AttributesTable({ data, ...props }: AttributesTableProps) 
               <Table.RowHeader>
                 <Code className="text-navy">{name}</Code>
               </Table.RowHeader>
-              <Table.Cell className="w-2/3 max-md:hidden">
+              <Table.Cell className="max-xs:hidden">
                 <AttributeType />
               </Table.Cell>
               <Table.Cell>
                 <ReferenceTablePopover>
                   <AttributeDescription />
-                  <div className="flex flex-col gap-2 text-xs md:hidden">
+                  <div className="flex flex-col gap-2 text-xs xs:hidden">
                     <div className="border-t border-gray-200 pt-2">
                       <div className="mb-1 font-bold">Type</div>
                       <AttributeType />

--- a/docs/src/components/reference/CssVariablesTable.tsx
+++ b/docs/src/components/reference/CssVariablesTable.tsx
@@ -16,8 +16,10 @@ export async function CssVariablesTable({ data, ...props }: CssVariablesTablePro
     <Table.Root {...props}>
       <Table.Head>
         <Table.Row>
-          <Table.ColumnHeader className="w-full md:w-1/3">CSS Variable</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-2/3 max-md:hidden">Type</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-full xs:w-48 sm:w-56 md:w-1/3">
+            CSS Variable
+          </Table.ColumnHeader>
+          <Table.ColumnHeader className="max-xs:hidden xs:w-full md:w-2/3">Type</Table.ColumnHeader>
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>
@@ -40,13 +42,13 @@ export async function CssVariablesTable({ data, ...props }: CssVariablesTablePro
               <Table.RowHeader>
                 <Code className="text-navy">{name}</Code>
               </Table.RowHeader>
-              <Table.Cell className="w-2/3 max-md:hidden">
+              <Table.Cell className="max-xs:hidden">
                 <CssVaribleType />
               </Table.Cell>
               <Table.Cell>
                 <ReferenceTablePopover>
                   <CssVaribleDescription />
-                  <div className="flex flex-col gap-2 text-xs md:hidden">
+                  <div className="flex flex-col gap-2 text-xs xs:hidden">
                     <div className="border-t border-gray-200 pt-2">
                       <div className="mb-1 font-bold">Type</div>
                       <CssVaribleType />

--- a/docs/src/components/reference/CssVariablesTable.tsx
+++ b/docs/src/components/reference/CssVariablesTable.tsx
@@ -16,8 +16,8 @@ export async function CssVariablesTable({ data, ...props }: CssVariablesTablePro
     <Table.Root {...props}>
       <Table.Head>
         <Table.Row>
-          <Table.ColumnHeader className="w-1/2 xs:w-5/8 md:w-1/3">CSS Variable</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-1/2 xs:w-3/8 md:w-2/3">Type</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-full md:w-1/3">CSS Variable</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-2/3 max-md:hidden">Type</Table.ColumnHeader>
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>
@@ -40,12 +40,18 @@ export async function CssVariablesTable({ data, ...props }: CssVariablesTablePro
               <Table.RowHeader>
                 <Code className="text-navy">{name}</Code>
               </Table.RowHeader>
-              <Table.Cell>
+              <Table.Cell className="w-2/3 max-md:hidden">
                 <CssVaribleType />
               </Table.Cell>
               <Table.Cell>
                 <ReferenceTablePopover>
                   <CssVaribleDescription />
+                  <div className="flex flex-col gap-2 text-xs md:hidden">
+                    <div className="border-t border-gray-200 pt-2">
+                      <div className="mb-1 font-bold">Type</div>
+                      <CssVaribleType />
+                    </div>
+                  </div>
                 </ReferenceTablePopover>
               </Table.Cell>
             </Table.Row>

--- a/docs/src/components/reference/CssVariablesTable.tsx
+++ b/docs/src/components/reference/CssVariablesTable.tsx
@@ -16,8 +16,8 @@ export async function CssVariablesTable({ data, ...props }: CssVariablesTablePro
     <Table.Root {...props}>
       <Table.Head>
         <Table.Row>
-          <Table.ColumnHeader className="w-1/2 xs:w-5/8 md:w-1/4">CSS Variable</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-1/2 xs:w-3/8 md:w-3/4">Type</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-1/2 xs:w-5/8 md:w-1/3">CSS Variable</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-1/2 xs:w-3/8 md:w-2/3">Type</Table.ColumnHeader>
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>

--- a/docs/src/components/reference/PropsTable.tsx
+++ b/docs/src/components/reference/PropsTable.tsx
@@ -16,9 +16,9 @@ export async function PropsTable({ data, ...props }: PropsTableProps) {
     <Table.Root {...props}>
       <Table.Head>
         <Table.Row>
-          <Table.ColumnHeader className="w-full xs:w-5/8 md:w-1/3">Prop</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-1/2 max-md:hidden">Type</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-3/8 max-xs:hidden md:w-1/6">Default</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-full xs:w-48 sm:w-56 md:w-1/3">Prop</Table.ColumnHeader>
+          <Table.ColumnHeader className="max-xs:hidden xs:w-full md:w-1/2">Type</Table.ColumnHeader>
+          <Table.ColumnHeader className="max-md:hidden md:w-1/6">Default</Table.ColumnHeader>
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>
@@ -46,21 +46,21 @@ export async function PropsTable({ data, ...props }: PropsTableProps) {
               <Table.RowHeader>
                 <Code className="text-navy">{name}</Code>
               </Table.RowHeader>
-              <Table.Cell className="max-md:hidden">
+              <Table.Cell className="max-xs:hidden">
                 <PropType />
               </Table.Cell>
-              <Table.Cell className="max-xs:hidden">
+              <Table.Cell className="max-md:hidden">
                 <PropDefault />
               </Table.Cell>
               <Table.Cell>
                 <ReferenceTablePopover>
                   <PropDescription />
                   <div className="flex flex-col gap-2 text-xs md:hidden">
-                    <div className="border-t border-gray-200 pt-2">
+                    <div className="border-t border-gray-200 pt-2 xs:hidden">
                       <div className="mb-1 font-bold">Type</div>
                       <PropType />
                     </div>
-                    <div className="border-t border-gray-200 pt-2 xs:hidden">
+                    <div className="border-t border-gray-200 pt-2">
                       <div className="mb-1 font-bold">Default</div>
                       <PropDefault />
                     </div>

--- a/docs/src/components/reference/PropsTable.tsx
+++ b/docs/src/components/reference/PropsTable.tsx
@@ -17,8 +17,8 @@ export async function PropsTable({ data, ...props }: PropsTableProps) {
       <Table.Head>
         <Table.Row>
           <Table.ColumnHeader className="w-1/2 xs:w-5/8 md:w-1/3">Prop</Table.ColumnHeader>
-          <Table.ColumnHeader className="max-md:hidden md:w-15/30">Type</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-1/2 xs:w-3/8 md:w-5/30">Default</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-1/2 max-md:hidden">Type</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-1/2 xs:w-3/8 md:w-1/6">Default</Table.ColumnHeader>
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>

--- a/docs/src/components/reference/PropsTable.tsx
+++ b/docs/src/components/reference/PropsTable.tsx
@@ -16,9 +16,9 @@ export async function PropsTable({ data, ...props }: PropsTableProps) {
     <Table.Root {...props}>
       <Table.Head>
         <Table.Row>
-          <Table.ColumnHeader className="w-1/2 xs:w-5/8 md:w-1/4">Prop</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-1/2 max-md:hidden">Type</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-1/2 xs:w-3/8 md:w-1/4">Default</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-1/2 xs:w-5/8 md:w-1/3">Prop</Table.ColumnHeader>
+          <Table.ColumnHeader className="max-md:hidden md:w-15/30">Type</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-1/2 xs:w-3/8 md:w-5/30">Default</Table.ColumnHeader>
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>

--- a/docs/src/components/reference/PropsTable.tsx
+++ b/docs/src/components/reference/PropsTable.tsx
@@ -16,9 +16,9 @@ export async function PropsTable({ data, ...props }: PropsTableProps) {
     <Table.Root {...props}>
       <Table.Head>
         <Table.Row>
-          <Table.ColumnHeader className="w-1/2 xs:w-5/8 md:w-1/3">Prop</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-full xs:w-5/8 md:w-1/3">Prop</Table.ColumnHeader>
           <Table.ColumnHeader className="w-1/2 max-md:hidden">Type</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-1/2 xs:w-3/8 md:w-1/6">Default</Table.ColumnHeader>
+          <Table.ColumnHeader className="w-3/8 max-xs:hidden md:w-1/6">Default</Table.ColumnHeader>
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>
@@ -49,15 +49,22 @@ export async function PropsTable({ data, ...props }: PropsTableProps) {
               <Table.Cell className="max-md:hidden">
                 <PropType />
               </Table.Cell>
-              <Table.Cell>
+              <Table.Cell className="max-xs:hidden">
                 <PropDefault />
               </Table.Cell>
               <Table.Cell>
                 <ReferenceTablePopover>
                   <PropDescription />
-                  <span className="mt-2 block border-t border-gray-200 pt-2 text-xs md:hidden">
-                    <PropType />
-                  </span>
+                  <div className="flex flex-col gap-2 text-xs md:hidden">
+                    <div className="border-t border-gray-200 pt-2">
+                      <div className="mb-1 font-bold">Type</div>
+                      <PropType />
+                    </div>
+                    <div className="border-t border-gray-200 pt-2 xs:hidden">
+                      <div className="mb-1 font-bold">Default</div>
+                      <PropDefault />
+                    </div>
+                  </div>
                 </ReferenceTablePopover>
               </Table.Cell>
             </Table.Row>

--- a/docs/src/components/reference/rehypeReference.mjs
+++ b/docs/src/components/reference/rehypeReference.mjs
@@ -99,12 +99,14 @@ export function rehypeReference() {
             }
           }
 
-          subtree.push(
-            createMdxElement({
-              name: PROPS_TABLE,
-              props: { data: def.props },
-            }),
-          );
+          if (Object.keys(def.props).length) {
+            subtree.push(
+              createMdxElement({
+                name: PROPS_TABLE,
+                props: { data: def.props },
+              }),
+            );
+          }
 
           if (def.dataAttributes) {
             subtree.push(

--- a/docs/src/syntax-highlighting/index.css
+++ b/docs/src/syntax-highlighting/index.css
@@ -20,8 +20,22 @@
   }
 }
 
+/* Collapse most colors to blue for inline code */
 [data-inline] {
+  --syntax-default: var(--color-blue);
   --syntax-entity: var(--color-blue);
   --syntax-parameter: var(--color-blue);
   --syntax-variable: var(--color-blue);
+  --syntax-keyword: var(--color-blue);
+  --syntax-string: var(--color-blue);
+  --syntax-nullish: var(--color-blue);
+}
+
+/* Recover some of the syntax highlighting colors in tables */
+[data-table-code] {
+  --syntax-default: var(--color-foreground);
+  --syntax-entity: var(--color-violet);
+  --syntax-keyword: var(--color-red);
+  --syntax-string: var(--color-navy);
+  --syntax-nullish: var(--color-gray-500);
 }

--- a/docs/src/syntax-highlighting/rehypeInlineCode.mjs
+++ b/docs/src/syntax-highlighting/rehypeInlineCode.mjs
@@ -30,7 +30,7 @@ export function rehypeInlineCode() {
       node.children?.forEach((part) => {
         const text = part.children[0]?.value;
         if (text === 'undefined' || text === 'null' || text === '""' || text === "''") {
-          part.properties.style = 'color: var(--color-gray-500)';
+          part.properties.style = 'color: var(--syntax-nullish, inherit)';
         }
       });
 


### PR DESCRIPTION
Fixes unnecessary empty props tables:

<img width="823" alt="image" src="https://github.com/user-attachments/assets/089e146d-8dc8-4728-9d9a-fe9a270f02d1" />

Fixes occasional stray pixels when table cells overflow

<img width="766" alt="image" src="https://github.com/user-attachments/assets/cd4f97f2-154d-4b5a-bc42-1eb9c0cb41a4" />

Increases the width of the first column in API reference tables to fit the CSS variable names:

<img width="822" alt="image" src="https://github.com/user-attachments/assets/a3b0707c-1222-4631-9225-b03751bc65e3" />
