### PR TITLE
[select] Fix item click with `defaultOpen` prop

### DIFF
--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -160,11 +160,9 @@ export const SelectItem = React.memo(
         selectionRef.current = {
           allowSelectedMouseUp: false,
           allowUnselectedMouseUp: false,
-          allowSelect: true,
         };
       },
       onKeyDown(event) {
-        selectionRef.current.allowSelect = true;
         lastKeyRef.current = event.key;
         store.set('activeIndex', indexRef.current);
       },
@@ -184,10 +182,8 @@ export const SelectItem = React.memo(
           return;
         }
 
-        if (selectionRef.current.allowSelect) {
-          lastKeyRef.current = null;
-          commitSelection(event.nativeEvent);
-        }
+        lastKeyRef.current = null;
+        commitSelection(event.nativeEvent);
       },
       onPointerEnter(event) {
         pointerTypeRef.current = event.pointerType;
@@ -217,11 +213,9 @@ export const SelectItem = React.memo(
           return;
         }
 
-        if (selectionRef.current.allowSelect || !selected) {
+        if (!selected) {
           commitSelection(event.nativeEvent);
         }
-
-        selectionRef.current.allowSelect = true;
       },
     };
 

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -296,6 +296,41 @@ describe('<Select.Root />', () => {
 
       expect(screen.getByRole('listbox', { hidden: false })).toBeVisible();
     });
+
+    it('should select an item and close when clicked while opened by default', async () => {
+      const handleValueChange = spy();
+
+      const { user } = await render(
+        <Select.Root defaultOpen onValueChange={handleValueChange}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      expect(screen.queryByRole('listbox')).toBeVisible();
+
+      const optionB = screen.getByRole('option', { name: 'b' });
+
+      fireEvent.mouseMove(optionB);
+      await user.click(optionB);
+      await flushMicrotasks();
+
+      expect(handleValueChange.callCount).to.equal(1);
+      expect(handleValueChange.args[0][0]).to.equal('b');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).to.equal(null);
+      });
+    });
   });
 
   describe('prop: onOpenChange', () => {

--- a/packages/react/src/select/root/SelectRootContext.ts
+++ b/packages/react/src/select/root/SelectRootContext.ts
@@ -32,7 +32,6 @@ export interface SelectRootContext {
   selectionRef: React.MutableRefObject<{
     allowUnselectedMouseUp: boolean;
     allowSelectedMouseUp: boolean;
-    allowSelect: boolean;
   }>;
   selectedItemTextRef: React.MutableRefObject<HTMLSpanElement | null>;
   fieldControlValidation: ReturnType<typeof useFieldControlValidation>;

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -96,7 +96,6 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
   const selectionRef = React.useRef({
     allowSelectedMouseUp: false,
     allowUnselectedMouseUp: false,
-    allowSelect: false,
   });
   const hasRegisteredRef = React.useRef(false);
   const alignItemWithTriggerActiveRef = React.useRef(false);

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -113,7 +113,6 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
     selectionRef.current = {
       allowSelectedMouseUp: false,
       allowUnselectedMouseUp: false,
-      allowSelect: true,
     };
 
     timeoutMouseDown.clear();


### PR DESCRIPTION
When specifying `defaultOpen` on `Select`, clicking an item is blocked initially and doesn't select. From what I see, the `allowSelect` state is needless on the ref.