### PR TITLE
[core] Remove hardcoded data attribute strings

### DIFF
--- a/docs/reference/generated/accordion-panel.json
+++ b/docs/reference/generated/accordion-panel.json
@@ -25,6 +25,9 @@
     "data-open": {
       "description": "Present when the accordion panel is open."
     },
+    "data-orientation": {
+      "description": "Indicates the orientation of the accordion."
+    },
     "data-disabled": {
       "description": "Present when the accordion item is disabled."
     },

--- a/docs/reference/generated/accordion-root.json
+++ b/docs/reference/generated/accordion-root.json
@@ -54,6 +54,9 @@
     }
   },
   "dataAttributes": {
+    "data-orientation": {
+      "description": "Indicates the orientation of the accordion."
+    },
     "data-disabled": {
       "description": "Present when the accordion is disabled."
     }

--- a/docs/reference/generated/slider-thumb.json
+++ b/docs/reference/generated/slider-thumb.json
@@ -63,6 +63,9 @@
     },
     "data-focused": {
       "description": "Present when the slider is focused (when wrapped in Field.Root)."
+    },
+    "data-index": {
+      "description": "Indicates the index of the thumb in range sliders."
     }
   },
   "cssVariables": {}

--- a/docs/reference/generated/tabs-panel.json
+++ b/docs/reference/generated/tabs-panel.json
@@ -31,6 +31,9 @@
     },
     "data-hidden": {
       "description": "Present when the panel is hidden."
+    },
+    "data-index": {
+      "description": "Indicates the index of the tab panel."
     }
   },
   "cssVariables": {}

--- a/packages/react/src/accordion/item/styleHooks.ts
+++ b/packages/react/src/accordion/item/styleHooks.ts
@@ -2,11 +2,12 @@ import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import { collapsibleOpenStateMapping as baseMapping } from '../../utils/collapsibleOpenStateMapping';
 import type { AccordionItem } from './AccordionItem';
 import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { AccordionItemDataAttributes } from './AccordionItemDataAttributes';
 
 export const accordionStyleHookMapping: CustomStyleHookMapping<AccordionItem.State> = {
   ...baseMapping,
   index: (value) => {
-    return Number.isInteger(value) ? { 'data-index': String(value) } : null;
+    return Number.isInteger(value) ? { [AccordionItemDataAttributes.index]: String(value) } : null;
   },
   ...transitionStatusMapping,
   value: () => null,

--- a/packages/react/src/accordion/panel/AccordionPanelDataAttributes.ts
+++ b/packages/react/src/accordion/panel/AccordionPanelDataAttributes.ts
@@ -1,3 +1,5 @@
+import { TransitionStatusDataAttributes } from '../../utils/styleHookMapping';
+
 export enum AccordionPanelDataAttributes {
   /**
    * Indicates the index of the accordion item.
@@ -19,9 +21,9 @@ export enum AccordionPanelDataAttributes {
   /**
    * Present when the panel is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**
    * Present when the panel is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = TransitionStatusDataAttributes.endingStyle,
 }

--- a/packages/react/src/accordion/panel/AccordionPanelDataAttributes.ts
+++ b/packages/react/src/accordion/panel/AccordionPanelDataAttributes.ts
@@ -9,6 +9,10 @@ export enum AccordionPanelDataAttributes {
    */
   open = 'data-open',
   /**
+   * Indicates the orientation of the accordion.
+   */
+  orientation = 'data-orientation',
+  /**
    * Present when the accordion item is disabled.
    */
   disabled = 'data-disabled',

--- a/packages/react/src/accordion/root/AccordionRootDataAttributes.ts
+++ b/packages/react/src/accordion/root/AccordionRootDataAttributes.ts
@@ -3,4 +3,8 @@ export enum AccordionRootDataAttributes {
    * Present when the accordion is disabled.
    */
   disabled = 'data-disabled',
+  /**
+   * Indicates the orientation of the accordion.
+   */
+  orientation = 'data-orientation',
 }

--- a/packages/react/src/alert-dialog/backdrop/AlertDialogBackdropDataAttributes.ts
+++ b/packages/react/src/alert-dialog/backdrop/AlertDialogBackdropDataAttributes.ts
@@ -1,18 +1,20 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum AlertDialogBackdropDataAttributes {
   /**
    * Present when the dialog is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the dialog is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the dialog is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the dialog is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
 }

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopupDataAttributes.ts
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopupDataAttributes.ts
@@ -1,20 +1,22 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum AlertDialogPopupDataAttributes {
   /**
    * Present when the dialog is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the dialog is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the dialog is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the dialog is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
   /**
    * Present when the dialog is nested within another dialog.
    */

--- a/packages/react/src/alert-dialog/trigger/AlertDialogTriggerDataAttributes.ts
+++ b/packages/react/src/alert-dialog/trigger/AlertDialogTriggerDataAttributes.ts
@@ -1,3 +1,5 @@
+import { CommonTriggerDataAttributes } from '../../utils/popupStateMapping';
+
 export enum AlertDialogTriggerDataAttributes {
   /**
    * Present when the trigger is disabled.
@@ -6,5 +8,5 @@ export enum AlertDialogTriggerDataAttributes {
   /**
    * Present when the corresponding dialog is open.
    */
-  popupOpen = 'data-popup-open',
+  popupOpen = CommonTriggerDataAttributes.popupOpen,
 }

--- a/packages/react/src/checkbox/indicator/CheckboxIndicatorDataAttributes.ts
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicatorDataAttributes.ts
@@ -1,3 +1,5 @@
+import { TransitionStatusDataAttributes } from '../../utils/styleHookMapping';
+
 export enum CheckboxIndicatorDataAttributes {
   /**
    * Present when the checkbox is checked.
@@ -22,11 +24,11 @@ export enum CheckboxIndicatorDataAttributes {
   /**
    * Present when the checkbox indicator is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**
    * Present when the checkbox indicator is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = TransitionStatusDataAttributes.endingStyle,
   /**
    * Present when the checkbox is in valid state (when wrapped in Field.Root).
    */

--- a/packages/react/src/collapsible/panel/CollapsiblePanelDataAttributes.ts
+++ b/packages/react/src/collapsible/panel/CollapsiblePanelDataAttributes.ts
@@ -1,3 +1,5 @@
+import { TransitionStatusDataAttributes } from '../../utils/styleHookMapping';
+
 export enum CollapsiblePanelDataAttributes {
   /**
    * Present when the collapsible panel is open.
@@ -10,9 +12,9 @@ export enum CollapsiblePanelDataAttributes {
   /**
    * Present when the panel is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**
    * Present when the panel is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = TransitionStatusDataAttributes.endingStyle,
 }

--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -8,6 +8,8 @@ import { useForkRef } from '../../utils/useForkRef';
 import { useOnMount } from '../../utils/useOnMount';
 import { warn } from '../../utils/warn';
 import type { AnimationType, Dimensions } from '../root/useCollapsibleRoot';
+import { CollapsiblePanelDataAttributes } from './CollapsiblePanelDataAttributes';
+import { AccordionRootDataAttributes } from '../../accordion/root/AccordionRootDataAttributes';
 
 export function useCollapsiblePanel(
   parameters: useCollapsiblePanel.Parameters,
@@ -98,7 +100,7 @@ export function useCollapsiblePanel(
        * Setting both to `0px` will break layout.
        */
       if (
-        element.getAttribute('data-orientation') === 'horizontal' ||
+        element.getAttribute(AccordionRootDataAttributes.orientation) === 'horizontal' ||
         panelStyles.transitionProperty.indexOf('width') > -1
       ) {
         transitionDimensionRef.current = 'width';
@@ -189,7 +191,7 @@ export function useCollapsiblePanel(
        * be mis-timed and appear to be complete skipped.
        */
       if (!shouldCancelInitialOpenTransitionRef.current && !keepMounted) {
-        panel.setAttribute('data-starting-style', '');
+        panel.setAttribute(CollapsiblePanelDataAttributes.startingStyle, '');
       }
 
       setDimensions({ height: panel.scrollHeight, width: panel.scrollWidth });
@@ -332,7 +334,7 @@ export function useCollapsiblePanel(
        * https://github.com/tailwindlabs/tailwindcss/pull/14625
        */
       if (animationTypeRef.current === 'css-transition') {
-        panel.setAttribute('data-starting-style', '');
+        panel.setAttribute(CollapsiblePanelDataAttributes.startingStyle, '');
       }
     }
   }, [hiddenUntilFound, hidden, animationTypeRef, panelRef]);

--- a/packages/react/src/dialog/backdrop/DialogBackdropDataAttributes.ts
+++ b/packages/react/src/dialog/backdrop/DialogBackdropDataAttributes.ts
@@ -1,18 +1,20 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum DialogBackdropDataAttributes {
   /**
    * Present when the dialog is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the dialog is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the dialog is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the dialog is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
 }

--- a/packages/react/src/dialog/popup/DialogPopupDataAttributes.ts
+++ b/packages/react/src/dialog/popup/DialogPopupDataAttributes.ts
@@ -1,20 +1,22 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum DialogPopupDataAttributes {
   /**
    * Present when the dialog is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the dialog is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the dialog is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the dialog is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
   /**
    * Present when the dialog is nested within another dialog.
    */

--- a/packages/react/src/dialog/trigger/DialogTriggerDataAttributes.ts
+++ b/packages/react/src/dialog/trigger/DialogTriggerDataAttributes.ts
@@ -1,3 +1,5 @@
+import { CommonTriggerDataAttributes } from '../../utils/popupStateMapping';
+
 export enum DialogTriggerDataAttributes {
   /**
    * Present when the trigger is disabled.
@@ -6,5 +8,5 @@ export enum DialogTriggerDataAttributes {
   /**
    * Present when the corresponding dialog is open.
    */
-  popupOpen = 'data-popup-open',
+  popupOpen = CommonTriggerDataAttributes.popupOpen,
 }

--- a/packages/react/src/menu/arrow/MenuArrowDataAttributes.ts
+++ b/packages/react/src/menu/arrow/MenuArrowDataAttributes.ts
@@ -1,16 +1,18 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum MenuArrowDataAttributes {
   /**
    * Present when the menu popup is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the menu popup is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the anchor is hidden.
    */
-  anchorHidden = 'data-anchor-hidden',
+  anchorHidden = CommonPopupDataAttributes.anchorHidden,
   /**
    * Indicates which side the menu is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/menu/backdrop/MenuBackdropDataAttributes.ts
+++ b/packages/react/src/menu/backdrop/MenuBackdropDataAttributes.ts
@@ -1,18 +1,20 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum MenuBackdropDataAttributes {
   /**
    * Present when the menu is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the menu is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the menu is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the menu is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
 }

--- a/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicatorDataAttributes.ts
+++ b/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicatorDataAttributes.ts
@@ -1,3 +1,5 @@
+import { TransitionStatusDataAttributes } from '../../utils/styleHookMapping';
+
 export enum MenuCheckboxItemIndicatorDataAttributes {
   /**
    * Present when the menu checkbox item is checked.
@@ -14,9 +16,9 @@ export enum MenuCheckboxItemIndicatorDataAttributes {
   /**
    * Present when the indicator is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**
    * Present when the indicator is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = TransitionStatusDataAttributes.endingStyle,
 }

--- a/packages/react/src/menu/popup/MenuPopupDataAttributes.ts
+++ b/packages/react/src/menu/popup/MenuPopupDataAttributes.ts
@@ -1,20 +1,22 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum MenuPopupDataAttributes {
   /**
    * Present when the menu is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the menu is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the menu is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the menu is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
   /**
    * Indicates which side the menu is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/menu/positioner/MenuPositionerDataAttributes.ts
+++ b/packages/react/src/menu/positioner/MenuPositionerDataAttributes.ts
@@ -1,16 +1,18 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum MenuPositionerDataAttributes {
   /**
    * Present when the menu popup is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the menu popup is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the anchor is hidden.
    */
-  anchorHidden = 'data-anchor-hidden',
+  anchorHidden = CommonPopupDataAttributes.anchorHidden,
   /**
    * Indicates which side the menu is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicatorDataAttributes.ts
+++ b/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicatorDataAttributes.ts
@@ -1,3 +1,5 @@
+import { TransitionStatusDataAttributes } from '../../utils/styleHookMapping';
+
 export enum MenuRadioItemIndicatorDataAttributes {
   /**
    * Present when the menu radio item is selected.
@@ -14,9 +16,9 @@ export enum MenuRadioItemIndicatorDataAttributes {
   /**
    * Present when the radio indicator is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**
    * Present when the radio indicator is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = TransitionStatusDataAttributes.endingStyle,
 }

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTriggerDataAttributes.ts
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTriggerDataAttributes.ts
@@ -1,6 +1,8 @@
+import { CommonTriggerDataAttributes } from '../../utils/popupStateMapping';
+
 export enum MenuSubmenuTriggerDataAttributes {
   /**
    * Present when the corresponding submenu is open.
    */
-  popupOpen = 'data-popup-open',
+  popupOpen = CommonTriggerDataAttributes.popupOpen,
 }

--- a/packages/react/src/menu/trigger/MenuTriggerDataAttributes.ts
+++ b/packages/react/src/menu/trigger/MenuTriggerDataAttributes.ts
@@ -1,10 +1,12 @@
+import { CommonTriggerDataAttributes } from '../../utils/popupStateMapping';
+
 export enum MenuTriggerDataAttributes {
   /**
    * Present when the corresponding menu is open.
    */
-  popupOpen = 'data-popup-open',
+  popupOpen = CommonTriggerDataAttributes.popupOpen,
   /**
    * Present when the trigger is pressed.
    */
-  pressed = 'data-pressed',
+  pressed = CommonTriggerDataAttributes.pressed,
 }

--- a/packages/react/src/menu/utils/styleHookMapping.ts
+++ b/packages/react/src/menu/utils/styleHookMapping.ts
@@ -1,15 +1,16 @@
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { MenuCheckboxItemDataAttributes } from '../checkbox-item/MenuCheckboxItemDataAttributes';
 
 export const itemMapping: CustomStyleHookMapping<{ checked: boolean }> = {
   checked(value): Record<string, string> {
     if (value) {
       return {
-        'data-checked': '',
+        [MenuCheckboxItemDataAttributes.checked]: '',
       };
     }
     return {
-      'data-unchecked': '',
+      [MenuCheckboxItemDataAttributes.unchecked]: '',
     };
   },
   ...transitionStatusMapping,

--- a/packages/react/src/popover/arrow/PopoverArrowDataAttributes.ts
+++ b/packages/react/src/popover/arrow/PopoverArrowDataAttributes.ts
@@ -1,16 +1,18 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum PopoverArrowDataAttributes {
   /**
    * Present when the popup is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the popup is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the anchor is hidden.
    */
-  anchorHidden = 'data-anchor-hidden',
+  anchorHidden = CommonPopupDataAttributes.anchorHidden,
   /**
    * Indicates which side the popup is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/popover/backdrop/PopoverBackdropDataAttributes.ts
+++ b/packages/react/src/popover/backdrop/PopoverBackdropDataAttributes.ts
@@ -1,18 +1,20 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum PopoverBackdropDataAttributes {
   /**
    * Present when the popup is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the popup is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the popup is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the popup is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
 }

--- a/packages/react/src/popover/popup/PopoverPopupDataAttributes.ts
+++ b/packages/react/src/popover/popup/PopoverPopupDataAttributes.ts
@@ -1,20 +1,22 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum PopoverPopupDataAttributes {
   /**
    * Present when the popup is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the popup is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the popup is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the popup is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
   /**
    * Indicates which side the popup is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/popover/positioner/PopoverPositionerDataAttributes.ts
+++ b/packages/react/src/popover/positioner/PopoverPositionerDataAttributes.ts
@@ -1,16 +1,18 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum PopoverPositionerDataAttributes {
   /**
    * Present when the popup is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the popup is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the anchor is hidden.
    */
-  anchorHidden = 'data-anchor-hidden',
+  anchorHidden = CommonPopupDataAttributes.anchorHidden,
   /**
    * Indicates which side the popup is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/popover/trigger/PopoverTriggerDataAttributes.ts
+++ b/packages/react/src/popover/trigger/PopoverTriggerDataAttributes.ts
@@ -1,10 +1,12 @@
+import { CommonTriggerDataAttributes } from '../../utils/popupStateMapping';
+
 export enum PopoverTriggerDataAttributes {
   /**
    * Present when the corresponding popover is open.
    */
-  popupOpen = 'data-popup-open',
+  popupOpen = CommonTriggerDataAttributes.popupOpen,
   /**
    * Present when the trigger is pressed.
    */
-  pressed = 'data-pressed',
+  pressed = CommonTriggerDataAttributes.pressed,
 }

--- a/packages/react/src/preview-card/arrow/PreviewCardArrowDataAttributes.ts
+++ b/packages/react/src/preview-card/arrow/PreviewCardArrowDataAttributes.ts
@@ -1,16 +1,18 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum PreviewCardArrowDataAttributes {
   /**
    * Present when the preview card is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the preview card is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the anchor is hidden.
    */
-  anchorHidden = 'data-anchor-hidden',
+  anchorHidden = CommonPopupDataAttributes.anchorHidden,
   /**
    * Indicates which side the preview card is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/preview-card/backdrop/PreviewCardBackdropDataAttributes.ts
+++ b/packages/react/src/preview-card/backdrop/PreviewCardBackdropDataAttributes.ts
@@ -1,18 +1,20 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum PreviewCardBackdropDataAttributes {
   /**
    * Present when the preview card is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the preview card is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the preview card is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the preview card is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
 }

--- a/packages/react/src/preview-card/popup/PreviewCardPopupDataAttributes.ts
+++ b/packages/react/src/preview-card/popup/PreviewCardPopupDataAttributes.ts
@@ -1,20 +1,22 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum PreviewCardPopupDataAttributes {
   /**
    * Present when the preview card is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the preview card is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the preview card is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the preview card is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
   /**
    * Indicates which side the preview card is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/preview-card/positioner/PreviewCardPositionerDataAttributes.ts
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositionerDataAttributes.ts
@@ -1,16 +1,18 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum PreviewCardPositionerDataAttributes {
   /**
    * Present when the preview card is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the preview card is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the anchor is hidden.
    */
-  anchorHidden = 'data-anchor-hidden',
+  anchorHidden = CommonPopupDataAttributes.anchorHidden,
   /**
    * Indicates which side the preview card is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/preview-card/trigger/PreviewCardTriggerDataAttributes.ts
+++ b/packages/react/src/preview-card/trigger/PreviewCardTriggerDataAttributes.ts
@@ -1,6 +1,8 @@
+import { CommonTriggerDataAttributes } from '../../utils/popupStateMapping';
+
 export enum PreviewCardTriggerDataAttributes {
   /**
    * Present when the corresponding preview card is open.
    */
-  popupOpen = 'data-popup-open',
+  popupOpen = CommonTriggerDataAttributes.popupOpen,
 }

--- a/packages/react/src/radio/utils/customStyleHookMapping.ts
+++ b/packages/react/src/radio/utils/customStyleHookMapping.ts
@@ -2,13 +2,14 @@ import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { transitionStatusMapping } from '../../utils/styleHookMapping';
 import { fieldValidityMapping } from '../../field/utils/constants';
+import { RadioRootDataAttributes } from '../root/RadioRootDataAttributes';
 
 export const customStyleHookMapping = {
   checked(value): Record<string, string> {
     if (value) {
-      return { 'data-checked': '' };
+      return { [RadioRootDataAttributes.checked]: '' };
     }
-    return { 'data-unchecked': '' };
+    return { [RadioRootDataAttributes.unchecked]: '' };
   },
   ...transitionStatusMapping,
   ...fieldValidityMapping,

--- a/packages/react/src/scroll-area/root/useScrollAreaRoot.ts
+++ b/packages/react/src/scroll-area/root/useScrollAreaRoot.ts
@@ -5,6 +5,7 @@ import { useBaseUiId } from '../../utils/useBaseUiId';
 import { SCROLL_TIMEOUT } from '../constants';
 import { getOffset } from '../utils/getOffset';
 import { ScrollAreaRootCssVars } from './ScrollAreaRootCssVars';
+import { ScrollAreaScrollbarDataAttributes } from '../scrollbar/ScrollAreaScrollbarDataAttributes';
 
 interface Size {
   width: number;
@@ -79,9 +80,9 @@ export function useScrollAreaRoot() {
     thumbDraggingRef.current = true;
     startYRef.current = event.clientY;
     startXRef.current = event.clientX;
-    currentOrientationRef.current = event.currentTarget.getAttribute('data-orientation') as
-      | 'vertical'
-      | 'horizontal';
+    currentOrientationRef.current = event.currentTarget.getAttribute(
+      ScrollAreaScrollbarDataAttributes.orientation,
+    ) as 'vertical' | 'horizontal';
 
     if (viewportRef.current) {
       startScrollTopRef.current = viewportRef.current.scrollTop;

--- a/packages/react/src/select/arrow/SelectArrowDataAttributes.ts
+++ b/packages/react/src/select/arrow/SelectArrowDataAttributes.ts
@@ -1,16 +1,18 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum SelectArrowDataAttributes {
   /**
    * Present when the select popup is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the select popup is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the anchor is hidden.
    */
-  anchorHidden = 'data-anchor-hidden',
+  anchorHidden = CommonPopupDataAttributes.anchorHidden,
   /**
    * Indicates which side the select is positioned relative to the trigger.
    * @type {'none' | 'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/select/backdrop/SelectBackdropDataAttributes.ts
+++ b/packages/react/src/select/backdrop/SelectBackdropDataAttributes.ts
@@ -1,18 +1,20 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum SelectBackdropDataAttributes {
   /**
    * Present when the select is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the select is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the select is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the select is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
 }

--- a/packages/react/src/select/popup/SelectPopupDataAttributes.ts
+++ b/packages/react/src/select/popup/SelectPopupDataAttributes.ts
@@ -1,20 +1,22 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum SelectPopupDataAttributes {
   /**
    * Present when the select is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the select is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the select is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the select is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
   /**
    * Indicates which side the select is positioned relative to the trigger.
    * @type {'none' | 'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/select/positioner/SelectPositionerDataAttributes.ts
+++ b/packages/react/src/select/positioner/SelectPositionerDataAttributes.ts
@@ -1,16 +1,18 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum SelectPositionerDataAttributes {
   /**
    * Present when the select popup is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the select popup is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the anchor is hidden.
    */
-  anchorHidden = 'data-anchor-hidden',
+  anchorHidden = CommonPopupDataAttributes.anchorHidden,
   /**
    * Indicates which side the select is positioned relative to the trigger.
    * @type {'none' | 'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/select/trigger/SelectTriggerDataAttributes.ts
+++ b/packages/react/src/select/trigger/SelectTriggerDataAttributes.ts
@@ -1,12 +1,14 @@
+import { CommonTriggerDataAttributes } from '../../utils/popupStateMapping';
+
 export enum SelectTriggerDataAttributes {
   /**
    * Present when the corresponding select is open.
    */
-  popupOpen = 'data-popup-open',
+  popupOpen = CommonTriggerDataAttributes.popupOpen,
   /**
    * Present when the trigger is pressed.
    */
-  pressed = 'data-pressed',
+  pressed = CommonTriggerDataAttributes.pressed,
   /**
    * Present when the select is disabled.
    */

--- a/packages/react/src/slider/root/useSliderRoot.ts
+++ b/packages/react/src/slider/root/useSliderRoot.ts
@@ -22,6 +22,7 @@ import { replaceArrayItemAtIndex } from '../utils/replaceArrayItemAtIndex';
 import { roundValueToStep } from '../utils/roundValueToStep';
 import { ThumbMetadata } from '../thumb/useSliderThumb';
 import { useEventCallback } from '../../utils/useEventCallback';
+import { SliderThumbDataAttributes } from '../thumb/SliderThumbDataAttributes';
 
 function areValuesEqual(
   newValue: number | readonly number[],
@@ -77,11 +78,11 @@ export function focusThumb(
 
   if (
     !sliderRef.current.contains(doc.activeElement) ||
-    Number(doc?.activeElement?.getAttribute('data-index')) !== thumbIndex
+    Number(doc?.activeElement?.getAttribute(SliderThumbDataAttributes.index)) !== thumbIndex
   ) {
     (
       sliderRef.current.querySelector(
-        `[type="range"][data-index="${thumbIndex}"]`,
+        `[type="range"][${SliderThumbDataAttributes.index}="${thumbIndex}"]`,
       ) as HTMLInputElement
     ).focus();
   }

--- a/packages/react/src/slider/thumb/SliderThumbDataAttributes.ts
+++ b/packages/react/src/slider/thumb/SliderThumbDataAttributes.ts
@@ -1,5 +1,9 @@
 export enum SliderThumbDataAttributes {
   /**
+   * Indicates the index of the thumb in range sliders.
+   */
+  index = 'data-index',
+  /**
    * Present while the user is dragging.
    */
   dragging = 'data-dragging',

--- a/packages/react/src/slider/thumb/useSliderThumb.ts
+++ b/packages/react/src/slider/thumb/useSliderThumb.ts
@@ -20,6 +20,7 @@ import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { getSliderValue } from '../utils/getSliderValue';
 import { roundValueToStep } from '../utils/roundValueToStep';
 import type { useSliderRoot } from '../root/useSliderRoot';
+import { SliderThumbDataAttributes } from './SliderThumbDataAttributes';
 
 export interface ThumbMetadata {
   inputId: string | undefined;
@@ -138,7 +139,7 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
     (externalProps = {}) => {
       return mergeProps(
         {
-          ['data-index' as string]: index,
+          [SliderThumbDataAttributes.index]: index,
           id: thumbId,
           onFocus() {
             setFocused(true);
@@ -284,7 +285,7 @@ export function useSliderThumb(parameters: useSliderThumb.Parameters): useSlider
                   index,
                 )
               : ariaValuetext || getDefaultAriaValueText(sliderValues, index, format ?? undefined),
-          ['data-index' as string]: index,
+          [SliderThumbDataAttributes.index as string]: index,
           disabled,
           id: inputId,
           max,

--- a/packages/react/src/switch/styleHooks.ts
+++ b/packages/react/src/switch/styleHooks.ts
@@ -1,18 +1,19 @@
 import type { SwitchRoot } from './root/SwitchRoot';
 import type { CustomStyleHookMapping } from '../utils/getStyleHookProps';
 import { fieldValidityMapping } from '../field/utils/constants';
+import { SwitchRootDataAttributes } from './root/SwitchRootDataAttributes';
 
 export const styleHookMapping: CustomStyleHookMapping<SwitchRoot.State> = {
   ...fieldValidityMapping,
   checked(value): Record<string, string> {
     if (value) {
       return {
-        'data-checked': '',
+        [SwitchRootDataAttributes.checked]: '',
       };
     }
 
     return {
-      'data-unchecked': '',
+      [SwitchRootDataAttributes.unchecked]: '',
     };
   },
 };

--- a/packages/react/src/tabs/panel/TabsPanelDataAttributes.ts
+++ b/packages/react/src/tabs/panel/TabsPanelDataAttributes.ts
@@ -1,5 +1,9 @@
 export enum TabsPanelDataAttributes {
   /**
+   * Indicates the index of the tab panel.
+   */
+  index = 'data-index',
+  /**
    * Indicates the direction of the activation (based on the previous selected tab).
    * @type {'left' | 'right' | 'up' | 'down' | 'none'}
    */

--- a/packages/react/src/tabs/panel/useTabsPanel.ts
+++ b/packages/react/src/tabs/panel/useTabsPanel.ts
@@ -7,6 +7,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import { useCompositeListItem } from '../../composite/list/useCompositeListItem';
 import type { TabsRootContext } from '../root/TabsRootContext';
 import type { TabValue } from '../root/TabsRoot';
+import { TabsPanelDataAttributes } from './TabsPanelDataAttributes';
 
 export interface TabPanelMetadata {
   id?: string;
@@ -56,7 +57,7 @@ function useTabsPanel(parameters: useTabsPanel.Parameters): useTabsPanel.ReturnV
           role: 'tabpanel',
           tabIndex: hidden ? -1 : 0,
           ref: handleRef,
-          ['data-index' as string]: index,
+          [TabsPanelDataAttributes.index]: index,
         },
         externalProps,
       );

--- a/packages/react/src/tabs/root/styleHooks.ts
+++ b/packages/react/src/tabs/root/styleHooks.ts
@@ -1,8 +1,9 @@
 import type { TabsRoot } from './TabsRoot';
 import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { TabsRootDataAttributes } from './TabsRootDataAttributes';
 
 export const tabsStyleHookMapping: CustomStyleHookMapping<TabsRoot.State> = {
   tabActivationDirection: (dir) => ({
-    'data-activation-direction': dir,
+    [TabsRootDataAttributes.activationDirection]: dir,
   }),
 };

--- a/packages/react/src/toggle-group/ToggleGroup.tsx
+++ b/packages/react/src/toggle-group/ToggleGroup.tsx
@@ -9,11 +9,12 @@ import { useDirection } from '../direction-provider/DirectionContext';
 import { useToolbarRootContext } from '../toolbar/root/ToolbarRootContext';
 import { useToggleGroup } from './useToggleGroup';
 import { ToggleGroupContext } from './ToggleGroupContext';
+import { ToggleGroupDataAttributes } from './ToggleGroupDataAttributes';
 
 const customStyleHookMapping = {
   multiple(value: boolean) {
     if (value) {
-      return { 'data-multiple': '' } as Record<string, string>;
+      return { [ToggleGroupDataAttributes.multiple]: '' } as Record<string, string>;
     }
     return null;
   },

--- a/packages/react/src/tooltip/arrow/TooltipArrowDataAttributes.ts
+++ b/packages/react/src/tooltip/arrow/TooltipArrowDataAttributes.ts
@@ -1,16 +1,18 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum TooltipArrowDataAttributes {
   /**
    * Present when the tooltip is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the tooltip is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the anchor is hidden.
    */
-  anchorHidden = 'data-anchor-hidden',
+  anchorHidden = CommonPopupDataAttributes.anchorHidden,
   /**
    * Indicates which side the tooltip is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}
@@ -19,5 +21,5 @@ export enum TooltipArrowDataAttributes {
   /**
    * Present when the tooltip arrow is uncentered.
    */
-  uncetered = 'data-uncentered',
+  uncentered = 'data-uncentered',
 }

--- a/packages/react/src/tooltip/popup/TooltipPopupDataAttributes.ts
+++ b/packages/react/src/tooltip/popup/TooltipPopupDataAttributes.ts
@@ -1,20 +1,22 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum TooltipPopupDataAttributes {
   /**
    * Present when the tooltip is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the tooltip is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the tooltip is animating in.
    */
-  startingStyle = 'data-starting-style',
+  startingStyle = CommonPopupDataAttributes.startingStyle,
   /**
    * Present when the tooltip is animating out.
    */
-  endingStyle = 'data-ending-style',
+  endingStyle = CommonPopupDataAttributes.endingStyle,
   /**
    * Indicates which side the tooltip is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/tooltip/positioner/TooltipPositionerDataAttributes.ts
+++ b/packages/react/src/tooltip/positioner/TooltipPositionerDataAttributes.ts
@@ -1,16 +1,18 @@
+import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
+
 export enum TooltipPositionerDataAttributes {
   /**
    * Present when the tooltip is open.
    */
-  open = 'data-open',
+  open = CommonPopupDataAttributes.open,
   /**
    * Present when the tooltip is closed.
    */
-  closed = 'data-closed',
+  closed = CommonPopupDataAttributes.closed,
   /**
    * Present when the anchor is hidden.
    */
-  anchorHidden = 'data-anchor-hidden',
+  anchorHidden = CommonPopupDataAttributes.anchorHidden,
   /**
    * Indicates which side the tooltip is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}

--- a/packages/react/src/tooltip/trigger/TooltipTriggerDataAttributes.ts
+++ b/packages/react/src/tooltip/trigger/TooltipTriggerDataAttributes.ts
@@ -1,6 +1,8 @@
+import { CommonTriggerDataAttributes } from '../../utils/popupStateMapping';
+
 export enum TooltipTriggerDataAttributes {
   /**
    * Present when the corresponding tooltip is open.
    */
-  popupOpen = 'data-popup-open',
+  popupOpen = CommonTriggerDataAttributes.popupOpen,
 }

--- a/packages/react/src/utils/collapsibleOpenStateMapping.ts
+++ b/packages/react/src/utils/collapsibleOpenStateMapping.ts
@@ -1,11 +1,13 @@
 import type { CustomStyleHookMapping } from './getStyleHookProps';
+import { CollapsiblePanelDataAttributes } from '../collapsible/panel/CollapsiblePanelDataAttributes';
+import { CollapsibleTriggerDataAttributes } from '../collapsible/trigger/CollapsibleTriggerDataAttributes';
 
 const PANEL_OPEN_HOOK = {
-  'data-open': '',
+  [CollapsiblePanelDataAttributes.open]: '',
 };
 
 const PANEL_CLOSED_HOOK = {
-  'data-closed': '',
+  [CollapsiblePanelDataAttributes.closed]: '',
 };
 
 export const triggerOpenStateMapping: CustomStyleHookMapping<{
@@ -14,7 +16,7 @@ export const triggerOpenStateMapping: CustomStyleHookMapping<{
   open(value) {
     if (value) {
       return {
-        'data-panel-open': '',
+        [CollapsibleTriggerDataAttributes.panelOpen]: '',
       };
     }
     return null;

--- a/packages/react/src/utils/popupStateMapping.ts
+++ b/packages/react/src/utils/popupStateMapping.ts
@@ -1,24 +1,59 @@
 import type { CustomStyleHookMapping } from './getStyleHookProps';
+import { TransitionStatusDataAttributes } from './styleHookMapping';
+
+export enum CommonPopupDataAttributes {
+  /**
+   * Present when the popup is open.
+   */
+  open = 'data-open',
+  /**
+   * Present when the popup is closed.
+   */
+  closed = 'data-closed',
+  /**
+   * Present when the popup is animating in.
+   */
+  startingStyle = TransitionStatusDataAttributes.startingStyle,
+  /**
+   * Present when the popup is animating out.
+   */
+  endingStyle = TransitionStatusDataAttributes.endingStyle,
+  /**
+   * Present when the anchor is hidden.
+   */
+  anchorHidden = 'data-anchor-hidden',
+}
+
+export enum CommonTriggerDataAttributes {
+  /**
+   * Present when the popup is open.
+   */
+  popupOpen = 'data-popup-open',
+  /**
+   * Present when a pressable trigger is pressed.
+   */
+  pressed = 'data-pressed',
+}
 
 const TRIGGER_HOOK = {
-  'data-popup-open': '',
+  [CommonTriggerDataAttributes.popupOpen]: '',
 };
 
 const PRESSABLE_TRIGGER_HOOK = {
-  'data-popup-open': '',
-  'data-pressed': '',
+  [CommonTriggerDataAttributes.popupOpen]: '',
+  [CommonTriggerDataAttributes.pressed]: '',
 };
 
 const POPUP_OPEN_HOOK = {
-  'data-open': '',
+  [CommonPopupDataAttributes.open]: '',
 };
 
 const POPUP_CLOSED_HOOK = {
-  'data-closed': '',
+  [CommonPopupDataAttributes.closed]: '',
 };
 
 const ANCHOR_HIDDEN_HOOK = {
-  'data-anchor-hidden': '',
+  [CommonPopupDataAttributes.anchorHidden]: '',
 };
 
 export const triggerOpenStateMapping = {

--- a/packages/react/src/utils/styleHookMapping.ts
+++ b/packages/react/src/utils/styleHookMapping.ts
@@ -1,8 +1,19 @@
 import type { TransitionStatus } from './useTransitionStatus';
 import type { CustomStyleHookMapping } from './getStyleHookProps';
 
-const STARTING_HOOK = { 'data-starting-style': '' };
-const ENDING_HOOK = { 'data-ending-style': '' };
+export enum TransitionStatusDataAttributes {
+  /**
+   * Present when the component is animating in.
+   */
+  startingStyle = 'data-starting-style',
+  /**
+   * Present when the component is animating out.
+   */
+  endingStyle = 'data-ending-style',
+}
+
+const STARTING_HOOK = { [TransitionStatusDataAttributes.startingStyle]: '' };
+const ENDING_HOOK = { [TransitionStatusDataAttributes.endingStyle]: '' };
 
 export const transitionStatusMapping = {
   transitionStatus(value): Record<string, string> | null {


### PR DESCRIPTION
Closes https://github.com/mui/base-ui/issues/1111

I made some common enums for some very widely used data attrs like `data-open`, `data-closed`, `data-starting-style` etc

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
