### PR TITLE
[tabs][RadioGroup] Handle modifier keys

### DIFF
--- a/packages/react/src/composite/composite.ts
+++ b/packages/react/src/composite/composite.ts
@@ -22,6 +22,13 @@ export const VERTICAL_KEYS_WITH_EXTRA_KEYS = [ARROW_UP, ARROW_DOWN, HOME, END];
 export const ARROW_KEYS = [...HORIZONTAL_KEYS, ...VERTICAL_KEYS];
 export const ALL_KEYS = [...ARROW_KEYS, HOME, END];
 
+export const SHIFT = 'Shift' as const;
+export const CONTROL = 'Control' as const;
+export const ALT = 'Alt' as const;
+export const META = 'Meta' as const;
+export const MODIFIER_KEYS = [SHIFT, CONTROL, ALT, META] as const;
+export type ModifierKey = (typeof MODIFIER_KEYS)[number];
+
 function stopEvent(event: Event | React.SyntheticEvent) {
   event.preventDefault();
   event.stopPropagation();

--- a/packages/react/src/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/composite/root/CompositeRoot.test.tsx
@@ -542,4 +542,71 @@ describe('Composite', () => {
       expect(item3).toHaveFocus();
     });
   });
+
+  describe('prop: modifierKeys', () => {
+    it('prevents arrow key navigation when any modifier key is pressed by default', async () => {
+      const { getByTestId } = render(
+        <CompositeRoot>
+          <CompositeItem data-testid="1">1</CompositeItem>
+          <CompositeItem data-testid="2">2</CompositeItem>
+        </CompositeRoot>,
+      );
+
+      const item1 = getByTestId('1');
+
+      act(() => item1.focus());
+
+      expect(item1).toHaveFocus();
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown', shiftKey: true });
+      await flushMicrotasks();
+      expect(item1).toHaveFocus();
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown', ctrlKey: true });
+      await flushMicrotasks();
+      expect(item1).toHaveFocus();
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown', altKey: true });
+      await flushMicrotasks();
+      expect(item1).toHaveFocus();
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown', metaKey: true });
+      await flushMicrotasks();
+      expect(item1).toHaveFocus();
+    });
+
+    it('specifies allowed modifier keys that do not prevent arrow key navigation when pressed', async () => {
+      const { getByTestId } = render(
+        <CompositeRoot modifierKeys={['Alt', 'Meta']}>
+          <CompositeItem data-testid="1">1</CompositeItem>
+          <CompositeItem data-testid="2">2</CompositeItem>
+          <CompositeItem data-testid="3">3</CompositeItem>
+        </CompositeRoot>,
+      );
+
+      const item1 = getByTestId('1');
+      const item2 = getByTestId('2');
+      const item3 = getByTestId('3');
+
+      act(() => item1.focus());
+
+      expect(item1).toHaveFocus();
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown', shiftKey: true });
+      await flushMicrotasks();
+      expect(item1).toHaveFocus();
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown', ctrlKey: true });
+      await flushMicrotasks();
+      expect(item1).toHaveFocus();
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown', altKey: true });
+      await flushMicrotasks();
+      expect(item2).toHaveFocus();
+
+      fireEvent.keyDown(item2, { key: 'ArrowDown', metaKey: true });
+      await flushMicrotasks();
+      expect(item3).toHaveFocus();
+    });
+  });
 });

--- a/packages/react/src/composite/root/CompositeRoot.tsx
+++ b/packages/react/src/composite/root/CompositeRoot.tsx
@@ -8,7 +8,7 @@ import { refType } from '../../utils/proptypes';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { TextDirection } from '../../direction-provider/DirectionContext';
-import type { Dimensions } from '../composite';
+import type { Dimensions, ModifierKey } from '../composite';
 
 /**
  * @ignore - internal component.
@@ -30,6 +30,7 @@ function CompositeRoot<Metadata extends {}>(props: CompositeRoot.Props<Metadata>
     stopEventPropagation,
     rootRef,
     disabledIndices,
+    modifierKeys,
     ...otherProps
   } = props;
 
@@ -47,6 +48,7 @@ function CompositeRoot<Metadata extends {}>(props: CompositeRoot.Props<Metadata>
       enableHomeAndEndKeys,
       direction,
       disabledIndices,
+      modifierKeys,
     });
 
   const { renderElement } = useComponentRenderer({
@@ -88,6 +90,7 @@ namespace CompositeRoot {
     stopEventPropagation?: boolean;
     rootRef?: React.RefObject<HTMLElement | null>;
     disabledIndices?: number[];
+    modifierKeys?: ModifierKey[];
   }
 }
 
@@ -144,6 +147,10 @@ CompositeRoot.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   loop: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  modifierKeys: PropTypes.arrayOf(PropTypes.oneOf(['Alt', 'Control', 'Meta', 'Shift']).isRequired),
   /**
    * @ignore
    */

--- a/packages/react/src/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/composite/root/useCompositeRoot.ts
@@ -77,6 +77,8 @@ function getDisallowedModifierKeys(modifierKeys: ModifierKey[]) {
   return MODIFIER_KEYS.filter((key) => !set.has(key));
 }
 
+const EMPTY_ARRAY: never[] = [];
+
 /**
  * @ignore - internal hook.
  */
@@ -94,7 +96,7 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
     enableHomeAndEndKeys = false,
     stopEventPropagation = false,
     disabledIndices,
-    modifierKeys = [],
+    modifierKeys = EMPTY_ARRAY,
   } = params;
 
   const [internalHighlightedIndex, internalSetHighlightedIndex] = React.useState(0);

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -307,6 +307,33 @@ describe('<RadioGroup />', () => {
 
           expect(c).toHaveFocus();
         });
+
+        describe('modifier keys', () => {
+          it('when Shift is pressed arrow keys move focus normally', async () => {
+            const { user } = await render(
+              <DirectionProvider direction={direction as TextDirection}>
+                <RadioGroup>
+                  <Radio.Root value="a" data-testid="a" />
+                  <Radio.Root value="b" data-testid="b" />
+                  <Radio.Root value="c" data-testid="c" />
+                </RadioGroup>
+              </DirectionProvider>,
+            );
+
+            const a = screen.getByTestId('a');
+            const b = screen.getByTestId('b');
+            const c = screen.getByTestId('c');
+
+            await user.keyboard('{Tab}');
+            expect(a).toHaveFocus();
+
+            await user.keyboard(`{Shift>}{${horizontalNextKey}}`);
+            expect(b).toHaveFocus();
+
+            await user.keyboard('{Shift>}{ArrowDown}');
+            expect(c).toHaveFocus();
+          });
+        });
       });
     });
   });

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import type { BaseUIComponentProps } from '../utils/types';
+import { SHIFT } from '../composite/composite';
 import { CompositeRoot } from '../composite/root/CompositeRoot';
 import { useComponentRenderer } from '../utils/useComponentRenderer';
 import { useEventCallback } from '../utils/useEventCallback';
@@ -11,6 +12,8 @@ import { RadioGroupContext } from './RadioGroupContext';
 import { useFieldRootContext } from '../field/root/FieldRootContext';
 import { fieldValidityMapping } from '../field/utils/constants';
 import type { FieldRoot } from '../field/root/FieldRoot';
+
+const MODIFIER_KEYS = [SHIFT];
 
 /**
  * Provides a shared state to a series of radio buttons.
@@ -77,7 +80,12 @@ const RadioGroup = React.forwardRef(function RadioGroup(
 
   return (
     <RadioGroupContext.Provider value={contextValue}>
-      <CompositeRoot direction={direction} enableHomeAndEndKeys={false} render={renderElement()} />
+      <CompositeRoot
+        direction={direction}
+        enableHomeAndEndKeys={false}
+        modifierKeys={MODIFIER_KEYS}
+        render={renderElement()}
+      />
       <input {...radioGroup.getInputProps()} />
     </RadioGroupContext.Provider>
   );

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -777,6 +777,46 @@ describe('<Tabs.Root />', () => {
               expect(thirdTab).toHaveFocus();
             });
           });
+
+          describe('modifier keys', () => {
+            ['Shift', 'Control', 'Alt', 'Meta'].forEach((modifierKey) => {
+              it(`does not move focus when modifier key: ${modifierKey} is pressed`, async () => {
+                const handleChange = spy();
+                const handleKeyDown = spy();
+                const { getAllByRole, user } = await render(
+                  <DirectionProvider direction={direction as TextDirection}>
+                    <Tabs.Root
+                      onValueChange={handleChange}
+                      onKeyDown={handleKeyDown}
+                      orientation={orientation as Tabs.Root.Props['orientation']}
+                      value={0}
+                    >
+                      <Tabs.List>
+                        <Tabs.Tab value={0} />
+                        <Tabs.Tab value={1} />
+                        <Tabs.Tab value={2} />
+                      </Tabs.List>
+                    </Tabs.Root>
+                  </DirectionProvider>,
+                );
+
+                const [firstTab] = getAllByRole('tab');
+
+                await user.keyboard('[Tab]');
+                expect(firstTab).toHaveFocus();
+
+                await user.keyboard(`{${modifierKey}>}{${nextItemKey}}`);
+                expect(firstTab).toHaveFocus();
+                expect(handleChange.callCount).to.equal(0);
+                expect(handleKeyDown.callCount).to.equal(2);
+
+                await user.keyboard(`{${modifierKey}>}{${previousItemKey}}`);
+                expect(firstTab).toHaveFocus();
+                expect(handleChange.callCount).to.equal(0);
+                expect(handleKeyDown.callCount).to.equal(4);
+              });
+            });
+          });
         },
       );
     });


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/issues/1465

All composite components will now prevent arrow key navigation if any modifier key (Shift, Ctrl, Alt, Meta) is pressed by default unless it's allowed with the `modifierKeys` prop.

The exception is RadioGroup since HTML radio groups work normally when `Shift` is held ([example](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#try_it))

Demo:
- Tabs will no longer navigate if any modifier key is pressed: https://deploy-preview-1529--base-ui.netlify.app/react/components/tabs
- RadioGroup works normally if `Shift` is pressed: https://deploy-preview-1529--base-ui.netlify.app/react/components/radio

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
