### PR TITLE
[scroll area] Handle touch momentum scrolling for programmatic scroll check

### DIFF
--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -11,6 +11,7 @@ import { MIN_THUMB_SIZE } from '../constants';
 import { clamp } from '../../utils/clamp';
 import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
 import { onVisible } from '../utils/onVisible';
+import { useTimeout } from '../../utils/useTimeout';
 
 /**
  * The actual scrollable container of the scroll area.
@@ -43,6 +44,7 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
   const direction = useDirection();
 
   const programmaticScrollRef = React.useRef(true);
+  const scrollEndTimeout = useTimeout();
 
   const computeThumbPosition = useEventCallback(() => {
     const viewportEl = viewportRef.current;
@@ -225,7 +227,16 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
         });
       }
 
-      programmaticScrollRef.current = true;
+      // Debounce the restoration of the programmatic flag so that it only
+      // flips back to `true` once scrolling has come to a rest. This ensures
+      // that momentum scrolling (where no further user-interaction events fire)
+      // is still treated as user-driven.
+      scrollEndTimeout.clear();
+      // 100 ms without scroll events ≈ scroll end
+      // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event
+      scrollEndTimeout.start(100, () => {
+        programmaticScrollRef.current = true;
+      });
     },
     onWheel: handleUserInteraction,
     onTouchMove: handleUserInteraction,


### PR DESCRIPTION
Since touch devices lack `onWheel` the scrolling state is unset while in momentum scroll phase: https://github.com/mui/base-ui/pull/1908