### PR TITLE
[select] Fix unexpected close when nested inside two popovers

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useDismiss.ts
+++ b/packages/react/src/floating-ui-react/hooks/useDismiss.ts
@@ -647,6 +647,7 @@ export function useDismiss(
       onPointerDownCapture: handleCaptureInside,
       onMouseDownCapture: handleCaptureInside,
       onClickCapture: handleCaptureInside,
+      onMouseUpCapture: handleCaptureInside,
     }),
     [closeOnEscapeKeyDown, handlePressedInside, handleCaptureInside],
   );


### PR DESCRIPTION
Fixes #2480

Creating a failing test for the previous behavior isn’t straightforward or possible with RTL’s available methods/events, so I’ve left it out.

This lets the popover know that the mouseup (in the specific scenario listed) occurred inside its React tree, blocking the outside press from closing it. `onClickCapture` didn't cover that scenario.

https://codesandbox.io/p/sandbox/adoring-kate-hfy8lg?file=%2Fpackage.json%3A3%2C96