### PR TITLE
[Dialog, AlertDialog] Add the `nested` style hook

### DIFF
--- a/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
+++ b/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
@@ -25,7 +25,7 @@ const AlertDialogBackdrop = React.forwardRef(function AlertDialogBackdrop(
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { render, className, keepMounted = false, ...other } = props;
-  const { open, hasParentDialog, mounted, transitionStatus } = useAlertDialogRootContext();
+  const { open, nested, mounted, transitionStatus } = useAlertDialogRootContext();
 
   const state: AlertDialogBackdrop.State = React.useMemo(
     () => ({
@@ -45,7 +45,7 @@ const AlertDialogBackdrop = React.forwardRef(function AlertDialogBackdrop(
   });
 
   // no need to render nested backdrops
-  const shouldRender = (keepMounted || mounted) && !hasParentDialog;
+  const shouldRender = (keepMounted || mounted) && !nested;
   if (!shouldRender) {
     return null;
   }

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.test.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, waitFor } from '@mui/internal-test-utils';
+import { act, waitFor, screen } from '@mui/internal-test-utils';
 import { AlertDialog } from '@base-ui-components/react/alert-dialog';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -191,6 +191,29 @@ describe('<AlertDialog.Popup />', () => {
       await waitFor(() => {
         expect(inputToFocus).toHaveFocus();
       });
+    });
+  });
+
+  describe('style hooks', () => {
+    it('adds the `nested` style hook if a dialog has a parent dialog', async () => {
+      await render(
+        <AlertDialog.Root open>
+          <AlertDialog.Portal>
+            <AlertDialog.Popup data-testid="parent-dialog" />
+            <AlertDialog.Root open>
+              <AlertDialog.Portal>
+                <AlertDialog.Popup data-testid="nested-dialog" />
+              </AlertDialog.Portal>
+            </AlertDialog.Root>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>,
+      );
+
+      const parentDialog = screen.getByTestId('parent-dialog');
+      const nestedDialog = screen.getByTestId('nested-dialog');
+
+      expect(parentDialog).not.to.have.attribute('data-nested');
+      expect(nestedDialog).to.have.attribute('data-nested');
     });
   });
 });

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -17,7 +17,6 @@ import { transitionStatusMapping } from '../../utils/styleHookMapping';
 const customStyleHookMapping: CustomStyleHookMapping<AlertDialogPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
-  nestedOpenDialogCount: (value) => ({ 'data-nested-dialogs': value.toString() }),
 };
 
 /**
@@ -37,6 +36,7 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
     floatingRootContext,
     getPopupProps,
     mounted,
+    nested,
     nestedOpenDialogCount,
     setOpen,
     open,
@@ -70,10 +70,10 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
   const state: AlertDialogPopup.State = React.useMemo(
     () => ({
       open,
-      nestedOpenDialogCount,
+      nested,
       transitionStatus,
     }),
-    [open, nestedOpenDialogCount, transitionStatus],
+    [open, nested, transitionStatus],
   );
 
   const { renderElement } = useComponentRenderer({
@@ -133,8 +133,11 @@ namespace AlertDialogPopup {
      * Whether the dialog is currently open.
      */
     open: boolean;
-    nestedOpenDialogCount: number;
     transitionStatus: TransitionStatus;
+    /**
+     * Whether the dialog is nested within a parent dialog.
+     */
+    nested: boolean;
   }
 }
 

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.tsx
@@ -27,11 +27,11 @@ const AlertDialogRoot: React.FC<AlertDialogRoot.Props> = function AlertDialogRoo
     onNestedDialogOpen: parentDialogRootContext?.onNestedDialogOpen,
   });
 
-  const hasParentDialog = Boolean(parentDialogRootContext);
+  const nested = Boolean(parentDialogRootContext);
 
-  const contextValue = React.useMemo(
-    () => ({ ...dialogRoot, hasParentDialog }),
-    [dialogRoot, hasParentDialog],
+  const contextValue: AlertDialogRootContext = React.useMemo(
+    () => ({ ...dialogRoot, nested }),
+    [dialogRoot, nested],
   );
 
   return (

--- a/packages/react/src/alert-dialog/root/AlertDialogRootContext.ts
+++ b/packages/react/src/alert-dialog/root/AlertDialogRootContext.ts
@@ -6,7 +6,7 @@ export interface AlertDialogRootContext extends useDialogRoot.ReturnValue {
   /**
    * Determines if the dialog is nested within a parent dialog.
    */
-  hasParentDialog: boolean;
+  nested: boolean;
 }
 
 export const AlertDialogRootContext = React.createContext<AlertDialogRootContext | undefined>(

--- a/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
+++ b/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
@@ -25,7 +25,7 @@ const DialogBackdrop = React.forwardRef(function DialogBackdrop(
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { render, className, keepMounted = false, ...other } = props;
-  const { open, hasParentDialog, mounted, transitionStatus } = useDialogRootContext();
+  const { open, nested, mounted, transitionStatus } = useDialogRootContext();
 
   const state: DialogBackdrop.State = React.useMemo(
     () => ({
@@ -45,7 +45,7 @@ const DialogBackdrop = React.forwardRef(function DialogBackdrop(
   });
 
   // no need to render nested backdrops
-  const shouldRender = (keepMounted || mounted) && !hasParentDialog;
+  const shouldRender = (keepMounted || mounted) && !nested;
   if (!shouldRender) {
     return null;
   }

--- a/packages/react/src/dialog/popup/DialogPopup.test.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { Dialog } from '@base-ui-components/react/dialog';
-import { act, waitFor } from '@mui/internal-test-utils';
+import { act, waitFor, screen } from '@mui/internal-test-utils';
 import { describeConformance, createRenderer } from '#test-utils';
 
 describe('<Dialog.Popup />', () => {
@@ -199,6 +199,29 @@ describe('<Dialog.Popup />', () => {
       await waitFor(() => {
         expect(inputToFocus).toHaveFocus();
       });
+    });
+  });
+
+  describe('style hooks', () => {
+    it('adds the `nested` style hook if a dialog has a parent dialog', async () => {
+      await render(
+        <Dialog.Root open>
+          <Dialog.Portal>
+            <Dialog.Popup data-testid="parent-dialog" />
+            <Dialog.Root open>
+              <Dialog.Portal>
+                <Dialog.Popup data-testid="nested-dialog" />
+              </Dialog.Portal>
+            </Dialog.Root>
+          </Dialog.Portal>
+        </Dialog.Root>,
+      );
+
+      const parentDialog = screen.getByTestId('parent-dialog');
+      const nestedDialog = screen.getByTestId('nested-dialog');
+
+      expect(parentDialog).not.to.have.attribute('data-nested');
+      expect(nestedDialog).to.have.attribute('data-nested');
     });
   });
 });

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -18,7 +18,6 @@ import { DialogPopupCssVars } from './DialogPopupCssVars';
 const customStyleHookMapping: CustomStyleHookMapping<DialogPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
-  nestedOpenDialogCount: (value) => ({ 'data-nested-dialogs': value.toString() }),
 };
 
 /**
@@ -40,6 +39,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
     getPopupProps,
     modal,
     mounted,
+    nested,
     nestedOpenDialogCount,
     setOpen,
     open,
@@ -72,7 +72,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
 
   const state: DialogPopup.State = {
     open,
-    nestedOpenDialogCount,
+    nested,
     transitionStatus,
   };
 
@@ -133,8 +133,11 @@ namespace DialogPopup {
      * Whether the dialog is currently open.
      */
     open: boolean;
-    nestedOpenDialogCount: number;
     transitionStatus: TransitionStatus;
+    /**
+     * Whether the dialog is nested within a parent dialog.
+     */
+    nested: boolean;
   }
 }
 

--- a/packages/react/src/dialog/root/DialogRoot.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.tsx
@@ -33,11 +33,11 @@ const DialogRoot = function DialogRoot(props: DialogRoot.Props) {
     onNestedDialogOpen: parentDialogRootContext?.onNestedDialogOpen,
   });
 
-  const hasParentDialog = Boolean(parentDialogRootContext);
+  const nested = Boolean(parentDialogRootContext);
 
   const contextValue = React.useMemo(
-    () => ({ ...dialogRoot, hasParentDialog, dismissible }),
-    [dialogRoot, hasParentDialog, dismissible],
+    () => ({ ...dialogRoot, nested, dismissible }),
+    [dialogRoot, nested, dismissible],
   );
 
   return (

--- a/packages/react/src/dialog/root/DialogRootContext.ts
+++ b/packages/react/src/dialog/root/DialogRootContext.ts
@@ -6,12 +6,11 @@ export interface DialogRootContext extends useDialogRoot.ReturnValue {
   /**
    * Determines if the dialog is nested within a parent dialog.
    */
-  hasParentDialog: boolean;
+  nested: boolean;
   /**
    * Determines whether the dialog should close on outside clicks.
-   * @default true
    */
-  dismissible?: boolean;
+  dismissible: boolean;
 }
 
 export const DialogRootContext = React.createContext<DialogRootContext | undefined>(undefined);


### PR DESCRIPTION
Added the `data-nested` style hook and removed `data-nested-dialogs` from Dialog.Popup and AlertDialog.Popup.