### PR TITLE
[Slider] Set `position: relative` on range slider indicator

### DIFF
--- a/packages/react/src/slider/indicator/useSliderIndicator.ts
+++ b/packages/react/src/slider/indicator/useSliderIndicator.ts
@@ -7,6 +7,7 @@ import type { useSliderRoot } from '../root/useSliderRoot';
 function getRangeStyles(orientation: useSliderRoot.Orientation, offset: number, leap: number) {
   if (orientation === 'vertical') {
     return {
+      position: 'relative',
       bottom: `${offset}%`,
       height: `${leap}%`,
       width: 'inherit',
@@ -14,6 +15,7 @@ function getRangeStyles(orientation: useSliderRoot.Orientation, offset: number, 
   }
 
   return {
+    position: 'relative',
     insetInlineStart: `${offset}%`,
     width: `${leap}%`,
     height: 'inherit',
@@ -36,12 +38,14 @@ export function useSliderIndicator(
     internalStyles = getRangeStyles(orientation, trackOffset, trackLeap);
   } else if (orientation === 'vertical') {
     internalStyles = {
+      position: 'relative',
       bottom: 0,
       height: `${percentageValues[0]}%`,
       width: 'inherit',
     };
   } else {
     internalStyles = {
+      position: 'relative',
       insetInlineStart: 0,
       width: `${percentageValues[0]}%`,
       height: 'inherit',


### PR DESCRIPTION
Removing `position: absolute` from `Indicator` makes range slider built-in styles look broken: https://codesandbox.io/p/sandbox/quiet-cache-mcf3cr

![Screenshot 2024-12-19 at 1 33 45 PM](https://github.com/user-attachments/assets/8a30d4b9-adc4-45e8-bf5c-30efa44e568e)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
