### PR TITLE
[navigation menu] Add `useButton` integration to `Trigger`

### DIFF
--- a/docs/reference/generated/navigation-menu-trigger.json
+++ b/docs/reference/generated/navigation-menu-trigger.json
@@ -2,6 +2,11 @@
   "name": "NavigationMenuTrigger",
   "description": "Opens the navigation menu popup when hovered or clicked, revealing the\nassociated content.\nRenders a `<button>` element.",
   "props": {
+    "nativeButton": {
+      "type": "boolean",
+      "default": "true",
+      "description": "Whether the component renders a native `<button>` element when replacing it\nvia the `render` prop.\nSet to `false` if the rendered element is not a button (e.g. `<div>`)."
+    },
     "className": {
       "type": "string | ((state: NavigationMenu.Trigger.State) => string)",
       "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -42,6 +42,7 @@ import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
 import { NavigationMenuPopupCssVars } from '../popup/NavigationMenuPopupCssVars';
 import { NavigationMenuPositionerCssVars } from '../positioner/NavigationMenuPositionerCssVars';
 import { CompositeItem } from '../../composite/item/CompositeItem';
+import { useButton } from '../../use-button';
 
 const TRIGGER_IDENTIFIER = 'data-navigation-menu-trigger';
 
@@ -56,7 +57,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   componentProps: NavigationMenuTrigger.Props,
   forwardedRef: React.ForwardedRef<HTMLButtonElement>,
 ) {
-  const { className, render, ...elementProps } = componentProps;
+  const { className, render, nativeButton = true, disabled, ...elementProps } = componentProps;
 
   const {
     value,
@@ -407,6 +408,12 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     },
   };
 
+  const { getButtonProps, buttonRef } = useButton({
+    disabled,
+    focusableWhenDisabled: true,
+    native: nativeButton,
+  });
+
   return (
     <React.Fragment>
       <CompositeItem
@@ -415,8 +422,8 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
         className={className}
         state={state}
         customStyleHookMapping={pressableTriggerOpenStateMapping}
-        refs={[forwardedRef, setTriggerElement]}
-        props={[getReferenceProps, defaultProps, elementProps]}
+        refs={[forwardedRef, setTriggerElement, buttonRef]}
+        props={[getReferenceProps, defaultProps, elementProps, getButtonProps]}
       />
       {isActiveItem && (
         <React.Fragment>
@@ -461,5 +468,13 @@ export namespace NavigationMenuTrigger {
     open: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<'button', State> {}
+  export interface Props extends BaseUIComponentProps<'button', State> {
+    /**
+     * Whether the component renders a native `<button>` element when replacing it
+     * via the `render` prop.
+     * Set to `false` if the rendered element is not a button (e.g. `<div>`).
+     * @default true
+     */
+    nativeButton?: boolean;
+  }
 }


### PR DESCRIPTION
`NavigationMenu.Trigger` was missing `useButton` integration