### PR TITLE
[core] Remove unused clsx dependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,7 +79,6 @@
     "@babel/runtime": "^7.26.0",
     "@floating-ui/react": "^0.27.2",
     "@floating-ui/utils": "^0.2.8",
-    "clsx": "^2.1.1",
     "prop-types": "^15.8.1",
     "use-sync-external-store": "^1.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,9 +630,6 @@ importers:
       '@floating-ui/utils':
         specifier: ^0.2.8
         version: 0.2.8
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1


### PR DESCRIPTION
We don't merge classes with clsx in the library.