### PR TITLE
[core] Export namespaces consistently

### DIFF
--- a/packages/react/src/accordion/header/AccordionHeader.tsx
+++ b/packages/react/src/accordion/header/AccordionHeader.tsx
@@ -33,7 +33,7 @@ const AccordionHeader = React.forwardRef(function AccordionHeader(
   return renderElement();
 });
 
-export namespace AccordionHeader {
+namespace AccordionHeader {
   export interface Props extends BaseUIComponentProps<'h3', AccordionItem.State> {}
 }
 

--- a/packages/react/src/accordion/item/AccordionItem.tsx
+++ b/packages/react/src/accordion/item/AccordionItem.tsx
@@ -135,7 +135,7 @@ const AccordionItem = React.forwardRef(function AccordionItem(
 
 export type AccordionItemValue = any | null;
 
-export namespace AccordionItem {
+namespace AccordionItem {
   export interface State extends AccordionRoot.State {
     index: number;
     open: boolean;

--- a/packages/react/src/accordion/panel/AccordionPanel.tsx
+++ b/packages/react/src/accordion/panel/AccordionPanel.tsx
@@ -93,7 +93,7 @@ const AccordionPanel = React.forwardRef(function AccordionPanel(
   return renderElement();
 });
 
-export namespace AccordionPanel {
+namespace AccordionPanel {
   export interface Props
     extends BaseUIComponentProps<'div', AccordionItem.State>,
       Pick<AccordionRoot.Props, 'hiddenUntilFound' | 'keepMounted'> {}

--- a/packages/react/src/accordion/root/AccordionRoot.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.tsx
@@ -114,7 +114,7 @@ const AccordionRoot = React.forwardRef(function AccordionRoot(
   );
 });
 
-export namespace AccordionRoot {
+namespace AccordionRoot {
   export interface State {
     value: AccordionValue;
     /**

--- a/packages/react/src/avatar/fallback/AvatarFallback.tsx
+++ b/packages/react/src/avatar/fallback/AvatarFallback.tsx
@@ -54,7 +54,7 @@ const AvatarFallback = React.forwardRef<HTMLSpanElement, AvatarFallback.Props>(
   },
 );
 
-export namespace AvatarFallback {
+namespace AvatarFallback {
   export interface Props extends BaseUIComponentProps<'span', AvatarRoot.State> {
     /**
      * How long to wait before showing the fallback. Specified in milliseconds.

--- a/packages/react/src/avatar/image/AvatarImage.tsx
+++ b/packages/react/src/avatar/image/AvatarImage.tsx
@@ -65,7 +65,7 @@ const AvatarImage = React.forwardRef<HTMLImageElement, AvatarImage.Props>(functi
   return imageLoadingStatus === 'loaded' ? renderElement() : null;
 });
 
-export namespace AvatarImage {
+namespace AvatarImage {
   export interface Props extends BaseUIComponentProps<'img', AvatarRoot.State> {
     /**
      * Callback fired when the loading status changes.

--- a/packages/react/src/avatar/root/AvatarRoot.tsx
+++ b/packages/react/src/avatar/root/AvatarRoot.tsx
@@ -51,7 +51,7 @@ const AvatarRoot = React.forwardRef<HTMLSpanElement, AvatarRoot.Props>(function 
 
 export type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
-export namespace AvatarRoot {
+namespace AvatarRoot {
   export interface Props extends BaseUIComponentProps<'span', State> {}
 
   export interface State {

--- a/packages/react/src/checkbox-group/CheckboxGroupContext.ts
+++ b/packages/react/src/checkbox-group/CheckboxGroupContext.ts
@@ -1,13 +1,13 @@
 'use client';
 import * as React from 'react';
-import { UseCheckboxGroupParent } from './useCheckboxGroupParent';
+import { useCheckboxGroupParent } from './useCheckboxGroupParent';
 
 export interface CheckboxGroupContext {
   value: string[] | undefined;
   defaultValue: string[] | undefined;
   setValue: (value: string[], event: Event) => void;
   allValues: string[] | undefined;
-  parent: UseCheckboxGroupParent.ReturnValue;
+  parent: useCheckboxGroupParent.ReturnValue;
   disabled: boolean;
 }
 

--- a/packages/react/src/checkbox-group/useCheckboxGroup.tsx
+++ b/packages/react/src/checkbox-group/useCheckboxGroup.tsx
@@ -5,12 +5,11 @@ import { useControlled } from '../utils/useControlled';
 import { useEventCallback } from '../utils/useEventCallback';
 import { useCheckboxGroupParent } from './useCheckboxGroupParent';
 import { useFieldRootContext } from '../field/root/FieldRootContext';
-import type { UseCheckboxGroupParent } from './useCheckboxGroupParent';
 import type { GenericHTMLProps } from '../utils/types';
 
 export function useCheckboxGroup(
-  params: UseCheckboxGroup.Parameters,
-): UseCheckboxGroup.ReturnValue {
+  params: useCheckboxGroup.Parameters,
+): useCheckboxGroup.ReturnValue {
   const { allValues, value: externalValue, defaultValue, onValueChange } = params;
 
   const { labelId } = useFieldRootContext();
@@ -53,7 +52,7 @@ export function useCheckboxGroup(
   );
 }
 
-namespace UseCheckboxGroup {
+namespace useCheckboxGroup {
   export interface Parameters {
     value?: string[];
     defaultValue?: string[];
@@ -65,6 +64,6 @@ namespace UseCheckboxGroup {
     getRootProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
     value: string[];
     setValue: (value: string[], event: Event) => void;
-    parent: UseCheckboxGroupParent.ReturnValue;
+    parent: useCheckboxGroupParent.ReturnValue;
   }
 }

--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
@@ -4,8 +4,8 @@ import { useBaseUiId } from '../utils/useBaseUiId';
 import { useEventCallback } from '../utils/useEventCallback';
 
 export function useCheckboxGroupParent(
-  params: UseCheckboxGroupParent.Parameters,
-): UseCheckboxGroupParent.ReturnValue {
+  params: useCheckboxGroupParent.Parameters,
+): useCheckboxGroupParent.ReturnValue {
   const { allValues = [], value = [], onValueChange: onValueChangeProp } = params;
 
   const uncontrolledStateRef = React.useRef(value);
@@ -19,7 +19,7 @@ export function useCheckboxGroupParent(
 
   const onValueChange = useEventCallback(onValueChangeProp);
 
-  const getParentProps: UseCheckboxGroupParent.ReturnValue['getParentProps'] = React.useCallback(
+  const getParentProps: useCheckboxGroupParent.ReturnValue['getParentProps'] = React.useCallback(
     () => ({
       id,
       indeterminate,
@@ -68,7 +68,7 @@ export function useCheckboxGroupParent(
     [allValues, checked, id, indeterminate, onValueChange, status, value.length],
   );
 
-  const getChildProps: UseCheckboxGroupParent.ReturnValue['getChildProps'] = React.useCallback(
+  const getChildProps: useCheckboxGroupParent.ReturnValue['getChildProps'] = React.useCallback(
     (name: string) => ({
       name,
       id: `${id}-${name}`,
@@ -100,7 +100,7 @@ export function useCheckboxGroupParent(
   );
 }
 
-export namespace UseCheckboxGroupParent {
+export namespace useCheckboxGroupParent {
   export interface Parameters {
     allValues?: string[];
     value?: string[];

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -7,7 +7,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useCustomStyleHookMapping } from '../utils/useCustomStyleHookMapping';
 import type { FieldRoot } from '../../field/root/FieldRoot';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { type UseCheckboxRoot, useCheckboxRoot } from './useCheckboxRoot';
+import { useCheckboxRoot } from './useCheckboxRoot';
 import { CheckboxRootContext } from './CheckboxRootContext';
 
 /**
@@ -139,7 +139,7 @@ namespace CheckboxRoot {
     indeterminate: boolean;
   }
   export interface Props
-    extends UseCheckboxRoot.Parameters,
+    extends useCheckboxRoot.Parameters,
       Omit<BaseUIComponentProps<'button', State>, 'onChange' | 'value'> {}
 }
 

--- a/packages/react/src/checkbox/root/useCheckboxRoot.ts
+++ b/packages/react/src/checkbox/root/useCheckboxRoot.ts
@@ -12,7 +12,7 @@ import { useFieldControlValidation } from '../../field/control/useFieldControlVa
 import { useField } from '../../field/useField';
 import { useCheckboxGroupContext } from '../../checkbox-group/CheckboxGroupContext';
 
-export function useCheckboxRoot(params: UseCheckboxRoot.Parameters): UseCheckboxRoot.ReturnValue {
+export function useCheckboxRoot(params: useCheckboxRoot.Parameters): useCheckboxRoot.ReturnValue {
   const {
     id: idProp,
     checked: externalChecked,
@@ -89,7 +89,7 @@ export function useCheckboxRoot(params: UseCheckboxRoot.Parameters): UseCheckbox
     }
   }, [checked, indeterminate, setFilled]);
 
-  const getButtonProps: UseCheckboxRoot.ReturnValue['getButtonProps'] = React.useCallback(
+  const getButtonProps: useCheckboxRoot.ReturnValue['getButtonProps'] = React.useCallback(
     (externalProps = {}) =>
       mergeReactProps<'button'>(getValidationProps(externalProps), {
         id,
@@ -143,7 +143,7 @@ export function useCheckboxRoot(params: UseCheckboxRoot.Parameters): UseCheckbox
     ],
   );
 
-  const getInputProps: UseCheckboxRoot.ReturnValue['getInputProps'] = React.useCallback(
+  const getInputProps: useCheckboxRoot.ReturnValue['getInputProps'] = React.useCallback(
     (externalProps = {}) =>
       mergeReactProps<'input'>(getInputValidationProps(externalProps), {
         checked,
@@ -225,7 +225,7 @@ export function useCheckboxRoot(params: UseCheckboxRoot.Parameters): UseCheckbox
   );
 }
 
-export namespace UseCheckboxRoot {
+export namespace useCheckboxRoot {
   export interface Parameters {
     /**
      * The id of the input element.

--- a/packages/react/src/collapsible/root/CollapsibleRoot.tsx
+++ b/packages/react/src/collapsible/root/CollapsibleRoot.tsx
@@ -77,9 +77,7 @@ const CollapsibleRoot = React.forwardRef(function CollapsibleRoot(
   );
 });
 
-export { CollapsibleRoot };
-
-export namespace CollapsibleRoot {
+namespace CollapsibleRoot {
   export interface State
     extends Pick<useCollapsibleRoot.ReturnValue, 'open' | 'disabled' | 'transitionStatus'> {}
 
@@ -89,6 +87,8 @@ export namespace CollapsibleRoot {
     render?: BaseUIComponentProps<'div', State>['render'] | null;
   }
 }
+
+export { CollapsibleRoot };
 
 CollapsibleRoot.propTypes /* remove-proptypes */ = {
   // ┌────────────────────────────── Warning ──────────────────────────────┐

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { NumberFieldRootContext } from './NumberFieldRootContext';
-import { UseNumberFieldRoot, useNumberFieldRoot } from './useNumberFieldRoot';
+import { useNumberFieldRoot } from './useNumberFieldRoot';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
@@ -92,9 +92,9 @@ const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
   );
 });
 
-export namespace NumberFieldRoot {
+namespace NumberFieldRoot {
   export interface Props
-    extends UseNumberFieldRoot.Parameters,
+    extends useNumberFieldRoot.Parameters,
       Omit<BaseUIComponentProps<'div', State>, 'onChange' | 'defaultValue'> {}
 
   export interface State extends FieldRoot.State {

--- a/packages/react/src/number-field/root/NumberFieldRootContext.ts
+++ b/packages/react/src/number-field/root/NumberFieldRootContext.ts
@@ -1,9 +1,9 @@
 'use client';
 import * as React from 'react';
-import type { UseNumberFieldRoot } from './useNumberFieldRoot';
+import type { useNumberFieldRoot } from './useNumberFieldRoot';
 import type { NumberFieldRoot } from './NumberFieldRoot';
 
-export interface NumberFieldRootContext extends UseNumberFieldRoot.ReturnValue {
+export interface NumberFieldRootContext extends useNumberFieldRoot.ReturnValue {
   state: NumberFieldRoot.State;
 }
 

--- a/packages/react/src/number-field/root/useNumberFieldRoot.ts
+++ b/packages/react/src/number-field/root/useNumberFieldRoot.ts
@@ -34,8 +34,8 @@ import { useField } from '../../field/useField';
 import type { ScrubHandle } from './useScrub.types';
 
 export function useNumberFieldRoot(
-  params: UseNumberFieldRoot.Parameters,
-): UseNumberFieldRoot.ReturnValue {
+  params: useNumberFieldRoot.Parameters,
+): useNumberFieldRoot.ReturnValue {
   const {
     id: idProp,
     name,
@@ -389,7 +389,7 @@ export function useNumberFieldRoot(
     [allowWheelScrub, incrementValue, disabled, readOnly, largeStep, step, getStepAmount],
   );
 
-  const getGroupProps: UseNumberFieldRoot.ReturnValue['getGroupProps'] = React.useCallback(
+  const getGroupProps: useNumberFieldRoot.ReturnValue['getGroupProps'] = React.useCallback(
     (externalProps = {}) =>
       mergeReactProps(externalProps, {
         role: 'group',
@@ -548,19 +548,19 @@ export function useNumberFieldRoot(
     ],
   );
 
-  const getIncrementButtonProps: UseNumberFieldRoot.ReturnValue['getIncrementButtonProps'] =
+  const getIncrementButtonProps: useNumberFieldRoot.ReturnValue['getIncrementButtonProps'] =
     React.useCallback(
       (externalProps) => getCommonButtonProps(true, externalProps),
       [getCommonButtonProps],
     );
 
-  const getDecrementButtonProps: UseNumberFieldRoot.ReturnValue['getDecrementButtonProps'] =
+  const getDecrementButtonProps: useNumberFieldRoot.ReturnValue['getDecrementButtonProps'] =
     React.useCallback(
       (externalProps) => getCommonButtonProps(false, externalProps),
       [getCommonButtonProps],
     );
 
-  const getInputProps: UseNumberFieldRoot.ReturnValue['getInputProps'] = React.useCallback(
+  const getInputProps: useNumberFieldRoot.ReturnValue['getInputProps'] = React.useCallback(
     (externalProps = {}) =>
       mergeReactProps<'input'>(getInputValidationProps(getValidationProps(externalProps)), {
         id,
@@ -818,7 +818,7 @@ export function useNumberFieldRoot(
   );
 }
 
-export namespace UseNumberFieldRoot {
+export namespace useNumberFieldRoot {
   export interface Parameters {
     /**
      * The id of the input element.

--- a/packages/react/src/number-field/root/useScrub.ts
+++ b/packages/react/src/number-field/root/useScrub.ts
@@ -9,7 +9,7 @@ import { ownerDocument, ownerWindow } from '../../utils/owner';
 import { useLatestRef } from '../../utils/useLatestRef';
 import { isWebKit } from '../../utils/detectBrowser';
 import { mergeReactProps } from '../../utils/mergeReactProps';
-import type { UseNumberFieldRoot } from './useNumberFieldRoot';
+import type { useNumberFieldRoot } from './useNumberFieldRoot';
 import { NumberFieldRootDataAttributes } from './NumberFieldRootDataAttributes';
 
 /**
@@ -110,7 +110,7 @@ export function useScrub(params: ScrubParams) {
     [],
   );
 
-  const getScrubAreaProps: UseNumberFieldRoot.ReturnValue['getScrubAreaProps'] = React.useCallback(
+  const getScrubAreaProps: useNumberFieldRoot.ReturnValue['getScrubAreaProps'] = React.useCallback(
     (externalProps = {}) =>
       mergeReactProps<'span'>(externalProps, {
         role: 'presentation',
@@ -156,7 +156,7 @@ export function useScrub(params: ScrubParams) {
     [readOnly, disabled, onScrubbingChange, inputRef, isScrubbing],
   );
 
-  const getScrubAreaCursorProps: UseNumberFieldRoot.ReturnValue['getScrubAreaCursorProps'] =
+  const getScrubAreaCursorProps: useNumberFieldRoot.ReturnValue['getScrubAreaCursorProps'] =
     React.useCallback(
       (externalProps = {}) =>
         mergeReactProps<'span'>(

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -66,7 +66,7 @@ const SliderControl = React.forwardRef(function SliderControl(
   return renderElement();
 });
 
-export namespace SliderControl {
+namespace SliderControl {
   export interface Props extends BaseUIComponentProps<'div', SliderRoot.State> {}
 }
 

--- a/packages/react/src/slider/indicator/SliderIndicator.tsx
+++ b/packages/react/src/slider/indicator/SliderIndicator.tsx
@@ -41,7 +41,7 @@ const SliderIndicator = React.forwardRef(function SliderIndicator(
   return renderElement();
 });
 
-export namespace SliderIndicator {
+namespace SliderIndicator {
   export interface Props extends BaseUIComponentProps<'div', SliderRoot.State> {}
 }
 

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -128,7 +128,7 @@ const SliderRoot = React.forwardRef(function SliderRoot<Value extends number | r
   propTypes?: any;
 };
 
-export namespace SliderRoot {
+namespace SliderRoot {
   export interface State extends FieldRoot.State {
     /**
      * The index of the active thumb.

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -150,7 +150,7 @@ const SliderThumb = React.forwardRef(function SliderThumb(
   });
 });
 
-export namespace SliderThumb {
+namespace SliderThumb {
   export interface State extends SliderRoot.State {}
 
   export interface Props

--- a/packages/react/src/slider/track/SliderTrack.tsx
+++ b/packages/react/src/slider/track/SliderTrack.tsx
@@ -39,7 +39,7 @@ const SliderTrack = React.forwardRef(function SliderTrack(
   return renderElement();
 });
 
-export namespace SliderTrack {
+namespace SliderTrack {
   export interface Props extends BaseUIComponentProps<'div', SliderRoot.State> {}
 }
 

--- a/packages/react/src/slider/value/SliderValue.tsx
+++ b/packages/react/src/slider/value/SliderValue.tsx
@@ -53,7 +53,7 @@ const SliderValue = React.forwardRef(function SliderValue(
   return renderElement();
 });
 
-export namespace SliderValue {
+namespace SliderValue {
   export interface Props
     extends Omit<BaseUIComponentProps<'output', SliderRoot.State>, 'children'> {
     /**

--- a/packages/react/src/toggle-group/ToggleGroup.tsx
+++ b/packages/react/src/toggle-group/ToggleGroup.tsx
@@ -6,7 +6,7 @@ import { useComponentRenderer } from '../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../utils/types';
 import { CompositeRoot } from '../composite/root/CompositeRoot';
 import { useDirection } from '../direction-provider/DirectionContext';
-import { useToggleGroup, type UseToggleGroup } from './useToggleGroup';
+import { useToggleGroup } from './useToggleGroup';
 import { ToggleGroupContext } from './ToggleGroupContext';
 
 const customStyleHookMapping = {
@@ -99,7 +99,7 @@ export { ToggleGroup };
 
 export type ToggleGroupOrientation = 'horizontal' | 'vertical';
 
-export namespace ToggleGroup {
+namespace ToggleGroup {
   export interface State {
     /**
      * Whether the component should ignore user interaction.
@@ -109,7 +109,7 @@ export namespace ToggleGroup {
   }
 
   export interface Props
-    extends Partial<UseToggleGroup.Parameters>,
+    extends Partial<useToggleGroup.Parameters>,
       Omit<BaseUIComponentProps<'div', State>, 'defaultValue'> {
     /**
      * Whether the component should ignore user interaction.

--- a/packages/react/src/toggle-group/useToggleGroup.ts
+++ b/packages/react/src/toggle-group/useToggleGroup.ts
@@ -5,7 +5,7 @@ import { useControlled } from '../utils/useControlled';
 import { useEventCallback } from '../utils/useEventCallback';
 import type { GenericHTMLProps } from '../utils/types';
 
-export function useToggleGroup(parameters: UseToggleGroup.Parameters): UseToggleGroup.ReturnValue {
+export function useToggleGroup(parameters: useToggleGroup.Parameters): useToggleGroup.ReturnValue {
   const { value, defaultValue, disabled, onValueChange, toggleMultiple } = parameters;
 
   const [groupValue, setValueState] = useControlled({
@@ -54,7 +54,7 @@ export function useToggleGroup(parameters: UseToggleGroup.Parameters): UseToggle
 
 export type ToggleGroupOrientation = 'horizontal' | 'vertical';
 
-export namespace UseToggleGroup {
+export namespace useToggleGroup {
   export interface Parameters {
     /**
      * The open state of the ToggleGroup represented by an array of

--- a/packages/react/src/toggle/Toggle.tsx
+++ b/packages/react/src/toggle/Toggle.tsx
@@ -67,7 +67,7 @@ const Toggle = React.forwardRef(function Toggle(
 
 export { Toggle };
 
-export namespace Toggle {
+namespace Toggle {
   export interface State {
     pressed: boolean;
     /**


### PR DESCRIPTION
While evaluating [API Extractor](https://api-extractor.com/) I noticed inconsistencies in how some of our namespaces are exported:
- there are redundant `export`s making API Explorer crash
- there are namespaces named differently to components/hooks (with differing casing).

This PR solves both of these issues.