### PR TITLE
[tooltip] Apply `pointer-events: none` to `Positioner` when not hoverable

### DIFF
--- a/packages/react/src/tooltip/positioner/useTooltipPositioner.ts
+++ b/packages/react/src/tooltip/positioner/useTooltipPositioner.ts
@@ -6,14 +6,14 @@ import { useTooltipRootContext } from '../root/TooltipRootContext';
 export function useTooltipPositioner(
   params: useTooltipPositioner.Parameters,
 ): useTooltipPositioner.ReturnValue {
-  const { open, trackCursorAxis, mounted } = useTooltipRootContext();
+  const { open, trackCursorAxis, hoverable, mounted } = useTooltipRootContext();
 
   const positioning = useAnchorPositioning(params);
 
   const props = React.useMemo<HTMLProps>(() => {
     const hiddenStyles: React.CSSProperties = {};
 
-    if (!open || trackCursorAxis === 'both') {
+    if (!open || trackCursorAxis === 'both' || !hoverable) {
       hiddenStyles.pointerEvents = 'none';
     }
 
@@ -25,7 +25,7 @@ export function useTooltipPositioner(
         ...hiddenStyles,
       },
     };
-  }, [open, trackCursorAxis, mounted, positioning.positionerStyles]);
+  }, [open, trackCursorAxis, hoverable, mounted, positioning.positionerStyles]);
 
   return React.useMemo(
     () => ({

--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -672,4 +672,52 @@ describe('<Tooltip.Root />', () => {
       expect(screen.queryByText('Content')).to.equal(null);
     });
   });
+
+  describe('prop: hoverable', () => {
+    it('applies pointer-events: none to the positioner when not hoverable', async () => {
+      await render(
+        <Root delay={0} hoverable={false}>
+          <Tooltip.Trigger />
+          <Tooltip.Portal>
+            <Tooltip.Positioner data-testid="positioner">
+              <Tooltip.Popup>Content</Tooltip.Popup>
+            </Tooltip.Positioner>
+          </Tooltip.Portal>
+        </Root>,
+      );
+
+      const trigger = screen.getByRole('button');
+
+      fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
+
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('positioner').style.pointerEvents).to.equal('none');
+    });
+
+    it('does not apply pointer-events: none to the positioner when hoverable', async () => {
+      await render(
+        <Root delay={0} hoverable>
+          <Tooltip.Trigger />
+          <Tooltip.Portal>
+            <Tooltip.Positioner data-testid="positioner">
+              <Tooltip.Popup>Content</Tooltip.Popup>
+            </Tooltip.Positioner>
+          </Tooltip.Portal>
+        </Root>,
+      );
+
+      const trigger = screen.getByRole('button');
+
+      fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
+
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('positioner').style.pointerEvents).to.equal('');
+    });
+  });
 });

--- a/packages/react/src/tooltip/root/TooltipRoot.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.tsx
@@ -47,8 +47,9 @@ export const TooltipRoot: React.FC<TooltipRoot.Props> = function TooltipRoot(pro
       delay: delayWithDefault,
       closeDelay: closeDelayWithDefault,
       trackCursorAxis,
+      hoverable,
     }),
-    [tooltipRoot, delayWithDefault, closeDelayWithDefault, trackCursorAxis],
+    [tooltipRoot, delayWithDefault, closeDelayWithDefault, trackCursorAxis, hoverable],
   );
 
   return (

--- a/packages/react/src/tooltip/root/TooltipRootContext.ts
+++ b/packages/react/src/tooltip/root/TooltipRootContext.ts
@@ -23,6 +23,7 @@ export interface TooltipRootContext {
   trackCursorAxis: 'none' | 'x' | 'y' | 'both';
   transitionStatus: TransitionStatus;
   onOpenChangeComplete: ((open: boolean) => void) | undefined;
+  hoverable: boolean;
 }
 
 export const TooltipRootContext = React.createContext<TooltipRootContext | undefined>(undefined);


### PR DESCRIPTION
Fixes #1913