### PR TITLE
[navigation menu] Close on link click by default

### DIFF
--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { expect } from 'chai';
+import { screen, flushMicrotasks } from '@mui/internal-test-utils';
 import { NavigationMenu } from '@base-ui-components/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -15,4 +17,41 @@ describe('<NavigationMenu.Link />', () => {
       );
     },
   }));
+
+  it('closes the menu when clicking a link', async () => {
+    const { user } = await render(
+      <NavigationMenu.Root>
+        <NavigationMenu.List>
+          <NavigationMenu.Item value="item-1">
+            <NavigationMenu.Trigger data-testid="trigger-1">Item 1</NavigationMenu.Trigger>
+            <NavigationMenu.Content data-testid="popup-1">
+              <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+        </NavigationMenu.List>
+
+        <NavigationMenu.Portal>
+          <NavigationMenu.Positioner>
+            <NavigationMenu.Popup>
+              <NavigationMenu.Viewport />
+            </NavigationMenu.Popup>
+          </NavigationMenu.Positioner>
+        </NavigationMenu.Portal>
+      </NavigationMenu.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger-1');
+
+    await user.click(trigger);
+    await flushMicrotasks();
+
+    expect(screen.queryByTestId('popup-1')).not.to.equal(null);
+    expect(trigger).to.have.attribute('aria-expanded', 'true');
+
+    const link = screen.getByRole('link', { name: 'Link 1' });
+    await user.click(link);
+
+    expect(screen.queryByTestId('popup-1')).to.equal(null);
+    expect(trigger).to.have.attribute('aria-expanded', 'false');
+  });
 });

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
@@ -27,6 +27,9 @@ export const NavigationMenuLink = React.forwardRef(function NavigationMenuLink(
 
   const defaultProps: HTMLProps = {
     tabIndex: undefined,
+    onClick(event) {
+      setValue(null, event.nativeEvent, 'link-press');
+    },
     onBlur(event) {
       if (
         positionerElement &&

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.tsx
@@ -56,7 +56,7 @@ export const NavigationMenuRoot = React.forwardRef(function NavigationMenuRoot(
   // Derive open state from value being non-nullish
   const open = value != null;
 
-  const closeReasonRef = React.useRef<BaseOpenChangeReason | undefined>(undefined);
+  const closeReasonRef = React.useRef<NavigationMenuRoot.OpenChangeReason | undefined>(undefined);
   const rootRef = React.useRef<HTMLDivElement | null>(null);
 
   const [positionerElement, setPositionerElement] = React.useState<HTMLElement | null>(null);
@@ -86,7 +86,11 @@ export const NavigationMenuRoot = React.forwardRef(function NavigationMenuRoot(
   }, [value]);
 
   const setValue = useEventCallback(
-    (nextValue: any, event: Event | undefined, reason: BaseOpenChangeReason | undefined) => {
+    (
+      nextValue: any,
+      event: Event | undefined,
+      reason: NavigationMenuRoot.OpenChangeReason | undefined,
+    ) => {
       if (!nextValue) {
         closeReasonRef.current = reason;
         setActivationDirection(null);
@@ -307,7 +311,7 @@ export namespace NavigationMenuRoot {
     onValueChange?: (
       value: any,
       event: Event | undefined,
-      reason: BaseOpenChangeReason | undefined,
+      reason: OpenChangeReason | undefined,
     ) => void;
     /**
      * How long to wait before opening the navigation menu. Specified in milliseconds.
@@ -334,4 +338,6 @@ export namespace NavigationMenuRoot {
      */
     unmount: () => void;
   }
+
+  export type OpenChangeReason = BaseOpenChangeReason | 'link-press';
 }

--- a/packages/react/src/navigation-menu/root/NavigationMenuRootContext.ts
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRootContext.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import type { FloatingRootContext } from '../../floating-ui-react';
-import type { BaseOpenChangeReason } from '../../utils/translateOpenChangeReason';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
+import type { NavigationMenuRoot } from './NavigationMenuRoot';
 
 export interface NavigationMenuRootContext {
   open: boolean;
   value: any;
-  setValue: (value: any, event?: Event, reason?: BaseOpenChangeReason) => void;
+  setValue: (value: any, event?: Event, reason?: NavigationMenuRoot.OpenChangeReason) => void;
   transitionStatus: TransitionStatus;
   mounted: boolean;
   popupElement: HTMLElement | null;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

When the navigation menu exists in a shared, this should be a default.