### PR TITLE
[Select][Popover][Tooltip] Avoid prop getters when merging props

### DIFF
--- a/packages/react/src/popover/popup/PopoverPopup.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.tsx
@@ -35,7 +35,7 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
     open,
     instantType,
     transitionStatus,
-    getPopupProps,
+    popupProps,
     titleId,
     descriptionId,
     popupRef,
@@ -77,8 +77,8 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
     state,
     ref: [forwardedRef, popupRef],
     props: [
+      popupProps,
       props,
-      getPopupProps,
       {
         style: transitionStatus === 'starting' ? { transition: 'none' } : {},
       },

--- a/packages/react/src/popover/root/PopoverRootContext.ts
+++ b/packages/react/src/popover/root/PopoverRootContext.ts
@@ -25,8 +25,8 @@ export interface PopoverRootContext {
   descriptionId: string | undefined;
   setDescriptionId: React.Dispatch<React.SetStateAction<string | undefined>>;
   floatingRootContext: FloatingRootContext;
-  getTriggerProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
-  getPopupProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
+  triggerProps: GenericHTMLProps;
+  popupProps: GenericHTMLProps;
   openMethod: InteractionType | null;
   openReason: OpenChangeReason | null;
   onOpenChangeComplete: ((open: boolean) => void) | undefined;

--- a/packages/react/src/popover/root/usePopoverRoot.ts
+++ b/packages/react/src/popover/root/usePopoverRoot.ts
@@ -17,7 +17,6 @@ import { OPEN_DELAY } from '../utils/constants';
 import type { GenericHTMLProps } from '../../utils/types';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { type InteractionType } from '../../utils/useEnhancedClickHandler';
-import { mergeProps } from '../../merge-props';
 import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
 import {
   translateOpenChangeReason,
@@ -185,7 +184,7 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
       setTitleId,
       descriptionId,
       setDescriptionId,
-      triggerProps: getReferenceProps(),
+      triggerProps: getReferenceProps(triggerProps),
       popupProps: getFloatingProps(),
       floatingRootContext: context,
       instantType,
@@ -203,6 +202,7 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
       titleId,
       descriptionId,
       getReferenceProps,
+      triggerProps,
       getFloatingProps,
       context,
       instantType,

--- a/packages/react/src/popover/root/usePopoverRoot.ts
+++ b/packages/react/src/popover/root/usePopoverRoot.ts
@@ -168,17 +168,7 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
   const dismiss = useDismiss(context);
   const role = useRole(context);
 
-  const { getReferenceProps, getFloatingProps: getPopupProps } = useInteractions([
-    hover,
-    click,
-    dismiss,
-    role,
-  ]);
-
-  const getTriggerProps = React.useCallback(
-    (externalProps = {}) => getReferenceProps(mergeProps(triggerProps, externalProps)),
-    [getReferenceProps, triggerProps],
-  );
+  const { getReferenceProps, getFloatingProps } = useInteractions([hover, click, dismiss, role]);
 
   return React.useMemo(
     () => ({
@@ -195,8 +185,8 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
       setTitleId,
       descriptionId,
       setDescriptionId,
-      getTriggerProps,
-      getPopupProps,
+      triggerProps: getReferenceProps(),
+      popupProps: getFloatingProps(),
       floatingRootContext: context,
       instantType,
       openMethod,
@@ -212,8 +202,8 @@ export function usePopoverRoot(params: usePopoverRoot.Parameters): usePopoverRoo
       positionerElement,
       titleId,
       descriptionId,
-      getTriggerProps,
-      getPopupProps,
+      getReferenceProps,
+      getFloatingProps,
       context,
       instantType,
       openMethod,
@@ -296,8 +286,8 @@ export namespace usePopoverRoot {
     descriptionId: string | undefined;
     setDescriptionId: React.Dispatch<React.SetStateAction<string | undefined>>;
     floatingRootContext: FloatingRootContext;
-    getTriggerProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
-    getPopupProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
+    triggerProps: GenericHTMLProps;
+    popupProps: GenericHTMLProps;
     instantType: 'dismiss' | 'click' | undefined;
     setTriggerElement: React.Dispatch<React.SetStateAction<Element | null>>;
     positionerElement: HTMLElement | null;

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -22,7 +22,7 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
 ) {
   const { render, className, disabled = false, ...elementProps } = componentProps;
 
-  const { open, setTriggerElement, getTriggerProps, openReason } = usePopoverRootContext();
+  const { open, setTriggerElement, triggerProps, openReason } = usePopoverRootContext();
 
   const state: PopoverTrigger.State = React.useMemo(
     () => ({
@@ -53,7 +53,7 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
   const renderElement = useRenderElement('button', componentProps, {
     state,
     ref: [buttonRef, setTriggerElement],
-    props: [getTriggerProps, elementProps, getButtonProps],
+    props: [triggerProps, elementProps, getButtonProps],
     customStyleHookMapping,
   });
 

--- a/packages/react/src/select/popup/SelectPopup.tsx
+++ b/packages/react/src/select/popup/SelectPopup.tsx
@@ -30,7 +30,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
 ) {
   const { render, className, ...elementProps } = componentProps;
 
-  const { id, open, popupRef, transitionStatus, mounted, onOpenChangeComplete, getRootPopupProps } =
+  const { id, open, popupRef, transitionStatus, mounted, onOpenChangeComplete, popupProps } =
     useSelectRootContext();
   const positioner = useSelectPositionerContext();
 
@@ -61,9 +61,9 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     state,
     customStyleHookMapping,
     props: [
+      popupProps,
       props,
       transitionStatus === 'starting' ? { style: { transition: 'none' } } : {},
-      getRootPopupProps,
       elementProps,
     ],
   });

--- a/packages/react/src/select/root/SelectRootContext.ts
+++ b/packages/react/src/select/root/SelectRootContext.ts
@@ -31,8 +31,8 @@ export interface SelectRootContext {
   setScrollDownArrowVisible: React.Dispatch<React.SetStateAction<boolean>>;
   listRef: React.MutableRefObject<Array<HTMLElement | null>>;
   popupRef: React.MutableRefObject<HTMLDivElement | null>;
-  getRootTriggerProps: (props?: GenericHTMLProps) => GenericHTMLProps;
-  getRootPopupProps: (props?: GenericHTMLProps) => GenericHTMLProps;
+  triggerProps: GenericHTMLProps;
+  popupProps: GenericHTMLProps;
   getItemProps: (
     props?: GenericHTMLProps & { active?: boolean; selected?: boolean },
   ) => Record<string, unknown>;

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -277,11 +277,13 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     },
   });
 
-  const {
-    getReferenceProps: getRootTriggerProps,
-    getFloatingProps: getRootPopupProps,
-    getItemProps,
-  } = useInteractions([click, dismiss, role, listNavigation, typeahead]);
+  const { getReferenceProps, getFloatingProps, getItemProps } = useInteractions([
+    click,
+    dismiss,
+    role,
+    listNavigation,
+    typeahead,
+  ]);
 
   const rootContext: SelectRootContext = React.useMemo(
     () => ({
@@ -311,8 +313,8 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
       labelsRef,
       typingRef,
       selectionRef,
-      getRootPopupProps,
-      getRootTriggerProps,
+      triggerProps: getReferenceProps(),
+      popupProps: getFloatingProps(),
       getItemProps,
       listRef,
       popupRef,
@@ -345,8 +347,8 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
       mounted,
       setMounted,
       label,
-      getRootPopupProps,
-      getRootTriggerProps,
+      getReferenceProps,
+      getFloatingProps,
       getItemProps,
       floatingRootContext,
       touchModality,

--- a/packages/react/src/select/trigger/useSelectTrigger.ts
+++ b/packages/react/src/select/trigger/useSelectTrigger.ts
@@ -27,7 +27,7 @@ export function useSelectTrigger(
     positionerElement,
     readOnly,
     alignItemWithTriggerActiveRef,
-    getRootTriggerProps,
+    triggerProps,
   } = useSelectRootContext();
 
   const { labelId, setTouched, setFocused, validationMode } = useFieldRootContext();
@@ -73,6 +73,7 @@ export function useSelectTrigger(
   }, [open, selectionRef]);
 
   const props: GenericHTMLProps = mergeProps<'button'>(
+    triggerProps,
     {
       'aria-labelledby': labelId,
       'aria-readonly': readOnly || undefined,
@@ -144,7 +145,6 @@ export function useSelectTrigger(
     },
     fieldControlValidation.getValidationProps,
     elementProps,
-    getRootTriggerProps,
     getButtonProps,
     // ensure nested useButton does not overwrite the combobox role:
     // <Toolbar.Button render={<Select.Trigger />} />

--- a/packages/react/src/tooltip/popup/TooltipPopup.tsx
+++ b/packages/react/src/tooltip/popup/TooltipPopup.tsx
@@ -28,7 +28,7 @@ export const TooltipPopup = React.forwardRef(function TooltipPopup(
 ) {
   const { className, render, ...elementProps } = componentProps;
 
-  const { open, instantType, transitionStatus, getPopupProps, popupRef, onOpenChangeComplete } =
+  const { open, instantType, transitionStatus, popupProps, popupRef, onOpenChangeComplete } =
     useTooltipRootContext();
   const { side, align } = useTooltipPositionerContext();
 
@@ -57,7 +57,7 @@ export const TooltipPopup = React.forwardRef(function TooltipPopup(
     state,
     ref: [forwardedRef, popupRef],
     props: [
-      getPopupProps,
+      popupProps,
       {
         style: transitionStatus === 'starting' ? { transition: 'none' } : {},
       },

--- a/packages/react/src/tooltip/root/TooltipRootContext.ts
+++ b/packages/react/src/tooltip/root/TooltipRootContext.ts
@@ -16,8 +16,8 @@ export interface TooltipRootContext {
   closeDelay: number;
   mounted: boolean;
   setMounted: React.Dispatch<React.SetStateAction<boolean>>;
-  getTriggerProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
-  getPopupProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
+  triggerProps: GenericHTMLProps;
+  popupProps: GenericHTMLProps;
   instantType: 'delay' | 'dismiss' | 'focus' | undefined;
   floatingRootContext: FloatingRootContext;
   trackCursorAxis: 'none' | 'x' | 'y' | 'both';

--- a/packages/react/src/tooltip/root/useTooltipRoot.ts
+++ b/packages/react/src/tooltip/root/useTooltipRoot.ts
@@ -163,7 +163,7 @@ export function useTooltipRoot(params: useTooltipRoot.Parameters): useTooltipRoo
     axis: trackCursorAxis === 'none' ? undefined : trackCursorAxis,
   });
 
-  const { getReferenceProps: getTriggerProps, getFloatingProps: getPopupProps } = useInteractions([
+  const { getReferenceProps, getFloatingProps } = useInteractions([
     hover,
     focus,
     dismiss,
@@ -180,8 +180,8 @@ export function useTooltipRoot(params: useTooltipRoot.Parameters): useTooltipRoo
       positionerElement,
       setPositionerElement,
       popupRef,
-      getTriggerProps,
-      getPopupProps,
+      triggerProps: getReferenceProps(),
+      popupProps: getFloatingProps(),
       floatingRootContext: context,
       instantType,
       transitionStatus,
@@ -193,8 +193,8 @@ export function useTooltipRoot(params: useTooltipRoot.Parameters): useTooltipRoo
       setMounted,
       positionerElement,
       setOpen,
-      getTriggerProps,
-      getPopupProps,
+      getReferenceProps,
+      getFloatingProps,
       context,
       instantType,
       transitionStatus,
@@ -267,8 +267,8 @@ export namespace useTooltipRoot {
     setOpen: (value: boolean, event?: Event, reason?: OpenChangeReason) => void;
     mounted: boolean;
     setMounted: React.Dispatch<React.SetStateAction<boolean>>;
-    getTriggerProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
-    getPopupProps: (externalProps?: GenericHTMLProps) => GenericHTMLProps;
+    triggerProps: GenericHTMLProps;
+    popupProps: GenericHTMLProps;
     floatingRootContext: FloatingRootContext;
     instantType: 'delay' | 'dismiss' | 'focus' | undefined;
     transitionStatus: TransitionStatus;

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -17,14 +17,14 @@ export const TooltipTrigger = React.forwardRef(function TooltipTrigger(
 ) {
   const { className, render, ...elementProps } = componentProps;
 
-  const { open, setTriggerElement, getTriggerProps } = useTooltipRootContext();
+  const { open, setTriggerElement, triggerProps } = useTooltipRootContext();
 
   const state: TooltipTrigger.State = React.useMemo(() => ({ open }), [open]);
 
   const renderElement = useRenderElement('button', componentProps, {
     state,
     ref: [forwardedRef, setTriggerElement],
-    props: [getTriggerProps, elementProps],
+    props: [triggerProps, elementProps],
     customStyleHookMapping: triggerOpenStateMapping,
   });
 


### PR DESCRIPTION
Doesn't affect Select specifically for release, but it's changed on main already.

Closes #1744