### PR TITLE
[menu] Default to `inline-end` side and `start` align for submenus

### DIFF
--- a/docs/reference/generated/menu-positioner.json
+++ b/docs/reference/generated/menu-positioner.json
@@ -4,7 +4,6 @@
   "props": {
     "align": {
       "type": "'start' | 'center' | 'end'",
-      "default": "'center'",
       "description": "How to align the popup relative to the specified side."
     },
     "alignOffset": {

--- a/docs/reference/generated/menu-positioner.json
+++ b/docs/reference/generated/menu-positioner.json
@@ -51,7 +51,6 @@
     },
     "side": {
       "type": "'bottom' | 'inline-end' | 'inline-start' | 'left' | 'right' | 'top'",
-      "default": "'bottom'",
       "description": "Which side of the anchor element to align the popup against.\nMay automatically change to avoid collisions."
     },
     "sideOffset": {

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -30,7 +30,7 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     render,
     keepMounted = false,
     side,
-    align = 'center',
+    align,
     sideOffset = 0,
     alignOffset = 0,
     collisionBoundary = 'clipping-ancestors',
@@ -53,8 +53,12 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
   const nodeId = useFloatingNodeId();
 
   let computedSide = side;
+  let computedAlign = align;
   if (!side) {
     computedSide = nested ? 'inline-end' : 'bottom';
+  }
+  if (!align) {
+    computedAlign = nested ? 'start' : 'center';
   }
 
   const positioner = useMenuPositioner({
@@ -65,7 +69,7 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     mounted,
     side: computedSide,
     sideOffset,
-    align,
+    align: computedAlign,
     alignOffset,
     arrowPadding,
     collisionBoundary,

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -52,9 +52,9 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
 
   const nodeId = useFloatingNodeId();
 
-  let computedSide = side ?? 'bottom';
-  if (nested) {
-    computedSide = side ?? 'inline-end';
+  let computedSide = side;
+  if (!side) {
+    computedSide = nested ? 'inline-end' : 'bottom';
   }
 
   const positioner = useMenuPositioner({

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { FloatingNode, useFloatingNodeId } from '@floating-ui/react';
 import { MenuPositionerContext } from './MenuPositionerContext';
 import { useMenuRootContext } from '../root/MenuRootContext';
-import type { Side } from '../../utils/useAnchorPositioning';
+import type { Align, Side } from '../../utils/useAnchorPositioning';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import { useMenuPositioner } from './useMenuPositioner';
@@ -142,7 +142,7 @@ export namespace MenuPositioner {
      */
     open: boolean;
     side: Side;
-    align: 'start' | 'end' | 'center';
+    align: Align;
     anchorHidden: boolean;
   }
 
@@ -158,7 +158,6 @@ MenuPositioner.propTypes /* remove-proptypes */ = {
   // └─────────────────────────────────────────────────────────────────────┘
   /**
    * How to align the popup relative to the specified side.
-   * @default 'center'
    */
   align: PropTypes.oneOf(['center', 'end', 'start']),
   /**

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -29,7 +29,7 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     className,
     render,
     keepMounted = false,
-    side = 'bottom',
+    side,
     align = 'center',
     sideOffset = 0,
     alignOffset = 0,
@@ -40,10 +40,22 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     ...otherProps
   } = props;
 
-  const { open, floatingRootContext, setPositionerElement, itemDomElements, itemLabels, mounted } =
-    useMenuRootContext();
+  const {
+    open,
+    floatingRootContext,
+    setPositionerElement,
+    itemDomElements,
+    itemLabels,
+    mounted,
+    nested,
+  } = useMenuRootContext();
 
   const nodeId = useFloatingNodeId();
+
+  let computedSide = side ?? 'bottom';
+  if (nested) {
+    computedSide = side ?? 'inline-end';
+  }
 
   const positioner = useMenuPositioner({
     anchor,
@@ -51,7 +63,7 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     positionMethod,
     open,
     mounted,
-    side,
+    side: computedSide,
     sideOffset,
     align,
     alignOffset,
@@ -223,7 +235,6 @@ MenuPositioner.propTypes /* remove-proptypes */ = {
   /**
    * Which side of the anchor element to align the popup against.
    * May automatically change to avoid collisions.
-   * @default 'bottom'
    */
   side: PropTypes.oneOf(['bottom', 'inline-end', 'inline-start', 'left', 'right', 'top']),
   /**

--- a/packages/react/src/menu/positioner/useMenuPositioner.ts
+++ b/packages/react/src/menu/positioner/useMenuPositioner.ts
@@ -97,7 +97,6 @@ export namespace useMenuPositioner {
     /**
      * Which side of the anchor element to align the popup against.
      * May automatically change to avoid collisions.
-     * @default 'bottom'
      */
     side?: Side;
     /**

--- a/packages/react/src/menu/positioner/useMenuPositioner.ts
+++ b/packages/react/src/menu/positioner/useMenuPositioner.ts
@@ -106,7 +106,6 @@ export namespace useMenuPositioner {
     sideOffset?: number;
     /**
      * How to align the popup relative to the specified side.
-     * @default 'center'
      */
     align?: 'start' | 'end' | 'center';
     /**


### PR DESCRIPTION
Closes #1079