### PR TITLE
[core] Remove tsbuildinfo from the built package

### DIFF
--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -1,0 +1,1 @@
+*.tsbuildinfo

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -66,7 +66,7 @@
     "build": "pnpm build:node && pnpm build:stable && pnpm build:types && pnpm build:copy-files && pnpm build:manifest",
     "build:node": "node ../../scripts/build.mjs node",
     "build:stable": "node ../../scripts/build.mjs stable",
-    "build:copy-files": "node ../../scripts/copyFiles.mjs",
+    "build:copy-files": "node ../../scripts/copyFiles.mjs ./.npmignore:./.npmignore",
     "build:types": "tsx ../../scripts/buildTypes.mjs --project tsconfig.build.json --copy build/cjs",
     "build:manifest": "tsx ./scripts/createPackageManifest.mts",
     "test:package": "publint ./build && attw --pack ./build",


### PR DESCRIPTION
Exclude the *.tsbuildinfo files from the published package. These files are meant to be used internally to speed up typechecking and have no use in distributed packages, increasing their weight unnecessarily.