### PR TITLE
[internal] Improve changelog generation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ _Sep 3, 2025_
   For example, `onOpenChange(open, event, reason)` becomes `onOpenChange(open, eventDetails)`, where `eventDetails` contains `event` and `reason` properties.
   ```diff
   -onOpenChange: (open, event, reason) => {
-  +onOpenChange: (open, eventDetails) => {
   -  if (reason === 'escape-key') {
+  +onOpenChange: (open, eventDetails) => {
   +  if (eventDetails.reason === 'escape-key') {
        // ...
      }


### PR DESCRIPTION
Simplify the changelog generation after I broke it. Help with #2615:

- Reduce the list of labels that we need to care about. Only docs, internal, test, and dependencies would force to ignore of a product scope label applied.
- Fix the "all component" scope generation.
- Only look at the "scope: " labels for the generation of the changelog.

And one potentially controversial change:

- Add an exception to the logic for the combobox product scope. The bet is that in practice, we very largely work on both `<Autocomplete>` and `<Combobox>` at the same time (my experience with this in Material UI), so it's actually simpler to have one "scope: autocomplete" + `component` labels when we want to be more granular (not frequent).
  The alternative would be to: 1. remove this custom logic, 2. rename `component: Combobox` to `scope: combobox`, and 3. rename `component: Autocomplete` to `scope: autocomplete`.
  
As far as I could test this PR, the generation is correct (relative to what we did for beta.3)

One step toward https://github.com/mui/mui-public/issues/639