### PR TITLE
[docs] Remove `rehypeEmptyLines`

### DIFF
--- a/docs/src/syntax-highlighting/index.mjs
+++ b/docs/src/syntax-highlighting/index.mjs
@@ -1,6 +1,5 @@
 import { createHighlighter } from 'shiki';
 import rehypePrettyCode from 'rehype-pretty-code';
-import { rehypeEmptyLines } from './rehypeEmptyLines.mjs';
 import { rehypeInlineCode } from './rehypeInlineCode.mjs';
 import { rehypePrettierIgnore } from './rehypePrettierIgnore.mjs';
 import { rehypeJsxExpressions } from './rehypeJsxExpressions.mjs';
@@ -349,7 +348,6 @@ export const rehypeSyntaxHighlighting = [
       defaultLang: 'tsx',
     },
   ],
-  rehypeEmptyLines,
   rehypePrettierIgnore,
   rehypeJsxExpressions,
   rehypeInlineCode,


### PR DESCRIPTION
Closes #1211. Not sure what this is for but it's breaking the code blocks.