### PR TITLE
[composites] Stop event propagation

### DIFF
--- a/packages/react/src/accordion/root/AccordionRoot.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.tsx
@@ -14,6 +14,7 @@ import {
   ARROW_LEFT,
   HOME,
   END,
+  stopEvent,
 } from '../../composite/composite';
 import { CompositeList } from '../../composite/list/CompositeList';
 import { useDirection } from '../../direction-provider/DirectionContext';
@@ -171,7 +172,7 @@ export const AccordionRoot = React.forwardRef(function AccordionRoot(
             return;
           }
 
-          event.preventDefault();
+          stopEvent(event);
 
           const triggers = getActiveTriggers(accordionItemRefs);
 

--- a/packages/react/src/composite/composite.ts
+++ b/packages/react/src/composite/composite.ts
@@ -33,6 +33,7 @@ export const VERTICAL_KEYS = [ARROW_UP, ARROW_DOWN];
 export const VERTICAL_KEYS_WITH_EXTRA_KEYS = [ARROW_UP, ARROW_DOWN, HOME, END];
 export const ARROW_KEYS = [...HORIZONTAL_KEYS, ...VERTICAL_KEYS];
 export const ALL_KEYS = [...ARROW_KEYS, HOME, END];
+export const COMPOSITE_KEYS = [ARROW_UP, ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, HOME, END];
 
 export const SHIFT = 'Shift' as const;
 export const CONTROL = 'Control' as const;

--- a/packages/react/src/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/composite/root/useCompositeRoot.ts
@@ -170,11 +170,6 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
               return;
             }
 
-            if ((event.target as HTMLElement).closest('[data-floating-ui-portal]') != null) {
-              // don't navigate if the event came from a popup
-              return;
-            }
-
             if (textDirectionRef?.current == null) {
               textDirectionRef.current = getTextDirection(element);
             }

--- a/packages/react/src/dialog/popup/useDialogPopup.tsx
+++ b/packages/react/src/dialog/popup/useDialogPopup.tsx
@@ -5,6 +5,7 @@ import { mergeProps } from '../../merge-props';
 import { type InteractionType } from '../../utils/useEnhancedClickHandler';
 import { GenericHTMLProps } from '../../utils/types';
 import { type OpenChangeReason } from '../../utils/translateOpenChangeReason';
+import { COMPOSITE_KEYS } from '../../composite/composite';
 
 export function useDialogPopup(parameters: useDialogPopup.Parameters): useDialogPopup.ReturnValue {
   const {
@@ -57,6 +58,11 @@ export function useDialogPopup(parameters: useDialogPopup.Parameters): useDialog
         ...getPopupProps(),
         ref: handleRef,
         hidden: !mounted,
+        onKeyDown(event) {
+          if (COMPOSITE_KEYS.includes(event.key)) {
+            event.stopPropagation();
+          }
+        },
       },
       externalProps,
     );

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -241,6 +241,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
               'ArrowRight',
               'Tab',
               'Enter',
+              'Escape',
             ].includes(event.key);
 
             if (

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { useModernLayoutEffect } from '@floating-ui/react/utils';
+import { useModernLayoutEffect, stopEvent } from '@floating-ui/react/utils';
 import { useNumberFieldRootContext } from '../root/NumberFieldRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
@@ -265,7 +265,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
             const amount = getStepAmount(event) ?? DEFAULT_STEP;
 
             // Prevent insertion of text or caret from moving.
-            event.preventDefault();
+            stopEvent(event);
 
             if (event.key === 'ArrowUp') {
               incrementValue(amount, 1, parsedValue, nativeEvent);

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -89,6 +89,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
         enableHomeAndEndKeys={false}
         modifierKeys={MODIFIER_KEYS}
         render={renderElement()}
+        stopEventPropagation
       />
       <input {...radioGroup.getInputProps()} />
     </RadioGroupContext.Provider>

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -16,7 +16,7 @@ import {
   ARROW_LEFT,
   HOME,
   END,
-  stopEvent,
+  COMPOSITE_KEYS,
 } from '../../composite/composite';
 import { useCompositeListItem } from '../../composite/list/useCompositeListItem';
 import { useDirection } from '../../direction-provider/DirectionContext';
@@ -32,7 +32,6 @@ import { SliderThumbDataAttributes } from './SliderThumbDataAttributes';
 const PAGE_UP = 'PageUp';
 const PAGE_DOWN = 'PageDown';
 
-const COMPOSITE_KEYS = [ARROW_UP, ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, HOME, END];
 const ALL_KEYS = [ARROW_UP, ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, HOME, END, PAGE_UP, PAGE_DOWN];
 
 function defaultRender(
@@ -227,6 +226,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
         if (COMPOSITE_KEYS.includes(event.key)) {
           event.stopPropagation();
         }
+
         let newValue = null;
         const isRange = sliderValues.length > 1;
         const roundedValue = roundValueToStep(thumbValue, step, min);
@@ -285,7 +285,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
 
         if (newValue !== null) {
           handleInputChange(newValue, index, event);
-          stopEvent(event);
+          event.preventDefault();
         }
       },
       ref: mergedThumbRef,

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -16,6 +16,7 @@ import {
   ARROW_LEFT,
   HOME,
   END,
+  stopEvent,
 } from '../../composite/composite';
 import { useCompositeListItem } from '../../composite/list/useCompositeListItem';
 import { useDirection } from '../../direction-provider/DirectionContext';
@@ -284,7 +285,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
 
         if (newValue !== null) {
           handleInputChange(newValue, index, event);
-          event.preventDefault();
+          stopEvent(event);
         }
       },
       ref: mergedThumbRef,

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -1065,8 +1065,8 @@ describe('<Tabs.Root />', () => {
     });
   });
 
-  describe('inside popup', () => {
-    it('Popover', async () => {
+  describe('popups', () => {
+    it('works inside Popover', async () => {
       function ExamplePopover() {
         return (
           <Popover.Root>
@@ -1075,7 +1075,7 @@ describe('<Tabs.Root />', () => {
               <Popover.Positioner sideOffset={8}>
                 <Popover.Popup>
                   <Tabs.Root defaultValue="overview">
-                    <Tabs.List className="relative z-0 flex gap-1 px-1 shadow-[inset_0_-1px] shadow-gray-200">
+                    <Tabs.List>
                       <Tabs.Tab value="overview">Overview</Tabs.Tab>
                       <Tabs.Tab value="projects">Projects</Tabs.Tab>
                       <Tabs.Tab value="account">Account</Tabs.Tab>
@@ -1106,7 +1106,7 @@ describe('<Tabs.Root />', () => {
       expect(tab2).toHaveFocus();
     });
 
-    it('Dialog', async () => {
+    it('works inside Dialog', async () => {
       function ExampleDialog() {
         return (
           <Dialog.Root>
@@ -1114,7 +1114,7 @@ describe('<Tabs.Root />', () => {
             <Dialog.Portal>
               <Dialog.Popup>
                 <Tabs.Root defaultValue="overview">
-                  <Tabs.List className="relative z-0 flex gap-1 px-1 shadow-[inset_0_-1px] shadow-gray-200">
+                  <Tabs.List>
                     <Tabs.Tab value="overview">Overview</Tabs.Tab>
                     <Tabs.Tab value="projects">Projects</Tabs.Tab>
                     <Tabs.Tab value="account">Account</Tabs.Tab>

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -6,6 +6,8 @@ import {
   DirectionProvider,
   type TextDirection,
 } from '@base-ui-components/react/direction-provider';
+import { Popover } from '@base-ui-components/react/popover';
+import { Dialog } from '@base-ui-components/react/dialog';
 import { Tabs } from '@base-ui-components/react/tabs';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -1060,6 +1062,86 @@ describe('<Tabs.Root />', () => {
       });
 
       expect(root).to.have.attribute('data-activation-direction', 'up');
+    });
+  });
+
+  describe('inside popup', () => {
+    it('Popover', async () => {
+      function ExamplePopover() {
+        return (
+          <Popover.Root>
+            <Popover.Trigger>Open</Popover.Trigger>
+            <Popover.Portal>
+              <Popover.Positioner sideOffset={8}>
+                <Popover.Popup>
+                  <Tabs.Root defaultValue="overview">
+                    <Tabs.List className="relative z-0 flex gap-1 px-1 shadow-[inset_0_-1px] shadow-gray-200">
+                      <Tabs.Tab value="overview">Overview</Tabs.Tab>
+                      <Tabs.Tab value="projects">Projects</Tabs.Tab>
+                      <Tabs.Tab value="account">Account</Tabs.Tab>
+                    </Tabs.List>
+                    <Tabs.Panel value="overview" />
+                    <Tabs.Panel value="projects" />
+                    <Tabs.Panel value="account" />
+                  </Tabs.Root>
+                </Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          </Popover.Root>
+        );
+      }
+
+      const { user } = await render(<ExamplePopover />);
+
+      const trigger = screen.getByRole('button', { name: 'Open' });
+
+      await user.click(trigger);
+
+      const tab1 = screen.getByRole('tab', { name: 'Overview' });
+      expect(tab1).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+
+      const tab2 = screen.getByRole('tab', { name: 'Projects' });
+      expect(tab2).toHaveFocus();
+    });
+
+    it('Dialog', async () => {
+      function ExampleDialog() {
+        return (
+          <Dialog.Root>
+            <Dialog.Trigger>Open</Dialog.Trigger>
+            <Dialog.Portal>
+              <Dialog.Popup>
+                <Tabs.Root defaultValue="overview">
+                  <Tabs.List className="relative z-0 flex gap-1 px-1 shadow-[inset_0_-1px] shadow-gray-200">
+                    <Tabs.Tab value="overview">Overview</Tabs.Tab>
+                    <Tabs.Tab value="projects">Projects</Tabs.Tab>
+                    <Tabs.Tab value="account">Account</Tabs.Tab>
+                  </Tabs.List>
+                  <Tabs.Panel value="overview" />
+                  <Tabs.Panel value="projects" />
+                  <Tabs.Panel value="account" />
+                </Tabs.Root>
+              </Dialog.Popup>
+            </Dialog.Portal>
+          </Dialog.Root>
+        );
+      }
+
+      const { user } = await render(<ExampleDialog />);
+
+      const trigger = screen.getByRole('button', { name: 'Open' });
+
+      await user.click(trigger);
+
+      const tab1 = screen.getByRole('tab', { name: 'Overview' });
+      expect(tab1).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+
+      const tab2 = screen.getByRole('tab', { name: 'Projects' });
+      expect(tab2).toHaveFocus();
     });
   });
 });

--- a/packages/react/src/toggle-group/ToggleGroup.tsx
+++ b/packages/react/src/toggle-group/ToggleGroup.tsx
@@ -112,7 +112,12 @@ export const ToggleGroup = React.forwardRef(function ToggleGroup(
       {toolbarContext ? (
         renderElement()
       ) : (
-        <CompositeRoot direction={direction} loop={loop} render={renderElement()} />
+        <CompositeRoot
+          direction={direction}
+          loop={loop}
+          render={renderElement()}
+          stopEventPropagation
+        />
       )}
     </ToggleGroupContext.Provider>
   );

--- a/packages/react/src/toolbar/button/ToolbarButton.test.tsx
+++ b/packages/react/src/toolbar/button/ToolbarButton.test.tsx
@@ -516,6 +516,33 @@ describe('<Toolbar.Button />', () => {
         await user.keyboard('[ArrowDown]');
         expect(onOpenChange.callCount).to.equal(0);
       });
+
+      it('prevents composite keydowns from escaping', async () => {
+        const onOpenChange = spy();
+        const { user } = await render(
+          <Toolbar.Root>
+            <Dialog.Root modal={false} onOpenChange={onOpenChange}>
+              <Toolbar.Button render={<Dialog.Trigger />}>dialog</Toolbar.Button>
+              <Dialog.Portal>
+                <Dialog.Backdrop />
+                <Dialog.Popup>
+                  <Dialog.Title>title text</Dialog.Title>
+                </Dialog.Popup>
+              </Dialog.Portal>
+            </Dialog.Root>
+
+            <Toolbar.Button>empty</Toolbar.Button>
+          </Toolbar.Root>,
+        );
+
+        expect(screen.queryByText('title text')).to.equal(null);
+
+        const trigger = screen.getByRole('button', { name: 'dialog' });
+        await user.click(trigger);
+        await user.keyboard('{ArrowRight}');
+
+        expect(onOpenChange.callCount).to.equal(1);
+      });
     });
 
     describe('AlertDialog', () => {
@@ -607,6 +634,33 @@ describe('<Toolbar.Button />', () => {
         await user.keyboard('[ArrowUp]');
         await user.keyboard('[ArrowDown]');
         expect(onOpenChange.callCount).to.equal(0);
+      });
+
+      it('prevents composite keydowns from escaping', async () => {
+        const onOpenChange = spy();
+        const { user } = await render(
+          <Toolbar.Root>
+            <AlertDialog.Root onOpenChange={onOpenChange}>
+              <Toolbar.Button render={<Dialog.Trigger />}>dialog</Toolbar.Button>
+              <AlertDialog.Portal>
+                <AlertDialog.Backdrop />
+                <AlertDialog.Popup>
+                  <AlertDialog.Title>title text</AlertDialog.Title>
+                </AlertDialog.Popup>
+              </AlertDialog.Portal>
+            </AlertDialog.Root>
+
+            <Toolbar.Button>empty</Toolbar.Button>
+          </Toolbar.Root>,
+        );
+
+        expect(screen.queryByText('title text')).to.equal(null);
+
+        const trigger = screen.getByRole('button', { name: 'dialog' });
+        await user.click(trigger);
+        await user.keyboard('{ArrowRight}');
+
+        expect(onOpenChange.callCount).to.equal(1);
       });
     });
 

--- a/packages/react/src/toolbar/button/ToolbarButton.test.tsx
+++ b/packages/react/src/toolbar/button/ToolbarButton.test.tsx
@@ -517,7 +517,7 @@ describe('<Toolbar.Button />', () => {
         expect(onOpenChange.callCount).to.equal(0);
       });
 
-      it('prevents composite keydowns from escaping', async () => {
+      it.only('prevents composite keydowns from escaping', async () => {
         const onOpenChange = spy();
         const { user } = await render(
           <Toolbar.Root>
@@ -526,7 +526,7 @@ describe('<Toolbar.Button />', () => {
               <Dialog.Portal>
                 <Dialog.Backdrop />
                 <Dialog.Popup>
-                  <Dialog.Title>title text</Dialog.Title>
+                  <Dialog.Title>title</Dialog.Title>
                 </Dialog.Popup>
               </Dialog.Portal>
             </Dialog.Root>
@@ -535,13 +535,18 @@ describe('<Toolbar.Button />', () => {
           </Toolbar.Root>,
         );
 
-        expect(screen.queryByText('title text')).to.equal(null);
+        expect(screen.queryByText('title')).to.equal(null);
 
         const trigger = screen.getByRole('button', { name: 'dialog' });
         await user.click(trigger);
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).toHaveFocus();
+        });
+
         await user.keyboard('{ArrowRight}');
 
-        expect(onOpenChange.callCount).to.equal(1);
+        expect(onOpenChange.lastCall.args[0]).to.equal(true);
       });
     });
 
@@ -645,7 +650,7 @@ describe('<Toolbar.Button />', () => {
               <AlertDialog.Portal>
                 <AlertDialog.Backdrop />
                 <AlertDialog.Popup>
-                  <AlertDialog.Title>title text</AlertDialog.Title>
+                  <AlertDialog.Title>title</AlertDialog.Title>
                 </AlertDialog.Popup>
               </AlertDialog.Portal>
             </AlertDialog.Root>
@@ -654,13 +659,18 @@ describe('<Toolbar.Button />', () => {
           </Toolbar.Root>,
         );
 
-        expect(screen.queryByText('title text')).to.equal(null);
+        expect(screen.queryByText('title')).to.equal(null);
 
         const trigger = screen.getByRole('button', { name: 'dialog' });
         await user.click(trigger);
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).toHaveFocus();
+        });
+
         await user.keyboard('{ArrowRight}');
 
-        expect(onOpenChange.callCount).to.equal(1);
+        expect(onOpenChange.lastCall.args[0]).to.equal(true);
       });
     });
 

--- a/packages/react/src/toolbar/button/ToolbarButton.test.tsx
+++ b/packages/react/src/toolbar/button/ToolbarButton.test.tsx
@@ -517,17 +517,14 @@ describe('<Toolbar.Button />', () => {
         expect(onOpenChange.callCount).to.equal(0);
       });
 
-      it.only('prevents composite keydowns from escaping', async () => {
+      it('prevents composite keydowns from escaping', async () => {
         const onOpenChange = spy();
         const { user } = await render(
           <Toolbar.Root>
             <Dialog.Root modal={false} onOpenChange={onOpenChange}>
               <Toolbar.Button render={<Dialog.Trigger />}>dialog</Toolbar.Button>
               <Dialog.Portal>
-                <Dialog.Backdrop />
-                <Dialog.Popup>
-                  <Dialog.Title>title</Dialog.Title>
-                </Dialog.Popup>
+                <Dialog.Popup />
               </Dialog.Portal>
             </Dialog.Root>
 
@@ -535,7 +532,7 @@ describe('<Toolbar.Button />', () => {
           </Toolbar.Root>,
         );
 
-        expect(screen.queryByText('title')).to.equal(null);
+        expect(screen.queryByRole('dialog')).to.equal(null);
 
         const trigger = screen.getByRole('button', { name: 'dialog' });
         await user.click(trigger);
@@ -648,10 +645,7 @@ describe('<Toolbar.Button />', () => {
             <AlertDialog.Root onOpenChange={onOpenChange}>
               <Toolbar.Button render={<Dialog.Trigger />}>dialog</Toolbar.Button>
               <AlertDialog.Portal>
-                <AlertDialog.Backdrop />
-                <AlertDialog.Popup>
-                  <AlertDialog.Title>title</AlertDialog.Title>
-                </AlertDialog.Popup>
+                <AlertDialog.Popup />
               </AlertDialog.Portal>
             </AlertDialog.Root>
 
@@ -659,13 +653,13 @@ describe('<Toolbar.Button />', () => {
           </Toolbar.Root>,
         );
 
-        expect(screen.queryByText('title')).to.equal(null);
+        expect(screen.queryByRole('dialog')).to.equal(null);
 
         const trigger = screen.getByRole('button', { name: 'dialog' });
         await user.click(trigger);
 
         await waitFor(() => {
-          expect(screen.queryByRole('dialog')).toHaveFocus();
+          expect(screen.queryByRole('alertdialog')).toHaveFocus();
         });
 
         await user.keyboard('{ArrowRight}');

--- a/packages/react/src/toolbar/input/useToolbarInput.ts
+++ b/packages/react/src/toolbar/input/useToolbarInput.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { mergeProps } from '../../merge-props';
 import { GenericHTMLProps } from '../../utils/types';
 import { useButton } from '../../use-button';
-import { ARROW_LEFT, ARROW_RIGHT } from '../../composite/composite';
+import { ARROW_LEFT, ARROW_RIGHT, stopEvent } from '../../composite/composite';
 
 export function useToolbarInput(
   parameters: useToolbarInput.Parameters,
@@ -29,7 +29,7 @@ export function useToolbarInput(
           },
           onKeyDown(event) {
             if (event.key !== ARROW_LEFT && event.key !== ARROW_RIGHT && disabled) {
-              event.preventDefault();
+              stopEvent(event);
             }
           },
           onPointerDown(event) {


### PR DESCRIPTION
Fixes #1759

Triggers preview: https://deploy-preview-1871--base-ui.netlify.app/experiments/toolbar/triggers

- Inside `Dialog`/`AlertDialog`, it prevents composite behavior from escaping itself. `Popover`/anything that doesn't trap focus or close when focus escapes it allows it
- Tabs and any other composite works inside a Dialog/Popover correctly