### PR TITLE
[docs] Use loose list when relevant

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/tooltip/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/tooltip/page.mdx
@@ -15,7 +15,9 @@
 To ensure that tooltips are accessible and helpful, follow these guidelines:
 
 - **Provide an accessible name for the trigger**: The tooltip's trigger must have a meaningful label. This can be its visible text or an `aria-label`/`aria-labelledby` attribute. The label should closely match the tooltip's content to ensure consistency for screen reader users.
+
 - **Avoid tooltips for critical information**: Tooltips work well for enhancing UI clarity (like labeling icon buttons) but should not be the sole means of conveying important information. Since tooltips do not appear on touch devices, consider using a [Popover](/react/components/popover) for essential content.
+
 - **Avoid tooltips for "infotips"**: If your tooltip is attached to an "info icon" button whose only purpose is to show the tooltip, opt for [Popover](/react/components/popover) and add the `openOnHover` prop instead. Tooltips should describe an element that performs an action separate from opening the tooltip itself.
 
 ## Anatomy

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -55,7 +55,7 @@ export const mdxComponents: MDXComponents = {
   h5: (props) => <h5 className="mt-8 mb-1.5 scroll-mt-6 font-medium text-balance" {...props} />,
   h6: (props) => <h6 className="mt-8 mb-1.5 scroll-mt-6 font-medium text-balance" {...props} />,
   p: (props) => <p className="mb-4" {...props} />,
-  li: (props) => <li className="mb-0.5" {...props} />,
+  li: (props) => <li className="mb-0.5 [&>p]:mb-2" {...props} />,
   ul: (props) => <ul className="mb-4 ml-4.5 list-disc" {...props} />,
   ol: (props) => <ol className="mb-4 ml-7 list-decimal" {...props} />,
   kbd: Kbd,


### PR DESCRIPTION
Current: https://base-ui.com/react/components/tooltip#accessibility-guidelines, rely on [Tight list](https://spec.commonmark.org/0.30/#tight)

<img width="782" alt="SCR-20250628-pige" src="https://github.com/user-attachments/assets/02221794-339a-4d3b-a625-b1a6611792c0" />

[Loose list](https://spec.commonmark.org/0.30/#loose), without CSS changes

<img width="785" alt="SCR-20250628-piie" src="https://github.com/user-attachments/assets/e85da8ee-c0c4-45a1-9a70-8bc760c116ad" />

PR:

<img width="773" alt="SCR-20250628-pidn" src="https://github.com/user-attachments/assets/b65c7ed4-a532-4de7-b487-14df85958094" />

---

Context, I was looking at https://github.com/mui/base-ui/issues/559#issuecomment-2614736116, had some fun, same as https://github.com/mui/material-ui/pull/36190.