### PR TITLE
[internal] Remove scope: infra

### DIFF
--- a/scripts/releaseChangelog.mts
+++ b/scripts/releaseChangelog.mts
@@ -256,7 +256,6 @@ function getScopeFromLabels(labels: string[]): ChangeScope {
   }
 
   if (
-    labels.includes('scope: infra') ||
     labels.includes('scope: code-infra') ||
     labels.includes('scope: docs-infra')
   ) {


### PR DESCRIPTION
I removed this `scope: infra` label in the GitHub organization. It's a clean-up.

*(Why: the "infra" is a team that covers what I believe are very different product spaces. I want to make it easy to go in-depth in each, where different people in the team that are not in the infra team can still work on those scopes as a side focus)*.