### PR TITLE
[docs] Improve favicon dark mode

### DIFF
--- a/.codesandbox/template/public/index.html
+++ b/.codesandbox/template/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="initial-scale=1, width=device-width" />
     <title>CRA + Base UI + TS</title>
   </head>

--- a/docs/public/static/favicon-dev.svg
+++ b/docs/public/static/favicon-dev.svg
@@ -1,0 +1,9 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<style>
+  @media (prefers-color-scheme: dark) {
+    .a { fill: #adb5bd; }
+  }
+</style>
+<path d="M9.37508 4.00068C9.16838 3.98792 9 4.15718 9 4.36447V16C12.3137 16 15 13.3113 15 9.99457C15 6.80395 12.5141 4.19446 9.37508 4.00068Z" class="a" fill="#7D7F85"/>
+<path fill-rule="evenodd" class="a" clip-rule="evenodd" d="M8 6.4V8V16C4.68629 16 2 13.1346 2 9.6V8V0C5.31371 0 8 2.86537 8 6.4Z" fill="#7D7F85"/>
+</svg>

--- a/docs/public/static/favicon-dev.svg
+++ b/docs/public/static/favicon-dev.svg
@@ -1,9 +1,10 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 <style>
   @media (prefers-color-scheme: dark) {
     .a { fill: #adb5bd; }
   }
 </style>
-<path d="M9.37508 4.00068C9.16838 3.98792 9 4.15718 9 4.36447V16C12.3137 16 15 13.3113 15 9.99457C15 6.80395 12.5141 4.19446 9.37508 4.00068Z" class="a" fill="#7D7F85"/>
-<path fill-rule="evenodd" class="a" clip-rule="evenodd" d="M8 6.4V8V16C4.68629 16 2 13.1346 2 9.6V8V0C5.31371 0 8 2.86537 8 6.4Z" fill="#7D7F85"/>
+<path d="M18.6251 7.00119C18.2806 6.97886 18 7.27506 18 7.63782V28C23.5228 28 28 23.2948 28 17.4905C28 11.9069 23.8568 7.3403 18.6251 7.00119Z" class="a" fill="#7d7f85"/>
+<path fill-rule="evenodd" class="a" clip-rule="evenodd" d="M16 11.2V14V28C10.4771 28 6 22.9856 6 16.8V14V0C11.5228 0 16 5.0144 16 11.2Z" fill="#7d7f85"/>
 </svg>

--- a/docs/public/static/favicon.svg
+++ b/docs/public/static/favicon.svg
@@ -1,9 +1,10 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 <style>
   @media (prefers-color-scheme: dark) {
     .a { fill: #fff; }
   }
 </style>
-<path d="M9.37508 4.00068C9.16838 3.98792 9 4.15718 9 4.36447V16C12.3137 16 15 13.3113 15 9.99457C15 6.80395 12.5141 4.19446 9.37508 4.00068Z" class="a" fill="#000"/>
-<path fill-rule="evenodd" class="a" clip-rule="evenodd" d="M8 6.4V8V16C4.68629 16 2 13.1346 2 9.6V8V0C5.31371 0 8 2.86537 8 6.4Z" fill="#000"/>
+<path d="M18.6251 7.00119C18.2806 6.97886 18 7.27506 18 7.63782V28C23.5228 28 28 23.2948 28 17.4905C28 11.9069 23.8568 7.3403 18.6251 7.00119Z" class="a" fill="#000"/>
+<path fill-rule="evenodd" class="a" clip-rule="evenodd" d="M16 11.2V14V28C10.4771 28 6 22.9856 6 16.8V14V0C11.5228 0 16 5.0144 16 11.2Z" fill="#000"/>
 </svg>

--- a/docs/public/static/favicon.svg
+++ b/docs/public/static/favicon.svg
@@ -1,4 +1,9 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9.37508 4.00068C9.16838 3.98792 9 4.15718 9 4.36447V16C12.3137 16 15 13.3113 15 9.99457C15 6.80395 12.5141 4.19446 9.37508 4.00068Z" fill="black"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M8 6.4V8V16C4.68629 16 2 13.1346 2 9.6V8V0C5.31371 0 8 2.86537 8 6.4Z" fill="black"/>
+<style>
+  @media (prefers-color-scheme: dark) {
+    .a { fill: #fff; }
+  }
+</style>
+<path d="M9.37508 4.00068C9.16838 3.98792 9 4.15718 9 4.36447V16C12.3137 16 15 13.3113 15 9.99457C15 6.80395 12.5141 4.19446 9.37508 4.00068Z" class="a" fill="#000"/>
+<path fill-rule="evenodd" class="a" clip-rule="evenodd" d="M8 6.4V8V16C4.68629 16 2 13.1346 2 9.6V8V0C5.31371 0 8 2.86537 8 6.4Z" fill="#000"/>
 </svg>

--- a/docs/src/app/Favicons.tsx
+++ b/docs/src/app/Favicons.tsx
@@ -5,13 +5,17 @@ export function Favicons() {
     <React.Fragment>
       {/* Separate set of favicons in dev so that the dev tabs are easier to spot */}
       {process.env.NODE_ENV !== 'production' && (
-        <link rel="icon" href="/static/favicon-dev.ico" sizes="32x32" />
+        <React.Fragment>
+          <link rel="icon" href="/static/favicon-dev.ico" sizes="32x32" />
+          <link rel="icon" href="/static/favicon-dev.svg" type="image/svg+xml" />
+        </React.Fragment>
       )}
-
       {process.env.NODE_ENV === 'production' && (
-        <link rel="icon" href="/static/favicon.ico" sizes="32x32" />
+        <React.Fragment>
+          <link rel="icon" href="/static/favicon.ico" sizes="32x32" />
+          <link rel="icon" href="/static/favicon.svg" type="image/svg+xml" />
+        </React.Fragment>
       )}
-
       {/* Used by Safari when the website is favourited */}
       <link rel="apple-touch-icon" href="/static/apple-touch-icon.png" />
     </React.Fragment>


### PR DESCRIPTION
Having some fun.

Before: https://deploy-preview-1715--base-ui.netlify.app/
After: https://deploy-preview-1717--base-ui.netlify.app/

<img width="794" alt="SCR-20250415-cmcu" src="https://github.com/user-attachments/assets/9b85197b-b61f-4826-a8b6-c1f610a56378" />

I'm not 100% sure about the experience, but that do seem better.

Context: https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs