### PR TITLE
[docs] Fix Tailwind creatable Combobox demo

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/tailwind/index.tsx
@@ -33,6 +33,7 @@ export default function ExampleCreatableCombobox() {
       return;
     }
 
+    // Ensure we don't collide with an existing id (e.g., value "docs" vs. existing id "docs")
     const existingIds = new Set(labels.map((l) => l.id));
     let uniqueId = baseId;
     if (existingIds.has(uniqueId)) {
@@ -62,6 +63,7 @@ export default function ExampleCreatableCombobox() {
   const trimmed = query.trim();
   const lowered = trimmed.toLocaleLowerCase();
   const exactExists = labels.some((l) => l.value.trim().toLocaleLowerCase() === lowered);
+  // Show the creatable item alongside matches if there's no exact match
   const itemsForView: Array<LabelItem> =
     trimmed !== '' && !exactExists
       ? [...labels, { creatable: trimmed, id: `create:${lowered}`, value: `Create "${trimmed}"` }]
@@ -88,6 +90,9 @@ export default function ExampleCreatableCombobox() {
         onInputValueChange={setQuery}
         onOpenChange={(open, details) => {
           if ('key' in details.event && details.event.key === 'Enter') {
+            // When pressing Enter:
+            // - If the typed value exactly matches an existing item, add that item to the selected chips
+            // - Otherwise, create a new item
             if (trimmed === '') {
               return;
             }
@@ -157,6 +162,7 @@ export default function ExampleCreatableCombobox() {
                     <Combobox.Item
                       key={item.id}
                       className="grid cursor-default grid-cols-[0.75rem_1fr] items-center gap-2 py-2 pr-8 pl-4 text-base leading-4 outline-none select-none [@media(hover:hover)]:[&[data-highlighted]]:relative [@media(hover:hover)]:[&[data-highlighted]]:z-0 [@media(hover:hover)]:[&[data-highlighted]]:text-gray-50 [@media(hover:hover)]:[&[data-highlighted]]:before:absolute [@media(hover:hover)]:[&[data-highlighted]]:before:inset-x-2 [@media(hover:hover)]:[&[data-highlighted]]:before:inset-y-0 [@media(hover:hover)]:[&[data-highlighted]]:before:z-[-1] [@media(hover:hover)]:[&[data-highlighted]]:before:rounded-sm [@media(hover:hover)]:[&[data-highlighted]]:before:bg-gray-900"
+                      value={item}
                     >
                       <span className="col-start-1">
                         <PlusIcon className="size-3" />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `value` prop was mistakenly missing for this Tailwind demo.

Fixes #2636

Type-wise, the `value` prop (unlike Select) could be required for Combobox to help prevent this issue.