### PR TITLE
[docs] Fix llms.txt link on mobile

### DIFF
--- a/docs/src/components/Header.tsx
+++ b/docs/src/components/Header.tsx
@@ -54,7 +54,7 @@ export function Header() {
                     <MobileNav.Heading>{section.label}</MobileNav.Heading>
                     <MobileNav.List>
                       {section.links.map((link) => (
-                        <MobileNav.Item key={link.href} href={link.href}>
+                        <MobileNav.Item key={link.href} href={link.href} external={link.external}>
                           <MobileNav.Label>{link.label}</MobileNav.Label>
                           {link.isNew && <MobileNav.Badge>New</MobileNav.Badge>}
                         </MobileNav.Item>

--- a/docs/src/components/MobileNav.tsx
+++ b/docs/src/components/MobileNav.tsx
@@ -174,19 +174,23 @@ interface ItemProps extends React.ComponentPropsWithoutRef<'li'> {
   rel?: string;
 }
 
-export function Item(props: ItemProps) {
+export function Item({ href, ...props }: ItemProps) {
   const setOpen = React.useContext(MobileNavStateCallback);
   return (
     <li {...props} className={clsx('MobileNavItem', props.className)}>
       <NextLink
         aria-current={props.active ? 'page' : undefined}
         className="MobileNavLink"
-        href={props.href}
+        href={href}
         rel={props.rel}
         // We handle scroll manually
         scroll={false}
         onClick={() => {
-          if (props.href === window.location.pathname) {
+          if (href.endsWith('txt')) {
+            return;
+          }
+
+          if (href === window.location.pathname) {
             // If the URL is the same, close, wait a little, and scroll to top smoothly
             setOpen(false);
             setTimeout(() => {

--- a/docs/src/components/MobileNav.tsx
+++ b/docs/src/components/MobileNav.tsx
@@ -172,24 +172,24 @@ interface ItemProps extends React.ComponentPropsWithoutRef<'li'> {
   active?: boolean;
   href: string;
   rel?: string;
+  external?: boolean;
 }
 
-export function Item({ href, ...props }: ItemProps) {
+export function Item({ href, external, ...props }: ItemProps) {
   const setOpen = React.useContext(MobileNavStateCallback);
+
+  const LinkComponent = external ? 'a' : NextLink;
+
   return (
     <li {...props} className={clsx('MobileNavItem', props.className)}>
-      <NextLink
+      <LinkComponent
         aria-current={props.active ? 'page' : undefined}
         className="MobileNavLink"
         href={href}
         rel={props.rel}
         // We handle scroll manually
-        scroll={false}
+        scroll={external ? undefined : false}
         onClick={() => {
-          if (href.endsWith('txt')) {
-            return;
-          }
-
           if (href === window.location.pathname) {
             // If the URL is the same, close, wait a little, and scroll to top smoothly
             setOpen(false);
@@ -206,7 +206,7 @@ export function Item({ href, ...props }: ItemProps) {
         }}
       >
         {props.children}
-      </NextLink>
+      </LinkComponent>
     </li>
   );
 }


### PR DESCRIPTION
The mobile nav component needs to take into account external links (`.txt`)

Also the `href` prop was incorrectly forwarded to `<li>`