### PR TITLE
[Dialog, Menu, Select] Set `pointer-events` on `InternalBackdrop` based on `open` state

### DIFF
--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -104,7 +104,7 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
 
   return (
     <React.Fragment>
-      {mounted && modal && <InternalBackdrop />}
+      {mounted && modal && <InternalBackdrop inert={!open} />}
       <FloatingFocusManager
         context={floatingContext}
         modal={open}

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -100,7 +100,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
 
   return (
     <React.Fragment>
-      {mounted && modal && <InternalBackdrop />}
+      {mounted && modal && <InternalBackdrop inert={!open} />}
       <FloatingFocusManager
         context={floatingContext}
         modal={open}

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -141,7 +141,7 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
 
   return (
     <MenuPositionerContext.Provider value={contextValue}>
-      {mounted && modal && parentNodeId === null && <InternalBackdrop />}
+      {mounted && modal && parentNodeId === null && <InternalBackdrop inert={!open} />}
       <FloatingNode id={nodeId}>
         <CompositeList elementsRef={itemDomElements} labelsRef={itemLabels}>
           {renderElement()}

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -84,7 +84,7 @@ const SelectPositioner = React.forwardRef(function SelectPositioner(
   return (
     <CompositeList elementsRef={listRef} labelsRef={labelsRef}>
       <SelectPositionerContext.Provider value={positioner}>
-        {mounted && modal && <InternalBackdrop />}
+        {mounted && modal && <InternalBackdrop inert={!open} />}
         {renderElement()}
       </SelectPositionerContext.Provider>
     </CompositeList>

--- a/packages/react/src/utils/InternalBackdrop.tsx
+++ b/packages/react/src/utils/InternalBackdrop.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * @ignore - internal component.
  */
-export function InternalBackdrop(props: InternalBackdrop.Props) {
+function InternalBackdrop(props: InternalBackdrop.Props) {
+  const { inert = false } = props;
   return (
     <div
       role="presentation"
@@ -19,7 +21,7 @@ export function InternalBackdrop(props: InternalBackdrop.Props) {
         // conditionally rendering the backdrop on `open` and using exit animations.
         // If the popup reopens before the exit animation finishes, the backdrop
         // receives this attribute, breaking outside click behavior.
-        pointerEvents: props.inert ? 'none' : undefined,
+        pointerEvents: inert ? 'none' : undefined,
       }}
     />
   );
@@ -34,3 +36,17 @@ namespace InternalBackdrop {
     inert?: boolean;
   }
 }
+
+InternalBackdrop.propTypes /* remove-proptypes */ = {
+  // ┌────────────────────────────── Warning ──────────────────────────────┐
+  // │ These PropTypes are generated from the TypeScript type definitions. │
+  // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
+  // └─────────────────────────────────────────────────────────────────────┘
+  /**
+   * Whether the backdrop should be inert (not block pointer events).
+   * @default false
+   */
+  inert: PropTypes.bool,
+} as any;
+
+export { InternalBackdrop };

--- a/packages/react/src/utils/InternalBackdrop.tsx
+++ b/packages/react/src/utils/InternalBackdrop.tsx
@@ -18,7 +18,7 @@ export function InternalBackdrop(props: InternalBackdrop.Props) {
         // blocks outside clicks from closing the popup. This issue arises when
         // conditionally rendering the backdrop on `open` and using exit animations.
         // If the popup reopens before the exit animation finishes, the backdrop
-        // becomes inert, breaking outside click behavior.
+        // receives this attribute, breaking outside click behavior.
         pointerEvents: props.inert ? 'none' : undefined,
       }}
     />

--- a/packages/react/src/utils/InternalBackdrop.tsx
+++ b/packages/react/src/utils/InternalBackdrop.tsx
@@ -3,6 +3,34 @@ import * as React from 'react';
 /**
  * @ignore - internal component.
  */
-export function InternalBackdrop() {
-  return <div role="presentation" style={{ position: 'fixed', inset: 0 }} />;
+export function InternalBackdrop(props: InternalBackdrop.Props) {
+  return (
+    <div
+      role="presentation"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        // Allows `:hover` events immediately after `open` changes to `false`,
+        // preventing a flicker when the cursor rests on the trigger. Flickers occur
+        // because CSS `:hover` is temporarily blocked during an exit animation,
+        // and `[data-popup-open]` is removed.
+        // Keeping the backdrop in the DOM avoids `[data-floating-ui-inert]`, which
+        // blocks outside clicks from closing the popup. This issue arises when
+        // conditionally rendering the backdrop on `open` and using exit animations.
+        // If the popup reopens before the exit animation finishes, the backdrop
+        // becomes inert, breaking outside click behavior.
+        pointerEvents: props.inert ? 'none' : undefined,
+      }}
+    />
+  );
+}
+
+namespace InternalBackdrop {
+  export interface Props {
+    /**
+     * Whether the backdrop should be inert (not block pointer events).
+     * @default false
+     */
+    inert?: boolean;
+  }
 }


### PR DESCRIPTION
This solves the flicker on the trigger due to the new internal backdrop without needing to change when `[data-popup-open]` is removed.

Before:

https://github.com/user-attachments/assets/9d83ea26-e5b1-4015-8921-c71d2120673f

After: 

https://github.com/user-attachments/assets/0df0dee2-2765-4c11-ba77-fa5d17f834d7

