### PR TITLE
[docs] Release header improvement

### DIFF
--- a/docs/src/app/(public)/(content)/react/overview/releases/page.mdx
+++ b/docs/src/app/(public)/(content)/react/overview/releases/page.mdx
@@ -3,6 +3,8 @@
 <Subtitle>Changelogs for each Base UI release.</Subtitle>
 <Meta name="description" content="Changelogs for each Base UI release." />
 
-## December 17, 2024
+## 1.0.0-alpha.4
+
+**December 17, 2024**
 
 Public alpha launch 🐣 Merry Xmas! 🎁


### PR DESCRIPTION
Having the versions in the table of content is much better for searchability than the dates. I moved the date after the header. 