### PR TITLE
[core] Rely more on baseline prettier config

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,8 @@
+const baseline = require('@mui/monorepo/prettier.config');
+
 module.exports = {
-  printWidth: 100,
-  singleQuote: true,
-  trailingComma: 'all',
+  ...baseline,
+  // TODO move to baseline config
   plugins: ['prettier-plugin-tailwindcss'],
   tailwindStylesheet: './docs/src/styles.css',
   overrides: [

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -2,8 +2,7 @@ const baseline = require('@mui/monorepo/prettier.config');
 
 module.exports = {
   ...baseline,
-  // TODO move to baseline config
-  plugins: ['prettier-plugin-tailwindcss'],
+  plugins: ['prettier-plugin-tailwindcss'], // TODO move to baseline config
   tailwindStylesheet: './docs/src/styles.css',
   overrides: [
     {


### PR DESCRIPTION
Avoid duplication, so we can have more of a shared baseline.

**Off-topic.** We will likely need to change how `@mui/monorepo/prettier.config` is handled and where the source is located, but duplication and best location are separate problems, e.g. mui/material-ui also has Tailwind CSS in its repo, it should have the plugin too.