### PR TITLE
[core] Fix CSS transition interruptibility

### DIFF
--- a/packages/react/src/collapsible/root/useCollapsibleRoot.ts
+++ b/packages/react/src/collapsible/root/useCollapsibleRoot.ts
@@ -29,7 +29,7 @@ export function useCollapsibleRoot(
     state: 'open',
   });
 
-  const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
+  const { mounted, setMounted, transitionStatus } = useTransitionStatus(open, true);
   const [visible, setVisible] = React.useState(open);
   const [{ height, width }, setDimensions] = React.useState<Dimensions>({
     height: undefined,

--- a/packages/react/src/utils/useTransitionStatus.ts
+++ b/packages/react/src/utils/useTransitionStatus.ts
@@ -8,10 +8,11 @@ export type TransitionStatus = 'starting' | 'ending' | 'idle' | undefined;
 /**
  * Provides a status string for CSS animations.
  * @param open - a boolean that determines if the element is open.
+ * @param enableIdleState - a boolean that enables the `'idle'` state between `'starting'` and `'ending'`
  */
-export function useTransitionStatus(open: boolean) {
+export function useTransitionStatus(open: boolean, enableIdleState: boolean = false) {
   const [transitionStatus, setTransitionStatus] = React.useState<TransitionStatus>(
-    open ? 'idle' : undefined,
+    open && enableIdleState ? 'idle' : undefined,
   );
   const [mounted, setMounted] = React.useState(open);
 
@@ -29,9 +30,24 @@ export function useTransitionStatus(open: boolean) {
   }
 
   useModernLayoutEffect(() => {
-    if (!open) {
+    if (!open || enableIdleState) {
       return undefined;
     }
+
+    const frame = AnimationFrame.request(() => {
+      setTransitionStatus(undefined);
+    });
+
+    return () => {
+      AnimationFrame.cancel(frame);
+    };
+  }, [enableIdleState, open]);
+
+  useModernLayoutEffect(() => {
+    if (!open || !enableIdleState) {
+      return undefined;
+    }
+
     if (open && mounted && transitionStatus !== 'idle') {
       setTransitionStatus('starting');
     }
@@ -43,7 +59,7 @@ export function useTransitionStatus(open: boolean) {
     return () => {
       AnimationFrame.cancel(frame);
     };
-  }, [open, mounted, setTransitionStatus, transitionStatus]);
+  }, [enableIdleState, open, mounted, setTransitionStatus, transitionStatus]);
 
   return React.useMemo(
     () => ({


### PR DESCRIPTION
Sandbox: https://codesandbox.io/p/sandbox/elastic-banzai-f44hrt

Fixes https://github.com/mui/base-ui/issues/1978

Adds a param to make the `'idle'` status optional

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
