### PR TITLE
[select] Reset state when selected item is removed

### DIFF
--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -48,8 +48,15 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
     ...elementProps
   } = componentProps;
 
-  const { store, listRef, labelsRef, alignItemWithTriggerActiveRef, valuesRef } =
-    useSelectRootContext();
+  const {
+    store,
+    listRef,
+    labelsRef,
+    alignItemWithTriggerActiveRef,
+    valuesRef,
+    initialValueRef,
+    setValue,
+  } = useSelectRootContext();
   const floatingRootContext = useSelectFloatingContext();
 
   const open = useStore(store, selectors.open);
@@ -165,13 +172,14 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
       return;
     }
 
-    if (!store.state.multiple && value !== null) {
+    if (prevSize !== 0 && !store.state.multiple && value !== null) {
       const valueIndex = valuesRef.current.indexOf(value);
       if (valueIndex === -1) {
-        store.apply({
-          label: '',
-          selectedIndex: null,
-        });
+        store.apply({ label: '', selectedIndex: null });
+        const initial = initialValueRef.current;
+        const hasInitial = initial != null && valuesRef.current.includes(initial);
+        const nextValue = hasInitial ? initial : null;
+        setValue(nextValue);
       }
     }
 

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -1465,7 +1465,220 @@ describe('<Select.Root />', () => {
 
       fireEvent.click(screen.getByText('Add'));
 
-      expect(screen.queryByRole('option', { name: 'a' })).to.have.attribute('data-selected');
+      expect(screen.queryByRole('option', { name: 'a' })).not.to.have.attribute('data-selected');
+    });
+
+    it('resets to default when the selected item is removed from the list', async () => {
+      function Test() {
+        const [items, setItems] = React.useState(['a', 'b', 'c']);
+        return (
+          <div>
+            <Select.Root defaultValue="b">
+              <Select.Trigger data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    {items.map((it) => (
+                      <Select.Item key={it} value={it}>
+                        {it}
+                      </Select.Item>
+                    ))}
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+            <button
+              data-testid="remove-c"
+              onClick={() => setItems((prev) => prev.filter((i) => i !== 'c'))}
+            >
+              Remove C
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(trigger);
+      await user.click(screen.getByRole('option', { name: 'c' }));
+
+      await user.click(screen.getByTestId('remove-c'));
+
+      await waitFor(() => {
+        expect(trigger).to.have.text('b');
+      });
+
+      await user.click(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'b' })).to.have.attribute('data-selected', '');
+      });
+    });
+
+    it('resets via onValueChange and does not break in controlled mode when the selected item is removed', async () => {
+      function TestControlled() {
+        const [items, setItems] = React.useState(['a', 'b', 'c']);
+        const [value, setValue] = React.useState('c');
+        return (
+          <div>
+            <Select.Root value={value} onValueChange={setValue}>
+              <Select.Trigger data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    {items.map((it) => (
+                      <Select.Item key={it} value={it}>
+                        {it}
+                      </Select.Item>
+                    ))}
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+            <button
+              data-testid="remove-c"
+              onClick={() => setItems((prev) => prev.filter((i) => i !== 'c'))}
+            >
+              Remove C
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<TestControlled />);
+
+      const trigger = screen.getByTestId('trigger');
+      expect(trigger).to.have.text('c');
+
+      await user.click(screen.getByTestId('remove-c'));
+
+      // Opening should not break; and no option is selected since the value is missing from list
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByRole('listbox')).toBeVisible();
+      });
+
+      const options = screen.getAllByRole('option');
+      options.forEach((opt) => {
+        expect(opt).not.to.have.attribute('data-selected');
+      });
+    });
+
+    it('falls back to null when both selected and initial default are removed (uncontrolled)', async () => {
+      function Test() {
+        const [items, setItems] = React.useState(['a', 'b', 'c']);
+        return (
+          <div>
+            <Select.Root defaultValue="b">
+              <Select.Trigger data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    {items.map((it) => (
+                      <Select.Item key={it} value={it}>
+                        {it}
+                      </Select.Item>
+                    ))}
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+            <button
+              data-testid="remove-b"
+              onClick={() => setItems((prev) => prev.filter((i) => i !== 'b'))}
+            >
+              Remove B
+            </button>
+            <button
+              data-testid="remove-c"
+              onClick={() => setItems((prev) => prev.filter((i) => i !== 'c'))}
+            >
+              Remove C
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(trigger);
+      await user.click(screen.getByRole('option', { name: 'c' }));
+
+      await user.click(screen.getByTestId('remove-b'));
+      await user.click(screen.getByTestId('remove-c'));
+
+      // Now no fallback remains; value should reset to null
+      await waitFor(() => {
+        expect(trigger).to.have.text('');
+      });
+
+      await user.click(trigger);
+
+      const options = screen.getAllByRole('option');
+      options.forEach((opt) => {
+        expect(opt).not.to.have.attribute('data-selected');
+      });
+    });
+
+    it('falls back to null when both selected and initial default are removed (controlled)', async () => {
+      function TestControlled() {
+        const [items, setItems] = React.useState(['a', 'b', 'c']);
+        const [value, setValue] = React.useState('c');
+        return (
+          <div>
+            <Select.Root value={value} onValueChange={setValue}>
+              <Select.Trigger data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    {items.map((it) => (
+                      <Select.Item key={it} value={it}>
+                        {it}
+                      </Select.Item>
+                    ))}
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+            <button
+              data-testid="remove-b"
+              onClick={() => setItems((prev) => prev.filter((i) => i !== 'b'))}
+            >
+              Remove B
+            </button>
+            <button
+              data-testid="remove-c"
+              onClick={() => setItems((prev) => prev.filter((i) => i !== 'c'))}
+            >
+              Remove C
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<TestControlled />);
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(screen.getByTestId('remove-b'));
+      await user.click(screen.getByTestId('remove-c'));
+
+      await user.click(trigger);
+      const options = screen.getAllByRole('option');
+      options.forEach((opt) => {
+        expect(opt).not.to.have.attribute('data-selected');
+      });
     });
   });
 

--- a/packages/react/src/select/root/SelectRootContext.ts
+++ b/packages/react/src/select/root/SelectRootContext.ts
@@ -45,6 +45,7 @@ export interface SelectRootContext {
   keyboardActiveRef: React.MutableRefObject<boolean>;
   alignItemWithTriggerActiveRef: React.RefObject<boolean>;
   highlightTimeout: Timeout;
+  initialValueRef: React.MutableRefObject<any>;
 }
 
 export const SelectRootContext = React.createContext<SelectRootContext | null>(null);

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -483,6 +483,7 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
       keyboardActiveRef,
       alignItemWithTriggerActiveRef,
       highlightTimeout,
+      initialValueRef,
     }),
     [
       store,
@@ -509,6 +510,7 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
       keyboardActiveRef,
       alignItemWithTriggerActiveRef,
       highlightTimeout,
+      initialValueRef,
     ],
   );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Works like the native `<select>` when the selected `<option>` gets removed from the list, resetting to the default state, or null if the default is also removed. Previously, it would not open correctly and would require a `key` to reset the internal state.