### PR TITLE
[docs][Tabs] Fix example component names

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/tabs/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/tabs/demos/hero/css-modules/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Tabs } from '@base-ui-components/react/tabs';
 import styles from './index.module.css';
 
-export default function ExampleScrollArea() {
+export default function ExampleTabs() {
   return (
     <Tabs.Root className={styles.Tabs} defaultValue="overview">
       <Tabs.List className={styles.List}>

--- a/docs/src/app/(public)/(content)/react/components/tabs/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/tabs/demos/hero/tailwind/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Tabs } from '@base-ui-components/react/tabs';
 
-export default function ExampleScrollArea() {
+export default function ExampleTabs() {
   return (
     <Tabs.Root className="rounded-md border border-gray-200" defaultValue="overview">
       <Tabs.List className="relative z-0 flex gap-1 px-1 shadow-[inset_0_-1px] shadow-gray-200">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

[Tabs examples](https://base-ui.com/react/components/tabs) are incorrectly named as `ExampleScrollArea`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
