### PR TITLE
[docs] Rename MUI -> Material UI

### DIFF
--- a/docs/src/app/(public)/(content)/react/overview/about/page.mdx
+++ b/docs/src/app/(public)/(content)/react/overview/about/page.mdx
@@ -27,9 +27,9 @@ Component APIs are fully open, so you have direct access to each node, you can e
 - **Colm Tuite** (Radix)
 - **Vlad Moroz** (Radix)
 - **James Nelson** (Floating UI)
-- **Michał Dudak** (MUI)
-- **Marija Najdova** (MUI)
-- **Albert Yu** (MUI)
+- **Michał Dudak** (Material UI)
+- **Marija Najdova** (Material UI + Fluent UI)
+- **Albert Yu** (Material UI)
 
 ## Community
 


### PR DESCRIPTION
I guess to be coherent with? https://github.com/mui/base-ui/blob/74a3d083b3e63224bee11f7b3d01ab558a4082b2/README.md?plain=1#L3

Also, if we are playing the game of previous projects, I imagine we should add fluent ui https://github.com/microsoft/fluentui/pulls?q=is%3Apr+author%3Amnajdova+is%3Aclosed (one of the two repos).