### PR TITLE
[popups] Use boolean values for fallback `initialFocus`/`finalFocus` behavior

### DIFF
--- a/docs/reference/generated/alert-dialog-popup.json
+++ b/docs/reference/generated/alert-dialog-popup.json
@@ -3,14 +3,14 @@
   "description": "A container for the alert dialog contents.\nRenders a `<div>` element.",
   "props": {
     "initialFocus": {
-      "type": "RefObject<HTMLElement | null> | ((openType: InteractionType) => void | HTMLElement | null) | null",
-      "description": "Determines the element to focus when the dialog is opened.\nBy default, the first focusable element is focused.\n\n- `null`: Do not focus any element.\n- `RefObject`: Focus the ref element. Falls back to default behavior when `null`.\n- `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the open. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.",
-      "detailedType": "| React.RefObject<HTMLElement | null>\n| ((\n    openType: InteractionType,\n  ) => void | HTMLElement | null)\n| null\n| undefined"
+      "type": "boolean | RefObject<HTMLElement | null> | ((openType: InteractionType) => boolean | void | HTMLElement | null)",
+      "description": "Determines the element to focus when the dialog is opened.\n\n- `false`: Do not move focus.\n- `true`: Move focus based on the default behavior (first tabbable element or popup).\n- `RefObject`: Move focus to the ref element.\n- `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).\n  Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.",
+      "detailedType": "| boolean\n| React.RefObject<HTMLElement | null>\n| ((\n    openType: InteractionType,\n  ) => boolean | void | HTMLElement | null)\n| undefined"
     },
     "finalFocus": {
-      "type": "RefObject<HTMLElement | null> | ((closeType: InteractionType) => void | HTMLElement | null) | null",
-      "description": "Determines the element to focus when the dialog is closed.\nBy default, focus returns to the trigger.\n\n- `null`: Do not focus any element.\n- `RefObject`: Focus the ref element. Falls back to default behavior when `null`.\n- `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the close. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.",
-      "detailedType": "| React.RefObject<HTMLElement | null>\n| ((\n    closeType: InteractionType,\n  ) => void | HTMLElement | null)\n| null\n| undefined"
+      "type": "boolean | RefObject<HTMLElement | null> | ((closeType: InteractionType) => boolean | void | HTMLElement | null)",
+      "description": "Determines the element to focus when the dialog is closed.\n\n- `false`: Do not move focus.\n- `true`: Move focus based on the default behavior (trigger or previously focused element).\n- `RefObject`: Move focus to the ref element.\n- `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).\n  Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.",
+      "detailedType": "| boolean\n| React.RefObject<HTMLElement | null>\n| ((\n    closeType: InteractionType,\n  ) => boolean | void | HTMLElement | null)\n| undefined"
     },
     "className": {
       "type": "string | ((state: AlertDialog.Popup.State) => string)",

--- a/docs/reference/generated/dialog-popup.json
+++ b/docs/reference/generated/dialog-popup.json
@@ -3,14 +3,14 @@
   "description": "A container for the dialog contents.\nRenders a `<div>` element.",
   "props": {
     "initialFocus": {
-      "type": "RefObject<HTMLElement | null> | ((openType: InteractionType) => void | HTMLElement | null) | null",
-      "description": "Determines the element to focus when the dialog is opened.\nBy default, the first focusable element is focused.\n\n- `null`: Do not focus any element.\n- `RefObject`: Focus the ref element. Falls back to default behavior when `null`.\n- `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the open. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.",
-      "detailedType": "| React.RefObject<HTMLElement | null>\n| ((\n    openType: InteractionType,\n  ) => void | HTMLElement | null)\n| null\n| undefined"
+      "type": "boolean | RefObject<HTMLElement | null> | ((openType: InteractionType) => boolean | void | HTMLElement | null)",
+      "description": "Determines the element to focus when the dialog is opened.\n\n- `false`: Do not move focus.\n- `true`: Move focus based on the default behavior (first tabbable element or popup).\n- `RefObject`: Move focus to the ref element.\n- `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).\n  Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.",
+      "detailedType": "| boolean\n| React.RefObject<HTMLElement | null>\n| ((\n    openType: InteractionType,\n  ) => boolean | void | HTMLElement | null)\n| undefined"
     },
     "finalFocus": {
-      "type": "RefObject<HTMLElement | null> | ((closeType: InteractionType) => void | HTMLElement | null) | null",
-      "description": "Determines the element to focus when the dialog is closed.\nBy default, focus returns to the trigger.\n\n- `null`: Do not focus any element.\n- `RefObject`: Focus the ref element. Falls back to default behavior when `null`.\n- `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the close. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.",
-      "detailedType": "| React.RefObject<HTMLElement | null>\n| ((\n    closeType: InteractionType,\n  ) => void | HTMLElement | null)\n| null\n| undefined"
+      "type": "boolean | RefObject<HTMLElement | null> | ((closeType: InteractionType) => boolean | void | HTMLElement | null)",
+      "description": "Determines the element to focus when the dialog is closed.\n\n- `false`: Do not move focus.\n- `true`: Move focus based on the default behavior (trigger or previously focused element).\n- `RefObject`: Move focus to the ref element.\n- `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).\n  Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.",
+      "detailedType": "| boolean\n| React.RefObject<HTMLElement | null>\n| ((\n    closeType: InteractionType,\n  ) => boolean | void | HTMLElement | null)\n| undefined"
     },
     "className": {
       "type": "string | ((state: Dialog.Popup.State) => string)",

--- a/docs/reference/generated/menu-popup.json
+++ b/docs/reference/generated/menu-popup.json
@@ -3,9 +3,9 @@
   "description": "A container for the menu items.\nRenders a `<div>` element.",
   "props": {
     "finalFocus": {
-      "type": "RefObject<HTMLElement | null> | ((closeType: InteractionType) => void | HTMLElement | null) | null",
-      "description": "Determines the element to focus when the menu is closed.\nBy default, focus returns to the trigger.\n\n- `null`: Do not focus any element.\n- `RefObject`: Focus the ref element. Falls back to default behavior when `null`.\n- `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the close. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.",
-      "detailedType": "| React.RefObject<HTMLElement | null>\n| ((\n    closeType: InteractionType,\n  ) => void | HTMLElement | null)\n| null\n| undefined"
+      "type": "boolean | RefObject<HTMLElement | null> | ((closeType: InteractionType) => boolean | void | HTMLElement | null)",
+      "description": "Determines the element to focus when the menu is closed.\n\n- `false`: Do not move focus.\n- `true`: Move focus based on the default behavior (trigger or previously focused element).\n- `RefObject`: Move focus to the ref element.\n- `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).\n  Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.",
+      "detailedType": "| boolean\n| React.RefObject<HTMLElement | null>\n| ((\n    closeType: InteractionType,\n  ) => boolean | void | HTMLElement | null)\n| undefined"
     },
     "id": {
       "type": "string",

--- a/docs/reference/generated/popover-popup.json
+++ b/docs/reference/generated/popover-popup.json
@@ -3,14 +3,14 @@
   "description": "A container for the popover contents.\nRenders a `<div>` element.",
   "props": {
     "initialFocus": {
-      "type": "RefObject<HTMLElement | null> | ((openType: InteractionType) => void | HTMLElement | null) | null",
-      "description": "Determines the element to focus when the popover is opened.\nBy default, the first focusable element is focused.\n\n- `null`: Do not focus any element.\n- `RefObject`: Focus the ref element. Falls back to default behavior when `null`.\n- `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the open. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.",
-      "detailedType": "| React.RefObject<HTMLElement | null>\n| ((\n    openType: InteractionType,\n  ) => void | HTMLElement | null)\n| null\n| undefined"
+      "type": "boolean | RefObject<HTMLElement | null> | ((openType: InteractionType) => boolean | void | HTMLElement | null)",
+      "description": "Determines the element to focus when the popover is opened.\n\n- `false`: Do not move focus.\n- `true`: Move focus based on the default behavior (first tabbable element or popup).\n- `RefObject`: Move focus to the ref element.\n- `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).\n  Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.",
+      "detailedType": "| boolean\n| React.RefObject<HTMLElement | null>\n| ((\n    openType: InteractionType,\n  ) => boolean | void | HTMLElement | null)\n| undefined"
     },
     "finalFocus": {
-      "type": "RefObject<HTMLElement | null> | ((closeType: InteractionType) => void | HTMLElement | null) | null",
-      "description": "Determines the element to focus when the popover is closed.\nBy default, focus returns to the trigger.\n\n- `null`: Do not focus any element.\n- `RefObject`: Focus the ref element. Falls back to default behavior when `null`.\n- `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the close. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.",
-      "detailedType": "| React.RefObject<HTMLElement | null>\n| ((\n    closeType: InteractionType,\n  ) => void | HTMLElement | null)\n| null\n| undefined"
+      "type": "boolean | RefObject<HTMLElement | null> | ((closeType: InteractionType) => boolean | void | HTMLElement | null)",
+      "description": "Determines the element to focus when the popover is closed.\n\n- `false`: Do not move focus.\n- `true`: Move focus based on the default behavior (trigger or previously focused element).\n- `RefObject`: Move focus to the ref element.\n- `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).\n  Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.",
+      "detailedType": "| boolean\n| React.RefObject<HTMLElement | null>\n| ((\n    closeType: InteractionType,\n  ) => boolean | void | HTMLElement | null)\n| undefined"
     },
     "className": {
       "type": "string | ((state: Popover.Popup.State) => string)",

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.test.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.test.tsx
@@ -141,7 +141,7 @@ describe('<AlertDialog.Popup />', () => {
       });
     });
 
-    it('should not move focus when initialFocus is null', async () => {
+    it('should not move focus when initialFocus is false', async () => {
       function TestComponent() {
         return (
           <div>
@@ -149,7 +149,7 @@ describe('<AlertDialog.Popup />', () => {
               <AlertDialog.Backdrop />
               <AlertDialog.Trigger>Open</AlertDialog.Trigger>
               <AlertDialog.Portal>
-                <AlertDialog.Popup data-testid="dialog" initialFocus={null}>
+                <AlertDialog.Popup data-testid="dialog" initialFocus={false}>
                   <input data-testid="input-1" />
                 </AlertDialog.Popup>
               </AlertDialog.Portal>
@@ -166,7 +166,31 @@ describe('<AlertDialog.Popup />', () => {
       });
     });
 
-    it('should default focus when initialFocus returns null', async () => {
+    it('should default focus when initialFocus returns true', async () => {
+      function TestComponent() {
+        return (
+          <div>
+            <AlertDialog.Root>
+              <AlertDialog.Backdrop />
+              <AlertDialog.Trigger>Open</AlertDialog.Trigger>
+              <AlertDialog.Portal>
+                <AlertDialog.Popup data-testid="dialog" initialFocus={() => true}>
+                  <input data-testid="input-1" />
+                </AlertDialog.Popup>
+              </AlertDialog.Portal>
+            </AlertDialog.Root>
+          </div>
+        );
+      }
+
+      const { getByText, getByTestId, user } = await render(<TestComponent />);
+      await user.click(getByText('Open'));
+      await waitFor(() => {
+        expect(getByTestId('input-1')).toHaveFocus();
+      });
+    });
+
+    it('uses default behavior when initialFocus returns null', async () => {
       function TestComponent() {
         return (
           <div>
@@ -285,7 +309,7 @@ describe('<AlertDialog.Popup />', () => {
       });
     });
 
-    it('should not move focus when finalFocus is null', async () => {
+    it('should not move focus when finalFocus is false', async () => {
       function TestComponent() {
         return (
           <div>
@@ -293,7 +317,7 @@ describe('<AlertDialog.Popup />', () => {
               <AlertDialog.Backdrop />
               <AlertDialog.Trigger>Open</AlertDialog.Trigger>
               <AlertDialog.Portal>
-                <AlertDialog.Popup finalFocus={null}>
+                <AlertDialog.Popup finalFocus={false}>
                   <AlertDialog.Close>Close</AlertDialog.Close>
                 </AlertDialog.Popup>
               </AlertDialog.Portal>
@@ -311,7 +335,33 @@ describe('<AlertDialog.Popup />', () => {
       });
     });
 
-    it('should move focus to the trigger when finalFocus returns null', async () => {
+    it('should move focus to the trigger when finalFocus returns true', async () => {
+      function TestComponent() {
+        return (
+          <div>
+            <AlertDialog.Root>
+              <AlertDialog.Backdrop />
+              <AlertDialog.Trigger>Open</AlertDialog.Trigger>
+              <AlertDialog.Portal>
+                <AlertDialog.Popup finalFocus={() => true}>
+                  <AlertDialog.Close>Close</AlertDialog.Close>
+                </AlertDialog.Popup>
+              </AlertDialog.Portal>
+            </AlertDialog.Root>
+          </div>
+        );
+      }
+
+      const { getByText, user } = await render(<TestComponent />);
+      const trigger = getByText('Open');
+      await user.click(trigger);
+      await user.click(getByText('Close'));
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
+      });
+    });
+
+    it('uses default behavior when finalFocus returns null', async () => {
       function TestComponent() {
         return (
           <div>

--- a/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
+++ b/packages/react/src/alert-dialog/popup/AlertDialogPopup.tsx
@@ -117,8 +117,7 @@ export const AlertDialogPopup = React.forwardRef(function AlertDialogPopup(
     if (interactionType === 'touch') {
       return popupRef.current;
     }
-
-    return 0;
+    return true;
   });
 
   const resolvedInitialFocus = initialFocus === undefined ? defaultInitialFocus : initialFocus;
@@ -142,28 +141,30 @@ export namespace AlertDialogPopup {
   export interface Props extends BaseUIComponentProps<'div', State> {
     /**
      * Determines the element to focus when the dialog is opened.
-     * By default, the first focusable element is focused.
      *
-     * - `null`: Do not focus any element.
-     * - `RefObject`: Focus the ref element. Falls back to default behavior when `null`.
-     * - `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the open. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.
+     * - `false`: Do not move focus.
+     * - `true`: Move focus based on the default behavior (first tabbable element or popup).
+     * - `RefObject`: Move focus to the ref element.
+     * - `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).
+     *   Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.
      */
     initialFocus?:
-      | null
+      | boolean
       | React.RefObject<HTMLElement | null>
-      | ((openType: InteractionType) => HTMLElement | null | void);
+      | ((openType: InteractionType) => boolean | HTMLElement | null | void);
     /**
      * Determines the element to focus when the dialog is closed.
-     * By default, focus returns to the trigger.
      *
-     * - `null`: Do not focus any element.
-     * - `RefObject`: Focus the ref element. Falls back to default behavior when `null`.
-     * - `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the close. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.
+     * - `false`: Do not move focus.
+     * - `true`: Move focus based on the default behavior (trigger or previously focused element).
+     * - `RefObject`: Move focus to the ref element.
+     * - `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).
+     *   Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.
      */
     finalFocus?:
-      | null
+      | boolean
       | React.RefObject<HTMLElement | null>
-      | ((closeType: InteractionType) => HTMLElement | null | void);
+      | ((closeType: InteractionType) => boolean | HTMLElement | null | void);
   }
 
   export interface State {

--- a/packages/react/src/dialog/popup/DialogPopup.test.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.test.tsx
@@ -147,7 +147,7 @@ describe('<Dialog.Popup />', () => {
       });
     });
 
-    it('should support element-returning function and no-op via null/void for initialFocus', async () => {
+    it('should support element-returning function and no-op via false/void for initialFocus', async () => {
       function TestComponent() {
         const input2Ref = React.useRef<HTMLInputElement>(null);
         const getEl = React.useCallback((type: string) => {
@@ -189,14 +189,14 @@ describe('<Dialog.Popup />', () => {
       });
     });
 
-    it('should not move focus when initialFocus is null', async () => {
+    it('should not move focus when initialFocus is false', async () => {
       function TestComponent() {
         return (
           <div>
             <Dialog.Root modal={false}>
               <Dialog.Trigger>Open</Dialog.Trigger>
               <Dialog.Portal>
-                <Dialog.Popup data-testid="dialog" initialFocus={null}>
+                <Dialog.Popup data-testid="dialog" initialFocus={false}>
                   <input data-testid="input-1" />
                 </Dialog.Popup>
               </Dialog.Portal>
@@ -213,7 +213,30 @@ describe('<Dialog.Popup />', () => {
       });
     });
 
-    it('should default focus when initialFocus returns null', async () => {
+    it('should default focus when initialFocus returns true', async () => {
+      function TestComponent() {
+        return (
+          <div>
+            <Dialog.Root modal={false}>
+              <Dialog.Trigger>Open</Dialog.Trigger>
+              <Dialog.Portal>
+                <Dialog.Popup data-testid="dialog" initialFocus={() => true}>
+                  <input data-testid="input-1" />
+                </Dialog.Popup>
+              </Dialog.Portal>
+            </Dialog.Root>
+          </div>
+        );
+      }
+
+      const { getByText, getByTestId, user } = await render(<TestComponent />);
+      await user.click(getByText('Open'));
+      await waitFor(() => {
+        expect(getByTestId('input-1')).toHaveFocus();
+      });
+    });
+
+    it('uses default behavior when initialFocus returns null', async () => {
       function TestComponent() {
         return (
           <div>
@@ -331,7 +354,7 @@ describe('<Dialog.Popup />', () => {
       });
     });
 
-    it('should not move focus when finalFocus is null', async () => {
+    it('should not move focus when finalFocus is false', async () => {
       function TestComponent() {
         return (
           <div>
@@ -339,7 +362,7 @@ describe('<Dialog.Popup />', () => {
               <Dialog.Backdrop />
               <Dialog.Trigger>Open</Dialog.Trigger>
               <Dialog.Portal>
-                <Dialog.Popup finalFocus={null}>
+                <Dialog.Popup finalFocus={false}>
                   <Dialog.Close>Close</Dialog.Close>
                 </Dialog.Popup>
               </Dialog.Portal>
@@ -357,7 +380,7 @@ describe('<Dialog.Popup />', () => {
       });
     });
 
-    it('should move focus to the trigger when finalFocus returns null', async () => {
+    it('should move focus to the trigger when finalFocus returns true', async () => {
       function TestComponent() {
         return (
           <div>
@@ -365,7 +388,7 @@ describe('<Dialog.Popup />', () => {
               <Dialog.Backdrop />
               <Dialog.Trigger>Open</Dialog.Trigger>
               <Dialog.Portal>
-                <Dialog.Popup finalFocus={() => null}>
+                <Dialog.Popup finalFocus={() => true}>
                   <Dialog.Close>Close</Dialog.Close>
                 </Dialog.Popup>
               </Dialog.Portal>
@@ -383,14 +406,14 @@ describe('<Dialog.Popup />', () => {
       });
     });
 
-    it('should support element-returning function and default via null + no-op via void for finalFocus based on closeType', async () => {
+    it('should support element-returning function and default via true + no-op via void for finalFocus based on closeType', async () => {
       function TestComponent() {
         const inputRef = React.useRef<HTMLInputElement>(null);
         const getEl = React.useCallback((type: string) => {
           if (type === 'keyboard') {
             return inputRef.current;
           }
-          return null; // default to trigger
+          return true; // default to trigger
         }, []);
 
         return (
@@ -413,7 +436,7 @@ describe('<Dialog.Popup />', () => {
 
       const trigger = getByText('Open');
 
-      // Close via pointer: null => default, should move focus to trigger
+      // Close via pointer: true => default, should move focus to trigger
       await user.click(trigger);
       await user.click(getByText('Close'));
       await waitFor(() => {
@@ -497,6 +520,32 @@ describe('<Dialog.Popup />', () => {
 
       await waitFor(() => {
         expect(getByTestId('final-outside')).not.toHaveFocus();
+      });
+    });
+
+    it('uses default behavior when finalFocus returns null', async () => {
+      function TestComponent() {
+        return (
+          <div>
+            <Dialog.Root>
+              <Dialog.Backdrop />
+              <Dialog.Trigger>Open</Dialog.Trigger>
+              <Dialog.Portal>
+                <Dialog.Popup finalFocus={() => null}>
+                  <Dialog.Close>Close</Dialog.Close>
+                </Dialog.Popup>
+              </Dialog.Portal>
+            </Dialog.Root>
+          </div>
+        );
+      }
+
+      const { getByText, user } = await render(<TestComponent />);
+      const trigger = getByText('Open');
+      await user.click(trigger);
+      await user.click(getByText('Close'));
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
       });
     });
   });

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -90,8 +90,7 @@ export const DialogPopup = React.forwardRef(function DialogPopup(
     if (interactionType === 'touch') {
       return popupRef.current;
     }
-
-    return 0;
+    return true;
   });
 
   const resolvedInitialFocus = initialFocus === undefined ? defaultInitialFocus : initialFocus;
@@ -148,28 +147,30 @@ export namespace DialogPopup {
   export interface Props extends BaseUIComponentProps<'div', State> {
     /**
      * Determines the element to focus when the dialog is opened.
-     * By default, the first focusable element is focused.
      *
-     * - `null`: Do not focus any element.
-     * - `RefObject`: Focus the ref element. Falls back to default behavior when `null`.
-     * - `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the open. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.
+     * - `false`: Do not move focus.
+     * - `true`: Move focus based on the default behavior (first tabbable element or popup).
+     * - `RefObject`: Move focus to the ref element.
+     * - `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).
+     *   Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.
      */
     initialFocus?:
-      | null
+      | boolean
       | React.RefObject<HTMLElement | null>
-      | ((openType: InteractionType) => HTMLElement | null | void);
+      | ((openType: InteractionType) => boolean | HTMLElement | null | void);
     /**
      * Determines the element to focus when the dialog is closed.
-     * By default, focus returns to the trigger.
      *
-     * - `null`: Do not focus any element.
-     * - `RefObject`: Focus the ref element. Falls back to default behavior when `null`.
-     * - `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the close. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.
+     * - `false`: Do not move focus.
+     * - `true`: Move focus based on the default behavior (trigger or previously focused element).
+     * - `RefObject`: Move focus to the ref element.
+     * - `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).
+     *   Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.
      */
     finalFocus?:
-      | null
+      | boolean
       | React.RefObject<HTMLElement | null>
-      | ((closeType: InteractionType) => HTMLElement | null | void);
+      | ((closeType: InteractionType) => boolean | HTMLElement | null | void);
   }
 
   export interface State {

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -53,7 +53,7 @@ beforeAll(() => {
 function App(
   props: Partial<
     Omit<FloatingFocusManagerProps, 'initialFocus'> & {
-      initialFocus?: 'two' | number;
+      initialFocus?: 'two' | boolean;
     }
   >,
 ) {
@@ -136,19 +136,13 @@ function Dialog({ render, open: passedOpen = false, children }: DialogProps) {
 
 describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
   describe('initialFocus', () => {
-    test('number', async () => {
-      const { rerender } = render(<App />);
+    test('default behavior focuses first tabbable element', async () => {
+      render(<App />);
 
       fireEvent.click(screen.getByTestId('reference'));
       await flushMicrotasks();
 
       expect(screen.getByTestId('one')).toHaveFocus();
-
-      rerender(<App initialFocus={1} />);
-      expect(screen.getByTestId('two')).not.toHaveFocus();
-
-      rerender(<App initialFocus={2} />);
-      expect(screen.getByTestId('three')).not.toHaveFocus();
     });
 
     test('ref', async () => {
@@ -1226,6 +1220,7 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
     function App({ restoreFocus = true }: { restoreFocus?: boolean }) {
       const [isOpen, setIsOpen] = React.useState(false);
       const [removed, setRemoved] = React.useState(false);
+      const twoRef = React.useRef<HTMLButtonElement | null>(null);
 
       const { refs, context } = useFloating({
         open: isOpen,
@@ -1240,10 +1235,14 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
           <button onClick={() => setRemoved(true)}>remove</button>
           <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
           {isOpen && (
-            <FloatingFocusManager context={context} restoreFocus={restoreFocus} initialFocus={1}>
+            <FloatingFocusManager
+              context={context}
+              restoreFocus={restoreFocus}
+              initialFocus={twoRef}
+            >
               <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating">
                 <button>one</button>
-                {!removed && <button>two</button>}
+                {!removed && <button ref={twoRef}>two</button>}
                 <button>three</button>
               </div>
             </FloatingFocusManager>
@@ -1369,7 +1368,7 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
           />
           {isOpen && (
             <FloatingPortal>
-              <FloatingFocusManager context={context} initialFocus={-1} modal={false}>
+              <FloatingFocusManager context={context} initialFocus={false} modal={false}>
                 <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
                   <button>one</button>
                   <button>two</button>
@@ -1522,7 +1521,7 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
             role="combobox"
           />
           {isOpen && (
-            <FloatingFocusManager context={context} initialFocus={-1}>
+            <FloatingFocusManager context={context} initialFocus={false}>
               <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating">
                 <button tabIndex={-1}>one</button>
               </div>
@@ -1673,7 +1672,7 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
         <>
           <button data-testid="reference" ref={refs.setReference} onClick={() => setIsOpen(true)} />
           {isOpen && (
-            <FloatingFocusManager context={context} initialFocus={-1} modal={false}>
+            <FloatingFocusManager context={context} initialFocus={false} modal={false}>
               <div ref={refs.setFloating} data-testid="floating" role="dialog" />
             </FloatingFocusManager>
           )}
@@ -1715,7 +1714,7 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
             ref
           </button>
           {isOpen && (
-            <FloatingFocusManager context={context} initialFocus={-1} modal={false}>
+            <FloatingFocusManager context={context} initialFocus={false} modal={false}>
               <div
                 ref={refs.setFloating}
                 role="listbox"

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -151,27 +151,34 @@ export interface FloatingFocusManagerProps {
    */
   order?: Array<'reference' | 'floating' | 'content'>;
   /**
-   * Which element to initially focus. Can be either a number (tabbable index as
-   * specified by the `order`) or a ref.
-   * @default 0
+   * Determines the element to focus when the floating element is opened.
+   *
+   * - `false`: Do not move focus.
+   * - `true`: Move focus based on the default behavior (first tabbable element or floating element).
+   * - `RefObject`: Move focus to the ref element.
+   * - `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).
+   *   Return an element to focus, `true` to use default behavior, `null` to fallback to default behavior,
+   *   or `false`/`undefined` to do nothing.
+   * @default true
    */
   initialFocus?:
-    | number
+    | boolean
     | React.RefObject<HTMLElement | null>
-    | null
-    | ((openType: InteractionType) => number | HTMLElement | null | void);
+    | ((openType: InteractionType) => boolean | HTMLElement | null | void);
   /**
-   * Determines if focus should be returned to the reference element once the
-   * floating element closes/unmounts (or if that is not available, the
-   * previously focused element). This prop is ignored if the floating element
-   * lost focus.
-   * It can be also set to a ref to explicitly control the element to return focus to.
+   * Determines the element to focus when the floating element is closed.
+   *
+   * - `false`: Do not move focus.
+   * - `true`: Move focus based on the default behavior (reference or previously focused element).
+   * - `RefObject`: Move focus to the ref element.
+   * - `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).
+   *   Return an element to focus, `true` to use the default behavior, `null` to fallback to default behavior,
+   *   or `false`/`undefined` to do nothing.
    * @default true
    */
   returnFocus?:
     | boolean
     | React.RefObject<HTMLElement | null>
-    | null
     | ((closeType: InteractionType) => boolean | HTMLElement | null | void);
   /**
    * Determines where focus should be restored if focus inside the floating element is lost
@@ -217,7 +224,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
     children,
     disabled = false,
     order = ['content'],
-    initialFocus = 0,
+    initialFocus = true,
     returnFocus = true,
     restoreFocus = false,
     modal = true,
@@ -236,7 +243,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
   const getNodeId = useEventCallback(() => dataRef.current.floatingContext?.nodeId);
   const getInsideElements = useEventCallback(getInsideElementsProp);
 
-  const ignoreInitialFocus = typeof initialFocus === 'number' && initialFocus < 0;
+  const ignoreInitialFocus = initialFocus === false;
   // If the reference is a combobox and is typeable (e.g. input/textarea),
   // there are different focus semantics. The guards should not be rendered, but
   // aria-hidden should be applied to all nodes still. Further, the visually
@@ -598,37 +605,24 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
           ? initialFocusValueOrFn(openInteractionTypeRef.current || '')
           : initialFocusValueOrFn;
 
-      // If the prop was explicitly set to null, do nothing.
-      if (initialFocusValueOrFn === null) {
-        return;
-      }
-
-      // If a function returned undefined/void, do nothing.
-      if (resolvedInitialFocus === undefined) {
-        return;
-      }
-
-      const normalizedInitialFocus = resolvedInitialFocus ?? 0; // null => default
-      const ignoreResolvedInitialFocus =
-        typeof normalizedInitialFocus === 'number' && normalizedInitialFocus < 0;
-
-      if (ignoreResolvedInitialFocus) {
+      // `null` should fallback to default behavior in case of an empty ref.
+      if (resolvedInitialFocus === undefined || resolvedInitialFocus === false) {
         return;
       }
 
       let elToFocus: FocusableElement | null | undefined;
-      if (typeof normalizedInitialFocus === 'number') {
-        elToFocus = focusableElements[normalizedInitialFocus];
-      } else if (normalizedInitialFocus && 'current' in normalizedInitialFocus) {
-        elToFocus = normalizedInitialFocus.current;
+      if (resolvedInitialFocus === true || resolvedInitialFocus === null) {
+        elToFocus = focusableElements[0] || floatingFocusElement;
+      } else if ('current' in resolvedInitialFocus) {
+        elToFocus = resolvedInitialFocus.current;
       } else {
-        elToFocus = normalizedInitialFocus as HTMLElement | null | undefined;
+        elToFocus = resolvedInitialFocus;
       }
       elToFocus = elToFocus || focusableElements[0] || floatingFocusElement;
 
       const focusAlreadyInsideFloatingEl = contains(floatingFocusElement, previouslyFocusedElement);
 
-      if (!ignoreResolvedInitialFocus && !focusAlreadyInsideFloatingEl && open) {
+      if (!focusAlreadyInsideFloatingEl && open) {
         enqueueFocus(elToFocus, {
           preventScroll: elToFocus === floatingFocusElement,
         });
@@ -706,19 +700,18 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
 
     function getReturnElement() {
       const returnFocusValueOrFn = returnFocusRef.current;
-      const resolvedReturnFocusValue =
+      let resolvedReturnFocusValue =
         typeof returnFocusValueOrFn === 'function'
           ? returnFocusValueOrFn(closeTypeRef.current)
           : returnFocusValueOrFn;
 
-      // If the prop was explicitly set to null, do nothing.
-      if (returnFocusValueOrFn === null) {
+      // `null` should fallback to default behavior in case of an empty ref.
+      if (resolvedReturnFocusValue === undefined || resolvedReturnFocusValue === false) {
         return null;
       }
 
-      // If a function returned undefined/void, do nothing.
-      if (resolvedReturnFocusValue === undefined) {
-        return null;
+      if (resolvedReturnFocusValue === null) {
+        resolvedReturnFocusValue = true;
       }
 
       if (typeof resolvedReturnFocusValue === 'boolean') {
@@ -728,7 +721,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
 
       const fallback = domReference || getPreviouslyFocusedElement() || fallbackEl;
 
-      if (resolvedReturnFocusValue && 'current' in resolvedReturnFocusValue) {
+      if ('current' in resolvedReturnFocusValue) {
         return resolvedReturnFocusValue.current || fallback;
       }
 

--- a/packages/react/src/menu/popup/MenuPopup.test.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.test.tsx
@@ -126,7 +126,7 @@ describe('<Menu.Popup />', () => {
       });
     });
 
-    it('should not move focus when finalFocus is null', async () => {
+    it('should not move focus when finalFocus is false', async () => {
       function TestComponent() {
         return (
           <div>
@@ -134,7 +134,7 @@ describe('<Menu.Popup />', () => {
               <Menu.Trigger>Open</Menu.Trigger>
               <Menu.Portal>
                 <Menu.Positioner>
-                  <Menu.Popup finalFocus={null}>
+                  <Menu.Popup finalFocus={false}>
                     <Menu.Item>Close</Menu.Item>
                   </Menu.Popup>
                 </Menu.Positioner>
@@ -155,7 +155,36 @@ describe('<Menu.Popup />', () => {
       });
     });
 
-    it('should move focus to trigger when finalFocus returns null', async () => {
+    it('should move focus to trigger when finalFocus returns true', async () => {
+      function TestComponent() {
+        return (
+          <div>
+            <Menu.Root>
+              <Menu.Trigger>Open</Menu.Trigger>
+              <Menu.Portal>
+                <Menu.Positioner>
+                  <Menu.Popup finalFocus={() => true}>
+                    <Menu.Item>Close</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
+          </div>
+        );
+      }
+
+      const { getByText, user, findByText } = await render(<TestComponent />);
+      const trigger = getByText('Open');
+
+      await user.click(trigger);
+      await user.click(await findByText('Close'));
+
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
+      });
+    });
+
+    it('uses default behavior when finalFocus returns null', async () => {
       function TestComponent() {
         return (
           <div>
@@ -175,10 +204,8 @@ describe('<Menu.Popup />', () => {
 
       const { getByText, user, findByText } = await render(<TestComponent />);
       const trigger = getByText('Open');
-
       await user.click(trigger);
       await user.click(await findByText('Close'));
-
       await waitFor(() => {
         expect(trigger).toHaveFocus();
       });

--- a/packages/react/src/menu/popup/MenuPopup.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.tsx
@@ -111,7 +111,7 @@ export const MenuPopup = React.forwardRef(function MenuPopup(
       modal={false}
       disabled={!mounted}
       returnFocus={finalFocus === undefined ? returnFocus : finalFocus}
-      initialFocus={parent.type === 'menu' ? -1 : 0}
+      initialFocus={parent.type !== 'menu'}
       restoreFocus
     >
       {element}
@@ -128,16 +128,17 @@ export namespace MenuPopup {
     id?: string;
     /**
      * Determines the element to focus when the menu is closed.
-     * By default, focus returns to the trigger.
      *
-     * - `null`: Do not focus any element.
-     * - `RefObject`: Focus the ref element. Falls back to default behavior when `null`.
-     * - `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the close. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.
+     * - `false`: Do not move focus.
+     * - `true`: Move focus based on the default behavior (trigger or previously focused element).
+     * - `RefObject`: Move focus to the ref element.
+     * - `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).
+     *   Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.
      */
     finalFocus?:
-      | null
+      | boolean
       | React.RefObject<HTMLElement | null>
-      | ((closeType: InteractionType) => HTMLElement | null | void);
+      | ((closeType: InteractionType) => boolean | HTMLElement | null | void);
   }
 
   export type State = {

--- a/packages/react/src/popover/popup/PopoverPopup.test.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.test.tsx
@@ -140,7 +140,7 @@ describe('<Popover.Popup />', () => {
       });
     });
 
-    it('should support element-returning function and no-op via null/void for initialFocus', async () => {
+    it('should support element-returning function and no-op via false/void for initialFocus', async () => {
       function TestComponent() {
         const input2Ref = React.useRef<HTMLInputElement>(null);
 
@@ -185,7 +185,7 @@ describe('<Popover.Popup />', () => {
       });
     });
 
-    it('should not move focus when initialFocus is null', async () => {
+    it('should not move focus when initialFocus is false', async () => {
       function TestComponent() {
         return (
           <div>
@@ -193,7 +193,7 @@ describe('<Popover.Popup />', () => {
               <Popover.Trigger>Open</Popover.Trigger>
               <Popover.Portal>
                 <Popover.Positioner>
-                  <Popover.Popup data-testid="popover" initialFocus={null}>
+                  <Popover.Popup data-testid="popover" initialFocus={false}>
                     <input data-testid="input-1" />
                   </Popover.Popup>
                 </Popover.Positioner>
@@ -211,7 +211,32 @@ describe('<Popover.Popup />', () => {
       });
     });
 
-    it('should default focus when initialFocus returns null', async () => {
+    it('should default focus when initialFocus returns true', async () => {
+      function TestComponent() {
+        return (
+          <div>
+            <Popover.Root>
+              <Popover.Trigger>Open</Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Positioner>
+                  <Popover.Popup data-testid="popover" initialFocus={() => true}>
+                    <input data-testid="input-1" />
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
+          </div>
+        );
+      }
+
+      const { getByText, getByTestId, user } = await render(<TestComponent />);
+      await user.click(getByText('Open'));
+      await waitFor(() => {
+        expect(getByTestId('input-1')).toHaveFocus();
+      });
+    });
+
+    it('uses default behavior when initialFocus returns null', async () => {
       function TestComponent() {
         return (
           <div>
@@ -347,7 +372,7 @@ describe('<Popover.Popup />', () => {
       });
     });
 
-    it('should not move focus when finalFocus is null', async () => {
+    it('should not move focus when finalFocus is false', async () => {
       function TestComponent() {
         return (
           <div>
@@ -355,7 +380,7 @@ describe('<Popover.Popup />', () => {
               <Popover.Trigger>Open</Popover.Trigger>
               <Popover.Portal>
                 <Popover.Positioner>
-                  <Popover.Popup finalFocus={null}>
+                  <Popover.Popup finalFocus={false}>
                     <Popover.Close>Close</Popover.Close>
                   </Popover.Popup>
                 </Popover.Positioner>
@@ -376,7 +401,7 @@ describe('<Popover.Popup />', () => {
       });
     });
 
-    it('should move focus to the trigger when finalFocus returns null', async () => {
+    it('should move focus to the trigger when finalFocus returns true', async () => {
       function TestComponent() {
         return (
           <div>
@@ -384,7 +409,7 @@ describe('<Popover.Popup />', () => {
               <Popover.Trigger>Open</Popover.Trigger>
               <Popover.Portal>
                 <Popover.Positioner>
-                  <Popover.Popup finalFocus={() => null}>
+                  <Popover.Popup finalFocus={() => true}>
                     <Popover.Close>Close</Popover.Close>
                   </Popover.Popup>
                 </Popover.Positioner>
@@ -405,14 +430,14 @@ describe('<Popover.Popup />', () => {
       });
     });
 
-    it('should support element-returning function and default via null + no-op via void for finalFocus based on closeType', async () => {
+    it('should support element-returning function and default via true + no-op via void for finalFocus based on closeType', async () => {
       function TestComponent() {
         const inputRef = React.useRef<HTMLInputElement>(null);
         const getEl = React.useCallback((type: string) => {
           if (type === 'keyboard') {
             return inputRef.current;
           }
-          return null;
+          return true;
         }, []);
 
         return (
@@ -436,7 +461,7 @@ describe('<Popover.Popup />', () => {
 
       const trigger = getByText('Open');
 
-      // Close via pointer: null => default, should move focus to trigger
+      // Close via pointer: true => default, should move focus to trigger
       await user.click(trigger);
       await user.click(getByText('Close'));
       await waitFor(() => {
@@ -448,6 +473,33 @@ describe('<Popover.Popup />', () => {
       await user.keyboard('{Escape}');
       await waitFor(() => {
         expect(getByTestId('final-input')).toHaveFocus();
+      });
+    });
+
+    it('uses default behavior when finalFocus returns null', async () => {
+      function TestComponent() {
+        return (
+          <div>
+            <Popover.Root>
+              <Popover.Trigger>Open</Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Positioner>
+                  <Popover.Popup finalFocus={() => null}>
+                    <Popover.Close>Close</Popover.Close>
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
+          </div>
+        );
+      }
+
+      const { getByText, user } = await render(<TestComponent />);
+      const trigger = getByText('Open');
+      await user.click(trigger);
+      await user.click(getByText('Close'));
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
       });
     });
   });

--- a/packages/react/src/popover/popup/PopoverPopup.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.tsx
@@ -65,11 +65,10 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
     if (interactionType === 'touch') {
       return popupRef.current;
     }
-
-    return 0;
+    return true;
   });
 
-  const initialFocusProp = initialFocus === undefined ? defaultInitialFocus : initialFocus;
+  const resolvedInitialFocus = initialFocus === undefined ? defaultInitialFocus : initialFocus;
 
   const state: PopoverPopup.State = React.useMemo(
     () => ({
@@ -103,7 +102,7 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
       openInteractionType={openMethod}
       modal={modal === 'trap-focus'}
       disabled={!mounted || openReason === 'trigger-hover'}
-      initialFocus={initialFocusProp}
+      initialFocus={resolvedInitialFocus}
       returnFocus={finalFocus}
       restoreFocus="popup"
     >
@@ -126,27 +125,29 @@ export namespace PopoverPopup {
   export interface Props extends BaseUIComponentProps<'div', State> {
     /**
      * Determines the element to focus when the popover is opened.
-     * By default, the first focusable element is focused.
      *
-     * - `null`: Do not focus any element.
-     * - `RefObject`: Focus the ref element. Falls back to default behavior when `null`.
-     * - `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the open. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.
+     * - `false`: Do not move focus.
+     * - `true`: Move focus based on the default behavior (first tabbable element or popup).
+     * - `RefObject`: Move focus to the ref element.
+     * - `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).
+     *   Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.
      */
     initialFocus?:
-      | null
+      | boolean
       | React.RefObject<HTMLElement | null>
-      | ((openType: InteractionType) => HTMLElement | null | void);
+      | ((openType: InteractionType) => void | boolean | HTMLElement | null);
     /**
      * Determines the element to focus when the popover is closed.
-     * By default, focus returns to the trigger.
      *
-     * - `null`: Do not focus any element.
-     * - `RefObject`: Focus the ref element. Falls back to default behavior when `null`.
-     * - `function`: Return the element to focus. Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`) that caused the close. Falls back to default behavior when `null` is returned, or does nothing when `void` is returned.
+     * - `false`: Do not move focus.
+     * - `true`: Move focus based on the default behavior (trigger or previously focused element).
+     * - `RefObject`: Move focus to the ref element.
+     * - `function`: Called with the interaction type (`mouse`, `touch`, `pen`, or `keyboard`).
+     *   Return an element to focus, `true` to use the default behavior, or `false`/`undefined` to do nothing.
      */
     finalFocus?:
-      | null
+      | boolean
       | React.RefObject<HTMLElement | null>
-      | ((closeType: InteractionType) => HTMLElement | null | void);
+      | ((closeType: InteractionType) => void | boolean | HTMLElement | null);
   }
 }

--- a/packages/react/test/floating-ui-tests/Menu.tsx
+++ b/packages/react/test/floating-ui-tests/Menu.tsx
@@ -262,7 +262,7 @@ export const MenuComponent = React.forwardRef<
               <FloatingFocusManager
                 context={context}
                 modal={false}
-                initialFocus={isNested ? -1 : 0}
+                initialFocus={!isNested}
                 returnFocus={!isNested}
               >
                 <div

--- a/packages/react/test/floating-ui-tests/MenuOrientation.tsx
+++ b/packages/react/test/floating-ui-tests/MenuOrientation.tsx
@@ -254,7 +254,7 @@ export const MenuComponent = React.forwardRef<
               <FloatingFocusManager
                 context={context}
                 modal={false}
-                initialFocus={isNested ? -1 : 0}
+                initialFocus={!isNested}
                 returnFocus={!isNested}
               >
                 <div

--- a/packages/react/test/floating-ui-tests/Navigation.tsx
+++ b/packages/react/test/floating-ui-tests/Navigation.tsx
@@ -86,7 +86,7 @@ export const NavigationItem = React.forwardRef<
       </li>
       <FloatingPortal>
         {open && (
-          <FloatingFocusManager context={context} modal={false} initialFocus={-1}>
+          <FloatingFocusManager context={context} modal={false} initialFocus={false}>
             <div
               data-testid="subnavigation"
               ref={refs.setFloating}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Based on feedback from users, so `initialFocus={false|true}` and `initialFocus={() => false|true}`  are consistent.

Returning `null` in a function is the same as `true`, so that ref object or query selector nulls safely fall back to the default behavior.

> Marked internal since it's a post-PR refactor not yet in a release

Note - not necessarily a breaking change but should probably be mentioned: some users were using `initialFocus={-1}` to block initial focus even though it was an invalid type; now it's `initialFocus={false}` (closes #1679)