### PR TITLE
[docs] Specify z-index on `keepMounted` popups/containers

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/select/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/select/demos/hero/css-modules/index.module.css
@@ -43,6 +43,11 @@
   display: flex;
 }
 
+.Positioner {
+  outline: none;
+  z-index: 1;
+}
+
 .Popup {
   box-sizing: border-box;
   padding-block: 0.25rem;

--- a/docs/src/app/(public)/(content)/react/components/select/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/select/demos/hero/tailwind/index.tsx
@@ -19,7 +19,7 @@ export default function ExampleSelect() {
         </Select.Icon>
       </Select.Trigger>
       <Select.Portal>
-        <Select.Positioner className="outline-none" sideOffset={8}>
+        <Select.Positioner className="outline-none z-10" sideOffset={8}>
           <Select.ScrollUpArrow className="top-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:top-[-100%] before:left-0 before:h-full before:w-full before:content-[''] data-[direction=down]:bottom-0 data-[direction=down]:before:bottom-[-100%]" />
           <Select.Popup className="group max-h-[var(--available-height)] origin-[var(--transform-origin)] overflow-y-auto rounded-md bg-[canvas] py-1 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[ending-style]:transition-none data-[starting-style]:scale-90 data-[starting-style]:opacity-0 data-[side=none]:data-[starting-style]:scale-100 data-[side=none]:data-[starting-style]:opacity-100 data-[side=none]:data-[starting-style]:transition-none dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300">
             {fonts.map(({ label, value }) => (

--- a/docs/src/app/(public)/(content)/react/components/select/demos/multiple/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/select/demos/multiple/css-modules/index.module.css
@@ -45,6 +45,7 @@
 
 .Positioner {
   outline: none;
+  z-index: 1;
 }
 
 .Popup {

--- a/docs/src/app/(public)/(content)/react/components/select/demos/multiple/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/select/demos/multiple/tailwind/index.tsx
@@ -38,7 +38,11 @@ export default function MultiSelectExample() {
         </Select.Icon>
       </Select.Trigger>
       <Select.Portal>
-        <Select.Positioner className="outline-none" sideOffset={8} alignItemWithTrigger={false}>
+        <Select.Positioner
+          className="outline-none z-10"
+          sideOffset={8}
+          alignItemWithTrigger={false}
+        >
           <Select.ScrollUpArrow className="top-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:top-[-100%] before:left-0 before:h-full before:w-full before:content-[''] data-[direction=down]:bottom-0 data-[direction=down]:before:bottom-[-100%]" />
           <Select.Popup className="group max-h-[var(--available-height)] origin-[var(--transform-origin)] overflow-y-auto rounded-md bg-[canvas] py-1 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[ending-style]:transition-none data-[starting-style]:scale-90 data-[starting-style]:opacity-0 data-[side=none]:data-[starting-style]:scale-100 data-[side=none]:data-[starting-style]:opacity-100 data-[side=none]:data-[starting-style]:transition-none dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300">
             {values.map((value) => (

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/custom/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/custom/css-modules/index.module.css
@@ -35,6 +35,7 @@
 
 .Viewport {
   position: fixed;
+  z-index: 1;
   width: 250px;
   margin: 0 auto;
   bottom: 1rem;

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/hero/css-modules/index.module.css
@@ -35,6 +35,7 @@
 
 .Viewport {
   position: fixed;
+  z-index: 1;
   width: 250px;
   margin: 0 auto;
   bottom: 1rem;

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/hero/tailwind/index.tsx
@@ -7,7 +7,7 @@ export default function ExampleToast() {
     <Toast.Provider>
       <ToastButton />
       <Toast.Portal>
-        <Toast.Viewport className="fixed top-auto right-[1rem] bottom-[1rem] mx-auto flex w-[250px] sm:right-[2rem] sm:bottom-[2rem] sm:w-[300px]">
+        <Toast.Viewport className="fixed z-10 top-auto right-[1rem] bottom-[1rem] mx-auto flex w-[250px] sm:right-[2rem] sm:bottom-[2rem] sm:w-[300px]">
           <ToastList />
         </Toast.Viewport>
       </Toast.Portal>

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/position/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/position/css-modules/index.module.css
@@ -35,6 +35,7 @@
 
 .Viewport {
   position: fixed;
+  z-index: 1;
   width: 100%;
   max-width: 300px;
   margin: 0 auto;

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/position/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/position/tailwind/index.tsx
@@ -7,7 +7,7 @@ export default function ExampleToast() {
     <Toast.Provider>
       <ToastButton />
       <Toast.Portal>
-        <Toast.Viewport className="fixed top-[1rem] right-0 bottom-auto left-0 mx-auto flex w-full max-w-[300px]">
+        <Toast.Viewport className="fixed z-10 top-[1rem] right-0 bottom-auto left-0 mx-auto flex w-full max-w-[300px]">
           <ToastList />
         </Toast.Viewport>
       </Toast.Portal>

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/promise/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/promise/css-modules/index.module.css
@@ -35,6 +35,7 @@
 
 .Viewport {
   position: fixed;
+  z-index: 1;
   width: 250px;
   margin: 0 auto;
   bottom: 1rem;

--- a/docs/src/app/(public)/(content)/react/components/toast/demos/undo/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/toast/demos/undo/css-modules/index.module.css
@@ -35,6 +35,7 @@
 
 .Viewport {
   position: fixed;
+  z-index: 1;
   width: 275px;
   margin: 0 auto;
   bottom: 1rem;


### PR DESCRIPTION
Containers or popups that are kept mounted in the DOM need to have `z-index` specified in order to appear above popups that are inserted later. e.g. `Toast.Viewport`, which is always in the DOM, should appear above `Dialog.Popup`.

`Select` and `Toast` are the two with implicit `keepMounted=true` behavior