### PR TITLE
[RadioGroup] Fix `Form`/`Field` validation integration

### DIFF
--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { RadioGroup } from '@base-ui-components/react/radio-group';
 import { Radio } from '@base-ui-components/react/radio';
+import { Field } from '@base-ui-components/react/field';
+import { Form } from '@base-ui-components/react/form';
 import {
   DirectionProvider,
   type TextDirection,
@@ -356,6 +358,48 @@ describe('<RadioGroup />', () => {
 
       expect(b).to.have.attribute('data-unchecked', '');
       expect(indicatorB).to.have.attribute('data-unchecked', '');
+    });
+  });
+
+  describe('Field', () => {
+    it('passes the `name` prop to the hidden input', () => {
+      render(
+        <Field.Root name="test" data-testid="field">
+          <RadioGroup name="group">
+            <Radio.Root value="a" data-testid="item" />
+          </RadioGroup>
+        </Field.Root>,
+      );
+
+      const input = screen.getByTestId('field').querySelector('input[name="test"]');
+      expect(input).not.to.equal(null);
+    });
+  });
+
+  describe('Form', () => {
+    it('triggers native HTML validation on submit', async () => {
+      const { user } = render(
+        <Form>
+          <Field.Root name="test" data-testid="field">
+            <RadioGroup name="group" required>
+              <Radio.Root value="a" data-testid="item" />
+            </RadioGroup>
+            <Field.Error match="valueMissing" data-testid="error">
+              required
+            </Field.Error>
+          </Field.Root>
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      const submit = screen.getByText('Submit');
+
+      expect(screen.queryByTestId('error')).to.equal(null);
+
+      await user.click(submit);
+
+      const error = screen.getByTestId('error');
+      expect(error).to.have.text('required');
     });
   });
 });

--- a/packages/react/src/radio-group/useRadioGroup.ts
+++ b/packages/react/src/radio-group/useRadioGroup.ts
@@ -7,16 +7,27 @@ import { useFieldRootContext } from '../field/root/FieldRootContext';
 import { useBaseUiId } from '../utils/useBaseUiId';
 import { useFieldControlValidation } from '../field/control/useFieldControlValidation';
 import { useField } from '../field/useField';
+import { visuallyHidden } from '../utils';
 
 export function useRadioGroup(params: useRadioGroup.Parameters) {
-  const { disabled = false, name, defaultValue, readOnly, value: externalValue } = params;
+  const {
+    disabled = false,
+    required,
+    name: nameProp,
+    defaultValue,
+    readOnly,
+    value: externalValue,
+  } = params;
 
   const {
     labelId,
     setTouched: setFieldTouched,
     setFocused,
     validationMode,
+    name: fieldName,
   } = useFieldRootContext();
+
+  const name = fieldName ?? nameProp;
 
   const fieldControlValidation = useFieldControlValidation();
 
@@ -91,15 +102,18 @@ export function useRadioGroup(params: useRadioGroup.Parameters) {
   const getInputProps = React.useCallback(
     (externalProps = {}) =>
       mergeReactProps<'input'>(fieldControlValidation.getInputValidationProps(externalProps), {
-        type: 'hidden',
         value: serializedCheckedValue,
         ref: fieldControlValidation.inputRef,
         id,
         name,
         disabled,
         readOnly,
+        required,
+        'aria-hidden': true,
+        tabIndex: -1,
+        style: visuallyHidden,
       }),
-    [fieldControlValidation, serializedCheckedValue, id, name, disabled, readOnly],
+    [fieldControlValidation, serializedCheckedValue, id, name, disabled, readOnly, required],
   );
 
   return React.useMemo(
@@ -120,6 +134,7 @@ namespace useRadioGroup {
   export interface Parameters {
     name?: string;
     disabled?: boolean;
+    required?: boolean;
     readOnly?: boolean;
     defaultValue?: unknown;
     value?: unknown;


### PR DESCRIPTION
1. The `name` prop wasn't being forwarded from `Field` to `RadioGroup` `<input>`
2. The `required` prop wasn't being forwarded from `RadioGroup` to `<input>`, and native HTML validation requires it be visually hidden, not true `type=hidden`

Part of #1425, mentioned in https://github.com/mui/base-ui/pull/1053/#discussion_r1942478141