### PR TITLE
[docs] Remove `1px` gap of space from Menubar and Tooltip panels

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/menubar/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/menubar/demos/hero/css-modules/index.module.css
@@ -1,6 +1,5 @@
 .Menubar {
   display: flex;
-  gap: 1px;
   background-color: var(--color-gray-50);
   border: 1px solid var(--color-gray-200);
   border-radius: 0.375rem;

--- a/docs/src/app/(public)/(content)/react/components/menubar/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/menubar/demos/hero/tailwind/index.tsx
@@ -4,7 +4,7 @@ import { Menu } from '@base-ui-components/react/menu';
 
 export default function ExampleMenubar() {
   return (
-    <Menubar className="flex gap-px rounded-md border border-gray-200 bg-gray-50 p-0.5">
+    <Menubar className="flex rounded-md border border-gray-200 bg-gray-50 p-0.5">
       <Menu.Root>
         <Menu.Trigger className="h-8 rounded px-3 text-sm font-medium text-gray-600 outline-none select-none focus-visible:bg-gray-100 data-[disabled]:opacity-50 data-[popup-open]:bg-gray-100">
           File

--- a/docs/src/app/(public)/(content)/react/components/tooltip/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/tooltip/demos/hero/css-modules/index.module.css
@@ -1,6 +1,5 @@
 .Panel {
   display: flex;
-  gap: 1px;
   border: 1px solid var(--color-gray-200);
   background-color: var(--color-gray-50);
   border-radius: 0.375rem;

--- a/docs/src/app/(public)/(content)/react/components/tooltip/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/tooltip/demos/hero/tailwind/index.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from '@base-ui-components/react/tooltip';
 export default function ExampleTooltip() {
   return (
     <Tooltip.Provider>
-      <div className="flex gap-px rounded-md border border-gray-200 bg-gray-50 p-0.5">
+      <div className="flex rounded-md border border-gray-200 bg-gray-50 p-0.5">
         <Tooltip.Root>
           <Tooltip.Trigger className="flex size-8 items-center justify-center rounded-sm text-gray-900 select-none hover:bg-gray-100 focus-visible:bg-none focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-200 data-[popup-open]:bg-gray-100 focus-visible:[&:not(:hover)]:bg-transparent">
             <BoldIcon aria-label="Bold" className="size-4" />


### PR DESCRIPTION
Fixes both of these cases by removing the `gap: 1px` property

## Menubar

It's possible to click in the 1px of dead space between items which feels broken.

https://github.com/user-attachments/assets/a1741989-3055-4897-9d00-e05807474d9f

## Tooltip

There's a ghosting effect when navigating (slowly) between tooltips because of the gap (with `0` `closeDelay`).

https://github.com/user-attachments/assets/10926c8f-9fd7-46fa-9dbb-6520014e2c93

