### PR TITLE
[docs] Misc fixes

### DIFF
--- a/docs/reference/generated/alert-dialog-root.json
+++ b/docs/reference/generated/alert-dialog-root.json
@@ -17,7 +17,7 @@
     },
     "actionsRef": {
       "type": "{ current: { unmount: func } }",
-      "description": "A ref to imperative actions."
+      "description": "A ref to imperative actions.\n- `unmount`: When specified, the dialog will not be unmounted when closed.\nInstead, the `unmount` function must be called to unmount the dialog manually.\nUseful when the dialog's animation is controlled by an external library."
     },
     "onOpenChangeComplete": {
       "type": "(open) => void",

--- a/docs/reference/generated/dialog-root.json
+++ b/docs/reference/generated/dialog-root.json
@@ -17,7 +17,7 @@
     },
     "actionsRef": {
       "type": "{ current: { unmount: func } }",
-      "description": "A ref to imperative actions."
+      "description": "A ref to imperative actions.\n- `unmount`: When specified, the dialog will not be unmounted when closed.\nInstead, the `unmount` function must be called to unmount the dialog manually.\nUseful when the dialog's animation is controlled by an external library."
     },
     "dismissible": {
       "type": "boolean",

--- a/docs/reference/generated/menu-root.json
+++ b/docs/reference/generated/menu-root.json
@@ -17,7 +17,7 @@
     },
     "actionsRef": {
       "type": "{ current: { unmount: func } }",
-      "description": "A ref to imperative actions."
+      "description": "A ref to imperative actions.\n- `unmount`: When specified, the menu will not be unmounted when closed.\nInstead, the `unmount` function must be called to unmount the menu manually.\nUseful when the menu's animation is controlled by an external library."
     },
     "closeParentOnEsc": {
       "type": "boolean",

--- a/docs/reference/generated/popover-root.json
+++ b/docs/reference/generated/popover-root.json
@@ -17,7 +17,7 @@
     },
     "actionsRef": {
       "type": "{ current: { unmount: func } }",
-      "description": "A ref to imperative actions."
+      "description": "A ref to imperative actions.\n- `unmount`: When specified, the popover will not be unmounted when closed.\nInstead, the `unmount` function must be called to unmount the popover manually.\nUseful when the popover's animation is controlled by an external library."
     },
     "modal": {
       "type": "boolean",

--- a/docs/reference/generated/preview-card-root.json
+++ b/docs/reference/generated/preview-card-root.json
@@ -17,7 +17,7 @@
     },
     "actionsRef": {
       "type": "{ current: { unmount: func } }",
-      "description": "A ref to imperative actions."
+      "description": "A ref to imperative actions.\n- `unmount`: When specified, the preview card will not be unmounted when closed.\nInstead, the `unmount` function must be called to unmount the preview card manually.\nUseful when the preview card's animation is controlled by an external library."
     },
     "onOpenChangeComplete": {
       "type": "(open) => void",

--- a/docs/reference/generated/select-root.json
+++ b/docs/reference/generated/select-root.json
@@ -34,7 +34,7 @@
     },
     "actionsRef": {
       "type": "{ current: { unmount: func } }",
-      "description": "A ref to imperative actions."
+      "description": "A ref to imperative actions.\n- `unmount`: When specified, the select will not be unmounted when closed.\nInstead, the `unmount` function must be called to unmount the select manually.\nUseful when the select's animation is controlled by an external library."
     },
     "alignItemToTrigger": {
       "type": "boolean",

--- a/docs/reference/generated/select-scroll-up-arrow.json
+++ b/docs/reference/generated/select-scroll-up-arrow.json
@@ -1,6 +1,6 @@
 {
   "name": "SelectScrollUpArrow",
-  "description": "An element that scrolls the select menu down when hovered.\nRenders a `<div>` element.",
+  "description": "An element that scrolls the select menu up when hovered.\nRenders a `<div>` element.",
   "props": {
     "className": {
       "type": "string | (state) => string",

--- a/docs/reference/generated/tooltip-root.json
+++ b/docs/reference/generated/tooltip-root.json
@@ -17,7 +17,7 @@
     },
     "actionsRef": {
       "type": "{ current: { unmount: func } }",
-      "description": "A ref to imperative actions."
+      "description": "A ref to imperative actions.\n- `unmount`: When specified, the tooltip will not be unmounted when closed.\nInstead, the `unmount` function must be called to unmount the tooltip manually.\nUseful when the tooltip's animation is controlled by an external library."
     },
     "onOpenChangeComplete": {
       "type": "(open) => void",

--- a/docs/src/app/(private)/experiments/toast.tsx
+++ b/docs/src/app/(private)/experiments/toast.tsx
@@ -83,10 +83,8 @@ function Toasts() {
   const { toasts } = Toast.useToastManager();
   return toasts.map((toast) => (
     <Toast.Root key={toast.id} toast={toast} className={styles.root}>
-      {toast.title && <Toast.Title>{toast.title}</Toast.Title>}
-      {toast.description && (
-        <Toast.Description>{toast.description}</Toast.Description>
-      )}
+      <Toast.Title />
+      <Toast.Description />
       {toast.type === 'undo' && (
         <button
           className={styles.button}

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/custom/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/custom/css-modules/index.tsx
@@ -58,7 +58,7 @@ function ToastList() {
       {isCustomToast(toast) && toast.data ? (
         <Toast.Description>`data.userId` is {toast.data.userId}</Toast.Description>
       ) : (
-        <Toast.Description>{toast.description}</Toast.Description>
+        <Toast.Description />
       )}
       <Toast.Close className={styles.Close} aria-label="Close">
         <XIcon className={styles.Icon} />

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/hero/css-modules/index.tsx
@@ -37,10 +37,8 @@ function ToastList() {
   const { toasts } = Toast.useToastManager();
   return toasts.map((toast) => (
     <Toast.Root key={toast.id} toast={toast} className={styles.Toast}>
-      <Toast.Title className={styles.Title}>{toast.title}</Toast.Title>
-      <Toast.Description className={styles.Description}>
-        {toast.description}
-      </Toast.Description>
+      <Toast.Title className={styles.Title} />
+      <Toast.Description className={styles.Description} />
       <Toast.Close className={styles.Close} aria-label="Close">
         <XIcon className={styles.Icon} />
       </Toast.Close>

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/hero/tailwind/index.tsx
@@ -49,12 +49,8 @@ function ToastList() {
           'calc(var(--toast-offset-y) * -1 + (var(--toast-index) * var(--gap) * -1) + var(--toast-swipe-movement-y))',
       }}
     >
-      <Toast.Title className="text-[0.975rem] leading-5 font-medium">
-        {toast.title}
-      </Toast.Title>
-      <Toast.Description className="text-[0.925rem] leading-5 text-gray-700">
-        {toast.description}
-      </Toast.Description>
+      <Toast.Title className="text-[0.975rem] leading-5 font-medium" />
+      <Toast.Description className="text-[0.925rem] leading-5 text-gray-700" />
       <Toast.Close
         className="absolute top-2 right-2 flex h-5 w-5 items-center justify-center rounded border-none bg-transparent text-gray-500 hover:bg-gray-100 hover:text-gray-700"
         aria-label="Close"

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/position/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/position/css-modules/index.tsx
@@ -42,10 +42,8 @@ function ToastList() {
       swipeDirection="up"
       className={styles.Toast}
     >
-      <Toast.Title className={styles.Title}>{toast.title}</Toast.Title>
-      <Toast.Description className={styles.Description}>
-        {toast.description}
-      </Toast.Description>
+      <Toast.Title className={styles.Title} />
+      <Toast.Description className={styles.Description} />
       <Toast.Close className={styles.Close} aria-label="Close">
         <XIcon className={styles.Icon} />
       </Toast.Close>

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/position/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/position/tailwind/index.tsx
@@ -50,12 +50,8 @@ function ToastList() {
           'calc(var(--toast-offset-y) + (var(--toast-index) * var(--gap)) + var(--toast-swipe-movement-y))',
       }}
     >
-      <Toast.Title className="text-[0.975rem] leading-5 font-medium">
-        {toast.title}
-      </Toast.Title>
-      <Toast.Description className="text-[0.925rem] leading-5 text-gray-700">
-        {toast.description}
-      </Toast.Description>
+      <Toast.Title className="text-[0.975rem] leading-5 font-medium" />
+      <Toast.Description className="text-[0.925rem] leading-5 text-gray-700" />
       <Toast.Close
         className="absolute top-2 right-2 flex h-5 w-5 items-center justify-center rounded border-none bg-transparent text-gray-500 hover:bg-gray-100 hover:text-gray-700"
         aria-label="Close"

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/promise/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/promise/css-modules/index.tsx
@@ -49,10 +49,8 @@ function ToastList() {
   const { toasts } = Toast.useToastManager();
   return toasts.map((toast) => (
     <Toast.Root key={toast.id} toast={toast} className={styles.Toast}>
-      <Toast.Title className={styles.Title}>{toast.title}</Toast.Title>
-      <Toast.Description className={styles.Description}>
-        {toast.description}
-      </Toast.Description>
+      <Toast.Title className={styles.Title} />
+      <Toast.Description className={styles.Description} />
       <Toast.Close className={styles.Close} aria-label="Close">
         <XIcon className={styles.Icon} />
       </Toast.Close>

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/undo/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/undo/css-modules/index.tsx
@@ -45,10 +45,8 @@ function ToastList() {
   const { toasts } = Toast.useToastManager();
   return toasts.map((toast) => (
     <Toast.Root key={toast.id} toast={toast} className={styles.Toast}>
-      <Toast.Title className={styles.Title}>{toast.title}</Toast.Title>
-      <Toast.Description className={styles.Description}>
-        {toast.description}
-      </Toast.Description>
+      <Toast.Title className={styles.Title} />
+      <Toast.Description className={styles.Description} />
       <Toast.Action className={styles.UndoButton} />
       <Toast.Close className={styles.Close} aria-label="Close">
         <XIcon className={styles.Icon} />

--- a/docs/src/app/(public)/(content)/react/handbook/animation/page.mdx
+++ b/docs/src/app/(public)/(content)/react/handbook/animation/page.mdx
@@ -10,7 +10,7 @@ Base UI components can be animated using CSS transitions, CSS animations, or Ja
 Use the following Base UI attributes for creating transitions when a component becomes visible or hidden:
 
 - `[data-starting-style]` corresponds to the initial style to transition from.
-- `[data-ending-style]` corresponds the final style to transition to.
+- `[data-ending-style]` corresponds to the final style to transition to.
 
 Transitions are recommended over CSS animations, because a transition can be smoothly cancelled midway.
 For example, if the user closes a popup before it finishes opening, with CSS transitions it will smoothly animate to its closed state without any abrupt changes.
@@ -38,7 +38,7 @@ For example, if the user closes a popup before it finishes opening, with CSS tra
 Use the following Base UI attributes for creating CSS animations when a component becomes visible or hidden:
 
 - `[data-open]` corresponds to the style applied when a component becomes visible.
-- `[data-closed]` corresponds the style applied before a component becomes hidden.
+- `[data-closed]` corresponds to the style applied before a component becomes hidden.
 
 ```css title="popover.css"
 @keyframes scaleIn {

--- a/docs/src/app/(public)/(content)/react/handbook/animation/page.mdx
+++ b/docs/src/app/(public)/(content)/react/handbook/animation/page.mdx
@@ -15,7 +15,7 @@ Use the following Base UI attributes for creating transitions when a component 
 Transitions are recommended over CSS animations, because a transition can be smoothly cancelled midway.
 For example, if the user closes a popup before it finishes opening, with CSS transitions it will smoothly animate to its closed state without any abrupt changes.
 
-```css title="popover.css"
+```css title="popover.css" {10-14}
 .Popup {
   box-sizing: border-box;
   padding: 1rem 1.5rem;

--- a/docs/src/app/(public)/(content)/react/handbook/styling/page.mdx
+++ b/docs/src/app/(public)/(content)/react/handbook/styling/page.mdx
@@ -13,13 +13,13 @@ You retain total control of your styling layer.
 
 ### CSS classes
 
-Components that render an HTML element accept a `className` prop to style it with CSS classes.
+Components that render an HTML element accept a `className` prop to style the element with CSS classes.
 
 ```tsx title="switch.tsx"
 <Switch.Thumb className="SwitchThumb" />
 ```
 
-It can also be passed a function that takes the component's state as an argument.
+The prop can also be passed a function that takes the component's state as an argument.
 
 ```tsx title="switch.tsx"
 <Switch.Thumb className={(state) => (state.checked ? 'checked' : 'unchecked')} />
@@ -45,7 +45,7 @@ Components expose CSS variables to aid in styling, often containing dynamic nume
 }
 ```
 
-Check out each component’s API reference for a complete list of available data attributes and CSS variables.
+Check out each component's API reference for a complete list of available data attributes and CSS variables.
 
 ## Tailwind CSS
 
@@ -58,16 +58,16 @@ import { Menu } from '@base-ui-components/react/menu';
 export default function ExampleMenu() {
   return (
     <Menu.Root>
-      <Menu.Trigger className="flex h-10 items-center justify-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100 data-[popup-open]:bg-gray-100">
+      <Menu.Trigger className="flex h-10 select-none items-center justify-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100 data-[popup-open]:bg-gray-100">
         Song
       </Menu.Trigger>
       <Menu.Portal>
         <Menu.Positioner className="outline-none" sideOffset={8}>
-          <Menu.Popup className="origin-[var(--transform-origin)] rounded-md bg-[canvas] py-1 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300">
-            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+          <Menu.Popup className="origin-[var(--transform-origin)] rounded-md bg-[canvas] py-1 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[starting-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300">
+            <Menu.Item className="flex cursor-default select-none py-2 pl-4 pr-8 text-sm leading-4 outline-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
               Add to Library
             </Menu.Item>
-            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+            <Menu.Item className="flex cursor-default select-none py-2 pl-4 pr-8 text-sm leading-4 outline-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
               Add to Playlist
             </Menu.Item>
           </Menu.Popup>

--- a/docs/src/app/(public)/(content)/react/handbook/styling/page.mdx
+++ b/docs/src/app/(public)/(content)/react/handbook/styling/page.mdx
@@ -58,16 +58,16 @@ import { Menu } from '@base-ui-components/react/menu';
 export default function ExampleMenu() {
   return (
     <Menu.Root>
-      <Menu.Trigger className="flex h-10 select-none items-center justify-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100 data-[popup-open]:bg-gray-100">
+      <Menu.Trigger className="flex h-10 items-center justify-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100 data-[popup-open]:bg-gray-100">
         Song
       </Menu.Trigger>
       <Menu.Portal>
         <Menu.Positioner className="outline-none" sideOffset={8}>
-          <Menu.Popup className="origin-[var(--transform-origin)] rounded-md bg-[canvas] py-1 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[starting-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300">
-            <Menu.Item className="flex cursor-default select-none py-2 pl-4 pr-8 text-sm leading-4 outline-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+          <Menu.Popup className="origin-[var(--transform-origin)] rounded-md bg-[canvas] py-1 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300">
+            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
               Add to Library
             </Menu.Item>
-            <Menu.Item className="flex cursor-default select-none py-2 pl-4 pr-8 text-sm leading-4 outline-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
               Add to Playlist
             </Menu.Item>
           </Menu.Popup>

--- a/docs/src/app/(public)/(content)/react/handbook/styling/page.mdx
+++ b/docs/src/app/(public)/(content)/react/handbook/styling/page.mdx
@@ -13,25 +13,41 @@ You retain total control of your styling layer.
 
 ### CSS classes
 
-Every component accepts a `className` prop which you can use to pass CSS classes to its DOM element.
-The `className` prop, in addition to accepting a string, can be defined as a function that takes a component state as an argument:
+Components that render an HTML element accept a `className` prop to style it with CSS classes.
+
+```tsx title="switch.tsx"
+<Switch.Thumb className="SwitchThumb" />
+```
+
+It can also be passed a function that takes the component's state as an argument.
 
 ```tsx title="switch.tsx"
 <Switch.Thumb className={(state) => (state.checked ? 'checked' : 'unchecked')} />
 ```
 
-### CSS variables
-
-Some components expose CSS custom properties to aid with styling, such as `--accordion-panel-height`, `--transform-origin`, or `--active-tab-width`.
-
 ### Data attributes
 
-Base UI components provide data attributes designed for styling their states.
-For example, a [Switch](/react/components/switch) may be styled using its `[data-checked]` and `[data-unchecked]` attributes, among others.
+Components provide data attributes designed for styling their states. For example, [Switch](/react/components/switch) can be styled using its `[data-checked]` and `[data-unchecked]` attributes, among others.
 
-Check out each component's API reference for a complete list of available data attributes.
+```css title="switch.css"
+.SwitchThumb[data-checked] {
+  background-color: green;
+}
+```
 
-## Tailwind
+### CSS variables
+
+Components expose CSS variables to aid in styling, often containing dynamic numeric values to be used in sizing or transform calculations. For example, [Popover](/react/components/popover) expose CSS variables on the `Popup` component like `--available-height` and `--anchor-width`.
+
+```css title="popover.css"
+.Popup {
+  max-height: var(--available-height);
+}
+```
+
+Check out each component’s API reference for a complete list of available data attributes and CSS variables.
+
+## Tailwind CSS
 
 Apply Tailwind classes to each part via the `className` prop.
 
@@ -42,16 +58,16 @@ import { Menu } from '@base-ui-components/react/menu';
 export default function ExampleMenu() {
   return (
     <Menu.Root>
-      <Menu.Trigger className="flex h-10 items-center justify-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100 data-[popup-open]:bg-gray-100">
+      <Menu.Trigger className="flex h-10 select-none items-center justify-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100 data-[popup-open]:bg-gray-100">
         Song
       </Menu.Trigger>
       <Menu.Portal>
         <Menu.Positioner className="outline-none" sideOffset={8}>
-          <Menu.Popup className="origin-[var(--transform-origin)] rounded-md bg-[canvas] py-1 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300">
-            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+          <Menu.Popup className="origin-[var(--transform-origin)] rounded-md bg-[canvas] py-1 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[starting-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300">
+            <Menu.Item className="flex cursor-default select-none py-2 pl-4 pr-8 text-sm leading-4 outline-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
               Add to Library
             </Menu.Item>
-            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+            <Menu.Item className="flex cursor-default select-none py-2 pl-4 pr-8 text-sm leading-4 outline-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
               Add to Playlist
             </Menu.Item>
           </Menu.Popup>

--- a/docs/src/app/(public)/(content)/react/handbook/styling/page.mdx
+++ b/docs/src/app/(public)/(content)/react/handbook/styling/page.mdx
@@ -37,7 +37,7 @@ Components provide data attributes designed for styling their states. For exampl
 
 ### CSS variables
 
-Components expose CSS variables to aid in styling, often containing dynamic numeric values to be used in sizing or transform calculations. For example, [Popover](/react/components/popover) expose CSS variables on the `Popup` component like `--available-height` and `--anchor-width`.
+Components expose CSS variables to aid in styling, often containing dynamic numeric values to be used in sizing or transform calculations. For example, [Popover](/react/components/popover) exposes CSS variables on its `Popup` component like `--available-height` and `--anchor-width`.
 
 ```css title="popover.css"
 .Popup {

--- a/docs/src/app/(public)/(content)/react/overview/quick-start/page.mdx
+++ b/docs/src/app/(public)/(content)/react/overview/quick-start/page.mdx
@@ -7,7 +7,7 @@
 
 Install Base UI using a package manager.
 
-```jsx title="Terminal"
+```bash title="Terminal"
 npm i @base-ui-components/react
 ```
 
@@ -20,7 +20,7 @@ To make portalled components always appear on top of the entire page, add the fo
 
 ```tsx title="layout.tsx"
 <body>
-  <div className="Root">
+  <div className="root">
     {/* prettier-ignore */}
     {children}
   </div>
@@ -28,12 +28,12 @@ To make portalled components always appear on top of the entire page, add the fo
 ```
 
 ```css title="styles.css"
-.Root {
+.root {
   isolation: isolate;
 }
 ```
 
-This style creates a separate stacking context for your application's `.Root` element.
+This style creates a separate stacking context for your application's `.root` element.
 This way, popups will always appear above the page contents, and any `z-index` property in your styles won't interfere with them.
 
 ## Assemble a component

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.tsx
@@ -66,6 +66,9 @@ AlertDialogRoot.propTypes /* remove-proptypes */ = {
   // └─────────────────────────────────────────────────────────────────────┘
   /**
    * A ref to imperative actions.
+   * - `unmount`: When specified, the dialog will not be unmounted when closed.
+   * Instead, the `unmount` function must be called to unmount the dialog manually.
+   * Useful when the dialog's animation is controlled by an external library.
    */
   actionsRef: PropTypes.shape({
     current: PropTypes.shape({

--- a/packages/react/src/dialog/root/DialogRoot.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.tsx
@@ -73,6 +73,9 @@ DialogRoot.propTypes /* remove-proptypes */ = {
   // └─────────────────────────────────────────────────────────────────────┘
   /**
    * A ref to imperative actions.
+   * - `unmount`: When specified, the dialog will not be unmounted when closed.
+   * Instead, the `unmount` function must be called to unmount the dialog manually.
+   * Useful when the dialog's animation is controlled by an external library.
    */
   actionsRef: PropTypes.shape({
     current: PropTypes.shape({

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -238,6 +238,9 @@ export interface SharedParameters {
   dismissible?: boolean;
   /**
    * A ref to imperative actions.
+   * - `unmount`: When specified, the dialog will not be unmounted when closed.
+   * Instead, the `unmount` function must be called to unmount the dialog manually.
+   * Useful when the dialog's animation is controlled by an external library.
    */
   actionsRef?: React.RefObject<{ unmount: () => void }>;
 }

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -151,6 +151,9 @@ namespace MenuRoot {
     openOnHover?: boolean;
     /**
      * A ref to imperative actions.
+     * - `unmount`: When specified, the menu will not be unmounted when closed.
+     * Instead, the `unmount` function must be called to unmount the menu manually.
+     * Useful when the menu's animation is controlled by an external library.
      */
     actionsRef?: React.RefObject<{ unmount: () => void }>;
   }
@@ -167,6 +170,9 @@ MenuRoot.propTypes /* remove-proptypes */ = {
   // └─────────────────────────────────────────────────────────────────────┘
   /**
    * A ref to imperative actions.
+   * - `unmount`: When specified, the menu will not be unmounted when closed.
+   * Instead, the `unmount` function must be called to unmount the menu manually.
+   * Useful when the menu's animation is controlled by an external library.
    */
   actionsRef: PropTypes.shape({
     current: PropTypes.shape({

--- a/packages/react/src/menu/root/useMenuRoot.ts
+++ b/packages/react/src/menu/root/useMenuRoot.ts
@@ -373,6 +373,9 @@ export namespace useMenuRoot {
     modal: boolean;
     /**
      * A ref to imperative actions.
+     * - `unmount`: When specified, the menu will not be unmounted when closed.
+     * Instead, the `unmount` function must be called to unmount the menu manually.
+     * Useful when the menu's animation is controlled by an external library.
      */
     actionsRef: React.RefObject<Actions> | undefined;
   }

--- a/packages/react/src/number-field/decrement/NumberFieldDecrement.tsx
+++ b/packages/react/src/number-field/decrement/NumberFieldDecrement.tsx
@@ -6,6 +6,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { NumberFieldRoot } from '../root/NumberFieldRoot';
 import { useNumberFieldButton } from '../root/useNumberFieldButton';
 import { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
+import { styleHookMapping } from '../utils/styleHooks';
 
 /**
  * A stepper button that decreases the field value when clicked.
@@ -78,6 +79,7 @@ const NumberFieldDecrement = React.forwardRef(function NumberFieldDecrement(
     state,
     className,
     extraProps: otherProps,
+    customStyleHookMapping: styleHookMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/group/NumberFieldGroup.tsx
+++ b/packages/react/src/number-field/group/NumberFieldGroup.tsx
@@ -6,6 +6,7 @@ import type { NumberFieldRoot } from '../root/NumberFieldRoot';
 import { mergeProps } from '../../merge-props';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
+import { styleHookMapping } from '../utils/styleHooks';
 
 /**
  * Groups the input with the increment and decrement buttons.
@@ -39,6 +40,7 @@ const NumberFieldGroup = React.forwardRef(function NumberFieldGroup(
     state,
     className,
     extraProps: otherProps,
+    customStyleHookMapping: styleHookMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/increment/NumberFieldIncrement.tsx
+++ b/packages/react/src/number-field/increment/NumberFieldIncrement.tsx
@@ -6,6 +6,7 @@ import { useNumberFieldButton } from '../root/useNumberFieldButton';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { NumberFieldRoot } from '../root/NumberFieldRoot';
 import type { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
+import { styleHookMapping } from '../utils/styleHooks';
 
 /**
  * A stepper button that increases the field value when clicked.
@@ -78,6 +79,7 @@ const NumberFieldIncrement = React.forwardRef(function NumberFieldIncrement(
     state,
     className,
     extraProps: otherProps,
+    customStyleHookMapping: styleHookMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -12,6 +12,12 @@ import { mergeProps } from '../../merge-props';
 import { DEFAULT_STEP } from '../utils/constants';
 import { ARABIC_RE, HAN_RE, getNumberLocaleDetails, parseNumber } from '../utils/parse';
 import type { NumberFieldRoot } from '../root/NumberFieldRoot';
+import { styleHookMapping } from '../utils/styleHooks';
+
+const customStyleHookMapping = {
+  ...fieldValidityMapping,
+  ...styleHookMapping,
+};
 
 /**
  * The native input control in the number field.
@@ -303,7 +309,7 @@ const NumberFieldInput = React.forwardRef(function NumberFieldInput(
     className,
     state,
     extraProps: otherProps,
-    customStyleHookMapping: fieldValidityMapping,
+    customStyleHookMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -7,6 +7,7 @@ import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { FieldRoot } from '../../field/root/FieldRoot';
+import { styleHookMapping } from '../utils/styleHooks';
 
 /**
  * Groups all parts of the number field and manages its state.
@@ -85,6 +86,7 @@ const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
     state,
     className,
     extraProps: otherProps,
+    customStyleHookMapping: styleHookMapping,
   });
 
   return (

--- a/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
+++ b/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
@@ -10,6 +10,7 @@ import type { BaseUIComponentProps, GenericHTMLProps } from '../../utils/types';
 import type { NumberFieldRoot } from '../root/NumberFieldRoot';
 import { ownerDocument } from '../../utils/owner';
 import { mergeProps } from '../../merge-props';
+import { styleHookMapping } from '../utils/styleHooks';
 
 /**
  * A custom element to display instead of the native cursor while using the scrub area.
@@ -57,6 +58,7 @@ const NumberFieldScrubAreaCursor = React.forwardRef(function NumberFieldScrubAre
     state,
     className,
     extraProps: otherProps,
+    customStyleHookMapping: styleHookMapping,
   });
 
   if (!isScrubbing || isWebKit() || isTouchInput || isPointerLockDenied) {

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
@@ -6,6 +6,7 @@ import { useNumberFieldRootContext } from '../root/NumberFieldRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { NumberFieldRoot } from '../root/NumberFieldRoot';
+import { styleHookMapping } from '../utils/styleHooks';
 
 /**
  * An interactive area where the user can click and drag to change the field value.
@@ -43,6 +44,7 @@ const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubArea(
     state,
     className,
     extraProps: otherProps,
+    customStyleHookMapping: styleHookMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/utils/styleHooks.ts
+++ b/packages/react/src/number-field/utils/styleHooks.ts
@@ -1,0 +1,7 @@
+import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { NumberFieldRoot } from '../root/NumberFieldRoot';
+
+export const styleHookMapping: CustomStyleHookMapping<NumberFieldRoot.State> = {
+  inputValue: () => null,
+  value: () => null,
+};

--- a/packages/react/src/popover/root/PopoverRoot.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.tsx
@@ -72,6 +72,9 @@ PopoverRoot.propTypes /* remove-proptypes */ = {
   // └─────────────────────────────────────────────────────────────────────┘
   /**
    * A ref to imperative actions.
+   * - `unmount`: When specified, the popover will not be unmounted when closed.
+   * Instead, the `unmount` function must be called to unmount the popover manually.
+   * Useful when the popover's animation is controlled by an external library.
    */
   actionsRef: PropTypes.shape({
     current: PropTypes.shape({

--- a/packages/react/src/popover/root/usePopoverRoot.ts
+++ b/packages/react/src/popover/root/usePopoverRoot.ts
@@ -266,6 +266,9 @@ export namespace usePopoverRoot {
     closeDelay?: number;
     /**
      * A ref to imperative actions.
+     * - `unmount`: When specified, the popover will not be unmounted when closed.
+     * Instead, the `unmount` function must be called to unmount the popover manually.
+     * Useful when the popover's animation is controlled by an external library.
      */
     actionsRef?: React.RefObject<Actions>;
     /**

--- a/packages/react/src/preview-card/root/PreviewCardRoot.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.tsx
@@ -60,6 +60,9 @@ PreviewCardRoot.propTypes /* remove-proptypes */ = {
   // └─────────────────────────────────────────────────────────────────────┘
   /**
    * A ref to imperative actions.
+   * - `unmount`: When specified, the preview card will not be unmounted when closed.
+   * Instead, the `unmount` function must be called to unmount the preview card manually.
+   * Useful when the preview card's animation is controlled by an external library.
    */
   actionsRef: PropTypes.shape({
     current: PropTypes.shape({

--- a/packages/react/src/preview-card/root/usePreviewCardRoot.ts
+++ b/packages/react/src/preview-card/root/usePreviewCardRoot.ts
@@ -191,6 +191,9 @@ export namespace usePreviewCardRoot {
     closeDelay?: number;
     /**
      * A ref to imperative actions.
+     * - `unmount`: When specified, the preview card will not be unmounted when closed.
+     * Instead, the `unmount` function must be called to unmount the preview card manually.
+     * Useful when the preview card's animation is controlled by an external library.
      */
     actionsRef?: React.RefObject<Actions>;
   }

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -138,6 +138,9 @@ SelectRoot.propTypes /* remove-proptypes */ = {
   // └─────────────────────────────────────────────────────────────────────┘
   /**
    * A ref to imperative actions.
+   * - `unmount`: When specified, the select will not be unmounted when closed.
+   * Instead, the `unmount` function must be called to unmount the select manually.
+   * Useful when the select's animation is controlled by an external library.
    */
   actionsRef: PropTypes.shape({
     current: PropTypes.shape({

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -426,7 +426,7 @@ export namespace useSelectRoot {
      */
     alignItemToTrigger?: boolean;
     /**
-     * The transition status of the Select.
+     * The transition status of the select.
      */
     transitionStatus?: TransitionStatus;
     /**
@@ -436,6 +436,9 @@ export namespace useSelectRoot {
     modal?: boolean;
     /**
      * A ref to imperative actions.
+     * - `unmount`: When specified, the select will not be unmounted when closed.
+     * Instead, the `unmount` function must be called to unmount the select manually.
+     * Useful when the select's animation is controlled by an external library.
      */
     actionsRef?: React.RefObject<Actions>;
   }

--- a/packages/react/src/select/scroll-down-arrow/SelectScrollDownArrow.tsx
+++ b/packages/react/src/select/scroll-down-arrow/SelectScrollDownArrow.tsx
@@ -19,6 +19,7 @@ const SelectScrollDownArrow = React.forwardRef(function SelectScrollDownArrow(
 
 namespace SelectScrollDownArrow {
   export interface State {}
+
   export interface Props extends BaseUIComponentProps<'div', State> {
     /**
      * Whether to keep the HTML element in the DOM while the select menu is not scrollable.

--- a/packages/react/src/select/scroll-up-arrow/SelectScrollUpArrow.tsx
+++ b/packages/react/src/select/scroll-up-arrow/SelectScrollUpArrow.tsx
@@ -5,7 +5,7 @@ import { SelectScrollArrow } from '../scroll-arrow/SelectScrollArrow';
 import type { BaseUIComponentProps } from '../../utils/types';
 
 /**
- * An element that scrolls the select menu down when hovered.
+ * An element that scrolls the select menu up when hovered.
  * Renders a `<div>` element.
  *
  * Documentation: [Base UI Select](https://base-ui.com/react/components/select)
@@ -19,6 +19,7 @@ const SelectScrollUpArrow = React.forwardRef(function SelectScrollUpArrow(
 
 namespace SelectScrollUpArrow {
   export interface State {}
+
   export interface Props extends BaseUIComponentProps<'div', State> {
     /**
      * Whether to keep the HTML element in the DOM while the select menu is not scrollable.

--- a/packages/react/src/tooltip/root/TooltipRoot.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.tsx
@@ -72,6 +72,9 @@ TooltipRoot.propTypes /* remove-proptypes */ = {
   // └─────────────────────────────────────────────────────────────────────┘
   /**
    * A ref to imperative actions.
+   * - `unmount`: When specified, the tooltip will not be unmounted when closed.
+   * Instead, the `unmount` function must be called to unmount the tooltip manually.
+   * Useful when the tooltip's animation is controlled by an external library.
    */
   actionsRef: PropTypes.shape({
     current: PropTypes.shape({

--- a/packages/react/src/tooltip/root/useTooltipRoot.ts
+++ b/packages/react/src/tooltip/root/useTooltipRoot.ts
@@ -224,6 +224,9 @@ export namespace useTooltipRoot {
     closeDelay?: number;
     /**
      * A ref to imperative actions.
+     * - `unmount`: When specified, the tooltip will not be unmounted when closed.
+     * Instead, the `unmount` function must be called to unmount the tooltip manually.
+     * Useful when the tooltip's animation is controlled by an external library.
      */
     actionsRef?: React.RefObject<Actions>;
   }


### PR DESCRIPTION
Most of these are unrelated but are small enough that it seems ok to batch them in one PR instead of creating many different ones:

- `actionsRef` wasn't documented in detail
- Typos on animations page
- `Toast.Title` and `Toast.Description` should be empty by default in the demos
- `inputValue` and `value` shouldn't be data attributes on `NumberField`
- Typo on `Select.ScrollUpArrow`
- Address handbook page issues