### PR TITLE
[docs] Fix SEO site name description

### DIFF
--- a/docs/src/app/(public)/page.tsx
+++ b/docs/src/app/(public)/page.tsx
@@ -7,23 +7,39 @@ import './page.css';
 
 export default function Homepage() {
   return (
-    <div className="HomepageRoot">
-      <div className="HomepageContent">
-        <Logo className="mb-8 ml-px" aria-label="Base UI" />
-        <h1 className="HomepageHeading">
-          Unstyled UI components for building accessible web apps and design systems.
-        </h1>
-        <p className="HomepageCaption">
-          From the creators of Radix, Floating&nbsp;UI, and Material&nbsp;UI.
-        </p>
-        <Link
-          className="-m-1 inline-flex items-center gap-1 p-1"
-          href="/react/overview/quick-start"
-        >
-          Documentation <ArrowRightIcon />
-        </Link>
+    <React.Fragment>
+      {/* Set the Site name for Google results. https://developers.google.com/search/docs/appearance/site-names */}
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'WebSite',
+            name: 'Base UI',
+            url: 'https://base-ui.com',
+          }),
+        }}
+      />
+      <div className="HomepageRoot">
+        <div className="HomepageContent">
+          <Logo className="mb-8 ml-px" aria-label="Base UI" />
+          <h1 className="HomepageHeading">
+            Unstyled UI components for building accessible web apps and design
+            systems.
+          </h1>
+          <p className="HomepageCaption">
+            From the creators of Radix, Floating&nbsp;UI, and Material&nbsp;UI.
+          </p>
+          <Link
+            className="-m-1 inline-flex items-center gap-1 p-1"
+            href="/react/overview/quick-start"
+          >
+            Documentation <ArrowRightIcon />
+          </Link>
+        </div>
       </div>
-    </div>
+    </React.Fragment>
   );
 }
 


### PR DESCRIPTION
Fix #1163

This still didn't change:

<img width="892" alt="SCR-20250301-qtbo" src="https://github.com/user-attachments/assets/40f03311-d022-4875-bd40-d3265e541f7f" />

It feels off. The solution is to apply the instructions of https://developers.google.com/search/docs/appearance/site-names#json-ld.

That seems correct: https://validator.schema.org/#url=https%3A%2F%2Fdeploy-preview-1520--base-ui.netlify.app%2F. We should see after a couple of days:

<img width="884" alt="SCR-20250301-qthq" src="https://github.com/user-attachments/assets/9a720f0a-efde-4e84-9b52-25f9fdd0fe0d" />

---

**Off-topic**: the URL is truncated, but a path like this:

<img width="411" alt="SCR-20250301-qufv" src="https://github.com/user-attachments/assets/0c5ec95e-6022-4de4-b0b9-06ae559ea9d4" />

would be clearer. Opened an umbrella issue for SEO: .