### PR TITLE
[docs] Mobile nav fixes

### DIFF
--- a/docs/src/components/CodeBlock.tsx
+++ b/docs/src/components/CodeBlock.tsx
@@ -79,6 +79,7 @@ export function Pre({ className, ...props }: React.ComponentProps<'pre'>) {
       }}
     >
       <ScrollArea.Viewport
+        style={{ overflow: undefined }}
         render={<pre {...props} id={codeId} className={clsx('CodeBlockPre', className)} />}
       />
       <ScrollArea.Scrollbar orientation="horizontal" />

--- a/docs/src/components/MobileNav.css
+++ b/docs/src/components/MobileNav.css
@@ -29,13 +29,10 @@
   }
 
   .MobileNavPopup {
-    /* TODO Vlad remove when the backdrop order bug is fixed */
-    z-index: 1;
-    outline: 0;
-
     position: fixed;
-    inset: 0;
     height: 100dvh;
+    inset: 0;
+    outline: 0;
 
     /* Half the transition duration for blur so the element sort of comes into the focus when it's halfway in */
     transition-duration: 600ms, 300ms;


### PR DESCRIPTION
- Wait for the URL to change before closing the mobile nav dialog. Otherwise, there might be a slight flash of content during the close animation as the navigation happens. This guarantees that closing the nav dialog smoothly “reveals” the new page.
- If navigating to the same page, close the nav and scroll up smoothly.
- Fix the flick down gesture animation after https://github.com/mui/base-ui/pull/1109 (we relied on the scroll lock to be on during the flick down)