### PR TITLE
[select] Fix focus jump while hovering while navigating with keyboard

### DIFF
--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -31,6 +31,7 @@ interface InnerSelectItemProps extends Omit<SelectItem.Props, 'value'> {
   indexRef: React.RefObject<number>;
   setActiveIndex: SelectIndexContext['setActiveIndex'];
   popupRef: React.RefObject<HTMLDivElement | null>;
+  keyboardActiveRef: React.RefObject<boolean>;
 }
 
 const InnerSelectItem = React.forwardRef(function InnerSelectItem(
@@ -54,6 +55,7 @@ const InnerSelectItem = React.forwardRef(function InnerSelectItem(
     indexRef,
     setActiveIndex,
     popupRef,
+    keyboardActiveRef,
     ...otherProps
   } = props;
 
@@ -81,6 +83,7 @@ const InnerSelectItem = React.forwardRef(function InnerSelectItem(
     indexRef,
     setActiveIndex,
     popupRef,
+    keyboardActiveRef,
   });
 
   const mergedRef = useForkRef(rootRef, forwardedRef);
@@ -149,6 +152,12 @@ InnerSelectItem.propTypes /* remove-proptypes */ = {
    */
   indexRef: PropTypes.shape({
     current: PropTypes.number.isRequired,
+  }).isRequired,
+  /**
+   * @ignore
+   */
+  keyboardActiveRef: PropTypes.shape({
+    current: PropTypes.bool.isRequired,
   }).isRequired,
   /**
    * Overrides the text label to use on the trigger when this item is selected
@@ -244,6 +253,7 @@ const SelectItem = React.forwardRef(function SelectItem(
     popupRef,
     registerSelectedItem,
     value,
+    keyboardActiveRef,
   } = useSelectRootContext();
 
   const itemRef = React.useRef<HTMLDivElement | null>(null);
@@ -291,6 +301,7 @@ const SelectItem = React.forwardRef(function SelectItem(
       indexRef={indexRef}
       setActiveIndex={setActiveIndex}
       popupRef={popupRef}
+      keyboardActiveRef={keyboardActiveRef}
       {...otherProps}
     />
   );

--- a/packages/react/src/select/item/useSelectItem.ts
+++ b/packages/react/src/select/item/useSelectItem.ts
@@ -21,6 +21,7 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
     indexRef,
     setActiveIndex,
     popupRef,
+    keyboardActiveRef,
   } = params;
 
   const ref = React.useRef<HTMLDivElement | null>(null);
@@ -64,7 +65,7 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
             },
             onMouseLeave(event) {
               const popup = popupRef.current;
-              if (!popup || !open) {
+              if (!popup || !open || keyboardActiveRef.current) {
                 return;
               }
 
@@ -87,8 +88,6 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
               // With `alignItemToTrigger`, avoid re-rendering the root due to `onMouseLeave`
               // firing and causing a performance issue when expanding the popup.
               if (popup.offsetHeight === prevPopupHeightRef.current) {
-                // Prevent `onFocus` from causing the highlight to be stuck when quickly moving
-                // the mouse out of the popup.
                 allowFocusSyncRef.current = false;
                 setActiveIndex(null);
                 requestAnimationFrame(() => {
@@ -162,6 +161,7 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
       getButtonProps,
       highlighted,
       indexRef,
+      keyboardActiveRef,
       open,
       popupRef,
       selected,
@@ -232,6 +232,7 @@ export namespace useSelectItem {
     indexRef: React.RefObject<number>;
     setActiveIndex: SelectIndexContext['setActiveIndex'];
     popupRef: React.RefObject<HTMLDivElement | null>;
+    keyboardActiveRef: React.RefObject<boolean>;
   }
 
   export interface ReturnValue {

--- a/packages/react/src/select/item/useSelectItem.ts
+++ b/packages/react/src/select/item/useSelectItem.ts
@@ -88,6 +88,8 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
               // With `alignItemToTrigger`, avoid re-rendering the root due to `onMouseLeave`
               // firing and causing a performance issue when expanding the popup.
               if (popup.offsetHeight === prevPopupHeightRef.current) {
+                // Prevent `onFocus` from causing the highlight to be stuck when quickly moving
+                // the mouse out of the popup.
                 allowFocusSyncRef.current = false;
                 setActiveIndex(null);
                 requestAnimationFrame(() => {

--- a/packages/react/src/select/popup/useSelectPopup.ts
+++ b/packages/react/src/select/popup/useSelectPopup.ts
@@ -25,6 +25,7 @@ export function useSelectPopup(): useSelectPopup.ReturnValue {
     setScrollUpArrowVisible,
     setScrollDownArrowVisible,
     setcontrolledAlignItemToTrigger,
+    keyboardActiveRef,
   } = useSelectRootContext();
 
   const initialHeightRef = React.useRef(0);
@@ -238,6 +239,15 @@ export function useSelectPopup(): useSelectPopup.ReturnValue {
       return mergeProps<'div'>(
         {
           ['data-id' as string]: `${id}-popup`,
+          onKeyDown() {
+            keyboardActiveRef.current = true;
+          },
+          onMouseMove() {
+            keyboardActiveRef.current = false;
+          },
+          onPointerDown() {
+            keyboardActiveRef.current = false;
+          },
           onScroll(event) {
             if (
               !alignItemToTrigger ||
@@ -312,9 +322,10 @@ export function useSelectPopup(): useSelectPopup.ReturnValue {
       );
     },
     [
-      getRootPositionerProps,
       id,
       alignItemToTrigger,
+      getRootPositionerProps,
+      keyboardActiveRef,
       positionerElement,
       popupRef,
       handleScrollArrowVisibility,

--- a/packages/react/src/select/popup/useSelectPopup.ts
+++ b/packages/react/src/select/popup/useSelectPopup.ts
@@ -245,9 +245,6 @@ export function useSelectPopup(): useSelectPopup.ReturnValue {
           onMouseMove() {
             keyboardActiveRef.current = false;
           },
-          onPointerDown() {
-            keyboardActiveRef.current = false;
-          },
           onScroll(event) {
             if (
               !alignItemToTrigger ||

--- a/packages/react/src/select/root/SelectRootContext.ts
+++ b/packages/react/src/select/root/SelectRootContext.ts
@@ -53,6 +53,7 @@ export interface SelectRootContext {
   modal: boolean;
   registerSelectedItem: (index: number) => void;
   onOpenChangeComplete?: (open: boolean) => void;
+  keyboardActiveRef: React.MutableRefObject<boolean>;
 }
 
 export const SelectRootContext = React.createContext<SelectRootContext | null>(null);

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -72,6 +72,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
   const valueRef = React.useRef<HTMLSpanElement | null>(null);
   const valuesRef = React.useRef<Array<any>>([]);
   const typingRef = React.useRef(false);
+  const keyboardActiveRef = React.useRef(false);
   const selectedItemTextRef = React.useRef<HTMLSpanElement | null>(null);
   const selectionRef = React.useRef({
     allowSelectedMouseUp: false,
@@ -250,7 +251,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     getItemProps,
   } = useInteractions([click, dismiss, role, listNavigation, typeahead]);
 
-  const rootContext = React.useMemo(
+  const rootContext: SelectRootContext = React.useMemo(
     () => ({
       id,
       name: params.name,
@@ -294,6 +295,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
       modal,
       registerSelectedItem,
       onOpenChangeComplete,
+      keyboardActiveRef,
     }),
     [
       id,
@@ -323,6 +325,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
       modal,
       registerSelectedItem,
       onOpenChangeComplete,
+      keyboardActiveRef,
     ],
   );
 


### PR DESCRIPTION
Fixes #1557

Since `focusItemOnHover` is disabled for `useListNavigation` to implement custom listeners, `onMouseLeave` is missing the pointer modality ref check to bail out of the `onMouseLeave` event handler. If they're actively using the keyboard the whole event handler needs to be ignored