### PR TITLE
[dependencies] Use babel-plugin-display-name from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
     "@babel/register": "^7.27.1",
-    "@mui/internal-babel-plugin-display-name": "github:mui/mui-public#master&path:./packages/babel-plugin-display-name",
+    "@mui/internal-babel-plugin-display-name": "^1.0.0",
     "@mui/internal-babel-plugin-resolve-imports": "^2.0.1",
     "@mui/internal-docs-utils": "^2.0.1",
     "@mui/internal-markdown": "^2.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: ^7.27.1
         version: 7.27.1(@babel/core@7.27.1)
       '@mui/internal-babel-plugin-display-name':
-        specifier: github:mui/mui-public#master&path:./packages/babel-plugin-display-name
-        version: https://codeload.github.com/mui/mui-public/tar.gz/931afef82da15f9926d06fbb220d2d681b9daea1#path:./packages/babel-plugin-display-name(@babel/core@7.27.1)(@babel/preset-react@7.27.1(@babel/core@7.27.1))
+        specifier: ^1.0.0
+        version: 1.0.0(@babel/core@7.27.1)(@babel/preset-react@7.27.1(@babel/core@7.27.1))
       '@mui/internal-babel-plugin-resolve-imports':
         specifier: ^2.0.1
         version: 2.0.2(@babel/core@7.27.1)
@@ -2128,9 +2128,8 @@ packages:
       '@types/react': ^19.1.2
       react: '>=16'
 
-  '@mui/internal-babel-plugin-display-name@https://codeload.github.com/mui/mui-public/tar.gz/931afef82da15f9926d06fbb220d2d681b9daea1#path:./packages/babel-plugin-display-name':
-    resolution: {path: ./packages/babel-plugin-display-name, tarball: https://codeload.github.com/mui/mui-public/tar.gz/931afef82da15f9926d06fbb220d2d681b9daea1}
-    version: 0.0.0
+  '@mui/internal-babel-plugin-display-name@1.0.0':
+    resolution: {integrity: sha512-Y7XQi8PhAxdY5IndQRn+az3u3xyAGP6Kw3uS/GU3f8dNzhLpcqo5PymeyF27yJ0ozmlEqRmGHuK3QXaRqK5XHA==}
     peerDependencies:
       '@babel/core': ^7.27.1
       '@babel/preset-react': ^7.27.1
@@ -11149,7 +11148,7 @@ snapshots:
       '@types/react': 19.1.2
       react: 19.1.0
 
-  '@mui/internal-babel-plugin-display-name@https://codeload.github.com/mui/mui-public/tar.gz/931afef82da15f9926d06fbb220d2d681b9daea1#path:./packages/babel-plugin-display-name(@babel/core@7.27.1)(@babel/preset-react@7.27.1(@babel/core@7.27.1))':
+  '@mui/internal-babel-plugin-display-name@1.0.0(@babel/core@7.27.1)(@babel/preset-react@7.27.1(@babel/core@7.27.1))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/helper-module-imports': 7.27.1


### PR DESCRIPTION
Having @mui/internal-babel-plugin-display-name defined as a git dependency from a master branch caused the dedupe step in CI to fail frequently when a new commit was pushed to this dependency's repo.
Changed to a regular npm dependency.