### PR TITLE
[docs] Skip unnecessary position changes when quick nav height is similar to viewport

### DIFF
--- a/docs/src/components/QuickNav/QuickNav.css
+++ b/docs/src/components/QuickNav/QuickNav.css
@@ -36,7 +36,7 @@
     position: relative;
     left: var(--quick-nav-margin-x);
     padding-top: 0.75rem;
-    padding-bottom: 1.5rem;
+    padding-bottom: 2.5rem;
     width: calc(var(--sidebar-width) - var(--quick-nav-margin-x) * 2);
   }
 

--- a/docs/src/components/QuickNav/QuickNav.tsx
+++ b/docs/src/components/QuickNav/QuickNav.tsx
@@ -24,6 +24,10 @@ function onMounted(ref: React.RefObject<HTMLDivElement | null>) {
     return undefined;
   }
 
+  const rem = parseFloat(getComputedStyle(document.documentElement).fontSize);
+  /** How much of the nav should be cut off at the bottom to stop using the default sticky top position */
+  const stickyTopThreshold = 2.25 * rem;
+
   let top: number;
   let bottom: number;
   let prevScrollY = window.scrollY;
@@ -179,10 +183,13 @@ function onMounted(ref: React.RefObject<HTMLDivElement | null>) {
 
       if (state === 'StickyTop') {
         const clippedAtBottom = bottom - window.innerHeight;
-        if (delta >= clippedAtBottom) {
-          stickToBottom();
-        } else {
-          unstick(top - delta, bottom - delta);
+
+        if (clippedAtBottom - top >= stickyTopThreshold) {
+          if (delta >= clippedAtBottom) {
+            stickToBottom();
+          } else {
+            unstick(top - delta, bottom - delta);
+          }
         }
         return;
       }


### PR DESCRIPTION
Prevent quick nav from adjusting the position if its height is similar to viewport height and the scroll difference would be unimportant

Avoids unnecessary movement

https://github.com/user-attachments/assets/ef9a5107-82db-4b9b-958d-c9102db06970

