### PR TITLE
Remove redundant Tailwind styles for ScrollArea Tailwind Example

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/scroll-area/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/scroll-area/demos/hero/tailwind/index.tsx
@@ -4,7 +4,7 @@ import { ScrollArea } from '@base-ui-components/react/scroll-area';
 export default function ExampleScrollArea() {
   return (
     <ScrollArea.Root className="h-[8.5rem] w-96 max-w-[calc(100vw-8rem)]">
-      <ScrollArea.Viewport className="h-full overscroll-contain rounded-md outline outline-1 -outline-offset-1 outline-gray-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-800">
+      <ScrollArea.Viewport className="h-full overscroll-contain rounded-md outline-1 -outline-offset-1 outline-gray-200 focus-visible:outline-2 focus-visible:outline-blue-800">
         <div className="flex flex-col gap-4 py-3 pr-6 pl-4 text-sm leading-[1.375rem] text-gray-900">
           <p>
             Vernacular architecture is building done outside any academic tradition,


### PR DESCRIPTION
<img width="1606" height="176" alt="CleanShot 2025-07-30 at 14 12 49@2x" src="https://github.com/user-attachments/assets/383021a1-7ad6-4514-b563-fee5011b253b" />
