### PR TITLE
[docs] Improve API reference copy

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/accordion/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/accordion/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Accordion } from '@base-ui-components/react/accordion';

--- a/docs/src/app/(public)/(content)/react/components/accordion/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/accordion/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Accordion } from '@base-ui-components/react/accordion';

--- a/docs/src/app/(public)/(content)/react/components/alert-dialog/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/alert-dialog/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { AlertDialog } from '@base-ui-components/react/alert-dialog';

--- a/docs/src/app/(public)/(content)/react/components/alert-dialog/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/alert-dialog/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { AlertDialog } from '@base-ui-components/react/alert-dialog';

--- a/docs/src/app/(public)/(content)/react/components/checkbox/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/checkbox/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Checkbox } from '@base-ui-components/react/checkbox';

--- a/docs/src/app/(public)/(content)/react/components/checkbox/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/checkbox/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Checkbox } from '@base-ui-components/react/checkbox';

--- a/docs/src/app/(public)/(content)/react/components/collapsible/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/collapsible/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Collapsible } from '@base-ui-components/react/collapsible';

--- a/docs/src/app/(public)/(content)/react/components/collapsible/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/collapsible/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Collapsible } from '@base-ui-components/react/collapsible';

--- a/docs/src/app/(public)/(content)/react/components/dialog/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Dialog } from '@base-ui-components/react/dialog';

--- a/docs/src/app/(public)/(content)/react/components/dialog/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Dialog } from '@base-ui-components/react/dialog';

--- a/docs/src/app/(public)/(content)/react/components/field/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/field/page.mdx
@@ -11,7 +11,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Field } from '@base-ui-components/react/field';

--- a/docs/src/app/(public)/(content)/react/components/field/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/field/page.mdx
@@ -11,7 +11,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Field } from '@base-ui-components/react/field';

--- a/docs/src/app/(public)/(content)/react/components/fieldset/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/fieldset/page.mdx
@@ -11,7 +11,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Fieldset } from '@base-ui-components/react/fieldset';

--- a/docs/src/app/(public)/(content)/react/components/fieldset/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/fieldset/page.mdx
@@ -11,7 +11,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Fieldset } from '@base-ui-components/react/fieldset';

--- a/docs/src/app/(public)/(content)/react/components/menu/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/menu/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Menu } from '@base-ui-components/react/menu';

--- a/docs/src/app/(public)/(content)/react/components/menu/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/menu/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Menu } from '@base-ui-components/react/menu';

--- a/docs/src/app/(public)/(content)/react/components/number-field/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/number-field/page.mdx
@@ -11,7 +11,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { NumberField } from '@base-ui-components/react/number-field';

--- a/docs/src/app/(public)/(content)/react/components/number-field/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/number-field/page.mdx
@@ -11,7 +11,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { NumberField } from '@base-ui-components/react/number-field';

--- a/docs/src/app/(public)/(content)/react/components/popover/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/popover/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Popover } from '@base-ui-components/react/popover';

--- a/docs/src/app/(public)/(content)/react/components/popover/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/popover/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Popover } from '@base-ui-components/react/popover';

--- a/docs/src/app/(public)/(content)/react/components/preview-card/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/preview-card/page.mdx
@@ -17,7 +17,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { PreviewCard } from '@base-ui-components/react/previewCard';

--- a/docs/src/app/(public)/(content)/react/components/preview-card/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/preview-card/page.mdx
@@ -17,7 +17,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { PreviewCard } from '@base-ui-components/react/previewCard';

--- a/docs/src/app/(public)/(content)/react/components/progress/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/progress/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Progress } from '@base-ui-components/react/progress';

--- a/docs/src/app/(public)/(content)/react/components/progress/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/progress/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Progress } from '@base-ui-components/react/progress';

--- a/docs/src/app/(public)/(content)/react/components/scroll-area/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/scroll-area/page.mdx
@@ -11,7 +11,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { ScrollArea } from '@base-ui-components/react/scroll-area';

--- a/docs/src/app/(public)/(content)/react/components/scroll-area/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/scroll-area/page.mdx
@@ -11,7 +11,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { ScrollArea } from '@base-ui-components/react/scroll-area';

--- a/docs/src/app/(public)/(content)/react/components/select/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/select/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Select } from '@base-ui-components/react/select';

--- a/docs/src/app/(public)/(content)/react/components/select/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/select/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Select } from '@base-ui-components/react/select';

--- a/docs/src/app/(public)/(content)/react/components/slider/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/slider/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Slider } from '@base-ui-components/react/slider';

--- a/docs/src/app/(public)/(content)/react/components/slider/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/slider/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Slider } from '@base-ui-components/react/slider';

--- a/docs/src/app/(public)/(content)/react/components/switch/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/switch/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Switch } from '@base-ui-components/react/switch';

--- a/docs/src/app/(public)/(content)/react/components/switch/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/switch/page.mdx
@@ -10,7 +10,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Switch } from '@base-ui-components/react/switch';

--- a/docs/src/app/(public)/(content)/react/components/tabs/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/tabs/page.mdx
@@ -11,7 +11,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Tabs } from '@base-ui-components/react/tabs';

--- a/docs/src/app/(public)/(content)/react/components/tabs/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/tabs/page.mdx
@@ -11,7 +11,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Tabs } from '@base-ui-components/react/tabs';

--- a/docs/src/app/(public)/(content)/react/components/tooltip/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/tooltip/page.mdx
@@ -12,7 +12,7 @@
 
 ## API reference
 
-Import the component and place its parts the following way:
+Import the component and assemble it as shown below:
 
 ```jsx title="Anatomy"
 import { Tooltip } from '@base-ui-components/react/tooltip';

--- a/docs/src/app/(public)/(content)/react/components/tooltip/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/tooltip/page.mdx
@@ -12,7 +12,7 @@
 
 ## API reference
 
-Import the component and assemble it as shown below:
+Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
 import { Tooltip } from '@base-ui-components/react/tooltip';


### PR DESCRIPTION
"place its parts the following way" struck me as awkward phrasing—how about "assemble ~it as shown below~ its parts"?