### PR TITLE
[Avatar] Support cross origin in useImageLoadingStatus

### DIFF
--- a/packages/react/src/avatar/image/AvatarImage.tsx
+++ b/packages/react/src/avatar/image/AvatarImage.tsx
@@ -25,11 +25,15 @@ const AvatarImage = React.forwardRef<HTMLImageElement, AvatarImage.Props>(functi
     render,
     onLoadingStatusChange: onLoadingStatusChangeProp,
     referrerPolicy,
+    crossOrigin,
     ...otherProps
   } = props;
 
   const context = useAvatarRootContext();
-  const imageLoadingStatus = useImageLoadingStatus(props.src, referrerPolicy);
+  const imageLoadingStatus = useImageLoadingStatus(props.src, {
+    referrerPolicy,
+    crossOrigin,
+  });
 
   const handleLoadingStatusChange = useEventCallback((status: ImageLoadingStatus) => {
     onLoadingStatusChangeProp?.(status);

--- a/packages/react/src/avatar/image/AvatarImage.tsx
+++ b/packages/react/src/avatar/image/AvatarImage.tsx
@@ -91,6 +91,10 @@ AvatarImage.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   /**
+   * @ignore
+   */
+  crossOrigin: PropTypes.oneOf(['', 'anonymous', 'use-credentials']),
+  /**
    * Callback fired when the loading status changes.
    */
   onLoadingStatusChange: PropTypes.func,

--- a/packages/react/src/avatar/image/useImageLoadingStatus.ts
+++ b/packages/react/src/avatar/image/useImageLoadingStatus.ts
@@ -39,9 +39,7 @@ export function useImageLoadingStatus(
     if (referrerPolicy) {
       image.referrerPolicy = referrerPolicy;
     }
-    if (typeof crossOrigin === 'string') {
-      image.crossOrigin = crossOrigin;
-    }
+    image.crossOrigin = crossOrigin ?? null;
     image.src = src;
 
     return () => {

--- a/packages/react/src/avatar/image/useImageLoadingStatus.ts
+++ b/packages/react/src/avatar/image/useImageLoadingStatus.ts
@@ -5,9 +5,14 @@ import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 
 export type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
+interface UseImageLoadingStatusOptions {
+  referrerPolicy?: React.HTMLAttributeReferrerPolicy;
+  crossOrigin?: string | null;
+}
+
 export function useImageLoadingStatus(
   src?: string,
-  referrerPolicy?: React.HTMLAttributeReferrerPolicy,
+  options?: UseImageLoadingStatusOptions,
 ): ImageLoadingStatus {
   const [loadingStatus, setLoadingStatus] = React.useState<ImageLoadingStatus>('idle');
 
@@ -31,15 +36,18 @@ export function useImageLoadingStatus(
     setLoadingStatus('loading');
     image.onload = updateStatus('loaded');
     image.onerror = updateStatus('error');
-    image.src = src;
-    if (referrerPolicy) {
-      image.referrerPolicy = referrerPolicy;
+    if (options?.referrerPolicy) {
+      image.referrerPolicy = options.referrerPolicy;
     }
+    if (options?.crossOrigin) {
+      image.crossOrigin = options.crossOrigin;
+    }
+    image.src = src;
 
     return () => {
       isMounted = false;
     };
-  }, [src, referrerPolicy]);
+  }, [src, options]);
 
   return loadingStatus;
 }

--- a/packages/react/src/avatar/image/useImageLoadingStatus.ts
+++ b/packages/react/src/avatar/image/useImageLoadingStatus.ts
@@ -7,12 +7,12 @@ export type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
 interface UseImageLoadingStatusOptions {
   referrerPolicy?: React.HTMLAttributeReferrerPolicy;
-  crossOrigin?: string | null;
+  crossOrigin?: React.ImgHTMLAttributes<HTMLImageElement>['crossOrigin'];
 }
 
 export function useImageLoadingStatus(
-  src?: string,
-  options?: UseImageLoadingStatusOptions,
+  src: string | undefined,
+  { referrerPolicy, crossOrigin }: UseImageLoadingStatusOptions,
 ): ImageLoadingStatus {
   const [loadingStatus, setLoadingStatus] = React.useState<ImageLoadingStatus>('idle');
 
@@ -36,18 +36,18 @@ export function useImageLoadingStatus(
     setLoadingStatus('loading');
     image.onload = updateStatus('loaded');
     image.onerror = updateStatus('error');
-    if (options?.referrerPolicy) {
-      image.referrerPolicy = options.referrerPolicy;
+    if (referrerPolicy) {
+      image.referrerPolicy = referrerPolicy;
     }
-    if (options?.crossOrigin) {
-      image.crossOrigin = options.crossOrigin;
+    if (typeof crossOrigin === 'string') {
+      image.crossOrigin = crossOrigin;
     }
     image.src = src;
 
     return () => {
       isMounted = false;
     };
-  }, [src, options?.crossOrigin, options?.referrerPolicy]);
+  }, [src, crossOrigin, referrerPolicy]);
 
   return loadingStatus;
 }

--- a/packages/react/src/avatar/image/useImageLoadingStatus.ts
+++ b/packages/react/src/avatar/image/useImageLoadingStatus.ts
@@ -47,7 +47,7 @@ export function useImageLoadingStatus(
     return () => {
       isMounted = false;
     };
-  }, [src, options]);
+  }, [src, options?.crossOrigin, options?.referrerPolicy]);
 
   return loadingStatus;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Description

Add crossOrigin Support to useImageLoadingStatus Hook. 

> This PR adds crossOrigin support to the useImageLoadingStatus hook to handle images hosted on external domains that require specific crossOrigin settings (anonymous or use-credentials).
> 
> By including this option, we ensure broader compatibility with external image sources and resolve potential loading issues.

Note: radix-ui/primitives(https://github.com/radix-ui/primitives) has this exact issue and already has a PR https://github.com/radix-ui/primitives/pull/3261. So here's a corresponding PR for Base UI 😊

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
