### PR TITLE
[menu] Fix closing the menu when clicking on checkboxitem/radioitem

### DIFF
--- a/packages/react/src/menu/trigger/useMenuTrigger.ts
+++ b/packages/react/src/menu/trigger/useMenuTrigger.ts
@@ -32,6 +32,12 @@ export function useMenuTrigger(parameters: useMenuTrigger.Parameters): useMenuTr
 
   const handleRef = useForkRef(buttonRef, setTriggerElement);
 
+  React.useEffect(() => {
+    if (!open) {
+      allowMouseUpTriggerRef.current = false;
+    }
+  }, [allowMouseUpTriggerRef, open]);
+
   const getTriggerProps = React.useCallback(
     (externalProps?: GenericHTMLProps): GenericHTMLProps => {
       return mergeReactProps(

--- a/packages/react/src/menu/trigger/useMenuTrigger.ts
+++ b/packages/react/src/menu/trigger/useMenuTrigger.ts
@@ -32,23 +32,6 @@ export function useMenuTrigger(parameters: useMenuTrigger.Parameters): useMenuTr
 
   const handleRef = useForkRef(buttonRef, setTriggerElement);
 
-  React.useEffect(() => {
-    if (open) {
-      // mousedown -> mouseup on menu item should not trigger it within 200ms.
-      allowMouseUpTriggerTimeoutRef.current = window.setTimeout(() => {
-        allowMouseUpTriggerRef.current = true;
-      }, 200);
-
-      return () => {
-        clearTimeout(allowMouseUpTriggerTimeoutRef.current);
-      };
-    }
-
-    allowMouseUpTriggerRef.current = false;
-
-    return undefined;
-  }, [allowMouseUpTriggerRef, open]);
-
   const getTriggerProps = React.useCallback(
     (externalProps?: GenericHTMLProps): GenericHTMLProps => {
       return mergeReactProps(
@@ -62,6 +45,11 @@ export function useMenuTrigger(parameters: useMenuTrigger.Parameters): useMenuTr
               return;
             }
 
+            // mousedown -> mouseup on menu item should not trigger it within 200ms.
+            allowMouseUpTriggerTimeoutRef.current = window.setTimeout(() => {
+              allowMouseUpTriggerRef.current = true;
+            }, 200);
+
             const doc = ownerDocument(event.currentTarget);
 
             function handleMouseUp(mouseEvent: MouseEvent) {
@@ -69,7 +57,10 @@ export function useMenuTrigger(parameters: useMenuTrigger.Parameters): useMenuTr
                 return;
               }
 
-              clearTimeout(allowMouseUpTriggerTimeoutRef.current);
+              if (allowMouseUpTriggerTimeoutRef.current !== -1) {
+                clearTimeout(allowMouseUpTriggerTimeoutRef.current);
+                allowMouseUpTriggerTimeoutRef.current = -1;
+              }
               allowMouseUpTriggerRef.current = false;
 
               const mouseUpTarget = mouseEvent.target as Element | null;


### PR DESCRIPTION
Prevents closing the menu when `defaultOpen = true` and user clicks on checkboxitem/radioitem.

Fixes #1297