### PR TITLE
[docs] Fix dead link to APCA

### DIFF
--- a/docs/src/app/(public)/(content)/react/overview/accessibility/page.mdx
+++ b/docs/src/app/(public)/(content)/react/overview/accessibility/page.mdx
@@ -30,7 +30,8 @@ WCAG provides [guidelines on focus appearance](https://www.w3.org/WAI/WCAG22/Und
 
 ## Color contrast
 
-When styling elements, it's important to meet the minimum requirements for color contrast between each foreground element and its corresponding background element. Unless your application has strict requirements around compliance with current standards, consider adhering to [APCA](https://www.myndex.com/APCA/), which is slated to become the new standard in WCAG 3.
+When styling elements, it's important to meet the minimum requirements for color contrast between each foreground element and its corresponding background element.
+Unless your application has strict requirements around compliance with current standards, consider adhering to [APCA](https://apcacontrast.com/), which is slated to become the new standard in WCAG 3.
 
 ## Accessible labels
 


### PR DESCRIPTION
The URL changed. From https://github.com/Myndex/SAPC-APCA/tree/master, we can confirm that is new URL is correct.