### PR TITLE
[useAnimationsFinished] Use second rAF instead of timeout

### DIFF
--- a/packages/react/src/utils/useAnimationsFinished.ts
+++ b/packages/react/src/utils/useAnimationsFinished.ts
@@ -60,7 +60,7 @@ export function useAnimationsFinished(
 
           // `open: true` animations need to wait for the next tick to be detected
           if (waitForNextTick) {
-            timeout.start(0, exec);
+            frame.request(exec);
           } else {
             exec();
           }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes `open: true` transitions not being detected (`data-starting-style` hasn't yet been removed) in Safari and sometimes in Firefox.