### PR TITLE
[menu] Remove the `keepMounted` prop from the Positioner

### DIFF
--- a/docs/data/components/menu/CheckboxItems.tsx
+++ b/docs/data/components/menu/CheckboxItems.tsx
@@ -14,8 +14,8 @@ export default function CheckboxItems() {
   return (
     <Menu.Root>
       <MenuButton>My account</MenuButton>
-      <Menu.Portal>
-        <MenuPositioner align="start" keepMounted>
+      <Menu.Portal keepMounted>
+        <MenuPositioner align="start">
           <MenuPopup>
             <MenuItem onClick={createHandleMenuClick('Profile')}>Profile</MenuItem>
             <MenuItem onClick={createHandleMenuClick('Language settings')}>

--- a/docs/data/components/menu/RadioItems.tsx
+++ b/docs/data/components/menu/RadioItems.tsx
@@ -7,8 +7,8 @@ export default function RadioItems() {
   return (
     <Menu.Root>
       <MenuButton>Font</MenuButton>
-      <Menu.Portal>
-        <MenuPositioner align="start" keepMounted>
+      <Menu.Portal keepMounted>
+        <MenuPositioner align="start">
           <MenuPopup>
             <Menu.RadioGroup defaultValue={'jetbrains-mono'}>
               <RadioItem value="cascadia-code">

--- a/docs/reference/generated/menu-positioner.json
+++ b/docs/reference/generated/menu-positioner.json
@@ -53,11 +53,6 @@
       "type": "string | (state) => string",
       "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
     },
-    "keepMounted": {
-      "type": "boolean",
-      "default": "false",
-      "description": "Whether to keep the HTML element in the DOM while the menu is hidden."
-    },
     "render": {
       "type": "React.ReactElement | (props, state) => React.ReactElement",
       "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."

--- a/docs/reference/generated/portal.json
+++ b/docs/reference/generated/portal.json
@@ -9,7 +9,7 @@
     "keepMounted": {
       "type": "boolean",
       "default": "false",
-      "description": "Whether to keep the portal mounted in the DOM while the popup is hidden."
+      "description": "Whether to keep the portal mounted in the DOM while its children are hidden."
     }
   },
   "dataAttributes": {},

--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.test.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.test.tsx
@@ -69,22 +69,24 @@ describe('<Menu.CheckboxItem />', () => {
 
     const { getAllByRole } = await render(
       <Menu.Root open>
-        <Menu.Positioner>
-          <Menu.Popup>
-            <Menu.CheckboxItem render={<LoggingRoot renderSpy={renderItem1Spy} />} id="item-1">
-              1
-            </Menu.CheckboxItem>
-            <Menu.CheckboxItem render={<LoggingRoot renderSpy={renderItem2Spy} />} id="item-2">
-              2
-            </Menu.CheckboxItem>
-            <Menu.CheckboxItem render={<LoggingRoot renderSpy={renderItem3Spy} />} id="item-3">
-              3
-            </Menu.CheckboxItem>
-            <Menu.CheckboxItem render={<LoggingRoot renderSpy={renderItem4Spy} />} id="item-4">
-              4
-            </Menu.CheckboxItem>
-          </Menu.Popup>
-        </Menu.Positioner>
+        <Menu.Portal>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.CheckboxItem render={<LoggingRoot renderSpy={renderItem1Spy} />} id="item-1">
+                1
+              </Menu.CheckboxItem>
+              <Menu.CheckboxItem render={<LoggingRoot renderSpy={renderItem2Spy} />} id="item-2">
+                2
+              </Menu.CheckboxItem>
+              <Menu.CheckboxItem render={<LoggingRoot renderSpy={renderItem3Spy} />} id="item-3">
+                3
+              </Menu.CheckboxItem>
+              <Menu.CheckboxItem render={<LoggingRoot renderSpy={renderItem4Spy} />} id="item-4">
+                4
+              </Menu.CheckboxItem>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
       </Menu.Root>,
     );
 
@@ -135,11 +137,13 @@ describe('<Menu.CheckboxItem />', () => {
         const { getByRole } = await render(
           <Menu.Root>
             <Menu.Trigger>Open</Menu.Trigger>
-            <Menu.Positioner>
-              <Menu.Popup>
-                <Menu.CheckboxItem checked={checked}>Item</Menu.CheckboxItem>
-              </Menu.Popup>
-            </Menu.Positioner>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.CheckboxItem checked={checked}>Item</Menu.CheckboxItem>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
           </Menu.Root>,
         );
 
@@ -156,11 +160,13 @@ describe('<Menu.CheckboxItem />', () => {
       const { getByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.CheckboxItem>Item</Menu.CheckboxItem>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.CheckboxItem>Item</Menu.CheckboxItem>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -183,11 +189,13 @@ describe('<Menu.CheckboxItem />', () => {
       const { getByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.CheckboxItem>Item</Menu.CheckboxItem>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.CheckboxItem>Item</Menu.CheckboxItem>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -213,11 +221,13 @@ describe('<Menu.CheckboxItem />', () => {
       const { getByRole, queryByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner keepMounted>
-            <Menu.Popup>
-              <Menu.CheckboxItem>Item</Menu.CheckboxItem>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal keepMounted>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.CheckboxItem>Item</Menu.CheckboxItem>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -245,11 +255,13 @@ describe('<Menu.CheckboxItem />', () => {
       const { getByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.CheckboxItem onCheckedChange={onCheckedChange}>Item</Menu.CheckboxItem>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.CheckboxItem onCheckedChange={onCheckedChange}>Item</Menu.CheckboxItem>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -272,11 +284,13 @@ describe('<Menu.CheckboxItem />', () => {
       const { getByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner keepMounted>
-            <Menu.Popup>
-              <Menu.CheckboxItem>Item</Menu.CheckboxItem>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal keepMounted>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.CheckboxItem>Item</Menu.CheckboxItem>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -301,11 +315,13 @@ describe('<Menu.CheckboxItem />', () => {
       const { getByRole, queryByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.CheckboxItem closeOnClick>Item</Menu.CheckboxItem>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.CheckboxItem closeOnClick>Item</Menu.CheckboxItem>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -322,11 +338,13 @@ describe('<Menu.CheckboxItem />', () => {
       const { getByRole, queryByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.CheckboxItem>Item</Menu.CheckboxItem>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.CheckboxItem>Item</Menu.CheckboxItem>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 

--- a/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
+++ b/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
@@ -24,13 +24,15 @@ describe('<Menu.GroupLabel />', () => {
     it('should have the role `presentation`', async () => {
       const { getByText } = await render(
         <Menu.Root open>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.Group>
-                <Menu.GroupLabel>Test group</Menu.GroupLabel>
-              </Menu.Group>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Group>
+                  <Menu.GroupLabel>Test group</Menu.GroupLabel>
+                </Menu.Group>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -41,13 +43,15 @@ describe('<Menu.GroupLabel />', () => {
     it("should reference the generated id in Group's `aria-labelledby`", async () => {
       const { getByText, getByRole } = await render(
         <Menu.Root open>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.Group>
-                <Menu.GroupLabel>Test group</Menu.GroupLabel>
-              </Menu.Group>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Group>
+                  <Menu.GroupLabel>Test group</Menu.GroupLabel>
+                </Menu.Group>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -60,13 +64,15 @@ describe('<Menu.GroupLabel />', () => {
     it("should reference the provided id in Group's `aria-labelledby`", async () => {
       const { getByRole } = await render(
         <Menu.Root open>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.Group>
-                <Menu.GroupLabel id="test-group">Test group</Menu.GroupLabel>
-              </Menu.Group>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Group>
+                  <Menu.GroupLabel id="test-group">Test group</Menu.GroupLabel>
+                </Menu.Group>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 

--- a/packages/react/src/menu/item/MenuItem.test.tsx
+++ b/packages/react/src/menu/item/MenuItem.test.tsx
@@ -69,22 +69,24 @@ describe('<Menu.Item />', () => {
 
     const { getAllByRole } = await render(
       <Menu.Root open>
-        <Menu.Positioner>
-          <Menu.Popup>
-            <Menu.Item render={<LoggingRoot renderSpy={renderItem1Spy} />} id="item-1">
-              1
-            </Menu.Item>
-            <Menu.Item render={<LoggingRoot renderSpy={renderItem2Spy} />} id="item-2">
-              2
-            </Menu.Item>
-            <Menu.Item render={<LoggingRoot renderSpy={renderItem3Spy} />} id="item-3">
-              3
-            </Menu.Item>
-            <Menu.Item render={<LoggingRoot renderSpy={renderItem4Spy} />} id="item-4">
-              4
-            </Menu.Item>
-          </Menu.Popup>
-        </Menu.Positioner>
+        <Menu.Portal>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item render={<LoggingRoot renderSpy={renderItem1Spy} />} id="item-1">
+                1
+              </Menu.Item>
+              <Menu.Item render={<LoggingRoot renderSpy={renderItem2Spy} />} id="item-2">
+                2
+              </Menu.Item>
+              <Menu.Item render={<LoggingRoot renderSpy={renderItem3Spy} />} id="item-3">
+                3
+              </Menu.Item>
+              <Menu.Item render={<LoggingRoot renderSpy={renderItem4Spy} />} id="item-4">
+                4
+              </Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
       </Menu.Root>,
     );
 
@@ -128,11 +130,13 @@ describe('<Menu.Item />', () => {
       const { getByRole, queryByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.Item>Item</Menu.Item>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Item>Item</Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -149,11 +153,13 @@ describe('<Menu.Item />', () => {
       const { getByRole, queryByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.Item closeOnClick={false}>Item</Menu.Item>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Item closeOnClick={false}>Item</Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 

--- a/packages/react/src/menu/positioner/MenuPositioner.test.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { FloatingRootContext, FloatingTree } from '@floating-ui/react';
-import userEvent from '@testing-library/user-event';
 import { flushMicrotasks } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui-components/react/menu';
 import { describeConformance, createRenderer } from '#test-utils';
@@ -58,18 +57,20 @@ describe('<Menu.Positioner />', () => {
         return (
           <div style={{ margin: '50px' }}>
             <Menu.Root open>
-              <Menu.Positioner
-                side="bottom"
-                align="start"
-                anchor={anchor}
-                arrowPadding={0}
-                data-testid="positioner"
-              >
-                <Menu.Popup>
-                  <Menu.Item>1</Menu.Item>
-                  <Menu.Item>2</Menu.Item>
-                </Menu.Popup>
-              </Menu.Positioner>
+              <Menu.Portal>
+                <Menu.Positioner
+                  side="bottom"
+                  align="start"
+                  anchor={anchor}
+                  arrowPadding={0}
+                  data-testid="positioner"
+                >
+                  <Menu.Popup>
+                    <Menu.Item>1</Menu.Item>
+                    <Menu.Item>2</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
             </Menu.Root>
             <div data-testid="anchor" style={{ marginTop: '100px' }} ref={anchor} />
           </div>
@@ -106,18 +107,20 @@ describe('<Menu.Positioner />', () => {
         return (
           <div style={{ margin: '50px' }}>
             <Menu.Root open>
-              <Menu.Positioner
-                side="bottom"
-                align="start"
-                anchor={anchor}
-                arrowPadding={0}
-                data-testid="positioner"
-              >
-                <Menu.Popup>
-                  <Menu.Item>1</Menu.Item>
-                  <Menu.Item>2</Menu.Item>
-                </Menu.Popup>
-              </Menu.Positioner>
+              <Menu.Portal>
+                <Menu.Positioner
+                  side="bottom"
+                  align="start"
+                  anchor={anchor}
+                  arrowPadding={0}
+                  data-testid="positioner"
+                >
+                  <Menu.Popup>
+                    <Menu.Item>1</Menu.Item>
+                    <Menu.Item>2</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
             </Menu.Root>
             <div data-testid="anchor" style={{ marginTop: '100px' }} ref={handleRef} />
           </div>
@@ -156,18 +159,20 @@ describe('<Menu.Positioner />', () => {
         return (
           <div style={{ margin: '50px' }}>
             <Menu.Root open>
-              <Menu.Positioner
-                side="bottom"
-                align="start"
-                anchor={getAnchor}
-                arrowPadding={0}
-                data-testid="positioner"
-              >
-                <Menu.Popup>
-                  <Menu.Item>1</Menu.Item>
-                  <Menu.Item>2</Menu.Item>
-                </Menu.Popup>
-              </Menu.Positioner>
+              <Menu.Portal>
+                <Menu.Positioner
+                  side="bottom"
+                  align="start"
+                  anchor={getAnchor}
+                  arrowPadding={0}
+                  data-testid="positioner"
+                >
+                  <Menu.Popup>
+                    <Menu.Item>1</Menu.Item>
+                    <Menu.Item>2</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
             </Menu.Root>
             <div data-testid="anchor" style={{ marginTop: '100px' }} ref={handleRef} />
           </div>
@@ -211,81 +216,25 @@ describe('<Menu.Positioner />', () => {
 
       const { getByTestId } = await render(
         <Menu.Root open>
-          <Menu.Positioner
-            side="bottom"
-            align="start"
-            anchor={virtualElement}
-            arrowPadding={0}
-            data-testid="positioner"
-          >
-            <Menu.Popup>
-              <Menu.Item>1</Menu.Item>
-              <Menu.Item>2</Menu.Item>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner
+              side="bottom"
+              align="start"
+              anchor={virtualElement}
+              arrowPadding={0}
+              data-testid="positioner"
+            >
+              <Menu.Popup>
+                <Menu.Item>1</Menu.Item>
+                <Menu.Item>2</Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
       const positioner = getByTestId('positioner');
       expect(positioner.style.getPropertyValue('transform')).to.equal(`translate(200px, 100px)`);
-    });
-  });
-
-  describe('prop: keepMounted', () => {
-    const user = userEvent.setup();
-
-    it('when keepMounted=true, should keep the content mounted when closed', async () => {
-      const { getByRole, queryByRole } = await render(
-        <Menu.Root>
-          <Menu.Trigger>Toggle</Menu.Trigger>
-          <Menu.Positioner keepMounted>
-            <Menu.Popup>
-              <Menu.Item>1</Menu.Item>
-              <Menu.Item>2</Menu.Item>
-            </Menu.Popup>
-          </Menu.Positioner>
-        </Menu.Root>,
-      );
-
-      const trigger = getByRole('button', { name: 'Toggle' });
-
-      expect(queryByRole('menu', { hidden: true })).not.to.equal(null);
-      expect(queryByRole('menu', { hidden: true })).toBeInaccessible();
-
-      await user.click(trigger);
-      await flushMicrotasks();
-      expect(queryByRole('menu', { hidden: false })).not.to.equal(null);
-      expect(queryByRole('menu', { hidden: false })).not.toBeInaccessible();
-
-      await user.click(trigger);
-      expect(queryByRole('menu', { hidden: true })).not.to.equal(null);
-      expect(queryByRole('menu', { hidden: true })).toBeInaccessible();
-    });
-
-    it('when keepMounted=false, should unmount the content when closed', async () => {
-      const { getByRole, queryByRole } = await render(
-        <Menu.Root>
-          <Menu.Trigger>Toggle</Menu.Trigger>
-          <Menu.Positioner keepMounted={false}>
-            <Menu.Popup>
-              <Menu.Item>1</Menu.Item>
-              <Menu.Item>2</Menu.Item>
-            </Menu.Popup>
-          </Menu.Positioner>
-        </Menu.Root>,
-      );
-
-      const trigger = getByRole('button', { name: 'Toggle' });
-
-      expect(queryByRole('menu', { hidden: true })).to.equal(null);
-
-      await user.click(trigger);
-      await flushMicrotasks();
-      expect(queryByRole('menu', { hidden: false })).not.to.equal(null);
-      expect(queryByRole('menu', { hidden: false })).not.toBeInaccessible();
-
-      await user.click(trigger);
-      expect(queryByRole('menu', { hidden: true })).to.equal(null);
     });
   });
 });

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -28,7 +28,6 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     positionMethod = 'absolute',
     className,
     render,
-    keepMounted = false,
     side,
     align,
     sideOffset = 0,
@@ -118,11 +117,6 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
     ref: mergedRef,
     extraProps: otherProps,
   });
-
-  const shouldRender = keepMounted || mounted;
-  if (!shouldRender) {
-    return null;
-  }
 
   return (
     <MenuPositionerContext.Provider value={contextValue}>
@@ -218,11 +212,6 @@ MenuPositioner.propTypes /* remove-proptypes */ = {
       top: PropTypes.number,
     }),
   ]),
-  /**
-   * Whether to keep the HTML element in the DOM while the menu is hidden.
-   * @default false
-   */
-  keepMounted: PropTypes.bool,
   /**
    * Determines which CSS `position` property to use.
    * @default 'absolute'

--- a/packages/react/src/menu/positioner/useMenuPositioner.ts
+++ b/packages/react/src/menu/positioner/useMenuPositioner.ts
@@ -14,7 +14,7 @@ import { useMenuRootContext } from '../root/MenuRootContext';
 export function useMenuPositioner(
   params: useMenuPositioner.Parameters,
 ): useMenuPositioner.ReturnValue {
-  const { keepMounted, mounted } = params;
+  const { mounted } = params;
 
   const { open } = useMenuRootContext();
 
@@ -33,7 +33,7 @@ export function useMenuPositioner(
     (externalProps = {}) => {
       const hiddenStyles: React.CSSProperties = {};
 
-      if (keepMounted && !open) {
+      if (!open) {
         hiddenStyles.pointerEvents = 'none';
       }
 
@@ -46,7 +46,7 @@ export function useMenuPositioner(
         },
       });
     },
-    [keepMounted, open, positionerStyles, mounted],
+    [open, positionerStyles, mounted],
   );
 
   return React.useMemo(
@@ -123,11 +123,6 @@ export namespace useMenuPositioner {
      * @default 5
      */
     collisionPadding?: Padding;
-    /**
-     * Whether to keep the HTML element in the DOM while the menu is hidden.
-     * @default false
-     */
-    keepMounted?: boolean;
     /**
      * Whether to maintain the menu in the viewport after
      * the anchor element is scrolled out of view.

--- a/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
@@ -79,40 +79,42 @@ describe('<Menu.RadioItem />', () => {
 
     const { getAllByRole } = await render(
       <Menu.Root open>
-        <Menu.Positioner>
-          <Menu.Popup>
-            <Menu.RadioGroup>
-              <Menu.RadioItem
-                value={1}
-                render={<LoggingRoot renderSpy={renderItem1Spy} />}
-                id="item-1"
-              >
-                1
-              </Menu.RadioItem>
-              <Menu.RadioItem
-                value={2}
-                render={<LoggingRoot renderSpy={renderItem2Spy} />}
-                id="item-2"
-              >
-                2
-              </Menu.RadioItem>
-              <Menu.RadioItem
-                value={3}
-                render={<LoggingRoot renderSpy={renderItem3Spy} />}
-                id="item-3"
-              >
-                3
-              </Menu.RadioItem>
-              <Menu.RadioItem
-                value={4}
-                render={<LoggingRoot renderSpy={renderItem4Spy} />}
-                id="item-4"
-              >
-                4
-              </Menu.RadioItem>
-            </Menu.RadioGroup>
-          </Menu.Popup>
-        </Menu.Positioner>
+        <Menu.Portal>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.RadioGroup>
+                <Menu.RadioItem
+                  value={1}
+                  render={<LoggingRoot renderSpy={renderItem1Spy} />}
+                  id="item-1"
+                >
+                  1
+                </Menu.RadioItem>
+                <Menu.RadioItem
+                  value={2}
+                  render={<LoggingRoot renderSpy={renderItem2Spy} />}
+                  id="item-2"
+                >
+                  2
+                </Menu.RadioItem>
+                <Menu.RadioItem
+                  value={3}
+                  render={<LoggingRoot renderSpy={renderItem3Spy} />}
+                  id="item-3"
+                >
+                  3
+                </Menu.RadioItem>
+                <Menu.RadioItem
+                  value={4}
+                  render={<LoggingRoot renderSpy={renderItem4Spy} />}
+                  id="item-4"
+                >
+                  4
+                </Menu.RadioItem>
+              </Menu.RadioGroup>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
       </Menu.Root>,
     );
 
@@ -157,13 +159,15 @@ describe('<Menu.RadioItem />', () => {
       const { getByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.RadioGroup defaultValue={0}>
-                <Menu.RadioItem value={1}>Item</Menu.RadioItem>
-              </Menu.RadioGroup>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.RadioGroup defaultValue={0}>
+                  <Menu.RadioItem value={1}>Item</Menu.RadioItem>
+                </Menu.RadioGroup>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -182,11 +186,13 @@ describe('<Menu.RadioItem />', () => {
         const { getByRole } = await render(
           <Menu.Root>
             <Menu.Trigger>Open</Menu.Trigger>
-            <Menu.Positioner>
-              <Menu.RadioGroup defaultValue={0}>
-                <Menu.RadioItem value={1}>Item</Menu.RadioItem>
-              </Menu.RadioGroup>
-            </Menu.Positioner>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.RadioGroup defaultValue={0}>
+                  <Menu.RadioItem value={1}>Item</Menu.RadioItem>
+                </Menu.RadioGroup>
+              </Menu.Positioner>
+            </Menu.Portal>
           </Menu.Root>,
         );
 
@@ -211,13 +217,15 @@ describe('<Menu.RadioItem />', () => {
       const { getByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.RadioGroup defaultValue={0} onValueChange={onValueChange}>
-                <Menu.RadioItem value={1}>Item</Menu.RadioItem>
-              </Menu.RadioGroup>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.RadioGroup defaultValue={0} onValueChange={onValueChange}>
+                  <Menu.RadioItem value={1}>Item</Menu.RadioItem>
+                </Menu.RadioGroup>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -235,13 +243,15 @@ describe('<Menu.RadioItem />', () => {
       const { getByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner keepMounted>
-            <Menu.Popup>
-              <Menu.RadioGroup defaultValue={0}>
-                <Menu.RadioItem value={1}>Item</Menu.RadioItem>
-              </Menu.RadioGroup>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal keepMounted>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.RadioGroup defaultValue={0}>
+                  <Menu.RadioItem value={1}>Item</Menu.RadioItem>
+                </Menu.RadioGroup>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -266,15 +276,17 @@ describe('<Menu.RadioItem />', () => {
       const { getByRole, queryByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.RadioGroup defaultValue={0}>
-                <Menu.RadioItem closeOnClick value={1}>
-                  Item
-                </Menu.RadioItem>
-              </Menu.RadioGroup>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.RadioGroup defaultValue={0}>
+                  <Menu.RadioItem closeOnClick value={1}>
+                    Item
+                  </Menu.RadioItem>
+                </Menu.RadioGroup>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -291,13 +303,15 @@ describe('<Menu.RadioItem />', () => {
       const { getByRole, queryByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.RadioGroup defaultValue={0}>
-                <Menu.RadioItem value={1}>Item</Menu.RadioItem>
-              </Menu.RadioGroup>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.RadioGroup defaultValue={0}>
+                  <Menu.RadioItem value={1}>Item</Menu.RadioItem>
+                </Menu.RadioGroup>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -20,13 +20,15 @@ describe('<Menu.Root />', () => {
       const { getByRole, getByTestId } = await render(
         <Menu.Root>
           <Menu.Trigger>Toggle</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.Item data-testid="item-1">1</Menu.Item>
-              <Menu.Item data-testid="item-2">2</Menu.Item>
-              <Menu.Item data-testid="item-3">3</Menu.Item>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Item data-testid="item-1">1</Menu.Item>
+                <Menu.Item data-testid="item-2">2</Menu.Item>
+                <Menu.Item data-testid="item-3">3</Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -65,13 +67,15 @@ describe('<Menu.Root />', () => {
       const { getByRole, getByTestId } = await render(
         <Menu.Root>
           <Menu.Trigger>Toggle</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.Item data-testid="item-1">1</Menu.Item>
-              <Menu.Item data-testid="item-2">2</Menu.Item>
-              <Menu.Item data-testid="item-3">3</Menu.Item>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Item data-testid="item-1">1</Menu.Item>
+                <Menu.Item data-testid="item-2">2</Menu.Item>
+                <Menu.Item data-testid="item-3">3</Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -103,14 +107,16 @@ describe('<Menu.Root />', () => {
       const { getByRole, getByTestId } = await render(
         <Menu.Root>
           <Menu.Trigger>Toggle</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.Item data-testid="item-1">1</Menu.Item>
-              <Menu.Item disabled data-testid="item-2">
-                2
-              </Menu.Item>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Item data-testid="item-1">1</Menu.Item>
+                <Menu.Item disabled data-testid="item-2">
+                  2
+                </Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -149,16 +155,18 @@ describe('<Menu.Root />', () => {
 
         const { getByText, getAllByRole } = await render(
           <Menu.Root open>
-            <Menu.Positioner>
-              <Menu.Popup>
-                <Menu.Item>Aa</Menu.Item>
-                <Menu.Item>Ba</Menu.Item>
-                <Menu.Item>Bb</Menu.Item>
-                <Menu.Item>Ca</Menu.Item>
-                <Menu.Item>Cb</Menu.Item>
-                <Menu.Item>Cd</Menu.Item>
-              </Menu.Popup>
-            </Menu.Positioner>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item>Aa</Menu.Item>
+                  <Menu.Item>Ba</Menu.Item>
+                  <Menu.Item>Bb</Menu.Item>
+                  <Menu.Item>Ca</Menu.Item>
+                  <Menu.Item>Cb</Menu.Item>
+                  <Menu.Item>Cd</Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
           </Menu.Root>,
         );
 
@@ -194,14 +202,16 @@ describe('<Menu.Root />', () => {
         const { getByRole, getAllByRole } = await render(
           <Menu.Root>
             <Menu.Trigger>Toggle</Menu.Trigger>
-            <Menu.Positioner>
-              <Menu.Popup>
-                <Menu.Item label="Aa">1</Menu.Item>
-                <Menu.Item label="Ba">2</Menu.Item>
-                <Menu.Item label="Bb">3</Menu.Item>
-                <Menu.Item label="Ca">4</Menu.Item>
-              </Menu.Popup>
-            </Menu.Positioner>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item label="Aa">1</Menu.Item>
+                  <Menu.Item label="Ba">2</Menu.Item>
+                  <Menu.Item label="Bb">3</Menu.Item>
+                  <Menu.Item label="Ca">4</Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
           </Menu.Root>,
         );
 
@@ -249,19 +259,21 @@ describe('<Menu.Root />', () => {
 
         const { getByText, getAllByRole } = await render(
           <Menu.Root open>
-            <Menu.Positioner>
-              <Menu.Popup>
-                <Menu.Item>Aa</Menu.Item>
-                <Menu.Item>Ba</Menu.Item>
-                <Menu.Item />
-                <Menu.Item>
-                  <div>Nested Content</div>
-                </Menu.Item>
-                <Menu.Item>{undefined}</Menu.Item>
-                <Menu.Item>{null}</Menu.Item>
-                <Menu.Item>Bc</Menu.Item>
-              </Menu.Popup>
-            </Menu.Positioner>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item>Aa</Menu.Item>
+                  <Menu.Item>Ba</Menu.Item>
+                  <Menu.Item />
+                  <Menu.Item>
+                    <div>Nested Content</div>
+                  </Menu.Item>
+                  <Menu.Item>{undefined}</Menu.Item>
+                  <Menu.Item>{null}</Menu.Item>
+                  <Menu.Item>Bc</Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
           </Menu.Root>,
         );
 
@@ -295,14 +307,16 @@ describe('<Menu.Root />', () => {
 
         const { getByText, getAllByRole } = await render(
           <Menu.Root open>
-            <Menu.Positioner>
-              <Menu.Popup>
-                <Menu.Item>Aa</Menu.Item>
-                <Menu.Item>Ba</Menu.Item>
-                <Menu.Item>Bb</Menu.Item>
-                <Menu.Item>Bą</Menu.Item>
-              </Menu.Popup>
-            </Menu.Positioner>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item>Aa</Menu.Item>
+                  <Menu.Item>Ba</Menu.Item>
+                  <Menu.Item>Bb</Menu.Item>
+                  <Menu.Item>Bą</Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
           </Menu.Root>,
         );
 
@@ -336,14 +350,16 @@ describe('<Menu.Root />', () => {
 
         const { getByText, getAllByRole } = await render(
           <Menu.Root open>
-            <Menu.Positioner>
-              <Menu.Popup>
-                <Menu.Item>Aa</Menu.Item>
-                <Menu.Item>ąa</Menu.Item>
-                <Menu.Item>ąb</Menu.Item>
-                <Menu.Item>ąc</Menu.Item>
-              </Menu.Popup>
-            </Menu.Positioner>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item>Aa</Menu.Item>
+                  <Menu.Item>ąa</Menu.Item>
+                  <Menu.Item>ąb</Menu.Item>
+                  <Menu.Item>ąc</Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
           </Menu.Root>,
         );
 
@@ -373,13 +389,15 @@ describe('<Menu.Root />', () => {
 
         const { getAllByRole } = await render(
           <Menu.Root open>
-            <Menu.Positioner>
-              <Menu.Popup>
-                <Menu.Item onClick={() => handleClick()}>Item One</Menu.Item>
-                <Menu.Item onClick={() => handleClick()}>Item Two</Menu.Item>
-                <Menu.Item onClick={() => handleClick()}>Item Three</Menu.Item>
-              </Menu.Popup>
-            </Menu.Positioner>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item onClick={() => handleClick()}>Item One</Menu.Item>
+                  <Menu.Item onClick={() => handleClick()}>Item Two</Menu.Item>
+                  <Menu.Item onClick={() => handleClick()}>Item Three</Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
           </Menu.Root>,
         );
 
@@ -413,20 +431,24 @@ describe('<Menu.Root />', () => {
         const { getByTestId, queryByTestId } = await render(
           <DirectionProvider direction={direction}>
             <Menu.Root open orientation={orientation}>
-              <Menu.Positioner>
-                <Menu.Popup>
-                  <Menu.Item>1</Menu.Item>
-                  <Menu.Root orientation={orientation}>
-                    <Menu.SubmenuTrigger data-testid="submenu-trigger">2</Menu.SubmenuTrigger>
-                    <Menu.Positioner>
-                      <Menu.Popup data-testid="submenu">
-                        <Menu.Item data-testid="submenu-item-1">2.1</Menu.Item>
-                        <Menu.Item>2.2</Menu.Item>
-                      </Menu.Popup>
-                    </Menu.Positioner>
-                  </Menu.Root>
-                </Menu.Popup>
-              </Menu.Positioner>
+              <Menu.Portal>
+                <Menu.Positioner>
+                  <Menu.Popup>
+                    <Menu.Item>1</Menu.Item>
+                    <Menu.Root orientation={orientation}>
+                      <Menu.SubmenuTrigger data-testid="submenu-trigger">2</Menu.SubmenuTrigger>
+                      <Menu.Portal>
+                        <Menu.Positioner>
+                          <Menu.Popup data-testid="submenu">
+                            <Menu.Item data-testid="submenu-item-1">2.1</Menu.Item>
+                            <Menu.Item>2.2</Menu.Item>
+                          </Menu.Popup>
+                        </Menu.Positioner>
+                      </Menu.Portal>
+                    </Menu.Root>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
             </Menu.Root>
           </DirectionProvider>,
         );
@@ -463,13 +485,15 @@ describe('<Menu.Root />', () => {
       return (
         <Menu.Root>
           <Menu.Trigger>Toggle</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.Item>1</Menu.Item>
-              <Menu.Item>2</Menu.Item>
-              <Menu.Item>3</Menu.Item>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Item>1</Menu.Item>
+                <Menu.Item>2</Menu.Item>
+                <Menu.Item>3</Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>
       );
     }
@@ -539,11 +563,13 @@ describe('<Menu.Root />', () => {
           <input type="text" />
           <Menu.Root>
             <Menu.Trigger>Toggle</Menu.Trigger>
-            <Menu.Positioner>
-              <Menu.Popup>
-                <Menu.Item>Close</Menu.Item>
-              </Menu.Popup>
-            </Menu.Positioner>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item>Close</Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
           </Menu.Root>
           <input type="text" />
         </div>,
@@ -571,11 +597,13 @@ describe('<Menu.Root />', () => {
           <input type="text" />
           <Menu.Root>
             <Menu.Trigger>Toggle</Menu.Trigger>
-            <Menu.Positioner keepMounted>
-              <Menu.Popup>
-                <Menu.Item>Close</Menu.Item>
-              </Menu.Popup>
-            </Menu.Positioner>
+            <Menu.Portal keepMounted>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item>Close</Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
           </Menu.Root>
           <input type="text" />
         </div>,
@@ -598,20 +626,24 @@ describe('<Menu.Root />', () => {
       const { getByRole, queryByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.Item>1</Menu.Item>
-              <Menu.Root>
-                <Menu.SubmenuTrigger>2</Menu.SubmenuTrigger>
-                <Menu.Positioner>
-                  <Menu.Popup>
-                    <Menu.Item>2.1</Menu.Item>
-                    <Menu.Item>2.2</Menu.Item>
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Root>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Item>1</Menu.Item>
+                <Menu.Root>
+                  <Menu.SubmenuTrigger>2</Menu.SubmenuTrigger>
+                  <Menu.Portal>
+                    <Menu.Positioner>
+                      <Menu.Popup>
+                        <Menu.Item>2.1</Menu.Item>
+                        <Menu.Item>2.2</Menu.Item>
+                      </Menu.Popup>
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.Root>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -645,20 +677,24 @@ describe('<Menu.Root />', () => {
       const { getByRole, queryAllByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner>
-            <Menu.Popup id="parent-menu">
-              <Menu.Item>1</Menu.Item>
-              <Menu.Root closeParentOnEsc={false}>
-                <Menu.SubmenuTrigger>2</Menu.SubmenuTrigger>
-                <Menu.Positioner>
-                  <Menu.Popup id="submenu">
-                    <Menu.Item>2.1</Menu.Item>
-                    <Menu.Item>2.2</Menu.Item>
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Root>
-            </Menu.Popup>
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup id="parent-menu">
+                <Menu.Item>1</Menu.Item>
+                <Menu.Root closeParentOnEsc={false}>
+                  <Menu.SubmenuTrigger>2</Menu.SubmenuTrigger>
+                  <Menu.Portal>
+                    <Menu.Positioner>
+                      <Menu.Popup id="submenu">
+                        <Menu.Item>2.1</Menu.Item>
+                        <Menu.Item>2.2</Menu.Item>
+                      </Menu.Popup>
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.Root>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -708,9 +744,11 @@ describe('<Menu.Root />', () => {
           <div>
             <button onClick={() => setOpen(false)}>Close</button>
             <Menu.Root open={open}>
-              <Menu.Positioner>
-                <Menu.Popup />
-              </Menu.Positioner>
+              <Menu.Portal>
+                <Menu.Positioner>
+                  <Menu.Popup />
+                </Menu.Positioner>
+              </Menu.Portal>
             </Menu.Root>
           </div>
         );
@@ -765,12 +803,14 @@ describe('<Menu.Root />', () => {
             <style dangerouslySetInnerHTML={{ __html: style }} />
             <button onClick={() => setOpen(false)}>Close</button>
             <Menu.Root open={open}>
-              <Menu.Positioner keepMounted>
-                <Menu.Popup
-                  className="animation-test-popup"
-                  onAnimationEnd={notifyAnimationFinished}
-                />
-              </Menu.Positioner>
+              <Menu.Portal keepMounted>
+                <Menu.Positioner>
+                  <Menu.Popup
+                    className="animation-test-popup"
+                    onAnimationEnd={notifyAnimationFinished}
+                  />
+                </Menu.Positioner>
+              </Menu.Portal>
             </Menu.Root>
           </div>
         );

--- a/packages/react/src/menu/trigger/MenuTrigger.test.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.test.tsx
@@ -61,9 +61,11 @@ describe('<Menu.Trigger />', () => {
       const { getByRole, queryByRole } = await render(
         <Menu.Root>
           <Menu.Trigger disabled />
-          <Menu.Positioner>
-            <Menu.Popup />
-          </Menu.Positioner>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup />
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -108,11 +110,13 @@ describe('<Menu.Trigger />', () => {
           const { getByRole, queryByRole } = await render(
             <Menu.Root>
               {buttonComponent}
-              <Menu.Positioner>
-                <Menu.Popup>
-                  <Menu.Item>1</Menu.Item>
-                </Menu.Popup>
-              </Menu.Positioner>
+              <Menu.Portal>
+                <Menu.Positioner>
+                  <Menu.Popup>
+                    <Menu.Item>1</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
             </Menu.Root>,
           );
 

--- a/packages/react/src/portal/Portal.tsx
+++ b/packages/react/src/portal/Portal.tsx
@@ -32,7 +32,7 @@ namespace Portal {
      */
     container?: HTMLElement | null | React.RefObject<HTMLElement | null>;
     /**
-     * Whether to keep the portal mounted in the DOM while the popup is hidden.
+     * Whether to keep the portal mounted in the DOM while its children are hidden.
      * @default false
      */
     keepMounted?: boolean;
@@ -55,7 +55,7 @@ Portal.propTypes /* remove-proptypes */ = {
    */
   container: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([HTMLElementType, refType]),
   /**
-   * Whether to keep the portal mounted in the DOM while the popup is hidden.
+   * Whether to keep the portal mounted in the DOM while its children are hidden.
    * @default false
    */
   keepMounted: PropTypes.bool,


### PR DESCRIPTION
As the Portal part has the `keepMounted` prop, it's no longer necessary to have it in Positioner.
