### PR TITLE
[docs] Fix line break for Floating UI brand name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Base UI
 
-From the creators of Radix, Floating UI, and Material UI, Base UI is an unstyled UI component library for building accessible user interfaces.
+From the creators of Radix, Floating UI, and Material UI, Base UI is an unstyled UI component library for building accessible user interfaces.
 
 ---
 
@@ -24,12 +24,12 @@ To see the latest updates, check out the [releases](https://base-ui.com/react/ov
 
 ## Team
 
-- Michał Dudak [@michaldudak](https://x.com/michaldudak)
-- James Nelson [@atomiksdev](https://x.com/atomiksdev)
-- Albert Yu [@mj12albert](https://github.com/mj12albert)
-- Colm Tuite [@colmtuite](https://x.com/colmtuite)
-- Marija Najdova [@marijanajdova](https://x.com/marijanajdova)
-- Vlad Moroz [@vladyslavmoroz](https://x.com/vladyslavmoroz)
+- **Colm Tuite** (Radix) [@colmtuite](https://x.com/colmtuite)
+- **Vlad Moroz** (Radix) [@vladyslavmoroz](https://x.com/vladyslavmoroz)
+- **James Nelson** (Floating UI) [@atomiksdev](https://x.com/atomiksdev)
+- **Michał Dudak** (Material UI) [@michaldudak](https://x.com/michaldudak)
+- **Marija Najdova** (Material UI + Fluent UI) [@marijanajdova](https://x.com/marijanajdova)
+- **Albert Yu** (Material UI) [@mj12albert](https://github.com/mj12albert)
 
 ## License
 

--- a/docs/src/app/(public)/(content)/react/overview/about/page.mdx
+++ b/docs/src/app/(public)/(content)/react/overview/about/page.mdx
@@ -6,7 +6,7 @@
   content="An overview of Base UI, providing information on its history, team, and goals."
 />
 
-From the creators of Radix, Material UI, and Floating UI, Base UI is an unstyled React component library for building accessible user interfaces.
+From the creators of Radix, Material UI, and Floating UI, Base UI is an unstyled React component library for building accessible user interfaces.
 Our focus is on accessibility, performance, and developer experience.
 Our goal is to provide a complete set of open-source UI components, with a delightful developer experience, in a sustainable way.
 
@@ -30,12 +30,12 @@ Component APIs are fully open, so you have direct access to each node, you can e
 
 ## Team
 
-- **Colm Tuite** (Radix)
-- **Vlad Moroz** (Radix)
-- **James Nelson** (Floating UI)
-- **Michał Dudak** (Material UI)
-- **Marija Najdova** (Material UI + Fluent UI)
-- **Albert Yu** (Material UI)
+- **Colm Tuite** (Radix) [@colmtuite](https://x.com/colmtuite)
+- **Vlad Moroz** (Radix) [@vladyslavmoroz](https://x.com/vladyslavmoroz)
+- **James Nelson** (Floating UI) [@atomiksdev](https://x.com/atomiksdev)
+- **Michał Dudak** (Material UI) [@michaldudak](https://x.com/michaldudak)
+- **Marija Najdova** (Material UI + Fluent UI) [@marijanajdova](https://x.com/marijanajdova)
+- **Albert Yu** (Material UI) [@mj12albert](https://github.com/mj12albert)
 
 ## Community
 

--- a/docs/src/app/(public)/page.tsx
+++ b/docs/src/app/(public)/page.tsx
@@ -14,7 +14,7 @@ export default function Homepage() {
           Unstyled UI components for building accessible web apps and design systems.
         </h1>
         <p className="HomepageCaption">
-          From the creators of Radix, Floating UI, and Material UI.
+          From the creators of Radix, Floating&nbsp;UI, and Material&nbsp;UI.
         </p>
         <Link
           className="-m-1 inline-flex items-center gap-1 p-1"


### PR DESCRIPTION
Fix https://base-ui.com/react/overview/about

<img width="448" alt="SCR-20241225-cdfp" src="https://github.com/user-attachments/assets/54b33e86-3b20-4747-904c-daa9cd5ffdad" />

While I was at it, I thought It would sync the team section to be the same between README visible on npm page and docs.