### PR TITLE
[docs] Fix Subtitle style

### DIFF
--- a/docs/src/components/Subtitle/Subtitle.css
+++ b/docs/src/components/Subtitle/Subtitle.css
@@ -1,6 +1,11 @@
 .Subtitle {
   @apply text-lg;
-  text-wrap: balance;
+  text-wrap: pretty;
   color: var(--color-gray);
   margin-bottom: 1.25rem;
+  gap: 0.5rem;
+
+  @media (min-width: 768px) {
+    gap: 2rem;
+  }
 }


### PR DESCRIPTION

<img width="792" height="344" alt="Screenshot 2025-07-29 at 5 12 09 pm" src="https://github.com/user-attachments/assets/3a400976-de85-4091-a33a-564f746ecc8d" />
