### PR TITLE
[docs] Use correct type for favicon

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -63,7 +63,7 @@ export const metadata: Metadata = {
       },
       {
         rel: 'icon',
-        type: 'svg+xml',
+        type: 'image/svg+xml',
         url:
           process.env.NODE_ENV !== 'production' ? '/static/favicon-dev.svg' : '/static/favicon.svg',
       },


### PR DESCRIPTION
See, it's not the correct type:

<img width="722" height="113" alt="SCR-20250816-psar" src="https://github.com/user-attachments/assets/00682d18-15fc-4247-a457-770d29a6805c" />

https://validator.w3.org/nu/?doc=https%3A%2F%2Fbase-ui.com%2Freact%2Foverview%2Fquick-start

The correct type can be seen in https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs.