### PR TITLE
Update detectBrowser.ts to fix react-router v7 framework crush

### DIFF
--- a/packages/utils/src/detectBrowser.ts
+++ b/packages/utils/src/detectBrowser.ts
@@ -25,7 +25,7 @@ export const isFirefox = hasNavigator && /firefox/i.test(userAgent);
 export const isSafari = hasNavigator && /apple/i.test(navigator.vendor);
 export const isAndroid = (hasNavigator && /android/i.test(platform)) || /android/i.test(userAgent);
 export const isMac =
-  hasNavigator && platform.toLowerCase().startsWith('mac') && !navigator.maxTouchPoints;
+  hasNavigator && platform?.toLowerCase().startsWith('mac') && !navigator.maxTouchPoints;
 export const isJSDOM = userAgent.includes('jsdom/');
 
 // Avoid Chrome DevTools blue warning.


### PR DESCRIPTION
This is a fix for #2287 to prevent react-router crushing when using Toast

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
