### PR TITLE
[context menu] Fix CheckboxItemIndicator export

### DIFF
--- a/packages/react/src/context-menu/index.parts.ts
+++ b/packages/react/src/context-menu/index.parts.ts
@@ -10,7 +10,7 @@ export { MenuGroup as Group } from '../menu/group/MenuGroup';
 export { MenuGroupLabel as GroupLabel } from '../menu/group-label/MenuGroupLabel';
 export { MenuItem as Item } from '../menu/item/MenuItem';
 export { MenuCheckboxItem as CheckboxItem } from '../menu/checkbox-item/MenuCheckboxItem';
-export { MenuCheckboxItemIndicator as ItemIndicator } from '../menu/checkbox-item-indicator/MenuCheckboxItemIndicator';
+export { MenuCheckboxItemIndicator as CheckboxItemIndicator } from '../menu/checkbox-item-indicator/MenuCheckboxItemIndicator';
 export { MenuRadioGroup as RadioGroup } from '../menu/radio-group/MenuRadioGroup';
 export { MenuRadioItem as RadioItem } from '../menu/radio-item/MenuRadioItem';
 export { MenuRadioItemIndicator as RadioItemIndicator } from '../menu/radio-item-indicator/MenuRadioItemIndicator';


### PR DESCRIPTION
🔴 ~`ItemIndicator`~ -> 🟢 `CheckboxItemIndicator`

Reported in https://discord.com/channels/1287292451308048406/1287292451308048409/1378046213001056316