### PR TITLE
feat(aspect-ratio): introduce `AspectRatio` component

### DIFF
--- a/docs/reference/generated/aspect-ratio.json
+++ b/docs/reference/generated/aspect-ratio.json
@@ -1,0 +1,20 @@
+{
+  "name": "AspectRatio",
+  "description": "A component that displays content within a desired ratio (e.g., 16 / 9, 4 / 3).",
+  "props": {
+    "ratio": {
+      "type": "number",
+      "description": "The desired aspect ratio (e.g., 16 / 9, 4 / 3)."
+    },
+    "className": {
+      "type": "string | ((state: AspectRatio.State) => string)",
+      "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+    },
+    "render": {
+      "type": "ReactElement | ((props: HTMLProps, state: AspectRatio.State) => ReactElement)",
+      "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+    }
+  },
+  "dataAttributes": {},
+  "cssVariables": {}
+}

--- a/docs/src/app/(public)/(content)/react/components/aspect-ratio/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/aspect-ratio/demos/hero/css-modules/index.module.css
@@ -1,0 +1,11 @@
+.wrapper {
+  width: 128px;
+  overflow: hidden;
+  border-radius: 0.25rem;
+}
+
+.wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}

--- a/docs/src/app/(public)/(content)/react/components/aspect-ratio/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/aspect-ratio/demos/hero/css-modules/index.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { AspectRatio } from '@base-ui-components/react/aspect-ratio';
+import styles from './index.module.css';
+
+export default function ExampleAspectRatio() {
+  return (
+    <div className={styles.wrapper}>
+      <AspectRatio ratio={5 / 8}>
+        <img
+          src="https://images.unsplash.com/photo-1543610892-0b1f7e6d8ac1?w=128&amp;h=128&amp;dpr=2&amp;q=80"
+          alt="https://images.unsplash.com/photo-1543610892-0b1f7e6d8ac1?w=128&amp;h=128&amp;dpr=2&amp;q=80"
+        />
+      </AspectRatio>
+    </div>
+  );
+}

--- a/docs/src/app/(public)/(content)/react/components/aspect-ratio/demos/hero/index.ts
+++ b/docs/src/app/(public)/(content)/react/components/aspect-ratio/demos/hero/index.ts
@@ -1,0 +1,3 @@
+'use client';
+export { default as CssModules } from './css-modules';
+export { default as Tailwind } from './tailwind';

--- a/docs/src/app/(public)/(content)/react/components/aspect-ratio/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/aspect-ratio/demos/hero/tailwind/index.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { AspectRatio } from '@base-ui-components/react/aspect-ratio';
+
+export default function ExampleAspectRatio() {
+  return (
+    <div className="w-32 overflow-hidden rounded">
+      <AspectRatio ratio={5 / 8}>
+        <img
+          className="size-full object-cover"
+          src="https://images.unsplash.com/photo-1543610892-0b1f7e6d8ac1?w=128&amp;h=128&amp;dpr=2&amp;q=80"
+          alt="https://images.unsplash.com/photo-1543610892-0b1f7e6d8ac1?w=128&amp;h=128&amp;dpr=2&amp;q=80"
+        />
+      </AspectRatio>
+    </div>
+  );
+}

--- a/docs/src/app/(public)/(content)/react/components/aspect-ratio/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/aspect-ratio/page.mdx
@@ -1,0 +1,23 @@
+# Aspect Ratio
+
+<Subtitle>A component that displays content within a desired aspect ratio.</Subtitle>
+<Meta
+  name="description"
+  content="A high-quality, unstyled React component that displays content within a desired aspect ratio."
+/>
+
+<Demo path="./demos/hero" />
+
+## Anatomy
+
+Import the component and assemble its parts:
+
+```jsx title="Anatomy"
+import { AlertDialog } from '@base-ui-components/react/alert-dialog';
+
+<AspectRatio></AspectRatio>;
+```
+
+## API reference
+
+<Reference component="AspectRatio" />

--- a/docs/src/nav.ts
+++ b/docs/src/nav.ts
@@ -49,6 +49,11 @@ export const nav = [
         href: '/react/components/alert-dialog',
       },
       {
+        label: 'Aspect Ratio',
+        href: '/react/components/aspect-ratio',
+        isNew: true,
+      },
+      {
         label: 'Avatar',
         href: '/react/components/avatar',
       },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,6 +29,7 @@
     ".": "./src/index.ts",
     "./accordion": "./src/accordion/index.ts",
     "./alert-dialog": "./src/alert-dialog/index.ts",
+    "./aspect-ratio": "./src/aspect-ratio/index.ts",
     "./avatar": "./src/avatar/index.ts",
     "./checkbox": "./src/checkbox/index.ts",
     "./checkbox-group": "./src/checkbox-group/index.ts",

--- a/packages/react/src/aspect-ratio/AspectRatio.test.tsx
+++ b/packages/react/src/aspect-ratio/AspectRatio.test.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { createRenderer } from '@mui/internal-test-utils';
+import { describeConformance } from '../../test/describeConformance';
+import { AspectRatio } from './AspectRatio';
+
+describe('<AspectRatio />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<AspectRatio />, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render,
+  }));
+});

--- a/packages/react/src/aspect-ratio/AspectRatio.tsx
+++ b/packages/react/src/aspect-ratio/AspectRatio.tsx
@@ -1,0 +1,65 @@
+'use client';
+import * as React from 'react';
+import type { BaseUIComponentProps } from '../utils/types';
+import { useRenderElement } from '../utils/useRenderElement';
+
+/**
+ * A component that displays content within a desired ratio (e.g., 16 / 9, 4 / 3).
+ *
+ * Documentation: [Base UI AspectRatio](https://base-ui.com/react/components/aspect-ratio)
+ */
+export const AspectRatio = React.forwardRef(function AspectRatio(
+  componentProps: AspectRatio.Props,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
+) {
+  const {
+    className,
+    render,
+    style,
+    children,
+    ratio = 1 / 1, // default ratio
+    ...elementProps
+  } = componentProps;
+
+  const element = useRenderElement('div', componentProps, {
+    ref: forwardedRef,
+    props: {
+      ...elementProps,
+      style: {
+        ...style,
+        // ensures children expand in ratio
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+      },
+      children,
+    },
+  });
+
+  return (
+    <div
+      style={{
+        // ensures inner element is contained
+        position: 'relative',
+        // ensures padding bottom trick maths works
+        width: '100%',
+        paddingBottom: `${100 / ratio}%`,
+      }}
+    >
+      {element}
+    </div>
+  );
+});
+
+export namespace AspectRatio {
+  export interface Props extends BaseUIComponentProps<'div', State> {
+    /**
+     * The desired aspect ratio (e.g., 16 / 9, 4 / 3).
+     */
+    ratio?: number;
+  }
+
+  export interface State {}
+}

--- a/packages/react/src/aspect-ratio/index.ts
+++ b/packages/react/src/aspect-ratio/index.ts
@@ -1,0 +1,1 @@
+export { AspectRatio } from './AspectRatio';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,6 @@
 export * from './accordion';
 export * from './alert-dialog';
+export * from './aspect-ratio';
 export * from './avatar';
 export * from './checkbox';
 export * from './checkbox-group';


### PR DESCRIPTION
Add a new `AspectRatio`(#2189) component to constrain its children to a given width-to-height ratio:

* Exposes `<AspectRatio ratio={number}>…</AspectRatio>`
* Sets up CSS Modules and Tailwind examples
* Includes unit tests for core behavior
* Ships a demo page under `docs/src/app/(public)/content/react/components/aspect-ratio`

This is my first contribution to base-ui. I’m learning the repo’s patterns and totally get if this component needs tweaks or isn’t the right fit for the project.

**Changed files**

* `packages/react/src/aspect-ratio/AspectRatio.tsx`
* `packages/react/src/aspect-ratio/index.ts`
* `docs/src/app/(public)/content/react/components/aspect-ratio/*`
* `packages/react/src/aspect-ratio/AspectRatio.test.tsx`

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
