### PR TITLE
[utils] Add `timeout.startIfEmpty()`

### DIFF
--- a/packages/utils/src/useTimeout.ts
+++ b/packages/utils/src/useTimeout.ts
@@ -24,6 +24,19 @@ export class Timeout {
     }, delay) as unknown as number; /* Node.js types are enabled in development */
   }
 
+  /**
+   * Executes `fn` after `delay` but only if no other timeout is ongoing.
+   */
+  startIfEmpty(delay: number, fn: Function) {
+    if (this.currentId !== EMPTY) {
+      return;
+    }
+    this.currentId = setTimeout(() => {
+      this.currentId = EMPTY;
+      fn();
+    }, delay) as unknown as number; /* Node.js types are enabled in development */
+  }
+
   isStarted() {
     return this.currentId !== EMPTY;
   }


### PR DESCRIPTION
This new method will allow me to get rid of [`throttle.ts`](https://github.com/mui/mui-x/blob/1d8854d9902cbabf034ddb469793c563918dd344/packages/x-internals/src/throttle/throttle.ts) once we migrate to BUI utils in X.