### PR TITLE
Ensure getButtonProps overrides other props

### DIFF
--- a/packages/react/src/collapsible/trigger/useCollapsibleTrigger.ts
+++ b/packages/react/src/collapsible/trigger/useCollapsibleTrigger.ts
@@ -20,20 +20,19 @@ export function useCollapsibleTrigger(
 
   const getRootProps: useCollapsibleTrigger.ReturnValue['getRootProps'] = React.useCallback(
     (externalProps: GenericHTMLProps = {}) =>
-      getButtonProps(
-        mergeReactProps(
-          {
-            type: 'button',
-            'aria-controls': panelId,
-            'aria-expanded': open,
-            disabled,
-            onClick() {
-              setOpen(!open);
-            },
-            ref: handleRef,
+      mergeReactProps(
+        {
+          type: 'button',
+          'aria-controls': panelId,
+          'aria-expanded': open,
+          disabled,
+          onClick() {
+            setOpen(!open);
           },
-          externalProps,
-        ),
+          ref: handleRef,
+        },
+        externalProps,
+        getButtonProps,
       ),
     [panelId, disabled, getButtonProps, handleRef, open, setOpen],
   );

--- a/packages/react/src/composite/item/useCompositeItem.ts
+++ b/packages/react/src/composite/item/useCompositeItem.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useCompositeRootContext } from '../root/CompositeRootContext';
 import { useCompositeListItem } from '../list/useCompositeListItem';
 import { mergeReactProps } from '../../utils/mergeReactProps';
+import type { GenericHTMLProps } from '../../utils/types';
 
 export interface UseCompositeItemParameters<Metadata> {
   metadata?: Metadata;
@@ -14,7 +15,7 @@ export function useCompositeItem<Metadata>(params: UseCompositeItemParameters<Me
   const isHighlighted = highlightedIndex === index;
 
   const getItemProps = React.useCallback(
-    (externalProps = {}) =>
+    (externalProps: GenericHTMLProps = {}) =>
       mergeReactProps<'div'>(
         {
           tabIndex: isHighlighted ? 0 : -1,

--- a/packages/react/src/select/item/useSelectItem.ts
+++ b/packages/react/src/select/item/useSelectItem.ts
@@ -46,114 +46,112 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
 
   const getItemProps = React.useCallback(
     (externalProps?: GenericHTMLProps): GenericHTMLProps => {
-      return getButtonProps(
-        mergeReactProps<'div'>(
-          {
-            'aria-disabled': disabled || undefined,
-            tabIndex: highlighted ? 0 : -1,
-            onFocus() {
-              if (allowFocusSyncRef.current) {
-                setActiveIndex(indexRef.current);
-              }
-            },
-            onMouseMove() {
+      return mergeReactProps<'div'>(
+        {
+          'aria-disabled': disabled || undefined,
+          tabIndex: highlighted ? 0 : -1,
+          onFocus() {
+            if (allowFocusSyncRef.current) {
               setActiveIndex(indexRef.current);
-              if (popupRef.current) {
-                prevPopupHeightRef.current = popupRef.current.offsetHeight;
-              }
-            },
-            onMouseLeave(event) {
-              const popup = popupRef.current;
-              if (!popup || !open) {
-                return;
-              }
-
-              const targetRect = event.currentTarget.getBoundingClientRect();
-
-              // Safari randomly fires `mouseleave` incorrectly when the item is
-              // aligned to the trigger. This is a workaround to prevent the highlight
-              // from being removed while the cursor is still within the bounds of the item.
-              // https://github.com/mui/base-ui/issues/869
-              const isWithinBounds =
-                targetRect.top + 1 <= event.clientY &&
-                event.clientY <= targetRect.bottom - 1 &&
-                targetRect.left + 1 <= event.clientX &&
-                event.clientX <= targetRect.right - 1;
-
-              if (isWithinBounds) {
-                return;
-              }
-
-              // With `alignItemToTrigger`, avoid re-rendering the root due to `onMouseLeave`
-              // firing and causing a performance issue when expanding the popup.
-              if (popup.offsetHeight === prevPopupHeightRef.current) {
-                // Prevent `onFocus` from causing the highlight to be stuck when quickly moving
-                // the mouse out of the popup.
-                allowFocusSyncRef.current = false;
-                setActiveIndex(null);
-                requestAnimationFrame(() => {
-                  popup.focus({ preventScroll: true });
-                  allowFocusSyncRef.current = true;
-                });
-              }
-            },
-            onTouchStart() {
-              selectionRef.current = {
-                allowSelectedMouseUp: false,
-                allowUnselectedMouseUp: false,
-                allowSelect: true,
-              };
-            },
-            onKeyDown(event) {
-              selectionRef.current.allowSelect = true;
-              lastKeyRef.current = event.key;
-            },
-            onClick(event) {
-              if (
-                disabled ||
-                (lastKeyRef.current === ' ' && typingRef.current) ||
-                (pointerTypeRef.current !== 'touch' && !highlighted)
-              ) {
-                return;
-              }
-
-              if (selectionRef.current.allowSelect) {
-                lastKeyRef.current = null;
-                commitSelection(event.nativeEvent);
-              }
-            },
-            onPointerEnter(event) {
-              pointerTypeRef.current = event.pointerType;
-            },
-            onPointerDown(event) {
-              pointerTypeRef.current = event.pointerType;
-            },
-            onMouseUp(event) {
-              if (disabled) {
-                return;
-              }
-              const disallowSelectedMouseUp =
-                !selectionRef.current.allowSelectedMouseUp && selected;
-              const disallowUnselectedMouseUp =
-                !selectionRef.current.allowUnselectedMouseUp && !selected;
-
-              if (
-                disallowSelectedMouseUp ||
-                disallowUnselectedMouseUp ||
-                (pointerTypeRef.current !== 'touch' && !highlighted)
-              ) {
-                return;
-              }
-
-              if (selectionRef.current.allowSelect || !selected) {
-                commitSelection(event.nativeEvent);
-              }
-
-              selectionRef.current.allowSelect = true;
-            },
+            }
           },
-          externalProps,
-        ),
+          onMouseMove() {
+            setActiveIndex(indexRef.current);
+            if (popupRef.current) {
+              prevPopupHeightRef.current = popupRef.current.offsetHeight;
+            }
+          },
+          onMouseLeave(event) {
+            const popup = popupRef.current;
+            if (!popup || !open) {
+              return;
+            }
+
+            const targetRect = event.currentTarget.getBoundingClientRect();
+
+            // Safari randomly fires `mouseleave` incorrectly when the item is
+            // aligned to the trigger. This is a workaround to prevent the highlight
+            // from being removed while the cursor is still within the bounds of the item.
+            // https://github.com/mui/base-ui/issues/869
+            const isWithinBounds =
+              targetRect.top + 1 <= event.clientY &&
+              event.clientY <= targetRect.bottom - 1 &&
+              targetRect.left + 1 <= event.clientX &&
+              event.clientX <= targetRect.right - 1;
+
+            if (isWithinBounds) {
+              return;
+            }
+
+            // With `alignItemToTrigger`, avoid re-rendering the root due to `onMouseLeave`
+            // firing and causing a performance issue when expanding the popup.
+            if (popup.offsetHeight === prevPopupHeightRef.current) {
+              // Prevent `onFocus` from causing the highlight to be stuck when quickly moving
+              // the mouse out of the popup.
+              allowFocusSyncRef.current = false;
+              setActiveIndex(null);
+              requestAnimationFrame(() => {
+                popup.focus({ preventScroll: true });
+                allowFocusSyncRef.current = true;
+              });
+            }
+          },
+          onTouchStart() {
+            selectionRef.current = {
+              allowSelectedMouseUp: false,
+              allowUnselectedMouseUp: false,
+              allowSelect: true,
+            };
+          },
+          onKeyDown(event) {
+            selectionRef.current.allowSelect = true;
+            lastKeyRef.current = event.key;
+          },
+          onClick(event) {
+            if (
+              disabled ||
+              (lastKeyRef.current === ' ' && typingRef.current) ||
+              (pointerTypeRef.current !== 'touch' && !highlighted)
+            ) {
+              return;
+            }
+
+            if (selectionRef.current.allowSelect) {
+              lastKeyRef.current = null;
+              commitSelection(event.nativeEvent);
+            }
+          },
+          onPointerEnter(event) {
+            pointerTypeRef.current = event.pointerType;
+          },
+          onPointerDown(event) {
+            pointerTypeRef.current = event.pointerType;
+          },
+          onMouseUp(event) {
+            if (disabled) {
+              return;
+            }
+            const disallowSelectedMouseUp = !selectionRef.current.allowSelectedMouseUp && selected;
+            const disallowUnselectedMouseUp =
+              !selectionRef.current.allowUnselectedMouseUp && !selected;
+
+            if (
+              disallowSelectedMouseUp ||
+              disallowUnselectedMouseUp ||
+              (pointerTypeRef.current !== 'touch' && !highlighted)
+            ) {
+              return;
+            }
+
+            if (selectionRef.current.allowSelect || !selected) {
+              commitSelection(event.nativeEvent);
+            }
+
+            selectionRef.current.allowSelect = true;
+          },
+        },
+        externalProps,
+        getButtonProps,
       );
     },
     [

--- a/packages/react/src/select/trigger/useSelectTrigger.ts
+++ b/packages/react/src/select/trigger/useSelectTrigger.ts
@@ -73,79 +73,78 @@ export function useSelectTrigger(
 
   const getTriggerProps = React.useCallback(
     (externalProps?: GenericHTMLProps): GenericHTMLProps => {
-      return getButtonProps(
-        mergeReactProps<'button'>(
-          {
-            'aria-labelledby': labelId,
-            'aria-readonly': readOnly || undefined,
-            tabIndex: disabled ? -1 : 0, // this is needed to make the button focused after click in Safari
-            ref: handleRef,
-            onFocus() {
-              setFocused(true);
-              // The popup element shouldn't obscure the focused trigger.
-              if (open && alignItemToTrigger) {
-                setOpen(false);
-              }
-            },
-            onBlur() {
-              setTouched(true);
-              setFocused(false);
+      return mergeReactProps<'button'>(
+        {
+          'aria-labelledby': labelId,
+          'aria-readonly': readOnly || undefined,
+          tabIndex: disabled ? -1 : 0, // this is needed to make the button focused after click in Safari
+          ref: handleRef,
+          onFocus() {
+            setFocused(true);
+            // The popup element shouldn't obscure the focused trigger.
+            if (open && alignItemToTrigger) {
+              setOpen(false);
+            }
+          },
+          onBlur() {
+            setTouched(true);
+            setFocused(false);
 
-              if (validationMode === 'onBlur') {
-                fieldControlValidation.commitValidation(value);
-              }
-            },
-            onPointerMove({ pointerType }) {
-              setTouchModality(pointerType === 'touch');
-            },
-            onPointerDown({ pointerType }) {
-              setTouchModality(pointerType === 'touch');
-            },
-            onMouseDown(event) {
-              if (open) {
+            if (validationMode === 'onBlur') {
+              fieldControlValidation.commitValidation(value);
+            }
+          },
+          onPointerMove({ pointerType }) {
+            setTouchModality(pointerType === 'touch');
+          },
+          onPointerDown({ pointerType }) {
+            setTouchModality(pointerType === 'touch');
+          },
+          onMouseDown(event) {
+            if (open) {
+              return;
+            }
+
+            const doc = ownerDocument(event.currentTarget);
+
+            function handleMouseUp(mouseEvent: MouseEvent) {
+              if (!triggerRef.current) {
                 return;
               }
 
-              const doc = ownerDocument(event.currentTarget);
+              const mouseUpTarget = mouseEvent.target as Element | null;
 
-              function handleMouseUp(mouseEvent: MouseEvent) {
-                if (!triggerRef.current) {
-                  return;
-                }
-
-                const mouseUpTarget = mouseEvent.target as Element | null;
-
-                // Early return if clicked on trigger element or its children
-                if (
-                  contains(triggerRef.current, mouseUpTarget) ||
-                  contains(positionerElement, mouseUpTarget) ||
-                  mouseUpTarget === triggerRef.current
-                ) {
-                  return;
-                }
-
-                const bounds = getPseudoElementBounds(triggerRef.current);
-
-                if (
-                  mouseEvent.clientX >= bounds.left - BOUNDARY_OFFSET &&
-                  mouseEvent.clientX <= bounds.right + BOUNDARY_OFFSET &&
-                  mouseEvent.clientY >= bounds.top - BOUNDARY_OFFSET &&
-                  mouseEvent.clientY <= bounds.bottom + BOUNDARY_OFFSET
-                ) {
-                  return;
-                }
-
-                setOpen(false, mouseEvent);
+              // Early return if clicked on trigger element or its children
+              if (
+                contains(triggerRef.current, mouseUpTarget) ||
+                contains(positionerElement, mouseUpTarget) ||
+                mouseUpTarget === triggerRef.current
+              ) {
+                return;
               }
 
-              // Firefox can fire this upon mousedown
-              timeoutRef.current = window.setTimeout(() => {
-                doc.addEventListener('mouseup', handleMouseUp, { once: true });
-              });
-            },
+              const bounds = getPseudoElementBounds(triggerRef.current);
+
+              if (
+                mouseEvent.clientX >= bounds.left - BOUNDARY_OFFSET &&
+                mouseEvent.clientX <= bounds.right + BOUNDARY_OFFSET &&
+                mouseEvent.clientY >= bounds.top - BOUNDARY_OFFSET &&
+                mouseEvent.clientY <= bounds.bottom + BOUNDARY_OFFSET
+              ) {
+                return;
+              }
+
+              setOpen(false, mouseEvent);
+            }
+
+            // Firefox can fire this upon mousedown
+            timeoutRef.current = window.setTimeout(() => {
+              doc.addEventListener('mouseup', handleMouseUp, { once: true });
+            });
           },
-          fieldControlValidation.getValidationProps(externalProps),
-        ),
+        },
+        fieldControlValidation.getValidationProps(externalProps),
+        getButtonProps,
       );
     },
     [

--- a/packages/react/src/tabs/tab/useTabsTab.ts
+++ b/packages/react/src/tabs/tab/useTabsTab.ts
@@ -85,22 +85,21 @@ function useTabsTab(parameters: useTabsTab.Parameters): useTabsTab.ReturnValue {
 
   const getRootProps = React.useCallback(
     (externalProps = {}) => {
-      return mergeReactProps<'button'>(
-        mergeReactProps(getButtonProps(), getItemProps()),
+      return mergeReactProps(
         {
           role: 'tab',
           'aria-controls': tabPanelId,
           'aria-selected': selected,
           id,
           ref: handleRef,
-          onClick(event) {
+          onClick(event: React.MouseEvent<HTMLButtonElement>) {
             if (selected || disabled) {
               return;
             }
 
             onTabActivation(tabValue, event.nativeEvent);
           },
-          onFocus(event) {
+          onFocus(event: React.FocusEvent<HTMLButtonElement>) {
             if (selected) {
               return;
             }
@@ -120,7 +119,7 @@ function useTabsTab(parameters: useTabsTab.Parameters): useTabsTab.ReturnValue {
               onTabActivation(tabValue, event.nativeEvent);
             }
           },
-          onPointerDown(event) {
+          onPointerDown(event: React.PointerEvent<HTMLButtonElement>) {
             if (selected || disabled) {
               return;
             }
@@ -141,6 +140,8 @@ function useTabsTab(parameters: useTabsTab.Parameters): useTabsTab.ReturnValue {
           },
         },
         externalProps,
+        getButtonProps,
+        getItemProps,
       );
     },
     [

--- a/packages/react/src/toggle/useToggle.ts
+++ b/packages/react/src/toggle/useToggle.ts
@@ -37,9 +37,8 @@ export function useToggle(parameters: useToggle.Parameters): useToggle.ReturnVal
   });
 
   const getRootProps = React.useCallback(
-    (externalProps?: GenericHTMLProps): GenericHTMLProps => {
+    (externalProps: GenericHTMLProps = {}): GenericHTMLProps => {
       return mergeReactProps(
-        getButtonProps(),
         {
           'aria-pressed': pressed,
           onClick(event: React.MouseEvent) {
@@ -50,6 +49,7 @@ export function useToggle(parameters: useToggle.Parameters): useToggle.ReturnVal
           ref: buttonRef,
         },
         externalProps,
+        getButtonProps,
       );
     },
     [getButtonProps, buttonRef, onPressedChange, pressed, setPressedState],


### PR DESCRIPTION
Since the merging order was reversed, `getButtonProps` needs to be moved after `externalProps` to ensure that getButtonProps overrides externalProps

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
