### PR TITLE
[core] Fix corepack installation in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,11 @@ commands:
         default: stable
 
     steps:
+      - run:
+          name: Set npm registry public signing keys
+          command: |
+            echo "export COREPACK_INTEGRITY_KEYS='$(curl https://registry.npmjs.org/-/npm/v1/keys | jq -c '{npm: .keys}')'" >> $BASH_ENV
+
       - when:
           condition: << parameters.browsers >>
           steps:


### PR DESCRIPTION
npmjs.org rotated the public signing keys but corepack hardcoded the old one, causing all the CI pipelines to fail ([example](https://app.circleci.com/pipelines/github/mui/base-ui/7353/workflows/1865f9ae-7da2-41ab-ac41-27acd7c04f19/jobs/65711)) because it couldn't install pnpm properly: https://github.com/nodejs/corepack/issues/612

This fix fetches the latest keys and storing them in an env variable, taken from this comment: https://github.com/nodejs/corepack/issues/612#issuecomment-2629911771

The alternatives are not as good:
- `npm install -g corepack@latest` will work but requires `sudo` in CircleCI which is annoying to install
- `COREPACK_INTEGRITY_KEYS=0` disable the signature check, risky!

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
