### PR TITLE
[field][input] Prevent defaultValue reset on focus for uncontrolled inputs

### DIFF
--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -90,6 +90,8 @@ export const FieldControl = React.forwardRef(function FieldControl(
     state: 'value',
   });
 
+  const isControlled = valueProp !== undefined;
+
   const setValue = useEventCallback((nextValue: string, event: Event) => {
     setValueUnwrapped(nextValue);
     onValueChange?.(nextValue, event);
@@ -114,9 +116,9 @@ export const FieldControl = React.forwardRef(function FieldControl(
         name,
         ref: inputRef,
         'aria-labelledby': labelId,
-        value,
+        ...(isControlled ? { value } : { defaultValue }),
         onChange(event) {
-          if (value != null) {
+          if (isControlled) {
             setValue(event.currentTarget.value, event.nativeEvent);
           }
 

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -795,4 +795,54 @@ describe('<Field.Root />', () => {
       });
     });
   });
+
+  describe('defaultValue behavior', () => {
+    it('should not reset to defaultValue when input value is programmatically changed and then focused', async () => {
+      const inputRef = React.createRef<HTMLInputElement>();
+
+      await render(
+        <Field.Root>
+          <Field.Control ref={inputRef} defaultValue="foo" data-testid="input" />
+        </Field.Root>
+      );
+
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      
+      expect(input.value).to.equal('foo');
+      
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
+      
+      expect(input.value).to.equal('');
+      
+      fireEvent.focus(input);
+      
+      expect(input.value).to.equal('');
+    });
+
+    it('should not reset to defaultValue when input value is programmatically changed to non-empty value and then focused', async () => {
+      const inputRef = React.createRef<HTMLInputElement>();
+
+      await render(
+        <Field.Root>
+          <Field.Control ref={inputRef} defaultValue="foo" data-testid="input" />
+        </Field.Root>
+      );
+
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      
+      expect(input.value).to.equal('foo');
+      
+      if (inputRef.current) {
+        inputRef.current.value = 'abc';
+      }
+      
+      expect(input.value).to.equal('abc');
+      
+      fireEvent.focus(input);
+      
+      expect(input.value).to.equal('abc');
+    });
+  });
 });


### PR DESCRIPTION
This will solve [#2530](https://github.com/mui/base-ui/issues/2530)

**Problem:**
Inputs wrapped in Field.Root were incorrectly resetting to their defaultValue when focused after being programmatically changed via ref (e.g., inputRef.current.value = ""). This behavior differed from plain HTML inputs and unwrapped Input components.

**Cause:**
The FieldControl component was always passing a value prop to the input element, making React treat it as controlled even when only defaultValue was provided. When the DOM value was changed directly, React's internal state wasn't updated, causing re-renders to reset the input.

 **My Solution:**
Modified FieldControl to conditionally pass either value (for controlled) or defaultValue (for uncontrolled) props to the input element, matching standard behavior.

Note: Before implementing the fix, I created some failing tests that reproduced the behaviour mentioned in the issue.