### PR TITLE
[slider] Use pointer capture when dragging

### DIFF
--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -284,7 +284,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
     onValueCommitted(lastChangedValueRef.current ?? finger.value, nativeEvent);
 
     if (
-      nativeEvent instanceof PointerEvent &&
+      'pointerType' in nativeEvent &&
       controlRef.current?.hasPointerCapture(nativeEvent.pointerId)
     ) {
       controlRef.current?.releasePointerCapture(nativeEvent.pointerId);


### PR DESCRIPTION
Demo: https://codesandbox.io/p/devbox/condescending-lamarr-8trt73

Fixes `[data-dragging]` and `onValueCommitted` from being stuck when the drag crosses an iframe

Closes https://github.com/mui/base-ui/issues/1970
Closes https://github.com/mui/base-ui/issues/1910

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
