### PR TITLE
[select] Pass `value` as second argument to function children `Select.Value`

### DIFF
--- a/packages/react/src/select/value/SelectValue.test.tsx
+++ b/packages/react/src/select/value/SelectValue.test.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { Select } from '@base-ui-components/react/select';
+import { spy } from 'sinon';
+import { expect } from 'chai';
+import { screen } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance } from '#test-utils';
+
+describe('<Select.Value />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Select.Value />, () => ({
+    refInstanceof: window.HTMLSpanElement,
+    render(node) {
+      return render(<Select.Root open>{node}</Select.Root>);
+    },
+  }));
+
+  describe('prop: placeholder', () => {
+    it('renders a placeholder when the value is null', async () => {
+      await render(
+        <Select.Root>
+          <Select.Value placeholder="Select a font" />
+        </Select.Root>,
+      );
+      expect(screen.getByText('Select a font')).not.to.equal(null);
+    });
+  });
+
+  describe('prop: children', () => {
+    it('accepts a function with label and value parameters', async () => {
+      const children = spy();
+      await render(
+        <Select.Root value="1">
+          <Select.Value placeholder="placeholder">{children}</Select.Value>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="1">one</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      expect(children.args[0][0]).to.equal('placeholder');
+      expect(children.args[0][1]).to.equal('1');
+      expect(children.args[4][0]).to.equal('one'); // 5th render
+    });
+  });
+});

--- a/packages/react/src/select/value/SelectValue.tsx
+++ b/packages/react/src/select/value/SelectValue.tsx
@@ -19,7 +19,7 @@ const SelectValue = React.forwardRef(function SelectValue(
 ) {
   const { className, render, children, placeholder, ...otherProps } = props;
 
-  const { label, valueRef } = useSelectRootContext();
+  const { value, label, valueRef } = useSelectRootContext();
 
   const mergedRef = useForkRef(forwardedRef, valueRef);
 
@@ -29,11 +29,14 @@ const SelectValue = React.forwardRef(function SelectValue(
     (externalProps = {}) =>
       mergeProps(
         {
-          children: typeof children === 'function' ? children(label) : label || placeholder,
+          children:
+            typeof children === 'function'
+              ? children(!label && placeholder ? placeholder : label, value)
+              : label || placeholder,
         },
         externalProps,
       ),
-    [children, label, placeholder],
+    [children, label, placeholder, value],
   );
 
   const { renderElement } = useComponentRenderer({
@@ -50,7 +53,7 @@ const SelectValue = React.forwardRef(function SelectValue(
 
 namespace SelectValue {
   export interface Props extends Omit<BaseUIComponentProps<'span', State>, 'children'> {
-    children?: null | ((value: string) => React.ReactNode);
+    children?: null | ((label: string, value: any) => React.ReactNode);
     /**
      * A placeholder value to display when no value is selected.
      *


### PR DESCRIPTION
Closes #1559

This matches the `Slider.Value` API:

https://github.com/mui/base-ui/blob/376df1d27a9fdff150bad474ca5627bd8dd8f426/packages/react/src/slider/value/SliderValue.tsx#L63-L65