### PR TITLE
[Field] Fix `FieldControl` [data-filled] not reacting to external value changes

### DIFF
--- a/packages/react/src/field/control/useFieldControl.ts
+++ b/packages/react/src/field/control/useFieldControl.ts
@@ -39,10 +39,13 @@ export function useFieldControl(params: useFieldControl.Parameters) {
   }, [id, setControlId]);
 
   useEnhancedEffect(() => {
-    if (inputRef.current?.value) {
+    const hasExternalValue = valueProp != null;
+    if (inputRef.current?.value || (hasExternalValue && valueProp !== '')) {
       setFilled(true);
+    } else if (hasExternalValue && valueProp === '') {
+      setFilled(false);
     }
-  }, [inputRef, setFilled]);
+  }, [inputRef, setFilled, valueProp]);
 
   const [value, setValueUnwrapped] = useControlled({
     controlled: valueProp,

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -1214,6 +1214,31 @@ describe('<Field.Root />', () => {
         expect(description).not.to.have.attribute('data-filled');
       });
 
+      it('changes [data-filled] when the value is changed externally', async () => {
+        function App() {
+          const [value, setValue] = React.useState('');
+          return (
+            <div>
+              <Field.Root>
+                <Field.Control value={value} onChange={(event) => setValue(event.target.value)} />
+              </Field.Root>
+              <button onClick={() => setValue('test')}>change</button>
+              <button onClick={() => setValue('')}>reset</button>
+            </div>
+          );
+        }
+
+        const { user } = await render(<App />);
+
+        expect(screen.getByRole('textbox')).not.to.have.attribute('data-filled', '');
+
+        await user.click(screen.getByRole('button', { name: 'change' }));
+        expect(screen.getByRole('textbox')).to.have.attribute('data-filled', '');
+
+        await user.click(screen.getByRole('button', { name: 'reset' }));
+        expect(screen.getByRole('textbox')).not.to.have.attribute('data-filled', '');
+      });
+
       describe('Checkbox', () => {
         it('adds [data-filled] attribute when checked after being initially unchecked', async () => {
           await render(


### PR DESCRIPTION
Previously, `FieldControl` only checked if the value exists on mount and `onChange`, but not when the `value` prop is changed externally