### PR TITLE
[menu] Fix submenu events

### DIFF
--- a/docs/src/app/(private)/experiments/menu/menu-fully-featured.tsx
+++ b/docs/src/app/(private)/experiments/menu/menu-fully-featured.tsx
@@ -83,6 +83,7 @@ export default function MenuFullyFeatured() {
                 <Menu.Portal>
                   <Menu.Positioner className={classes.Positioner} sideOffset={8}>
                     <Menu.Popup className={classes.Popup}>
+                      <div>Non-focusable text</div>
                       <Menu.Group>
                         <Menu.GroupLabel className={classes.GroupLabel}>
                           Radio items

--- a/packages/react/src/floating-ui-react/hooks/useHover.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHover.ts
@@ -462,14 +462,11 @@ export function useHover(context: FloatingRootContext, props: UseHoverProps = {}
       timeout.clear();
       restTimeout.clear();
     };
-  }, [
-    enabled,
-    elements.domReference,
-    cleanupMouseMoveHandler,
-    clearPointerEvents,
-    timeout,
-    restTimeout,
-  ]);
+  }, [enabled, elements.domReference, cleanupMouseMoveHandler, timeout, restTimeout]);
+
+  React.useEffect(() => {
+    return clearPointerEvents;
+  }, []);
 
   const reference: ElementProps['reference'] = React.useMemo(() => {
     function setPointerRef(event: React.PointerEvent) {

--- a/packages/react/src/floating-ui-react/hooks/useHover.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHover.ts
@@ -466,7 +466,7 @@ export function useHover(context: FloatingRootContext, props: UseHoverProps = {}
 
   React.useEffect(() => {
     return clearPointerEvents;
-  }, []);
+  }, [clearPointerEvents]);
 
   const reference: ElementProps['reference'] = React.useMemo(() => {
     function setPointerRef(event: React.PointerEvent) {

--- a/packages/react/src/floating-ui-react/hooks/useHover.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHover.ts
@@ -461,7 +461,6 @@ export function useHover(context: FloatingRootContext, props: UseHoverProps = {}
       cleanupMouseMoveHandler();
       timeout.clear();
       restTimeout.clear();
-      clearPointerEvents();
     };
   }, [
     enabled,

--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
@@ -11,6 +11,7 @@ import { useRenderElement } from '../../utils/useRenderElement';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import type { BaseUIComponentProps, HTMLProps, NonNativeButtonProps } from '../../utils/types';
 import { itemMapping } from '../utils/styleHookMapping';
+import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 
 const InnerMenuCheckboxItem = React.memo(
   React.forwardRef(function InnerMenuCheckboxItem(
@@ -32,6 +33,7 @@ const InnerMenuCheckboxItem = React.memo(
       allowMouseUpTriggerRef,
       typingRef,
       nativeButton,
+      nodeId,
       ...elementProps
     } = componentProps;
 
@@ -51,11 +53,16 @@ const InnerMenuCheckboxItem = React.memo(
       allowMouseUpTriggerRef,
       typingRef,
       nativeButton,
+      nodeId,
       itemMetadata: REGULAR_ITEM,
     });
 
     const state: MenuCheckboxItem.State = React.useMemo(
-      () => ({ disabled, highlighted, checked }),
+      () => ({
+        disabled,
+        highlighted,
+        checked,
+      }),
       [disabled, highlighted, checked],
     );
 
@@ -101,6 +108,8 @@ export const MenuCheckboxItem = React.forwardRef(function MenuCheckboxItem(
   const mergedRef = useMergedRefs(forwardedRef, listItem.ref, itemRef);
 
   const { itemProps, activeIndex, allowMouseUpTriggerRef, typingRef } = useMenuRootContext();
+  const menuPositionerContext = useMenuPositionerContext(true);
+
   const id = useBaseUiId(idProp);
 
   const highlighted = listItem.index === activeIndex;
@@ -122,6 +131,7 @@ export const MenuCheckboxItem = React.forwardRef(function MenuCheckboxItem(
       typingRef={typingRef}
       closeOnClick={closeOnClick}
       nativeButton={nativeButton}
+      nodeId={menuPositionerContext?.floatingContext.nodeId}
     />
   );
 });
@@ -134,6 +144,7 @@ interface InnerMenuCheckboxItemProps extends MenuCheckboxItem.Props {
   typingRef: React.RefObject<boolean>;
   closeOnClick: boolean;
   nativeButton: boolean;
+  nodeId: string | undefined;
 }
 
 export namespace MenuCheckboxItem {

--- a/packages/react/src/menu/item/MenuItem.tsx
+++ b/packages/react/src/menu/item/MenuItem.tsx
@@ -8,6 +8,7 @@ import { useRenderElement } from '../../utils/useRenderElement';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import type { BaseUIComponentProps, HTMLProps, NonNativeButtonProps } from '../../utils/types';
 import { useCompositeListItem } from '../../composite/list/useCompositeListItem';
+import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 
 const InnerMenuItem = React.memo(
   React.forwardRef(function InnerMenuItem(
@@ -26,6 +27,7 @@ const InnerMenuItem = React.memo(
       allowMouseUpTriggerRef,
       typingRef,
       nativeButton,
+      nodeId,
       ...elementProps
     } = componentProps;
 
@@ -38,6 +40,7 @@ const InnerMenuItem = React.memo(
       allowMouseUpTriggerRef,
       typingRef,
       nativeButton,
+      nodeId,
       itemMetadata: REGULAR_ITEM,
     });
 
@@ -74,6 +77,7 @@ export const MenuItem = React.forwardRef(function MenuItem(
   const mergedRef = useMergedRefs(forwardedRef, listItem.ref, itemRef);
 
   const { itemProps, activeIndex, allowMouseUpTriggerRef, typingRef } = useMenuRootContext();
+  const menuPositionerContext = useMenuPositionerContext(true);
   const id = useBaseUiId(idProp);
 
   const highlighted = listItem.index === activeIndex;
@@ -94,6 +98,7 @@ export const MenuItem = React.forwardRef(function MenuItem(
       allowMouseUpTriggerRef={allowMouseUpTriggerRef}
       typingRef={typingRef}
       nativeButton={nativeButton}
+      nodeId={menuPositionerContext?.floatingContext.nodeId}
     />
   );
 });
@@ -105,6 +110,7 @@ interface InnerMenuItemProps extends MenuItem.Props {
   allowMouseUpTriggerRef: React.RefObject<boolean>;
   typingRef: React.RefObject<boolean>;
   nativeButton: boolean;
+  nodeId: string | undefined;
 }
 
 export namespace MenuItem {

--- a/packages/react/src/menu/positioner/MenuPositionerContext.ts
+++ b/packages/react/src/menu/positioner/MenuPositionerContext.ts
@@ -22,9 +22,11 @@ export const MenuPositionerContext = React.createContext<MenuPositionerContext |
   undefined,
 );
 
-export function useMenuPositionerContext() {
+export function useMenuPositionerContext(optional?: false): MenuPositionerContext;
+export function useMenuPositionerContext(optional: true): MenuPositionerContext | undefined;
+export function useMenuPositionerContext(optional?: boolean) {
   const context = React.useContext(MenuPositionerContext);
-  if (context === undefined) {
+  if (context === undefined && !optional) {
     throw new Error(
       'Base UI: MenuPositionerContext is missing. MenuPositioner parts must be placed within <Menu.Positioner>.',
     );

--- a/packages/react/src/menu/radio-item/MenuRadioItem.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.tsx
@@ -11,6 +11,7 @@ import { MenuRadioItemContext } from './MenuRadioItemContext';
 import { itemMapping } from '../utils/styleHookMapping';
 import { useCompositeListItem } from '../../composite/list/useCompositeListItem';
 import { REGULAR_ITEM, useMenuItem } from '../item/useMenuItem';
+import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 
 const InnerMenuRadioItem = React.memo(
   React.forwardRef(function InnerMenuRadioItem(
@@ -31,6 +32,7 @@ const InnerMenuRadioItem = React.memo(
       allowMouseUpTriggerRef,
       typingRef,
       nativeButton,
+      nodeId,
       ...elementProps
     } = componentProps;
 
@@ -44,9 +46,17 @@ const InnerMenuRadioItem = React.memo(
       typingRef,
       nativeButton,
       itemMetadata: REGULAR_ITEM,
+      nodeId,
     });
 
-    const state: MenuRadioItem.State = { disabled, highlighted, checked };
+    const state: MenuRadioItem.State = React.useMemo(
+      () => ({
+        disabled,
+        highlighted,
+        checked,
+      }),
+      [disabled, highlighted, checked],
+    );
 
     return useRenderElement('div', componentProps, {
       state,
@@ -93,8 +103,9 @@ export const MenuRadioItem = React.forwardRef(function MenuRadioItem(
   const mergedRef = useMergedRefs(forwardedRef, listItem.ref, itemRef);
 
   const { itemProps, activeIndex, allowMouseUpTriggerRef, typingRef } = useMenuRootContext();
-  const id = useBaseUiId(idProp);
+  const menuPositionerContext = useMenuPositionerContext(true);
 
+  const id = useBaseUiId(idProp);
   const highlighted = listItem.index === activeIndex;
   const { events: menuEvents } = useFloatingTree()!;
 
@@ -140,6 +151,7 @@ export const MenuRadioItem = React.forwardRef(function MenuRadioItem(
         typingRef={typingRef}
         closeOnClick={closeOnClick}
         nativeButton={nativeButton}
+        nodeId={menuPositionerContext?.floatingContext.nodeId}
       />
     </MenuRadioItemContext.Provider>
   );
@@ -155,6 +167,7 @@ interface InnerMenuRadioItemProps extends Omit<MenuRadioItem.Props, 'value'> {
   typingRef: React.RefObject<boolean>;
   closeOnClick: boolean;
   nativeButton: boolean;
+  nodeId: string | undefined;
 }
 
 export namespace MenuRadioItem {

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -1258,7 +1258,9 @@ describe('<Menu.Root />', () => {
 
       const submenu = getByTestId('submenu');
 
-      await userEvent.unhover(menu);
+      // Use fireEvent to bypass pointer-events checks during safe-polygon pointer events mutation
+      fireEvent.mouseMove(menu);
+      fireEvent.mouseLeave(menu);
       await userEvent.hover(submenu);
 
       await waitFor(() => {

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -1268,6 +1268,86 @@ describe('<Menu.Root />', () => {
         expect(getByTestId('submenu')).not.to.equal(null);
       });
     });
+
+    it('keeps the parent submenu open after a third-level submenu closes due to sibling hover', async () => {
+      const { getByRole, getByTestId } = await render(
+        <Menu.Root openOnHover delay={0}>
+          <Menu.Trigger>Open</Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Positioner data-testid="menu">
+              <Menu.Popup>
+                <Menu.SubmenuRoot delay={0}>
+                  <Menu.SubmenuTrigger>Level 1</Menu.SubmenuTrigger>
+                  <Menu.Portal>
+                    <Menu.Positioner data-testid="submenu-1">
+                      <Menu.Popup>
+                        <Menu.Item data-testid="parent-item">Parent Sibling</Menu.Item>
+                        <Menu.SubmenuRoot delay={0}>
+                          <Menu.SubmenuTrigger>Level 2</Menu.SubmenuTrigger>
+                          <Menu.Portal>
+                            <Menu.Positioner data-testid="submenu-2">
+                              <Menu.Popup>
+                                <Menu.Item>Child Item</Menu.Item>
+                              </Menu.Popup>
+                            </Menu.Positioner>
+                          </Menu.Portal>
+                        </Menu.SubmenuRoot>
+                      </Menu.Popup>
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.SubmenuRoot>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const trigger = getByRole('button', { name: 'Open' });
+
+      await act(async () => {
+        trigger.focus();
+      });
+
+      await userEvent.hover(trigger);
+
+      await waitFor(() => {
+        expect(getByTestId('menu')).not.to.equal(null);
+      });
+
+      // Open first-level submenu
+      const level1Trigger = getByRole('menuitem', { name: 'Level 1' });
+      await userEvent.hover(level1Trigger);
+
+      await waitFor(() => {
+        expect(getByTestId('submenu-1')).not.to.equal(null);
+      });
+
+      // Open second-level submenu
+      const level2Trigger = getByRole('menuitem', { name: 'Level 2' });
+      await userEvent.hover(level2Trigger);
+
+      await waitFor(() => {
+        expect(getByTestId('submenu-2')).not.to.equal(null);
+      });
+
+      // Hover a sibling item in the parent submenu to close the second-level submenu
+      const parentSibling = getByRole('menuitem', { name: 'Parent Sibling' });
+      // Use fireEvent to bypass pointer-events checks during safe-polygon pointer events mutation
+      fireEvent.mouseMove(parentSibling);
+
+      await waitFor(() => {
+        expect(() => getByTestId('submenu-2')).to.throw();
+      });
+
+      // Now unhover the parent submenu container; it should remain open
+      const submenu1 = getByTestId('submenu-1');
+      fireEvent.mouseLeave(submenu1);
+
+      // Parent submenu should still be open
+      await waitFor(() => {
+        expect(getByTestId('submenu-1')).not.to.equal(null);
+      });
+    });
   });
 
   describe('prop: closeDelay', () => {

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -8,6 +8,7 @@ import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 import { useCompositeListItem } from '../../composite/list/useCompositeListItem';
 import { useMenuItem } from '../item/useMenuItem';
 import { useRenderElement } from '../../utils/useRenderElement';
+import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 
 /**
  * A menu item that opens a submenu.
@@ -39,6 +40,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function SubmenuTriggerCompon
     disabled,
     allowMouseUpTriggerRef,
   } = useMenuRootContext();
+  const menuPositionerContext = useMenuPositionerContext();
 
   if (parent.type !== 'menu') {
     throw new Error('Base UI: <Menu.SubmenuTrigger> must be placed in <Menu.SubmenuRoot>.');
@@ -72,6 +74,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function SubmenuTriggerCompon
     typingRef,
     nativeButton,
     itemMetadata,
+    nodeId: menuPositionerContext?.floatingContext.nodeId,
   });
 
   const state: MenuSubmenuTrigger.State = React.useMemo(


### PR DESCRIPTION
Fixes a bunch edge-casey scenarios with submenus

1. Closing submenus across 3+ levels
- Hover third level nested submenu
- Hover root menu
- Now closes both submenus (previously, only the third would close)

2. Ensuring hover mouseleave is blocked when returning to the parent
- Hover third level nested submenu
- Hover its direct parent (second level)
- Hover out of the second level
- Now doesn't close (previously it would)

3. Ensuring submenus close when focusing a menu item in the parent
- Hover a submenu and onto a "non-focusable" section of text inside of it
- Hover out onto any menu item in the parent
- Now closes (previously it would stay stuck open until a different submenu opened)

https://deploy-preview-2483--base-ui.netlify.app/experiments/menu/menu-fully-featured