### PR TITLE
[Avatar] Add missing Avatar export

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,6 @@
 export * from './accordion';
 export * from './alert-dialog';
+export * from './avatar';
 export * from './checkbox';
 export * from './checkbox-group';
 export * from './collapsible';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Thank you for the `alpha.6 ` release, just noticed that `Avatar` was missing from the main export when testing it

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
