### PR TITLE
[useButton] Default `tabIndex` to `0`

### DIFF
--- a/packages/react/src/menu/trigger/useMenuTrigger.ts
+++ b/packages/react/src/menu/trigger/useMenuTrigger.ts
@@ -105,7 +105,6 @@ export function useMenuTrigger(parameters: useMenuTrigger.Parameters): useMenuTr
         },
         externalProps,
         getButtonProps,
-        menuParent.type === 'menubar' ? { tabIndex: undefined } : {},
       );
     },
     [
@@ -114,7 +113,6 @@ export function useMenuTrigger(parameters: useMenuTrigger.Parameters): useMenuTr
       open,
       allowMouseUpTriggerRef,
       allowMouseUpTriggerTimeout,
-      menuParent.type,
       handleMouseUp,
     ],
   );

--- a/packages/react/src/menu/trigger/useMenuTrigger.ts
+++ b/packages/react/src/menu/trigger/useMenuTrigger.ts
@@ -88,7 +88,6 @@ export function useMenuTrigger(parameters: useMenuTrigger.Parameters): useMenuTr
       return mergeProps(
         {
           'aria-haspopup': 'menu' as const,
-          ...(menuParent.type === 'menubar' ? {} : { tabIndex: 0 }), // this is needed to make the button focused after click in Safari
           ref: handleRef,
           onMouseDown: (event: React.MouseEvent) => {
             if (open) {
@@ -106,6 +105,7 @@ export function useMenuTrigger(parameters: useMenuTrigger.Parameters): useMenuTr
         },
         externalProps,
         getButtonProps,
+        menuParent.type === 'menubar' ? { tabIndex: undefined } : {},
       );
     },
     [

--- a/packages/react/src/select/trigger/useSelectTrigger.ts
+++ b/packages/react/src/select/trigger/useSelectTrigger.ts
@@ -81,7 +81,7 @@ export function useSelectTrigger(
     {
       'aria-labelledby': labelId,
       'aria-readonly': readOnly || undefined,
-      tabIndex: disabled ? -1 : 0, // this is needed to make the button focused after click in Safari
+      tabIndex: disabled ? -1 : 0,
       ref: handleRef,
       onFocus(event) {
         setFocused(true);

--- a/packages/react/src/use-button/useButton.test.tsx
+++ b/packages/react/src/use-button/useButton.test.tsx
@@ -76,11 +76,11 @@ describe('useButton', () => {
   });
 
   describe('param: tabIndex', () => {
-    it('does not return tabIndex in getButtonProps when host component is BUTTON', async () => {
+    it('returns tabIndex in getButtonProps when host component is BUTTON', async () => {
       function TestButton() {
         const { getButtonProps } = useButton();
 
-        expect(getButtonProps().tabIndex).to.equal(undefined);
+        expect(getButtonProps().tabIndex).to.equal(0);
 
         return <button {...getButtonProps()} />;
       }
@@ -94,7 +94,7 @@ describe('useButton', () => {
         const buttonRef = React.useRef(null);
         const { getButtonProps } = useButton({ buttonRef });
 
-        expect(getButtonProps().tabIndex).to.equal(buttonRef.current ? 0 : undefined);
+        expect(getButtonProps().tabIndex).to.equal(0);
 
         return <span {...getButtonProps()} />;
       }

--- a/packages/react/src/use-button/useButton.ts
+++ b/packages/react/src/use-button/useButton.ts
@@ -13,7 +13,7 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
     buttonRef: externalRef,
     disabled = false,
     focusableWhenDisabled,
-    tabIndex,
+    tabIndex = 0,
     type = 'button',
     elementName: elementNameProp,
   } = parameters;


### PR DESCRIPTION
Modern Safari allows buttons to receive focus upon click/mousedown if they have a tabIndex of `0`. This ensures the `:focus-visible` style won't appear once focus moves to a popup.

https://github.com/mui/base-ui/pull/1846#issuecomment-2887579218