### PR TITLE
docs(menu): remove undocumented Menu.Backdrop from Anatomy section

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/menu/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/menu/page.mdx
@@ -18,7 +18,6 @@ import { Menu } from '@base-ui-components/react/menu';
 <Menu.Root>
   <Menu.Trigger />
   <Menu.Portal>
-    <Menu.Backdrop />
     <Menu.Positioner>
       <Menu.Popup>
         <Menu.Arrow />
@@ -93,7 +92,6 @@ To create a submenu, nest another menu inside the parent menu with `<Menu.Submen
 <Menu.Root>
   <Menu.Trigger />
   <Menu.Portal>
-    <Menu.Backdrop />
     <Menu.Positioner>
       <Menu.Popup>
         <Menu.Arrow />

--- a/docs/src/app/(public)/(content)/react/components/menu/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/menu/page.mdx
@@ -18,6 +18,7 @@ import { Menu } from '@base-ui-components/react/menu';
 <Menu.Root>
   <Menu.Trigger />
   <Menu.Portal>
+    <Menu.Backdrop />
     <Menu.Positioner>
       <Menu.Popup>
         <Menu.Arrow />
@@ -43,7 +44,7 @@ import { Menu } from '@base-ui-components/react/menu';
 
 <Reference
   component="Menu"
-  parts="Root, Trigger, Portal, Positioner, Popup, Arrow, Item, SubmenuRoot, SubmenuTrigger, Group, GroupLabel, RadioGroup, RadioItem, RadioItemIndicator, CheckboxItem, CheckboxItemIndicator, Separator"
+  parts="Root, Trigger, Portal, Backdrop, Positioner, Popup, Arrow, Item, SubmenuRoot, SubmenuTrigger, Group, GroupLabel, RadioGroup, RadioItem, RadioItemIndicator, CheckboxItem, CheckboxItemIndicator, Separator"
 />
 
 ## Examples


### PR DESCRIPTION
Menu.Backdrop is shown in the Anatomy but is not documented or exposed in the Menu API. This commit removes it from the Anatomy section to avoid confusion.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
