### PR TITLE
[internal] Automerge dev dependency renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
       "matchPackageNames": ["@mui/*", "!@mui/internal-*", "!@mui/docs"],
       "allowedVersions": "!/-dev/"
     },
-       {
+    {
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchPackageNames": ["@mui/*"],


### PR DESCRIPTION
This is to avoid the manual labour on non-risky renovate PRs, like: https://github.com/mui/base-ui/pull/2463.

It's already successfully used in `mui-x`: https://github.com/mui/mui-x/blob/49d5efda4018f7e50c4a2cb93ecc7ca4bad4a5f1/renovate.json#L9-L13