### PR TITLE
[useAnchorPositioning] Fix `limitShift` offset based on arrow size

### DIFF
--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -222,14 +222,16 @@ export function useAnchorPositioning(
             limiter:
               sticky || shiftCrossAxis
                 ? undefined
-                : limitShift(() => {
+                : limitShift((limitData) => {
                     if (!arrowRef.current) {
                       return {};
                     }
-                    const { height } = arrowRef.current.getBoundingClientRect();
+                    const { width, height } = arrowRef.current.getBoundingClientRect();
+                    const arrowSize = getSideAxis(limitData.placement) === 'y' ? width : height;
                     return {
                       offset:
-                        height / 2 + (typeof collisionPadding === 'number' ? collisionPadding : 0),
+                        arrowSize / 2 +
+                        (typeof collisionPadding === 'number' ? collisionPadding : 0),
                     };
                   }),
           };


### PR DESCRIPTION
Super tiny fix - this offset was based on the assumption that the width/height of the arrow is the same (a square) but our docs explicitly don't do this and is likely to be found in the wild. Right now if the popup is shifted so the adjacent edges of the popup and trigger are meant to be touching, the arrow would point to empty space (by ~5px) rather than the very edge of the trigger.

Previous:

<img width="956" height="592" alt="Screenshot 2025-08-24 at 4 01 01 pm" src="https://github.com/user-attachments/assets/c6e8b826-04b6-429b-860e-1ac53522263f" />
