### PR TITLE
[code-infra] Fix publishing of packages with internal dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       - run: pnpm validate-declarations
       - name: Publish to pkg-pr-new
         if: matrix.os == 'ubuntu-latest'
-        run: pnpm dlx pkg-pr-new publish './packages/react' './packages/utils' --compact --pnpm --peerDeps --template './examples/*'
+        run: pnpm dlx pkg-pr-new publish $(pnpm code-infra list-workspaces --public-only --output=publish-dir) --packageManager=pnpm --template './examples/*'


### PR DESCRIPTION
After the introduction of the utils package, pr.pkg.new stopped working correctly due to https://github.com/stackblitz-labs/pkg.pr.new/issues/389. The `react` package does not reference the preview version of the `utils` package.

This workaround removes the `--pnpm` flag and points pkg.pr.new CLI to the build output of individual packages.