### PR TITLE
[core] Fix useSyncExternalStoreWithSelector in React 17

### DIFF
--- a/packages/react/src/utils/store/useSelector.ts
+++ b/packages/react/src/utils/store/useSelector.ts
@@ -1,4 +1,5 @@
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector';
+// We need to import the shim because React 17 does not support the `useSyncExternalStore` API.
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 import type { Store } from './Store';
 
 export function useSelector<State, Value>(


### PR DESCRIPTION
Fix `useSyncExternalStore` import error in React 17. `use-sync-external-store/with-selector` does not import the shim, so it broke in React 17 which does not support `useSyncExternalStore`. The fix is to import `use-sync-external-store/shim/with-selector`.



This `use-sync-external-store/with-selector` import was added in [this commit](https://github.com/mui/base-ui/commit/5f03b929a5b1574fe3b860eca9de82ce22f61bcf#diff-44c136f3e29e44aa0beba0f06be73bbd87198d24961b506693f495755516ca06), so it isn't in any release yet.

[Error reproduction](https://codesandbox.io/p/sandbox/gracious-rosalind-chwync)

[Fix confirmation](https://codesandbox.io/p/devbox/heuristic-williams-r7lr9g?workspaceId=ws_PFkFFPimWAz2h3GBs6bbWx)

More info: https://github.com/mui/mui-x/issues/18303#issuecomment-2958392341