### PR TITLE
[useButton] Fix `focusableWhenDisabled` components

### DIFF
--- a/docs/reference/generated/menu-radio-group.json
+++ b/docs/reference/generated/menu-radio-group.json
@@ -15,6 +15,11 @@
       "default": "() => {}",
       "description": "Function called when the selected value changes."
     },
+    "disabled": {
+      "type": "boolean",
+      "default": "false",
+      "description": "Whether the component should ignore user interaction."
+    },
     "children": {
       "type": "React.ReactNode",
       "description": "The content of the component."

--- a/packages/react/src/accordion/root/useAccordionRoot.ts
+++ b/packages/react/src/accordion/root/useAccordionRoot.ts
@@ -28,9 +28,7 @@ function getActiveTriggers(accordionItemRefs: {
 
 function isDisabled(element: HTMLElement | null) {
   return (
-    element === null ||
-    element.hasAttribute('disabled') ||
-    element.getAttribute('data-disabled') === 'true'
+    element === null || element.hasAttribute('disabled') || element.hasAttribute('data-disabled')
   );
 }
 

--- a/packages/react/src/collapsible/trigger/useCollapsibleTrigger.ts
+++ b/packages/react/src/collapsible/trigger/useCollapsibleTrigger.ts
@@ -20,21 +20,17 @@ export function useCollapsibleTrigger(
 
   const getRootProps: useCollapsibleTrigger.ReturnValue['getRootProps'] = React.useCallback(
     (externalProps: GenericHTMLProps = {}) =>
-      mergeReactProps(
-        externalProps,
-        mergeReactProps(
-          {
-            type: 'button',
-            'aria-controls': panelId,
-            'aria-expanded': open,
-            disabled,
-            onClick() {
-              setOpen(!open);
-            },
-            ref: handleRef,
+      getButtonProps(
+        mergeReactProps(externalProps, {
+          type: 'button',
+          'aria-controls': panelId,
+          'aria-expanded': open,
+          disabled,
+          onClick() {
+            setOpen(!open);
           },
-          getButtonProps(),
-        ),
+          ref: handleRef,
+        }),
       ),
     [panelId, disabled, getButtonProps, handleRef, open, setOpen],
   );

--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.test.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.test.tsx
@@ -331,4 +331,53 @@ describe('<Menu.CheckboxItem />', () => {
       expect(queryByRole('menu')).not.to.equal(null);
     });
   });
+
+  describe('focusableWhenDisabled', () => {
+    it('can be focused but not interacted with when disabled', async () => {
+      const handleCheckedChange = spy();
+      const handleClick = spy();
+      const handleKeyDown = spy();
+      const handleKeyUp = spy();
+
+      const { getByRole } = await render(
+        <Menu.Root open>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.CheckboxItem
+                  disabled
+                  onCheckedChange={handleCheckedChange}
+                  onClick={handleClick}
+                  onKeyDown={handleKeyDown}
+                  onKeyUp={handleKeyUp}
+                >
+                  Item
+                </Menu.CheckboxItem>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const item = getByRole('menuitemcheckbox');
+      await act(() => item.focus());
+      expect(item).toHaveFocus();
+
+      fireEvent.keyDown(item, { key: 'Enter' });
+      expect(handleKeyDown.callCount).to.equal(1);
+      expect(handleClick.callCount).to.equal(0);
+      expect(handleCheckedChange.callCount).to.equal(0);
+
+      fireEvent.keyUp(item, { key: 'Space' });
+      expect(handleKeyUp.callCount).to.equal(1);
+      expect(handleClick.callCount).to.equal(0);
+      expect(handleCheckedChange.callCount).to.equal(0);
+
+      fireEvent.click(item);
+      expect(handleKeyDown.callCount).to.equal(1);
+      expect(handleKeyUp.callCount).to.equal(1);
+      expect(handleClick.callCount).to.equal(0);
+      expect(handleCheckedChange.callCount).to.equal(0);
+    });
+  });
 });

--- a/packages/react/src/menu/item/MenuItem.test.tsx
+++ b/packages/react/src/menu/item/MenuItem.test.tsx
@@ -240,15 +240,21 @@ describe('<Menu.Item />', () => {
 
   describe('disabled state', () => {
     it('can be focused but not interacted with when disabled', async () => {
-      const handleKeyDown = spy();
       const handleClick = spy();
+      const handleKeyDown = spy();
+      const handleKeyUp = spy();
 
       const { getByRole } = await render(
         <Menu.Root open>
           <Menu.Portal>
             <Menu.Positioner>
               <Menu.Popup>
-                <Menu.Item disabled onClick={handleClick} onKeyDown={handleKeyDown}>
+                <Menu.Item
+                  disabled
+                  onClick={handleClick}
+                  onKeyDown={handleKeyDown}
+                  onKeyUp={handleKeyUp}
+                >
                   Item
                 </Menu.Item>
               </Menu.Popup>
@@ -258,19 +264,20 @@ describe('<Menu.Item />', () => {
       );
 
       const item = getByRole('menuitem');
-      act(() => item.focus());
+      await act(() => item.focus());
       expect(item).toHaveFocus();
 
       fireEvent.keyDown(item, { key: 'Enter' });
       expect(handleKeyDown.callCount).to.equal(1);
       expect(handleClick.callCount).to.equal(0);
 
-      fireEvent.keyDown(item, { key: 'Space' });
-      expect(handleKeyDown.callCount).to.equal(2);
+      fireEvent.keyUp(item, { key: 'Space' });
+      expect(handleKeyUp.callCount).to.equal(1);
       expect(handleClick.callCount).to.equal(0);
 
       fireEvent.click(item);
-      expect(handleKeyDown.callCount).to.equal(2);
+      expect(handleKeyDown.callCount).to.equal(1);
+      expect(handleKeyUp.callCount).to.equal(1);
       expect(handleClick.callCount).to.equal(0);
     });
   });

--- a/packages/react/src/menu/item/MenuItem.test.tsx
+++ b/packages/react/src/menu/item/MenuItem.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { MemoryRouter, Route, Routes, Link, useLocation } from 'react-router-dom';
-import { act, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui-components/react/menu';
 import { describeConformance, createRenderer, isJSDOM } from '#test-utils';
 
@@ -235,6 +235,43 @@ describe('<Menu.Item />', () => {
       expect(screen.getByText(/page one/i)).not.to.equal(null);
 
       expect(locationDisplay).to.have.text('/');
+    });
+  });
+
+  describe('disabled state', () => {
+    it('can be focused but not interacted with when disabled', async () => {
+      const handleKeyDown = spy();
+      const handleClick = spy();
+
+      const { getByRole } = await render(
+        <Menu.Root open>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Item disabled onClick={handleClick} onKeyDown={handleKeyDown}>
+                  Item
+                </Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const item = getByRole('menuitem');
+      act(() => item.focus());
+      expect(item).toHaveFocus();
+
+      fireEvent.keyDown(item, { key: 'Enter' });
+      expect(handleKeyDown.callCount).to.equal(1);
+      expect(handleClick.callCount).to.equal(0);
+
+      fireEvent.keyDown(item, { key: 'Space' });
+      expect(handleKeyDown.callCount).to.equal(2);
+      expect(handleClick.callCount).to.equal(0);
+
+      fireEvent.click(item);
+      expect(handleKeyDown.callCount).to.equal(2);
+      expect(handleClick.callCount).to.equal(0);
     });
   });
 });

--- a/packages/react/src/menu/radio-group/MenuRadioGroup.tsx
+++ b/packages/react/src/menu/radio-group/MenuRadioGroup.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { MenuRadioGroupContext } from './MenuRadioGroupContext';
+import { NOOP } from '../../utils/noop';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useControlled } from '../../utils/useControlled';
 import { useEventCallback } from '../../utils/useEventCallback';
-
-const EMPTY_OBJECT = {};
-const NOOP = () => {};
 
 /**
  * Groups related radio items.
@@ -22,7 +20,8 @@ const MenuRadioGroup = React.forwardRef(function MenuRadioGroup(
     className,
     value: valueProp,
     defaultValue,
-    onValueChange: onValueChangeProp = NOOP,
+    onValueChange: onValueChangeProp,
+    disabled = false,
     ...other
   } = props;
 
@@ -32,7 +31,7 @@ const MenuRadioGroup = React.forwardRef(function MenuRadioGroup(
     name: 'MenuRadioGroup',
   });
 
-  const onValueChange = useEventCallback(onValueChangeProp);
+  const onValueChange = useEventCallback(onValueChangeProp ?? NOOP);
 
   const setValue = React.useCallback(
     (newValue: any, event: Event) => {
@@ -42,23 +41,27 @@ const MenuRadioGroup = React.forwardRef(function MenuRadioGroup(
     [onValueChange, setValueUnwrapped],
   );
 
+  const state = React.useMemo(() => ({ disabled }), [disabled]);
+
   const { renderElement } = useComponentRenderer({
     render: render || 'div',
     className,
-    state: EMPTY_OBJECT,
+    state,
     extraProps: {
       role: 'group',
+      'aria-disabled': disabled || undefined,
       ...other,
     },
     ref: forwardedRef,
   });
 
-  const context = React.useMemo(
+  const context: MenuRadioGroupContext = React.useMemo(
     () => ({
       value,
       setValue,
+      disabled,
     }),
-    [value, setValue],
+    [value, setValue, disabled],
   );
 
   return (
@@ -92,9 +95,17 @@ namespace MenuRadioGroup {
      * @default () => {}
      */
     onValueChange?: (value: any, event: Event) => void;
+    /**
+     * Whether the component should ignore user interaction.
+     *
+     * @default false
+     */
+    disabled?: boolean;
   }
 
-  export type State = {};
+  export type State = {
+    disabled: boolean;
+  };
 }
 
 MenuRadioGroup.propTypes /* remove-proptypes */ = {
@@ -117,6 +128,12 @@ MenuRadioGroup.propTypes /* remove-proptypes */ = {
    * To render a controlled radio group, use the `value` prop instead.
    */
   defaultValue: PropTypes.any,
+  /**
+   * Whether the component should ignore user interaction.
+   *
+   * @default false
+   */
+  disabled: PropTypes.bool,
   /**
    * Function called when the selected value changes.
    *

--- a/packages/react/src/menu/radio-group/MenuRadioGroupContext.ts
+++ b/packages/react/src/menu/radio-group/MenuRadioGroupContext.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 export interface MenuRadioGroupContext {
   value: any;
   setValue: (newValue: any, event: Event) => void;
+  disabled: boolean;
 }
 
 export const MenuRadioGroupContext = React.createContext<MenuRadioGroupContext | undefined>(

--- a/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
@@ -299,4 +299,44 @@ describe('<Menu.RadioItem />', () => {
       expect(queryByRole('menu')).not.to.equal(null);
     });
   });
+
+  describe('focusableWhenDisabled', () => {
+    it('can be focused but not interacted with when a radio group is disabled', async () => {
+      const handleKeyDown = spy();
+      const handleClick = spy();
+      const handleValueChange = spy();
+
+      const { getAllByRole } = await render(
+        <Menu.Root open>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.RadioGroup defaultValue={0} disabled onValueChange={handleValueChange}>
+                  <Menu.RadioItem value="one" onClick={handleClick} onKeyDown={handleKeyDown}>
+                    one
+                  </Menu.RadioItem>
+                  <Menu.RadioItem value="two" onClick={handleClick} onKeyDown={handleKeyDown}>
+                    two
+                  </Menu.RadioItem>
+                </Menu.RadioGroup>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const [item1, item2] = getAllByRole('menuitemradio');
+
+      expect(item1).to.have.attribute('data-disabled');
+      expect(item2).to.have.attribute('data-disabled');
+
+      await act(() => item1.focus());
+      expect(item1).toHaveFocus();
+
+      fireEvent.keyDown(item1, { key: 'Enter' });
+      expect(handleKeyDown.callCount).to.equal(1);
+      expect(handleClick.callCount).to.equal(0);
+      expect(handleValueChange.callCount).to.equal(0);
+    });
+  });
 });

--- a/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
@@ -9,6 +9,7 @@ import { MenuRadioGroupContext } from '../radio-group/MenuRadioGroupContext';
 const testRadioGroupContext = {
   value: '0',
   setValue: () => {},
+  disabled: false,
 };
 
 describe('<Menu.RadioItem />', () => {
@@ -302,8 +303,9 @@ describe('<Menu.RadioItem />', () => {
 
   describe('focusableWhenDisabled', () => {
     it('can be focused but not interacted with when a radio group is disabled', async () => {
-      const handleKeyDown = spy();
       const handleClick = spy();
+      const handleKeyDown = spy();
+      const handleKeyUp = spy();
       const handleValueChange = spy();
 
       const { getAllByRole } = await render(
@@ -312,10 +314,20 @@ describe('<Menu.RadioItem />', () => {
             <Menu.Positioner>
               <Menu.Popup>
                 <Menu.RadioGroup defaultValue={0} disabled onValueChange={handleValueChange}>
-                  <Menu.RadioItem value="one" onClick={handleClick} onKeyDown={handleKeyDown}>
+                  <Menu.RadioItem
+                    value="one"
+                    onClick={handleClick}
+                    onKeyDown={handleKeyDown}
+                    onKeyUp={handleKeyUp}
+                  >
                     one
                   </Menu.RadioItem>
-                  <Menu.RadioItem value="two" onClick={handleClick} onKeyDown={handleKeyDown}>
+                  <Menu.RadioItem
+                    value="two"
+                    onClick={handleClick}
+                    onKeyDown={handleKeyDown}
+                    onKeyUp={handleKeyUp}
+                  >
                     two
                   </Menu.RadioItem>
                 </Menu.RadioGroup>
@@ -337,6 +349,105 @@ describe('<Menu.RadioItem />', () => {
       expect(handleKeyDown.callCount).to.equal(1);
       expect(handleClick.callCount).to.equal(0);
       expect(handleValueChange.callCount).to.equal(0);
+
+      fireEvent.keyUp(item1, { key: 'Space' });
+      expect(handleKeyDown.callCount).to.equal(1);
+      expect(handleClick.callCount).to.equal(0);
+      expect(handleValueChange.callCount).to.equal(0);
+
+      fireEvent.click(item1);
+      expect(handleClick.callCount).to.equal(0);
+      expect(handleValueChange.callCount).to.equal(0);
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown' });
+      expect(handleKeyDown.callCount).to.equal(2);
+      expect(item2).toHaveFocus();
+
+      fireEvent.keyDown(item2, { key: 'Enter' });
+      expect(handleKeyDown.callCount).to.equal(3);
+      expect(handleClick.callCount).to.equal(0);
+      expect(handleValueChange.callCount).to.equal(0);
+
+      fireEvent.keyUp(item2, { key: 'Space' });
+      expect(handleKeyDown.callCount).to.equal(3);
+      expect(handleClick.callCount).to.equal(0);
+      expect(handleValueChange.callCount).to.equal(0);
+
+      fireEvent.click(item2);
+      expect(handleClick.callCount).to.equal(0);
+      expect(handleValueChange.callCount).to.equal(0);
     });
+  });
+
+  it('can be focused but not interacted with when individual items are disabled', async () => {
+    const handleClick = spy();
+    const handleKeyDown = spy();
+    const handleKeyUp = spy();
+    const handleValueChange = spy();
+
+    const { getAllByRole } = await render(
+      <Menu.Root open>
+        <Menu.Portal>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.RadioGroup defaultValue={0} onValueChange={handleValueChange}>
+                <Menu.RadioItem
+                  value="one"
+                  onClick={handleClick}
+                  onKeyDown={handleKeyDown}
+                  onKeyUp={handleKeyUp}
+                  disabled
+                >
+                  one
+                </Menu.RadioItem>
+                <Menu.RadioItem
+                  value="two"
+                  onClick={handleClick}
+                  onKeyDown={handleKeyDown}
+                  onKeyUp={handleKeyUp}
+                >
+                  two
+                </Menu.RadioItem>
+              </Menu.RadioGroup>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>,
+    );
+
+    const [item1, item2] = getAllByRole('menuitemradio');
+
+    expect(item1).to.have.attribute('data-disabled');
+    expect(item2).to.not.have.attribute('data-disabled');
+
+    await act(() => item1.focus());
+    expect(item1).toHaveFocus();
+
+    fireEvent.keyDown(item1, { key: 'Enter' });
+    expect(handleKeyDown.callCount).to.equal(1);
+    expect(handleClick.callCount).to.equal(0);
+    expect(handleValueChange.callCount).to.equal(0);
+
+    fireEvent.keyUp(item1, { key: 'Space' });
+    expect(handleKeyDown.callCount).to.equal(1);
+    expect(handleClick.callCount).to.equal(0);
+    expect(handleValueChange.callCount).to.equal(0);
+
+    fireEvent.click(item1);
+    expect(handleClick.callCount).to.equal(0);
+    expect(handleValueChange.callCount).to.equal(0);
+
+    fireEvent.keyDown(item1, { key: 'ArrowDown' });
+    expect(handleKeyDown.callCount).to.equal(2);
+    expect(item2).toHaveFocus();
+
+    fireEvent.keyDown(item2, { key: 'Enter' });
+    expect(handleKeyDown.callCount).to.equal(3);
+    expect(handleClick.callCount).to.equal(1);
+    expect(handleValueChange.callCount).to.equal(1);
+    expect(handleValueChange.args[0][0]).to.equal('two');
+
+    fireEvent.keyDown(item2, { key: 'ArrowDown' });
+    expect(item1).toHaveFocus();
   });
 });

--- a/packages/react/src/menu/radio-item/MenuRadioItem.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.tsx
@@ -159,7 +159,14 @@ const MenuRadioItem = React.forwardRef(function MenuRadioItem(
   props: MenuRadioItem.Props,
   forwardedRef: React.ForwardedRef<Element>,
 ) {
-  const { id: idProp, value, label, disabled = false, closeOnClick = false, ...other } = props;
+  const {
+    id: idProp,
+    value,
+    label,
+    disabled: disabledProp = false,
+    closeOnClick = false,
+    ...other
+  } = props;
 
   const itemRef = React.useRef<HTMLElement>(null);
   const listItem = useCompositeListItem({ label });
@@ -171,7 +178,13 @@ const MenuRadioItem = React.forwardRef(function MenuRadioItem(
   const highlighted = listItem.index === activeIndex;
   const { events: menuEvents } = useFloatingTree()!;
 
-  const { value: selectedValue, setValue: setSelectedValue } = useMenuRadioGroupContext();
+  const {
+    value: selectedValue,
+    setValue: setSelectedValue,
+    disabled: groupDisabled,
+  } = useMenuRadioGroupContext();
+
+  const disabled = groupDisabled || disabledProp;
 
   // This wrapper component is used as a performance optimization.
   // MenuRadioItem reads the context and re-renders the actual MenuRadioItem
@@ -197,6 +210,7 @@ const MenuRadioItem = React.forwardRef(function MenuRadioItem(
         {...other}
         id={id}
         ref={mergedRef}
+        disabled={disabled}
         highlighted={highlighted}
         menuEvents={menuEvents}
         propGetter={getItemProps}

--- a/packages/react/src/menu/trigger/useMenuTrigger.ts
+++ b/packages/react/src/menu/trigger/useMenuTrigger.ts
@@ -40,9 +40,8 @@ export function useMenuTrigger(parameters: useMenuTrigger.Parameters): useMenuTr
 
   const getTriggerProps = React.useCallback(
     (externalProps?: GenericHTMLProps): GenericHTMLProps => {
-      return mergeReactProps(
-        externalProps,
-        {
+      return getButtonProps(
+        mergeReactProps(externalProps, {
           'aria-haspopup': 'menu' as const,
           tabIndex: 0, // this is needed to make the button focused after click in Safari
           ref: handleRef,
@@ -95,8 +94,7 @@ export function useMenuTrigger(parameters: useMenuTrigger.Parameters): useMenuTr
 
             doc.addEventListener('mouseup', handleMouseUp, { once: true });
           },
-        },
-        getButtonProps(),
+        }),
       );
     },
     [getButtonProps, handleRef, open, setOpen, positionerRef, allowMouseUpTriggerRef],

--- a/packages/react/src/select/item/SelectItem.test.tsx
+++ b/packages/react/src/select/item/SelectItem.test.tsx
@@ -136,7 +136,7 @@ describe('<Select.Item />', () => {
     );
 
     const item = screen.getByText('two');
-    act(() => item.focus());
+    await act(() => item.focus());
     expect(item).toHaveFocus();
   });
 

--- a/packages/react/src/select/item/SelectItem.test.tsx
+++ b/packages/react/src/select/item/SelectItem.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Select } from '@base-ui-components/react/select';
-import { fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { expect } from 'chai';
 
@@ -115,6 +115,29 @@ describe('<Select.Item />', () => {
     await waitFor(() => {
       expect(value.textContent).to.equal('two');
     });
+  });
+
+  it('should focus disabled items', async () => {
+    await render(
+      <Select.Root open>
+        <Select.Trigger data-testid="trigger">
+          <Select.Value data-testid="value" />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="two" disabled>
+                two
+              </Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const item = screen.getByText('two');
+    act(() => item.focus());
+    expect(item).toHaveFocus();
   });
 
   it('should not select disabled item', async () => {

--- a/packages/react/src/select/item/useSelectItem.ts
+++ b/packages/react/src/select/item/useSelectItem.ts
@@ -50,9 +50,6 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
         mergeReactProps<'div'>(externalProps, {
           'aria-disabled': disabled || undefined,
           tabIndex: highlighted ? 0 : -1,
-          style: {
-            pointerEvents: disabled ? 'none' : undefined,
-          },
           onFocus() {
             if (allowFocusSyncRef.current) {
               setActiveIndex(indexRef.current);
@@ -112,6 +109,7 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
           },
           onClick(event) {
             if (
+              disabled ||
               (lastKeyRef.current === ' ' && typingRef.current) ||
               (pointerTypeRef.current !== 'touch' && !highlighted)
             ) {
@@ -130,6 +128,9 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
             pointerTypeRef.current = event.pointerType;
           },
           onMouseUp(event) {
+            if (disabled) {
+              return;
+            }
             const disallowSelectedMouseUp = !selectionRef.current.allowSelectedMouseUp && selected;
             const disallowUnselectedMouseUp =
               !selectionRef.current.allowUnselectedMouseUp && !selected;

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -20,6 +20,14 @@ import type { SelectRootContext } from './SelectRootContext';
 import type { SelectIndexContext } from './SelectIndexContext';
 import { useAfterExitAnimation } from '../../utils/useAfterExitAnimation';
 
+const EMPTY_ARRAY: never[] = [];
+
+function isDisabled(element: HTMLElement | null) {
+  return (
+    element == null || element.hasAttribute('disabled') || element.hasAttribute('data-disabled')
+  );
+}
+
 export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelectRoot.ReturnValue {
   const {
     id: idProp,
@@ -175,8 +183,10 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     },
   });
 
+  const triggerDisabled = isDisabled(triggerElement);
+
   const click = useClick(floatingRootContext, {
-    enabled: !readOnly,
+    enabled: !readOnly && !disabled && !triggerDisabled,
     event: 'mousedown',
   });
 
@@ -190,10 +200,11 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
   });
 
   const listNavigation = useListNavigation(floatingRootContext, {
-    enabled: !readOnly,
+    enabled: !readOnly && !disabled,
     listRef,
     activeIndex,
     selectedIndex,
+    disabledIndices: EMPTY_ARRAY,
     onNavigate(nextActiveIndex) {
       // Retain the highlight while transitioning out.
       if (nextActiveIndex === null && !open) {
@@ -207,8 +218,8 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     focusItemOnHover: false,
   });
 
-  const typehaead = useTypeahead(floatingRootContext, {
-    enabled: !readOnly,
+  const typeahead = useTypeahead(floatingRootContext, {
+    enabled: !readOnly && !disabled,
     listRef: labelsRef,
     activeIndex,
     selectedIndex,
@@ -230,7 +241,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     getReferenceProps: getRootTriggerProps,
     getFloatingProps: getRootPositionerProps,
     getItemProps,
-  } = useInteractions([click, dismiss, role, listNavigation, typehaead]);
+  } = useInteractions([click, dismiss, role, listNavigation, typeahead]);
 
   const rootContext = React.useMemo(
     () => ({

--- a/packages/react/src/select/trigger/SelectTrigger.test.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.test.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { Select } from '@base-ui-components/react/select';
 import { createRenderer, describeConformance } from '#test-utils';
 import { expect } from 'chai';
-import { act, screen } from '@mui/internal-test-utils';
+import { spy } from 'sinon';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 
 describe('<Select.Trigger />', () => {
   const { render } = createRenderer();
@@ -13,6 +14,61 @@ describe('<Select.Trigger />', () => {
       return render(<Select.Root open>{node}</Select.Root>);
     },
   }));
+
+  describe('disabled state', () => {
+    it('cannot be focused when disabled', async () => {
+      const { user } = await render(
+        <Select.Root defaultValue="b">
+          <Select.Trigger data-testid="trigger" disabled>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      expect(trigger).to.have.attribute('data-disabled');
+
+      await user.keyboard('[Tab]');
+
+      expect(expect(document.activeElement)).to.not.equal(trigger);
+    });
+
+    it('does not toggle the popup when disabled', async () => {
+      const handleOpenChange = spy();
+      await render(
+        <Select.Root defaultValue="b" onOpenChange={handleOpenChange}>
+          <Select.Trigger data-testid="trigger" disabled>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).to.equal(null);
+      });
+      expect(handleOpenChange.callCount).to.equal(0);
+    });
+  });
 
   describe('style hooks', () => {
     it('should have the data-popup-open and data-pressed attributes when open', async () => {

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -35,8 +35,9 @@ const SelectTrigger = React.forwardRef(function SelectTrigger(
     () => ({
       ...fieldState,
       open,
+      disabled,
     }),
-    [fieldState, open],
+    [fieldState, open, disabled],
   );
 
   const { renderElement } = useComponentRenderer({

--- a/packages/react/src/select/trigger/useSelectTrigger.ts
+++ b/packages/react/src/select/trigger/useSelectTrigger.ts
@@ -77,7 +77,7 @@ export function useSelectTrigger(
         mergeReactProps<'button'>(fieldControlValidation.getValidationProps(externalProps), {
           'aria-labelledby': labelId,
           'aria-readonly': readOnly || undefined,
-          tabIndex: 0, // this is needed to make the button focused after click in Safari
+          tabIndex: disabled ? -1 : 0, // this is needed to make the button focused after click in Safari
           ref: handleRef,
           onFocus() {
             // The popup element shouldn't obscure the focused trigger.
@@ -141,18 +141,19 @@ export function useSelectTrigger(
       );
     },
     [
-      fieldControlValidation,
-      labelId,
-      readOnly,
-      handleRef,
-      getButtonProps,
-      open,
       alignItemToTrigger,
+      disabled,
+      fieldControlValidation,
+      getButtonProps,
+      handleRef,
+      labelId,
+      open,
+      positionerElement,
+      readOnly,
       setOpen,
       setTouched,
-      value,
       setTouchModality,
-      positionerElement,
+      value,
     ],
   );
 

--- a/packages/react/src/select/trigger/useSelectTrigger.ts
+++ b/packages/react/src/select/trigger/useSelectTrigger.ts
@@ -73,9 +73,8 @@ export function useSelectTrigger(
 
   const getTriggerProps = React.useCallback(
     (externalProps?: GenericHTMLProps): GenericHTMLProps => {
-      return mergeReactProps<'button'>(
-        fieldControlValidation.getValidationProps(externalProps),
-        {
+      return getButtonProps(
+        mergeReactProps<'button'>(fieldControlValidation.getValidationProps(externalProps), {
           'aria-labelledby': labelId,
           'aria-readonly': readOnly || undefined,
           tabIndex: 0, // this is needed to make the button focused after click in Safari
@@ -138,8 +137,7 @@ export function useSelectTrigger(
               doc.addEventListener('mouseup', handleMouseUp, { once: true });
             });
           },
-        },
-        getButtonProps(),
+        }),
       );
     },
     [

--- a/packages/react/src/use-button/useButton.test.tsx
+++ b/packages/react/src/use-button/useButton.test.tsx
@@ -18,13 +18,14 @@ describe('useButton', () => {
       }
       const { getByRole } = await render(<TestButton disabled />);
       const button = getByRole('button');
-      act(() => button.focus());
+      await act(() => button.focus());
       expect(button).toHaveFocus();
     });
 
     it('prevents interactions with the button', async () => {
-      const handleKeyDown = spy();
       const handleClick = spy();
+      const handleKeyDown = spy();
+      const handleKeyUp = spy();
 
       function TestButton(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
         const { disabled, ...otherProps } = props;
@@ -34,23 +35,29 @@ describe('useButton', () => {
       }
 
       const { getByRole } = await render(
-        <TestButton disabled onKeyDown={handleKeyDown} onClick={handleClick} />,
+        <TestButton
+          disabled
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
+          onKeyUp={handleKeyUp}
+        />,
       );
       const button = getByRole('button');
 
-      act(() => button.focus());
+      await act(() => button.focus());
       expect(button).toHaveFocus();
 
       fireEvent.keyDown(button, { key: 'Enter' });
       expect(handleKeyDown.callCount).to.equal(1);
       expect(handleClick.callCount).to.equal(0);
 
-      fireEvent.keyDown(button, { key: 'Space' });
-      expect(handleKeyDown.callCount).to.equal(2);
+      fireEvent.keyUp(button, { key: 'Space' });
+      expect(handleKeyUp.callCount).to.equal(1);
       expect(handleClick.callCount).to.equal(0);
 
       fireEvent.click(button);
-      expect(handleKeyDown.callCount).to.equal(2);
+      expect(handleKeyDown.callCount).to.equal(1);
+      expect(handleKeyUp.callCount).to.equal(1);
       expect(handleClick.callCount).to.equal(0);
     });
   });
@@ -152,7 +159,7 @@ describe('useButton', () => {
 
       const button = getByRole('button');
 
-      act(() => button.focus());
+      await act(() => button.focus());
       expect(button).toHaveFocus();
 
       expect(handleKeyDown.callCount).to.equal(0);

--- a/packages/react/src/use-button/useButton.ts
+++ b/packages/react/src/use-button/useButton.ts
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { NOOP } from '../utils/noop';
 import { useForkRef } from '../utils/useForkRef';
 import { mergeReactProps } from '../utils/mergeReactProps';
 import { useEventCallback } from '../utils/useEventCallback';
@@ -65,9 +66,18 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
   }, [disabled, elementName, focusableWhenDisabled, tabIndex]);
 
   const getButtonProps = React.useCallback(
-    (externalProps: GenericButtonProps): GenericButtonProps => {
-      return mergeReactProps(externalProps, buttonProps, {
+    (externalProps: GenericButtonProps = {}): GenericButtonProps => {
+      const onClickProp = externalProps?.onClick ?? NOOP;
+
+      const otherExternalProps = { ...externalProps };
+      delete otherExternalProps.onClick;
+      return mergeReactProps(otherExternalProps, buttonProps, {
         type,
+        onClick(event: React.MouseEvent) {
+          if (!disabled) {
+            onClickProp(event);
+          }
+        },
         onKeyDown(event: React.KeyboardEvent) {
           if (event.target === event.currentTarget && !isNativeButton() && event.key === ' ') {
             event.preventDefault();
@@ -81,7 +91,7 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
             event.key === 'Enter' &&
             !disabled
           ) {
-            externalProps?.onClick?.(event);
+            onClickProp(event);
             event.preventDefault();
           }
         },
@@ -95,7 +105,7 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
             !disabled &&
             event.key === ' '
           ) {
-            externalProps.onClick?.(event);
+            onClickProp(event);
           }
         },
         ref: mergedRef,


### PR DESCRIPTION
Using `mergeReactProps`, our event handlers can't (easily) prevent external handlers since external ones are called first, it seems best to just bypass mergeReactProps here and manually call the external `onClick`.

Additionally found these issues along the way and fixed them:
- `<Menu.RadioGroup disabled />` didn't work
- `<Select.Trigger disabled />` didn't work

Closes https://github.com/mui/base-ui/issues/1312

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
