### PR TITLE
[docs] Fix formatting of arrays in API reference

### DIFF
--- a/docs/reference/generated/toast-root.json
+++ b/docs/reference/generated/toast-root.json
@@ -3,7 +3,7 @@
   "description": "Groups all parts of an individual toast.\nRenders a `<div>` element.",
   "props": {
     "swipeDirection": {
-      "type": "'left' | 'right' | 'up' | 'down' | 'left' | 'right' | 'up' | 'down'[]",
+      "type": "'left' | 'right' | 'up' | 'down' | ('left' | 'right' | 'up' | 'down')[]",
       "description": "Direction(s) in which the toast can be swiped to dismiss.\nDefaults to `['down', 'right']`."
     },
     "toast": {

--- a/scripts/api-docs-builder/src/formatter.ts
+++ b/scripts/api-docs-builder/src/formatter.ts
@@ -111,7 +111,13 @@ export function formatType(
   }
 
   if (type instanceof rae.ArrayNode) {
-    return `${formatType(type.elementType, false)}[]`;
+    const formattedMemberType = formatType(type.elementType, false);
+
+    if (formattedMemberType.includes(' ')) {
+      return `(${formattedMemberType})[]`;
+    }
+
+    return `${formattedMemberType}[]`;
   }
 
   if (type instanceof rae.FunctionNode) {


### PR DESCRIPTION
Fixed how arrays of complex types are displayed in the docs

Before:
![image](https://github.com/user-attachments/assets/3babc281-260d-4d88-bca5-c9f6512a7121)

After:
![image](https://github.com/user-attachments/assets/f9dbb65a-55e8-4a5f-bff8-ab84c65d4c68)

Preview: https://deploy-preview-1765--base-ui.netlify.app/react/components/toast#root

Related to #1754