### PR TITLE
[menu] Add missing `'use client'` to `RadioGroup` part

### DIFF
--- a/packages/react/src/menu/radio-group/MenuRadioGroup.tsx
+++ b/packages/react/src/menu/radio-group/MenuRadioGroup.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { MenuRadioGroupContext } from './MenuRadioGroupContext';
 import { BaseUIComponentProps } from '../../utils/types';


### PR DESCRIPTION
I confirmed that if even one re-exported component is missing `'use client'`, the entire export breaks, even if you don't use that part.

Fixes #1841. We could consider marking the index files with `'use client'` again instead, unless granularly choosing which components to mark is better still.