### PR TITLE
[select][number field] Fix revalidation on change

### DIFF
--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -112,12 +112,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       blockRevalidationRef.current = false;
       return;
     }
-
-    // Defer the validation until after React has committed the DOM updates
-    // to ensure the hidden input element reflects the latest value.
-    queueMicrotask(() => {
-      commitValidation(value, true);
-    });
+    commitValidation(value, true);
   }, [commitValidation, validationMode, value]);
 
   useModernLayoutEffect(() => {

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -112,7 +112,12 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       blockRevalidationRef.current = false;
       return;
     }
-    commitValidation(value, true);
+
+    // Defer the validation until after React has committed the DOM updates
+    // to ensure the hidden input element reflects the latest value.
+    queueMicrotask(() => {
+      commitValidation(value, true);
+    });
   }, [commitValidation, validationMode, value]);
 
   useModernLayoutEffect(() => {

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -395,6 +395,26 @@ describe('<NumberField />', () => {
       }).format(1000);
       expect(input).to.have.value(expectedValue);
     });
+
+    it('reflects controlled value changes in the textbox', async () => {
+      function App() {
+        const [val, setVal] = React.useState<number | null>(1);
+        return (
+          <div>
+            <NumberField value={val} onValueChange={setVal} />
+            <button onClick={() => setVal(1234)}>set</button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<App />);
+      const input = screen.getByRole('textbox');
+
+      expect(input).to.have.value('1');
+
+      await user.click(screen.getByText('set'));
+      expect(input).to.have.value((1234).toLocaleString());
+    });
   });
 
   describe('prop: allowWheelScrub', () => {

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -579,6 +579,35 @@ describe('<NumberField />', () => {
       expect(input).not.to.have.attribute('aria-invalid');
       expect(screen.queryByTestId('error')).to.equal(null);
     });
+
+    it('revalidates immediately after form submission errors using increment button', async () => {
+      const { user } = await render(
+        <Form>
+          <Field.Root name="quantity">
+            <NumberField required />
+            <Field.Error match="valueMissing" data-testid="error">
+              required
+            </Field.Error>
+          </Field.Root>
+          <button type="submit" data-testid="submit">
+            Submit
+          </button>
+        </Form>,
+      );
+
+      const submit = screen.getByTestId('submit');
+      await user.click(submit);
+
+      expect(screen.getByTestId('error')).to.have.text('required');
+      const input = screen.getByRole('textbox');
+      expect(input).to.have.attribute('aria-invalid', 'true');
+
+      const incrementButton = screen.getByLabelText('Increase');
+      await user.click(incrementButton);
+
+      expect(screen.queryByTestId('error')).to.equal(null);
+      expect(input).not.to.have.attribute('aria-invalid');
+    });
   });
 
   describe('Field', () => {

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -179,9 +179,15 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
       setValueUnwrapped(validatedValue);
       setDirty(validatedValue !== validityData.initialValue);
 
-      // We need to force a re-render, because while the value may be unchanged, the formatting may
-      // be different. This forces the `useModernLayoutEffect` to run which acts as a single source of
-      // truth to sync the input value.
+      // Keep the visible input in sync immediately when programmatic changes occur
+      // (increment/decrement, wheel, etc). During direct typing we don't want
+      // to overwrite the user-provided text until blur, so we gate on
+      // `allowInputSyncRef`.
+      if (allowInputSyncRef.current) {
+        setInputValue(formatNumber(validatedValue, locale, format));
+      }
+
+      // Formatting can change even if the numeric value hasn't, so ensure a re-render when needed.
       forceRender();
     },
   );

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -941,6 +941,49 @@ describe('<Select.Root />', () => {
       expect(screen.queryByTestId('error')).to.equal(null);
       expect(trigger).not.to.have.attribute('aria-invalid');
     });
+
+    it('revalidates immediately after form submission errors', async () => {
+      const { user } = await renderFakeTimers(
+        <Form>
+          <Field.Root name="select">
+            <Select.Root required>
+              <Select.Trigger data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    <Select.Item value="a">a</Select.Item>
+                    <Select.Item value="b">b</Select.Item>
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+            <Field.Error match="valueMissing" data-testid="error">
+              required
+            </Field.Error>
+          </Field.Root>
+          <button type="submit" data-testid="submit">
+            Submit
+          </button>
+        </Form>,
+      );
+
+      const submit = screen.getByTestId('submit');
+      await user.click(submit);
+
+      expect(screen.getByTestId('error')).to.have.text('required');
+      const trigger = screen.getByTestId('trigger');
+      expect(trigger).to.have.attribute('aria-invalid', 'true');
+
+      await user.click(trigger);
+      await flushMicrotasks();
+      clock.tick(200);
+      await user.click(screen.getByRole('option', { name: 'b' }));
+
+      expect(screen.queryByTestId('error')).to.equal(null);
+      expect(trigger).not.to.have.attribute('aria-invalid');
+    });
   });
 
   describe('Field', () => {

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -5,6 +5,7 @@ import { SelectRootContext, SelectFloatingContext } from './SelectRootContext';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { visuallyHidden } from '../../utils/visuallyHidden';
 import { useForkRef } from '../../utils/useForkRef';
+import { serializeValue } from '../utils/serialize';
 
 /**
  * Groups all parts of the select.
@@ -59,15 +60,7 @@ export const SelectRoot: SelectRoot = function SelectRoot<Value>(
 
   const ref = useForkRef(inputRef, rootContext.fieldControlValidation.inputRef);
 
-  const serializedValue = React.useMemo(() => {
-    if (value == null) {
-      return ''; // avoid uncontrolled -> controlled error
-    }
-    if (typeof value === 'string') {
-      return value;
-    }
-    return JSON.stringify(value);
-  }, [value]);
+  const serializedValue = React.useMemo(() => serializeValue(value), [value]);
 
   return (
     <SelectRootContext.Provider value={rootContext}>

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -35,7 +35,7 @@ export const SelectRoot: SelectRoot = function SelectRoot<Value>(
     items,
   } = props;
 
-  const { rootContext, floatingContext } = useSelectRoot<Value>({
+  const { rootContext, floatingContext, value } = useSelectRoot<Value>({
     id,
     value: valueProp,
     defaultValue,
@@ -55,8 +55,6 @@ export const SelectRoot: SelectRoot = function SelectRoot<Value>(
   const store = rootContext.store;
 
   const { setDirty, validityData, validationMode, controlId } = useFieldRootContext();
-
-  const value = store.state.value;
 
   const ref = useForkRef(inputRef, rootContext.fieldControlValidation.inputRef);
 

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -156,6 +156,12 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
 
     clearErrors(name);
     setDirty(nextValue !== validityData.initialValue);
+
+    // Defer the validation until after React has committed the DOM updates
+    // to ensure the hidden input element reflects the latest value.
+    queueMicrotask(() => {
+      commitValidation(nextValue, true);
+    });
   });
 
   useField({

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -31,6 +31,7 @@ import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useFormContext } from '../../form/FormContext';
 import { useLatestRef } from '../../utils/useLatestRef';
 import { useField } from '../../field/useField';
+import { serializeValue } from '../utils/serialize';
 
 export type SelectOpenChangeReason = BaseOpenChangeReason | 'window-resize';
 
@@ -157,11 +158,13 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     clearErrors(name);
     setDirty(nextValue !== validityData.initialValue);
 
-    // Defer the validation until after React has committed the DOM updates
-    // to ensure the hidden input element reflects the latest value.
-    queueMicrotask(() => {
-      commitValidation(nextValue, validationMode !== 'onChange');
-    });
+    // Ensure validation uses the latest value.
+    const inputEl = fieldControlValidation.inputRef.current;
+    if (inputEl) {
+      inputEl.value = serializeValue(nextValue);
+    }
+
+    commitValidation(nextValue, validationMode !== 'onChange');
   });
 
   useField({

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -160,7 +160,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     // Defer the validation until after React has committed the DOM updates
     // to ensure the hidden input element reflects the latest value.
     queueMicrotask(() => {
-      commitValidation(nextValue, true);
+      commitValidation(nextValue, validationMode !== 'onChange');
     });
   });
 

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -176,7 +176,7 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     commitValidation(value, validationMode !== 'onChange');
 
     if (validationMode === 'onChange') {
-      commitValidation?.(value);
+      commitValidation(value);
     }
   }, [
     value,

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -87,8 +87,6 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
     state: 'open',
   });
 
-  const isValueControlled = params.value !== undefined;
-
   const listRef = React.useRef<Array<HTMLElement | null>>([]);
   const labelsRef = React.useRef<Array<string | null>>([]);
   const popupRef = React.useRef<HTMLDivElement | null>(null);
@@ -243,10 +241,6 @@ export function useSelectRoot<T>(params: useSelectRoot.Parameters<T>): useSelect
   const setValue = useEventCallback((nextValue: any, event?: Event) => {
     params.onValueChange?.(nextValue, event);
     setValueUnwrapped(nextValue);
-
-    if (!isValueControlled) {
-      updateValue(nextValue);
-    }
   });
 
   const hasRegisteredRef = React.useRef(false);

--- a/packages/react/src/select/utils/serialize.ts
+++ b/packages/react/src/select/utils/serialize.ts
@@ -1,0 +1,13 @@
+export function serializeValue(value: unknown): string {
+  if (value == null) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Select was a regression from `beta.0`, likely due to the Store refactoring - the `store` value is updated later than the internal `value`, so the hidden `<input>` was getting a slightly stale value - the internal hook to commit the validation therefore was executing sooner than React had updated the hidden input `value` in the DOM for native validation
NumberField issue existed in `beta.0`

https://deploy-preview-2174--base-ui.netlify.app/experiments/form

1. Press submit without filling anything in
2. NumberField: Press increment -> validates immediately (required blur before)
3. Select: choose a value -> validates immediately (required blur before)