### PR TITLE
[Collapsible] POC using `grid-template-*` properties as open/close animation target

### DIFF
--- a/docs/src/app/(private)/experiments/collapsible2/transitions.module.css
+++ b/docs/src/app/(private)/experiments/collapsible2/transitions.module.css
@@ -1,0 +1,76 @@
+.Root {
+  --width: 320px;
+  --duration: 800ms;
+
+  width: var(--width);
+
+  & + .Root {
+    margin-top: 2rem;
+  }
+}
+
+.Panel {
+  display: grid;
+  box-sizing: border-box;
+  width: 100%;
+  grid-template-rows: 1fr;
+
+  transition: all var(--duration);
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    grid-template-rows: 0fr;
+  }
+}
+
+.Content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  background-color: var(--color-gray-200);
+  cursor: text;
+
+  & p {
+    overflow-wrap: break-word;
+  }
+}
+
+.Trigger {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  background-color: var(--color-gray-200);
+  color: var(--color-gray-900);
+
+  &[data-panel-open] .Icon {
+    transform: rotate(90deg);
+  }
+}
+
+.Icon {
+  width: 0.75rem;
+  height: 0.75rem;
+  transition: transform var(--duration) ease-out;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 5rem;
+}
+
+.wrapper {
+  font-family: system-ui, sans-serif;
+  line-height: 1.4;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: stretch;
+  gap: 1rem;
+  align-self: flex-start;
+}

--- a/docs/src/app/(private)/experiments/collapsible2/transitions.tsx
+++ b/docs/src/app/(private)/experiments/collapsible2/transitions.tsx
@@ -1,0 +1,91 @@
+'use client';
+import * as React from 'react';
+import { Collapsible } from '@base-ui-components/react/collapsible2';
+import { ChevronIcon } from '../collapsible/_icons';
+import styles from './transitions.module.css';
+
+export default function CssTransitions() {
+  return (
+    <div className={styles.grid}>
+      <div className={styles.wrapper}>
+        <pre>keepMounted: true</pre>
+        <Collapsible.Root className={styles.Root} defaultOpen>
+          <Collapsible.Trigger className={styles.Trigger}>
+            <ChevronIcon className={styles.Icon} />
+            Trigger
+          </Collapsible.Trigger>
+          <Collapsible.Panel className={styles.Panel} keepMounted>
+            <div className={styles.Content}>
+              <p>
+                He rubbed his eyes, and came close to the picture, and examined it
+                again. There were no signs of any change when he looked into the
+                actual painting, and yet there was no doubt that the whole expression
+                had altered. It was not a mere fancy of his own. The thing was
+                horribly apparent.
+              </p>
+            </div>
+          </Collapsible.Panel>
+        </Collapsible.Root>
+
+        <Collapsible.Root className={styles.Root} defaultOpen={false}>
+          <Collapsible.Trigger className={styles.Trigger}>
+            <ChevronIcon className={styles.Icon} />
+            Trigger
+          </Collapsible.Trigger>
+          <Collapsible.Panel className={styles.Panel} keepMounted>
+            <div className={styles.Content}>
+              <p>
+                He rubbed his eyes, and came close to the picture, and examined it
+                again. There were no signs of any change when he looked into the
+                actual painting, and yet there was no doubt that the whole expression
+                had altered. It was not a mere fancy of his own. The thing was
+                horribly apparent.
+              </p>
+            </div>
+          </Collapsible.Panel>
+        </Collapsible.Root>
+        <small>———</small>
+      </div>
+
+      <div className={styles.wrapper}>
+        <pre>keepMounted: false</pre>
+        <Collapsible.Root className={styles.Root} defaultOpen>
+          <Collapsible.Trigger className={styles.Trigger}>
+            <ChevronIcon className={styles.Icon} />
+            Trigger
+          </Collapsible.Trigger>
+          <Collapsible.Panel className={styles.Panel} keepMounted={false}>
+            <div className={styles.Content}>
+              <p>
+                He rubbed his eyes, and came close to the picture, and examined it
+                again. There were no signs of any change when he looked into the
+                actual painting, and yet there was no doubt that the whole expression
+                had altered. It was not a mere fancy of his own. The thing was
+                horribly apparent.
+              </p>
+            </div>
+          </Collapsible.Panel>
+        </Collapsible.Root>
+
+        <Collapsible.Root className={styles.Root} defaultOpen={false}>
+          <Collapsible.Trigger className={styles.Trigger}>
+            <ChevronIcon className={styles.Icon} />
+            Trigger
+          </Collapsible.Trigger>
+          <Collapsible.Panel className={styles.Panel} keepMounted={false}>
+            <div className={styles.Content}>
+              <p>
+                He rubbed his eyes, and came close to the picture, and examined it
+                again. There were no signs of any change when he looked into the
+                actual painting, and yet there was no doubt that the whole expression
+                had altered. It was not a mere fancy of his own. The thing was
+                horribly apparent.
+              </p>
+            </div>
+          </Collapsible.Panel>
+        </Collapsible.Root>
+        <small>———</small>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,6 +33,7 @@
     "./checkbox": "./src/checkbox/index.ts",
     "./checkbox-group": "./src/checkbox-group/index.ts",
     "./collapsible": "./src/collapsible/index.ts",
+    "./collapsible2": "./src/collapsible2/index.ts",
     "./dialog": "./src/dialog/index.ts",
     "./direction-provider": "./src/direction-provider/index.ts",
     "./field": "./src/field/index.ts",

--- a/packages/react/src/collapsible2/index.parts.ts
+++ b/packages/react/src/collapsible2/index.parts.ts
@@ -1,0 +1,3 @@
+export { CollapsibleRoot as Root } from './root/CollapsibleRoot';
+export { CollapsibleTrigger as Trigger } from './trigger/CollapsibleTrigger';
+export { CollapsiblePanel as Panel } from './panel/CollapsiblePanel';

--- a/packages/react/src/collapsible2/index.ts
+++ b/packages/react/src/collapsible2/index.ts
@@ -1,0 +1,1 @@
+export * as Collapsible from './index.parts';

--- a/packages/react/src/collapsible2/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible2/panel/CollapsiblePanel.test.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { act, fireEvent, flushMicrotasks } from '@mui/internal-test-utils';
+import { Collapsible } from '@base-ui-components/react/collapsible';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+
+const PANEL_CONTENT = 'This is panel content';
+
+describe('<Collapsible.Panel />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Collapsible.Panel />, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render: (node) => {
+      return render(<Collapsible.Root defaultOpen>{node}</Collapsible.Root>);
+    },
+  }));
+
+  describe('prop: keepMounted', () => {
+    it('does not unmount the panel when true', async () => {
+      function App() {
+        const [open, setOpen] = React.useState(false);
+        return (
+          <Collapsible.Root open={open} onOpenChange={setOpen}>
+            <Collapsible.Trigger />
+            <Collapsible.Panel keepMounted>{PANEL_CONTENT}</Collapsible.Panel>
+          </Collapsible.Root>
+        );
+      }
+
+      const { queryByText, getByRole } = await render(<App />);
+
+      const trigger = getByRole('button');
+
+      expect(trigger).to.have.attribute('aria-expanded', 'false');
+      expect(trigger.getAttribute('aria-controls')).to.equal(
+        queryByText(PANEL_CONTENT)?.getAttribute('id'),
+      );
+      expect(queryByText(PANEL_CONTENT)).to.not.equal(null);
+      expect(queryByText(PANEL_CONTENT)).not.toBeVisible();
+      expect(queryByText(PANEL_CONTENT)).to.have.attribute('data-closed');
+
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      expect(trigger).to.have.attribute('aria-expanded', 'true');
+
+      expect(queryByText(PANEL_CONTENT)).toBeVisible();
+      expect(queryByText(PANEL_CONTENT)).to.have.attribute('data-open');
+      expect(trigger).to.have.attribute('data-panel-open');
+
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      expect(trigger).to.have.attribute('aria-expanded', 'false');
+      expect(trigger.getAttribute('aria-controls')).to.equal(
+        queryByText(PANEL_CONTENT)?.getAttribute('id'),
+      );
+      expect(queryByText(PANEL_CONTENT)).not.toBeVisible();
+      expect(queryByText(PANEL_CONTENT)).to.have.attribute('data-closed');
+    });
+  });
+
+  // we test firefox in browserstack which does not support this yet
+  describe.skipIf(!('onbeforematch' in window) || isJSDOM)('prop: hiddenUntilFound', () => {
+    it('uses `hidden="until-found" to hide panel when true', async () => {
+      const handleOpenChange = spy();
+
+      const { queryByText } = await render(
+        <Collapsible.Root defaultOpen={false} onOpenChange={handleOpenChange}>
+          <Collapsible.Trigger />
+          <Collapsible.Panel hiddenUntilFound keepMounted>
+            {PANEL_CONTENT}
+          </Collapsible.Panel>
+        </Collapsible.Root>,
+      );
+
+      const panel = queryByText(PANEL_CONTENT);
+
+      act(() => {
+        const event = new window.Event('beforematch', {
+          bubbles: true,
+          cancelable: false,
+        });
+        panel?.dispatchEvent(event);
+      });
+
+      expect(handleOpenChange.callCount).to.equal(1);
+      expect(panel).to.have.attribute('data-open');
+    });
+  });
+});

--- a/packages/react/src/collapsible2/panel/CollapsiblePanel.tsx
+++ b/packages/react/src/collapsible2/panel/CollapsiblePanel.tsx
@@ -1,0 +1,134 @@
+'use client';
+import * as React from 'react';
+import { BaseUIComponentProps } from '../../utils/types';
+import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
+import { useRenderElement } from '../../utils/useRenderElement';
+import { warn } from '../../utils/warn';
+import { useCollapsibleRootContext } from '../root/CollapsibleRootContext';
+import type { CollapsibleRoot } from '../root/CollapsibleRoot';
+import { collapsibleStyleHookMapping } from '../root/styleHooks';
+import { useCollapsiblePanel } from './useCollapsiblePanel';
+
+/**
+ * A panel with the collapsible contents.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Collapsible](https://base-ui.com/react/components/collapsible)
+ */
+const CollapsiblePanel = React.forwardRef(function CollapsiblePanel(
+  componentProps: CollapsiblePanel.Props,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
+) {
+  const {
+    className,
+    hiddenUntilFound: hiddenUntilFoundProp,
+    id: idProp,
+    keepMounted: keepMountedProp,
+    render,
+    children,
+    ...elementProps
+  } = componentProps;
+
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEnhancedEffect(() => {
+      if (hiddenUntilFoundProp && keepMountedProp === false) {
+        warn(
+          'The `keepMounted={false}` prop on a Collapsible will be ignored when using `hiddenUntilFound` since it requires the Panel to remain mounted even when closed.',
+        );
+      }
+    }, [hiddenUntilFoundProp, keepMountedProp]);
+  }
+
+  const {
+    abortControllerRef,
+    animationTypeRef,
+    mounted,
+    onOpenChange,
+    open,
+    panelId,
+    panelRef,
+    runOnceAnimationsFinish,
+    setHiddenUntilFound,
+    setKeepMounted,
+    setMounted,
+    setOpen,
+    setPanelId,
+    setVisible,
+    state,
+    visible,
+  } = useCollapsibleRootContext();
+
+  const hiddenUntilFound = hiddenUntilFoundProp ?? false;
+  const keepMounted = keepMountedProp ?? false;
+
+  useEnhancedEffect(() => {
+    setHiddenUntilFound(hiddenUntilFound);
+  }, [setHiddenUntilFound, hiddenUntilFound]);
+
+  useEnhancedEffect(() => {
+    setKeepMounted(keepMounted);
+  }, [setKeepMounted, keepMounted]);
+
+  const { props } = useCollapsiblePanel({
+    abortControllerRef,
+    animationTypeRef,
+    externalRef: forwardedRef,
+    hiddenUntilFound,
+    id: idProp ?? panelId,
+    keepMounted,
+    mounted,
+    onOpenChange,
+    open,
+    panelRef,
+    runOnceAnimationsFinish,
+    setMounted,
+    setOpen,
+    setPanelId,
+    setVisible,
+    visible,
+  });
+
+  const renderElement = useRenderElement('div', componentProps, {
+    state,
+    ref: [forwardedRef, panelRef],
+    props: [
+      props,
+      {
+        children: <div style={{ overflow: 'hidden', padding: 0 }}>{children}</div>,
+      },
+      elementProps,
+    ],
+    customStyleHookMapping: collapsibleStyleHookMapping,
+  });
+
+  const shouldRender = keepMounted || hiddenUntilFound || (!keepMounted && mounted);
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return renderElement();
+});
+
+export { CollapsiblePanel };
+
+namespace CollapsiblePanel {
+  export interface Props extends BaseUIComponentProps<'div', CollapsibleRoot.State> {
+    /**
+     * Allows the browser’s built-in page search to find and expand the panel contents.
+     *
+     * Overrides the `keepMounted` prop and uses `hidden="until-found"`
+     * to hide the element without removing it from the DOM.
+     *
+     * @default false
+     */
+    hiddenUntilFound?: boolean;
+    /**
+     * Whether to keep the element in the DOM while the panel is hidden.
+     * This prop is ignored when `hiddenUntilFound` is used.
+     * @default false
+     */
+    keepMounted?: boolean;
+  }
+}

--- a/packages/react/src/collapsible2/panel/CollapsiblePanelDataAttributes.ts
+++ b/packages/react/src/collapsible2/panel/CollapsiblePanelDataAttributes.ts
@@ -1,0 +1,20 @@
+import { TransitionStatusDataAttributes } from '../../utils/styleHookMapping';
+
+export enum CollapsiblePanelDataAttributes {
+  /**
+   * Present when the collapsible panel is open.
+   */
+  open = 'data-open',
+  /**
+   * Present when the collapsible panel is closed.
+   */
+  closed = 'data-closed',
+  /**
+   * Present when the panel is animating in.
+   */
+  startingStyle = TransitionStatusDataAttributes.startingStyle,
+  /**
+   * Present when the panel is animating out.
+   */
+  endingStyle = TransitionStatusDataAttributes.endingStyle,
+}

--- a/packages/react/src/collapsible2/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible2/panel/useCollapsiblePanel.ts
@@ -1,0 +1,309 @@
+'use client';
+import * as React from 'react';
+import { GenericHTMLProps } from '../../utils/types';
+import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
+import { useEventCallback } from '../../utils/useEventCallback';
+import { useForkRef } from '../../utils/useForkRef';
+import { useOnMount } from '../../utils/useOnMount';
+import { warn } from '../../utils/warn';
+import type { AnimationType } from '../root/useCollapsibleRoot';
+import { CollapsiblePanelDataAttributes } from './CollapsiblePanelDataAttributes';
+
+export function useCollapsiblePanel(
+  parameters: useCollapsiblePanel.Parameters,
+): useCollapsiblePanel.ReturnValue {
+  const {
+    abortControllerRef,
+    animationTypeRef,
+    externalRef,
+    hiddenUntilFound,
+    keepMounted,
+    id: idParam,
+    mounted,
+    onOpenChange,
+    open,
+    panelRef,
+    runOnceAnimationsFinish,
+    setMounted,
+    setOpen,
+    setPanelId,
+    setVisible,
+    visible,
+  } = parameters;
+
+  const isBeforeMatchRef = React.useRef(false);
+  const latestAnimationNameRef = React.useRef<string>(null);
+  const shouldCancelInitialOpenAnimationRef = React.useRef(open);
+  const shouldCancelInitialOpenTransitionRef = React.useRef(open);
+
+  /**
+   * When opening, the `hidden` attribute is removed immediately.
+   * When closing, the `hidden` attribute is set after any exit animations runs.
+   */
+  const hidden = React.useMemo(() => {
+    if (animationTypeRef.current === 'css-animation') {
+      return !visible;
+    }
+    return !open && !mounted;
+  }, [open, mounted, visible, animationTypeRef]);
+
+  useEnhancedEffect(() => {
+    if (!keepMounted && !open) {
+      setPanelId(undefined);
+    } else {
+      setPanelId(idParam);
+    }
+    return () => {
+      setPanelId(undefined);
+    };
+  }, [idParam, setPanelId, keepMounted, open]);
+
+  /**
+   * When `keepMounted` is `true` this runs once as soon as it exists in the DOM
+   * regardless of initial open state.
+   *
+   * When `keepMounted` is `false` this runs on every mount, typically every
+   * time it opens. If the panel is in the middle of a close transition that is
+   * interrupted and re-opens, this won't run as the panel was not unmounted.
+   */
+  const handlePanelRef = useEventCallback((element: HTMLElement) => {
+    if (!element) {
+      return undefined;
+    }
+    if (animationTypeRef.current == null) {
+      const panelStyles = getComputedStyle(element);
+      /**
+       * animationTypeRef is safe to read in render because it's only ever set
+       * once here during the first render and never again.
+       * https://react.dev/learn/referencing-values-with-refs#best-practices-for-refs
+       */
+      if (panelStyles.animationName !== 'none' && panelStyles.transitionDuration !== '0s') {
+        warn('CSS transitions and CSS animations both detected');
+      } else if (panelStyles.animationName === 'none' && panelStyles.transitionDuration !== '0s') {
+        animationTypeRef.current = 'css-transition';
+      } else if (panelStyles.animationName !== 'none' && panelStyles.transitionDuration === '0s') {
+        animationTypeRef.current = 'css-animation';
+      } else {
+        animationTypeRef.current = 'none';
+      }
+    }
+
+    if (animationTypeRef.current !== 'css-transition') {
+      return undefined;
+    }
+
+    if (shouldCancelInitialOpenTransitionRef.current) {
+      element.style.setProperty('transition-duration', '0s');
+    }
+
+    let frame = -1;
+    let nextFrame = -1;
+
+    frame = requestAnimationFrame(() => {
+      shouldCancelInitialOpenTransitionRef.current = false;
+      nextFrame = requestAnimationFrame(() => {
+        /**
+         * This is slightly faster than another RAF and is the earliest
+         * opportunity to remove the temporary `transition-duration: 0s` that
+         * was applied to cancel opening transitions of initially open panels.
+         * https://nolanlawson.com/2018/09/25/accurately-measuring-layout-on-the-web/
+         */
+        setTimeout(() => {
+          element.style.removeProperty('transition-duration');
+        });
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      cancelAnimationFrame(nextFrame);
+    };
+  });
+
+  const mergedPanelRef = useForkRef(externalRef, panelRef, handlePanelRef);
+
+  useEnhancedEffect(() => {
+    if (animationTypeRef.current !== 'css-animation') {
+      return;
+    }
+
+    const panel = panelRef.current;
+    if (!panel) {
+      return;
+    }
+
+    latestAnimationNameRef.current = panel.style.animationName || latestAnimationNameRef.current;
+
+    panel.style.setProperty('animation-name', 'none');
+
+    if (!shouldCancelInitialOpenAnimationRef.current && !isBeforeMatchRef.current) {
+      panel.style.removeProperty('animation-name');
+    }
+
+    if (open) {
+      if (abortControllerRef.current != null) {
+        abortControllerRef.current.abort();
+        abortControllerRef.current = null;
+      }
+      setMounted(true);
+      setVisible(true);
+    } else {
+      abortControllerRef.current = new AbortController();
+      runOnceAnimationsFinish(() => {
+        setMounted(false);
+        setVisible(false);
+        abortControllerRef.current = null;
+      }, abortControllerRef.current.signal);
+    }
+  }, [
+    abortControllerRef,
+    animationTypeRef,
+    open,
+    panelRef,
+    runOnceAnimationsFinish,
+    setMounted,
+    setVisible,
+    visible,
+  ]);
+
+  useOnMount(() => {
+    const frame = requestAnimationFrame(() => {
+      shouldCancelInitialOpenAnimationRef.current = false;
+    });
+    return () => cancelAnimationFrame(frame);
+  });
+
+  useEnhancedEffect(() => {
+    if (!hiddenUntilFound) {
+      return undefined;
+    }
+
+    const panel = panelRef.current;
+    if (!panel) {
+      return undefined;
+    }
+
+    let frame = -1;
+    let nextFrame = -1;
+
+    if (open && isBeforeMatchRef.current) {
+      panel.style.transitionDuration = '0s';
+      frame = requestAnimationFrame(() => {
+        isBeforeMatchRef.current = false;
+        nextFrame = requestAnimationFrame(() => {
+          setTimeout(() => {
+            panel.style.removeProperty('transition-duration');
+          });
+        });
+      });
+    }
+
+    return () => {
+      cancelAnimationFrame(frame);
+      cancelAnimationFrame(nextFrame);
+    };
+  }, [hiddenUntilFound, open, panelRef]);
+
+  useEnhancedEffect(() => {
+    const panel = panelRef.current;
+
+    if (panel && hiddenUntilFound && hidden) {
+      /**
+       * React only supports a boolean for the `hidden` attribute and forces
+       * legit string values to booleans so we have to force it back in the DOM
+       * when necessary: https://github.com/facebook/react/issues/24740
+       */
+      panel.setAttribute('hidden', 'until-found');
+      /**
+       * Set data-starting-style here to persist the closed styles, this is to
+       * prevent transitions from starting when the `hidden` attribute changes
+       * to `'until-found'` as they could have different `display` properties:
+       * https://github.com/tailwindlabs/tailwindcss/pull/14625
+       */
+      if (animationTypeRef.current === 'css-transition') {
+        panel.setAttribute(CollapsiblePanelDataAttributes.startingStyle, '');
+      }
+    }
+  }, [hiddenUntilFound, hidden, animationTypeRef, panelRef]);
+
+  React.useEffect(
+    function registerBeforeMatchListener() {
+      const panel = panelRef.current;
+      if (!panel) {
+        return undefined;
+      }
+
+      function handleBeforeMatch() {
+        isBeforeMatchRef.current = true;
+        setOpen(true);
+        onOpenChange(true);
+      }
+
+      panel.addEventListener('beforematch', handleBeforeMatch);
+
+      return () => {
+        panel.removeEventListener('beforematch', handleBeforeMatch);
+      };
+    },
+    [onOpenChange, panelRef, setOpen],
+  );
+
+  return React.useMemo(
+    () => ({
+      props: {
+        hidden,
+        id: idParam,
+        ref: mergedPanelRef,
+      },
+    }),
+    [hidden, idParam, mergedPanelRef],
+  );
+}
+
+export namespace useCollapsiblePanel {
+  export interface Parameters {
+    abortControllerRef: React.RefObject<AbortController | null>;
+    animationTypeRef: React.RefObject<AnimationType>;
+    externalRef: React.ForwardedRef<HTMLDivElement>;
+    /**
+     * Allows the browser’s built-in page search to find and expand the panel contents.
+     *
+     * Overrides the `keepMounted` prop and uses `hidden="until-found"`
+     * to hide the element without removing it from the DOM.
+     */
+    hiddenUntilFound: boolean;
+    /**
+     * The `id` attribute of the panel.
+     */
+    id: React.HTMLAttributes<Element>['id'];
+    /**
+     * Whether to keep the element in the DOM while the panel is closed.
+     * This prop is ignored when `hiddenUntilFound` is used.
+     */
+    keepMounted: boolean;
+    /**
+     * Whether the collapsible panel is currently mounted.
+     */
+    mounted: boolean;
+    onOpenChange: (open: boolean) => void;
+    /**
+     * Whether the collapsible panel is currently open.
+     */
+    open: boolean;
+    panelRef: React.RefObject<HTMLElement | null>;
+    runOnceAnimationsFinish: (fnToExecute: () => void, signal?: AbortSignal | null) => void;
+    setMounted: (nextMounted: boolean) => void;
+    setOpen: (nextOpen: boolean) => void;
+    setPanelId: (id: string | undefined) => void;
+    setVisible: React.Dispatch<React.SetStateAction<boolean>>;
+    /**
+     * The visible state of the panel used to determine the `[hidden]` attribute
+     * only when CSS keyframe animations are used.
+     */
+    visible: boolean;
+  }
+
+  export interface ReturnValue {
+    props: GenericHTMLProps;
+  }
+}

--- a/packages/react/src/collapsible2/root/CollapsibleRoot.test.tsx
+++ b/packages/react/src/collapsible2/root/CollapsibleRoot.test.tsx
@@ -1,0 +1,170 @@
+'use client';
+import * as React from 'react';
+import { expect } from 'chai';
+import { Collapsible } from '@base-ui-components/react/collapsible';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+
+const PANEL_CONTENT = 'This is panel content';
+
+describe('<Collapsible.Root />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Collapsible.Root />, () => ({
+    render,
+    refInstanceof: window.HTMLDivElement,
+  }));
+
+  describe('ARIA attributes', () => {
+    it('sets ARIA attributes', async () => {
+      const { getByTestId, getByRole } = await render(
+        <Collapsible.Root defaultOpen>
+          <Collapsible.Trigger />
+          <Collapsible.Panel data-testid="panel" />
+        </Collapsible.Root>,
+      );
+
+      const trigger = getByRole('button');
+      const panel = getByTestId('panel');
+
+      expect(trigger).to.have.attribute('aria-expanded');
+
+      expect(trigger.getAttribute('aria-controls')).to.equal(panel.getAttribute('id'));
+    });
+  });
+
+  describe('collapsible status', () => {
+    it('disabled status', async () => {
+      const { getByRole } = await render(
+        <Collapsible.Root disabled>
+          <Collapsible.Trigger />
+          <Collapsible.Panel data-testid="panel" />
+        </Collapsible.Root>,
+      );
+
+      const trigger = getByRole('button');
+
+      expect(trigger).to.have.attribute('data-disabled');
+    });
+  });
+
+  describe.skipIf(isJSDOM)('open state', () => {
+    it('controlled mode', async () => {
+      function App() {
+        const [open, setOpen] = React.useState(false);
+        return (
+          <React.Fragment>
+            <Collapsible.Root open={open}>
+              <Collapsible.Trigger>trigger</Collapsible.Trigger>
+              <Collapsible.Panel>This is panel content</Collapsible.Panel>
+            </Collapsible.Root>
+            <button type="button" onClick={() => setOpen(!open)}>
+              toggle
+            </button>
+          </React.Fragment>
+        );
+      }
+      const { queryByText, getByRole, user } = await render(<App />);
+
+      const externalTrigger = getByRole('button', { name: 'toggle' });
+      const trigger = getByRole('button', { name: 'trigger' });
+
+      expect(trigger).to.not.have.attribute('aria-controls');
+      expect(trigger).to.have.attribute('aria-expanded', 'false');
+      expect(queryByText(PANEL_CONTENT)).to.equal(null);
+
+      await user.click(externalTrigger);
+
+      expect(trigger).to.have.attribute('aria-expanded', 'true');
+
+      expect(queryByText(PANEL_CONTENT)).to.not.equal(null);
+      expect(queryByText(PANEL_CONTENT)).toBeVisible();
+      expect(queryByText(PANEL_CONTENT)).to.have.attribute('data-open');
+      expect(trigger).to.have.attribute('data-panel-open');
+
+      await user.click(externalTrigger);
+
+      expect(trigger).to.not.have.attribute('aria-controls');
+      expect(trigger).to.have.attribute('aria-expanded', 'false');
+      expect(queryByText(PANEL_CONTENT)).to.equal(null);
+    });
+
+    it('uncontrolled mode', async () => {
+      const { getByRole, queryByText, user } = await render(
+        <Collapsible.Root defaultOpen={false}>
+          <Collapsible.Trigger />
+          <Collapsible.Panel>This is panel content</Collapsible.Panel>
+        </Collapsible.Root>,
+      );
+
+      const trigger = getByRole('button');
+
+      expect(trigger).to.not.have.attribute('aria-controls');
+      expect(trigger).to.have.attribute('aria-expanded', 'false');
+      expect(queryByText(PANEL_CONTENT)).to.equal(null);
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger });
+
+      expect(trigger).to.have.attribute('aria-expanded', 'true');
+      expect(queryByText(PANEL_CONTENT)).to.not.equal(null);
+      expect(queryByText(PANEL_CONTENT)).toBeVisible();
+      expect(queryByText(PANEL_CONTENT)).to.have.attribute('data-open');
+      expect(trigger).to.have.attribute('data-panel-open');
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger });
+
+      expect(trigger).to.not.have.attribute('aria-controls');
+      expect(trigger).to.have.attribute('aria-expanded', 'false');
+      expect(trigger).to.not.have.attribute('data-panel-open');
+      expect(queryByText(PANEL_CONTENT)).to.equal(null);
+    });
+  });
+
+  describe('prop: render', () => {
+    it('does not render a root element when `null`', async () => {
+      const { getByRole, container } = await render(
+        <Collapsible.Root defaultOpen render={null}>
+          <Collapsible.Trigger />
+          <Collapsible.Panel>This is panel content</Collapsible.Panel>
+        </Collapsible.Root>,
+      );
+
+      const trigger = getByRole('button');
+      expect(container.firstElementChild as HTMLElement).to.equal(trigger);
+    });
+  });
+
+  describe.skipIf(isJSDOM)('keyboard interactions', () => {
+    ['Enter', 'Space'].forEach((key) => {
+      it(`key: ${key} should toggle the Collapsible`, async () => {
+        const { queryByText, getByRole, user } = await render(
+          <Collapsible.Root defaultOpen={false}>
+            <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+            <Collapsible.Panel>This is panel content</Collapsible.Panel>
+          </Collapsible.Root>,
+        );
+
+        const trigger = getByRole('button');
+
+        expect(trigger).to.have.attribute('aria-expanded', 'false');
+        expect(queryByText(PANEL_CONTENT)).to.equal(null);
+
+        await user.keyboard('[Tab]');
+        expect(trigger).toHaveFocus();
+        await user.keyboard(`[${key}]`);
+
+        expect(trigger).to.have.attribute('aria-expanded', 'true');
+        expect(trigger).to.have.attribute('data-panel-open');
+        expect(queryByText(PANEL_CONTENT)).toBeVisible();
+        expect(queryByText(PANEL_CONTENT)).to.not.equal(null);
+        expect(queryByText(PANEL_CONTENT)).to.have.attribute('data-open');
+
+        await user.keyboard(`[${key}]`);
+
+        expect(trigger).to.not.have.attribute('aria-controls');
+        expect(trigger).to.have.attribute('aria-expanded', 'false');
+        expect(trigger).not.to.have.attribute('data-panel-open');
+        expect(queryByText(PANEL_CONTENT)).to.equal(null);
+      });
+    });
+  });
+});

--- a/packages/react/src/collapsible2/root/CollapsibleRoot.tsx
+++ b/packages/react/src/collapsible2/root/CollapsibleRoot.tsx
@@ -1,0 +1,110 @@
+'use client';
+import * as React from 'react';
+import { BaseUIComponentProps } from '../../utils/types';
+import { useRenderElement } from '../../utils/useRenderElement';
+import { useEventCallback } from '../../utils/useEventCallback';
+import { useCollapsibleRoot } from './useCollapsibleRoot';
+import { CollapsibleRootContext } from './CollapsibleRootContext';
+import { collapsibleStyleHookMapping } from './styleHooks';
+
+/**
+ * Groups all parts of the collapsible.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Collapsible](https://base-ui.com/react/components/collapsible)
+ */
+const CollapsibleRoot = React.forwardRef(function CollapsibleRoot(
+  componentProps: CollapsibleRoot.Props,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
+) {
+  const {
+    className,
+    defaultOpen = false,
+    disabled = false,
+    onOpenChange: onOpenChangeProp,
+    open,
+    ...elementProps
+  } = componentProps;
+
+  const onOpenChange = useEventCallback(onOpenChangeProp);
+
+  const collapsible = useCollapsibleRoot({
+    open,
+    defaultOpen,
+    onOpenChange,
+    disabled,
+  });
+
+  const state: CollapsibleRoot.State = React.useMemo(
+    () => ({
+      open: collapsible.open,
+      disabled: collapsible.disabled,
+      transitionStatus: collapsible.transitionStatus,
+    }),
+    [collapsible.open, collapsible.disabled, collapsible.transitionStatus],
+  );
+
+  const contextValue: CollapsibleRootContext = React.useMemo(
+    () => ({
+      ...collapsible,
+      onOpenChange,
+      state,
+    }),
+    [collapsible, onOpenChange, state],
+  );
+
+  // @ts-expect-error Collapsible accepts `render={null}`
+  const renderElement = useRenderElement('div', componentProps, {
+    state,
+    ref: forwardedRef,
+    props: elementProps,
+    customStyleHookMapping: collapsibleStyleHookMapping,
+  });
+
+  if (componentProps.render !== null) {
+    return (
+      <CollapsibleRootContext.Provider value={contextValue}>
+        {renderElement()}
+      </CollapsibleRootContext.Provider>
+    );
+  }
+
+  return (
+    <CollapsibleRootContext.Provider value={contextValue}>
+      {elementProps.children}
+    </CollapsibleRootContext.Provider>
+  );
+});
+
+namespace CollapsibleRoot {
+  export interface State
+    extends Pick<useCollapsibleRoot.ReturnValue, 'open' | 'disabled' | 'transitionStatus'> {}
+
+  export interface Props extends Omit<BaseUIComponentProps<'div', State>, 'render'> {
+    /**
+     * Whether the collapsible panel is currently open.
+     *
+     * To render an uncontrolled collapsible, use the `defaultOpen` prop instead.
+     */
+    open?: boolean;
+    /**
+     * Whether the collapsible panel is initially open.
+     *
+     * To render a controlled collapsible, use the `open` prop instead.
+     * @default false
+     */
+    defaultOpen?: boolean;
+    /**
+     * Event handler called when the panel is opened or closed.
+     */
+    onOpenChange?: (open: boolean) => void;
+    /**
+     * Whether the component should ignore user interaction.
+     * @default false
+     */
+    disabled?: boolean;
+    render?: BaseUIComponentProps<'div', State>['render'] | null;
+  }
+}
+
+export { CollapsibleRoot };

--- a/packages/react/src/collapsible2/root/CollapsibleRootContext.ts
+++ b/packages/react/src/collapsible2/root/CollapsibleRootContext.ts
@@ -1,0 +1,28 @@
+'use client';
+import * as React from 'react';
+import type { useCollapsibleRoot } from './useCollapsibleRoot';
+import type { CollapsibleRoot } from './CollapsibleRoot';
+
+export interface CollapsibleRootContext extends useCollapsibleRoot.ReturnValue {
+  onOpenChange: (open: boolean) => void;
+  state: CollapsibleRoot.State;
+}
+
+export const CollapsibleRootContext = React.createContext<CollapsibleRootContext | undefined>(
+  undefined,
+);
+
+if (process.env.NODE_ENV !== 'production') {
+  CollapsibleRootContext.displayName = 'CollapsibleRootContext';
+}
+
+export function useCollapsibleRootContext() {
+  const context = React.useContext(CollapsibleRootContext);
+  if (context === undefined) {
+    throw new Error(
+      'Base UI: CollapsibleRootContext is missing. Collapsible parts must be placed within <Collapsible.Root>.',
+    );
+  }
+
+  return context;
+}

--- a/packages/react/src/collapsible2/root/styleHooks.ts
+++ b/packages/react/src/collapsible2/root/styleHooks.ts
@@ -1,0 +1,9 @@
+import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { collapsibleOpenStateMapping as baseMapping } from '../../utils/collapsibleOpenStateMapping';
+import type { CollapsibleRoot } from './CollapsibleRoot';
+import { transitionStatusMapping } from '../../utils/styleHookMapping';
+
+export const collapsibleStyleHookMapping: CustomStyleHookMapping<CollapsibleRoot.State> = {
+  ...baseMapping,
+  ...transitionStatusMapping,
+};

--- a/packages/react/src/collapsible2/root/useCollapsibleRoot.ts
+++ b/packages/react/src/collapsible2/root/useCollapsibleRoot.ts
@@ -1,0 +1,201 @@
+'use client';
+import * as React from 'react';
+import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
+import { useBaseUiId } from '../../utils/useBaseUiId';
+import { useControlled } from '../../utils/useControlled';
+import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
+import { useEventCallback } from '../../utils/useEventCallback';
+import { useTransitionStatus, TransitionStatus } from '../../utils/useTransitionStatus';
+
+export type AnimationType = 'css-transition' | 'css-animation' | 'none' | null;
+
+export function useCollapsibleRoot(
+  parameters: useCollapsibleRoot.Parameters,
+): useCollapsibleRoot.ReturnValue {
+  const { open: openParam, defaultOpen, onOpenChange, disabled } = parameters;
+
+  const isControlledRef = React.useRef(openParam !== undefined);
+
+  const [open, setOpen] = useControlled({
+    controlled: openParam,
+    default: defaultOpen,
+    name: 'Collapsible',
+    state: 'open',
+  });
+
+  const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
+  const [visible, setVisible] = React.useState(open);
+  const [panelId, setPanelId] = React.useState<string | undefined>(useBaseUiId());
+
+  const [hiddenUntilFound, setHiddenUntilFound] = React.useState(false);
+  const [keepMounted, setKeepMounted] = React.useState(false);
+
+  const abortControllerRef = React.useRef<AbortController | null>(null);
+  const animationTypeRef = React.useRef<AnimationType>(null);
+  const panelRef: React.RefObject<HTMLElement | null> = React.useRef(null);
+
+  const runOnceAnimationsFinish = useAnimationsFinished(panelRef, false);
+
+  const handleTrigger = useEventCallback(() => {
+    const nextOpen = !open;
+
+    const panel = panelRef.current;
+
+    if (animationTypeRef.current === 'css-animation' && panel != null) {
+      panel.style.removeProperty('animation-name');
+    }
+
+    if (!hiddenUntilFound && !keepMounted) {
+      if (animationTypeRef.current != null && animationTypeRef.current !== 'css-animation') {
+        if (!mounted && nextOpen) {
+          setMounted(true);
+        }
+      }
+
+      if (animationTypeRef.current === 'css-animation') {
+        if (!visible && nextOpen) {
+          setVisible(true);
+        }
+        if (!mounted && nextOpen) {
+          setMounted(true);
+        }
+      }
+    }
+
+    setOpen(nextOpen);
+    onOpenChange(nextOpen);
+
+    if (animationTypeRef.current === 'none') {
+      if (mounted && !nextOpen) {
+        setMounted(false);
+      }
+    }
+
+    if (animationTypeRef.current === 'css-transition') {
+      if (abortControllerRef.current != null) {
+        abortControllerRef.current.abort();
+        abortControllerRef.current = null;
+      }
+
+      if (!nextOpen) {
+        abortControllerRef.current = new AbortController();
+
+        runOnceAnimationsFinish(() => {
+          setMounted(false);
+          abortControllerRef.current = null;
+        }, abortControllerRef.current.signal);
+      }
+    }
+  });
+
+  useEnhancedEffect(() => {
+    /**
+     * Unmount immediately when closing in controlled mode and keepMounted={false}
+     * and no CSS animations or transitions are applied
+     */
+    if (isControlledRef.current && animationTypeRef.current === 'none' && !keepMounted && !open) {
+      setMounted(false);
+    }
+  }, [keepMounted, open, openParam, setMounted]);
+
+  return React.useMemo(
+    () => ({
+      abortControllerRef,
+      animationTypeRef,
+      disabled,
+      handleTrigger,
+      mounted,
+      open,
+      panelId,
+      panelRef,
+      runOnceAnimationsFinish,
+      setHiddenUntilFound,
+      setKeepMounted,
+      setMounted,
+      setOpen,
+      setPanelId,
+      setVisible,
+      transitionStatus,
+      visible,
+    }),
+    [
+      abortControllerRef,
+      animationTypeRef,
+      disabled,
+      handleTrigger,
+      mounted,
+      open,
+      panelId,
+      panelRef,
+      runOnceAnimationsFinish,
+      setHiddenUntilFound,
+      setKeepMounted,
+      setMounted,
+      setOpen,
+      setPanelId,
+      setVisible,
+      transitionStatus,
+      visible,
+    ],
+  );
+}
+
+export namespace useCollapsibleRoot {
+  export interface Parameters {
+    /**
+     * Whether the collapsible panel is currently open.
+     *
+     * To render an uncontrolled collapsible, use the `defaultOpen` prop instead.
+     */
+    open?: boolean;
+    /**
+     * Whether the collapsible panel is initially open.
+     *
+     * To render a controlled collapsible, use the `open` prop instead.
+     * @default false
+     */
+    defaultOpen?: boolean;
+    /**
+     * Event handler called when the panel is opened or closed.
+     */
+    onOpenChange: (open: boolean) => void;
+    /**
+     * Whether the component should ignore user interaction.
+     * @default false
+     */
+    disabled: boolean;
+  }
+
+  export interface ReturnValue {
+    abortControllerRef: React.RefObject<AbortController | null>;
+    animationTypeRef: React.RefObject<AnimationType>;
+    /**
+     * Whether the component should ignore user interaction.
+     */
+    disabled: boolean;
+    handleTrigger: () => void;
+    /**
+     * Whether the collapsible panel is currently mounted.
+     */
+    mounted: boolean;
+    /**
+     * Whether the collapsible panel is currently open.
+     */
+    open: boolean;
+    panelId: React.HTMLAttributes<Element>['id'];
+    panelRef: React.RefObject<HTMLElement | null>;
+    runOnceAnimationsFinish: (fnToExecute: () => void, signal?: AbortSignal | null) => void;
+    setHiddenUntilFound: React.Dispatch<React.SetStateAction<boolean>>;
+    setKeepMounted: React.Dispatch<React.SetStateAction<boolean>>;
+    setMounted: (open: boolean) => void;
+    setOpen: (open: boolean) => void;
+    setPanelId: (id: string | undefined) => void;
+    setVisible: React.Dispatch<React.SetStateAction<boolean>>;
+    transitionStatus: TransitionStatus;
+    /**
+     * The visible state of the panel used to determine the `[hidden]` attribute
+     * only when CSS keyframe animations are used.
+     */
+    visible: boolean;
+  }
+}

--- a/packages/react/src/collapsible2/trigger/CollapsibleTrigger.test.tsx
+++ b/packages/react/src/collapsible2/trigger/CollapsibleTrigger.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { createRenderer } from '@mui/internal-test-utils';
+import { Collapsible } from '@base-ui-components/react/collapsible';
+import { describeConformance } from '../../../test/describeConformance';
+
+describe('<Collapsible.Trigger />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Collapsible.Trigger />, () => ({
+    inheritComponent: 'button',
+    render: (node) => {
+      const { container, ...other } = render(<Collapsible.Root>{node}</Collapsible.Root>);
+
+      return { container, ...other };
+    },
+    refInstanceof: window.HTMLButtonElement,
+  }));
+});

--- a/packages/react/src/collapsible2/trigger/CollapsibleTrigger.tsx
+++ b/packages/react/src/collapsible2/trigger/CollapsibleTrigger.tsx
@@ -1,0 +1,66 @@
+'use client';
+import * as React from 'react';
+import { triggerOpenStateMapping } from '../../utils/collapsibleOpenStateMapping';
+import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { useRenderElement } from '../../utils/useRenderElement';
+import { BaseUIComponentProps } from '../../utils/types';
+import { useButton } from '../../use-button';
+import { useCollapsibleRootContext } from '../root/CollapsibleRootContext';
+import { CollapsibleRoot } from '../root/CollapsibleRoot';
+
+const styleHookMapping: CustomStyleHookMapping<CollapsibleRoot.State> = {
+  ...triggerOpenStateMapping,
+  ...transitionStatusMapping,
+};
+
+/**
+ * A button that opens and closes the collapsible panel.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Collapsible](https://base-ui.com/react/components/collapsible)
+ */
+const CollapsibleTrigger = React.forwardRef(function CollapsibleTrigger(
+  componentProps: CollapsibleTrigger.Props,
+  forwardedRef: React.ForwardedRef<HTMLButtonElement>,
+) {
+  const {
+    panelId,
+    open,
+    handleTrigger,
+    state,
+    disabled: contextDisabled,
+  } = useCollapsibleRootContext();
+
+  const { className, disabled = contextDisabled, id, render, ...elementProps } = componentProps;
+
+  const { getButtonProps, buttonRef } = useButton({
+    disabled,
+    focusableWhenDisabled: true,
+  });
+
+  const props = React.useMemo(
+    () => ({
+      'aria-controls': panelId,
+      'aria-expanded': open,
+      disabled,
+      onClick: handleTrigger,
+    }),
+    [panelId, disabled, open, handleTrigger],
+  );
+
+  const renderElement = useRenderElement('button', componentProps, {
+    state,
+    ref: [forwardedRef, buttonRef],
+    props: [props, elementProps, getButtonProps],
+    customStyleHookMapping: styleHookMapping,
+  });
+
+  return renderElement();
+});
+
+export { CollapsibleTrigger };
+
+namespace CollapsibleTrigger {
+  export interface Props extends BaseUIComponentProps<'button', CollapsibleRoot.State> {}
+}

--- a/packages/react/src/collapsible2/trigger/CollapsibleTriggerDataAttributes.ts
+++ b/packages/react/src/collapsible2/trigger/CollapsibleTriggerDataAttributes.ts
@@ -1,0 +1,6 @@
+export enum CollapsibleTriggerDataAttributes {
+  /**
+   * Present when the collapsible panel is open.
+   */
+  panelOpen = 'data-panel-open',
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,7 @@ export * from './avatar';
 export * from './checkbox';
 export * from './checkbox-group';
 export * from './collapsible';
+export * from './collapsible2';
 export * from './dialog';
 export * from './direction-provider';
 export * from './field';


### PR DESCRIPTION
Demo: https://deploy-preview-1770--base-ui.netlify.app/experiments/collapsible2/transitions

### API

The anatomy remains the same, except `Collapsible.Panel` must render an extra `div` (internally) around its children

CSS transitions:
```css
.Panel {
  display: grid;
  grid-template-rows: 1fr;

  transition: all var(--duration);

  &[data-starting-style],
  &[data-ending-style] {
    opacity: 0;
    grid-template-rows: 0fr;
  }
}
```

CSS animations:
```css
@keyframes slide-down {
  from {
    grid-template-rows: 0fr;
  }

  to {
    grid-template-rows: 1fr;
  }
}

@keyframes slide-up {
  from {
    grid-template-rows: 1fr;
  }

  to {
    grid-template-rows: 0fr;
  }
}

.Panel {
  display: grid;

  &[data-open] {
    animation: slide-down var(--duration) ease-out;
  }

  &[data-closed] {
    animation: slide-up var(--duration) ease-in;
  }
}
```

### 👍 
- Don't need to manage resizing when using CSS transitions

### 👎 
- When transitioning, the size of the panel isn't 1:1 with the actual layout. Notice the size of the gap between the two collapsibles as it transitions:

https://github.com/user-attachments/assets/c11935be-04fb-458d-b656-d867b30314a1

When transitioning `height` it looks like this:

https://github.com/user-attachments/assets/31605424-ce69-4784-a10a-b932cf5298cf

Ariakit has the same issue: https://codesandbox.io/p/sandbox/hungry-goldwasser-mktxk5

- It's even more difficult to suppress the initial open animation when using CSS animations


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
