### PR TITLE
[dialog] Disable modality of closing dialogs

### DIFF
--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -96,7 +96,7 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
   return (
     <FloatingFocusManager
       context={floatingContext}
-      modal
+      modal={open}
       disabled={!mounted}
       initialFocus={resolvedInitialFocus}
       returnFocus={finalFocus}

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -95,7 +95,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
   return (
     <FloatingFocusManager
       context={floatingContext}
-      modal
+      modal={open}
       disabled={!mounted}
       closeOnFocusOut={dismissible}
       initialFocus={resolvedInitialFocus}

--- a/packages/react/src/dialog/popup/useDialogPopup.tsx
+++ b/packages/react/src/dialog/popup/useDialogPopup.tsx
@@ -55,7 +55,7 @@ export function useDialogPopup(parameters: useDialogPopup.Parameters): useDialog
   const id = useBaseUiId(idParam);
   const handleRef = useForkRef(ref, popupRef, setPopupElement);
 
-  useScrollLock(modal && mounted, elements.floating);
+  useScrollLock(modal && open, elements.floating);
 
   // Default initial focus logic:
   // If opened by touch, focus the popup element to prevent the virtual keyboard from opening


### PR DESCRIPTION
Do not wait for the exit animation to complete before unlocking page scroll and allowing outside clicks/tabbing out in Dialog and AlertDialog

Closes #1108