### PR TITLE
[internal] Improve useControlled() strict mode handling

### DIFF
--- a/packages/utils/src/useControlled.test.tsx
+++ b/packages/utils/src/useControlled.test.tsx
@@ -124,7 +124,7 @@ describe('useControlled', () => {
       }).not.toErrorDev();
     });
 
-    it('should not when when an array', () => {
+    it('should not warn when an array', () => {
       function TestComponentArray() {
         useControlled({
           controlled: undefined,

--- a/packages/utils/src/useControlled.test.tsx
+++ b/packages/utils/src/useControlled.test.tsx
@@ -14,14 +14,14 @@ interface TestComponentProps {
   children: (parames: TestComponentChildrenArgument) => React.ReactNode;
 }
 
-const TestComponent = ({ value: valueProp, defaultValue, children }: TestComponentProps) => {
+function TestComponent({ value: valueProp, defaultValue, children }: TestComponentProps) {
   const [value, setValue] = useControlled({
     controlled: valueProp,
     default: defaultValue,
     name: 'TestComponent',
   });
   return children({ value, setValue });
-};
+}
 
 describe('useControlled', () => {
   const { render } = createRenderer();
@@ -73,7 +73,7 @@ describe('useControlled', () => {
     );
   });
 
-  it('warns when switching from controlled to uncontrolled', () => {
+  it('should warn when switching from controlled to uncontrolled', () => {
     let setProps: (newProps: any) => void;
 
     expect(() => {
@@ -87,39 +87,56 @@ describe('useControlled', () => {
     );
   });
 
-  it('warns when changing the defaultValue prop after initial rendering', () => {
-    let setProps: (newProps: any) => void;
+  describe('warns when changing the defaultValue prop after initial rendering', () => {
+    it('should detect changes', () => {
+      let setProps: (newProps: any) => void;
 
-    expect(() => {
-      ({ setProps } = render(<TestComponent>{() => null}</TestComponent>));
-    }).not.toErrorDev();
+      expect(() => {
+        ({ setProps } = render(<TestComponent>{() => null}</TestComponent>));
+      }).not.toErrorDev();
 
-    expect(() => {
-      setProps({ defaultValue: 1 });
-    }).toErrorDev(
-      'Base UI: A component is changing the default value state of an uncontrolled TestComponent after being initialized.',
-    );
-  });
+      expect(() => {
+        setProps({ defaultValue: 1 });
+      }).toErrorDev(
+        'Base UI: A component is changing the default value state of an uncontrolled TestComponent after being initialized.',
+      );
+    });
 
-  it('should not raise a warning if changing the defaultValue when controlled', () => {
-    let setProps: (newProps: any) => void;
+    it('should not warn when controlled', () => {
+      let setProps: (newProps: any) => void;
 
-    expect(() => {
-      ({ setProps } = render(
-        <TestComponent value={1} defaultValue={0}>
-          {() => null}
-        </TestComponent>,
-      ));
-    }).not.toErrorDev();
+      expect(() => {
+        ({ setProps } = render(
+          <TestComponent value={1} defaultValue={0}>
+            {() => null}
+          </TestComponent>,
+        ));
+      }).not.toErrorDev();
 
-    expect(() => {
-      setProps({ defaultValue: 1 });
-    }).not.toErrorDev();
-  });
+      expect(() => {
+        setProps({ defaultValue: 1 });
+      }).not.toErrorDev();
+    });
 
-  it('should not raise a warning if setting NaN as the defaultValue when uncontrolled', () => {
-    expect(() => {
-      render(<TestComponent defaultValue={NaN}>{() => null}</TestComponent>);
-    }).not.toErrorDev();
+    it('should not warn when NaN', () => {
+      expect(() => {
+        render(<TestComponent defaultValue={NaN}>{() => null}</TestComponent>);
+      }).not.toErrorDev();
+    });
+
+    it('should not when when an array', () => {
+      function TestComponentArray() {
+        useControlled({
+          controlled: undefined,
+          default: [],
+          name: 'TestComponent',
+        });
+        return null;
+      }
+
+      expect(() => {
+        render(<TestComponentArray />);
+      }).not.toErrorDev();
+    });
   });
 });

--- a/packages/utils/src/useControlled.ts
+++ b/packages/utils/src/useControlled.ts
@@ -54,7 +54,6 @@ export function useControlled<T = unknown>({
     const { current: defaultValue } = React.useRef(defaultProp);
 
     React.useEffect(() => {
-      // Object.is() is not equivalent to the === operator.
       // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is for more details.
       if (!isControlled && JSON.stringify(defaultValue) !== JSON.stringify(defaultProp)) {
         console.error(

--- a/packages/utils/src/useControlled.ts
+++ b/packages/utils/src/useControlled.ts
@@ -56,7 +56,7 @@ export function useControlled<T = unknown>({
     React.useEffect(() => {
       // Object.is() is not equivalent to the === operator.
       // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is for more details.
-      if (!isControlled && !Object.is(defaultValue, defaultProp)) {
+      if (!isControlled && JSON.stringify(defaultValue) !== JSON.stringify(defaultProp)) {
         console.error(
           [
             `Base UI: A component is changing the default ${state} state of an uncontrolled ${name} after being initialized. ` +


### PR DESCRIPTION
Same as https://github.com/mui/material-ui/pull/46807.

*Since we are increasingly placing mui/base-ui at the core, I could have opened a PR here first (and propagated it in mui/material-ui), but I feel like there is a stronger test coverage in mui/material-ui ("stronger" = a large one, [3650 tests](https://app.circleci.com/pipelines/github/mui/base-ui/13134/workflows/1707fedf-411d-41b8-b252-d74318168640/jobs/133378) vs. [8253 tests](https://app.circleci.com/pipelines/github/mui/material-ui/159098/workflows/8cad5a20-3c67-4418-b80d-5dc9f89bf056/jobs/850554)), so I would rather test changes where the **hardest** constraints are first. However, we probably want to review them here first, and only after approve changes on mui/material-ui.*