### PR TITLE
[Dialogs] Support multiple non-nested modal backdrops

### DIFF
--- a/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
+++ b/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
@@ -46,7 +46,6 @@ const AlertDialogBackdrop = React.forwardRef(function AlertDialogBackdrop(
     extraProps: {
       role: 'presentation',
       hidden: !mounted,
-      'data-base-ui-backdrop': '',
       ...other,
     },
     customStyleHookMapping,

--- a/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
+++ b/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
@@ -8,6 +8,7 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { useForkRef } from '../../utils/useForkRef';
 
 const customStyleHookMapping: CustomStyleHookMapping<AlertDialogBackdrop.State> = {
   ...baseMapping,
@@ -25,7 +26,7 @@ const AlertDialogBackdrop = React.forwardRef(function AlertDialogBackdrop(
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { render, className, ...other } = props;
-  const { open, nested, mounted, transitionStatus } = useAlertDialogRootContext();
+  const { open, nested, mounted, transitionStatus, backdropRef } = useAlertDialogRootContext();
 
   const state: AlertDialogBackdrop.State = React.useMemo(
     () => ({
@@ -35,11 +36,13 @@ const AlertDialogBackdrop = React.forwardRef(function AlertDialogBackdrop(
     [open, transitionStatus],
   );
 
+  const mergedRef = useForkRef(backdropRef, forwardedRef);
+
   const { renderElement } = useComponentRenderer({
     render: render ?? 'div',
     className,
     state,
-    ref: forwardedRef,
+    ref: mergedRef,
     extraProps: { role: 'presentation', hidden: !mounted, ...other },
     customStyleHookMapping,
   });

--- a/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
+++ b/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
@@ -43,7 +43,12 @@ const AlertDialogBackdrop = React.forwardRef(function AlertDialogBackdrop(
     className,
     state,
     ref: mergedRef,
-    extraProps: { role: 'presentation', hidden: !mounted, ...other },
+    extraProps: {
+      role: 'presentation',
+      hidden: !mounted,
+      'data-base-ui-backdrop': '',
+      ...other,
+    },
     customStyleHookMapping,
   });
 

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -53,6 +53,7 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
     titleElementId,
     transitionStatus,
     modal,
+    internalBackdropRef,
   } = useAlertDialogRootContext();
 
   useAlertDialogPortalContext();
@@ -101,14 +102,13 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
 
   return (
     <React.Fragment>
-      {mounted && modal && <InternalBackdrop inert={!open} />}
+      {mounted && modal && <InternalBackdrop ref={internalBackdropRef} inert={!open} />}
       <FloatingFocusManager
         context={floatingRootContext}
         modal={open}
         disabled={!mounted}
         initialFocus={resolvedInitialFocus}
         returnFocus={finalFocus}
-        outsideElementsInert
       >
         {renderElement()}
       </FloatingFocusManager>

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
@@ -87,49 +87,19 @@ describe('<AlertDialog.Root />', () => {
   });
 
   describe.skipIf(isJSDOM)('modality', () => {
-    it('makes other interactive elements on the page inert when a modal dialog is open and restores them after the dialog is closed', async () => {
-      const { user } = await render(
-        <div>
-          <input data-testid="input" />
-          <textarea data-testid="textarea" />
-
-          <AlertDialog.Root>
-            <AlertDialog.Trigger>Open Dialog</AlertDialog.Trigger>
-            <AlertDialog.Portal>
-              <AlertDialog.Popup>
-                <AlertDialog.Close>Close Dialog</AlertDialog.Close>
-              </AlertDialog.Popup>
-            </AlertDialog.Portal>
-          </AlertDialog.Root>
-
-          <button type="button">Another Button</button>
-        </div>,
+    it('makes other interactive elements on the page inert when a modal dialog is open', async () => {
+      await render(
+        <AlertDialog.Root defaultOpen>
+          <AlertDialog.Trigger>Open Dialog</AlertDialog.Trigger>
+          <AlertDialog.Portal>
+            <AlertDialog.Popup>
+              <AlertDialog.Close>Close Dialog</AlertDialog.Close>
+            </AlertDialog.Popup>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>,
       );
 
-      const outsideElements = [
-        screen.getByTestId('input'),
-        screen.getByTestId('textarea'),
-        screen.getByRole('button', { name: 'Another Button' }),
-      ];
-
-      const trigger = screen.getByRole('button', { name: 'Open Dialog' });
-      await user.click(trigger);
-
-      await waitFor(() => {
-        outsideElements.forEach((element) => {
-          // The `inert` attribute can be applied to the element itself or to an ancestor
-          expect(element.closest('[inert]')).not.to.equal(null);
-        });
-      });
-
-      const close = screen.getByRole('button', { name: 'Close Dialog' });
-      await user.click(close);
-
-      await waitFor(() => {
-        outsideElements.forEach((element) => {
-          expect(element.closest('[inert]')).to.equal(null);
-        });
-      });
+      expect(document.querySelector('[data-base-ui-backdrop]')).not.to.equal(null);
     });
   });
 });

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { screen } from '@mui/internal-test-utils';
 import { AlertDialog } from '@base-ui-components/react/alert-dialog';
 import { createRenderer, isJSDOM } from '#test-utils';
 import { spy } from 'sinon';

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
@@ -125,7 +125,7 @@ describe('<AlertDialog.Root />', () => {
         </AlertDialog.Root>,
       );
 
-      expect(document.querySelector('[data-base-ui-backdrop]')).not.to.equal(null);
+      expect(screen.getByRole('presentation', { hidden: true })).not.to.equal(null);
     });
   });
 });

--- a/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
+++ b/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
@@ -46,7 +46,6 @@ const DialogBackdrop = React.forwardRef(function DialogBackdrop(
     extraProps: {
       role: 'presentation',
       hidden: !mounted,
-      'data-base-ui-backdrop': '',
       ...other,
     },
     customStyleHookMapping,

--- a/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
+++ b/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
@@ -8,6 +8,7 @@ import { type BaseUIComponentProps } from '../../utils/types';
 import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { useForkRef } from '../../utils/useForkRef';
 
 const customStyleHookMapping: CustomStyleHookMapping<DialogBackdrop.State> = {
   ...baseMapping,
@@ -25,7 +26,7 @@ const DialogBackdrop = React.forwardRef(function DialogBackdrop(
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { render, className, ...other } = props;
-  const { open, nested, mounted, transitionStatus } = useDialogRootContext();
+  const { open, nested, mounted, transitionStatus, backdropRef } = useDialogRootContext();
 
   const state: DialogBackdrop.State = React.useMemo(
     () => ({
@@ -35,12 +36,19 @@ const DialogBackdrop = React.forwardRef(function DialogBackdrop(
     [open, transitionStatus],
   );
 
+  const mergedRef = useForkRef(backdropRef, forwardedRef);
+
   const { renderElement } = useComponentRenderer({
     render: render ?? 'div',
     className,
     state,
-    ref: forwardedRef,
-    extraProps: { role: 'presentation', hidden: !mounted, ...other },
+    ref: mergedRef,
+    extraProps: {
+      role: 'presentation',
+      hidden: !mounted,
+      'data-base-ui-backdrop': '',
+      ...other,
+    },
     customStyleHookMapping,
   });
 

--- a/packages/react/src/dialog/popup/DialogPopup.test.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.test.tsx
@@ -326,7 +326,7 @@ describe('<Dialog.Popup />', () => {
 
       expect(computedStyles.getPropertyValue('--nested-dialogs')).to.equal('1');
 
-      await user.click(screen.getByRole('button', { name: 'toggle' }));
+      await user.click(screen.getByRole('button', { name: 'toggle', hidden: true }));
 
       expect(computedStyles.getPropertyValue('--nested-dialogs')).to.equal('0');
     });

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -55,7 +55,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
     setPopupElementId,
     titleElementId,
     transitionStatus,
-    backdropRef,
+    internalBackdropRef,
   } = useDialogRootContext();
 
   useDialogPortalContext();
@@ -98,7 +98,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
 
   return (
     <React.Fragment>
-      {mounted && modal && <InternalBackdrop ref={backdropRef} inert={!open} />}
+      {mounted && modal && <InternalBackdrop ref={internalBackdropRef} inert={!open} />}
       <FloatingFocusManager
         context={floatingRootContext}
         modal={open}

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -55,6 +55,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
     setPopupElementId,
     titleElementId,
     transitionStatus,
+    backdropRef,
   } = useDialogRootContext();
 
   useDialogPortalContext();
@@ -97,7 +98,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
 
   return (
     <React.Fragment>
-      {mounted && modal && <InternalBackdrop inert={!open} />}
+      {mounted && modal && <InternalBackdrop ref={backdropRef} inert={!open} />}
       <FloatingFocusManager
         context={floatingRootContext}
         modal={open}
@@ -105,7 +106,6 @@ const DialogPopup = React.forwardRef(function DialogPopup(
         closeOnFocusOut={dismissible}
         initialFocus={resolvedInitialFocus}
         returnFocus={finalFocus}
-        outsideElementsInert={modal}
       >
         {renderElement()}
       </FloatingFocusManager>

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -490,7 +490,7 @@ describe('<Dialog.Root />', () => {
       const [openNested2, setOpenNested2] = React.useState(false);
 
       return (
-        <>
+        <div>
           <Dialog.Root>
             <Dialog.Trigger>Trigger</Dialog.Trigger>
             <Dialog.Portal>
@@ -514,7 +514,7 @@ describe('<Dialog.Root />', () => {
               <Dialog.Popup>Final nested</Dialog.Popup>
             </Dialog.Portal>
           </Dialog.Root>
-        </>
+        </div>
       );
     }
 
@@ -540,7 +540,7 @@ describe('<Dialog.Root />', () => {
       const [openNested2, setOpenNested2] = React.useState(false);
 
       return (
-        <>
+        <div>
           <Dialog.Root>
             <Dialog.Trigger>Trigger</Dialog.Trigger>
             <Dialog.Portal>
@@ -561,7 +561,7 @@ describe('<Dialog.Root />', () => {
               <Dialog.Popup data-testid="level-3">Final nested</Dialog.Popup>
             </Dialog.Portal>
           </Dialog.Root>
-        </>
+        </div>
       );
     }
 

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -264,7 +264,7 @@ describe('<Dialog.Root />', () => {
         </Dialog.Root>,
       );
 
-      await user.click(document.querySelector('[data-base-ui-backdrop]') as HTMLElement);
+      await user.click(screen.getByRole('presentation', { hidden: true }));
 
       expect(handleOpenChange.callCount).to.equal(1);
       expect(handleOpenChange.firstCall.args[2]).to.equal('outside-press');
@@ -315,7 +315,7 @@ describe('<Dialog.Root />', () => {
   });
 
   describe.skipIf(isJSDOM)('prop: modal', () => {
-    it('makes other interactive elements on the page inert when a modal dialog is open and restores them after the dialog is closed', async () => {
+    it('makes other interactive elements on the page inert when a modal dialog is open', async () => {
       await render(
         <Dialog.Root defaultOpen modal>
           <Dialog.Trigger>Open Dialog</Dialog.Trigger>
@@ -327,7 +327,7 @@ describe('<Dialog.Root />', () => {
         </Dialog.Root>,
       );
 
-      expect(document.querySelector('[data-base-ui-backdrop]')).not.to.equal(null);
+      expect(screen.getByRole('presentation', { hidden: true })).not.to.equal(null);
     });
 
     it('does not make other interactive elements on the page inert when a non-modal dialog is open', async () => {
@@ -342,7 +342,7 @@ describe('<Dialog.Root />', () => {
         </Dialog.Root>,
       );
 
-      expect(document.querySelector('[data-base-ui-backdrop]')).to.equal(null);
+      expect(screen.queryByRole('presentation')).to.equal(null);
     });
   });
 
@@ -576,7 +576,7 @@ describe('<Dialog.Root />', () => {
     const nestedButton2 = screen.getByRole('button', { name: 'Open nested 2' });
     await user.click(nestedButton2);
 
-    const backdrops = Array.from(document.querySelectorAll('[data-base-ui-backdrop]'));
+    const backdrops = Array.from(document.querySelectorAll('[role="presentation"]'));
     await user.click(backdrops[backdrops.length - 1]);
 
     expect(screen.queryByTestId('level-3')).to.equal(null);

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -93,10 +93,10 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
     outsidePressEvent: 'mousedown',
     outsidePress(event) {
       const target = getTarget(event) as Element | null;
-      if (isTopmost && dismissible && target) {
-        const backdrop = target.closest('[data-base-ui-backdrop]') as HTMLDivElement | null;
+      if (isTopmost && dismissible) {
+        const backdrop = target as HTMLDivElement | null;
         // Only close if the click occurred on the dialog's owning backdrop.
-        // This supports nested modal dialogs that aren't nested in the React tree:
+        // This supports multiple modal dialogs that aren't nested in the React tree:
         // https://github.com/mui/base-ui/issues/1320
         if (modal) {
           return backdrop

--- a/packages/react/src/utils/InternalBackdrop.tsx
+++ b/packages/react/src/utils/InternalBackdrop.tsx
@@ -12,7 +12,7 @@ const InternalBackdrop = React.forwardRef(function InternalBackdrop(
   return (
     <div
       ref={ref}
-      data-base-ui-backdrop
+      data-base-ui-backdrop=""
       role="presentation"
       style={{
         position: 'fixed',

--- a/packages/react/src/utils/InternalBackdrop.tsx
+++ b/packages/react/src/utils/InternalBackdrop.tsx
@@ -4,10 +4,15 @@ import PropTypes from 'prop-types';
 /**
  * @ignore - internal component.
  */
-function InternalBackdrop(props: InternalBackdrop.Props) {
+const InternalBackdrop = React.forwardRef(function InternalBackdrop(
+  props: InternalBackdrop.Props,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
   const { inert = false } = props;
   return (
     <div
+      ref={ref}
+      data-base-ui-backdrop
       role="presentation"
       style={{
         position: 'fixed',
@@ -25,7 +30,7 @@ function InternalBackdrop(props: InternalBackdrop.Props) {
       }}
     />
   );
-}
+});
 
 namespace InternalBackdrop {
   export interface Props {

--- a/packages/react/src/utils/InternalBackdrop.tsx
+++ b/packages/react/src/utils/InternalBackdrop.tsx
@@ -12,7 +12,6 @@ const InternalBackdrop = React.forwardRef(function InternalBackdrop(
   return (
     <div
       ref={ref}
-      data-base-ui-backdrop=""
       role="presentation"
       style={{
         position: 'fixed',


### PR DESCRIPTION
This detects if the click occurred on the dialog's owning backdrop. This ensures dialogs that opened previously but aren't nested in the React tree won't close. This fixes bugs related to multiple "unrelated" dialogs that open independently without using any kind of Provider.

Note: non-nested dialogs don't support CSS variables or limiting to only one (topmost) backdrop as that requires context/React tree nesting. I figure that feature is usually useful for closely related dialogs that will be nested in the React tree anyway.

Closes #1320