### PR TITLE
[use-scroll-lock] Fix iOS html overflow

### DIFF
--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -9,7 +9,9 @@ let restore: () => void = () => {};
 
 function preventScrollIOS(referenceElement?: Element | null) {
   const doc = ownerDocument(referenceElement);
+  const html = doc.documentElement;
   const body = doc.body;
+  const htmlStyle = html.style;
   const bodyStyle = body.style;
 
   // iOS 12 does not support `visualViewport`.
@@ -17,6 +19,11 @@ function preventScrollIOS(referenceElement?: Element | null) {
   const offsetTop = window.visualViewport?.offsetTop || 0;
   const scrollX = bodyStyle.left ? parseFloat(bodyStyle.left) : window.scrollX;
   const scrollY = bodyStyle.top ? parseFloat(bodyStyle.top) : window.scrollY;
+
+  originalHtmlStyles = {
+    overflowX: htmlStyle.overflowX,
+    overflowY: htmlStyle.overflowY,
+  };
 
   originalBodyStyles = {
     position: bodyStyle.position,
@@ -27,6 +34,10 @@ function preventScrollIOS(referenceElement?: Element | null) {
     overflowY: bodyStyle.overflowY,
   };
 
+  Object.assign(htmlStyle, {
+    overflow: 'visible',
+  });
+
   Object.assign(bodyStyle, {
     position: 'fixed',
     top: `${-(scrollY - Math.floor(offsetTop))}px`,
@@ -36,6 +47,7 @@ function preventScrollIOS(referenceElement?: Element | null) {
   });
 
   return () => {
+    Object.assign(htmlStyle, originalHtmlStyles);
     Object.assign(bodyStyle, originalBodyStyles);
     window.scrollTo({ left: scrollX, top: scrollY, behavior: 'instant' });
   };


### PR DESCRIPTION
Docs scroll locking on iOS has been bugged since I added the following style to maintain a stable gutter for hard scrollbars in [#1096](https://github.com/mui/base-ui/pull/1096):
```
html {
  overflow-y: scroll
}
```

(I don't want to use `scrollbar-gutter` because it is not supported in Safari and renders page background instead of an empty scrollbar, which looks weird with our design)

on iOS this causes two things:
- Scrolling up while scroll is locked makes the html element catch the scroll
- If you start scrolling down after that, you are scrolling the contents behind the dialog