### PR TITLE
[menu] Handle Enter keypress the same as click

### DIFF
--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.test.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.test.tsx
@@ -210,17 +210,17 @@ describe('<Menu.CheckboxItem />', () => {
       expect(item).to.have.attribute('data-unchecked', '');
     });
 
-    it(`toggles the checked state and closes the menu when Enter is pressed`, async function test(t = {}) {
+    it(`toggles the checked state when Enter is pressed`, async function test(t = {}) {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // @ts-expect-error to support mocha and vitest
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         this?.skip?.() || t?.skip();
       }
 
-      const { getByRole, queryByRole } = await render(
+      const { getByRole } = await render(
         <Menu.Root>
           <Menu.Trigger>Open</Menu.Trigger>
-          <Menu.Positioner keepMounted>
+          <Menu.Positioner>
             <Menu.Popup>
               <Menu.CheckboxItem>Item</Menu.CheckboxItem>
             </Menu.Popup>
@@ -241,9 +241,6 @@ describe('<Menu.CheckboxItem />', () => {
       });
 
       await user.keyboard(`[Enter]`);
-
-      expect(queryByRole('menu', { hidden: false })).to.equal(null);
-      await user.click(trigger);
       expect(item).to.have.attribute('data-checked', '');
     });
 

--- a/packages/react/src/menu/item/useMenuItem.ts
+++ b/packages/react/src/menu/item/useMenuItem.ts
@@ -40,13 +40,6 @@ export function useMenuItem(params: useMenuItem.Parameters): useMenuItem.ReturnV
             }
           },
           onClick: (event: React.MouseEvent | React.KeyboardEvent) => {
-            if (event.type === 'keydown') {
-              if ((event as React.KeyboardEvent).key === 'Enter') {
-                menuEvents.emit('close', event);
-                return;
-              }
-            }
-
             if (closeOnClick) {
               menuEvents.emit('close', event);
             }


### PR DESCRIPTION
Previously, selecting a menu item with Enter would close the menu regardless of `closeOnClick` setting. Now it behaves just like clicking.
