### PR TITLE
[docs] Remove `keepMounted` from `Dialog.Portal` part

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.tsx
@@ -6,7 +6,7 @@ export default function ExampleDialog() {
   return (
     <Dialog.Root>
       <Dialog.Trigger className={styles.Button}>View notifications</Dialog.Trigger>
-      <Dialog.Portal keepMounted>
+      <Dialog.Portal>
         <Dialog.Backdrop className={styles.Backdrop} />
         <Dialog.Popup className={styles.Popup}>
           <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>


### PR DESCRIPTION
This prop shouldn't be present in the CSS Modules example