### PR TITLE
[core] Disable NextJS dev mode build indicator

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -88,9 +88,7 @@ const nextConfig = {
     esmExternals: true,
     workerThreads: false,
   },
-  devIndicators: {
-    appIsrStatus: false,
-  },
+  devIndicators: false,
 };
 
 // Remove deprecated options that come from `withDocsInfra()` and cause warnings


### PR DESCRIPTION
![Screenshot 2025-03-28 at 2 55 13 PM](https://github.com/user-attachments/assets/452a1d14-4814-4559-9e55-8abd12192fa9)

I noticed the current config option has been deprecated

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
