### PR TITLE
[performance] Skip most of useRenderElement logic when unnecessary

### DIFF
--- a/docs/reference/generated/use-render.json
+++ b/docs/reference/generated/use-render.json
@@ -18,7 +18,12 @@
     "props": {
       "type": "Record<string, unknown>",
       "description": "Props to be spread on the rendered element.\nThey are merged with the internal props of the component, so that event handlers\nare merged, `className` strings and `style` properties are joined, while other external props overwrite the\ninternal ones."
+    },
+    "enabled": {
+      "type": "boolean",
+      "default": "true",
+      "description": "If `false`, the hook will skip most of its internal logic and return `null`.\nThis is useful for rendering a component conditionally."
     }
   },
-  "returnValue": {}
+  "returnValue": "useRender.ReturnValue"
 }

--- a/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
+++ b/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
@@ -52,7 +52,7 @@ export const NumberFieldScrubAreaCursor = React.forwardRef(function NumberFieldS
     customStyleHookMapping: styleHookMapping,
   });
 
-  return ReactDOM.createPortal(renderedElement, ownerDocument(element).body);
+  return renderedElement && ReactDOM.createPortal(renderedElement, ownerDocument(element).body);
 });
 
 export namespace NumberFieldScrubAreaCursor {

--- a/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
+++ b/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
@@ -29,13 +29,13 @@ export const NumberFieldScrubAreaCursor = React.forwardRef(function NumberFieldS
   const { isScrubbing, isTouchInput, isPointerLockDenied, scrubAreaCursorRef } =
     useNumberFieldScrubAreaContext();
 
-  const [element, setElement] = React.useState<Element | null>(null);
+  const [domElement, setDomElement] = React.useState<Element | null>(null);
 
   const shouldRender = isScrubbing && !isWebKit && !isTouchInput && !isPointerLockDenied;
 
-  const renderedElement = useRenderElement('span', componentProps, {
+  const element = useRenderElement('span', componentProps, {
     enabled: shouldRender,
-    ref: [forwardedRef, scrubAreaCursorRef, setElement],
+    ref: [forwardedRef, scrubAreaCursorRef, setDomElement],
     state,
     props: [
       {
@@ -52,7 +52,7 @@ export const NumberFieldScrubAreaCursor = React.forwardRef(function NumberFieldS
     customStyleHookMapping: styleHookMapping,
   });
 
-  return renderedElement && ReactDOM.createPortal(renderedElement, ownerDocument(element).body);
+  return element && ReactDOM.createPortal(element, ownerDocument(domElement).body);
 });
 
 export namespace NumberFieldScrubAreaCursor {

--- a/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
+++ b/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.tsx
@@ -8,7 +8,7 @@ import type { NumberFieldRoot } from '../root/NumberFieldRoot';
 import { ownerDocument } from '../../utils/owner';
 import { styleHookMapping } from '../utils/styleHooks';
 import { useNumberFieldScrubAreaContext } from '../scrub-area/NumberFieldScrubAreaContext';
-import { useRenderElementLazy } from '../../utils/useRenderElement';
+import { useRenderElement } from '../../utils/useRenderElement';
 
 /**
  * A custom element to display instead of the native cursor while using the scrub area.
@@ -31,7 +31,10 @@ export const NumberFieldScrubAreaCursor = React.forwardRef(function NumberFieldS
 
   const [element, setElement] = React.useState<Element | null>(null);
 
-  const renderElement = useRenderElementLazy('span', componentProps, {
+  const shouldRender = isScrubbing && !isWebKit && !isTouchInput && !isPointerLockDenied;
+
+  const renderedElement = useRenderElement('span', componentProps, {
+    enabled: shouldRender,
     ref: [forwardedRef, scrubAreaCursorRef, setElement],
     state,
     props: [
@@ -49,11 +52,7 @@ export const NumberFieldScrubAreaCursor = React.forwardRef(function NumberFieldS
     customStyleHookMapping: styleHookMapping,
   });
 
-  if (!isScrubbing || isWebKit || isTouchInput || isPointerLockDenied) {
-    return null;
-  }
-
-  return ReactDOM.createPortal(renderElement(), ownerDocument(element).body);
+  return ReactDOM.createPortal(renderedElement, ownerDocument(element).body);
 });
 
 export namespace NumberFieldScrubAreaCursor {

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -4,7 +4,7 @@ import { NOOP } from '../../utils/noop';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useForkRef } from '../../utils/useForkRef';
 import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
-import { useRenderElementLazy } from '../../utils/useRenderElement';
+import { useRenderElement } from '../../utils/useRenderElement';
 import { visuallyHidden } from '../../utils/visuallyHidden';
 import { useButton } from '../../use-button';
 import { ACTIVE_COMPOSITE_ITEM } from '../../composite/constants';
@@ -163,7 +163,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
 
   const contextValue: RadioRootContext = React.useMemo(() => state, [state]);
 
-  const renderElement = useRenderElementLazy('button', componentProps, {
+  const element = useRenderElement('button', componentProps, {
     state,
     ref: [forwardedRef, buttonRef],
     props: [
@@ -177,7 +177,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
 
   return (
     <RadioRootContext.Provider value={contextValue}>
-      {setCheckedValue === NOOP ? renderElement() : <CompositeItem render={renderElement()} />}
+      {setCheckedValue === NOOP ? element : <CompositeItem render={element} />}
       <input {...inputProps} />
     </RadioRootContext.Provider>
   );

--- a/packages/react/src/use-render/useRender.ts
+++ b/packages/react/src/use-render/useRender.ts
@@ -64,7 +64,13 @@ export namespace useRender {
      * internal ones.
      */
     props?: Record<string, unknown>;
+    /**
+     * If `false`, the hook will skip most of its internal logic and return `null`.
+     * This is useful for rendering a component conditionally.
+     * @default true
+     */
+    enabled?: boolean;
   }
 
-  export type ReturnValue = React.ReactElement;
+  export type ReturnValue = React.ReactElement | null;
 }

--- a/packages/react/src/utils/useRenderElement.tsx
+++ b/packages/react/src/utils/useRenderElement.tsx
@@ -19,28 +19,39 @@ export function useRenderElement<
   State extends Record<string, any>,
   RenderedElementType extends Element,
   TagName extends IntrinsicTagName | undefined,
+  Enabled extends boolean | undefined | never = never,
 >(
   element: TagName,
   componentProps: useRenderElement.ComponentProps<State>,
-  params: useRenderElement.Parameters<State, RenderedElementType, TagName> = {},
-) {
+  params: useRenderElement.Parameters<State, RenderedElementType, TagName, Enabled> = {},
+): Enabled extends false ? null : React.ReactElement<Record<string, unknown>> {
   const renderProp = componentProps.render;
   const outProps = useRenderElementProps(componentProps, params);
+  if (params.enabled === false) {
+    return null as Enabled extends false ? null : React.ReactElement<Record<string, unknown>>;
+  }
+
   const state = params.state ?? (EMPTY_OBJECT as State);
-  return evaluateRenderProp(element, renderProp, outProps, state);
+  return evaluateRenderProp(element, renderProp, outProps, state) as Enabled extends false
+    ? null
+    : React.ReactElement<Record<string, unknown>>;
 }
 
 /**
  * Returns a function that renders a Base UI element.
+ *
+ * @deprecated Use `useRenderElement` instead and pass `enabled = false` to its options instead.
  */
+// TODO: Remove once useComponentRenderer is no longer used.
 export function useRenderElementLazy<
   State extends Record<string, any>,
   RenderedElementType extends Element,
   TagName extends IntrinsicTagName | undefined,
+  Enabled extends boolean | undefined | never,
 >(
   element: TagName,
   componentProps: useRenderElement.ComponentProps<State>,
-  params: useRenderElement.Parameters<State, RenderedElementType, TagName> = {},
+  params: useRenderElement.Parameters<State, RenderedElementType, TagName, Enabled> = {},
 ) {
   const renderProp = componentProps.render;
   const outProps = useRenderElementProps(componentProps, params);
@@ -55,10 +66,11 @@ function useRenderElementProps<
   State extends Record<string, any>,
   RenderedElementType extends Element,
   TagName extends IntrinsicTagName | undefined,
+  Enabled extends boolean | undefined | never,
 >(
   componentProps: useRenderElement.ComponentProps<State>,
-  params: useRenderElement.Parameters<State, RenderedElementType, TagName> = {},
-) {
+  params: useRenderElement.Parameters<State, RenderedElementType, TagName, Enabled> = {},
+): React.HTMLAttributes<any> & React.RefAttributes<any> {
   const { className: classNameProp, render: renderProp } = componentProps;
 
   const {
@@ -68,9 +80,10 @@ function useRenderElementProps<
     props,
     disableStyleHooks,
     customStyleHookMapping,
+    enabled = true,
   } = params;
 
-  const className = resolveClassName(classNameProp, state);
+  const className = enabled ? resolveClassName(classNameProp, state) : undefined;
 
   let styleHooks: Record<string, string> | undefined;
   if (disableStyleHooks !== true) {
@@ -78,25 +91,33 @@ function useRenderElementProps<
     // always unset, so this `if` block is stable across renders.
     /* eslint-disable-next-line react-hooks/rules-of-hooks */
     styleHooks = React.useMemo(
-      () => getStyleHookProps(state, customStyleHookMapping),
-      [state, customStyleHookMapping],
+      () => (enabled ? getStyleHookProps(state, customStyleHookMapping) : EMPTY_OBJECT),
+      [state, customStyleHookMapping, enabled],
     );
   }
 
-  const outProps: React.HTMLAttributes<any> & React.RefAttributes<any> = propGetter(
-    mergeObjects(styleHooks, Array.isArray(props) ? mergePropsN(props) : props) ?? EMPTY_OBJECT,
-  );
+  const outProps: React.HTMLAttributes<any> & React.RefAttributes<any> = enabled
+    ? propGetter(
+        mergeObjects(styleHooks, Array.isArray(props) ? mergePropsN(props) : props) ?? EMPTY_OBJECT,
+      )
+    : EMPTY_OBJECT;
 
   // SAFETY: The `useForkRef` functions use a single hook to store the same value,
   // switching between them at runtime is safe. If this assertion fails, React will
   // throw at runtime anyway.
   /* eslint-disable react-hooks/rules-of-hooks */
-  if (Array.isArray(ref)) {
+  if (!enabled) {
+    useForkRef(null, null);
+  } else if (Array.isArray(ref)) {
     outProps.ref = useForkRefN(outProps.ref, getChildRef(renderProp), ...ref);
   } else {
     outProps.ref = useForkRef(outProps.ref, getChildRef(renderProp), ref);
   }
   /* eslint-enable react-hooks/rules-of-hooks */
+
+  if (!enabled) {
+    return EMPTY_OBJECT;
+  }
 
   if (className !== undefined) {
     outProps.className = className;
@@ -153,7 +174,18 @@ type RenderFunctionProps<TagName> = TagName extends keyof React.JSX.IntrinsicEle
   : React.HTMLAttributes<any>;
 
 export namespace useRenderElement {
-  export type Parameters<State, RenderedElementType extends Element, TagName> = {
+  export type Parameters<
+    State,
+    RenderedElementType extends Element,
+    TagName,
+    Enabled extends boolean | undefined | never,
+  > = {
+    /**
+     * If `false`, the hook will skip most of its internal logic and return `null`.
+     * This is useful for rendering a component conditionally.
+     * @default true
+     */
+    enabled?: Enabled;
     /**
      * @deprecated
      */

--- a/scripts/api-docs-builder/src/formatter.ts
+++ b/scripts/api-docs-builder/src/formatter.ts
@@ -51,7 +51,7 @@ export function formatType(
   jsdocTags: rae.DocumentationTag[] | undefined = undefined,
   expandObjects: boolean = false,
 ): string {
-  const typeTag = jsdocTags?.find((tag) => tag.name === 'type');
+  const typeTag = jsdocTags?.find?.((tag) => tag.name === 'type');
   const typeValue = typeTag?.value;
 
   if (typeValue) {


### PR DESCRIPTION
Instead of using `useRenderElementLazy` which skips just a small part of processing when there's nothing to render, I introduced an `enabled` parameter to `useRenderElement`. It skips most of the logic (including prop merging).

There were some TS acrobatics necessary to ensure `useRenderElement` actually returns a `React.ReactElement` when enabled and `null` when disabled.