### PR TITLE
[docs] Remove unnecessary finalFocus

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/alert-dialog/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/alert-dialog/page.mdx
@@ -41,22 +41,18 @@ import { AlertDialog } from '@base-ui-components/react/alert-dialog';
 
 In order to open a dialog using a menu, control the dialog state and open it imperatively using the `onClick` handler on the menu item.
 
-Make sure to also use the dialog's `finalFocus` prop to return focus back to the menu trigger.
-
 ```tsx {12-13,17-18,24-25,28-29} title="Connecting a dialog to a menu"
 import * as React from 'react';
 import { AlertDialog } from '@base-ui-components/react/alert-dialog';
 import { Menu } from '@base-ui-components/react/menu';
 
 function ExampleMenu() {
-  const menuTriggerRef = React.useRef<HTMLButtonElement>(null);
   const [dialogOpen, setDialogOpen] = React.useState(false);
 
   return (
     <React.Fragment>
       <Menu.Root>
-        {/* Set the trigger ref */}
-        <Menu.Trigger ref={menuTriggerRef}>Open menu</Menu.Trigger>
+        <Menu.Trigger>Open menu</Menu.Trigger>
         <Menu.Portal>
           <Menu.Positioner>
             <Menu.Popup>
@@ -71,8 +67,7 @@ function ExampleMenu() {
       <AlertDialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
         <AlertDialog.Portal>
           <AlertDialog.Backdrop />
-          {/* Return focus to the menu trigger when the dialog is closed */}
-          <AlertDialog.Popup finalFocus={menuTriggerRef}>
+          <AlertDialog.Popup>
             {/* prettier-ignore */}
             {/* Rest of the dialog */}
           </AlertDialog.Popup>

--- a/docs/src/app/(public)/(content)/react/components/dialog/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/page.mdx
@@ -98,22 +98,18 @@ It's also common to use `onOpenChange` if your app needs to do something when th
 
 In order to open a dialog using a menu, control the dialog state and open it imperatively using the `onClick` handler on the menu item.
 
-Make sure to also use the dialog's `finalFocus` prop to return focus back to the menu trigger.
-
 ```tsx {12-13,17-18,24-25,28-29} title="Connecting a dialog to a menu"
 import * as React from 'react';
 import { Dialog } from '@base-ui-components/react/dialog';
 import { Menu } from '@base-ui-components/react/menu';
 
 function ExampleMenu() {
-  const menuTriggerRef = React.useRef<HTMLButtonElement>(null);
   const [dialogOpen, setDialogOpen] = React.useState(false);
 
   return (
     <React.Fragment>
       <Menu.Root>
-        {/* Set the trigger ref */}
-        <Menu.Trigger ref={menuTriggerRef}>Open menu</Menu.Trigger>
+        <Menu.Trigger>Open menu</Menu.Trigger>
         <Menu.Portal>
           <Menu.Positioner>
             <Menu.Popup>
@@ -128,8 +124,7 @@ function ExampleMenu() {
       <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
         <Dialog.Portal>
           <Dialog.Backdrop />
-          {/* Return focus to the menu trigger when the dialog is closed */}
-          <Dialog.Popup finalFocus={menuTriggerRef}>
+          <Dialog.Popup>
             {/* prettier-ignore */}
             {/* Rest of the dialog */}
           </Dialog.Popup>

--- a/docs/src/app/(public)/(content)/react/components/menu/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/menu/page.mdx
@@ -130,22 +130,18 @@ Use the `render` prop to compose a menu item with an anchor element.
 
 In order to open a dialog using a menu, control the dialog state and open it imperatively using the `onClick` handler on the menu item.
 
-Make sure to also use the dialog's `finalFocus` prop to return focus back to the menu trigger.
-
 ```tsx {12-13,17-18,24-25,28-29} title="Connecting a dialog to a menu"
 import * as React from 'react';
 import { Dialog } from '@base-ui-components/react/dialog';
 import { Menu } from '@base-ui-components/react/menu';
 
 function ExampleMenu() {
-  const menuTriggerRef = React.useRef<HTMLButtonElement>(null);
   const [dialogOpen, setDialogOpen] = React.useState(false);
 
   return (
     <React.Fragment>
       <Menu.Root>
-        {/* Set the trigger ref */}
-        <Menu.Trigger ref={menuTriggerRef}>Open menu</Menu.Trigger>
+        <Menu.Trigger>Open menu</Menu.Trigger>
         <Menu.Portal>
           <Menu.Positioner>
             <Menu.Popup>
@@ -160,8 +156,7 @@ function ExampleMenu() {
       <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
         <Dialog.Portal>
           <Dialog.Backdrop />
-          {/* Return focus to the menu trigger when the dialog is closed */}
-          <Dialog.Popup finalFocus={menuTriggerRef}>
+          <Dialog.Popup>
             {/* prettier-ignore */}
             {/* Rest of the dialog */}
           </Dialog.Popup>


### PR DESCRIPTION
Three snippets in the docs mention how to "manually" return focus to the menu trigger when closing a dialog that was open from a menu item. This is not required anymore since it's the default behavior. See https://codesandbox.io/p/sandbox/sharp-sky-jr38qg?file=/src/App.tsx

This PR removes `finalFocus` from the relevant snippets.