### PR TITLE
[useScrollLock] New implementation

### DIFF
--- a/docs/src/app/(private)/experiments/scroll-lock.tsx
+++ b/docs/src/app/(private)/experiments/scroll-lock.tsx
@@ -20,11 +20,25 @@ export default function ScrollLock() {
       <div
         style={{
           position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100%',
+          background: 'lightgray',
+          textAlign: 'right',
+          padding: 5,
+        }}
+      >
+        Fixed content should not shift
+      </div>
+      <div
+        style={{
+          position: 'fixed',
           top: 15,
           display: 'flex',
           gap: 10,
-          background: 'white',
-          padding: 20,
+          background: 'rgba(0,0,0,0.1)',
+          backdropFilter: 'blur(20px)',
+          padding: 10,
         }}
       >
         <div>

--- a/docs/src/components/CodeBlock.css
+++ b/docs/src/components/CodeBlock.css
@@ -30,11 +30,6 @@
       display: none;
     }
 
-    /* iOS Safari appears to flicker the scroll containers during tasking animations */
-    [data-mobile-nav-open] & {
-      overflow: hidden;
-    }
-
     /* Scroll containers may be focusable */
     &:focus-visible {
       position: relative;
@@ -64,11 +59,6 @@
     overflow: auto;
     /* Prevent Chrome/Safari page navigation gestures when scrolling horizontally */
     overscroll-behavior-x: contain;
-
-    /* iOS Safari appears to flicker the scroll containers during tasking animations */
-    [data-mobile-nav-open] & {
-      overflow: hidden;
-    }
 
     & code {
       /* Different fonts may introduce vertical align issues */

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -16,11 +16,6 @@
     overscroll-behavior-x: contain;
     scrollbar-width: thin;
 
-    /* iOS Safari appears to flicker the scroll containers during tasking animations */
-    [data-mobile-nav-open] & {
-      overflow: hidden;
-    }
-
     /* Scroll containers may be focusable */
     &:focus-visible {
       position: relative;
@@ -71,11 +66,6 @@
     scrollbar-width: none;
     &::-webkit-scrollbar {
       display: none;
-    }
-
-    /* iOS Safari appears to flicker the scroll containers during tasking animations */
-    [data-mobile-nav-open] & {
-      overflow: hidden;
     }
 
     /* Scroll containers may be focusable */
@@ -179,11 +169,6 @@
       overflow: auto;
       /* Prevent Chrome/Safari page navigation gestures when scrolling horizontally */
       overscroll-behavior-x: contain;
-
-      /* iOS Safari appears to flicker the scroll containers during tasking animations */
-      [data-mobile-nav-open] & {
-        overflow: hidden;
-      }
 
       /* Scroll containers may be focusable */
       &:focus-visible {

--- a/docs/src/components/MobileNav.tsx
+++ b/docs/src/components/MobileNav.tsx
@@ -46,23 +46,6 @@ function PopupImpl({ children }: React.PropsWithChildren) {
     rem.current = parseFloat(getComputedStyle(document.documentElement).fontSize);
   }, []);
 
-  // iOS Safari appears to flicker the scroll containers during tasking animations
-  // As a workaround, we set an attribute on body to know when the nav is mounted
-  // and disable scroll on the problematic scroll containers in the meantime
-  const timeout = React.useRef(0);
-  React.useLayoutEffect(() => {
-    window.clearTimeout(timeout.current);
-    document.body.setAttribute('data-mobile-nav-open', '');
-    return () => {
-      window.clearTimeout(timeout.current);
-      timeout.current = window.setTimeout(() => {
-        document.body.removeAttribute('data-mobile-nav-open');
-        // Safari seems to need some arbitrary time to be done with whatever causes the flicker
-        // Using setTimeout 0, RAFs, or even double RAFs doesn't work reliably
-      }, 100);
-    };
-  }, []);
-
   return (
     <React.Fragment>
       <div className="MobileNavBottomOverscroll" />

--- a/docs/src/components/Table.css
+++ b/docs/src/components/Table.css
@@ -78,10 +78,5 @@
     &::-webkit-scrollbar {
       display: none;
     }
-
-    /* iOS Safari appears to flicker the scroll containers during tasking animations */
-    [data-mobile-nav-open] & {
-      overflow: hidden;
-    }
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,6 +79,7 @@
     "@babel/runtime": "^7.26.0",
     "@floating-ui/react": "^0.27.2",
     "@floating-ui/utils": "^0.2.8",
+    "@react-aria/overlays": "^3.24.0",
     "prop-types": "^15.8.1",
     "use-sync-external-store": "^1.4.0"
   },

--- a/packages/react/src/utils/detectBrowser.ts
+++ b/packages/react/src/utils/detectBrowser.ts
@@ -1,3 +1,5 @@
+import { getUserAgent } from '@floating-ui/react/utils';
+
 interface NavigatorUAData {
   brands: Array<{ brand: string; version: string }>;
   mobile: boolean;
@@ -28,4 +30,8 @@ export function isWebKit() {
 
 export function isIOS() {
   return /iP(hone|ad|od)|iOS/.test(getPlatform());
+}
+
+export function isFirefox() {
+  return /firefox/i.test(getUserAgent());
 }

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { usePreventScroll } from '@react-aria/overlays';
-import { isFirefox, isIOS } from './detectBrowser';
+import { isFirefox, isIOS, isWebKit } from './detectBrowser';
 import { ownerDocument, ownerWindow } from './owner';
 import { useEnhancedEffect } from './useEnhancedEffect';
 
@@ -36,6 +36,11 @@ function preventScrollStandard(referenceElement?: Element | null) {
   let scrollLeft = 0;
   let resizeRaf = -1;
 
+  // Pinch-zoom in Safari causes a shift. Just don't lock scroll if there's any pinch-zoom.
+  if (isWebKit() && (win.visualViewport?.scale ?? 1) !== 1) {
+    return () => {};
+  }
+
   function lockScroll() {
     const htmlStyles = win.getComputedStyle(html);
     const bodyStyles = win.getComputedStyle(body);
@@ -51,6 +56,7 @@ function preventScrollStandard(referenceElement?: Element | null) {
     originalBodyStyles = {
       position: body.style.position,
       height: body.style.height,
+      width: body.style.width,
       boxSizing: body.style.boxSizing,
       overflowY: body.style.overflowY,
       overflowX: body.style.overflowX,

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -1,7 +1,7 @@
+import { usePreventScroll } from '@react-aria/overlays';
 import { isIOS } from './detectBrowser';
 import { ownerDocument, ownerWindow } from './owner';
 import { useEnhancedEffect } from './useEnhancedEffect';
-import { usePreventScroll } from '@react-aria/overlays';
 
 let originalHtmlStyles = {};
 let originalBodyStyles = {};
@@ -152,6 +152,9 @@ function preventScrollStandard(referenceElement?: Element | null) {
  */
 export function useScrollLock(enabled: boolean = true, referenceElement?: Element | null) {
   usePreventScroll({
+    // react-aria will remove the scrollbar offset immediately upon close, since we use `open`,
+    // not `mounted`, to disable/enable the scroll lock. However since iOS has no fixed
+    // scrollbars, no layouting issues occur.
     isDisabled: !isIOS() || !enabled,
   });
 

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -78,7 +78,7 @@ function preventScrollStandard(referenceElement?: Element | null) {
 
     Object.assign(body.style, {
       position: 'relative',
-      height: `calc(100dvh - ${bodyVerticalMargins}px)`,
+      height: bodyVerticalMargins ? `calc(100dvh - ${bodyVerticalMargins}px)` : '100dvh',
       boxSizing: 'border-box',
       overflow: 'hidden',
     });

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -111,7 +111,14 @@ function preventScrollStandard(referenceElement?: Element | null) {
     const bodyVerticalMargins =
       parseFloat(bodyStyles.marginTop) + parseFloat(bodyStyles.marginBottom);
 
-    const heightProperty = CSS.supports('height', '1dvh') ? 'dvh' : 'vh';
+    let heightProperty = 'vh';
+    if (
+      typeof CSS !== 'undefined' &&
+      typeof CSS.supports === 'function' &&
+      CSS.supports('height', '1dvh')
+    ) {
+      heightProperty = 'dvh';
+    }
 
     Object.assign(body.style, {
       position: 'relative',

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -72,8 +72,9 @@ function preventScrollStandard(referenceElement?: Element | null) {
     const hasConstantOverflowX =
       htmlStyles.overflowX === 'scroll' || bodyStyles.overflowX === 'scroll';
 
-    const scrollbarWidth = win.innerWidth - html.clientWidth;
-    const scrollbarHeight = win.innerHeight - html.clientHeight;
+    // Values can be negative in Firefox
+    const scrollbarWidth = Math.max(0, win.innerWidth - html.clientWidth);
+    const scrollbarHeight = Math.max(0, win.innerHeight - html.clientHeight);
 
     Object.assign(html.style, {
       overflowY:

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -1,6 +1,7 @@
 import { isIOS } from './detectBrowser';
 import { ownerDocument, ownerWindow } from './owner';
 import { useEnhancedEffect } from './useEnhancedEffect';
+import { usePreventScroll } from '@react-aria/overlays';
 
 let originalHtmlStyles = {};
 let originalBodyStyles = {};
@@ -150,16 +151,18 @@ function preventScrollStandard(referenceElement?: Element | null) {
  * @param enabled - Whether to enable the scroll lock.
  */
 export function useScrollLock(enabled: boolean = true, referenceElement?: Element | null) {
+  usePreventScroll({
+    isDisabled: !isIOS() || !enabled,
+  });
+
   useEnhancedEffect(() => {
-    if (!enabled) {
+    if (!enabled || isIOS()) {
       return undefined;
     }
 
     preventScrollCount += 1;
     if (preventScrollCount === 1) {
-      restore = isIOS()
-        ? preventScrollIOS(referenceElement)
-        : preventScrollStandard(referenceElement);
+      restore = preventScrollStandard(referenceElement);
     }
 
     return () => {

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -9,20 +9,19 @@ let originalBodyStyles = {};
 let preventScrollCount = 0;
 let restore: () => void = () => {};
 
-function hasInsetScrollbars(referenceElement?: Element | null) {
-  if (typeof document === 'undefined') {
-    return false;
-  }
-  const doc = ownerDocument(referenceElement);
-  const win = ownerWindow(doc);
-  return win.innerWidth - doc.documentElement.clientWidth > 0;
+function supportsDvh() {
+  return (
+    typeof CSS !== 'undefined' &&
+    typeof CSS.supports === 'function' &&
+    CSS.supports('height', '1dvh')
+  );
 }
 
 function preventScrollStandard(referenceElement?: Element | null) {
   const doc = ownerDocument(referenceElement);
   const html = doc.documentElement;
   const body = doc.body;
-  const win = ownerWindow(doc);
+  const win = ownerWindow(html);
 
   let scrollTop: number = 0;
   let resizeRaf = -1;
@@ -68,18 +67,9 @@ function preventScrollStandard(referenceElement?: Element | null) {
     const bodyVerticalMargins =
       parseFloat(bodyStyles.marginTop) + parseFloat(bodyStyles.marginBottom);
 
-    let heightProperty = 'vh';
-    if (
-      typeof CSS !== 'undefined' &&
-      typeof CSS.supports === 'function' &&
-      CSS.supports('height', '1dvh')
-    ) {
-      heightProperty = 'dvh';
-    }
-
     Object.assign(body.style, {
       position: 'relative',
-      height: `calc(100${heightProperty} - ${bodyVerticalMargins}px)`,
+      height: `calc(100dvh - ${bodyVerticalMargins}px)`,
       boxSizing: 'border-box',
       overflow: 'hidden',
     });
@@ -117,10 +107,7 @@ function preventScrollStandard(referenceElement?: Element | null) {
  * @param enabled - Whether to enable the scroll lock.
  */
 export function useScrollLock(enabled: boolean = true, referenceElement?: Element | null) {
-  const isReactAriaHook = React.useMemo(
-    () => isIOS() || !hasInsetScrollbars(referenceElement),
-    [referenceElement],
-  );
+  const isReactAriaHook = React.useMemo(() => isIOS() || !supportsDvh(), []);
 
   usePreventScroll({
     // react-aria will remove the scrollbar offset immediately upon close, since we use `open`,

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -35,6 +35,7 @@ function preventScrollStandard(referenceElement?: Element | null) {
 
     originalHtmlStyles = {
       overflowY: html.style.overflowY,
+      overflowX: html.style.overflowX,
     };
 
     originalBodyStyles = {

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -85,12 +85,14 @@ function preventScrollStandard(referenceElement?: Element | null) {
     });
 
     body.scrollTop = scrollTop;
+    html.setAttribute('data-base-ui-scroll-locked', '');
   }
 
   function cleanup() {
     Object.assign(html.style, originalHtmlStyles);
     Object.assign(body.style, originalBodyStyles);
     html.scrollTop = scrollTop;
+    html.removeAttribute('data-base-ui-scroll-locked');
   }
 
   function handleResize() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,7 +328,7 @@ importers:
         version: 5.31.0
       terser-webpack-plugin:
         specifier: ^5.3.10
-        version: 5.3.10(webpack@5.94.0)
+        version: 5.3.10(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -349,7 +349,7 @@ importers:
         version: 2.1.8(@types/node@18.19.67)(@vitest/browser@2.1.8)(@vitest/ui@2.1.8)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.6.5(@types/node@18.19.67)(typescript@5.7.2))(terser@5.31.0)
       webpack:
         specifier: ^5.91.0
-        version: 5.94.0(webpack-cli@5.1.4)
+        version: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
       webpack-bundle-analyzer:
         specifier: ^4.10.2
         version: 4.10.2
@@ -388,7 +388,7 @@ importers:
         version: 11.13.5(@emotion/react@11.13.5(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1)
       '@mdx-js/loader':
         specifier: ^3.1.0
-        version: 3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))
       '@mdx-js/mdx':
         specifier: ^3.1.0
         version: 3.1.0(acorn@8.14.0)
@@ -400,7 +400,7 @@ importers:
         version: 6.2.0(@emotion/react@11.13.5(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1)
       '@next/mdx':
         specifier: ^15.0.3
-        version: 15.0.3(@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4)))(@mdx-js/react@3.1.0(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))
+        version: 15.0.3(@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))))(@mdx-js/react@3.1.0(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))
       '@react-spring/web':
         specifier: ^9.7.5
         version: 9.7.5(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
@@ -748,7 +748,7 @@ importers:
         version: 11.2.0
       html-webpack-plugin:
         specifier: ^5.6.3
-        version: 5.6.3(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 5.6.3(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))
       is-wsl:
         specifier: ^3.1.0
         version: 3.1.0
@@ -796,7 +796,7 @@ importers:
         version: 1.6.28
       webpack:
         specifier: ^5.91.0
-        version: 5.94.0(webpack-cli@5.1.4)
+        version: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -11324,12 +11324,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4))':
+  '@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))':
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       source-map: 0.7.4
     optionalDependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
     transitivePeerDependencies:
       - acorn
       - supports-color
@@ -11592,11 +11592,11 @@ snapshots:
     dependencies:
       glob: 10.3.10
 
-  '@next/mdx@15.0.3(@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4)))(@mdx-js/react@3.1.0(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))':
+  '@next/mdx@15.0.3(@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))))(@mdx-js/react@3.1.0(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))':
     dependencies:
       source-map: 0.7.4
     optionalDependencies:
-      '@mdx-js/loader': 3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4))
+      '@mdx-js/loader': 3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))
       '@mdx-js/react': 3.1.0(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1)
 
   '@next/swc-darwin-arm64@15.0.3':
@@ -13068,19 +13068,19 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.94.0)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)
 
   '@xtuc/ieee754@1.2.0': {}
@@ -13370,7 +13370,7 @@ snapshots:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
 
   babel-plugin-add-import-extension@1.6.0(@babel/core@7.26.0):
     dependencies:
@@ -13884,7 +13884,7 @@ snapshots:
     dependencies:
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
 
   compression@1.7.4:
     dependencies:
@@ -14068,7 +14068,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
 
   css-select@4.3.0:
     dependencies:
@@ -15785,7 +15785,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.94.0(webpack-cli@5.1.4)):
+  html-webpack-plugin@5.6.3(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -15793,7 +15793,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
 
   htmlparser2@6.1.0:
     dependencies:
@@ -16495,7 +16495,7 @@ snapshots:
     dependencies:
       glob: 7.2.3
       minimatch: 9.0.4
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
       webpack-merge: 4.2.2
 
   karma@6.4.4:
@@ -18362,7 +18362,7 @@ snapshots:
       postcss: 8.4.49
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
     transitivePeerDependencies:
       - typescript
 
@@ -19530,7 +19530,7 @@ snapshots:
 
   style-loader@4.0.0(webpack@5.94.0):
     dependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
 
   style-to-object@0.4.4:
     dependencies:
@@ -19702,14 +19702,14 @@ snapshots:
     dependencies:
       rimraf: 2.5.4
 
-  terser-webpack-plugin@5.3.10(webpack@5.94.0):
+  terser-webpack-plugin@5.3.10(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.0
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
 
   terser@5.31.0:
     dependencies:
@@ -20273,9 +20273,9 @@ snapshots:
   webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -20284,7 +20284,7 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
@@ -20301,7 +20301,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.94.0(webpack-cli@5.1.4):
+  webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)):
     dependencies:
       '@types/estree': 1.0.6
       '@webassemblyjs/ast': 1.12.1
@@ -20323,7 +20323,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
+      terser-webpack-plugin: 5.3.10(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,7 +328,7 @@ importers:
         version: 5.31.0
       terser-webpack-plugin:
         specifier: ^5.3.10
-        version: 5.3.10(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))
+        version: 5.3.10(webpack@5.94.0)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -349,7 +349,7 @@ importers:
         version: 2.1.8(@types/node@18.19.67)(@vitest/browser@2.1.8)(@vitest/ui@2.1.8)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.6.5(@types/node@18.19.67)(typescript@5.7.2))(terser@5.31.0)
       webpack:
         specifier: ^5.91.0
-        version: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+        version: 5.94.0(webpack-cli@5.1.4)
       webpack-bundle-analyzer:
         specifier: ^4.10.2
         version: 4.10.2
@@ -388,7 +388,7 @@ importers:
         version: 11.13.5(@emotion/react@11.13.5(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1)
       '@mdx-js/loader':
         specifier: ^3.1.0
-        version: 3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))
+        version: 3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4))
       '@mdx-js/mdx':
         specifier: ^3.1.0
         version: 3.1.0(acorn@8.14.0)
@@ -400,7 +400,7 @@ importers:
         version: 6.2.0(@emotion/react@11.13.5(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1)
       '@next/mdx':
         specifier: ^15.0.3
-        version: 15.0.3(@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))))(@mdx-js/react@3.1.0(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))
+        version: 15.0.3(@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4)))(@mdx-js/react@3.1.0(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))
       '@react-spring/web':
         specifier: ^9.7.5
         version: 9.7.5(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
@@ -630,6 +630,9 @@ importers:
       '@floating-ui/utils':
         specifier: ^0.2.8
         version: 0.2.8
+      '@react-aria/overlays':
+        specifier: ^3.24.0
+        version: 3.24.0(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -745,7 +748,7 @@ importers:
         version: 11.2.0
       html-webpack-plugin:
         specifier: ^5.6.3
-        version: 5.6.3(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))
+        version: 5.6.3(webpack@5.94.0(webpack-cli@5.1.4))
       is-wsl:
         specifier: ^3.1.0
         version: 3.1.0
@@ -793,7 +796,7 @@ importers:
         version: 1.6.28
       webpack:
         specifier: ^5.91.0
-        version: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+        version: 5.94.0(webpack-cli@5.1.4)
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -1907,6 +1910,21 @@ packages:
   '@floating-ui/utils@0.2.8':
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
 
+  '@formatjs/ecma402-abstract@2.3.1':
+    resolution: {integrity: sha512-Ip9uV+/MpLXWRk03U/GzeJMuPeOXpJBSB5V1tjA6kJhvqssye5J5LoYLc7Z5IAHb7nR62sRoguzrFiVCP/hnzw==}
+
+  '@formatjs/fast-memoize@2.2.5':
+    resolution: {integrity: sha512-6PoewUMrrcqxSoBXAOJDiW1m+AmkrAj0RiXnOMD59GRaswjXhm3MDhgepXPBgonc09oSirAJTsAggzAGQf6A6g==}
+
+  '@formatjs/icu-messageformat-parser@2.9.7':
+    resolution: {integrity: sha512-cuEHyRM5VqLQobANOjtjlgU7+qmk9Q3fDQuBiRRJ3+Wp3ZoZhpUPtUfuimZXsir6SaI2TaAJ+SLo9vLnV5QcbA==}
+
+  '@formatjs/icu-skeleton-parser@1.8.11':
+    resolution: {integrity: sha512-8LlHHE/yL/zVJZHAX3pbKaCjZKmBIO6aJY1mkVh4RMSEu/2WRZ4Ysvv3kKXJ9M8RJLBHdnk1/dUQFdod1Dt7Dw==}
+
+  '@formatjs/intl-localematcher@0.5.9':
+    resolution: {integrity: sha512-8zkGu/sv5euxbjfZ/xmklqLyDGQSxsLqg8XOq88JW3cmJtzhCP8EtSJXlaKZnVO4beEaoiT9wj4eIoCQ9smwxA==}
+
   '@gitbeaker/core@38.12.1':
     resolution: {integrity: sha512-8XMVcBIdVAAoxn7JtqmZ2Ee8f+AZLcCPmqEmPFOXY2jPS84y/DERISg/+sbhhb18iRy+ZsZhpWgQ/r3CkYNJOQ==}
     engines: {node: '>=18.0.0'}
@@ -2068,6 +2086,18 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^18.19.67
+
+  '@internationalized/date@3.6.0':
+    resolution: {integrity: sha512-+z6ti+CcJnRlLHok/emGEsWQhe7kfSmEW+/6qCzvKY67YPh7YOBfvc7+/+NXq+zJlbArg30tYpqLjNgcAYv2YQ==}
+
+  '@internationalized/message@3.1.6':
+    resolution: {integrity: sha512-JxbK3iAcTIeNr1p0WIFg/wQJjIzJt9l/2KNY/48vXV7GRGZSv3zMxJsce008fZclk2cDC8y0Ig3odceHO7EfNQ==}
+
+  '@internationalized/number@3.6.0':
+    resolution: {integrity: sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==}
+
+  '@internationalized/string@3.2.5':
+    resolution: {integrity: sha512-rKs71Zvl2OKOHM+mzAFMIyqR5hI1d1O6BBkMK2/lkfg3fkmVh9Eeg0awcA8W2WqYqDOv6a86DIOlFpggwLtbuw==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2711,6 +2741,43 @@ packages:
   '@polka/url@1.0.0-next.25':
     resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
 
+  '@react-aria/focus@3.19.0':
+    resolution: {integrity: sha512-hPF9EXoUQeQl1Y21/rbV2H4FdUR2v+4/I0/vB+8U3bT1CJ+1AFj1hc/rqx2DqEwDlEwOHN+E4+mRahQmlybq0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/i18n@3.12.4':
+    resolution: {integrity: sha512-j9+UL3q0Ls8MhXV9gtnKlyozq4aM95YywXqnmJtzT1rYeBx7w28hooqrWkCYLfqr4OIryv1KUnPiCSLwC2OC7w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/interactions@3.22.5':
+    resolution: {integrity: sha512-kMwiAD9E0TQp+XNnOs13yVJghiy8ET8L0cbkeuTgNI96sOAp/63EJ1FSrDf17iD8sdjt41LafwX/dKXW9nCcLQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/overlays@3.24.0':
+    resolution: {integrity: sha512-0kAXBsMNTc/a3M07tK9Cdt/ea8CxTAEJ223g8YgqImlmoBBYAL7dl5G01IOj67TM64uWPTmZrOklBchHWgEm3A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/ssr@3.9.7':
+    resolution: {integrity: sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==}
+    engines: {node: '>= 12'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/utils@3.26.0':
+    resolution: {integrity: sha512-LkZouGSjjQ0rEqo4XJosS4L3YC/zzQkfRM3KoqK6fUOmUJ9t0jQ09WjiF+uOoG9u+p30AVg3TrZRUWmoTS+koQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/visually-hidden@3.8.18':
+    resolution: {integrity: sha512-l/0igp+uub/salP35SsNWq5mGmg3G5F5QMS1gDZ8p28n7CgjvzyiGhJbbca7Oxvaw1HRFzVl9ev+89I7moNnFQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@react-spring/animated@9.7.5':
     resolution: {integrity: sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==}
     peerDependencies:
@@ -2737,6 +2804,31 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  '@react-stately/overlays@3.6.12':
+    resolution: {integrity: sha512-QinvZhwZgj8obUyPIcyURSCjTZlqZYRRCS60TF8jH8ZpT0tEAuDb3wvhhSXuYA3Xo9EHLwvLjEf3tQKKdAQArw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/utils@3.10.5':
+    resolution: {integrity: sha512-iMQSGcpaecghDIh3mZEpZfoFH3ExBwTtuBEcvZ2XnGzCgQjeYXcMdIUwAfVQLXFTdHUHGF6Gu6/dFrYsCzySBQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/button@3.10.1':
+    resolution: {integrity: sha512-XTtap8o04+4QjPNAshFWOOAusUTxQlBjU2ai0BTVLShQEjHhRVDBIWsI2B2FKJ4KXT6AZ25llaxhNrreWGonmA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/overlays@3.8.11':
+    resolution: {integrity: sha512-aw7T0rwVI3EuyG5AOaEIk8j7dZJQ9m34XAztXJVZ/W2+4pDDkLDbJ/EAPnuo2xGYRGhowuNDn4tDju01eHYi+w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/shared@3.26.0':
+    resolution: {integrity: sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@remix-run/router@1.21.0':
     resolution: {integrity: sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==}
@@ -5837,6 +5929,9 @@ packages:
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
+
+  intl-messageformat@10.7.10:
+    resolution: {integrity: sha512-hp7iejCBiJdW3zmOe18FdlJu8U/JsADSDiBPQhfdSeI8B9POtvPRvPh3nMlvhYayGMKLv6maldhR7y3Pf1vkpw==}
 
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
@@ -10916,6 +11011,32 @@ snapshots:
 
   '@floating-ui/utils@0.2.8': {}
 
+  '@formatjs/ecma402-abstract@2.3.1':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.5
+      '@formatjs/intl-localematcher': 0.5.9
+      decimal.js: 10.4.3
+      tslib: 2.6.2
+
+  '@formatjs/fast-memoize@2.2.5':
+    dependencies:
+      tslib: 2.6.2
+
+  '@formatjs/icu-messageformat-parser@2.9.7':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.1
+      '@formatjs/icu-skeleton-parser': 1.8.11
+      tslib: 2.6.2
+
+  '@formatjs/icu-skeleton-parser@1.8.11':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.1
+      tslib: 2.6.2
+
+  '@formatjs/intl-localematcher@0.5.9':
+    dependencies:
+      tslib: 2.6.2
+
   '@gitbeaker/core@38.12.1':
     dependencies:
       '@gitbeaker/requester-utils': 38.12.1
@@ -11056,6 +11177,23 @@ snapshots:
     dependencies:
       '@types/node': 18.19.67
 
+  '@internationalized/date@3.6.0':
+    dependencies:
+      '@swc/helpers': 0.5.13
+
+  '@internationalized/message@3.1.6':
+    dependencies:
+      '@swc/helpers': 0.5.13
+      intl-messageformat: 10.7.10
+
+  '@internationalized/number@3.6.0':
+    dependencies:
+      '@swc/helpers': 0.5.13
+
+  '@internationalized/string@3.2.5':
+    dependencies:
+      '@swc/helpers': 0.5.13
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -11186,12 +11324,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))':
+  '@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4))':
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       source-map: 0.7.4
     optionalDependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - acorn
       - supports-color
@@ -11454,11 +11592,11 @@ snapshots:
     dependencies:
       glob: 10.3.10
 
-  '@next/mdx@15.0.3(@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))))(@mdx-js/react@3.1.0(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))':
+  '@next/mdx@15.0.3(@mdx-js/loader@3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4)))(@mdx-js/react@3.1.0(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1))':
     dependencies:
       source-map: 0.7.4
     optionalDependencies:
-      '@mdx-js/loader': 3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))
+      '@mdx-js/loader': 3.1.0(acorn@8.14.0)(webpack@5.94.0(webpack-cli@5.1.4))
       '@mdx-js/react': 3.1.0(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.1)
 
   '@next/swc-darwin-arm64@15.0.3':
@@ -11932,6 +12070,73 @@ snapshots:
 
   '@polka/url@1.0.0-next.25': {}
 
+  '@react-aria/focus@3.19.0(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      '@react-aria/interactions': 3.22.5(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-aria/utils': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@swc/helpers': 0.5.13
+      clsx: 2.1.1
+      react: 19.0.0-rc-fb9a90fa48-20240614
+
+  '@react-aria/i18n@3.12.4(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      '@internationalized/date': 3.6.0
+      '@internationalized/message': 3.1.6
+      '@internationalized/number': 3.6.0
+      '@internationalized/string': 3.2.5
+      '@react-aria/ssr': 3.9.7(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-aria/utils': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@swc/helpers': 0.5.13
+      react: 19.0.0-rc-fb9a90fa48-20240614
+
+  '@react-aria/interactions@3.22.5(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      '@react-aria/ssr': 3.9.7(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-aria/utils': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@swc/helpers': 0.5.13
+      react: 19.0.0-rc-fb9a90fa48-20240614
+
+  '@react-aria/overlays@3.24.0(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      '@react-aria/focus': 3.19.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-aria/i18n': 3.12.4(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-aria/interactions': 3.22.5(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-aria/ssr': 3.9.7(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-aria/utils': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-aria/visually-hidden': 3.8.18(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-stately/overlays': 3.6.12(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-types/button': 3.10.1(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-types/overlays': 3.8.11(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@swc/helpers': 0.5.13
+      react: 19.0.0-rc-fb9a90fa48-20240614
+      react-dom: 19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614)
+
+  '@react-aria/ssr@3.9.7(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      '@swc/helpers': 0.5.13
+      react: 19.0.0-rc-fb9a90fa48-20240614
+
+  '@react-aria/utils@3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      '@react-aria/ssr': 3.9.7(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-stately/utils': 3.10.5(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@swc/helpers': 0.5.13
+      clsx: 2.1.1
+      react: 19.0.0-rc-fb9a90fa48-20240614
+
+  '@react-aria/visually-hidden@3.8.18(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      '@react-aria/interactions': 3.22.5(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-aria/utils': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@swc/helpers': 0.5.13
+      react: 19.0.0-rc-fb9a90fa48-20240614
+
   '@react-spring/animated@9.7.5(react@19.0.0-rc-fb9a90fa48-20240614)':
     dependencies:
       '@react-spring/shared': 9.7.5(react@19.0.0-rc-fb9a90fa48-20240614)
@@ -11963,6 +12168,32 @@ snapshots:
       '@react-spring/types': 9.7.5
       react: 19.0.0-rc-fb9a90fa48-20240614
       react-dom: 19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614)
+
+  '@react-stately/overlays@3.6.12(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      '@react-stately/utils': 3.10.5(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@react-types/overlays': 3.8.11(react@19.0.0-rc-fb9a90fa48-20240614)
+      '@swc/helpers': 0.5.13
+      react: 19.0.0-rc-fb9a90fa48-20240614
+
+  '@react-stately/utils@3.10.5(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      '@swc/helpers': 0.5.13
+      react: 19.0.0-rc-fb9a90fa48-20240614
+
+  '@react-types/button@3.10.1(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      react: 19.0.0-rc-fb9a90fa48-20240614
+
+  '@react-types/overlays@3.8.11(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)
+      react: 19.0.0-rc-fb9a90fa48-20240614
+
+  '@react-types/shared@3.26.0(react@19.0.0-rc-fb9a90fa48-20240614)':
+    dependencies:
+      react: 19.0.0-rc-fb9a90fa48-20240614
 
   '@remix-run/router@1.21.0': {}
 
@@ -12837,19 +13068,19 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)
 
   '@xtuc/ieee754@1.2.0': {}
@@ -13139,7 +13370,7 @@ snapshots:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
 
   babel-plugin-add-import-extension@1.6.0(@babel/core@7.26.0):
     dependencies:
@@ -13653,7 +13884,7 @@ snapshots:
     dependencies:
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
 
   compression@1.7.4:
     dependencies:
@@ -13837,7 +14068,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
 
   css-select@4.3.0:
     dependencies:
@@ -15554,7 +15785,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))):
+  html-webpack-plugin@5.6.3(webpack@5.94.0(webpack-cli@5.1.4)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -15562,7 +15793,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -15725,6 +15956,13 @@ snapshots:
       side-channel: 1.0.6
 
   interpret@3.1.1: {}
+
+  intl-messageformat@10.7.10:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.1
+      '@formatjs/fast-memoize': 2.2.5
+      '@formatjs/icu-messageformat-parser': 2.9.7
+      tslib: 2.6.2
 
   ip-address@9.0.5:
     dependencies:
@@ -16257,7 +16495,7 @@ snapshots:
     dependencies:
       glob: 7.2.3
       minimatch: 9.0.4
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-merge: 4.2.2
 
   karma@6.4.4:
@@ -18124,7 +18362,7 @@ snapshots:
       postcss: 8.4.49
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
 
@@ -19292,7 +19530,7 @@ snapshots:
 
   style-loader@4.0.0(webpack@5.94.0):
     dependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
 
   style-to-object@0.4.4:
     dependencies:
@@ -19464,14 +19702,14 @@ snapshots:
     dependencies:
       rimraf: 2.5.4
 
-  terser-webpack-plugin@5.3.10(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))):
+  terser-webpack-plugin@5.3.10(webpack@5.94.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.0
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
 
   terser@5.31.0:
     dependencies:
@@ -20035,9 +20273,9 @@ snapshots:
   webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))(webpack@5.94.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.94.0)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -20046,7 +20284,7 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0))
+      webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
@@ -20063,7 +20301,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)):
+  webpack@5.94.0(webpack-cli@5.1.4):
     dependencies:
       '@types/estree': 1.0.6
       '@webassemblyjs/ast': 1.12.1
@@ -20085,7 +20323,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)))
+      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:


### PR DESCRIPTION
Closes #1156

A new custom implementation is used across non-iOS browsers, handling the previous edge cases on Firefox as well, removing the patch we gave it.

### iOS

As far as I can tell, scroll containers are optimized in iOS similar to the `will-change` property (adding it causes the flicker everywhere), possibly due to some compositing step in the browser when animations are occurring when scrolled down(?). The new implementation on iOS also flickered, but even worse and had other issues.

For iOS, there seems to be 3 options:

1. Accept that iOS has this flicker issue and has workarounds (like we did on the docs for the main nav). We could make this easier, maybe?
2. Use a scroll lock dependency just for iOS, or browsers without inset scrollbars.
3. Accept that iOS can't lock scroll at all without causing problems

I personally feel like number 2 is the best option, so I've done this in the PR. `@react-aria/overlays`' `usePreventScroll` hook seems like the best one and handles an enormous number of edge cases, and is kept up to date. It also seems to address the macOS "scrollbar popping" issue in most cases

@vladmoroz the side nav seems to need updating with the new non-iOS implementation? 