### PR TITLE
[select] Ensure positionerElement is available in document mouseup

### DIFF
--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -18,6 +18,7 @@ import { useEventCallback } from '../../utils/useEventCallback';
 import { useForkRef } from '../../utils';
 import { useButton } from '../../use-button';
 import type { FieldRoot } from '../../field/root/FieldRoot';
+import { useLatestRef } from '../../utils/useLatestRef';
 
 const BOUNDARY_OFFSET = 2;
 
@@ -63,6 +64,8 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const value = useSelector(store, selectors.value);
   const triggerProps = useSelector(store, selectors.triggerProps);
   const positionerElement = useSelector(store, selectors.positionerElement);
+
+  const positionerRef = useLatestRef(positionerElement);
 
   const { labelId, setTouched, setFocused, validationMode } = useFieldRootContext();
 
@@ -175,7 +178,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
           // Early return if clicked on trigger element or its children
           if (
             contains(triggerRef.current, mouseUpTarget) ||
-            contains(positionerElement, mouseUpTarget) ||
+            contains(positionerRef.current, mouseUpTarget) ||
             mouseUpTarget === triggerRef.current
           ) {
             return;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

`positionerElement` can be `null` in the `mouseup` initially. This can cause `cancel-open` to fire on a `multiple` select incorrectly when tap-clicking (not force-clicking), closing it unexpectedly on the first selection.