### PR TITLE
[docs] Viewport tweaks

### DIFF
--- a/docs/src/app/(public)/(content)/layout.tsx
+++ b/docs/src/app/(public)/(content)/layout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { Metadata } from 'next/types';
+import type { Metadata, Viewport } from 'next/types';
 import * as SideNav from 'docs/src/components/SideNav';
 import * as QuickNav from 'docs/src/components/quick-nav/QuickNav';
 import { Header } from 'docs/src/components/Header';
@@ -36,4 +36,28 @@ export default function Layout({ children }: React.PropsWithChildren) {
 export const metadata: Metadata = {
   title: null,
   description: null,
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    // Desktop Safari header background
+    {
+      media: '(prefers-color-scheme: light) and (min-width: 1024px)',
+      color: 'oklch(95% 0.25% 264)',
+    },
+    {
+      media: '(prefers-color-scheme: dark) and (min-width: 1024px)',
+      color: 'oklch(25% 1% 264)',
+    },
+
+    // Mobile Safari header background (match the site header)
+    {
+      media: '(prefers-color-scheme: light)',
+      color: 'oklch(98% 0.25% 264)',
+    },
+    {
+      media: '(prefers-color-scheme: dark)',
+      color: 'oklch(17% 1% 264)',
+    },
+  ],
 };

--- a/docs/src/app/(public)/layout.tsx
+++ b/docs/src/app/(public)/layout.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { Metadata } from 'next/types';
 import { GoogleAnalytics } from 'docs/src/components/GoogleAnalytics';
 import { DocsProviders } from 'docs/src/components/DocsProviders';
 import 'docs/src/styles.css';
@@ -16,3 +17,7 @@ export default function Layout({ children }: React.PropsWithChildren) {
     </DocsProviders>
   );
 }
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://base-ui.com'),
+};

--- a/docs/src/app/(public)/page.tsx
+++ b/docs/src/app/(public)/page.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Link } from 'docs/src/components/Link';
 import { ArrowRightIcon } from 'docs/src/components/icons/ArrowRightIcon';
 import { Logo } from 'docs/src/components/Logo';
@@ -38,4 +38,28 @@ export const metadata: Metadata = {
   openGraph: {
     description,
   },
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    // Desktop Safari page background
+    {
+      media: '(prefers-color-scheme: light) and (min-width: 1024px)',
+      color: 'oklch(95% 0.25% 264)',
+    },
+    {
+      media: '(prefers-color-scheme: dark) and (min-width: 1024px)',
+      color: 'oklch(25% 1% 264)',
+    },
+
+    // Mobile Safari header background (match the page)
+    {
+      media: '(prefers-color-scheme: light)',
+      color: '#FFF',
+    },
+    {
+      media: '(prefers-color-scheme: dark)',
+      color: '#000',
+    },
+  ],
 };

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -8,18 +8,6 @@ export default function Layout({ children }: React.PropsWithChildren) {
       <head>
         <meta name="viewport" content="initial-scale=1, width=device-width" />
         <Favicons />
-
-        {/* iOS header background */}
-        <meta
-          name="theme-color"
-          content="oklch(98% 0.25% 264)"
-          media="(prefers-color-scheme: light)"
-        />
-        <meta
-          name="theme-color"
-          content="oklch(17% 1% 264)"
-          media="(prefers-color-scheme: dark)"
-        />
       </head>
       <body>{children}</body>
     </html>

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -210,6 +210,14 @@
 }
 
 @layer all {
+  html {
+    /* Smooth scroll for anchors */
+    scroll-behavior: smooth;
+
+    /* Stable scrollbar */
+    overflow-y: scroll;
+  }
+
   body {
     font-synthesis: none;
     -webkit-font-smoothing: antialiased;

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -211,9 +211,6 @@
 
 @layer all {
   html {
-    /* Smooth scroll for anchors */
-    scroll-behavior: smooth;
-
     /* Stable scrollbar */
     overflow-y: scroll;
   }


### PR DESCRIPTION
Updated desktop Safari browser header theme to feel distinct from the site header / site background:

https://github.com/user-attachments/assets/7b208b92-6a97-4424-9887-1a41f5cc2273

***

Updated mobile Safari browser header theme to blend with the site header / site background:

https://github.com/user-attachments/assets/7f267daf-4f34-4521-ad3b-4e32a06e1483

***

Updated scroll anchors to use native smooth scrolling:

https://github.com/user-attachments/assets/ce220110-03e2-407d-8068-0610f5870b6a

***

Added `overflow-y: scroll` to `html` for a stable scrollbar
