### PR TITLE
[code-infra] Prefer `describe.skipIf` instead of `describeSkipIf` on tests

### DIFF
--- a/packages/react/src/menu/positioner/MenuPositioner.test.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
-import { describeSkipIf, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
+import { flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui-components/react/menu';
 import { describeConformance, createRenderer, isJSDOM } from '#test-utils';
 
@@ -378,7 +378,7 @@ describe('<Menu.Positioner />', () => {
   const triggerStyle = { width: anchorWidth, height: anchorHeight };
   const popupStyle = { width: popupWidth, height: popupHeight };
 
-  describeSkipIf(isJSDOM)('prop: sideOffset', () => {
+  describe.skipIf(isJSDOM)('prop: sideOffset', () => {
     it('offsets the side when a number is specified', async () => {
       const sideOffset = 7;
       await render(
@@ -491,7 +491,7 @@ describe('<Menu.Positioner />', () => {
     });
   });
 
-  describeSkipIf(isJSDOM)('prop: alignOffset', () => {
+  describe.skipIf(isJSDOM)('prop: alignOffset', () => {
     it('offsets the align when a number is specified', async () => {
       const alignOffset = 7;
       await render(

--- a/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Popover } from '@base-ui-components/react/popover';
-import { describeSkipIf, screen } from '@mui/internal-test-utils';
+import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -34,7 +34,7 @@ describe('<Popover.Positioner />', () => {
   const triggerStyle = { width: anchorWidth, height: anchorHeight };
   const popupStyle = { width: popupWidth, height: popupHeight };
 
-  describeSkipIf(isJSDOM)('prop: sideOffset', () => {
+  describe.skipIf(isJSDOM)('prop: sideOffset', () => {
     it('offsets the side when a number is specified', async () => {
       const sideOffset = 7;
       await render(
@@ -147,7 +147,7 @@ describe('<Popover.Positioner />', () => {
     });
   });
 
-  describeSkipIf(isJSDOM)('prop: alignOffset', () => {
+  describe.skipIf(isJSDOM)('prop: alignOffset', () => {
     it('offsets the align when a number is specified', async () => {
       const alignOffset = 7;
       await render(

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PreviewCard } from '@base-ui-components/react/preview-card';
-import { describeSkipIf, screen } from '@mui/internal-test-utils';
+import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -34,7 +34,7 @@ describe('<PreviewCard.Positioner />', () => {
   const triggerStyle = { width: anchorWidth, height: anchorHeight };
   const popupStyle = { width: popupWidth, height: popupHeight };
 
-  describeSkipIf(isJSDOM)('prop: sideOffset', () => {
+  describe.skipIf(isJSDOM)('prop: sideOffset', () => {
     it('offsets the side when a number is specified', async () => {
       const sideOffset = 7;
       await render(
@@ -147,7 +147,7 @@ describe('<PreviewCard.Positioner />', () => {
     });
   });
 
-  describeSkipIf(isJSDOM)('prop: alignOffset', () => {
+  describe.skipIf(isJSDOM)('prop: alignOffset', () => {
     it('offsets the align when a number is specified', async () => {
       const alignOffset = 7;
       await render(

--- a/packages/react/src/select/positioner/SelectPositioner.test.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Select } from '@base-ui-components/react/select';
-import { describeSkipIf, screen } from '@mui/internal-test-utils';
+import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -34,7 +34,7 @@ describe('<Select.Positioner />', () => {
   const triggerStyle = { width: anchorWidth, height: anchorHeight };
   const popupStyle = { width: popupWidth, height: popupHeight };
 
-  describeSkipIf(isJSDOM)('prop: sideOffset', () => {
+  describe.skipIf(isJSDOM)('prop: sideOffset', () => {
     it('offsets the side when a number is specified', async () => {
       const sideOffset = 7;
       await render(
@@ -158,7 +158,7 @@ describe('<Select.Positioner />', () => {
     });
   });
 
-  describeSkipIf(isJSDOM)('prop: alignOffset', () => {
+  describe.skipIf(isJSDOM)('prop: alignOffset', () => {
     it('offsets the align when a number is specified', async () => {
       const alignOffset = 7;
       await render(

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Tooltip } from '@base-ui-components/react/tooltip';
-import { describeSkipIf, screen } from '@mui/internal-test-utils';
+import { screen } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -34,7 +34,7 @@ describe('<Tooltip.Positioner />', () => {
   const triggerStyle = { width: anchorWidth, height: anchorHeight };
   const popupStyle = { width: popupWidth, height: popupHeight };
 
-  describeSkipIf(isJSDOM)('prop: sideOffset', () => {
+  describe.skipIf(isJSDOM)('prop: sideOffset', () => {
     it('offsets the side when a number is specified', async () => {
       const sideOffset = 7;
       await render(
@@ -147,7 +147,7 @@ describe('<Tooltip.Positioner />', () => {
     });
   });
 
-  describeSkipIf(isJSDOM)('prop: alignOffset', () => {
+  describe.skipIf(isJSDOM)('prop: alignOffset', () => {
     it('offsets the align when a number is specified', async () => {
       const alignOffset = 7;
       await render(


### PR DESCRIPTION
Related to https://github.com/mui/material-ui/pull/46108

There I've moved `describeSkipIf` to a deep import to fix a type clash, but `base-ui` uses vitest for everything, so you shouldn't need to use that shim.