### PR TITLE
[select] Fix scroll arrows visibility based on scroll amount

### DIFF
--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -375,14 +375,10 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
       return;
     }
 
-    const firstItemTop = firstItem.offsetTop;
-    const lastItemBottom = lastItem.offsetTop + lastItem.offsetHeight;
-
     const viewportTop = popupElement.scrollTop;
     const viewportBottom = popupElement.scrollTop + popupElement.clientHeight;
-
-    const shouldShowUp = viewportTop > firstItemTop + 1;
-    const shouldShowDown = viewportBottom < lastItemBottom - 1;
+    const shouldShowUp = viewportTop > 1;
+    const shouldShowDown = viewportBottom < popupElement.scrollHeight - 1;
 
     if (store.state.scrollUpArrowVisible !== shouldShowUp) {
       store.set('scrollUpArrowVisible', shouldShowUp);

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -360,21 +360,6 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
       return;
     }
 
-    const list = listRef.current;
-    const firstItem = list.find((item) => item != null);
-    let lastItem: HTMLElement | undefined;
-    for (let i = list.length - 1; i >= 0; i -= 1) {
-      const item = list[i];
-      if (item) {
-        lastItem = item;
-        break;
-      }
-    }
-
-    if (!firstItem || !lastItem) {
-      return;
-    }
-
     const viewportTop = popupElement.scrollTop;
     const viewportBottom = popupElement.scrollTop + popupElement.clientHeight;
     const shouldShowUp = viewportTop > 1;


### PR DESCRIPTION
This is a small tweak to #2523 to show the scroll arrows past the first or last item to include popup padding or labels. The initial visibility should use slightly different logic to the scroll arrow handlers.