### PR TITLE
[docs] Reshuffle font sizes

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/css-modules/index.module.css
@@ -57,8 +57,8 @@
   height: var(--accordion-panel-height);
   overflow: hidden;
   color: var(--color-gray-600);
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
   transition: height 150ms ease-out;
 
   &[data-starting-style],
@@ -68,5 +68,5 @@
 }
 
 .Content {
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }

--- a/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/css-modules/index.tsx
@@ -14,8 +14,8 @@ export default function ExampleAccordion() {
         </Accordion.Header>
         <Accordion.Panel className={styles.Panel}>
           <div className={styles.Content}>
-            Base UI is a library of high-quality, accessible, unstyled React
-            components for design systems and web apps.
+            Base UI is a library of high-quality unstyled React components for design
+            systems and web apps.
           </div>
         </Accordion.Panel>
       </Accordion.Item>
@@ -30,7 +30,7 @@ export default function ExampleAccordion() {
         <Accordion.Panel className={styles.Panel}>
           <div className={styles.Content}>
             Head to the “Quick start” guide in the docs. If you’ve used unstyled
-            libraries before, you’ll feel right at home.
+            libraries before, you’ll feel at home.
           </div>
         </Accordion.Panel>
       </Accordion.Item>

--- a/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/tailwind/index.tsx
@@ -11,10 +11,10 @@ export default function ExampleAccordion() {
             <PlusIcon className="mr-2 size-3 transition-all ease-out group-data-[panel-open]:scale-110 group-data-[panel-open]:rotate-45" />
           </Accordion.Trigger>
         </Accordion.Header>
-        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-sm text-gray-600 transition-[height] ease-out [[data-starting-style],[data-ending-style]]:h-0">
+        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-base text-gray-600 transition-[height] ease-out [[data-starting-style],[data-ending-style]]:h-0">
           <div className="pb-3">
-            Base UI is a library of high-quality, accessible, unstyled React
-            components for design systems and web apps.
+            Base UI is a library of high-quality unstyled React components for design
+            systems and web apps.
           </div>
         </Accordion.Panel>
       </Accordion.Item>
@@ -26,10 +26,10 @@ export default function ExampleAccordion() {
             <PlusIcon className="mr-2 size-3 transition-all ease-out group-data-[panel-open]:scale-110 group-data-[panel-open]:rotate-45" />
           </Accordion.Trigger>
         </Accordion.Header>
-        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-sm text-gray-600 transition-[height] ease-out [[data-starting-style],[data-ending-style]]:h-0">
+        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-base text-gray-600 transition-[height] ease-out [[data-starting-style],[data-ending-style]]:h-0">
           <div className="pb-3">
             Head to the “Quick start” guide in the docs. If you’ve used unstyled
-            libraries before, you’ll feel right at home.
+            libraries before, you’ll feel at home.
           </div>
         </Accordion.Panel>
       </Accordion.Item>
@@ -41,7 +41,7 @@ export default function ExampleAccordion() {
             <PlusIcon className="mr-2 size-3 transition-all ease-out group-data-[panel-open]:scale-110 group-data-[panel-open]:rotate-45" />
           </Accordion.Trigger>
         </Accordion.Header>
-        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-sm text-gray-600 transition-[height] ease-out [[data-starting-style],[data-ending-style]]:h-0">
+        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-base text-gray-600 transition-[height] ease-out [[data-starting-style],[data-ending-style]]:h-0">
           <div className="pb-3">Of course! Base UI is free and open source.</div>
         </Accordion.Panel>
       </Accordion.Item>

--- a/docs/src/app/(public)/(content)/react/components/collapsible/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/collapsible/demos/hero/css-modules/index.module.css
@@ -19,8 +19,8 @@
   background-color: var(--color-gray-100);
   color: var(--color-gray-900);
   font-family: inherit;
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 500;
 
   @media (hover: hover) {
@@ -54,8 +54,8 @@
   flex-direction: column;
   justify-content: flex-end;
   overflow: hidden;
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   transition: all 150ms ease-out;
 
   &[data-starting-style],

--- a/docs/src/app/(public)/(content)/react/components/field/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/field/demos/hero/css-modules/index.module.css
@@ -6,8 +6,8 @@
 }
 
 .Label {
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 500;
   color: var(--color-gray-900);
 }
@@ -32,14 +32,14 @@
 }
 
 .Error {
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-red-800);
 }
 
 .Description {
   margin: 0;
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-gray-600);
 }

--- a/docs/src/app/(public)/(content)/react/components/fieldset/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/fieldset/demos/hero/css-modules/index.module.css
@@ -25,8 +25,8 @@
 }
 
 .Label {
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 500;
   color: var(--color-gray-900);
 }
@@ -51,14 +51,14 @@
 }
 
 .Error {
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-red-800);
 }
 
 .Description {
   margin: 0;
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-gray-600);
 }

--- a/docs/src/app/(public)/(content)/react/components/form/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/form/demos/hero/css-modules/index.module.css
@@ -12,8 +12,8 @@
 }
 
 .Label {
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 500;
   color: var(--color-gray-900);
 }
@@ -38,8 +38,8 @@
 }
 
 .Error {
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-red-800);
 }
 

--- a/docs/src/app/(public)/(content)/react/components/menu/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/menu/demos/hero/css-modules/index.module.css
@@ -121,7 +121,7 @@
   padding-left: 1rem;
   padding-right: 2rem;
   display: flex;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   line-height: 1rem;
 
   &[data-highlighted] {

--- a/docs/src/app/(public)/(content)/react/components/number-field/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/number-field/demos/hero/css-modules/index.module.css
@@ -17,8 +17,8 @@
 
 .Label {
   cursor: ew-resize;
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 500;
   color: var(--color-gray-900);
 }

--- a/docs/src/app/(public)/(content)/react/components/preview-card/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/preview-card/demos/hero/css-modules/index.module.css
@@ -111,8 +111,8 @@
 
 .Summary {
   margin: 0;
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-gray-900);
   text-wrap: pretty;
 }

--- a/docs/src/app/(public)/(content)/react/components/scroll-area/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/scroll-area/demos/hero/css-modules/index.module.css
@@ -21,12 +21,14 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 0.75rem 1.25rem;
+  padding-block: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1.5rem;
 }
 
 .Paragraph {
   margin: 0;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   line-height: 1.375rem;
   color: var(--color-gray-900);
 }

--- a/docs/src/app/(public)/(content)/react/components/scroll-area/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/scroll-area/demos/hero/tailwind/index.tsx
@@ -5,8 +5,8 @@ export default function ExampleScrollArea() {
   return (
     <ScrollArea.Root className="h-[8.5rem] w-96 max-w-[calc(100vw-8rem)]">
       <ScrollArea.Viewport className="h-full overscroll-contain rounded-md outline -outline-offset-1 outline-gray-200 focus-visible:outline-2 focus-visible:outline-blue-800">
-        <div className="flex flex-col gap-4 px-5 py-3">
-          <p className="text-sm text-gray-900">
+        <div className="flex flex-col gap-4 py-3 pr-6 pl-4 text-sm leading-[1.375rem] text-gray-900">
+          <p>
             Vernacular architecture is building done outside any academic tradition,
             and without professional guidance. It is not a particular architectural
             movement or style, but rather a broad category, encompassing a wide range
@@ -17,7 +17,7 @@ export default function ExampleScrollArea() {
             the small percentage of new buildings every year designed by architects
             and built by engineers.
           </p>
-          <p className="text-sm text-gray-900">
+          <p>
             This type of architecture usually serves immediate, local needs, is
             constrained by the materials available in its particular region and
             reflects local traditions and cultural practices. The study of vernacular

--- a/docs/src/app/(public)/(content)/react/components/select/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/select/demos/hero/css-modules/index.module.css
@@ -120,7 +120,7 @@
 .Item {
   box-sizing: border-box;
   outline: 0;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   line-height: 1rem;
   padding-block: 0.5rem;
   padding-left: 0.625rem;

--- a/docs/src/app/(public)/(content)/react/components/separator/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/separator/demos/hero/css-modules/index.module.css
@@ -4,8 +4,8 @@
 }
 
 .Link {
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-gray-900);
   text-decoration-color: var(--color-gray-400);
   text-decoration-thickness: 1px;

--- a/docs/src/app/(public)/(content)/react/components/tabs/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/tabs/demos/hero/css-modules/index.module.css
@@ -23,7 +23,7 @@
   appearance: none;
   color: var(--color-gray-600);
   font-family: inherit;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
   user-select: none;

--- a/docs/src/app/(public)/(content)/react/components/tabs/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/tabs/demos/hero/tailwind/index.tsx
@@ -6,19 +6,19 @@ export default function ExampleScrollArea() {
     <Tabs.Root className="rounded-md border border-gray-200" defaultValue="overview">
       <Tabs.List className="relative z-0 flex gap-1 px-1 shadow-[inset_0_-1px] shadow-gray-200">
         <Tabs.Tab
-          className="flex h-8 items-center justify-center border-0 px-2 text-xs font-medium text-gray-600 outline-0 select-none before:inset-x-0 before:inset-y-1 before:rounded-sm before:-outline-offset-1 before:outline-blue-800 hover:text-gray-900 focus-visible:relative focus-visible:before:absolute focus-visible:before:outline-2 data-[selected]:text-gray-900"
+          className="flex h-8 items-center justify-center border-0 px-2 text-sm font-medium text-gray-600 outline-0 select-none before:inset-x-0 before:inset-y-1 before:rounded-sm before:-outline-offset-1 before:outline-blue-800 hover:text-gray-900 focus-visible:relative focus-visible:before:absolute focus-visible:before:outline-2 data-[selected]:text-gray-900"
           value="overview"
         >
           Overview
         </Tabs.Tab>
         <Tabs.Tab
-          className="flex h-8 items-center justify-center border-0 px-2 text-xs font-medium text-gray-600 outline-0 select-none before:inset-x-0 before:inset-y-1 before:rounded-sm before:-outline-offset-1 before:outline-blue-800 hover:text-gray-900 focus-visible:relative focus-visible:before:absolute focus-visible:before:outline-2 data-[selected]:text-gray-900"
+          className="flex h-8 items-center justify-center border-0 px-2 text-sm font-medium text-gray-600 outline-0 select-none before:inset-x-0 before:inset-y-1 before:rounded-sm before:-outline-offset-1 before:outline-blue-800 hover:text-gray-900 focus-visible:relative focus-visible:before:absolute focus-visible:before:outline-2 data-[selected]:text-gray-900"
           value="projects"
         >
           Projects
         </Tabs.Tab>
         <Tabs.Tab
-          className="flex h-8 items-center justify-center border-0 px-2 text-xs font-medium text-gray-600 outline-0 select-none before:inset-x-0 before:inset-y-1 before:rounded-sm before:-outline-offset-1 before:outline-blue-800 hover:text-gray-900 focus-visible:relative focus-visible:before:absolute focus-visible:before:outline-2 data-[selected]:text-gray-900"
+          className="flex h-8 items-center justify-center border-0 px-2 text-sm font-medium text-gray-600 outline-0 select-none before:inset-x-0 before:inset-y-1 before:rounded-sm before:-outline-offset-1 before:outline-blue-800 hover:text-gray-900 focus-visible:relative focus-visible:before:absolute focus-visible:before:outline-2 data-[selected]:text-gray-900"
           value="account"
         >
           Account

--- a/docs/src/app/(public)/(content)/react/components/tooltip/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/tooltip/demos/hero/css-modules/index.module.css
@@ -51,8 +51,8 @@
 
 .Popup {
   box-sizing: border-box;
-  font-size: 0.9375rem;
-  line-height: 1.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   display: flex;
   flex-direction: column;
   padding: 0.25rem 0.5rem;

--- a/docs/src/components/CodeBlock.css
+++ b/docs/src/components/CodeBlock.css
@@ -45,6 +45,7 @@
   }
 
   .CodeBlockPanelTitle {
+    @apply text-sm;
     color: var(--color-foreground);
     font-weight: 500;
   }

--- a/docs/src/components/Header.css
+++ b/docs/src/components/Header.css
@@ -1,6 +1,6 @@
 @layer components {
   .Header {
-    @apply text-sm;
+    @apply text-md;
     position: absolute;
     left: 0;
     top: 0;

--- a/docs/src/components/Header.tsx
+++ b/docs/src/components/Header.tsx
@@ -67,7 +67,7 @@ export function Header() {
                       <NpmIcon />
                       <span className="flex flex-grow-1 items-baseline justify-between">
                         npm package
-                        <span className="text-sm text-gray-600">{VERSION}</span>
+                        <span className="text-md text-gray-600">{VERSION}</span>
                       </span>
                     </MobileNav.Item>
                     <MobileNav.Item href="https://github.com/mui/base-ui" rel="noopener">

--- a/docs/src/components/Link.tsx
+++ b/docs/src/components/Link.tsx
@@ -3,19 +3,26 @@ import clsx from 'clsx';
 import NextLink from 'next/link';
 import { ExternalLinkIcon } from 'docs/src/components/icons/ExternalLinkIcon';
 
-export function Link(props: React.ComponentProps<typeof NextLink>) {
-  if (typeof props.href === 'string' && props.href.startsWith('http')) {
+export function Link({ href, className, ...props }: React.ComponentProps<typeof NextLink>) {
+  // Sometimes link come from component descriptions; in this case, remove the domain
+  if (typeof href === 'string' && href.startsWith('https://base-ui.com')) {
+    href = href.replace('https://base-ui.com', '');
+  }
+
+  if (typeof href === 'string' && href.startsWith('http')) {
     return (
       <NextLink
+        href={href}
         target="_blank"
         rel="noopener"
         {...props}
-        className={clsx('Link inline-flex items-center gap-1', props.className)}
+        className={clsx('Link inline-flex items-center gap-1', className)}
       >
         {props.children}
         <ExternalLinkIcon />
       </NextLink>
     );
   }
-  return <NextLink {...props} className={clsx('Link', props.className)} />;
+
+  return <NextLink href={href} className={clsx('Link', className)} {...props} />;
 }

--- a/docs/src/components/Select.css
+++ b/docs/src/components/Select.css
@@ -60,7 +60,7 @@
     }
 
     @media (pointer: coarse) {
-      @apply text-sm;
+      @apply text-md;
       height: 2.25rem;
       grid-template-columns: 0.5rem 0.75rem 0.5rem auto 1.5rem;
     }

--- a/docs/src/components/SideNav.css
+++ b/docs/src/components/SideNav.css
@@ -2,7 +2,7 @@
   .SideNavRoot {
     /* Match quick nav spacing so side nav and quick nav are visually aligned */
     --side-nav-item-height: 2rem;
-    --side-nav-item-line-height: var(--text-sm--line-height);
+    --side-nav-item-line-height: var(--text-md--line-height);
     --side-nav-item-padding-y: calc(
       var(--side-nav-item-height) / 2 - var(--side-nav-item-line-height) / 2
     );
@@ -16,7 +16,7 @@
         var(--side-nav-scrollbar-thumb-width) / 2
     );
 
-    @apply text-sm;
+    @apply text-md;
     position: sticky;
     top: 0;
 

--- a/docs/src/components/Table.css
+++ b/docs/src/components/Table.css
@@ -1,6 +1,6 @@
 @layer components {
   .TableRoot {
-    @apply text-xs;
+    @apply text-sm;
     color: var(--color-gray);
     border: 1px solid var(--color-gray-200);
     border-collapse: separate;

--- a/docs/src/components/TableCode.tsx
+++ b/docs/src/components/TableCode.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import clsx from 'clsx';
 import { Code } from './Code';
 import { getChildrenText } from '../getChildrenText';
 
@@ -7,7 +8,7 @@ interface TableCodeProps extends React.ComponentProps<'code'> {
 }
 
 /** An inline code component that breaks long union types into multiple lines */
-export function TableCode({ children, printWidth = 40, ...props }: TableCodeProps) {
+export function TableCode({ children, className, printWidth = 40, ...props }: TableCodeProps) {
   const text = getChildrenText(children);
 
   if (text.includes('|') && text.length > printWidth) {
@@ -65,7 +66,7 @@ export function TableCode({ children, printWidth = 40, ...props }: TableCodeProp
   }
 
   return (
-    <Code data-table-code="" {...props}>
+    <Code data-table-code="" className={clsx('text-xs', className)} {...props}>
       {children}
     </Code>
   );

--- a/docs/src/components/quick-nav/QuickNav.css
+++ b/docs/src/components/quick-nav/QuickNav.css
@@ -10,14 +10,14 @@
 
     /* Use line height instead of fixed item height in case text breaks into multiple lines */
     --quick-nav-item-height: 2rem;
-    --quick-nav-item-line-height: var(--text-sm--line-height);
+    --quick-nav-item-line-height: var(--text-md--line-height);
     --quick-nav-item-padding-y: calc(
       var(--quick-nav-item-height) / 2 - var(--quick-nav-item-line-height) / 2
     );
 
     /* The variable is used in JS positioning logic */
     --top: -1px;
-    @apply text-sm;
+    @apply text-md;
     z-index: 1;
     position: sticky;
     top: var(--top);

--- a/docs/src/components/reference/AttributesTable.tsx
+++ b/docs/src/components/reference/AttributesTable.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { createMdxComponent } from 'docs/src/mdx/createMdxComponent';
 import { inlineMdxComponents } from 'docs/src/mdx-components';
 import { rehypeSyntaxHighlighting } from 'docs/src/syntax-highlighting';
+import { ReferenceTablePopover } from './ReferenceTablePopover';
 import type { AttributeDef } from './types';
 import * as Table from '../Table';
-import { ReferenceTablePopover } from './ReferenceTablePopover';
-import { Code } from '../Code';
+import { TableCode } from '../TableCode';
 
 interface AttributesTableProps extends React.ComponentProps<typeof Table.Root> {
   data: Record<string, AttributeDef>;
@@ -38,7 +38,7 @@ export async function AttributesTable({ data, ...props }: AttributesTableProps) 
           return (
             <Table.Row key={name}>
               <Table.RowHeader>
-                <Code className="text-navy">{name}</Code>
+                <TableCode className="text-navy">{name}</TableCode>
               </Table.RowHeader>
               <Table.Cell colSpan={2}>
                 <div className="hidden xs:contents">

--- a/docs/src/components/reference/CssVariablesTable.tsx
+++ b/docs/src/components/reference/CssVariablesTable.tsx
@@ -5,7 +5,7 @@ import { rehypeSyntaxHighlighting } from 'docs/src/syntax-highlighting';
 import { ReferenceTablePopover } from './ReferenceTablePopover';
 import * as Table from '../Table';
 import type { CssVariableDef } from './types';
-import { Code } from '../Code';
+import { TableCode } from '../TableCode';
 
 interface CssVariablesTableProps extends React.ComponentProps<typeof Table.Root> {
   data: Record<string, CssVariableDef>;
@@ -38,7 +38,7 @@ export async function CssVariablesTable({ data, ...props }: CssVariablesTablePro
           return (
             <Table.Row key={name}>
               <Table.RowHeader>
-                <Code className="text-navy">{name}</Code>
+                <TableCode className="text-navy">{name}</TableCode>
               </Table.RowHeader>
               <Table.Cell colSpan={2}>
                 <div className="hidden xs:contents">

--- a/docs/src/components/reference/PropsTable.tsx
+++ b/docs/src/components/reference/PropsTable.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { createMdxComponent } from 'docs/src/mdx/createMdxComponent';
-import { inlineMdxComponents, tableMdxComponents } from 'docs/src/mdx-components';
+import { inlineMdxComponents } from 'docs/src/mdx-components';
 import { rehypeSyntaxHighlighting } from 'docs/src/syntax-highlighting';
 import { ReferenceTablePopover } from './ReferenceTablePopover';
 import * as Table from '../Table';
 import type { PropDef } from './types';
-import { Code } from '../Code';
+import { TableCode } from '../TableCode';
 
 interface PropsTableProps extends React.ComponentProps<typeof Table.Root> {
   data: Record<string, PropDef>;
@@ -30,12 +30,12 @@ export async function PropsTable({ data, ...props }: PropsTableProps) {
 
           const PropType = await createMdxComponent(`\`${prop.type}\``, {
             rehypePlugins: rehypeSyntaxHighlighting,
-            useMDXComponents: () => tableMdxComponents,
+            useMDXComponents: () => ({ code: TableCode }),
           });
 
           const PropDefault = await createMdxComponent(`\`${prop.default}\``, {
             rehypePlugins: rehypeSyntaxHighlighting,
-            useMDXComponents: () => tableMdxComponents,
+            useMDXComponents: () => ({ code: TableCode }),
           });
 
           const PropDescription = await createMdxComponent(prop.description, {
@@ -46,7 +46,7 @@ export async function PropsTable({ data, ...props }: PropsTableProps) {
           return (
             <Table.Row key={name}>
               <Table.RowHeader>
-                <Code className="text-navy">{name}</Code>
+                <TableCode className="text-navy">{name}</TableCode>
               </Table.RowHeader>
               <Table.Cell className="max-xs:hidden">
                 <PropType />
@@ -57,7 +57,7 @@ export async function PropsTable({ data, ...props }: PropsTableProps) {
               <Table.Cell>
                 <ReferenceTablePopover>
                   <PropDescription />
-                  <div className="flex flex-col gap-2 text-xs md:hidden">
+                  <div className="flex flex-col gap-2 text-md md:hidden">
                     <div className="border-t border-gray-200 pt-2 xs:hidden">
                       <div className="mb-1 font-bold">Type</div>
                       <PropType />

--- a/docs/src/components/reference/ReferenceTablePopover.tsx
+++ b/docs/src/components/reference/ReferenceTablePopover.tsx
@@ -32,7 +32,7 @@ export function ReferenceTablePopover({ children }: React.PropsWithChildren) {
           sideOffset={9}
           collisionPadding={16}
         >
-          <Popover.Popup render={<Popup className="px-4 py-3.5 text-sm" />}>
+          <Popover.Popup render={<Popup className="px-4 py-3 text-md" />}>
             <div className="flex max-w-72 flex-col gap-3 text-pretty">{children}</div>
           </Popover.Popup>
         </Popover.Positioner>

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -7,7 +7,6 @@ import { Code } from './components/Code';
 import { PropsTable } from './components/reference/PropsTable';
 import { AttributesTable } from './components/reference/AttributesTable';
 import { CssVariablesTable } from './components/reference/CssVariablesTable';
-import { TableCode } from './components/TableCode';
 import { getChildrenText } from './getChildrenText';
 import { Link } from './components/Link';
 import { Subtitle } from './components/subtitle/Subtitle';

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -85,14 +85,6 @@ export const inlineMdxComponents: MDXComponents = {
   p: (props) => <p {...props} />,
 };
 
-export const tableMdxComponents: MDXComponents = {
-  ...mdxComponents,
-  // Unwrap paragraphs in tables
-  // eslint-disable-next-line react/jsx-no-useless-fragment
-  p: (props) => <React.Fragment {...props} />,
-  code: TableCode,
-};
-
 export function useMDXComponents(): MDXComponents {
   return mdxComponents;
 }

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -95,7 +95,7 @@
 
   --text-sm: 0.875rem;
   --text-sm--line-height: 1.25rem;
-  --text-sm--letter-spacing: 0.0005em;
+  --text-sm--letter-spacing: 0em;
 
   --text-md: 0.9375rem;
   --text-md--line-height: 1.375rem;

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -93,9 +93,13 @@
   --text-xs--line-height: 1.25rem;
   --text-xs--letter-spacing: 0.001em;
 
-  --text-sm: 0.9375rem;
-  --text-sm--line-height: 1.375rem;
-  --text-sm--letter-spacing: 0em;
+  --text-sm: 0.875rem;
+  --text-sm--line-height: 1.25rem;
+  --text-sm--letter-spacing: 0.0005em;
+
+  --text-md: 0.9375rem;
+  --text-md--line-height: 1.375rem;
+  --text-md--letter-spacing: 0em;
 
   --text-base: 1rem;
   --text-base--line-height: 1.5rem;
@@ -173,6 +177,10 @@
 /* Disable docs-specific variables in the demos. Keep this in sync with the "@theme" block above */
 @layer theme {
   [data-demo] {
+    --text-md: initial;
+    --text-md--line-height: initial;
+    --text-md--letter-spacing: initial;
+
     --color-gray: initial;
     --color-navy: initial;
     --color-green: initial;


### PR DESCRIPTION
- Adjust font sizes so that table paragraphs are 14px
- Aligns `text-sm` with the default Tailwind theme
- Make sure links to base-ui.com don't open in new tab