### PR TITLE
[Tooltip] Remove `trackCursorAxis` type from `Positioner`

### DIFF
--- a/docs/reference/generated/tooltip-positioner.json
+++ b/docs/reference/generated/tooltip-positioner.json
@@ -56,11 +56,6 @@
       "default": "true",
       "description": "Whether the popup tracks any layout shift of its positioning anchor."
     },
-    "trackCursorAxis": {
-      "type": "'none' | 'both' | 'x' | 'y'",
-      "default": "'none'",
-      "description": "Determines which axis the tooltip should track the cursor on."
-    },
     "className": {
       "type": "string | ((state: State) => string)",
       "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."

--- a/packages/react/src/tooltip/positioner/useTooltipPositioner.ts
+++ b/packages/react/src/tooltip/positioner/useTooltipPositioner.ts
@@ -41,11 +41,6 @@ export namespace useTooltipPositioner {
 
   export interface SharedParameters extends useAnchorPositioning.SharedParameters {
     /**
-     * Determines which axis the tooltip should track the cursor on.
-     * @default 'none'
-     */
-    trackCursorAxis?: 'none' | 'x' | 'y' | 'both';
-    /**
      * Which side of the anchor element to align the popup against.
      * May automatically change to avoid collisions.
      * @default 'top'


### PR DESCRIPTION
This is only on the `Root`.