### PR TITLE
[docs] Expose data attrs descriptions and improve table code formatter

### DIFF
--- a/docs/src/components/TableCode.tsx
+++ b/docs/src/components/TableCode.tsx
@@ -22,19 +22,21 @@ export function TableCode({ children, printWidth = 40, ...props }: TableCodeProp
         return;
       }
 
-      if (getChildrenText(child).trim() === '|' && depth < 1) {
+      const str = getChildrenText(child);
+
+      if (str.trim() === '|' && depth < 1) {
         groupIndex += 1;
         unionGroups.push([]);
         return;
       }
 
-      if (getChildrenText(child).trim() === '(') {
+      str.split('(').forEach(() => {
         depth += 1;
-      }
+      });
 
-      if (getChildrenText(child).trim() === ')') {
+      str.split(')').forEach(() => {
         depth -= 1;
-      }
+      });
 
       unionGroups[groupIndex].push(child);
     });

--- a/docs/src/components/TableCode.tsx
+++ b/docs/src/components/TableCode.tsx
@@ -18,15 +18,20 @@ export function TableCode({ children, printWidth = 40, ...props }: TableCodeProp
     let groupIndex = 0;
     parts.forEach((child, index) => {
       if (index === 0) {
-        unionGroups.push([child]);
-        return;
+        unionGroups.push([]);
       }
 
       const str = getChildrenText(child);
 
-      if (str.trim() === '|' && depth < 1) {
-        groupIndex += 1;
+      // Solo function return values shouldn't be broken up, e.g. in:
+      // `(value) => string | string[] | null | Promise`
+      if (str.includes('=>') && depth < 1) {
+        depth += 1;
+      }
+
+      if (str.trim() === '|' && depth < 1 && index !== 0) {
         unionGroups.push([]);
+        groupIndex += 1;
         return;
       }
 

--- a/docs/src/components/reference/AttributesTable.tsx
+++ b/docs/src/components/reference/AttributesTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createMdxComponent } from 'docs/src/mdx/createMdxComponent';
-import { inlineMdxComponents, tableMdxComponents } from 'docs/src/mdx-components';
+import { inlineMdxComponents } from 'docs/src/mdx-components';
 import { rehypeSyntaxHighlighting } from 'docs/src/syntax-highlighting';
 import type { AttributeDef } from './types';
 import * as Table from '../Table';
@@ -19,21 +19,16 @@ export async function AttributesTable({ data, ...props }: AttributesTableProps) 
           <Table.ColumnHeader className="w-full xs:w-48 sm:w-56 md:w-1/3">
             Attribute
           </Table.ColumnHeader>
-          <Table.ColumnHeader className="max-xs:hidden xs:w-full md:w-2/3">Type</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-10" aria-label="Description" />
+          <Table.ColumnHeader className="w-10 xs:w-2/3">
+            <div className="sr-only xs:not-sr-only xs:contents">Description</div>
+          </Table.ColumnHeader>
+          {/* A cell to maintain a layout consistent with the props table */}
+          <Table.ColumnHeader className="w-10 max-xs:hidden" aria-hidden role="presentation" />
         </Table.Row>
       </Table.Head>
       <Table.Body>
         {Object.keys(data).map(async (name) => {
           const attribute = data[name];
-
-          let AttributeType: (props: any) => React.JSX.Element = EmptyAttribute;
-          if (attribute.type) {
-            AttributeType = await createMdxComponent(`\`${attribute.type}\``, {
-              rehypePlugins: rehypeSyntaxHighlighting,
-              useMDXComponents: () => tableMdxComponents,
-            });
-          }
 
           const AttributeDescription = await createMdxComponent(attribute.description, {
             rehypePlugins: rehypeSyntaxHighlighting,
@@ -45,19 +40,15 @@ export async function AttributesTable({ data, ...props }: AttributesTableProps) 
               <Table.RowHeader>
                 <Code className="text-navy">{name}</Code>
               </Table.RowHeader>
-              <Table.Cell className="max-xs:hidden">
-                <AttributeType />
-              </Table.Cell>
-              <Table.Cell>
-                <ReferenceTablePopover>
+              <Table.Cell colSpan={2}>
+                <div className="hidden xs:contents">
                   <AttributeDescription />
-                  <div className="flex flex-col gap-2 text-xs xs:hidden">
-                    <div className="border-t border-gray-200 pt-2">
-                      <div className="mb-1 font-bold">Type</div>
-                      <AttributeType />
-                    </div>
-                  </div>
-                </ReferenceTablePopover>
+                </div>
+                <div className="contents xs:hidden">
+                  <ReferenceTablePopover>
+                    <AttributeDescription />
+                  </ReferenceTablePopover>
+                </div>
               </Table.Cell>
             </Table.Row>
           );
@@ -65,8 +56,4 @@ export async function AttributesTable({ data, ...props }: AttributesTableProps) 
       </Table.Body>
     </Table.Root>
   );
-}
-
-function EmptyAttribute() {
-  return <span className="text-gray-500">Empty attribute</span>;
 }

--- a/docs/src/components/reference/CssVariablesTable.tsx
+++ b/docs/src/components/reference/CssVariablesTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createMdxComponent } from 'docs/src/mdx/createMdxComponent';
-import { inlineMdxComponents, tableMdxComponents } from 'docs/src/mdx-components';
+import { inlineMdxComponents } from 'docs/src/mdx-components';
 import { rehypeSyntaxHighlighting } from 'docs/src/syntax-highlighting';
 import { ReferenceTablePopover } from './ReferenceTablePopover';
 import * as Table from '../Table';
@@ -19,18 +19,16 @@ export async function CssVariablesTable({ data, ...props }: CssVariablesTablePro
           <Table.ColumnHeader className="w-full xs:w-48 sm:w-56 md:w-1/3">
             CSS Variable
           </Table.ColumnHeader>
-          <Table.ColumnHeader className="max-xs:hidden xs:w-full md:w-2/3">Type</Table.ColumnHeader>
-          <Table.ColumnHeader className="w-10" aria-label="Description" />
+          <Table.ColumnHeader className="w-10 xs:w-2/3">
+            <div className="sr-only xs:not-sr-only xs:contents">Description</div>
+          </Table.ColumnHeader>
+          {/* A cell to maintain a layout consistent with the props table */}
+          <Table.ColumnHeader className="w-10 max-xs:hidden" aria-hidden role="presentation" />
         </Table.Row>
       </Table.Head>
       <Table.Body>
         {Object.keys(data).map(async (name) => {
           const cssVariable = data[name];
-
-          const CssVaribleType = await createMdxComponent(`\`${cssVariable.type}\``, {
-            rehypePlugins: rehypeSyntaxHighlighting,
-            useMDXComponents: () => tableMdxComponents,
-          });
 
           const CssVaribleDescription = await createMdxComponent(cssVariable.description, {
             rehypePlugins: rehypeSyntaxHighlighting,
@@ -42,19 +40,15 @@ export async function CssVariablesTable({ data, ...props }: CssVariablesTablePro
               <Table.RowHeader>
                 <Code className="text-navy">{name}</Code>
               </Table.RowHeader>
-              <Table.Cell className="max-xs:hidden">
-                <CssVaribleType />
-              </Table.Cell>
-              <Table.Cell>
-                <ReferenceTablePopover>
+              <Table.Cell colSpan={2}>
+                <div className="hidden xs:contents">
                   <CssVaribleDescription />
-                  <div className="flex flex-col gap-2 text-xs xs:hidden">
-                    <div className="border-t border-gray-200 pt-2">
-                      <div className="mb-1 font-bold">Type</div>
-                      <CssVaribleType />
-                    </div>
-                  </div>
-                </ReferenceTablePopover>
+                </div>
+                <div className="contents xs:hidden">
+                  <ReferenceTablePopover>
+                    <CssVaribleDescription />
+                  </ReferenceTablePopover>
+                </div>
               </Table.Cell>
             </Table.Row>
           );

--- a/docs/src/components/reference/PropsTable.tsx
+++ b/docs/src/components/reference/PropsTable.tsx
@@ -17,8 +17,10 @@ export async function PropsTable({ data, ...props }: PropsTableProps) {
       <Table.Head>
         <Table.Row>
           <Table.ColumnHeader className="w-full xs:w-48 sm:w-56 md:w-1/3">Prop</Table.ColumnHeader>
-          <Table.ColumnHeader className="max-xs:hidden xs:w-full md:w-1/2">Type</Table.ColumnHeader>
-          <Table.ColumnHeader className="max-md:hidden md:w-1/6">Default</Table.ColumnHeader>
+          <Table.ColumnHeader className="max-xs:hidden xs:w-full md:w-7/15">
+            Type
+          </Table.ColumnHeader>
+          <Table.ColumnHeader className="max-md:hidden md:w-1/5">Default</Table.ColumnHeader>
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>

--- a/docs/src/components/reference/ReferenceTablePopover.tsx
+++ b/docs/src/components/reference/ReferenceTablePopover.tsx
@@ -32,7 +32,7 @@ export function ReferenceTablePopover({ children }: React.PropsWithChildren) {
           sideOffset={9}
           collisionPadding={16}
         >
-          <Popover.Popup render={<Popup className="px-4 py-3.5 text-sm" />}>
+          <Popover.Popup render={<Popup className="px-3 py-2.5 text-sm" />}>
             <div className="flex max-w-72 flex-col gap-3 text-pretty">{children}</div>
           </Popover.Popup>
         </Popover.Positioner>

--- a/docs/src/components/reference/ReferenceTablePopover.tsx
+++ b/docs/src/components/reference/ReferenceTablePopover.tsx
@@ -32,7 +32,7 @@ export function ReferenceTablePopover({ children }: React.PropsWithChildren) {
           sideOffset={9}
           collisionPadding={16}
         >
-          <Popover.Popup render={<Popup className="px-3 py-2.5 text-sm" />}>
+          <Popover.Popup render={<Popup className="px-4 py-3.5 text-sm" />}>
             <div className="flex max-w-72 flex-col gap-3 text-pretty">{children}</div>
           </Popover.Popup>
         </Popover.Positioner>

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -16,6 +16,7 @@ interface MDXComponents {
   [key: string]: React.FC<any> | MDXComponents;
 }
 
+// Maintain spacing between MDX components here
 export const mdxComponents: MDXComponents = {
   a: (props) => <Link {...props} />,
   code: (props) => <Code className="data-[inline]:mx-[0.1em]" {...props} />,
@@ -86,6 +87,7 @@ export const inlineMdxComponents: MDXComponents = {
 
 export const tableMdxComponents: MDXComponents = {
   ...mdxComponents,
+  // Unwrap paragraphs in tables
   // eslint-disable-next-line react/jsx-no-useless-fragment
   p: (props) => <React.Fragment {...props} />,
   code: TableCode,


### PR DESCRIPTION
- Expose descriptions for data attributes and CSS variables
- Tweak reference tables column widths
- Improve table code formatter
  - Handle union types when returned by a solo function:
  - Sturdier handling of nested union types

https://deploy-preview-1086--base-ui.netlify.app/

