### PR TITLE
[docs] Have 404 link points to first page of docs

### DIFF
--- a/docs/src/app/not-found.tsx
+++ b/docs/src/app/not-found.tsx
@@ -13,7 +13,7 @@ export default function NotFound() {
           <Logo className="mb-8 ml-px" aria-label="Base UI" />
           <h1 className="NotFoundHeading">404</h1>
           <p className="NotFoundCaption">
-            This page couldn’t be found. Please return to the docs or create a
+            This page couldn't be found. Please return to the docs or create a
             corresponding issue on GitHub.
           </p>
           <div className="flex flex-col items-start gap-2">

--- a/docs/src/app/not-found.tsx
+++ b/docs/src/app/not-found.tsx
@@ -19,7 +19,7 @@ export default function NotFound() {
           <div className="flex flex-col items-start gap-2">
             <Link
               className="-m-1 inline-flex items-center gap-1 p-1"
-              href="/react/components/accordion"
+              href="/react/overview/quick-start"
             >
               Documentation <ArrowRightIcon />
             </Link>


### PR DESCRIPTION
I guess it makes a bit more sense to start from the first page of the docs when hitting a 404? it could also help better appreciate traffic on the docs pages to know where we should allocate more time.