### PR TITLE
[core] Refactor: "style hooks" to "state attributes"

### DIFF
--- a/packages/react/src/accordion/header/AccordionHeader.tsx
+++ b/packages/react/src/accordion/header/AccordionHeader.tsx
@@ -4,7 +4,7 @@ import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import type { AccordionItem } from '../item/AccordionItem';
 import { useAccordionItemContext } from '../item/AccordionItemContext';
-import { accordionStyleHookMapping } from '../item/styleHooks';
+import { accordionMapping } from '../item/stateAttributesMapping';
 
 /**
  * A heading that labels the corresponding panel.
@@ -24,7 +24,7 @@ export const AccordionHeader = React.forwardRef(function AccordionHeader(
     state,
     ref: forwardedRef,
     props: elementProps,
-    customStyleHookMapping: accordionStyleHookMapping,
+    stateAttributesMapping: accordionMapping,
   });
 
   return element;

--- a/packages/react/src/accordion/item/AccordionItem.tsx
+++ b/packages/react/src/accordion/item/AccordionItem.tsx
@@ -13,7 +13,7 @@ import { useCompositeListItem } from '../../composite/list/useCompositeListItem'
 import type { AccordionRoot } from '../root/AccordionRoot';
 import { useAccordionRootContext } from '../root/AccordionRootContext';
 import { AccordionItemContext } from './AccordionItemContext';
-import { accordionStyleHookMapping } from './styleHooks';
+import { accordionMapping } from './stateAttributesMapping';
 
 /**
  * Groups an accordion header with the corresponding panel.
@@ -119,7 +119,7 @@ export const AccordionItem = React.forwardRef(function AccordionItem(
     state,
     ref: mergedRef,
     props: elementProps,
-    customStyleHookMapping: accordionStyleHookMapping,
+    stateAttributesMapping: accordionMapping,
   });
 
   return (

--- a/packages/react/src/accordion/item/stateAttributesMapping.ts
+++ b/packages/react/src/accordion/item/stateAttributesMapping.ts
@@ -1,10 +1,10 @@
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { collapsibleOpenStateMapping as baseMapping } from '../../utils/collapsibleOpenStateMapping';
 import type { AccordionItem } from './AccordionItem';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { AccordionItemDataAttributes } from './AccordionItemDataAttributes';
 
-export const accordionStyleHookMapping: CustomStyleHookMapping<AccordionItem.State> = {
+export const accordionMapping: StateAttributesMapping<AccordionItem.State> = {
   ...baseMapping,
   index: (value) => {
     return Number.isInteger(value) ? { [AccordionItemDataAttributes.index]: String(value) } : null;

--- a/packages/react/src/accordion/panel/AccordionPanel.tsx
+++ b/packages/react/src/accordion/panel/AccordionPanel.tsx
@@ -10,7 +10,7 @@ import { useAccordionRootContext } from '../root/AccordionRootContext';
 import type { AccordionRoot } from '../root/AccordionRoot';
 import type { AccordionItem } from '../item/AccordionItem';
 import { useAccordionItemContext } from '../item/AccordionItemContext';
-import { accordionStyleHookMapping } from '../item/styleHooks';
+import { accordionMapping } from '../item/stateAttributesMapping';
 import { AccordionPanelCssVars } from './AccordionPanelCssVars';
 import { usePanelResize } from '../../utils/usePanelResize';
 
@@ -124,7 +124,7 @@ export const AccordionPanel = React.forwardRef(function AccordionPanel(
       },
       elementProps,
     ],
-    customStyleHookMapping: accordionStyleHookMapping,
+    stateAttributesMapping: accordionMapping,
   });
 
   const shouldRender = keepMounted || hiddenUntilFound || (!keepMounted && mounted);

--- a/packages/react/src/accordion/panel/AccordionPanelDataAttributes.ts
+++ b/packages/react/src/accordion/panel/AccordionPanelDataAttributes.ts
@@ -1,4 +1,4 @@
-import { TransitionStatusDataAttributes } from '../../utils/styleHookMapping';
+import { TransitionStatusDataAttributes } from '../../utils/stateAttributesMapping';
 
 export enum AccordionPanelDataAttributes {
   /**

--- a/packages/react/src/accordion/root/AccordionRoot.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.tsx
@@ -22,7 +22,7 @@ import { AccordionRootContext } from './AccordionRootContext';
 
 const SUPPORTED_KEYS = new Set([ARROW_DOWN, ARROW_UP, ARROW_RIGHT, ARROW_LEFT, HOME, END]);
 
-const rootStyleHookMapping = {
+const rootMapping = {
   value: () => null,
 };
 
@@ -245,7 +245,7 @@ export const AccordionRoot = React.forwardRef(function AccordionRoot(
       },
       elementProps,
     ],
-    customStyleHookMapping: rootStyleHookMapping,
+    stateAttributesMapping: rootMapping,
   });
 
   return (

--- a/packages/react/src/accordion/trigger/AccordionTrigger.tsx
+++ b/packages/react/src/accordion/trigger/AccordionTrigger.tsx
@@ -57,7 +57,7 @@ export const AccordionTrigger = React.forwardRef(function AccordionTrigger(
     state,
     ref: [forwardedRef, buttonRef],
     props: [props, elementProps, getButtonProps],
-    customStyleHookMapping: triggerOpenStateMapping,
+    stateAttributesMapping: triggerOpenStateMapping,
   });
 
   return element;

--- a/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
+++ b/packages/react/src/alert-dialog/backdrop/AlertDialogBackdrop.tsx
@@ -4,13 +4,13 @@ import { useAlertDialogRootContext } from '../root/AlertDialogRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import type { BaseUIComponentProps } from '../../utils/types';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useForkRef } from '../../utils/useForkRef';
 import { mergeProps } from '../../merge-props';
 
-const customStyleHookMapping: CustomStyleHookMapping<AlertDialogBackdrop.State> = {
+const stateAttributesMapping: StateAttributesMapping<AlertDialogBackdrop.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
 };
@@ -54,7 +54,7 @@ export const AlertDialogBackdrop = React.forwardRef(function AlertDialogBackdrop
       },
       other,
     ),
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   // no need to render nested backdrops

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -6,18 +6,18 @@ import { useAlertDialogRootContext } from '../root/AlertDialogRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import { useForkRef } from '../../utils/useForkRef';
 import { InteractionType } from '../../utils/useEnhancedClickHandler';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { AlertDialogPopupDataAttributes } from './AlertDialogPopupDataAttributes';
 import { InternalBackdrop } from '../../utils/InternalBackdrop';
 import { useAlertDialogPortalContext } from '../portal/AlertDialogPortalContext';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { inertValue } from '../../utils/inertValue';
 
-const customStyleHookMapping: CustomStyleHookMapping<AlertDialogPopup.State> = {
+const stateAttributesMapping: StateAttributesMapping<AlertDialogPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
   nestedDialogOpen(value) {
@@ -105,7 +105,7 @@ export const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
       style: { ...other.style, '--nested-dialogs': nestedOpenDialogCount },
       role: 'alertdialog',
     },
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return (

--- a/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
+++ b/packages/react/src/alert-dialog/trigger/AlertDialogTrigger.tsx
@@ -42,7 +42,7 @@ export const AlertDialogTrigger = React.forwardRef(function AlertDialogTrigger(
     state,
     propGetter: (externalProps) => getButtonProps(getTriggerProps(externalProps)),
     extraProps: other,
-    customStyleHookMapping: triggerOpenStateMapping,
+    stateAttributesMapping: triggerOpenStateMapping,
     ref: mergedRef,
   });
 

--- a/packages/react/src/avatar/fallback/AvatarFallback.tsx
+++ b/packages/react/src/avatar/fallback/AvatarFallback.tsx
@@ -5,7 +5,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useTimeout } from '../../utils/useTimeout';
 import { useAvatarRootContext } from '../root/AvatarRootContext';
 import type { AvatarRoot } from '../root/AvatarRoot';
-import { avatarStyleHookMapping } from '../root/styleHooks';
+import { avatarMapping } from '../root/stateAttributesMapping';
 
 /**
  * Rendered when the image fails to load or when no image is provided.
@@ -43,7 +43,7 @@ export const AvatarFallback = React.forwardRef(function AvatarFallback(
     className,
     ref: forwardedRef,
     extraProps: otherProps,
-    customStyleHookMapping: avatarStyleHookMapping,
+    stateAttributesMapping: avatarMapping,
   });
 
   const shouldRender = imageLoadingStatus !== 'loaded' && delayPassed;

--- a/packages/react/src/avatar/image/AvatarImage.tsx
+++ b/packages/react/src/avatar/image/AvatarImage.tsx
@@ -6,7 +6,7 @@ import { useEventCallback } from '../../utils/useEventCallback';
 import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
 import { useAvatarRootContext } from '../root/AvatarRootContext';
 import type { AvatarRoot } from '../root/AvatarRoot';
-import { avatarStyleHookMapping } from '../root/styleHooks';
+import { avatarMapping } from '../root/stateAttributesMapping';
 import { useImageLoadingStatus, ImageLoadingStatus } from './useImageLoadingStatus';
 
 /**
@@ -58,7 +58,7 @@ export const AvatarImage = React.forwardRef(function AvatarImage(
     className,
     ref: forwardedRef,
     extraProps: otherProps,
-    customStyleHookMapping: avatarStyleHookMapping,
+    stateAttributesMapping: avatarMapping,
   });
 
   return imageLoadingStatus === 'loaded' ? renderElement() : null;

--- a/packages/react/src/avatar/root/AvatarRoot.tsx
+++ b/packages/react/src/avatar/root/AvatarRoot.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { AvatarRootContext } from './AvatarRootContext';
-import { avatarStyleHookMapping } from './styleHooks';
+import { avatarMapping } from './stateAttributesMapping';
 
 /**
  * Displays a user's profile picture, initials, or fallback icon.
@@ -40,7 +40,7 @@ export const AvatarRoot = React.forwardRef(function AvatarRoot(
     className,
     ref: forwardedRef,
     extraProps: otherProps,
-    customStyleHookMapping: avatarStyleHookMapping,
+    stateAttributesMapping: avatarMapping,
   });
 
   return (

--- a/packages/react/src/avatar/root/stateAttributesMapping.ts
+++ b/packages/react/src/avatar/root/stateAttributesMapping.ts
@@ -1,0 +1,3 @@
+export const avatarMapping = {
+  imageLoadingStatus: () => null,
+};

--- a/packages/react/src/avatar/root/styleHooks.ts
+++ b/packages/react/src/avatar/root/styleHooks.ts
@@ -1,3 +1,0 @@
-export const avatarStyleHookMapping = {
-  imageLoadingStatus: () => null,
-};

--- a/packages/react/src/checkbox-group/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.tsx
@@ -54,7 +54,7 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
     state,
     ref: forwardedRef,
     extraProps: otherProps,
-    customStyleHookMapping: fieldValidityMapping,
+    stateAttributesMapping: fieldValidityMapping,
   });
 
   const contextValue: CheckboxGroupContext = React.useMemo(

--- a/packages/react/src/checkbox/indicator/CheckboxIndicator.tsx
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicator.tsx
@@ -2,14 +2,14 @@
 import * as React from 'react';
 import { useCheckboxRootContext } from '../root/CheckboxRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
-import { useCustomStyleHookMapping } from '../utils/useCustomStyleHookMapping';
+import { useStateAttributesMapping } from '../utils/useStateAttributesMapping';
 import type { CheckboxRoot } from '../root/CheckboxRoot';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { type TransitionStatus, useTransitionStatus } from '../../utils/useTransitionStatus';
 import { useForkRef } from '../../utils/useForkRef';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { fieldValidityMapping } from '../../field/utils/constants';
 
 /**
@@ -51,15 +51,15 @@ export const CheckboxIndicator = React.forwardRef(function CheckboxIndicator(
     },
   });
 
-  const baseStyleHookMapping = useCustomStyleHookMapping(rootState);
+  const baseMapping = useStateAttributesMapping(rootState);
 
-  const customStyleHookMapping: CustomStyleHookMapping<CheckboxIndicator.State> = React.useMemo(
+  const stateAttributesMapping: StateAttributesMapping<CheckboxIndicator.State> = React.useMemo(
     () => ({
-      ...baseStyleHookMapping,
+      ...baseMapping,
       ...transitionStatusMapping,
       ...fieldValidityMapping,
     }),
-    [baseStyleHookMapping],
+    [baseMapping],
   );
 
   const { renderElement } = useComponentRenderer({
@@ -67,7 +67,7 @@ export const CheckboxIndicator = React.forwardRef(function CheckboxIndicator(
     ref: mergedRef,
     state,
     className,
-    customStyleHookMapping,
+    stateAttributesMapping,
     extraProps: otherProps,
   });
 

--- a/packages/react/src/checkbox/indicator/CheckboxIndicatorDataAttributes.ts
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicatorDataAttributes.ts
@@ -1,4 +1,4 @@
-import { TransitionStatusDataAttributes } from '../../utils/styleHookMapping';
+import { TransitionStatusDataAttributes } from '../../utils/stateAttributesMapping';
 
 export enum CheckboxIndicatorDataAttributes {
   /**

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useCheckboxGroupContext } from '../../checkbox-group/CheckboxGroupContext';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
-import { useCustomStyleHookMapping } from '../utils/useCustomStyleHookMapping';
+import { useStateAttributesMapping } from '../utils/useStateAttributesMapping';
 import type { FieldRoot } from '../../field/root/FieldRoot';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useCheckboxRoot } from './useCheckboxRoot';
@@ -90,7 +90,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     [fieldState, computedChecked, disabled, readOnly, required, computedIndeterminate],
   );
 
-  const customStyleHookMapping = useCustomStyleHookMapping(state);
+  const stateAttributesMapping = useStateAttributesMapping(state);
 
   const { renderElement } = useComponentRenderer({
     propGetter: getRootProps,
@@ -98,7 +98,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     ref: forwardedRef,
     state,
     className,
-    customStyleHookMapping,
+    stateAttributesMapping,
     extraProps: {
       ...otherProps,
       ...otherGroupProps,

--- a/packages/react/src/checkbox/utils/useStateAttributesMapping.ts
+++ b/packages/react/src/checkbox/utils/useStateAttributesMapping.ts
@@ -1,11 +1,11 @@
 'use client';
 import * as React from 'react';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import type { CheckboxRoot } from '../root/CheckboxRoot';
 import { CheckboxRootDataAttributes } from '../root/CheckboxRootDataAttributes';
 
-export function useCustomStyleHookMapping(state: CheckboxRoot.State) {
-  return React.useMemo<CustomStyleHookMapping<typeof state>>(
+export function useStateAttributesMapping(state: CheckboxRoot.State) {
+  return React.useMemo<StateAttributesMapping<typeof state>>(
     () => ({
       checked(value): Record<string, string> {
         if (state.indeterminate) {

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
@@ -6,7 +6,7 @@ import { useRenderElement } from '../../utils/useRenderElement';
 import { warn } from '../../utils/warn';
 import { useCollapsibleRootContext } from '../root/CollapsibleRootContext';
 import type { CollapsibleRoot } from '../root/CollapsibleRoot';
-import { collapsibleStyleHookMapping } from '../root/styleHooks';
+import { collapsibleMapping } from '../root/stateAttributesMapping';
 import { useCollapsiblePanel } from './useCollapsiblePanel';
 import { CollapsiblePanelCssVars } from './CollapsiblePanelCssVars';
 import { usePanelResize } from '../../utils/usePanelResize';
@@ -117,7 +117,7 @@ export const CollapsiblePanel = React.forwardRef(function CollapsiblePanel(
       },
       elementProps,
     ],
-    customStyleHookMapping: collapsibleStyleHookMapping,
+    stateAttributesMapping: collapsibleMapping,
   });
 
   const shouldRender = keepMounted || hiddenUntilFound || (!keepMounted && mounted);

--- a/packages/react/src/collapsible/panel/CollapsiblePanelDataAttributes.ts
+++ b/packages/react/src/collapsible/panel/CollapsiblePanelDataAttributes.ts
@@ -1,4 +1,4 @@
-import { TransitionStatusDataAttributes } from '../../utils/styleHookMapping';
+import { TransitionStatusDataAttributes } from '../../utils/stateAttributesMapping';
 
 export enum CollapsiblePanelDataAttributes {
   /**

--- a/packages/react/src/collapsible/root/CollapsibleRoot.tsx
+++ b/packages/react/src/collapsible/root/CollapsibleRoot.tsx
@@ -5,7 +5,7 @@ import { useRenderElement } from '../../utils/useRenderElement';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useCollapsibleRoot } from './useCollapsibleRoot';
 import { CollapsibleRootContext } from './CollapsibleRootContext';
-import { collapsibleStyleHookMapping } from './styleHooks';
+import { collapsibleMapping } from './stateAttributesMapping';
 
 /**
  * Groups all parts of the collapsible.
@@ -58,7 +58,7 @@ export const CollapsibleRoot = React.forwardRef(function CollapsibleRoot(
     state,
     ref: forwardedRef,
     props: elementProps,
-    customStyleHookMapping: collapsibleStyleHookMapping,
+    stateAttributesMapping: collapsibleMapping,
   });
 
   if (componentProps.render !== null) {

--- a/packages/react/src/collapsible/root/stateAttributesMapping.ts
+++ b/packages/react/src/collapsible/root/stateAttributesMapping.ts
@@ -1,0 +1,9 @@
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
+import { collapsibleOpenStateMapping as baseMapping } from '../../utils/collapsibleOpenStateMapping';
+import type { CollapsibleRoot } from './CollapsibleRoot';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
+
+export const collapsibleMapping: StateAttributesMapping<CollapsibleRoot.State> = {
+  ...baseMapping,
+  ...transitionStatusMapping,
+};

--- a/packages/react/src/collapsible/root/styleHooks.ts
+++ b/packages/react/src/collapsible/root/styleHooks.ts
@@ -1,9 +1,0 @@
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import { collapsibleOpenStateMapping as baseMapping } from '../../utils/collapsibleOpenStateMapping';
-import type { CollapsibleRoot } from './CollapsibleRoot';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
-
-export const collapsibleStyleHookMapping: CustomStyleHookMapping<CollapsibleRoot.State> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};

--- a/packages/react/src/collapsible/trigger/CollapsibleTrigger.tsx
+++ b/packages/react/src/collapsible/trigger/CollapsibleTrigger.tsx
@@ -1,15 +1,15 @@
 'use client';
 import * as React from 'react';
 import { triggerOpenStateMapping } from '../../utils/collapsibleOpenStateMapping';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useButton } from '../../use-button';
 import { useCollapsibleRootContext } from '../root/CollapsibleRootContext';
 import { CollapsibleRoot } from '../root/CollapsibleRoot';
 
-const styleHookMapping: CustomStyleHookMapping<CollapsibleRoot.State> = {
+const stateAttributesMapping: StateAttributesMapping<CollapsibleRoot.State> = {
   ...triggerOpenStateMapping,
   ...transitionStatusMapping,
 };
@@ -53,7 +53,7 @@ export const CollapsibleTrigger = React.forwardRef(function CollapsibleTrigger(
     state,
     ref: [forwardedRef, buttonRef],
     props: [props, elementProps, getButtonProps],
-    customStyleHookMapping: styleHookMapping,
+    stateAttributesMapping: stateAttributesMapping,
   });
 
   return element;

--- a/packages/react/src/collapsible/trigger/CollapsibleTrigger.tsx
+++ b/packages/react/src/collapsible/trigger/CollapsibleTrigger.tsx
@@ -53,7 +53,7 @@ export const CollapsibleTrigger = React.forwardRef(function CollapsibleTrigger(
     state,
     ref: [forwardedRef, buttonRef],
     props: [props, elementProps, getButtonProps],
-    stateAttributesMapping: stateAttributesMapping,
+    stateAttributesMapping,
   });
 
   return element;

--- a/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
+++ b/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
@@ -5,12 +5,12 @@ import { mergeProps } from '../../merge-props';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { type TransitionStatus } from '../../utils/useTransitionStatus';
 import { type BaseUIComponentProps } from '../../utils/types';
-import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { type StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useForkRef } from '../../utils/useForkRef';
 
-const customStyleHookMapping: CustomStyleHookMapping<DialogBackdrop.State> = {
+const stateAttributesMapping: StateAttributesMapping<DialogBackdrop.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
 };
@@ -54,7 +54,7 @@ export const DialogBackdrop = React.forwardRef(function DialogBackdrop(
       },
       other,
     ),
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   // no need to render nested backdrops

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -6,11 +6,11 @@ import { useDialogRootContext } from '../root/DialogRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { type BaseUIComponentProps } from '../../utils/types';
 import { type TransitionStatus } from '../../utils/useTransitionStatus';
-import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { type StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import { useForkRef } from '../../utils/useForkRef';
 import { InteractionType } from '../../utils/useEnhancedClickHandler';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { DialogPopupCssVars } from './DialogPopupCssVars';
 import { DialogPopupDataAttributes } from './DialogPopupDataAttributes';
 import { InternalBackdrop } from '../../utils/InternalBackdrop';
@@ -18,7 +18,7 @@ import { useDialogPortalContext } from '../portal/DialogPortalContext';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { inertValue } from '../../utils/inertValue';
 
-const customStyleHookMapping: CustomStyleHookMapping<DialogPopup.State> = {
+const stateAttributesMapping: StateAttributesMapping<DialogPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
   nestedDialogOpen(value) {
@@ -106,7 +106,7 @@ export const DialogPopup = React.forwardRef(function DialogPopup(
       ...other,
       style: { ...other.style, [DialogPopupCssVars.nestedDialogs]: nestedOpenDialogCount },
     },
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return (

--- a/packages/react/src/dialog/trigger/DialogTrigger.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.tsx
@@ -42,7 +42,7 @@ export const DialogTrigger = React.forwardRef(function DialogTrigger(
     state,
     propGetter: (externalProps) => getButtonProps(getTriggerProps(externalProps)),
     extraProps: other,
-    customStyleHookMapping: triggerOpenStateMapping,
+    stateAttributesMapping: triggerOpenStateMapping,
   });
 
   return renderElement();

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -145,7 +145,7 @@ export const FieldControl = React.forwardRef(function FieldControl(
       getInputValidationProps(),
       elementProps,
     ],
-    customStyleHookMapping: fieldValidityMapping,
+    stateAttributesMapping: fieldValidityMapping,
   });
 
   return element;

--- a/packages/react/src/field/description/FieldDescription.tsx
+++ b/packages/react/src/field/description/FieldDescription.tsx
@@ -42,7 +42,7 @@ export const FieldDescription = React.forwardRef(function FieldDescription(
     ref: forwardedRef,
     state,
     props: [{ id }, elementProps],
-    customStyleHookMapping: fieldValidityMapping,
+    stateAttributesMapping: fieldValidityMapping,
   });
 
   return element;

--- a/packages/react/src/field/error/FieldError.tsx
+++ b/packages/react/src/field/error/FieldError.tsx
@@ -70,7 +70,7 @@ export const FieldError = React.forwardRef(function FieldError(
       },
       elementProps,
     ],
-    customStyleHookMapping: fieldValidityMapping,
+    stateAttributesMapping: fieldValidityMapping,
   });
 
   if (!rendered) {

--- a/packages/react/src/field/label/FieldLabel.tsx
+++ b/packages/react/src/field/label/FieldLabel.tsx
@@ -53,7 +53,7 @@ export const FieldLabel = React.forwardRef(function FieldLabel(
       },
       elementProps,
     ],
-    customStyleHookMapping: fieldValidityMapping,
+    stateAttributesMapping: fieldValidityMapping,
   });
 
   return element;

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -133,7 +133,7 @@ export const FieldRoot = React.forwardRef(function FieldRoot(
     ref: forwardedRef,
     state,
     props: elementProps,
-    customStyleHookMapping: fieldValidityMapping,
+    stateAttributesMapping: fieldValidityMapping,
   });
 
   return <FieldRootContext.Provider value={contextValue}>{element}</FieldRootContext.Provider>;

--- a/packages/react/src/menu/arrow/MenuArrow.tsx
+++ b/packages/react/src/menu/arrow/MenuArrow.tsx
@@ -45,7 +45,7 @@ export const MenuArrow = React.forwardRef(function MenuArrow(
       'aria-hidden': true,
       ...otherProps,
     },
-    customStyleHookMapping: popupStateMapping,
+    stateAttributesMapping: popupStateMapping,
   });
 
   return renderElement();

--- a/packages/react/src/menu/backdrop/MenuBackdrop.tsx
+++ b/packages/react/src/menu/backdrop/MenuBackdrop.tsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 import { useMenuRootContext } from '../root/MenuRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { type StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { mergeProps } from '../../merge-props';
 
-const customStyleHookMapping: CustomStyleHookMapping<MenuBackdrop.State> = {
+const stateAttributesMapping: StateAttributesMapping<MenuBackdrop.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
 };
@@ -52,7 +52,7 @@ export const MenuBackdrop = React.forwardRef(function MenuBackdrop(
       },
       other,
     ),
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return renderElement();

--- a/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.tsx
+++ b/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useMenuCheckboxItemContext } from '../checkbox-item/MenuCheckboxItemContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { BaseUIComponentProps } from '../../utils/types';
-import { itemMapping } from '../utils/styleHookMapping';
+import { itemMapping } from '../utils/stateAttributesMapping';
 import { TransitionStatus, useTransitionStatus } from '../../utils/useTransitionStatus';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useForkRef } from '../../utils/useForkRef';
@@ -51,7 +51,7 @@ export const MenuCheckboxItemIndicator = React.forwardRef(function MenuCheckboxI
     render: render || 'span',
     className,
     state,
-    customStyleHookMapping: itemMapping,
+    stateAttributesMapping: itemMapping,
     extraProps: {
       'aria-hidden': true,
       ...other,

--- a/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicatorDataAttributes.ts
+++ b/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicatorDataAttributes.ts
@@ -1,4 +1,4 @@
-import { TransitionStatusDataAttributes } from '../../utils/styleHookMapping';
+import { TransitionStatusDataAttributes } from '../../utils/stateAttributesMapping';
 
 export enum MenuCheckboxItemIndicatorDataAttributes {
   /**

--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
@@ -8,7 +8,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import type { BaseUIComponentProps, HTMLProps } from '../../utils/types';
 import { useForkRef } from '../../utils/useForkRef';
-import { itemMapping } from '../utils/styleHookMapping';
+import { itemMapping } from '../utils/stateAttributesMapping';
 import { useCompositeListItem } from '../../composite/list/useCompositeListItem';
 import { mergeProps } from '../../merge-props';
 
@@ -58,7 +58,7 @@ const InnerMenuCheckboxItem = React.memo(
       className,
       state,
       propGetter: (externalProps) => mergeProps(itemProps, externalProps, getItemProps),
-      customStyleHookMapping: itemMapping,
+      stateAttributesMapping: itemMapping,
       extraProps: other,
     });
 

--- a/packages/react/src/menu/popup/MenuPopup.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.tsx
@@ -7,15 +7,15 @@ import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { BaseUIComponentProps } from '../../utils/types';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import type { Side } from '../../utils/useAnchorPositioning';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import { mergeProps } from '../../merge-props';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 
-const customStyleHookMapping: CustomStyleHookMapping<MenuPopup.State> = {
+const stateAttributesMapping: StateAttributesMapping<MenuPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
 };
@@ -89,7 +89,7 @@ export const MenuPopup = React.forwardRef(function MenuPopup(
       popupProps,
       other,
     ),
-    customStyleHookMapping,
+    stateAttributesMapping,
     ref: mergedRef,
   });
 

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -123,7 +123,7 @@ export const MenuPositioner = React.forwardRef(function MenuPositioner(
     render: render ?? 'div',
     className,
     state,
-    customStyleHookMapping: popupStateMapping,
+    stateAttributesMapping: popupStateMapping,
     ref: mergedRef,
     extraProps: {
       ...positioner.positionerProps,

--- a/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.tsx
+++ b/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useMenuRadioItemContext } from '../radio-item/MenuRadioItemContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { BaseUIComponentProps } from '../../utils/types';
-import { itemMapping } from '../utils/styleHookMapping';
+import { itemMapping } from '../utils/stateAttributesMapping';
 import { TransitionStatus, useTransitionStatus } from '../../utils/useTransitionStatus';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useForkRef } from '../../utils/useForkRef';
@@ -51,7 +51,7 @@ export const MenuRadioItemIndicator = React.forwardRef(function MenuRadioItemInd
     render: render || 'span',
     className,
     state,
-    customStyleHookMapping: itemMapping,
+    stateAttributesMapping: itemMapping,
     extraProps: {
       'aria-hidden': true,
       ...other,

--- a/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicatorDataAttributes.ts
+++ b/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicatorDataAttributes.ts
@@ -1,4 +1,4 @@
-import { TransitionStatusDataAttributes } from '../../utils/styleHookMapping';
+import { TransitionStatusDataAttributes } from '../../utils/stateAttributesMapping';
 
 export enum MenuRadioItemIndicatorDataAttributes {
   /**

--- a/packages/react/src/menu/radio-item/MenuRadioItem.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.tsx
@@ -9,7 +9,7 @@ import type { BaseUIComponentProps, HTMLProps } from '../../utils/types';
 import { useForkRef } from '../../utils/useForkRef';
 import { useMenuRadioGroupContext } from '../radio-group/MenuRadioGroupContext';
 import { MenuRadioItemContext } from './MenuRadioItemContext';
-import { itemMapping } from '../utils/styleHookMapping';
+import { itemMapping } from '../utils/stateAttributesMapping';
 import { useCompositeListItem } from '../../composite/list/useCompositeListItem';
 import { mergeProps } from '../../merge-props';
 
@@ -54,7 +54,7 @@ const InnerMenuRadioItem = React.memo(
       className,
       state,
       propGetter: (externalProps) => mergeProps(itemProps, externalProps, getItemProps),
-      customStyleHookMapping: itemMapping,
+      stateAttributesMapping: itemMapping,
       extraProps: other,
     });
 

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -70,7 +70,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function SubmenuTriggerCompon
     state,
     propGetter: (externalProps: HTMLProps) =>
       mergeProps(rootTriggerProps, itemProps, externalProps, getTriggerProps),
-    customStyleHookMapping: triggerOpenStateMapping,
+    stateAttributesMapping: triggerOpenStateMapping,
     extraProps: other,
   });
 

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -64,7 +64,7 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
     className,
     state,
     propGetter,
-    customStyleHookMapping: pressableTriggerOpenStateMapping,
+    stateAttributesMapping: pressableTriggerOpenStateMapping,
     extraProps: other,
   });
 

--- a/packages/react/src/menu/utils/stateAttributesMapping.ts
+++ b/packages/react/src/menu/utils/stateAttributesMapping.ts
@@ -1,8 +1,8 @@
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { MenuCheckboxItemDataAttributes } from '../checkbox-item/MenuCheckboxItemDataAttributes';
 
-export const itemMapping: CustomStyleHookMapping<{ checked: boolean }> = {
+export const itemMapping: StateAttributesMapping<{ checked: boolean }> = {
   checked(value): Record<string, string> {
     if (value) {
       return {

--- a/packages/react/src/number-field/decrement/NumberFieldDecrement.tsx
+++ b/packages/react/src/number-field/decrement/NumberFieldDecrement.tsx
@@ -5,7 +5,7 @@ import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { NumberFieldRoot } from '../root/NumberFieldRoot';
 import { useNumberFieldButton } from '../root/useNumberFieldButton';
 import { BaseUIComponentProps, HTMLProps } from '../../utils/types';
-import { styleHookMapping } from '../utils/styleHooks';
+import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 
 /**
  * A stepper button that decreases the field value when clicked.
@@ -78,7 +78,7 @@ export const NumberFieldDecrement = React.forwardRef(function NumberFieldDecreme
     state,
     className,
     extraProps: otherProps,
-    customStyleHookMapping: styleHookMapping,
+    stateAttributesMapping: stateAttributesMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/decrement/NumberFieldDecrement.tsx
+++ b/packages/react/src/number-field/decrement/NumberFieldDecrement.tsx
@@ -78,7 +78,7 @@ export const NumberFieldDecrement = React.forwardRef(function NumberFieldDecreme
     state,
     className,
     extraProps: otherProps,
-    stateAttributesMapping: stateAttributesMapping,
+    stateAttributesMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/group/NumberFieldGroup.tsx
+++ b/packages/react/src/number-field/group/NumberFieldGroup.tsx
@@ -39,7 +39,7 @@ export const NumberFieldGroup = React.forwardRef(function NumberFieldGroup(
     state,
     className,
     extraProps: otherProps,
-    stateAttributesMapping: stateAttributesMapping,
+    stateAttributesMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/group/NumberFieldGroup.tsx
+++ b/packages/react/src/number-field/group/NumberFieldGroup.tsx
@@ -5,7 +5,7 @@ import type { NumberFieldRoot } from '../root/NumberFieldRoot';
 import { mergeProps } from '../../merge-props';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
-import { styleHookMapping } from '../utils/styleHooks';
+import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 
 /**
  * Groups the input with the increment and decrement buttons.
@@ -39,7 +39,7 @@ export const NumberFieldGroup = React.forwardRef(function NumberFieldGroup(
     state,
     className,
     extraProps: otherProps,
-    customStyleHookMapping: styleHookMapping,
+    stateAttributesMapping: stateAttributesMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/increment/NumberFieldIncrement.tsx
+++ b/packages/react/src/number-field/increment/NumberFieldIncrement.tsx
@@ -5,7 +5,7 @@ import { useNumberFieldButton } from '../root/useNumberFieldButton';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { NumberFieldRoot } from '../root/NumberFieldRoot';
 import type { BaseUIComponentProps, HTMLProps } from '../../utils/types';
-import { styleHookMapping } from '../utils/styleHooks';
+import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 
 /**
  * A stepper button that increases the field value when clicked.
@@ -78,7 +78,7 @@ export const NumberFieldIncrement = React.forwardRef(function NumberFieldIncreme
     state,
     className,
     extraProps: otherProps,
-    customStyleHookMapping: styleHookMapping,
+    stateAttributesMapping: stateAttributesMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/increment/NumberFieldIncrement.tsx
+++ b/packages/react/src/number-field/increment/NumberFieldIncrement.tsx
@@ -78,7 +78,7 @@ export const NumberFieldIncrement = React.forwardRef(function NumberFieldIncreme
     state,
     className,
     extraProps: otherProps,
-    stateAttributesMapping: stateAttributesMapping,
+    stateAttributesMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -12,13 +12,13 @@ import { mergeProps } from '../../merge-props';
 import { DEFAULT_STEP } from '../utils/constants';
 import { ARABIC_RE, HAN_RE, getNumberLocaleDetails, parseNumber } from '../utils/parse';
 import type { NumberFieldRoot } from '../root/NumberFieldRoot';
-import { styleHookMapping } from '../utils/styleHooks';
+import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 import { useField } from '../../field/useField';
 import { useFormContext } from '../../form/FormContext';
 
-const customStyleHookMapping = {
+const stateAttributesMapping = {
   ...fieldValidityMapping,
-  ...styleHookMapping,
+  ...stateAttributesMapping,
 };
 
 const NAVIGATE_KEYS = new Set([
@@ -353,7 +353,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
     className,
     state,
     extraProps: otherProps,
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return renderElement();

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -6,7 +6,7 @@ import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { FieldRoot } from '../../field/root/FieldRoot';
-import { styleHookMapping } from '../utils/styleHooks';
+import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 
 /**
  * Groups all parts of the number field and manages its state.
@@ -81,7 +81,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
     state,
     className,
     extraProps: otherProps,
-    customStyleHookMapping: styleHookMapping,
+    stateAttributesMapping: stateAttributesMapping,
   });
 
   return (

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -81,7 +81,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
     state,
     className,
     extraProps: otherProps,
-    stateAttributesMapping: stateAttributesMapping,
+    stateAttributesMapping,
   });
 
   return (

--- a/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
+++ b/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
@@ -59,7 +59,7 @@ export const NumberFieldScrubAreaCursor = React.forwardRef(function NumberFieldS
     state,
     className,
     extraProps: otherProps,
-    stateAttributesMapping: stateAttributesMapping,
+    stateAttributesMapping,
   });
 
   if (!isScrubbing || isWebKit || isTouchInput || isPointerLockDenied) {

--- a/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
+++ b/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
@@ -9,7 +9,7 @@ import type { BaseUIComponentProps, HTMLProps } from '../../utils/types';
 import type { NumberFieldRoot } from '../root/NumberFieldRoot';
 import { ownerDocument } from '../../utils/owner';
 import { mergeProps } from '../../merge-props';
-import { styleHookMapping } from '../utils/styleHooks';
+import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 import { useNumberFieldScrubAreaContext } from '../scrub-area/NumberFieldScrubAreaContext';
 
 /**
@@ -59,7 +59,7 @@ export const NumberFieldScrubAreaCursor = React.forwardRef(function NumberFieldS
     state,
     className,
     extraProps: otherProps,
-    customStyleHookMapping: styleHookMapping,
+    stateAttributesMapping: stateAttributesMapping,
   });
 
   if (!isScrubbing || isWebKit || isTouchInput || isPointerLockDenied) {

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
@@ -5,7 +5,7 @@ import { useNumberFieldRootContext } from '../root/NumberFieldRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useForkRef } from '../../utils/useForkRef';
 import type { NumberFieldRoot } from '../root/NumberFieldRoot';
-import { styleHookMapping } from '../utils/styleHooks';
+import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 import { useScrub } from './useScrub';
 import { NumberFieldScrubAreaContext } from './NumberFieldScrubAreaContext';
 
@@ -45,7 +45,7 @@ export const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubAr
     state,
     className,
     extraProps: otherProps,
-    customStyleHookMapping: styleHookMapping,
+    stateAttributesMapping: stateAttributesMapping,
   });
 
   const contextValue: NumberFieldScrubAreaContext = React.useMemo(

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
@@ -45,7 +45,7 @@ export const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubAr
     state,
     className,
     extraProps: otherProps,
-    stateAttributesMapping: stateAttributesMapping,
+    stateAttributesMapping,
   });
 
   const contextValue: NumberFieldScrubAreaContext = React.useMemo(

--- a/packages/react/src/number-field/utils/stateAttributesMapping.ts
+++ b/packages/react/src/number-field/utils/stateAttributesMapping.ts
@@ -1,0 +1,7 @@
+import { StateAttributesMapping } from '../../utils/mapStateAttributes';
+import type { NumberFieldRoot } from '../root/NumberFieldRoot';
+
+export const stateAttributesMapping: StateAttributesMapping<NumberFieldRoot.State> = {
+  inputValue: () => null,
+  value: () => null,
+};

--- a/packages/react/src/number-field/utils/styleHooks.ts
+++ b/packages/react/src/number-field/utils/styleHooks.ts
@@ -1,7 +1,0 @@
-import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
-import type { NumberFieldRoot } from '../root/NumberFieldRoot';
-
-export const styleHookMapping: CustomStyleHookMapping<NumberFieldRoot.State> = {
-  inputValue: () => null,
-  value: () => null,
-};

--- a/packages/react/src/popover/arrow/PopoverArrow.tsx
+++ b/packages/react/src/popover/arrow/PopoverArrow.tsx
@@ -36,7 +36,7 @@ export const PopoverArrow = React.forwardRef(function PopoverArrow(
     state,
     ref: [forwardedRef, arrowRef],
     props: [{ style: arrowStyles, 'aria-hidden': true }, elementProps],
-    customStyleHookMapping: popupStateMapping,
+    stateAttributesMapping: popupStateMapping,
   });
 
   return element;

--- a/packages/react/src/popover/backdrop/PopoverBackdrop.tsx
+++ b/packages/react/src/popover/backdrop/PopoverBackdrop.tsx
@@ -2,13 +2,13 @@
 import * as React from 'react';
 import { usePopoverRootContext } from '../root/PopoverRootContext';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { type StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useRenderElement } from '../../utils/useRenderElement';
 
-const customStyleHookMapping: CustomStyleHookMapping<PopoverBackdrop.State> = {
+const stateAttributesMapping: StateAttributesMapping<PopoverBackdrop.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
 };
@@ -50,7 +50,7 @@ export const PopoverBackdrop = React.forwardRef(function PopoverBackdrop(
       },
       elementProps,
     ],
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return element;

--- a/packages/react/src/popover/popup/PopoverPopup.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.tsx
@@ -6,15 +6,15 @@ import { usePopoverPositionerContext } from '../positioner/PopoverPositionerCont
 import { usePopoverPopup } from './usePopoverPopup';
 import type { Side, Align } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import { InteractionType } from '../../utils/useEnhancedClickHandler';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useRenderElement } from '../../utils/useRenderElement';
 
-const customStyleHookMapping: CustomStyleHookMapping<PopoverPopup.State> = {
+const stateAttributesMapping: StateAttributesMapping<PopoverPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
 };
@@ -84,7 +84,7 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
       },
       elementProps,
     ],
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return (

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -81,7 +81,7 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     state,
     props: [positioner.props, elementProps],
     ref: [forwardedRef, setPositionerElement],
-    customStyleHookMapping: popupStateMapping,
+    stateAttributesMapping: popupStateMapping,
   });
 
   return (

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -7,7 +7,7 @@ import {
   triggerOpenStateMapping,
   pressableTriggerOpenStateMapping,
 } from '../../utils/popupStateMapping';
-import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { useRenderElement } from '../../utils/useRenderElement';
 
 /**
@@ -37,7 +37,7 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
     buttonRef: forwardedRef,
   });
 
-  const customStyleHookMapping: CustomStyleHookMapping<{ open: boolean }> = React.useMemo(
+  const stateAttributesMapping: StateAttributesMapping<{ open: boolean }> = React.useMemo(
     () => ({
       open(value) {
         if (value && openReason === 'click') {
@@ -54,7 +54,7 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
     state,
     ref: [buttonRef, setTriggerElement],
     props: [triggerProps, elementProps, getButtonProps],
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return element;

--- a/packages/react/src/preview-card/arrow/PreviewCardArrow.tsx
+++ b/packages/react/src/preview-card/arrow/PreviewCardArrow.tsx
@@ -55,7 +55,7 @@ export const PreviewCardArrow = React.forwardRef(function PreviewCardArrow(
     state,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupStateMapping,
+    stateAttributesMapping: popupStateMapping,
   });
 
   return renderElement();

--- a/packages/react/src/preview-card/backdrop/PreviewCardBackdrop.tsx
+++ b/packages/react/src/preview-card/backdrop/PreviewCardBackdrop.tsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { usePreviewCardRootContext } from '../root/PreviewCardContext';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { type CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { type StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { mergeProps } from '../../merge-props';
 
-const customStyleHookMapping: CustomStyleHookMapping<PreviewCardBackdrop.State> = {
+const stateAttributesMapping: StateAttributesMapping<PreviewCardBackdrop.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
 };
@@ -53,7 +53,7 @@ export const PreviewCardBackdrop = React.forwardRef(function PreviewCardBackdrop
       },
       other,
     ),
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return renderElement();

--- a/packages/react/src/preview-card/popup/PreviewCardPopup.tsx
+++ b/packages/react/src/preview-card/popup/PreviewCardPopup.tsx
@@ -5,16 +5,16 @@ import { usePreviewCardRootContext } from '../root/PreviewCardContext';
 import { usePreviewCardPositionerContext } from '../positioner/PreviewCardPositionerContext';
 import { usePreviewCardPopup } from './usePreviewCardPopup';
 import { useForkRef } from '../../utils/useForkRef';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { mergeProps } from '../../merge-props';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 
-const customStyleHookMapping: CustomStyleHookMapping<PreviewCardPopup.State> = {
+const stateAttributesMapping: StateAttributesMapping<PreviewCardPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
 };
@@ -76,7 +76,7 @@ export const PreviewCardPopup = React.forwardRef(function PreviewCardPopup(
             otherProps,
           )
         : otherProps,
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return renderElement();

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
@@ -94,7 +94,7 @@ export const PreviewCardPositioner = React.forwardRef(function PreviewCardPositi
     state,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: popupStateMapping,
+    stateAttributesMapping: popupStateMapping,
   });
 
   return (

--- a/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
+++ b/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
@@ -31,7 +31,7 @@ export const PreviewCardTrigger = React.forwardRef(function PreviewCardTrigger(
     state,
     ref: mergedRef,
     extraProps: otherProps,
-    customStyleHookMapping: triggerOpenStateMapping,
+    stateAttributesMapping: triggerOpenStateMapping,
   });
 
   return renderElement();

--- a/packages/react/src/progress/indicator/ProgressIndicator.tsx
+++ b/packages/react/src/progress/indicator/ProgressIndicator.tsx
@@ -4,7 +4,7 @@ import { useRenderElement } from '../../utils/useRenderElement';
 import { valueToPercent } from '../../utils/valueToPercent';
 import type { ProgressRoot } from '../root/ProgressRoot';
 import { useProgressRootContext } from '../root/ProgressRootContext';
-import { progressStyleHookMapping } from '../root/styleHooks';
+import { progressMapping } from '../root/stateAttributesMapping';
 import type { BaseUIComponentProps } from '../../utils/types';
 
 /**
@@ -45,7 +45,7 @@ export const ProgressIndicator = React.forwardRef(function ProgressIndicator(
       },
       elementProps,
     ],
-    customStyleHookMapping: progressStyleHookMapping,
+    stateAttributesMapping: progressMapping,
   });
 
   return element;

--- a/packages/react/src/progress/label/ProgressLabel.tsx
+++ b/packages/react/src/progress/label/ProgressLabel.tsx
@@ -4,7 +4,7 @@ import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
 import { useProgressRootContext } from '../root/ProgressRootContext';
-import { progressStyleHookMapping } from '../root/styleHooks';
+import { progressMapping } from '../root/stateAttributesMapping';
 import type { ProgressRoot } from '../root/ProgressRoot';
 import type { BaseUIComponentProps } from '../../utils/types';
 
@@ -38,7 +38,7 @@ export const ProgressLabel = React.forwardRef(function ProgressLabel(
       },
       elementProps,
     ],
-    customStyleHookMapping: progressStyleHookMapping,
+    stateAttributesMapping: progressMapping,
   });
 
   return element;

--- a/packages/react/src/progress/root/ProgressRoot.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.tsx
@@ -4,7 +4,7 @@ import { formatNumber } from '../../utils/formatNumber';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useLatestRef } from '../../utils/useLatestRef';
 import { ProgressRootContext } from './ProgressRootContext';
-import { progressStyleHookMapping } from './styleHooks';
+import { progressMapping } from './stateAttributesMapping';
 import { BaseUIComponentProps } from '../../utils/types';
 
 function formatValue(
@@ -99,7 +99,7 @@ export const ProgressRoot = React.forwardRef(function ProgressRoot(
       },
       elementProps,
     ],
-    customStyleHookMapping: progressStyleHookMapping,
+    stateAttributesMapping: progressMapping,
   });
 
   return (

--- a/packages/react/src/progress/root/stateAttributesMapping.ts
+++ b/packages/react/src/progress/root/stateAttributesMapping.ts
@@ -1,8 +1,8 @@
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import type { ProgressRoot } from './ProgressRoot';
 import { ProgressRootDataAttributes } from './ProgressRootDataAttributes';
 
-export const progressStyleHookMapping: CustomStyleHookMapping<ProgressRoot.State> = {
+export const progressMapping: StateAttributesMapping<ProgressRoot.State> = {
   status(value): Record<string, string> | null {
     if (value === 'progressing') {
       return { [ProgressRootDataAttributes.progressing]: '' };

--- a/packages/react/src/progress/track/ProgressTrack.tsx
+++ b/packages/react/src/progress/track/ProgressTrack.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useProgressRootContext } from '../root/ProgressRootContext';
-import { progressStyleHookMapping } from '../root/styleHooks';
+import { progressMapping } from '../root/stateAttributesMapping';
 import type { ProgressRoot } from '../root/ProgressRoot';
 import type { BaseUIComponentProps } from '../../utils/types';
 
@@ -24,7 +24,7 @@ export const ProgressTrack = React.forwardRef(function ProgressTrack(
     state,
     ref: forwardedRef,
     props: elementProps,
-    customStyleHookMapping: progressStyleHookMapping,
+    stateAttributesMapping: progressMapping,
   });
 
   return element;

--- a/packages/react/src/progress/value/ProgressValue.tsx
+++ b/packages/react/src/progress/value/ProgressValue.tsx
@@ -4,7 +4,7 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useProgressRootContext } from '../root/ProgressRootContext';
 import type { ProgressRoot } from '../root/ProgressRoot';
-import { progressStyleHookMapping } from '../root/styleHooks';
+import { progressMapping } from '../root/stateAttributesMapping';
 /**
  * A text label displaying the current value.
  * Renders a `<span>` element.
@@ -35,7 +35,7 @@ export const ProgressValue = React.forwardRef(function ProgressValue(
       },
       elementProps,
     ],
-    customStyleHookMapping: progressStyleHookMapping,
+    stateAttributesMapping: progressMapping,
   });
 
   return element;

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -79,7 +79,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
     className,
     state,
     extraProps: otherProps,
-    customStyleHookMapping: fieldValidityMapping,
+    stateAttributesMapping: fieldValidityMapping,
   });
 
   return (

--- a/packages/react/src/radio/indicator/RadioIndicator.tsx
+++ b/packages/react/src/radio/indicator/RadioIndicator.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useRadioRootContext } from '../root/RadioRootContext';
-import { customStyleHookMapping } from '../utils/customStyleHookMapping';
+import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useForkRef } from '../../utils/useForkRef';
 import { type TransitionStatus, useTransitionStatus } from '../../utils/useTransitionStatus';
@@ -43,7 +43,7 @@ export const RadioIndicator = React.forwardRef(function RadioIndicator(
     className,
     state,
     extraProps: otherProps,
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   useOpenChangeComplete({

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -8,7 +8,7 @@ import { RadioRootContext } from './RadioRootContext';
 import { CompositeItem } from '../../composite/item/CompositeItem';
 import { NOOP } from '../../utils/noop';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
-import { customStyleHookMapping } from '../utils/customStyleHookMapping';
+import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 
 /**
  * Represents the radio button itself.
@@ -71,7 +71,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
     className,
     state,
     extraProps: otherProps,
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return (

--- a/packages/react/src/radio/utils/stateAttributesMapping.ts
+++ b/packages/react/src/radio/utils/stateAttributesMapping.ts
@@ -1,10 +1,10 @@
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { fieldValidityMapping } from '../../field/utils/constants';
 import { RadioRootDataAttributes } from '../root/RadioRootDataAttributes';
 
-export const customStyleHookMapping = {
+export const stateAttributesMapping = {
   checked(value): Record<string, string> {
     if (value) {
       return { [RadioRootDataAttributes.checked]: '' };
@@ -13,7 +13,7 @@ export const customStyleHookMapping = {
   },
   ...transitionStatusMapping,
   ...fieldValidityMapping,
-} satisfies CustomStyleHookMapping<{
+} satisfies StateAttributesMapping<{
   checked: boolean;
   transitionStatus: TransitionStatus;
   valid: boolean | null;

--- a/packages/react/src/select/arrow/SelectArrow.tsx
+++ b/packages/react/src/select/arrow/SelectArrow.tsx
@@ -4,12 +4,12 @@ import { useSelectPositionerContext } from '../positioner/SelectPositionerContex
 import { useSelectRootContext } from '../root/SelectRootContext';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useRenderElement } from '../../utils/useRenderElement';
 
-const customStyleHookMapping: CustomStyleHookMapping<SelectArrow.State> = {
+const stateAttributesMapping: StateAttributesMapping<SelectArrow.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
 };
@@ -44,7 +44,7 @@ export const SelectArrow = React.forwardRef(function SelectArrow(
     state,
     ref: [arrowRef, forwardedRef],
     props: [{ style: arrowStyles, 'aria-hidden': true }, elementProps],
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   if (alignItemWithTriggerActive) {

--- a/packages/react/src/select/backdrop/SelectBackdrop.tsx
+++ b/packages/react/src/select/backdrop/SelectBackdrop.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useSelectRootContext } from '../root/SelectRootContext';
 import { popupStateMapping } from '../../utils/popupStateMapping';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useRenderElement } from '../../utils/useRenderElement';
 
-const customStyleHookMapping: CustomStyleHookMapping<SelectBackdrop.State> = {
+const stateAttributesMapping: StateAttributesMapping<SelectBackdrop.State> = {
   ...popupStateMapping,
   ...transitionStatusMapping,
 };
@@ -49,7 +49,7 @@ export const SelectBackdrop = React.forwardRef(function SelectBackdrop(
       },
       elementProps,
     ],
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return element;

--- a/packages/react/src/select/item-indicator/SelectItemIndicator.tsx
+++ b/packages/react/src/select/item-indicator/SelectItemIndicator.tsx
@@ -5,7 +5,7 @@ import { useSelectItemContext } from '../item/SelectItemContext';
 import { type TransitionStatus, useTransitionStatus } from '../../utils/useTransitionStatus';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useRenderElement } from '../../utils/useRenderElement';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 
 /**
  * Indicates whether the select item is selected.
@@ -44,7 +44,7 @@ export const SelectItemIndicator = React.forwardRef(function SelectItemIndicator
       },
       elementProps,
     ],
-    customStyleHookMapping: transitionStatusMapping,
+    stateAttributesMapping: transitionStatusMapping,
   });
 
   useOpenChangeComplete({

--- a/packages/react/src/select/popup/SelectPopup.tsx
+++ b/packages/react/src/select/popup/SelectPopup.tsx
@@ -5,15 +5,15 @@ import type { BaseUIComponentProps } from '../../utils/types';
 import { useSelectRootContext } from '../root/SelectRootContext';
 import { popupStateMapping } from '../../utils/popupStateMapping';
 import type { Side } from '../../utils/useAnchorPositioning';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { useSelectPopup } from './useSelectPopup';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { useSelectPositionerContext } from '../positioner/SelectPositionerContext';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useRenderElement } from '../../utils/useRenderElement';
 
-const customStyleHookMapping: CustomStyleHookMapping<SelectPopup.State> = {
+const stateAttributesMapping: StateAttributesMapping<SelectPopup.State> = {
   ...popupStateMapping,
   ...transitionStatusMapping,
 };
@@ -59,7 +59,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
   const element = useRenderElement('div', componentProps, {
     ref: [forwardedRef, popupRef],
     state,
-    customStyleHookMapping,
+    stateAttributesMapping,
     props: [
       popupProps,
       props,

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -104,7 +104,7 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
   const element = useRenderElement('div', componentProps, {
     ref: [forwardedRef, setPositionerElement],
     state,
-    customStyleHookMapping: popupStateMapping,
+    stateAttributesMapping: popupStateMapping,
     props: [positioner.getPositionerProps, elementProps],
   });
 

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -7,9 +7,9 @@ import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { pressableTriggerOpenStateMapping } from '../../utils/popupStateMapping';
 import { fieldValidityMapping } from '../../field/utils/constants';
 import { useRenderElement } from '../../utils/useRenderElement';
-import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { StateAttributesMapping } from '../../utils/mapStateAttributes';
 
-const customStyleHookMapping: CustomStyleHookMapping<SelectTrigger.State> = {
+const stateAttributesMapping: StateAttributesMapping<SelectTrigger.State> = {
   ...pressableTriggerOpenStateMapping,
   ...fieldValidityMapping,
 };
@@ -51,7 +51,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const element = useRenderElement('div', componentProps, {
     ref: [forwardedRef, triggerRef],
     state,
-    customStyleHookMapping,
+    stateAttributesMapping,
     props,
   });
 

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -10,7 +10,7 @@ import { valueToPercent } from '../../utils/valueToPercent';
 import { useDirection } from '../../direction-provider/DirectionContext';
 import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
 import { useSliderRootContext } from '../root/SliderRootContext';
-import { sliderStyleHookMapping } from '../root/styleHooks';
+import { sliderMapping } from '../root/stateAttributesMapping';
 import type { SliderRoot } from '../root/SliderRoot';
 import { replaceArrayItemAtIndex } from '../utils/replaceArrayItemAtIndex';
 import { roundValueToStep } from '../utils/roundValueToStep';
@@ -403,7 +403,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
       },
       elementProps,
     ],
-    customStyleHookMapping: sliderStyleHookMapping,
+    stateAttributesMapping: sliderMapping,
   });
 
   return element;

--- a/packages/react/src/slider/indicator/SliderIndicator.tsx
+++ b/packages/react/src/slider/indicator/SliderIndicator.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import type { BaseUIComponentProps, Orientation } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useSliderRootContext } from '../root/SliderRootContext';
-import { sliderStyleHookMapping } from '../root/styleHooks';
+import { sliderMapping } from '../root/stateAttributesMapping';
 import type { SliderRoot } from '../root/SliderRoot';
 import { valueArrayToPercentages } from '../utils/valueArrayToPercentages';
 
@@ -72,7 +72,7 @@ export const SliderIndicator = React.forwardRef(function SliderIndicator(
     state,
     ref: forwardedRef,
     props: [{ style }, elementProps],
-    customStyleHookMapping: sliderStyleHookMapping,
+    stateAttributesMapping: sliderMapping,
   });
 
   return element;

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -21,7 +21,7 @@ import { asc } from '../utils/asc';
 import { getSliderValue } from '../utils/getSliderValue';
 import { validateMinimumDistance } from '../utils/validateMinimumDistance';
 import type { ThumbMetadata } from '../thumb/SliderThumb';
-import { sliderStyleHookMapping } from './styleHooks';
+import { sliderMapping } from './stateAttributesMapping';
 import { SliderRootContext } from './SliderRootContext';
 import { useFormContext } from '../../form/FormContext';
 
@@ -329,7 +329,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
       getValidationProps(elementProps),
       elementProps,
     ],
-    customStyleHookMapping: sliderStyleHookMapping,
+    stateAttributesMapping: sliderMapping,
   });
 
   return (

--- a/packages/react/src/slider/root/stateAttributesMapping.ts
+++ b/packages/react/src/slider/root/stateAttributesMapping.ts
@@ -1,7 +1,7 @@
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { CustomMapping } from '../../utils/mapStateAttributes';
 import type { SliderRoot } from './SliderRoot';
 
-export const sliderStyleHookMapping: CustomStyleHookMapping<SliderRoot.State> = {
+export const sliderMapping: CustomMapping<SliderRoot.State> = {
   activeThumbIndex: () => null,
   max: () => null,
   min: () => null,

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { formatNumber } from '../../utils/formatNumber';
-import { getStyleHookProps } from '../../utils/getStyleHookProps';
+import { mapStateAttributes } from '../../utils/mapStateAttributes';
 import { mergeProps } from '../../merge-props';
 import { isReactVersionAtLeast } from '../../utils/reactVersion';
 import { resolveClassName } from '../../utils/resolveClassName';
@@ -198,8 +198,8 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
     } satisfies React.CSSProperties;
   }, [activeIndex, isRtl, orientation, percent, index]);
 
-  const styleHooks = React.useMemo(
-    () => getStyleHookProps({ disabled, dragging: index !== -1 && activeIndex === index }),
+  const stateAttributesMapping = React.useMemo(
+    () => mapStateAttributes({ disabled, dragging: index !== -1 && activeIndex === index }),
     [activeIndex, disabled, index],
   );
 
@@ -300,7 +300,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
       style: getThumbStyle(),
       tabIndex: externalTabIndex ?? (disabled ? undefined : 0),
     },
-    styleHooks,
+    stateAttributesMapping,
     elementProps,
   );
 

--- a/packages/react/src/slider/track/SliderTrack.tsx
+++ b/packages/react/src/slider/track/SliderTrack.tsx
@@ -4,7 +4,7 @@ import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useSliderRootContext } from '../root/SliderRootContext';
 import type { SliderRoot } from '../root/SliderRoot';
-import { sliderStyleHookMapping } from '../root/styleHooks';
+import { sliderMapping } from '../root/stateAttributesMapping';
 
 /**
  * Contains the slider indicator and represents the entire range of the slider.
@@ -31,7 +31,7 @@ export const SliderTrack = React.forwardRef(function SliderTrack(
       },
       elementProps,
     ],
-    customStyleHookMapping: sliderStyleHookMapping,
+    stateAttributesMapping: sliderMapping,
   });
 
   return element;

--- a/packages/react/src/slider/value/SliderValue.tsx
+++ b/packages/react/src/slider/value/SliderValue.tsx
@@ -4,7 +4,7 @@ import { formatNumber } from '../../utils/formatNumber';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useSliderRootContext } from '../root/SliderRootContext';
-import { sliderStyleHookMapping } from '../root/styleHooks';
+import { sliderMapping } from '../root/stateAttributesMapping';
 import type { SliderRoot } from '../root/SliderRoot';
 
 /**
@@ -67,7 +67,7 @@ export const SliderValue = React.forwardRef(function SliderValue(
       },
       elementProps,
     ],
-    customStyleHookMapping: sliderStyleHookMapping,
+    stateAttributesMapping: sliderMapping,
   });
 
   return element;

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useSwitchRoot } from './useSwitchRoot';
 import { SwitchRootContext } from './SwitchRootContext';
-import { styleHookMapping } from '../styleHooks';
+import { stateAttributesMapping } from '../stateAttributesMapping';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import type { FieldRoot } from '../../field/root/FieldRoot';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
@@ -53,7 +53,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     propGetter: getButtonProps,
     state,
     extraProps: other,
-    customStyleHookMapping: styleHookMapping,
+    stateAttributesMapping: stateAttributesMapping,
     ref: forwardedRef,
   });
 

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -53,7 +53,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     propGetter: getButtonProps,
     state,
     extraProps: other,
-    stateAttributesMapping: stateAttributesMapping,
+    stateAttributesMapping,
     ref: forwardedRef,
   });
 

--- a/packages/react/src/switch/stateAttributesMapping.ts
+++ b/packages/react/src/switch/stateAttributesMapping.ts
@@ -1,9 +1,9 @@
 import type { SwitchRoot } from './root/SwitchRoot';
-import type { CustomStyleHookMapping } from '../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../utils/mapStateAttributes';
 import { fieldValidityMapping } from '../field/utils/constants';
 import { SwitchRootDataAttributes } from './root/SwitchRootDataAttributes';
 
-export const styleHookMapping: CustomStyleHookMapping<SwitchRoot.State> = {
+export const stateAttributesMapping: StateAttributesMapping<SwitchRoot.State> = {
   ...fieldValidityMapping,
   checked(value): Record<string, string> {
     if (value) {

--- a/packages/react/src/switch/thumb/SwitchThumb.tsx
+++ b/packages/react/src/switch/thumb/SwitchThumb.tsx
@@ -5,7 +5,7 @@ import { useSwitchRootContext } from '../root/SwitchRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { styleHookMapping } from '../styleHooks';
+import { stateAttributesMapping } from '../stateAttributesMapping';
 
 /**
  * The movable part of the switch that indicates whether the switch is on or off.
@@ -29,7 +29,7 @@ export const SwitchThumb = React.forwardRef(function SwitchThumb(
     className,
     state: extendedState,
     extraProps: other,
-    customStyleHookMapping: styleHookMapping,
+    stateAttributesMapping: stateAttributesMapping,
     ref: forwardedRef,
   });
 

--- a/packages/react/src/switch/thumb/SwitchThumb.tsx
+++ b/packages/react/src/switch/thumb/SwitchThumb.tsx
@@ -29,7 +29,7 @@ export const SwitchThumb = React.forwardRef(function SwitchThumb(
     className,
     state: extendedState,
     extraProps: other,
-    stateAttributesMapping: stateAttributesMapping,
+    stateAttributesMapping,
     ref: forwardedRef,
   });
 

--- a/packages/react/src/tabs/indicator/TabsIndicator.tsx
+++ b/packages/react/src/tabs/indicator/TabsIndicator.tsx
@@ -5,7 +5,7 @@ import { useOnMount } from '../../utils/useOnMount';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { TabsOrientation, TabsRoot } from '../root/TabsRoot';
 import { useTabsRootContext } from '../root/TabsRootContext';
-import { tabsStyleHookMapping } from '../root/styleHooks';
+import { tabsMapping } from '../root/stateAttributesMapping';
 import { useTabsListContext } from '../list/TabsListContext';
 import { ActiveTabPosition, ActiveTabSize, useTabsIndicator } from './useTabsIndicator';
 import { script as prehydrationScript } from './prehydrationScript.min';
@@ -66,8 +66,8 @@ export const TabsIndicator = React.forwardRef(function TabIndicator(
       'data-instance-id': !(isMounted && renderBeforeHydration) ? instanceId : undefined,
       suppressHydrationWarning: true,
     },
-    customStyleHookMapping: {
-      ...tabsStyleHookMapping,
+    stateAttributesMapping: {
+      ...tabsMapping,
       selectedTabPosition: noop,
       selectedTabSize: noop,
     },

--- a/packages/react/src/tabs/list/TabsList.tsx
+++ b/packages/react/src/tabs/list/TabsList.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { CompositeRoot } from '../../composite/root/CompositeRoot';
-import { tabsStyleHookMapping } from '../root/styleHooks';
+import { tabsMapping } from '../root/stateAttributesMapping';
 import { useTabsRootContext } from '../root/TabsRootContext';
 import { TabsRoot } from '../root/TabsRoot';
 import { type TabMetadata } from '../tab/useTabsTab';
@@ -62,7 +62,7 @@ export const TabsList = React.forwardRef(function TabsList(
     className,
     state,
     extraProps: other,
-    customStyleHookMapping: tabsStyleHookMapping,
+    stateAttributesMapping: tabsMapping,
   });
 
   const tabsListContextValue: TabsListContext = React.useMemo(

--- a/packages/react/src/tabs/panel/TabsPanel.tsx
+++ b/packages/react/src/tabs/panel/TabsPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useTabsPanel } from './useTabsPanel';
-import { tabsStyleHookMapping } from '../root/styleHooks';
+import { tabsMapping } from '../root/stateAttributesMapping';
 import { useTabsRootContext } from '../root/TabsRootContext';
 import { useComponentRenderer } from '../../utils/useComponentRenderer';
 import { TabsRoot, type TabValue } from '../root/TabsRoot';
@@ -48,7 +48,7 @@ export const TabsPanel = React.forwardRef(function TabPanel(
     className,
     state,
     extraProps: { ...other, children: hidden && !keepMounted ? undefined : children },
-    customStyleHookMapping: tabsStyleHookMapping,
+    stateAttributesMapping: tabsMapping,
   });
 
   return renderElement();

--- a/packages/react/src/tabs/root/TabsRoot.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.tsx
@@ -6,7 +6,7 @@ import { CompositeList } from '../../composite/list/CompositeList';
 import { useDirection } from '../../direction-provider/DirectionContext';
 import { useTabsRoot } from './useTabsRoot';
 import { TabsRootContext } from './TabsRootContext';
-import { tabsStyleHookMapping } from './styleHooks';
+import { tabsMapping } from './stateAttributesMapping';
 import { TabPanelMetadata } from '../panel/useTabsPanel';
 
 /**
@@ -83,7 +83,7 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
     state,
     extraProps: other,
     ref: forwardedRef,
-    customStyleHookMapping: tabsStyleHookMapping,
+    stateAttributesMapping: tabsMapping,
   });
 
   return (

--- a/packages/react/src/tabs/root/stateAttributesMapping.ts
+++ b/packages/react/src/tabs/root/stateAttributesMapping.ts
@@ -1,8 +1,8 @@
 import type { TabsRoot } from './TabsRoot';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { TabsRootDataAttributes } from './TabsRootDataAttributes';
 
-export const tabsStyleHookMapping: CustomStyleHookMapping<TabsRoot.State> = {
+export const tabsMapping: StateAttributesMapping<TabsRoot.State> = {
   tabActivationDirection: (dir) => ({
     [TabsRootDataAttributes.activationDirection]: dir,
   }),

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -4,11 +4,11 @@ import { activeElement, contains, getTarget } from '@floating-ui/react/utils';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { ToastObject as ToastObjectType } from '../useToastManager';
 import { ToastRootContext } from './ToastRootContext';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { visuallyHidden } from '../../utils/visuallyHidden';
 import { useToastContext } from '../provider/ToastProviderContext';
-import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { ownerDocument } from '../../utils/owner';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
@@ -16,7 +16,7 @@ import { ToastRootCssVars } from './ToastRootCssVars';
 import { useOnMount } from '../../utils/useOnMount';
 import { useTimeout } from '../../utils/useTimeout';
 
-const customStyleHookMapping: CustomStyleHookMapping<ToastRoot.State> = {
+const stateAttributesMapping: StateAttributesMapping<ToastRoot.State> = {
   ...transitionStatusMapping,
   swipeDirection(value) {
     return value ? { 'data-swipe-direction': value } : null;
@@ -564,7 +564,7 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
   const element = useRenderElement('div', componentProps, {
     ref: [forwardedRef, toastRoot.rootRef],
     state,
-    customStyleHookMapping,
+    stateAttributesMapping,
     props: [
       props,
       elementProps,

--- a/packages/react/src/toggle-group/ToggleGroup.tsx
+++ b/packages/react/src/toggle-group/ToggleGroup.tsx
@@ -10,7 +10,7 @@ import { useToolbarRootContext } from '../toolbar/root/ToolbarRootContext';
 import { ToggleGroupContext } from './ToggleGroupContext';
 import { ToggleGroupDataAttributes } from './ToggleGroupDataAttributes';
 
-const customStyleHookMapping = {
+const stateAttributesMapping = {
   multiple(value: boolean) {
     if (value) {
       return { [ToggleGroupDataAttributes.multiple]: '' } as Record<string, string>;
@@ -104,7 +104,7 @@ export const ToggleGroup = React.forwardRef(function ToggleGroup(
       },
       elementProps,
     ],
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return (

--- a/packages/react/src/tooltip/arrow/TooltipArrow.tsx
+++ b/packages/react/src/tooltip/arrow/TooltipArrow.tsx
@@ -35,7 +35,7 @@ export const TooltipArrow = React.forwardRef(function TooltipArrow(
     state,
     ref: [forwardedRef, arrowRef],
     props: [{ style: arrowStyles, 'aria-hidden': true }, elementProps],
-    customStyleHookMapping: popupStateMapping,
+    stateAttributesMapping: popupStateMapping,
   });
 
   return element;

--- a/packages/react/src/tooltip/popup/TooltipPopup.tsx
+++ b/packages/react/src/tooltip/popup/TooltipPopup.tsx
@@ -4,14 +4,14 @@ import { useTooltipRootContext } from '../root/TooltipRootContext';
 import { useTooltipPositionerContext } from '../positioner/TooltipPositionerContext';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
-import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
+import type { StateAttributesMapping } from '../../utils/mapStateAttributes';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
-import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useRenderElement } from '../../utils/useRenderElement';
 
-const customStyleHookMapping: CustomStyleHookMapping<TooltipPopup.State> = {
+const stateAttributesMapping: StateAttributesMapping<TooltipPopup.State> = {
   ...baseMapping,
   ...transitionStatusMapping,
 };
@@ -63,7 +63,7 @@ export const TooltipPopup = React.forwardRef(function TooltipPopup(
       },
       elementProps,
     ],
-    customStyleHookMapping,
+    stateAttributesMapping,
   });
 
   return element;

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
@@ -80,7 +80,7 @@ export const TooltipPositioner = React.forwardRef(function TooltipPositioner(
     state,
     props: [positioner.props, elementProps],
     ref: [forwardedRef, setPositionerElement],
-    customStyleHookMapping: popupStateMapping,
+    stateAttributesMapping: popupStateMapping,
   });
 
   return (

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -25,7 +25,7 @@ export const TooltipTrigger = React.forwardRef(function TooltipTrigger(
     state,
     ref: [forwardedRef, setTriggerElement],
     props: [triggerProps, elementProps],
-    customStyleHookMapping: triggerOpenStateMapping,
+    stateAttributesMapping: triggerOpenStateMapping,
   });
 
   return element;

--- a/packages/react/src/utils/collapsibleOpenStateMapping.ts
+++ b/packages/react/src/utils/collapsibleOpenStateMapping.ts
@@ -1,4 +1,4 @@
-import type { CustomStyleHookMapping } from './getStyleHookProps';
+import type { StateAttributesMapping } from './mapStateAttributes';
 import { CollapsiblePanelDataAttributes } from '../collapsible/panel/CollapsiblePanelDataAttributes';
 import { CollapsibleTriggerDataAttributes } from '../collapsible/trigger/CollapsibleTriggerDataAttributes';
 
@@ -10,7 +10,7 @@ const PANEL_CLOSED_HOOK = {
   [CollapsiblePanelDataAttributes.closed]: '',
 };
 
-export const triggerOpenStateMapping: CustomStyleHookMapping<{
+export const triggerOpenStateMapping: StateAttributesMapping<{
   open: boolean;
 }> = {
   open(value) {
@@ -30,6 +30,6 @@ export const collapsibleOpenStateMapping = {
     }
     return PANEL_CLOSED_HOOK;
   },
-} satisfies CustomStyleHookMapping<{
+} satisfies StateAttributesMapping<{
   open: boolean;
 }>;

--- a/packages/react/src/utils/mapStateAttributes.test.ts
+++ b/packages/react/src/utils/mapStateAttributes.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { getStyleHookProps } from './getStyleHookProps';
+import { mapStateAttributes } from './mapStateAttributes';
 
-describe('getStyleHookProps', () => {
+describe('mapStateAttributes', () => {
   it('converts the state fields to data attributes', () => {
     const state = {
       checked: true,
@@ -9,7 +9,7 @@ describe('getStyleHookProps', () => {
       count: 42,
     };
 
-    const result = getStyleHookProps(state);
+    const result = mapStateAttributes(state);
     expect(result).to.deep.equal({
       'data-checked': '',
       'data-orientation': 'vertical',
@@ -22,7 +22,7 @@ describe('getStyleHookProps', () => {
       readOnly: true,
     };
 
-    const result = getStyleHookProps(state);
+    const result = mapStateAttributes(state);
     expect(result).to.deep.equal({
       'data-readonly': '',
     });
@@ -34,7 +34,7 @@ describe('getStyleHookProps', () => {
       disabled: false,
     };
 
-    const result = getStyleHookProps(state);
+    const result = mapStateAttributes(state);
     expect(result).to.deep.equal({ 'data-required': '' });
   });
 
@@ -44,7 +44,7 @@ describe('getStyleHookProps', () => {
       disabled: false,
     };
 
-    const result = getStyleHookProps(state);
+    const result = mapStateAttributes(state);
     expect(result).not.to.haveOwnProperty('data-disabled');
   });
 
@@ -55,7 +55,7 @@ describe('getStyleHookProps', () => {
       count: 42,
     };
 
-    const result = getStyleHookProps(state, {
+    const result = mapStateAttributes(state, {
       checked: (value) => ({ 'data-state': value ? 'checked' : 'unchecked' }),
     });
 
@@ -72,7 +72,7 @@ describe('getStyleHookProps', () => {
       orientation: 'vertical',
     };
 
-    const result = getStyleHookProps(state, {
+    const result = mapStateAttributes(state, {
       checked: (value) => (value === true ? { 'data-state': 'checked' } : null),
     });
 

--- a/packages/react/src/utils/mapStateAttributes.ts
+++ b/packages/react/src/utils/mapStateAttributes.ts
@@ -1,10 +1,10 @@
-export type CustomStyleHookMapping<State> = {
+export type StateAttributesMapping<State> = {
   [Property in keyof State]?: (state: State[Property]) => Record<string, string> | null;
 };
 
-export function getStyleHookProps<State extends Record<string, any>>(
+export function mapStateAttributes<State extends Record<string, any>>(
   state: State,
-  customMapping?: CustomStyleHookMapping<State>,
+  customMapping?: StateAttributesMapping<State>,
 ) {
   const props: Record<string, string> = {};
 

--- a/packages/react/src/utils/popupStateMapping.ts
+++ b/packages/react/src/utils/popupStateMapping.ts
@@ -1,5 +1,5 @@
-import type { CustomStyleHookMapping } from './getStyleHookProps';
-import { TransitionStatusDataAttributes } from './styleHookMapping';
+import type { StateAttributesMapping } from './mapStateAttributes';
+import { TransitionStatusDataAttributes } from './stateAttributesMapping';
 
 export enum CommonPopupDataAttributes {
   /**
@@ -63,7 +63,7 @@ export const triggerOpenStateMapping = {
     }
     return null;
   },
-} satisfies CustomStyleHookMapping<{ open: boolean }>;
+} satisfies StateAttributesMapping<{ open: boolean }>;
 
 export const pressableTriggerOpenStateMapping = {
   open(value) {
@@ -72,7 +72,7 @@ export const pressableTriggerOpenStateMapping = {
     }
     return null;
   },
-} satisfies CustomStyleHookMapping<{ open: boolean }>;
+} satisfies StateAttributesMapping<{ open: boolean }>;
 
 export const popupStateMapping = {
   open(value) {
@@ -87,4 +87,4 @@ export const popupStateMapping = {
     }
     return null;
   },
-} satisfies CustomStyleHookMapping<{ open: boolean; anchorHidden: boolean }>;
+} satisfies StateAttributesMapping<{ open: boolean; anchorHidden: boolean }>;

--- a/packages/react/src/utils/stateAttributesMapping.ts
+++ b/packages/react/src/utils/stateAttributesMapping.ts
@@ -1,5 +1,5 @@
 import type { TransitionStatus } from './useTransitionStatus';
-import type { CustomStyleHookMapping } from './getStyleHookProps';
+import type { StateAttributesMapping } from './mapStateAttributes';
 
 export enum TransitionStatusDataAttributes {
   /**
@@ -25,4 +25,4 @@ export const transitionStatusMapping = {
     }
     return null;
   },
-} satisfies CustomStyleHookMapping<{ transitionStatus: TransitionStatus }>;
+} satisfies StateAttributesMapping<{ transitionStatus: TransitionStatus }>;

--- a/packages/react/src/utils/useComponentRenderer.ts
+++ b/packages/react/src/utils/useComponentRenderer.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CustomStyleHookMapping } from './getStyleHookProps';
+import { StateAttributesMapping } from './mapStateAttributes';
 import { useRenderElementLazy } from './useRenderElement';
 import type { ComponentRenderFn, HTMLProps } from './types';
 
@@ -38,11 +38,11 @@ export interface ComponentRendererSettings<State, RenderedElementType extends El
   /**
    * A mapping of state to style hooks.
    */
-  customStyleHookMapping?: CustomStyleHookMapping<State>;
+  stateAttributesMapping?: StateAttributesMapping<State>;
   /**
    * If true, style hooks are generated.
    */
-  styleHooks?: boolean;
+  stateAttributesMapping?: boolean;
 }
 
 /**

--- a/packages/react/src/utils/useRenderElement.tsx
+++ b/packages/react/src/utils/useRenderElement.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { BaseUIComponentProps, ComponentRenderFn, HTMLProps } from './types';
-import { CustomStyleHookMapping, getStyleHookProps } from './getStyleHookProps';
+import { StateAttributesMapping, mapStateAttributes } from './mapStateAttributes';
 import { useForkRef, useForkRefN } from './useForkRef';
 import { resolveClassName } from './resolveClassName';
 import { isReactVersionAtLeast } from './reactVersion';
@@ -67,24 +67,25 @@ function useRenderElementProps<
     ref,
     props,
     disableStyleHooks,
-    customStyleHookMapping,
+    stateAttributesMapping,
   } = params;
 
   const className = resolveClassName(classNameProp, state);
 
-  let styleHooks: Record<string, string> | undefined;
+  let stateAttributesMapping: Record<string, string> | undefined;
   if (disableStyleHooks !== true) {
     // SAFETY: We use typings to ensure `disableStyleHooks` is either always set or
     // always unset, so this `if` block is stable across renders.
     /* eslint-disable-next-line react-hooks/rules-of-hooks */
-    styleHooks = React.useMemo(
-      () => getStyleHookProps(state, customStyleHookMapping),
-      [state, customStyleHookMapping],
+    stateAttributesMapping = React.useMemo(
+      () => mapStateAttributes(state, stateAttributesMapping),
+      [state, stateAttributesMapping],
     );
   }
 
   const outProps: React.HTMLAttributes<any> & React.RefAttributes<any> = propGetter(
-    mergeObjects(styleHooks, Array.isArray(props) ? mergePropsN(props) : props) ?? EMPTY_OBJECT,
+    mergeObjects(stateAttributesMapping, Array.isArray(props) ? mergePropsN(props) : props) ??
+      EMPTY_OBJECT,
   );
 
   // SAFETY: The `useForkRef` functions use a single hook to store the same value,
@@ -179,8 +180,8 @@ export namespace useRenderElement {
     /**
      * A mapping of state to style hooks.
      */
-    customStyleHookMapping?: CustomStyleHookMapping<State>;
-  } /* This typing ensures `disableStyleHookMapping` is constantly defined or undefined */ & (
+    stateAttributesMapping?: StateAttributesMapping<State>;
+  } /* This typing ensures `disableMapping` is constantly defined or undefined */ & (
     | {
         /**
          * Disable style hook mapping.


### PR DESCRIPTION
Get rid of the "style hooks" terminology which is unclear.

Now that I read the PR, I feel like it could be simply `stateMapping` instead of `stateAttributesMapping`. The "attributes" token would be missing, but it would be less verbose and "state mapping" is clear enough as a concept, imo. Opinions welcome, I could go with either.