### PR TITLE
[docs] Use discord redirect

### DIFF
--- a/.github/ISSUE_TEMPLATE/3.get-help.md
+++ b/.github/ISSUE_TEMPLATE/3.get-help.md
@@ -7,4 +7,4 @@ about: 'Ask a question.'
 
 ## Ask a question
 
-Before opening an issue, please consider starting a [GitHub Discussion](https://github.com/mui/base-ui/discussions) or asking the community for help in our [Discord](https://discord.com/channels/1287292451308048406/1287292451308048409).
+Before opening an issue, please consider starting a [GitHub Discussion](https://github.com/mui/base-ui/discussions) or asking the community for help in our [Discord](https://base-ui.com/r/discord).

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -3,6 +3,9 @@
 /inbox* / 301
 /trash / 301
 
+# For links that we can't edit later on, for example hosted in the code published on npm
+/r/discord https://discord.com/invite/g6C3hUtuxz 302
+
 # Legacy redirection
 # Added in chronological order (the last line is the most recent one)
 # To be removed 3+ years after being introduced

--- a/docs/src/app/(public)/(content)/react/overview/about/page.mdx
+++ b/docs/src/app/(public)/(content)/react/overview/about/page.mdx
@@ -46,7 +46,7 @@ If you want to file a bug report or contribute, visit our [GitHub](https://githu
 
 ### Discord
 
-For community support, questions, and tips, join our [Discord](https://discord.gg/g6C3hUtuxz).
+For community support, questions, and tips, join our [Discord](https://base-ui.com/r/discord).
 
 ### X
 


### PR DESCRIPTION
The value of this change:

- Makes the link we share on socials, etc. feel more official, and clean
- Make it easy in case Discord changes the invitation URL (unlikely to happen)

Also, once we reach level 3 of the boost in Discord, we can have plain text invitation URLs from Discord.

---

**Off-topic**. As long as Base UI userbase is small, directing users to Discord for support can be interesting, we have the same strategy with Toolpad, it helps go in depth in the user feedback.
However, after some level of scale (volume of questions), I believe it's really important that we move all support off of it, instead to GitHub issues + Stack Overflow; and only use Discord for community bounding like in https://mui.com/material-ui/getting-started/support/#discord. The reason is searchability, minimizing information fragmentation, and empowering the communtiy to step in, I have never seen it scale without.