### PR TITLE
[test] Skip flaky test run on chromium

### DIFF
--- a/packages/react/src/toolbar/button/ToolbarButton.test.tsx
+++ b/packages/react/src/toolbar/button/ToolbarButton.test.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@base-ui-components/react/popover';
 import { Toggle } from '@base-ui-components/react/toggle';
 import { ToggleGroup } from '@base-ui-components/react/toggle-group';
 import { screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance } from '#test-utils';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { NOOP } from '../../utils/noop';
 import { ToolbarRootContext } from '../root/ToolbarRootContext';
 import { CompositeRootContext } from '../../composite/root/CompositeRootContext';
@@ -331,7 +331,7 @@ describe('<Toolbar.Button />', () => {
         expect(trigger).to.have.attribute('aria-haspopup', 'listbox');
       });
 
-      it('handles interactions', async () => {
+      it.skipIf(!isJSDOM)('handles interactions', async () => {
         const handleValueChange = spy();
         const { getByTestId, user } = await render(
           <Toolbar.Root>


### PR DESCRIPTION
One of the ToolbarButton tests is particularly flaky on Chromium (https://app.circleci.com/pipelines/github/mui/base-ui/11319/workflows/ba25bc1b-9e1a-4f13-9f30-eb4f8664e811/jobs/112307). We'll run it on JSDOM only.