### PR TITLE
[popover][Menu] Fix `inert` prop compatibility in React <19

### DIFF
--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -11,6 +11,7 @@ import { useMenuPositioner } from './useMenuPositioner';
 import { BaseUIComponentProps } from '../../utils/types';
 import { popupStateMapping } from '../../utils/popupStateMapping';
 import { CompositeList } from '../../composite/list/CompositeList';
+import { inertValue } from '../../utils/inertValue';
 import { InternalBackdrop } from '../../utils/InternalBackdrop';
 import { HTMLElementType, refType } from '../../utils/proptypes';
 import { useMenuPortalContext } from '../portal/MenuPortalContext';
@@ -134,7 +135,7 @@ const MenuPositioner = React.forwardRef(function MenuPositioner(
   return (
     <MenuPositionerContext.Provider value={contextValue}>
       {mounted && modal && openReason !== 'hover' && parentNodeId === null && (
-        <InternalBackdrop inert={!open} />
+        <InternalBackdrop inert={inertValue(!open)} />
       )}
       <FloatingNode id={nodeId}>
         <CompositeList elementsRef={itemDomElements} labelsRef={itemLabels}>

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -11,6 +11,7 @@ import type { Side, Align } from '../../utils/useAnchorPositioning';
 import { popupStateMapping } from '../../utils/popupStateMapping';
 import { HTMLElementType, refType } from '../../utils/proptypes';
 import { usePopoverPortalContext } from '../portal/PopoverPortalContext';
+import { inertValue } from '../../utils/inertValue';
 import { InternalBackdrop } from '../../utils/InternalBackdrop';
 
 /**
@@ -94,7 +95,7 @@ const PopoverPositioner = React.forwardRef(function PopoverPositioner(
   return (
     <PopoverPositionerContext.Provider value={positioner}>
       {mounted && modal && openReason !== 'hover' && openMethod !== 'touch' && (
-        <InternalBackdrop inert={!open} />
+        <InternalBackdrop inert={inertValue(!open)} />
       )}
       {renderElement()}
     </PopoverPositionerContext.Provider>

--- a/packages/react/src/utils/inertValue.ts
+++ b/packages/react/src/utils/inertValue.ts
@@ -1,9 +1,7 @@
-import * as React from 'react';
+import { isReactVersionAtLeast } from './reactVersion';
 
 export function inertValue(value?: boolean): string | boolean | undefined {
-  const pieces = React.version.split('.');
-  const major = parseInt(pieces[0], 10);
-  if (major >= 19) {
+  if (isReactVersionAtLeast(19)) {
     return value;
   }
   // compatibility with React < 19

--- a/packages/react/src/utils/inertValue.ts
+++ b/packages/react/src/utils/inertValue.ts
@@ -1,9 +1,9 @@
 import { isReactVersionAtLeast } from './reactVersion';
 
-export function inertValue(value?: boolean): string | boolean | undefined {
+export function inertValue(value?: boolean): boolean | undefined {
   if (isReactVersionAtLeast(19)) {
     return value;
   }
   // compatibility with React < 19
-  return value ? 'true' : undefined;
+  return (value ? 'true' : undefined) as boolean | undefined;
 }

--- a/packages/react/src/utils/inertValue.ts
+++ b/packages/react/src/utils/inertValue.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export function inertValue(value?: boolean): string | boolean | undefined {
+  const pieces = React.version.split('.');
+  const major = parseInt(pieces[0], 10);
+  if (major >= 19) {
+    return value;
+  }
+  // compatibility with React < 19
+  return value ? 'true' : undefined;
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/mui/base-ui/pull/1548.

[Older versions of React will give warnings](https://github.com/facebook/react/issues/17157#issuecomment-2003750544) like:

```
Received `false` for a non-boolean attribute `inert`.

If you want to write it to the DOM, pass a string instead: inert="false" or inert={value.toString()}.

If you used to conditionally omit it with inert={condition && value}, pass inert={condition ? value : undefined} instead.
```

I found [a fix within `react-spectrum`](https://github.com/adobe/react-spectrum/pull/7519) which I've ported into this repository.