### PR TITLE
[perf] Fix `useLockScroll` forced reflows

### DIFF
--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -162,7 +162,7 @@ class ScrollLocker {
       this.restore?.();
       this.restore = null;
     }
-  }
+  };
 
   private lock(referenceElement: Element | null) {
     const isOverflowHiddenLock = isIOS() || (isFirefox() && !hasInsetScrollbars(referenceElement));

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -157,7 +157,7 @@ class ScrollLocker {
     this.unlockFrame.request(this.unlock);
   };
 
-  private unlock() {
+  private unlock = () => {
     if (this.lockCount === 0 && this.restore) {
       this.restore?.();
       this.restore = null;

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -7,8 +7,6 @@ let originalHtmlStyles: Partial<CSSStyleDeclaration> = {};
 let originalBodyStyles: Partial<CSSStyleDeclaration> = {};
 let originalHtmlScrollBehavior = '';
 
-const NOOP = () => {};
-
 function hasInsetScrollbars(referenceElement: Element | null) {
   if (typeof document === 'undefined') {
     return false;
@@ -141,7 +139,9 @@ function preventScrollStandard(referenceElement: Element | null) {
 
 class ScrollLocker {
   lockCount = 0;
+
   restore = null as (() => void) | null;
+
   unlockFrame = AnimationFrame.create();
 
   acquire(referenceElement: Element | null) {

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -49,6 +49,8 @@ function preventScrollStandard(referenceElement: Element | null) {
   }
 
   function lockScroll() {
+    /* DOM reads: */
+
     const htmlStyles = win.getComputedStyle(html);
     const bodyStyles = win.getComputedStyle(body);
 
@@ -85,17 +87,19 @@ function preventScrollStandard(referenceElement: Element | null) {
     const scrollbarWidth = Math.max(0, win.innerWidth - html.clientWidth);
     const scrollbarHeight = Math.max(0, win.innerHeight - html.clientHeight);
 
+    // Avoid shift due to the default <body> margin. This does cause elements to be clipped
+    // with whitespace. Warn if <body> has margins?
+    const marginY = parseFloat(bodyStyles.marginTop) + parseFloat(bodyStyles.marginBottom);
+    const marginX = parseFloat(bodyStyles.marginLeft) + parseFloat(bodyStyles.marginRight);
+
+    /*  DOM writes: do not read the DOM past this point */
+
     Object.assign(html.style, {
       overflowY:
         !hasScrollbarGutterStable && (isScrollableY || hasConstantOverflowY) ? 'scroll' : 'hidden',
       overflowX:
         !hasScrollbarGutterStable && (isScrollableX || hasConstantOverflowX) ? 'scroll' : 'hidden',
     });
-
-    // Avoid shift due to the default <body> margin. This does cause elements to be clipped
-    // with whitespace. Warn if <body> has margins?
-    const marginY = parseFloat(bodyStyles.marginTop) + parseFloat(bodyStyles.marginBottom);
-    const marginX = parseFloat(bodyStyles.marginLeft) + parseFloat(bodyStyles.marginRight);
 
     Object.assign(body.style, {
       position: 'relative',

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -4,6 +4,8 @@ import { useModernLayoutEffect } from './useModernLayoutEffect';
 import { Timeout } from './useTimeout';
 import { AnimationFrame } from './useAnimationFrame';
 
+/* eslint-disable lines-between-class-members */
+
 let originalHtmlStyles: Partial<CSSStyleDeclaration> = {};
 let originalBodyStyles: Partial<CSSStyleDeclaration> = {};
 let originalHtmlScrollBehavior = '';
@@ -140,9 +142,7 @@ function preventScrollStandard(referenceElement: Element | null) {
 
 class ScrollLocker {
   lockCount = 0;
-
   restore = null as (() => void) | null;
-
   timeoutLock = Timeout.create();
   timeoutUnlock = Timeout.create();
 

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -156,7 +156,9 @@ class ScrollLocker {
 
   release = () => {
     this.lockCount -= 1;
-    this.timeoutUnlock.start(0, this.unlock);
+    if (this.lockCount === 0 && this.restore) {
+      this.timeoutUnlock.start(0, this.unlock);
+    }
   };
 
   private unlock = () => {

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -204,23 +204,20 @@ export function useScrollLock(params: {
   const { enabled = true, mounted, open, referenceElement = null } = params;
 
   // https://github.com/mui/base-ui/issues/1135
-  if (isWebKit()) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useModernLayoutEffect(() => {
-      if (mounted && !open) {
-        const doc = ownerDocument(referenceElement);
-        const originalUserSelect = doc.body.style.userSelect;
-        const originalWebkitUserSelect = doc.body.style.webkitUserSelect;
-        doc.body.style.userSelect = 'none';
-        doc.body.style.webkitUserSelect = 'none';
-        return () => {
-          doc.body.style.userSelect = originalUserSelect;
-          doc.body.style.webkitUserSelect = originalWebkitUserSelect;
-        };
-      }
-      return undefined;
-    }, [mounted, open, referenceElement]);
-  }
+  useModernLayoutEffect(() => {
+    if (isWebKit() && mounted && !open) {
+      const doc = ownerDocument(referenceElement);
+      const originalUserSelect = doc.body.style.userSelect;
+      const originalWebkitUserSelect = doc.body.style.webkitUserSelect;
+      doc.body.style.userSelect = 'none';
+      doc.body.style.webkitUserSelect = 'none';
+      return () => {
+        doc.body.style.userSelect = originalUserSelect;
+        doc.body.style.webkitUserSelect = originalWebkitUserSelect;
+      };
+    }
+    return undefined;
+  }, [mounted, open, referenceElement]);
 
   useModernLayoutEffect(() => {
     if (!enabled) {

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -92,7 +92,10 @@ function preventScrollStandard(referenceElement: Element | null) {
     const marginY = parseFloat(bodyStyles.marginTop) + parseFloat(bodyStyles.marginBottom);
     const marginX = parseFloat(bodyStyles.marginLeft) + parseFloat(bodyStyles.marginRight);
 
-    /*  DOM writes: do not read the DOM past this point */
+    /*
+     * DOM writes:
+     * Do not read the DOM past this point!
+     */
 
     Object.assign(html.style, {
       overflowY:


### PR DESCRIPTION
The current implementation is causing lots of reflows.

Test case: https://www.notion.so/mui-org/Menu-profiling-1eecbfe7b66080c9a810c82f2308f04d

The "menu click" portion highlighted below is the render-blocking JS that needs to run before the browser repaints. After these changes, floating-ui becomes an interesting optimization target as it's the next big render-blocking task.

### Before

![image](https://github.com/user-attachments/assets/c32ef873-5160-4e5e-a824-781e01322c54)

### After

![image](https://github.com/user-attachments/assets/40e2d092-afba-403b-bc10-91bab1dc4432)
