### PR TITLE
[number field][docs] Fix rounded input border on iOS

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/number-field/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/number-field/demos/hero/css-modules/index.module.css
@@ -31,6 +31,7 @@
   box-sizing: border-box;
   margin: 0;
   padding: 0;
+  border-radius: 0;
   border-top: 1px solid var(--color-gray-200);
   border-bottom: 1px solid var(--color-gray-200);
   border-left: none;


### PR DESCRIPTION
The `.Increment`/`.Decrement` buttons cascade issue is unrelated in this case. It just needs to unset the default UA style.