### PR TITLE
[internal] Remove implicit private: false in package.json

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@base-ui-components/react",
   "version": "1.0.0-beta.2",
-  "private": false,
   "author": "MUI Team",
   "description": "Base UI is a library of headless ('unstyled') React components and low-level hooks. You gain complete control over your app's CSS and accessibility features.",
   "keywords": [


### PR DESCRIPTION
https://unpkg.com/@base-ui-components/react@1.0.0-beta.2/package.json this is redundant; we never add this in the other public npm packages.