### PR TITLE
[menubar] Fix `closeOnClick: false` not working in nested menus

### DIFF
--- a/docs/src/app/(private)/experiments/menubar.tsx
+++ b/docs/src/app/(private)/experiments/menubar.tsx
@@ -146,6 +146,55 @@ export default function MenubarExperiment() {
                     <span className={menuClasses.RadioItemText}>Dark mode</span>
                   </Menu.RadioItem>
                 </Menu.RadioGroup>
+
+                <Menu.Root>
+                  <Menu.SubmenuTrigger className={menuClasses.SubmenuTrigger}>
+                    Layout
+                    <ChevronRightIcon />
+                  </Menu.SubmenuTrigger>
+
+                  <Menu.Portal>
+                    <Menu.Positioner
+                      className={menuClasses.Positioner}
+                      sideOffset={8}
+                    >
+                      <Menu.Popup className={menuClasses.Popup}>
+                        <Menu.RadioGroup defaultValue="light">
+                          <Menu.RadioItem
+                            className={menuClasses.RadioItem}
+                            value="light"
+                          >
+                            <Menu.RadioItemIndicator
+                              className={menuClasses.RadioItemIndicator}
+                            >
+                              <CheckIcon
+                                className={menuClasses.RadioItemIndicatorIcon}
+                              />
+                            </Menu.RadioItemIndicator>
+                            <span className={menuClasses.RadioItemText}>
+                              Single column
+                            </span>
+                          </Menu.RadioItem>
+                          <Menu.RadioItem
+                            className={menuClasses.RadioItem}
+                            value="dark"
+                          >
+                            <Menu.RadioItemIndicator
+                              className={menuClasses.RadioItemIndicator}
+                            >
+                              <CheckIcon
+                                className={menuClasses.RadioItemIndicatorIcon}
+                              />
+                            </Menu.RadioItemIndicator>
+                            <span className={menuClasses.RadioItemText}>
+                              Multiple columns
+                            </span>
+                          </Menu.RadioItem>
+                        </Menu.RadioGroup>
+                      </Menu.Popup>
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.Root>
               </Menu.Popup>
             </Menu.Positioner>
           </Menu.Portal>

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -124,9 +124,8 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
             doc.addEventListener('mouseup', handleDocumentMouseUp, { once: true });
           },
           onMouseUp: () => {
-            // Clicking and releasing the mouse button quickly can fire the mouseup ewvent even before the document.mouseup
-            // has a chance to register. In these cases, we want to ensure that the
-            // allowMouseUpTriggerRef is reset to false.
+            // Clicking and releasing the mouse button quickly can fire the mouseup event even before the document.mouseup
+            // has a chance to register. In these cases, we want to ensure that the allowMouseUpTriggerRef is reset to false.
             allowMouseUpTriggerTimeout.clear();
             allowMouseUpTriggerRef.current = false;
           },

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -66,12 +66,16 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
   }, [allowMouseUpTriggerRef, open, parent.type]);
 
   const handleDocumentMouseUp = useEventCallback((mouseEvent: MouseEvent) => {
-    if (!triggerRef.current || !allowMouseUpTriggerRef.current) {
+    if (!triggerRef.current) {
       return;
     }
 
     allowMouseUpTriggerTimeout.clear();
     allowMouseUpTriggerRef.current = false;
+
+    if (!allowMouseUpTriggerRef.current) {
+      return;
+    }
 
     const mouseUpTarget = mouseEvent.target as Element | null;
 
@@ -122,12 +126,6 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
 
             const doc = ownerDocument(event.currentTarget);
             doc.addEventListener('mouseup', handleDocumentMouseUp, { once: true });
-          },
-          onMouseUp: () => {
-            // Clicking and releasing the mouse button quickly can fire the mouseup event even before the document.mouseup
-            // has a chance to register. In these cases, we want to ensure that the allowMouseUpTriggerRef is reset to false.
-            allowMouseUpTriggerTimeout.clear();
-            allowMouseUpTriggerRef.current = false;
           },
         },
         externalProps,

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -65,8 +65,8 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
     }
   }, [allowMouseUpTriggerRef, open, parent.type]);
 
-  const handleMouseUp = useEventCallback((mouseEvent: MouseEvent) => {
-    if (!triggerRef.current) {
+  const handleDocumentMouseUp = useEventCallback((mouseEvent: MouseEvent) => {
+    if (!triggerRef.current || !allowMouseUpTriggerRef.current) {
       return;
     }
 
@@ -100,9 +100,9 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
   React.useEffect(() => {
     if (open && lastOpenChangeReason === 'trigger-hover') {
       const doc = ownerDocument(triggerRef.current);
-      doc.addEventListener('mouseup', handleMouseUp, { once: true });
+      doc.addEventListener('mouseup', handleDocumentMouseUp, { once: true });
     }
-  }, [open, handleMouseUp, lastOpenChangeReason]);
+  }, [open, handleDocumentMouseUp, lastOpenChangeReason]);
 
   const getTriggerProps = React.useCallback(
     (externalProps?: HTMLProps): HTMLProps => {
@@ -121,7 +121,14 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
             });
 
             const doc = ownerDocument(event.currentTarget);
-            doc.addEventListener('mouseup', handleMouseUp, { once: true });
+            doc.addEventListener('mouseup', handleDocumentMouseUp, { once: true });
+          },
+          onMouseUp: () => {
+            // Clicking and releasing the mouse button quickly can fire the mouseup ewvent even before the document.mouseup
+            // has a chance to register. In these cases, we want to ensure that the
+            // allowMouseUpTriggerRef is reset to false.
+            allowMouseUpTriggerTimeout.clear();
+            allowMouseUpTriggerRef.current = false;
           },
         },
         externalProps,
@@ -134,7 +141,7 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
       open,
       allowMouseUpTriggerRef,
       allowMouseUpTriggerTimeout,
-      handleMouseUp,
+      handleDocumentMouseUp,
     ],
   );
 


### PR DESCRIPTION
Prevents closing the menu by emitting `'cancel-open'` when `allowMouseUpTriggerRef` is `false`

Fixes #2092