### PR TITLE
[Tooltip] Fix `Provider` `delay=0` not being respected

### DIFF
--- a/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
+++ b/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
@@ -25,7 +25,7 @@ describe('<Tooltip.Provider />', () => {
         </Tooltip.Provider>,
       );
 
-      const trigger = document.querySelector('button')!;
+      const trigger = screen.getByRole('button');
 
       fireEvent.mouseEnter(trigger);
       fireEvent.mouseMove(trigger);
@@ -39,6 +39,30 @@ describe('<Tooltip.Provider />', () => {
       clock.tick(9_000);
 
       await flushMicrotasks();
+
+      expect(screen.queryByText('Content')).not.to.equal(null);
+    });
+
+    it('respects delay=0', async () => {
+      await render(
+        <Tooltip.Provider delay={0}>
+          <Tooltip.Root>
+            <Tooltip.Trigger />
+            <Tooltip.Portal>
+              <Tooltip.Positioner>
+                <Tooltip.Popup>Content</Tooltip.Popup>
+              </Tooltip.Positioner>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </Tooltip.Provider>,
+      );
+
+      const trigger = screen.getByRole('button');
+
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
+
+      clock.tick(0);
 
       expect(screen.queryByText('Content')).not.to.equal(null);
     });
@@ -61,7 +85,7 @@ describe('<Tooltip.Provider />', () => {
         </Tooltip.Provider>,
       );
 
-      const trigger = document.querySelector('button')!;
+      const trigger = screen.getByRole('button');
 
       fireEvent.mouseEnter(trigger);
       fireEvent.mouseMove(trigger);

--- a/packages/react/src/tooltip/provider/TooltipProvider.tsx
+++ b/packages/react/src/tooltip/provider/TooltipProvider.tsx
@@ -12,7 +12,7 @@ import { FloatingDelayGroup } from '@floating-ui/react';
 const TooltipProvider: React.FC<TooltipProvider.Props> = function TooltipProvider(props) {
   const { delay, closeDelay, timeout = 400 } = props;
   return (
-    <FloatingDelayGroup delay={{ open: delay ?? 0, close: closeDelay ?? 0 }} timeoutMs={timeout}>
+    <FloatingDelayGroup delay={{ open: delay, close: closeDelay }} timeoutMs={timeout}>
       {props.children}
     </FloatingDelayGroup>
   );

--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -330,7 +330,7 @@ describe('<Tooltip.Root />', () => {
   describe('prop: delay', () => {
     clock.withFakeTimers();
 
-    it('should open after delay with rest type by default', async () => {
+    it('should open after rest delay', async () => {
       await render(
         <Root delay={100}>
           <Tooltip.Trigger />

--- a/packages/react/src/tooltip/root/useTooltipRoot.ts
+++ b/packages/react/src/tooltip/root/useTooltipRoot.ts
@@ -104,15 +104,17 @@ export function useTooltipRoot(params: useTooltipRoot.Parameters): useTooltipRoo
   });
 
   const { delay: groupDelay, isInstantPhase, currentId } = useDelayGroup(context);
-  const openGroupDelay = typeof groupDelay === 'object' ? groupDelay.open : groupDelay;
-  const closeGroupDelay = typeof groupDelay === 'object' ? groupDelay.close : groupDelay;
+  // We only pass an object to `FloatingDelayGroup`. A number means the Provider is not
+  // present, so we should ignore the value by using `undefined`.
+  const openGroupDelay = typeof groupDelay === 'object' ? groupDelay.open : undefined;
+  const closeGroupDelay = typeof groupDelay === 'object' ? groupDelay.close : undefined;
 
   let instantType = isInstantPhase ? ('delay' as const) : instantTypeState;
   if (!open && context.floatingId === currentId) {
     instantType = instantTypeState;
   }
 
-  const computedRestMs = openGroupDelay || delayWithDefault;
+  const computedRestMs = openGroupDelay ?? delayWithDefault;
   let computedCloseDelay: number | undefined = closeDelayWithDefault;
 
   // A provider is present and the close delay is not set.


### PR DESCRIPTION
Fixes #1404 (presumably, as the issue is missing some details). 

The `||` fallback needs to be `??` to respect `0`. This requires modifications in the delay provider to ensure the existing behavior to respect delays regarding a `Provider` being present or not