### PR TITLE
[field][checkbox group] Fix `validate` fn incorrectly running twice

### DIFF
--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -203,14 +203,12 @@ describe('<CheckboxGroup />', () => {
 
   describe('Field', () => {
     it('prop: validationMode=onChange', async () => {
+      const validateSpy = spy((value) => {
+        const v = value as string[];
+        return v.includes('fuji-apple') ? 'error' : null;
+      });
       render(
-        <Field.Root
-          validationMode="onChange"
-          validate={(value) => {
-            const v = value as string[];
-            return v.includes('fuji-apple') ? 'error' : null;
-          }}
-        >
+        <Field.Root validationMode="onChange" validate={validateSpy}>
           <CheckboxGroup defaultValue={['fuji-apple']}>
             <Checkbox.Root name="fuji-apple" data-testid="button-1" />
             <Checkbox.Root name="gala-apple" data-testid="button-2" />
@@ -232,24 +230,36 @@ describe('<CheckboxGroup />', () => {
       expect(button1).not.to.have.attribute('aria-invalid');
       expect(button2).not.to.have.attribute('aria-invalid');
       expect(button3).not.to.have.attribute('aria-invalid');
+      expect(validateSpy.callCount).to.equal(1);
+      expect(validateSpy.args[0][0]).to.deep.equal([]);
 
       fireEvent.click(button2);
 
       expect(button1).not.to.have.attribute('aria-invalid');
       expect(button2).not.to.have.attribute('aria-invalid');
       expect(button3).not.to.have.attribute('aria-invalid');
+      expect(validateSpy.callCount).to.equal(2);
+      expect(validateSpy.args[1][0]).to.deep.equal(['gala-apple']);
 
       fireEvent.click(button1);
 
       expect(button1).to.have.attribute('aria-invalid', 'true');
       expect(button2).to.have.attribute('aria-invalid', 'true');
       expect(button3).to.have.attribute('aria-invalid', 'true');
+      expect(validateSpy.callCount).to.equal(3);
+      expect(validateSpy.args[2][0]).to.deep.equal(['gala-apple', 'fuji-apple']);
 
       fireEvent.click(button3);
 
       expect(button1).to.have.attribute('aria-invalid', 'true');
       expect(button2).to.have.attribute('aria-invalid', 'true');
       expect(button3).to.have.attribute('aria-invalid', 'true');
+      expect(validateSpy.callCount).to.equal(4);
+      expect(validateSpy.args[3][0]).to.deep.equal([
+        'gala-apple',
+        'fuji-apple',
+        'granny-smith-apple',
+      ]);
     });
 
     it('prop: validationMode=onBlur', async () => {

--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -263,14 +263,12 @@ describe('<CheckboxGroup />', () => {
     });
 
     it('prop: validationMode=onBlur', async () => {
+      const validateSpy = spy((value) => {
+        const v = value as string[];
+        return v.includes('fuji-apple') ? 'error' : null;
+      });
       render(
-        <Field.Root
-          validationMode="onBlur"
-          validate={(value) => {
-            const v = value as string[];
-            return v.includes('fuji-apple') ? 'error' : null;
-          }}
-        >
+        <Field.Root validationMode="onBlur" validate={validateSpy}>
           <CheckboxGroup defaultValue={['fuji-apple']}>
             <Checkbox.Root name="fuji-apple" data-testid="button-1" />
             <Checkbox.Root name="gala-apple" data-testid="button-2" />
@@ -289,21 +287,30 @@ describe('<CheckboxGroup />', () => {
       expect(button3).not.to.have.attribute('aria-invalid');
 
       fireEvent.click(button1);
+      expect(validateSpy.callCount).to.equal(0);
       fireEvent.blur(button1);
+      expect(validateSpy.callCount).to.equal(1);
+      expect(validateSpy.args[0][0]).to.deep.equal([]);
 
       expect(button1).not.to.have.attribute('aria-invalid');
       expect(button2).not.to.have.attribute('aria-invalid');
       expect(button3).not.to.have.attribute('aria-invalid');
 
       fireEvent.click(button3);
+      expect(validateSpy.callCount).to.equal(1);
       fireEvent.blur(button3);
+      expect(validateSpy.callCount).to.equal(2);
+      expect(validateSpy.args[1][0]).to.deep.equal(['granny-smith-apple']);
 
       expect(button1).not.to.have.attribute('aria-invalid');
       expect(button2).not.to.have.attribute('aria-invalid');
       expect(button3).not.to.have.attribute('aria-invalid');
 
       fireEvent.click(button1);
+      expect(validateSpy.callCount).to.equal(2);
       fireEvent.blur(button1);
+      expect(validateSpy.callCount).to.equal(3);
+      expect(validateSpy.args[2][0]).to.deep.equal(['granny-smith-apple', 'fuji-apple']);
 
       expect(button1).to.have.attribute('aria-invalid', 'true');
       expect(button2).to.have.attribute('aria-invalid', 'true');

--- a/packages/react/src/checkbox/root/useCheckboxRoot.ts
+++ b/packages/react/src/checkbox/root/useCheckboxRoot.ts
@@ -218,7 +218,7 @@ export function useCheckboxRoot(params: useCheckboxRoot.Parameters): useCheckbox
             }
           },
         },
-        getInputValidationProps(externalProps),
+        groupContext ? getValidationProps(externalProps) : getInputValidationProps(externalProps),
       ),
     [
       checked,
@@ -228,6 +228,7 @@ export function useCheckboxRoot(params: useCheckboxRoot.Parameters): useCheckbox
       required,
       mergedInputRef,
       getInputValidationProps,
+      getValidationProps,
       setDirty,
       validityData.initialValue,
       setCheckedState,


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/issues/1950

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
