### PR TITLE
[NumberField] Fix `large/smallStep` getting stuck

### DIFF
--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -226,7 +226,7 @@ const NumberFieldInput = React.forwardRef(function NumberFieldInput(
             // We need to commit the number at this point if the input hasn't been blurred.
             const parsedValue = parseNumber(inputValue, locale, formatOptionsRef.current);
 
-            const amount = getStepAmount() ?? DEFAULT_STEP;
+            const amount = getStepAmount(event) ?? DEFAULT_STEP;
 
             // Prevent insertion of text or caret from moving.
             event.preventDefault();

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -329,57 +329,51 @@ describe('<NumberField />', () => {
     });
   });
 
-  describe('prop: largeStep', () => {
+  describe.skipIf(isJSDOM)('prop: largeStep', () => {
     it('should increment the value by the default `largeStep` prop of 10 while holding the shift key', async () => {
       await render(<NumberField defaultValue={5} />);
       const input = screen.getByRole('textbox');
-      fireEvent.keyDown(document.body, { shiftKey: true });
-      fireEvent.pointerDown(screen.getByLabelText('Increase'));
+      fireEvent.pointerDown(screen.getByLabelText('Increase'), { shiftKey: true });
       expect(input).to.have.value('20');
     });
 
     it('should decrement the value by the default `largeStep` prop of 10 while holding the shift key', async () => {
       await render(<NumberField defaultValue={6} />);
       const input = screen.getByRole('textbox');
-      fireEvent.keyDown(document.body, { shiftKey: true });
-      fireEvent.pointerDown(screen.getByLabelText('Decrease'));
+      fireEvent.pointerDown(screen.getByLabelText('Decrease'), { shiftKey: true });
       expect(input).to.have.value('0');
     });
 
     it('should use explicit `largeStep` value if provided while holding the shift key', async () => {
       await render(<NumberField defaultValue={5} largeStep={5} />);
       const input = screen.getByRole('textbox');
-      fireEvent.keyDown(document.body, { shiftKey: true });
-      fireEvent.pointerDown(screen.getByLabelText('Increase'));
+      fireEvent.pointerDown(screen.getByLabelText('Increase'), { shiftKey: true });
       expect(input).to.have.value('10');
     });
 
     it('should not use the `largeStep` prop if no longer holding the shift key', async () => {
       await render(<NumberField defaultValue={5} largeStep={5} />);
       const input = screen.getByRole('textbox');
-      fireEvent.keyDown(document.body, { shiftKey: true });
-      fireEvent.pointerDown(screen.getByLabelText('Increase'));
+      fireEvent.pointerDown(screen.getByLabelText('Increase'), { shiftKey: true });
       expect(input).to.have.value('10');
       fireEvent.keyUp(input, { shiftKey: true });
-      fireEvent.pointerDown(screen.getByLabelText('Increase'));
+      fireEvent.pointerDown(screen.getByLabelText('Increase'), { shiftKey: true });
       expect(input).to.have.value('15');
     });
   });
 
-  describe('prop: smallStep', () => {
+  describe.skipIf(isJSDOM)('prop: smallStep', () => {
     it('should increment the value by the default `smallStep` prop of 0.1 while holding the alt key', async () => {
       await render(<NumberField defaultValue={5} />);
       const input = screen.getByRole('textbox');
-      fireEvent.keyDown(document.body, { altKey: true });
-      fireEvent.pointerDown(screen.getByLabelText('Increase'));
+      fireEvent.pointerDown(screen.getByLabelText('Increase'), { altKey: true });
       expect(input).to.have.value((5.1).toLocaleString());
     });
 
     it('should decrement the value by the default `smallStep` prop of 0.1 while holding the alt key', async () => {
       await render(<NumberField defaultValue={6} />);
       const input = screen.getByRole('textbox');
-      fireEvent.keyDown(document.body, { altKey: true });
-      fireEvent.pointerDown(screen.getByLabelText('Decrease'));
+      fireEvent.pointerDown(screen.getByLabelText('Decrease'), { altKey: true });
       expect(input).to.have.value((5.9).toLocaleString());
     });
 
@@ -387,7 +381,7 @@ describe('<NumberField />', () => {
       await render(<NumberField defaultValue={5} smallStep={0.5} />);
       const input = screen.getByRole('textbox');
       fireEvent.keyDown(document.body, { altKey: true });
-      fireEvent.pointerDown(screen.getByLabelText('Increase'));
+      fireEvent.pointerDown(screen.getByLabelText('Increase'), { altKey: true });
       expect(input).to.have.value((5.5).toLocaleString());
     });
 
@@ -395,8 +389,7 @@ describe('<NumberField />', () => {
       await render(<NumberField defaultValue={5} smallStep={0.5} />);
       const input = screen.getByRole('textbox');
       const button = screen.getByLabelText('Increase');
-      fireEvent.keyDown(document.body, { altKey: true });
-      fireEvent.pointerDown(button);
+      fireEvent.pointerDown(button, { altKey: true });
       expect(input).to.have.value((5.5).toLocaleString());
       fireEvent.keyUp(input, { altKey: false });
       fireEvent.pointerDown(button);

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -156,7 +156,7 @@ NumberFieldRoot.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   /**
-   * The uncontrolled value of the field when it’s initially rendered.
+   * The uncontrolled value of the field when it's initially rendered.
    *
    * To render a controlled number field, use the `value` prop instead.
    */

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -156,7 +156,7 @@ NumberFieldRoot.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   /**
-   * The uncontrolled value of the field when it's initially rendered.
+   * The uncontrolled value of the field when it’s initially rendered.
    *
    * To render a controlled number field, use the `value` prop instead.
    */

--- a/packages/react/src/number-field/root/useNumberFieldButton.ts
+++ b/packages/react/src/number-field/root/useNumberFieldButton.ts
@@ -8,7 +8,8 @@ import {
 } from '../utils/constants';
 import { mergeProps } from '../../merge-props';
 import { parseNumber } from '../utils/parse';
-import { GenericHTMLProps } from '../../utils/types';
+import type { GenericHTMLProps } from '../../utils/types';
+import type { EventWithOptionalKeyState } from '../utils/types';
 
 export function useNumberFieldButton(
   params: useNumberFieldButton.Parameters,
@@ -219,7 +220,7 @@ namespace useNumberFieldButton {
     allowInputSyncRef: React.RefObject<boolean | null>;
     disabled: boolean;
     formatOptionsRef: React.RefObject<Intl.NumberFormatOptions | undefined>;
-    getStepAmount: (event?: { altKey?: boolean; shiftKey?: boolean }) => number | undefined;
+    getStepAmount: (event?: EventWithOptionalKeyState) => number | undefined;
     id: string | undefined;
     incrementValue: (
       amount: number,

--- a/packages/react/src/number-field/root/useNumberFieldButton.ts
+++ b/packages/react/src/number-field/root/useNumberFieldButton.ts
@@ -94,7 +94,7 @@ export function useNumberFieldButton(
 
             commitValue(event.nativeEvent);
 
-            const amount = getStepAmount() ?? DEFAULT_STEP;
+            const amount = getStepAmount(event) ?? DEFAULT_STEP;
 
             incrementValue(amount, isIncrement ? 1 : -1, undefined, event.nativeEvent);
           },
@@ -116,7 +116,7 @@ export function useNumberFieldButton(
             if (event.pointerType !== 'touch') {
               event.preventDefault();
               inputRef.current?.focus();
-              startAutoChange(isIncrement);
+              startAutoChange(isIncrement, event);
             } else {
               // We need to check if the pointerdown was intentional, and not the result of a scroll
               // or pinch-zoom. In that case, we don't want to change the value.
@@ -125,7 +125,7 @@ export function useNumberFieldButton(
                 movesAfterTouchRef.current = 0;
                 if (moves != null && moves < MAX_POINTER_MOVES_AFTER_TOUCH) {
                   ignoreClickRef.current = true;
-                  startAutoChange(isIncrement);
+                  startAutoChange(isIncrement, event);
                 } else {
                   stopAutoChange();
                 }
@@ -163,7 +163,7 @@ export function useNumberFieldButton(
               return;
             }
 
-            startAutoChange(isIncrement);
+            startAutoChange(isIncrement, event);
           },
           onMouseLeave() {
             if (isTouchingButtonRef.current) {
@@ -219,7 +219,7 @@ namespace useNumberFieldButton {
     allowInputSyncRef: React.RefObject<boolean | null>;
     disabled: boolean;
     formatOptionsRef: React.RefObject<Intl.NumberFormatOptions | undefined>;
-    getStepAmount: () => number | undefined;
+    getStepAmount: (event?: { altKey?: boolean; shiftKey?: boolean }) => number | undefined;
     id: string | undefined;
     incrementValue: (
       amount: number,
@@ -237,7 +237,7 @@ namespace useNumberFieldButton {
     movesAfterTouchRef: React.RefObject<number | null>;
     readOnly: boolean;
     setValue: (unvalidatedValue: number | null, event?: Event) => void;
-    startAutoChange: (isIncrement: boolean) => void;
+    startAutoChange: (isIncrement: boolean, event?: React.MouseEvent | Event) => void;
     stopAutoChange: () => void;
     value: number | null;
     valueRef: React.RefObject<number | null>;

--- a/packages/react/src/number-field/root/useNumberFieldRoot.ts
+++ b/packages/react/src/number-field/root/useNumberFieldRoot.ts
@@ -18,6 +18,7 @@ import { useFieldControlValidation } from '../../field/control/useFieldControlVa
 import { useForkRef } from '../../utils/useForkRef';
 import { useField } from '../../field/useField';
 import type { ScrubHandle } from './useScrub';
+import type { EventWithOptionalKeyState } from '../utils/types';
 
 export function useNumberFieldRoot(
   params: useNumberFieldRoot.Parameters,
@@ -139,7 +140,7 @@ export function useNumberFieldRoot(
     return keys;
   });
 
-  const getStepAmount = useEventCallback((event?: { altKey?: boolean; shiftKey?: boolean }) => {
+  const getStepAmount = useEventCallback((event?: EventWithOptionalKeyState) => {
     if (event?.altKey) {
       return smallStep;
     }
@@ -152,7 +153,7 @@ export function useNumberFieldRoot(
   const setValue = useEventCallback(
     (unvalidatedValue: number | null, event?: React.MouseEvent | Event) => {
       const validatedValue = toValidatedNumber(unvalidatedValue, {
-        step: getStepAmount(event as { altKey?: boolean; shiftKey?: boolean }),
+        step: getStepAmount(event as EventWithOptionalKeyState),
         format: formatOptionsRef.current,
         minWithDefault,
         maxWithDefault,
@@ -227,8 +228,7 @@ export function useNumberFieldRoot(
       );
 
       function tick() {
-        const amount =
-          getStepAmount(triggerEvent as { altKey?: boolean; shiftKey?: boolean }) ?? DEFAULT_STEP;
+        const amount = getStepAmount(triggerEvent as EventWithOptionalKeyState) ?? DEFAULT_STEP;
         incrementValue(amount, isIncrement ? 1 : -1, undefined, triggerEvent);
       }
 
@@ -518,7 +518,7 @@ export namespace useNumberFieldRoot {
     readOnly: boolean;
     id: string | undefined;
     setValue: (unvalidatedValue: number | null, event?: Event) => void;
-    getStepAmount: (event?: { altKey?: boolean; shiftKey?: boolean }) => number | undefined;
+    getStepAmount: (event?: EventWithOptionalKeyState) => number | undefined;
     incrementValue: (
       amount: number,
       dir: 1 | -1,

--- a/packages/react/src/number-field/root/useNumberFieldRoot.ts
+++ b/packages/react/src/number-field/root/useNumberFieldRoot.ts
@@ -104,8 +104,6 @@ export function useNumberFieldRoot(
   const tickIntervalRef = React.useRef(-1);
   const intentionalTouchCheckTimeoutRef = React.useRef(-1);
   const isPressedRef = React.useRef(false);
-  const isHoldingShiftRef = React.useRef(false);
-  const isHoldingAltRef = React.useRef(false);
   const movesAfterTouchRef = React.useRef(0);
   const allowInputSyncRef = React.useRef(true);
   const unsubscribeFromGlobalContextMenuRef = React.useRef<() => void>(() => {});
@@ -141,41 +139,48 @@ export function useNumberFieldRoot(
     return keys;
   });
 
-  const getStepAmount = useEventCallback(() => {
-    if (isHoldingAltRef.current) {
+  const getStepAmount = useEventCallback((event?: { altKey?: boolean; shiftKey?: boolean }) => {
+    if (event?.altKey) {
       return smallStep;
     }
-    if (isHoldingShiftRef.current) {
+    if (event?.shiftKey) {
       return largeStep;
     }
     return step;
   });
 
-  const setValue = useEventCallback((unvalidatedValue: number | null, event?: Event) => {
-    const validatedValue = toValidatedNumber(unvalidatedValue, {
-      step: getStepAmount(),
-      format: formatOptionsRef.current,
-      minWithDefault,
-      maxWithDefault,
-      minWithZeroDefault,
-    });
+  const setValue = useEventCallback(
+    (unvalidatedValue: number | null, event?: React.MouseEvent | Event) => {
+      const validatedValue = toValidatedNumber(unvalidatedValue, {
+        step: getStepAmount(event as { altKey?: boolean; shiftKey?: boolean }),
+        format: formatOptionsRef.current,
+        minWithDefault,
+        maxWithDefault,
+        minWithZeroDefault,
+      });
 
-    onValueChange?.(validatedValue, event);
-    setValueUnwrapped(validatedValue);
-    setDirty(validatedValue !== validityData.initialValue);
+      onValueChange?.(validatedValue, event && 'nativeEvent' in event ? event.nativeEvent : event);
+      setValueUnwrapped(validatedValue);
+      setDirty(validatedValue !== validityData.initialValue);
 
-    if (validationMode === 'onChange') {
-      commitValidation(validatedValue);
-    }
+      if (validationMode === 'onChange') {
+        commitValidation(validatedValue);
+      }
 
-    // We need to force a re-render, because while the value may be unchanged, the formatting may
-    // be different. This forces the `useEnhancedEffect` to run which acts as a single source of
-    // truth to sync the input value.
-    forceRender();
-  });
+      // We need to force a re-render, because while the value may be unchanged, the formatting may
+      // be different. This forces the `useEnhancedEffect` to run which acts as a single source of
+      // truth to sync the input value.
+      forceRender();
+    },
+  );
 
   const incrementValue = useEventCallback(
-    (amount: number, dir: 1 | -1, currentValue?: number | null, event?: Event) => {
+    (
+      amount: number,
+      dir: 1 | -1,
+      currentValue?: number | null,
+      event?: React.MouseEvent | Event,
+    ) => {
       const prevValue = currentValue == null ? valueRef.current : currentValue;
       const nextValue =
         typeof prevValue === 'number' ? prevValue + amount * dir : Math.max(0, min ?? 0);
@@ -191,46 +196,49 @@ export function useNumberFieldRoot(
     movesAfterTouchRef.current = 0;
   });
 
-  const startAutoChange = useEventCallback((isIncrement: boolean) => {
-    stopAutoChange();
+  const startAutoChange = useEventCallback(
+    (isIncrement: boolean, triggerEvent?: React.MouseEvent | Event) => {
+      stopAutoChange();
 
-    if (!inputRef.current) {
-      return;
-    }
+      if (!inputRef.current) {
+        return;
+      }
 
-    const win = ownerWindow(inputRef.current);
+      const win = ownerWindow(inputRef.current);
 
-    function handleContextMenu(event: Event) {
-      event.preventDefault();
-    }
+      function handleContextMenu(event: Event) {
+        event.preventDefault();
+      }
 
-    // A global context menu is necessary to prevent the context menu from appearing when the touch
-    // is slightly outside of the element's hit area.
-    win.addEventListener('contextmenu', handleContextMenu);
-    unsubscribeFromGlobalContextMenuRef.current = () => {
-      win.removeEventListener('contextmenu', handleContextMenu);
-    };
+      // A global context menu is necessary to prevent the context menu from appearing when the touch
+      // is slightly outside of the element's hit area.
+      win.addEventListener('contextmenu', handleContextMenu);
+      unsubscribeFromGlobalContextMenuRef.current = () => {
+        win.removeEventListener('contextmenu', handleContextMenu);
+      };
 
-    win.addEventListener(
-      'pointerup',
-      () => {
-        isPressedRef.current = false;
-        stopAutoChange();
-      },
-      { once: true },
-    );
+      win.addEventListener(
+        'pointerup',
+        () => {
+          isPressedRef.current = false;
+          stopAutoChange();
+        },
+        { once: true },
+      );
 
-    function tick() {
-      const amount = getStepAmount() ?? DEFAULT_STEP;
-      incrementValue(amount, isIncrement ? 1 : -1);
-    }
+      function tick() {
+        const amount =
+          getStepAmount(triggerEvent as { altKey?: boolean; shiftKey?: boolean }) ?? DEFAULT_STEP;
+        incrementValue(amount, isIncrement ? 1 : -1, undefined, triggerEvent);
+      }
 
-    tick();
+      tick();
 
-    startTickTimeoutRef.current = window.setTimeout(() => {
-      tickIntervalRef.current = window.setInterval(tick, CHANGE_VALUE_TICK_DELAY);
-    }, START_AUTO_CHANGE_DELAY);
-  });
+      startTickTimeoutRef.current = window.setTimeout(() => {
+        tickIntervalRef.current = window.setInterval(tick, CHANGE_VALUE_TICK_DELAY);
+      }, START_AUTO_CHANGE_DELAY);
+    },
+  );
 
   // We need to update the input value when the external `value` prop changes. This ends up acting
   // as a single source of truth to update the input value, bypassing the need to manually set it in
@@ -281,51 +289,6 @@ export function useNumberFieldRoot(
     return () => stopAutoChange();
   }, [stopAutoChange]);
 
-  React.useEffect(
-    function registerGlobalStepModifierKeyListeners() {
-      if (disabled || readOnly || !inputRef.current) {
-        return undefined;
-      }
-
-      function handleWindowKeyDown(event: KeyboardEvent) {
-        if (event.shiftKey) {
-          isHoldingShiftRef.current = true;
-        }
-        if (event.altKey) {
-          isHoldingAltRef.current = true;
-        }
-      }
-
-      function handleWindowKeyUp(event: KeyboardEvent) {
-        if (!event.shiftKey) {
-          isHoldingShiftRef.current = false;
-        }
-        if (!event.altKey) {
-          isHoldingAltRef.current = false;
-        }
-      }
-
-      function handleWindowBlur() {
-        // A keyup event may not be dispatched when the window loses focus.
-        isHoldingShiftRef.current = false;
-        isHoldingAltRef.current = false;
-      }
-
-      const win = ownerWindow(inputRef.current);
-
-      win.addEventListener('keydown', handleWindowKeyDown, true);
-      win.addEventListener('keyup', handleWindowKeyUp, true);
-      win.addEventListener('blur', handleWindowBlur);
-
-      return () => {
-        win.removeEventListener('keydown', handleWindowKeyDown, true);
-        win.removeEventListener('keyup', handleWindowKeyUp, true);
-        win.removeEventListener('blur', handleWindowBlur);
-      };
-    },
-    [disabled, readOnly],
-  );
-
   // The `onWheel` prop can't be prevented, so we need to use a global event listener.
   React.useEffect(
     function registerElementWheelListener() {
@@ -346,7 +309,7 @@ export function useNumberFieldRoot(
         // Prevent the default behavior to avoid scrolling the page.
         event.preventDefault();
 
-        const amount = getStepAmount() ?? DEFAULT_STEP;
+        const amount = getStepAmount(event) ?? DEFAULT_STEP;
 
         incrementValue(amount, event.deltaY > 0 ? -1 : 1, undefined, event);
       }
@@ -507,7 +470,7 @@ export namespace useNumberFieldRoot {
      */
     value?: number | null;
     /**
-     * The uncontrolled value of the field when it’s initially rendered.
+     * The uncontrolled value of the field when it's initially rendered.
      *
      * To render a controlled number field, use the `value` prop instead.
      */
@@ -547,7 +510,7 @@ export namespace useNumberFieldRoot {
     scrubHandleRef: React.RefObject<ScrubHandle | null>;
     scrubAreaRef: React.RefObject<HTMLSpanElement | null>;
     scrubAreaCursorRef: React.RefObject<HTMLSpanElement | null>;
-    startAutoChange: (isIncrement: boolean) => void;
+    startAutoChange: (isIncrement: boolean, event?: React.MouseEvent | Event) => void;
     stopAutoChange: () => void;
     minWithDefault: number;
     maxWithDefault: number;
@@ -555,7 +518,7 @@ export namespace useNumberFieldRoot {
     readOnly: boolean;
     id: string | undefined;
     setValue: (unvalidatedValue: number | null, event?: Event) => void;
-    getStepAmount: () => number | undefined;
+    getStepAmount: (event?: { altKey?: boolean; shiftKey?: boolean }) => number | undefined;
     incrementValue: (
       amount: number,
       dir: 1 | -1,

--- a/packages/react/src/number-field/root/useNumberFieldRoot.ts
+++ b/packages/react/src/number-field/root/useNumberFieldRoot.ts
@@ -470,7 +470,7 @@ export namespace useNumberFieldRoot {
      */
     value?: number | null;
     /**
-     * The uncontrolled value of the field when it's initially rendered.
+     * The uncontrolled value of the field when it’s initially rendered.
      *
      * To render a controlled number field, use the `value` prop instead.
      */

--- a/packages/react/src/number-field/root/useScrub.ts
+++ b/packages/react/src/number-field/root/useScrub.ts
@@ -200,7 +200,7 @@ export function useScrub(params: useScrub.Parameters) {
         if (Math.abs(cumulativeDelta) >= pixelSensitivity) {
           cumulativeDelta = 0;
           const dValue = direction === 'vertical' ? -movementY : movementX;
-          incrementValue(dValue * (getStepAmount() ?? DEFAULT_STEP), 1);
+          incrementValue(dValue * (getStepAmount(event) ?? DEFAULT_STEP), 1);
         }
       }
 
@@ -276,6 +276,6 @@ export namespace useScrub {
     value: number | null;
     inputRef: React.RefObject<HTMLInputElement | null>;
     incrementValue: (amount: number, dir: 1 | -1, currentValue?: number | null) => void;
-    getStepAmount: () => number | undefined;
+    getStepAmount: (event?: { altKey?: boolean; shiftKey?: boolean }) => number | undefined;
   }
 }

--- a/packages/react/src/number-field/root/useScrub.ts
+++ b/packages/react/src/number-field/root/useScrub.ts
@@ -11,6 +11,7 @@ import { mergeProps } from '../../merge-props';
 import type { useNumberFieldRoot } from './useNumberFieldRoot';
 import { NumberFieldRootDataAttributes } from './NumberFieldRootDataAttributes';
 import { useEventCallback } from '../../utils/useEventCallback';
+import type { EventWithOptionalKeyState } from '../utils/types';
 
 /**
  * @ignore - internal hook.
@@ -276,6 +277,6 @@ export namespace useScrub {
     value: number | null;
     inputRef: React.RefObject<HTMLInputElement | null>;
     incrementValue: (amount: number, dir: 1 | -1, currentValue?: number | null) => void;
-    getStepAmount: (event?: { altKey?: boolean; shiftKey?: boolean }) => number | undefined;
+    getStepAmount: (event?: EventWithOptionalKeyState) => number | undefined;
   }
 }

--- a/packages/react/src/number-field/utils/types.ts
+++ b/packages/react/src/number-field/utils/types.ts
@@ -1,0 +1,4 @@
+export interface EventWithOptionalKeyState {
+  altKey?: boolean;
+  shiftKey?: boolean;
+}


### PR DESCRIPTION
Replaces the global listeners by checking for `event.shfitKey/altKey` on the event if available. 

The only times it's not available on the event is when pressing and holding the increment button and then pressing shift midway through, but I don't consider that to be very important/relevant

Fixes #1064