### PR TITLE
[menu] Fix item `closeOnClick` docs

### DIFF
--- a/docs/reference/generated/menu-checkbox-item.json
+++ b/docs/reference/generated/menu-checkbox-item.json
@@ -25,7 +25,7 @@
     },
     "closeOnClick": {
       "type": "boolean",
-      "default": "true",
+      "default": "false",
       "description": "Whether to close the menu when the item is clicked."
     },
     "disabled": {

--- a/docs/reference/generated/menu-radio-item.json
+++ b/docs/reference/generated/menu-radio-item.json
@@ -17,7 +17,7 @@
     },
     "closeOnClick": {
       "type": "boolean",
-      "default": "true",
+      "default": "false",
       "description": "Whether to close the menu when the item is clicked."
     },
     "disabled": {

--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
@@ -21,7 +21,7 @@ const InnerMenuCheckboxItem = React.forwardRef(function InnerMenuItem(
     defaultChecked,
     onCheckedChange,
     className,
-    closeOnClick = false,
+    closeOnClick,
     disabled = false,
     highlighted,
     id,
@@ -96,10 +96,8 @@ InnerMenuCheckboxItem.propTypes /* remove-proptypes */ = {
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   /**
    * Whether to close the menu when the item is clicked.
-   *
-   * @default true
    */
-  closeOnClick: PropTypes.bool,
+  closeOnClick: PropTypes.bool.isRequired,
   /**
    * Whether the checkbox item is initially ticked.
    *
@@ -171,7 +169,7 @@ const MenuCheckboxItem = React.forwardRef(function MenuCheckboxItem(
   props: MenuCheckboxItem.Props,
   forwardedRef: React.ForwardedRef<Element>,
 ) {
-  const { id: idProp, label, ...other } = props;
+  const { id: idProp, label, closeOnClick = false, ...other } = props;
 
   const itemRef = React.useRef<HTMLElement>(null);
   const listItem = useCompositeListItem({ label });
@@ -197,6 +195,7 @@ const MenuCheckboxItem = React.forwardRef(function MenuCheckboxItem(
       propGetter={getItemProps}
       allowMouseUpTriggerRef={allowMouseUpTriggerRef}
       typingRef={typingRef}
+      closeOnClick={closeOnClick}
     />
   );
 });
@@ -207,6 +206,7 @@ interface InnerMenuCheckboxItemProps extends MenuCheckboxItem.Props {
   menuEvents: FloatingEvents;
   allowMouseUpTriggerRef: React.RefObject<boolean>;
   typingRef: React.RefObject<boolean>;
+  closeOnClick: boolean;
 }
 
 namespace MenuCheckboxItem {
@@ -260,8 +260,7 @@ namespace MenuCheckboxItem {
     id?: string;
     /**
      * Whether to close the menu when the item is clicked.
-     *
-     * @default true
+     * @default false
      */
     closeOnClick?: boolean;
   }
@@ -284,8 +283,7 @@ MenuCheckboxItem.propTypes /* remove-proptypes */ = {
   children: PropTypes.node,
   /**
    * Whether to close the menu when the item is clicked.
-   *
-   * @default true
+   * @default false
    */
   closeOnClick: PropTypes.bool,
   /**

--- a/packages/react/src/menu/radio-item/MenuRadioItem.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.tsx
@@ -21,7 +21,7 @@ const InnerMenuRadioItem = React.forwardRef(function InnerMenuItem(
     checked,
     setChecked,
     className,
-    closeOnClick = false,
+    closeOnClick,
     disabled = false,
     highlighted,
     id,
@@ -93,10 +93,8 @@ InnerMenuRadioItem.propTypes /* remove-proptypes */ = {
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   /**
    * Whether to close the menu when the item is clicked.
-   *
-   * @default true
    */
-  closeOnClick: PropTypes.bool,
+  closeOnClick: PropTypes.bool.isRequired,
   /**
    * Whether the component should ignore user interaction.
    * @default false
@@ -161,7 +159,7 @@ const MenuRadioItem = React.forwardRef(function MenuRadioItem(
   props: MenuRadioItem.Props,
   forwardedRef: React.ForwardedRef<Element>,
 ) {
-  const { id: idProp, value, label, disabled = false, ...other } = props;
+  const { id: idProp, value, label, disabled = false, closeOnClick = false, ...other } = props;
 
   const itemRef = React.useRef<HTMLElement>(null);
   const listItem = useCompositeListItem({ label });
@@ -206,6 +204,7 @@ const MenuRadioItem = React.forwardRef(function MenuRadioItem(
         checked={selectedValue === value}
         setChecked={setChecked}
         typingRef={typingRef}
+        closeOnClick={closeOnClick}
       />
     </MenuRadioItemContext.Provider>
   );
@@ -219,6 +218,7 @@ interface InnerMenuRadioItemProps extends Omit<MenuRadioItem.Props, 'value'> {
   checked: boolean;
   setChecked: (event: Event) => void;
   typingRef: React.RefObject<boolean>;
+  closeOnClick: boolean;
 }
 
 namespace MenuRadioItem {
@@ -260,8 +260,7 @@ namespace MenuRadioItem {
     id?: string;
     /**
      * Whether to close the menu when the item is clicked.
-     *
-     * @default true
+     * @default false
      */
     closeOnClick?: boolean;
   }
@@ -278,8 +277,7 @@ MenuRadioItem.propTypes /* remove-proptypes */ = {
   children: PropTypes.node,
   /**
    * Whether to close the menu when the item is clicked.
-   *
-   * @default true
+   * @default false
    */
   closeOnClick: PropTypes.bool,
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Docs were not truthful as `closeOnClick` was defined in the `InnerMenuItem` as `false`, which defined the default and the linter didn't catch it was incorrect.

Closes #1122
