### PR TITLE
[slider] Fix thumb `:focus-visible` with mixed keyboard and pointer modality

### DIFF
--- a/docs/src/app/(private)/experiments/forms/form.module.css
+++ b/docs/src/app/(private)/experiments/forms/form.module.css
@@ -597,8 +597,8 @@
   outline: 1px solid var(--color-gray-300);
   user-select: none;
 
-  &:focus,
-  &:focus-visible {
+  &:has(:focus),
+  &:has(:focus-visible) {
     outline: 2px solid var(--color-blue);
   }
 }

--- a/docs/src/app/(private)/experiments/slider/inset.mac.module.css
+++ b/docs/src/app/(private)/experiments/slider/inset.mac.module.css
@@ -64,7 +64,7 @@
   box-shadow: 0px 0px 3px 0px var(--color-gray-300);
   user-select: none;
 
-  &:focus-visible {
+  &:has(:focus-visible) {
     outline: 2px solid var(--color-blue);
   }
 

--- a/docs/src/app/(private)/experiments/slider/inset.native.module.css
+++ b/docs/src/app/(private)/experiments/slider/inset.native.module.css
@@ -71,7 +71,7 @@
 
   user-select: none;
 
-  &:focus-visible {
+  &:has(:focus-visible) {
     outline: 2px solid var(--color-blue);
     outline-offset: 2px;
   }

--- a/docs/src/app/(private)/experiments/slider/slider.module.css
+++ b/docs/src/app/(private)/experiments/slider/slider.module.css
@@ -57,7 +57,7 @@
   outline: 1px solid var(--color-gray-300);
   user-select: none;
 
-  &:focus-visible {
+  &:has(:focus-visible) {
     outline: 2px solid var(--color-blue);
   }
 }

--- a/docs/src/app/(private)/experiments/slider/small.module.css
+++ b/docs/src/app/(private)/experiments/slider/small.module.css
@@ -58,7 +58,7 @@
   outline: 1px solid var(--color-gray-300);
   user-select: none;
 
-  &:focus-visible {
+  &:has(:focus-visible) {
     outline: 2px solid var(--color-blue);
   }
 }

--- a/docs/src/app/(private)/experiments/slider/vertical.module.css
+++ b/docs/src/app/(private)/experiments/slider/vertical.module.css
@@ -54,7 +54,7 @@
   outline: 1px solid var(--color-gray-300);
   user-select: none;
 
-  &:focus-visible {
+  &:has(:focus-visible) {
     outline: 2px solid var(--color-blue);
   }
 }

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -3,7 +3,8 @@ import * as React from 'react';
 import { ownerDocument } from '@base-ui-components/utils/owner';
 import { useAnimationFrame } from '@base-ui-components/utils/useAnimationFrame';
 import { useEventCallback } from '@base-ui-components/utils/useEventCallback';
-import { activeElement } from '../../floating-ui-react/utils';
+import { activeElement, contains } from '../../floating-ui-react/utils';
+import type { Coords } from '../../floating-ui-react/types';
 import { clamp } from '../../utils/clamp';
 import type { BaseUIComponentProps, Orientation } from '../../utils/types';
 import { createBaseUIEventDetails } from '../../utils/createBaseUIEventDetails';
@@ -59,7 +60,7 @@ function getControlOffset(styles: CSSStyleDeclaration | null, orientation: Orien
 function getFingerPosition(
   event: TouchEvent | PointerEvent | React.PointerEvent,
   touchIdRef: React.RefObject<any>,
-): FingerPosition | null {
+): Coords | null {
   // The event is TouchEvent
   if (touchIdRef.current !== undefined && (event as TouchEvent).changedTouches) {
     const touchEvent = event as TouchEvent;
@@ -140,7 +141,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
 
   const getFingerState = useEventCallback(
     (
-      fingerPosition: FingerPosition | null,
+      fingerPosition: Coords | null,
       /**
        * When `true`, closestThumbIndexRef is updated.
        * It's `true` when called by touchstart or pointerdown.
@@ -379,7 +380,8 @@ export const SliderControl = React.forwardRef(function SliderControl(
               return;
             }
 
-            const pressedOnFocusedThumb = thumbRefs.current[finger.thumbIndex]?.contains(
+            const pressedOnFocusedThumb = contains(
+              thumbRefs.current[finger.thumbIndex],
               activeElement(ownerDocument(control)),
             );
 
@@ -421,11 +423,6 @@ export const SliderControl = React.forwardRef(function SliderControl(
 
   return element;
 });
-
-export interface FingerPosition {
-  x: number;
-  y: number;
-}
 
 interface FingerState {
   value: number | number[];

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -96,7 +96,6 @@ export const SliderControl = React.forwardRef(function SliderControl(
   const { render: renderProp, className, ...elementProps } = componentProps;
 
   const {
-    active: activeThumbIndex,
     disabled,
     dragging,
     fieldControlValidation,
@@ -218,19 +217,9 @@ export const SliderControl = React.forwardRef(function SliderControl(
   );
 
   const focusThumb = useEventCallback((thumbIndex: number) => {
-    const control = controlRef.current;
-    if (!control) {
-      return;
-    }
-
-    const activeEl = activeElement(ownerDocument(control));
-
-    if (activeEl == null || !control.contains(activeEl) || activeThumbIndex !== thumbIndex) {
-      setActive(thumbIndex);
-      thumbRefs.current?.[thumbIndex]
-        ?.querySelector<HTMLInputElement>('input[type="range"]')
-        ?.focus({ preventScroll: true });
-    }
+    thumbRefs.current?.[thumbIndex]
+      ?.querySelector<HTMLInputElement>('input[type="range"]')
+      ?.focus({ preventScroll: true });
   });
 
   const handleTouchMove = useEventCallback((nativeEvent: TouchEvent | PointerEvent) => {

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -229,7 +229,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
       setActive(thumbIndex);
       thumbRefs.current?.[thumbIndex]
         ?.querySelector<HTMLInputElement>('input[type="range"]')
-        ?.focus();
+        ?.focus({ preventScroll: true });
     }
   });
 
@@ -267,7 +267,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
   const handleTouchEnd = useEventCallback((nativeEvent: TouchEvent | PointerEvent) => {
     const fingerPosition = getFingerPosition(nativeEvent, touchIdRef);
     setDragging(false);
-
+    pressedInputRef.current = null;
     if (fingerPosition == null) {
       return;
     }
@@ -390,10 +390,9 @@ export const SliderControl = React.forwardRef(function SliderControl(
               return;
             }
 
-            const pressedOnFocusedThumb =
-              pressedInputRef.current != null &&
-              activeElement(ownerDocument(control)) === pressedInputRef.current &&
-              thumbRefs.current[finger.thumbIndex]?.contains(pressedInputRef.current);
+            const pressedOnFocusedThumb = thumbRefs.current[finger.thumbIndex]?.contains(
+              activeElement(ownerDocument(control)),
+            );
 
             if (pressedOnFocusedThumb) {
               event.preventDefault();
@@ -402,6 +401,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
                 focusThumb(finger.thumbIndex);
               });
             }
+
             setDragging(true);
             // if the event lands on a thumb, don't change the value, just get the
             // percentageValue difference represented by the distance between the click origin

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as React from 'react';
 import { spy, stub } from 'sinon';
-import { act, flushMicrotasks, fireEvent, screen } from '@mui/internal-test-utils';
+import { act, flushMicrotasks, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import {
   DirectionProvider,
   type TextDirection,
@@ -804,7 +804,9 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
         clientX: 1,
       });
 
-      expect(slider).toHaveFocus();
+      await waitFor(() => {
+        expect(slider).toHaveFocus();
+      });
     });
 
     it.skipIf(isWebKit)('should not override the event.target on touch events', async () => {

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -120,6 +120,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   const sliderRef = React.useRef<HTMLElement>(null);
   const controlRef = React.useRef<HTMLElement>(null);
   const thumbRefs = React.useRef<(HTMLElement | null)[]>([]);
+  const pressedInputRef = React.useRef<HTMLInputElement>(null);
   const inputRef = useMergedRefs(inputRefProp, fieldControlValidation.inputRef);
   const lastChangedValueRef = React.useRef<number | readonly number[] | null>(null);
   const formatOptionsRef = useLatestRef(format);
@@ -272,6 +273,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
       disabled,
       dragging,
       fieldControlValidation,
+      pressedInputRef,
       formatOptionsRef,
       handleInputChange,
       labelId: ariaLabelledby,
@@ -300,6 +302,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
       disabled,
       dragging,
       fieldControlValidation,
+      pressedInputRef,
       formatOptionsRef,
       handleInputChange,
       largeStep,

--- a/packages/react/src/slider/root/SliderRootContext.ts
+++ b/packages/react/src/slider/root/SliderRootContext.ts
@@ -15,6 +15,7 @@ export interface SliderRootContext {
   dragging: boolean;
   disabled: boolean;
   fieldControlValidation: useFieldControlValidation.ReturnValue;
+  pressedInputRef: React.RefObject<HTMLInputElement | null>;
   formatOptionsRef: React.RefObject<Intl.NumberFormatOptions | undefined>;
   handleInputChange: (
     valueInput: number,

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -106,6 +106,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
   const {
     active: activeIndex,
     disabled: contextDisabled,
+    pressedInputRef,
     fieldControlValidation,
     formatOptionsRef,
     handleInputChange,
@@ -128,6 +129,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
   const { controlId, setControlId, setTouched, setFocused, validationMode } = useFieldRootContext();
 
   const thumbRef = React.useRef<HTMLElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   useIsoLayoutEffect(() => {
     setControlId(inputId);
@@ -316,10 +318,10 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
   const children = childrenProp ? (
     <React.Fragment>
       {childrenProp}
-      <input {...inputProps} />
+      <input ref={inputRef} {...inputProps} />
     </React.Fragment>
   ) : (
-    <input {...inputProps} />
+    <input ref={inputRef} {...inputProps} />
   );
 
   const element = useRenderElement('div', componentProps, {
@@ -332,6 +334,16 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
         id,
         onBlur: onBlurProp,
         onFocus: onFocusProp,
+        onPointerDown() {
+          if (inputRef.current) {
+            pressedInputRef.current = inputRef.current;
+          }
+        },
+        onPointerUp() {
+          if (pressedInputRef.current != null && pressedInputRef.current === inputRef.current) {
+            pressedInputRef.current = null;
+          }
+        },
         style: getThumbStyle(),
         tabIndex: -1,
       },

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -335,13 +335,8 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
         onBlur: onBlurProp,
         onFocus: onFocusProp,
         onPointerDown() {
-          if (inputRef.current) {
+          if (inputRef.current != null && pressedInputRef.current !== inputRef.current) {
             pressedInputRef.current = inputRef.current;
-          }
-        },
-        onPointerUp() {
-          if (pressedInputRef.current != null && pressedInputRef.current === inputRef.current) {
-            pressedInputRef.current = null;
           }
         },
         style: getThumbStyle(),


### PR DESCRIPTION
### Preview
Single thumb: https://deploy-preview-2584--base-ui.netlify.app/react/components/slider

https://github.com/user-attachments/assets/70cff343-46da-4ffa-9ee3-afda8b0598a0

Multiple thumbs: https://deploy-preview-2584--base-ui.netlify.app/react/components/slider#range-slider

https://github.com/user-attachments/assets/82c8eed1-e124-46e9-bc38-95e42e518900

Differences from other libraries:
- Using the pointer (only) on the thumb doesn't trigger `:focus-visible` which is a bug in Radix https://github.com/radix-ui/primitives/issues/2397
- Using the pointer on a thumb that already shows `:focus-visible` without moving focus (e.g. starting a drag) does not cancel `:focus-visible`, there's a [web platform test](https://wpt.live/css/selectors/focus-visible-007.html) related to this. This is [different from RA](https://react-spectrum.adobe.com/react-aria/Slider.html#example) where dragging the thumb that already has `:focus-visible` will cancel it which seems incorrect.

Doesn't work in Firefox due to a [browser bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1775199).

Fixes https://github.com/mui/base-ui/issues/2512

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
