### PR TITLE
[composite] Fix `scrollIntoViewIfNeeded` typo

### DIFF
--- a/packages/react/src/composite/composite.ts
+++ b/packages/react/src/composite/composite.ts
@@ -124,7 +124,7 @@ export function scrollIntoViewIfNeeded(
 
   if (isOverflowingY && orientation !== 'horizontal') {
     const elementOffsetTop = getOffset(scrollContainer, element, 'top');
-    const containerStyles = getStyles(element);
+    const containerStyles = getStyles(scrollContainer);
     const elementStyles = getStyles(element);
 
     if (


### PR DESCRIPTION
Missed in https://github.com/mui/base-ui/pull/2332

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
