### PR TITLE
[Dialog, AlertDialog] Add the `data-has-nested-dialogs` hook

### DIFF
--- a/docs/reference/generated/alert-dialog-popup.json
+++ b/docs/reference/generated/alert-dialog-popup.json
@@ -31,9 +31,11 @@
     "data-closed": {
       "description": "Present when the dialog is closed."
     },
-    "data-nested-dialogs": {
-      "description": "Indicates how many dialogs are nested within.",
-      "type": "number"
+    "data-has-nested-dialogs": {
+      "description": "Present when the dialog has other open dialogs nested within it."
+    },
+    "data-nested": {
+      "description": "Present when the dialog is nested within another dialog."
     },
     "data-starting-style": {
       "description": "Present when the dialog is animating in."

--- a/docs/reference/generated/dialog-popup.json
+++ b/docs/reference/generated/dialog-popup.json
@@ -31,9 +31,11 @@
     "data-closed": {
       "description": "Present when the dialog is closed."
     },
-    "data-nested-dialogs": {
-      "description": "Indicates how many dialogs are nested within.",
-      "type": "number"
+    "data-has-nested-dialogs": {
+      "description": "Present when the dialog has other open dialogs nested within it."
+    },
+    "data-nested": {
+      "description": "Present when the dialog is nested within another dialog."
     },
     "data-starting-style": {
       "description": "Present when the dialog is animating in."

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.test.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.test.tsx
@@ -195,14 +195,20 @@ describe('<AlertDialog.Popup />', () => {
   });
 
   describe('style hooks', () => {
-    it('adds the `nested` style hook if a dialog has a parent dialog', async () => {
+    it('adds the `nested` and `has-nested-dialogs` style hooks if a dialog has a parent dialog', async () => {
       await render(
         <AlertDialog.Root open>
           <AlertDialog.Portal>
             <AlertDialog.Popup data-testid="parent-dialog" />
             <AlertDialog.Root open>
               <AlertDialog.Portal>
-                <AlertDialog.Popup data-testid="nested-dialog" />
+                <AlertDialog.Popup data-testid="nested-dialog">
+                  <AlertDialog.Root>
+                    <AlertDialog.Portal>
+                      <AlertDialog.Popup />
+                    </AlertDialog.Portal>
+                  </AlertDialog.Root>
+                </AlertDialog.Popup>
               </AlertDialog.Portal>
             </AlertDialog.Root>
           </AlertDialog.Portal>
@@ -214,6 +220,9 @@ describe('<AlertDialog.Popup />', () => {
 
       expect(parentDialog).not.to.have.attribute('data-nested');
       expect(nestedDialog).to.have.attribute('data-nested');
+
+      expect(parentDialog).to.have.attribute('data-has-nested-dialogs');
+      expect(nestedDialog).not.to.have.attribute('data-has-nested-dialogs');
     });
   });
 });

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -17,6 +17,9 @@ import { transitionStatusMapping } from '../../utils/styleHookMapping';
 const customStyleHookMapping: CustomStyleHookMapping<AlertDialogPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
+  hasNestedDialogs(value) {
+    return value ? { 'data-has-nested-dialogs': '' } : null;
+  },
 };
 
 /**
@@ -67,13 +70,16 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
     titleElementId,
   });
 
+  const hasNestedDialogs = nestedOpenDialogCount > 0;
+
   const state: AlertDialogPopup.State = React.useMemo(
     () => ({
       open,
       nested,
       transitionStatus,
+      hasNestedDialogs,
     }),
-    [open, nested, transitionStatus],
+    [open, nested, transitionStatus, hasNestedDialogs],
   );
 
   const { renderElement } = useComponentRenderer({
@@ -138,6 +144,10 @@ namespace AlertDialogPopup {
      * Whether the dialog is nested within a parent dialog.
      */
     nested: boolean;
+    /**
+     * Whether the dialog has nested dialogs open.
+     */
+    hasNestedDialogs: boolean;
   }
 }
 

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -13,12 +13,13 @@ import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping'
 import { useForkRef } from '../../utils/useForkRef';
 import { InteractionType } from '../../utils/useEnhancedClickHandler';
 import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { AlertDialogPopupDataAttributes } from './AlertDialogPopupDataAttributes';
 
 const customStyleHookMapping: CustomStyleHookMapping<AlertDialogPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
   hasNestedDialogs(value) {
-    return value ? { 'data-has-nested-dialogs': '' } : null;
+    return value ? { [AlertDialogPopupDataAttributes.hasNestedDialogs]: '' } : null;
   },
 };
 

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopupDataAttributes.ts
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopupDataAttributes.ts
@@ -16,8 +16,11 @@ export enum AlertDialogPopupDataAttributes {
    */
   endingStyle = 'data-ending-style',
   /**
-   * Indicates how many dialogs are nested within.
-   * @type {number}
+   * Present when the dialog is nested within another dialog.
    */
-  nestedDialogs = 'data-nested-dialogs',
+  nested = 'data-nested',
+  /**
+   * Present when the dialog has other open dialogs nested within it.
+   */
+  hasNestedDialogs = 'data-has-nested-dialogs',
 }

--- a/packages/react/src/dialog/popup/DialogPopup.test.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.test.tsx
@@ -203,14 +203,20 @@ describe('<Dialog.Popup />', () => {
   });
 
   describe('style hooks', () => {
-    it('adds the `nested` style hook if a dialog has a parent dialog', async () => {
+    it('adds the `nested` and `has-nested-dialogs` style hooks if a dialog has a parent dialog', async () => {
       await render(
         <Dialog.Root open>
           <Dialog.Portal>
             <Dialog.Popup data-testid="parent-dialog" />
             <Dialog.Root open>
               <Dialog.Portal>
-                <Dialog.Popup data-testid="nested-dialog" />
+                <Dialog.Popup data-testid="nested-dialog">
+                  <Dialog.Root>
+                    <Dialog.Portal>
+                      <Dialog.Popup />
+                    </Dialog.Portal>
+                  </Dialog.Root>
+                </Dialog.Popup>
               </Dialog.Portal>
             </Dialog.Root>
           </Dialog.Portal>
@@ -222,6 +228,9 @@ describe('<Dialog.Popup />', () => {
 
       expect(parentDialog).not.to.have.attribute('data-nested');
       expect(nestedDialog).to.have.attribute('data-nested');
+
+      expect(parentDialog).to.have.attribute('data-has-nested-dialogs');
+      expect(nestedDialog).not.to.have.attribute('data-has-nested-dialogs');
     });
   });
 });

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -18,6 +18,9 @@ import { DialogPopupCssVars } from './DialogPopupCssVars';
 const customStyleHookMapping: CustomStyleHookMapping<DialogPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
+  hasNestedDialogs(value) {
+    return value ? { 'data-has-nested-dialogs': '' } : null;
+  },
 };
 
 /**
@@ -74,6 +77,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
     open,
     nested,
     transitionStatus,
+    hasNestedDialogs: nestedOpenDialogCount > 0,
   };
 
   const { renderElement } = useComponentRenderer({
@@ -138,6 +142,10 @@ namespace DialogPopup {
      * Whether the dialog is nested within a parent dialog.
      */
     nested: boolean;
+    /**
+     * Whether the dialog has nested dialogs open.
+     */
+    hasNestedDialogs: boolean;
   }
 }
 

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -14,12 +14,13 @@ import { useForkRef } from '../../utils/useForkRef';
 import { InteractionType } from '../../utils/useEnhancedClickHandler';
 import { transitionStatusMapping } from '../../utils/styleHookMapping';
 import { DialogPopupCssVars } from './DialogPopupCssVars';
+import { DialogPopupDataAttributes } from './DialogPopupDataAttributes';
 
 const customStyleHookMapping: CustomStyleHookMapping<DialogPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
   hasNestedDialogs(value) {
-    return value ? { 'data-has-nested-dialogs': '' } : null;
+    return value ? { [DialogPopupDataAttributes.hasNestedDialogs]: '' } : null;
   },
 };
 

--- a/packages/react/src/dialog/popup/DialogPopupDataAttributes.ts
+++ b/packages/react/src/dialog/popup/DialogPopupDataAttributes.ts
@@ -16,8 +16,11 @@ export enum DialogPopupDataAttributes {
    */
   endingStyle = 'data-ending-style',
   /**
-   * Indicates how many dialogs are nested within.
-   * @type {number}
+   * Present when the dialog is nested within another dialog.
    */
-  nestedDialogs = 'data-nested-dialogs',
+  nested = 'data-nested',
+  /**
+   * Present when the dialog has other open dialogs nested within it.
+   */
+  hasNestedDialogs = 'data-has-nested-dialogs',
 }


### PR DESCRIPTION
Adds the style hook when the Dialog/AlertDialog has open subdialogs (of the same type)
