### PR TITLE
[useButton] Avoid applying type attribute to non-button tags

### DIFF
--- a/packages/react/src/use-button/useButton.test.tsx
+++ b/packages/react/src/use-button/useButton.test.tsx
@@ -225,5 +225,17 @@ describe('useButton', () => {
       const { getByRole } = await render(<TestButton type="submit">Submit</TestButton>);
       expect(getByRole('button')).to.have.property('type', 'submit');
     });
+
+    it('should not set type attribute on non-button elements', async () => {
+      function TestButton(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+        const { disabled, ...otherProps } = props;
+        const { getButtonProps } = useButton({ disabled });
+
+        return <span {...getButtonProps(otherProps)} />;
+      }
+
+      const { getByRole } = await render(<TestButton>Submit</TestButton>);
+      expect(getByRole('button')).not.to.have.property('type');
+    });
   });
 });

--- a/packages/react/src/use-button/useButton.test.tsx
+++ b/packages/react/src/use-button/useButton.test.tsx
@@ -226,7 +226,7 @@ describe('useButton', () => {
       expect(getByRole('button')).to.have.property('type', 'submit');
     });
 
-    it('should not set type attribute on non-button elements', async () => {
+    it('does not set type attribute by default on non-button elements', async () => {
       function TestButton(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
         const { disabled, ...otherProps } = props;
         const { getButtonProps } = useButton({ disabled });
@@ -234,8 +234,8 @@ describe('useButton', () => {
         return <span {...getButtonProps(otherProps)} />;
       }
 
-      const { getByRole } = await render(<TestButton>Submit</TestButton>);
-      expect(getByRole('button')).not.to.have.property('type');
+      const { getByRole } = await render(<TestButton />);
+      expect(getByRole('button')).not.to.have.attribute('type');
     });
   });
 });

--- a/packages/react/src/use-button/useButton.ts
+++ b/packages/react/src/use-button/useButton.ts
@@ -104,7 +104,7 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
 
       return mergeProps<'button' | 'input'>(
         {
-          type,
+          type: elementName === 'BUTTON' || elementName === 'INPUT' ? type : undefined,
           onClick(event: React.MouseEvent) {
             if (disabled) {
               event.preventDefault();
@@ -182,7 +182,16 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
         otherExternalProps,
       );
     },
-    [buttonProps, disabled, focusableWhenDisabled, isNativeButton, isValidLink, mergedRef, type],
+    [
+      buttonProps,
+      disabled,
+      elementName,
+      focusableWhenDisabled,
+      isNativeButton,
+      isValidLink,
+      mergedRef,
+      type,
+    ],
   );
 
   return {


### PR DESCRIPTION
`<div type="button">` became a default after #1594 