### PR TITLE
[safePolygon] Check for `performance` existence on server

### DIFF
--- a/packages/react/src/floating-ui-react/safePolygon.ts
+++ b/packages/react/src/floating-ui-react/safePolygon.ts
@@ -54,10 +54,10 @@ export function safePolygon(options: SafePolygonOptions = {}) {
   let hasLanded = false;
   let lastX: number | null = null;
   let lastY: number | null = null;
-  let lastCursorTime = Date.now();
+  let lastCursorTime = typeof performance !== 'undefined' ? performance.now() : 0;
 
   function getCursorSpeed(x: number, y: number): number | null {
-    const currentTime = Date.now();
+    const currentTime = performance.now();
     const elapsedTime = currentTime - lastCursorTime;
 
     if (lastX === null || lastY === null || elapsedTime === 0) {

--- a/packages/react/src/floating-ui-react/safePolygon.ts
+++ b/packages/react/src/floating-ui-react/safePolygon.ts
@@ -54,10 +54,10 @@ export function safePolygon(options: SafePolygonOptions = {}) {
   let hasLanded = false;
   let lastX: number | null = null;
   let lastY: number | null = null;
-  let lastCursorTime = performance.now();
+  let lastCursorTime = Date.now();
 
   function getCursorSpeed(x: number, y: number): number | null {
-    const currentTime = performance.now();
+    const currentTime = Date.now();
     const elapsedTime = currentTime - lastCursorTime;
 
     if (lastX === null || lastY === null || elapsedTime === 0) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Mentioned on Discord, some exotic runtimes (not Node.js/CF Workers) don't support `performance` and need a polyfill. It's not necessary to use here and can be replaced with `Date.now()`.