### PR TITLE
[preview card] Integrate inline positioning

### DIFF
--- a/docs/src/app/(private)/experiments/inline-positioning.module.css
+++ b/docs/src/app/(private)/experiments/inline-positioning.module.css
@@ -1,0 +1,174 @@
+.Experiment {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  padding: clamp(3rem, 8vw, 6rem) 1.5rem 5rem;
+}
+
+.Section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 32rem;
+}
+
+.SectionLabel {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-gray-500);
+}
+
+.Paragraph {
+  margin: 0;
+  max-width: 30rem;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--color-gray-900);
+  text-wrap: pretty;
+}
+
+.Link {
+  outline: 0;
+  color: var(--color-blue);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-decoration-color: color-mix(in oklab, var(--color-blue), transparent 40%);
+  text-underline-offset: 2px;
+
+  @media (hover: hover) {
+    &:hover {
+      text-decoration-color: var(--color-blue);
+    }
+  }
+
+  &[data-popup-open] {
+    text-decoration-color: var(--color-blue);
+  }
+
+  &:focus-visible {
+    border-radius: 0.125rem;
+    outline: 2px solid var(--color-blue);
+    text-decoration-line: none;
+  }
+}
+
+.PreviewPopup {
+  box-sizing: border-box;
+  border-radius: 0.5rem;
+  background-color: canvas;
+  transform-origin: var(--transform-origin);
+  transition:
+    transform 150ms,
+    opacity 150ms;
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+
+  @media (prefers-color-scheme: light) {
+    outline: 1px solid var(--color-gray-200);
+    box-shadow:
+      0 10px 15px -3px var(--color-gray-200),
+      0 4px 6px -4px var(--color-gray-200);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    outline: 1px solid var(--color-gray-300);
+    outline-offset: -1px;
+  }
+}
+
+.PreviewPopup {
+  width: 256px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.65rem;
+}
+
+.Arrow {
+  display: flex;
+
+  &[data-side='top'] {
+    bottom: -8px;
+    rotate: 180deg;
+  }
+
+  &[data-side='bottom'] {
+    top: -8px;
+    rotate: 0deg;
+  }
+
+  &[data-side='left'] {
+    right: -13px;
+    rotate: 90deg;
+  }
+
+  &[data-side='right'] {
+    left: -13px;
+    rotate: -90deg;
+  }
+}
+
+.ArrowFill {
+  fill: canvas;
+}
+
+.ArrowOuterStroke {
+  @media (prefers-color-scheme: light) {
+    fill: var(--color-gray-200);
+  }
+}
+
+.ArrowInnerStroke {
+  @media (prefers-color-scheme: dark) {
+    fill: var(--color-gray-300);
+  }
+}
+
+.Artwork {
+  min-height: 126px;
+  border-radius: 0.375rem;
+  display: flex;
+  align-items: flex-end;
+  padding: 0.75rem;
+}
+
+.ArtworkLabel {
+  display: inline-flex;
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  background-color: color-mix(in oklab, white, transparent 25%);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(24 24 27 / 0.88);
+}
+
+.CardBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.CardTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.2;
+  font-weight: 600;
+  color: var(--color-gray-900);
+}
+
+.Summary {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.35;
+  color: var(--color-gray-700);
+  text-wrap: pretty;
+}

--- a/docs/src/app/(private)/experiments/inline-positioning.module.css
+++ b/docs/src/app/(private)/experiments/inline-positioning.module.css
@@ -56,7 +56,12 @@
 }
 
 .PreviewPopup {
+  width: 256px;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.65rem;
   border-radius: 0.5rem;
   background-color: canvas;
   transform-origin: var(--transform-origin);
@@ -81,14 +86,6 @@
     outline: 1px solid var(--color-gray-300);
     outline-offset: -1px;
   }
-}
-
-.PreviewPopup {
-  width: 256px;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  padding: 0.65rem;
 }
 
 .Arrow {

--- a/docs/src/app/(private)/experiments/inline-positioning.tsx
+++ b/docs/src/app/(private)/experiments/inline-positioning.tsx
@@ -1,0 +1,169 @@
+'use client';
+import * as React from 'react';
+import { PreviewCard } from '@base-ui/react/preview-card';
+import { type SettingsMetadata, useExperimentSettings } from './_components/SettingsPanel';
+import styles from './inline-positioning.module.css';
+
+interface Settings {
+  use300msDelay: boolean;
+}
+
+const DELAY_MS = 300;
+
+function getDelay(settings: Settings) {
+  return settings.use300msDelay ? DELAY_MS : 0;
+}
+
+const previewCards = {
+  classicalProportion: {
+    href: 'https://en.wikipedia.org/wiki/Proportion_(architecture)',
+    title: 'Classical proportion',
+    summary:
+      'A compact reference for ratios, page blocks, and the calm geometry that still shapes editorial layouts.',
+    artwork: 'linear-gradient(135deg, #efe5d3 0%, #d9c7a5 48%, #b88b4a 100%)',
+  },
+  opticalSizing: {
+    href: 'https://en.wikipedia.org/wiki/Optical_size',
+    title: 'Optical sizing',
+    summary:
+      'Type tuned for its rendered size keeps counters open, joins sturdy, and rhythm readable at small scales.',
+    artwork: 'linear-gradient(135deg, #dbeafe 0%, #bfdbfe 48%, #60a5fa 100%)',
+  },
+  newspaperSystems: {
+    href: 'https://en.wikipedia.org/wiki/Newspaper_design',
+    title: 'Newspaper systems',
+    summary:
+      'Narrow columns and tightly controlled measures make wrapped inline anchors especially easy to inspect.',
+    artwork: 'linear-gradient(135deg, #e5e7eb 0%, #d1d5db 52%, #9ca3af 100%)',
+  },
+  marginAlignment: {
+    href: 'https://en.wikipedia.org/wiki/Hanging_punctuation',
+    title: 'Optical margin alignment',
+    summary:
+      'Hanging punctuation keeps the text edge visually straight even when commas and quotes sit outside the block.',
+    artwork: 'linear-gradient(135deg, #fce7f3 0%, #fbcfe8 52%, #f472b6 100%)',
+  },
+  captionRhythm: {
+    href: 'https://en.wikipedia.org/wiki/Grid_(graphic_design)',
+    title: 'Caption rhythm',
+    summary:
+      'Captions and asides often contain the longest inline references in a layout, which makes them a useful wrap case.',
+    artwork: 'linear-gradient(135deg, #dcfce7 0%, #bbf7d0 48%, #4ade80 100%)',
+  },
+  joinedFragments: {
+    href: 'https://en.wikipedia.org/wiki/Line_wrap_and_word_wrap',
+    title: 'Joined fragments',
+    summary:
+      'Two neighboring inline references should still track the hovered line even when they meet at punctuation.',
+    artwork: 'linear-gradient(135deg, #ede9fe 0%, #ddd6fe 48%, #8b5cf6 100%)',
+  },
+  pairedReferences: {
+    href: 'https://en.wikipedia.org/wiki/Microtypography',
+    title: 'Paired references',
+    summary:
+      'This case helps inspect how a second link behaves when it starts exactly where another wrapped trigger ends.',
+    artwork: 'linear-gradient(135deg, #fef3c7 0%, #fde68a 52%, #f59e0b 100%)',
+  },
+} as const;
+
+export default function InlinePositioningExperiment() {
+  return (
+    <div className={styles.Experiment}>
+      <section className={styles.Section}>
+        <p className={styles.SectionLabel}>Preview Cards</p>
+        <p className={styles.Paragraph}>
+          Editors still bounce between{' '}
+          <PreviewCardLink {...previewCards.classicalProportion}>
+            classical proportion
+          </PreviewCardLink>
+          , <PreviewCardLink {...previewCards.opticalSizing}>optical sizing</PreviewCardLink>, and{' '}
+          <PreviewCardLink {...previewCards.newspaperSystems}>
+            newspaper systems that deliberately wrap across several carefully measured lines
+          </PreviewCardLink>
+          . They also compare{' '}
+          <PreviewCardLink {...previewCards.marginAlignment}>
+            optical margin alignment
+          </PreviewCardLink>{' '}
+          with{' '}
+          <PreviewCardLink {...previewCards.captionRhythm}>
+            caption rhythms that keep long annotations moving into the next line
+          </PreviewCardLink>
+          , while slash-joined references like{' '}
+          <PreviewCardLink {...previewCards.joinedFragments}>
+            joined inline fragments that want to wrap awkwardly
+          </PreviewCardLink>
+          /
+          <PreviewCardLink {...previewCards.pairedReferences}>
+            paired references that continue immediately after the slash
+          </PreviewCardLink>{' '}
+          make it easier to inspect conjoining inline cases.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+interface PreviewCardLinkProps {
+  href: string;
+  title: string;
+  summary: string;
+  artwork: string;
+  children: React.ReactNode;
+}
+
+function PreviewCardLink(props: PreviewCardLinkProps) {
+  const { settings } = useExperimentSettings<Settings>();
+  const { href, title, summary, artwork, children } = props;
+  const delay = getDelay(settings);
+
+  return (
+    <PreviewCard.Root>
+      <PreviewCard.Trigger className={styles.Link} closeDelay={delay} delay={delay} href={href}>
+        {children}
+      </PreviewCard.Trigger>
+      <PreviewCard.Portal>
+        <PreviewCard.Positioner sideOffset={8}>
+          <PreviewCard.Popup className={styles.PreviewPopup}>
+            <PreviewCard.Arrow className={styles.Arrow}>
+              <ArrowSvg />
+            </PreviewCard.Arrow>
+            <div className={styles.Artwork} style={{ background: artwork }}>
+              <span className={styles.ArtworkLabel}>{title}</span>
+            </div>
+            <div className={styles.CardBody}>
+              <p className={styles.CardTitle}>{title}</p>
+              <p className={styles.Summary}>{summary}</p>
+            </div>
+          </PreviewCard.Popup>
+        </PreviewCard.Positioner>
+      </PreviewCard.Portal>
+    </PreviewCard.Root>
+  );
+}
+
+function ArrowSvg(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg width="20" height="10" viewBox="0 0 20 10" fill="none" {...props}>
+      <path
+        d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
+        className={styles.ArrowFill}
+      />
+      <path
+        d="M8.99542 1.85876C9.75604 1.17425 10.9106 1.17422 11.6713 1.85878L16.5281 6.22989C17.0789 6.72568 17.7938 7.00001 18.5349 7.00001L15.89 7L11.0023 2.60207C10.622 2.2598 10.0447 2.2598 9.66436 2.60207L4.77734 7L2.13171 7.00001C2.87284 7.00001 3.58774 6.72568 4.13861 6.22989L8.99542 1.85876Z"
+        className={styles.ArrowOuterStroke}
+      />
+      <path
+        d="M10.3333 3.34539L5.47654 7.71648C4.55842 8.54279 3.36693 9 2.13172 9H0V8H2.13172C3.11989 8 4.07308 7.63423 4.80758 6.97318L9.66437 2.60207C10.0447 2.25979 10.622 2.2598 11.0023 2.60207L15.8591 6.97318C16.5936 7.63423 17.5468 8 18.5349 8H20V9H18.5349C17.2998 9 16.1083 8.54278 15.1901 7.71648L10.3333 3.34539Z"
+        className={styles.ArrowInnerStroke}
+      />
+    </svg>
+  );
+}
+
+export const settingsMetadata: SettingsMetadata<Settings> = {
+  use300msDelay: {
+    type: 'boolean',
+    label: 'Use 300ms delay',
+    default: false,
+  },
+};

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { afterEach, expect } from 'vitest';
 import * as React from 'react';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { screen, waitFor } from '@mui/internal-test-utils';
@@ -341,6 +341,13 @@ describe('<PreviewCard.Positioner />', () => {
   });
 
   describe.skipIf(isJSDOM)('multiline inline trigger', () => {
+    afterEach(() => {
+      window.scrollTo(0, 0);
+      document.documentElement.style.height = '';
+      document.body.style.height = '';
+      document.body.style.margin = '';
+    });
+
     it('positions the popup relative to the hovered line of a multiline trigger', async () => {
       const { user } = await render(
         <div>
@@ -396,6 +403,72 @@ describe('<PreviewCard.Positioner />', () => {
         expect(positionerY).to.be.closeTo(expectedY, 2);
 
         // x-coordinate should also be relative to where we hovered on the second line
+        expect(positionerX).to.be.greaterThanOrEqual(secondLineRect.left - 10);
+        expect(positionerX).to.be.lessThanOrEqual(secondLineRect.right + 10);
+      });
+    });
+
+    it('keeps the popup aligned after page scroll', async () => {
+      document.documentElement.style.height = '4000px';
+      document.body.style.height = '4000px';
+      document.body.style.margin = '0';
+
+      const { user } = await render(
+        <div>
+          <div style={{ height: 1200 }} />
+          <PreviewCard.Root>
+            <PreviewCard.Trigger
+              delay={0}
+              data-testid="trigger"
+              style={{ display: 'inline', width: 100, lineHeight: 20 }}
+            >
+              This is a long text that will wrap across multiple lines in the trigger element
+            </PreviewCard.Trigger>
+            <PreviewCard.Portal>
+              <PreviewCard.Positioner data-testid="positioner" side="bottom" sideOffset={5}>
+                <PreviewCard.Popup style={{ width: 80, height: 40 }}>
+                  Preview Content
+                </PreviewCard.Popup>
+              </PreviewCard.Positioner>
+            </PreviewCard.Portal>
+          </PreviewCard.Root>
+          <div style={{ height: 1200 }} />
+        </div>,
+      );
+
+      window.scrollTo(0, 1000);
+
+      await waitFor(() => {
+        expect(window.scrollY).toBe(1000);
+      });
+
+      const trigger = screen.getByTestId('trigger');
+      const triggerRects = trigger.getClientRects();
+
+      expect(triggerRects.length).to.be.greaterThan(1);
+
+      const secondLineRect = triggerRects[1];
+      const secondLineCenterX = secondLineRect.left + secondLineRect.width / 2;
+      const secondLineCenterY = secondLineRect.top + secondLineRect.height / 2;
+
+      await user.pointer([
+        { target: document.body },
+        {
+          target: trigger,
+          coords: { clientX: secondLineCenterX, clientY: secondLineCenterY },
+        },
+      ]);
+
+      const positioner = screen.getByTestId('positioner');
+      await waitFor(() => {
+        expect(positioner).toBeVisible();
+      });
+
+      const expectedY = secondLineRect.bottom + 5;
+
+      await waitFor(() => {
+        const { x: positionerX, y: positionerY } = positioner.getBoundingClientRect();
+        expect(positionerY).to.be.closeTo(expectedY, 2);
         expect(positionerX).to.be.greaterThanOrEqual(secondLineRect.left - 10);
         expect(positionerX).to.be.lessThanOrEqual(secondLineRect.right + 10);
       });

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -11,6 +11,46 @@ const Trigger = React.forwardRef(function Trigger(
   return <PreviewCard.Trigger {...props} ref={ref} render={<div />} />;
 });
 
+type RectLike = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+};
+
+function mockClientRects(element: Element, rects: RectLike[]) {
+  const left = Math.min(...rects.map((rect) => rect.left));
+  const top = Math.min(...rects.map((rect) => rect.top));
+  const right = Math.max(...rects.map((rect) => rect.right));
+  const bottom = Math.max(...rects.map((rect) => rect.bottom));
+  const boundingRect = DOMRect.fromRect({
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
+  });
+
+  Object.defineProperty(element, 'getClientRects', {
+    configurable: true,
+    value: () =>
+      rects.map((rect) =>
+        DOMRect.fromRect({
+          x: rect.left,
+          y: rect.top,
+          width: rect.width,
+          height: rect.height,
+        }),
+      ),
+  });
+
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => boundingRect,
+  });
+}
+
 describe('<PreviewCard.Positioner />', () => {
   const { render } = createRenderer();
 
@@ -297,6 +337,252 @@ describe('<PreviewCard.Positioner />', () => {
     const positioner = screen.getByTestId('positioner');
     await waitFor(() => {
       expect(positioner.style.transform).toBe('');
+    });
+  });
+
+  describe.skipIf(isJSDOM)('multiline inline trigger', () => {
+    it('positions the popup relative to the hovered line of a multiline trigger', async () => {
+      const { user } = await render(
+        <div>
+          <PreviewCard.Root>
+            <PreviewCard.Trigger
+              delay={0}
+              data-testid="trigger"
+              style={{ display: 'inline', width: 100, lineHeight: 20 }}
+            >
+              This is a long text that will wrap across multiple lines in the trigger element
+            </PreviewCard.Trigger>
+            <PreviewCard.Portal>
+              <PreviewCard.Positioner data-testid="positioner" side="bottom" sideOffset={5}>
+                <PreviewCard.Popup style={{ width: 80, height: 40 }}>
+                  Preview Content
+                </PreviewCard.Popup>
+              </PreviewCard.Positioner>
+            </PreviewCard.Portal>
+          </PreviewCard.Root>
+        </div>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      const triggerRects = trigger.getClientRects();
+
+      expect(triggerRects.length).to.be.greaterThan(1);
+
+      // Enter over the second line so opening on hover uses the correct inline rect.
+      const secondLineRect = triggerRects[1];
+      const secondLineCenterX = secondLineRect.left + secondLineRect.width / 2;
+      const secondLineCenterY = secondLineRect.top + secondLineRect.height / 2;
+
+      await user.pointer([
+        { target: document.body },
+        {
+          target: trigger,
+          coords: { clientX: secondLineCenterX, clientY: secondLineCenterY },
+        },
+      ]);
+
+      const positioner = screen.getByTestId('positioner');
+      await waitFor(() => {
+        expect(positioner).toBeVisible();
+      });
+
+      // The positioner should be positioned relative to the second line,
+      // not the first line or the bounding client rect.
+      // y-coordinate should be close to the second line's bottom + sideOffset
+      const expectedY = secondLineRect.bottom + 5;
+
+      await waitFor(() => {
+        const { x: positionerX, y: positionerY } = positioner.getBoundingClientRect();
+        expect(positionerY).to.be.closeTo(expectedY, 2);
+
+        // x-coordinate should also be relative to where we hovered on the second line
+        expect(positionerX).to.be.greaterThanOrEqual(secondLineRect.left - 10);
+        expect(positionerX).to.be.lessThanOrEqual(secondLineRect.right + 10);
+      });
+    });
+
+    it('positions the popup relative to the side-aligned rect when open is controlled', async () => {
+      const sideOffset = 5;
+      const inlinePopupHeight = 40;
+
+      await render(
+        <div>
+          <PreviewCard.Root open>
+            <PreviewCard.Trigger
+              delay={0}
+              data-testid="trigger"
+              style={{ display: 'inline', width: 100, lineHeight: 20 }}
+            >
+              This is a long text that will wrap across multiple lines in the trigger element
+            </PreviewCard.Trigger>
+            <PreviewCard.Portal>
+              <PreviewCard.Positioner
+                data-testid="positioner"
+                side="bottom"
+                sideOffset={sideOffset}
+              >
+                <PreviewCard.Popup style={{ width: 80, height: inlinePopupHeight }}>
+                  Preview Content
+                </PreviewCard.Popup>
+              </PreviewCard.Positioner>
+            </PreviewCard.Portal>
+          </PreviewCard.Root>
+        </div>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      const triggerRects = trigger.getClientRects();
+
+      expect(triggerRects.length).to.be.greaterThan(1);
+
+      const targetRect = triggerRects[triggerRects.length - 1];
+      const expectedY = targetRect.bottom + sideOffset;
+
+      await waitFor(() => {
+        const positioner = screen.getByTestId('positioner');
+        expect(positioner).toBeVisible();
+
+        const { x: positionerX, y: positionerY } = positioner.getBoundingClientRect();
+        expect(positionerY).to.be.closeTo(expectedY, 2);
+        expect(positionerX).to.be.greaterThanOrEqual(targetRect.left - 10);
+        expect(positionerX).to.be.lessThanOrEqual(targetRect.right + 10);
+      });
+    });
+
+    it('ignores stale hovered coords when a controlled trigger switch reuses the popup', async () => {
+      function Test() {
+        const [open, setOpen] = React.useState(false);
+        const [triggerId, setTriggerId] = React.useState<string | null>(null);
+
+        return (
+          <div>
+            <PreviewCard.Root
+              open={open}
+              triggerId={triggerId}
+              onOpenChange={(nextOpen, eventDetails) => {
+                setOpen(nextOpen);
+                setTriggerId(eventDetails.trigger?.id ?? null);
+              }}
+            >
+              <PreviewCard.Trigger
+                href="#"
+                id="trigger-1"
+                data-testid="trigger-1"
+                delay={0}
+                style={{ display: 'inline' }}
+              >
+                Trigger 1
+              </PreviewCard.Trigger>
+              <PreviewCard.Trigger
+                href="#"
+                id="trigger-2"
+                data-testid="trigger-2"
+                delay={0}
+                style={{ display: 'inline' }}
+              >
+                Trigger 2
+              </PreviewCard.Trigger>
+              <PreviewCard.Portal>
+                <PreviewCard.Positioner data-testid="positioner" side="bottom" sideOffset={5}>
+                  <PreviewCard.Popup style={{ width: 80, height: 40 }}>
+                    Preview Content
+                  </PreviewCard.Popup>
+                </PreviewCard.Positioner>
+              </PreviewCard.Portal>
+            </PreviewCard.Root>
+
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(true);
+                setTriggerId('trigger-2');
+              }}
+            >
+              Switch
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+      const trigger1 = screen.getByTestId('trigger-1');
+      const trigger2 = screen.getByTestId('trigger-2');
+
+      mockClientRects(trigger1, [
+        { left: 180, top: 0, right: 220, bottom: 10, width: 40, height: 10 },
+        { left: 100, top: 20, right: 160, bottom: 30, width: 60, height: 10 },
+      ]);
+      mockClientRects(trigger2, [
+        { left: 180, top: 100, right: 220, bottom: 110, width: 40, height: 10 },
+        { left: 100, top: 120, right: 160, bottom: 130, width: 60, height: 10 },
+      ]);
+
+      await user.pointer([
+        { target: document.body },
+        { target: trigger1, coords: { clientX: 200, clientY: 5 } },
+      ]);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('positioner')).toBeVisible();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Switch' }));
+
+      await waitFor(() => {
+        const { x: positionerX, y: positionerY } = screen
+          .getByTestId('positioner')
+          .getBoundingClientRect();
+
+        expect(positionerY).to.be.closeTo(135, 2);
+        expect(positionerX).to.be.greaterThanOrEqual(90);
+        expect(positionerX).to.be.lessThanOrEqual(170);
+      });
+    });
+
+    it('positions the popup relative to the side-aligned rect when opened via focus', async () => {
+      const sideOffset = 5;
+      const inlinePopupHeight = 40;
+      const { user } = await render(
+        <div>
+          <PreviewCard.Root>
+            <PreviewCard.Trigger
+              delay={0}
+              data-testid="trigger"
+              tabIndex={0}
+              style={{ display: 'inline', width: 100, lineHeight: 20 }}
+            >
+              This is a long text that will wrap across multiple lines in the trigger element
+            </PreviewCard.Trigger>
+            <PreviewCard.Portal>
+              <PreviewCard.Positioner data-testid="positioner" side="top" sideOffset={sideOffset}>
+                <PreviewCard.Popup style={{ width: 80, height: inlinePopupHeight }}>
+                  Preview Content
+                </PreviewCard.Popup>
+              </PreviewCard.Positioner>
+            </PreviewCard.Portal>
+          </PreviewCard.Root>
+        </div>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      const triggerRects = trigger.getClientRects();
+
+      expect(triggerRects.length).to.be.greaterThan(1);
+
+      const targetRect = triggerRects[0];
+      const expectedY = targetRect.top - inlinePopupHeight - sideOffset;
+
+      await user.tab();
+
+      await waitFor(() => {
+        const positioner = screen.getByTestId('positioner');
+        expect(positioner).toBeVisible();
+
+        const { x: positionerX, y: positionerY } = positioner.getBoundingClientRect();
+        expect(positionerY).to.be.closeTo(expectedY, 2);
+        expect(positionerX).to.be.greaterThanOrEqual(targetRect.left - 10);
+        expect(positionerX).to.be.lessThanOrEqual(targetRect.right + 10);
+      });
     });
   });
 });

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -350,6 +350,7 @@ describe('<PreviewCard.Positioner />', () => {
 
   describe.skipIf(isJSDOM)('multiline inline trigger', () => {
     afterEach(() => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
       window.scrollTo(0, 0);
       document.documentElement.style.height = '';
       document.body.style.height = '';
@@ -521,6 +522,82 @@ describe('<PreviewCard.Positioner />', () => {
 
       await user.pointer([
         { target: document.body },
+        {
+          target: trigger,
+          coords: {
+            clientX: secondLineRect.left + secondLineRect.width / 2,
+            clientY: secondLineRect.top + secondLineRect.height / 2,
+          },
+        },
+      ]);
+
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, secondLineRect.bottom + 5);
+      });
+    });
+
+    it('re-anchors to a newly entered line while reopening during close transition', async () => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+      const style = `
+        @keyframes preview-card-inline-reentry-close-transition {
+          from { opacity: 1; }
+          to { opacity: 0.01; }
+        }
+        [data-testid="popup"][data-ending-style] {
+          animation: preview-card-inline-reentry-close-transition 50ms linear forwards;
+        }
+      `;
+
+      const { user } = await render(
+        <React.Fragment>
+          <style>{style}</style>
+          <div style={multilineWrapperStyle}>
+            <PreviewCard.Root>
+              <PreviewCard.Trigger delay={0} data-testid="trigger" style={multilineTriggerStyle}>
+                This is a long text that will wrap across multiple lines in the trigger element
+              </PreviewCard.Trigger>
+              <PreviewCard.Portal>
+                <PreviewCard.Positioner data-testid="positioner" side="bottom" sideOffset={5}>
+                  <PreviewCard.Popup data-testid="popup" style={{ width: 80, height: 40 }}>
+                    Preview Content
+                  </PreviewCard.Popup>
+                </PreviewCard.Positioner>
+              </PreviewCard.Portal>
+            </PreviewCard.Root>
+          </div>
+        </React.Fragment>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      const triggerRects = trigger.getClientRects();
+
+      expect(triggerRects.length).toBeGreaterThan(2);
+
+      const firstLineRect = triggerRects[0];
+      const secondLineRect = triggerRects[1];
+
+      await user.pointer([
+        { target: document.body },
+        {
+          target: trigger,
+          coords: {
+            clientX: firstLineRect.left + firstLineRect.width / 2,
+            clientY: firstLineRect.top + firstLineRect.height / 2,
+          },
+        },
+      ]);
+
+      const positioner = screen.getByTestId('positioner');
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, firstLineRect.bottom + 5);
+      });
+
+      await user.pointer([{ target: document.body, coords: { clientX: 300, clientY: 300 } }]);
+      await waitFor(() => {
+        expect(screen.getByTestId('popup')).toHaveAttribute('data-ending-style');
+      });
+
+      await user.pointer([
         {
           target: trigger,
           coords: {

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -20,6 +20,14 @@ type RectLike = {
   height: number;
 };
 
+const multilineWrapperStyle = { width: 140 };
+const multilineTriggerStyle = { display: 'inline', lineHeight: '20px' };
+
+function expectWithin(actual: number, expected: number, tolerance = 2) {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(tolerance);
+}
+
+// These overrides are safe because each test renders fresh trigger elements before mocking them.
 function mockClientRects(element: Element, rects: RectLike[]) {
   const left = Math.min(...rects.map((rect) => rect.left));
   const top = Math.min(...rects.map((rect) => rect.top));
@@ -350,13 +358,9 @@ describe('<PreviewCard.Positioner />', () => {
 
     it('positions the popup relative to the hovered line of a multiline trigger', async () => {
       const { user } = await render(
-        <div>
+        <div style={multilineWrapperStyle}>
           <PreviewCard.Root>
-            <PreviewCard.Trigger
-              delay={0}
-              data-testid="trigger"
-              style={{ display: 'inline', width: 100, lineHeight: 20 }}
-            >
+            <PreviewCard.Trigger delay={0} data-testid="trigger" style={multilineTriggerStyle}>
               This is a long text that will wrap across multiple lines in the trigger element
             </PreviewCard.Trigger>
             <PreviewCard.Portal>
@@ -373,7 +377,7 @@ describe('<PreviewCard.Positioner />', () => {
       const trigger = screen.getByTestId('trigger');
       const triggerRects = trigger.getClientRects();
 
-      expect(triggerRects.length).to.be.greaterThan(1);
+      expect(triggerRects.length).toBeGreaterThan(2);
 
       // Enter over the second line so opening on hover uses the correct inline rect.
       const secondLineRect = triggerRects[1];
@@ -399,13 +403,13 @@ describe('<PreviewCard.Positioner />', () => {
       const expectedY = secondLineRect.bottom + 5;
 
       await waitFor(() => {
-        const { x: positionerX, y: positionerY } = positioner.getBoundingClientRect();
-        expect(positionerY).to.be.closeTo(expectedY, 2);
-
-        // x-coordinate should also be relative to where we hovered on the second line
-        expect(positionerX).to.be.greaterThanOrEqual(secondLineRect.left - 10);
-        expect(positionerX).to.be.lessThanOrEqual(secondLineRect.right + 10);
+        expectWithin(positioner.getBoundingClientRect().y, expectedY);
       });
+
+      // x-coordinate should also be relative to where we hovered on the second line
+      const { x: positionerX } = positioner.getBoundingClientRect();
+      expect(positionerX).toBeGreaterThanOrEqual(secondLineRect.left - 10);
+      expect(positionerX).toBeLessThanOrEqual(secondLineRect.right + 10);
     });
 
     it('keeps the popup aligned after page scroll', async () => {
@@ -416,22 +420,20 @@ describe('<PreviewCard.Positioner />', () => {
       const { user } = await render(
         <div>
           <div style={{ height: 1200 }} />
-          <PreviewCard.Root>
-            <PreviewCard.Trigger
-              delay={0}
-              data-testid="trigger"
-              style={{ display: 'inline', width: 100, lineHeight: 20 }}
-            >
-              This is a long text that will wrap across multiple lines in the trigger element
-            </PreviewCard.Trigger>
-            <PreviewCard.Portal>
-              <PreviewCard.Positioner data-testid="positioner" side="bottom" sideOffset={5}>
-                <PreviewCard.Popup style={{ width: 80, height: 40 }}>
-                  Preview Content
-                </PreviewCard.Popup>
-              </PreviewCard.Positioner>
-            </PreviewCard.Portal>
-          </PreviewCard.Root>
+          <div style={multilineWrapperStyle}>
+            <PreviewCard.Root>
+              <PreviewCard.Trigger delay={0} data-testid="trigger" style={multilineTriggerStyle}>
+                This is a long text that will wrap across multiple lines in the trigger element
+              </PreviewCard.Trigger>
+              <PreviewCard.Portal>
+                <PreviewCard.Positioner data-testid="positioner" side="bottom" sideOffset={5}>
+                  <PreviewCard.Popup style={{ width: 80, height: 40 }}>
+                    Preview Content
+                  </PreviewCard.Popup>
+                </PreviewCard.Positioner>
+              </PreviewCard.Portal>
+            </PreviewCard.Root>
+          </div>
           <div style={{ height: 1200 }} />
         </div>,
       );
@@ -445,7 +447,7 @@ describe('<PreviewCard.Positioner />', () => {
       const trigger = screen.getByTestId('trigger');
       const triggerRects = trigger.getClientRects();
 
-      expect(triggerRects.length).to.be.greaterThan(1);
+      expect(triggerRects.length).toBeGreaterThan(1);
 
       const secondLineRect = triggerRects[1];
       const secondLineCenterX = secondLineRect.left + secondLineRect.width / 2;
@@ -467,11 +469,12 @@ describe('<PreviewCard.Positioner />', () => {
       const expectedY = secondLineRect.bottom + 5;
 
       await waitFor(() => {
-        const { x: positionerX, y: positionerY } = positioner.getBoundingClientRect();
-        expect(positionerY).to.be.closeTo(expectedY, 2);
-        expect(positionerX).to.be.greaterThanOrEqual(secondLineRect.left - 10);
-        expect(positionerX).to.be.lessThanOrEqual(secondLineRect.right + 10);
+        expectWithin(positioner.getBoundingClientRect().y, expectedY);
       });
+
+      const { x: positionerX } = positioner.getBoundingClientRect();
+      expect(positionerX).toBeGreaterThanOrEqual(secondLineRect.left - 10);
+      expect(positionerX).toBeLessThanOrEqual(secondLineRect.right + 10);
     });
 
     it('positions the popup relative to the side-aligned rect when open is controlled', async () => {
@@ -479,13 +482,9 @@ describe('<PreviewCard.Positioner />', () => {
       const inlinePopupHeight = 40;
 
       await render(
-        <div>
+        <div style={multilineWrapperStyle}>
           <PreviewCard.Root open>
-            <PreviewCard.Trigger
-              delay={0}
-              data-testid="trigger"
-              style={{ display: 'inline', width: 100, lineHeight: 20 }}
-            >
+            <PreviewCard.Trigger delay={0} data-testid="trigger" style={multilineTriggerStyle}>
               This is a long text that will wrap across multiple lines in the trigger element
             </PreviewCard.Trigger>
             <PreviewCard.Portal>
@@ -506,20 +505,23 @@ describe('<PreviewCard.Positioner />', () => {
       const trigger = screen.getByTestId('trigger');
       const triggerRects = trigger.getClientRects();
 
-      expect(triggerRects.length).to.be.greaterThan(1);
+      expect(triggerRects.length).toBeGreaterThan(1);
 
       const targetRect = triggerRects[triggerRects.length - 1];
       const expectedY = targetRect.bottom + sideOffset;
+      const positioner = screen.getByTestId('positioner');
 
       await waitFor(() => {
-        const positioner = screen.getByTestId('positioner');
         expect(positioner).toBeVisible();
-
-        const { x: positionerX, y: positionerY } = positioner.getBoundingClientRect();
-        expect(positionerY).to.be.closeTo(expectedY, 2);
-        expect(positionerX).to.be.greaterThanOrEqual(targetRect.left - 10);
-        expect(positionerX).to.be.lessThanOrEqual(targetRect.right + 10);
       });
+
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, expectedY);
+      });
+
+      const { x: positionerX } = positioner.getBoundingClientRect();
+      expect(positionerX).toBeGreaterThanOrEqual(targetRect.left - 10);
+      expect(positionerX).toBeLessThanOrEqual(targetRect.right + 10);
     });
 
     it('ignores stale hovered coords when a controlled trigger switch reuses the popup', async () => {
@@ -601,14 +603,77 @@ describe('<PreviewCard.Positioner />', () => {
 
       await user.click(screen.getByRole('button', { name: 'Switch' }));
 
-      await waitFor(() => {
-        const { x: positionerX, y: positionerY } = screen
-          .getByTestId('positioner')
-          .getBoundingClientRect();
+      const positioner = screen.getByTestId('positioner');
 
-        expect(positionerY).to.be.closeTo(135, 2);
-        expect(positionerX).to.be.greaterThanOrEqual(90);
-        expect(positionerX).to.be.lessThanOrEqual(170);
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, 135);
+      });
+
+      const { x: positionerX } = positioner.getBoundingClientRect();
+      expect(positionerX).toBeGreaterThanOrEqual(90);
+      expect(positionerX).toBeLessThanOrEqual(170);
+    });
+
+    it('uses the hovered line with a custom anchor in a clipped keepMounted portal', async () => {
+      document.body.style.margin = '0';
+
+      function Test() {
+        const triggerRef = React.useRef<HTMLAnchorElement | null>(null);
+        const [portalContainer, setPortalContainer] = React.useState<HTMLDivElement | null>(null);
+
+        return (
+          <div>
+            <div ref={setPortalContainer} data-testid="portal-container" />
+            <PreviewCard.Root>
+              <PreviewCard.Trigger ref={triggerRef} href="#" delay={0} data-testid="trigger">
+                Trigger
+              </PreviewCard.Trigger>
+              <PreviewCard.Portal keepMounted container={portalContainer}>
+                <PreviewCard.Positioner
+                  anchor={triggerRef}
+                  collisionBoundary={{ x: 0, y: 0, width: 300, height: 120 }}
+                  collisionPadding={0}
+                  data-testid="positioner"
+                  side="bottom"
+                  sideOffset={5}
+                >
+                  <PreviewCard.Popup style={{ width: 80, height: 40 }}>
+                    Preview Content
+                  </PreviewCard.Popup>
+                </PreviewCard.Positioner>
+              </PreviewCard.Portal>
+            </PreviewCard.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+      const portalContainer = screen.getByTestId('portal-container');
+      const trigger = screen.getByTestId('trigger');
+      const positioner = screen.getByTestId('positioner');
+
+      mockClientRects(trigger, [
+        { left: 180, top: 80, right: 220, bottom: 90, width: 40, height: 10 },
+        { left: 0, top: 100, right: 60, bottom: 110, width: 60, height: 10 },
+      ]);
+
+      await user.pointer([
+        { target: document.body },
+        { target: trigger, coords: { clientX: 30, clientY: 105 } },
+      ]);
+
+      await waitFor(() => {
+        expect(positioner).toBeVisible();
+      });
+
+      expect(portalContainer).toContainElement(positioner);
+
+      await waitFor(() => {
+        expect(positioner).toHaveAttribute('data-side', 'top');
+      });
+
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, 55);
       });
     });
 
@@ -616,13 +681,13 @@ describe('<PreviewCard.Positioner />', () => {
       const sideOffset = 5;
       const inlinePopupHeight = 40;
       const { user } = await render(
-        <div>
+        <div style={{ ...multilineWrapperStyle, marginTop: 100 }}>
           <PreviewCard.Root>
             <PreviewCard.Trigger
               delay={0}
               data-testid="trigger"
               tabIndex={0}
-              style={{ display: 'inline', width: 100, lineHeight: 20 }}
+              style={multilineTriggerStyle}
             >
               This is a long text that will wrap across multiple lines in the trigger element
             </PreviewCard.Trigger>
@@ -640,22 +705,26 @@ describe('<PreviewCard.Positioner />', () => {
       const trigger = screen.getByTestId('trigger');
       const triggerRects = trigger.getClientRects();
 
-      expect(triggerRects.length).to.be.greaterThan(1);
+      expect(triggerRects.length).toBeGreaterThan(1);
 
       const targetRect = triggerRects[0];
       const expectedY = targetRect.top - inlinePopupHeight - sideOffset;
 
       await user.tab();
 
-      await waitFor(() => {
-        const positioner = screen.getByTestId('positioner');
-        expect(positioner).toBeVisible();
+      const positioner = screen.getByTestId('positioner');
 
-        const { x: positionerX, y: positionerY } = positioner.getBoundingClientRect();
-        expect(positionerY).to.be.closeTo(expectedY, 2);
-        expect(positionerX).to.be.greaterThanOrEqual(targetRect.left - 10);
-        expect(positionerX).to.be.lessThanOrEqual(targetRect.right + 10);
+      await waitFor(() => {
+        expect(positioner).toBeVisible();
       });
+
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, expectedY);
+      });
+
+      const { x: positionerX } = positioner.getBoundingClientRect();
+      expect(positionerX).toBeGreaterThanOrEqual(targetRect.left - 10);
+      expect(positionerX).toBeLessThanOrEqual(targetRect.right + 10);
     });
   });
 });

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -524,6 +524,100 @@ describe('<PreviewCard.Positioner />', () => {
       expect(positionerX).toBeLessThanOrEqual(targetRect.right + 10);
     });
 
+    it('clears hovered-line coords after close before controlled reopen of the same trigger', async () => {
+      const sideOffset = 5;
+
+      function Test() {
+        const [open, setOpen] = React.useState(false);
+        const [triggerId, setTriggerId] = React.useState<string | null>(null);
+
+        return (
+          <div style={multilineWrapperStyle}>
+            <PreviewCard.Root
+              open={open}
+              triggerId={triggerId}
+              onOpenChange={(nextOpen, eventDetails) => {
+                setOpen(nextOpen);
+                setTriggerId(eventDetails.trigger?.id ?? null);
+              }}
+            >
+              <PreviewCard.Trigger
+                delay={0}
+                data-testid="trigger"
+                id="trigger"
+                style={multilineTriggerStyle}
+              >
+                This is a long text that will wrap across multiple lines in the trigger element
+              </PreviewCard.Trigger>
+              <PreviewCard.Portal keepMounted>
+                <PreviewCard.Positioner
+                  data-testid="positioner"
+                  side="bottom"
+                  sideOffset={sideOffset}
+                >
+                  <PreviewCard.Popup style={{ width: 80, height: 40 }}>
+                    Preview Content
+                  </PreviewCard.Popup>
+                </PreviewCard.Positioner>
+              </PreviewCard.Portal>
+            </PreviewCard.Root>
+
+            <button
+              type="button"
+              onClick={() => {
+                setTriggerId('trigger');
+                setOpen(true);
+              }}
+            >
+              Open
+            </button>
+            <button type="button" onClick={() => setOpen(false)}>
+              Close
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+      const trigger = screen.getByTestId('trigger');
+      const triggerRects = trigger.getClientRects();
+
+      expect(triggerRects.length).toBeGreaterThan(2);
+
+      const secondLineRect = triggerRects[1];
+      await user.pointer([
+        { target: document.body },
+        {
+          target: trigger,
+          coords: {
+            clientX: secondLineRect.left + secondLineRect.width / 2,
+            clientY: secondLineRect.top + secondLineRect.height / 2,
+          },
+        },
+      ]);
+
+      const positioner = screen.getByTestId('positioner');
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, secondLineRect.bottom + sideOffset);
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Close' }));
+      await waitFor(() => {
+        expect(positioner).toHaveAttribute('hidden');
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Open' }));
+
+      const targetRect = triggerRects[triggerRects.length - 1];
+      await waitFor(() => {
+        expect(positioner).toBeVisible();
+      });
+
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, targetRect.bottom + sideOffset);
+      });
+    });
+
     it('ignores stale hovered coords when a controlled trigger switch reuses the popup', async () => {
       function Test() {
         const [open, setOpen] = React.useState(false);
@@ -725,6 +819,81 @@ describe('<PreviewCard.Positioner />', () => {
       const { x: positionerX } = positioner.getBoundingClientRect();
       expect(positionerX).toBeGreaterThanOrEqual(targetRect.left - 10);
       expect(positionerX).toBeLessThanOrEqual(targetRect.right + 10);
+    });
+
+    it('clears hovered-line coords when opened via focus', async () => {
+      const sideOffset = 5;
+      const inlinePopupHeight = 40;
+
+      function Test() {
+        const [open, setOpen] = React.useState(false);
+        const [triggerId, setTriggerId] = React.useState<string | null>(null);
+
+        return (
+          <div style={{ ...multilineWrapperStyle, marginTop: 100 }}>
+            <PreviewCard.Root
+              open={open}
+              triggerId={triggerId}
+              onOpenChange={(nextOpen, eventDetails) => {
+                if (eventDetails.reason === 'trigger-focus') {
+                  setOpen(nextOpen);
+                  setTriggerId(eventDetails.trigger?.id ?? null);
+                }
+              }}
+            >
+              <PreviewCard.Trigger
+                delay={0}
+                data-testid="trigger"
+                id="trigger"
+                tabIndex={0}
+                style={multilineTriggerStyle}
+              >
+                This is a long text that will wrap across multiple lines in the trigger element
+              </PreviewCard.Trigger>
+              <PreviewCard.Portal keepMounted>
+                <PreviewCard.Positioner data-testid="positioner" side="top" sideOffset={sideOffset}>
+                  <PreviewCard.Popup style={{ width: 80, height: inlinePopupHeight }}>
+                    Preview Content
+                  </PreviewCard.Popup>
+                </PreviewCard.Positioner>
+              </PreviewCard.Portal>
+            </PreviewCard.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+      const trigger = screen.getByTestId('trigger');
+      const triggerRects = trigger.getClientRects();
+
+      expect(triggerRects.length).toBeGreaterThan(2);
+
+      const secondLineRect = triggerRects[1];
+      await user.pointer([
+        { target: document.body },
+        {
+          target: trigger,
+          coords: {
+            clientX: secondLineRect.left + secondLineRect.width / 2,
+            clientY: secondLineRect.top + secondLineRect.height / 2,
+          },
+        },
+      ]);
+
+      const targetRect = triggerRects[0];
+      const expectedY = targetRect.top - inlinePopupHeight - sideOffset;
+
+      await user.tab();
+
+      const positioner = screen.getByTestId('positioner');
+
+      await waitFor(() => {
+        expect(positioner).toBeVisible();
+      });
+
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, expectedY);
+      });
     });
   });
 });

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -413,6 +413,63 @@ describe('<PreviewCard.Positioner />', () => {
       expect(positionerX).toBeLessThanOrEqual(secondLineRect.right + 10);
     });
 
+    it('uses the latest hovered line when opening after a delay', async () => {
+      const { user } = await render(
+        <div style={multilineWrapperStyle}>
+          <PreviewCard.Root>
+            <PreviewCard.Trigger delay={100} data-testid="trigger" style={multilineTriggerStyle}>
+              This is a long text that will wrap across multiple lines in the trigger element
+            </PreviewCard.Trigger>
+            <PreviewCard.Portal>
+              <PreviewCard.Positioner data-testid="positioner" side="bottom" sideOffset={5}>
+                <PreviewCard.Popup style={{ width: 80, height: 40 }}>
+                  Preview Content
+                </PreviewCard.Popup>
+              </PreviewCard.Positioner>
+            </PreviewCard.Portal>
+          </PreviewCard.Root>
+        </div>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      const triggerRects = trigger.getClientRects();
+
+      expect(triggerRects.length).toBeGreaterThan(2);
+
+      const firstLineRect = triggerRects[0];
+      const secondLineRect = triggerRects[1];
+
+      await user.pointer([
+        { target: document.body },
+        {
+          target: trigger,
+          coords: {
+            clientX: firstLineRect.left + firstLineRect.width / 2,
+            clientY: firstLineRect.top + firstLineRect.height / 2,
+          },
+        },
+      ]);
+
+      await user.pointer([
+        {
+          target: trigger,
+          coords: {
+            clientX: secondLineRect.left + secondLineRect.width / 2,
+            clientY: secondLineRect.top + secondLineRect.height / 2,
+          },
+        },
+      ]);
+
+      const positioner = await screen.findByTestId('positioner');
+      await waitFor(() => {
+        expect(positioner).toBeVisible();
+      });
+
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, secondLineRect.bottom + 5);
+      });
+    });
+
     it('keeps the popup aligned after page scroll', async () => {
       document.documentElement.style.height = '4000px';
       document.body.style.height = '4000px';

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -477,6 +477,64 @@ describe('<PreviewCard.Positioner />', () => {
       expect(positionerX).toBeLessThanOrEqual(secondLineRect.right + 10);
     });
 
+    it('re-anchors to a newly entered line while already open', async () => {
+      const { user } = await render(
+        <div style={multilineWrapperStyle}>
+          <PreviewCard.Root>
+            <PreviewCard.Trigger delay={0} data-testid="trigger" style={multilineTriggerStyle}>
+              This is a long text that will wrap across multiple lines in the trigger element
+            </PreviewCard.Trigger>
+            <PreviewCard.Portal>
+              <PreviewCard.Positioner data-testid="positioner" side="bottom" sideOffset={5}>
+                <PreviewCard.Popup style={{ width: 80, height: 40 }}>
+                  Preview Content
+                </PreviewCard.Popup>
+              </PreviewCard.Positioner>
+            </PreviewCard.Portal>
+          </PreviewCard.Root>
+        </div>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      const triggerRects = trigger.getClientRects();
+
+      expect(triggerRects.length).toBeGreaterThan(2);
+
+      const firstLineRect = triggerRects[0];
+      const secondLineRect = triggerRects[1];
+
+      await user.pointer([
+        { target: document.body },
+        {
+          target: trigger,
+          coords: {
+            clientX: firstLineRect.left + firstLineRect.width / 2,
+            clientY: firstLineRect.top + firstLineRect.height / 2,
+          },
+        },
+      ]);
+
+      const positioner = screen.getByTestId('positioner');
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, firstLineRect.bottom + 5);
+      });
+
+      await user.pointer([
+        { target: document.body },
+        {
+          target: trigger,
+          coords: {
+            clientX: secondLineRect.left + secondLineRect.width / 2,
+            clientY: secondLineRect.top + secondLineRect.height / 2,
+          },
+        },
+      ]);
+
+      await waitFor(() => {
+        expectWithin(positioner.getBoundingClientRect().y, secondLineRect.bottom + 5);
+      });
+    });
+
     it('positions the popup relative to the side-aligned rect when open is controlled', async () => {
       const sideOffset = 5;
       const inlinePopupHeight = 40;

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
@@ -14,6 +14,7 @@ import { usePreviewCardPortalContext } from '../portal/PreviewCardPortalContext'
 import { POPUP_COLLISION_AVOIDANCE } from '../../internals/constants';
 import { adaptiveOrigin } from '../../utils/adaptiveOriginMiddleware';
 import { usePositioner } from '../../utils/usePositioner';
+import { createInlineMiddleware } from '../../utils/popups';
 
 /**
  * Positions the popup against the trigger.
@@ -54,6 +55,7 @@ export const PreviewCardPositioner = React.forwardRef(function PreviewCardPositi
   const instantType = store.useState('instantType');
   const transitionStatus = store.useState('transitionStatus');
   const hasViewport = store.useState('hasViewport');
+  const inlineRectCoordsRef = store.context.inlineRectCoordsRef;
 
   const positioning = useAnchorPositioning({
     anchor,
@@ -73,6 +75,7 @@ export const PreviewCardPositioner = React.forwardRef(function PreviewCardPositi
     nodeId,
     collisionAvoidance,
     adaptiveOrigin: hasViewport ? adaptiveOrigin : undefined,
+    inline: createInlineMiddleware(inlineRectCoordsRef),
   });
 
   const state: PreviewCardPositionerState = {

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
@@ -78,17 +78,13 @@ export const PreviewCardPositioner = React.forwardRef(function PreviewCardPositi
     adaptiveOrigin: hasViewport ? adaptiveOrigin : undefined,
     inline: createInlineMiddleware(inlineRectCoordsRef),
   });
+  const updatePosition = positioning.update;
 
   useIsoLayoutEffect(() => {
-    const update = positioning.update;
-    store.context.inlineRectPositionerUpdateRef.current = update;
-
-    return () => {
-      if (store.context.inlineRectPositionerUpdateRef.current === update) {
-        store.context.inlineRectPositionerUpdateRef.current = undefined;
-      }
-    };
-  }, [store, positioning.update]);
+    if (open && mounted) {
+      updatePosition();
+    }
+  }, [open, mounted, updatePosition]);
 
   const state: PreviewCardPositionerState = {
     open,

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { usePreviewCardRootContext } from '../root/PreviewCardContext';
 import { PreviewCardPositionerContext } from './PreviewCardPositionerContext';
 import { FloatingNode, useFloatingNodeId } from '../../floating-ui-react';
@@ -77,6 +78,17 @@ export const PreviewCardPositioner = React.forwardRef(function PreviewCardPositi
     adaptiveOrigin: hasViewport ? adaptiveOrigin : undefined,
     inline: createInlineMiddleware(inlineRectCoordsRef),
   });
+
+  useIsoLayoutEffect(() => {
+    const update = positioning.update;
+    store.context.inlineRectPositionerUpdateRef.current = update;
+
+    return () => {
+      if (store.context.inlineRectPositionerUpdateRef.current === update) {
+        store.context.inlineRectPositionerUpdateRef.current = undefined;
+      }
+    };
+  }, [store, positioning.update]);
 
   const state: PreviewCardPositionerState = {
     open,

--- a/packages/react/src/preview-card/root/PreviewCardRoot.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.tsx
@@ -64,7 +64,9 @@ function PreviewCardRootComponent<Payload>(props: PreviewCardRoot.Props<Payload>
   const payload = store.useState('payload') as Payload | undefined;
 
   useImplicitActiveTrigger(store);
-  const { forceUnmount } = useOpenStateTransitions(open, store);
+  const { forceUnmount } = useOpenStateTransitions(open, store, () => {
+    store.context.inlineRectCoordsRef.current = undefined;
+  });
 
   useIsoLayoutEffect(() => {
     if (open) {

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -4,6 +4,7 @@ import { createSelector, ReactStore } from '@base-ui/utils/store';
 import {
   createPopupFloatingRootContext,
   createInitialPopupStoreState,
+  InlineRectCoords,
   PopupStoreContext,
   popupStoreSelectors,
   PopupStoreState,
@@ -22,6 +23,7 @@ export type State<Payload> = PopupStoreState<Payload> & {
 
 export type Context = PopupStoreContext<PreviewCardRoot.ChangeEventDetails> & {
   closeDelayRef: React.RefObject<number>;
+  inlineRectCoordsRef: React.MutableRefObject<InlineRectCoords | undefined>;
 };
 
 const selectors = {
@@ -52,6 +54,7 @@ export class PreviewCardStore<Payload> extends ReactStore<
         onOpenChangeComplete: undefined,
         triggerElements,
         closeDelayRef: { current: CLOSE_DELAY },
+        inlineRectCoordsRef: { current: undefined },
       },
       selectors,
     );

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -83,7 +83,14 @@ export class PreviewCardStore<Payload> extends ReactStore<
     }
 
     const event = eventDetails.event;
-    if (nextOpen && isHover && eventDetails.trigger && 'clientX' in event && 'clientY' in event) {
+    if (
+      nextOpen &&
+      isHover &&
+      eventDetails.trigger &&
+      'clientX' in event &&
+      'clientY' in event &&
+      this.context.inlineRectCoordsRef.current?.element !== eventDetails.trigger
+    ) {
       updateInlineRectCoords(
         this.context.inlineRectCoordsRef,
         eventDetails.trigger,

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -10,6 +10,7 @@ import {
   PopupStoreState,
   PopupTriggerMap,
   setOpenTriggerState,
+  updateInlineRectCoords,
   usePopupStore,
 } from '../../utils/popups';
 import { type PreviewCardRoot } from '../root/PreviewCardRoot';
@@ -24,7 +25,6 @@ export type State<Payload> = PopupStoreState<Payload> & {
 export type Context = PopupStoreContext<PreviewCardRoot.ChangeEventDetails> & {
   closeDelayRef: React.RefObject<number>;
   inlineRectCoordsRef: React.MutableRefObject<InlineRectCoords | undefined>;
-  inlineRectPositionerUpdateRef: React.MutableRefObject<(() => void) | undefined>;
 };
 
 const selectors = {
@@ -56,7 +56,6 @@ export class PreviewCardStore<Payload> extends ReactStore<
         triggerElements,
         closeDelayRef: { current: CLOSE_DELAY },
         inlineRectCoordsRef: { current: undefined },
-        inlineRectPositionerUpdateRef: { current: undefined },
       },
       selectors,
     );
@@ -81,6 +80,16 @@ export class PreviewCardStore<Payload> extends ReactStore<
 
     if (eventDetails.isCanceled) {
       return;
+    }
+
+    const event = eventDetails.event;
+    if (nextOpen && isHover && eventDetails.trigger && 'clientX' in event && 'clientY' in event) {
+      updateInlineRectCoords(
+        this.context.inlineRectCoordsRef,
+        eventDetails.trigger,
+        event.clientX,
+        event.clientY,
+      );
     }
 
     this.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -24,6 +24,7 @@ export type State<Payload> = PopupStoreState<Payload> & {
 export type Context = PopupStoreContext<PreviewCardRoot.ChangeEventDetails> & {
   closeDelayRef: React.RefObject<number>;
   inlineRectCoordsRef: React.MutableRefObject<InlineRectCoords | undefined>;
+  inlineRectPositionerUpdateRef: React.MutableRefObject<(() => void) | undefined>;
 };
 
 const selectors = {
@@ -55,6 +56,7 @@ export class PreviewCardStore<Payload> extends ReactStore<
         triggerElements,
         closeDelayRef: { current: CLOSE_DELAY },
         inlineRectCoordsRef: { current: undefined },
+        inlineRectPositionerUpdateRef: { current: undefined },
       },
       selectors,
     );

--- a/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
+++ b/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
@@ -8,7 +8,7 @@ import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useBaseUiId } from '../../internals/useBaseUiId';
 import { PreviewCardHandle } from '../store/PreviewCardHandle';
-import { useTriggerDataForwarding } from '../../utils/popups';
+import { getInlineRectTriggerProps, useTriggerDataForwarding } from '../../utils/popups';
 import { CLOSE_DELAY, OPEN_DELAY } from '../utils/constants';
 import { safePolygon, useFocus, useHoverReferenceInteraction } from '../../floating-ui-react';
 
@@ -46,6 +46,7 @@ export const PreviewCardTrigger = fastComponentRef(function PreviewCardTrigger(
   const isTriggerActive = store.useState('isTriggerActive', thisTriggerId);
   const isOpenedByThisTrigger = store.useState('isOpenedByTrigger', thisTriggerId);
   const floatingRootContext = store.useState('floatingRootContext');
+  const inlineRectCoordsRef = store.context.inlineRectCoordsRef;
 
   const triggerElementRef = React.useRef<Element | null>(null);
 
@@ -82,6 +83,10 @@ export const PreviewCardTrigger = fastComponentRef(function PreviewCardTrigger(
   const state: PreviewCardTriggerState = { open: isOpenedByThisTrigger };
 
   const rootTriggerProps = store.useState('triggerProps', isMountedByThisTrigger);
+  const inlineRectTriggerProps = getInlineRectTriggerProps(
+    inlineRectCoordsRef,
+    isOpenedByThisTrigger,
+  );
 
   const element = useRenderElement('a', componentProps, {
     state,
@@ -90,6 +95,7 @@ export const PreviewCardTrigger = fastComponentRef(function PreviewCardTrigger(
       hoverProps,
       focusProps.reference,
       rootTriggerProps,
+      inlineRectTriggerProps,
       { id: thisTriggerId },
       elementProps,
     ],

--- a/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
+++ b/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
@@ -8,7 +8,11 @@ import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useBaseUiId } from '../../internals/useBaseUiId';
 import { PreviewCardHandle } from '../store/PreviewCardHandle';
-import { getInlineRectTriggerProps, useTriggerDataForwarding } from '../../utils/popups';
+import {
+  getInlineRectTriggerProps,
+  updateInlineRectCoords,
+  useTriggerDataForwarding,
+} from '../../utils/popups';
 import { CLOSE_DELAY, OPEN_DELAY } from '../utils/constants';
 import { safePolygon, useFocus, useHoverReferenceInteraction } from '../../floating-ui-react';
 
@@ -41,6 +45,7 @@ export const PreviewCardTrigger = fastComponentRef(function PreviewCardTrigger(
       'Base UI: <PreviewCard.Trigger> must be either used within a <PreviewCard.Root> component or provided with a handle.',
     );
   }
+  const previewCardStore = store;
 
   const thisTriggerId = useBaseUiId(idProp);
   const isTriggerActive = store.useState('isTriggerActive', thisTriggerId);
@@ -67,6 +72,34 @@ export const PreviewCardTrigger = fastComponentRef(function PreviewCardTrigger(
       store.context.closeDelayRef.current = closeDelayWithDefault;
     }
   }, [store, isMountedByThisTrigger, closeDelayWithDefault]);
+
+  useIsoLayoutEffect(() => {
+    const element = triggerElementRef.current;
+
+    if (!element) {
+      return undefined;
+    }
+
+    function handleMouseOver(event: Event) {
+      const mouseEvent = event as MouseEvent;
+      const nextCoords = updateInlineRectCoords(
+        inlineRectCoordsRef,
+        element as Element,
+        mouseEvent.clientX,
+        mouseEvent.clientY,
+      );
+
+      if (nextCoords && previewCardStore.select('mounted')) {
+        previewCardStore.context.inlineRectPositionerUpdateRef.current?.();
+      }
+    }
+
+    element.addEventListener('mouseover', handleMouseOver, true);
+
+    return () => {
+      element.removeEventListener('mouseover', handleMouseOver, true);
+    };
+  }, [inlineRectCoordsRef, previewCardStore]);
 
   const hoverProps = useHoverReferenceInteraction(floatingRootContext, {
     mouseOnly: true,

--- a/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
+++ b/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
@@ -8,11 +8,7 @@ import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useBaseUiId } from '../../internals/useBaseUiId';
 import { PreviewCardHandle } from '../store/PreviewCardHandle';
-import {
-  getInlineRectTriggerProps,
-  updateInlineRectCoords,
-  useTriggerDataForwarding,
-} from '../../utils/popups';
+import { getInlineRectTriggerProps, useTriggerDataForwarding } from '../../utils/popups';
 import { CLOSE_DELAY, OPEN_DELAY } from '../utils/constants';
 import { safePolygon, useFocus, useHoverReferenceInteraction } from '../../floating-ui-react';
 
@@ -45,7 +41,6 @@ export const PreviewCardTrigger = fastComponentRef(function PreviewCardTrigger(
       'Base UI: <PreviewCard.Trigger> must be either used within a <PreviewCard.Root> component or provided with a handle.',
     );
   }
-  const previewCardStore = store;
 
   const thisTriggerId = useBaseUiId(idProp);
   const isTriggerActive = store.useState('isTriggerActive', thisTriggerId);
@@ -72,34 +67,6 @@ export const PreviewCardTrigger = fastComponentRef(function PreviewCardTrigger(
       store.context.closeDelayRef.current = closeDelayWithDefault;
     }
   }, [store, isMountedByThisTrigger, closeDelayWithDefault]);
-
-  useIsoLayoutEffect(() => {
-    const element = triggerElementRef.current;
-
-    if (!element) {
-      return undefined;
-    }
-
-    function handleMouseOver(event: Event) {
-      const mouseEvent = event as MouseEvent;
-      const nextCoords = updateInlineRectCoords(
-        inlineRectCoordsRef,
-        element as Element,
-        mouseEvent.clientX,
-        mouseEvent.clientY,
-      );
-
-      if (nextCoords && previewCardStore.select('mounted')) {
-        previewCardStore.context.inlineRectPositionerUpdateRef.current?.();
-      }
-    }
-
-    element.addEventListener('mouseover', handleMouseOver, true);
-
-    return () => {
-      element.removeEventListener('mouseover', handleMouseOver, true);
-    };
-  }, [inlineRectCoordsRef, previewCardStore]);
 
   const hoverProps = useHoverReferenceInteraction(floatingRootContext, {
     mouseOnly: true,

--- a/packages/react/src/utils/popups/index.ts
+++ b/packages/react/src/utils/popups/index.ts
@@ -1,3 +1,4 @@
+export * from './inlineRect';
 export * from './popupStoreUtils';
 export * from './popupTriggerMap';
 export * from './store';

--- a/packages/react/src/utils/popups/inlineRect.test.ts
+++ b/packages/react/src/utils/popups/inlineRect.test.ts
@@ -1,11 +1,7 @@
 import type * as React from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { InlineRectCoords } from './inlineRect';
-import {
-  createInlineMiddleware,
-  getInlineRectHoverCoords,
-  getInlineRectTriggerProps,
-} from './inlineRect';
+import { createInlineMiddleware, getInlineRectTriggerProps } from './inlineRect';
 
 type RectLike = {
   left: number;
@@ -40,49 +36,44 @@ function createMiddlewareState(
   trigger: Element,
   placement: string,
   referenceRect: { x: number; y: number; width: number; height: number },
+  options?: {
+    getElementRects?: (rect: RectLike & { x: number; y: number }) => {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+    };
+  },
 ) {
+  const floatingRect = { x: 0, y: 0, width: 20, height: 10 };
+
   return {
     placement,
-    elements: { reference: trigger },
+    strategy: 'absolute',
+    elements: { reference: trigger, floating: document.createElement('div') },
     rects: {
       reference: referenceRect,
-      floating: { x: 0, y: 0, width: 20, height: 10 },
+      floating: floatingRect,
+    },
+    platform: {
+      getElementRects: async ({
+        reference,
+      }: {
+        reference: { getBoundingClientRect(): RectLike & { x: number; y: number } };
+      }) => {
+        const rect = reference.getBoundingClientRect();
+        return {
+          reference: options?.getElementRects
+            ? options.getElementRects(rect)
+            : { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+          floating: floatingRect,
+        };
+      },
     },
   };
 }
 
-function createInlineRectState(
-  element: Element,
-  coords: InlineRectCoords,
-): React.RefObject<InlineRectCoords | undefined> {
-  return {
-    current: { ...coords, element },
-  };
-}
-
 describe('inlineRect', () => {
-  it('returns undefined when there is only one rect', () => {
-    const rects: RectLike[] = [{ left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 }];
-    const trigger = createTrigger(rects);
-    const event = createMouseEvent(trigger, 5, 5);
-
-    expect(getInlineRectHoverCoords(event)).toBeUndefined();
-  });
-
-  it('returns the closest rect coordinates for multi-line elements', () => {
-    const rects: RectLike[] = [
-      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
-      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
-    ];
-    const trigger = createTrigger(rects);
-    const event = createMouseEvent(trigger, 5, 25);
-
-    expect(getInlineRectHoverCoords(event)).toEqual({
-      x: 5,
-      y: 25,
-    });
-  });
-
   it('clears stored coords on focus', () => {
     const trigger = document.createElement('span');
     const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
@@ -94,59 +85,54 @@ describe('inlineRect', () => {
     expect(coordsRef.current).toBeUndefined();
   });
 
-  it('updates stored coords on mouse move while closed', () => {
-    const rects: RectLike[] = [
+  it('stores undefined when the trigger does not wrap', () => {
+    const trigger = createTrigger([
       { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
-      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
-    ];
-    const trigger = createTrigger(rects);
-    const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = { current: undefined };
-    const event = createMouseEvent(trigger, 5, 25);
+    ]);
+    const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
+      current: { x: 1, y: 1, element: trigger },
+    };
 
-    getInlineRectTriggerProps(coordsRef, false).onMouseMove?.(event);
+    getInlineRectTriggerProps(coordsRef, false).onMouseMove?.(createMouseEvent(trigger, 5, 5));
 
-    expect(coordsRef.current).toEqual({ x: 5, y: 25, element: trigger });
+    expect(coordsRef.current).toBeUndefined();
   });
 
-  it('updates stored coords on mouse enter before opening', () => {
-    const rects: RectLike[] = [
+  it('updates stored coords on mouse move while closed', () => {
+    const trigger = createTrigger([
       { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
       { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
-    ];
-    const trigger = createTrigger(rects);
+    ]);
     const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = { current: undefined };
-    const event = createMouseEvent(trigger, 5, 25);
 
-    getInlineRectTriggerProps(coordsRef, true).onMouseEnter?.(event);
+    getInlineRectTriggerProps(coordsRef, false).onMouseMove?.(createMouseEvent(trigger, 5, 25));
 
     expect(coordsRef.current).toEqual({ x: 5, y: 25, element: trigger });
   });
 
   it('does not update stored coords on mouse move while open', () => {
-    const rects: RectLike[] = [
+    const trigger = createTrigger([
       { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
       { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
-    ];
-    const trigger = createTrigger(rects);
+    ]);
     const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
       current: { x: 1, y: 1, element: trigger },
     };
-    const event = createMouseEvent(trigger, 5, 25);
 
-    getInlineRectTriggerProps(coordsRef, true).onMouseMove?.(event);
+    getInlineRectTriggerProps(coordsRef, true).onMouseMove?.(createMouseEvent(trigger, 5, 25));
 
     expect(coordsRef.current).toEqual({ x: 1, y: 1, element: trigger });
   });
 
-  it('creates inline middleware rects that offset based on stored coords', async () => {
+  it('creates inline middleware rects from the hovered line', async () => {
     const rects: RectLike[] = [
       { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
       { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
     ];
     const trigger = createTrigger(rects);
-    const coordsRef = createInlineRectState(trigger, { x: 2, y: 23 });
-
-    const middleware = createInlineMiddleware(coordsRef);
+    const middleware = createInlineMiddleware({
+      current: { x: 2, y: 23, element: trigger },
+    });
 
     expect(
       await middleware.fn?.(
@@ -167,29 +153,14 @@ describe('inlineRect', () => {
     });
   });
 
-  it('uses the side-aligned rect when coords are missing', async () => {
-    const rects: RectLike[] = [{ left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 }];
-    const trigger = createTrigger(rects);
-    const coordsRef: React.RefObject<InlineRectCoords | undefined> = { current: undefined };
-
-    const middleware = createInlineMiddleware(coordsRef);
-
-    expect(
-      await middleware.fn?.(
-        createMiddlewareState(trigger, 'bottom', { x: 0, y: 0, width: 10, height: 10 }) as never,
-      ),
-    ).toEqual({});
-  });
-
-  it('uses edge-aligned rects for right placements', async () => {
+  it('uses the edge-aligned rect for right placements', async () => {
     const rects: RectLike[] = [
       { left: 0, top: 0, right: 40, bottom: 10, width: 40, height: 10 },
       { left: 0, top: 20, right: 60, bottom: 30, width: 60, height: 10 },
       { left: 20, top: 40, right: 60, bottom: 50, width: 40, height: 10 },
     ];
     const trigger = createTrigger(rects);
-    const coordsRef: React.RefObject<InlineRectCoords | undefined> = { current: undefined };
-    const middleware = createInlineMiddleware(coordsRef);
+    const middleware = createInlineMiddleware({ current: undefined });
 
     expect(
       await middleware.fn?.(
@@ -210,35 +181,6 @@ describe('inlineRect', () => {
     });
   });
 
-  it('uses edge-aligned rects for left placements', async () => {
-    const rects: RectLike[] = [
-      { left: 20, top: 0, right: 60, bottom: 10, width: 40, height: 10 },
-      { left: 0, top: 20, right: 40, bottom: 30, width: 40, height: 10 },
-      { left: 0, top: 40, right: 60, bottom: 50, width: 60, height: 10 },
-    ];
-    const trigger = createTrigger(rects);
-    const coordsRef: React.RefObject<InlineRectCoords | undefined> = { current: undefined };
-    const middleware = createInlineMiddleware(coordsRef);
-
-    expect(
-      await middleware.fn?.(
-        createMiddlewareState(trigger, 'left', { x: 0, y: 0, width: 60, height: 50 }) as never,
-      ),
-    ).toEqual({
-      reset: {
-        rects: {
-          reference: {
-            x: rects[1].left,
-            y: rects[1].top,
-            width: rects[0].right - rects[1].left,
-            height: rects[2].bottom - rects[1].top,
-          },
-          floating: { x: 0, y: 0, width: 20, height: 10 },
-        },
-      },
-    });
-  });
-
   it('ignores stored coords from a different element', async () => {
     const previousTrigger = createTrigger([
       { left: 80, top: 0, right: 120, bottom: 10, width: 40, height: 10 },
@@ -249,8 +191,9 @@ describe('inlineRect', () => {
       { left: 0, top: 120, right: 60, bottom: 130, width: 60, height: 10 },
     ];
     const trigger = createTrigger(rects);
-    const coordsRef = createInlineRectState(previousTrigger, { x: 100, y: 5 });
-    const middleware = createInlineMiddleware(coordsRef);
+    const middleware = createInlineMiddleware({
+      current: { x: 100, y: 5, element: previousTrigger },
+    });
 
     expect(
       await middleware.fn?.(
@@ -269,5 +212,45 @@ describe('inlineRect', () => {
         },
       },
     });
+  });
+
+  it('converts client-space inline rects through the positioning platform', async () => {
+    const rects: RectLike[] = [
+      { left: 140, top: 300, right: 180, bottom: 310, width: 40, height: 10 },
+      { left: 100, top: 320, right: 180, bottom: 330, width: 80, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+    const getElementRects = vi.fn((rect: RectLike & { x: number; y: number }) => ({
+      x: rect.x,
+      y: rect.y + 500,
+      width: rect.width,
+      height: rect.height,
+    }));
+    const middleware = createInlineMiddleware({ current: undefined });
+
+    expect(
+      await middleware.fn?.(
+        createMiddlewareState(
+          trigger,
+          'top',
+          { x: 100, y: 800, width: 80, height: 30 },
+          { getElementRects },
+        ) as never,
+      ),
+    ).toEqual({
+      reset: {
+        rects: {
+          reference: {
+            x: rects[0].left,
+            y: rects[0].top + 500,
+            width: rects[0].width,
+            height: rects[1].bottom - rects[0].top,
+          },
+          floating: { x: 0, y: 0, width: 20, height: 10 },
+        },
+      },
+    });
+
+    expect(getElementRects).toHaveBeenCalledOnce();
   });
 });

--- a/packages/react/src/utils/popups/inlineRect.test.ts
+++ b/packages/react/src/utils/popups/inlineRect.test.ts
@@ -1,0 +1,273 @@
+import type * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import type { InlineRectCoords } from './inlineRect';
+import {
+  createInlineMiddleware,
+  getInlineRectHoverCoords,
+  getInlineRectTriggerProps,
+} from './inlineRect';
+
+type RectLike = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+};
+
+function createTrigger(rects: RectLike[]) {
+  const trigger = document.createElement('span');
+  Object.defineProperty(trigger, 'getClientRects', {
+    value: () => rects,
+  });
+  return trigger;
+}
+
+function createMouseEvent(
+  trigger: Element,
+  clientX: number,
+  clientY: number,
+): React.MouseEvent<Element> {
+  return {
+    currentTarget: trigger,
+    clientX,
+    clientY,
+  } as unknown as React.MouseEvent<Element>;
+}
+
+function createMiddlewareState(
+  trigger: Element,
+  placement: string,
+  referenceRect: { x: number; y: number; width: number; height: number },
+) {
+  return {
+    placement,
+    elements: { reference: trigger },
+    rects: {
+      reference: referenceRect,
+      floating: { x: 0, y: 0, width: 20, height: 10 },
+    },
+  };
+}
+
+function createInlineRectState(
+  element: Element,
+  coords: InlineRectCoords,
+): React.RefObject<InlineRectCoords | undefined> {
+  return {
+    current: { ...coords, element },
+  };
+}
+
+describe('inlineRect', () => {
+  it('returns undefined when there is only one rect', () => {
+    const rects: RectLike[] = [{ left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 }];
+    const trigger = createTrigger(rects);
+    const event = createMouseEvent(trigger, 5, 5);
+
+    expect(getInlineRectHoverCoords(event)).toBeUndefined();
+  });
+
+  it('returns the closest rect coordinates for multi-line elements', () => {
+    const rects: RectLike[] = [
+      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
+      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+    const event = createMouseEvent(trigger, 5, 25);
+
+    expect(getInlineRectHoverCoords(event)).toEqual({
+      x: 5,
+      y: 25,
+    });
+  });
+
+  it('clears stored coords on focus', () => {
+    const trigger = document.createElement('span');
+    const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
+      current: { x: 2, y: 3, element: trigger },
+    };
+
+    getInlineRectTriggerProps(coordsRef, false).onFocus?.({} as React.FocusEvent<Element>);
+
+    expect(coordsRef.current).toBeUndefined();
+  });
+
+  it('updates stored coords on mouse move while closed', () => {
+    const rects: RectLike[] = [
+      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
+      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+    const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = { current: undefined };
+    const event = createMouseEvent(trigger, 5, 25);
+
+    getInlineRectTriggerProps(coordsRef, false).onMouseMove?.(event);
+
+    expect(coordsRef.current).toEqual({ x: 5, y: 25, element: trigger });
+  });
+
+  it('updates stored coords on mouse enter before opening', () => {
+    const rects: RectLike[] = [
+      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
+      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+    const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = { current: undefined };
+    const event = createMouseEvent(trigger, 5, 25);
+
+    getInlineRectTriggerProps(coordsRef, true).onMouseEnter?.(event);
+
+    expect(coordsRef.current).toEqual({ x: 5, y: 25, element: trigger });
+  });
+
+  it('does not update stored coords on mouse move while open', () => {
+    const rects: RectLike[] = [
+      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
+      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+    const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
+      current: { x: 1, y: 1, element: trigger },
+    };
+    const event = createMouseEvent(trigger, 5, 25);
+
+    getInlineRectTriggerProps(coordsRef, true).onMouseMove?.(event);
+
+    expect(coordsRef.current).toEqual({ x: 1, y: 1, element: trigger });
+  });
+
+  it('creates inline middleware rects that offset based on stored coords', async () => {
+    const rects: RectLike[] = [
+      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
+      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+    const coordsRef = createInlineRectState(trigger, { x: 2, y: 23 });
+
+    const middleware = createInlineMiddleware(coordsRef);
+
+    expect(
+      await middleware.fn?.(
+        createMiddlewareState(trigger, 'bottom', { x: 0, y: 0, width: 10, height: 10 }) as never,
+      ),
+    ).toEqual({
+      reset: {
+        rects: {
+          reference: {
+            x: rects[1].left,
+            y: rects[0].top,
+            width: rects[1].width,
+            height: rects[1].bottom - rects[0].top,
+          },
+          floating: { x: 0, y: 0, width: 20, height: 10 },
+        },
+      },
+    });
+  });
+
+  it('uses the side-aligned rect when coords are missing', async () => {
+    const rects: RectLike[] = [{ left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 }];
+    const trigger = createTrigger(rects);
+    const coordsRef: React.RefObject<InlineRectCoords | undefined> = { current: undefined };
+
+    const middleware = createInlineMiddleware(coordsRef);
+
+    expect(
+      await middleware.fn?.(
+        createMiddlewareState(trigger, 'bottom', { x: 0, y: 0, width: 10, height: 10 }) as never,
+      ),
+    ).toEqual({});
+  });
+
+  it('uses edge-aligned rects for right placements', async () => {
+    const rects: RectLike[] = [
+      { left: 0, top: 0, right: 40, bottom: 10, width: 40, height: 10 },
+      { left: 0, top: 20, right: 60, bottom: 30, width: 60, height: 10 },
+      { left: 20, top: 40, right: 60, bottom: 50, width: 40, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+    const coordsRef: React.RefObject<InlineRectCoords | undefined> = { current: undefined };
+    const middleware = createInlineMiddleware(coordsRef);
+
+    expect(
+      await middleware.fn?.(
+        createMiddlewareState(trigger, 'right', { x: 0, y: 0, width: 60, height: 50 }) as never,
+      ),
+    ).toEqual({
+      reset: {
+        rects: {
+          reference: {
+            x: rects[0].left,
+            y: rects[1].top,
+            width: rects[1].right - rects[0].left,
+            height: rects[2].bottom - rects[1].top,
+          },
+          floating: { x: 0, y: 0, width: 20, height: 10 },
+        },
+      },
+    });
+  });
+
+  it('uses edge-aligned rects for left placements', async () => {
+    const rects: RectLike[] = [
+      { left: 20, top: 0, right: 60, bottom: 10, width: 40, height: 10 },
+      { left: 0, top: 20, right: 40, bottom: 30, width: 40, height: 10 },
+      { left: 0, top: 40, right: 60, bottom: 50, width: 60, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+    const coordsRef: React.RefObject<InlineRectCoords | undefined> = { current: undefined };
+    const middleware = createInlineMiddleware(coordsRef);
+
+    expect(
+      await middleware.fn?.(
+        createMiddlewareState(trigger, 'left', { x: 0, y: 0, width: 60, height: 50 }) as never,
+      ),
+    ).toEqual({
+      reset: {
+        rects: {
+          reference: {
+            x: rects[1].left,
+            y: rects[1].top,
+            width: rects[0].right - rects[1].left,
+            height: rects[2].bottom - rects[1].top,
+          },
+          floating: { x: 0, y: 0, width: 20, height: 10 },
+        },
+      },
+    });
+  });
+
+  it('ignores stored coords from a different element', async () => {
+    const previousTrigger = createTrigger([
+      { left: 80, top: 0, right: 120, bottom: 10, width: 40, height: 10 },
+      { left: 0, top: 20, right: 60, bottom: 30, width: 60, height: 10 },
+    ]);
+    const rects: RectLike[] = [
+      { left: 80, top: 100, right: 120, bottom: 110, width: 40, height: 10 },
+      { left: 0, top: 120, right: 60, bottom: 130, width: 60, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+    const coordsRef = createInlineRectState(previousTrigger, { x: 100, y: 5 });
+    const middleware = createInlineMiddleware(coordsRef);
+
+    expect(
+      await middleware.fn?.(
+        createMiddlewareState(trigger, 'bottom', { x: 0, y: 100, width: 120, height: 30 }) as never,
+      ),
+    ).toEqual({
+      reset: {
+        rects: {
+          reference: {
+            x: rects[1].left,
+            y: rects[0].top,
+            width: rects[1].width,
+            height: rects[1].bottom - rects[0].top,
+          },
+          floating: { x: 0, y: 0, width: 20, height: 10 },
+        },
+      },
+    });
+  });
+});

--- a/packages/react/src/utils/popups/inlineRect.test.ts
+++ b/packages/react/src/utils/popups/inlineRect.test.ts
@@ -1,7 +1,11 @@
 import type * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import type { InlineRectCoords } from './inlineRect';
-import { createInlineMiddleware, getInlineRectTriggerProps } from './inlineRect';
+import {
+  createInlineMiddleware,
+  getInlineRectTriggerProps,
+  updateInlineRectCoords,
+} from './inlineRect';
 
 type RectLike = {
   left: number;
@@ -140,6 +144,20 @@ describe('inlineRect', () => {
     };
 
     getInlineRectTriggerProps(coordsRef, true).onMouseEnter?.(createMouseEvent(trigger, 5, 25));
+
+    expect(coordsRef.current).toEqual({ x: 5, y: 25, lineIndex: 1, element: trigger });
+  });
+
+  it('updates stored coords from a native mouse event while open', () => {
+    const trigger = createTrigger([
+      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
+      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
+    ]);
+    const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
+      current: { x: 1, y: 1, lineIndex: 0, element: trigger },
+    };
+
+    updateInlineRectCoords(coordsRef, trigger, 5, 25);
 
     expect(coordsRef.current).toEqual({ x: 5, y: 25, lineIndex: 1, element: trigger });
   });

--- a/packages/react/src/utils/popups/inlineRect.test.ts
+++ b/packages/react/src/utils/popups/inlineRect.test.ts
@@ -12,10 +12,10 @@ type RectLike = {
   height: number;
 };
 
-function createTrigger(rects: RectLike[]) {
+function createTrigger(rects: RectLike[] | (() => RectLike[])) {
   const trigger = document.createElement('span');
   Object.defineProperty(trigger, 'getClientRects', {
-    value: () => rects,
+    value: () => (typeof rects === 'function' ? rects() : rects),
   });
   return trigger;
 }
@@ -33,11 +33,14 @@ function createMouseEvent(
 }
 
 function createMiddlewareState(
-  trigger: Element,
+  reference: Element | { getClientRects(): ArrayLike<RectLike>; contextElement?: Element },
   placement: string,
   referenceRect: { x: number; y: number; width: number; height: number },
   options?: {
-    getElementRects?: (rect: RectLike & { x: number; y: number }) => {
+    getElementRects?: (
+      rect: RectLike & { x: number; y: number },
+      contextElement: Element | undefined,
+    ) => {
       x: number;
       y: number;
       width: number;
@@ -50,21 +53,24 @@ function createMiddlewareState(
   return {
     placement,
     strategy: 'absolute',
-    elements: { reference: trigger, floating: document.createElement('div') },
+    elements: { reference, floating: document.createElement('div') },
     rects: {
       reference: referenceRect,
       floating: floatingRect,
     },
     platform: {
       getElementRects: async ({
-        reference,
+        reference: positioningReference,
       }: {
-        reference: { getBoundingClientRect(): RectLike & { x: number; y: number } };
+        reference: {
+          contextElement?: Element;
+          getBoundingClientRect(): RectLike & { x: number; y: number };
+        };
       }) => {
-        const rect = reference.getBoundingClientRect();
+        const rect = positioningReference.getBoundingClientRect();
         return {
           reference: options?.getElementRects
-            ? options.getElementRects(rect)
+            ? options.getElementRects(rect, positioningReference.contextElement)
             : { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
           floating: floatingRect,
         };
@@ -77,7 +83,7 @@ describe('inlineRect', () => {
   it('clears stored coords on focus', () => {
     const trigger = document.createElement('span');
     const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
-      current: { x: 2, y: 3, element: trigger },
+      current: { x: 2, y: 3, lineIndex: undefined, element: trigger },
     };
 
     getInlineRectTriggerProps(coordsRef, false).onFocus?.({} as React.FocusEvent<Element>);
@@ -90,7 +96,7 @@ describe('inlineRect', () => {
       { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
     ]);
     const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
-      current: { x: 1, y: 1, element: trigger },
+      current: { x: 1, y: 1, lineIndex: 0, element: trigger },
     };
 
     getInlineRectTriggerProps(coordsRef, false).onMouseMove?.(createMouseEvent(trigger, 5, 5));
@@ -107,7 +113,7 @@ describe('inlineRect', () => {
 
     getInlineRectTriggerProps(coordsRef, false).onMouseMove?.(createMouseEvent(trigger, 5, 25));
 
-    expect(coordsRef.current).toEqual({ x: 5, y: 25, element: trigger });
+    expect(coordsRef.current).toEqual({ x: 5, y: 25, lineIndex: 1, element: trigger });
   });
 
   it('does not update stored coords on mouse move while open', () => {
@@ -116,22 +122,23 @@ describe('inlineRect', () => {
       { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
     ]);
     const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
-      current: { x: 1, y: 1, element: trigger },
+      current: { x: 1, y: 1, lineIndex: 0, element: trigger },
     };
 
     getInlineRectTriggerProps(coordsRef, true).onMouseMove?.(createMouseEvent(trigger, 5, 25));
 
-    expect(coordsRef.current).toEqual({ x: 1, y: 1, element: trigger });
+    expect(coordsRef.current).toEqual({ x: 1, y: 1, lineIndex: 0, element: trigger });
   });
 
   it('creates inline middleware rects from the hovered line', async () => {
     const rects: RectLike[] = [
-      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
-      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
+      { left: 0, top: 0, right: 80, bottom: 10, width: 80, height: 10 },
+      { left: 0, top: 20, right: 80, bottom: 30, width: 80, height: 10 },
+      { left: 0, top: 40, right: 80, bottom: 50, width: 80, height: 10 },
     ];
     const trigger = createTrigger(rects);
     const middleware = createInlineMiddleware({
-      current: { x: 2, y: 23, element: trigger },
+      current: { x: 2, y: 23, lineIndex: 1, element: trigger },
     });
 
     expect(
@@ -143,9 +150,43 @@ describe('inlineRect', () => {
         rects: {
           reference: {
             x: rects[1].left,
-            y: rects[0].top,
+            y: rects[1].top,
             width: rects[1].width,
-            height: rects[1].bottom - rects[0].top,
+            height: rects[1].height,
+          },
+          floating: { x: 0, y: 0, width: 20, height: 10 },
+        },
+      },
+    });
+  });
+
+  it('reuses the captured line index if client coordinates become stale', async () => {
+    let rects: RectLike[] = [
+      { left: 80, top: 0, right: 120, bottom: 10, width: 40, height: 10 },
+      { left: 0, top: 20, right: 60, bottom: 30, width: 60, height: 10 },
+    ];
+    const trigger = createTrigger(() => rects);
+    const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = { current: undefined };
+
+    getInlineRectTriggerProps(coordsRef, false).onMouseEnter?.(createMouseEvent(trigger, 100, 5));
+
+    rects = [
+      { left: 80, top: 100, right: 120, bottom: 110, width: 40, height: 10 },
+      { left: 0, top: 120, right: 60, bottom: 130, width: 60, height: 10 },
+    ];
+
+    expect(
+      await createInlineMiddleware(coordsRef).fn?.(
+        createMiddlewareState(trigger, 'bottom', { x: 0, y: 100, width: 120, height: 30 }) as never,
+      ),
+    ).toEqual({
+      reset: {
+        rects: {
+          reference: {
+            x: rects[0].left,
+            y: rects[0].top,
+            width: rects[0].width,
+            height: rects[0].height,
           },
           floating: { x: 0, y: 0, width: 20, height: 10 },
         },
@@ -192,7 +233,7 @@ describe('inlineRect', () => {
     ];
     const trigger = createTrigger(rects);
     const middleware = createInlineMiddleware({
-      current: { x: 100, y: 5, element: previousTrigger },
+      current: { x: 100, y: 5, lineIndex: 0, element: previousTrigger },
     });
 
     expect(
@@ -207,6 +248,39 @@ describe('inlineRect', () => {
             y: rects[0].top,
             width: rects[1].width,
             height: rects[1].bottom - rects[0].top,
+          },
+          floating: { x: 0, y: 0, width: 20, height: 10 },
+        },
+      },
+    });
+  });
+
+  it('accepts stored coords from a virtual reference context element', async () => {
+    const rects: RectLike[] = [
+      { left: 80, top: 0, right: 120, bottom: 10, width: 40, height: 10 },
+      { left: 0, top: 20, right: 60, bottom: 30, width: 60, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+    const reference = {
+      contextElement: trigger,
+      getClientRects: () => rects,
+    };
+    const middleware = createInlineMiddleware({
+      current: { x: 100, y: 5, lineIndex: 0, element: trigger },
+    });
+
+    expect(
+      await middleware.fn?.(
+        createMiddlewareState(reference, 'bottom', { x: 0, y: 0, width: 120, height: 30 }) as never,
+      ),
+    ).toEqual({
+      reset: {
+        rects: {
+          reference: {
+            x: rects[0].left,
+            y: rects[0].top,
+            width: rects[0].width,
+            height: rects[0].height,
           },
           floating: { x: 0, y: 0, width: 20, height: 10 },
         },

--- a/packages/react/src/utils/popups/inlineRect.test.ts
+++ b/packages/react/src/utils/popups/inlineRect.test.ts
@@ -130,7 +130,7 @@ describe('inlineRect', () => {
     expect(coordsRef.current).toEqual({ x: 1, y: 1, lineIndex: 0, element: trigger });
   });
 
-  it('does not update stored coords on mouse enter while open', () => {
+  it('updates stored coords on mouse enter while open', () => {
     const trigger = createTrigger([
       { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
       { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
@@ -141,7 +141,7 @@ describe('inlineRect', () => {
 
     getInlineRectTriggerProps(coordsRef, true).onMouseEnter?.(createMouseEvent(trigger, 5, 25));
 
-    expect(coordsRef.current).toEqual({ x: 1, y: 1, lineIndex: 0, element: trigger });
+    expect(coordsRef.current).toEqual({ x: 5, y: 25, lineIndex: 1, element: trigger });
   });
 
   it('creates inline middleware rects from the hovered line', async () => {

--- a/packages/react/src/utils/popups/inlineRect.test.ts
+++ b/packages/react/src/utils/popups/inlineRect.test.ts
@@ -130,6 +130,20 @@ describe('inlineRect', () => {
     expect(coordsRef.current).toEqual({ x: 1, y: 1, lineIndex: 0, element: trigger });
   });
 
+  it('does not update stored coords on mouse enter while open', () => {
+    const trigger = createTrigger([
+      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
+      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
+    ]);
+    const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
+      current: { x: 1, y: 1, lineIndex: 0, element: trigger },
+    };
+
+    getInlineRectTriggerProps(coordsRef, true).onMouseEnter?.(createMouseEvent(trigger, 5, 25));
+
+    expect(coordsRef.current).toEqual({ x: 1, y: 1, lineIndex: 0, element: trigger });
+  });
+
   it('creates inline middleware rects from the hovered line', async () => {
     const rects: RectLike[] = [
       { left: 0, top: 0, right: 80, bottom: 10, width: 80, height: 10 },
@@ -220,6 +234,114 @@ describe('inlineRect', () => {
         },
       },
     });
+  });
+
+  it('uses the edge-aligned rect for left placements', async () => {
+    const rects: RectLike[] = [
+      { left: 20, top: 0, right: 60, bottom: 10, width: 40, height: 10 },
+      { left: 0, top: 20, right: 60, bottom: 30, width: 60, height: 10 },
+      { left: 0, top: 40, right: 40, bottom: 50, width: 40, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+    const middleware = createInlineMiddleware({ current: undefined });
+
+    expect(
+      await middleware.fn?.(
+        createMiddlewareState(trigger, 'left', { x: 0, y: 0, width: 60, height: 50 }) as never,
+      ),
+    ).toEqual({
+      reset: {
+        rects: {
+          reference: {
+            x: rects[1].left,
+            y: rects[1].top,
+            width: rects[1].right - rects[1].left,
+            height: rects[2].bottom - rects[1].top,
+          },
+          floating: { x: 0, y: 0, width: 20, height: 10 },
+        },
+      },
+    });
+  });
+
+  it('uses the fallback rect for disjoint two-line rects when coords miss', async () => {
+    const rects: RectLike[] = [
+      { left: 80, top: 0, right: 120, bottom: 10, width: 40, height: 10 },
+      { left: 0, top: 20, right: 60, bottom: 30, width: 60, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+
+    expect(
+      await createInlineMiddleware({
+        current: { x: 200, y: 200, lineIndex: undefined, element: trigger },
+      }).fn?.(
+        createMiddlewareState(trigger, 'bottom', { x: 80, y: 0, width: 40, height: 30 }) as never,
+      ),
+    ).toEqual({
+      reset: {
+        rects: {
+          reference: {
+            x: rects[1].left,
+            y: rects[0].top,
+            width: rects[0].right - rects[1].left,
+            height: rects[1].bottom - rects[0].top,
+          },
+          floating: { x: 0, y: 0, width: 20, height: 10 },
+        },
+      },
+    });
+  });
+
+  it('does not create inline rects when the reference does not wrap', async () => {
+    const trigger = createTrigger([
+      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
+    ]);
+
+    expect(
+      await createInlineMiddleware({ current: undefined }).fn?.(
+        createMiddlewareState(trigger, 'bottom', { x: 0, y: 0, width: 10, height: 10 }) as never,
+      ),
+    ).toEqual({});
+  });
+
+  it('does not run when the reference has no client rects', async () => {
+    const state = createMiddlewareState(document.createElement('span'), 'bottom', {
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    });
+
+    expect(
+      await createInlineMiddleware({ current: undefined }).fn?.({
+        ...state,
+        elements: {
+          ...state.elements,
+          reference: {},
+        },
+      } as never),
+    ).toEqual({});
+  });
+
+  it('does not reset when the inline rect matches the current reference rect', async () => {
+    const rects: RectLike[] = [
+      { left: 0, top: 0, right: 80, bottom: 10, width: 80, height: 10 },
+      { left: 0, top: 20, right: 80, bottom: 30, width: 80, height: 10 },
+    ];
+    const trigger = createTrigger(rects);
+
+    expect(
+      await createInlineMiddleware({
+        current: { x: 2, y: 23, lineIndex: 1, element: trigger },
+      }).fn?.(
+        createMiddlewareState(trigger, 'bottom', {
+          x: rects[1].left,
+          y: rects[1].top,
+          width: rects[1].width,
+          height: rects[1].height,
+        }) as never,
+      ),
+    ).toEqual({});
   });
 
   it('ignores stored coords from a different element', async () => {

--- a/packages/react/src/utils/popups/inlineRect.ts
+++ b/packages/react/src/utils/popups/inlineRect.ts
@@ -1,0 +1,268 @@
+import * as React from 'react';
+import type { Middleware } from '@floating-ui/react-dom';
+
+export interface InlineRectCoords {
+  /** The x position in viewport coordinates. */
+  x: number;
+  /** The y position in viewport coordinates. */
+  y: number;
+  /** The trigger element whose rects produced these coordinates. */
+  element?: Element | undefined;
+}
+
+interface RectLike {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+interface ClientRectsReference {
+  getClientRects(): ArrayLike<RectLike>;
+}
+
+function copyRect(rect: RectLike): RectLike {
+  return {
+    left: rect.left,
+    top: rect.top,
+    right: rect.right,
+    bottom: rect.bottom,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function toRect(rect: RectLike) {
+  return {
+    x: rect.left,
+    y: rect.top,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function getBoundingRect(rects: readonly RectLike[]) {
+  let left = Number.POSITIVE_INFINITY;
+  let top = Number.POSITIVE_INFINITY;
+  let right = Number.NEGATIVE_INFINITY;
+  let bottom = Number.NEGATIVE_INFINITY;
+
+  for (const rect of rects) {
+    if (rect.left < left) {
+      left = rect.left;
+    }
+
+    if (rect.top < top) {
+      top = rect.top;
+    }
+
+    if (rect.right > right) {
+      right = rect.right;
+    }
+
+    if (rect.bottom > bottom) {
+      bottom = rect.bottom;
+    }
+  }
+
+  return {
+    left,
+    top,
+    right,
+    bottom,
+    width: right - left,
+    height: bottom - top,
+  };
+}
+
+function getRectsByLine(rects: ArrayLike<RectLike>) {
+  const lines: RectLike[] = [];
+  let previousRect: RectLike | undefined;
+
+  for (const rect of Array.from(rects).sort((a, b) => a.top - b.top)) {
+    if (!previousRect || rect.top - previousRect.top > previousRect.height / 2) {
+      lines.push(copyRect(rect));
+    } else {
+      const line = lines[lines.length - 1];
+      line.left = Math.min(line.left, rect.left);
+      line.right = Math.max(line.right, rect.right);
+      line.bottom = Math.max(line.bottom, rect.bottom);
+      line.width = line.right - line.left;
+      line.height = line.bottom - line.top;
+    }
+
+    previousRect = rect;
+  }
+
+  return lines;
+}
+
+function getInlineReferenceRect(
+  reference: ClientRectsReference,
+  placement: string,
+  coords: InlineRectCoords | undefined,
+) {
+  const clientRects = getRectsByLine(reference.getClientRects());
+
+  if (clientRects.length < 2) {
+    return null;
+  }
+
+  const fallback = getBoundingRect(clientRects);
+  const x = coords?.x;
+  const y = coords?.y;
+  const side = placement[0];
+
+  if (
+    clientRects.length === 2 &&
+    clientRects[0].left > clientRects[1].right &&
+    x != null &&
+    y != null
+  ) {
+    return toRect(
+      clientRects.find(
+        (rect) =>
+          x > rect.left - 2 && x < rect.right + 2 && y > rect.top - 2 && y < rect.bottom + 2,
+      ) || fallback,
+    );
+  }
+
+  if (side === 't' || side === 'b') {
+    const firstRect = clientRects[0];
+    const lastRect = clientRects[clientRects.length - 1];
+    const targetRect = side === 't' ? firstRect : lastRect;
+
+    return toRect({
+      left: targetRect.left,
+      top: firstRect.top,
+      right: targetRect.right,
+      bottom: lastRect.bottom,
+      width: targetRect.width,
+      height: lastRect.bottom - firstRect.top,
+    });
+  }
+
+  const firstRect = clientRects[0];
+  const isLeft = side === 'l';
+  let edge = isLeft ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+  let left = firstRect.left;
+  let right = firstRect.right;
+  let targetFirstRect = firstRect;
+  let targetLastRect = firstRect;
+
+  for (const rect of clientRects) {
+    left = Math.min(left, rect.left);
+    right = Math.max(right, rect.right);
+
+    const nextEdge = isLeft ? rect.left : rect.right;
+
+    if ((isLeft && nextEdge < edge) || (!isLeft && nextEdge > edge)) {
+      edge = nextEdge;
+      targetFirstRect = rect;
+      targetLastRect = rect;
+    } else if (nextEdge === edge) {
+      targetLastRect = rect;
+    }
+  }
+
+  return toRect({
+    left,
+    top: targetFirstRect.top,
+    right,
+    bottom: targetLastRect.bottom,
+    width: right - left,
+    height: targetLastRect.bottom - targetFirstRect.top,
+  });
+}
+
+/**
+ * Gets the inline rect hover coords from a mouse event.
+ * Returns undefined if the element has less than 2 client rects (i.e., it's not wrapped).
+ */
+export function getInlineRectHoverCoords(
+  event: React.MouseEvent<Element>,
+): InlineRectCoords | undefined {
+  if (event.currentTarget.getClientRects().length < 2) {
+    return undefined;
+  }
+
+  return {
+    x: event.clientX,
+    y: event.clientY,
+  };
+}
+
+export function getInlineRectTriggerProps(
+  coordsRef: React.RefObject<InlineRectCoords | undefined>,
+  isOpen: boolean,
+): Pick<React.HTMLAttributes<Element>, 'onFocus' | 'onMouseEnter' | 'onMouseMove'> {
+  function updateCoords(event: React.MouseEvent<Element>) {
+    const coords = getInlineRectHoverCoords(event);
+    coordsRef.current = coords ? { ...coords, element: event.currentTarget } : undefined;
+  }
+
+  return {
+    onFocus() {
+      coordsRef.current = undefined;
+    },
+    onMouseEnter(event: React.MouseEvent<Element>) {
+      updateCoords(event);
+    },
+    onMouseMove(event: React.MouseEvent<Element>) {
+      if (isOpen) {
+        return;
+      }
+
+      updateCoords(event);
+    },
+  };
+}
+
+/**
+ * Creates an inline middleware that positions the floating element relative to the
+ * hovered rect of a wrapped inline element (e.g., a multi-line link).
+ */
+export function createInlineMiddleware(
+  coordsRef: React.RefObject<InlineRectCoords | undefined>,
+): Middleware {
+  return {
+    name: 'inline',
+    fn(state) {
+      const reference = state.elements.reference;
+
+      if (
+        typeof (reference as Partial<ClientRectsReference> | null)?.getClientRects !== 'function'
+      ) {
+        return {};
+      }
+
+      const coords = coordsRef.current;
+      const rect = getInlineReferenceRect(
+        reference as ClientRectsReference,
+        state.placement,
+        coords?.element === reference ? coords : undefined,
+      );
+
+      if (
+        !rect ||
+        (state.rects.reference.x === rect.x &&
+          state.rects.reference.y === rect.y &&
+          state.rects.reference.width === rect.width &&
+          state.rects.reference.height === rect.height)
+      ) {
+        return {};
+      }
+
+      return {
+        reset: {
+          rects: {
+            reference: rect,
+            floating: state.rects.floating,
+          },
+        },
+      };
+    },
+  };
+}

--- a/packages/react/src/utils/popups/inlineRect.ts
+++ b/packages/react/src/utils/popups/inlineRect.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { Middleware } from '@floating-ui/react-dom';
+import type { Middleware, VirtualElement } from '@floating-ui/react-dom';
 
 export interface InlineRectCoords {
   /** The x position in viewport coordinates. */
@@ -7,7 +7,7 @@ export interface InlineRectCoords {
   /** The y position in viewport coordinates. */
   y: number;
   /** The trigger element whose rects produced these coordinates. */
-  element?: Element | undefined;
+  element: Element;
 }
 
 interface RectLike {
@@ -19,8 +19,40 @@ interface RectLike {
   height: number;
 }
 
+interface ClientRectLike extends RectLike {
+  x: number;
+  y: number;
+}
+
 interface ClientRectsReference {
   getClientRects(): ArrayLike<RectLike>;
+}
+
+function getInlineRectCoords(event: React.MouseEvent<Element>): InlineRectCoords | undefined {
+  const { currentTarget, clientX, clientY } = event;
+
+  if (currentTarget.getClientRects().length < 2) {
+    return undefined;
+  }
+
+  return {
+    x: clientX,
+    y: clientY,
+    element: currentTarget,
+  };
+}
+
+function createRect(left: number, top: number, right: number, bottom: number): ClientRectLike {
+  return {
+    left,
+    top,
+    right,
+    bottom,
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
+  };
 }
 
 function copyRect(rect: RectLike): RectLike {
@@ -34,54 +66,20 @@ function copyRect(rect: RectLike): RectLike {
   };
 }
 
-function toRect(rect: RectLike) {
-  return {
-    x: rect.left,
-    y: rect.top,
-    width: rect.width,
-    height: rect.height,
-  };
-}
-
-function getBoundingRect(rects: readonly RectLike[]) {
+function getLineRects(rects: ArrayLike<RectLike>) {
+  const lines: RectLike[] = [];
+  let previousRect: RectLike | undefined;
   let left = Number.POSITIVE_INFINITY;
   let top = Number.POSITIVE_INFINITY;
   let right = Number.NEGATIVE_INFINITY;
   let bottom = Number.NEGATIVE_INFINITY;
 
-  for (const rect of rects) {
-    if (rect.left < left) {
-      left = rect.left;
-    }
-
-    if (rect.top < top) {
-      top = rect.top;
-    }
-
-    if (rect.right > right) {
-      right = rect.right;
-    }
-
-    if (rect.bottom > bottom) {
-      bottom = rect.bottom;
-    }
-  }
-
-  return {
-    left,
-    top,
-    right,
-    bottom,
-    width: right - left,
-    height: bottom - top,
-  };
-}
-
-function getRectsByLine(rects: ArrayLike<RectLike>) {
-  const lines: RectLike[] = [];
-  let previousRect: RectLike | undefined;
-
   for (const rect of Array.from(rects).sort((a, b) => a.top - b.top)) {
+    left = Math.min(left, rect.left);
+    top = Math.min(top, rect.top);
+    right = Math.max(right, rect.right);
+    bottom = Math.max(bottom, rect.bottom);
+
     if (!previousRect || rect.top - previousRect.top > previousRect.height / 2) {
       lines.push(copyRect(rect));
     } else {
@@ -96,63 +94,55 @@ function getRectsByLine(rects: ArrayLike<RectLike>) {
     previousRect = rect;
   }
 
-  return lines;
+  return {
+    lines,
+    fallback: createRect(left, top, right, bottom),
+  };
 }
 
 function getInlineReferenceRect(
   reference: ClientRectsReference,
   placement: string,
   coords: InlineRectCoords | undefined,
-) {
-  const clientRects = getRectsByLine(reference.getClientRects());
+): ClientRectLike | null {
+  const { lines, fallback } = getLineRects(reference.getClientRects());
 
-  if (clientRects.length < 2) {
+  if (lines.length < 2) {
     return null;
   }
 
-  const fallback = getBoundingRect(clientRects);
   const x = coords?.x;
   const y = coords?.y;
   const side = placement[0];
 
-  if (
-    clientRects.length === 2 &&
-    clientRects[0].left > clientRects[1].right &&
-    x != null &&
-    y != null
-  ) {
-    return toRect(
-      clientRects.find(
-        (rect) =>
-          x > rect.left - 2 && x < rect.right + 2 && y > rect.top - 2 && y < rect.bottom + 2,
-      ) || fallback,
+  if (lines.length === 2 && lines[0].left > lines[1].right && x != null && y != null) {
+    const rect = lines.find(
+      (lineRect) =>
+        x > lineRect.left - 2 &&
+        x < lineRect.right + 2 &&
+        y > lineRect.top - 2 &&
+        y < lineRect.bottom + 2,
     );
+
+    return rect ? createRect(rect.left, rect.top, rect.right, rect.bottom) : fallback;
   }
 
   if (side === 't' || side === 'b') {
-    const firstRect = clientRects[0];
-    const lastRect = clientRects[clientRects.length - 1];
+    const firstRect = lines[0];
+    const lastRect = lines[lines.length - 1];
     const targetRect = side === 't' ? firstRect : lastRect;
 
-    return toRect({
-      left: targetRect.left,
-      top: firstRect.top,
-      right: targetRect.right,
-      bottom: lastRect.bottom,
-      width: targetRect.width,
-      height: lastRect.bottom - firstRect.top,
-    });
+    return createRect(targetRect.left, firstRect.top, targetRect.right, lastRect.bottom);
   }
 
-  const firstRect = clientRects[0];
   const isLeft = side === 'l';
+  let left = lines[0].left;
+  let right = lines[0].right;
   let edge = isLeft ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
-  let left = firstRect.left;
-  let right = firstRect.right;
-  let targetFirstRect = firstRect;
-  let targetLastRect = firstRect;
+  let targetFirstRect = lines[0];
+  let targetLastRect = lines[0];
 
-  for (const rect of clientRects) {
+  for (const rect of lines) {
     left = Math.min(left, rect.left);
     right = Math.max(right, rect.right);
 
@@ -167,31 +157,15 @@ function getInlineReferenceRect(
     }
   }
 
-  return toRect({
-    left,
-    top: targetFirstRect.top,
-    right,
-    bottom: targetLastRect.bottom,
-    width: right - left,
-    height: targetLastRect.bottom - targetFirstRect.top,
-  });
+  return createRect(left, targetFirstRect.top, right, targetLastRect.bottom);
 }
 
-/**
- * Gets the inline rect hover coords from a mouse event.
- * Returns undefined if the element has less than 2 client rects (i.e., it's not wrapped).
- */
-export function getInlineRectHoverCoords(
-  event: React.MouseEvent<Element>,
-): InlineRectCoords | undefined {
-  if (event.currentTarget.getClientRects().length < 2) {
-    return undefined;
+function getContextElement(reference: Element | VirtualElement): Element | undefined {
+  if ('contextElement' in reference) {
+    return reference.contextElement;
   }
 
-  return {
-    x: event.clientX,
-    y: event.clientY,
-  };
+  return typeof Element !== 'undefined' && reference instanceof Element ? reference : undefined;
 }
 
 export function getInlineRectTriggerProps(
@@ -199,8 +173,7 @@ export function getInlineRectTriggerProps(
   isOpen: boolean,
 ): Pick<React.HTMLAttributes<Element>, 'onFocus' | 'onMouseEnter' | 'onMouseMove'> {
   function updateCoords(event: React.MouseEvent<Element>) {
-    const coords = getInlineRectHoverCoords(event);
-    coordsRef.current = coords ? { ...coords, element: event.currentTarget } : undefined;
+    coordsRef.current = getInlineRectCoords(event);
   }
 
   return {
@@ -220,16 +193,12 @@ export function getInlineRectTriggerProps(
   };
 }
 
-/**
- * Creates an inline middleware that positions the floating element relative to the
- * hovered rect of a wrapped inline element (e.g., a multi-line link).
- */
 export function createInlineMiddleware(
   coordsRef: React.RefObject<InlineRectCoords | undefined>,
 ): Middleware {
   return {
     name: 'inline',
-    fn(state) {
+    async fn(state) {
       const reference = state.elements.reference;
 
       if (
@@ -245,22 +214,33 @@ export function createInlineMiddleware(
         coords?.element === reference ? coords : undefined,
       );
 
+      if (!rect || typeof state.platform.getElementRects !== 'function') {
+        return {};
+      }
+
+      const resetRects = await state.platform.getElementRects({
+        reference: {
+          contextElement: getContextElement(reference),
+          getBoundingClientRect() {
+            return rect;
+          },
+        },
+        floating: state.elements.floating,
+        strategy: state.strategy,
+      });
+
       if (
-        !rect ||
-        (state.rects.reference.x === rect.x &&
-          state.rects.reference.y === rect.y &&
-          state.rects.reference.width === rect.width &&
-          state.rects.reference.height === rect.height)
+        state.rects.reference.x === resetRects.reference.x &&
+        state.rects.reference.y === resetRects.reference.y &&
+        state.rects.reference.width === resetRects.reference.width &&
+        state.rects.reference.height === resetRects.reference.height
       ) {
         return {};
       }
 
       return {
         reset: {
-          rects: {
-            reference: rect,
-            floating: state.rects.floating,
-          },
+          rects: resetRects,
         },
       };
     },

--- a/packages/react/src/utils/popups/inlineRect.ts
+++ b/packages/react/src/utils/popups/inlineRect.ts
@@ -205,20 +205,18 @@ export function getInlineRectTriggerProps(
     coordsRef.current = getInlineRectCoords(event);
   }
 
+  function updateCoordsIfClosed(event: React.MouseEvent<Element>) {
+    if (!isOpen) {
+      updateCoords(event);
+    }
+  }
+
   return {
     onFocus() {
       coordsRef.current = undefined;
     },
-    onMouseEnter(event: React.MouseEvent<Element>) {
-      updateCoords(event);
-    },
-    onMouseMove(event: React.MouseEvent<Element>) {
-      if (isOpen) {
-        return;
-      }
-
-      updateCoords(event);
-    },
+    onMouseEnter: updateCoordsIfClosed,
+    onMouseMove: updateCoordsIfClosed,
   };
 }
 

--- a/packages/react/src/utils/popups/inlineRect.ts
+++ b/packages/react/src/utils/popups/inlineRect.ts
@@ -1,11 +1,18 @@
 import * as React from 'react';
 import type { Middleware, VirtualElement } from '@floating-ui/react-dom';
+import { isElement } from '@floating-ui/utils/dom';
+
+// Floating UI ships an `inline()` middleware. This local version mirrors its line-rect
+// selection while adding trigger identity checks, delayed-open hit-line reuse, and
+// improved left/right edge grouping for Preview Card's reusable trigger model.
 
 export interface InlineRectCoords {
   /** The x position in viewport coordinates. */
   x: number;
   /** The y position in viewport coordinates. */
   y: number;
+  /** The line index under the pointer when coordinates were captured. */
+  lineIndex?: number | undefined;
   /** The trigger element whose rects produced these coordinates. */
   element: Element;
 }
@@ -26,20 +33,6 @@ interface ClientRectLike extends RectLike {
 
 interface ClientRectsReference {
   getClientRects(): ArrayLike<RectLike>;
-}
-
-function getInlineRectCoords(event: React.MouseEvent<Element>): InlineRectCoords | undefined {
-  const { currentTarget, clientX, clientY } = event;
-
-  if (currentTarget.getClientRects().length < 2) {
-    return undefined;
-  }
-
-  return {
-    x: clientX,
-    y: clientY,
-    element: currentTarget,
-  };
 }
 
 function createRect(left: number, top: number, right: number, bottom: number): ClientRectLike {
@@ -100,6 +93,38 @@ function getLineRects(rects: ArrayLike<RectLike>) {
   };
 }
 
+function findLineIndex(lines: RectLike[], x: number, y: number) {
+  return lines.findIndex(
+    (lineRect) =>
+      x > lineRect.left - 2 &&
+      x < lineRect.right + 2 &&
+      y > lineRect.top - 2 &&
+      y < lineRect.bottom + 2,
+  );
+}
+
+function createClientRect(rect: RectLike) {
+  return createRect(rect.left, rect.top, rect.right, rect.bottom);
+}
+
+function getInlineRectCoords(event: React.MouseEvent<Element>): InlineRectCoords | undefined {
+  const { currentTarget, clientX, clientY } = event;
+  const { lines } = getLineRects(currentTarget.getClientRects());
+
+  if (lines.length < 2) {
+    return undefined;
+  }
+
+  const lineIndex = findLineIndex(lines, clientX, clientY);
+
+  return {
+    x: clientX,
+    y: clientY,
+    lineIndex: lineIndex === -1 ? undefined : lineIndex,
+    element: currentTarget,
+  };
+}
+
 function getInlineReferenceRect(
   reference: ClientRectsReference,
   placement: string,
@@ -115,16 +140,20 @@ function getInlineReferenceRect(
   const y = coords?.y;
   const side = placement[0];
 
-  if (lines.length === 2 && lines[0].left > lines[1].right && x != null && y != null) {
-    const rect = lines.find(
-      (lineRect) =>
-        x > lineRect.left - 2 &&
-        x < lineRect.right + 2 &&
-        y > lineRect.top - 2 &&
-        y < lineRect.bottom + 2,
-    );
+  if (coords?.lineIndex != null && lines[coords.lineIndex]) {
+    return createClientRect(lines[coords.lineIndex]);
+  }
 
-    return rect ? createRect(rect.left, rect.top, rect.right, rect.bottom) : fallback;
+  if (x != null && y != null) {
+    const lineIndex = findLineIndex(lines, x, y);
+
+    if (lineIndex !== -1) {
+      return createClientRect(lines[lineIndex]);
+    }
+  }
+
+  if (lines.length === 2 && lines[0].left > lines[1].right && x != null && y != null) {
+    return fallback;
   }
 
   if (side === 't' || side === 'b') {
@@ -161,11 +190,11 @@ function getInlineReferenceRect(
 }
 
 function getContextElement(reference: Element | VirtualElement): Element | undefined {
-  if ('contextElement' in reference) {
+  if ('contextElement' in reference && reference.contextElement) {
     return reference.contextElement;
   }
 
-  return typeof Element !== 'undefined' && reference instanceof Element ? reference : undefined;
+  return isElement(reference) ? reference : undefined;
 }
 
 export function getInlineRectTriggerProps(
@@ -207,11 +236,14 @@ export function createInlineMiddleware(
         return {};
       }
 
+      const contextElement = getContextElement(reference);
       const coords = coordsRef.current;
+      const currentCoords =
+        coords?.element === reference || coords?.element === contextElement ? coords : undefined;
       const rect = getInlineReferenceRect(
         reference as ClientRectsReference,
         state.placement,
-        coords?.element === reference ? coords : undefined,
+        currentCoords,
       );
 
       if (!rect || typeof state.platform.getElementRects !== 'function') {
@@ -220,7 +252,7 @@ export function createInlineMiddleware(
 
       const resetRects = await state.platform.getElementRects({
         reference: {
-          contextElement: getContextElement(reference),
+          contextElement,
           getBoundingClientRect() {
             return rect;
           },

--- a/packages/react/src/utils/popups/inlineRect.ts
+++ b/packages/react/src/utils/popups/inlineRect.ts
@@ -205,7 +205,7 @@ export function getInlineRectTriggerProps(
     coordsRef.current = getInlineRectCoords(event);
   }
 
-  function updateCoordsIfClosed(event: React.MouseEvent<Element>) {
+  function updateCoordsOnMove(event: React.MouseEvent<Element>) {
     if (!isOpen) {
       updateCoords(event);
     }
@@ -215,8 +215,8 @@ export function getInlineRectTriggerProps(
     onFocus() {
       coordsRef.current = undefined;
     },
-    onMouseEnter: updateCoordsIfClosed,
-    onMouseMove: updateCoordsIfClosed,
+    onMouseEnter: updateCoords,
+    onMouseMove: updateCoordsOnMove,
   };
 }
 

--- a/packages/react/src/utils/popups/inlineRect.ts
+++ b/packages/react/src/utils/popups/inlineRect.ts
@@ -107,9 +107,12 @@ function createClientRect(rect: RectLike) {
   return createRect(rect.left, rect.top, rect.right, rect.bottom);
 }
 
-function getInlineRectCoords(event: React.MouseEvent<Element>): InlineRectCoords | undefined {
-  const { currentTarget, clientX, clientY } = event;
-  const { lines } = getLineRects(currentTarget.getClientRects());
+function getInlineRectCoords(
+  element: Element,
+  clientX: number,
+  clientY: number,
+): InlineRectCoords | undefined {
+  const { lines } = getLineRects(element.getClientRects());
 
   if (lines.length < 2) {
     return undefined;
@@ -121,7 +124,7 @@ function getInlineRectCoords(event: React.MouseEvent<Element>): InlineRectCoords
     x: clientX,
     y: clientY,
     lineIndex: lineIndex === -1 ? undefined : lineIndex,
-    element: currentTarget,
+    element,
   };
 }
 
@@ -202,7 +205,7 @@ export function getInlineRectTriggerProps(
   isOpen: boolean,
 ): Pick<React.HTMLAttributes<Element>, 'onFocus' | 'onMouseEnter' | 'onMouseMove'> {
   function updateCoords(event: React.MouseEvent<Element>) {
-    coordsRef.current = getInlineRectCoords(event);
+    updateInlineRectCoords(coordsRef, event.currentTarget, event.clientX, event.clientY);
   }
 
   function updateCoordsOnMove(event: React.MouseEvent<Element>) {
@@ -218,6 +221,17 @@ export function getInlineRectTriggerProps(
     onMouseEnter: updateCoords,
     onMouseMove: updateCoordsOnMove,
   };
+}
+
+export function updateInlineRectCoords(
+  coordsRef: React.RefObject<InlineRectCoords | undefined>,
+  element: Element,
+  clientX: number,
+  clientY: number,
+) {
+  const nextCoords = getInlineRectCoords(element, clientX, clientY);
+  coordsRef.current = nextCoords;
+  return nextCoords;
 }
 
 export function createInlineMiddleware(

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -134,6 +134,7 @@ export function useAnchorPositioning(
     sticky = false,
     arrowPadding = 5,
     disableAnchorTracking = false,
+    inline: inlineMiddleware,
     // Private parameters
     keepMounted = false,
     floatingRootContext,
@@ -228,7 +229,13 @@ export function useAnchorPositioning(
   const sideOffsetDep = typeof sideOffset !== 'function' ? sideOffset : 0;
   const alignOffsetDep = typeof alignOffset !== 'function' ? alignOffset : 0;
 
-  const middleware: UseFloatingOptions['middleware'] = [
+  const middleware: UseFloatingOptions['middleware'] = [];
+
+  if (inlineMiddleware) {
+    middleware.push(inlineMiddleware);
+  }
+
+  middleware.push(
     offset(
       (state) => {
         const data = getOffsetData(state, sideParam, isRtl);
@@ -250,7 +257,7 @@ export function useAnchorPositioning(
       },
       [sideOffsetDep, alignOffsetDep, isRtl, sideParam],
     ),
-  ];
+  );
 
   const shiftDisabled = collisionAvoidanceAlign === 'none' && collisionAvoidanceSide !== 'shift';
   const crossAxisShiftEnabled =
@@ -725,6 +732,7 @@ export interface UseAnchorPositioningParameters extends UseAnchorPositioningShar
   shiftCrossAxis?: boolean | undefined;
   lazyFlip?: boolean | undefined;
   externalTree?: FloatingTreeStore | undefined;
+  inline?: Middleware | undefined;
 }
 
 export interface UseAnchorPositioningReturnValue {

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -732,6 +732,10 @@ export interface UseAnchorPositioningParameters extends UseAnchorPositioningShar
   shiftCrossAxis?: boolean | undefined;
   lazyFlip?: boolean | undefined;
   externalTree?: FloatingTreeStore | undefined;
+  /**
+   * Optional middleware that can replace the measured reference rect before offsets and collision
+   * middleware run. Used by Preview Card to position against a specific inline line box.
+   */
   inline?: Middleware | undefined;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #2064

Previously it would choose the whole bounding client rect rather than choosing an individual client rect. `align="start"` sort of alleviates this problem but you can't use center positioning or other sides.

https://deploy-preview-2074--base-ui.netlify.app/experiments/inline-positioning


https://github.com/user-attachments/assets/c73bdb71-7625-4c1c-9a9c-f54ccf7e3b53

