### PR TITLE
[tooltip] Add default values for delay and closeDelay props in TooltipProvider

### DIFF
--- a/docs/reference/generated/tooltip-provider.json
+++ b/docs/reference/generated/tooltip-provider.json
@@ -4,10 +4,12 @@
   "props": {
     "delay": {
       "type": "number",
+      "default": "600",
       "description": "How long to wait before opening a tooltip. Specified in milliseconds."
     },
     "closeDelay": {
       "type": "number",
+      "default": "0",
       "description": "How long to wait before closing a tooltip. Specified in milliseconds."
     },
     "timeout": {

--- a/packages/react/src/tooltip/provider/TooltipProvider.tsx
+++ b/packages/react/src/tooltip/provider/TooltipProvider.tsx
@@ -34,10 +34,12 @@ export namespace TooltipProvider {
     children?: React.ReactNode;
     /**
      * How long to wait before opening a tooltip. Specified in milliseconds.
+     * @default 600
      */
     delay?: number;
     /**
      * How long to wait before closing a tooltip. Specified in milliseconds.
+     * @default 0
      */
     closeDelay?: number;
     /**


### PR DESCRIPTION
I was just browsing docs and found default values for delay and closeDelay props in TooltipProvider are missing