### PR TITLE
[ScrollArea] Differentiate `x`/`y` orientation `data-scrolling`

### DIFF
--- a/packages/react/src/scroll-area/root/ScrollAreaRootContext.ts
+++ b/packages/react/src/scroll-area/root/ScrollAreaRootContext.ts
@@ -9,8 +9,10 @@ export interface ScrollAreaRootContext {
   touchModality: boolean;
   hovering: boolean;
   setHovering: React.Dispatch<React.SetStateAction<boolean>>;
-  scrolling: boolean;
-  setScrolling: React.Dispatch<React.SetStateAction<boolean>>;
+  scrollingX: boolean;
+  setScrollingX: React.Dispatch<React.SetStateAction<boolean>>;
+  scrollingY: boolean;
+  setScrollingY: React.Dispatch<React.SetStateAction<boolean>>;
   viewportRef: React.RefObject<HTMLDivElement | null>;
   scrollbarYRef: React.RefObject<HTMLDivElement | null>;
   thumbYRef: React.RefObject<HTMLDivElement | null>;
@@ -20,7 +22,7 @@ export interface ScrollAreaRootContext {
   handlePointerDown: (event: React.PointerEvent) => void;
   handlePointerMove: (event: React.PointerEvent) => void;
   handlePointerUp: (event: React.PointerEvent) => void;
-  handleScroll: () => void;
+  handleScroll: (scrollPosition: { x: number; y: number }) => void;
   rootId: string | undefined;
   hiddenState: {
     scrollbarYHidden: boolean;

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -18,7 +18,7 @@ describe('<ScrollArea.Scrollbar />', () => {
     },
   }));
 
-  it('adds [data-scrolling] attribute when viewport is scrolled', async () => {
+  it('adds [data-scrolling] attribute when viewport is scrolled in the correct direction', async () => {
     await render(
       <ScrollArea.Root style={{ width: 200, height: 200 }}>
         <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
@@ -32,19 +32,40 @@ describe('<ScrollArea.Scrollbar />', () => {
 
     const verticalScrollbar = screen.getByTestId('vertical');
     const horizontalScrollbar = screen.getByTestId('horizontal');
+    const viewport = screen.getByTestId('viewport');
 
     expect(verticalScrollbar).not.to.have.attribute('data-scrolling');
     expect(horizontalScrollbar).not.to.have.attribute('data-scrolling');
 
-    fireEvent.scroll(screen.getByTestId('viewport'));
+    fireEvent.scroll(viewport, {
+      target: {
+        scrollTop: 1,
+      },
+    });
 
     expect(verticalScrollbar).to.have.attribute('data-scrolling', '');
-    expect(horizontalScrollbar).to.have.attribute('data-scrolling', '');
+    expect(horizontalScrollbar).not.to.have.attribute('data-scrolling', '');
 
     clock.tick(SCROLL_TIMEOUT - 1);
 
     expect(verticalScrollbar).to.have.attribute('data-scrolling', '');
-    expect(horizontalScrollbar).to.have.attribute('data-scrolling', '');
+    expect(horizontalScrollbar).not.to.have.attribute('data-scrolling', '');
+
+    fireEvent.scroll(viewport, {
+      target: {
+        scrollLeft: 1,
+      },
+    });
+
+    clock.tick(1); // vertical just finished
+
+    expect(verticalScrollbar).not.to.have.attribute('data-scrolling');
+    expect(horizontalScrollbar).to.have.attribute('data-scrolling');
+
+    clock.tick(SCROLL_TIMEOUT - 2); // already ticked 1ms above
+
+    expect(verticalScrollbar).not.to.have.attribute('data-scrolling');
+    expect(horizontalScrollbar).to.have.attribute('data-scrolling');
 
     clock.tick(1);
 

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
@@ -20,7 +20,7 @@ const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar(
 ) {
   const { render, className, orientation = 'vertical', keepMounted = false, ...otherProps } = props;
 
-  const { hovering, scrolling, hiddenState, scrollbarYRef, scrollbarXRef } =
+  const { hovering, scrollingX, scrollingY, hiddenState, scrollbarYRef, scrollbarXRef } =
     useScrollAreaRootContext();
 
   const mergedRef = useForkRef(
@@ -31,10 +31,13 @@ const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar(
   const state: ScrollAreaScrollbar.State = React.useMemo(
     () => ({
       hovering,
-      scrolling,
+      scrolling: {
+        horizontal: scrollingX,
+        vertical: scrollingY,
+      }[orientation],
       orientation,
     }),
-    [hovering, scrolling, orientation],
+    [hovering, scrollingX, scrollingY, orientation],
   );
 
   const { getScrollbarProps } = useScrollAreaScrollbar({

--- a/packages/react/src/scroll-area/thumb/ScrollAreaThumb.tsx
+++ b/packages/react/src/scroll-area/thumb/ScrollAreaThumb.tsx
@@ -27,7 +27,8 @@ const ScrollAreaThumb = React.forwardRef(function ScrollAreaThumb(
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
-    setScrolling,
+    setScrollingX,
+    setScrollingY,
   } = useScrollAreaRootContext();
 
   const { orientation } = useScrollAreaScrollbarContext();
@@ -45,7 +46,12 @@ const ScrollAreaThumb = React.forwardRef(function ScrollAreaThumb(
       onPointerDown: handlePointerDown,
       onPointerMove: handlePointerMove,
       onPointerUp(event) {
-        setScrolling(false);
+        if (orientation === 'vertical') {
+          setScrollingY(false);
+        }
+        if (orientation === 'horizontal') {
+          setScrollingX(false);
+        }
         handlePointerUp(event);
       },
       style: {

--- a/packages/react/src/scroll-area/viewport/useScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/useScrollAreaViewport.tsx
@@ -184,8 +184,16 @@ export function useScrollAreaViewport(params: useScrollAreaViewport.Parameters) 
           overflow: 'scroll',
         },
         onScroll() {
+          if (!viewportRef.current) {
+            return;
+          }
+
           computeThumb();
-          handleScroll();
+
+          handleScroll({
+            x: viewportRef.current.scrollLeft,
+            y: viewportRef.current.scrollTop,
+          });
         },
         children: (
           <div

--- a/packages/react/src/scroll-area/viewport/useScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/useScrollAreaViewport.tsx
@@ -213,6 +213,7 @@ export function useScrollAreaViewport(params: useScrollAreaViewport.Parameters) 
       children,
       computeThumb,
       handleScroll,
+      viewportRef,
     ],
   );
 


### PR DESCRIPTION
Closes #982

Previously both scrollbars received `data-scrolling` even if the orientation of the scroll was for the other scrollbar. This splits the states so they time out independently.