### PR TITLE
[Slider] Fix thumb positioning when controlled value violates min/max/step

### DIFF
--- a/packages/react/src/slider/control/SliderControl.test.tsx
+++ b/packages/react/src/slider/control/SliderControl.test.tsx
@@ -44,7 +44,6 @@ const testRootContext: SliderRootContext = {
   registerSliderControl: NOOP,
   setActive: NOOP,
   setDragging: NOOP,
-  setPercentageValues: NOOP,
   setThumbMap: NOOP,
   setValue: NOOP,
   step: 1,

--- a/packages/react/src/slider/indicator/SliderIndicator.test.tsx
+++ b/packages/react/src/slider/indicator/SliderIndicator.test.tsx
@@ -44,7 +44,6 @@ const testRootContext: SliderRootContext = {
   registerSliderControl: NOOP,
   setActive: NOOP,
   setDragging: NOOP,
-  setPercentageValues: NOOP,
   setThumbMap: NOOP,
   setValue: NOOP,
   step: 1,

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -1640,6 +1640,29 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
       await render(<TestSlider tabIndex={-1} value={30} />);
       expect(screen.getByRole('slider')).to.have.property('tabIndex', -1);
     });
+
+    it('keypresses should correct invalid values', async () => {
+      function App() {
+        const [val, setVal] = React.useState(5.4698);
+        return (
+          <Slider.Root value={val} onValueChange={setVal} min={0} max={10} step={1}>
+            <Slider.Control>
+              <Slider.Track>
+                <Slider.Indicator />
+                <Slider.Thumb data-testid="thumb" />
+              </Slider.Track>
+            </Slider.Control>
+          </Slider.Root>
+        );
+      }
+      const { user } = await render(<App />);
+
+      expect(screen.getByRole('slider')).to.have.attribute('aria-valuenow', '5.4698');
+      await user.keyboard('[Tab]');
+      expect(screen.getByTestId('thumb')).toHaveFocus();
+      await user.keyboard('[ArrowRight]');
+      expect(screen.getByRole('slider')).to.have.attribute('aria-valuenow', '6');
+    });
   });
 
   describe('prop: format', () => {

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -116,7 +116,9 @@ const SliderRoot = React.forwardRef(function SliderRoot<Value extends number | r
 
   return (
     <SliderRootContext.Provider value={contextValue}>
-      <CompositeList elementsRef={slider.thumbRefs}>{renderElement()}</CompositeList>
+      <CompositeList elementsRef={slider.thumbRefs} onMapChange={slider.setThumbMap}>
+        {renderElement()}
+      </CompositeList>
     </SliderRootContext.Provider>
   );
 }) as {

--- a/packages/react/src/slider/root/useSliderRoot.ts
+++ b/packages/react/src/slider/root/useSliderRoot.ts
@@ -59,7 +59,7 @@ function findClosest(values: readonly number[], currentValue: number) {
 function valueArrayToPercentages(values: number[], min: number, max: number) {
   const output = [];
   for (let i = 0; i < values.length; i += 1) {
-    output.push(valueToPercent(values[i], min, max));
+    output.push(clamp(valueToPercent(values[i], min, max), 0, 100));
   }
   return output;
 }
@@ -381,7 +381,7 @@ export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRo
     }
 
     if (typeof valueUnwrapped === 'number') {
-      const newPercentageValue = valueToPercent(valueUnwrapped, min, max);
+      const newPercentageValue = clamp(valueToPercent(valueUnwrapped, min, max), 0, 100);
       if (newPercentageValue !== percentageValues[0] && !Number.isNaN(newPercentageValue)) {
         setPercentageValues([newPercentageValue]);
       }
@@ -445,7 +445,6 @@ export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRo
       registerSliderControl,
       setActive,
       setDragging,
-      setPercentageValues,
       setThumbMap,
       setValue,
       step,
@@ -475,7 +474,6 @@ export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRo
       registerSliderControl,
       setActive,
       setDragging,
-      setPercentageValues,
       setThumbMap,
       setValue,
       step,
@@ -640,7 +638,6 @@ export namespace useSliderRoot {
     registerSliderControl: (element: HTMLElement | null) => void;
     setActive: React.Dispatch<React.SetStateAction<number>>;
     setDragging: React.Dispatch<React.SetStateAction<boolean>>;
-    setPercentageValues: React.Dispatch<React.SetStateAction<readonly number[]>>;
     setThumbMap: React.Dispatch<
       React.SetStateAction<Map<Node, CompositeMetadata<ThumbMetadata> | null>>
     >;

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -73,7 +73,6 @@ const testRootContext: SliderRootContext = {
   registerSliderControl: NOOP,
   setActive: NOOP,
   setDragging: NOOP,
-  setPercentageValues: NOOP,
   setThumbMap: NOOP,
   setValue: NOOP,
   step: 1,

--- a/packages/react/src/slider/thumb/useSliderThumb.ts
+++ b/packages/react/src/slider/thumb/useSliderThumb.ts
@@ -18,6 +18,7 @@ import { useDirection } from '../../direction-provider/DirectionContext';
 import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { getSliderValue } from '../utils/getSliderValue';
+import { roundValueToStep } from '../utils/roundValueToStep';
 import type { useSliderRoot } from '../root/useSliderRoot';
 
 export interface ThumbMetadata {
@@ -159,13 +160,20 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
           onKeyDown(event: React.KeyboardEvent) {
             let newValue = null;
             const isRange = sliderValues.length > 1;
+            const roundedValue = roundValueToStep(thumbValue, step, min);
             switch (event.key) {
               case ARROW_UP:
-                newValue = getNewValue(thumbValue, event.shiftKey ? largeStep : step, 1, min, max);
+                newValue = getNewValue(
+                  roundedValue,
+                  event.shiftKey ? largeStep : step,
+                  1,
+                  min,
+                  max,
+                );
                 break;
               case ARROW_RIGHT:
                 newValue = getNewValue(
-                  thumbValue,
+                  roundedValue,
                   event.shiftKey ? largeStep : step,
                   isRtl ? -1 : 1,
                   min,
@@ -173,11 +181,17 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
                 );
                 break;
               case ARROW_DOWN:
-                newValue = getNewValue(thumbValue, event.shiftKey ? largeStep : step, -1, min, max);
+                newValue = getNewValue(
+                  roundedValue,
+                  event.shiftKey ? largeStep : step,
+                  -1,
+                  min,
+                  max,
+                );
                 break;
               case ARROW_LEFT:
                 newValue = getNewValue(
-                  thumbValue,
+                  roundedValue,
                   event.shiftKey ? largeStep : step,
                   isRtl ? 1 : -1,
                   min,
@@ -185,10 +199,10 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
                 );
                 break;
               case 'PageUp':
-                newValue = getNewValue(thumbValue, largeStep, 1, min, max);
+                newValue = getNewValue(roundedValue, largeStep, 1, min, max);
                 break;
               case 'PageDown':
-                newValue = getNewValue(thumbValue, largeStep, -1, min, max);
+                newValue = getNewValue(roundedValue, largeStep, -1, min, max);
                 break;
               case END:
                 newValue = max;

--- a/packages/react/src/slider/track/SliderTrack.test.tsx
+++ b/packages/react/src/slider/track/SliderTrack.test.tsx
@@ -44,7 +44,6 @@ const testRootContext: SliderRootContext = {
   registerSliderControl: NOOP,
   setActive: NOOP,
   setDragging: NOOP,
-  setPercentageValues: NOOP,
   setThumbMap: NOOP,
   setValue: NOOP,
   step: 1,

--- a/packages/react/src/slider/value/SliderValue.test.tsx
+++ b/packages/react/src/slider/value/SliderValue.test.tsx
@@ -46,7 +46,6 @@ const testRootContext: SliderRootContext = {
   registerSliderControl: NOOP,
   setActive: NOOP,
   setDragging: NOOP,
-  setPercentageValues: NOOP,
   setThumbMap: NOOP,
   setValue: NOOP,
   step: 1,


### PR DESCRIPTION
Before: https://codesandbox.io/p/sandbox/ancient-sunset-v4kx8d
After: https://codesandbox.io/p/devbox/bold-visvesvaraya-7vsy9w

The % values should be clamped before updating the state to prevent the thumb/indicator from ever going out of bounds.

Fixes https://github.com/mui/base-ui/issues/1423


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
