### PR TITLE
[useButton] Prevent `Space` key default on keydown

### DIFF
--- a/packages/react/src/use-button/useButton.ts
+++ b/packages/react/src/use-button/useButton.ts
@@ -90,16 +90,23 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
               return;
             }
 
-            // Keyboard accessibility for non interactive elements
-            if (
+            const shouldClick =
               event.target === event.currentTarget &&
               !isNativeButton &&
               !isValidLink() &&
-              event.key === 'Enter' &&
-              !disabled
-            ) {
-              externalOnClick?.(event);
-              event.preventDefault();
+              !disabled;
+            const isEnterKey = event.key === 'Enter';
+            const isSpaceKey = event.key === ' ';
+
+            // Keyboard accessibility for non interactive elements
+            if (shouldClick) {
+              if (isSpaceKey || isEnterKey) {
+                event.preventDefault();
+              }
+
+              if (isEnterKey) {
+                externalOnClick?.(event);
+              }
             }
           },
           onKeyUp(event: BaseUIEvent<React.KeyboardEvent>) {


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/pull/2241#pullrequestreview-3015072212

For components that render a non-`<button>` element, scrolling on <kbd>Space</kbd> should be prevented as with native buttons