### PR TITLE
[docs] Fix wrong button > div structure

### DIFF
--- a/docs/src/components/Header.tsx
+++ b/docs/src/components/Header.tsx
@@ -40,10 +40,10 @@ export function Header() {
         <div className="flex show-side-nav:hidden">
           <MobileNav.Root>
             <MobileNav.Trigger className="HeaderButton">
-              <div className="flex w-4 flex-col items-center gap-1">
-                <div className="h-0.5 w-3.5 bg-current" />
-                <div className="h-0.5 w-3.5 bg-current" />
-              </div>
+              <span className="flex w-4 flex-col items-center gap-1">
+                <span className="h-0.5 w-3.5 bg-current" />
+                <span className="h-0.5 w-3.5 bg-current" />
+              </span>
               Navigation
             </MobileNav.Trigger>
             <MobileNav.Portal>


### PR DESCRIPTION
The error:

<img width="1007" height="225" alt="SCR-20250816-ppul" src="https://github.com/user-attachments/assets/81c9eaa4-77fd-4131-bdf3-a5d379021f7f" />

https://validator.w3.org/nu/?doc=https%3A%2F%2Fbase-ui.com%2Freact%2Foverview%2Fquick-start

Some more explanations on this:

- https://github.com/validator/validator/issues/1332#issuecomment-1064202494
- https://stackoverflow.com/questions/31020667/div-not-allowed-as-child-element-of-button

Some cleanup for fun. 