### PR TITLE
[select] Fix programmatic value changes and autofill handling

### DIFF
--- a/packages/react/src/select/portal/SelectPortal.tsx
+++ b/packages/react/src/select/portal/SelectPortal.tsx
@@ -17,9 +17,9 @@ export function SelectPortal(props: SelectPortal.Props) {
 
   const { store } = useSelectRootContext();
   const mounted = useSelector(store, selectors.mounted);
-  const typeaheadReady = useSelector(store, selectors.typeaheadReady);
+  const forceMount = useSelector(store, selectors.forceMount);
 
-  const shouldRender = mounted || typeaheadReady;
+  const shouldRender = mounted || forceMount;
   if (!shouldRender) {
     return null;
   }

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -320,12 +320,10 @@ describe('<Select.Root />', () => {
 
     const trigger = screen.getByTestId('trigger');
 
-    fireEvent.click(trigger);
-
+    fireEvent.change(container.querySelector('[name="select"]')!, { target: { value: 'b' } });
     await flushMicrotasks();
 
-    fireEvent.change(container.querySelector('[name="select"]')!, { target: { value: 'b' } });
-
+    fireEvent.click(trigger);
     await flushMicrotasks();
 
     expect(screen.getByRole('option', { name: 'b', hidden: false })).to.have.attribute(

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -163,6 +163,33 @@ describe('<Select.Root />', () => {
       expect(onValueChange.callCount).to.equal(0);
       expect(trigger).to.have.text('a');
     });
+
+    it('updates <Select.Value /> label when the value prop changes before the popup opens', async () => {
+      const { setProps } = await render(
+        <Select.Root value="b">
+          <Select.Trigger data-testid="trigger">
+            <Select.Value placeholder="b" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+
+      expect(trigger).to.have.text('b');
+
+      await setProps({ value: 'a' });
+      await flushMicrotasks();
+
+      expect(trigger).to.have.text('a');
+    });
   });
 
   describe('prop: onValueChange', () => {

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -86,20 +86,24 @@ export const SelectRoot: SelectRoot = function SelectRoot<Value>(
 
               const nextValue = event.target.value;
 
-              const exactValue = rootContext.valuesRef.current.find(
-                (v) =>
-                  v === nextValue ||
-                  (typeof value === 'string' && nextValue.toLowerCase() === v.toLowerCase()),
-              );
+              store.set('forceMount', true);
 
-              if (exactValue != null) {
-                setDirty(exactValue !== validityData.initialValue);
-                rootContext.setValue?.(exactValue, event.nativeEvent);
+              queueMicrotask(() => {
+                const exactValue = rootContext.valuesRef.current.find(
+                  (v) =>
+                    v === nextValue ||
+                    (typeof value === 'string' && nextValue.toLowerCase() === v.toLowerCase()),
+                );
 
-                if (validationMode === 'onChange') {
-                  rootContext.fieldControlValidation.commitValidation(exactValue);
+                if (exactValue != null) {
+                  setDirty(exactValue !== validityData.initialValue);
+                  rootContext.setValue?.(exactValue, event.nativeEvent);
+
+                  if (validationMode === 'onChange') {
+                    rootContext.fieldControlValidation.commitValidation(exactValue);
+                  }
                 }
-              }
+              });
             },
             id,
             name: rootContext.name,

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -112,7 +112,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
         label: '',
         open,
         mounted,
-        typeaheadReady: false,
+        forceMount: false,
         transitionStatus,
         touchModality: false,
         activeIndex: null,
@@ -127,6 +127,14 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
         alignItemWithTriggerActive: false,
       }),
   ).current;
+
+  const initialValueRef = React.useRef(value);
+  useModernLayoutEffect(() => {
+    // Ensure the values and labels are registered for programmatic value changes.
+    if (value !== initialValueRef.current) {
+      store.set('forceMount', true);
+    }
+  }, [store, value]);
 
   const activeIndex = useSelector(store, selectors.activeIndex);
   const selectedIndex = useSelector(store, selectors.selectedIndex);

--- a/packages/react/src/select/store.ts
+++ b/packages/react/src/select/store.ts
@@ -11,7 +11,7 @@ export type State = {
 
   open: boolean;
   mounted: boolean;
-  typeaheadReady: boolean;
+  forceMount: boolean;
   transitionStatus: TransitionStatus;
   touchModality: boolean;
 
@@ -40,7 +40,7 @@ export const selectors = {
 
   open: createSelector((state: State) => state.open),
   mounted: createSelector((state: State) => state.mounted),
-  typeaheadReady: createSelector((state: State) => state.typeaheadReady),
+  forceMount: createSelector((state: State) => state.forceMount),
   transitionStatus: createSelector((state: State) => state.transitionStatus),
   touchModality: createSelector((state: State) => state.touchModality),
 

--- a/packages/react/src/select/trigger/useSelectTrigger.ts
+++ b/packages/react/src/select/trigger/useSelectTrigger.ts
@@ -97,13 +97,13 @@ export function useSelectTrigger(
           setOpen(false, event.nativeEvent, 'focus-out');
         }
 
-        // Saves a re-render on initial click: `typeaheadReady === true` mounts
+        // Saves a re-render on initial click: `forceMount === true` mounts
         // the items before `open === true`. We could sync those cycles better
         // without a timeout, but this is enough for now.
         //
         // XXX: might be causing `act()` warnings.
         timeoutFocus.start(0, () => {
-          store.set('typeaheadReady', true);
+          store.set('forceMount', true);
         });
       },
       onBlur() {


### PR DESCRIPTION
From #2083. Since the items aren't rendered on mount anymore, they need to be force mounted when either:

1. `onChange` on the hidden input (for autofill handling) is invoked
2. The value changes externally (controlled mode) before the popup is opened to register the values/labels