### PR TITLE
[docs][Tabs] Set `display: none` on panel hidden state for CSS modules

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/tabs/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/tabs/demos/hero/css-modules/index.module.css
@@ -83,6 +83,10 @@
     outline-offset: -1px;
     border-radius: 0.375rem;
   }
+
+  &[hidden] {
+    display: none;
+  }
 }
 
 .Icon {


### PR DESCRIPTION
In our docs the CSS modules demo was actually using Tailwind's `[hidden]:where(...)` rule to hide inactive panels, and `display: flex` on the panel has higher specificity than the UA `[hidden]` style

Fixes https://github.com/mui/base-ui/issues/1801

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
