### PR TITLE
[dialog] Allow document to slide input into view on iOS when keyboard opens

### DIFF
--- a/docs/src/app/(private)/experiments/mobile-scroll-lock.module.css
+++ b/docs/src/app/(private)/experiments/mobile-scroll-lock.module.css
@@ -1,0 +1,100 @@
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.5rem;
+  padding: 0 0.875rem;
+  margin: 0;
+  outline: 0;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 0.375rem;
+  background-color: var(--color-gray-50);
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5rem;
+  color: var(--color-gray-900);
+  user-select: none;
+
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--color-gray-100);
+    }
+  }
+
+  &:active {
+    background-color: var(--color-gray-100);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: -1px;
+  }
+}
+
+.Backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: black;
+  opacity: 0.2;
+  transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
+
+  @media (prefers-color-scheme: dark) {
+    opacity: 0.7;
+  }
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+  }
+}
+
+.Popup {
+  box-sizing: border-box;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 24rem;
+  max-width: calc(100vw - 3rem);
+  margin-top: -2rem;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  outline: 1px solid var(--color-gray-200);
+  background-color: var(--color-gray-50);
+  color: var(--color-gray-900);
+  transition: all 150ms;
+
+  @media (prefers-color-scheme: dark) {
+    outline: 1px solid var(--color-gray-300);
+  }
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+}
+
+.Title {
+  margin-top: -0.375rem;
+  margin-bottom: 0.25rem;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  letter-spacing: -0.0025em;
+  font-weight: 500;
+}
+
+.Description {
+  margin: 0 0 1.5rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: var(--color-gray-600);
+}
+
+.Actions {
+  display: flex;
+  justify-content: end;
+  gap: 1rem;
+}

--- a/docs/src/app/(private)/experiments/mobile-scroll-lock.tsx
+++ b/docs/src/app/(private)/experiments/mobile-scroll-lock.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { Dialog } from '@base-ui-components/react/dialog';
+import styles from './mobile-scroll-lock.module.css';
+
+export default function ExampleDialog() {
+  return (
+    <div style={{ height: 2000 }}>
+      <Dialog.Root>
+        <Dialog.Trigger className={styles.Button} style={{ marginTop: 500 }}>
+          View notifications
+        </Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Backdrop className={styles.Backdrop} />
+          <Dialog.Popup className={styles.Popup}>
+            <textarea
+              placeholder="What's on your mind?"
+              style={{ width: '100%', height: 300 }}
+            />
+            <div className={styles.Actions}>
+              <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </div>
+  );
+}

--- a/docs/src/app/(private)/experiments/mobile-scroll-lock.tsx
+++ b/docs/src/app/(private)/experiments/mobile-scroll-lock.tsx
@@ -19,6 +19,23 @@ export default function ExampleDialog() {
             <div className={styles.Actions}>
               <Dialog.Close className={styles.Button}>Close</Dialog.Close>
             </div>
+            <Dialog.Root>
+              <Dialog.Trigger className={styles.Button}>
+                View notifications
+              </Dialog.Trigger>
+              <Dialog.Portal>
+                <Dialog.Backdrop className={styles.Backdrop} />
+                <Dialog.Popup className={styles.Popup}>
+                  <textarea
+                    placeholder="What's on your mind?"
+                    style={{ width: '100%', height: 300 }}
+                  />
+                  <div className={styles.Actions}>
+                    <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+                  </div>
+                </Dialog.Popup>
+              </Dialog.Portal>
+            </Dialog.Root>
           </Dialog.Popup>
         </Dialog.Portal>
       </Dialog.Root>

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -23,7 +23,7 @@ import {
   type OpenChangeReason,
   translateOpenChangeReason,
 } from '../../utils/translateOpenChangeReason';
-import { useIOSDocumentSlide } from '../../utils/useIOSDocumentSlide';
+import { useIOSKeyboardSlideFix } from '../../utils/useIOSKeyboardSlideFix';
 
 export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.ReturnValue {
   const {
@@ -128,7 +128,7 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
   const enableScrollLock = open && modal === true;
   const enableScrollLockIOS = enableScrollLock && allowIOSLock;
 
-  const iOSDocumentSlide = useIOSDocumentSlide({
+  const iOSKeyboardSlideFix = useIOSKeyboardSlideFix({
     enabled: enableScrollLock,
     setLock: setAllowIOSLock,
     popupRef,
@@ -145,7 +145,7 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
     role,
     click,
     dismiss,
-    iOSDocumentSlide,
+    iOSKeyboardSlideFix,
   ]);
 
   React.useEffect(() => {

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -55,6 +55,7 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
   );
   const [triggerElement, setTriggerElement] = React.useState<Element | null>(null);
   const [popupElement, setPopupElement] = React.useState<HTMLElement | null>(null);
+  const [allowIOSLock, setAllowIOSLock] = React.useState(true);
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
 
@@ -82,17 +83,6 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
   });
 
   React.useImperativeHandle(params.actionsRef, () => ({ unmount: handleUnmount }), [handleUnmount]);
-
-  const [allowIOSLock, setAllowIOSLock] = React.useState(true);
-  const enableScrollLock = open && modal === true;
-  const enableScrollLockIOS = enableScrollLock && allowIOSLock;
-
-  useScrollLock({
-    enabled: enableScrollLockIOS,
-    mounted,
-    open,
-    referenceElement: popupElement,
-  });
 
   const handleFloatingUIOpenChange = (
     nextOpen: boolean,
@@ -136,6 +126,9 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
     escapeKey: isTopmost,
   });
 
+  const enableScrollLock = open && modal === true;
+  const enableScrollLockIOS = enableScrollLock && allowIOSLock;
+
   const iOSDocumentSlide = useIOSDocumentSlide({
     enabled: enableScrollLock,
     popupRef,
@@ -149,6 +142,13 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
         setAllowIOSLock(true);
       }
     },
+  });
+
+  useScrollLock({
+    enabled: enableScrollLockIOS,
+    mounted,
+    open,
+    referenceElement: popupElement,
   });
 
   const { getReferenceProps, getFloatingProps } = useInteractions([

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -23,7 +23,6 @@ import {
   type OpenChangeReason,
   translateOpenChangeReason,
 } from '../../utils/translateOpenChangeReason';
-import { isIOS } from '../../utils/detectBrowser';
 import { useIOSDocumentSlide } from '../../utils/useIOSDocumentSlide';
 
 export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.ReturnValue {
@@ -131,17 +130,8 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
 
   const iOSDocumentSlide = useIOSDocumentSlide({
     enabled: enableScrollLock,
+    setLock: setAllowIOSLock,
     popupRef,
-    onDisableLock() {
-      if (isIOS()) {
-        setAllowIOSLock(false);
-      }
-    },
-    onEnableLock() {
-      if (isIOS()) {
-        setAllowIOSLock(true);
-      }
-    },
   });
 
   useScrollLock({

--- a/packages/react/src/popover/root/usePopoverRoot.ts
+++ b/packages/react/src/popover/root/usePopoverRoot.ts
@@ -26,7 +26,6 @@ import {
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { PATIENT_CLICK_THRESHOLD } from '../../utils/constants';
 import { useScrollLock } from '../../utils/useScrollLock';
-import { useIOSKeyboardSlideFix } from '../../utils/useIOSKeyboardSlideFix';
 
 export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoot.ReturnValue {
   const {
@@ -50,7 +49,6 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
   const [positionerElement, setPositionerElement] = React.useState<HTMLElement | null>(null);
   const [openReason, setOpenReason] = React.useState<OpenChangeReason | null>(null);
   const [stickIfOpen, setStickIfOpen] = React.useState(true);
-  const [allowIOSLock, setAllowIOSLock] = React.useState(true);
 
   const popupRef = React.useRef<HTMLElement>(null);
   const stickIfOpenTimeoutRef = React.useRef(-1);
@@ -170,28 +168,11 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
   const dismiss = useDismiss(context);
   const role = useRole(context);
 
-  const enableScrollLock = open && modal === true;
-  const enableScrollLockIOS = enableScrollLock && allowIOSLock;
-
-  const iOSDocumentSlide = useIOSKeyboardSlideFix({
-    enabled: enableScrollLock,
-    setLock: setAllowIOSLock,
-    popupRef,
-  });
-
-  useScrollLock({
-    enabled: enableScrollLockIOS,
-    mounted,
-    open,
-    referenceElement: positionerElement,
-  });
-
   const { getReferenceProps, getFloatingProps: getPopupProps } = useInteractions([
     hover,
     click,
     dismiss,
     role,
-    iOSDocumentSlide,
   ]);
 
   const getTriggerProps = React.useCallback(

--- a/packages/react/src/utils/useIOSDocumentSlide.ts
+++ b/packages/react/src/utils/useIOSDocumentSlide.ts
@@ -23,9 +23,18 @@ export function useIOSDocumentSlide(params: {
   const setLock = useEventCallback(setLockParam);
 
   const scrollRef = React.useRef({ x: 0, y: 0 });
+  const hasBeenEnabledRef = React.useRef(enabled);
 
   useEnhancedEffect(() => {
     if (!isIOS()) {
+      return;
+    }
+
+    if (enabled) {
+      hasBeenEnabledRef.current = true;
+    }
+
+    if (!hasBeenEnabledRef.current) {
       return;
     }
 

--- a/packages/react/src/utils/useIOSDocumentSlide.ts
+++ b/packages/react/src/utils/useIOSDocumentSlide.ts
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import type { ElementProps } from '@floating-ui/react';
+import { getTarget, isTypeableElement } from '@floating-ui/react/utils';
+import { useEnhancedEffect } from './useEnhancedEffect';
+import { isIOS } from './detectBrowser';
+import { ownerDocument } from './owner';
+import { useEventCallback } from './useEventCallback';
+
+/**
+ * Temporarily allows disabling the scroll lock when a typeable element (e.g. input or textarea)
+ * is focused. This allows the document to slide up when the keyboard is shown on iOS.
+ * Scroll needs to be manually restored since the sliding causes the page to scroll in the
+ * background.
+ * https://github.com/mui/base-ui/issues/1455
+ */
+export function useIOSDocumentSlide(params: {
+  enabled: boolean;
+  popupRef: React.RefObject<HTMLElement | null>;
+  onDisableLock: () => void;
+  onEnableLock: () => void;
+}) {
+  const {
+    enabled,
+    onDisableLock: onDisableLockParam,
+    onEnableLock: onEnableLockParam,
+    popupRef,
+  } = params;
+
+  const onDisableLock = useEventCallback(onDisableLockParam);
+  const onEnableLock = useEventCallback(onEnableLockParam);
+
+  const scrollRef = React.useRef({ x: 0, y: 0 });
+
+  useEnhancedEffect(() => {
+    if (!isIOS()) {
+      return;
+    }
+
+    const doc = ownerDocument(popupRef.current);
+    const html = doc.documentElement;
+    if (enabled) {
+      scrollRef.current = { x: html.scrollLeft, y: html.scrollTop };
+    } else {
+      html.scrollTop = scrollRef.current.y;
+      html.scrollLeft = scrollRef.current.x;
+    }
+  }, [enabled, popupRef]);
+
+  const floating: ElementProps['floating'] = React.useMemo(
+    () => ({
+      onFocus(event) {
+        const target = getTarget(event.nativeEvent) as Element | null;
+        if (isTypeableElement(target)) {
+          onDisableLock();
+          window.setTimeout(onEnableLock);
+        }
+      },
+    }),
+    [onDisableLock, onEnableLock],
+  );
+
+  return React.useMemo(() => ({ floating }), [floating]);
+}

--- a/packages/react/src/utils/useIOSDocumentSlide.ts
+++ b/packages/react/src/utils/useIOSDocumentSlide.ts
@@ -42,6 +42,10 @@ export function useIOSDocumentSlide(params: {
   const floating: ElementProps['floating'] = React.useMemo(
     () => ({
       onFocus(event) {
+        if (!isIOS()) {
+          return;
+        }
+
         const target = getTarget(event.nativeEvent) as Element | null;
         if (isTypeableElement(target)) {
           setLock(false);

--- a/packages/react/src/utils/useIOSDocumentSlide.ts
+++ b/packages/react/src/utils/useIOSDocumentSlide.ts
@@ -16,18 +16,11 @@ import { useEventCallback } from './useEventCallback';
 export function useIOSDocumentSlide(params: {
   enabled: boolean;
   popupRef: React.RefObject<HTMLElement | null>;
-  onDisableLock: () => void;
-  onEnableLock: () => void;
+  setLock: (lock: boolean) => void;
 }) {
-  const {
-    enabled,
-    onDisableLock: onDisableLockParam,
-    onEnableLock: onEnableLockParam,
-    popupRef,
-  } = params;
+  const { enabled, setLock: setLockParam, popupRef } = params;
 
-  const onDisableLock = useEventCallback(onDisableLockParam);
-  const onEnableLock = useEventCallback(onEnableLockParam);
+  const setLock = useEventCallback(setLockParam);
 
   const scrollRef = React.useRef({ x: 0, y: 0 });
 
@@ -51,12 +44,12 @@ export function useIOSDocumentSlide(params: {
       onFocus(event) {
         const target = getTarget(event.nativeEvent) as Element | null;
         if (isTypeableElement(target)) {
-          onDisableLock();
-          window.setTimeout(onEnableLock);
+          setLock(false);
+          setTimeout(() => setLock(true));
         }
       },
     }),
-    [onDisableLock, onEnableLock],
+    [setLock],
   );
 
   return React.useMemo(() => ({ floating }), [floating]);

--- a/packages/react/src/utils/useIOSKeyboardSlideFix.ts
+++ b/packages/react/src/utils/useIOSKeyboardSlideFix.ts
@@ -46,8 +46,8 @@ export function useIOSKeyboardSlideFix(params: {
       return () => {
         // Doesn't work on Chrome iOS; Safari and Edge work correctly
         if (getPreventScrollCount() === 0) {
-          html.scrollTop = scrollY;
           html.scrollLeft = scrollX;
+          html.scrollTop = scrollY;
         }
       };
     }

--- a/packages/react/src/utils/useIOSKeyboardSlideFix.ts
+++ b/packages/react/src/utils/useIOSKeyboardSlideFix.ts
@@ -48,21 +48,24 @@ export function useIOSKeyboardSlideFix(params: {
     }
   }, [enabled, popupRef]);
 
+  const handlePress = useEventCallback((event: React.FocusEvent | React.MouseEvent) => {
+    if (!isIOS()) {
+      return;
+    }
+
+    const target = getTarget(event.nativeEvent) as Element | null;
+    if (isTypeableElement(target)) {
+      setLock(false);
+      setTimeout(() => setLock(true));
+    }
+  });
+
   const floating: ElementProps['floating'] = React.useMemo(
     () => ({
-      onFocus(event) {
-        if (!isIOS()) {
-          return;
-        }
-
-        const target = getTarget(event.nativeEvent) as Element | null;
-        if (isTypeableElement(target)) {
-          setLock(false);
-          setTimeout(() => setLock(true));
-        }
-      },
+      onFocus: handlePress,
+      onClick: handlePress,
     }),
-    [setLock],
+    [handlePress],
   );
 
   return React.useMemo(() => ({ floating }), [floating]);

--- a/packages/react/src/utils/useIOSKeyboardSlideFix.ts
+++ b/packages/react/src/utils/useIOSKeyboardSlideFix.ts
@@ -67,13 +67,13 @@ export function useIOSKeyboardSlideFix(params: {
     }
   });
 
-  const floating: ElementProps['floating'] = React.useMemo(
+  return React.useMemo(
     () => ({
-      onFocus: handlePress,
-      onClick: handlePress,
+      floating: {
+        onFocus: handlePress,
+        onClick: handlePress,
+      } satisfies ElementProps['floating'],
     }),
     [handlePress],
   );
-
-  return React.useMemo(() => ({ floating }), [floating]);
 }

--- a/packages/react/src/utils/useIOSKeyboardSlideFix.ts
+++ b/packages/react/src/utils/useIOSKeyboardSlideFix.ts
@@ -67,12 +67,12 @@ export function useIOSKeyboardSlideFix(params: {
     }
   });
 
-  return React.useMemo(
+  return React.useMemo<ElementProps>(
     () => ({
       floating: {
         onFocus: handlePress,
         onClick: handlePress,
-      } satisfies ElementProps['floating'],
+      },
     }),
     [handlePress],
   );

--- a/packages/react/src/utils/useIOSKeyboardSlideFix.ts
+++ b/packages/react/src/utils/useIOSKeyboardSlideFix.ts
@@ -13,7 +13,7 @@ import { useEventCallback } from './useEventCallback';
  * background.
  * https://github.com/mui/base-ui/issues/1455
  */
-export function useIOSDocumentSlide(params: {
+export function useIOSKeyboardSlideFix(params: {
   enabled: boolean;
   popupRef: React.RefObject<HTMLElement | null>;
   setLock: (lock: boolean) => void;

--- a/packages/react/src/utils/useIOSKeyboardSlideFix.ts
+++ b/packages/react/src/utils/useIOSKeyboardSlideFix.ts
@@ -44,6 +44,7 @@ export function useIOSKeyboardSlideFix(params: {
       const scrollX = html.scrollLeft;
       const scrollY = html.scrollTop;
       return () => {
+        // Doesn't work on Chrome iOS; Safari and Edge work correctly
         if (getPreventScrollCount() === 0) {
           html.scrollTop = scrollY;
           html.scrollLeft = scrollX;

--- a/packages/react/src/utils/useIOSKeyboardSlideFix.ts
+++ b/packages/react/src/utils/useIOSKeyboardSlideFix.ts
@@ -23,7 +23,6 @@ export function useIOSKeyboardSlideFix(params: {
 
   const setLock = useEventCallback(setLockParam);
 
-  const scrollRef = React.useRef({ x: 0, y: 0 });
   const hasBeenEnabledRef = React.useRef(enabled);
 
   useEnhancedEffect(() => {
@@ -42,11 +41,12 @@ export function useIOSKeyboardSlideFix(params: {
     const doc = ownerDocument(popupRef.current);
     const html = doc.documentElement;
     if (enabled) {
-      scrollRef.current = { x: html.scrollLeft, y: html.scrollTop };
+      const scrollX = html.scrollLeft;
+      const scrollY = html.scrollTop;
       return () => {
         if (getPreventScrollCount() === 0) {
-          html.scrollTop = scrollRef.current.y;
-          html.scrollLeft = scrollRef.current.x;
+          html.scrollTop = scrollY;
+          html.scrollLeft = scrollX;
         }
       };
     }

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -10,6 +10,10 @@ let originalHtmlScrollBehavior = '';
 let preventScrollCount = 0;
 let restore: () => void = () => {};
 
+export function getPreventScrollCount() {
+  return preventScrollCount;
+}
+
 function supportsDvh() {
   return (
     typeof CSS !== 'undefined' &&


### PR DESCRIPTION
Fixes #1455

The way inputs slide inside Popover/anchored elements is a lot stranger so this is just restricted to Dialog, for now

Test on iOS: https://deploy-preview-1735--base-ui.netlify.app/experiments/mobile-scroll-lock