### PR TITLE
[Slider] Fix thumb positioning

### DIFF
--- a/packages/react/src/slider/control/SliderControl.test.tsx
+++ b/packages/react/src/slider/control/SliderControl.test.tsx
@@ -6,7 +6,7 @@ import { NOOP } from '../../utils/noop';
 
 const testRootContext: SliderRootContext = {
   active: -1,
-  handleInputChange: NOOP,
+  commitValue: NOOP,
   dragging: false,
   disabled: false,
   getFingerState: () => ({
@@ -15,7 +15,7 @@ const testRootContext: SliderRootContext = {
     percentageValues: [0],
     thumbIndex: 0,
   }),
-  setValue: NOOP,
+  handleInputChange: NOOP,
   largeStep: 10,
   lastChangedValueRef: { current: null },
   thumbMap: new Map(),
@@ -23,7 +23,6 @@ const testRootContext: SliderRootContext = {
   min: 0,
   minStepsBetweenValues: 0,
   name: '',
-  onValueCommitted: NOOP,
   orientation: 'horizontal',
   state: {
     activeThumbIndex: -1,
@@ -47,6 +46,7 @@ const testRootContext: SliderRootContext = {
   setDragging: NOOP,
   setPercentageValues: NOOP,
   setThumbMap: NOOP,
+  setValue: NOOP,
   step: 1,
   tabIndex: null,
   thumbRefs: { current: [] },

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -21,12 +21,12 @@ const SliderControl = React.forwardRef(function SliderControl(
   const { render: renderProp, className, ...otherProps } = props;
 
   const {
+    commitValue,
     disabled,
     dragging,
     getFingerState,
     lastChangedValueRef,
     minStepsBetweenValues,
-    onValueCommitted,
     percentageValues,
     registerSliderControl,
     setActive,
@@ -38,12 +38,12 @@ const SliderControl = React.forwardRef(function SliderControl(
   } = useSliderRootContext();
 
   const { getRootProps } = useSliderControl({
+    commitValue,
     disabled,
     dragging,
     getFingerState,
     lastChangedValueRef,
     minStepsBetweenValues,
-    onValueCommitted,
     percentageValues,
     registerSliderControl,
     rootRef: forwardedRef,

--- a/packages/react/src/slider/control/useSliderControl.ts
+++ b/packages/react/src/slider/control/useSliderControl.ts
@@ -51,7 +51,7 @@ export function useSliderControl(
     getFingerState,
     lastChangedValueRef,
     minStepsBetweenValues,
-    onValueCommitted,
+    commitValue,
     percentageValues,
     registerSliderControl,
     rootRef: externalRef,
@@ -128,11 +128,9 @@ export function useSliderControl(
     setActive(-1);
 
     commitValidation(lastChangedValueRef.current ?? finger.value);
-
-    onValueCommitted(lastChangedValueRef.current ?? finger.value, nativeEvent);
+    commitValue(lastChangedValueRef.current ?? finger.value, nativeEvent);
 
     touchIdRef.current = null;
-
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     stopListening();
   });
@@ -280,7 +278,7 @@ export namespace useSliderControl {
       | 'getFingerState'
       | 'lastChangedValueRef'
       | 'minStepsBetweenValues'
-      | 'onValueCommitted'
+      | 'commitValue'
       | 'percentageValues'
       | 'registerSliderControl'
       | 'setActive'

--- a/packages/react/src/slider/indicator/SliderIndicator.test.tsx
+++ b/packages/react/src/slider/indicator/SliderIndicator.test.tsx
@@ -6,7 +6,7 @@ import { NOOP } from '../../utils/noop';
 
 const testRootContext: SliderRootContext = {
   active: -1,
-  handleInputChange: NOOP,
+  commitValue: NOOP,
   dragging: false,
   disabled: false,
   getFingerState: () => ({
@@ -15,7 +15,7 @@ const testRootContext: SliderRootContext = {
     percentageValues: [0],
     thumbIndex: 0,
   }),
-  setValue: NOOP,
+  handleInputChange: NOOP,
   largeStep: 10,
   lastChangedValueRef: { current: null },
   thumbMap: new Map(),
@@ -23,7 +23,6 @@ const testRootContext: SliderRootContext = {
   min: 0,
   minStepsBetweenValues: 0,
   name: '',
-  onValueCommitted: NOOP,
   orientation: 'horizontal',
   state: {
     activeThumbIndex: -1,
@@ -47,6 +46,7 @@ const testRootContext: SliderRootContext = {
   setDragging: NOOP,
   setPercentageValues: NOOP,
   setThumbMap: NOOP,
+  setValue: NOOP,
   step: 1,
   tabIndex: null,
   thumbRefs: { current: [] },

--- a/packages/react/src/slider/root/useSliderRoot.ts
+++ b/packages/react/src/slider/root/useSliderRoot.ts
@@ -363,6 +363,24 @@ export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRo
   );
 
   useEnhancedEffect(() => {
+    if (valueProp === undefined || dragging) {
+      return;
+    }
+
+    if (typeof valueUnwrapped === 'number') {
+      const newPercentageValue = valueToPercent(valueUnwrapped, min, max);
+      if (newPercentageValue !== percentageValues[0]) {
+        setPercentageValues([newPercentageValue]);
+      }
+    } else if (Array.isArray(valueUnwrapped)) {
+      const newPercentageValues = [];
+      for (let i = 0; i < valueUnwrapped.length; i += 1) {
+        newPercentageValues.push(valueToPercent(valueUnwrapped[i], min, max));
+      }
+    }
+  }, [dragging, min, max, percentageValues, setPercentageValues, valueProp, valueUnwrapped]);
+
+  useEnhancedEffect(() => {
     const activeEl = activeElement(ownerDocument(sliderRef.current));
     if (disabled && sliderRef.current?.contains(activeEl)) {
       // This is necessary because Firefox and Safari will keep focus

--- a/packages/react/src/slider/root/useSliderRoot.ts
+++ b/packages/react/src/slider/root/useSliderRoot.ts
@@ -55,6 +55,14 @@ function findClosest(values: readonly number[], currentValue: number) {
   return closestIndex;
 }
 
+function valueArrayToPercentages(values: number[], min: number, max: number) {
+  const output = [];
+  for (let i = 0; i < values.length; i += 1) {
+    output.push(valueToPercent(values[i], min, max));
+  }
+  return output;
+}
+
 export function focusThumb(
   thumbIndex: number,
   sliderRef: React.RefObject<HTMLElement | null>,
@@ -193,11 +201,7 @@ export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRo
   }, [max, min, range, valueUnwrapped]);
 
   function initializePercentageValues() {
-    const vals = [];
-    for (let i = 0; i < values.length; i += 1) {
-      vals.push(valueToPercent(values[i], min, max));
-    }
-    return vals;
+    return valueArrayToPercentages(values, min, max);
   }
 
   const [percentageValues, setPercentageValues] = React.useState<readonly number[]>(
@@ -237,9 +241,9 @@ export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRo
   // for pointer drag only
   const commitValue = useEventCallback((value: number | readonly number[], event: Event) => {
     if (Array.isArray(value)) {
-      const newPercentageValues = [];
-      for (let i = 0; i < value.length; i += 1) {
-        newPercentageValues.push(valueToPercent(value[i], min, max));
+      const newPercentageValues = valueArrayToPercentages(value, min, max);
+      if (!areArraysEqual(newPercentageValues, percentageValues)) {
+        setPercentageValues(newPercentageValues);
       }
     } else if (typeof value === 'number') {
       setPercentageValues([valueToPercent(value, min, max)]);
@@ -373,9 +377,9 @@ export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRo
         setPercentageValues([newPercentageValue]);
       }
     } else if (Array.isArray(valueUnwrapped)) {
-      const newPercentageValues = [];
-      for (let i = 0; i < valueUnwrapped.length; i += 1) {
-        newPercentageValues.push(valueToPercent(valueUnwrapped[i], min, max));
+      const newPercentageValues = valueArrayToPercentages(valueUnwrapped, min, max);
+      if (!areArraysEqual(newPercentageValues, percentageValues)) {
+        setPercentageValues(newPercentageValues);
       }
     }
   }, [dragging, min, max, percentageValues, setPercentageValues, valueProp, valueUnwrapped]);

--- a/packages/react/src/slider/root/useSliderRoot.ts
+++ b/packages/react/src/slider/root/useSliderRoot.ts
@@ -580,7 +580,7 @@ export namespace useSliderRoot {
     active: number;
     'aria-labelledby'?: string;
     /**
-     * Callback fired when drag ends and invokes onValueCommitted.
+     * Function to be called when drag ends. Invokes onValueCommitted.
      */
     commitValue: (newValue: number | readonly number[], event: Event) => void;
     dragging: boolean;

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -95,87 +95,193 @@ describe('<Slider.Thumb />', () => {
   }));
 
   describe.skipIf(isJSDOM)('positioning styles', () => {
-    it('positions the thumb when dragged', async () => {
-      const { getByTestId } = await render(
-        <Slider.Root
-          style={{
-            // browser tests render with 1024px width by default
-            // this is just to make the values asserted more readable
-            width: '1000px',
-          }}
-        >
-          <Slider.Control data-testid="control">
-            <Slider.Track>
-              <Slider.Indicator />
-              <Slider.Thumb data-testid="thumb" />
-            </Slider.Track>
-          </Slider.Control>
-        </Slider.Root>,
-      );
+    describe('positions the thumb when dragged', () => {
+      it('single thumb', async () => {
+        const { getByTestId } = await render(
+          <Slider.Root
+            style={{
+              // browser tests render with 1024px width by default
+              // this is just to make the values asserted more readable
+              width: '1000px',
+            }}
+          >
+            <Slider.Control data-testid="control">
+              <Slider.Track>
+                <Slider.Indicator />
+                <Slider.Thumb data-testid="thumb" />
+              </Slider.Track>
+            </Slider.Control>
+          </Slider.Root>,
+        );
 
-      const sliderControl = getByTestId('control');
+        const sliderControl = getByTestId('control');
 
-      const thumbStyles = getComputedStyle(getByTestId('thumb'));
+        const thumbStyles = getComputedStyle(getByTestId('thumb'));
 
-      stub(sliderControl, 'getBoundingClientRect').callsFake(
-        () => GETBOUNDINGCLIENTRECT_HORIZONTAL_SLIDER_RETURN_VAL,
-      );
+        stub(sliderControl, 'getBoundingClientRect').callsFake(
+          () => GETBOUNDINGCLIENTRECT_HORIZONTAL_SLIDER_RETURN_VAL,
+        );
 
-      fireEvent.touchStart(
-        sliderControl,
-        createTouches([{ identifier: 1, clientX: 20, clientY: 0 }]),
-      );
-      fireEvent.touchMove(
-        document.body,
-        createTouches([{ identifier: 1, clientX: 199, clientY: 0 }]),
-      );
-      fireEvent.touchMove(
-        document.body,
-        createTouches([{ identifier: 1, clientX: 199, clientY: 0 }]),
-      );
+        fireEvent.touchStart(
+          sliderControl,
+          createTouches([{ identifier: 1, clientX: 20, clientY: 0 }]),
+        );
+        fireEvent.touchMove(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 199, clientY: 0 }]),
+        );
+        fireEvent.touchMove(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 199, clientY: 0 }]),
+        );
 
-      fireEvent.touchMove(
-        document.body,
-        createTouches([{ identifier: 1, clientX: 199, clientY: 0 }]),
-      );
+        fireEvent.touchMove(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 199, clientY: 0 }]),
+        );
 
-      expect(thumbStyles.getPropertyValue('left')).to.equal('199px');
-      fireEvent.touchEnd(document.body, createTouches([{ identifier: 1, clientX: 0, clientY: 0 }]));
-      expect(thumbStyles.getPropertyValue('left')).to.equal('200px');
+        expect(thumbStyles.getPropertyValue('left')).to.equal('199px');
+        fireEvent.touchEnd(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 0, clientY: 0 }]),
+        );
+        expect(thumbStyles.getPropertyValue('left')).to.equal('200px');
+      });
+
+      it('multiple thumbs', async () => {
+        const { getByTestId, getAllByTestId } = await render(
+          <Slider.Root
+            defaultValue={[20, 40]}
+            style={{
+              // browser tests render with 1024px width by default
+              // this is just to make the values asserted more readable
+              width: '1000px',
+            }}
+          >
+            <Slider.Control data-testid="control">
+              <Slider.Track>
+                <Slider.Indicator />
+                <Slider.Thumb data-testid="thumb" />
+                <Slider.Thumb data-testid="thumb" />
+              </Slider.Track>
+            </Slider.Control>
+          </Slider.Root>,
+        );
+
+        const sliderControl = getByTestId('control');
+
+        const computedStyles = {
+          thumb1: getComputedStyle(getAllByTestId('thumb')[0]),
+          thumb2: getComputedStyle(getAllByTestId('thumb')[1]),
+        };
+
+        stub(sliderControl, 'getBoundingClientRect').callsFake(
+          () => GETBOUNDINGCLIENTRECT_HORIZONTAL_SLIDER_RETURN_VAL,
+        );
+
+        fireEvent.touchStart(
+          sliderControl,
+          createTouches([{ identifier: 1, clientX: 400, clientY: 0 }]),
+        );
+        fireEvent.touchMove(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 699, clientY: 0 }]),
+        );
+        fireEvent.touchMove(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 699, clientY: 0 }]),
+        );
+
+        fireEvent.touchMove(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 699, clientY: 0 }]),
+        );
+
+        expect(computedStyles.thumb2.getPropertyValue('left')).to.equal('699px');
+        fireEvent.touchEnd(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 0, clientY: 0 }]),
+        );
+        expect(computedStyles.thumb1.getPropertyValue('left')).to.equal('200px');
+        expect(computedStyles.thumb2.getPropertyValue('left')).to.equal('700px');
+      });
     });
 
-    it('positions the thumb when the controlled value changes externally', async () => {
-      function App() {
-        const [val, setVal] = React.useState(20);
-        return (
-          <React.Fragment>
-            <button onClick={() => setVal(55)} />
-            <Slider.Root
-              value={val}
-              onValueChange={(newVal) => setVal(newVal as number)}
-              style={{
-                // browser tests render with 1024px width by default
-                // this is just to make the values asserted more readable
-                width: '100px',
-              }}
-            >
-              <Slider.Control data-testid="control">
-                <Slider.Track>
-                  <Slider.Indicator />
-                  <Slider.Thumb data-testid="thumb" />
-                </Slider.Track>
-              </Slider.Control>
-            </Slider.Root>
-          </React.Fragment>
-        );
-      }
-      const { getByTestId, getByRole } = await render(<App />);
+    describe('positions the thumb when the controlled value changes externally', () => {
+      it('single thumb', async () => {
+        function App() {
+          const [val, setVal] = React.useState(20);
+          return (
+            <React.Fragment>
+              <button onClick={() => setVal(55)} />
+              <Slider.Root
+                value={val}
+                onValueChange={(newVal) => setVal(newVal as number)}
+                style={{
+                  // browser tests render with 1024px width by default
+                  // this is just to make the values asserted more readable
+                  width: '100px',
+                }}
+              >
+                <Slider.Control data-testid="control">
+                  <Slider.Track>
+                    <Slider.Indicator />
+                    <Slider.Thumb data-testid="thumb" />
+                  </Slider.Track>
+                </Slider.Control>
+              </Slider.Root>
+            </React.Fragment>
+          );
+        }
+        const { getByTestId, getByRole } = await render(<App />);
 
-      const thumbStyles = getComputedStyle(getByTestId('thumb'));
-      expect(thumbStyles.getPropertyValue('left')).to.equal('20px');
+        const thumbStyles = getComputedStyle(getByTestId('thumb'));
+        expect(thumbStyles.getPropertyValue('left')).to.equal('20px');
 
-      fireEvent.click(getByRole('button'));
-      expect(thumbStyles.getPropertyValue('left')).to.equal('55px');
+        fireEvent.click(getByRole('button'));
+        expect(thumbStyles.getPropertyValue('left')).to.equal('55px');
+      });
+
+      it('multiple thumbs', async () => {
+        function App() {
+          const [val, setVal] = React.useState([20, 50]);
+          return (
+            <React.Fragment>
+              <button onClick={() => setVal([33, 72])} />
+              <Slider.Root
+                value={val}
+                onValueChange={(newVal) => setVal(newVal as number[])}
+                style={{
+                  // browser tests render with 1024px width by default
+                  // this is just to make the values asserted more readable
+                  width: '100px',
+                }}
+              >
+                <Slider.Control data-testid="control">
+                  <Slider.Track>
+                    <Slider.Indicator />
+                    <Slider.Thumb data-testid="thumb" />
+                    <Slider.Thumb data-testid="thumb" />
+                  </Slider.Track>
+                </Slider.Control>
+              </Slider.Root>
+            </React.Fragment>
+          );
+        }
+        const { getAllByTestId, getByRole } = await render(<App />);
+
+        const computedStyles = {
+          thumb1: getComputedStyle(getAllByTestId('thumb')[0]),
+          thumb2: getComputedStyle(getAllByTestId('thumb')[1]),
+        };
+
+        expect(computedStyles.thumb1.getPropertyValue('left')).to.equal('20px');
+        expect(computedStyles.thumb2.getPropertyValue('left')).to.equal('50px');
+
+        fireEvent.click(getByRole('button'));
+        expect(computedStyles.thumb1.getPropertyValue('left')).to.equal('33px');
+        expect(computedStyles.thumb2.getPropertyValue('left')).to.equal('72px');
+      });
     });
   });
 });

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -94,8 +94,8 @@ describe('<Slider.Thumb />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
-  describe.skipIf(isJSDOM)('internal styles', () => {
-    it('positions the thumb when the value changes', async () => {
+  describe.skipIf(isJSDOM)('positioning styles', () => {
+    it('positions the thumb when dragged', async () => {
       const { getByTestId } = await render(
         <Slider.Root
           style={{
@@ -142,6 +142,40 @@ describe('<Slider.Thumb />', () => {
       expect(thumbStyles.getPropertyValue('left')).to.equal('199px');
       fireEvent.touchEnd(document.body, createTouches([{ identifier: 1, clientX: 0, clientY: 0 }]));
       expect(thumbStyles.getPropertyValue('left')).to.equal('200px');
+    });
+
+    it('positions the thumb when the controlled value changes externally', async () => {
+      function App() {
+        const [val, setVal] = React.useState(20);
+        return (
+          <React.Fragment>
+            <button onClick={() => setVal(55)} />
+            <Slider.Root
+              value={val}
+              onValueChange={(newVal) => setVal(newVal as number)}
+              style={{
+                // browser tests render with 1024px width by default
+                // this is just to make the values asserted more readable
+                width: '100px',
+              }}
+            >
+              <Slider.Control data-testid="control">
+                <Slider.Track>
+                  <Slider.Indicator />
+                  <Slider.Thumb data-testid="thumb" />
+                </Slider.Track>
+              </Slider.Control>
+            </Slider.Root>
+          </React.Fragment>
+        );
+      }
+      const { getByTestId, getByRole } = await render(<App />);
+
+      const thumbStyles = getComputedStyle(getByTestId('thumb'));
+      expect(thumbStyles.getPropertyValue('left')).to.equal('20px');
+
+      fireEvent.click(getByRole('button'));
+      expect(thumbStyles.getPropertyValue('left')).to.equal('55px');
     });
   });
 });

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -35,7 +35,7 @@ function createTouches(touches: Touches) {
 
 const testRootContext: SliderRootContext = {
   active: -1,
-  handleInputChange: NOOP,
+  commitValue: NOOP,
   dragging: false,
   disabled: false,
   getFingerState: () => ({
@@ -44,7 +44,7 @@ const testRootContext: SliderRootContext = {
     percentageValues: [0],
     thumbIndex: 0,
   }),
-  setValue: NOOP,
+  handleInputChange: NOOP,
   largeStep: 10,
   lastChangedValueRef: { current: null },
   thumbMap: new Map(),
@@ -52,7 +52,6 @@ const testRootContext: SliderRootContext = {
   min: 0,
   minStepsBetweenValues: 0,
   name: '',
-  onValueCommitted: NOOP,
   orientation: 'horizontal',
   state: {
     activeThumbIndex: -1,
@@ -76,6 +75,7 @@ const testRootContext: SliderRootContext = {
   setDragging: NOOP,
   setPercentageValues: NOOP,
   setThumbMap: NOOP,
+  setValue: NOOP,
   step: 1,
   tabIndex: null,
   thumbRefs: { current: [] },

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -1,8 +1,37 @@
 import * as React from 'react';
+import { expect } from 'chai';
+import { stub } from 'sinon';
+import { fireEvent } from '@mui/internal-test-utils';
 import { Slider } from '@base-ui-components/react/slider';
-import { createRenderer, describeConformance } from '#test-utils';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { SliderRootContext } from '../root/SliderRootContext';
 import { NOOP } from '../../utils/noop';
+
+type Touches = Array<Pick<Touch, 'identifier' | 'clientX' | 'clientY'>>;
+
+const GETBOUNDINGCLIENTRECT_HORIZONTAL_SLIDER_RETURN_VAL = {
+  width: 1000,
+  height: 10,
+  bottom: 10,
+  left: 0,
+  x: 0,
+  y: 0,
+  top: 0,
+  right: 0,
+  toJSON() {},
+};
+
+function createTouches(touches: Touches) {
+  return {
+    changedTouches: touches.map(
+      (touch) =>
+        new Touch({
+          target: document.body,
+          ...touch,
+        }),
+    ),
+  };
+}
 
 const testRootContext: SliderRootContext = {
   active: -1,
@@ -64,4 +93,55 @@ describe('<Slider.Thumb />', () => {
     },
     refInstanceof: window.HTMLDivElement,
   }));
+
+  describe.skipIf(isJSDOM)('internal styles', () => {
+    it('positions the thumb when the value changes', async () => {
+      const { getByTestId } = await render(
+        <Slider.Root
+          style={{
+            // browser tests render with 1024px width by default
+            // this is just to make the values asserted more readable
+            width: '1000px',
+          }}
+        >
+          <Slider.Control data-testid="control">
+            <Slider.Track>
+              <Slider.Indicator />
+              <Slider.Thumb data-testid="thumb" />
+            </Slider.Track>
+          </Slider.Control>
+        </Slider.Root>,
+      );
+
+      const sliderControl = getByTestId('control');
+
+      const thumbStyles = getComputedStyle(getByTestId('thumb'));
+
+      stub(sliderControl, 'getBoundingClientRect').callsFake(
+        () => GETBOUNDINGCLIENTRECT_HORIZONTAL_SLIDER_RETURN_VAL,
+      );
+
+      fireEvent.touchStart(
+        sliderControl,
+        createTouches([{ identifier: 1, clientX: 20, clientY: 0 }]),
+      );
+      fireEvent.touchMove(
+        document.body,
+        createTouches([{ identifier: 1, clientX: 199, clientY: 0 }]),
+      );
+      fireEvent.touchMove(
+        document.body,
+        createTouches([{ identifier: 1, clientX: 199, clientY: 0 }]),
+      );
+
+      fireEvent.touchMove(
+        document.body,
+        createTouches([{ identifier: 1, clientX: 199, clientY: 0 }]),
+      );
+
+      expect(thumbStyles.getPropertyValue('left')).to.equal('199px');
+      fireEvent.touchEnd(document.body, createTouches([{ identifier: 1, clientX: 0, clientY: 0 }]));
+      expect(thumbStyles.getPropertyValue('left')).to.equal('200px');
+    });
+  });
 });

--- a/packages/react/src/slider/track/SliderTrack.test.tsx
+++ b/packages/react/src/slider/track/SliderTrack.test.tsx
@@ -6,7 +6,7 @@ import { NOOP } from '../../utils/noop';
 
 const testRootContext: SliderRootContext = {
   active: -1,
-  handleInputChange: NOOP,
+  commitValue: NOOP,
   dragging: false,
   disabled: false,
   getFingerState: () => ({
@@ -15,7 +15,7 @@ const testRootContext: SliderRootContext = {
     percentageValues: [0],
     thumbIndex: 0,
   }),
-  setValue: NOOP,
+  handleInputChange: NOOP,
   largeStep: 10,
   lastChangedValueRef: { current: null },
   thumbMap: new Map(),
@@ -23,7 +23,6 @@ const testRootContext: SliderRootContext = {
   min: 0,
   minStepsBetweenValues: 0,
   name: '',
-  onValueCommitted: NOOP,
   orientation: 'horizontal',
   state: {
     activeThumbIndex: -1,
@@ -47,6 +46,7 @@ const testRootContext: SliderRootContext = {
   setDragging: NOOP,
   setPercentageValues: NOOP,
   setThumbMap: NOOP,
+  setValue: NOOP,
   step: 1,
   tabIndex: null,
   thumbRefs: { current: [] },

--- a/packages/react/src/slider/value/SliderValue.test.tsx
+++ b/packages/react/src/slider/value/SliderValue.test.tsx
@@ -8,7 +8,7 @@ import { NOOP } from '../../utils/noop';
 
 const testRootContext: SliderRootContext = {
   active: -1,
-  handleInputChange: NOOP,
+  commitValue: NOOP,
   dragging: false,
   disabled: false,
   getFingerState: () => ({
@@ -17,7 +17,7 @@ const testRootContext: SliderRootContext = {
     percentageValues: [0],
     thumbIndex: 0,
   }),
-  setValue: NOOP,
+  handleInputChange: NOOP,
   largeStep: 10,
   lastChangedValueRef: { current: null },
   thumbMap: new Map(),
@@ -25,7 +25,6 @@ const testRootContext: SliderRootContext = {
   min: 0,
   minStepsBetweenValues: 0,
   name: '',
-  onValueCommitted: NOOP,
   orientation: 'horizontal',
   state: {
     activeThumbIndex: -1,
@@ -49,6 +48,7 @@ const testRootContext: SliderRootContext = {
   setDragging: NOOP,
   setPercentageValues: NOOP,
   setThumbMap: NOOP,
+  setValue: NOOP,
   step: 1,
   tabIndex: null,
   thumbRefs: { current: [] },


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/issues/1360
Fixes https://github.com/mui/base-ui/issues/1406

**Demo:** https://stackblitz.com/edit/vitejs-vite-zsatgbgk?file=src%2FApp.tsx

The demo shows both fixes:
- when setting the value with the NumberField, the corresponding slider should reposition correctly
- when dragging a thumb to match the same value set by a NumberField (of an adjacent row) the thumbs should line up exactly and have the same CSS `width` value

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
