### PR TITLE
[menu] Fix focus returning to root when submenus have exit transitions

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -662,7 +662,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
       const isFocusInsideFloatingTree =
         contains(floating, activeEl) ||
         (tree &&
-          getNodeChildren(tree.nodesRef.current, getNodeId()).some((node) =>
+          getNodeChildren(tree.nodesRef.current, getNodeId(), false).some((node) =>
             contains(node.context?.elements.floating, activeEl),
           ));
 

--- a/packages/react/src/floating-ui-react/utils/nodes.test.ts
+++ b/packages/react/src/floating-ui-react/utils/nodes.test.ts
@@ -1,0 +1,101 @@
+import type { FloatingContext } from '../types';
+import { getNodeAncestors, getNodeChildren } from './nodes';
+
+const contextOpen = { open: true } as FloatingContext;
+const contextClosed = { open: false } as FloatingContext;
+
+test('getNodeChildren returns an array of children, ignoring closed ones when onlyOpenChildren=true', () => {
+  expect(
+    getNodeChildren(
+      [
+        { id: '0', parentId: null, context: contextOpen },
+        { id: '1', parentId: '0', context: contextOpen },
+        { id: '2', parentId: '1', context: contextOpen },
+        { id: '3', parentId: '1', context: contextOpen },
+        { id: '4', parentId: '1', context: contextClosed },
+      ],
+      '0',
+      true,
+    ),
+  ).toEqual([
+    { id: '1', parentId: '0', context: contextOpen },
+    { id: '2', parentId: '1', context: contextOpen },
+    { id: '3', parentId: '1', context: contextOpen },
+  ]);
+});
+
+test('getNodeChildren returns an array of children, including closed ones when onlyOpenChildren=false', () => {
+  expect(
+    getNodeChildren(
+      [
+        { id: '0', parentId: null, context: contextOpen },
+        { id: '1', parentId: '0', context: contextOpen },
+        { id: '2', parentId: '1', context: contextOpen },
+        { id: '3', parentId: '1', context: contextOpen },
+        { id: '4', parentId: '1', context: contextClosed },
+      ],
+      '0',
+      false,
+    ),
+  ).toEqual([
+    { id: '1', parentId: '0', context: contextOpen },
+    { id: '2', parentId: '1', context: contextOpen },
+    { id: '3', parentId: '1', context: contextOpen },
+    { id: '4', parentId: '1', context: contextClosed },
+  ]);
+});
+
+test('getNodeChildren handles deep parent structures correctly (onlyOpenChildren=true)', () => {
+  const nodes = [
+    { id: '0', parentId: null, context: contextOpen },
+    { id: '1', parentId: '0', context: contextOpen },
+    { id: '2', parentId: '1', context: contextClosed },
+    { id: '3', parentId: '2', context: contextOpen },
+    { id: '4', parentId: '2', context: contextClosed },
+    { id: '5', parentId: '0', context: contextOpen },
+    { id: '6', parentId: '5', context: contextOpen },
+  ];
+
+  expect(getNodeChildren(nodes, '0', true)).toEqual([
+    { id: '1', parentId: '0', context: contextOpen },
+    { id: '5', parentId: '0', context: contextOpen },
+    { id: '6', parentId: '5', context: contextOpen },
+  ]);
+});
+
+test('getNodeChildren handles deep parent structures correctly (onlyOpenChildren=false)', () => {
+  const nodes = [
+    { id: '0', parentId: null, context: contextOpen },
+    { id: '1', parentId: '0', context: contextOpen },
+    { id: '2', parentId: '1', context: contextClosed },
+    { id: '3', parentId: '2', context: contextOpen },
+    { id: '4', parentId: '2', context: contextClosed },
+    { id: '5', parentId: '0', context: contextOpen },
+    { id: '6', parentId: '5', context: contextOpen },
+  ];
+
+  expect(getNodeChildren(nodes, '0', false)).toEqual([
+    { id: '1', parentId: '0', context: contextOpen },
+    { id: '2', parentId: '1', context: contextClosed },
+    { id: '3', parentId: '2', context: contextOpen },
+    { id: '4', parentId: '2', context: contextClosed },
+    { id: '5', parentId: '0', context: contextOpen },
+    { id: '6', parentId: '5', context: contextOpen },
+  ]);
+});
+
+test('getNodeAncestors returns an array of ancestors', () => {
+  expect(
+    getNodeAncestors(
+      [
+        { id: '0', parentId: null },
+        { id: '1', parentId: '0' },
+        { id: '2', parentId: '1' },
+      ],
+      '2',
+    ),
+  ).toEqual([
+    { id: '1', parentId: '0' },
+    { id: '0', parentId: null },
+  ]);
+});

--- a/packages/react/src/floating-ui-react/utils/nodes.ts
+++ b/packages/react/src/floating-ui-react/utils/nodes.ts
@@ -6,21 +6,14 @@ export function getNodeChildren<RT extends ReferenceType = ReferenceType>(
   nodes: Array<FloatingNodeType<RT>>,
   id: string | undefined,
   onlyOpenChildren = true,
-) {
-  let allChildren = nodes.filter((node) => node.parentId === id && node.context?.open);
-  let currentChildren = allChildren;
-
-  while (currentChildren.length) {
-    currentChildren = onlyOpenChildren
-      ? nodes.filter((node) =>
-          currentChildren?.some((n) => node.parentId === n.id && node.context?.open),
-        )
-      : nodes;
-
-    allChildren = allChildren.concat(currentChildren);
-  }
-
-  return allChildren;
+): Array<FloatingNodeType<RT>> {
+  const directChildren = nodes.filter(
+    (node) => node.parentId === id && (!onlyOpenChildren || node.context?.open),
+  );
+  return directChildren.flatMap((child) => [
+    child,
+    ...getNodeChildren(nodes, child.id, onlyOpenChildren),
+  ]);
 }
 
 export function getDeepestNode<RT extends ReferenceType = ReferenceType>(


### PR DESCRIPTION
The key is `isFocusInsideFloatingTree` needs to be true because sometimes the `activeElement` is one of the submenu items. However, the `isFocusInsideFloatingTree` check was faulty because `getNodeChildren` filters out closed children, but since they have an exit transition, they're closed-but-still-mounted (and the `activeElement` _can_ be inside them). In this case it shouldn't filter the open children so the `contains` check can work.

https://github.com/mui/base-ui/blob/11cbf2185d74ce5468263f31828cec0b68ad49c1/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx#L682-L684

On https://deploy-preview-2171--base-ui.netlify.app/experiments/menu/menu-fully-featured
Open root, navigate to the second nested submenu, press <kbd>Escape</kbd>. Try it several times since it didn't fail every time previously.