### PR TITLE
[docs] Improve focus outline for header links

### DIFF
--- a/docs/src/components/HeadingLink.css
+++ b/docs/src/components/HeadingLink.css
@@ -1,4 +1,7 @@
 .HeadingLink {
+  padding: 0.5em;
+  margin-inline: -0.5em;
+
   &:focus-visible {
     outline: 2px solid var(--color-blue);
     outline-offset: -2px;


### PR DESCRIPTION
Noticed this when working on https://github.com/mui/base-ui/pull/1738

Links have this nice padding:

<img width="118" height="78" alt="Screenshot 2025-07-17 at 15 28 00" src="https://github.com/user-attachments/assets/6916cfd5-8fb2-4769-b1d2-974767f54b31" />
<img width="103" height="56" alt="Screenshot 2025-07-17 at 15 28 13" src="https://github.com/user-attachments/assets/23237e94-2686-47ec-9064-9723a8918913" />

but the header links look bad
<img width="190" height="66" alt="Screenshot 2025-07-17 at 15 28 21" src="https://github.com/user-attachments/assets/6e41e64f-b41b-4098-9bd5-f2a88e625baf" />


after this PR:
<img width="261" height="116" alt="Screenshot 2025-07-17 at 15 29 17" src="https://github.com/user-attachments/assets/3574c322-0345-490f-aae9-1be379369593" />

