### PR TITLE
[core] Improve code readability when using mergeProps

### DIFF
--- a/packages/react/src/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/composite/root/useCompositeRoot.ts
@@ -94,165 +94,167 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
 
   const elementsRef = React.useRef<Array<HTMLDivElement | null>>([]);
 
+  const defaultProps = {
+    'aria-orientation': orientation === 'both' ? undefined : orientation,
+    ref: mergedRef,
+    onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
+      const RELEVANT_KEYS = enableHomeAndEndKeys ? ALL_KEYS : ARROW_KEYS;
+      if (!RELEVANT_KEYS.includes(event.key)) {
+        return;
+      }
+
+      const element = rootRef.current;
+      if (!element) {
+        return;
+      }
+
+      if (textDirectionRef?.current == null) {
+        textDirectionRef.current = getTextDirection(element);
+      }
+      const isRtl = textDirectionRef.current === 'rtl';
+
+      let nextIndex = highlightedIndex;
+      const minIndex = getMinIndex(elementsRef, disabledIndices);
+      const maxIndex = getMaxIndex(elementsRef, disabledIndices);
+
+      if (isGrid) {
+        const sizes =
+          itemSizes ||
+          Array.from({ length: elementsRef.current.length }, () => ({
+            width: 1,
+            height: 1,
+          }));
+        // To calculate movements on the grid, we use hypothetical cell indices
+        // as if every item was 1x1, then convert back to real indices.
+        const cellMap = buildCellMap(sizes, cols, dense);
+        const minGridIndex = cellMap.findIndex(
+          (index) =>
+            index != null && !isDisabled(elementsRef.current, index, disabledIndices),
+        );
+        // last enabled index
+        const maxGridIndex = cellMap.reduce(
+          (foundIndex: number, index, cellIndex) =>
+            index != null && !isDisabled(elementsRef.current, index, disabledIndices)
+              ? cellIndex
+              : foundIndex,
+          -1,
+        );
+
+        nextIndex = cellMap[
+          getGridNavigatedIndex(
+            {
+              current: cellMap.map((itemIndex) =>
+                itemIndex ? elementsRef.current[itemIndex] : null,
+              ),
+            },
+            {
+              event,
+              orientation,
+              loop,
+              cols,
+              // treat undefined (empty grid spaces) as disabled indices so we
+              // don't end up in them
+              disabledIndices: getCellIndices(
+                [
+                  ...(disabledIndices ||
+                    elementsRef.current.map((_, index) =>
+                      isDisabled(elementsRef.current, index) ? index : undefined,
+                    )),
+                  undefined,
+                ],
+                cellMap,
+              ),
+              minIndex: minGridIndex,
+              maxIndex: maxGridIndex,
+              prevIndex: getCellIndexOfCorner(
+                highlightedIndex > maxIndex ? minIndex : highlightedIndex,
+                sizes,
+                cellMap,
+                cols,
+                // use a corner matching the edge closest to the direction we're
+                // moving in so we don't end up in the same item. Prefer
+                // top/left over bottom/right.
+                // eslint-disable-next-line no-nested-ternary
+                event.key === ARROW_DOWN ? 'bl' : event.key === ARROW_RIGHT ? 'tr' : 'tl',
+              ),
+              rtl: isRtl,
+            },
+          )
+        ] as number; // navigated cell will never be nullish
+      }
+
+      const horizontalEndKey = isRtl ? ARROW_LEFT : ARROW_RIGHT;
+      const toEndKeys = {
+        horizontal: [horizontalEndKey],
+        vertical: [ARROW_DOWN],
+        both: [horizontalEndKey, ARROW_DOWN],
+      }[orientation];
+
+      const horizontalStartKey = isRtl ? ARROW_RIGHT : ARROW_LEFT;
+      const toStartKeys = {
+        horizontal: [horizontalStartKey],
+        vertical: [ARROW_UP],
+        both: [horizontalStartKey, ARROW_UP],
+      }[orientation];
+
+      const preventedKeys = isGrid
+        ? RELEVANT_KEYS
+        : {
+            horizontal: enableHomeAndEndKeys
+              ? HORIZONTAL_KEYS_WITH_EXTRA_KEYS
+              : HORIZONTAL_KEYS,
+            vertical: enableHomeAndEndKeys ? VERTICAL_KEYS_WITH_EXTRA_KEYS : VERTICAL_KEYS,
+            both: RELEVANT_KEYS,
+          }[orientation];
+
+      if (enableHomeAndEndKeys) {
+        if (event.key === HOME) {
+          nextIndex = minIndex;
+        } else if (event.key === END) {
+          nextIndex = maxIndex;
+        }
+      }
+
+      if (
+        nextIndex === highlightedIndex &&
+        [...toEndKeys, ...toStartKeys].includes(event.key)
+      ) {
+        if (loop && nextIndex === maxIndex && toEndKeys.includes(event.key)) {
+          nextIndex = minIndex;
+        } else if (loop && nextIndex === minIndex && toStartKeys.includes(event.key)) {
+          nextIndex = maxIndex;
+        } else {
+          nextIndex = findNonDisabledIndex(elementsRef, {
+            startingIndex: nextIndex,
+            decrement: toStartKeys.includes(event.key),
+            disabledIndices,
+          });
+        }
+      }
+
+      if (nextIndex !== highlightedIndex && !isIndexOutOfBounds(elementsRef, nextIndex)) {
+        if (stopEventPropagation) {
+          event.stopPropagation();
+        }
+
+        if (preventedKeys.includes(event.key)) {
+          event.preventDefault();
+        }
+
+        onHighlightedIndexChange(nextIndex);
+
+        // Wait for FocusManager `returnFocus` to execute.
+        queueMicrotask(() => {
+          elementsRef.current[nextIndex]?.focus();
+        });
+      }
+    },
+  };
+
   const getRootProps = React.useCallback(
     (externalProps = {}) =>
       mergeProps<'div'>(
-        {
-          'aria-orientation': orientation === 'both' ? undefined : orientation,
-          ref: mergedRef,
-          onKeyDown(event) {
-            const RELEVANT_KEYS = enableHomeAndEndKeys ? ALL_KEYS : ARROW_KEYS;
-            if (!RELEVANT_KEYS.includes(event.key)) {
-              return;
-            }
-
-            const element = rootRef.current;
-            if (!element) {
-              return;
-            }
-
-            if (textDirectionRef?.current == null) {
-              textDirectionRef.current = getTextDirection(element);
-            }
-            const isRtl = textDirectionRef.current === 'rtl';
-
-            let nextIndex = highlightedIndex;
-            const minIndex = getMinIndex(elementsRef, disabledIndices);
-            const maxIndex = getMaxIndex(elementsRef, disabledIndices);
-
-            if (isGrid) {
-              const sizes =
-                itemSizes ||
-                Array.from({ length: elementsRef.current.length }, () => ({
-                  width: 1,
-                  height: 1,
-                }));
-              // To calculate movements on the grid, we use hypothetical cell indices
-              // as if every item was 1x1, then convert back to real indices.
-              const cellMap = buildCellMap(sizes, cols, dense);
-              const minGridIndex = cellMap.findIndex(
-                (index) =>
-                  index != null && !isDisabled(elementsRef.current, index, disabledIndices),
-              );
-              // last enabled index
-              const maxGridIndex = cellMap.reduce(
-                (foundIndex: number, index, cellIndex) =>
-                  index != null && !isDisabled(elementsRef.current, index, disabledIndices)
-                    ? cellIndex
-                    : foundIndex,
-                -1,
-              );
-
-              nextIndex = cellMap[
-                getGridNavigatedIndex(
-                  {
-                    current: cellMap.map((itemIndex) =>
-                      itemIndex ? elementsRef.current[itemIndex] : null,
-                    ),
-                  },
-                  {
-                    event,
-                    orientation,
-                    loop,
-                    cols,
-                    // treat undefined (empty grid spaces) as disabled indices so we
-                    // don't end up in them
-                    disabledIndices: getCellIndices(
-                      [
-                        ...(disabledIndices ||
-                          elementsRef.current.map((_, index) =>
-                            isDisabled(elementsRef.current, index) ? index : undefined,
-                          )),
-                        undefined,
-                      ],
-                      cellMap,
-                    ),
-                    minIndex: minGridIndex,
-                    maxIndex: maxGridIndex,
-                    prevIndex: getCellIndexOfCorner(
-                      highlightedIndex > maxIndex ? minIndex : highlightedIndex,
-                      sizes,
-                      cellMap,
-                      cols,
-                      // use a corner matching the edge closest to the direction we're
-                      // moving in so we don't end up in the same item. Prefer
-                      // top/left over bottom/right.
-                      // eslint-disable-next-line no-nested-ternary
-                      event.key === ARROW_DOWN ? 'bl' : event.key === ARROW_RIGHT ? 'tr' : 'tl',
-                    ),
-                    rtl: isRtl,
-                  },
-                )
-              ] as number; // navigated cell will never be nullish
-            }
-
-            const horizontalEndKey = isRtl ? ARROW_LEFT : ARROW_RIGHT;
-            const toEndKeys = {
-              horizontal: [horizontalEndKey],
-              vertical: [ARROW_DOWN],
-              both: [horizontalEndKey, ARROW_DOWN],
-            }[orientation];
-
-            const horizontalStartKey = isRtl ? ARROW_RIGHT : ARROW_LEFT;
-            const toStartKeys = {
-              horizontal: [horizontalStartKey],
-              vertical: [ARROW_UP],
-              both: [horizontalStartKey, ARROW_UP],
-            }[orientation];
-
-            const preventedKeys = isGrid
-              ? RELEVANT_KEYS
-              : {
-                  horizontal: enableHomeAndEndKeys
-                    ? HORIZONTAL_KEYS_WITH_EXTRA_KEYS
-                    : HORIZONTAL_KEYS,
-                  vertical: enableHomeAndEndKeys ? VERTICAL_KEYS_WITH_EXTRA_KEYS : VERTICAL_KEYS,
-                  both: RELEVANT_KEYS,
-                }[orientation];
-
-            if (enableHomeAndEndKeys) {
-              if (event.key === HOME) {
-                nextIndex = minIndex;
-              } else if (event.key === END) {
-                nextIndex = maxIndex;
-              }
-            }
-
-            if (
-              nextIndex === highlightedIndex &&
-              [...toEndKeys, ...toStartKeys].includes(event.key)
-            ) {
-              if (loop && nextIndex === maxIndex && toEndKeys.includes(event.key)) {
-                nextIndex = minIndex;
-              } else if (loop && nextIndex === minIndex && toStartKeys.includes(event.key)) {
-                nextIndex = maxIndex;
-              } else {
-                nextIndex = findNonDisabledIndex(elementsRef, {
-                  startingIndex: nextIndex,
-                  decrement: toStartKeys.includes(event.key),
-                  disabledIndices,
-                });
-              }
-            }
-
-            if (nextIndex !== highlightedIndex && !isIndexOutOfBounds(elementsRef, nextIndex)) {
-              if (stopEventPropagation) {
-                event.stopPropagation();
-              }
-
-              if (preventedKeys.includes(event.key)) {
-                event.preventDefault();
-              }
-
-              onHighlightedIndexChange(nextIndex);
-
-              // Wait for FocusManager `returnFocus` to execute.
-              queueMicrotask(() => {
-                elementsRef.current[nextIndex]?.focus();
-              });
-            }
-          },
-        },
+        defaultProps,
         externalProps,
       ),
     [

--- a/packages/react/src/field/control/useFieldControl.ts
+++ b/packages/react/src/field/control/useFieldControl.ts
@@ -66,48 +66,50 @@ export function useFieldControl(params: useFieldControl.Parameters) {
     controlRef: inputRef,
   });
 
+  const defaultProps = {
+    id,
+    disabled,
+    name,
+    ref: inputRef,
+    'aria-labelledby': labelId,
+    value,
+    onChange(event: React.ChangeEvent<HTMLInputElement>) {
+      if (value != null) {
+        setValue(event.currentTarget.value, event.nativeEvent);
+      }
+
+      setDirty(event.currentTarget.value !== validityData.initialValue);
+      setFilled(event.currentTarget.value !== '');
+
+      if (name && {}.hasOwnProperty.call(errors, name)) {
+        const nextErrors = { ...errors };
+        delete nextErrors[name];
+        onClearErrors(nextErrors);
+      }
+    },
+    onFocus() {
+      setFocused(true);
+    },
+    onBlur(event: React.FocusEvent<HTMLInputElement>) {
+      setTouched(true);
+      setFocused(false);
+
+      if (validationMode === 'onBlur') {
+        commitValidation(event.currentTarget.value);
+      }
+    },
+    onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+      if (event.currentTarget.tagName === 'INPUT' && event.key === 'Enter') {
+        setTouched(true);
+        commitValidation(event.currentTarget.value);
+      }
+    },
+  }
+
   const getControlProps = React.useCallback(
     (externalProps = {}) =>
       mergeProps<'input'>(
-        {
-          id,
-          disabled,
-          name,
-          ref: inputRef,
-          'aria-labelledby': labelId,
-          value,
-          onChange(event) {
-            if (value != null) {
-              setValue(event.currentTarget.value, event.nativeEvent);
-            }
-
-            setDirty(event.currentTarget.value !== validityData.initialValue);
-            setFilled(event.currentTarget.value !== '');
-
-            if (name && {}.hasOwnProperty.call(errors, name)) {
-              const nextErrors = { ...errors };
-              delete nextErrors[name];
-              onClearErrors(nextErrors);
-            }
-          },
-          onFocus() {
-            setFocused(true);
-          },
-          onBlur(event) {
-            setTouched(true);
-            setFocused(false);
-
-            if (validationMode === 'onBlur') {
-              commitValidation(event.currentTarget.value);
-            }
-          },
-          onKeyDown(event) {
-            if (event.currentTarget.tagName === 'INPUT' && event.key === 'Enter') {
-              setTouched(true);
-              commitValidation(event.currentTarget.value);
-            }
-          },
-        },
+        defaultProps,
         getValidationProps(getInputValidationProps(externalProps)),
       ),
     [


### PR DESCRIPTION
A proposal of how we can write more readable code when it comes to using `mergeProps`. There is one subtle issue with the typings, if I use React.ComponentsPropsWithRef<'div'> on the defaultProps const, it fails because of our refs, as they are always defined as `React.useRef<HTMLElement | null>`, so I just kept the type as is, but added the event handlers event types. Let me know if you think we should change this.

In addition I don't think we need to always define the new const, maybe just in places where the code is not readable. I changed two examples places, if we agree on the pattern I will do the changes on the rest codebase.