### PR TITLE
[code-infra] Update the changelog generator to use new GH labels

### DIFF
--- a/scripts/releaseChangelog.mts
+++ b/scripts/releaseChangelog.mts
@@ -10,6 +10,8 @@ import packageJson from '../package.json';
 
 const exec = promisify(childProcess.exec);
 
+const GENERAL_CHANGES_HEADER = 'general changes';
+
 async function main(parameters: CommandParameters) {
   const { githubToken, lastRelease: previousReleaseParam, release, format } = parameters;
 
@@ -212,6 +214,13 @@ function getFormattedChangelogEntries(
   }
 
   const changedComponents = Array.from(changes.keys()).sort((a, b) => {
+    if (a === GENERAL_CHANGES_HEADER) {
+      return -1;
+    }
+    if (b === GENERAL_CHANGES_HEADER) {
+      return 1;
+    }
+
     return a.localeCompare(b);
   });
 
@@ -226,6 +235,10 @@ function getFormattedChangelogEntries(
 }
 
 function getComponentsFromLabels(labels: string[]): string[] {
+  if (labels.includes('all components')) {
+    return [GENERAL_CHANGES_HEADER];
+  }
+
   const components = labels
     .filter((label) => {
       return label.startsWith('component:');
@@ -259,7 +272,9 @@ function getScopeFromLabels(labels: string[]): ChangeScope {
     return 'release';
   }
 
-  // TODO: find refactoring-related label
+  if (labels.includes('internal')) {
+    return 'refactoring';
+  }
 
   return 'public-api';
 }

--- a/scripts/releaseChangelog.mts
+++ b/scripts/releaseChangelog.mts
@@ -230,7 +230,7 @@ function getFormattedChangelogEntries(
       return '';
     }
 
-    return `### ${_.startCase(component)}\n\n${componentChanges.breaking.join('\n')}${componentChanges.breaking.length > 0 && componentChanges.nonBreaking.length > 0 ? '\n' : ''}${componentChanges.nonBreaking.join('\n')}\n`;
+    return `${formatHeader(component)}${componentChanges.breaking.join('\n')}${componentChanges.breaking.length > 0 && componentChanges.nonBreaking.length > 0 ? '\n' : ''}${componentChanges.nonBreaking.join('\n')}\n`;
   });
 }
 
@@ -241,10 +241,10 @@ function getComponentsFromLabels(labels: string[]): string[] {
 
   const components = labels
     .filter((label) => {
-      return label.startsWith('component:');
+      return label.startsWith('component:') || label.startsWith('hook:');
     })
     .map((label) => {
-      return label.replace('component: ', '');
+      return label.replace('component: ', '').replace('hook: ', '');
     });
 
   return components;
@@ -287,6 +287,18 @@ function cleanCommitMessage(commitMessage: string) {
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;')
     .trim();
+}
+
+function formatHeader(section: string): string {
+  if (/^use[A-Z]/.test(section)) {
+    return `### ${section}\n\n`;
+  }
+
+  if (section === GENERAL_CHANGES_HEADER) {
+    return `### General changes\n\n`;
+  }
+
+  return `### ${_.startCase(section)}\n\n`;
 }
 
 type CommitDetails = {

--- a/scripts/releaseChangelog.mts
+++ b/scripts/releaseChangelog.mts
@@ -272,8 +272,8 @@ function getScopeFromLabels(labels: string[]): ChangeScope {
     return 'release';
   }
 
-  if (labels.includes('internal')) {
-    return 'refactoring';
+  if (labels.includes('internal') || labels.includes('test')) {
+    return 'internal';
   }
 
   return 'public-api';
@@ -314,7 +314,7 @@ interface CommandParameters {
   format: 'changelog' | 'docs';
 }
 
-type ChangeScope = 'docs' | 'infra' | 'public-api' | 'refactoring' | 'dependencies' | 'release';
+type ChangeScope = 'docs' | 'infra' | 'public-api' | 'internal' | 'dependencies' | 'release';
 
 interface ChangelogEntry {
   title: string;


### PR DESCRIPTION
Updated the changelog generation script to include PR marked with `all components` label and exclude the ones with the `internal` label.