### PR TITLE
[select] Fix scroll-item-into-view in fallback mode after keyboard interaction

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -412,6 +412,8 @@ export function useListNavigation(
     }
 
     if (activeIndex == null) {
+      forceSyncFocusRef.current = false;
+
       if (selectedIndexRef.current != null) {
         return;
       }
@@ -450,8 +452,6 @@ export function useListNavigation(
             onNavigate();
           }
         };
-
-        forceSyncFocusRef.current = false;
 
         waitForListPopulated();
       }
@@ -555,26 +555,31 @@ export function useListNavigation(
         syncCurrentTarget(currentTarget);
       },
       onClick: ({ currentTarget }) => currentTarget.focus({ preventScroll: true }), // Safari
-      ...(focusItemOnHover && {
-        onMouseMove({ currentTarget }) {
-          forceSyncFocusRef.current = true;
-          forceScrollIntoViewRef.current = false;
+      onMouseMove({ currentTarget }) {
+        forceSyncFocusRef.current = true;
+        forceScrollIntoViewRef.current = false;
+        if (focusItemOnHover) {
           syncCurrentTarget(currentTarget);
-        },
-        onPointerLeave({ pointerType }) {
-          if (!isPointerModalityRef.current || pointerType === 'touch') {
-            return;
-          }
+        }
+      },
+      onPointerLeave({ pointerType }) {
+        if (!isPointerModalityRef.current || pointerType === 'touch') {
+          return;
+        }
 
-          forceSyncFocusRef.current = true;
-          indexRef.current = -1;
-          onNavigate();
+        forceSyncFocusRef.current = true;
 
-          if (!virtual) {
-            floatingFocusElementRef.current?.focus({ preventScroll: true });
-          }
-        },
-      }),
+        if (focusItemOnHover) {
+          return;
+        }
+
+        indexRef.current = -1;
+        onNavigate();
+
+        if (!virtual) {
+          floatingFocusElementRef.current?.focus({ preventScroll: true });
+        }
+      },
     };
 
     return itemProps;

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -569,7 +569,7 @@ export function useListNavigation(
 
         forceSyncFocusRef.current = true;
 
-        if (focusItemOnHover) {
+        if (!focusItemOnHover) {
           return;
         }
 


### PR DESCRIPTION
(Post-`beta.0` regression fix, so doesn't need to be mentioned in release)

Repro:

1. Open select with long scrollable list such that it enters fallback mode with `alignItemWithTrigger` still enabled
2. Scroll to last item, interact using keyboard
3. Close, re-open select, did not scroll the item into view

This _only_ happens with `alignItemWithTrigger` being in fallback mode, and only after interacting with the keyboard

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
