### PR TITLE
[useRender] Refine docs and APIs

### DIFF
--- a/docs/src/app/(public)/(content)/react/utils/use-render/demos/render-callback/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/demos/render-callback/css-modules/index.tsx
@@ -4,11 +4,11 @@ import { useRender } from '@base-ui-components/react/use-render';
 import { mergeProps } from '@base-ui-components/react/merge-props';
 import styles from './index.module.css';
 
-type CounterState = {
+interface CounterState {
   odd: boolean;
-};
+}
 
-interface CounterProps extends useRender.ElementProps<'button', CounterState> {
+interface CounterProps extends useRender.ComponentProps<'button', CounterState> {
   className?: string;
   onClick?: (event: React.MouseEvent) => void;
   ['aria-label']?: string;
@@ -16,11 +16,11 @@ interface CounterProps extends useRender.ElementProps<'button', CounterState> {
 
 function Counter(props: CounterProps) {
   const { render = <button />, ...otherProps } = props;
+
   const [count, setCount] = React.useState(0);
   const odd = count % 2 === 1;
   const state = React.useMemo(() => ({ odd }), [odd]);
 
-  // The Props type is an alias of React.ComponentPropsWithoutRef
   const defaultProps: mergeProps.Props<'button'> = {
     className: styles.Button,
     type: 'button',
@@ -29,7 +29,9 @@ function Counter(props: CounterProps) {
         Counter: <span>{count}</span>
       </React.Fragment>
     ),
-    onClick: () => setCount((prev) => prev + 1),
+    onClick() {
+      setCount((prev) => prev + 1);
+    },
     'aria-label': `Count is ${count}, click to increase.`,
   };
 

--- a/docs/src/app/(public)/(content)/react/utils/use-render/demos/render-callback/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/demos/render-callback/css-modules/index.tsx
@@ -21,7 +21,7 @@ function Counter(props: CounterProps) {
   const odd = count % 2 === 1;
   const state = React.useMemo(() => ({ odd }), [odd]);
 
-  const defaultProps: mergeProps.Props<'button'> = {
+  const defaultProps: useRender.ElementProps<'button'> = {
     className: styles.Button,
     type: 'button',
     children: (
@@ -38,7 +38,7 @@ function Counter(props: CounterProps) {
   const { renderElement } = useRender({
     render,
     state,
-    props: mergeProps(defaultProps, otherProps),
+    props: mergeProps<'button'>(defaultProps, otherProps),
   });
 
   return renderElement();

--- a/docs/src/app/(public)/(content)/react/utils/use-render/demos/render-callback/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/demos/render-callback/css-modules/index.tsx
@@ -8,11 +8,7 @@ interface CounterState {
   odd: boolean;
 }
 
-interface CounterProps extends useRender.ComponentProps<'button', CounterState> {
-  className?: string;
-  onClick?: (event: React.MouseEvent) => void;
-  ['aria-label']?: string;
-}
+interface CounterProps extends useRender.ComponentProps<'button', CounterState> {}
 
 function Counter(props: CounterProps) {
   const { render = <button />, ...otherProps } = props;

--- a/docs/src/app/(public)/(content)/react/utils/use-render/demos/render/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/demos/render/css-modules/index.tsx
@@ -4,20 +4,14 @@ import { useRender } from '@base-ui-components/react/use-render';
 import { mergeProps } from '@base-ui-components/react/merge-props';
 import styles from './index.module.css';
 
-// ElementProps contains the 'render' prop type
-interface TextProps extends useRender.ElementProps<'p'> {
-  children: React.ReactNode;
-}
+interface TextProps extends useRender.ComponentProps<'p'> {}
 
 function Text(props: TextProps) {
-  const { render = <p />, ref, ...otherProps } = props;
+  const { render = <p />, ...otherProps } = props;
 
   const { renderElement } = useRender({
     render,
-    props: {
-      ref,
-      ...mergeProps({ className: styles.Text }, otherProps),
-    },
+    props: mergeProps({ className: styles.Text }, otherProps),
   });
 
   return renderElement();

--- a/docs/src/app/(public)/(content)/react/utils/use-render/demos/render/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/demos/render/css-modules/index.tsx
@@ -11,7 +11,7 @@ function Text(props: TextProps) {
 
   const { renderElement } = useRender({
     render,
-    props: mergeProps({ className: styles.Text }, otherProps),
+    props: mergeProps<'p'>({ className: styles.Text }, otherProps),
   });
 
   return renderElement();

--- a/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
@@ -36,19 +36,43 @@ The `useRender` hook enables custom components to provide a `render` prop to ove
 
 ### Return value
 
-The hook returns a `renderElement` function that returns the element to be rendered when called.
+<PropsReferenceTable
+  type="return"
+  data={{
+    renderElement: {
+      type: '() => React.ReactElement',
+      description: 'The React element to be rendered.',
+    },
+  }}
+/>
+
+```tsx title="renderElement function" "renderElement"
+const { renderElement } = useRender({
+  // Input parameters
+});
+
+const element = renderElement();
+```
+
+### TypeScript
+
+To type a component's props, use the `useRender.ComponentProps` interface. It provides the `render` prop and HTML attributes.
+
+```tsx title="Typing component props"
+interface MyProps extends useRender.ComponentProps<'div'> {}
+```
 
 ## Examples
 
-A `render` prop for a custom Text component lets consumers use the `render` prop to replace the default rendered `p` element with a different element tag.
+A `render` prop for a custom Text component lets consumers use it to replace the default rendered `p` element with a different element tag or component.
 
 <Demo path="./demos/render" />
 
-The callback version of the `render` prop also enables accessing the `state` of a component.
+The callback version of the `render` prop enables more control of how props are spread, and also passes the internal `state` of a component.
 
 <Demo path="./demos/render-callback" />
 
-### Merging props
+## Merging props
 
 The `mergeProps` function merges two or more sets of React props together. It safely merges three types of props:
 
@@ -58,13 +82,32 @@ The `mergeProps` function merges two or more sets of React props together. It sa
 
 `mergeProps` merges objects from left to right, so that subsequent objects' properties in the arguments overwrite previous ones. Merging props is useful when creating custom components, as well as inside the callback version of the `render` prop for any Base UI component.
 
-#### Merging refs
+```jsx title="Using mergeProps in the render callback"
+import { mergeProps } from '@base-ui-components/react/merge-props';
+import styles from './index.module.css';
 
-When building custom components, you often need to control a ref internally while still letting external consumers pass their own ref. Ref merging lets both parties have access to the underlying DOM element—the `refs` option in `useRender` enables this, which holds an array of refs to be merged together.
+function Button() {
+  return (
+    <Component
+      render={(props, state) => (
+        <button
+          {...mergeProps(props, {
+            className: styles.Button,
+          })}
+        />
+      )}
+    />
+  );
+}
+```
+
+## Merging refs
+
+When building custom components, you often need to control a ref internally while still letting external consumers pass their own—merging refs lets both parties have access to the underlying DOM element. The `refs` option in `useRender` enables this, which holds an array of refs to be merged together.
 
 In React 19, `React.forwardRef()` is not needed when building primitive components, as the external ref prop is already contained inside `props`. Your internal ref can be passed to `refs` to be merged with `props.ref`:
 
-```tsx title="React 19"
+```tsx title="React 19" {7} "internalRef"
 function Text({ render = <p />, ...props }: TextProps) {
   const internalRef = React.useRef<HTMLElement | null>(null);
 
@@ -80,7 +123,9 @@ function Text({ render = <p />, ...props }: TextProps) {
 
 In older versions of React, you need to use `React.forwardRef()` and add the forwarded ref to the `refs` array along with your own internal ref:
 
-```tsx title="React 18 and 17"
+The [Examples](#examples) above assume React 19, and should be modified to use `React.forwardRef()` to support React 18 and 17.
+
+```tsx title="React 18 and 17" {10} "forwardedRef" "internalRef"
 const Text = React.forwardRef(function Text(
   { render = <p />, ...props }: TextProps,
   forwardedRef: React.ForwardedRef<HTMLElement>,
@@ -97,26 +142,40 @@ const Text = React.forwardRef(function Text(
 });
 ```
 
-```jsx {7-7} title="Using mergeProps in the render callback"
-import { mergeProps } from '@base-ui-components/react/merge-props';
-import styles from './index.module.css';
+## TypeScript
 
-function Button() {
-  return (
-    <Component
-      render={(props, state) => <button {...mergeProps(props, { className: styles.Button })} />}
-    />
-  );
+To type a component's internal default props, use the `useRender.ElementProps` interface.
+
+```tsx title="Typing default props"
+function Button({ render = <button />, ...props }: ButtonProps) {
+  const defaultProps: useRender.ElementProps<'button'> = {
+    className: styles.Button,
+    type: 'button',
+    children: 'Click me',
+  };
+
+  const { renderElement } = useRender({
+    render,
+    props: mergeProps(defaultProps, props),
+  });
+
+  return renderElement();
 }
 ```
 
-### Migrating from Radix
+Type inference is also available:
 
-Radix uses the `asChild` prop, while Base UI uses the `render` prop. Learn more about how composition works in Base UI in the [composition guide](/react/handbook/composition).
+```tsx title="Type inference"
+mergeProps<'button'>({ type: 'button' }, externalProps);
+```
 
-In Radix, the `Slot` component lets you implement an `asChild` prop.
+## Migrating from Radix UI
 
-```jsx title="Custom asChild prop with Radix"
+Radix UI uses an `asChild` prop, while Base UI uses a `render` prop. Learn more about how composition works in Base UI in the [composition guide](/react/handbook/composition).
+
+In Radix UI, the `Slot` component lets you implement an `asChild` prop.
+
+```jsx title="Radix UI Slot component"
 import { Slot } from 'radix-ui';
 
 function Button({ asChild, ...props }) {
@@ -130,9 +189,9 @@ function Button({ asChild, ...props }) {
 </Button>;
 ```
 
-In Base UI `useRender` lets you implement a `render` prop. The example below is the equivalent implementation to the Radix example above.
+In Base UI, `useRender` lets you implement a `render` prop. The example below is the equivalent implementation to the Radix example above.
 
-```jsx title="Custom render prop with Base UI"
+```jsx title="Base UI render prop"
 import { useRender } from '@base-ui-components/react/use-render';
 
 function Button({ render = <button />, ...props }) {

--- a/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
@@ -54,14 +54,6 @@ const { renderElement } = useRender({
 const element = renderElement();
 ```
 
-### TypeScript
-
-To type a component's props, use the `useRender.ComponentProps` interface. It provides the `render` prop and HTML attributes.
-
-```tsx title="Typing component props"
-interface MyProps extends useRender.ComponentProps<'div'> {}
-```
-
 ## Examples
 
 A `render` prop for a custom Text component lets consumers use it to replace the default rendered `p` element with a different tag or component.
@@ -99,6 +91,12 @@ function Button() {
     />
   );
 }
+```
+
+An explicit tag type is also possible, with `mergeProps` defaulting to `'div'`.
+
+```tsx title="Explicit tag type"
+mergeProps<'button'>({ type: 'button' }, externalProps);
 ```
 
 ## Merging refs
@@ -144,9 +142,14 @@ const Text = React.forwardRef(function Text(
 
 ## TypeScript
 
-To type a component's internal default props, use the `useRender.ElementProps` interface.
+To type props, there are two interfaces:
 
-```tsx title="Typing default props"
+- `useRender.ComponentProps` for a component's external (public) props. It types the `render` prop and HTML attributes.
+- `useRender.ElementProps` for the element's internal (private) props. It types HTML attributes alone.
+
+```tsx title="Typing props" {1,4}
+interface ButtonProps extends useRender.ComponentProps<'button'> {}
+
 function Button({ render = <button />, ...props }: ButtonProps) {
   const defaultProps: useRender.ElementProps<'button'> = {
     className: styles.Button,
@@ -161,12 +164,6 @@ function Button({ render = <button />, ...props }: ButtonProps) {
 
   return renderElement();
 }
-```
-
-An explicit tag type is also possible, with `mergeProps` defaulting to `'div'`.
-
-```tsx title="Explicit tag type"
-mergeProps<'button'>({ type: 'button' }, externalProps);
 ```
 
 ## Migrating from Radix UI

--- a/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
@@ -74,7 +74,7 @@ The `mergeProps` function merges two or more sets of React props together. It sa
 
 `mergeProps` merges objects from left to right, so that subsequent objects' properties in the arguments overwrite previous ones. Merging props is useful when creating custom components, as well as inside the callback version of the `render` prop for any Base UI component.
 
-```jsx title="Using mergeProps in the render callback"
+```tsx title="Using mergeProps in the render callback"
 import { mergeProps } from '@base-ui-components/react/merge-props';
 import styles from './index.module.css';
 
@@ -83,7 +83,7 @@ function Button() {
     <Component
       render={(props, state) => (
         <button
-          {...mergeProps(props, {
+          {...mergeProps<'button'>(props, {
             className: styles.Button,
           })}
         />
@@ -121,7 +121,7 @@ function Text({ render = <p />, ...props }: TextProps) {
 
 In older versions of React, you need to use `React.forwardRef()` and add the forwarded ref to the `refs` array along with your own internal ref.
 
-The [Examples](#examples) above assume React 19, and should be modified to use `React.forwardRef()` to support React 18 and 17.
+The [examples](#examples) above assume React 19, and should be modified to use `React.forwardRef()` to support React 18 and 17.
 
 ```tsx title="React 18 and 17" {10} "forwardedRef" "internalRef"
 const Text = React.forwardRef(function Text(
@@ -159,7 +159,7 @@ function Button({ render = <button />, ...props }: ButtonProps) {
 
   const { renderElement } = useRender({
     render,
-    props: mergeProps(defaultProps, props),
+    props: mergeProps<'button'>(defaultProps, props),
   });
 
   return renderElement();

--- a/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
@@ -93,12 +93,6 @@ function Button() {
 }
 ```
 
-An explicit tag type is also possible, with `mergeProps` defaulting to `'div'`.
-
-```tsx title="Explicit tag type"
-mergeProps<'button'>({ type: 'button' }, externalProps);
-```
-
 ## Merging refs
 
 When building custom components, you often need to control a ref internally while still letting external consumers pass their own—merging refs lets both parties have access to the underlying DOM element. The `refs` option in `useRender` enables this, which holds an array of refs to be merged together.

--- a/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
@@ -4,7 +4,7 @@
 
 <Meta name="description" content="Hook for enabling a render prop in custom components." />
 
-The `useRender` hook enables custom components to provide a `render` prop to override the default rendered element.
+The `useRender` hook lets you build custom components that provide a `render` prop to override the default rendered element.
 
 ## API reference
 

--- a/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
@@ -20,7 +20,7 @@ The `useRender` hook enables custom components to provide a `render` prop to ove
     props: {
       type: 'Record<string, unknown>',
       description:
-        'Props to be spread on the rendered element.\n\nThey are merged with the internal props\n of the component, so that event handlers are merged,\nclass names and styles are joined, and other external props overwrite the internal ones.',
+        'Props to be spread on the rendered element.\n\nThey are merged with the internal props\n of the component, so that event handlers are merged,\n`className` strings and `style` properties are joined, and other external props overwrite the internal ones.',
     },
     refs: {
       type: 'React.Ref<RenderedElementType>[]',
@@ -64,7 +64,7 @@ interface MyProps extends useRender.ComponentProps<'div'> {}
 
 ## Examples
 
-A `render` prop for a custom Text component lets consumers use it to replace the default rendered `p` element with a different element tag or component.
+A `render` prop for a custom Text component lets consumers use it to replace the default rendered `p` element with a different tag or component.
 
 <Demo path="./demos/render" />
 
@@ -121,7 +121,7 @@ function Text({ render = <p />, ...props }: TextProps) {
 }
 ```
 
-In older versions of React, you need to use `React.forwardRef()` and add the forwarded ref to the `refs` array along with your own internal ref:
+In older versions of React, you need to use `React.forwardRef()` and add the forwarded ref to the `refs` array along with your own internal ref.
 
 The [Examples](#examples) above assume React 19, and should be modified to use `React.forwardRef()` to support React 18 and 17.
 
@@ -163,9 +163,9 @@ function Button({ render = <button />, ...props }: ButtonProps) {
 }
 ```
 
-Type inference is also available:
+An explicit tag type is also possible, with `mergeProps` defaulting to `'div'`.
 
-```tsx title="Type inference"
+```tsx title="Explicit tag type"
 mergeProps<'button'>({ type: 'button' }, externalProps);
 ```
 

--- a/docs/src/components/ReferenceTable/PropsReferenceTable.tsx
+++ b/docs/src/components/ReferenceTable/PropsReferenceTable.tsx
@@ -9,18 +9,31 @@ import { TableCode } from '../TableCode';
 
 interface PropsReferenceTableProps extends React.ComponentProps<typeof Table.Root> {
   data: Record<string, PropDef>;
+  type?: 'props' | 'return';
 }
 
-export async function PropsReferenceTable({ data, ...props }: PropsReferenceTableProps) {
+export async function PropsReferenceTable({
+  data,
+  type = 'props',
+  ...props
+}: PropsReferenceTableProps) {
   return (
     <Table.Root {...props}>
       <Table.Head>
         <Table.Row>
           <Table.ColumnHeader className="w-full xs:w-48 sm:w-56 md:w-1/3">Prop</Table.ColumnHeader>
-          <Table.ColumnHeader className="max-xs:hidden xs:w-full md:w-7/15">
+          <Table.ColumnHeader
+            className={
+              type === 'props'
+                ? 'max-xs:hidden xs:w-full md:w-7/15'
+                : 'max-xs:hidden xs:w-full md:w-full'
+            }
+          >
             Type
           </Table.ColumnHeader>
-          <Table.ColumnHeader className="max-md:hidden md:w-1/5">Default</Table.ColumnHeader>
+          {type === 'props' && (
+            <Table.ColumnHeader className="max-md:hidden md:w-1/5">Default</Table.ColumnHeader>
+          )}
           <Table.ColumnHeader className="w-10" aria-label="Description" />
         </Table.Row>
       </Table.Head>
@@ -51,9 +64,11 @@ export async function PropsReferenceTable({ data, ...props }: PropsReferenceTabl
               <Table.Cell className="max-xs:hidden">
                 <PropType />
               </Table.Cell>
-              <Table.Cell className="max-md:hidden">
-                <PropDefault />
-              </Table.Cell>
+              {type === 'props' && (
+                <Table.Cell className="max-md:hidden">
+                  <PropDefault />
+                </Table.Cell>
+              )}
               <Table.Cell>
                 <ReferenceTablePopover>
                   <PropDescription />
@@ -62,10 +77,12 @@ export async function PropsReferenceTable({ data, ...props }: PropsReferenceTabl
                       <div className="mb-1 font-bold">Type</div>
                       <PropType />
                     </div>
-                    <div className="border-t border-gray-200 pt-2">
-                      <div className="mb-1 font-bold">Default</div>
-                      <PropDefault />
-                    </div>
+                    {type === 'props' && (
+                      <div className="border-t border-gray-200 pt-2">
+                        <div className="mb-1 font-bold">Default</div>
+                        <PropDefault />
+                      </div>
+                    )}
                   </div>
                 </ReferenceTablePopover>
               </Table.Cell>

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -50,7 +50,6 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
     openMethod,
     popupRef,
     setPopupElement,
-    setPopupElementId,
     titleElementId,
     transitionStatus,
     modal,
@@ -83,7 +82,6 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
     openMethod,
     ref: mergedRef,
     setPopupElement,
-    setPopupElementId,
     titleElementId,
   });
 

--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -286,10 +286,10 @@ export function useCollapsiblePanel(
 
   const getRootProps: useCollapsiblePanel.ReturnValue['getRootProps'] = React.useCallback(
     (externalProps = {}) =>
-      mergeProps(
+      mergeProps<'button'>(
         {
           id,
-          hidden: isOpen ? undefined : hidden,
+          hidden: isOpen ? undefined : Boolean(hidden),
           ref: mergedRef,
         },
         externalProps,

--- a/packages/react/src/collapsible/trigger/useCollapsibleTrigger.ts
+++ b/packages/react/src/collapsible/trigger/useCollapsibleTrigger.ts
@@ -21,7 +21,7 @@ export function useCollapsibleTrigger(
   const getRootProps: useCollapsibleTrigger.ReturnValue['getRootProps'] = React.useCallback(
     (externalProps: GenericHTMLProps = {}) =>
       getButtonProps(
-        mergeProps(
+        mergeProps<'button'>(
           {
             type: 'button',
             'aria-controls': panelId,

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -53,7 +53,6 @@ const DialogPopup = React.forwardRef(function DialogPopup(
     openMethod,
     popupRef,
     setPopupElement,
-    setPopupElementId,
     titleElementId,
     transitionStatus,
     onOpenChangeComplete,
@@ -85,7 +84,6 @@ const DialogPopup = React.forwardRef(function DialogPopup(
     openMethod,
     ref: mergedRef,
     setPopupElement,
-    setPopupElementId,
     titleElementId,
   });
 

--- a/packages/react/src/dialog/popup/useDialogPopup.tsx
+++ b/packages/react/src/dialog/popup/useDialogPopup.tsx
@@ -1,9 +1,7 @@
 'use client';
 import * as React from 'react';
-import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useForkRef } from '../../utils/useForkRef';
 import { mergeProps } from '../../merge-props';
-import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
 import { type InteractionType } from '../../utils/useEnhancedClickHandler';
 import { GenericHTMLProps } from '../../utils/types';
 import { type OpenChangeReason } from '../../utils/translateOpenChangeReason';
@@ -12,20 +10,17 @@ export function useDialogPopup(parameters: useDialogPopup.Parameters): useDialog
   const {
     descriptionElementId,
     getPopupProps,
-    id: idParam,
     initialFocus,
     modal,
     mounted,
     openMethod,
     ref,
-    setPopupElementId,
     setPopupElement,
     titleElementId,
   } = parameters;
 
   const popupRef = React.useRef<HTMLElement>(null);
 
-  const id = useBaseUiId(idParam);
   const handleRef = useForkRef(ref, popupRef, setPopupElement);
 
   // Default initial focus logic:
@@ -51,13 +46,6 @@ export function useDialogPopup(parameters: useDialogPopup.Parameters): useDialog
     return initialFocus;
   }, [defaultInitialFocus, initialFocus, openMethod]);
 
-  useEnhancedEffect(() => {
-    setPopupElementId(id);
-    return () => {
-      setPopupElementId(undefined);
-    };
-  }, [id, setPopupElementId]);
-
   const getRootProps = (externalProps: React.HTMLAttributes<any>) =>
     mergeProps<'div'>(
       {
@@ -67,7 +55,6 @@ export function useDialogPopup(parameters: useDialogPopup.Parameters): useDialog
         role: 'dialog',
         tabIndex: -1,
         ...getPopupProps(),
-        id,
         ref: handleRef,
         hidden: !mounted,
       },
@@ -111,10 +98,6 @@ export namespace useDialogPopup {
      * The id of the description element associated with the dialog.
      */
     descriptionElementId: string | undefined;
-    /**
-     * Callback to set the id of the popup element.
-     */
-    setPopupElementId: (id: string | undefined) => void;
     /**
      * Determines the element to focus when the dialog is opened.
      * By default, the first focusable element is focused.

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -6,6 +6,7 @@ import {
   useDismiss,
   useFloatingRootContext,
   useInteractions,
+  useRole,
   type OpenChangeReason as FloatingUIOpenChangeReason,
 } from '@floating-ui/react';
 import { getTarget } from '@floating-ui/react/utils';
@@ -99,6 +100,7 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
   const [ownNestedOpenDialogs, setOwnNestedOpenDialogs] = React.useState(0);
   const isTopmost = ownNestedOpenDialogs === 0;
 
+  const role = useRole(context);
   const click = useClick(context);
   const dismiss = useDismiss(context, {
     outsidePressEvent: 'mousedown',
@@ -121,7 +123,7 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
     escapeKey: isTopmost,
   });
 
-  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
+  const { getReferenceProps, getFloatingProps } = useInteractions([role, click, dismiss]);
 
   React.useEffect(() => {
     if (onNestedDialogOpen && open) {
@@ -149,6 +151,11 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
 
   const { openMethod, triggerProps } = useOpenInteractionType(open);
 
+  const getTriggerProps = React.useCallback(
+    (externalProps = {}) => getReferenceProps(mergeProps(triggerProps, externalProps)),
+    [getReferenceProps, triggerProps],
+  );
+
   return React.useMemo(() => {
     return {
       modal,
@@ -166,10 +173,7 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
       openMethod,
       mounted,
       transitionStatus,
-      getTriggerProps: (externalProps?: React.HTMLProps<Element>) =>
-        getReferenceProps(
-          mergeProps(triggerProps, mergeProps({ 'aria-controls': popupElementId }, externalProps)),
-        ),
+      getTriggerProps,
       getPopupProps: getFloatingProps,
       setTriggerElement,
       setPopupElement,
@@ -180,23 +184,19 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
     } satisfies useDialogRoot.ReturnValue;
   }, [
     modal,
-    open,
     setOpen,
+    open,
     titleElementId,
     descriptionElementId,
     popupElementId,
-    handleNestedDialogClose,
     handleNestedDialogOpen,
+    handleNestedDialogClose,
     ownNestedOpenDialogs,
     openMethod,
     mounted,
     transitionStatus,
-    getReferenceProps,
+    getTriggerProps,
     getFloatingProps,
-    setTriggerElement,
-    setPopupElement,
-    triggerProps,
-    popupRef,
     context,
   ]);
 }

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -53,7 +53,6 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
   );
   const [triggerElement, setTriggerElement] = React.useState<Element | null>(null);
   const [popupElement, setPopupElement] = React.useState<HTMLElement | null>(null);
-  const [popupElementId, setPopupElementId] = React.useState<string | undefined>(undefined);
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
 
@@ -165,8 +164,6 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
       setTitleElementId,
       descriptionElementId,
       setDescriptionElementId,
-      popupElementId,
-      setPopupElementId,
       onNestedDialogOpen: handleNestedDialogOpen,
       onNestedDialogClose: handleNestedDialogClose,
       nestedOpenDialogCount: ownNestedOpenDialogs,
@@ -188,7 +185,6 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
     open,
     titleElementId,
     descriptionElementId,
-    popupElementId,
     handleNestedDialogOpen,
     handleNestedDialogClose,
     ownNestedOpenDialogs,
@@ -299,17 +295,9 @@ export namespace useDialogRoot {
      */
     openMethod: InteractionType | null;
     /**
-     * The id of the popup element.
-     */
-    popupElementId: string | undefined;
-    /**
      * Callback to set the id of the description element associated with the dialog.
      */
     setDescriptionElementId: (elementId: string | undefined) => void;
-    /**
-     * Callback to set the id of the popup element.
-     */
-    setPopupElementId: (elementId: string | undefined) => void;
     /**
      * Callback to set the id of the title element.
      */

--- a/packages/react/src/field/control/useFieldControlValidation.ts
+++ b/packages/react/src/field/control/useFieldControlValidation.ts
@@ -110,7 +110,7 @@ export function useFieldControlValidation() {
 
   const getValidationProps = React.useCallback(
     (externalProps = {}) =>
-      mergeProps(
+      mergeProps<any>(
         {
           ...(messageIds.length && { 'aria-describedby': messageIds.join(' ') }),
           ...(state.valid === false && { 'aria-invalid': true }),

--- a/packages/react/src/fieldset/root/FieldsetRoot.tsx
+++ b/packages/react/src/fieldset/root/FieldsetRoot.tsx
@@ -14,7 +14,7 @@ import type { BaseUIComponentProps } from '../../utils/types';
  */
 const FieldsetRoot = React.forwardRef(function FieldsetRoot(
   props: FieldsetRoot.Props,
-  forwardedRef: React.ForwardedRef<HTMLFieldSetElement>,
+  forwardedRef: React.ForwardedRef<HTMLElement>,
 ) {
   const { render, className, disabled = false, ...otherProps } = props;
 

--- a/packages/react/src/merge-props/mergeProps.test.ts
+++ b/packages/react/src/merge-props/mergeProps.test.ts
@@ -136,7 +136,7 @@ describe('mergeProps', () => {
   it('prevents handlers merged after event.preventBaseUIHandler() is called', () => {
     const log: string[] = [];
 
-    const mergedProps = mergeProps(
+    const mergedProps = mergeProps<any>(
       {
         onClick() {
           log.push('2');
@@ -164,7 +164,7 @@ describe('mergeProps', () => {
     it('handles non-standard event handlers without error', () => {
       const log: string[] = [];
 
-      const mergedProps = mergeProps(
+      const mergedProps = mergeProps<any>(
         {
           onValueChange() {
             log.push('1');

--- a/packages/react/src/merge-props/mergeProps.ts
+++ b/packages/react/src/merge-props/mergeProps.ts
@@ -29,11 +29,11 @@ type MergableProps<T extends React.ElementType> =
  * @param props props to merge.
  * @returns the merged props.
  */
-function mergeProps<T extends React.ElementType>(
-  ...props: MergableProps<T>[]
-): WithBaseUIEvent<React.ComponentPropsWithRef<T>> {
+export function mergeProps<Tag extends React.ElementType = 'div'>(
+  ...props: MergableProps<Tag>[]
+): WithBaseUIEvent<React.ComponentPropsWithRef<Tag>> {
   if (props.length === 0) {
-    return {} as WithBaseUIEvent<React.ComponentPropsWithRef<T>>;
+    return {} as WithBaseUIEvent<React.ComponentPropsWithRef<Tag>>;
   }
 
   if (props.length === 1) {
@@ -51,26 +51,25 @@ function mergeProps<T extends React.ElementType>(
     if (isPropsGetter(propsOrPropsGetter)) {
       merged = propsOrPropsGetter(merged);
     } else {
-      merged = merge(merged, propsOrPropsGetter as WithBaseUIEvent<React.ComponentPropsWithRef<T>>);
+      merged = merge(
+        merged,
+        propsOrPropsGetter as WithBaseUIEvent<React.ComponentPropsWithRef<Tag>>,
+      );
     }
   }
 
-  return merged ?? ({} as WithBaseUIEvent<React.ComponentPropsWithRef<T>>);
+  return merged ?? ({} as WithBaseUIEvent<React.ComponentPropsWithRef<Tag>>);
 }
 
-namespace mergeProps {
-  export type Props<T extends React.ElementType> = React.ComponentPropsWithoutRef<T>;
-}
-
-function resolvePropsGetter<T extends React.ElementType>(
+function resolvePropsGetter<Tag extends React.ElementType>(
   propsOrPropsGetter: MergableProps<React.ElementType>,
-  previousProps: WithBaseUIEvent<React.ComponentPropsWithRef<T>>,
+  previousProps: WithBaseUIEvent<React.ComponentPropsWithRef<Tag>>,
 ) {
   if (isPropsGetter(propsOrPropsGetter)) {
     return propsOrPropsGetter(previousProps);
   }
 
-  return propsOrPropsGetter ?? ({} as WithBaseUIEvent<React.ComponentPropsWithRef<T>>);
+  return propsOrPropsGetter ?? ({} as WithBaseUIEvent<React.ComponentPropsWithRef<Tag>>);
 }
 
 /**
@@ -193,5 +192,3 @@ function mergeClassNames(ourClassName: string | undefined, theirClassName: strin
 function isSyntheticEvent(event: unknown): event is React.SyntheticEvent {
   return event != null && typeof event === 'object' && 'nativeEvent' in event;
 }
-
-export { mergeProps };

--- a/packages/react/src/merge-props/mergeProps.ts
+++ b/packages/react/src/merge-props/mergeProps.ts
@@ -29,7 +29,7 @@ type MergableProps<T extends React.ElementType> =
  * @param props props to merge.
  * @returns the merged props.
  */
-export function mergeProps<Tag extends React.ElementType = 'div'>(
+export function mergeProps<Tag extends React.ElementType>(
   ...props: MergableProps<Tag>[]
 ): WithBaseUIEvent<React.ComponentPropsWithRef<Tag>> {
   if (props.length === 0) {

--- a/packages/react/src/popover/root/usePopoverRoot.ts
+++ b/packages/react/src/popover/root/usePopoverRoot.ts
@@ -169,6 +169,11 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
 
   const { openMethod, triggerProps } = useOpenInteractionType(open);
 
+  const getRootTriggerProps = React.useCallback(
+    (externalProps = {}) => getReferenceProps(mergeProps(triggerProps, externalProps)),
+    [getReferenceProps, triggerProps],
+  );
+
   return React.useMemo(
     () => ({
       open,
@@ -184,8 +189,7 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
       setTitleId,
       descriptionId,
       setDescriptionId,
-      getRootTriggerProps: (externalProps?: React.HTMLProps<Element>) =>
-        getReferenceProps(mergeProps(triggerProps, externalProps)),
+      getRootTriggerProps,
       getRootPopupProps: getFloatingProps,
       floatingRootContext: context,
       instantType,
@@ -194,20 +198,19 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
       onOpenChangeComplete,
     }),
     [
-      mounted,
       open,
-      setMounted,
       setOpen,
+      mounted,
+      setMounted,
       transitionStatus,
       positionerElement,
       titleId,
       descriptionId,
-      getReferenceProps,
+      getRootTriggerProps,
       getFloatingProps,
       context,
       instantType,
       openMethod,
-      triggerProps,
       openReason,
       onOpenChangeComplete,
     ],

--- a/packages/react/src/select/icon/SelectIcon.tsx
+++ b/packages/react/src/select/icon/SelectIcon.tsx
@@ -20,7 +20,7 @@ const SelectIcon = React.forwardRef(function SelectIcon(
   const state: SelectIcon.State = React.useMemo(() => ({}), []);
 
   const getIconProps = React.useCallback((externalProps: React.ComponentProps<'span'>) => {
-    return mergeProps(
+    return mergeProps<'span'>(
       {
         'aria-hidden': true,
         children: '▼',

--- a/packages/react/src/slider/indicator/useSliderIndicator.ts
+++ b/packages/react/src/slider/indicator/useSliderIndicator.ts
@@ -4,7 +4,11 @@ import { mergeProps } from '../../merge-props';
 import type { GenericHTMLProps } from '../../utils/types';
 import type { useSliderRoot } from '../root/useSliderRoot';
 
-function getRangeStyles(orientation: useSliderRoot.Orientation, offset: number, leap: number) {
+function getRangeStyles(
+  orientation: useSliderRoot.Orientation,
+  offset: number,
+  leap: number,
+): React.CSSProperties {
   if (orientation === 'vertical') {
     return {
       position: 'relative',
@@ -29,7 +33,7 @@ export function useSliderIndicator(
 ): useSliderIndicator.ReturnValue {
   const { orientation, percentageValues } = parameters;
 
-  let internalStyles;
+  let internalStyles: React.CSSProperties;
 
   if (percentageValues.length > 1) {
     const trackOffset = percentageValues[0];

--- a/packages/react/src/slider/thumb/useSliderThumb.ts
+++ b/packages/react/src/slider/thumb/useSliderThumb.ts
@@ -131,14 +131,14 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
       // So the non active thumb doesn't show its label on hover.
       pointerEvents: activeIndex !== -1 && activeIndex !== index ? 'none' : undefined,
       zIndex: activeIndex === index ? 1 : undefined,
-    };
+    } satisfies React.CSSProperties;
   }, [activeIndex, isRtl, orientation, percent, index]);
 
   const getRootProps: useSliderThumb.ReturnValue['getRootProps'] = React.useCallback(
     (externalProps = {}) => {
       return mergeProps(
         {
-          'data-index': index,
+          ['data-index' as string]: index,
           id: thumbId,
           onFocus() {
             setFocused(true);
@@ -263,12 +263,12 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
 
   const getThumbInputProps: useSliderThumb.ReturnValue['getThumbInputProps'] = React.useCallback(
     (externalProps = {}) => {
-      let cssWritingMode;
+      let cssWritingMode: React.CSSProperties['writingMode'];
       if (orientation === 'vertical') {
         cssWritingMode = isRtl ? 'vertical-rl' : 'vertical-lr';
       }
 
-      return mergeProps(
+      return mergeProps<'input'>(
         {
           'aria-label': getAriaLabel != null ? getAriaLabel(index) : ariaLabel,
           'aria-labelledby': ariaLabelledby,
@@ -284,7 +284,7 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
                   index,
                 )
               : ariaValuetext || getDefaultAriaValueText(sliderValues, index, format ?? undefined),
-          'data-index': index,
+          ['data-index' as string]: index,
           disabled,
           id: inputId,
           max,

--- a/packages/react/src/slider/value/useSliderValue.ts
+++ b/packages/react/src/slider/value/useSliderValue.ts
@@ -27,7 +27,7 @@ export function useSliderValue(parameters: useSliderValue.Parameters): useSlider
 
   const getRootProps = React.useCallback(
     (externalProps = {}) => {
-      return mergeProps(
+      return mergeProps<'output'>(
         {
           // off by default because it will keep announcing when the slider is being dragged
           // and also when the value is changing (but not yet committed)

--- a/packages/react/src/tabs/panel/useTabsPanel.ts
+++ b/packages/react/src/tabs/panel/useTabsPanel.ts
@@ -47,9 +47,7 @@ function useTabsPanel(parameters: useTabsPanel.Parameters): useTabsPanel.ReturnV
   }, [getTabIdByPanelValueOrIndex, index, valueParam]);
 
   const getRootProps = React.useCallback(
-    (
-      externalProps: React.ComponentPropsWithoutRef<'div'> = {},
-    ): React.ComponentPropsWithRef<'div'> => {
+    (externalProps = {}) => {
       return mergeProps(
         {
           'aria-labelledby': correspondingTabId,
@@ -58,7 +56,7 @@ function useTabsPanel(parameters: useTabsPanel.Parameters): useTabsPanel.ReturnV
           role: 'tabpanel',
           tabIndex: hidden ? -1 : 0,
           ref: handleRef,
-          'data-index': index,
+          ['data-index' as string]: index,
         },
         externalProps,
       );

--- a/packages/react/src/use-button/useButton.ts
+++ b/packages/react/src/use-button/useButton.ts
@@ -65,7 +65,7 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
   }, [disabled, elementName, focusableWhenDisabled, tabIndex]);
 
   const getButtonProps = React.useCallback(
-    (externalProps: GenericButtonProps = {}): GenericButtonProps => {
+    (externalProps: GenericButtonProps = {}) => {
       const {
         onClick: externalOnClick,
         onMouseDown: externalOnMouseDown,
@@ -74,20 +74,20 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
         ...otherExternalProps
       } = externalProps;
 
-      return mergeProps(
+      return mergeProps<'button'>(
         {
           type,
-          onClick(event: React.MouseEvent) {
+          onClick(event) {
             if (!disabled) {
               externalOnClick?.(event);
             }
           },
-          onMouseDown(event: React.MouseEvent) {
+          onMouseDown(event) {
             if (!disabled) {
               externalOnMouseDown?.(event);
             }
           },
-          onKeyDown(event: BaseUIEvent<React.KeyboardEvent>) {
+          onKeyDown(event) {
             if (event.target === event.currentTarget && !isNativeButton() && event.key === ' ') {
               event.preventDefault();
             }

--- a/packages/react/src/use-render/useRender.ts
+++ b/packages/react/src/use-render/useRender.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import type { ComponentRenderFn } from '../utils/types';
 import { useComponentRenderer } from '../utils/useComponentRenderer';
-import { defaultRenderFunctions } from '../utils/defaultRenderFunctions';
 import { GenericHTMLProps } from '../utils/types';
 
 const emptyObject = {};
@@ -32,8 +31,7 @@ export function useRender<
 export namespace useRender {
   export type RenderProp<State = Record<string, unknown>> =
     | ComponentRenderFn<React.HTMLAttributes<any>, State>
-    | React.ReactElement<Record<string, unknown>>
-    | keyof typeof defaultRenderFunctions;
+    | React.ReactElement<Record<string, unknown>>;
 
   export type ElementProps<ElementType extends React.ElementType> =
     React.ComponentPropsWithRef<ElementType>;

--- a/packages/react/src/use-render/useRender.ts
+++ b/packages/react/src/use-render/useRender.ts
@@ -7,13 +7,13 @@ import { GenericHTMLProps } from '../utils/types';
 const emptyObject = {};
 
 /**
- * Returns a function that renders a Base UI component.
+ * Returns an object with a `renderElement` function that renders a Base UI component.
  */
 export function useRender<
   State extends Record<string, unknown>,
   RenderedElementType extends Element,
->(settings: useRender.Parameters<State, RenderedElementType>) {
-  const { render, props, state, refs } = settings;
+>(params: useRender.Parameters<State, RenderedElementType>) {
+  const { render, props, state, refs } = params;
   const { ref, ...extraProps } = props ?? {};
 
   const refsArray = React.useMemo(() => {
@@ -25,7 +25,7 @@ export function useRender<
     state: (state ?? emptyObject) as State,
     ref: refsArray,
     extraProps,
-    skipGeneratingStyleHooks: true,
+    styleHooks: false,
   });
 }
 
@@ -35,7 +35,10 @@ export namespace useRender {
     | React.ReactElement<Record<string, unknown>>
     | keyof typeof defaultRenderFunctions;
 
-  export type ElementProps<
+  export type ElementProps<ElementType extends React.ElementType> =
+    React.ComponentPropsWithRef<ElementType>;
+
+  export type ComponentProps<
     ElementType extends React.ElementType,
     State = {},
     RenderFunctionProps = GenericHTMLProps,
@@ -57,17 +60,17 @@ export namespace useRender {
      */
     render: RenderProp<State>;
     /**
-     * The refs to apply to the rendered element.
+     * Refs to be merged together to access the rendered DOM element.
      */
     refs?: React.Ref<RenderedElementType>[];
     /**
-     * The state of the component. It will be used as a parameter for the render callback.
+     * The state of the component, passed as the second argument to the `render` callback.
      */
     state?: State;
     /**
      * Props to be spread on the rendered element.
      * They are merged with the internal props of the component, so that event handlers
-     * are merged, class names and styles are joined, and other external props overwrite the
+     * are merged and class names and style properties are joined, while other external props overwrite the
      * internal ones.
      */
     props?: Record<string, unknown> & { ref?: React.Ref<RenderedElementType> };

--- a/packages/react/src/use-render/useRender.ts
+++ b/packages/react/src/use-render/useRender.ts
@@ -70,7 +70,7 @@ export namespace useRender {
     /**
      * Props to be spread on the rendered element.
      * They are merged with the internal props of the component, so that event handlers
-     * are merged and class names and style properties are joined, while other external props overwrite the
+     * are merged, `className` strings and `style` properties are joined, while other external props overwrite the
      * internal ones.
      */
     props?: Record<string, unknown> & { ref?: React.Ref<RenderedElementType> };

--- a/packages/react/src/utils/useComponentRenderer.ts
+++ b/packages/react/src/utils/useComponentRenderer.ts
@@ -43,9 +43,9 @@ export interface ComponentRendererSettings<State, RenderedElementType extends El
    */
   customStyleHookMapping?: CustomStyleHookMapping<State>;
   /**
-   * If true, style hooks are not generated.
+   * If true, style hooks are generated.
    */
-  skipGeneratingStyleHooks?: boolean;
+  styleHooks?: boolean;
 }
 
 const emptyObject = {};
@@ -67,16 +67,16 @@ export function useComponentRenderer<
     propGetter = (props) => props,
     extraProps,
     customStyleHookMapping,
-    skipGeneratingStyleHooks = false,
+    styleHooks: generateStyleHooks = true,
   } = settings;
 
   const className = resolveClassName(classNameProp, state);
   const styleHooks = React.useMemo(() => {
-    if (skipGeneratingStyleHooks) {
+    if (!generateStyleHooks) {
       return emptyObject;
     }
     return getStyleHookProps(state, customStyleHookMapping);
-  }, [state, customStyleHookMapping, skipGeneratingStyleHooks]);
+  }, [state, customStyleHookMapping, generateStyleHooks]);
 
   const ownProps: Record<string, any> = {
     ...styleHooks,


### PR DESCRIPTION
This is a continuation of #1418.

Docs: https://deploy-preview-1551--base-ui.netlify.app/react/utils/use-render

APIs refined:

1. `useRender.ElementProps` becomes `useRender.ComponentProps`. Since it's used for _components_ and has a special `render` prop, it doesn't make sense to use the word `Element`
2. `mergeProps.Props` -> `useRender.ElementProps`. These are raw element props, and it's confusing to have a namespace on `mergeProps` and two separate things to remember. We might as well reuse `useRender` for this purpose.
3. ~`mergeProps` defaults to `'div'` tag to get type inference out of the box for the most common case (I'm not sold on this being a good default, but it's easy to forget adding a tag and losing inference and types)~
4. Small tweaks to utility naming
5. Docs improvements