### PR TITLE
[field] Set `valueMissing` to false if only error and not dirtied

### DIFF
--- a/packages/react/src/field/control/useFieldControlValidation.ts
+++ b/packages/react/src/field/control/useFieldControlValidation.ts
@@ -67,6 +67,7 @@ export function useFieldControlValidation() {
       // to reduce error noise.
       if (hasOnlyValueMissingError && !markedDirtyRef.current) {
         computedState.valid = true;
+        computedState.valueMissing = false;
       }
 
       return computedState;

--- a/packages/react/src/field/error/FieldError.test.tsx
+++ b/packages/react/src/field/error/FieldError.test.tsx
@@ -48,8 +48,8 @@ describe('<Field.Error />', () => {
     expect(screen.queryByText('Message')).not.to.equal(null);
   });
 
-  describe('prop: show', () => {
-    it('should only render when `show` matches constraint validation', () => {
+  describe('prop: match', () => {
+    it('should only render when `match` matches constraint validation', () => {
       render(
         <Field.Root>
           <Field.Control required />

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -21,6 +21,40 @@ describe('<Field.Root />', () => {
     render,
   }));
 
+  it('should not mark invalid if `valueMissing` is the only error and not yet dirtied', async () => {
+    await render(
+      <Field.Root>
+        <Field.Control data-testid="control" required />
+      </Field.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+
+    fireEvent.focus(control);
+    fireEvent.blur(control);
+
+    expect(control).not.to.have.attribute('data-invalid');
+    expect(control).not.to.have.attribute('aria-invalid');
+  });
+
+  it('should mark invalid if `valueMissing` is the only error and dirtied', async () => {
+    await render(
+      <Field.Root>
+        <Field.Control data-testid="control" required />
+      </Field.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+
+    fireEvent.focus(control);
+    fireEvent.change(control, { target: { value: 'a' } });
+    fireEvent.change(control, { target: { value: '' } });
+    fireEvent.blur(control);
+
+    expect(control).to.have.attribute('data-invalid', '');
+    expect(control).to.have.attribute('aria-invalid', 'true');
+  });
+
   describe('prop: disabled', () => {
     it('should add data-disabled style hook to all components', async () => {
       await render(


### PR DESCRIPTION
After #1779, we need to set the error field itself back to false as well to ignore it.