### PR TITLE
[select] Avoid double commit on value change

### DIFF
--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -839,6 +839,14 @@ describe('<Field.Root />', () => {
   });
 
   describe('style hooks', () => {
+    const { render: renderFakeTimers, clock } = createRenderer({
+      clockOptions: {
+        shouldAdvanceTime: true,
+      },
+    });
+
+    clock.withFakeTimers();
+
     describe('touched', () => {
       it('should apply [data-touched] style hook to all components when touched', async () => {
         await render(
@@ -1141,7 +1149,7 @@ describe('<Field.Root />', () => {
       });
 
       it('supports Select', async () => {
-        const { user } = await render(
+        const { user } = await renderFakeTimers(
           <Field.Root>
             <Select.Root>
               <Select.Trigger data-testid="trigger" />
@@ -1162,16 +1170,14 @@ describe('<Field.Root />', () => {
         expect(trigger).not.to.have.attribute('data-dirty');
 
         await userEvent.click(trigger);
-
         await flushMicrotasks();
+        clock.tick(200);
 
         const option = screen.getByRole('option', { name: 'Option 1' });
 
         // Arrow Down to focus the Option 1
         await user.keyboard('{ArrowDown}');
-
         await userEvent.click(option);
-
         await flushMicrotasks();
 
         expect(trigger).to.have.attribute('data-dirty', '');
@@ -1386,7 +1392,7 @@ describe('<Field.Root />', () => {
 
       describe('Select', () => {
         it('adds [data-filled] attribute when filled', async () => {
-          const { user } = await render(
+          const { user } = await renderFakeTimers(
             <Field.Root>
               <Select.Root>
                 <Select.Trigger data-testid="trigger" />
@@ -1407,16 +1413,14 @@ describe('<Field.Root />', () => {
           expect(trigger).not.to.have.attribute('data-filled');
 
           await userEvent.click(trigger);
-
           await flushMicrotasks();
+          clock.tick(200);
 
           const option = screen.getByRole('option', { name: 'Option 1' });
 
           // Arrow Down to focus the Option 1
           await user.keyboard('{ArrowDown}');
-
           await userEvent.click(option);
-
           await flushMicrotasks();
 
           expect(trigger).to.have.attribute('data-filled', '');

--- a/packages/react/src/select/item/SelectItem.test.tsx
+++ b/packages/react/src/select/item/SelectItem.test.tsx
@@ -7,6 +7,14 @@ import { expect } from 'chai';
 describe('<Select.Item />', () => {
   const { render } = createRenderer();
 
+  const { render: renderFakeTimers, clock } = createRenderer({
+    clockOptions: {
+      shouldAdvanceTime: true,
+    },
+  });
+
+  clock.withFakeTimers();
+
   describeConformance(<Select.Item value="" />, () => ({
     refInstanceof: window.HTMLDivElement,
     render(node) {
@@ -172,7 +180,7 @@ describe('<Select.Item />', () => {
   });
 
   it('should focus the selected item upon opening the popup', async () => {
-    const { user } = await render(
+    const { user } = await renderFakeTimers(
       <Select.Root>
         <Select.Trigger data-testid="trigger">
           <Select.Value data-testid="value" />
@@ -192,13 +200,10 @@ describe('<Select.Item />', () => {
     const trigger = screen.getByTestId('trigger');
 
     await user.click(trigger);
-
-    await flushMicrotasks();
+    clock.tick(200);
 
     await user.click(screen.getByRole('option', { name: 'three' }));
     await user.click(trigger);
-
-    await flushMicrotasks();
 
     await waitFor(() => {
       expect(screen.getByRole('option', { name: 'three' })).toHaveFocus();

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -77,7 +77,7 @@ const InnerSelectItem = React.forwardRef(function InnerSelectItem(
     selected,
     ref: forwardedRef,
     typingRef,
-    handleSelect: () => setValue(value),
+    handleSelect: (event) => setValue(value, event),
     selectionRef,
     selectedIndexRef,
     indexRef,

--- a/packages/react/src/select/item/useSelectItem.ts
+++ b/packages/react/src/select/item/useSelectItem.ts
@@ -34,14 +34,14 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
     buttonRef: mergedRef,
   });
 
-  const commitSelection = useEventCallback((event: Event) => {
-    handleSelect();
+  const commitSelection = useEventCallback((event: MouseEvent) => {
+    handleSelect(event);
     setOpen(false, event);
   });
 
   const lastKeyRef = React.useRef<string | null>(null);
   const pointerTypeRef = React.useRef<'mouse' | 'touch' | 'pen'>('mouse');
-
+  const didMouseDownRef = React.useRef(false);
   const prevPopupHeightRef = React.useRef(0);
   const allowFocusSyncRef = React.useRef(true);
 
@@ -109,11 +109,12 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
             lastKeyRef.current = event.key;
           },
           onClick(event) {
-            if (
-              disabled ||
-              (lastKeyRef.current === ' ' && typingRef.current) ||
-              (pointerTypeRef.current !== 'touch' && !highlighted)
-            ) {
+            if (didMouseDownRef.current) {
+              didMouseDownRef.current = false;
+              return;
+            }
+
+            if (disabled || (lastKeyRef.current === ' ' && typingRef.current)) {
               return;
             }
 
@@ -127,11 +128,13 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
           },
           onPointerDown(event) {
             pointerTypeRef.current = event.pointerType;
+            didMouseDownRef.current = true;
           },
           onMouseUp(event) {
             if (disabled) {
               return;
             }
+
             const disallowSelectedMouseUp = !selectionRef.current.allowSelectedMouseUp && selected;
             const disallowUnselectedMouseUp =
               !selectionRef.current.allowUnselectedMouseUp && !selected;
@@ -213,7 +216,7 @@ export namespace useSelectItem {
     /**
      * The function to handle the selection of the item.
      */
-    handleSelect: () => void;
+    handleSelect: (event: MouseEvent) => void;
     /**
      * The ref to the selection state of the item.
      */

--- a/packages/react/src/select/item/useSelectItem.ts
+++ b/packages/react/src/select/item/useSelectItem.ts
@@ -41,7 +41,7 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
 
   const lastKeyRef = React.useRef<string | null>(null);
   const pointerTypeRef = React.useRef<'mouse' | 'touch' | 'pen'>('mouse');
-  const didMouseDownRef = React.useRef(false);
+  const didPointerDownRef = React.useRef(false);
   const prevPopupHeightRef = React.useRef(0);
   const allowFocusSyncRef = React.useRef(true);
 
@@ -109,8 +109,8 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
             lastKeyRef.current = event.key;
           },
           onClick(event) {
-            if (didMouseDownRef.current) {
-              didMouseDownRef.current = false;
+            if (didPointerDownRef.current) {
+              didPointerDownRef.current = false;
               return;
             }
 
@@ -128,7 +128,7 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
           },
           onPointerDown(event) {
             pointerTypeRef.current = event.pointerType;
-            didMouseDownRef.current = true;
+            didPointerDownRef.current = true;
           },
           onMouseUp(event) {
             if (disabled) {


### PR DESCRIPTION
Closes #1589

Solution here is to only run `onClick` if there wasn't a `pointerdown` on the item when the click occurred (since `onMouseUp` also runs). `onClick` doesn't run if a pointerdown didn't occur first.

Also ensures the `event` is passed for `onValueChange`