### PR TITLE
[popups] Use consistent `inert` attr and map `[data-popup-open]` back to `open`

### DIFF
--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -17,6 +17,7 @@ import { AlertDialogPopupDataAttributes } from './AlertDialogPopupDataAttributes
 import { InternalBackdrop } from '../../utils/InternalBackdrop';
 import { useAlertDialogPortalContext } from '../portal/AlertDialogPortalContext';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
+import { inertValue } from '../../utils/inertValue';
 
 const customStyleHookMapping: CustomStyleHookMapping<AlertDialogPopup.State> = {
   ...baseMapping,
@@ -112,7 +113,7 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
 
   return (
     <React.Fragment>
-      {mounted && modal && <InternalBackdrop ref={internalBackdropRef} />}
+      {mounted && modal && <InternalBackdrop ref={internalBackdropRef} inert={inertValue(!open)} />}
       <FloatingFocusManager
         context={floatingRootContext}
         disabled={!mounted}

--- a/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
+++ b/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
@@ -20,14 +20,14 @@ const AlertDialogTrigger = React.forwardRef(function AlertDialogTrigger(
 ) {
   const { render, className, disabled = false, ...other } = props;
 
-  const { mounted, setTriggerElement, getTriggerProps } = useAlertDialogRootContext();
+  const { open, setTriggerElement, getTriggerProps } = useAlertDialogRootContext();
 
   const state: AlertDialogTrigger.State = React.useMemo(
     () => ({
       disabled,
-      open: mounted,
+      open,
     }),
-    [disabled, mounted],
+    [disabled, open],
   );
 
   const mergedRef = useForkRef(forwardedRef, setTriggerElement);

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -18,6 +18,7 @@ import { DialogPopupDataAttributes } from './DialogPopupDataAttributes';
 import { InternalBackdrop } from '../../utils/InternalBackdrop';
 import { useDialogPortalContext } from '../portal/DialogPortalContext';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
+import { inertValue } from '../../utils/inertValue';
 
 const customStyleHookMapping: CustomStyleHookMapping<DialogPopup.State> = {
   ...baseMapping,
@@ -108,7 +109,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
 
   return (
     <React.Fragment>
-      {mounted && modal && <InternalBackdrop ref={internalBackdropRef} />}
+      {mounted && modal && <InternalBackdrop ref={internalBackdropRef} inert={inertValue(!open)} />}
       <FloatingFocusManager
         context={floatingRootContext}
         disabled={!mounted}

--- a/packages/react/src/dialog/trigger/DialogTrigger.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.tsx
@@ -20,14 +20,14 @@ const DialogTrigger = React.forwardRef(function DialogTrigger(
 ) {
   const { render, className, disabled = false, ...other } = props;
 
-  const { mounted, setTriggerElement, getTriggerProps } = useDialogRootContext();
+  const { open, setTriggerElement, getTriggerProps } = useDialogRootContext();
 
   const state: DialogTrigger.State = React.useMemo(
     () => ({
       disabled,
-      open: mounted,
+      open,
     }),
-    [disabled, mounted],
+    [disabled, open],
   );
 
   const mergedRef = useForkRef(forwardedRef, setTriggerElement);

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -25,7 +25,6 @@ const MenuTrigger = React.forwardRef(function MenuTrigger(
     disabled: menuDisabled,
     setTriggerElement,
     open,
-    mounted,
     setOpen,
     allowMouseUpTriggerRef,
     positionerRef,
@@ -44,9 +43,9 @@ const MenuTrigger = React.forwardRef(function MenuTrigger(
   const state: MenuTrigger.State = React.useMemo(
     () => ({
       disabled,
-      open: mounted,
+      open,
     }),
-    [disabled, mounted],
+    [disabled, open],
   );
 
   const propGetter = React.useCallback(

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -24,14 +24,14 @@ const PopoverTrigger = React.forwardRef(function PopoverTrigger(
 ) {
   const { render, className, disabled = false, ...otherProps } = props;
 
-  const { mounted, setTriggerElement, getRootTriggerProps, openReason } = usePopoverRootContext();
+  const { open, setTriggerElement, getRootTriggerProps, openReason } = usePopoverRootContext();
 
   const state: PopoverTrigger.State = React.useMemo(
     () => ({
       disabled,
-      open: mounted,
+      open,
     }),
-    [disabled, mounted],
+    [disabled, open],
   );
 
   const { getButtonProps, buttonRef } = useButton({

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -12,6 +12,7 @@ import type { Align, Side } from '../../utils/useAnchorPositioning';
 import { SelectPositionerContext } from './SelectPositionerContext';
 import { InternalBackdrop } from '../../utils/InternalBackdrop';
 import { HTMLElementType, refType } from '../../utils/proptypes';
+import { inertValue } from '../../utils/inertValue';
 
 /**
  * Positions the select menu popup against the trigger.
@@ -85,7 +86,7 @@ const SelectPositioner = React.forwardRef(function SelectPositioner(
   return (
     <CompositeList elementsRef={listRef} labelsRef={labelsRef}>
       <SelectPositionerContext.Provider value={positioner}>
-        {mounted && modal && <InternalBackdrop />}
+        {mounted && modal && <InternalBackdrop inert={inertValue(!open)} />}
         {renderElement()}
       </SelectPositionerContext.Provider>
     </CompositeList>

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -23,7 +23,7 @@ const SelectTrigger = React.forwardRef(function SelectTrigger(
 
   const { state: fieldState, disabled: fieldDisabled } = useFieldRootContext();
 
-  const { getRootTriggerProps, disabled: selectDisabled, mounted } = useSelectRootContext();
+  const { getRootTriggerProps, disabled: selectDisabled, open } = useSelectRootContext();
 
   const disabled = fieldDisabled || selectDisabled || disabledProp;
 
@@ -35,10 +35,10 @@ const SelectTrigger = React.forwardRef(function SelectTrigger(
   const state: SelectTrigger.State = React.useMemo(
     () => ({
       ...fieldState,
-      open: mounted,
+      open,
       disabled,
     }),
-    [fieldState, mounted, disabled],
+    [fieldState, open, disabled],
   );
 
   const styleHookMapping = React.useMemo(


### PR DESCRIPTION
The real `inert` attribute [prevents the selection issue on Firefox](https://github.com/mui/base-ui/pull/1573) while still allowing `[data-popup-open]` to map to `open` instead of `mounted` like before, which looks better for transitions