### PR TITLE
[slider] Drop `inputId` prop from Thumb

### DIFF
--- a/docs/reference/generated/slider-thumb.json
+++ b/docs/reference/generated/slider-thumb.json
@@ -10,9 +10,6 @@
       "type": "((formattedValue: string, value: number, index: number) => string) | null",
       "description": "Accepts a function which returns a string value that provides a user-friendly name for the current value of the slider.\nThis is important for screen reader users."
     },
-    "inputId": {
-      "type": "string"
-    },
     "disabled": {
       "type": "boolean",
       "default": "false",

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -95,7 +95,6 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
     getAriaLabel: getAriaLabelProp,
     getAriaValueText: getAriaValueTextProp,
     id: idProp,
-    inputId: inputIdProp,
     onBlur: onBlurProp,
     onFocus: onFocusProp,
     onKeyDown: onKeyDownProp,
@@ -105,7 +104,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
   } = componentProps;
 
   const id = useBaseUiId(idProp);
-  const inputId = useBaseUiId(inputIdProp);
+  const inputId = `${id}-input`;
 
   const render = renderProp ?? defaultRender;
 
@@ -413,7 +412,6 @@ export namespace SliderThumb {
      * @type {((formattedValue: string, value: number, index: number) => string) | null}
      */
     getAriaValueText?: ((formattedValue: string, value: number, index: number) => string) | null;
-    inputId?: string;
     /**
      * Allows you to replace the component’s HTML element
      * with a different tag, or compose it with another component.


### PR DESCRIPTION
We decided to only expose the `inputRef`: https://github.com/mui/base-ui/issues/1619

The `<input>` element's `id` is now the Thumb's id + `-input`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
