### PR TITLE
[docs] Fix composition render prop example for internalState naming

### DIFF
--- a/docs/data/getting-started/usage/usage.mdx
+++ b/docs/data/getting-started/usage/usage.mdx
@@ -31,8 +31,8 @@ Using a function gives you complete control over spreading props and allows you 
 
 ```jsx
 <Switch.Thumb
-  render={(props, internalState) => (
-    <span {...props}>{internalState.checked ? <CheckedIcon /> : <UncheckedIcon />}</span>
+  render={(props, state) => (
+    <span {...props}>{state.checked ? <CheckedIcon /> : <UncheckedIcon />}</span>
   )}
 />
 ```

--- a/docs/src/app/(public)/(content)/react/handbook/composition/page.mdx
+++ b/docs/src/app/(public)/(content)/react/handbook/composition/page.mdx
@@ -77,8 +77,8 @@ If you are working in an extremely performance-sensitive application, you might 
 
 ```tsx title="switch.tsx"
 <Switch.Thumb
-  render={(props, internalState) => (
-    <span {...props}>{internalState.checked ? <CheckedIcon /> : <UncheckedIcon />}</span>
+  render={(props, state) => (
+    <span {...props}>{state.checked ? <CheckedIcon /> : <UncheckedIcon />}</span>
   )}
 />
 ```

--- a/docs/src/app/(public)/(content)/react/handbook/composition/page.mdx
+++ b/docs/src/app/(public)/(content)/react/handbook/composition/page.mdx
@@ -77,7 +77,7 @@ If you are working in an extremely performance-sensitive application, you might 
 
 ```tsx title="switch.tsx"
 <Switch.Thumb
-  render={(props, state) => (
+  render={(props, internalState) => (
     <span {...props}>{internalState.checked ? <CheckedIcon /> : <UncheckedIcon />}</span>
   )}
 />


### PR DESCRIPTION
Fixes render prop example to match variable and naming from other examples.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
