### PR TITLE
[code-infra] Specify permissions for the fixed-issue action

### DIFF
--- a/.github/workflows/fixed-issue.yml
+++ b/.github/workflows/fixed-issue.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   add-comment:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
     steps:
       - name: Get associated PRs
         id: get-prs


### PR DESCRIPTION
The fixed-issue workflow failed to run because of insufficient permissions (see https://github.com/mui/base-ui/actions/runs/15275161487/job/42959662346 for example).