### PR TITLE
[AlertDialog][Dialog][Popover] Fix non-interactive button disabled state

### DIFF
--- a/docs/reference/generated/alert-dialog-close.json
+++ b/docs/reference/generated/alert-dialog-close.json
@@ -11,6 +11,10 @@
       "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
     }
   },
-  "dataAttributes": {},
+  "dataAttributes": {
+    "data-disabled": {
+      "description": "Present when the button is disabled."
+    }
+  },
   "cssVariables": {}
 }

--- a/docs/reference/generated/alert-dialog-trigger.json
+++ b/docs/reference/generated/alert-dialog-trigger.json
@@ -14,6 +14,9 @@
   "dataAttributes": {
     "data-popup-open": {
       "description": "Present when the corresponding dialog is open."
+    },
+    "data-disabled": {
+      "description": "Present when the trigger is disabled."
     }
   },
   "cssVariables": {}

--- a/docs/reference/generated/dialog-close.json
+++ b/docs/reference/generated/dialog-close.json
@@ -11,6 +11,10 @@
       "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
     }
   },
-  "dataAttributes": {},
+  "dataAttributes": {
+    "data-disabled": {
+      "description": "Present when the button is disabled."
+    }
+  },
   "cssVariables": {}
 }

--- a/docs/reference/generated/dialog-trigger.json
+++ b/docs/reference/generated/dialog-trigger.json
@@ -14,6 +14,9 @@
   "dataAttributes": {
     "data-popup-open": {
       "description": "Present when the corresponding dialog is open."
+    },
+    "data-disabled": {
+      "description": "Present when the trigger is disabled."
     }
   },
   "cssVariables": {}

--- a/packages/react/src/alert-dialog/close/AlertDialogClose.test.tsx
+++ b/packages/react/src/alert-dialog/close/AlertDialogClose.test.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { spy } from 'sinon';
 import { AlertDialog } from '@base-ui-components/react/alert-dialog';
+import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<AlertDialog.Close />', () => {
@@ -18,4 +20,69 @@ describe('<AlertDialog.Close />', () => {
       );
     },
   }));
+
+  describe('prop: disabled', () => {
+    it('disables the button', async () => {
+      const handleOpenChange = spy();
+
+      const { user } = await render(
+        <AlertDialog.Root onOpenChange={handleOpenChange}>
+          <AlertDialog.Trigger>Open</AlertDialog.Trigger>
+          <AlertDialog.Portal>
+            <AlertDialog.Popup>
+              <AlertDialog.Close disabled>Close</AlertDialog.Close>
+            </AlertDialog.Popup>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>,
+      );
+
+      expect(handleOpenChange.callCount).to.equal(0);
+
+      const openButton = screen.getByText('Open');
+      await user.click(openButton);
+
+      expect(handleOpenChange.callCount).to.equal(1);
+      expect(handleOpenChange.firstCall.args[0]).to.equal(true);
+
+      const closeButton = screen.getByText('Close');
+      expect(closeButton).to.have.attribute('disabled');
+      expect(closeButton).to.have.attribute('data-disabled');
+      await user.click(closeButton);
+
+      expect(handleOpenChange.callCount).to.equal(1);
+    });
+
+    it('custom element', async () => {
+      const handleOpenChange = spy();
+
+      const { user } = await render(
+        <AlertDialog.Root onOpenChange={handleOpenChange}>
+          <AlertDialog.Trigger>Open</AlertDialog.Trigger>
+          <AlertDialog.Portal>
+            <AlertDialog.Popup>
+              <AlertDialog.Close disabled render={<span />}>
+                Close
+              </AlertDialog.Close>
+            </AlertDialog.Popup>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>,
+      );
+
+      expect(handleOpenChange.callCount).to.equal(0);
+
+      const openButton = screen.getByText('Open');
+      await user.click(openButton);
+
+      expect(handleOpenChange.callCount).to.equal(1);
+      expect(handleOpenChange.firstCall.args[0]).to.equal(true);
+
+      const closeButton = screen.getByText('Close');
+      expect(closeButton).to.not.have.attribute('disabled');
+      expect(closeButton).to.have.attribute('data-disabled');
+      expect(closeButton).to.have.attribute('aria-disabled', 'true');
+      await user.click(closeButton);
+
+      expect(handleOpenChange.callCount).to.equal(1);
+    });
+  });
 });

--- a/packages/react/src/alert-dialog/close/AlertDialogClose.test.tsx
+++ b/packages/react/src/alert-dialog/close/AlertDialogClose.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { spy } from 'sinon';
 import { AlertDialog } from '@base-ui-components/react/alert-dialog';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/alert-dialog/close/AlertDialogClose.tsx
+++ b/packages/react/src/alert-dialog/close/AlertDialogClose.tsx
@@ -6,8 +6,6 @@ import { useDialogClose } from '../../dialog/close/useDialogClose';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 
-const state = {};
-
 /**
  * A button that closes the alert dialog.
  * Renders a `<button>` element.
@@ -18,16 +16,17 @@ const AlertDialogClose = React.forwardRef(function AlertDialogClose(
   props: AlertDialogClose.Props,
   forwardedRef: React.ForwardedRef<HTMLButtonElement>,
 ) {
-  const { render, className, ...other } = props;
+  const { render, className, disabled = false, ...other } = props;
   const { open, setOpen } = useAlertDialogRootContext();
-  const { getRootProps } = useDialogClose({ open, setOpen });
+  const { getRootProps } = useDialogClose({ disabled, open, setOpen, rootRef: forwardedRef });
+
+  const state: AlertDialogClose.State = React.useMemo(() => ({ disabled }), [disabled]);
 
   const { renderElement } = useComponentRenderer({
     render: render ?? 'button',
     className,
     state,
     propGetter: getRootProps,
-    ref: forwardedRef,
     extraProps: other,
   });
 
@@ -37,7 +36,12 @@ const AlertDialogClose = React.forwardRef(function AlertDialogClose(
 namespace AlertDialogClose {
   export interface Props extends BaseUIComponentProps<'button', State> {}
 
-  export interface State {}
+  export interface State {
+    /**
+     * Whether the button is currently disabled.
+     */
+    disabled: boolean;
+  }
 }
 
 AlertDialogClose.propTypes /* remove-proptypes */ = {

--- a/packages/react/src/alert-dialog/close/AlertDialogClose.tsx
+++ b/packages/react/src/alert-dialog/close/AlertDialogClose.tsx
@@ -59,6 +59,10 @@ AlertDialogClose.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   /**
+   * @ignore
+   */
+  disabled: PropTypes.bool,
+  /**
    * Allows you to replace the component’s HTML element
    * with a different tag, or compose it with another component.
    *

--- a/packages/react/src/alert-dialog/close/AlertDialogCloseDataAttributes.ts
+++ b/packages/react/src/alert-dialog/close/AlertDialogCloseDataAttributes.ts
@@ -1,0 +1,6 @@
+export enum AlertDialogCloseDataAttributes {
+  /**
+   * Present when the button is disabled.
+   */
+  disabled = 'data-disabled',
+}

--- a/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.test.tsx
+++ b/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { AlertDialog } from '@base-ui-components/react/alert-dialog';
+import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<AlertDialog.Trigger />', () => {
@@ -16,4 +17,55 @@ describe('<AlertDialog.Trigger />', () => {
       );
     },
   }));
+
+  describe('prop: disabled', () => {
+    it('disables the dialog', async () => {
+      const { user } = await render(
+        <AlertDialog.Root>
+          <AlertDialog.Trigger disabled />
+          <AlertDialog.Portal>
+            <AlertDialog.Backdrop />
+            <AlertDialog.Popup>
+              <AlertDialog.Title>title text</AlertDialog.Title>
+            </AlertDialog.Popup>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>,
+      );
+
+      const trigger = screen.getByRole('button');
+      expect(trigger).to.have.attribute('disabled');
+      expect(trigger).to.have.attribute('data-disabled');
+
+      await user.click(trigger);
+      expect(screen.queryByText('title text')).to.equal(null);
+
+      await user.keyboard('[Tab]');
+      expect(document.activeElement).to.not.equal(trigger);
+    });
+
+    it('custom element', async () => {
+      const { user } = await render(
+        <AlertDialog.Root>
+          <AlertDialog.Trigger disabled render={<span />} />
+          <AlertDialog.Portal>
+            <AlertDialog.Backdrop />
+            <AlertDialog.Popup>
+              <AlertDialog.Title>title text</AlertDialog.Title>
+            </AlertDialog.Popup>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>,
+      );
+
+      const trigger = screen.getByRole('button');
+      expect(trigger).to.not.have.attribute('disabled');
+      expect(trigger).to.have.attribute('data-disabled');
+      expect(trigger).to.have.attribute('aria-disabled', 'true');
+
+      await user.click(trigger);
+      expect(screen.queryByText('title text')).to.equal(null);
+
+      await user.keyboard('[Tab]');
+      expect(document.activeElement).to.not.equal(trigger);
+    });
+  });
 });

--- a/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.test.tsx
+++ b/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { AlertDialog } from '@base-ui-components/react/alert-dialog';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
+++ b/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useAlertDialogRootContext } from '../root/AlertDialogRootContext';
+import { useButton } from '../../use-button/useButton';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
@@ -17,18 +18,26 @@ const AlertDialogTrigger = React.forwardRef(function AlertDialogTrigger(
   props: AlertDialogTrigger.Props,
   forwardedRef: React.ForwardedRef<HTMLButtonElement>,
 ) {
-  const { render, className, ...other } = props;
+  const { render, className, disabled = false, ...other } = props;
   const { open, setTriggerElement, getTriggerProps } = useAlertDialogRootContext();
 
-  const state: AlertDialogTrigger.State = React.useMemo(() => ({ open }), [open]);
+  const state: AlertDialogTrigger.State = React.useMemo(
+    () => ({ disabled, open }),
+    [disabled, open],
+  );
 
   const mergedRef = useForkRef(forwardedRef, setTriggerElement);
+
+  const { getButtonProps } = useButton({
+    disabled,
+    buttonRef: mergedRef,
+  });
 
   const { renderElement } = useComponentRenderer({
     render: render ?? 'button',
     className,
     state,
-    propGetter: getTriggerProps,
+    propGetter: (externalProps) => getButtonProps(getTriggerProps(externalProps)),
     extraProps: other,
     customStyleHookMapping: triggerOpenStateMapping,
     ref: mergedRef,
@@ -41,6 +50,10 @@ namespace AlertDialogTrigger {
   export interface Props extends BaseUIComponentProps<'button', State> {}
 
   export interface State {
+    /**
+     * Whether the dialog is currently disabled.
+     */
+    disabled: boolean;
     /**
      * Whether the dialog is currently open.
      */

--- a/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
+++ b/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
@@ -76,6 +76,10 @@ AlertDialogTrigger.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   /**
+   * @ignore
+   */
+  disabled: PropTypes.bool,
+  /**
    * Allows you to replace the component’s HTML element
    * with a different tag, or compose it with another component.
    *

--- a/packages/react/src/alert-dialog/trigger/AlertDialogTriggerDataAttributes.ts
+++ b/packages/react/src/alert-dialog/trigger/AlertDialogTriggerDataAttributes.ts
@@ -1,5 +1,9 @@
 export enum AlertDialogTriggerDataAttributes {
   /**
+   * Present when the trigger is disabled.
+   */
+  disabled = 'data-disabled',
+  /**
    * Present when the corresponding dialog is open.
    */
   popupOpen = 'data-popup-open',

--- a/packages/react/src/dialog/close/DialogClose.test.tsx
+++ b/packages/react/src/dialog/close/DialogClose.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { spy } from 'sinon';
 import { Dialog } from '@base-ui-components/react/dialog';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/dialog/close/DialogClose.test.tsx
+++ b/packages/react/src/dialog/close/DialogClose.test.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { spy } from 'sinon';
 import { Dialog } from '@base-ui-components/react/dialog';
+import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Dialog.Close />', () => {
@@ -17,4 +19,69 @@ describe('<Dialog.Close />', () => {
       );
     },
   }));
+
+  describe('prop: disabled', () => {
+    it('disables the button', async () => {
+      const handleOpenChange = spy();
+
+      const { user } = await render(
+        <Dialog.Root onOpenChange={handleOpenChange}>
+          <Dialog.Trigger>Open</Dialog.Trigger>
+          <Dialog.Portal>
+            <Dialog.Popup>
+              <Dialog.Close disabled>Close</Dialog.Close>
+            </Dialog.Popup>
+          </Dialog.Portal>
+        </Dialog.Root>,
+      );
+
+      expect(handleOpenChange.callCount).to.equal(0);
+
+      const openButton = screen.getByText('Open');
+      await user.click(openButton);
+
+      expect(handleOpenChange.callCount).to.equal(1);
+      expect(handleOpenChange.firstCall.args[0]).to.equal(true);
+
+      const closeButton = screen.getByText('Close');
+      expect(closeButton).to.have.attribute('disabled');
+      expect(closeButton).to.have.attribute('data-disabled');
+      await user.click(closeButton);
+
+      expect(handleOpenChange.callCount).to.equal(1);
+    });
+
+    it('custom element', async () => {
+      const handleOpenChange = spy();
+
+      const { user } = await render(
+        <Dialog.Root onOpenChange={handleOpenChange}>
+          <Dialog.Trigger>Open</Dialog.Trigger>
+          <Dialog.Portal>
+            <Dialog.Popup>
+              <Dialog.Close disabled render={<span />}>
+                Close
+              </Dialog.Close>
+            </Dialog.Popup>
+          </Dialog.Portal>
+        </Dialog.Root>,
+      );
+
+      expect(handleOpenChange.callCount).to.equal(0);
+
+      const openButton = screen.getByText('Open');
+      await user.click(openButton);
+
+      expect(handleOpenChange.callCount).to.equal(1);
+      expect(handleOpenChange.firstCall.args[0]).to.equal(true);
+
+      const closeButton = screen.getByText('Close');
+      expect(closeButton).to.not.have.attribute('disabled');
+      expect(closeButton).to.have.attribute('data-disabled');
+      expect(closeButton).to.have.attribute('aria-disabled', 'true');
+      await user.click(closeButton);
+
+      expect(handleOpenChange.callCount).to.equal(1);
+    });
+  });
 });

--- a/packages/react/src/dialog/close/DialogClose.tsx
+++ b/packages/react/src/dialog/close/DialogClose.tsx
@@ -59,6 +59,10 @@ DialogClose.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   /**
+   * @ignore
+   */
+  disabled: PropTypes.bool,
+  /**
    * Allows you to replace the component’s HTML element
    * with a different tag, or compose it with another component.
    *

--- a/packages/react/src/dialog/close/DialogClose.tsx
+++ b/packages/react/src/dialog/close/DialogClose.tsx
@@ -6,8 +6,6 @@ import { useDialogRootContext } from '../root/DialogRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 
-const state = {};
-
 /**
  * A button that closes the dialog.
  * Renders a `<button>` element.
@@ -18,16 +16,17 @@ const DialogClose = React.forwardRef(function DialogClose(
   props: DialogClose.Props,
   forwardedRef: React.ForwardedRef<HTMLButtonElement>,
 ) {
-  const { render, className, ...other } = props;
+  const { render, className, disabled = false, ...other } = props;
   const { open, setOpen } = useDialogRootContext();
-  const { getRootProps } = useDialogClose({ open, setOpen });
+  const { getRootProps } = useDialogClose({ disabled, open, setOpen, rootRef: forwardedRef });
+
+  const state: DialogClose.State = React.useMemo(() => ({ disabled }), [disabled]);
 
   const { renderElement } = useComponentRenderer({
     render: render ?? 'button',
     className,
     state,
     propGetter: getRootProps,
-    ref: forwardedRef,
     extraProps: other,
   });
 
@@ -37,7 +36,12 @@ const DialogClose = React.forwardRef(function DialogClose(
 namespace DialogClose {
   export interface Props extends BaseUIComponentProps<'button', State> {}
 
-  export interface State {}
+  export interface State {
+    /**
+     * Whether the button is currently disabled.
+     */
+    disabled: boolean;
+  }
 }
 
 DialogClose.propTypes /* remove-proptypes */ = {

--- a/packages/react/src/dialog/close/DialogCloseDataAttributes.ts
+++ b/packages/react/src/dialog/close/DialogCloseDataAttributes.ts
@@ -1,0 +1,6 @@
+export enum DialogCloseDataAttributes {
+  /**
+   * Present when the button is disabled.
+   */
+  disabled = 'data-disabled',
+}

--- a/packages/react/src/dialog/close/useDialogClose.ts
+++ b/packages/react/src/dialog/close/useDialogClose.ts
@@ -1,11 +1,13 @@
 'use client';
 import * as React from 'react';
+import { useButton } from '../../use-button/useButton';
 import { mergeReactProps } from '../../utils/mergeReactProps';
 import { OpenChangeReason } from '../../utils/translateOpenChangeReason';
+import type { GenericHTMLProps } from '../../utils/types';
 import { useEventCallback } from '../../utils/useEventCallback';
 
 export function useDialogClose(params: useDialogClose.Parameters): useDialogClose.ReturnValue {
-  const { open, setOpen } = params;
+  const { open, setOpen, rootRef: externalRef, disabled } = params;
 
   const handleClick = useEventCallback((event: React.MouseEvent) => {
     if (open) {
@@ -13,8 +15,13 @@ export function useDialogClose(params: useDialogClose.Parameters): useDialogClos
     }
   });
 
-  const getRootProps = (externalProps: React.HTMLAttributes<any>) =>
-    mergeReactProps(externalProps, { onClick: handleClick });
+  const { getButtonProps } = useButton({
+    disabled,
+    buttonRef: externalRef,
+  });
+
+  const getRootProps = (externalProps: GenericHTMLProps) =>
+    mergeReactProps(getButtonProps, externalProps, { onClick: handleClick });
 
   return {
     getRootProps,
@@ -23,6 +30,10 @@ export function useDialogClose(params: useDialogClose.Parameters): useDialogClos
 
 export namespace useDialogClose {
   export interface Parameters {
+    /**
+     * Whether the button is currently disabled.
+     */
+    disabled: boolean;
     /**
      * Whether the dialog is currently open.
      */
@@ -35,6 +46,7 @@ export namespace useDialogClose {
       event: Event | undefined,
       reason: OpenChangeReason | undefined,
     ) => void;
+    rootRef: React.Ref<HTMLElement>;
   }
 
   export interface ReturnValue {

--- a/packages/react/src/dialog/trigger/DialogTrigger.test.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { Dialog } from '@base-ui-components/react/dialog';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/dialog/trigger/DialogTrigger.test.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Dialog } from '@base-ui-components/react/dialog';
+import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Dialog.Trigger />', () => {
@@ -15,4 +16,55 @@ describe('<Dialog.Trigger />', () => {
       );
     },
   }));
+
+  describe('prop: disabled', () => {
+    it('disables the dialog', async () => {
+      const { user } = await render(
+        <Dialog.Root modal={false}>
+          <Dialog.Trigger disabled />
+          <Dialog.Portal>
+            <Dialog.Backdrop />
+            <Dialog.Popup>
+              <Dialog.Title>title text</Dialog.Title>
+            </Dialog.Popup>
+          </Dialog.Portal>
+        </Dialog.Root>,
+      );
+
+      const trigger = screen.getByRole('button');
+      expect(trigger).to.have.attribute('disabled');
+      expect(trigger).to.have.attribute('data-disabled');
+
+      await user.click(trigger);
+      expect(screen.queryByText('title text')).to.equal(null);
+
+      await user.keyboard('[Tab]');
+      expect(document.activeElement).to.not.equal(trigger);
+    });
+
+    it('custom element', async () => {
+      const { user } = await render(
+        <Dialog.Root modal={false}>
+          <Dialog.Trigger disabled render={<span />} />
+          <Dialog.Portal>
+            <Dialog.Backdrop />
+            <Dialog.Popup>
+              <Dialog.Title>title text</Dialog.Title>
+            </Dialog.Popup>
+          </Dialog.Portal>
+        </Dialog.Root>,
+      );
+
+      const trigger = screen.getByRole('button');
+      expect(trigger).to.not.have.attribute('disabled');
+      expect(trigger).to.have.attribute('data-disabled');
+      expect(trigger).to.have.attribute('aria-disabled', 'true');
+
+      await user.click(trigger);
+      expect(screen.queryByText('title text')).to.equal(null);
+
+      await user.keyboard('[Tab]');
+      expect(document.activeElement).to.not.equal(trigger);
+    });
+  });
 });

--- a/packages/react/src/dialog/trigger/DialogTrigger.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useDialogRootContext } from '../root/DialogRootContext';
+import { useButton } from '../../use-button/useButton';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
@@ -17,21 +18,25 @@ const DialogTrigger = React.forwardRef(function DialogTrigger(
   props: DialogTrigger.Props,
   forwardedRef: React.ForwardedRef<HTMLButtonElement>,
 ) {
-  const { render, className, ...other } = props;
+  const { render, className, disabled = false, ...other } = props;
   const { open, setTriggerElement, getTriggerProps } = useDialogRootContext();
 
-  const state: DialogTrigger.State = React.useMemo(() => ({ open }), [open]);
+  const state: DialogTrigger.State = React.useMemo(() => ({ disabled, open }), [disabled, open]);
 
   const mergedRef = useForkRef(forwardedRef, setTriggerElement);
+
+  const { getButtonProps } = useButton({
+    disabled,
+    buttonRef: mergedRef,
+  });
 
   const { renderElement } = useComponentRenderer({
     render: render ?? 'button',
     className,
     state,
-    propGetter: getTriggerProps,
+    propGetter: (externalProps) => getButtonProps(getTriggerProps(externalProps)),
     extraProps: other,
     customStyleHookMapping: triggerOpenStateMapping,
-    ref: mergedRef,
   });
 
   return renderElement();
@@ -41,6 +46,10 @@ namespace DialogTrigger {
   export interface Props extends BaseUIComponentProps<'button', State> {}
 
   export interface State {
+    /**
+     * Whether the dialog is currently disabled.
+     */
+    disabled: boolean;
     /**
      * Whether the dialog is currently open.
      */
@@ -62,6 +71,10 @@ DialogTrigger.propTypes /* remove-proptypes */ = {
    * returns a class based on the component’s state.
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  disabled: PropTypes.bool,
   /**
    * Allows you to replace the component’s HTML element
    * with a different tag, or compose it with another component.

--- a/packages/react/src/dialog/trigger/DialogTriggerDataAttributes.ts
+++ b/packages/react/src/dialog/trigger/DialogTriggerDataAttributes.ts
@@ -1,5 +1,9 @@
 export enum DialogTriggerDataAttributes {
   /**
+   * Present when the trigger is disabled.
+   */
+  disabled = 'data-disabled',
+  /**
    * Present when the corresponding dialog is open.
    */
   popupOpen = 'data-popup-open',

--- a/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
@@ -15,6 +15,55 @@ describe('<Popover.Trigger />', () => {
     },
   }));
 
+  describe('prop: disabled', () => {
+    it('disables the popover', async () => {
+      const { user } = await render(
+        <Popover.Root>
+          <Popover.Trigger disabled />
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup>Content</Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>,
+      );
+
+      const trigger = screen.getByRole('button');
+      expect(trigger).to.have.attribute('disabled');
+      expect(trigger).to.have.attribute('data-disabled');
+
+      await user.click(trigger);
+      expect(screen.queryByText('Content')).to.equal(null);
+
+      await user.keyboard('[Tab]');
+      expect(document.activeElement).to.not.equal(trigger);
+    });
+
+    it('custom element', async () => {
+      const { user } = await render(
+        <Popover.Root>
+          <Popover.Trigger disabled render={<span />} />
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup>Content</Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>,
+      );
+
+      const trigger = screen.getByRole('button');
+      expect(trigger).to.not.have.attribute('disabled');
+      expect(trigger).to.have.attribute('data-disabled');
+      expect(trigger).to.have.attribute('aria-disabled', 'true');
+
+      await user.click(trigger);
+      expect(screen.queryByText('Content')).to.equal(null);
+
+      await user.keyboard('[Tab]');
+      expect(document.activeElement).to.not.equal(trigger);
+    });
+  });
+
   describe('style hooks', () => {
     it('should have the data-popup-open and data-pressed attributes when open by clicking', async () => {
       await render(

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { usePopoverRootContext } from '../root/PopoverRootContext';
+import { useButton } from '../../use-button/useButton';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
@@ -21,13 +22,18 @@ const PopoverTrigger = React.forwardRef(function PopoverTrigger(
   props: PopoverTrigger.Props,
   forwardedRef: React.ForwardedRef<any>,
 ) {
-  const { render, className, ...otherProps } = props;
+  const { render, className, disabled = false, ...otherProps } = props;
 
   const { open, setTriggerElement, getRootTriggerProps, openReason } = usePopoverRootContext();
 
-  const state: PopoverTrigger.State = React.useMemo(() => ({ open }), [open]);
+  const state: PopoverTrigger.State = React.useMemo(() => ({ disabled, open }), [disabled, open]);
 
-  const mergedRef = useForkRef(forwardedRef, setTriggerElement);
+  const { getButtonProps, buttonRef } = useButton({
+    disabled,
+    buttonRef: forwardedRef,
+  });
+
+  const mergedRef = useForkRef(buttonRef, setTriggerElement);
 
   const customStyleHookMapping: CustomStyleHookMapping<{ open: boolean }> = React.useMemo(
     () => ({
@@ -43,7 +49,7 @@ const PopoverTrigger = React.forwardRef(function PopoverTrigger(
   );
 
   const { renderElement } = useComponentRenderer({
-    propGetter: getRootTriggerProps,
+    propGetter: (externalProps) => getButtonProps(getRootTriggerProps(externalProps)),
     render: render ?? 'button',
     className,
     state,
@@ -57,6 +63,10 @@ const PopoverTrigger = React.forwardRef(function PopoverTrigger(
 
 namespace PopoverTrigger {
   export interface State {
+    /**
+     * Whether the popover is currently disabled.
+     */
+    disabled: boolean;
     /**
      * Whether the popover is currently open.
      */
@@ -80,6 +90,10 @@ PopoverTrigger.propTypes /* remove-proptypes */ = {
    * returns a class based on the component’s state.
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  disabled: PropTypes.bool,
   /**
    * Allows you to replace the component’s HTML element
    * with a different tag, or compose it with another component.


### PR DESCRIPTION
Closes https://github.com/mui/base-ui/issues/1470

Demo: https://codesandbox.io/p/devbox/suspicious-bessie-khdjkj?file=%2Fsrc%2FApp.tsx%3A8%2C1

Use useButton internally in (Alert)Dialog.Trigger, (Alert)Dialog.Close, Popover.Trigger to fix their disabled states:
- always sets `data-disabled` when disabled for consistency, even when it's a native `button` element
- when a non-interactive element (e.g. a span) is rendered, functionality is disabled accordingly and `aria-disabled` is used instead of the HTML `disabled` attribute


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
