### PR TITLE
[docs-infra] Improve contribution DX

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -3,7 +3,8 @@ import type { Metadata, Viewport } from 'next';
 
 export default function Layout({ children }: React.PropsWithChildren) {
   return (
-    <html lang="en">
+    // Use suppressHydrationWarning to avoid https://github.com/facebook/react/issues/24430
+    <html lang="en" suppressHydrationWarning>
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
Anytime I open Base UI docs in dev mode to contribute ("I" as a contributor from the community), we get a warning (I have the Grammarly extension enabled, with the localhost option of Grammarly disabled): 

<img width="1015" height="508" alt="SCR-20250802-rdzf" src="https://github.com/user-attachments/assets/5b7a3c97-7365-40d5-97c4-f5688efbd800" />

It's because of this:

- https://github.com/facebook/react/issues/24430
- https://github.com/vercel/next.js/issues/81381
- https://www.reddit.com/r/nextjs/comments/1ibwe1o/hydration_warning_fix_grammarly/
- https://stackoverflow.com/questions/75337953/what-causes-nextjs-warning-extra-attributes-from-the-server-data-new-gr-c-s-c

It looks like we need to copy Next.js's docs: https://github.com/vercel/next.js/blob/825753a284bb49f3143c4fe6d04e37ca5f856b42/apps/docs/app/layout.tsx#L12. If even they do it, then, most likely, we should too. This should help the developers in the community contribute more.