### PR TITLE
[use-scroll-lock] Fix scroll lock with scroll-behavior: smooth

### DIFF
--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -37,7 +37,7 @@ function preventScrollIOS(referenceElement?: Element | null) {
 
   return () => {
     Object.assign(bodyStyle, originalBodyStyles);
-    window.scrollTo(scrollX, scrollY);
+    window.scrollTo({ left: scrollX, top: scrollY, behavior: 'instant' });
   };
 }
 
@@ -113,7 +113,7 @@ function preventScrollStandard(referenceElement?: Element | null) {
     Object.assign(bodyStyle, originalBodyStyles);
 
     if (window.scrollTo.toString().includes('[native code]')) {
-      window.scrollTo(scrollX, scrollY);
+      window.scrollTo({ left: scrollX, top: scrollY, behavior: 'instant' });
     }
   }
 


### PR DESCRIPTION
The scroll lock has an issue when using `scroll-behavior: smooth` on `html`:

https://github.com/user-attachments/assets/095acc69-9ec9-4b62-924e-ed8238dc39b5

