### PR TITLE
[docs] checkbox group: granny smith apple naming consistency

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/checkbox-group/demos/parent/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/checkbox-group/demos/parent/css-modules/index.tsx
@@ -3,7 +3,7 @@ import { Checkbox } from '@base-ui-components/react/checkbox';
 import { CheckboxGroup } from '@base-ui-components/react/checkbox-group';
 import styles from './index.module.css';
 
-const fruits = ['fuji-apple', 'gala-apple', 'granny-smith'];
+const fruits = ['fuji-apple', 'gala-apple', 'granny-smith-apple'];
 
 export default function ExampleCheckboxGroup() {
   const [value, setValue] = React.useState<string[]>([]);
@@ -58,7 +58,7 @@ export default function ExampleCheckboxGroup() {
       </label>
 
       <label className={styles.Item}>
-        <Checkbox.Root value="granny-smith" className={styles.Checkbox}>
+        <Checkbox.Root value="granny-smith-apple" className={styles.Checkbox}>
           <Checkbox.Indicator className={styles.Indicator}>
             <CheckIcon className={styles.Icon} />
           </Checkbox.Indicator>


### PR DESCRIPTION
- [ ✅] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Noticed minor inconsistency with 🍎 naming when only 2/3 boxes were checked while pulling in the code from the snippet

Love the work you guys are doing!