### PR TITLE
[docs-infra] Fix GA4 configuration

### DIFF
--- a/docs/src/blocks/GoogleAnalytics.tsx
+++ b/docs/src/blocks/GoogleAnalytics.tsx
@@ -26,7 +26,7 @@ const GoogleAnalytics = React.memo(function GoogleAnalytics(props: GoogleAnalyti
 
     function gtag(...args: unknown[]) {
       // @ts-expect-error
-      window.dataLayer.push(...args);
+      window.dataLayer.push([...args]);
     }
 
     window.gtag = gtag;


### PR DESCRIPTION
I'm preparing the monthly meeting, I wanted to review GA stats on Base UI, I was curious to asses how simularweb data is accurate vs. not (helpful to know how much to rely on it) and to check the difference of screen pixel density in base-ui.com vs. mui.com.

GA today simply doesn't work on base-ui.com. There are probably more to make it work, but this is a quick win, to go back to how mui.com is correctly configured. https://app.netlify.com/sites/base-ui/metrics/analytics is also an option but seems limited to 30 days, not good enough.

before https://deploy-preview-1666--base-ui.netlify.app/
<img width="364" alt="SCR-20250402-oklv" src="https://github.com/user-attachments/assets/64e74b22-2d76-4989-b265-5a4b8f8bf647" />

after https://deploy-preview-1667--base-ui.netlify.app/
<img width="370" alt="SCR-20250402-oknc" src="https://github.com/user-attachments/assets/bd58515d-4d81-49bc-8258-a99d17ce9577" />

---

**Off topic**. Code owners now seem to spam a bit.