### PR TITLE
[tabs] Fix being able to activate a disabled tab

### DIFF
--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -301,6 +301,58 @@ describe('<Tabs.Root />', () => {
     });
   });
 
+  describe('pointer navigation', () => {
+    it('activates the clicked tab', async () => {
+      const { user } = await render(
+        <Tabs.Root defaultValue={0}>
+          <Tabs.List activateOnFocus={false}>
+            <Tabs.Tab value={0}>Tab 1</Tabs.Tab>
+            <Tabs.Tab value={1}>Tab 2</Tabs.Tab>
+            <Tabs.Tab value={2}>Tab 3</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel>Panel 1</Tabs.Panel>
+          <Tabs.Panel>Panel 2</Tabs.Panel>
+          <Tabs.Panel>Panel 3</Tabs.Panel>
+        </Tabs.Root>,
+      );
+
+      const tab2 = screen.getByRole('tab', { name: 'Tab 2' });
+      await user.click(tab2);
+
+      const panels = screen.getAllByRole('tabpanel', { hidden: true });
+
+      expect(panels[0]).to.have.attribute('hidden');
+      expect(panels[1]).not.to.have.attribute('hidden');
+      expect(panels[2]).to.have.attribute('hidden');
+    });
+
+    it('does not activate the clicked disabled tab', async () => {
+      const { user } = await render(
+        <Tabs.Root defaultValue={0}>
+          <Tabs.List activateOnFocus={false}>
+            <Tabs.Tab value={0}>Tab 1</Tabs.Tab>
+            <Tabs.Tab disabled value={1}>
+              Tab 2
+            </Tabs.Tab>
+            <Tabs.Tab value={2}>Tab 3</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel>Panel 1</Tabs.Panel>
+          <Tabs.Panel>Panel 2</Tabs.Panel>
+          <Tabs.Panel>Panel 3</Tabs.Panel>
+        </Tabs.Root>,
+      );
+
+      const tab2 = screen.getByRole('tab', { name: 'Tab 2' });
+      await user.click(tab2);
+
+      const panels = screen.getAllByRole('tabpanel', { hidden: true });
+
+      expect(panels[0]).not.to.have.attribute('hidden');
+      expect(panels[1]).to.have.attribute('hidden');
+      expect(panels[2]).to.have.attribute('hidden');
+    });
+  });
+
   describe('keyboard navigation when focus is on a tab', () => {
     [
       ['horizontal', 'ltr', 'ArrowLeft', 'ArrowRight'],

--- a/packages/react/src/tabs/tab/useTabsTab.ts
+++ b/packages/react/src/tabs/tab/useTabsTab.ts
@@ -97,7 +97,7 @@ function useTabsTab(parameters: useTabsTab.Parameters): useTabsTab.ReturnValue {
             onTabActivation(tabValue, event.nativeEvent);
           },
           onFocus(event) {
-            if (!activateOnFocus || selected) {
+            if (!activateOnFocus || selected || disabled) {
               return;
             }
 

--- a/packages/react/src/tabs/tab/useTabsTab.ts
+++ b/packages/react/src/tabs/tab/useTabsTab.ts
@@ -90,7 +90,7 @@ function useTabsTab(parameters: useTabsTab.Parameters): useTabsTab.ReturnValue {
           id,
           ref: handleRef,
           onClick(event) {
-            if (selected) {
+            if (selected || disabled) {
               return;
             }
 
@@ -106,7 +106,7 @@ function useTabsTab(parameters: useTabsTab.Parameters): useTabsTab.ReturnValue {
             }
           },
           onPointerDown(event) {
-            if (selected) {
+            if (selected || disabled) {
               return;
             }
 
@@ -138,6 +138,7 @@ function useTabsTab(parameters: useTabsTab.Parameters): useTabsTab.ReturnValue {
       selected,
       tabPanelId,
       tabValue,
+      disabled,
     ],
   );
 


### PR DESCRIPTION
Placing a `disabled` prop on a `Tabs.Tab` only prevented it from being activated via a keyboard, but not with a pointer.

Before: https://codesandbox.io/p/sandbox/gallant-sunset-rq8gt4?file=%2Fsrc%2Findex.module.css
After: https://codesandbox.io/p/sandbox/kind-newton-xmpj8v?workspaceId=ws_QAeLcZEcDnfGaFA47etEUH
