### PR TITLE
[menu] Do not close the menu when touching the subtrigger on iOS

### DIFF
--- a/packages/react/src/menu/item/useMenuItem.ts
+++ b/packages/react/src/menu/item/useMenuItem.ts
@@ -44,8 +44,12 @@ export function useMenuItem(params: useMenuItem.Parameters): useMenuItem.ReturnV
               menuEvents.emit('close', event);
             }
           },
-          onMouseUp: (event: React.MouseEvent) => {
-            if (itemRef.current && allowMouseUpTriggerRef.current) {
+          onPointerUp: (event: React.PointerEvent) => {
+            if (
+              itemRef.current &&
+              allowMouseUpTriggerRef.current &&
+              event.pointerType !== 'touch'
+            ) {
               // This fires whenever the user clicks on the trigger, moves the cursor, and releases it over the item.
               // We trigger the click and override the `closeOnClick` preference to always close the menu.
               itemRef.current.click();


### PR DESCRIPTION
This is a quick workaround. We should look for the root cause.