### PR TITLE
[code-infra] Add links to canary releases on closed issues

### DIFF
--- a/.github/workflows/fixed-issue.yml
+++ b/.github/workflows/fixed-issue.yml
@@ -107,8 +107,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Get PR number from the previous step's output
+            const prNumber = '${{ steps.get-prs.outputs.pr_number }}';
             const issueNumber = context.payload.issue.number;
-            const prNumber = steps.get-prs.outputs.pr_number;
 
             // Get issue labels
             const issue = context.payload.issue;

--- a/.github/workflows/fixed-issue.yml
+++ b/.github/workflows/fixed-issue.yml
@@ -42,7 +42,17 @@ jobs:
             const issueNumber = context.payload.issue.number;
             const prNumber = steps.get-prs.outputs.pr_number;
 
-            const commentBody = `This fix or feature will be available in the next npm release of Base UI.
+            // Get issue labels
+            const issue = context.payload.issue;
+            const labels = issue.labels.map(label => label.name);
+
+            // Check if this is a bug/regression or a feature
+            const isBug = labels.some(label =>
+              label.includes("bug 🐛") || label.includes("regression 🐛"));
+
+            const typeText = isBug ? "fix" : "feature";
+
+            const commentBody = `This ${typeText} will be available in the next npm release of Base UI.
 
             In the meantime, you can try it out on our Canary release channel:
 

--- a/.github/workflows/fixed-issue.yml
+++ b/.github/workflows/fixed-issue.yml
@@ -1,0 +1,58 @@
+name: Comment on fixed issues
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get associated PRs
+        id: get-prs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+
+            // Search for PRs that mention the issue number
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged linked:issue-${issue_number}`;
+            const searchResult = await github.rest.search.issuesAndPullRequests({
+              q: query
+            });
+
+            if (searchResult.data.items.length === 0) {
+              console.log('No merged PRs found for this issue');
+              return;
+            }
+
+            // Get the first merged PR number
+            const prNumber = searchResult.data.items[0].number;
+            console.log(`Found merged PR #${prNumber} associated with issue #${issue_number}`);
+
+            // Set output for the next step
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('has_pr', 'true');
+
+      - name: Add comment to issue
+        if: steps.get-prs.outputs.has_pr == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const prNumber = steps.get-prs.outputs.pr_number;
+
+            const commentBody = `This fix or feature will be available in the next npm release of Base UI.
+
+            In the meantime, you can try it out on our Canary release channel:
+
+            npm i https://pkg.pr.new/@base-ui-components/react@${prNumber}`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: commentBody
+            });
+
+            console.log(`Added comment to issue #${issueNumber}`);

--- a/.github/workflows/fixed-issue.yml
+++ b/.github/workflows/fixed-issue.yml
@@ -117,15 +117,17 @@ jobs:
 
             // Check if this is a bug/regression or a feature
             const isBug = labels.some(label =>
-              label.includes("bug 🐛") || label.includes("regression 🐛"));
+              label.includes('bug 🐛') || label.includes('regression 🐛'));
 
-            const typeText = isBug ? "fix" : "feature";
+            const typeText = isBug ? 'fix' : 'feature';
 
             const commentBody = `This ${typeText} will be available in the next npm release of Base UI.
 
             In the meantime, you can try it out on our Canary release channel:
 
-            npm i https://pkg.pr.new/@base-ui-components/react@${prNumber}`;
+            \`\`\`sh
+            npm i https://pkg.pr.new/@base-ui-components/react@${prNumber}
+            \`\`\``;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/fixed-issue.yml
+++ b/.github/workflows/fixed-issue.yml
@@ -15,24 +15,92 @@ jobs:
           script: |
             const issue_number = context.payload.issue.number;
 
-            // Search for PRs that mention the issue number
-            const query = `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged linked:issue-${issue_number}`;
-            const searchResult = await github.rest.search.issuesAndPullRequests({
-              q: query
-            });
+            console.log(`Processing issue #${issue_number}`);
 
-            if (searchResult.data.items.length === 0) {
-              console.log('No merged PRs found for this issue');
-              return;
+            // Use GraphQL to find PRs that close this issue
+            const query = `
+              query($owner:String!, $repo:String!, $issueNumber:Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $issueNumber) {
+                    timelineItems(last: 100, itemTypes: [CONNECTED_EVENT, CROSS_REFERENCED_EVENT]) {
+                      nodes {
+                        __typename
+                        ... on ConnectedEvent {
+                          subject {
+                            ... on PullRequest {
+                              number
+                              merged
+                              mergedAt
+                            }
+                          }
+                        }
+                        ... on CrossReferencedEvent {
+                          source {
+                            ... on PullRequest {
+                              number
+                              merged
+                              mergedAt
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const variables = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issueNumber: parseInt(issue_number)
+            };
+
+            try {
+              const result = await github.graphql(query, variables);
+              console.log('GraphQL query completed successfully');
+
+              // Extract all merged PRs that are linked to this issue
+              const relatedPRs = [];
+              if (result.repository.issue) {
+                const timelineItems = result.repository.issue.timelineItems.nodes;
+
+                for (const item of timelineItems) {
+                  let pr = null;
+
+                  if (item.__typename === 'ConnectedEvent' && item.subject) {
+                    pr = item.subject;
+                  } else if (item.__typename === 'CrossReferencedEvent' && item.source) {
+                    pr = item.source;
+                  }
+
+                  if (pr && pr.merged) {
+                    relatedPRs.push({
+                      number: pr.number,
+                      mergedAt: pr.mergedAt
+                    });
+                  }
+                }
+              }
+
+              // Sort by merge date (newest first) and take the first one
+              relatedPRs.sort((a, b) => new Date(b.mergedAt) - new Date(a.mergedAt));
+
+              if (relatedPRs.length === 0) {
+                console.log('No merged PRs found for this issue');
+                return;
+              }
+
+              const prNumber = relatedPRs[0].number;
+              console.log(`Found merged PR #${prNumber} associated with issue #${issue_number}`);
+
+              // Set output for the next step
+              core.setOutput('pr_number', prNumber);
+              core.setOutput('has_pr', 'true');
+
+            } catch (error) {
+              console.error('Error fetching related PRs:', error);
             }
-
-            // Get the first merged PR number
-            const prNumber = searchResult.data.items[0].number;
-            console.log(`Found merged PR #${prNumber} associated with issue #${issue_number}`);
-
-            // Set output for the next step
-            core.setOutput('pr_number', prNumber);
-            core.setOutput('has_pr', 'true');
 
       - name: Add comment to issue
         if: steps.get-prs.outputs.has_pr == 'true'


### PR DESCRIPTION
Created an Action that adds a comment to issues when they're closed.
The comment points to the canary release that has a fix for the issue.

Tested on https://github.com/michaldudak/base-ui/issues/1#issuecomment-2851270731