### PR TITLE
[code-infra] Restrict GitHub Actions permissions

### DIFF
--- a/.github/workflows/fixed-issue.yml
+++ b/.github/workflows/fixed-issue.yml
@@ -4,6 +4,8 @@ on:
   issues:
     types: [closed]
 
+permissions: {}
+
 jobs:
   add-comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should fix: https://securityscorecards.dev/viewer/?uri=github.com%2Fmui%2Fbase-ui

<img width="600" alt="SCR-20250628-pluz" src="https://github.com/user-attachments/assets/04f73d8d-1229-44e3-bfa4-09558683d2c4" />
