### PR TITLE
[all-components] Do not overwrite event handler when `undefined` is passed explicitly

### DIFF
--- a/packages/react/src/dialog/close/DialogClose.test.tsx
+++ b/packages/react/src/dialog/close/DialogClose.test.tsx
@@ -85,4 +85,33 @@ describe('<Dialog.Close />', () => {
       expect(handleOpenChange.callCount).to.equal(1);
     });
   });
+
+  it('closes the dialog when undefined is passed to the `onClick` prop', async () => {
+    const handleOpenChange = spy();
+
+    const { user } = await render(
+      <Dialog.Root onOpenChange={handleOpenChange}>
+        <Dialog.Trigger>Open</Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Popup>
+            <Dialog.Close onClick={undefined}>Close</Dialog.Close>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>,
+    );
+
+    expect(handleOpenChange.callCount).to.equal(0);
+
+    const openButton = screen.getByText('Open');
+    await user.click(openButton);
+
+    expect(handleOpenChange.callCount).to.equal(1);
+    expect(handleOpenChange.firstCall.args[0]).to.equal(true);
+
+    const closeButton = screen.getByText('Close');
+    await user.click(closeButton);
+
+    expect(handleOpenChange.callCount).to.equal(2);
+    expect(handleOpenChange.secondCall.args[0]).to.equal(false);
+  });
 });

--- a/packages/react/src/merge-props/mergeProps.test.ts
+++ b/packages/react/src/merge-props/mergeProps.test.ts
@@ -51,6 +51,29 @@ describe('mergeProps', () => {
     expect(log).to.deep.equal(['1', '2', '3']);
   });
 
+  it('merges undefined event handlers', () => {
+    const log: string[] = [];
+
+    const mergedProps = mergeProps<'button'>(
+      {
+        onClick() {
+          log.push('3');
+        },
+      },
+      {
+        onClick: undefined,
+      },
+      {
+        onClick() {
+          log.push('1');
+        },
+      },
+    );
+
+    mergedProps.onClick?.({ nativeEvent: new MouseEvent('click') } as any);
+    expect(log).to.deep.equal(['1', '3']);
+  });
+
   it('merges styles', () => {
     const theirProps = {
       style: { color: 'red' },

--- a/packages/react/src/merge-props/mergeProps.ts
+++ b/packages/react/src/merge-props/mergeProps.ts
@@ -79,7 +79,7 @@ export function mergePropsN<T extends ElementType>(props: InputProps<T>[]): Prop
     return EMPTY_PROPS as PropsOf<T>;
   }
   if (props.length === 1) {
-    return resolvePropsGetter(props[0], EMPTY_PROPS);
+    return resolvePropsGetter(props[0], EMPTY_PROPS) as PropsOf<T>;
   }
 
   // We need to mutably own `merged`
@@ -149,7 +149,7 @@ function isEventHandler(key: string, value: unknown) {
     code1 === 110 /* n */ &&
     code2 >= 65 /* A */ &&
     code2 <= 90 /* Z */ &&
-    typeof value === 'function'
+    (typeof value === 'function' || typeof value === 'undefined')
   );
 }
 
@@ -170,7 +170,7 @@ function resolvePropsGetter<T extends ElementType>(
   return inputProps ?? (EMPTY_PROPS as PropsOf<T>);
 }
 
-function mergeEventHandlers(ourHandler: Function, theirHandler: Function) {
+function mergeEventHandlers(ourHandler: Function | undefined, theirHandler: Function | undefined) {
   if (!theirHandler) {
     return ourHandler;
   }


### PR DESCRIPTION
`mergeProps` was handling event handlers incorrectly - when explicit `undefined` was passed, the merged result was `undefined` and other handlers were ignored.

For example, `<Dialog.Close onClick={undefined} />` would not close a Dialog.