### PR TITLE
[docs] Fix broken code highlighting inline style

### DIFF
--- a/docs/src/blocks/Demo/DemoSourceBrowser.tsx
+++ b/docs/src/blocks/Demo/DemoSourceBrowser.tsx
@@ -26,7 +26,8 @@ export const DemoSourceBrowser = React.forwardRef<HTMLPreElement, React.Componen
       const style = Object.fromEntries(
         styleAttr
           .split(';')
-          .map((str) => str.split(':').map(([key, value]) => [camelCase(key), value])),
+          .map((str) => str.split(':'))
+          .map(([key, value]) => [camelCase(key), value]),
       );
 
       return (


### PR DESCRIPTION
The inline style applied is wrong:

<img width="938" height="105" alt="SCR-20250816-pygk" src="https://github.com/user-attachments/assets/b5d383c4-9f18-4aa1-ab82-7c2acc22c104" />

https://validator.w3.org/nu/?doc=https%3A%2F%2Fbase-ui.com%2Freact%2Foverview%2Fquick-start

This now respects the initial intent. I couldn't notice UI changes after this, arguably, we could also remove all inline styles.

Preview: https://deploy-preview-2522--base-ui.netlify.app/react/components/checkbox