### PR TITLE
[docs] Improve Link component

### DIFF
--- a/docs/src/app/(public)/(content)/layout.tsx
+++ b/docs/src/app/(public)/(content)/layout.tsx
@@ -18,7 +18,7 @@ export default function Layout({ children }: React.PropsWithChildren) {
             <SideNav.List>
               {section.links.map((link) => (
                 <SideNav.Item key={link.href} href={link.href} external={link.external}>
-                  <SideNav.Label>{link.label}</SideNav.Label>
+                  {link.label}
                   {link.isNew && <SideNav.Badge>New</SideNav.Badge>}
                 </SideNav.Item>
               ))}

--- a/docs/src/components/Header.tsx
+++ b/docs/src/components/Header.tsx
@@ -7,7 +7,6 @@ import { NpmIcon } from '../icons/NpmIcon';
 import { Logo } from './Logo';
 import { SkipNav } from './SkipNav';
 
-const VERSION = process.env.LIB_VERSION;
 export const HEADER_HEIGHT = 48;
 
 export function Header() {
@@ -18,7 +17,6 @@ export function Header() {
         <NextLink href="/" className="HeaderLogoLink">
           <Logo aria-label="Base UI" />
         </NextLink>
-
         <div className="flex gap-6 max-show-side-nav:hidden">
           <NextLink href="/careers/design-engineer" className="HeaderLink">
             Careers
@@ -29,14 +27,13 @@ export function Header() {
             rel="noopener"
           >
             <NpmIcon />
-            {VERSION}
+            {process.env.LIB_VERSION}
           </a>
           <a className="HeaderLink" href="https://github.com/mui/base-ui" rel="noopener">
             <GitHubIcon />
             GitHub
           </a>
         </div>
-
         <div className="flex show-side-nav:hidden">
           <MobileNav.Root>
             <MobileNav.Trigger className="HeaderButton">
@@ -62,7 +59,6 @@ export function Header() {
                     </MobileNav.List>
                   </MobileNav.Section>
                 ))}
-
                 <MobileNav.Section>
                   <MobileNav.Heading>Resources</MobileNav.Heading>
                   <MobileNav.List>
@@ -78,7 +74,7 @@ export function Header() {
                       <NpmIcon />
                       <span className="flex flex-grow-1 items-baseline justify-between">
                         npm package
-                        <span className="text-md text-gray-600">{VERSION}</span>
+                        <span className="text-md text-gray-600">{process.env.LIB_VERSION}</span>
                       </span>
                     </MobileNav.Item>
                     <MobileNav.Item href="https://github.com/mui/base-ui" rel="noopener">

--- a/docs/src/components/Link.tsx
+++ b/docs/src/components/Link.tsx
@@ -3,19 +3,22 @@ import clsx from 'clsx';
 import NextLink from 'next/link';
 import { ExternalLinkIcon } from 'docs/src/icons/ExternalLinkIcon';
 
-export function Link({ href, className, ...props }: React.ComponentProps<typeof NextLink>) {
+export function Link(props: React.ComponentProps<typeof NextLink>) {
+  const { href, className } = props;
+  let pathname = typeof href === 'string' ? href : href.pathname!;
+
   // Sometimes link come from component descriptions; in this case, remove the domain
-  if (typeof href === 'string' && href.startsWith('https://base-ui.com')) {
-    href = href.replace('https://base-ui.com', '');
+  if (pathname.startsWith('https://base-ui.com/')) {
+    pathname = pathname.replace('https://base-ui.com/', '/');
   }
 
-  if (typeof href === 'string' && href.startsWith('http')) {
+  if (pathname.startsWith('http')) {
     return (
       <NextLink
-        href={href}
         target="_blank"
         rel="noopener"
         {...props}
+        href={href}
         className={clsx('Link mr-[0.125em] inline-flex items-center gap-[0.25em]', className)}
       >
         {props.children}
@@ -24,10 +27,10 @@ export function Link({ href, className, ...props }: React.ComponentProps<typeof 
     );
   }
 
-  if (typeof href === 'string' && (href.endsWith('.md') || href.endsWith('.txt'))) {
-    // Relative url, but outside the Next.js router
-    return <a href={href} className={clsx('Link', className)} {...props} />;
+  if (pathname.endsWith('.md') || pathname.endsWith('.txt')) {
+    // Relative URL, but outside the Next.js router
+    return <a {...props} href={pathname} className={clsx('Link', className)} />;
   }
 
-  return <NextLink href={href} className={clsx('Link', className)} {...props} />;
+  return <NextLink {...props} className={clsx('Link', className)} />;
 }


### PR DESCRIPTION
A few fixes for fun:

1. There is https://github.com/mui/base-ui/security/code-scanning/20. Fixed
2. The href type https://nextjs.org/docs/pages/api-reference/components/link#reference can be an object too. Fixed
3. Avoid destructuring objects when possible (using ...)
4. We have a heavy DOM structure for nothing; we don't need those 42 `SideNavLabel` span nodes. The more components we add, the heavier:

<img width="302" height="113" alt="SCR-20250816-peyz" src="https://github.com/user-attachments/assets/383c9130-47bb-4235-8cb4-2a988585a2c7" />

Fixed

5. By default, Next.js prefetches all the links as soon as they enter the viewport (https://nextjs.org/docs/app/api-reference/components/link#prefetch). For a side nav, it spams requests to the CDN for nothing:

https://github.com/user-attachments/assets/906396b3-7bbf-44a0-84c9-7f4db10bb91e

Instead, wait for the user to hover link. Fixed

6. Avoiding binding onClick so many times. Fixed

Preview: https://deploy-preview-2519--base-ui.netlify.app/react/overview/quick-start