### PR TITLE
[number field] Remove `invalid` prop

### DIFF
--- a/docs/reference/generated/number-field-root.json
+++ b/docs/reference/generated/number-field-root.json
@@ -74,11 +74,6 @@
       "default": "false",
       "description": "Whether the user must enter a value before submitting a form."
     },
-    "invalid": {
-      "type": "boolean",
-      "default": "false",
-      "description": "Whether the field is forcefully marked as invalid."
-    },
     "inputRef": {
       "type": "Ref<HTMLInputElement>",
       "description": "A ref to access the hidden input element."

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -491,11 +491,6 @@ export namespace NumberFieldRoot {
      */
     disabled?: boolean;
     /**
-     * Whether the field is forcefully marked as invalid.
-     * @default false
-     */
-    invalid?: boolean;
-    /**
      * Whether the user should be unable to change the field value.
      * @default false
      */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This likely existed for the initial implementation, before we made `Field`. It shouldn't be documented as a prop.