### PR TITLE
[docs] Add security coverage

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ The versions of the project that are currently supported with security updates.
 
 | Base UI version | Release    | Supported          |
 | --------------: | :--------- | :----------------- |
-|         <1.0.0 | 2024-12-17 | :white_check_mark: |
+|          <1.0.0 | 2024-12-17 | :white_check_mark: |
 
 ## Reporting a vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ The versions of the project that are currently supported with security updates.
 
 | Base UI version | Release    | Supported          |
 | --------------: | :--------- | :----------------- |
-|         <=1.0.0 | 2024-12-17 | :white_check_mark: |
+|         <1.0.0 | 2024-12-17 | :white_check_mark: |
 
 ## Reporting a vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security policy
+
+## Supported versions
+
+The versions of the project that are currently supported with security updates.
+
+| Base UI version | Release    | Supported          |
+| --------------: | :--------- | :----------------- |
+|         <=1.0.0 | 2024-12-17 | :white_check_mark: |
+
+## Reporting a vulnerability
+
+You can report a vulnerability by contacting us via email at [security@mui.com](mailto:security@mui.com).


### PR DESCRIPTION
Today, https://github.com/mui/base-ui/security/policy has the content of https://github.com/mui/.github/blob/master/SECURITY.md. It seems that it would be better to add something custom.
