### PR TITLE
[Slider] Prevent range slider thumbs from being dragged past each other

### DIFF
--- a/packages/react/src/slider/root/useSliderRoot.ts
+++ b/packages/react/src/slider/root/useSliderRoot.ts
@@ -350,18 +350,20 @@ export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRo
       }
 
       const closestThumbIndex = closestThumbIndexRef.current ?? 0;
+      const minValueDifference = minStepsBetweenValues * step;
+      const minPercentageDifference = (minValueDifference * 100) / (max - min);
 
       // Bound the new value to the thumb's neighbours.
       newValue = clamp(
         newValue,
-        values[closestThumbIndex - 1] + minStepsBetweenValues || -Infinity,
-        values[closestThumbIndex + 1] - minStepsBetweenValues || Infinity,
+        values[closestThumbIndex - 1] + minValueDifference || -Infinity,
+        values[closestThumbIndex + 1] - minValueDifference || Infinity,
       );
 
       const newPercentageValue = clamp(
         valueRescaled * 100,
-        percentageValues[closestThumbIndex - 1] ?? -Infinity,
-        percentageValues[closestThumbIndex + 1] ?? Infinity,
+        percentageValues[closestThumbIndex - 1] + minPercentageDifference || -Infinity,
+        percentageValues[closestThumbIndex + 1] - minPercentageDifference || Infinity,
       );
 
       return {

--- a/packages/react/src/slider/root/useSliderRoot.ts
+++ b/packages/react/src/slider/root/useSliderRoot.ts
@@ -358,13 +358,19 @@ export function useSliderRoot(parameters: useSliderRoot.Parameters): useSliderRo
         values[closestThumbIndex + 1] - minStepsBetweenValues || Infinity,
       );
 
+      const newPercentageValue = clamp(
+        valueRescaled * 100,
+        percentageValues[closestThumbIndex - 1] ?? -Infinity,
+        percentageValues[closestThumbIndex + 1] ?? Infinity,
+      );
+
       return {
         value: replaceArrayItemAtIndex(values, closestThumbIndex, newValue),
         valueRescaled,
         percentageValues: replaceArrayItemAtIndex(
           percentageValues,
           closestThumbIndex,
-          valueRescaled * 100,
+          newPercentageValue,
         ),
         thumbIndex: closestThumbIndex,
       };

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -204,6 +204,44 @@ describe('<Slider.Thumb />', () => {
         expect(computedStyles.thumb1.getPropertyValue('left')).to.equal('200px');
         expect(computedStyles.thumb2.getPropertyValue('left')).to.equal('700px');
       });
+
+      it('thumbs cannot be dragged past each other', async () => {
+        const { getByTestId } = await render(
+          <Slider.Root
+            defaultValue={[20, 40]}
+            style={{
+              width: '1000px',
+            }}
+          >
+            <Slider.Control data-testid="control">
+              <Slider.Track>
+                <Slider.Indicator />
+                <Slider.Thumb data-testid="thumb1" />
+                <Slider.Thumb />
+              </Slider.Track>
+            </Slider.Control>
+          </Slider.Root>,
+        );
+
+        const sliderControl = getByTestId('control');
+
+        const computedStyles = getComputedStyle(getByTestId('thumb1'));
+
+        stub(sliderControl, 'getBoundingClientRect').callsFake(
+          () => GETBOUNDINGCLIENTRECT_HORIZONTAL_SLIDER_RETURN_VAL,
+        );
+
+        fireEvent.touchStart(
+          sliderControl,
+          createTouches([{ identifier: 1, clientX: 200, clientY: 0 }]),
+        );
+        fireEvent.touchMove(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 600, clientY: 0 }]),
+        );
+
+        expect(computedStyles.getPropertyValue('left')).to.equal('400px');
+      });
     });
 
     describe('positions the thumb when the controlled value changes externally', () => {


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/issues/1602

Demo: https://codesandbox.io/p/sandbox/great-wu-p6trjf

The issue was that `percentageValues` which determines the positioning also need to be clamped with adjacent values in range sliders like the value itself

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
