### PR TITLE
[docs] Nested dialogs nit

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.tsx
@@ -25,7 +25,7 @@ export default function ExampleDialog() {
                       Customize notifications
                     </Dialog.Title>
                     <Dialog.Description className={styles.Description}>
-                      You can customize your notifications here.
+                      Review your settings here.
                     </Dialog.Description>
                     <div className={styles.Actions}>
                       <Dialog.Close className={styles.Button}>Close</Dialog.Close>

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/tailwind/index.tsx
@@ -28,7 +28,7 @@ export default function ExampleDialog() {
                       Customize notification
                     </Dialog.Title>
                     <Dialog.Description className="mb-6 text-base text-gray-600">
-                      You can customize your notifications here.
+                      Review your settings here.
                     </Dialog.Description>
                     <div className="flex items-center justify-end gap-4">
                       <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">


### PR DESCRIPTION
Can't see the nesting on a small screen because the child dialog is taller due to a line break

![BE499971-CBB4-4540-BAAE-3E92D2A49AEE_1_102_o](https://github.com/user-attachments/assets/d0651ffd-f8cc-459b-94d7-0e8d4554a698)
