### PR TITLE
[scroll area] Disable `user-select` on scrollbar and non-main button interactions

### DIFF
--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
@@ -84,6 +84,10 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
   });
 
   const handlePointerDown = useEventCallback((event: React.PointerEvent) => {
+    if (event.button !== 0) {
+      return;
+    }
+
     thumbDraggingRef.current = true;
     startYRef.current = event.clientY;
     startXRef.current = event.clientX;

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
@@ -111,6 +111,10 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
   const props: HTMLProps = {
     ...(rootId && { 'data-id': `${rootId}-scrollbar` }),
     onPointerDown(event) {
+      if (event.button !== 0) {
+        return;
+      }
+
       // Ignore clicks on thumb
       if (event.currentTarget !== event.target) {
         return;

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
@@ -177,6 +177,8 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
     style: {
       position: 'absolute',
       touchAction: 'none',
+      WebkitUserSelect: 'none',
+      userSelect: 'none',
       ...(orientation === 'vertical' && {
         top: 0,
         bottom: `var(${ScrollAreaRootCssVars.scrollAreaCornerHeight})`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/base-ui/issues/2329

Doesn't seem to repro on macOS or Windows, so likely caused by some specific esoteric setup