### PR TITLE
[Form] Fix focusing of invalid field controls on errors prop change

### DIFF
--- a/packages/react/src/form/Form.test.tsx
+++ b/packages/react/src/form/Form.test.tsx
@@ -14,6 +14,40 @@ describe('<Form />', () => {
   }));
 
   describe('prop: errors', () => {
+    function App() {
+      const [errors, setErrors] = React.useState<Form.Props['errors']>({
+        foo: 'bar',
+      });
+
+      return (
+        <Form
+          errors={errors}
+          onClearErrors={setErrors}
+          onSubmit={(event) => {
+            event.preventDefault();
+            const formData = new FormData(event.currentTarget);
+            const name = formData.get('name') as string;
+            const age = formData.get('age') as string;
+
+            setErrors({
+              ...(name === '' && { name: 'Name is required' }),
+              ...(age === '' && { age: 'Age is required' }),
+            });
+          }}
+        >
+          <Field.Root name="name">
+            <Field.Control data-testid="name" />
+            <Field.Error data-testid="name-error" />
+          </Field.Root>
+          <Field.Root name="age">
+            <Field.Control data-testid="age" />
+            <Field.Error data-testid="age-error" />
+          </Field.Root>
+          <button>Submit</button>
+        </Form>
+      );
+    }
+
     it('should mark <Field.Control> as invalid and populate <Field.Error>', () => {
       render(
         <Form errors={{ foo: 'bar' }}>
@@ -40,6 +74,45 @@ describe('<Form />', () => {
 
       expect(screen.queryByTestId('error')).to.equal(null);
       expect(screen.getByRole('textbox')).not.to.have.attribute('aria-invalid');
+    });
+
+    it('focuses the first invalid field only on submit', async () => {
+      const { user } = render(<App />);
+
+      const submit = screen.getByRole('button');
+      const name = screen.getByTestId('name');
+      const age = screen.getByTestId('age');
+
+      await user.click(submit);
+
+      expect(name).toHaveFocus();
+
+      fireEvent.change(name, { target: { value: 'John' } });
+
+      expect(age).not.toHaveFocus();
+
+      await user.click(submit);
+
+      expect(age).toHaveFocus();
+
+      fireEvent.change(age, { target: { value: '42' } });
+
+      await user.click(submit);
+
+      expect(age).not.toHaveFocus();
+    });
+
+    it('removes errors upon change', async () => {
+      render(<App />);
+
+      const name = screen.getByTestId('name');
+      const age = screen.getByTestId('age');
+
+      fireEvent.change(name, { target: { value: 'John' } });
+      fireEvent.change(age, { target: { value: '42' } });
+
+      expect(screen.queryByTestId('name-error')).to.equal(null);
+      expect(screen.queryByTestId('age-error')).to.equal(null);
     });
   });
 


### PR DESCRIPTION
Fixes #1361

This uses a ref to check when `onSubmit` is called and assigns it to `true`. The effect to react to `errors` changing only runs once after the event fires. Also removed the manual `onSubmit` call, since `mergeReactProps` already does this now