### PR TITLE
[core] Performance: inline style tags

### DIFF
--- a/packages/react/src/merge-props/mergeProps.ts
+++ b/packages/react/src/merge-props/mergeProps.ts
@@ -200,7 +200,10 @@ export function makeEventPreventable<T extends React.SyntheticEvent>(event: Base
   return event;
 }
 
-function mergeClassNames(ourClassName: string | undefined, theirClassName: string | undefined) {
+export function mergeClassNames(
+  ourClassName: string | undefined,
+  theirClassName: string | undefined,
+) {
   if (theirClassName) {
     if (ourClassName) {
       // eslint-disable-next-line prefer-template

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
@@ -8,6 +8,7 @@ import { useEventCallback } from '../../utils/useEventCallback';
 import { SCROLL_TIMEOUT } from '../constants';
 import { getOffset } from '../utils/getOffset';
 import { ScrollAreaScrollbarDataAttributes } from '../scrollbar/ScrollAreaScrollbarDataAttributes';
+import { STYLE_DISABLE_SCROLLBAR } from '../../utils/styles';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useTimeout } from '../../utils/useTimeout';
 
@@ -257,23 +258,9 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
     ],
   );
 
-  const viewportId = `[data-id="${rootId}-viewport"]`;
-
-  const html = React.useMemo(
-    () => ({
-      __html: `${viewportId}{scrollbar-width:none}${viewportId}::-webkit-scrollbar{display:none}`,
-    }),
-    [viewportId],
-  );
-
   return (
     <ScrollAreaRootContext.Provider value={contextValue}>
-      {rootId && (
-        <style
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={html}
-        />
-      )}
+      {STYLE_DISABLE_SCROLLBAR.element}
       {element}
     </ScrollAreaRootContext.Provider>
   );

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -9,6 +9,7 @@ import { useDirection } from '../../direction-provider/DirectionContext';
 import { getOffset } from '../utils/getOffset';
 import { MIN_THUMB_SIZE } from '../constants';
 import { clamp } from '../../utils/clamp';
+import { STYLE_DISABLE_SCROLLBAR } from '../../utils/styles';
 import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
 import { onVisible } from '../utils/onVisible';
 
@@ -202,6 +203,7 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     ...(rootId && { 'data-id': `${rootId}-viewport` }),
     // https://accessibilityinsights.io/info-examples/web/scrollable-region-focusable/
     ...((!hiddenState.scrollbarXHidden || !hiddenState.scrollbarYHidden) && { tabIndex: 0 }),
+    className: STYLE_DISABLE_SCROLLBAR.className,
     style: {
       overflow: 'scroll',
     },

--- a/packages/react/src/select/popup/SelectPopup.tsx
+++ b/packages/react/src/select/popup/SelectPopup.tsx
@@ -9,6 +9,7 @@ import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import { useSelectPopup } from './useSelectPopup';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { useSelectPositionerContext } from '../positioner/SelectPositionerContext';
+import { STYLE_DISABLE_SCROLLBAR } from '../../utils/styles';
 import { transitionStatusMapping } from '../../utils/styleHookMapping';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useRenderElement } from '../../utils/useRenderElement';
@@ -63,28 +64,20 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     props: [
       popupProps,
       props,
-      transitionStatus === 'starting' ? { style: { transition: 'none' } } : {},
+      {
+        style: transitionStatus === 'starting' ? { transition: 'none' } : undefined,
+        className:
+          id && positioner.alignItemWithTriggerActive
+            ? STYLE_DISABLE_SCROLLBAR.className
+            : undefined,
+      },
       elementProps,
     ],
   });
 
-  const popupSelector = `[data-id="${id}-popup"]`;
-
-  const html = React.useMemo(
-    () => ({
-      __html: `${popupSelector}{scrollbar-width:none}${popupSelector}::-webkit-scrollbar{display:none}`,
-    }),
-    [popupSelector],
-  );
-
   return (
     <React.Fragment>
-      {id && positioner.alignItemWithTriggerActive && (
-        <style
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={html}
-        />
-      )}
+      {STYLE_DISABLE_SCROLLBAR.element}
       <FloatingFocusManager context={positioner.context} modal={false} disabled={!mounted}>
         {element}
       </FloatingFocusManager>

--- a/packages/react/src/utils/styles.tsx
+++ b/packages/react/src/utils/styles.tsx
@@ -1,0 +1,8 @@
+export const STYLE_DISABLE_SCROLLBAR = {
+  className: 'base-ui-disable-scrollbar',
+  element: (
+    <style href="/base-ui-disable-scrollbar">
+      {`.base-ui-disable-scrollbar{scrollbar-width:none}.base-ui-disable-scrollbar::-webkit-scrollbar{display:none}`}
+    </style>
+  ),
+};

--- a/packages/react/src/utils/styles.tsx
+++ b/packages/react/src/utils/styles.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react'
+
 export const STYLE_DISABLE_SCROLLBAR = {
   className: 'base-ui-disable-scrollbar',
   element: (

--- a/packages/react/src/utils/useRenderElement.tsx
+++ b/packages/react/src/utils/useRenderElement.tsx
@@ -4,7 +4,7 @@ import { CustomStyleHookMapping, getStyleHookProps } from './getStyleHookProps';
 import { useForkRef, useForkRefN } from './useForkRef';
 import { resolveClassName } from './resolveClassName';
 import { isReactVersionAtLeast } from './reactVersion';
-import { mergeProps, mergePropsN } from '../merge-props';
+import { mergeProps, mergePropsN, mergeClassNames } from '../merge-props';
 import { mergeObjects } from './mergeObjects';
 
 type IntrinsicTagName = keyof React.JSX.IntrinsicElements;
@@ -99,7 +99,7 @@ function useRenderElementProps<
   /* eslint-enable react-hooks/rules-of-hooks */
 
   if (className !== undefined) {
-    outProps.className = className;
+    outProps.className = mergeClassNames(outProps.className, className);
   }
 
   return outProps;


### PR DESCRIPTION
Avoid HTML parsing/reflow/restyle costs. The blue stacks here are the inline `<style>` tags' content being re-parsed everytime.

![Screenshot From 2025-05-20 18-07-54](https://github.com/user-attachments/assets/734ee384-8a4e-44da-a206-1956e867b247)
