### PR TITLE
[useButton] Default to `'button'` type

### DIFF
--- a/packages/react/src/collapsible/trigger/useCollapsibleTrigger.ts
+++ b/packages/react/src/collapsible/trigger/useCollapsibleTrigger.ts
@@ -21,7 +21,6 @@ export function useCollapsibleTrigger(
     (externalProps: GenericHTMLProps = {}) =>
       mergeProps(
         {
-          type: 'button',
           'aria-controls': panelId,
           'aria-expanded': open,
           disabled,

--- a/packages/react/src/collapsible/trigger/useCollapsibleTrigger.ts
+++ b/packages/react/src/collapsible/trigger/useCollapsibleTrigger.ts
@@ -13,7 +13,6 @@ export function useCollapsibleTrigger(
   const { getButtonProps, buttonRef } = useButton({
     disabled,
     focusableWhenDisabled: true,
-    type: 'button',
   });
 
   const handleRef = useForkRef(externalRef, buttonRef);

--- a/packages/react/src/tabs/tab/useTabsTab.ts
+++ b/packages/react/src/tabs/tab/useTabsTab.ts
@@ -73,7 +73,6 @@ function useTabsTab(parameters: useTabsTab.Parameters): useTabsTab.ReturnValue {
   const { getButtonProps, buttonRef } = useButton({
     disabled,
     focusableWhenDisabled: true,
-    type: 'button',
   });
 
   const handleRef = useForkRef(compositeItemRef, buttonRef, externalRef);

--- a/packages/react/src/toggle/useToggle.ts
+++ b/packages/react/src/toggle/useToggle.ts
@@ -33,7 +33,6 @@ export function useToggle(parameters: useToggle.Parameters): useToggle.ReturnVal
   const { getButtonProps, buttonRef } = useButton({
     disabled,
     buttonRef: externalRef,
-    type: 'button',
   });
 
   const getRootProps = React.useCallback(

--- a/packages/react/src/toolbar/button/ToolbarButton.tsx
+++ b/packages/react/src/toolbar/button/ToolbarButton.tsx
@@ -39,7 +39,6 @@ const ToolbarButton = React.forwardRef(function ToolbarButton(
     buttonRef: forwardedRef,
     disabled,
     focusableWhenDisabled,
-    type: 'button',
   });
 
   const state: ToolbarButton.State = React.useMemo(

--- a/packages/react/src/use-button/useButton.test.tsx
+++ b/packages/react/src/use-button/useButton.test.tsx
@@ -200,4 +200,30 @@ describe('useButton', () => {
       expect(container.firstChild).to.have.text('Submit');
     });
   });
+
+  describe('param: type', () => {
+    it('defaults to button', async () => {
+      function TestButton(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+        const { disabled, type, ...otherProps } = props;
+        const { getButtonProps } = useButton({ disabled, type });
+
+        return <button {...getButtonProps(otherProps)} />;
+      }
+
+      const { getByRole } = await render(<TestButton>Submit</TestButton>);
+      expect(getByRole('button')).to.have.property('type', 'button');
+    });
+
+    it('should set the type attribute', async () => {
+      function TestButton(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+        const { disabled, type, ...otherProps } = props;
+        const { getButtonProps } = useButton({ disabled, type });
+
+        return <button {...getButtonProps(otherProps)} />;
+      }
+
+      const { getByRole } = await render(<TestButton type="submit">Submit</TestButton>);
+      expect(getByRole('button')).to.have.property('type', 'submit');
+    });
+  });
 });

--- a/packages/react/src/use-button/useButton.ts
+++ b/packages/react/src/use-button/useButton.ts
@@ -14,7 +14,7 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
     disabled = false,
     focusableWhenDisabled,
     tabIndex,
-    type,
+    type = 'button',
     elementName: elementNameProp,
   } = parameters;
   const buttonRef = React.useRef<HTMLButtonElement | HTMLAnchorElement | HTMLElement | null>(null);


### PR DESCRIPTION
I found an issue with the [Close confirmation](https://base-ui.com/react/components/dialog#close-confirmation) example which has a `<form>` wrapper, where the close button now uses the default `submit` type. 

There seemed to be a regression (likely due to the prop merging changes) that causes the `type` of the default button renderer function to be overridden with `undefined` type from `useButton`, so now it's a submit button incorrectly.

The hook specifies `'button'` as the default type in jsdoc but not in the runtime code. As far as I can tell, we have no submit button component anywhere for this not to be the default