### PR TITLE
[core] Fix render prop types

### DIFF
--- a/packages/react/src/tooltip/trigger/TooltipTrigger.spec.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.spec.tsx
@@ -1,5 +1,6 @@
+import type * as React from 'react';
 import { Tooltip } from '@base-ui-components/react/tooltip';
 
 // `props: any` will error
-<Tooltip.Trigger render={(props) => <button {...props} />} />;
+<Tooltip.Trigger render={(props) => <button type="button" {...props} />} />;
 <Tooltip.Trigger render={(props) => <input {...props} />} />;

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.spec.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.spec.tsx
@@ -1,0 +1,5 @@
+import { Tooltip } from '@base-ui-components/react/tooltip';
+
+// `props: any` will error
+<Tooltip.Trigger render={(props) => <button {...props} />} />;
+<Tooltip.Trigger render={(props) => <input {...props} />} />;

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useTooltipRootContext } from '../root/TooltipRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
-import type { BaseUIComponentProps } from '../../utils/types';
+import type { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
 import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 
 /**
@@ -46,7 +46,7 @@ namespace TooltipTrigger {
     open: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<any, State> {}
+  export interface Props extends BaseUIComponentProps<'div', State> {}
 }
 
 TooltipTrigger.propTypes /* remove-proptypes */ = {

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -55,6 +55,10 @@ TooltipTrigger.propTypes /* remove-proptypes */ = {
   // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
   // └─────────────────────────────────────────────────────────────────────┘
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * CSS class applied to the element, or a function that
    * returns a class based on the component’s state.
    */

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useTooltipRootContext } from '../root/TooltipRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
-import type { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
+import type { BaseUIComponentProps } from '../../utils/types';
 import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 
 /**

--- a/packages/react/src/utils/types.ts
+++ b/packages/react/src/utils/types.ts
@@ -39,7 +39,7 @@ export type ComponentRenderFn<Props, State> = (
 export type BaseUIComponentProps<
   ElementType extends React.ElementType,
   State,
-  RenderFunctionProps = React.HTMLAttributes<any>,
+  RenderFunctionProps = GenericHTMLProps,
 > = Omit<WithBaseUIEvent<React.ComponentPropsWithoutRef<ElementType>>, 'className'> & {
   /**
    * CSS class applied to the element, or a function that


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Continues #1209

Switches to `GenericHTMLProps` for the `render` props type. This includes the `ref` which was previously missing. Using `'div'` for Tooltip uses the `GenericHTMLProps` regardless.