### PR TITLE
[popups] Fix selection on outside press on Firefox with modal prop

### DIFF
--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -112,7 +112,7 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
 
   return (
     <React.Fragment>
-      {mounted && modal && <InternalBackdrop ref={internalBackdropRef} inert={!open} />}
+      {mounted && modal && <InternalBackdrop ref={internalBackdropRef} />}
       <FloatingFocusManager
         context={floatingRootContext}
         disabled={!mounted}

--- a/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
+++ b/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
@@ -19,11 +19,15 @@ const AlertDialogTrigger = React.forwardRef(function AlertDialogTrigger(
   forwardedRef: React.ForwardedRef<HTMLButtonElement>,
 ) {
   const { render, className, disabled = false, ...other } = props;
-  const { open, setTriggerElement, getTriggerProps } = useAlertDialogRootContext();
+
+  const { mounted, setTriggerElement, getTriggerProps } = useAlertDialogRootContext();
 
   const state: AlertDialogTrigger.State = React.useMemo(
-    () => ({ disabled, open }),
-    [disabled, open],
+    () => ({
+      disabled,
+      open: mounted,
+    }),
+    [disabled, mounted],
   );
 
   const mergedRef = useForkRef(forwardedRef, setTriggerElement);

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -108,7 +108,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
 
   return (
     <React.Fragment>
-      {mounted && modal && <InternalBackdrop ref={internalBackdropRef} inert={!open} />}
+      {mounted && modal && <InternalBackdrop ref={internalBackdropRef} />}
       <FloatingFocusManager
         context={floatingRootContext}
         disabled={!mounted}

--- a/packages/react/src/dialog/trigger/DialogTrigger.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.tsx
@@ -19,9 +19,16 @@ const DialogTrigger = React.forwardRef(function DialogTrigger(
   forwardedRef: React.ForwardedRef<HTMLButtonElement>,
 ) {
   const { render, className, disabled = false, ...other } = props;
-  const { open, setTriggerElement, getTriggerProps } = useDialogRootContext();
 
-  const state: DialogTrigger.State = React.useMemo(() => ({ disabled, open }), [disabled, open]);
+  const { mounted, setTriggerElement, getTriggerProps } = useDialogRootContext();
+
+  const state: DialogTrigger.State = React.useMemo(
+    () => ({
+      disabled,
+      open: mounted,
+    }),
+    [disabled, mounted],
+  );
 
   const mergedRef = useForkRef(forwardedRef, setTriggerElement);
 

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -133,9 +133,7 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
 
   return (
     <MenuPositionerContext.Provider value={contextValue}>
-      {mounted && modal && openReason !== 'hover' && parentNodeId === null && (
-        <InternalBackdrop inert={!open} />
-      )}
+      {mounted && modal && openReason !== 'hover' && parentNodeId === null && <InternalBackdrop />}
       <FloatingNode id={nodeId}>
         <CompositeList elementsRef={itemDomElements} labelsRef={itemLabels}>
           {renderElement()}

--- a/packages/react/src/menu/trigger/MenuTrigger.test.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.test.tsx
@@ -189,6 +189,11 @@ describe('<Menu.Trigger />', () => {
       await renderFakeTimers(
         <Menu.Root delay={0} openOnHover>
           <Menu.Trigger />
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup />
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 
@@ -230,6 +235,11 @@ describe('<Menu.Trigger />', () => {
       await renderFakeTimers(
         <Menu.Root delay={0} openOnHover>
           <Menu.Trigger />
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup />
+            </Menu.Positioner>
+          </Menu.Portal>
         </Menu.Root>,
       );
 

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -25,6 +25,7 @@ const MenuTrigger = React.forwardRef(function MenuTrigger(
     disabled: menuDisabled,
     setTriggerElement,
     open,
+    mounted,
     setOpen,
     allowMouseUpTriggerRef,
     positionerRef,
@@ -40,7 +41,13 @@ const MenuTrigger = React.forwardRef(function MenuTrigger(
     positionerRef,
   });
 
-  const state: MenuTrigger.State = React.useMemo(() => ({ open }), [open]);
+  const state: MenuTrigger.State = React.useMemo(
+    () => ({
+      disabled,
+      open: mounted,
+    }),
+    [disabled, mounted],
+  );
 
   const propGetter = React.useCallback(
     (externalProps: GenericHTMLProps) =>

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -86,7 +86,7 @@ const PopoverPositioner = React.forwardRef(function PopoverPositioner(
 
   return (
     <PopoverPositionerContext.Provider value={positioner}>
-      {mounted && modal && openReason !== 'hover' && <InternalBackdrop inert={!open} />}
+      {mounted && modal && openReason !== 'hover' && <InternalBackdrop />}
       {renderElement()}
     </PopoverPositionerContext.Provider>
   );

--- a/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
@@ -86,6 +86,11 @@ describe('<Popover.Trigger />', () => {
       const { user } = await render(
         <Popover.Root openOnHover delay={0}>
           <Popover.Trigger />
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup />
+            </Popover.Positioner>
+          </Popover.Portal>
         </Popover.Root>,
       );
 
@@ -101,6 +106,11 @@ describe('<Popover.Trigger />', () => {
       const { user } = await render(
         <Popover.Root delay={0} openOnHover>
           <Popover.Trigger />
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup />
+            </Popover.Positioner>
+          </Popover.Portal>
         </Popover.Root>,
       );
 
@@ -119,6 +129,11 @@ describe('<Popover.Trigger />', () => {
       const { user } = await render(
         <Popover.Root openOnHover>
           <Popover.Trigger />
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup />
+            </Popover.Positioner>
+          </Popover.Portal>
         </Popover.Root>,
       );
 
@@ -143,6 +158,11 @@ describe('<Popover.Trigger />', () => {
       await renderFakeTimers(
         <Popover.Root delay={0} openOnHover>
           <Popover.Trigger />
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup />
+            </Popover.Positioner>
+          </Popover.Portal>
         </Popover.Root>,
       );
 
@@ -161,6 +181,11 @@ describe('<Popover.Trigger />', () => {
       await renderFakeTimers(
         <Popover.Root delay={0} openOnHover>
           <Popover.Trigger />
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup />
+            </Popover.Positioner>
+          </Popover.Portal>
         </Popover.Root>,
       );
 
@@ -179,6 +204,11 @@ describe('<Popover.Trigger />', () => {
       await renderFakeTimers(
         <Popover.Root delay={0} openOnHover>
           <Popover.Trigger />
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup />
+            </Popover.Positioner>
+          </Popover.Portal>
         </Popover.Root>,
       );
 
@@ -202,6 +232,11 @@ describe('<Popover.Trigger />', () => {
       await renderFakeTimers(
         <Popover.Root delay={0} openOnHover>
           <Popover.Trigger />
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup />
+            </Popover.Positioner>
+          </Popover.Portal>
         </Popover.Root>,
       );
 

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -24,9 +24,15 @@ const PopoverTrigger = React.forwardRef(function PopoverTrigger(
 ) {
   const { render, className, disabled = false, ...otherProps } = props;
 
-  const { open, setTriggerElement, getRootTriggerProps, openReason } = usePopoverRootContext();
+  const { mounted, setTriggerElement, getRootTriggerProps, openReason } = usePopoverRootContext();
 
-  const state: PopoverTrigger.State = React.useMemo(() => ({ disabled, open }), [disabled, open]);
+  const state: PopoverTrigger.State = React.useMemo(
+    () => ({
+      disabled,
+      open: mounted,
+    }),
+    [disabled, mounted],
+  );
 
   const { getButtonProps, buttonRef } = useButton({
     disabled,

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -85,7 +85,7 @@ const SelectPositioner = React.forwardRef(function SelectPositioner(
   return (
     <CompositeList elementsRef={listRef} labelsRef={labelsRef}>
       <SelectPositionerContext.Provider value={positioner}>
-        {mounted && modal && <InternalBackdrop inert={!open} />}
+        {mounted && modal && <InternalBackdrop />}
         {renderElement()}
       </SelectPositionerContext.Provider>
     </CompositeList>

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -23,7 +23,7 @@ const SelectTrigger = React.forwardRef(function SelectTrigger(
 
   const { state: fieldState, disabled: fieldDisabled } = useFieldRootContext();
 
-  const { getRootTriggerProps, disabled: selectDisabled, open } = useSelectRootContext();
+  const { getRootTriggerProps, disabled: selectDisabled, mounted } = useSelectRootContext();
 
   const disabled = fieldDisabled || selectDisabled || disabledProp;
 
@@ -35,10 +35,10 @@ const SelectTrigger = React.forwardRef(function SelectTrigger(
   const state: SelectTrigger.State = React.useMemo(
     () => ({
       ...fieldState,
-      open,
+      open: mounted,
       disabled,
     }),
-    [fieldState, open, disabled],
+    [fieldState, mounted, disabled],
   );
 
   const styleHookMapping = React.useMemo(

--- a/packages/react/src/utils/InternalBackdrop.tsx
+++ b/packages/react/src/utils/InternalBackdrop.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * @ignore - internal component.
@@ -11,6 +12,7 @@ const InternalBackdrop = React.forwardRef(function InternalBackdrop(
     <div
       ref={ref}
       role="presentation"
+      {...props}
       style={{
         position: 'fixed',
         inset: 0,
@@ -18,5 +20,20 @@ const InternalBackdrop = React.forwardRef(function InternalBackdrop(
     />
   );
 });
+
+InternalBackdrop.propTypes /* remove-proptypes */ = {
+  // ┌────────────────────────────── Warning ──────────────────────────────┐
+  // │ These PropTypes are generated from the TypeScript type definitions. │
+  // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
+  // └─────────────────────────────────────────────────────────────────────┘
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+} as any;
 
 export { InternalBackdrop };

--- a/packages/react/src/utils/InternalBackdrop.tsx
+++ b/packages/react/src/utils/InternalBackdrop.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 
 /**
  * @ignore - internal component.
  */
 const InternalBackdrop = React.forwardRef(function InternalBackdrop(
-  props: InternalBackdrop.Props,
+  props: React.ComponentPropsWithoutRef<'div'>,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { inert = false } = props;
   return (
     <div
       ref={ref}
@@ -16,41 +14,9 @@ const InternalBackdrop = React.forwardRef(function InternalBackdrop(
       style={{
         position: 'fixed',
         inset: 0,
-        // Allows `:hover` events immediately after `open` changes to `false`,
-        // preventing a flicker when the cursor rests on the trigger. Flickers occur
-        // because CSS `:hover` is temporarily blocked during an exit animation,
-        // and `[data-popup-open]` is removed.
-        // Keeping the backdrop in the DOM avoids `[data-floating-ui-inert]`, which
-        // blocks outside clicks from closing the popup. This issue arises when
-        // conditionally rendering the backdrop on `open` and using exit animations.
-        // If the popup reopens before the exit animation finishes, the backdrop
-        // receives this attribute, breaking outside click behavior.
-        pointerEvents: inert ? 'none' : undefined,
       }}
     />
   );
 });
-
-namespace InternalBackdrop {
-  export interface Props {
-    /**
-     * Whether the backdrop should be inert (not block pointer events).
-     * @default false
-     */
-    inert?: boolean;
-  }
-}
-
-InternalBackdrop.propTypes /* remove-proptypes */ = {
-  // ┌────────────────────────────── Warning ──────────────────────────────┐
-  // │ These PropTypes are generated from the TypeScript type definitions. │
-  // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
-  // └─────────────────────────────────────────────────────────────────────┘
-  /**
-   * Whether the backdrop should be inert (not block pointer events).
-   * @default false
-   */
-  inert: PropTypes.bool,
-} as any;
 
 export { InternalBackdrop };


### PR DESCRIPTION
This was reported on Discord and is worse on Firefox. When simply pressing outside (with a hard click on a trackpad) it selects the document's text unexpectedly. 

The internal backdrop `pointer-events: none` style seems to cause the bug while closing on FF & Safari; `modal={false}` is the current workaround since it avoids rendering the backdrop

In order to maintain the fix in https://github.com/mui/base-ui/pull/1221, I changed the style hook for `[data-popup-open]` to match the `mounted` state to prevent the flicker instead. It doesn't map 1:1 with the `open` state, but I'm not sure if that matters here since in practice you want it kept when mounted, not open