### PR TITLE
[Toast] Fix swipe jump on iOS

### DIFF
--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -147,9 +147,23 @@ describe('<Toast.Root />', () => {
       });
       // Fire an initial move event close to the start to trigger the isFirstPointerMoveRef logic correctly.
       // This simulates the finger moving slightly before the main swipe movement is registered.
+      let deltaX = 0;
+      if (endX > startX) {
+        deltaX = 1;
+      } else if (endX < startX) {
+        deltaX = -1;
+      }
+
+      let deltaY = 0;
+      if (endY > startY) {
+        deltaY = 1;
+      } else if (endY < startY) {
+        deltaY = -1;
+      }
+
       fireEvent.pointerMove(element, {
-        clientX: startX + (endX > startX ? 1 : endX < startX ? -1 : 0),
-        clientY: startY + (endY > startY ? 1 : endY < startY ? -1 : 0),
+        clientX: startX + deltaX,
+        clientY: startY + deltaY,
         bubbles: true,
         pointerId: 1,
       });

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -145,6 +145,15 @@ describe('<Toast.Root />', () => {
         bubbles: true,
         pointerId: 1,
       });
+      // Fire an initial move event close to the start to trigger the isFirstPointerMoveRef logic correctly.
+      // This simulates the finger moving slightly before the main swipe movement is registered.
+      fireEvent.pointerMove(element, {
+        clientX: startX + (endX > startX ? 1 : endX < startX ? -1 : 0),
+        clientY: startY + (endY > startY ? 1 : endY < startY ? -1 : 0),
+        bubbles: true,
+        pointerId: 1,
+      });
+      // Fire the main move event to the end position.
       fireEvent.pointerMove(element, {
         clientX: endX,
         clientY: endY,

--- a/packages/react/src/toast/root/useToastRoot.ts
+++ b/packages/react/src/toast/root/useToastRoot.ts
@@ -103,6 +103,7 @@ export function useToastRoot(props: useToastRoot.Parameters): useToastRoot.Retur
   const maxSwipeDisplacementRef = React.useRef(0);
   const cancelledSwipeRef = React.useRef(false);
   const swipeCancelBaselineRef = React.useRef({ x: 0, y: 0 });
+  const isFirstPointerMoveRef = React.useRef(false);
 
   const domIndex = React.useMemo(() => toasts.indexOf(toast), [toast, toasts]);
   const visibleIndex = React.useMemo(
@@ -220,6 +221,7 @@ export function useToastRoot(props: useToastRoot.Parameters): useToastRoot.Retur
     setIsSwiping(true);
     setIsRealSwipe(false);
     setLockedDirection(null);
+    isFirstPointerMoveRef.current = true;
 
     rootRef.current?.setPointerCapture(event.pointerId);
   });
@@ -231,6 +233,13 @@ export function useToastRoot(props: useToastRoot.Parameters): useToastRoot.Retur
 
     // Prevent text selection on Safari
     event.preventDefault();
+
+    if (isFirstPointerMoveRef.current) {
+      // Adjust the starting position to the current position on the first move
+      // to account for the delay between pointerdown and the first pointermove on iOS.
+      dragStartPosRef.current = { x: event.clientX, y: event.clientY };
+      isFirstPointerMoveRef.current = false;
+    }
 
     const { clientY, clientX, movementX, movementY } = event;
 


### PR DESCRIPTION
On iOS, the `pointermove` doesn't start firing until swiping ~10px after `pointerdown`. This led to a glitchy jump after swiping past that threshold, which was mentioned by @colmtuite. But the solution to fix this is quite straightforward (as commented), the swipe movement is adjusted from when it starts moving, not where the finger is after swiping