### PR TITLE
[Popover, Tooltip] Fix PopoverTrigger and TooltipTrigger prop types

### DIFF
--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -72,6 +72,10 @@ PopoverTrigger.propTypes /* remove-proptypes */ = {
   // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
   // └─────────────────────────────────────────────────────────────────────┘
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * CSS class applied to the element, or a function that
    * returns a class based on the component’s state.
    */

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -63,7 +63,7 @@ namespace PopoverTrigger {
     open: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<any, State> {}
+  export interface Props extends BaseUIComponentProps<'button', State> {}
 }
 
 PopoverTrigger.propTypes /* remove-proptypes */ = {

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -46,7 +46,7 @@ namespace TooltipTrigger {
     open: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<any, State> {}
+  export interface Props extends BaseUIComponentProps<'button', State> {}
 }
 
 TooltipTrigger.propTypes /* remove-proptypes */ = {

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -46,7 +46,7 @@ namespace TooltipTrigger {
     open: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<'button', State> {}
+  export interface Props extends BaseUIComponentProps<any, State> {}
 }
 
 TooltipTrigger.propTypes /* remove-proptypes */ = {
@@ -54,10 +54,6 @@ TooltipTrigger.propTypes /* remove-proptypes */ = {
   // │ These PropTypes are generated from the TypeScript type definitions. │
   // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
   // └─────────────────────────────────────────────────────────────────────┘
-  /**
-   * @ignore
-   */
-  children: PropTypes.node,
   /**
    * CSS class applied to the element, or a function that
    * returns a class based on the component’s state.

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -55,6 +55,10 @@ TooltipTrigger.propTypes /* remove-proptypes */ = {
   // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
   // └─────────────────────────────────────────────────────────────────────┘
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * CSS class applied to the element, or a function that
    * returns a class based on the component’s state.
    */


### PR DESCRIPTION
Fix wrong prop types.
<img width="781" alt="スクリーンショット 2024-12-21 5 09 47" src="https://github.com/user-attachments/assets/33f2efb0-5ed0-42e0-8fc3-9afda8e3939c" />

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).