### PR TITLE
[input] Extend `Field.Control.State`

### DIFF
--- a/packages/react/src/input/Input.tsx
+++ b/packages/react/src/input/Input.tsx
@@ -13,8 +13,7 @@ export const Input = React.forwardRef(function Input(
   props: Input.Props,
   forwardedRef: React.ForwardedRef<HTMLInputElement>,
 ) {
-  const { render, className, ...otherProps } = props;
-  return <Field.Control ref={forwardedRef} render={render} className={className} {...otherProps} />;
+  return <Field.Control ref={forwardedRef} {...props} />;
 });
 
 export namespace Input {
@@ -26,5 +25,5 @@ export namespace Input {
     defaultValue?: Field.Control.Props['defaultValue'];
   }
 
-  export interface State {}
+  export interface State extends Field.Control.State {}
 }


### PR DESCRIPTION
Fixes #1951 

Also, with the new docs generator, there's no need to destructure props needlessly