### PR TITLE
[ScrollArea] Display Content part in docs

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/scroll-area/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/scroll-area/page.mdx
@@ -25,4 +25,4 @@ import { ScrollArea } from '@base-ui-components/react/scroll-area';
 </ScrollArea.Root>;
 ```
 
-<Reference component="ScrollArea" parts="Root, Viewport, Scrollbar, Thumb, Corner" />
+<Reference component="ScrollArea" parts="Root, Viewport, Content, Scrollbar, Thumb, Corner" />


### PR DESCRIPTION
`ScrollArea.Content` was not displayed in the docs.