### PR TITLE
[test] Fix vitest deprecation message

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,7 +7,7 @@ const WORKSPACE_ROOT = resolve(CURRENT_DIR, './');
 
 export default defineConfig({
   test: {
-    workspace: [
+    projects: [
       'packages/*/vitest.config.mts',
       'docs/vitest.config.mts',
       'test/e2e/vitest.config.mts',


### PR DESCRIPTION
You can see the deprecation in https://app.circleci.com/pipelines/github/mui/base-ui/12499/workflows/b2d1ea31-8408-400f-b770-e20ed33000e1/jobs/126078

<img width="1488" height="72" alt="SCR-20250802-tmnv" src="https://github.com/user-attachments/assets/d177f096-49b0-40f8-a270-7ff075a570c5" />

And in https://vitest.dev/guide/projects

I noticed this in #2434