### PR TITLE
[tooltip] Fix error when combining `defaultOpen` and `disabled`

### DIFF
--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -671,6 +671,21 @@ describe('<Tooltip.Root />', () => {
 
       expect(screen.queryByText('Content')).to.equal(null);
     });
+
+    it('does not throw error when combined with defaultOpen', async () => {
+      await render(
+        <Root defaultOpen disabled>
+          <Tooltip.Trigger />
+          <Tooltip.Portal>
+            <Tooltip.Positioner>
+              <Tooltip.Popup>Content</Tooltip.Popup>
+            </Tooltip.Positioner>
+          </Tooltip.Portal>
+        </Root>,
+      );
+
+      expect(screen.queryByText('Content')).not.to.equal(null);
+    });
   });
 
   describe('prop: hoverable', () => {


### PR DESCRIPTION
Closes #2371

The `setOpen` handler needs to be a non `useEventCallback`-wrapped one to do the set-state-in-render technique