### PR TITLE
[tabs] Fix highlight sync when focus is inside list

### DIFF
--- a/packages/react/src/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/composite/root/useCompositeRoot.ts
@@ -112,19 +112,6 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
     }
   });
 
-  // Ensure external controlled updates moves focus to the highlighted item
-  // if focus is currently inside the list.
-  // https://github.com/mui/base-ui/issues/2101
-  useIsoLayoutEffect(() => {
-    const activeEl = activeElement(ownerDocument(rootRef.current)) as HTMLDivElement | null;
-    if (elementsRef.current.includes(activeEl)) {
-      const focusedItem = elementsRef.current[highlightedIndex];
-      if (focusedItem && focusedItem !== activeEl) {
-        focusedItem.focus();
-      }
-    }
-  }, [highlightedIndex]);
-
   const onMapChange = useEventCallback((map: Map<Element, CompositeMetadata<any>>) => {
     if (map.size === 0 || hasSetDefaultIndexRef.current) {
       return;

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -1152,33 +1152,73 @@ describe('<Tabs.Root />', () => {
     });
   });
 
-  it('updates the highlighted index when value changes externally', async () => {
-    const { getAllByRole, setProps } = await render(
-      <Tabs.Root value={0}>
-        <Tabs.List activateOnFocus={false}>
-          <Tabs.Tab value={0} />
-          <Tabs.Tab value={1} />
-          <Tabs.Tab value={2} />
-        </Tabs.List>
-      </Tabs.Root>,
-    );
+  describe('highlight synchronization on external value change relative to focus', () => {
+    it('when focus is outside the tablist, highlight follows the new selected tab (tabIndex=0 moves)', async () => {
+      const { getAllByRole, setProps } = await render(
+        <Tabs.Root value={0}>
+          <Tabs.List activateOnFocus={false}>
+            <Tabs.Tab value={0} />
+            <Tabs.Tab value={1} />
+            <Tabs.Tab value={2} />
+          </Tabs.List>
+        </Tabs.Root>,
+      );
 
-    const [firstTab, secondTab, thirdTab] = getAllByRole('tab');
+      const [firstTab, secondTab, thirdTab] = getAllByRole('tab');
 
-    expect(firstTab.tabIndex).to.equal(0);
+      expect(firstTab.tabIndex).to.equal(0);
 
-    await setProps({ value: 2 });
-    await flushMicrotasks();
+      await setProps({ value: 2 });
+      await flushMicrotasks();
 
-    expect(firstTab.tabIndex).to.equal(-1);
-    expect(secondTab.tabIndex).to.equal(-1);
-    expect(thirdTab.tabIndex).to.equal(0);
+      expect(firstTab.tabIndex).to.equal(-1);
+      expect(secondTab.tabIndex).to.equal(-1);
+      expect(thirdTab.tabIndex).to.equal(0);
 
-    await setProps({ value: 1 });
-    await flushMicrotasks();
+      await setProps({ value: 1 });
+      await flushMicrotasks();
 
-    expect(firstTab.tabIndex).to.equal(-1);
-    expect(secondTab.tabIndex).to.equal(0);
-    expect(thirdTab.tabIndex).to.equal(-1);
+      expect(firstTab.tabIndex).to.equal(-1);
+      expect(secondTab.tabIndex).to.equal(0);
+      expect(thirdTab.tabIndex).to.equal(-1);
+    });
+
+    it('when focus is inside the tablist, highlight stays put on external change and arrow keys continue from the focused tab', async () => {
+      const { getAllByRole, setProps } = await render(
+        <Tabs.Root value={0}>
+          <Tabs.List activateOnFocus={false}>
+            <Tabs.Tab value={0}>Tab 1</Tabs.Tab>
+            <Tabs.Tab value={1}>Tab 2</Tabs.Tab>
+            <Tabs.Tab value={2}>Tab 3</Tabs.Tab>
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      const [firstTab, secondTab, thirdTab] = getAllByRole('tab');
+
+      await act(async () => {
+        firstTab.focus();
+      });
+      expect(firstTab).to.have.property('tabIndex', 0);
+
+      await setProps({ value: 2 });
+      await flushMicrotasks();
+
+      // Highlight should not change (still on first tab), but selection did
+      expect(firstTab.tabIndex).to.equal(0);
+      expect(secondTab.tabIndex).to.equal(-1);
+      expect(thirdTab.tabIndex).to.equal(-1);
+      expect(firstTab).to.have.attribute('aria-selected', 'false');
+      expect(thirdTab).to.have.attribute('aria-selected', 'true');
+
+      // Arrow navigation should continue from the highlighted tab
+      fireEvent.keyDown(firstTab, { key: 'ArrowRight' });
+      await flushMicrotasks();
+
+      expect(secondTab).toHaveFocus();
+      // Selection remains the externally-set tab since activateOnFocus=false
+      expect(thirdTab).to.have.attribute('aria-selected', 'true');
+      expect(secondTab).to.have.attribute('aria-selected', 'false');
+    });
   });
 });


### PR DESCRIPTION
Fixes behavior for https://github.com/mui/base-ui/issues/2101#issuecomment-3168360195. Ensures focus doesn't move while inside the list and the selected tab changes.