### PR TITLE
[composites] Avoid double `useRenderElement` passes

### DIFF
--- a/packages/react/src/composite/item/CompositeItem.tsx
+++ b/packages/react/src/composite/item/CompositeItem.tsx
@@ -3,27 +3,45 @@ import * as React from 'react';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useCompositeItem } from './useCompositeItem';
 import type { BaseUIComponentProps } from '../../utils/types';
+import { EMPTY_OBJECT, EMPTY_ARRAY } from '../../utils/constants';
+import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 
 /**
  * @internal
  */
-export function CompositeItem<Metadata>(componentProps: CompositeItem.Props<Metadata>) {
-  const { render, className, itemRef = null, metadata, ...elementProps } = componentProps;
+export function CompositeItem<Metadata, State extends Record<string, any>>(
+  componentProps: CompositeItem.Props<Metadata, State>,
+) {
+  const {
+    render,
+    className,
+    state = EMPTY_OBJECT as State,
+    props = EMPTY_ARRAY,
+    refs = EMPTY_ARRAY,
+    metadata,
+    customStyleHookMapping,
+    tag = 'div',
+    ...elementProps
+  } = componentProps;
 
   const { compositeProps, compositeRef } = useCompositeItem({ metadata });
 
-  return useRenderElement('div', componentProps, {
-    ref: [itemRef, compositeRef],
-    props: [compositeProps, elementProps],
+  return useRenderElement(tag, componentProps, {
+    state,
+    ref: [...refs, compositeRef],
+    props: [compositeProps, ...props, elementProps],
+    customStyleHookMapping,
   });
 }
 
 export namespace CompositeItem {
-  export interface State {}
-
-  export interface Props<Metadata> extends Omit<BaseUIComponentProps<'div', State>, 'itemRef'> {
-    // the itemRef name collides with https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/itemref
-    itemRef?: React.RefObject<HTMLElement | null>;
+  export interface Props<Metadata, State extends Record<string, any>>
+    extends Pick<BaseUIComponentProps<any, State>, 'render' | 'className'> {
     metadata?: Metadata;
+    refs?: React.Ref<HTMLElement | null>[];
+    props?: Array<Record<string, any> | (() => Record<string, any>)>;
+    state?: State;
+    customStyleHookMapping?: CustomStyleHookMapping<State>;
+    tag: keyof React.JSX.IntrinsicElements;
   }
 }

--- a/packages/react/src/composite/item/CompositeItem.tsx
+++ b/packages/react/src/composite/item/CompositeItem.tsx
@@ -36,7 +36,8 @@ export function CompositeItem<Metadata, State extends Record<string, any>>(
 
 export namespace CompositeItem {
   export interface Props<Metadata, State extends Record<string, any>>
-    extends Pick<BaseUIComponentProps<any, State>, 'render' | 'className' | 'children'> {
+    extends Pick<BaseUIComponentProps<any, State>, 'render' | 'className'> {
+    children?: React.ReactNode;
     metadata?: Metadata;
     refs?: React.Ref<HTMLElement | null>[];
     props?: Array<Record<string, any> | (() => Record<string, any>)>;

--- a/packages/react/src/composite/item/CompositeItem.tsx
+++ b/packages/react/src/composite/item/CompositeItem.tsx
@@ -36,7 +36,7 @@ export function CompositeItem<Metadata, State extends Record<string, any>>(
 
 export namespace CompositeItem {
   export interface Props<Metadata, State extends Record<string, any>>
-    extends Pick<BaseUIComponentProps<any, State>, 'render' | 'className'> {
+    extends Pick<BaseUIComponentProps<any, State>, 'render' | 'className' | 'children'> {
     metadata?: Metadata;
     refs?: React.Ref<HTMLElement | null>[];
     props?: Array<Record<string, any> | (() => Record<string, any>)>;

--- a/packages/react/src/composite/item/CompositeItem.tsx
+++ b/packages/react/src/composite/item/CompositeItem.tsx
@@ -42,6 +42,6 @@ export namespace CompositeItem {
     props?: Array<Record<string, any> | (() => Record<string, any>)>;
     state?: State;
     customStyleHookMapping?: CustomStyleHookMapping<State>;
-    tag: keyof React.JSX.IntrinsicElements;
+    tag?: keyof React.JSX.IntrinsicElements;
   }
 }

--- a/packages/react/src/composite/item/CompositeItem.tsx
+++ b/packages/react/src/composite/item/CompositeItem.tsx
@@ -10,11 +10,11 @@ import type { BaseUIComponentProps } from '../../utils/types';
 export function CompositeItem<Metadata>(componentProps: CompositeItem.Props<Metadata>) {
   const { render, className, itemRef = null, metadata, ...elementProps } = componentProps;
 
-  const { props, ref } = useCompositeItem({ metadata });
+  const { compositeProps, compositeRef } = useCompositeItem({ metadata });
 
   return useRenderElement('div', componentProps, {
-    ref: [itemRef, ref],
-    props: [props, elementProps],
+    ref: [itemRef, compositeRef],
+    props: [compositeProps, elementProps],
   });
 }
 

--- a/packages/react/src/composite/item/useCompositeItem.ts
+++ b/packages/react/src/composite/item/useCompositeItem.ts
@@ -10,9 +10,11 @@ export interface UseCompositeItemParameters<Metadata> {
 }
 
 export function useCompositeItem<Metadata>(params: UseCompositeItemParameters<Metadata> = {}) {
-  const compositeRootContext = useCompositeRootContext(true);
+  const { highlightItemOnHover, highlightedIndex, onHighlightedIndexChange } =
+    useCompositeRootContext();
   const { ref, index } = useCompositeListItem(params);
-  const isHighlighted = compositeRootContext?.highlightedIndex === index;
+
+  const isHighlighted = highlightedIndex === index;
 
   const itemRef = React.useRef<HTMLElement | null>(null);
   const mergedRef = useForkRef(ref, itemRef);
@@ -21,11 +23,11 @@ export function useCompositeItem<Metadata>(params: UseCompositeItemParameters<Me
     () => ({
       tabIndex: isHighlighted ? 0 : -1,
       onFocus() {
-        compositeRootContext?.onHighlightedIndexChange(index);
+        onHighlightedIndexChange(index);
       },
       onMouseMove() {
         const item = itemRef.current;
-        if (!compositeRootContext?.highlightItemOnHover || !item) {
+        if (!highlightItemOnHover || !item) {
           return;
         }
 
@@ -35,7 +37,7 @@ export function useCompositeItem<Metadata>(params: UseCompositeItemParameters<Me
         }
       },
     }),
-    [index, isHighlighted, compositeRootContext],
+    [isHighlighted, onHighlightedIndexChange, index, highlightItemOnHover],
   );
 
   return {

--- a/packages/react/src/composite/item/useCompositeItem.ts
+++ b/packages/react/src/composite/item/useCompositeItem.ts
@@ -10,10 +10,9 @@ export interface UseCompositeItemParameters<Metadata> {
 }
 
 export function useCompositeItem<Metadata>(params: UseCompositeItemParameters<Metadata> = {}) {
-  const { highlightedIndex, onHighlightedIndexChange, highlightItemOnHover } =
-    useCompositeRootContext();
+  const compositeRootContext = useCompositeRootContext(true);
   const { ref, index } = useCompositeListItem(params);
-  const isHighlighted = highlightedIndex === index;
+  const isHighlighted = compositeRootContext?.highlightedIndex === index;
 
   const itemRef = React.useRef<HTMLElement | null>(null);
   const mergedRef = useForkRef(ref, itemRef);
@@ -22,11 +21,11 @@ export function useCompositeItem<Metadata>(params: UseCompositeItemParameters<Me
     () => ({
       tabIndex: isHighlighted ? 0 : -1,
       onFocus() {
-        onHighlightedIndexChange(index);
+        compositeRootContext?.onHighlightedIndexChange(index);
       },
       onMouseMove() {
         const item = itemRef.current;
-        if (!highlightItemOnHover || !item) {
+        if (!compositeRootContext?.highlightItemOnHover || !item) {
           return;
         }
 
@@ -36,7 +35,7 @@ export function useCompositeItem<Metadata>(params: UseCompositeItemParameters<Me
         }
       },
     }),
-    [index, isHighlighted, onHighlightedIndexChange, highlightItemOnHover],
+    [index, isHighlighted, compositeRootContext],
   );
 
   return React.useMemo(

--- a/packages/react/src/composite/item/useCompositeItem.ts
+++ b/packages/react/src/composite/item/useCompositeItem.ts
@@ -17,7 +17,7 @@ export function useCompositeItem<Metadata>(params: UseCompositeItemParameters<Me
   const itemRef = React.useRef<HTMLElement | null>(null);
   const mergedRef = useForkRef(ref, itemRef);
 
-  const props = React.useMemo<HTMLProps>(
+  const compositeProps = React.useMemo<HTMLProps>(
     () => ({
       tabIndex: isHighlighted ? 0 : -1,
       onFocus() {
@@ -38,12 +38,9 @@ export function useCompositeItem<Metadata>(params: UseCompositeItemParameters<Me
     [index, isHighlighted, compositeRootContext],
   );
 
-  return React.useMemo(
-    () => ({
-      props,
-      ref: mergedRef as React.RefCallback<HTMLElement | null>,
-      index,
-    }),
-    [props, index, mergedRef],
-  );
+  return {
+    compositeProps,
+    compositeRef: mergedRef as React.RefCallback<HTMLElement | null>,
+    index,
+  };
 }

--- a/packages/react/src/composite/root/CompositeRoot.tsx
+++ b/packages/react/src/composite/root/CompositeRoot.tsx
@@ -95,7 +95,7 @@ export function CompositeRoot<Metadata extends {}, State extends Record<string, 
 
 export namespace CompositeRoot {
   export interface Props<Metadata, State extends Record<string, any>>
-    extends BaseUIComponentProps<'div', State> {
+    extends Pick<BaseUIComponentProps<'div', State>, 'render' | 'className' | 'children'> {
     props?: Array<Record<string, any> | (() => Record<string, any>)>;
     state?: State;
     customStyleHookMapping?: CustomStyleHookMapping<State>;

--- a/packages/react/src/composite/root/CompositeRoot.tsx
+++ b/packages/react/src/composite/root/CompositeRoot.tsx
@@ -8,16 +8,22 @@ import { useRenderElement } from '../../utils/useRenderElement';
 import type { BaseUIComponentProps } from '../../utils/types';
 import type { Dimensions, ModifierKey } from '../composite';
 import { useDirection } from '../../direction-provider/DirectionContext';
-
-const COMPOSITE_ROOT_STATE = {};
+import { EMPTY_ARRAY, EMPTY_OBJECT } from '../../utils/constants';
+import { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 
 /**
  * @internal
  */
-export function CompositeRoot<Metadata extends {}>(componentProps: CompositeRoot.Props<Metadata>) {
+export function CompositeRoot<Metadata extends {}, State extends Record<string, any>>(
+  componentProps: CompositeRoot.Props<Metadata, State>,
+) {
   const {
     render,
     className,
+    refs = EMPTY_ARRAY,
+    props = EMPTY_ARRAY,
+    state = EMPTY_OBJECT as State,
+    customStyleHookMapping,
     highlightedIndex: highlightedIndexProp,
     onHighlightedIndexChange: onHighlightedIndexChangeProp,
     orientation,
@@ -38,7 +44,7 @@ export function CompositeRoot<Metadata extends {}>(componentProps: CompositeRoot
   const direction = useDirection();
 
   const {
-    props,
+    props: defaultProps,
     highlightedIndex,
     onHighlightedIndexChange,
     elementsRef,
@@ -67,8 +73,10 @@ export function CompositeRoot<Metadata extends {}>(componentProps: CompositeRoot
   );
 
   const element = useRenderElement('div', componentProps, {
-    state: COMPOSITE_ROOT_STATE,
-    props: [props, elementProps],
+    state,
+    ref: refs,
+    props: [defaultProps, ...props, elementProps],
+    customStyleHookMapping,
   });
 
   const contextValue: CompositeRootContext = React.useMemo(
@@ -86,9 +94,13 @@ export function CompositeRoot<Metadata extends {}>(componentProps: CompositeRoot
 }
 
 export namespace CompositeRoot {
-  export interface State {}
-
-  export interface Props<Metadata> extends BaseUIComponentProps<'div', State> {
+  export interface Props<Metadata, State extends Record<string, any>>
+    extends BaseUIComponentProps<'div', State> {
+    props?: Array<Record<string, any> | (() => Record<string, any>)>;
+    state?: State;
+    customStyleHookMapping?: CustomStyleHookMapping<State>;
+    refs?: React.Ref<HTMLElement | null>[];
+    tag?: keyof React.JSX.IntrinsicElements;
     orientation?: 'horizontal' | 'vertical' | 'both';
     cols?: number;
     loop?: boolean;

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -14,7 +14,7 @@ import { useTimeout } from '../../utils/useTimeout';
 import { ownerDocument } from '../../utils/owner';
 import { getPseudoElementBounds } from '../../utils/getPseudoElementBounds';
 import { useEventCallback } from '../../utils/useEventCallback';
-import { useCompositeItem } from '../../composite/item/useCompositeItem';
+import { CompositeItem } from '../../composite/item/CompositeItem';
 
 const BOUNDARY_OFFSET = 2;
 
@@ -47,7 +47,6 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
     lastOpenChangeReason,
     rootId,
   } = useMenuRootContext();
-  const { compositeProps, compositeRef } = useCompositeItem();
 
   const disabled = disabledProp || menuDisabled;
 
@@ -155,17 +154,32 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
 
   const isMenubar = parent.type === 'menubar';
 
-  return useRenderElement('button', componentProps, {
-    state,
+  const ref = [triggerRef, forwardedRef, buttonRef];
+  const props = [rootTriggerProps, elementProps, getTriggerProps];
+
+  const element = useRenderElement('button', componentProps, {
+    enabled: !isMenubar,
     customStyleHookMapping: pressableTriggerOpenStateMapping,
-    ref: [triggerRef, forwardedRef, buttonRef, isMenubar ? compositeRef : undefined],
-    props: [
-      isMenubar ? compositeProps : undefined,
-      rootTriggerProps,
-      elementProps,
-      getTriggerProps,
-    ],
+    state,
+    ref,
+    props,
   });
+
+  if (isMenubar) {
+    return (
+      <CompositeItem
+        tag="button"
+        render={render}
+        className={className}
+        state={state}
+        refs={ref}
+        props={props}
+        customStyleHookMapping={pressableTriggerOpenStateMapping}
+      />
+    );
+  }
+
+  return element;
 });
 
 export namespace MenuTrigger {

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -47,7 +47,7 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
     lastOpenChangeReason,
     rootId,
   } = useMenuRootContext();
-  const { props: compositeProps, ref: compositeRef } = useCompositeItem();
+  const { compositeProps, compositeRef } = useCompositeItem();
 
   const disabled = disabledProp || menuDisabled;
 

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { getParentNode, isHTMLElement, isLastTraversableNode } from '@floating-ui/utils/dom';
 import { contains } from '../../floating-ui-react/utils';
 import { useFloatingTree } from '../../floating-ui-react/index';
-import { CompositeItem } from '../../composite/item/CompositeItem';
 import { useMenuRootContext } from '../root/MenuRootContext';
 import { pressableTriggerOpenStateMapping } from '../../utils/popupStateMapping';
 import { useRenderElement } from '../../utils/useRenderElement';
@@ -15,6 +14,7 @@ import { useTimeout } from '../../utils/useTimeout';
 import { ownerDocument } from '../../utils/owner';
 import { getPseudoElementBounds } from '../../utils/getPseudoElementBounds';
 import { useEventCallback } from '../../utils/useEventCallback';
+import { useCompositeItem } from '../../composite/item/useCompositeItem';
 
 const BOUNDARY_OFFSET = 2;
 
@@ -47,6 +47,7 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
     lastOpenChangeReason,
     rootId,
   } = useMenuRootContext();
+  const { props: compositeProps, ref: compositeRef } = useCompositeItem();
 
   const disabled = disabledProp || menuDisabled;
 
@@ -152,18 +153,19 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
     [disabled, open],
   );
 
-  const element = useRenderElement('button', componentProps, {
+  const isMenubar = parent.type === 'menubar';
+
+  return useRenderElement('button', componentProps, {
     state,
     customStyleHookMapping: pressableTriggerOpenStateMapping,
-    ref: [triggerRef, forwardedRef, buttonRef],
-    props: [rootTriggerProps, elementProps, getTriggerProps],
+    ref: [triggerRef, forwardedRef, buttonRef, isMenubar ? compositeRef : undefined],
+    props: [
+      isMenubar ? compositeProps : undefined,
+      rootTriggerProps,
+      elementProps,
+      getTriggerProps,
+    ],
   });
-
-  if (parent.type === 'menubar') {
-    return <CompositeItem render={element} />;
-  }
-
-  return element;
 });
 
 export namespace MenuTrigger {

--- a/packages/react/src/menubar/Menubar.tsx
+++ b/packages/react/src/menubar/Menubar.tsx
@@ -12,7 +12,6 @@ import { BaseUIComponentProps } from '../utils/types';
 import { MenubarContext, useMenubarContext } from './MenubarContext';
 import { useScrollLock } from '../utils';
 import { CompositeRoot } from '../composite/root/CompositeRoot';
-import { useRenderElement } from '../utils/useRenderElement';
 import { AnimationFrame } from '../utils/useAnimationFrame';
 import { useBaseUiId } from '../utils/useBaseUiId';
 
@@ -32,7 +31,7 @@ export const Menubar = React.forwardRef(function Menubar(
     className,
     modal = true,
     id: idProp,
-    ...otherProps
+    ...elementProps
   } = props;
 
   const [contentElement, setContentElement] = React.useState<HTMLElement | null>(null);
@@ -58,12 +57,6 @@ export const Menubar = React.forwardRef(function Menubar(
   const contentRef = React.useRef<HTMLDivElement>(null);
   const allowMouseUpTriggerRef = React.useRef(false);
 
-  const element = useRenderElement('div', props, {
-    state,
-    props: [{ role: 'menubar', id }, otherProps],
-    ref: [forwardedRef, setContentElement, contentRef],
-  });
-
   const context: MenubarContext = React.useMemo(
     () => ({
       contentElement,
@@ -83,7 +76,11 @@ export const Menubar = React.forwardRef(function Menubar(
       <FloatingTree>
         <MenubarContent>
           <CompositeRoot
-            render={element}
+            render={render}
+            className={className}
+            state={state}
+            refs={[forwardedRef, setContentElement, contentRef]}
+            props={[{ role: 'menubar', id }, elementProps]}
             orientation={orientation}
             loop={loop}
             highlightItemOnHover={hasSubmenuOpen}

--- a/packages/react/src/navigation-menu/content/NavigationMenuContent.tsx
+++ b/packages/react/src/navigation-menu/content/NavigationMenuContent.tsx
@@ -3,8 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { FloatingNode } from '../../floating-ui-react';
 import { contains } from '../../floating-ui-react/utils';
-import type { BaseUIComponentProps } from '../../utils/types';
-import { useRenderElement } from '../../utils/useRenderElement';
+import type { BaseUIComponentProps, HTMLProps } from '../../utils/types';
 import {
   useNavigationMenuRootContext,
   useNavigationMenuTreeContext,
@@ -90,7 +89,7 @@ export const NavigationMenuContent = React.forwardRef(function NavigationMenuCon
     [currentContentRef],
   );
 
-  const commonProps: React.ComponentProps<'div'> = {
+  const commonProps: HTMLProps = {
     onFocus() {
       setFocusInside(true);
     },
@@ -101,32 +100,32 @@ export const NavigationMenuContent = React.forwardRef(function NavigationMenuCon
     },
   };
 
+  const defaultProps: HTMLProps =
+    !open && mounted
+      ? {
+          style: { position: 'absolute', top: 0, left: 0 },
+          inert: inertValue(!focusInside),
+          ...commonProps,
+        }
+      : commonProps;
+
   const shouldRender = viewportElement !== null && mounted;
 
-  const element = useRenderElement('div', componentProps, {
-    enabled: shouldRender,
-    state,
-    ref: [forwardedRef, ref, handleCurrentContentRef],
-    props: [
-      !open && mounted
-        ? {
-            style: { position: 'absolute', top: 0, left: 0 },
-            inert: inertValue(!focusInside),
-            ...commonProps,
-          }
-        : commonProps,
-      elementProps,
-    ],
-    customStyleHookMapping,
-  });
-
-  if (!viewportElement || !element) {
+  if (!viewportElement || !shouldRender) {
     return null;
   }
 
   return ReactDOM.createPortal(
     <FloatingNode id={nodeId}>
-      <CompositeRoot render={element} stopEventPropagation />
+      <CompositeRoot
+        render={render}
+        className={className}
+        state={state}
+        refs={[forwardedRef, ref, handleCurrentContentRef]}
+        props={[defaultProps, elementProps]}
+        customStyleHookMapping={customStyleHookMapping}
+        stopEventPropagation
+      />
     </FloatingNode>,
     viewportElement,
   );

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
@@ -1,14 +1,13 @@
 'use client';
 import * as React from 'react';
 import { useFloatingTree } from '../../floating-ui-react';
-import type { BaseUIComponentProps } from '../../utils/types';
-import { useRenderElement } from '../../utils/useRenderElement';
+import type { BaseUIComponentProps, HTMLProps } from '../../utils/types';
 import {
   useNavigationMenuRootContext,
   useNavigationMenuTreeContext,
 } from '../root/NavigationMenuRootContext';
 import { isOutsideMenuEvent } from '../utils/isOutsideMenuEvent';
-import { useCompositeItem } from '../../composite/item/useCompositeItem';
+import { CompositeItem } from '../../composite/item/CompositeItem';
 
 /**
  * A link in the navigation menu that can be used to navigate to a different page or section.
@@ -25,31 +24,33 @@ export const NavigationMenuLink = React.forwardRef(function NavigationMenuLink(
   const { setValue, popupElement, rootRef } = useNavigationMenuRootContext();
   const nodeId = useNavigationMenuTreeContext();
   const tree = useFloatingTree();
-  const { compositeProps, compositeRef } = useCompositeItem();
 
-  return useRenderElement('a', componentProps, {
-    ref: [forwardedRef, compositeRef],
-    props: [
-      compositeProps,
-      {
-        tabIndex: undefined,
-        onBlur(event) {
-          if (
-            isOutsideMenuEvent(
-              {
-                currentTarget: event.currentTarget,
-                relatedTarget: event.relatedTarget as HTMLElement | null,
-              },
-              { popupElement, rootRef, tree, nodeId },
-            )
-          ) {
-            setValue(null, event.nativeEvent, undefined);
-          }
-        },
-      },
-      elementProps,
-    ],
-  });
+  const defaultProps: HTMLProps = {
+    tabIndex: undefined,
+    onBlur(event) {
+      if (
+        isOutsideMenuEvent(
+          {
+            currentTarget: event.currentTarget,
+            relatedTarget: event.relatedTarget as HTMLElement | null,
+          },
+          { popupElement, rootRef, tree, nodeId },
+        )
+      ) {
+        setValue(null, event.nativeEvent, undefined);
+      }
+    },
+  };
+
+  return (
+    <CompositeItem
+      tag="a"
+      render={render}
+      className={className}
+      refs={[forwardedRef]}
+      props={[defaultProps, elementProps]}
+    />
+  );
 });
 
 export namespace NavigationMenuLink {

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import { useFloatingTree } from '../../floating-ui-react';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
-import { CompositeItem } from '../../composite/item/CompositeItem';
 import {
   useNavigationMenuRootContext,
   useNavigationMenuTreeContext,
 } from '../root/NavigationMenuRootContext';
 import { isOutsideMenuEvent } from '../utils/isOutsideMenuEvent';
+import { useCompositeItem } from '../../composite/item/useCompositeItem';
 
 /**
  * A link in the navigation menu that can be used to navigate to a different page or section.
@@ -25,11 +25,14 @@ export const NavigationMenuLink = React.forwardRef(function NavigationMenuLink(
   const { setValue, popupElement, rootRef } = useNavigationMenuRootContext();
   const nodeId = useNavigationMenuTreeContext();
   const tree = useFloatingTree();
+  const { props: compositeProps, ref: compositeRef } = useCompositeItem();
 
-  const element = useRenderElement('a', componentProps, {
-    ref: forwardedRef,
+  return useRenderElement('a', componentProps, {
+    ref: [forwardedRef, compositeRef],
     props: [
+      compositeProps,
       {
+        tabIndex: undefined,
         onBlur(event) {
           if (
             isOutsideMenuEvent(
@@ -47,8 +50,6 @@ export const NavigationMenuLink = React.forwardRef(function NavigationMenuLink(
       elementProps,
     ],
   });
-
-  return <CompositeItem render={element} tabIndex={undefined} />;
 });
 
 export namespace NavigationMenuLink {

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
@@ -25,7 +25,7 @@ export const NavigationMenuLink = React.forwardRef(function NavigationMenuLink(
   const { setValue, popupElement, rootRef } = useNavigationMenuRootContext();
   const nodeId = useNavigationMenuTreeContext();
   const tree = useFloatingTree();
-  const { props: compositeProps, ref: compositeRef } = useCompositeItem();
+  const { compositeProps, compositeRef } = useCompositeItem();
 
   return useRenderElement('a', componentProps, {
     ref: [forwardedRef, compositeRef],

--- a/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
+++ b/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import type { BaseUIComponentProps } from '../../utils/types';
-import { useRenderElement } from '../../utils/useRenderElement';
 import { CompositeRoot } from '../../composite/root/CompositeRoot';
 import { useNavigationMenuRootContext } from '../root/NavigationMenuRootContext';
 
@@ -26,14 +25,17 @@ export const NavigationMenuList = React.forwardRef(function NavigationMenuList(
     [open],
   );
 
-  const element = useRenderElement('div', componentProps, {
-    state,
-    ref: forwardedRef,
-    props: elementProps,
-  });
-
   return (
-    <CompositeRoot render={element} loop={false} orientation={orientation} stopEventPropagation />
+    <CompositeRoot
+      render={render}
+      className={className}
+      state={state}
+      refs={[forwardedRef]}
+      props={[elementProps]}
+      loop={false}
+      orientation={orientation}
+      stopEventPropagation
+    />
   );
 });
 

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -34,7 +34,6 @@ import { PATIENT_CLICK_THRESHOLD } from '../../utils/constants';
 import { FocusGuard } from '../../utils/FocusGuard';
 import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
 import { visuallyHidden } from '../../utils/visuallyHidden';
-import { CompositeItem } from '../../composite/item/CompositeItem';
 import { pressableTriggerOpenStateMapping } from '../../utils/popupStateMapping';
 import { isOutsideMenuEvent } from '../utils/isOutsideMenuEvent';
 import { useTimeout } from '../../utils/useTimeout';
@@ -43,6 +42,7 @@ import { useLatestRef } from '../../utils/useLatestRef';
 import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
 import { NavigationMenuPopupCssVars } from '../popup/NavigationMenuPopupCssVars';
 import { NavigationMenuPositionerCssVars } from '../positioner/NavigationMenuPositionerCssVars';
+import { useCompositeItem } from '../../composite/item/useCompositeItem';
 
 const TRIGGER_IDENTIFIER = 'data-navigation-menu-trigger';
 
@@ -81,6 +81,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   const itemValue = useNavigationMenuItemContext();
   const nodeId = useNavigationMenuTreeContext();
   const tree = useFloatingTree();
+  const { props: compositeProps, ref: compositeRef } = useCompositeItem();
 
   const stickIfOpenTimeout = useTimeout();
   const focusFrame = useAnimationFrame();
@@ -371,8 +372,9 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
 
   const element = useRenderElement('button', componentProps, {
     state,
-    ref: [forwardedRef, setTriggerElement],
+    ref: [forwardedRef, setTriggerElement, compositeRef],
     props: [
+      compositeProps,
       getReferenceProps,
       {
         tabIndex: 0,
@@ -419,7 +421,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
 
   return (
     <React.Fragment>
-      <CompositeItem render={element} />
+      {element}
       {isActiveItem && (
         <React.Fragment>
           <FocusGuard

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -81,7 +81,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   const itemValue = useNavigationMenuItemContext();
   const nodeId = useNavigationMenuTreeContext();
   const tree = useFloatingTree();
-  const { props: compositeProps, ref: compositeRef } = useCompositeItem();
+  const { compositeProps, compositeRef } = useCompositeItem();
 
   const stickIfOpenTimeout = useTimeout();
   const focusFrame = useAnimationFrame();

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -18,8 +18,7 @@ import {
   isOutsideEvent,
   stopEvent,
 } from '../../floating-ui-react/utils';
-import type { BaseUIComponentProps } from '../../utils/types';
-import { useRenderElement } from '../../utils/useRenderElement';
+import type { BaseUIComponentProps, HTMLProps } from '../../utils/types';
 import { useNavigationMenuItemContext } from '../item/NavigationMenuItemContext';
 import {
   useNavigationMenuRootContext,
@@ -42,7 +41,7 @@ import { useLatestRef } from '../../utils/useLatestRef';
 import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
 import { NavigationMenuPopupCssVars } from '../popup/NavigationMenuPopupCssVars';
 import { NavigationMenuPositionerCssVars } from '../positioner/NavigationMenuPositionerCssVars';
-import { useCompositeItem } from '../../composite/item/useCompositeItem';
+import { CompositeItem } from '../../composite/item/CompositeItem';
 
 const TRIGGER_IDENTIFIER = 'data-navigation-menu-trigger';
 
@@ -81,7 +80,6 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   const itemValue = useNavigationMenuItemContext();
   const nodeId = useNavigationMenuTreeContext();
   const tree = useFloatingTree();
-  const { compositeProps, compositeRef } = useCompositeItem();
 
   const stickIfOpenTimeout = useTimeout();
   const focusFrame = useAnimationFrame();
@@ -370,58 +368,56 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     setPointerType(event.pointerType);
   }
 
-  const element = useRenderElement('button', componentProps, {
-    state,
-    ref: [forwardedRef, setTriggerElement, compositeRef],
-    props: [
-      compositeProps,
-      getReferenceProps,
-      {
-        tabIndex: 0,
-        onMouseEnter: handleOpenEvent,
-        onClick: handleOpenEvent,
-        onPointerEnter: handleSetPointerType,
-        onPointerDown: handleSetPointerType,
-        'aria-expanded': isActiveItem,
-        'aria-controls': isActiveItem ? popupElement?.id : undefined,
-        [TRIGGER_IDENTIFIER as string]: '',
-        onMouseMove() {
-          allowFocusRef.current = false;
-        },
-        onKeyDown(event) {
-          allowFocusRef.current = true;
-          const openHorizontal = orientation === 'horizontal' && event.key === 'ArrowDown';
-          const openVertical = orientation === 'vertical' && event.key === 'ArrowRight';
+  const defaultProps: HTMLProps = {
+    tabIndex: 0,
+    onMouseEnter: handleOpenEvent,
+    onClick: handleOpenEvent,
+    onPointerEnter: handleSetPointerType,
+    onPointerDown: handleSetPointerType,
+    'aria-expanded': isActiveItem,
+    'aria-controls': isActiveItem ? popupElement?.id : undefined,
+    [TRIGGER_IDENTIFIER as string]: '',
+    onMouseMove() {
+      allowFocusRef.current = false;
+    },
+    onKeyDown(event) {
+      allowFocusRef.current = true;
+      const openHorizontal = orientation === 'horizontal' && event.key === 'ArrowDown';
+      const openVertical = orientation === 'vertical' && event.key === 'ArrowRight';
 
-          if (openHorizontal || openVertical) {
-            setValue(itemValue, event.nativeEvent, 'list-navigation');
-            handleOpenEvent(event);
-            stopEvent(event);
-          }
-        },
-        onBlur(event) {
-          if (
-            event.relatedTarget &&
-            isOutsideMenuEvent(
-              {
-                currentTarget: event.currentTarget,
-                relatedTarget: event.relatedTarget as HTMLElement | null,
-              },
-              { popupElement, rootRef, tree, nodeId },
-            )
-          ) {
-            setValue(null, event.nativeEvent, 'focus-out');
-          }
-        },
-      },
-      elementProps,
-    ],
-    customStyleHookMapping: pressableTriggerOpenStateMapping,
-  });
+      if (openHorizontal || openVertical) {
+        setValue(itemValue, event.nativeEvent, 'list-navigation');
+        handleOpenEvent(event);
+        stopEvent(event);
+      }
+    },
+    onBlur(event) {
+      if (
+        event.relatedTarget &&
+        isOutsideMenuEvent(
+          {
+            currentTarget: event.currentTarget,
+            relatedTarget: event.relatedTarget as HTMLElement | null,
+          },
+          { popupElement, rootRef, tree, nodeId },
+        )
+      ) {
+        setValue(null, event.nativeEvent, 'focus-out');
+      }
+    },
+  };
 
   return (
     <React.Fragment>
-      {element}
+      <CompositeItem
+        tag="button"
+        render={render}
+        className={className}
+        state={state}
+        customStyleHookMapping={pressableTriggerOpenStateMapping}
+        refs={[forwardedRef, setTriggerElement]}
+        props={[getReferenceProps, defaultProps, elementProps]}
+      />
       {isActiveItem && (
         <React.Fragment>
           <FocusGuard

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -5,9 +5,8 @@ import { useBaseUiId } from '../utils/useBaseUiId';
 import { useControlled } from '../utils/useControlled';
 import { useForkRef } from '../utils/useForkRef';
 import { useModernLayoutEffect } from '../utils/useModernLayoutEffect';
-import { useRenderElement } from '../utils/useRenderElement';
 import { useEventCallback } from '../utils/useEventCallback';
-import type { BaseUIComponentProps } from '../utils/types';
+import type { BaseUIComponentProps, HTMLProps } from '../utils/types';
 import { visuallyHidden } from '../utils/visuallyHidden';
 import { SHIFT } from '../composite/composite';
 import { CompositeRoot } from '../composite/root/CompositeRoot';
@@ -197,34 +196,30 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
     ],
   );
 
-  const element = useRenderElement('div', componentProps, {
-    ref: forwardedRef,
-    state,
-    props: [
-      {
-        role: 'radiogroup',
-        'aria-required': required || undefined,
-        'aria-disabled': disabled || undefined,
-        'aria-readonly': readOnly || undefined,
-        'aria-labelledby': labelId,
-        onFocus() {
-          setFocused(true);
-        },
-        onBlur,
-        onKeyDownCapture,
-      },
-      fieldControlValidation.getValidationProps,
-      elementProps,
-    ],
-    customStyleHookMapping: fieldValidityMapping,
-  });
+  const defaultProps: HTMLProps = {
+    role: 'radiogroup',
+    'aria-required': required || undefined,
+    'aria-disabled': disabled || undefined,
+    'aria-readonly': readOnly || undefined,
+    'aria-labelledby': labelId,
+    onFocus() {
+      setFocused(true);
+    },
+    onBlur,
+    onKeyDownCapture,
+  };
 
   return (
     <RadioGroupContext.Provider value={contextValue}>
       <CompositeRoot
         enableHomeAndEndKeys={false}
         modifierKeys={MODIFIER_KEYS}
-        render={element}
+        render={render}
+        className={className}
+        state={state}
+        props={[defaultProps, fieldControlValidation.getValidationProps, elementProps]}
+        refs={[forwardedRef]}
+        customStyleHookMapping={fieldValidityMapping}
         stopEventPropagation
       />
       <input {...inputProps} />

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -212,14 +212,14 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
   return (
     <RadioGroupContext.Provider value={contextValue}>
       <CompositeRoot
-        enableHomeAndEndKeys={false}
-        modifierKeys={MODIFIER_KEYS}
         render={render}
         className={className}
         state={state}
         props={[defaultProps, fieldControlValidation.getValidationProps, elementProps]}
         refs={[forwardedRef]}
         customStyleHookMapping={fieldValidityMapping}
+        enableHomeAndEndKeys={false}
+        modifierKeys={MODIFIER_KEYS}
         stopEventPropagation
       />
       <input {...inputProps} />

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -49,7 +49,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
     fieldControlValidation,
     registerControlRef,
   } = useRadioGroupContext();
-  const { props: compositeProps, ref: compositeRef } = useCompositeItem();
+  const { compositeProps, compositeRef } = useCompositeItem();
 
   const { state: fieldState, disabled: fieldDisabled } = useFieldRootContext();
 

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -15,7 +15,6 @@ import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { customStyleHookMapping } from '../utils/customStyleHookMapping';
 import { useRadioGroupContext } from '../../radio-group/RadioGroupContext';
 import { RadioRootContext } from './RadioRootContext';
-import { CompositeItem } from '../../composite/item/CompositeItem';
 import { EMPTY_OBJECT } from '../../utils/constants';
 
 /**

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -9,11 +9,11 @@ import { useRenderElement } from '../../utils/useRenderElement';
 import { visuallyHidden } from '../../utils/visuallyHidden';
 import { useButton } from '../../use-button';
 import { ACTIVE_COMPOSITE_ITEM } from '../../composite/constants';
-import { CompositeItem } from '../../composite/item/CompositeItem';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { customStyleHookMapping } from '../utils/customStyleHookMapping';
 import { useRadioGroupContext } from '../../radio-group/RadioGroupContext';
 import { RadioRootContext } from './RadioRootContext';
+import { useCompositeItem } from '../../composite/item/useCompositeItem';
 
 /**
  * Represents the radio button itself.
@@ -49,6 +49,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
     fieldControlValidation,
     registerControlRef,
   } = useRadioGroupContext();
+  const { props: compositeProps, ref: compositeRef } = useCompositeItem();
 
   const { state: fieldState, disabled: fieldDisabled } = useFieldRootContext();
 
@@ -172,10 +173,13 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
 
   const contextValue: RadioRootContext = React.useMemo(() => state, [state]);
 
+  const isRadioGroup = setCheckedValue !== NOOP;
+
   const element = useRenderElement('button', componentProps, {
     state,
-    ref: [forwardedRef, registerControlRef, buttonRef],
+    ref: [forwardedRef, registerControlRef, buttonRef, isRadioGroup ? compositeRef : undefined],
     props: [
+      isRadioGroup ? compositeProps : undefined,
       rootProps,
       fieldControlValidation?.getValidationProps ?? undefined,
       elementProps,
@@ -186,7 +190,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
 
   return (
     <RadioRootContext.Provider value={contextValue}>
-      {setCheckedValue === NOOP ? element : <CompositeItem render={element} />}
+      {element}
       <input {...inputProps} />
     </RadioRootContext.Provider>
   );

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -13,7 +13,8 @@ import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { customStyleHookMapping } from '../utils/customStyleHookMapping';
 import { useRadioGroupContext } from '../../radio-group/RadioGroupContext';
 import { RadioRootContext } from './RadioRootContext';
-import { useCompositeItem } from '../../composite/item/useCompositeItem';
+import { CompositeItem } from '../../composite/item/CompositeItem';
+import { EMPTY_OBJECT } from '../../utils/constants';
 
 /**
  * Represents the radio button itself.
@@ -49,7 +50,6 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
     fieldControlValidation,
     registerControlRef,
   } = useRadioGroupContext();
-  const { compositeProps, compositeRef } = useCompositeItem();
 
   const { state: fieldState, disabled: fieldDisabled } = useFieldRootContext();
 
@@ -175,22 +175,37 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
 
   const isRadioGroup = setCheckedValue !== NOOP;
 
+  const refs = [forwardedRef, registerControlRef, buttonRef];
+  const props = [
+    rootProps,
+    fieldControlValidation?.getValidationProps ?? EMPTY_OBJECT,
+    elementProps,
+    getButtonProps,
+  ];
+
   const element = useRenderElement('button', componentProps, {
+    enabled: !isRadioGroup,
     state,
-    ref: [forwardedRef, registerControlRef, buttonRef, isRadioGroup ? compositeRef : undefined],
-    props: [
-      isRadioGroup ? compositeProps : undefined,
-      rootProps,
-      fieldControlValidation?.getValidationProps ?? undefined,
-      elementProps,
-      getButtonProps,
-    ],
+    ref: refs,
+    props,
     customStyleHookMapping,
   });
 
   return (
     <RadioRootContext.Provider value={contextValue}>
-      {element}
+      {isRadioGroup ? (
+        <CompositeItem
+          tag="button"
+          render={render}
+          className={className}
+          state={state}
+          refs={refs}
+          props={props}
+          customStyleHookMapping={customStyleHookMapping}
+        />
+      ) : (
+        element
+      )}
       <input {...inputProps} />
     </RadioRootContext.Provider>
   );

--- a/packages/react/src/tabs/list/TabsList.tsx
+++ b/packages/react/src/tabs/list/TabsList.tsx
@@ -1,9 +1,8 @@
 'use client';
 import * as React from 'react';
-import { BaseUIComponentProps } from '../../utils/types';
+import { BaseUIComponentProps, HTMLProps } from '../../utils/types';
 import { useEventCallback } from '../../utils/useEventCallback';
 import { useModernLayoutEffect } from '../../utils/useModernLayoutEffect';
-import { useRenderElement } from '../../utils/useRenderElement';
 import { CompositeRoot } from '../../composite/root/CompositeRoot';
 import { tabsStyleHookMapping } from '../root/styleHooks';
 import { useTabsRootContext } from '../root/TabsRootContext';
@@ -66,18 +65,10 @@ export const TabsList = React.forwardRef(function TabsList(
     [orientation, tabActivationDirection],
   );
 
-  const element = useRenderElement('div', componentProps, {
-    state,
-    ref: [forwardedRef, tabsListRef],
-    props: [
-      {
-        'aria-orientation': orientation === 'vertical' ? 'vertical' : undefined,
-        role: 'tablist',
-      },
-      elementProps,
-    ],
-    customStyleHookMapping: tabsStyleHookMapping,
-  });
+  const defaultProps: HTMLProps = {
+    'aria-orientation': orientation === 'vertical' ? 'vertical' : undefined,
+    role: 'tablist',
+  };
 
   const tabsListContextValue: TabsListContext = React.useMemo(
     () => ({
@@ -100,14 +91,19 @@ export const TabsList = React.forwardRef(function TabsList(
 
   return (
     <TabsListContext.Provider value={tabsListContextValue}>
-      <CompositeRoot<TabsTab.Metadata>
+      <CompositeRoot
+        render={render}
+        className={className}
+        state={state}
+        refs={[forwardedRef, tabsListRef]}
+        props={[defaultProps, elementProps]}
+        customStyleHookMapping={tabsStyleHookMapping}
         highlightedIndex={highlightedTabIndex}
         enableHomeAndEndKeys
         loop={loop}
         orientation={orientation}
         onHighlightedIndexChange={setHighlightedTabIndex}
         onMapChange={setTabMap}
-        render={element}
         disabledIndices={EMPTY_ARRAY}
       />
     </TabsListContext.Provider>

--- a/packages/react/src/tabs/tab/TabsTab.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.tsx
@@ -50,8 +50,8 @@ export const TabsTab = React.forwardRef(function Tab(
   );
 
   const {
-    props: compositeItemProps,
-    ref: compositeItemRef,
+    compositeProps,
+    compositeRef,
     index,
     // hook is used instead of the CompositeItem component
     // because the index is needed for Tab internals
@@ -155,8 +155,9 @@ export const TabsTab = React.forwardRef(function Tab(
 
   const element = useRenderElement('button', componentProps, {
     state,
-    ref: [forwardedRef, buttonRef, compositeItemRef],
+    ref: [forwardedRef, buttonRef, compositeRef],
     props: [
+      compositeProps,
       {
         role: 'tab',
         'aria-controls': tabPanelId,
@@ -172,7 +173,6 @@ export const TabsTab = React.forwardRef(function Tab(
       },
       elementProps,
       getButtonProps,
-      compositeItemProps,
     ],
   });
 

--- a/packages/react/src/toggle-group/ToggleGroup.tsx
+++ b/packages/react/src/toggle-group/ToggleGroup.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useRenderElement } from '../utils/useRenderElement';
-import type { BaseUIComponentProps, Orientation } from '../utils/types';
+import type { BaseUIComponentProps, HTMLProps, Orientation } from '../utils/types';
 import { CompositeRoot } from '../composite/root/CompositeRoot';
 import { useControlled } from '../utils/useControlled';
 import { useEventCallback } from '../utils/useEventCallback';
@@ -92,15 +92,15 @@ export const ToggleGroup = React.forwardRef(function ToggleGroup(
     [disabled, orientation, setGroupValue, groupValue],
   );
 
+  const defaultProps: HTMLProps = {
+    role: 'group',
+  };
+
   const element = useRenderElement('div', componentProps, {
+    enabled: Boolean(toolbarContext),
     state,
     ref: forwardedRef,
-    props: [
-      {
-        role: 'group',
-      },
-      elementProps,
-    ],
+    props: [defaultProps, elementProps],
     customStyleHookMapping,
   });
 
@@ -109,7 +109,16 @@ export const ToggleGroup = React.forwardRef(function ToggleGroup(
       {toolbarContext ? (
         element
       ) : (
-        <CompositeRoot loop={loop} render={element} stopEventPropagation />
+        <CompositeRoot
+          render={render}
+          className={className}
+          state={state}
+          refs={[forwardedRef]}
+          props={[defaultProps, elementProps]}
+          customStyleHookMapping={customStyleHookMapping}
+          loop={loop}
+          stopEventPropagation
+        />
       )}
     </ToggleGroupContext.Provider>
   );

--- a/packages/react/src/toggle/Toggle.test.tsx
+++ b/packages/react/src/toggle/Toggle.test.tsx
@@ -4,6 +4,7 @@ import { spy } from 'sinon';
 import { act } from '@mui/internal-test-utils';
 import { Toggle } from '@base-ui-components/react/toggle';
 import { createRenderer, describeConformance } from '#test-utils';
+import { ToggleGroup } from '../toggle-group/ToggleGroup';
 
 describe('<Toggle />', () => {
   const { render } = createRenderer();
@@ -98,6 +99,29 @@ describe('<Toggle />', () => {
 
       expect(handlePressed.callCount).to.equal(0);
       expect(button).to.have.attribute('aria-pressed', 'false');
+    });
+  });
+
+  describe('prop: render', async () => {
+    it('should pass composite props', async () => {
+      const renderSpy = spy();
+
+      function ToggleRenderComponent({
+        renderProps,
+      }: {
+        renderProps: React.ComponentProps<'button'>;
+      }) {
+        renderSpy(renderProps);
+        return <button type="button" {...renderProps} />;
+      }
+
+      await render(
+        <ToggleGroup defaultValue={['left']}>
+          <Toggle value="left" render={(props) => <ToggleRenderComponent renderProps={props} />} />
+        </ToggleGroup>,
+      );
+
+      expect(renderSpy.lastCall.args[0]).to.have.property('tabIndex', 0);
     });
   });
 });

--- a/packages/react/src/toggle/Toggle.tsx
+++ b/packages/react/src/toggle/Toggle.tsx
@@ -35,7 +35,7 @@ export const Toggle = React.forwardRef(function Toggle(
   const value = valueProp ?? '';
 
   const groupContext = useToggleGroupContext();
-  const { props: compositeProps, ref: compositeRef } = useCompositeItem();
+  const { compositeProps, compositeRef } = useCompositeItem();
 
   const groupValue = groupContext?.value ?? [];
 

--- a/packages/react/src/toggle/Toggle.tsx
+++ b/packages/react/src/toggle/Toggle.tsx
@@ -6,7 +6,7 @@ import { useRenderElement } from '../utils/useRenderElement';
 import type { BaseUIComponentProps } from '../utils/types';
 import { useToggleGroupContext } from '../toggle-group/ToggleGroupContext';
 import { useButton } from '../use-button/useButton';
-import { useCompositeItem } from '../composite/item/useCompositeItem';
+import { CompositeItem } from '../composite/item/CompositeItem';
 
 /**
  * A two-state button that can be on or off.
@@ -35,7 +35,6 @@ export const Toggle = React.forwardRef(function Toggle(
   const value = valueProp ?? '';
 
   const groupContext = useToggleGroupContext();
-  const { compositeProps, compositeRef } = useCompositeItem();
 
   const groupValue = groupContext?.value ?? [];
 
@@ -68,23 +67,41 @@ export const Toggle = React.forwardRef(function Toggle(
     [disabled, pressed],
   );
 
-  return useRenderElement('button', componentProps, {
-    state,
-    ref: [buttonRef, forwardedRef, groupContext ? compositeRef : undefined],
-    props: [
-      groupContext ? compositeProps : undefined,
-      {
-        'aria-pressed': pressed,
-        onClick(event: React.MouseEvent) {
-          const nextPressed = !pressed;
-          setPressedState(nextPressed);
-          onPressedChange(nextPressed, event.nativeEvent);
-        },
+  const refs = [buttonRef, forwardedRef];
+  const props = [
+    {
+      'aria-pressed': pressed,
+      onClick(event: React.MouseEvent) {
+        const nextPressed = !pressed;
+        setPressedState(nextPressed);
+        onPressedChange(nextPressed, event.nativeEvent);
       },
-      elementProps,
-      getButtonProps,
-    ],
+    },
+    elementProps,
+    getButtonProps,
+  ];
+
+  const element = useRenderElement('button', componentProps, {
+    enabled: !groupContext,
+    state,
+    ref: refs,
+    props,
   });
+
+  if (groupContext) {
+    return (
+      <CompositeItem
+        tag="button"
+        render={render}
+        className={className}
+        state={state}
+        refs={refs}
+        props={props}
+      />
+    );
+  }
+
+  return element;
 });
 
 export namespace Toggle {

--- a/packages/react/src/toggle/Toggle.tsx
+++ b/packages/react/src/toggle/Toggle.tsx
@@ -4,9 +4,9 @@ import { useControlled } from '../utils/useControlled';
 import { useEventCallback } from '../utils/useEventCallback';
 import { useRenderElement } from '../utils/useRenderElement';
 import type { BaseUIComponentProps } from '../utils/types';
-import { CompositeItem } from '../composite/item/CompositeItem';
 import { useToggleGroupContext } from '../toggle-group/ToggleGroupContext';
 import { useButton } from '../use-button/useButton';
+import { useCompositeItem } from '../composite/item/useCompositeItem';
 
 /**
  * A two-state button that can be on or off.
@@ -35,6 +35,7 @@ export const Toggle = React.forwardRef(function Toggle(
   const value = valueProp ?? '';
 
   const groupContext = useToggleGroupContext();
+  const { props: compositeProps, ref: compositeRef } = useCompositeItem();
 
   const groupValue = groupContext?.value ?? [];
 
@@ -67,10 +68,11 @@ export const Toggle = React.forwardRef(function Toggle(
     [disabled, pressed],
   );
 
-  const element = useRenderElement('button', componentProps, {
+  return useRenderElement('button', componentProps, {
     state,
-    ref: [buttonRef, forwardedRef],
+    ref: [buttonRef, forwardedRef, groupContext ? compositeRef : undefined],
     props: [
+      groupContext ? compositeProps : undefined,
       {
         'aria-pressed': pressed,
         onClick(event: React.MouseEvent) {
@@ -83,8 +85,6 @@ export const Toggle = React.forwardRef(function Toggle(
       getButtonProps,
     ],
   });
-
-  return groupContext ? <CompositeItem render={element} /> : element;
 });
 
 export namespace Toggle {

--- a/packages/react/src/toolbar/button/ToolbarButton.tsx
+++ b/packages/react/src/toolbar/button/ToolbarButton.tsx
@@ -30,7 +30,7 @@ export const ToolbarButton = React.forwardRef(function ToolbarButton(
   const itemMetadata = React.useMemo(() => ({ focusableWhenDisabled }), [focusableWhenDisabled]);
 
   const { disabled: toolbarDisabled, orientation } = useToolbarRootContext();
-  const { props: compositeProps, ref: compositeRef } = useCompositeItem({
+  const { compositeProps, compositeRef } = useCompositeItem({
     metadata: itemMetadata,
   });
 

--- a/packages/react/src/toolbar/button/ToolbarButton.tsx
+++ b/packages/react/src/toolbar/button/ToolbarButton.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useButton } from '../../use-button';
-import { CompositeItem } from '../../composite/item/CompositeItem';
 import type { ToolbarRoot } from '../root/ToolbarRoot';
 import { useToolbarRootContext } from '../root/ToolbarRootContext';
 import { useToolbarGroupContext } from '../group/ToolbarGroupContext';
+import { useCompositeItem } from '../../composite/item/useCompositeItem';
 
 /**
  * A button that can be used as-is or as a trigger for other components.
@@ -27,11 +27,14 @@ export const ToolbarButton = React.forwardRef(function ToolbarButton(
     ...elementProps
   } = componentProps;
 
+  const itemMetadata = React.useMemo(() => ({ focusableWhenDisabled }), [focusableWhenDisabled]);
+
   const { disabled: toolbarDisabled, orientation } = useToolbarRootContext();
+  const { props: compositeProps, ref: compositeRef } = useCompositeItem({
+    metadata: itemMetadata,
+  });
 
   const groupContext = useToolbarGroupContext(true);
-
-  const itemMetadata = React.useMemo(() => ({ focusableWhenDisabled }), [focusableWhenDisabled]);
 
   const disabled = toolbarDisabled || (groupContext?.disabled ?? false) || disabledProp;
 
@@ -50,10 +53,11 @@ export const ToolbarButton = React.forwardRef(function ToolbarButton(
     [disabled, focusableWhenDisabled, orientation],
   );
 
-  const element = useRenderElement('button', componentProps, {
+  return useRenderElement('button', componentProps, {
     state,
-    ref: [forwardedRef, buttonRef],
+    ref: [forwardedRef, buttonRef, compositeRef],
     props: [
+      compositeProps,
       elementProps,
       // for integrating with Menu and Select disabled states, `disabled` is
       // intentionally duplicated even though getButtonProps includes it already
@@ -62,8 +66,6 @@ export const ToolbarButton = React.forwardRef(function ToolbarButton(
       getButtonProps,
     ],
   });
-
-  return <CompositeItem<ToolbarRoot.ItemMetadata> metadata={itemMetadata} render={element} />;
 });
 
 export namespace ToolbarButton {

--- a/packages/react/src/toolbar/button/ToolbarButton.tsx
+++ b/packages/react/src/toolbar/button/ToolbarButton.tsx
@@ -1,12 +1,11 @@
 'use client';
 import * as React from 'react';
 import { BaseUIComponentProps } from '../../utils/types';
-import { useRenderElement } from '../../utils/useRenderElement';
 import { useButton } from '../../use-button';
 import type { ToolbarRoot } from '../root/ToolbarRoot';
 import { useToolbarRootContext } from '../root/ToolbarRootContext';
 import { useToolbarGroupContext } from '../group/ToolbarGroupContext';
-import { useCompositeItem } from '../../composite/item/useCompositeItem';
+import { CompositeItem } from '../../composite/item/CompositeItem';
 
 /**
  * A button that can be used as-is or as a trigger for other components.
@@ -30,9 +29,6 @@ export const ToolbarButton = React.forwardRef(function ToolbarButton(
   const itemMetadata = React.useMemo(() => ({ focusableWhenDisabled }), [focusableWhenDisabled]);
 
   const { disabled: toolbarDisabled, orientation } = useToolbarRootContext();
-  const { compositeProps, compositeRef } = useCompositeItem({
-    metadata: itemMetadata,
-  });
 
   const groupContext = useToolbarGroupContext(true);
 
@@ -53,19 +49,24 @@ export const ToolbarButton = React.forwardRef(function ToolbarButton(
     [disabled, focusableWhenDisabled, orientation],
   );
 
-  return useRenderElement('button', componentProps, {
-    state,
-    ref: [forwardedRef, buttonRef, compositeRef],
-    props: [
-      compositeProps,
-      elementProps,
-      // for integrating with Menu and Select disabled states, `disabled` is
-      // intentionally duplicated even though getButtonProps includes it already
-      // TODO: follow up after https://github.com/mui/base-ui/issues/1976#issuecomment-2916905663
-      { disabled },
-      getButtonProps,
-    ],
-  });
+  return (
+    <CompositeItem
+      tag="button"
+      render={render}
+      className={className}
+      metadata={itemMetadata}
+      state={state}
+      refs={[forwardedRef, buttonRef]}
+      props={[
+        elementProps,
+        // for integrating with Menu and Select disabled states, `disabled` is
+        // intentionally duplicated even though getButtonProps includes it already
+        // TODO: follow up after https://github.com/mui/base-ui/issues/1976#issuecomment-2916905663
+        { disabled },
+        getButtonProps,
+      ]}
+    />
+  );
 });
 
 export namespace ToolbarButton {

--- a/packages/react/src/toolbar/input/ToolbarInput.tsx
+++ b/packages/react/src/toolbar/input/ToolbarInput.tsx
@@ -30,7 +30,7 @@ export const ToolbarInput = React.forwardRef(function ToolbarInput(
   const itemMetadata = React.useMemo(() => ({ focusableWhenDisabled }), [focusableWhenDisabled]);
 
   const { disabled: toolbarDisabled, orientation } = useToolbarRootContext();
-  const { props: compositeProps, ref: compositeRef } = useCompositeItem({
+  const { compositeProps, compositeRef } = useCompositeItem({
     metadata: itemMetadata,
   });
 

--- a/packages/react/src/toolbar/input/ToolbarInput.tsx
+++ b/packages/react/src/toolbar/input/ToolbarInput.tsx
@@ -1,13 +1,12 @@
 'use client';
 import * as React from 'react';
-import { BaseUIComponentProps } from '../../utils/types';
+import { BaseUIComponentProps, HTMLProps } from '../../utils/types';
 import { useFocusableWhenDisabled } from '../../utils/useFocusableWhenDisabled';
-import { useRenderElement } from '../../utils/useRenderElement';
 import { ARROW_LEFT, ARROW_RIGHT, stopEvent } from '../../composite/composite';
 import type { ToolbarRoot } from '../root/ToolbarRoot';
 import { useToolbarRootContext } from '../root/ToolbarRootContext';
 import { useToolbarGroupContext } from '../group/ToolbarGroupContext';
-import { useCompositeItem } from '../../composite/item/useCompositeItem';
+import { CompositeItem } from '../../composite/item/CompositeItem';
 
 /**
  * A native input element that integrates with Toolbar keyboard navigation.
@@ -30,9 +29,6 @@ export const ToolbarInput = React.forwardRef(function ToolbarInput(
   const itemMetadata = React.useMemo(() => ({ focusableWhenDisabled }), [focusableWhenDisabled]);
 
   const { disabled: toolbarDisabled, orientation } = useToolbarRootContext();
-  const { compositeProps, compositeRef } = useCompositeItem({
-    metadata: itemMetadata,
-  });
 
   const groupContext = useToolbarGroupContext(true);
 
@@ -54,32 +50,35 @@ export const ToolbarInput = React.forwardRef(function ToolbarInput(
     [disabled, focusableWhenDisabled, orientation],
   );
 
-  return useRenderElement('input', componentProps, {
-    state,
-    ref: [forwardedRef, compositeRef],
-    props: [
-      compositeProps,
-      {
-        onClick(event) {
-          if (disabled) {
-            event.preventDefault();
-          }
-        },
-        onKeyDown(event) {
-          if (event.key !== ARROW_LEFT && event.key !== ARROW_RIGHT && disabled) {
-            stopEvent(event);
-          }
-        },
-        onPointerDown(event) {
-          if (disabled) {
-            event.preventDefault();
-          }
-        },
-      },
-      elementProps,
-      focusableWhenDisabledProps,
-    ],
-  });
+  const defaultProps: HTMLProps = {
+    onClick(event) {
+      if (disabled) {
+        event.preventDefault();
+      }
+    },
+    onKeyDown(event) {
+      if (event.key !== ARROW_LEFT && event.key !== ARROW_RIGHT && disabled) {
+        stopEvent(event);
+      }
+    },
+    onPointerDown(event) {
+      if (disabled) {
+        event.preventDefault();
+      }
+    },
+  };
+
+  return (
+    <CompositeItem
+      tag="input"
+      render={render}
+      className={className}
+      metadata={itemMetadata}
+      state={state}
+      refs={[forwardedRef]}
+      props={[defaultProps, elementProps, focusableWhenDisabledProps]}
+    />
+  );
 });
 
 export namespace ToolbarInput {

--- a/packages/react/src/toolbar/input/ToolbarInput.tsx
+++ b/packages/react/src/toolbar/input/ToolbarInput.tsx
@@ -4,10 +4,10 @@ import { BaseUIComponentProps } from '../../utils/types';
 import { useFocusableWhenDisabled } from '../../utils/useFocusableWhenDisabled';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { ARROW_LEFT, ARROW_RIGHT, stopEvent } from '../../composite/composite';
-import { CompositeItem } from '../../composite/item/CompositeItem';
 import type { ToolbarRoot } from '../root/ToolbarRoot';
 import { useToolbarRootContext } from '../root/ToolbarRootContext';
 import { useToolbarGroupContext } from '../group/ToolbarGroupContext';
+import { useCompositeItem } from '../../composite/item/useCompositeItem';
 
 /**
  * A native input element that integrates with Toolbar keyboard navigation.
@@ -27,11 +27,14 @@ export const ToolbarInput = React.forwardRef(function ToolbarInput(
     ...elementProps
   } = componentProps;
 
+  const itemMetadata = React.useMemo(() => ({ focusableWhenDisabled }), [focusableWhenDisabled]);
+
   const { disabled: toolbarDisabled, orientation } = useToolbarRootContext();
+  const { props: compositeProps, ref: compositeRef } = useCompositeItem({
+    metadata: itemMetadata,
+  });
 
   const groupContext = useToolbarGroupContext(true);
-
-  const itemMetadata = React.useMemo(() => ({ focusableWhenDisabled }), [focusableWhenDisabled]);
 
   const disabled = toolbarDisabled || (groupContext?.disabled ?? false) || disabledProp;
 
@@ -51,10 +54,11 @@ export const ToolbarInput = React.forwardRef(function ToolbarInput(
     [disabled, focusableWhenDisabled, orientation],
   );
 
-  const element = useRenderElement('input', componentProps, {
+  return useRenderElement('input', componentProps, {
     state,
-    ref: forwardedRef,
+    ref: [forwardedRef, compositeRef],
     props: [
+      compositeProps,
       {
         onClick(event) {
           if (disabled) {
@@ -76,8 +80,6 @@ export const ToolbarInput = React.forwardRef(function ToolbarInput(
       focusableWhenDisabledProps,
     ],
   });
-
-  return <CompositeItem<ToolbarRoot.ItemMetadata> metadata={itemMetadata} render={element} />;
 });
 
 export namespace ToolbarInput {

--- a/packages/react/src/toolbar/link/ToolbarLink.tsx
+++ b/packages/react/src/toolbar/link/ToolbarLink.tsx
@@ -1,10 +1,9 @@
 'use client';
 import * as React from 'react';
-import { useRenderElement } from '../../utils/useRenderElement';
 import { BaseUIComponentProps } from '../../utils/types';
 import type { ToolbarRoot } from '../root/ToolbarRoot';
 import { useToolbarRootContext } from '../root/ToolbarRootContext';
-import { useCompositeItem } from '../../composite/item/useCompositeItem';
+import { CompositeItem } from '../../composite/item/CompositeItem';
 
 const TOOLBAR_LINK_METADATA = {
   // links cannot be disabled, this metadata is only used for deriving `disabledIndices``
@@ -25,9 +24,6 @@ export const ToolbarLink = React.forwardRef(function ToolbarLink(
   const { className, render, ...elementProps } = componentProps;
 
   const { orientation } = useToolbarRootContext();
-  const { compositeProps, compositeRef } = useCompositeItem({
-    metadata: TOOLBAR_LINK_METADATA,
-  });
 
   const state: ToolbarLink.State = React.useMemo(
     () => ({
@@ -36,11 +32,17 @@ export const ToolbarLink = React.forwardRef(function ToolbarLink(
     [orientation],
   );
 
-  return useRenderElement('a', componentProps, {
-    state,
-    ref: [forwardedRef, compositeRef],
-    props: [compositeProps, elementProps],
-  });
+  return (
+    <CompositeItem
+      tag="a"
+      render={render}
+      className={className}
+      metadata={TOOLBAR_LINK_METADATA}
+      state={state}
+      refs={[forwardedRef]}
+      props={[elementProps]}
+    />
+  );
 });
 
 export namespace ToolbarLink {

--- a/packages/react/src/toolbar/link/ToolbarLink.tsx
+++ b/packages/react/src/toolbar/link/ToolbarLink.tsx
@@ -2,9 +2,9 @@
 import * as React from 'react';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { BaseUIComponentProps } from '../../utils/types';
-import { CompositeItem } from '../../composite/item/CompositeItem';
 import type { ToolbarRoot } from '../root/ToolbarRoot';
 import { useToolbarRootContext } from '../root/ToolbarRootContext';
+import { useCompositeItem } from '../../composite/item/useCompositeItem';
 
 const TOOLBAR_LINK_METADATA = {
   // links cannot be disabled, this metadata is only used for deriving `disabledIndices``
@@ -25,6 +25,9 @@ export const ToolbarLink = React.forwardRef(function ToolbarLink(
   const { className, render, ...elementProps } = componentProps;
 
   const { orientation } = useToolbarRootContext();
+  const { props: compositeProps, ref: compositeRef } = useCompositeItem({
+    metadata: TOOLBAR_LINK_METADATA,
+  });
 
   const state: ToolbarLink.State = React.useMemo(
     () => ({
@@ -33,15 +36,11 @@ export const ToolbarLink = React.forwardRef(function ToolbarLink(
     [orientation],
   );
 
-  const element = useRenderElement('a', componentProps, {
+  return useRenderElement('a', componentProps, {
     state,
-    ref: forwardedRef,
-    props: elementProps,
+    ref: [forwardedRef, compositeRef],
+    props: [compositeProps, elementProps],
   });
-
-  return (
-    <CompositeItem<ToolbarRoot.ItemMetadata> metadata={TOOLBAR_LINK_METADATA} render={element} />
-  );
 });
 
 export namespace ToolbarLink {

--- a/packages/react/src/toolbar/link/ToolbarLink.tsx
+++ b/packages/react/src/toolbar/link/ToolbarLink.tsx
@@ -25,7 +25,7 @@ export const ToolbarLink = React.forwardRef(function ToolbarLink(
   const { className, render, ...elementProps } = componentProps;
 
   const { orientation } = useToolbarRootContext();
-  const { props: compositeProps, ref: compositeRef } = useCompositeItem({
+  const { compositeProps, compositeRef } = useCompositeItem({
     metadata: TOOLBAR_LINK_METADATA,
   });
 

--- a/packages/react/src/toolbar/root/ToolbarRoot.tsx
+++ b/packages/react/src/toolbar/root/ToolbarRoot.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
-import { BaseUIComponentProps, Orientation as BaseOrientation } from '../../utils/types';
-import { useRenderElement } from '../../utils/useRenderElement';
+import { BaseUIComponentProps, Orientation as BaseOrientation, HTMLProps } from '../../utils/types';
 import { CompositeRoot } from '../../composite/root/CompositeRoot';
 import type { CompositeMetadata } from '../../composite/list/CompositeList';
 import { ToolbarRootContext } from './ToolbarRootContext';
@@ -51,27 +50,24 @@ export const ToolbarRoot = React.forwardRef(function ToolbarRoot(
 
   const state = React.useMemo(() => ({ disabled, orientation }), [disabled, orientation]);
 
-  const element = useRenderElement('div', componentProps, {
-    state,
-    ref: forwardedRef,
-    props: [
-      {
-        'aria-orientation': orientation,
-        role: 'toolbar',
-      },
-      elementProps,
-    ],
-  });
+  const defaultProps: HTMLProps = {
+    'aria-orientation': orientation,
+    role: 'toolbar',
+  };
 
   return (
     <ToolbarRootContext.Provider value={toolbarRootContext}>
       <CompositeRoot
+        render={render}
+        className={className}
+        state={state}
+        refs={[forwardedRef]}
+        props={[defaultProps, elementProps]}
         cols={cols}
         disabledIndices={disabledIndices}
         loop={loop}
         onMapChange={setItemMap}
         orientation={orientation}
-        render={element}
       />
     </ToolbarRootContext.Provider>
   );

--- a/packages/react/src/utils/constants.ts
+++ b/packages/react/src/utils/constants.ts
@@ -2,6 +2,7 @@ export const TYPEAHEAD_RESET_MS = 500;
 export const PATIENT_CLICK_THRESHOLD = 500;
 export const DISABLED_TRANSITIONS_STYLE = { style: { transition: 'none' } };
 export const EMPTY_OBJECT = {};
+export const EMPTY_ARRAY = [];
 
 /**
  * Used for dropdowns that usually strictly prefer top/bottom placements and


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #2255 by avoiding two `useRenderElement` passes 