### PR TITLE
[code-infra] Remove babel alias and fix extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,6 +327,9 @@ jobs:
           name: Build packages
           command: pnpm release:build
       - run:
+          name: Test Node.js module resolution
+          command: pnpm -F @base-ui/test-node-resolution test
+      - run:
           name: Verify built packages
           command: pnpm -r test:package
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,21 +3,8 @@ const path = require('path');
 const errorCodesPath = path.resolve(__dirname, './docs/public/static/error-codes.json');
 const missingError = process.env.MUI_EXTRACT_ERROR_CODES === 'true' ? 'write' : 'annotate';
 
-function resolveAliasPath(relativeToBabelConf) {
-  const resolvedPath = path.relative(process.cwd(), path.resolve(__dirname, relativeToBabelConf));
-  return `./${resolvedPath.replace('\\', '/')}`;
-}
-
 module.exports = function getBabelConfig(api) {
   const useESModules = !api.env(['node']);
-
-  const defaultAlias = {
-    docs: resolveAliasPath('./docs'),
-    test: resolveAliasPath('./test'),
-    '@mui-internal/api-docs-builder': resolveAliasPath(
-      './node_modules/@mui/monorepo/packages/api-docs-builder',
-    ),
-  };
 
   const presets = [
     [
@@ -57,16 +44,6 @@ module.exports = function getBabelConfig(api) {
         version: '^7.4.4',
       },
     ],
-  ];
-
-  const devPlugins = [
-    [
-      'babel-plugin-module-resolver',
-      {
-        root: ['./'],
-        alias: defaultAlias,
-      },
-    ],
     'babel-plugin-add-import-extension',
   ];
 
@@ -93,15 +70,8 @@ module.exports = function getBabelConfig(api) {
       },
     ],
     env: {
-      development: {
-        plugins: devPlugins,
-      },
       test: {
         sourceMaps: 'both',
-        plugins: devPlugins,
-      },
-      production: {
-        plugins: ['babel-plugin-add-import-extension'],
       },
     },
   };

--- a/babel.config.js
+++ b/babel.config.js
@@ -44,7 +44,7 @@ module.exports = function getBabelConfig(api) {
         version: '^7.4.4',
       },
     ],
-    'babel-plugin-add-import-extension',
+    ...(useESModules ? ['babel-plugin-add-import-extension'] : []),
   ];
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -747,6 +747,12 @@ importers:
         specifier: ^17.7.2
         version: 17.7.2
 
+  test/node-resolution:
+    dependencies:
+      '@base-ui-components/react':
+        specifier: workspace:*
+        version: link:../../packages/react/build
+
 packages:
 
   '@alloc/quick-lru@5.2.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,5 @@ packages:
   - 'packages/*'
   - 'docs'
   - 'test'
+  - 'test/*'
   - 'scripts/*'

--- a/test/node-resolution/index.mjs
+++ b/test/node-resolution/index.mjs
@@ -1,0 +1,6 @@
+/* eslint-disable no-console */
+import * as base from '@base-ui-components/react';
+import { Accordion } from '@base-ui-components/react/accordion';
+
+console.assert(base, 'base');
+console.assert(Accordion, 'Accordion');

--- a/test/node-resolution/package.json
+++ b/test/node-resolution/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@base-ui/test-node-resolution",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node ./index.mjs"
+  },
+  "dependencies": {
+    "@base-ui-components/react": "workspace:*"
+  }
+}


### PR DESCRIPTION
File extensions were broken since https://github.com/mui/base-ui/pull/1662. I believe the alias is only there in core to serve the mocha tests. we should never alias in babel.

To do:
- [x] Add a test that captures this
- [ ] ~Move to `@mui/internal-babel-plugin-resolve-imports`?~ Let's concentrate on this when unifying all package build pipelines across the company