### PR TITLE
[popups] Adjust `collisionAvoidance` defaults

### DIFF
--- a/docs/src/app/(private)/experiments/popups/popups-transform-origin.module.css
+++ b/docs/src/app/(private)/experiments/popups/popups-transform-origin.module.css
@@ -12,8 +12,6 @@
 }
 
 .Trigger {
-  position: relative;
-  top: 100px;
   background: #ddd;
   width: 75px;
   height: 50px;

--- a/docs/src/app/(private)/experiments/popups/popups-transform-origin.tsx
+++ b/docs/src/app/(private)/experiments/popups/popups-transform-origin.tsx
@@ -35,6 +35,28 @@ function PopoverWithArrow({ side }: { side: Side }) {
   );
 }
 
+function ShiftSide({ side }: { side: Side }) {
+  return (
+    <PopoverPrimitive.Root>
+      <PopoverPrimitive.Trigger className={styles.Trigger}>
+        {side}
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Positioner
+          side={side}
+          sideOffset={20}
+          collisionAvoidance={{ side: 'shift' }}
+        >
+          <PopoverPrimitive.Popup
+            className={styles.Popup}
+            style={{ height: 600, maxHeight: 'var(--available-height)' }}
+          />
+        </PopoverPrimitive.Positioner>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}
+
 export default function PopupTransformOrigin() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
@@ -45,11 +67,17 @@ export default function PopupTransformOrigin() {
         <Popover side="bottom" />
         <Popover side="left" />
       </div>
+      <h2>With arrow</h2>
       <div style={{ display: 'flex', gap: 10 }}>
         <PopoverWithArrow side="top" />
         <PopoverWithArrow side="right" />
         <PopoverWithArrow side="bottom" />
         <PopoverWithArrow side="left" />
+      </div>
+      <h2>Shift side</h2>
+      <div style={{ display: 'flex', gap: 10 }}>
+        <ShiftSide side="top" />
+        <ShiftSide side="bottom" />
       </div>
     </div>
   );

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -17,7 +17,7 @@ import { CompositeList } from '../../composite/list/CompositeList';
 import { inertValue } from '../../utils/inertValue';
 import { InternalBackdrop } from '../../utils/InternalBackdrop';
 import { useMenuPortalContext } from '../portal/MenuPortalContext';
-import { DEFAULT_COLLISION_AVOIDANCE } from '../../utils/constants';
+import { DROPDOWN_COLLISION_AVOIDANCE } from '../../utils/constants';
 import { useContextMenuRootContext } from '../../context-menu/root/ContextMenuRootContext';
 
 /**
@@ -44,7 +44,7 @@ export const MenuPositioner = React.forwardRef(function MenuPositioner(
     arrowPadding = 5,
     sticky = false,
     trackAnchor = true,
-    collisionAvoidance = DEFAULT_COLLISION_AVOIDANCE,
+    collisionAvoidance = DROPDOWN_COLLISION_AVOIDANCE,
     ...otherProps
   } = props;
 

--- a/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
+++ b/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
@@ -10,17 +10,13 @@ import {
   useNavigationMenuTreeContext,
 } from '../root/NavigationMenuRootContext';
 import { useNavigationMenuPortalContext } from '../portal/NavigationMenuPortalContext';
-import {
-  CollisionAvoidance,
-  useAnchorPositioning,
-  type Align,
-  type Side,
-} from '../../utils/useAnchorPositioning';
+import { useAnchorPositioning, type Align, type Side } from '../../utils/useAnchorPositioning';
 import { NavigationMenuPositionerContext } from './NavigationMenuPositionerContext';
 import { ownerDocument } from '../../utils/owner';
 import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
 import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
 import { popupStateMapping } from '../../utils/popupStateMapping';
+import { DROPDOWN_COLLISION_AVOIDANCE, POPUP_COLLISION_AVOIDANCE } from '../../utils/constants';
 
 const adaptiveOrigin: Middleware = {
   name: 'adaptiveOrigin',
@@ -80,14 +76,6 @@ const adaptiveOrigin: Middleware = {
   },
 };
 
-const defaultCollisionAvoidance: CollisionAvoidance = {
-  fallbackAxisSide: 'none',
-};
-
-const defaultNestedCollisionAvoidance: CollisionAvoidance = {
-  fallbackAxisSide: 'end',
-};
-
 /**
  * Positions the navigation menu against the currently active trigger.
  * Renders a `<div>` element.
@@ -112,7 +100,7 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
     alignOffset = 0,
     collisionBoundary = 'clipping-ancestors',
     collisionPadding = 5,
-    collisionAvoidance = nested ? defaultNestedCollisionAvoidance : defaultCollisionAvoidance,
+    collisionAvoidance = nested ? POPUP_COLLISION_AVOIDANCE : DROPDOWN_COLLISION_AVOIDANCE,
     arrowPadding = 5,
     sticky = false,
     trackAnchor = true,

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -11,7 +11,7 @@ import { usePopoverPortalContext } from '../portal/PopoverPortalContext';
 import { inertValue } from '../../utils/inertValue';
 import { InternalBackdrop } from '../../utils/InternalBackdrop';
 import { useRenderElement } from '../../utils/useRenderElement';
-import { DEFAULT_COLLISION_AVOIDANCE } from '../../utils/constants';
+import { POPUP_COLLISION_AVOIDANCE } from '../../utils/constants';
 
 /**
  * Positions the popover against the trigger.
@@ -37,7 +37,7 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     arrowPadding = 5,
     sticky = false,
     trackAnchor = true,
-    collisionAvoidance = DEFAULT_COLLISION_AVOIDANCE,
+    collisionAvoidance = POPUP_COLLISION_AVOIDANCE,
     ...elementProps
   } = componentProps;
 

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
@@ -9,7 +9,7 @@ import type { Side, Align } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { popupStateMapping } from '../../utils/popupStateMapping';
 import { usePreviewCardPortalContext } from '../portal/PreviewCardPortalContext';
-import { DEFAULT_COLLISION_AVOIDANCE } from '../../utils/constants';
+import { POPUP_COLLISION_AVOIDANCE } from '../../utils/constants';
 
 /**
  * Positions the popup against the trigger.
@@ -35,7 +35,7 @@ export const PreviewCardPositioner = React.forwardRef(function PreviewCardPositi
     arrowPadding = 5,
     sticky = false,
     trackAnchor = true,
-    collisionAvoidance = DEFAULT_COLLISION_AVOIDANCE,
+    collisionAvoidance = POPUP_COLLISION_AVOIDANCE,
     ...otherProps
   } = props;
 

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -10,7 +10,7 @@ import { SelectPositionerContext } from './SelectPositionerContext';
 import { InternalBackdrop } from '../../utils/InternalBackdrop';
 import { inertValue } from '../../utils/inertValue';
 import { useRenderElement } from '../../utils/useRenderElement';
-import { DEFAULT_COLLISION_AVOIDANCE } from '../../utils/constants';
+import { DROPDOWN_COLLISION_AVOIDANCE } from '../../utils/constants';
 import { clearPositionerStyles } from '../popup/utils';
 import { useSelectIndexContext } from '../root/SelectIndexContext';
 import { useEventCallback } from '../../utils/useEventCallback';
@@ -40,7 +40,7 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
     sticky = false,
     trackAnchor = true,
     alignItemWithTrigger = true,
-    collisionAvoidance = DEFAULT_COLLISION_AVOIDANCE,
+    collisionAvoidance = DROPDOWN_COLLISION_AVOIDANCE,
     ...elementProps
   } = componentProps;
 

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
@@ -8,7 +8,7 @@ import type { Side, Align } from '../../utils/useAnchorPositioning';
 import { popupStateMapping } from '../../utils/popupStateMapping';
 import { useTooltipPortalContext } from '../portal/TooltipPortalContext';
 import { useRenderElement } from '../../utils/useRenderElement';
-import { DEFAULT_COLLISION_AVOIDANCE } from '../../utils/constants';
+import { POPUP_COLLISION_AVOIDANCE } from '../../utils/constants';
 
 /**
  * Positions the tooltip against the trigger.
@@ -34,7 +34,7 @@ export const TooltipPositioner = React.forwardRef(function TooltipPositioner(
     arrowPadding = 5,
     sticky = false,
     trackAnchor = true,
-    collisionAvoidance = DEFAULT_COLLISION_AVOIDANCE,
+    collisionAvoidance = POPUP_COLLISION_AVOIDANCE,
     ...elementProps
   } = componentProps;
 

--- a/packages/react/src/utils/constants.ts
+++ b/packages/react/src/utils/constants.ts
@@ -1,6 +1,21 @@
 export const TYPEAHEAD_RESET_MS = 500;
 export const PATIENT_CLICK_THRESHOLD = 500;
-export const DEFAULT_COLLISION_AVOIDANCE = {
+
+/**
+ * Used for dropdowns that usually strictly prefer top/bottom placements and
+ * use `var(--available-height)` to limit their height.
+ */
+export const DROPDOWN_COLLISION_AVOIDANCE = {
+  side: 'flip',
+  align: 'flip',
+  fallbackAxisSide: 'none',
+} as const;
+
+/**
+ * Used by regular popups that usually aren't scrollable and are allowed to
+ * freely flip to any axis of placement.
+ */
+export const POPUP_COLLISION_AVOIDANCE = {
   side: 'flip',
   align: 'flip',
   fallbackAxisSide: 'end',

--- a/packages/react/src/utils/constants.ts
+++ b/packages/react/src/utils/constants.ts
@@ -6,8 +6,6 @@ export const PATIENT_CLICK_THRESHOLD = 500;
  * use `var(--available-height)` to limit their height.
  */
 export const DROPDOWN_COLLISION_AVOIDANCE = {
-  side: 'flip',
-  align: 'flip',
   fallbackAxisSide: 'none',
 } as const;
 
@@ -16,7 +14,5 @@ export const DROPDOWN_COLLISION_AVOIDANCE = {
  * freely flip to any axis of placement.
  */
 export const POPUP_COLLISION_AVOIDANCE = {
-  side: 'flip',
-  align: 'flip',
   fallbackAxisSide: 'end',
 } as const;

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -17,8 +17,9 @@ import {
   type Padding,
   type FloatingContext,
   type Side as PhysicalSide,
+  type MiddlewareState,
 } from '@floating-ui/react';
-import { getSide, getAlignment, type Rect } from '@floating-ui/utils';
+import { getSide, getAlignment, type Rect, getSideAxis } from '@floating-ui/utils';
 import { useModernLayoutEffect } from './useModernLayoutEffect';
 import { useDirection } from '../direction-provider/DirectionContext';
 import { useLatestRef } from './useLatestRef';
@@ -37,6 +38,17 @@ function getLogicalSide(sideParam: Side, renderedSide: PhysicalSide, isRtl: bool
       left: isLogicalSideParam ? logicalLeft : 'left',
     } satisfies Record<PhysicalSide, Side>
   )[renderedSide];
+}
+
+function getOffsetData(state: MiddlewareState, sideParam: Side, isRtl: boolean) {
+  const { rects, placement } = state;
+  const data = {
+    side: getLogicalSide(sideParam, getSide(placement), isRtl),
+    align: getAlignment(placement) || 'center',
+    anchor: { width: rects.reference.width, height: rects.reference.height },
+    positioner: { width: rects.floating.width, height: rects.floating.height },
+  } as const;
+  return data;
 }
 
 export type Side = 'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start';
@@ -155,13 +167,8 @@ export function useAnchorPositioning(
 
   const middleware: UseFloatingOptions['middleware'] = [
     offset(
-      ({ rects, placement: currentPlacement }) => {
-        const data = {
-          side: getLogicalSide(sideParam, getSide(currentPlacement), isRtl),
-          align: getAlignment(currentPlacement) || 'center',
-          anchor: { width: rects.reference.width, height: rects.reference.height },
-          positioner: { width: rects.floating.width, height: rects.floating.height },
-        } as const;
+      (state) => {
+        const data = getOffsetData(state, sideParam, isRtl);
 
         const sideAxis =
           typeof sideOffsetRef.current === 'function'
@@ -182,6 +189,10 @@ export function useAnchorPositioning(
     ),
   ];
 
+  const shiftDisabled = collisionAvoidanceAlign === 'none' && collisionAvoidanceSide !== 'shift';
+  const crossAxisShiftEnabled =
+    !shiftDisabled && (sticky || shiftCrossAxis || collisionAvoidanceSide === 'shift');
+
   const flipMiddleware =
     collisionAvoidanceSide === 'none'
       ? null
@@ -191,39 +202,37 @@ export function useAnchorPositioning(
           crossAxis: collisionAvoidanceAlign === 'flip' ? 'alignment' : false,
           fallbackAxisSideDirection: collisionAvoidanceFallbackAxisSide,
         });
-  const shiftMiddleware =
-    collisionAvoidanceAlign === 'none' && collisionAvoidanceSide !== 'shift'
-      ? null
-      : shift(
-          (data) => {
-            const html = ownerDocument(data.elements.floating).documentElement;
-            return {
-              ...commonCollisionProps,
-              // Use the Layout Viewport to avoid shifting around when pinch-zooming
-              // for context menus.
-              rootBoundary: shiftCrossAxis
-                ? { x: 0, y: 0, width: html.clientWidth, height: html.clientHeight }
-                : undefined,
-              mainAxis: collisionAvoidanceAlign !== 'none',
-              crossAxis: sticky || shiftCrossAxis || collisionAvoidanceSide === 'shift',
-              limiter:
-                sticky || shiftCrossAxis
-                  ? undefined
-                  : limitShift(() => {
-                      if (!arrowRef.current) {
-                        return {};
-                      }
-                      const { height } = arrowRef.current.getBoundingClientRect();
-                      return {
-                        offset:
-                          height / 2 +
-                          (typeof collisionPadding === 'number' ? collisionPadding : 0),
-                      };
-                    }),
-            };
-          },
-          [commonCollisionProps, sticky, shiftCrossAxis, collisionPadding, collisionAvoidanceAlign],
-        );
+  const shiftMiddleware = shiftDisabled
+    ? null
+    : shift(
+        (data) => {
+          const html = ownerDocument(data.elements.floating).documentElement;
+          return {
+            ...commonCollisionProps,
+            // Use the Layout Viewport to avoid shifting around when pinch-zooming
+            // for context menus.
+            rootBoundary: shiftCrossAxis
+              ? { x: 0, y: 0, width: html.clientWidth, height: html.clientHeight }
+              : undefined,
+            mainAxis: collisionAvoidanceAlign !== 'none',
+            crossAxis: crossAxisShiftEnabled,
+            limiter:
+              sticky || shiftCrossAxis
+                ? undefined
+                : limitShift(() => {
+                    if (!arrowRef.current) {
+                      return {};
+                    }
+                    const { height } = arrowRef.current.getBoundingClientRect();
+                    return {
+                      offset:
+                        height / 2 + (typeof collisionPadding === 'number' ? collisionPadding : 0),
+                    };
+                  }),
+          };
+        },
+        [commonCollisionProps, sticky, shiftCrossAxis, collisionPadding, collisionAvoidanceAlign],
+      );
 
   // https://floating-ui.com/docs/flip#combining-with-shift
   if (
@@ -262,24 +271,40 @@ export function useAnchorPositioning(
     hide(),
     {
       name: 'transformOrigin',
-      fn({ elements, middlewareData, placement: renderedPlacement }) {
+      fn(state) {
+        const { elements, middlewareData, placement: renderedPlacement, rects, y } = state;
+
         const currentRenderedSide = getSide(renderedPlacement);
+        const currentRenderedAxis = getSideAxis(currentRenderedSide);
         const arrowEl = arrowRef.current;
-        const arrowX = middlewareData.arrow?.x ?? 0;
-        const arrowY = middlewareData.arrow?.y ?? 0;
-        const arrowWidth = arrowEl?.clientWidth ?? 0;
-        const arrowHeight = arrowEl?.clientHeight ?? 0;
+        const arrowX = middlewareData.arrow?.x || 0;
+        const arrowY = middlewareData.arrow?.y || 0;
+        const arrowWidth = arrowEl?.clientWidth || 0;
+        const arrowHeight = arrowEl?.clientHeight || 0;
         const transformX = arrowX + arrowWidth / 2;
         const transformY = arrowY + arrowHeight / 2;
+        const shiftY = Math.abs(middlewareData.shift?.y || 0);
+        const halfAnchorHeight = rects.reference.height / 2;
+        const isOverlappingAnchor =
+          shiftY >
+          (typeof sideOffset === 'function'
+            ? sideOffset(getOffsetData(state, sideParam, isRtl))
+            : sideOffset);
 
-        const transformOrigin = {
+        const adjacentTransformOrigin = {
           top: `${transformX}px calc(100% + ${sideOffset}px)`,
           bottom: `${transformX}px ${-sideOffset}px`,
           left: `calc(100% + ${sideOffset}px) ${transformY}px`,
           right: `${-sideOffset}px ${transformY}px`,
         }[currentRenderedSide];
+        const overlapTransformOrigin = `${transformX}px ${rects.reference.y + halfAnchorHeight - y}px`;
 
-        elements.floating.style.setProperty('--transform-origin', transformOrigin);
+        elements.floating.style.setProperty(
+          '--transform-origin',
+          crossAxisShiftEnabled && currentRenderedAxis === 'y' && isOverlappingAnchor
+            ? overlapTransformOrigin
+            : adjacentTransformOrigin,
+        );
 
         return {};
       },


### PR DESCRIPTION
Adjustment to https://github.com/mui/base-ui/pull/1849. (`internal` tag as that PR can be used for release reference alone)

You don't want Select or Menu to flip to the right or left as a default if they don't fit on the top or bottom side, since they prefer to limit the height (`flip()` acts before `size()` does).

On the other hand, Popover, Tooltip, and Preview Card don't follow this and should flip the axis by default.

Also fixes `--transform-origin` calculation when `collisionAvoidance.side = 'shift'`: https://deploy-preview-1977--base-ui.netlify.app/experiments/popups/popups-transform-origin