### PR TITLE
[useScrollLock] Bail if `<html>` already has hidden overflow

### DIFF
--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -3,6 +3,7 @@ import { ownerDocument, ownerWindow } from './owner';
 import { useModernLayoutEffect } from './useModernLayoutEffect';
 import { Timeout } from './useTimeout';
 import { AnimationFrame } from './useAnimationFrame';
+import { NOOP } from './noop';
 
 /* eslint-disable lines-between-class-members */
 
@@ -170,6 +171,16 @@ class ScrollLocker {
 
   private lock(referenceElement: Element | null) {
     if (this.lockCount === 0 || this.restore !== null) {
+      return;
+    }
+
+    const doc = ownerDocument(referenceElement);
+    const html = doc.documentElement;
+    const htmlOverflowY = ownerWindow(html).getComputedStyle(html).overflowY;
+
+    // If the site author already hid overflow on <html>, respect it and bail out.
+    if (htmlOverflowY === 'hidden') {
+      this.restore = NOOP;
       return;
     }
 


### PR DESCRIPTION
Fixes #2077
Fixes #2078 

@oliverjash

This should fix both issues since the crux is that a scroll lock is already active, but it's not our one. If we respect it, it should prevent the issues.