### PR TITLE
[accordion][tabs] Make `value` a required prop

### DIFF
--- a/docs/reference/generated/accordion-item.json
+++ b/docs/reference/generated/accordion-item.json
@@ -3,7 +3,8 @@
   "description": "Groups an accordion header with the corresponding panel.\nRenders a `<div>` element.",
   "props": {
     "value": {
-      "type": "any"
+      "type": "any",
+      "required": true
     },
     "onOpenChange": {
       "type": "((open: boolean) => void)",

--- a/docs/reference/generated/tabs-panel.json
+++ b/docs/reference/generated/tabs-panel.json
@@ -4,6 +4,7 @@
   "props": {
     "value": {
       "type": "Tabs.Tab.Value",
+      "required": true,
       "description": "The value of the TabPanel. It will be shown when the Tab with the corresponding value is selected.\nIf not provided, it will fall back to the index of the panel.\nIt is recommended to explicitly provide it, as it's required for the tab panel to be rendered on the server."
     },
     "className": {

--- a/docs/reference/generated/tabs-tab.json
+++ b/docs/reference/generated/tabs-tab.json
@@ -4,6 +4,7 @@
   "props": {
     "value": {
       "type": "Tabs.Tab.Value",
+      "required": true,
       "description": "The value of the Tab.\nWhen not specified, the value is the child position index."
     },
     "nativeButton": {

--- a/docs/src/app/(private)/experiments/accordion/horizontal.tsx
+++ b/docs/src/app/(private)/experiments/accordion/horizontal.tsx
@@ -23,7 +23,7 @@ export default function App() {
           openMultiple={false}
         >
           {['one', 'two', 'three'].map((value) => (
-            <Accordion.Item className={styles.Item} key={value}>
+            <Accordion.Item value={value} className={styles.Item} key={value}>
               <Accordion.Header className={styles.Header}>
                 <Accordion.Trigger className={styles.Trigger} data-value={value}>
                   <span className={styles.Label}>{displayValueMap[value]}</span>

--- a/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/css-modules/index.tsx
@@ -5,7 +5,7 @@ import styles from './index.module.css';
 export default function ExampleAccordion() {
   return (
     <Accordion.Root className={styles.Accordion}>
-      <Accordion.Item className={styles.Item}>
+      <Accordion.Item value={0} className={styles.Item}>
         <Accordion.Header className={styles.Header}>
           <Accordion.Trigger className={styles.Trigger}>
             What is Base UI?
@@ -20,7 +20,7 @@ export default function ExampleAccordion() {
         </Accordion.Panel>
       </Accordion.Item>
 
-      <Accordion.Item className={styles.Item}>
+      <Accordion.Item value={1} className={styles.Item}>
         <Accordion.Header className={styles.Header}>
           <Accordion.Trigger className={styles.Trigger}>
             How do I get started?
@@ -35,7 +35,7 @@ export default function ExampleAccordion() {
         </Accordion.Panel>
       </Accordion.Item>
 
-      <Accordion.Item className={styles.Item}>
+      <Accordion.Item value={2} className={styles.Item}>
         <Accordion.Header className={styles.Header}>
           <Accordion.Trigger className={styles.Trigger}>
             Can I use it for my project?

--- a/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/accordion/demos/hero/tailwind/index.tsx
@@ -4,7 +4,7 @@ import { Accordion } from '@base-ui-components/react/accordion';
 export default function ExampleAccordion() {
   return (
     <Accordion.Root className="flex w-96 max-w-[calc(100vw-8rem)] flex-col justify-center text-gray-900">
-      <Accordion.Item className="border-b border-gray-200">
+      <Accordion.Item value={0} className="border-b border-gray-200">
         <Accordion.Header>
           <Accordion.Trigger className="group relative flex w-full items-baseline justify-between gap-4 bg-gray-50 py-2 pr-1 pl-3 text-left font-medium hover:bg-gray-100 focus-visible:z-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-800">
             What is Base UI?
@@ -19,7 +19,7 @@ export default function ExampleAccordion() {
         </Accordion.Panel>
       </Accordion.Item>
 
-      <Accordion.Item className="border-b border-gray-200">
+      <Accordion.Item value={1} className="border-b border-gray-200">
         <Accordion.Header>
           <Accordion.Trigger className="group relative flex w-full items-baseline justify-between gap-4 bg-gray-50 py-2 pr-1 pl-3 text-left font-medium hover:bg-gray-100 focus-visible:z-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-800">
             How do I get started?
@@ -34,7 +34,7 @@ export default function ExampleAccordion() {
         </Accordion.Panel>
       </Accordion.Item>
 
-      <Accordion.Item className="border-b border-gray-200">
+      <Accordion.Item value={2} className="border-b border-gray-200">
         <Accordion.Header>
           <Accordion.Trigger className="group relative flex w-full items-baseline justify-between gap-4 bg-gray-50 py-2 pr-1 pl-3 text-left font-medium hover:bg-gray-100 focus-visible:z-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-800">
             Can I use it for my project?

--- a/packages/react/src/accordion/header/AccordionHeader.test.tsx
+++ b/packages/react/src/accordion/header/AccordionHeader.test.tsx
@@ -9,7 +9,7 @@ describe('<Accordion.Header />', () => {
     render: (node) =>
       render(
         <Accordion.Root>
-          <Accordion.Item>{node}</Accordion.Item>
+          <Accordion.Item value={0}>{node}</Accordion.Item>
         </Accordion.Root>,
       ),
     refInstanceof: window.HTMLHeadingElement,

--- a/packages/react/src/accordion/item/AccordionItem.test.tsx
+++ b/packages/react/src/accordion/item/AccordionItem.test.tsx
@@ -23,7 +23,7 @@ const accordionRootContextValue: AccordionRootContext = {
 describe('<Accordion.Item />', () => {
   const { render } = createRenderer();
 
-  describeConformance(<Accordion.Item />, () => ({
+  describeConformance(<Accordion.Item value={0} />, () => ({
     render: (node) =>
       render(
         <AccordionRootContext.Provider value={accordionRootContextValue}>

--- a/packages/react/src/accordion/item/AccordionItem.tsx
+++ b/packages/react/src/accordion/item/AccordionItem.tsx
@@ -30,7 +30,7 @@ export const AccordionItem = React.forwardRef(function AccordionItem(
     disabled: disabledProp = false,
     onOpenChange: onOpenChangeProp,
     render,
-    value: valueProp,
+    value,
     ...elementProps
   } = componentProps;
 
@@ -43,8 +43,6 @@ export const AccordionItem = React.forwardRef(function AccordionItem(
     state: rootState,
     value: openValues,
   } = useAccordionRootContext();
-
-  const value = valueProp ?? index;
 
   const disabled = disabledProp || contextDisabled;
 
@@ -143,6 +141,6 @@ export namespace AccordionItem {
   export interface Props
     extends BaseUIComponentProps<'div', State>,
       Partial<Pick<useCollapsibleRoot.Parameters, 'disabled' | 'onOpenChange'>> {
-    value?: AccordionItemValue;
+    value: AccordionItemValue;
   }
 }

--- a/packages/react/src/accordion/panel/AccordionPanel.test.tsx
+++ b/packages/react/src/accordion/panel/AccordionPanel.test.tsx
@@ -9,7 +9,7 @@ describe('<Accordion.Panel />', () => {
     render: (node) =>
       render(
         <Accordion.Root>
-          <Accordion.Item>{node}</Accordion.Item>
+          <Accordion.Item value={0}>{node}</Accordion.Item>
         </Accordion.Root>,
       ),
     refInstanceof: window.HTMLDivElement,

--- a/packages/react/src/accordion/root/AccordionRoot.test.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.test.tsx
@@ -20,7 +20,7 @@ describe('<Accordion.Root />', () => {
     it('renders correct ARIA attributes', async () => {
       const { getByRole, queryByText, container } = await render(
         <Accordion.Root defaultValue={[0]}>
-          <Accordion.Item>
+          <Accordion.Item value={0}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 1</Accordion.Trigger>
             </Accordion.Header>
@@ -44,7 +44,7 @@ describe('<Accordion.Root />', () => {
     it.skipIf(isJSDOM)('open state', async () => {
       const { getByRole, queryByText, user } = await render(
         <Accordion.Root>
-          <Accordion.Item>
+          <Accordion.Item value={0}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 1</Accordion.Trigger>
             </Accordion.Header>
@@ -76,13 +76,13 @@ describe('<Accordion.Root />', () => {
       it('default item value', async () => {
         const { queryByText } = await render(
           <Accordion.Root defaultValue={[1]}>
-            <Accordion.Item>
+            <Accordion.Item value={0}>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 1</Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Panel>{PANEL_CONTENT_1}</Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item>
+            <Accordion.Item value={1}>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 2</Accordion.Trigger>
               </Accordion.Header>
@@ -128,7 +128,7 @@ describe('<Accordion.Root />', () => {
     it.skipIf(isJSDOM)('open state', async () => {
       const { getByRole, queryByText, setProps } = await render(
         <Accordion.Root value={[]}>
-          <Accordion.Item>
+          <Accordion.Item value={0}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 1</Accordion.Trigger>
             </Accordion.Header>
@@ -157,31 +157,7 @@ describe('<Accordion.Root />', () => {
     });
 
     describe('prop: value', () => {
-      it('default item value', async () => {
-        const { queryByText } = await render(
-          <Accordion.Root value={[1]}>
-            <Accordion.Item>
-              <Accordion.Header>
-                <Accordion.Trigger>Trigger 1</Accordion.Trigger>
-              </Accordion.Header>
-              <Accordion.Panel>{PANEL_CONTENT_1}</Accordion.Panel>
-            </Accordion.Item>
-            <Accordion.Item>
-              <Accordion.Header>
-                <Accordion.Trigger>Trigger 2</Accordion.Trigger>
-              </Accordion.Header>
-              <Accordion.Panel>{PANEL_CONTENT_2}</Accordion.Panel>
-            </Accordion.Item>
-          </Accordion.Root>,
-        );
-
-        expect(queryByText(PANEL_CONTENT_1)).to.equal(null);
-
-        expect(queryByText(PANEL_CONTENT_2)).toBeVisible();
-        expect(queryByText(PANEL_CONTENT_2)).to.have.attribute('data-open');
-      });
-
-      it('custom item value', async () => {
+      it('item value', async () => {
         const { queryByText } = await render(
           <Accordion.Root value={['one']}>
             <Accordion.Item value="one">
@@ -212,13 +188,13 @@ describe('<Accordion.Root />', () => {
     it('can disable the whole accordion', async () => {
       const { getByTestId, getAllByRole, queryByText } = await render(
         <Accordion.Root defaultValue={[0]} disabled>
-          <Accordion.Item data-testid="item1">
+          <Accordion.Item value={0} data-testid="item1">
             <Accordion.Header>
               <Accordion.Trigger>Trigger 1</Accordion.Trigger>
             </Accordion.Header>
             <Accordion.Panel>{PANEL_CONTENT_1}</Accordion.Panel>
           </Accordion.Item>
-          <Accordion.Item data-testid="item2">
+          <Accordion.Item value={1} data-testid="item2">
             <Accordion.Header>
               <Accordion.Trigger>Trigger 2</Accordion.Trigger>
             </Accordion.Header>
@@ -241,13 +217,13 @@ describe('<Accordion.Root />', () => {
     it('can disable one accordion item', async () => {
       const { getAllByRole, getByTestId, queryByText } = await render(
         <Accordion.Root defaultValue={[0]}>
-          <Accordion.Item data-testid="item1" disabled>
+          <Accordion.Item value={0} data-testid="item1" disabled>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 1</Accordion.Trigger>
             </Accordion.Header>
             <Accordion.Panel>{PANEL_CONTENT_1}</Accordion.Panel>
           </Accordion.Item>
-          <Accordion.Item data-testid="item2">
+          <Accordion.Item value={1} data-testid="item2">
             <Accordion.Header>
               <Accordion.Trigger>Trigger 2</Accordion.Trigger>
             </Accordion.Header>
@@ -276,7 +252,7 @@ describe('<Accordion.Root />', () => {
       it(`key: ${key} toggles the Accordion open state`, async () => {
         const { getByRole, queryByText, user } = await render(
           <Accordion.Root>
-            <Accordion.Item>
+            <Accordion.Item value={0}>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 1</Accordion.Trigger>
               </Accordion.Header>
@@ -311,13 +287,13 @@ describe('<Accordion.Root />', () => {
     it('ArrowUp and ArrowDown moves focus between triggers and loops by default', async () => {
       const { getAllByRole, user } = await render(
         <Accordion.Root>
-          <Accordion.Item>
+          <Accordion.Item value={0}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 1</Accordion.Trigger>
             </Accordion.Header>
             <Accordion.Panel>1</Accordion.Panel>
           </Accordion.Item>
-          <Accordion.Item>
+          <Accordion.Item value={1}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 2</Accordion.Trigger>
             </Accordion.Header>
@@ -347,19 +323,19 @@ describe('<Accordion.Root />', () => {
     it('Arrow keys should not put focus on disabled accordion items', async () => {
       const { getAllByRole, user } = await render(
         <Accordion.Root>
-          <Accordion.Item>
+          <Accordion.Item value={0}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 1</Accordion.Trigger>
             </Accordion.Header>
             <Accordion.Panel>1</Accordion.Panel>
           </Accordion.Item>
-          <Accordion.Item disabled>
+          <Accordion.Item value={1} disabled>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 2</Accordion.Trigger>
             </Accordion.Header>
             <Accordion.Panel>2</Accordion.Panel>
           </Accordion.Item>
-          <Accordion.Item>
+          <Accordion.Item value={2}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 3</Accordion.Trigger>
             </Accordion.Header>
@@ -384,25 +360,25 @@ describe('<Accordion.Root />', () => {
       it('End key moves focus the last trigger', async () => {
         const { getAllByRole, user } = await render(
           <Accordion.Root>
-            <Accordion.Item>
+            <Accordion.Item value={0}>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 1</Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Panel>1</Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item disabled>
+            <Accordion.Item value={1} disabled>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 2</Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Panel>2</Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item>
+            <Accordion.Item value={2}>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 3</Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Panel>This is the contents of Accordion.Panel 3</Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item>
+            <Accordion.Item value={3}>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 4</Accordion.Trigger>
               </Accordion.Header>
@@ -423,25 +399,25 @@ describe('<Accordion.Root />', () => {
       it('Home key moves focus to the first trigger', async () => {
         const { getAllByRole, user } = await render(
           <Accordion.Root>
-            <Accordion.Item>
+            <Accordion.Item value={0}>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 1</Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Panel>1</Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item disabled>
+            <Accordion.Item value={1} disabled>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 2</Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Panel>2</Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item>
+            <Accordion.Item value={2}>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 3</Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Panel>This is the contents of Accordion.Panel 3</Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item>
+            <Accordion.Item value={3}>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 4</Accordion.Trigger>
               </Accordion.Header>
@@ -464,13 +440,13 @@ describe('<Accordion.Root />', () => {
       it('can disable focus looping between triggers', async () => {
         const { getAllByRole, user } = await render(
           <Accordion.Root loop={false}>
-            <Accordion.Item>
+            <Accordion.Item value={0}>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 1</Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Panel>1</Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item>
+            <Accordion.Item value={1}>
               <Accordion.Header>
                 <Accordion.Trigger>Trigger 2</Accordion.Trigger>
               </Accordion.Header>
@@ -497,13 +473,13 @@ describe('<Accordion.Root />', () => {
     it('multiple items can be open by default', async () => {
       const { getAllByRole, queryByText, user } = await render(
         <Accordion.Root>
-          <Accordion.Item>
+          <Accordion.Item value={0}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 1</Accordion.Trigger>
             </Accordion.Header>
             <Accordion.Panel>{PANEL_CONTENT_1}</Accordion.Panel>
           </Accordion.Item>
-          <Accordion.Item>
+          <Accordion.Item value={1}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 2</Accordion.Trigger>
             </Accordion.Header>
@@ -531,13 +507,13 @@ describe('<Accordion.Root />', () => {
     it('when false only one item can be open', async () => {
       const { getAllByRole, queryByText, user } = await render(
         <Accordion.Root openMultiple={false}>
-          <Accordion.Item>
+          <Accordion.Item value={0}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 1</Accordion.Trigger>
             </Accordion.Header>
             <Accordion.Panel>{PANEL_CONTENT_1}</Accordion.Panel>
           </Accordion.Item>
-          <Accordion.Item>
+          <Accordion.Item value={1}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 2</Accordion.Trigger>
             </Accordion.Header>
@@ -571,13 +547,13 @@ describe('<Accordion.Root />', () => {
     it('ArrowLeft/Right moves focus in horizontal orientation', async () => {
       const { getAllByRole, user } = await render(
         <Accordion.Root orientation="horizontal">
-          <Accordion.Item>
+          <Accordion.Item value={0}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 1</Accordion.Trigger>
             </Accordion.Header>
             <Accordion.Panel>1</Accordion.Panel>
           </Accordion.Item>
-          <Accordion.Item>
+          <Accordion.Item value={1}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 2</Accordion.Trigger>
             </Accordion.Header>
@@ -609,13 +585,13 @@ describe('<Accordion.Root />', () => {
         const { getAllByRole, user } = await render(
           <DirectionProvider direction="rtl">
             <Accordion.Root orientation="horizontal">
-              <Accordion.Item>
+              <Accordion.Item value={0}>
                 <Accordion.Header>
                   <Accordion.Trigger>Trigger 1</Accordion.Trigger>
                 </Accordion.Header>
                 <Accordion.Panel>1</Accordion.Panel>
               </Accordion.Item>
-              <Accordion.Item>
+              <Accordion.Item value={1}>
                 <Accordion.Header>
                   <Accordion.Trigger>Trigger 2</Accordion.Trigger>
                 </Accordion.Header>
@@ -651,13 +627,13 @@ describe('<Accordion.Root />', () => {
 
       const { getAllByRole, user } = await render(
         <Accordion.Root onValueChange={onValueChange}>
-          <Accordion.Item>
+          <Accordion.Item value={0}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 1</Accordion.Trigger>
             </Accordion.Header>
             <Accordion.Panel>1</Accordion.Panel>
           </Accordion.Item>
-          <Accordion.Item>
+          <Accordion.Item value={1}>
             <Accordion.Header>
               <Accordion.Trigger>Trigger 2</Accordion.Trigger>
             </Accordion.Header>

--- a/packages/react/src/accordion/trigger/AccordionTrigger.test.tsx
+++ b/packages/react/src/accordion/trigger/AccordionTrigger.test.tsx
@@ -9,7 +9,7 @@ describe('<Accordion.Trigger />', () => {
     render: (node) =>
       render(
         <Accordion.Root>
-          <Accordion.Item>{node}</Accordion.Item>
+          <Accordion.Item value={0}>{node}</Accordion.Item>
         </Accordion.Root>,
       ),
     refInstanceof: window.HTMLButtonElement,

--- a/packages/react/src/tabs/panel/TabsPanel.tsx
+++ b/packages/react/src/tabs/panel/TabsPanel.tsx
@@ -8,7 +8,6 @@ import { tabsStyleHookMapping } from '../root/styleHooks';
 import { useTabsRootContext } from '../root/TabsRootContext';
 import type { TabsRoot } from '../root/TabsRoot';
 import type { TabsTab } from '../tab/TabsTab';
-import { TabsPanelDataAttributes } from './TabsPanelDataAttributes';
 
 /**
  * A panel displayed when the corresponding tab is active.
@@ -23,7 +22,7 @@ export const TabsPanel = React.forwardRef(function TabPanel(
   const {
     children,
     className,
-    value: valueProp,
+    value,
     render,
     keepMounted = false,
     ...elementProps
@@ -31,7 +30,7 @@ export const TabsPanel = React.forwardRef(function TabPanel(
 
   const {
     value: selectedValue,
-    getTabIdByPanelValueOrIndex,
+    getTabIdByPanelValue,
     orientation,
     tabActivationDirection,
   } = useTabsRootContext();
@@ -41,30 +40,29 @@ export const TabsPanel = React.forwardRef(function TabPanel(
   const metadata = React.useMemo(
     () => ({
       id,
-      value: valueProp,
+      value,
     }),
-    [id, valueProp],
+    [id, value],
   );
 
   const { ref: listItemRef, index } = useCompositeListItem<TabsPanel.Metadata>({
     metadata,
   });
 
-  const tabPanelValue = valueProp ?? index;
-
-  const hidden = tabPanelValue !== selectedValue;
+  const hidden = value !== selectedValue;
 
   const correspondingTabId = React.useMemo(() => {
-    return getTabIdByPanelValueOrIndex(valueProp, index);
-  }, [getTabIdByPanelValueOrIndex, index, valueProp]);
+    return getTabIdByPanelValue(value);
+  }, [getTabIdByPanelValue, value]);
 
   const state: TabsPanel.State = React.useMemo(
     () => ({
       hidden,
       orientation,
       tabActivationDirection,
+      index,
     }),
-    [hidden, orientation, tabActivationDirection],
+    [hidden, orientation, tabActivationDirection, index],
   );
 
   const element = useRenderElement('div', componentProps, {
@@ -77,7 +75,6 @@ export const TabsPanel = React.forwardRef(function TabPanel(
         id: id ?? undefined,
         role: 'tabpanel',
         tabIndex: hidden ? -1 : 0,
-        [TabsPanelDataAttributes.index as string]: index,
       },
       elementProps,
       { children: hidden && !keepMounted ? undefined : children },
@@ -105,7 +102,7 @@ export namespace TabsPanel {
      * It is recommended to explicitly provide it, as it's required for the tab panel to be rendered on the server.
      * @type Tabs.Tab.Value
      */
-    value?: TabsTab.Value;
+    value: TabsTab.Value;
     /**
      * Whether to keep the HTML element in the DOM while the panel is hidden.
      * @default false

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -71,13 +71,13 @@ describe('<Tabs.Root />', () => {
           <Tabs.List>
             <Tabs.Tab value="tab-0" />
             <Tabs.Tab value="tab-1" id="explicit-tab-id-1" />
-            <Tabs.Tab />
-            <Tabs.Tab id="explicit-tab-id-3" />
+            <Tabs.Tab value="tab-2" />
+            <Tabs.Tab value="tab-3" id="explicit-tab-id-3" />
           </Tabs.List>
           <Tabs.Panel value="tab-1" />
           <Tabs.Panel value="tab-0" />
-          <Tabs.Panel />
-          <Tabs.Panel />
+          <Tabs.Panel value="tab-3" />
+          <Tabs.Panel value="tab-2" />
         </Tabs.Root>,
       );
 
@@ -86,8 +86,8 @@ describe('<Tabs.Root />', () => {
 
       expect(tabPanels[0]).to.have.attribute('aria-labelledby', tabs[1].id);
       expect(tabPanels[1]).to.have.attribute('aria-labelledby', tabs[0].id);
-      expect(tabPanels[2]).to.have.attribute('aria-labelledby', tabs[2].id);
-      expect(tabPanels[3]).to.have.attribute('aria-labelledby', tabs[3].id);
+      expect(tabPanels[2]).to.have.attribute('aria-labelledby', tabs[3].id);
+      expect(tabPanels[3]).to.have.attribute('aria-labelledby', tabs[2].id);
     });
 
     it('sets the aria-controls attribute on tabs to the corresponding tab panel id', async () => {
@@ -96,13 +96,13 @@ describe('<Tabs.Root />', () => {
           <Tabs.List>
             <Tabs.Tab value="tab-0" />
             <Tabs.Tab value="tab-1" id="explicit-tab-id-1" />
-            <Tabs.Tab />
-            <Tabs.Tab id="explicit-tab-id-3" />
+            <Tabs.Tab value="tab-2" />
+            <Tabs.Tab value="tab-3" id="explicit-tab-id-3" />
           </Tabs.List>
           <Tabs.Panel value="tab-1" />
           <Tabs.Panel value="tab-0" />
-          <Tabs.Panel />
-          <Tabs.Panel />
+          <Tabs.Panel value="tab-3" />
+          <Tabs.Panel value="tab-2" />
         </Tabs.Root>,
       );
 
@@ -111,8 +111,8 @@ describe('<Tabs.Root />', () => {
 
       expect(tabs[0]).to.have.attribute('aria-controls', tabPanels[1].id);
       expect(tabs[1]).to.have.attribute('aria-controls', tabPanels[0].id);
-      expect(tabs[2]).to.have.attribute('aria-controls', tabPanels[2].id);
-      expect(tabs[3]).to.have.attribute('aria-controls', tabPanels[3].id);
+      expect(tabs[2]).to.have.attribute('aria-controls', tabPanels[3].id);
+      expect(tabs[3]).to.have.attribute('aria-controls', tabPanels[2].id);
     });
   });
 
@@ -312,9 +312,9 @@ describe('<Tabs.Root />', () => {
             <Tabs.Tab value={1}>Tab 2</Tabs.Tab>
             <Tabs.Tab value={2}>Tab 3</Tabs.Tab>
           </Tabs.List>
-          <Tabs.Panel>Panel 1</Tabs.Panel>
-          <Tabs.Panel>Panel 2</Tabs.Panel>
-          <Tabs.Panel>Panel 3</Tabs.Panel>
+          <Tabs.Panel value={0}>Panel 1</Tabs.Panel>
+          <Tabs.Panel value={1}>Panel 2</Tabs.Panel>
+          <Tabs.Panel value={2}>Panel 3</Tabs.Panel>
         </Tabs.Root>,
       );
 
@@ -338,9 +338,9 @@ describe('<Tabs.Root />', () => {
             </Tabs.Tab>
             <Tabs.Tab value={2}>Tab 3</Tabs.Tab>
           </Tabs.List>
-          <Tabs.Panel>Panel 1</Tabs.Panel>
-          <Tabs.Panel>Panel 2</Tabs.Panel>
-          <Tabs.Panel>Panel 3</Tabs.Panel>
+          <Tabs.Panel value={0}>Panel 1</Tabs.Panel>
+          <Tabs.Panel value={1}>Panel 2</Tabs.Panel>
+          <Tabs.Panel value={2}>Panel 3</Tabs.Panel>
         </Tabs.Root>,
       );
 
@@ -1014,8 +1014,8 @@ describe('<Tabs.Root />', () => {
       const { getAllByRole, getByTestId } = await render(
         <Tabs.Root data-testid="root">
           <Tabs.List>
-            <Tabs.Tab />
-            <Tabs.Tab />
+            <Tabs.Tab value={0} />
+            <Tabs.Tab value={1} />
           </Tabs.List>
         </Tabs.Root>,
       );
@@ -1041,8 +1041,8 @@ describe('<Tabs.Root />', () => {
       const { getAllByRole, getByTestId } = await render(
         <Tabs.Root data-testid="root" orientation="vertical">
           <Tabs.List>
-            <Tabs.Tab style={{ display: 'block' }} />
-            <Tabs.Tab style={{ display: 'block' }} />
+            <Tabs.Tab value={0} style={{ display: 'block' }} />
+            <Tabs.Tab value={1} style={{ display: 'block' }} />
           </Tabs.List>
         </Tabs.Root>,
       );

--- a/packages/react/src/tabs/root/TabsRoot.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.tsx
@@ -66,24 +66,10 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
   );
 
   // get the `id` attribute of <Tabs.Panel> to set as the value of `aria-controls` on <Tabs.Tab>
-  const getTabPanelIdByTabValueOrIndex = React.useCallback(
-    (tabValue: TabsTab.Value | undefined, index: number) => {
-      if (tabValue === undefined && index < 0) {
-        return undefined;
-      }
-
+  const getTabPanelIdByTabValue = React.useCallback(
+    (tabValue: TabsTab.Value) => {
       for (const tabPanelMetadata of tabPanelMap.values()) {
-        // find by tabValue
         if (tabValue !== undefined && tabPanelMetadata && tabValue === tabPanelMetadata?.value) {
-          return tabPanelMetadata.id;
-        }
-
-        // find by index
-        if (
-          tabValue === undefined &&
-          tabPanelMetadata?.index &&
-          tabPanelMetadata?.index === index
-        ) {
           return tabPanelMetadata.id;
         }
       }
@@ -94,28 +80,10 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
   );
 
   // get the `id` attribute of <Tabs.Tab> to set as the value of `aria-labelledby` on <Tabs.Panel>
-  const getTabIdByPanelValueOrIndex = React.useCallback(
-    (tabPanelValue: TabsTab.Value | undefined, index: number) => {
-      if (tabPanelValue === undefined && index < 0) {
-        return undefined;
-      }
-
+  const getTabIdByPanelValue = React.useCallback(
+    (tabPanelValue: TabsTab.Value) => {
       for (const tabMetadata of tabMap.values()) {
-        // find by tabPanelValue
-        if (
-          tabPanelValue !== undefined &&
-          index > -1 &&
-          tabPanelValue === (tabMetadata?.value ?? tabMetadata?.index ?? undefined)
-        ) {
-          return tabMetadata?.id;
-        }
-
-        // find by index
-        if (
-          tabPanelValue === undefined &&
-          index > -1 &&
-          index === (tabMetadata?.value ?? tabMetadata?.index ?? undefined)
-        ) {
+        if (tabPanelValue === (tabMetadata?.value ?? tabMetadata?.index ?? undefined)) {
           return tabMetadata?.id;
         }
       }
@@ -127,13 +95,9 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
 
   // used in `useActivationDirectionDetector` for setting data-activation-direction
   const getTabElementBySelectedValue = React.useCallback(
-    (selectedValue: TabsTab.Value | undefined): HTMLElement | null => {
-      if (selectedValue === undefined) {
-        return null;
-      }
-
+    (selectedValue: TabsTab.Value): HTMLElement | null => {
       for (const [tabElement, tabMetadata] of tabMap.entries()) {
-        if (tabMetadata != null && selectedValue === (tabMetadata.value ?? tabMetadata.index)) {
+        if (tabMetadata != null && selectedValue === tabMetadata.value) {
           return tabElement as HTMLElement;
         }
       }
@@ -147,8 +111,8 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
     () => ({
       direction,
       getTabElementBySelectedValue,
-      getTabIdByPanelValueOrIndex,
-      getTabPanelIdByTabValueOrIndex,
+      getTabIdByPanelValue,
+      getTabPanelIdByTabValue,
       onValueChange,
       orientation,
       setTabMap,
@@ -158,8 +122,8 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
     [
       direction,
       getTabElementBySelectedValue,
-      getTabIdByPanelValueOrIndex,
-      getTabPanelIdByTabValueOrIndex,
+      getTabIdByPanelValue,
+      getTabPanelIdByTabValue,
       onValueChange,
       orientation,
       setTabMap,

--- a/packages/react/src/tabs/root/TabsRootContext.ts
+++ b/packages/react/src/tabs/root/TabsRootContext.ts
@@ -29,16 +29,13 @@ export interface TabsRootContext {
    * @param (any | undefined) panelValue Value to find the Tab for.
    * @param (number) index The index of the TabPanel to look for.
    */
-  getTabIdByPanelValueOrIndex: (
-    panelValue: TabsTab.Value | undefined,
-    index: number,
-  ) => string | undefined;
+  getTabIdByPanelValue: (panelValue: TabsTab.Value) => string | undefined;
   /**
    * Gets the `id` attribute of the TabPanel that corresponds to the given Tab value or index.
    * @param (any | undefined) tabValue Value to find the Tab for.
    * @param (number) index The index of the Tab to look for.
    */
-  getTabPanelIdByTabValueOrIndex: (tabValue: any, index: number) => string | undefined;
+  getTabPanelIdByTabValue: (tabValue: TabsTab.Value) => string | undefined;
   setTabMap: (map: Map<Node, (TabsTab.Metadata & { index?: number | null }) | null>) => void;
   /**
    * The position of the active tab relative to the previously active tab.

--- a/packages/react/src/tabs/tab/TabsTab.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.tsx
@@ -27,27 +27,20 @@ export const TabsTab = React.forwardRef(function Tab(
     className,
     disabled = false,
     render,
-    value: valueProp,
+    value,
     id: idProp,
     nativeButton = true,
     ...elementProps
   } = componentProps;
 
-  const {
-    value: selectedTabValue,
-    getTabPanelIdByTabValueOrIndex,
-    orientation,
-  } = useTabsRootContext();
+  const { value: selectedTabValue, getTabPanelIdByTabValue, orientation } = useTabsRootContext();
 
   const { activateOnFocus, highlightedTabIndex, onTabActivation, setHighlightedTabIndex } =
     useTabsListContext();
 
   const id = useBaseUiId(idProp);
 
-  const tabMetadata = React.useMemo(
-    () => ({ disabled, id, value: valueProp }),
-    [disabled, id, valueProp],
-  );
+  const tabMetadata = React.useMemo(() => ({ disabled, id, value }), [disabled, id, value]);
 
   const {
     props: compositeItemProps,
@@ -57,17 +50,11 @@ export const TabsTab = React.forwardRef(function Tab(
     // because the index is needed for Tab internals
   } = useCompositeItem<TabsTab.Metadata>({ metadata: tabMetadata });
 
-  const tabValue = valueProp ?? index;
-
   // the `selected` state isn't set on the server (it relies on effects to be calculated),
   // so we fall back to checking the `value` param with the selectedTabValue from the TabsContext
   const selected = React.useMemo(() => {
-    if (valueProp === undefined) {
-      return index < 0 ? false : index === selectedTabValue;
-    }
-
-    return valueProp === selectedTabValue;
-  }, [index, selectedTabValue, valueProp]);
+    return value === selectedTabValue;
+  }, [selectedTabValue, value]);
 
   const isSelectionSyncedWithHighlightRef = React.useRef(false);
 
@@ -87,9 +74,7 @@ export const TabsTab = React.forwardRef(function Tab(
     focusableWhenDisabled: true,
   });
 
-  // const handleRef = useForkRef(compositeItemRef, buttonRef, externalRef);
-
-  const tabPanelId = index > -1 ? getTabPanelIdByTabValueOrIndex(valueProp, index) : undefined;
+  const tabPanelId = index > -1 ? getTabPanelIdByTabValue(value) : undefined;
 
   const isPressingRef = React.useRef(false);
   const isMainButtonRef = React.useRef(false);
@@ -101,7 +86,7 @@ export const TabsTab = React.forwardRef(function Tab(
       return;
     }
 
-    onTabActivation(tabValue, event.nativeEvent);
+    onTabActivation(value, event.nativeEvent);
   });
 
   const onFocus = useEventCallback((event: React.FocusEvent<HTMLButtonElement>) => {
@@ -121,7 +106,7 @@ export const TabsTab = React.forwardRef(function Tab(
       (activateOnFocus && !isPressingRef.current) || // keyboard focus
       (isPressingRef.current && isMainButtonRef.current) // focus caused by pointerdown
     ) {
-      onTabActivation(tabValue, event.nativeEvent);
+      onTabActivation(value, event.nativeEvent);
     }
   });
 
@@ -216,7 +201,7 @@ export namespace TabsTab {
      * When not specified, the value is the child position index.
      * @type Tabs.Tab.Value
      */
-    value?: Value;
+    value: Value;
     /**
      * Whether the component renders a native `<button>` element when replacing it
      * via the `render` prop.


### PR DESCRIPTION
Made `value` in Accordion.Item, Tabs.Tab, and Tabs.Panel a mandatory prop. This helps to solve several issues with these components:
- closes #1880
- closes #1872
- closes #1588
- closes #2096

