### PR TITLE
[NumberField] Fix parse of numbers with spaces as thousands separators

### DIFF
--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -545,5 +545,19 @@ describe('<NumberField />', () => {
       const expectedValue = new Intl.NumberFormat().format(1000.5);
       expect(input).to.have.value(expectedValue);
     });
+
+    it('should handle locales using space as the thousands separator', async () => {
+      await render(<NumberField defaultValue={12345.5} locale="pl" />);
+
+      const input = screen.getByRole('textbox');
+      const expectedValue = new Intl.NumberFormat('pl').format(12345.5);
+      expect(input).to.have.value(expectedValue);
+
+      const incrementButton = screen.getByLabelText('Increase');
+      fireEvent.click(incrementButton);
+
+      const newExpectedValue = new Intl.NumberFormat('pl').format(12346.5);
+      expect(input).to.have.value(newExpectedValue);
+    });
   });
 });

--- a/packages/react/src/number-field/root/useNumberFieldRoot.ts
+++ b/packages/react/src/number-field/root/useNumberFieldRoot.ts
@@ -400,6 +400,7 @@ export function useNumberFieldRoot(
       min,
       max,
       setInputValue,
+      locale,
       ...scrub,
     }),
     [
@@ -433,6 +434,7 @@ export function useNumberFieldRoot(
       min,
       max,
       setInputValue,
+      locale,
     ],
   );
 }
@@ -577,6 +579,6 @@ export namespace useNumberFieldRoot {
     min: number | undefined;
     max: number | undefined;
     setInputValue: React.Dispatch<React.SetStateAction<string>>;
-    locale?: Intl.LocalesArgument;
+    locale: Intl.LocalesArgument;
   }
 }

--- a/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.test.tsx
+++ b/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.test.tsx
@@ -65,6 +65,7 @@ const defaultTestContext = {
   stopAutoChange: NOOP,
   value: null,
   valueRef: { current: null },
+  locale: 'en',
 } as NumberFieldRootContext;
 
 describe('<NumberField.ScrubAreaCursor />', () => {

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -12,7 +12,7 @@ export function getNumberLocaleDetails(
   locale?: Intl.LocalesArgument,
   options?: Intl.NumberFormatOptions,
 ) {
-  const parts = getFormatter(locale, options).formatToParts(1111.1);
+  const parts = getFormatter(locale, options).formatToParts(11111.1);
   const result: Partial<Record<Intl.NumberFormatPartTypes, string | undefined>> = {};
 
   parts.forEach((part) => {

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -50,7 +50,7 @@ export function parseNumber(
   if (group) {
     // Check if the group separator is a space-like character.
     // If so, we'll replace all such characters with an empty string.
-    groupRegex = /\p{Zs}/u.test(group ?? '') ? /\p{Zs}/gu : new RegExp(`\\${group}`, 'g');
+    groupRegex = /\p{Zs}/u.test(group) ? /\p{Zs}/gu : new RegExp(`\\${group}`, 'g');
   }
 
   const regexesToReplace = [

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -46,9 +46,15 @@ export function parseNumber(
   }
 
   const { group, decimal, currency, unit } = getNumberLocaleDetails(computedLocale, options);
+  let groupRegex: RegExp | null = null;
+  if (group) {
+    // Check if the group separator is a space-like character.
+    // If so, we'll replace all such characters with an empty string.
+    groupRegex = /\p{Zs}/u.test(group ?? '') ? /\p{Zs}/gu : new RegExp(`\\${group}`, 'g');
+  }
 
   const regexesToReplace = [
-    { regex: group ? new RegExp(`\\${group}`, 'g') : null, replacement: '' },
+    { regex: group ? groupRegex : null, replacement: '' },
     { regex: decimal ? new RegExp(`\\${decimal}`, 'g') : null, replacement: '.' },
     { regex: currency ? new RegExp(`\\${currency}`, 'g') : null, replacement: '' },
     { regex: unit ? new RegExp(`\\${unit}`, 'g') : null, replacement: '' },


### PR DESCRIPTION
Certain locales define space as a thousands separator in numbers. The NumberField incorrectly parsed numbers from these locales. If a thousands separator is a space-like character (including non-breaking  and different width spaces), we treat every space-like character as a possible separator.

Fixes https://github.com/mui/base-ui/issues/1576
