### PR TITLE
[Checkbox] Set `aria-required`, use `useButton`

### DIFF
--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -14,6 +14,19 @@ describe('<Checkbox.Root />', () => {
     render,
   }));
 
+  describe('ARIA attributes', () => {
+    it('sets the correct aria attributes', async () => {
+      const { getByRole, getByTestId, setProps } = await render(
+        <Checkbox.Root data-testid="test" required={false} />,
+      );
+
+      expect(getByRole('checkbox')).to.equal(getByTestId('test'));
+      expect(getByRole('checkbox')).to.have.attribute('aria-checked');
+      await setProps({ required: true });
+      expect(getByRole('checkbox')).to.have.attribute('aria-required', 'true');
+    });
+  });
+
   describe('extra props', () => {
     it('can override the built-in attributes', async () => {
       const { container } = await render(<Checkbox.Root role="switch" />);

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -60,7 +60,7 @@ const CheckboxRoot = React.forwardRef(function CheckboxRoot(
 
   const disabled = fieldDisabled || groupContext?.disabled || disabledProp;
 
-  const { checked, getInputProps, getButtonProps } = useCheckboxRoot({
+  const { checked, getInputProps, getRootProps } = useCheckboxRoot({
     ...props,
     disabled,
     inputRef,
@@ -93,7 +93,7 @@ const CheckboxRoot = React.forwardRef(function CheckboxRoot(
   const customStyleHookMapping = useCustomStyleHookMapping(state);
 
   const { renderElement } = useComponentRenderer({
-    propGetter: getButtonProps,
+    propGetter: getRootProps,
     render: render ?? 'button',
     ref: forwardedRef,
     state,

--- a/packages/react/src/checkbox/root/useCheckboxRoot.ts
+++ b/packages/react/src/checkbox/root/useCheckboxRoot.ts
@@ -7,6 +7,7 @@ import { mergeProps } from '../../merge-props';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useEnhancedEffect } from '../../utils/useEnhancedEffect';
+import { useButton } from '../../use-button/useButton';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
 import { useField } from '../../field/useField';
@@ -50,6 +51,11 @@ export function useCheckboxRoot(params: useCheckboxRoot.Parameters): useCheckbox
 
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
+
+  const { getButtonProps } = useButton({
+    disabled,
+    buttonRef,
+  });
 
   const {
     getValidationProps,
@@ -95,7 +101,7 @@ export function useCheckboxRoot(params: useCheckboxRoot.Parameters): useCheckbox
     }
   }, [checked, indeterminate, setFilled]);
 
-  const getButtonProps: useCheckboxRoot.ReturnValue['getButtonProps'] = React.useCallback(
+  const getRootProps: useCheckboxRoot.ReturnValue['getRootProps'] = React.useCallback(
     (externalProps = {}) =>
       mergeProps<'button'>(
         {
@@ -106,6 +112,7 @@ export function useCheckboxRoot(params: useCheckboxRoot.Parameters): useCheckbox
           disabled,
           'aria-checked': indeterminate ? 'mixed' : checked,
           'aria-readonly': readOnly || undefined,
+          'aria-required': required || undefined,
           'aria-labelledby': labelId,
           onFocus() {
             setFocused(true);
@@ -134,14 +141,17 @@ export function useCheckboxRoot(params: useCheckboxRoot.Parameters): useCheckbox
           },
         },
         getValidationProps(externalProps),
+        getButtonProps,
       ),
     [
       getValidationProps,
+      getButtonProps,
       id,
       disabled,
       indeterminate,
       checked,
       readOnly,
+      required,
       labelId,
       setFocused,
       setTouched,
@@ -229,10 +239,10 @@ export function useCheckboxRoot(params: useCheckboxRoot.Parameters): useCheckbox
   return React.useMemo(
     () => ({
       checked,
-      getButtonProps,
+      getRootProps,
       getInputProps,
     }),
-    [checked, getButtonProps, getInputProps],
+    [checked, getRootProps, getInputProps],
   );
 }
 
@@ -323,7 +333,7 @@ export namespace useCheckboxRoot {
      * @param externalProps custom props for the button element
      * @returns props that should be spread on the button element
      */
-    getButtonProps: (
+    getRootProps: (
       externalProps?: React.ComponentPropsWithRef<'button'>,
     ) => React.ComponentPropsWithRef<'button'>;
   }


### PR DESCRIPTION
Closes https://github.com/mui/base-ui/issues/1775

- Sets `aria-required="true"` when required (matches Radio)
- CheckboxRoot internally uses `useButton` https://github.com/mui/base-ui/issues/1712

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
