### PR TITLE
[menu] Add `finalFocus` and `closeDelay` props

### DIFF
--- a/docs/reference/generated/context-menu-root.json
+++ b/docs/reference/generated/context-menu-root.json
@@ -33,11 +33,6 @@
       "default": "false",
       "description": "Whether the component should ignore user interaction."
     },
-    "closeDelay": {
-      "type": "number",
-      "default": "0",
-      "description": "How long to wait before closing the menu that was opened on hover.\nSpecified in milliseconds.\n\nRequires the `openOnHover` prop."
-    },
     "loop": {
       "type": "boolean",
       "default": "true",

--- a/docs/reference/generated/context-menu-root.json
+++ b/docs/reference/generated/context-menu-root.json
@@ -33,6 +33,11 @@
       "default": "false",
       "description": "Whether the component should ignore user interaction."
     },
+    "closeDelay": {
+      "type": "number",
+      "default": "0",
+      "description": "How long to wait before closing the menu that was opened on hover.\nSpecified in milliseconds.\n\nRequires the `openOnHover` prop."
+    },
     "loop": {
       "type": "boolean",
       "default": "true",

--- a/docs/reference/generated/menu-popup.json
+++ b/docs/reference/generated/menu-popup.json
@@ -2,6 +2,10 @@
   "name": "MenuPopup",
   "description": "A container for the menu items.\nRenders a `<div>` element.",
   "props": {
+    "finalFocus": {
+      "type": "RefObject<HTMLElement | null>",
+      "description": "Determines the element to focus when the menu is closed.\nBy default, focus returns to the trigger."
+    },
     "id": {
       "type": "string"
     },

--- a/docs/reference/generated/menu-root.json
+++ b/docs/reference/generated/menu-root.json
@@ -47,6 +47,11 @@
       "default": "100",
       "description": "How long to wait before the menu may be opened on hover. Specified in milliseconds.\n\nRequires the `openOnHover` prop."
     },
+    "closeDelay": {
+      "type": "number",
+      "default": "0",
+      "description": "How long to wait before closing the menu that was opened on hover.\nSpecified in milliseconds.\n\nRequires the `openOnHover` prop."
+    },
     "loop": {
       "type": "boolean",
       "default": "true",

--- a/packages/react/src/context-menu/root/ContextMenuRoot.tsx
+++ b/packages/react/src/context-menu/root/ContextMenuRoot.tsx
@@ -48,5 +48,6 @@ export function ContextMenuRoot(props: ContextMenuRoot.Props) {
 export namespace ContextMenuRoot {
   export interface State {}
 
-  export interface Props extends Omit<Menu.Root.Props, 'modal' | 'openOnHover' | 'delay'> {}
+  export interface Props
+    extends Omit<Menu.Root.Props, 'modal' | 'openOnHover' | 'delay' | 'closeDelay'> {}
 }

--- a/packages/react/src/menu/popup/MenuPopup.test.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Menu } from '@base-ui-components/react/menu';
+import { expect } from 'chai';
 import { createRenderer, describeConformance } from '#test-utils';
+import { act, waitFor } from '@mui/internal-test-utils';
 
 describe('<Menu.Popup />', () => {
   const { render } = createRenderer();
@@ -17,4 +19,81 @@ describe('<Menu.Popup />', () => {
     },
     refInstanceof: window.HTMLDivElement,
   }));
+
+  describe('prop: finalFocus', () => {
+    it('should focus the trigger by default when closed', async () => {
+      const { getByText } = await render(
+        <div>
+          <input />
+          <Menu.Root>
+            <Menu.Trigger>Open</Menu.Trigger>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item>Close</Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
+          </Menu.Root>
+          <input />
+        </div>,
+      );
+
+      const trigger = getByText('Open');
+      await act(async () => {
+        trigger.click();
+      });
+
+      const closeButton = getByText('Close');
+      await act(async () => {
+        closeButton.click();
+      });
+
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
+      });
+    });
+
+    it('should focus the element provided to the prop when closed', async () => {
+      function TestComponent() {
+        const inputRef = React.useRef<HTMLInputElement | null>(null);
+        return (
+          <div>
+            <input />
+            <Menu.Root>
+              <Menu.Trigger>Open</Menu.Trigger>
+              <Menu.Portal>
+                <Menu.Positioner>
+                  <Menu.Popup finalFocus={inputRef}>
+                    <Menu.Item>Close</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
+            <input />
+            <input data-testid="input-to-focus" ref={inputRef} />
+            <input />
+          </div>
+        );
+      }
+
+      const { getByText, getByTestId } = await render(<TestComponent />);
+
+      const trigger = getByText('Open');
+      await act(async () => {
+        trigger.click();
+      });
+
+      const closeButton = getByText('Close');
+      await act(async () => {
+        closeButton.click();
+      });
+
+      const inputToFocus = getByTestId('input-to-focus');
+
+      await waitFor(() => {
+        expect(inputToFocus).toHaveFocus();
+      });
+    });
+  });
 });

--- a/packages/react/src/menu/popup/MenuPopup.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.tsx
@@ -113,7 +113,7 @@ export const MenuPopup = React.forwardRef(function MenuPopup(
       context={floatingContext}
       modal={false}
       disabled={!mounted}
-      returnFocus={returnFocus}
+      returnFocus={finalFocus || returnFocus}
       initialFocus={parent.type === 'menu' ? -1 : 0}
       restoreFocus
     >

--- a/packages/react/src/menu/popup/MenuPopup.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.tsx
@@ -33,7 +33,7 @@ export const MenuPopup = React.forwardRef(function MenuPopup(
   props: MenuPopup.Props,
   forwardedRef: React.ForwardedRef<Element>,
 ) {
-  const { render, className, ...other } = props;
+  const { render, className, finalFocus, ...other } = props;
 
   const {
     open,
@@ -129,6 +129,11 @@ export namespace MenuPopup {
      * @ignore
      */
     id?: string;
+    /**
+     * Determines the element to focus when the menu is closed.
+     * By default, focus returns to the trigger.
+     */
+    finalFocus?: React.RefObject<HTMLElement | null>;
   }
 
   export type State = {

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, flushMicrotasks, waitFor, screen } from '@mui/internal-test-utils';
+import { act, flushMicrotasks, waitFor, screen, fireEvent } from '@mui/internal-test-utils';
 import { DirectionProvider } from '@base-ui-components/react/direction-provider';
 import { Menu } from '@base-ui-components/react/menu';
 import userEvent from '@testing-library/user-event';
@@ -1206,6 +1206,44 @@ describe('<Menu.Root />', () => {
       await waitFor(() => {
         expect(getByTestId('submenu')).not.to.equal(null);
       });
+    });
+  });
+
+  describe('prop: closeDelay', () => {
+    const { render: renderFakeTimers, clock } = createRenderer();
+
+    clock.withFakeTimers();
+
+    it('should close after delay', async () => {
+      await renderFakeTimers(
+        <Menu.Root openOnHover delay={0} closeDelay={100}>
+          <Menu.Trigger />
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>Content</Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const anchor = screen.getByRole('button');
+
+      fireEvent.mouseEnter(anchor);
+      fireEvent.mouseMove(anchor);
+
+      await flushMicrotasks();
+
+      expect(screen.getByText('Content')).not.to.equal(null);
+
+      fireEvent.mouseLeave(anchor);
+
+      clock.tick(50);
+
+      expect(screen.getByText('Content')).not.to.equal(null);
+
+      clock.tick(50);
+
+      expect(screen.queryByText('Content')).to.equal(null);
     });
   });
 

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -57,6 +57,7 @@ export const MenuRoot: React.FC<MenuRoot.Props> = function MenuRoot(props) {
     actionsRef,
     openOnHover: openOnHoverProp,
     delay = 100,
+    closeDelay = 0,
     closeParentOnEsc = true,
   } = props;
 
@@ -328,7 +329,7 @@ export const MenuRoot: React.FC<MenuRoot.Props> = function MenuRoot(props) {
     mouseOnly: true,
     move: parent.type === 'menu',
     restMs: parent.type !== undefined ? undefined : delay,
-    delay: parent.type === 'menu' ? { open: delay } : 0,
+    delay: parent.type === 'menu' ? { open: delay, close: closeDelay } : { close: closeDelay },
   });
 
   const focus = useFocus(floatingRootContext, {
@@ -566,6 +567,14 @@ export namespace MenuRoot {
      * @default 100
      */
     delay?: number;
+    /**
+     * How long to wait before closing the menu that was opened on hover.
+     * Specified in milliseconds.
+     *
+     * Requires the `openOnHover` prop.
+     * @default 0
+     */
+    closeDelay?: number;
     /**
      * Whether the menu should also open when the trigger is hovered.
      *


### PR DESCRIPTION
Closes #1855

`closeDelay` was another prop missing that `Popover` and other hoverable ones have.