### PR TITLE
[core] Set default regression port

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "pnpm test:chromium",
     "test:e2e": "cross-env NODE_ENV=production pnpm test:e2e:build && concurrently --success first --kill-others \"pnpm test:e2e:run\" \"pnpm test:e2e:server\"",
     "test:e2e:build": "vite build --config test/e2e/vite.config.mjs",
-    "test:e2e:dev": "vite --config test/e2e/vite.config.mjs -l info",
+    "test:e2e:dev": "vite --config test/e2e/vite.config.mjs -l info --port 5173",
     "test:e2e:run": "cross-env VITEST_ENV=chromium vitest --project e2e",
     "test:e2e:server": "serve test/e2e -p 5173",
     "test:regressions": "cross-env NODE_ENV=production pnpm test:regressions:build && concurrently --success first --kill-others \"pnpm test:regressions:run\" \"pnpm test:regressions:server\"",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:e2e:server": "serve test/e2e -p 5173",
     "test:regressions": "cross-env NODE_ENV=production pnpm test:regressions:build && concurrently --success first --kill-others \"pnpm test:regressions:run\" \"pnpm test:regressions:server\"",
     "test:regressions:build": "vite build --config test/regressions/vite.config.mjs",
-    "test:regressions:dev": "vite --config test/regressions/vite.config.mjs",
+    "test:regressions:dev": "vite --config test/regressions/vite.config.mjs --port 5173",
     "test:regressions:run": "cross-env VITEST_ENV=chromium vitest --project regressions",
     "test:regressions:server": "serve test/regressions -p 5173",
     "test:jsdom": "cross-env NODE_ENV=test VITEST_ENV=jsdom vitest --project @base-ui-components/react --project docs",


### PR DESCRIPTION
I was trying to understand why the visual regression tests work correctly in Base UI but are broken in MUI X. Turns out, we didn't correctly copy Base UI in MUI X https://github.com/mui/mui-x/pull/17564. But also, turns out, that Base UI rely on the default port of Vite to not change (https://www.reddit.com/r/programming/comments/xh1vyr/fun_fact_vites_default_port_is_5173_which_spells/) for this to work. Since we might want to scope the port per project, not be dependent on the default port, and help debug, it seems best to explicitly specify the value.