### PR TITLE
[core] refactor: useModernLayoutEffect => useLayoutEffect

### DIFF
--- a/docs/src/blocks/GoogleAnalytics.tsx
+++ b/docs/src/blocks/GoogleAnalytics.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useMediaQuery } from '@base-ui-components/react/unstable-use-media-query';
-import { useModernLayoutEffect } from '@base-ui-components/react/utils';
+import { useLayoutEffect } from '@base-ui-components/react/utils';
 
 let boundDataGaListener = false;
 
@@ -20,7 +20,7 @@ export const GoogleAnalytics = React.memo(function GoogleAnalytics(props: Google
     userLanguage,
   } = props;
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     // @ts-expect-error
     window.dataLayer = window.dataLayer || [];
 

--- a/docs/src/blocks/PackageManagerSnippet/PackageManagerSnippetProvider.tsx
+++ b/docs/src/blocks/PackageManagerSnippet/PackageManagerSnippetProvider.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useModernLayoutEffect } from '@base-ui-components/react/utils';
+import { useLayoutEffect } from '@base-ui-components/react/utils';
 import * as React from 'react';
 
 export interface PackageManagerSnippetContext {
@@ -35,7 +35,7 @@ export function PackageManagerSnippetProvider(props: PackageManagerSnippetProvid
     localStorage.setItem(STORAGE_KEY, newValue);
   }, []);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     const savedValue = localStorage.getItem(STORAGE_KEY);
 
     if (savedValue) {

--- a/docs/src/blocks/PackageManagerSnippet/PackageManagerSnippetRoot.tsx
+++ b/docs/src/blocks/PackageManagerSnippet/PackageManagerSnippetRoot.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { Tabs } from '@base-ui-components/react/tabs';
-import { useModernLayoutEffect } from '@base-ui-components/react/utils';
+import { useLayoutEffect } from '@base-ui-components/react/utils';
 import { usePackageManagerSnippetContext } from './PackageManagerSnippetProvider';
 
 export function PackageManagerSnippetRoot(props: PackageManagerSnippetRoot.Props) {
@@ -19,7 +19,7 @@ export function PackageManagerSnippetRoot(props: PackageManagerSnippetRoot.Props
     [setGlobalPreference],
   );
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (options.some((option) => option.value === globalPreference)) {
       setValue(globalPreference);
     }

--- a/docs/src/components/Demo/DemoVariantSelectorProvider.tsx
+++ b/docs/src/components/Demo/DemoVariantSelectorProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { useModernLayoutEffect } from '@base-ui-components/react/utils';
+import { useLayoutEffect } from '@base-ui-components/react/utils';
 
 export interface DemoVariantSelectorContext {
   selectedVariant: string;
@@ -46,7 +46,7 @@ export function DemoVariantSelectorProvider(props: DemoVariantSelectorProviderPr
     localStorage.setItem(LANGUAGE_STORAGE_KEY, value);
   }, []);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     const variantPreference = localStorage.getItem(VARIANT_STORAGE_KEY);
     const languagePreference = localStorage.getItem(LANGUAGE_STORAGE_KEY);
 

--- a/packages/react/src/accordion/panel/AccordionPanel.tsx
+++ b/packages/react/src/accordion/panel/AccordionPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { BaseUIComponentProps } from '../../utils/types';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { warn } from '../../utils/warn';
 import { useCollapsibleRootContext } from '../../collapsible/root/CollapsibleRootContext';
@@ -63,7 +63,7 @@ export const AccordionPanel = React.forwardRef(function AccordionPanel(
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useModernLayoutEffect(() => {
+    useLayoutEffect(() => {
       if (keepMountedProp === false && hiddenUntilFound) {
         warn(
           'The `keepMounted={false}` prop on a Accordion.Panel will be ignored when using `contextHiddenUntilFound` on the Panel or the Root since it requires the panel to remain mounted when closed.',
@@ -72,11 +72,11 @@ export const AccordionPanel = React.forwardRef(function AccordionPanel(
     }, [hiddenUntilFound, keepMountedProp]);
   }
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setHiddenUntilFound(hiddenUntilFound);
   }, [setHiddenUntilFound, hiddenUntilFound]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setKeepMounted(keepMounted);
   }, [setKeepMounted, keepMounted]);
 

--- a/packages/react/src/accordion/root/AccordionRoot.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.tsx
@@ -4,7 +4,7 @@ import { BaseUIComponentProps, Orientation } from '../../utils/types';
 import { isElementDisabled } from '../../utils/isElementDisabled';
 import { useControlled } from '../../utils/useControlled';
 import { useEventCallback } from '../../utils/useEventCallback';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { warn } from '../../utils/warn';
 import {
@@ -74,7 +74,7 @@ export const AccordionRoot = React.forwardRef(function AccordionRoot(
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useModernLayoutEffect(() => {
+    useLayoutEffect(() => {
       if (hiddenUntilFoundProp && keepMountedProp === false) {
         warn(
           'The `keepMounted={false}` prop on a Accordion.Root will be ignored when using `hiddenUntilFound` since it requires Panels to remain mounted when closed.',

--- a/packages/react/src/accordion/trigger/AccordionTrigger.tsx
+++ b/packages/react/src/accordion/trigger/AccordionTrigger.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { triggerOpenStateMapping } from '../../utils/collapsibleOpenStateMapping';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useButton } from '../../use-button';
@@ -33,7 +33,7 @@ export const AccordionTrigger = React.forwardRef(function AccordionTrigger(
 
   const { state, setTriggerId, triggerId: id } = useAccordionItemContext();
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (idProp) {
       setTriggerId(idProp);
     }

--- a/packages/react/src/alert-dialog/description/AlertDialogDescription.tsx
+++ b/packages/react/src/alert-dialog/description/AlertDialogDescription.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useAlertDialogRootContext } from '../root/AlertDialogRootContext';
 import { mergeProps } from '../../merge-props';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import type { BaseUIComponentProps } from '../../utils/types';
 
@@ -24,7 +24,7 @@ export const AlertDialogDescription = React.forwardRef(function AlertDialogDescr
 
   const id = useBaseUiId(idProp);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setDescriptionElementId(id);
     return () => {
       setDescriptionElementId(undefined);

--- a/packages/react/src/alert-dialog/title/AlertDialogTitle.tsx
+++ b/packages/react/src/alert-dialog/title/AlertDialogTitle.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useAlertDialogRootContext } from '../root/AlertDialogRootContext';
 import { mergeProps } from '../../merge-props';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import type { BaseUIComponentProps } from '../../utils/types';
 
@@ -24,7 +24,7 @@ export const AlertDialogTitle = React.forwardRef(function AlertDialogTitle(
 
   const id = useBaseUiId(idProp);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setTitleElementId(id);
     return () => {
       setTitleElementId(undefined);

--- a/packages/react/src/avatar/image/AvatarImage.tsx
+++ b/packages/react/src/avatar/image/AvatarImage.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useEventCallback } from '../../utils/useEventCallback';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useAvatarRootContext } from '../root/AvatarRootContext';
 import type { AvatarRoot } from '../root/AvatarRoot';
 import { avatarStyleHookMapping } from '../root/styleHooks';
@@ -39,7 +39,7 @@ export const AvatarImage = React.forwardRef(function AvatarImage(
     context.setImageLoadingStatus(status);
   });
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (imageLoadingStatus !== 'idle') {
       handleLoadingStatusChange(imageLoadingStatus);
     }

--- a/packages/react/src/avatar/image/useImageLoadingStatus.ts
+++ b/packages/react/src/avatar/image/useImageLoadingStatus.ts
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { NOOP } from '../../utils/noop';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 
 export type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
@@ -16,7 +16,7 @@ export function useImageLoadingStatus(
 ): ImageLoadingStatus {
   const [loadingStatus, setLoadingStatus] = React.useState<ImageLoadingStatus>('idle');
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!src) {
       setLoadingStatus('error');
       return NOOP;

--- a/packages/react/src/checkbox/root/useCheckboxRoot.ts
+++ b/packages/react/src/checkbox/root/useCheckboxRoot.ts
@@ -6,7 +6,7 @@ import { useForkRef } from '../../utils/useForkRef';
 import { mergeProps } from '../../merge-props';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useEventCallback } from '../../utils/useEventCallback';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useButton } from '../../use-button/useButton';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
@@ -77,7 +77,7 @@ export function useCheckboxRoot(params: useCheckboxRoot.Parameters): useCheckbox
   const onCheckedChange = useEventCallback(onCheckedChangeProp);
   const id = useBaseUiId(idProp);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setControlId(id);
     return () => {
       setControlId(undefined);
@@ -94,7 +94,7 @@ export function useCheckboxRoot(params: useCheckboxRoot.Parameters): useCheckbox
   const inputRef = React.useRef<HTMLInputElement>(null);
   const mergedInputRef = useForkRef(externalInputRef, inputRef, inputValidationRef);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (inputRef.current) {
       inputRef.current.indeterminate = indeterminate;
       if (checked) {

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { BaseUIComponentProps } from '../../utils/types';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { warn } from '../../utils/warn';
 import { useCollapsibleRootContext } from '../root/CollapsibleRootContext';
@@ -32,7 +32,7 @@ export const CollapsiblePanel = React.forwardRef(function CollapsiblePanel(
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useModernLayoutEffect(() => {
+    useLayoutEffect(() => {
       if (hiddenUntilFoundProp && keepMountedProp === false) {
         warn(
           'The `keepMounted={false}` prop on a Collapsible will be ignored when using `hiddenUntilFound` since it requires the Panel to remain mounted even when closed.',
@@ -67,11 +67,11 @@ export const CollapsiblePanel = React.forwardRef(function CollapsiblePanel(
   const hiddenUntilFound = hiddenUntilFoundProp ?? false;
   const keepMounted = keepMountedProp ?? false;
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setHiddenUntilFound(hiddenUntilFound);
   }, [setHiddenUntilFound, hiddenUntilFound]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setKeepMounted(keepMounted);
   }, [setKeepMounted, keepMounted]);
 

--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { HTMLProps } from '../../utils/types';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useForkRef } from '../../utils/useForkRef';
 import { useOnMount } from '../../utils/useOnMount';
@@ -54,7 +54,7 @@ export function useCollapsiblePanel(
     return !open && !mounted;
   }, [open, mounted, visible, animationTypeRef]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!keepMounted && !open) {
       setPanelId(undefined);
     } else {
@@ -161,7 +161,7 @@ export function useCollapsiblePanel(
    * 1. When `keepMounted={false}`, the panel may not exist in the DOM
    * 2. When controlled, the open state may change externally without involving the trigger
    */
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (animationTypeRef.current !== 'css-transition' || keepMounted) {
       return undefined;
     }
@@ -231,7 +231,7 @@ export function useCollapsiblePanel(
     transitionDimensionRef,
   ]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (animationTypeRef.current !== 'css-animation') {
       return;
     }
@@ -285,7 +285,7 @@ export function useCollapsiblePanel(
     return () => AnimationFrame.cancel(frame);
   });
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!hiddenUntilFound) {
       return undefined;
     }
@@ -317,7 +317,7 @@ export function useCollapsiblePanel(
     };
   }, [hiddenUntilFound, open, panelRef, setDimensions]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     const panel = panelRef.current;
 
     if (panel && hiddenUntilFound && hidden) {

--- a/packages/react/src/collapsible/root/useCollapsibleRoot.ts
+++ b/packages/react/src/collapsible/root/useCollapsibleRoot.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useControlled } from '../../utils/useControlled';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { AnimationFrame } from '../../utils/useAnimationFrame';
 import { useTransitionStatus, TransitionStatus } from '../../utils/useTransitionStatus';
@@ -138,7 +138,7 @@ export function useCollapsibleRoot(
     }
   });
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     /**
      * Unmount immediately when closing in controlled mode and keepMounted={false}
      * and no CSS animations or transitions are applied

--- a/packages/react/src/composite/list/CompositeList.tsx
+++ b/packages/react/src/composite/list/CompositeList.tsx
@@ -2,7 +2,7 @@
 'use client';
 import * as React from 'react';
 import { CompositeListContext } from './CompositeListContext';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 
 function sortByDocumentPosition(a: Element, b: Element) {
   const position = a.compareDocumentPosition(b);
@@ -58,7 +58,7 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     return newMap;
   }, [map]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (elementsRef.current.length !== sortedMap.size) {
       elementsRef.current.length = sortedMap.size;
     }

--- a/packages/react/src/composite/list/useCompositeListItem.ts
+++ b/packages/react/src/composite/list/useCompositeListItem.ts
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useCompositeListContext } from './CompositeListContext';
 
 export interface UseCompositeListItemParameters<Metadata> {
@@ -42,7 +42,7 @@ export function useCompositeListItem<Metadata>(
     [index, elementsRef, labelsRef, label],
   );
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     const node = componentRef.current;
     if (node) {
       register(node, metadata);
@@ -53,7 +53,7 @@ export function useCompositeListItem<Metadata>(
     return undefined;
   }, [register, unregister, metadata]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     const i = componentRef.current ? map.get(componentRef.current)?.index : null;
 
     if (i != null) {

--- a/packages/react/src/dialog/description/DialogDescription.tsx
+++ b/packages/react/src/dialog/description/DialogDescription.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useDialogRootContext } from '../root/DialogRootContext';
 import { mergeProps } from '../../merge-props';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import type { BaseUIComponentProps } from '../../utils/types';
 
@@ -24,7 +24,7 @@ export const DialogDescription = React.forwardRef(function DialogDescription(
 
   const id = useBaseUiId(idProp);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setDescriptionElementId(id);
     return () => {
       setDescriptionElementId(undefined);

--- a/packages/react/src/dialog/title/DialogTitle.tsx
+++ b/packages/react/src/dialog/title/DialogTitle.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useDialogRootContext } from '../root/DialogRootContext';
 import { mergeProps } from '../../merge-props';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { type BaseUIComponentProps } from '../../utils/types';
 
@@ -24,7 +24,7 @@ export const DialogTitle = React.forwardRef(function DialogTitle(
 
   const id = useBaseUiId(idProp);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setTitleElementId(id);
     return () => {
       setTitleElementId(undefined);

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -7,7 +7,7 @@ import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useField } from '../useField';
-import { useControlled, useModernLayoutEffect } from '../../utils';
+import { useControlled, useLayoutEffect } from '../../utils';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useFieldControlValidation } from './useFieldControlValidation';
 
@@ -66,14 +66,14 @@ export const FieldControl = React.forwardRef(function FieldControl(
 
   const id = useBaseUiId(idProp);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setControlId(id);
     return () => {
       setControlId(undefined);
     };
   }, [id, setControlId]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     const hasExternalValue = valueProp != null;
     if (inputRef.current?.value || (hasExternalValue && valueProp !== '')) {
       setFilled(true);

--- a/packages/react/src/field/description/FieldDescription.tsx
+++ b/packages/react/src/field/description/FieldDescription.tsx
@@ -5,7 +5,7 @@ import { useFieldRootContext } from '../root/FieldRootContext';
 import { fieldValidityMapping } from '../utils/constants';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useBaseUiId } from '../../utils/useBaseUiId';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useRenderElement } from '../../utils/useRenderElement';
 
 /**
@@ -26,7 +26,7 @@ export const FieldDescription = React.forwardRef(function FieldDescription(
 
   const { setMessageIds } = useFieldRootContext();
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!id) {
       return undefined;
     }

--- a/packages/react/src/field/error/FieldError.tsx
+++ b/packages/react/src/field/error/FieldError.tsx
@@ -6,7 +6,7 @@ import { fieldValidityMapping } from '../utils/constants';
 import { useFormContext } from '../../form/FormContext';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 
 /**
@@ -38,7 +38,7 @@ export const FieldError = React.forwardRef(function FieldError(
     rendered = validityData.state.valid === false;
   }
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!rendered || !id) {
       return undefined;
     }

--- a/packages/react/src/field/label/FieldLabel.tsx
+++ b/packages/react/src/field/label/FieldLabel.tsx
@@ -5,7 +5,7 @@ import { FieldRoot } from '../root/FieldRoot';
 import { useFieldRootContext } from '../root/FieldRootContext';
 import { fieldValidityMapping } from '../utils/constants';
 import { useBaseUiId } from '../../utils/useBaseUiId';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 
@@ -25,7 +25,7 @@ export const FieldLabel = React.forwardRef(function FieldLabel(
 
   const id = useBaseUiId(idProp);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setLabelId(id);
     return () => {
       setLabelId(undefined);

--- a/packages/react/src/field/useField.ts
+++ b/packages/react/src/field/useField.ts
@@ -1,5 +1,5 @@
 import * as ReactDOM from 'react-dom';
-import { useModernLayoutEffect } from '../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../utils/useLayoutEffect';
 import { getCombinedFieldValidityData } from './utils/getCombinedFieldValidityData';
 import { useFormContext } from '../form/FormContext';
 import { useFieldRootContext } from './root/FieldRootContext';
@@ -12,7 +12,7 @@ export function useField(params: useField.Parameters) {
 
   const getValueRef = useLatestRef(params.getValue);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     let initialValue = value;
     if (initialValue === undefined) {
       initialValue = getValueRef.current?.();
@@ -23,7 +23,7 @@ export function useField(params: useField.Parameters) {
     }
   }, [setValidityData, value, validityData.initialValue, getValueRef]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (id) {
       formRef.current.fields.set(id, {
         controlRef,

--- a/packages/react/src/fieldset/legend/useFieldsetLegend.ts
+++ b/packages/react/src/fieldset/legend/useFieldsetLegend.ts
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { mergeProps } from '../../merge-props';
 import { useBaseUiId } from '../../utils/useBaseUiId';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useFieldsetRootContext } from '../root/FieldsetRootContext';
 
 export function useFieldsetLegend(params: useFieldsetLegend.Parameters) {
@@ -12,7 +12,7 @@ export function useFieldsetLegend(params: useFieldsetLegend.Parameters) {
 
   const id = useBaseUiId(idProp);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setLegendId(id);
     return () => {
       setLegendId(undefined);

--- a/packages/react/src/menu/group-label/MenuGroupLabel.tsx
+++ b/packages/react/src/menu/group-label/MenuGroupLabel.tsx
@@ -4,7 +4,7 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useMenuGroupRootContext } from '../group/MenuGroupContext';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 
 const state = {};
 
@@ -24,7 +24,7 @@ export const MenuGroupLabel = React.forwardRef(function MenuGroupLabelComponent(
 
   const { setLabelId } = useMenuGroupRootContext();
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setLabelId(id);
     return () => {
       setLabelId(undefined);

--- a/packages/react/src/menu/item/useMenuItem.ts
+++ b/packages/react/src/menu/item/useMenuItem.ts
@@ -5,7 +5,7 @@ import { useButton } from '../../use-button';
 import { mergeProps } from '../../merge-props';
 import { HTMLProps, BaseUIEvent } from '../../utils/types';
 import { useForkRef } from '../../utils/useForkRef';
-import { useModernLayoutEffect } from '../../utils';
+import { useLayoutEffect } from '../../utils';
 import { addHighlight, removeHighlight } from '../../utils/highlighted';
 
 export function useMenuItem(params: useMenuItem.Parameters): useMenuItem.ReturnValue {
@@ -28,7 +28,7 @@ export function useMenuItem(params: useMenuItem.Parameters): useMenuItem.ReturnV
     buttonRef: useForkRef(externalRef, itemRef),
   });
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (highlighted) {
       addHighlight(itemRef);
     } else {

--- a/packages/react/src/meter/label/MeterLabel.tsx
+++ b/packages/react/src/meter/label/MeterLabel.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { mergeProps } from '../../merge-props';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useMeterRootContext } from '../root/MeterRootContext';
 import type { MeterRoot } from '../root/MeterRoot';
 import { BaseUIComponentProps } from '../../utils/types';
@@ -25,7 +25,7 @@ export const MeterLabel = React.forwardRef(function MeterLabel(
 
   const { setLabelId } = useMeterRootContext();
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setLabelId(id);
     return () => setLabelId(undefined);
   }, [id, setLabelId]);

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { useModernLayoutEffect, stopEvent } from '@floating-ui/react/utils';
+import { useLayoutEffect, stopEvent } from '@floating-ui/react/utils';
 import { useNumberFieldRootContext } from '../root/NumberFieldRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
@@ -80,7 +80,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
   const prevValueRef = React.useRef(value);
   const prevInputValueRef = React.useRef(inputValue);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (prevValueRef.current === value && prevInputValueRef.current === inputValue) {
       return;
     }
@@ -94,7 +94,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
     }
   }, [value, inputValue, name, clearErrors, validationMode, commitValidation]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     prevValueRef.current = value;
     prevInputValueRef.current = inputValue;
   }, [value, inputValue]);

--- a/packages/react/src/number-field/root/useNumberFieldRoot.ts
+++ b/packages/react/src/number-field/root/useNumberFieldRoot.ts
@@ -9,7 +9,7 @@ import { ownerDocument, ownerWindow } from '../../utils/owner';
 import { useTimeout, Timeout } from '../../utils/useTimeout';
 import { useInterval } from '../../utils/useInterval';
 import { useControlled } from '../../utils/useControlled';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useForcedRerendering } from '../../utils/useForcedRerendering';
 import { useBaseUiId } from '../../utils/useBaseUiId';
@@ -65,7 +65,7 @@ export function useNumberFieldRoot(
 
   const id = useBaseUiId(idProp);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setControlId(id);
     return () => {
       setControlId(undefined);
@@ -82,7 +82,7 @@ export function useNumberFieldRoot(
   const value = valueUnwrapped ?? null;
   const valueRef = useLatestRef(value);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setFilled(value !== null);
   }, [setFilled, value]);
 
@@ -99,7 +99,7 @@ export function useNumberFieldRoot(
   const allowInputSyncRef = React.useRef(true);
   const unsubscribeFromGlobalContextMenuRef = React.useRef<() => void>(() => {});
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (validityData.initialValue === null && value !== validityData.initialValue) {
       setValidityData((prev) => ({ ...prev, initialValue: value }));
     }
@@ -158,7 +158,7 @@ export function useNumberFieldRoot(
       setDirty(validatedValue !== validityData.initialValue);
 
       // We need to force a re-render, because while the value may be unchanged, the formatting may
-      // be different. This forces the `useModernLayoutEffect` to run which acts as a single source of
+      // be different. This forces the `useLayoutEffect` to run which acts as a single source of
       // truth to sync the input value.
       forceRender();
     },
@@ -239,7 +239,7 @@ export function useNumberFieldRoot(
   // ESLint is disabled because it needs to run even if the parsed value hasn't changed, since the
   // value still can be formatted differently.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useModernLayoutEffect(function syncFormattedInputValueOnValueChange() {
+  useLayoutEffect(function syncFormattedInputValueOnValueChange() {
     // This ensures the value is only updated on blur rather than every keystroke, but still
     // allows the input value to be updated when the value is changed externally.
     if (!allowInputSyncRef.current) {
@@ -253,7 +253,7 @@ export function useNumberFieldRoot(
     }
   });
 
-  useModernLayoutEffect(
+  useLayoutEffect(
     function setDynamicInputModeForIOS() {
       if (!isIOS()) {
         return;

--- a/packages/react/src/popover/description/PopoverDescription.tsx
+++ b/packages/react/src/popover/description/PopoverDescription.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { usePopoverRootContext } from '../root/PopoverRootContext';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { useModernLayoutEffect } from '../../utils';
+import { useLayoutEffect } from '../../utils';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useRenderElement } from '../../utils/useRenderElement';
 
@@ -22,7 +22,7 @@ export const PopoverDescription = React.forwardRef(function PopoverDescription(
 
   const id = useBaseUiId(elementProps.id);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setDescriptionId(id);
     return () => {
       setDescriptionId(undefined);

--- a/packages/react/src/popover/title/PopoverTitle.tsx
+++ b/packages/react/src/popover/title/PopoverTitle.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { usePopoverRootContext } from '../root/PopoverRootContext';
 import { useRenderElement } from '../../utils/useRenderElement';
-import { useModernLayoutEffect } from '../../utils';
+import { useLayoutEffect } from '../../utils';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 
 /**
@@ -22,7 +22,7 @@ export const PopoverTitle = React.forwardRef(function PopoverTitle(
 
   const id = useBaseUiId(elementProps.id);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setTitleId(id);
     return () => {
       setTitleId(undefined);

--- a/packages/react/src/popover/title/usePopoverTitle.ts
+++ b/packages/react/src/popover/title/usePopoverTitle.ts
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { mergeProps } from '../../merge-props';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import type { HTMLProps } from '../../utils/types';
 
@@ -22,7 +22,7 @@ export function usePopoverTitle(params: usePopoverTitle.Parameters): usePopoverT
     [id],
   );
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setTitleId(id);
     return () => {
       setTitleId(undefined);

--- a/packages/react/src/progress/label/ProgressLabel.tsx
+++ b/packages/react/src/progress/label/ProgressLabel.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useRenderElement } from '../../utils/useRenderElement';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useProgressRootContext } from '../root/ProgressRootContext';
 import { progressStyleHookMapping } from '../root/styleHooks';
 import type { ProgressRoot } from '../root/ProgressRoot';
@@ -24,7 +24,7 @@ export const ProgressLabel = React.forwardRef(function ProgressLabel(
 
   const { setLabelId, state } = useProgressRootContext();
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setLabelId(id);
     return () => setLabelId(undefined);
   }, [id, setLabelId]);

--- a/packages/react/src/radio-group/useRadioGroup.ts
+++ b/packages/react/src/radio-group/useRadioGroup.ts
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { contains, useModernLayoutEffect } from '@floating-ui/react/utils';
+import { contains, useLayoutEffect } from '@floating-ui/react/utils';
 import { mergeProps } from '../merge-props';
 import { useControlled } from '../utils/useControlled';
 import { useFieldRootContext } from '../field/root/FieldRootContext';
@@ -57,7 +57,7 @@ export function useRadioGroup(params: useRadioGroup.Parameters) {
 
   const prevValueRef = React.useRef(checkedValue);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (prevValueRef.current === checkedValue) {
       return;
     }
@@ -71,7 +71,7 @@ export function useRadioGroup(params: useRadioGroup.Parameters) {
     }
   }, [name, clearErrors, validationMode, checkedValue, fieldControlValidation]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     prevValueRef.current = checkedValue;
   }, [checkedValue]);
 

--- a/packages/react/src/radio/root/useRadioRoot.tsx
+++ b/packages/react/src/radio/root/useRadioRoot.tsx
@@ -4,7 +4,7 @@ import { mergeProps } from '../../merge-props';
 import { visuallyHidden } from '../../utils/visuallyHidden';
 import { useRadioGroupContext } from '../../radio-group/RadioGroupContext';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { ACTIVE_COMPOSITE_ITEM } from '../../composite/constants';
 import { useForkRef } from '../../utils/useForkRef';
 
@@ -27,7 +27,7 @@ export function useRadioRoot(params: useRadioRoot.Parameters) {
   const inputRef = React.useRef<HTMLInputElement>(null);
   const ref = useForkRef(inputRefProp, inputRef);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (inputRef.current?.checked) {
       setFilled(true);
     }

--- a/packages/react/src/scroll-area/content/ScrollAreaContent.tsx
+++ b/packages/react/src/scroll-area/content/ScrollAreaContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { useModernLayoutEffect } from '../../utils';
+import { useLayoutEffect } from '../../utils';
 import { useScrollAreaViewportContext } from '../viewport/ScrollAreaViewportContext';
 import { useRenderElement } from '../../utils/useRenderElement';
 
@@ -21,7 +21,7 @@ export const ScrollAreaContent = React.forwardRef(function ScrollAreaContent(
 
   const { computeThumbPosition } = useScrollAreaViewportContext();
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (typeof ResizeObserver === 'undefined') {
       return undefined;
     }

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -9,7 +9,7 @@ import { useDirection } from '../../direction-provider/DirectionContext';
 import { getOffset } from '../utils/getOffset';
 import { MIN_THUMB_SIZE } from '../constants';
 import { clamp } from '../../utils/clamp';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { onVisible } from '../utils/onVisible';
 
 /**
@@ -159,7 +159,7 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     });
   });
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!viewportRef.current) {
       return undefined;
     }
@@ -168,12 +168,12 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     return cleanup;
   }, [computeThumbPosition, viewportRef]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     // Wait for scrollbar-related refs to be set
     queueMicrotask(computeThumbPosition);
   }, [computeThumbPosition, hiddenState, direction]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     // `onMouseEnter` doesn't fire upon load, so we need to check if the viewport is already
     // being hovered.
     if (viewportRef.current?.matches(':hover')) {

--- a/packages/react/src/select/group-label/SelectGroupLabel.tsx
+++ b/packages/react/src/select/group-label/SelectGroupLabel.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useSelectGroupContext } from '../group/SelectGroupContext';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useRenderElement } from '../../utils/useRenderElement';
 
 /**
@@ -22,7 +22,7 @@ export const SelectGroupLabel = React.forwardRef(function SelectGroupLabel(
 
   const id = useBaseUiId(idProp);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setLabelId(id);
   }, [id, setLabelId]);
 

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -7,7 +7,7 @@ import { useCompositeListItem } from '../../composite/list/useCompositeListItem'
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useSelectItem } from './useSelectItem';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useLatestRef } from '../../utils/useLatestRef';
 import { SelectItemContext } from './SelectItemContext';
 import { useRenderElement } from '../../utils/useRenderElement';
@@ -154,7 +154,7 @@ export const SelectItem = React.forwardRef(function SelectItem(
 
   const hasRegistered = listItem.index !== -1;
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!hasRegistered) {
       return undefined;
     }
@@ -167,7 +167,7 @@ export const SelectItem = React.forwardRef(function SelectItem(
     };
   }, [hasRegistered, listItem.index, valueProp, valuesRef]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (hasRegistered && valueProp === value) {
       registerSelectedItem(listItem.index);
     }

--- a/packages/react/src/select/item/useSelectItem.ts
+++ b/packages/react/src/select/item/useSelectItem.ts
@@ -8,7 +8,7 @@ import { useTimeout } from '../../utils/useTimeout';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { SelectIndexContext } from '../root/SelectIndexContext';
 import { useForkRef } from '../../utils/useForkRef';
-import { useModernLayoutEffect } from '../../utils';
+import { useLayoutEffect } from '../../utils';
 import { addHighlight, hasHighlight, removeHighlight } from '../../utils/highlighted';
 import { isMouseWithinBounds } from '../../utils/isMouseWithinBounds';
 import { AnimationFrame } from '../../utils/useAnimationFrame';
@@ -66,7 +66,7 @@ export function useSelectItem(params: useSelectItem.Parameters): useSelectItem.R
     return handlePopupLeave;
   }, [handlePopupLeave]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!open) {
       return;
     }

--- a/packages/react/src/select/popup/useSelectPopup.ts
+++ b/packages/react/src/select/popup/useSelectPopup.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { HTMLProps } from '../../utils/types';
 import { useSelectRootContext } from '../root/SelectRootContext';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { ownerDocument, ownerWindow } from '../../utils/owner';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { clearPositionerStyles } from './utils';
@@ -54,7 +54,7 @@ export function useSelectPopup(): useSelectPopup.ReturnValue {
     }
   });
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (
       alignItemWithTriggerActive ||
       !positionerElement ||
@@ -76,7 +76,7 @@ export function useSelectPopup(): useSelectPopup.ReturnValue {
     };
   }, [alignItemWithTriggerActive, positionerElement]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (mounted || alignItemWithTriggerActive) {
       return;
     }
@@ -91,7 +91,7 @@ export function useSelectPopup(): useSelectPopup.ReturnValue {
     }
   }, [mounted, alignItemWithTriggerActive, positionerElement]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (
       !mounted ||
       !alignItemWithTriggerActive ||

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -13,7 +13,7 @@ import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useControlled } from '../../utils/useControlled';
 import { useTransitionStatus } from '../../utils';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { warn } from '../../utils/warn';
 import type { SelectRootContext } from './SelectRootContext';
@@ -57,7 +57,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setControlId(id);
     return () => {
       setControlId(undefined);
@@ -78,7 +78,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     state: 'open',
   });
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setFilled(value !== null);
   }, [setFilled, value]);
 
@@ -120,7 +120,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
 
   const prevValueRef = React.useRef(value);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (prevValueRef.current === value) {
       return;
     }
@@ -132,7 +132,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     }
   }, [value, commitValidation, clearErrors, name, validationMode]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     prevValueRef.current = value;
   }, [value]);
 
@@ -206,7 +206,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     }
   });
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!hasRegisteredRef.current) {
       return;
     }

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -9,7 +9,7 @@ import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useControlled } from '../../utils/useControlled';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useLatestRef } from '../../utils/useLatestRef';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { warn } from '../../utils/warn';
 import { CompositeList, type CompositeMetadata } from '../../composite/list/CompositeList';
@@ -124,7 +124,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     () => new Map<Node, CompositeMetadata<ThumbMetadata> | null>(),
   );
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setControlId(id);
     return () => {
       setControlId(undefined);
@@ -206,7 +206,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     },
   );
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (valueProp === undefined || dragging) {
       return;
     }
@@ -216,7 +216,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     }
   }, [dragging, min, max, valueProp]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     const activeEl = activeElement(ownerDocument(sliderRef.current));
     if (disabled && sliderRef.current?.contains(activeEl)) {
       // This is necessary because Firefox and Safari will keep focus

--- a/packages/react/src/switch/root/useSwitchRoot.ts
+++ b/packages/react/src/switch/root/useSwitchRoot.ts
@@ -7,7 +7,7 @@ import { mergeProps } from '../../merge-props';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useBaseUiId } from '../../utils/useBaseUiId';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
 import { useField } from '../../field/useField';
 import { useFormContext } from '../../form/FormContext';
@@ -53,7 +53,7 @@ export function useSwitchRoot(params: useSwitchRoot.Parameters): useSwitchRoot.R
 
   const id = useBaseUiId(idProp);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     setControlId(id);
     return () => {
       setControlId(undefined);
@@ -79,7 +79,7 @@ export function useSwitchRoot(params: useSwitchRoot.Parameters): useSwitchRoot.R
     controlRef: buttonRef,
   });
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (inputRef.current) {
       setFilled(inputRef.current.checked);
     }

--- a/packages/react/src/tabs/list/useTabsList.ts
+++ b/packages/react/src/tabs/list/useTabsList.ts
@@ -4,7 +4,7 @@ import type { TabsRootContext } from '../root/TabsRootContext';
 import { type TabsOrientation, type TabActivationDirection } from '../root/TabsRoot';
 import { mergeProps } from '../../merge-props';
 import { HTMLProps } from '../../utils/types';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useForkRef } from '../../utils/useForkRef';
 import { useEventCallback } from '../../utils/useEventCallback';
 
@@ -76,7 +76,7 @@ function useActivationDirectionDetector(
 ): (newValue: any) => TabActivationDirection {
   const previousTabEdge = React.useRef<number | null>(null);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     // Whenever orientation changes, reset the state.
     if (selectedTabValue == null || tabsListRef.current == null) {
       previousTabEdge.current = null;

--- a/packages/react/src/tabs/tab/useTabsTab.ts
+++ b/packages/react/src/tabs/tab/useTabsTab.ts
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { mergeProps } from '../../merge-props';
 import { ownerDocument } from '../../utils/owner';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useForkRef } from '../../utils/useForkRef';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useButton } from '../../use-button';
@@ -60,7 +60,7 @@ export function useTabsTab(parameters: useTabsTab.Parameters): useTabsTab.Return
 
   const isSelectionSyncedWithHighlightRef = React.useRef(false);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (isSelectionSyncedWithHighlightRef.current === true) {
       return;
     }

--- a/packages/react/src/toast/description/ToastDescription.tsx
+++ b/packages/react/src/toast/description/ToastDescription.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useToastRootContext } from '../root/ToastRootContext';
 import { useId } from '../../utils/useId';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useRenderElement } from '../../utils/useRenderElement';
 
 /**
@@ -29,7 +29,7 @@ export const ToastDescription = React.forwardRef(function ToastDescription(
 
   const { setDescriptionId } = useToastRootContext();
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!shouldRender) {
       return undefined;
     }

--- a/packages/react/src/toast/title/ToastTitle.tsx
+++ b/packages/react/src/toast/title/ToastTitle.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useToastRootContext } from '../root/ToastRootContext';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { useId } from '../../utils/useId';
 import { useRenderElement } from '../../utils/useRenderElement';
 
@@ -28,7 +28,7 @@ export const ToastTitle = React.forwardRef(function ToastTitle(
 
   const { setTitleId } = useToastRootContext();
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!shouldRender) {
       return undefined;
     }

--- a/packages/react/src/toast/viewport/FocusGuard.tsx
+++ b/packages/react/src/toast/viewport/FocusGuard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { isSafari } from '@floating-ui/react/utils';
-import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../../utils/useLayoutEffect';
 import { visuallyHidden } from '../../utils/visuallyHidden';
 
 /**
@@ -12,7 +12,7 @@ export const FocusGuard = React.forwardRef(function FocusGuard(
 ) {
   const [role, setRole] = React.useState<'button' | undefined>();
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (isSafari()) {
       // Unlike other screen readers such as NVDA and JAWS, the virtual cursor
       // on VoiceOver does trigger the onFocus event, so we can use the focus

--- a/packages/react/src/unstable-no-ssr/NoSsr.tsx
+++ b/packages/react/src/unstable-no-ssr/NoSsr.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { useModernLayoutEffect } from '../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../utils/useLayoutEffect';
 import { NoSsrProps } from './NoSsr.types';
 
 /**
@@ -19,7 +19,7 @@ export function NoSsr(props: NoSsrProps): React.JSX.Element {
   const { children, defer = false, fallback = null } = props;
   const [mountedState, setMountedState] = React.useState(false);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!defer) {
       setMountedState(true);
     }

--- a/packages/react/src/use-button/useButton.ts
+++ b/packages/react/src/use-button/useButton.ts
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useForkRef } from '../utils/useForkRef';
 import { makeEventPreventable, mergeProps } from '../merge-props';
-import { useModernLayoutEffect } from '../utils/useModernLayoutEffect';
+import { useLayoutEffect } from '../utils/useLayoutEffect';
 import { useEventCallback } from '../utils/useEventCallback';
 import { useRootElementName } from '../utils/useRootElementName';
 import { useCompositeRootContext } from '../composite/root/CompositeRootContext';
@@ -80,7 +80,7 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
   // <Toolbar.Button disabled render={<Menu.Trigger />} />
   // the `disabled` prop needs to pass through 2 `useButton`s then finally
   // delete the `disabled` attribute from DOM
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     const element = buttonRef.current;
     if (!(element instanceof HTMLButtonElement)) {
       return;

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -2,7 +2,7 @@
 
 export * from './getReactElementRef';
 export * from './useControlled';
-export * from './useModernLayoutEffect';
+export * from './useLayoutEffect';
 export * from './useForkRef';
 export * from './useId';
 export * from './useScrollLock';

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -19,7 +19,7 @@ import {
   type Side as PhysicalSide,
 } from '@floating-ui/react';
 import { getSide, getAlignment, type Rect } from '@floating-ui/utils';
-import { useModernLayoutEffect } from './useModernLayoutEffect';
+import { useLayoutEffect } from './useLayoutEffect';
 import { useDirection } from '../direction-provider/DirectionContext';
 import { useLatestRef } from './useLatestRef';
 import { useEventCallback } from './useEventCallback';
@@ -255,7 +255,7 @@ export function useAnchorPositioning(
 
   const registeredPositionReferenceRef = React.useRef<Element | VirtualElement | null>(null);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!mounted) {
       return;
     }

--- a/packages/react/src/utils/useLayoutEffect.ts
+++ b/packages/react/src/utils/useLayoutEffect.ts
@@ -1,0 +1,6 @@
+'use client';
+import * as React from 'react';
+import { useModernLayoutEffect } from '@floating-ui/react/utils';
+
+/** A `React.useLayoutEffect` that doesn't warn in non-browser environments */
+export const useLayoutEffect = useModernLayoutEffect as typeof React.useLayoutEffect;

--- a/packages/react/src/utils/useModernLayoutEffect.ts
+++ b/packages/react/src/utils/useModernLayoutEffect.ts
@@ -1,2 +1,0 @@
-'use client';
-export { useModernLayoutEffect } from '@floating-ui/react/utils';

--- a/packages/react/src/utils/useRootElementName.ts
+++ b/packages/react/src/utils/useRootElementName.ts
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { useModernLayoutEffect } from './useModernLayoutEffect';
+import { useLayoutEffect } from './useLayoutEffect';
 import { warn } from './warn';
 
 interface UseRootElementNameParameters {
@@ -34,7 +34,7 @@ export function useRootElementName(
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useModernLayoutEffect(() => {
+    useLayoutEffect(() => {
       if (rootElementNameProp && rootElementName !== rootElementNameProp.toUpperCase()) {
         warn(
           `useRootElementName expected the '${rootElementNameProp}' element, but a '${rootElementName.toLowerCase()}' was rendered instead`,

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { isFirefox, isIOS, isWebKit } from './detectBrowser';
 import { ownerDocument, ownerWindow } from './owner';
-import { useModernLayoutEffect } from './useModernLayoutEffect';
+import { useLayoutEffect } from './useLayoutEffect';
 import { AnimationFrame } from './useAnimationFrame';
 
 let originalHtmlStyles: Partial<CSSStyleDeclaration> = {};
@@ -155,7 +155,7 @@ export function useScrollLock(params: {
     [enabled, referenceElement],
   );
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     // https://github.com/mui/base-ui/issues/1135
     if (mounted && !open && isWebKit()) {
       const doc = ownerDocument(referenceElement);
@@ -171,7 +171,7 @@ export function useScrollLock(params: {
     return undefined;
   }, [mounted, open, referenceElement]);
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!enabled) {
       return undefined;
     }

--- a/packages/react/src/utils/useTransitionStatus.ts
+++ b/packages/react/src/utils/useTransitionStatus.ts
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { useModernLayoutEffect } from './useModernLayoutEffect';
+import { useLayoutEffect } from './useLayoutEffect';
 import { AnimationFrame } from './useAnimationFrame';
 
 export type TransitionStatus = 'starting' | 'ending' | 'idle' | undefined;
@@ -28,7 +28,7 @@ export function useTransitionStatus(open: boolean) {
     setTransitionStatus(undefined);
   }
 
-  useModernLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!open) {
       return undefined;
     }


### PR DESCRIPTION
Following this discussion: https://mui-org.slack.com/archives/C011VC970AW/p1738093359898899

The "modern" token doesn't bring any useful semantic, and makes the codebase more verbose. I've also added jsdocs & typings in our re-export because somehow the typings and jump-to-definition don't work for the floating-ui package, so I had to manually find that function to find what it does.