### PR TITLE
[docs] Disable infotip for empty prop descriptions

### DIFF
--- a/docs/src/components/ReferenceTable/PropsReferenceTable.tsx
+++ b/docs/src/components/ReferenceTable/PropsReferenceTable.tsx
@@ -70,21 +70,23 @@ export async function PropsReferenceTable({
                 </Table.Cell>
               )}
               <Table.Cell>
-                <ReferenceTablePopover>
-                  <PropDescription />
-                  <div className="flex flex-col gap-2 text-md md:hidden">
-                    <div className="border-t border-gray-200 pt-2 xs:hidden">
-                      <div className="mb-1 font-bold">Type</div>
-                      <PropType />
-                    </div>
-                    {type === 'props' && (
-                      <div className="border-t border-gray-200 pt-2">
-                        <div className="mb-1 font-bold">Default</div>
-                        <PropDefault />
+                {prop.description && (
+                  <ReferenceTablePopover>
+                    <PropDescription />
+                    <div className="flex flex-col gap-2 text-md md:hidden">
+                      <div className="border-t border-gray-200 pt-2 xs:hidden">
+                        <div className="mb-1 font-bold">Type</div>
+                        <PropType />
                       </div>
-                    )}
-                  </div>
-                </ReferenceTablePopover>
+                      {type === 'props' && (
+                        <div className="border-t border-gray-200 pt-2">
+                          <div className="mb-1 font-bold">Default</div>
+                          <PropDefault />
+                        </div>
+                      )}
+                    </div>
+                  </ReferenceTablePopover>
+                )}
               </Table.Cell>
             </Table.Row>
           );


### PR DESCRIPTION
Fixes #1742. There's other props like `id` as well