### PR TITLE
[NumberField] Fix ScrubArea on Safari

### DIFF
--- a/packages/react/src/number-field/root/useScrub.ts
+++ b/packages/react/src/number-field/root/useScrub.ts
@@ -170,16 +170,14 @@ export function useScrub(params: useScrub.Parameters) {
       let cumulativeDelta = 0;
 
       function handleScrubPointerUp(event: PointerEvent) {
-        if (!isWebKit()) {
-          try {
-            // Avoid errors in testing environments.
-            ownerDocument(scrubAreaRef.current).exitPointerLock();
-          } catch {
-            //
-          } finally {
-            isScrubbingRef.current = false;
-            onScrubbingChange(false, event);
-          }
+        try {
+          // Avoid errors in testing environments.
+          ownerDocument(scrubAreaRef.current).exitPointerLock();
+        } catch {
+          //
+        } finally {
+          isScrubbingRef.current = false;
+          onScrubbingChange(false, event);
         }
       }
 


### PR DESCRIPTION
There should be no WebKit check for pointerup release. After the promise changes, Safari no longer cancels scrubbing.