### PR TITLE
[field][form] Deregister fields from `Form` when unmounting

### DIFF
--- a/packages/react/src/field/useField.ts
+++ b/packages/react/src/field/useField.ts
@@ -63,6 +63,15 @@ export function useField(params: useField.Parameters) {
     validityData,
     value,
   ]);
+
+  useModernLayoutEffect(() => {
+    const fields = formRef.current.fields;
+    return () => {
+      if (id) {
+        fields.delete(id);
+      }
+    };
+  }, [formRef, id]);
 }
 
 export namespace useField {

--- a/packages/react/src/form/Form.test.tsx
+++ b/packages/react/src/form/Form.test.tsx
@@ -64,6 +64,7 @@ describe('<Form />', () => {
     const submit = screen.getByText('Submit');
 
     await user.click(submit);
+    expect(submitSpy.callCount).to.equal(0);
     expect(screen.getByTestId('email')).to.have.attribute('aria-invalid', 'true');
 
     await user.click(screen.getByRole('checkbox'));

--- a/packages/react/src/form/Form.test.tsx
+++ b/packages/react/src/form/Form.test.tsx
@@ -35,6 +35,42 @@ describe('<Form />', () => {
     expect(onSubmit.called).to.equal(false);
   });
 
+  it('unmounted fields should be removed from the form', async () => {
+    const submitSpy = spy((event) => event.preventDefault());
+    function App() {
+      const [checked, setChecked] = React.useState(true);
+
+      return (
+        <Form onSubmit={submitSpy}>
+          <Field.Root name="name">
+            <Field.Control defaultValue="Alice" />
+          </Field.Root>
+
+          <input type="checkbox" checked={checked} onChange={() => setChecked(!checked)} />
+
+          {checked && (
+            <Field.Root name="email">
+              <Field.Control defaultValue="" required data-testid="email" />
+            </Field.Root>
+          )}
+
+          <button>Submit</button>
+        </Form>
+      );
+    }
+
+    const { user } = await render(<App />);
+
+    const submit = screen.getByText('Submit');
+
+    await user.click(submit);
+    expect(screen.getByTestId('email')).to.have.attribute('aria-invalid', 'true');
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(submit);
+    expect(submitSpy.callCount).to.equal(1);
+  });
+
   describe('prop: errors', () => {
     function App() {
       const [errors, setErrors] = React.useState<Form.Props['errors']>({


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/issues/2228

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
