### PR TITLE
[menubar] Fix triggers role

### DIFF
--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -115,8 +115,8 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
   const getTriggerProps = React.useCallback(
     (externalProps?: HTMLProps): HTMLProps => {
       return mergeProps(
+        isMenubar ? { role: 'menuitem' } : {},
         {
-          role: isMenubar ? 'menuitem' : undefined,
           'aria-haspopup': 'menu' as const,
           ref: handleRef,
           onMouseDown: (event: React.MouseEvent) => {

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -110,10 +110,13 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
     }
   }, [open, handleDocumentMouseUp, lastOpenChangeReason]);
 
+  const isMenubar = parent.type === 'menubar';
+
   const getTriggerProps = React.useCallback(
     (externalProps?: HTMLProps): HTMLProps => {
       return mergeProps(
         {
+          role: isMenubar ? 'menuitem' : undefined,
           'aria-haspopup': 'menu' as const,
           ref: handleRef,
           onMouseDown: (event: React.MouseEvent) => {
@@ -141,6 +144,7 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
       allowMouseUpTriggerRef,
       allowMouseUpTriggerTimeout,
       handleDocumentMouseUp,
+      isMenubar,
     ],
   );
 
@@ -151,8 +155,6 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
     }),
     [disabled, open],
   );
-
-  const isMenubar = parent.type === 'menubar';
 
   const ref = [triggerRef, forwardedRef, buttonRef];
   const props = [rootTriggerProps, elementProps, getTriggerProps];

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -672,4 +672,18 @@ describe('<Menubar />', () => {
       });
     },
   );
+
+  describe('role', () => {
+    it('sets role="menubar" on the root element', async () => {
+      const { container } = await render(<TestMenubar />);
+      const menubar = container.firstChild as HTMLElement;
+      expect(menubar).to.have.attribute('role', 'menubar');
+    });
+
+    it('sets role="menuitem" on menu triggers', async () => {
+      const { getAllByRole } = await render(<TestMenubar />);
+      const menuItems = getAllByRole('menuitem');
+      expect(menuItems).to.have.length(3);
+    });
+  });
 });

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -675,14 +675,13 @@ describe('<Menubar />', () => {
 
   describe('role', () => {
     it('sets role="menubar" on the root element', async () => {
-      const { container } = await render(<TestMenubar />);
-      const menubar = container.firstChild as HTMLElement;
-      expect(menubar).to.have.attribute('role', 'menubar');
+      await render(<TestMenubar />);
+      expect(screen.queryByRole('menubar')).not.to.equal(null);
     });
 
     it('sets role="menuitem" on menu triggers', async () => {
-      const { getAllByRole } = await render(<TestMenubar />);
-      const menuItems = getAllByRole('menuitem');
+      await render(<TestMenubar />);
+      const menuItems = screen.getAllByRole('menuitem');
       expect(menuItems).to.have.length(3);
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

`Menubar` `Menu.Trigger`s should have `role="menuitem"`.