### PR TITLE
[visuallyHidden] Set top left position

### DIFF
--- a/packages/react/src/utils/visuallyHidden.ts
+++ b/packages/react/src/utils/visuallyHidden.ts
@@ -8,6 +8,8 @@ export const visuallyHidden: React.CSSProperties = {
   overflow: 'hidden',
   padding: 0,
   position: 'absolute',
+  top: 0,
+  left: 0,
   whiteSpace: 'nowrap',
   width: '1px',
 };

--- a/packages/react/src/utils/visuallyHidden.ts
+++ b/packages/react/src/utils/visuallyHidden.ts
@@ -7,7 +7,7 @@ export const visuallyHidden: React.CSSProperties = {
   margin: '-1px',
   overflow: 'hidden',
   padding: 0,
-  position: 'absolute',
+  position: 'fixed',
   top: 0,
   left: 0,
   whiteSpace: 'nowrap',

--- a/packages/react/src/utils/visuallyHidden.ts
+++ b/packages/react/src/utils/visuallyHidden.ts
@@ -1,15 +1,15 @@
 import * as React from 'react';
 
 export const visuallyHidden: React.CSSProperties = {
-  border: 0,
   clip: 'rect(0 0 0 0)',
-  height: '1px',
-  margin: '-1px',
   overflow: 'hidden',
-  padding: 0,
+  whiteSpace: 'nowrap',
   position: 'fixed',
   top: 0,
   left: 0,
-  whiteSpace: 'nowrap',
-  width: '1px',
+  border: 0,
+  padding: 0,
+  width: 1,
+  height: 1,
+  margin: -1,
 };


### PR DESCRIPTION
Prevents scrollbars from appearing when the natural position of the visually hidden element exceeds viewport width (e.g. it is in a scroll container)

https://mui-org.slack.com/archives/C02P87NQLJC/p1734038721374039

Issue at hand

Uploading Screen Recording 2024-12-12 at 22.20.42.mov…

