### PR TITLE
[docs] Fix composition link in useRender doc

### DIFF
--- a/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
@@ -162,7 +162,7 @@ function Button({ render = <button />, ...props }: ButtonProps) {
 
 ## Migrating from Radix UI
 
-Radix UI uses an `asChild` prop, while Base UI uses a `render` prop. Learn more about how composition works in Base UI in the [composition guide](/react/handbook/composition).
+Radix UI uses an `asChild` prop, while Base UI uses a `render` prop. Learn more about how composition works in Base UI in the [composition guide](/docs/src/app/(public)/(content)/react/handbook/composition/page.mdx).
 
 In Radix UI, the `Slot` component lets you implement an `asChild` prop.
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
The composition guide link in [useRender doc](/mui/base-ui/blob/master/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx) does not working. so fix it
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
