### PR TITLE
[useScrollLock] Enforce `scrollbar-gutter: stable` if supported

### DIFF
--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -70,7 +70,7 @@ function preventScrollStandard(referenceElement: Element | null) {
     };
 
     // Handle `scrollbar-gutter` in Chrome when there is no scrollable content.
-    const hasScrollbarGutterStable = htmlStyles.scrollbarGutter?.includes('stable');
+    const supportsStableScrollbarGutter = CSS.supports('scrollbar-gutter', 'stable');
 
     const isScrollableY = html.scrollHeight > html.clientHeight;
     const isScrollableX = html.scrollWidth > html.clientWidth;
@@ -94,10 +94,15 @@ function preventScrollStandard(referenceElement: Element | null) {
      */
 
     Object.assign(html.style, {
+      scrollbarGutter: 'stable',
       overflowY:
-        !hasScrollbarGutterStable && (isScrollableY || hasConstantOverflowY) ? 'scroll' : 'hidden',
+        !supportsStableScrollbarGutter && (isScrollableY || hasConstantOverflowY)
+          ? 'scroll'
+          : 'hidden',
       overflowX:
-        !hasScrollbarGutterStable && (isScrollableX || hasConstantOverflowX) ? 'scroll' : 'hidden',
+        !supportsStableScrollbarGutter && (isScrollableX || hasConstantOverflowX)
+          ? 'scroll'
+          : 'hidden',
     });
 
     Object.assign(body.style, {


### PR DESCRIPTION
Prevents elastic scrolling while scroll is locked by default