### PR TITLE
[useAnchorPositioning] Ensure `keepMounted` is a private param

### DIFF
--- a/packages/react/src/menu/positioner/MenuPositioner.spec.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.spec.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Menu } from '@base-ui-components/react';
 
 // @ts-expect-error - `keepMounted` should not be available

--- a/packages/react/src/menu/positioner/MenuPositioner.spec.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.spec.tsx
@@ -1,0 +1,4 @@
+import { Menu } from '@base-ui-components/react';
+
+// @ts-expect-error - `keepMounted` should not be available
+<Menu.Positioner keepMounted />;

--- a/packages/react/src/popover/positioner/PopoverPositioner.spec.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.spec.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Popover } from '@base-ui-components/react';
 
 // @ts-expect-error - `keepMounted` should not be available

--- a/packages/react/src/popover/positioner/PopoverPositioner.spec.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.spec.tsx
@@ -1,0 +1,4 @@
+import { Popover } from '@base-ui-components/react';
+
+// @ts-expect-error - `keepMounted` should not be available
+<Popover.Positioner keepMounted />;

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.spec.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.spec.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { PreviewCard } from '@base-ui-components/react';
 
 // @ts-expect-error - `keepMounted` should not be available

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.spec.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.spec.tsx
@@ -1,0 +1,4 @@
+import { PreviewCard } from '@base-ui-components/react';
+
+// @ts-expect-error - `keepMounted` should not be available
+<PreviewCard.Positioner keepMounted />;

--- a/packages/react/src/select/positioner/SelectPositioner.spec.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.spec.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Select } from '@base-ui-components/react';
 
 // @ts-expect-error - `keepMounted` should not be available

--- a/packages/react/src/select/positioner/SelectPositioner.spec.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.spec.tsx
@@ -1,0 +1,4 @@
+import { Select } from '@base-ui-components/react';
+
+// @ts-expect-error - `keepMounted` should not be available
+<Select.Positioner keepMounted />;

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.spec.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.spec.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Tooltip } from '@base-ui-components/react';
 
 // @ts-expect-error - `keepMounted` should not be available

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.spec.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.spec.tsx
@@ -1,0 +1,4 @@
+import { Tooltip } from '@base-ui-components/react';
+
+// @ts-expect-error - `keepMounted` should not be available
+<Tooltip.Positioner keepMounted />;

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -67,8 +67,8 @@ export function useAnchorPositioning(
     collisionPadding = 5,
     sticky = false,
     arrowPadding = 5,
-    keepMounted = false,
     // Private parameters
+    keepMounted = false,
     floatingRootContext,
     mounted,
     trackAnchor = true,
@@ -422,14 +422,10 @@ export namespace useAnchorPositioning {
      * @default true
      */
     trackAnchor?: boolean;
-    /**
-     * Whether to keep the popup mounted in the DOM while it's hidden.
-     * @default false
-     */
-    keepMounted?: boolean;
   }
 
   export interface Parameters extends SharedParameters {
+    keepMounted?: boolean;
     trackCursorAxis?: 'none' | 'x' | 'y' | 'both';
     floatingRootContext?: FloatingRootContext;
     mounted: boolean;


### PR DESCRIPTION
`keepMounted` should only exist on `Portal` parts - `Positioner` parts were inheriting it incorrectly as a type from `useAnchorPositioning.SharedParameters`