### PR TITLE
[NumberField] Correct percentage parse handling

### DIFF
--- a/packages/react/src/number-field/utils/parse.test.ts
+++ b/packages/react/src/number-field/utils/parse.test.ts
@@ -44,5 +44,13 @@ describe('NumberField parse', () => {
     it('returns null for an invalid number', () => {
       expect(parseNumber('invalid')).to.equal(null);
     });
+
+    it('handles percentages with style: "percent"', () => {
+      expect(parseNumber('12%', 'en-US', { style: 'percent' })).to.equal(0.12);
+    });
+
+    it('handles percentages with style: "unit" and unit: "percent"', () => {
+      expect(parseNumber('12%', 'en-US', { style: 'unit', unit: 'percent' })).to.equal(12);
+    });
   });
 });

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -71,7 +71,11 @@ export function parseNumber(
 
   let num = parseFloat(unformattedNumber);
 
-  if (PERCENT_RE.test(formattedNumber)) {
+  const style = options?.style;
+  const isUnitPercent = style === 'unit' && options?.unit === 'percent';
+  const isPercent = PERCENT_RE.test(formattedNumber) || style === 'percent';
+
+  if (!isUnitPercent && isPercent) {
     num /= 100;
   }
 


### PR DESCRIPTION
Fixes #1675

When `style: "percent"`, it's expected that the number is divided by 100 (0.1 = 10%, etc.)
When `style: "unit"`, then the percent is not divided, so 40 = 40%.

https://codesandbox.io/p/sandbox/base-ui-cra-ts-forked-7xzgdc?file=%2Fsrc%2FApp.tsx