### PR TITLE
[NumberField] Remove floating point errors when `snapOnStep` is disabled

### DIFF
--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -157,4 +157,14 @@ describe('NumberField validate', () => {
       });
     });
   });
+
+  it('removes floating point errors by default', () => {
+    expect(
+      toValidatedNumber(0.2 + 0.1, {
+        ...defaultOptions,
+        step: undefined,
+        snapOnStep: false,
+      }),
+    ).to.equal(0.3);
+  });
 });

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -64,5 +64,5 @@ export function toValidatedNumber(
     }
   }
 
-  return clampedValue;
+  return removeFloatingPointErrors(clampedValue, format);
 }


### PR DESCRIPTION
Since `snapOnStep` was added, this end branch ran by default, which doesn't rmove floating point errors.  It should still remove floating point errors as it does when it's enabled