### PR TITLE
[menu] Fix iPad detection when applying scroll lock

### DIFF
--- a/packages/react/src/utils/detectBrowser.ts
+++ b/packages/react/src/utils/detectBrowser.ts
@@ -7,18 +7,24 @@ interface NavigatorUAData {
 }
 
 // Avoid Chrome DevTools blue warning.
-export function getPlatform(): string {
+export function getNavigatorData(): { platform: string; maxTouchPoints: number } {
   if (typeof navigator === 'undefined') {
-    return '';
+    return { platform: '', maxTouchPoints: -1 };
   }
 
   const uaData = (navigator as any).userAgentData as NavigatorUAData | undefined;
 
   if (uaData?.platform) {
-    return uaData.platform;
+    return {
+      platform: uaData.platform,
+      maxTouchPoints: navigator.maxTouchPoints,
+    };
   }
 
-  return navigator.platform;
+  return {
+    platform: navigator.platform,
+    maxTouchPoints: navigator.maxTouchPoints,
+  };
 }
 
 export function isWebKit() {
@@ -29,7 +35,15 @@ export function isWebKit() {
 }
 
 export function isIOS() {
-  return /iP(hone|ad|od)|iOS/.test(getPlatform());
+  const nav = getNavigatorData();
+
+  // iPads can claim to be MacIntel
+  // https://github.com/getsentry/sentry-javascript/issues/12127
+  if (nav.platform === 'MacIntel' && nav.maxTouchPoints > 1) {
+    return true;
+  }
+
+  return /iP(hone|ad|od)|iOS/.test(nav.platform);
 }
 
 export function isFirefox() {


### PR DESCRIPTION
Closes https://github.com/mui/base-ui/issues/1309

Safari on iPad reports `navigator.platform` as `'MacIntel'` (instead of `'iPad'`), reference: https://github.com/getsentry/sentry-javascript/issues/12127

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
