### PR TITLE
[core] Make `mergeReactProps` work with non-native event handlers

### DIFF
--- a/packages/react/src/utils/mergeReactProps.test.ts
+++ b/packages/react/src/utils/mergeReactProps.test.ts
@@ -15,9 +15,9 @@ describe('mergeReactProps', () => {
     };
     const mergedProps = mergeReactProps<'button'>(theirProps, ourProps);
 
-    mergedProps.onClick?.({} as any);
-    mergedProps.onKeyDown?.({} as any);
-    mergedProps.onPaste?.({} as any);
+    mergedProps.onClick?.({ nativeEvent: new MouseEvent('click') } as any);
+    mergedProps.onKeyDown?.({ nativeEvent: new MouseEvent('keydown') } as any);
+    mergedProps.onPaste?.({ nativeEvent: new Event('paste') } as any);
 
     expect(theirProps.onClick.calledBefore(ourProps.onClick)).to.equal(true);
     expect(theirProps.onClick.callCount).to.equal(1);
@@ -47,7 +47,7 @@ describe('mergeReactProps', () => {
       },
     );
 
-    mergedProps.onClick?.({} as any);
+    mergedProps.onClick?.({ nativeEvent: new MouseEvent('click') } as any);
     expect(log).to.deep.equal(['1', '2', '3']);
   });
 
@@ -106,7 +106,7 @@ describe('mergeReactProps', () => {
       },
     );
 
-    mergedProps.onClick?.({} as any);
+    mergedProps.onClick?.({ nativeEvent: new MouseEvent('click') } as any);
 
     expect(ran).to.equal(true);
   });
@@ -132,7 +132,7 @@ describe('mergeReactProps', () => {
       },
     );
 
-    mergedProps.onClick?.({} as any);
+    mergedProps.onClick?.({ nativeEvent: new MouseEvent('click') } as any);
 
     expect(ran).to.equal(false);
   });
@@ -159,9 +159,32 @@ describe('mergeReactProps', () => {
       },
     );
 
-    mergedProps.onClick?.({} as any);
+    mergedProps.onClick?.({ nativeEvent: new MouseEvent('click') });
 
     expect(log).to.deep.equal(['0', '1']);
+  });
+
+  [true, 13, 'newValue', { key: 'value' }, ['value'], () => 'value'].forEach((eventArgument) => {
+    it('handles non-standard event handlers without error', () => {
+      const log: string[] = [];
+
+      const mergedProps = mergeReactProps(
+        {
+          onValueChange() {
+            log.push('0');
+          },
+        },
+        {
+          onValueChange() {
+            log.push('1');
+          },
+        },
+      );
+
+      mergedProps.onValueChange(eventArgument);
+
+      expect(log).to.deep.equal(['0', '1']);
+    });
   });
 
   it('merges internal props so that the ones defined first override the ones defined later', () => {

--- a/packages/react/src/utils/mergeReactProps.test.ts
+++ b/packages/react/src/utils/mergeReactProps.test.ts
@@ -16,8 +16,8 @@ describe('mergeReactProps', () => {
     const mergedProps = mergeReactProps<'button'>(theirProps, ourProps);
 
     mergedProps.onClick?.({ nativeEvent: new MouseEvent('click') } as any);
-    mergedProps.onKeyDown?.({ nativeEvent: new MouseEvent('keydown') } as any);
-    mergedProps.onPaste?.({ nativeEvent: new Event('paste') } as any);
+    mergedProps.onKeyDown?.({ nativeEvent: new KeyboardEvent('keydown') } as any);
+    mergedProps.onPaste?.({ nativeEvent: new ClipboardEvent('paste') } as any);
 
     expect(theirProps.onClick.calledBefore(ourProps.onClick)).to.equal(true);
     expect(theirProps.onClick.callCount).to.equal(1);

--- a/packages/react/src/utils/mergeReactProps.test.ts
+++ b/packages/react/src/utils/mergeReactProps.test.ts
@@ -17,7 +17,7 @@ describe('mergeReactProps', () => {
 
     mergedProps.onClick?.({ nativeEvent: new MouseEvent('click') } as any);
     mergedProps.onKeyDown?.({ nativeEvent: new KeyboardEvent('keydown') } as any);
-    mergedProps.onPaste?.({ nativeEvent: new ClipboardEvent('paste') } as any);
+    mergedProps.onPaste?.({ nativeEvent: new Event('paste') } as any);
 
     expect(theirProps.onClick.calledBefore(ourProps.onClick)).to.equal(true);
     expect(theirProps.onClick.callCount).to.equal(1);
@@ -70,9 +70,8 @@ describe('mergeReactProps', () => {
     const theirProps = {
       style: { color: 'red' },
     };
-    const ourProps = {
-      style: undefined,
-    };
+    const ourProps = {};
+
     const mergedProps = mergeReactProps<'button'>(theirProps, ourProps);
 
     expect(mergedProps.style).to.deep.equal({
@@ -81,12 +80,8 @@ describe('mergeReactProps', () => {
   });
 
   it('does not merge styles if both are undefined', () => {
-    const theirProps = {
-      style: undefined,
-    };
-    const ourProps = {
-      style: undefined,
-    };
+    const theirProps = {};
+    const ourProps = {};
     const mergedProps = mergeReactProps<'button'>(theirProps, ourProps);
 
     expect(mergedProps.style).to.equal(undefined);
@@ -116,23 +111,24 @@ describe('mergeReactProps', () => {
 
     const mergedProps = mergeReactProps<'button'>(
       {
-        onClick(event) {
+        onClick: function onClick1(event) {
           event.preventBaseUIHandler();
         },
       },
       {
-        onClick() {
+        onClick: function onClick2() {
           ran = true;
         },
       },
       {
-        onClick() {
+        onClick: function onClick3() {
           ran = true;
         },
       },
     );
 
-    mergedProps.onClick?.({ nativeEvent: new MouseEvent('click') } as any);
+    const event = { nativeEvent: new MouseEvent('click') } as any;
+    mergedProps.onClick?.(event);
 
     expect(ran).to.equal(false);
   });

--- a/packages/react/src/utils/mergeReactProps.ts
+++ b/packages/react/src/utils/mergeReactProps.ts
@@ -32,21 +32,21 @@ function merge<T extends React.ElementType>(
   }
 
   return Object.entries(externalProps).reduce(
-    (mergedProps, [externalPropName, externalPropValue]) => {
-      if (isEventHandler(externalPropName, externalPropValue)) {
-        mergedProps[externalPropName] = mergeEventHandlers(
-          externalPropValue,
-          internalProps[externalPropName],
-        );
-      } else if (externalPropName === 'style') {
-        mergedProps[externalPropName] = mergeStyles(
+    (mergedProps, [propName, externalPropValue]) => {
+      if (isEventHandler(propName, externalPropValue)) {
+        mergedProps[propName] = mergeEventHandlers(externalPropValue, internalProps[propName]);
+      } else if (propName === 'style') {
+        mergedProps[propName] = mergeStyles(
           externalPropValue as React.CSSProperties,
           internalProps.style,
         );
-      } else if (externalPropName === 'className') {
-        mergeClassNames(externalPropValue as string, internalProps.className);
+      } else if (propName === 'className') {
+        mergedProps[propName] = mergeClassNames(
+          externalPropValue as string,
+          internalProps.className,
+        );
       } else {
-        mergedProps[externalPropName] = externalPropValue;
+        mergedProps[propName] = externalPropValue;
       }
 
       return mergedProps;
@@ -57,11 +57,12 @@ function merge<T extends React.ElementType>(
 
 function isEventHandler(key: string, value: unknown) {
   // This approach is more efficient than using a regex.
+  const thirdCharCode = key.charCodeAt(2);
   return (
     key[0] === 'o' &&
     key[1] === 'n' &&
-    key.charCodeAt(2) >= 65 /* A */ &&
-    key.charCodeAt(2) <= 90 /* Z */ &&
+    thirdCharCode >= 65 /* A */ &&
+    thirdCharCode <= 90 /* Z */ &&
     typeof value === 'function'
   );
 }

--- a/packages/react/src/utils/mergeReactProps.ts
+++ b/packages/react/src/utils/mergeReactProps.ts
@@ -115,6 +115,6 @@ function mergeClassNames(theirClassName: string | undefined, ourClassName: strin
   return ourClassName;
 }
 
-function isSyntheticEvent(event: React.SyntheticEvent | {}): event is React.SyntheticEvent {
-  return typeof event === 'object' && 'nativeEvent' in event;
+function isSyntheticEvent(event: React.SyntheticEvent | unknown): event is React.SyntheticEvent {
+  return event != null && typeof event === 'object' && 'nativeEvent' in event;
 }


### PR DESCRIPTION
Fixed the `mergeReactProps` utility to handle event handlers that don't have the event as the first parameter. It now checks if the parameter is an object and contains the `nativeEvent` field before adding the `preventBaseUIHandler` method.

Additionally, I refactored the implementation to be more readable.

Fixes #1430