### PR TITLE
[support-infra] Rename label core to internal

### DIFF
--- a/scripts/releaseChangelog.mts
+++ b/scripts/releaseChangelog.mts
@@ -256,7 +256,6 @@ function getScopeFromLabels(labels: string[]): ChangeScope {
   }
 
   if (
-    labels.includes('core') ||
     labels.includes('scope: infra') ||
     labels.includes('scope: code-infra') ||
     labels.includes('scope: docs-infra')


### PR DESCRIPTION
One step to execute https://www.notion.so/mui-org/Labeling-in-GitHub-1f1cbfe7b66081d8b18de652877d671e?source=copy_link#209cbfe7b660809b9528ff22dfa4c1f1.

I noticed this on #2434, I was about to add the "core" label until I realized we are renaming it in the organization. So I updated all the issues / PRs in this repository.