### PR TITLE
[docs] fix swipeDirection type in ToastRoot

### DIFF
--- a/docs/reference/generated/toast-root.json
+++ b/docs/reference/generated/toast-root.json
@@ -3,7 +3,7 @@
   "description": "Groups all parts of an individual toast.\nRenders a `<div>` element.",
   "props": {
     "swipeDirection": {
-      "type": "'left' | 'right' | 'up' | 'down' | 'left' | 'right' | 'up' | 'down'[]",
+      "type": "'left' | 'right' | 'up' | 'down' | ('left' | 'right' | 'up' | 'down')[]",
       "description": "Direction(s) in which the toast can be swiped to dismiss.\nDefaults to `['down', 'right']`."
     },
     "toast": {


### PR DESCRIPTION
Hello,

I adjusted the following type in the documentation. 

![fix](https://github.com/user-attachments/assets/310a007f-4738-4020-99c2-f5c97c9afcb1)


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
