### PR TITLE
[docs] Separate anatomy sections from API reference

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/accordion/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/accordion/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -24,5 +24,7 @@ import { Accordion } from '@base-ui-components/react/accordion';
   </Accordion.Item>
 </Accordion.Root>;
 ```
+
+## API reference
 
 <Reference component="Accordion" parts="Root, Item, Header, Trigger, Panel" />

--- a/docs/src/app/(public)/(content)/react/components/alert-dialog/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/alert-dialog/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -27,6 +27,8 @@ import { AlertDialog } from '@base-ui-components/react/alert-dialog';
   </AlertDialog.Portal>
 </AlertDialog.Root>;
 ```
+
+## API reference
 
 <Reference
   component="AlertDialog"

--- a/docs/src/app/(public)/(content)/react/components/avatar/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/avatar/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -20,5 +20,7 @@ import { Avatar } from '@base-ui-components/react/avatar';
   <Avatar.Fallback>LT</Avatar.Fallback>
 </Avatar.Root>;
 ```
+
+## API reference
 
 <Reference component="Avatar" parts="Root, Image, Fallback" />

--- a/docs/src/app/(public)/(content)/react/components/checkbox-group/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/checkbox-group/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Checkbox Group is composed together with [Checkbox](/react/components/checkbox). Import the components and place them together:
 
@@ -20,6 +20,8 @@ import { CheckboxGroup } from '@base-ui-components/react/checkbox-group';
   <Checkbox.Root />
 </CheckboxGroup>;
 ```
+
+## API reference
 
 <Reference component="CheckboxGroup" />
 

--- a/docs/src/app/(public)/(content)/react/components/checkbox/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/checkbox/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -19,5 +19,7 @@ import { Checkbox } from '@base-ui-components/react/checkbox';
   <Checkbox.Indicator />
 </Checkbox.Root>;
 ```
+
+## API reference
 
 <Reference component="Checkbox" parts="Root, Indicator" />

--- a/docs/src/app/(public)/(content)/react/components/collapsible/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/collapsible/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -20,5 +20,7 @@ import { Collapsible } from '@base-ui-components/react/collapsible';
   <Collapsible.Panel />
 </Collapsible.Root>;
 ```
+
+## API reference
 
 <Reference component="Collapsible" parts="Root, Trigger, Panel" />

--- a/docs/src/app/(public)/(content)/react/components/dialog/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -27,6 +27,8 @@ import { Dialog } from '@base-ui-components/react/dialog';
   </Dialog.Portal>
 </Dialog.Root>;
 ```
+
+## API reference
 
 <Reference
   component="Dialog"

--- a/docs/src/app/(public)/(content)/react/components/field/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/field/page.mdx
@@ -9,7 +9,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -24,5 +24,7 @@ import { Field } from '@base-ui-components/react/field';
   <Field.Validity />
 </Field.Root>;
 ```
+
+## API reference
 
 <Reference component="Field" parts="Root, Label, Control, Description, Error, Validity" />

--- a/docs/src/app/(public)/(content)/react/components/fieldset/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/fieldset/page.mdx
@@ -9,7 +9,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -20,5 +20,7 @@ import { Fieldset } from '@base-ui-components/react/fieldset';
   <Fieldset.Legend />
 </Fieldset.Root>;
 ```
+
+## API reference
 
 <Reference component="Fieldset" parts="Root, Legend" />

--- a/docs/src/app/(public)/(content)/react/components/form/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/form/page.mdx
@@ -9,7 +9,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Form is composed together with [Field](/react/components/field). Import the components and place them together:
 
@@ -25,6 +25,8 @@ import { Form } from '@base-ui-components/react/form';
   </Field.Root>
 </Form>;
 ```
+
+## API reference
 
 <Reference component="Form" />
 

--- a/docs/src/app/(public)/(content)/react/components/input/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/input/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and use it as a single part:
 
@@ -17,5 +17,7 @@ import { Input } from '@base-ui-components/react/input';
 
 <Input />;
 ```
+
+## API reference
 
 <Reference component="Input" />

--- a/docs/src/app/(public)/(content)/react/components/menu/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/menu/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -36,6 +36,8 @@ import { Menu } from '@base-ui-components/react/menu';
   </Menu.Portal>
 </Menu.Root>;
 ```
+
+## API reference
 
 <Reference
   component="Menu"

--- a/docs/src/app/(public)/(content)/react/components/meter/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/meter/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -23,5 +23,7 @@ import { Meter } from '@base-ui-components/react/meter';
   <Meter.Value />
 </Meter.Root>;
 ```
+
+## API reference
 
 <Reference component="Meter" parts="Root, Track, Indicator, Value, Label" />

--- a/docs/src/app/(public)/(content)/react/components/number-field/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/number-field/page.mdx
@@ -9,7 +9,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -27,6 +27,8 @@ import { NumberField } from '@base-ui-components/react/number-field';
   </NumberField.Group>
 </NumberField.Root>;
 ```
+
+## API reference
 
 <Reference
   component="NumberField"

--- a/docs/src/app/(public)/(content)/react/components/popover/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/popover/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -30,6 +30,8 @@ import { Popover } from '@base-ui-components/react/popover';
   </Popover.Portal>
 </Popover.Root>;
 ```
+
+## API reference
 
 <Reference
   component="Popover"

--- a/docs/src/app/(public)/(content)/react/components/preview-card/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/preview-card/page.mdx
@@ -15,7 +15,7 @@
   href="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=448&h=300"
 />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -34,6 +34,8 @@ import { PreviewCard } from '@base-ui-components/react/previewCard';
   </PreviewCard.Portal>
 </PreviewCard.Root>;
 ```
+
+## API reference
 
 <Reference
   component="PreviewCard"

--- a/docs/src/app/(public)/(content)/react/components/progress/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/progress/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -23,5 +23,7 @@ import { Progress } from '@base-ui-components/react/progress';
   <Progress.Value />
 </Progress.Root>;
 ```
+
+## API reference
 
 <Reference component="Progress" parts="Root, Track, Indicator, Value, Label" />

--- a/docs/src/app/(public)/(content)/react/components/radio/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/radio/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Radio is always placed within Radio Group. Import the components and place them together:
 
@@ -22,6 +22,8 @@ import { RadioGroup } from '@base-ui-components/react/radio-group';
   </Radio.Root>
 </RadioGroup>;
 ```
+
+## API reference
 
 <Reference component="RadioGroup" />
 <Reference component="Radio" parts="Root, Indicator" />

--- a/docs/src/app/(public)/(content)/react/components/scroll-area/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/scroll-area/page.mdx
@@ -9,7 +9,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -24,5 +24,7 @@ import { ScrollArea } from '@base-ui-components/react/scroll-area';
   <ScrollArea.Corner />
 </ScrollArea.Root>;
 ```
+
+## API reference
 
 <Reference component="ScrollArea" parts="Root, Viewport, Content, Scrollbar, Thumb, Corner" />

--- a/docs/src/app/(public)/(content)/react/components/select/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/select/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -41,6 +41,8 @@ import { Select } from '@base-ui-components/react/select';
   </Select.Portal>
 </Select.Root>;
 ```
+
+## API reference
 
 <Reference
   component="Select"

--- a/docs/src/app/(public)/(content)/react/components/separator/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/separator/page.mdx
@@ -9,7 +9,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and use it as a single part:
 
@@ -18,5 +18,7 @@ import { Separator } from '@base-ui-components/react/separator';
 
 <Separator />;
 ```
+
+## API reference
 
 <Reference component="Separator" />

--- a/docs/src/app/(public)/(content)/react/components/slider/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/slider/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -25,6 +25,8 @@ import { Slider } from '@base-ui-components/react/slider';
   </Slider.Control>
 </Slider.Root>;
 ```
+
+## API reference
 
 <Reference component="Slider" parts="Root, Value, Control, Track, Indicator, Thumb" />
 

--- a/docs/src/app/(public)/(content)/react/components/switch/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/switch/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -19,5 +19,7 @@ import { Switch } from '@base-ui-components/react/switch';
   <Switch.Thumb />
 </Switch.Root>;
 ```
+
+## API reference
 
 <Reference component="Switch" parts="Root, Thumb" />

--- a/docs/src/app/(public)/(content)/react/components/tabs/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/tabs/page.mdx
@@ -9,7 +9,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -24,5 +24,7 @@ import { Tabs } from '@base-ui-components/react/tabs';
   <Tabs.Panel />
 </Tabs.Root>;
 ```
+
+## API reference
 
 <Reference component="Tabs" parts="Root, List, Tab, Indicator, Panel" />

--- a/docs/src/app/(public)/(content)/react/components/toast/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/toast/page.mdx
@@ -15,7 +15,7 @@
 - <kbd>F6</kbd> lets users jump into the toast viewport landmark region to navigate toasts with
   keyboard focus.
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -33,6 +33,8 @@ import { Toast } from '@base-ui-components/react/toast';
   </Toast.Viewport>
 </Toast.Provider>;
 ```
+
+## API reference
 
 <Reference component="Toast" parts="Provider, Viewport, Root, Title, Description, Action, Close" />
 

--- a/docs/src/app/(public)/(content)/react/components/toggle-group/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/toggle-group/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and use it as a single part:
 
@@ -17,5 +17,7 @@ import { ToggleGroup } from '@base-ui-components/react/toggle-group';
 
 <ToggleGroup />;
 ```
+
+## API reference
 
 <Reference component="ToggleGroup" />

--- a/docs/src/app/(public)/(content)/react/components/toggle/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/toggle/page.mdx
@@ -8,7 +8,7 @@
 
 <Demo path="./demos/hero" />
 
-## API reference
+## Anatomy
 
 Import the component and use it as a single part:
 
@@ -17,5 +17,7 @@ import { Toggle } from '@base-ui-components/react/toggle';
 
 <Toggle />;
 ```
+
+## API reference
 
 <Reference component="Toggle" />

--- a/docs/src/app/(public)/(content)/react/components/toolbar/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/toolbar/page.mdx
@@ -14,7 +14,7 @@ To ensure that toolbars are accessible and helpful, follow these guidelines:
 
 - **Use inputs sparingly**: Left and right arrow keys are used to both move the text insertion cursor in an input, and to navigate among controls in horizontal toolbars. When using an input in a horizontal toolbar, use only one and place it as the last element of the toolbar.
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -32,6 +32,8 @@ import { Toolbar } from '@base-ui-components/react/toolbar';
   <Toolbar.Input />
 </Toolbar.Root>;
 ```
+
+## API reference
 
 <Reference component="Toolbar" parts="Root, Button, Link, Input, Group, Separator" />
 

--- a/docs/src/app/(public)/(content)/react/components/tooltip/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/tooltip/page.mdx
@@ -18,7 +18,7 @@ To ensure that tooltips are accessible and helpful, follow these guidelines:
 - **Avoid tooltips for critical information**: Tooltips work well for enhancing UI clarity (like labeling icon buttons) but should not be the sole means of conveying important information. Since tooltips do not appear on touch devices, consider using a [Popover](/react/components/popover) for essential content.
 - **Avoid tooltips for "infotips"**: If your tooltip is attached to an "info icon" button whose only purpose is to show the tooltip, opt for [Popover](/react/components/popover) and add the `openOnHover` prop instead. Tooltips should describe an element that performs an action separate from opening the tooltip itself.
 
-## API reference
+## Anatomy
 
 Import the component and assemble its parts:
 
@@ -38,5 +38,7 @@ import { Tooltip } from '@base-ui-components/react/tooltip';
   </Tooltip.Root>
 </Tooltip.Provider>;
 ```
+
+## API reference
 
 <Reference component="Tooltip" parts="Provider, Root, Trigger, Portal, Positioner, Popup, Arrow" />


### PR DESCRIPTION
Example: https://deploy-preview-1803--base-ui.netlify.app/react/components/field#anatomy

Closes https://github.com/mui/base-ui/issues/1799

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
