### PR TITLE
[test] Add more conformance tests for popups

### DIFF
--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -37,7 +37,7 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
   props: AlertDialogPopup.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { className, id, render, initialFocus, finalFocus, ...other } = props;
+  const { className, render, initialFocus, finalFocus, ...other } = props;
 
   const {
     descriptionElementId,
@@ -75,7 +75,6 @@ const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
   const { getRootProps, resolvedInitialFocus } = useDialogPopup({
     descriptionElementId,
     getPopupProps,
-    id,
     initialFocus,
     modal: true,
     mounted,
@@ -178,10 +177,6 @@ AlertDialogPopup.propTypes /* remove-proptypes */ = {
    * By default, focus returns to the trigger.
    */
   finalFocus: refType,
-  /**
-   * @ignore
-   */
-  id: PropTypes.string,
   /**
    * Determines the element to focus when the dialog is opened.
    * By default, the first focusable element is focused.

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
@@ -24,6 +24,7 @@ describe('<AlertDialog.Root />', () => {
     render,
     triggerMouseAction: 'click',
     expectedPopupRole: 'alertdialog',
+    expectedAriaHasPopupValue: 'dialog',
   });
 
   it('ARIA attributes', async () => {

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -38,7 +38,7 @@ const DialogPopup = React.forwardRef(function DialogPopup(
   props: DialogPopup.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { className, finalFocus, id, initialFocus, render, ...other } = props;
+  const { className, finalFocus, initialFocus, render, ...other } = props;
 
   const {
     descriptionElementId,
@@ -77,7 +77,6 @@ const DialogPopup = React.forwardRef(function DialogPopup(
   const { getRootProps, resolvedInitialFocus } = useDialogPopup({
     descriptionElementId,
     getPopupProps,
-    id,
     initialFocus,
     modal,
     mounted,
@@ -175,10 +174,6 @@ DialogPopup.propTypes /* remove-proptypes */ = {
    * By default, focus returns to the trigger.
    */
   finalFocus: refType,
-  /**
-   * @ignore
-   */
-  id: PropTypes.string,
   /**
    * Determines the element to focus when the dialog is opened.
    * By default, the first focusable element is focused.

--- a/packages/react/src/dialog/popup/useDialogPopup.tsx
+++ b/packages/react/src/dialog/popup/useDialogPopup.tsx
@@ -70,10 +70,6 @@ export function useDialogPopup(parameters: useDialogPopup.Parameters): useDialog
 export namespace useDialogPopup {
   export interface Parameters {
     /**
-     * The id of the dialog element.
-     */
-    id?: string;
-    /**
      * The ref to the dialog element.
      */
     ref: React.Ref<HTMLElement>;

--- a/packages/react/test/popupConformanceTests.tsx
+++ b/packages/react/test/popupConformanceTests.tsx
@@ -80,6 +80,28 @@ export function popupConformanceTests(config: PopupTestConfig) {
             expect(trigger).to.have.attribute('aria-controls', popup?.id);
           });
 
+          it('has the `aria-expanded` attribute on the trigger when open', async () => {
+            const { user } = await render(prepareComponent({}));
+            const trigger = getTrigger();
+            if (!alwaysMounted) {
+              expect(getPopup()).to.equal(null);
+            } else {
+              expect(getPopup()).toBeInaccessible();
+            }
+            expect(trigger).to.have.attribute('aria-expanded', 'false');
+            await user.click(trigger);
+            expect(getPopup()).to.have.attribute('data-open');
+            expect(trigger).to.have.attribute('aria-expanded', 'true');
+          });
+
+          if (expectedPopupRole) {
+            it('has the `aria-haspopup` attribute on the trigger', async () => {
+              await render(prepareComponent({ root: { open: true } }));
+              const trigger = getTrigger();
+              expect(trigger).to.have.attribute('aria-haspopup', expectedPopupRole);
+            });
+          }
+
           it('allows a custom `id` prop', async () => {
             await render(prepareComponent({ root: { open: true }, popup: { id: 'MyPopupId' } }));
             const trigger = getTrigger();

--- a/packages/react/test/popupConformanceTests.tsx
+++ b/packages/react/test/popupConformanceTests.tsx
@@ -10,6 +10,7 @@ export function popupConformanceTests(config: PopupTestConfig) {
     triggerMouseAction,
     render,
     expectedPopupRole,
+    expectedAriaHasPopupValue = expectedPopupRole,
     alwaysMounted = false,
   } = config;
 
@@ -94,16 +95,16 @@ export function popupConformanceTests(config: PopupTestConfig) {
             expect(trigger).to.have.attribute('aria-expanded', 'true');
           });
 
-          if (expectedPopupRole) {
+          if (expectedAriaHasPopupValue) {
             it('has the `aria-haspopup` attribute on the trigger', async () => {
               await render(prepareComponent({ root: { open: true } }));
               const trigger = getTrigger();
-              expect(trigger).to.have.attribute('aria-haspopup', expectedPopupRole);
+              expect(trigger).to.have.attribute('aria-haspopup', expectedAriaHasPopupValue);
             });
           }
 
           it('allows a custom `id` prop', async () => {
-            await render(prepareComponent({ root: { open: true }, popup: { id: 'MyPopupId' } }));
+            await render(prepareComponent({ root: { open: true }, popup: { id: 'TestId' } }));
             const trigger = getTrigger();
             const popup = getPopup();
             expect(trigger.getAttribute('aria-controls')).to.equal(popup?.getAttribute('id'));
@@ -226,6 +227,10 @@ export interface PopupTestConfig {
    * Expected `role` attribute of the popup element.
    */
   expectedPopupRole?: string;
+  /**
+   * Expected `aria-haspopup` attribute of the trigger element.
+   */
+  expectedAriaHasPopupValue?: string;
   /**
    * Whether the popup contents are always present in the DOM.
    */

--- a/packages/react/test/popupConformanceTests.tsx
+++ b/packages/react/test/popupConformanceTests.tsx
@@ -79,6 +79,13 @@ export function popupConformanceTests(config: PopupTestConfig) {
             const popup = getPopup();
             expect(trigger).to.have.attribute('aria-controls', popup?.id);
           });
+
+          it('allows a custom `id` prop', async () => {
+            await render(prepareComponent({ root: { open: true }, popup: { id: 'MyPopupId' } }));
+            const trigger = getTrigger();
+            const popup = getPopup();
+            expect(trigger.getAttribute('aria-controls')).to.equal(popup?.getAttribute('id'));
+          });
         }
       });
     }
@@ -214,6 +221,7 @@ interface TriggerProps {
 
 interface PopupProps {
   className?: string;
+  id?: string;
   'data-testid'?: string;
   onAnimationEnd?: () => void;
 }


### PR DESCRIPTION
Adds tests for https://github.com/mui/base-ui/issues/1552

The underlying issue is fixed in floating-ui

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
