### PR TITLE
[core] Allow undefined function for `useEventCallback`

### DIFF
--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
@@ -6,7 +6,7 @@ import { useEventCallback } from '../utils/useEventCallback';
 export function useCheckboxGroupParent(
   params: UseCheckboxGroupParent.Parameters,
 ): UseCheckboxGroupParent.ReturnValue {
-  const { allValues = [], value = [], onValueChange: onValueChangeProp = () => {} } = params;
+  const { allValues = [], value = [], onValueChange: onValueChangeProp } = params;
 
   const uncontrolledStateRef = React.useRef(value);
   const disabledStatesRef = React.useRef(new Map<string, boolean>());

--- a/packages/react/src/checkbox/root/useCheckboxRoot.ts
+++ b/packages/react/src/checkbox/root/useCheckboxRoot.ts
@@ -17,7 +17,7 @@ export function useCheckboxRoot(params: UseCheckboxRoot.Parameters): UseCheckbox
     id: idProp,
     checked: externalChecked,
     inputRef: externalInputRef,
-    onCheckedChange: onCheckedChangeProp = () => {},
+    onCheckedChange: onCheckedChangeProp,
     name,
     value,
     defaultChecked = false,

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -35,7 +35,7 @@ const FieldRoot = React.forwardRef(function FieldRoot(
 
   const { errors } = useFormContext();
 
-  const validate = useEventCallback(validateProp);
+  const validate = useEventCallback(validateProp || (() => null));
 
   const disabled = disabledFieldset || disabledProp;
 

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -35,7 +35,7 @@ const FieldRoot = React.forwardRef(function FieldRoot(
 
   const { errors } = useFormContext();
 
-  const validate = useEventCallback(validateProp || (() => null));
+  const validate = useEventCallback(validateProp);
 
   const disabled = disabledFieldset || disabledProp;
 

--- a/packages/react/src/form/Form.tsx
+++ b/packages/react/src/form/Form.tsx
@@ -30,8 +30,8 @@ const Form = React.forwardRef(function Form(
     fields: new Map(),
   });
 
-  const onSubmit = useEventCallback(onSubmitProp || (() => {}));
-  const onClearErrors = useEventCallback(onClearErrorsProp || (() => {}));
+  const onSubmit = useEventCallback(onSubmitProp);
+  const onClearErrors = useEventCallback(onClearErrorsProp);
 
   const getFormProps = React.useCallback(
     (externalProps = {}) =>

--- a/packages/react/src/menu/radio-group/MenuRadioGroup.tsx
+++ b/packages/react/src/menu/radio-group/MenuRadioGroup.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { MenuRadioGroupContext } from './MenuRadioGroupContext';
-import { NOOP } from '../../utils/noop';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useControlled } from '../../utils/useControlled';
@@ -31,7 +30,7 @@ const MenuRadioGroup = React.forwardRef(function MenuRadioGroup(
     name: 'MenuRadioGroup',
   });
 
-  const onValueChange = useEventCallback(onValueChangeProp ?? NOOP);
+  const onValueChange = useEventCallback(onValueChangeProp);
 
   const setValue = React.useCallback(
     (newValue: any, event: Event) => {

--- a/packages/react/src/number-field/root/useNumberFieldRoot.ts
+++ b/packages/react/src/number-field/root/useNumberFieldRoot.ts
@@ -52,7 +52,7 @@ export function useNumberFieldRoot(
     allowWheelScrub = false,
     format,
     value: externalValue,
-    onValueChange: onValueChangeProp = () => {},
+    onValueChange: onValueChangeProp,
     defaultValue,
   } = params;
 

--- a/packages/react/src/popover/root/usePopoverRoot.ts
+++ b/packages/react/src/popover/root/usePopoverRoot.ts
@@ -29,7 +29,7 @@ import { PATIENT_CLICK_THRESHOLD } from '../../utils/constants';
 export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoot.ReturnValue {
   const {
     open: externalOpen,
-    onOpenChange: onOpenChangeProp = () => {},
+    onOpenChange: onOpenChangeProp,
     defaultOpen = false,
     delay,
     closeDelay,

--- a/packages/react/src/preview-card/root/usePreviewCardRoot.ts
+++ b/packages/react/src/preview-card/root/usePreviewCardRoot.ts
@@ -26,7 +26,7 @@ export function usePreviewCardRoot(
 ): usePreviewCardRoot.ReturnValue {
   const {
     open: externalOpen,
-    onOpenChange: onOpenChangeProp = () => {},
+    onOpenChange: onOpenChangeProp,
     defaultOpen = false,
     delay,
     closeDelay,

--- a/packages/react/src/switch/root/useSwitchRoot.ts
+++ b/packages/react/src/switch/root/useSwitchRoot.ts
@@ -15,7 +15,7 @@ export function useSwitchRoot(params: useSwitchRoot.Parameters): useSwitchRoot.R
   const {
     id: idProp,
     checked: checkedProp,
-    onCheckedChange: onCheckedChangeProp = () => {},
+    onCheckedChange: onCheckedChangeProp,
     defaultChecked,
     name,
     readOnly,

--- a/packages/react/src/tooltip/root/useTooltipRoot.ts
+++ b/packages/react/src/tooltip/root/useTooltipRoot.ts
@@ -26,7 +26,7 @@ import { useAfterExitAnimation } from '../../utils/useAfterExitAnimation';
 export function useTooltipRoot(params: useTooltipRoot.Parameters): useTooltipRoot.ReturnValue {
   const {
     open: externalOpen,
-    onOpenChange: onOpenChangeProp = () => {},
+    onOpenChange: onOpenChangeProp,
     defaultOpen = false,
     hoverable = true,
     trackCursorAxis = 'none',

--- a/packages/react/src/utils/useEventCallback.ts
+++ b/packages/react/src/utils/useEventCallback.ts
@@ -2,27 +2,18 @@
 import * as React from 'react';
 import { useEnhancedEffect } from './useEnhancedEffect';
 
+type AnyFunction = (...args: any[]) => any;
+
 /**
  * Inspired by https://github.com/facebook/react/issues/14099#issuecomment-440013892
  * See RFC in https://github.com/reactjs/rfcs/pull/220
  */
-function useEventCallback<Fn extends (...args: any[]) => any = (...args: unknown[]) => unknown>(
-  fn: Fn,
-): Fn;
-function useEventCallback<Args extends unknown[], Return>(
-  fn: (...args: Args) => Return,
-): (...args: Args) => Return;
-function useEventCallback<Args extends unknown[], Return>(
-  fn: (...args: Args) => Return,
-): (...args: Args) => Return {
+function useEventCallback<Fn extends AnyFunction>(fn?: Fn) {
   const ref = React.useRef(fn);
   useEnhancedEffect(() => {
     ref.current = fn;
   });
-  return React.useRef((...args: Args) =>
-    // @ts-expect-error hide `this`
-    (0, ref.current!)(...args),
-  ).current;
+  return React.useCallback<AnyFunction>((...args) => ref.current?.(...args), []) as Fn;
 }
 
 export { useEventCallback };


### PR DESCRIPTION
Avoids needing to pass an empty NOOP function to `useEventCallback` for optional function props