### PR TITLE
[tooltip] WAI-ARIA attributes 

### DIFF
--- a/packages/react/src/tooltip/popup/TooltipPopup.test.tsx
+++ b/packages/react/src/tooltip/popup/TooltipPopup.test.tsx
@@ -33,4 +33,38 @@ describe('<Tooltip.Popup />', () => {
 
     expect(screen.getByText('Content')).not.to.equal(null);
   });
+
+  it('describes the trigger element with its generated id', async () => {
+    const { getByRole } = await render(
+      <Tooltip.Root open>
+        <Tooltip.Trigger>Open</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Positioner>
+            <Tooltip.Popup>Content</Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>,
+    );
+
+    const trigger = getByRole('button', { name: 'Open' });
+    const popup = getByRole('tooltip');
+    expect(trigger).to.have.attribute('aria-describedby', popup.id);
+  });
+
+  it('describes the trigger element with its provided id', async () => {
+    const id = 'custom-tooltip-id';
+    const { getByRole } = await render(
+      <Tooltip.Root open>
+        <Tooltip.Trigger>Open</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Positioner>
+            <Tooltip.Popup id={id}>Content</Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>,
+    );
+
+    const trigger = getByRole('button', { name: 'Open' });
+    expect(trigger).to.have.attribute('aria-describedby', id);
+  });
 });

--- a/packages/react/src/tooltip/popup/TooltipPopup.tsx
+++ b/packages/react/src/tooltip/popup/TooltipPopup.tsx
@@ -58,6 +58,9 @@ export const TooltipPopup = React.forwardRef(function TooltipPopup(
     state,
     ref: [forwardedRef, popupRef],
     props: [
+      {
+        role: 'tooltip',
+      },
       popupProps,
       transitionStatus === 'starting' ? DISABLED_TRANSITIONS_STYLE : EMPTY_OBJECT,
       elementProps,

--- a/packages/react/src/tooltip/popup/TooltipPopup.tsx
+++ b/packages/react/src/tooltip/popup/TooltipPopup.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { useIsoLayoutEffect } from '@base-ui-components/utils/useIsoLayoutEffect';
 import { useTooltipRootContext } from '../root/TooltipRootContext';
 import { useTooltipPositionerContext } from '../positioner/TooltipPositionerContext';
 import type { BaseUIComponentProps } from '../../utils/types';
@@ -8,6 +9,7 @@ import type { CustomStyleHookMapping } from '../../utils/getStyleHookProps';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { transitionStatusMapping } from '../../utils/styleHookMapping';
+import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { EMPTY_OBJECT, DISABLED_TRANSITIONS_STYLE } from '../../utils/constants';
@@ -27,11 +29,27 @@ export const TooltipPopup = React.forwardRef(function TooltipPopup(
   componentProps: TooltipPopup.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { className, render, ...elementProps } = componentProps;
+  const { className, render, id: idProp, ...elementProps } = componentProps;
 
-  const { open, instantType, transitionStatus, popupProps, popupRef, onOpenChangeComplete } =
-    useTooltipRootContext();
+  const id = useBaseUiId(idProp);
+
+  const {
+    open,
+    instantType,
+    transitionStatus,
+    popupProps,
+    popupRef,
+    onOpenChangeComplete,
+    setPopupId,
+  } = useTooltipRootContext();
   const { side, align } = useTooltipPositionerContext();
+
+  useIsoLayoutEffect(() => {
+    setPopupId(id);
+    return () => {
+      setPopupId(undefined);
+    };
+  }, [setPopupId, id]);
 
   useOpenChangeComplete({
     open,
@@ -59,6 +77,7 @@ export const TooltipPopup = React.forwardRef(function TooltipPopup(
     ref: [forwardedRef, popupRef],
     props: [
       {
+        id,
         role: 'tooltip',
       },
       popupProps,

--- a/packages/react/src/tooltip/root/TooltipRoot.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.tsx
@@ -47,6 +47,8 @@ export function TooltipRoot(props: TooltipRoot.Props) {
   const [positionerElement, setPositionerElement] = React.useState<HTMLElement | null>(null);
   const [instantTypeState, setInstantTypeState] = React.useState<'dismiss' | 'focus'>();
 
+  const [popupId, setPopupId] = React.useState<string | undefined>(undefined);
+
   const popupRef = React.useRef<HTMLElement>(null);
 
   const [openState, setOpenState] = useControlled({
@@ -187,6 +189,8 @@ export function TooltipRoot(props: TooltipRoot.Props) {
       setTriggerElement,
       positionerElement,
       setPositionerElement,
+      popupId,
+      setPopupId,
       popupRef,
       triggerProps: getReferenceProps(),
       popupProps: getFloatingProps(),
@@ -203,6 +207,8 @@ export function TooltipRoot(props: TooltipRoot.Props) {
       setTriggerElement,
       positionerElement,
       setPositionerElement,
+      popupId,
+      setPopupId,
       popupRef,
       getReferenceProps,
       getFloatingProps,

--- a/packages/react/src/tooltip/root/TooltipRootContext.ts
+++ b/packages/react/src/tooltip/root/TooltipRootContext.ts
@@ -17,6 +17,8 @@ export interface TooltipRootContext {
   setTriggerElement: (el: Element | null) => void;
   positionerElement: HTMLElement | null;
   setPositionerElement: (el: HTMLElement | null) => void;
+  popupId: string | undefined;
+  setPopupId: (id: string | undefined) => void;
   popupRef: React.RefObject<HTMLElement | null>;
   delay: number;
   closeDelay: number;

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -17,14 +17,20 @@ export const TooltipTrigger = React.forwardRef(function TooltipTrigger(
 ) {
   const { className, render, ...elementProps } = componentProps;
 
-  const { open, setTriggerElement, triggerProps } = useTooltipRootContext();
+  const { open, setTriggerElement, popupId, triggerProps } = useTooltipRootContext();
 
   const state: TooltipTrigger.State = React.useMemo(() => ({ open }), [open]);
 
   const element = useRenderElement('button', componentProps, {
     state,
     ref: [forwardedRef, setTriggerElement],
-    props: [triggerProps, elementProps],
+    props: [
+      {
+        'aria-describedby': popupId,
+      },
+      triggerProps,
+      elementProps,
+    ],
     customStyleHookMapping: triggerOpenStateMapping,
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In accordance with the tooltip pattern defined in the [W3C documentation](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/#wai-ariaroles,states,andproperties), the following attributes have been added to the Tooltip component.

- Added `role="tooltip"` to `<Tooltip.Popup />`.
- Added `aria-describedby` to `<Tooltip.Trigger />`.

Additionally, a test for the `aria-describedby` attribute has been added to the `TooltipPopup.test.tsx` file.