### PR TITLE
[dialog] Fix popup prop merging

### DIFF
--- a/docs/src/app/(private)/experiments/menu/complex-nesting.tsx
+++ b/docs/src/app/(private)/experiments/menu/complex-nesting.tsx
@@ -48,9 +48,10 @@ export default function MenuComplexNestingExperiment() {
 
                 <Dialog.Root>
                   <Menu.Item
-                    render={<Dialog.Trigger nativeButton={false} />}
+                    render={<Dialog.Trigger />}
                     className={styles.Item}
                     closeOnClick={false}
+                    nativeButton
                   >
                     Open Settings
                   </Menu.Item>

--- a/docs/src/app/(private)/experiments/menu/complex-nesting.tsx
+++ b/docs/src/app/(private)/experiments/menu/complex-nesting.tsx
@@ -48,7 +48,7 @@ export default function MenuComplexNestingExperiment() {
 
                 <Dialog.Root>
                   <Menu.Item
-                    render={<Dialog.Trigger />}
+                    render={<Dialog.Trigger nativeButton={false} />}
                     className={styles.Item}
                     closeOnClick={false}
                   >

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -71,9 +71,8 @@ export const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
 
   const mergedRef = useForkRef(forwardedRef, popupRef);
 
-  const { getRootProps, resolvedInitialFocus } = useDialogPopup({
+  const { popupProps, resolvedInitialFocus } = useDialogPopup({
     descriptionElementId,
-    getPopupProps,
     initialFocus,
     modal: true,
     mounted,
@@ -99,6 +98,8 @@ export const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
   const element = useRenderElement('div', componentProps, {
     state,
     props: [
+      getPopupProps(),
+      popupProps,
       {
         style: {
           [AlertDialogPopupCssVars.nestedDialogs]: nestedOpenDialogCount,
@@ -106,7 +107,6 @@ export const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
         role: 'alertdialog',
       },
       elementProps,
-      getRootProps,
     ],
     customStyleHookMapping,
   });

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -72,9 +72,8 @@ export const DialogPopup = React.forwardRef(function DialogPopup(
 
   const mergedRef = useForkRef(forwardedRef, popupRef);
 
-  const { getRootProps, resolvedInitialFocus } = useDialogPopup({
+  const { popupProps, resolvedInitialFocus } = useDialogPopup({
     descriptionElementId,
-    getPopupProps,
     initialFocus,
     modal,
     mounted,
@@ -100,13 +99,14 @@ export const DialogPopup = React.forwardRef(function DialogPopup(
   const element = useRenderElement('div', componentProps, {
     state,
     props: [
+      getPopupProps(),
+      popupProps,
       {
         style: {
           [DialogPopupCssVars.nestedDialogs]: nestedOpenDialogCount,
         } as React.CSSProperties,
       },
       elementProps,
-      getRootProps,
     ],
     customStyleHookMapping,
   });

--- a/packages/react/src/dialog/popup/useDialogPopup.tsx
+++ b/packages/react/src/dialog/popup/useDialogPopup.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import { useForkRef } from '../../utils/useForkRef';
-import { mergeProps } from '../../merge-props';
 import type { DialogOpenChangeReason } from '../root/useDialogRoot';
 import { type InteractionType } from '../../utils/useEnhancedClickHandler';
 import { HTMLProps } from '../../utils/types';
@@ -10,7 +9,6 @@ import { COMPOSITE_KEYS } from '../../composite/composite';
 export function useDialogPopup(parameters: useDialogPopup.Parameters): useDialogPopup.ReturnValue {
   const {
     descriptionElementId,
-    getPopupProps,
     initialFocus,
     modal,
     mounted,
@@ -47,28 +45,23 @@ export function useDialogPopup(parameters: useDialogPopup.Parameters): useDialog
     return initialFocus;
   }, [defaultInitialFocus, initialFocus, openMethod]);
 
-  const getRootProps = (externalProps: React.HTMLAttributes<any>) =>
-    mergeProps<'div'>(
-      {
-        'aria-labelledby': titleElementId ?? undefined,
-        'aria-describedby': descriptionElementId ?? undefined,
-        'aria-modal': mounted && modal === true ? true : undefined,
-        role: 'dialog',
-        tabIndex: -1,
-        ...getPopupProps(),
-        ref: handleRef,
-        hidden: !mounted,
-        onKeyDown(event) {
-          if (COMPOSITE_KEYS.has(event.key)) {
-            event.stopPropagation();
-          }
-        },
-      },
-      externalProps,
-    );
+  const popupProps: HTMLProps = {
+    'aria-labelledby': titleElementId ?? undefined,
+    'aria-describedby': descriptionElementId ?? undefined,
+    'aria-modal': mounted && modal === true ? true : undefined,
+    role: 'dialog',
+    tabIndex: -1,
+    ref: handleRef,
+    hidden: !mounted,
+    onKeyDown(event) {
+      if (COMPOSITE_KEYS.has(event.key)) {
+        event.stopPropagation();
+      }
+    },
+  };
 
   return {
-    getRootProps,
+    popupProps,
     resolvedInitialFocus,
   };
 }
@@ -109,22 +102,13 @@ export namespace useDialogPopup {
      */
     mounted: boolean;
     /**
-     * The resolver for the popup element props.
-     */
-    getPopupProps: () => HTMLProps;
-    /**
      * Callback to register the popup element.
      */
     setPopupElement: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
   }
 
   export interface ReturnValue {
-    /**
-     * Resolver for the root element props.
-     */
-    getRootProps: (
-      externalProps: React.ComponentPropsWithRef<'div'>,
-    ) => React.ComponentPropsWithRef<'div'>;
+    popupProps: HTMLProps;
     resolvedInitialFocus: React.RefObject<HTMLElement | null> | number;
   }
 }

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -616,6 +616,51 @@ describe('<Dialog.Root />', () => {
         expect(screen.queryByRole('dialog')).to.equal(null);
       });
     });
+
+    it('should not close the parent menu when Escape is pressed in a nested dialog', async () => {
+      const { user } = await render(
+        <Menu.Root>
+          <Menu.Trigger>Open menu</Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Dialog.Root>
+                  <Menu.Item closeOnClick={false} render={<Dialog.Trigger nativeButton={false} />}>
+                    Open dialog
+                  </Menu.Item>
+                  <Dialog.Portal>
+                    <Dialog.Popup />
+                  </Dialog.Portal>
+                </Dialog.Root>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const menuTrigger = screen.getByRole('button', { name: 'Open menu' });
+      await user.click(menuTrigger);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.to.equal(null);
+      });
+
+      const dialogTrigger = screen.getByRole('menuitem', { name: 'Open dialog' });
+      await user.click(dialogTrigger);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.to.equal(null);
+      });
+
+      await user.keyboard('[Escape]');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).to.equal(null);
+      });
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.to.equal(null);
+      });
+    });
   });
 
   describe('prop: actionsRef', () => {


### PR DESCRIPTION
With #2042, merging with main I noticed two issues:

- `nativeButton={false}` must be specified on `Dialog.Trigger` since the `Menu.Item` is rendering it, which is not a native button (the keyboard handlers didn't work, only the pointer).  I wonder if this can be made more obvious/clear.
- The prop merging was incorrect in `useDialogPopup`, causing the `onKeyDown` handler to overwrite and break the handlers that handled the `Escape` event key bubbling