### PR TITLE
[menu] Unset `role` from Trigger

### DIFF
--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -414,13 +414,13 @@ export const MenuRoot: React.FC<MenuRoot.Props> = function MenuRoot(props) {
   ]);
 
   const triggerProps = React.useMemo(() => {
-    const props = getReferenceProps({
+    const referenceProps = getReferenceProps({
       onMouseEnter() {
         setHoverEnabled(true);
       },
     });
-    delete props.role;
-    return props;
+    delete referenceProps.role;
+    return referenceProps;
   }, [getReferenceProps]);
 
   const popupProps = React.useMemo(

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -413,15 +413,15 @@ export const MenuRoot: React.FC<MenuRoot.Props> = function MenuRoot(props) {
     typeahead,
   ]);
 
-  const triggerProps = React.useMemo(
-    () =>
-      getReferenceProps({
-        onMouseEnter() {
-          setHoverEnabled(true);
-        },
-      }),
-    [getReferenceProps],
-  );
+  const triggerProps = React.useMemo(() => {
+    const props = getReferenceProps({
+      onMouseEnter() {
+        setHoverEnabled(true);
+      },
+    });
+    delete props.role;
+    return props;
+  }, [getReferenceProps]);
 
   const popupProps = React.useMemo(
     () =>

--- a/packages/react/src/menu/trigger/MenuTrigger.test.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.test.tsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
 import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui-components/react/menu';
+import { Popover } from '@base-ui-components/react/popover';
 import { describeConformance, createRenderer } from '#test-utils';
 import { PATIENT_CLICK_THRESHOLD } from '../../utils/constants';
 
@@ -327,5 +328,25 @@ describe('<Menu.Trigger />', () => {
 
       expect(queryByRole('menu', { hidden: false })).to.equal(null);
     });
+  });
+
+  it('does not have role prop inside a Popover', async () => {
+    const { getByTestId } = await render(
+      <Popover.Root open>
+        <Popover.Trigger>Open</Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Positioner>
+            <Popover.Popup>
+              <Menu.Root>
+                <Menu.Trigger data-testid="menu-trigger" />
+              </Menu.Root>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>,
+    );
+
+    const button = getByTestId('menu-trigger');
+    expect(button).not.to.have.attribute('role');
   });
 });

--- a/packages/react/src/menu/trigger/MenuTrigger.test.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.test.tsx
@@ -349,4 +349,24 @@ describe('<Menu.Trigger />', () => {
     const button = getByTestId('menu-trigger');
     expect(button).not.to.have.attribute('role');
   });
+
+  it('has a role prop inside a Popover when not a native button', async () => {
+    const { getByTestId } = await render(
+      <Popover.Root open>
+        <Popover.Trigger>Open</Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Positioner>
+            <Popover.Popup>
+              <Menu.Root>
+                <Menu.Trigger data-testid="menu-trigger" render={<span />} />
+              </Menu.Root>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>,
+    );
+
+    const button = getByTestId('menu-trigger');
+    expect(button).to.have.attribute('role', 'button');
+  });
 });


### PR DESCRIPTION
Fixes #2039

The problem is the `useRole` hook checks `FloatingTree` by default, not the `MenuRootContext`, and since the Popover now has one, it adds the nested role incorrectly