### PR TITLE
[useRender] Add `defaultTag` parameter

### DIFF
--- a/docs/src/app/(public)/(content)/react/utils/use-render/demos/render-callback/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/demos/render-callback/css-modules/index.tsx
@@ -11,7 +11,7 @@ interface CounterState {
 interface CounterProps extends useRender.ComponentProps<'button', CounterState> {}
 
 function Counter(props: CounterProps) {
-  const { render = <button />, ...otherProps } = props;
+  const { render, ...otherProps } = props;
 
   const [count, setCount] = React.useState(0);
   const odd = count % 2 === 1;
@@ -32,6 +32,7 @@ function Counter(props: CounterProps) {
   };
 
   const element = useRender({
+    defaultTag: 'button',
     render,
     state,
     props: mergeProps<'button'>(defaultProps, otherProps),

--- a/docs/src/app/(public)/(content)/react/utils/use-render/demos/render/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/demos/render/css-modules/index.tsx
@@ -7,9 +7,10 @@ import styles from './index.module.css';
 interface TextProps extends useRender.ComponentProps<'p'> {}
 
 function Text(props: TextProps) {
-  const { render = <p />, ...otherProps } = props;
+  const { render, ...otherProps } = props;
 
   const element = useRender({
+    defaultTag: 'p',
     render,
     props: mergeProps<'p'>({ className: styles.Text }, otherProps),
   });

--- a/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
+++ b/docs/src/app/(public)/(content)/react/utils/use-render/page.mdx
@@ -98,10 +98,11 @@ When building custom components, you often need to control a ref internally whil
 In React 19, `React.forwardRef()` is not needed when building primitive components, as the external ref prop is already contained inside `props`. Your internal ref can be passed to `ref` to be merged with `props.ref`:
 
 ```tsx title="React 19" {5} "internalRef"
-function Text({ render = <p />, ...props }: TextProps) {
+function Text({ render, ...props }: TextProps) {
   const internalRef = React.useRef<HTMLElement | null>(null);
 
   const element = useRender({
+    defaultTag: 'p',
     ref: internalRef,
     props,
     render,
@@ -117,12 +118,13 @@ The [examples](#examples) above assume React 19, and should be modified to use `
 
 ```tsx title="React 18 and 17" {8} "forwardedRef" "internalRef"
 const Text = React.forwardRef(function Text(
-  { render = <p />, ...props }: TextProps,
+  { render, ...props }: TextProps,
   forwardedRef: React.ForwardedRef<HTMLElement>,
 ) {
   const internalRef = React.useRef<HTMLElement | null>(null);
 
   const element = useRender({
+    defaultTag: 'p',
     ref: [forwardedRef, internalRef],
     props,
     render,
@@ -142,7 +144,7 @@ To type props, there are two interfaces:
 ```tsx title="Typing props" {1,4}
 interface ButtonProps extends useRender.ComponentProps<'button'> {}
 
-function Button({ render = <button />, ...props }: ButtonProps) {
+function Button({ render, ...props }: ButtonProps) {
   const defaultProps: useRender.ElementProps<'button'> = {
     className: styles.Button,
     type: 'button',
@@ -150,6 +152,7 @@ function Button({ render = <button />, ...props }: ButtonProps) {
   };
 
   const element = useRender({
+    defaultTag: 'button',
     render,
     props: mergeProps<'button'>(defaultProps, props),
   });
@@ -183,10 +186,14 @@ In Base UI, `useRender` lets you implement a `render` prop. The example below is
 ```jsx title="Base UI render prop"
 import { useRender } from '@base-ui-components/react/use-render';
 
-function Button({ render = <button />, ...props }) {
-  return useRender({ render, props });
+function Button({ render, ...props }) {
+  return useRender({
+    defaultTag: 'button',
+    render,
+    props,
+  });
 }
 
 // Usage
-<Button render={<a href="/contact">Contact</a>} />;
+<Button render={<a href="/contact" />}>Contact</Button>;
 ```

--- a/packages/react/src/use-render/useRender.test.tsx
+++ b/packages/react/src/use-render/useRender.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer } from '@mui/internal-test-utils';
 import { useRender } from '@base-ui-components/react/use-render';
+import { createRenderer } from '#test-utils';
 
 describe('useRender', () => {
   const { render } = createRenderer();
@@ -67,6 +67,40 @@ describe('useRender', () => {
 
     refs.forEach((ref) => {
       expect(ref).to.deep.equal({ current: container.firstElementChild });
+    });
+  });
+
+  describe('param: defaultTag', () => {
+    it('renders the element with the default tag with no render prop', async () => {
+      function TestComponent({ defaultTag }: { defaultTag: keyof React.JSX.IntrinsicElements }) {
+        return useRender({ defaultTag });
+      }
+
+      const { container, setProps } = await render(<TestComponent defaultTag="div" />);
+      expect(container.firstElementChild).to.have.property('tagName', 'DIV');
+
+      await setProps({ defaultTag: 'span' });
+      expect(container.firstElementChild).to.have.property('tagName', 'SPAN');
+    });
+
+    it('is overwritten by the render prop', async () => {
+      function TestComponent({
+        render: renderProp,
+        defaultTag,
+      }: {
+        render: useRender.Parameters<{}, Element, undefined>['render'];
+        defaultTag: keyof React.JSX.IntrinsicElements;
+      }) {
+        return useRender({ render: renderProp, defaultTag });
+      }
+
+      const { container, setProps } = await render(
+        <TestComponent defaultTag="div" render={<span />} />,
+      );
+      expect(container.firstElementChild).to.have.property('tagName', 'SPAN');
+
+      await setProps({ defaultTag: 'a' });
+      expect(container.firstElementChild).to.have.property('tagName', 'SPAN');
     });
   });
 });

--- a/packages/react/src/use-render/useRender.ts
+++ b/packages/react/src/use-render/useRender.ts
@@ -20,7 +20,7 @@ export function useRender<
   };
   renderParams.disableStyleHooks = true;
 
-  return useRenderElement(undefined, renderParams, renderParams);
+  return useRenderElement(renderParams.defaultTag, renderParams, renderParams);
 }
 
 export namespace useRender {
@@ -55,7 +55,7 @@ export namespace useRender {
     /**
      * The React element or a function that returns one to override the default element.
      */
-    render: RenderProp<State>;
+    render?: RenderProp<State>;
     /**
      * The ref to apply to the rendered element.
      */
@@ -77,6 +77,11 @@ export namespace useRender {
      * @default true
      */
     enabled?: Enabled;
+    /**
+     * The default tag to use for the rendered element.
+     * @default 'div'
+     */
+    defaultTag?: keyof React.JSX.IntrinsicElements;
   }
 
   export type ReturnValue<Enabled extends boolean | undefined> = Enabled extends false


### PR DESCRIPTION
Adds a `defaultTag: typeof React.JSX.IntrinsicElements` property to the `useRender` options, instead of needing to set a default to `useRender`, which uses `React.cloneElement` and is a slower default for perf sensitive primitives