### PR TITLE
[toast] Fix `promise` method timeout option handling

### DIFF
--- a/packages/react/src/toast/provider/ToastProvider.tsx
+++ b/packages/react/src/toast/provider/ToastProvider.tsx
@@ -257,12 +257,16 @@ export const ToastProvider: React.FC<ToastProvider.Props> = function ToastProvid
 
       const handledPromise = promiseValue
         .then((result: Value) => {
+          const successOptions = resolvePromiseOptions(options.success, result);
           update(id, {
-            ...resolvePromiseOptions(options.success, result),
+            ...successOptions,
             type: 'success',
           });
 
-          scheduleTimer(id, timeout, () => close(id));
+          const successTimeout = successOptions.timeout ?? timeout;
+          if (successTimeout > 0) {
+            scheduleTimer(id, successTimeout, () => close(id));
+          }
 
           if (hoveringRef.current || focusedRef.current || !windowFocusedRef.current) {
             pauseTimers();
@@ -271,12 +275,16 @@ export const ToastProvider: React.FC<ToastProvider.Props> = function ToastProvid
           return result;
         })
         .catch((error) => {
+          const errorOptions = resolvePromiseOptions(options.error, error);
           update(id, {
-            ...resolvePromiseOptions(options.error, error),
+            ...errorOptions,
             type: 'error',
           });
 
-          scheduleTimer(id, timeout, () => close(id));
+          const errorTimeout = errorOptions.timeout ?? timeout;
+          if (errorTimeout > 0) {
+            scheduleTimer(id, errorTimeout, () => close(id));
+          }
 
           if (hoveringRef.current || focusedRef.current || !windowFocusedRef.current) {
             pauseTimers();


### PR DESCRIPTION
Fixes #2291

Takes into account the `timeout` option of the `success`/`error` states of `toastManager.promise()`