### PR TITLE
[docs] Migrate experiments to use `Menu.SubmenuRoot`

### DIFF
--- a/docs/src/app/(private)/experiments/menu/menu-horizontal.tsx
+++ b/docs/src/app/(private)/experiments/menu/menu-horizontal.tsx
@@ -19,7 +19,7 @@ export default function NestedMenu() {
         <Menu.Portal>
           <Menu.Positioner side="bottom" align="start" sideOffset={6} anchor={containerRef}>
             <MenuRootPopup>
-              <Menu.Root openOnHover={false}>
+              <Menu.SubmenuRoot openOnHover={false}>
                 <SubmenuTrigger>Text color</SubmenuTrigger>
                 <Menu.Portal>
                   <Menu.Positioner align="start" side="bottom" sideOffset={12}>
@@ -34,14 +34,14 @@ export default function NestedMenu() {
                     </MenuPopup>
                   </Menu.Positioner>
                 </Menu.Portal>
-              </Menu.Root>
+              </Menu.SubmenuRoot>
 
-              <Menu.Root openOnHover={false}>
+              <Menu.SubmenuRoot openOnHover={false}>
                 <SubmenuTrigger>Style</SubmenuTrigger>
                 <Menu.Portal>
                   <Menu.Positioner align="start" side="bottom" sideOffset={12}>
                     <MenuPopup>
-                      <Menu.Root>
+                      <Menu.SubmenuRoot>
                         <SubmenuTrigger>Heading</SubmenuTrigger>
                         <Menu.Portal>
                           <Menu.Positioner align="start" side="right" sideOffset={12}>
@@ -58,11 +58,11 @@ export default function NestedMenu() {
                             </MenuPopup>
                           </Menu.Positioner>
                         </Menu.Portal>
-                      </Menu.Root>
+                      </Menu.SubmenuRoot>
                       <MenuItem onClick={createHandleMenuClick('Style/Paragraph')}>
                         Paragraph
                       </MenuItem>
-                      <Menu.Root disabled>
+                      <Menu.SubmenuRoot disabled>
                         <SubmenuTrigger>List</SubmenuTrigger>
                         <Menu.Portal>
                           <Menu.Positioner align="start" side="bottom" sideOffset={12}>
@@ -76,11 +76,11 @@ export default function NestedMenu() {
                             </MenuPopup>
                           </Menu.Positioner>
                         </Menu.Portal>
-                      </Menu.Root>
+                      </Menu.SubmenuRoot>
                     </MenuPopup>
                   </Menu.Positioner>
                 </Menu.Portal>
-              </Menu.Root>
+              </Menu.SubmenuRoot>
             </MenuRootPopup>
           </Menu.Positioner>
         </Menu.Portal>

--- a/docs/src/app/(private)/experiments/menu/menu-nested.tsx
+++ b/docs/src/app/(private)/experiments/menu/menu-nested.tsx
@@ -18,7 +18,7 @@ export default function NestedMenu() {
         <Menu.Portal>
           <Menu.Positioner side="bottom" align="start" sideOffset={6}>
             <MenuPopup>
-              <Menu.Root>
+              <Menu.SubmenuRoot>
                 <SubmenuTrigger>Text color</SubmenuTrigger>
                 <Menu.Portal>
                   <Menu.Positioner align="start" side="right" sideOffset={12}>
@@ -33,14 +33,14 @@ export default function NestedMenu() {
                     </MenuPopup>
                   </Menu.Positioner>
                 </Menu.Portal>
-              </Menu.Root>
+              </Menu.SubmenuRoot>
 
-              <Menu.Root>
+              <Menu.SubmenuRoot>
                 <SubmenuTrigger>Style</SubmenuTrigger>
                 <Menu.Portal>
                   <Menu.Positioner align="start" side="right" sideOffset={12}>
                     <MenuPopup>
-                      <Menu.Root>
+                      <Menu.SubmenuRoot>
                         <SubmenuTrigger>Heading</SubmenuTrigger>
                         <Menu.Portal>
                           <Menu.Positioner align="start" side="right" sideOffset={12}>
@@ -57,11 +57,11 @@ export default function NestedMenu() {
                             </MenuPopup>
                           </Menu.Positioner>
                         </Menu.Portal>
-                      </Menu.Root>
+                      </Menu.SubmenuRoot>
                       <MenuItem onClick={createHandleMenuClick('Style/Paragraph')}>
                         Paragraph
                       </MenuItem>
-                      <Menu.Root disabled>
+                      <Menu.SubmenuRoot disabled>
                         <SubmenuTrigger>List</SubmenuTrigger>
                         <Menu.Portal>
                           <Menu.Positioner align="start" side="right" sideOffset={12}>
@@ -75,11 +75,11 @@ export default function NestedMenu() {
                             </MenuPopup>
                           </Menu.Positioner>
                         </Menu.Portal>
-                      </Menu.Root>
+                      </Menu.SubmenuRoot>
                     </MenuPopup>
                   </Menu.Positioner>
                 </Menu.Portal>
-              </Menu.Root>
+              </Menu.SubmenuRoot>
 
               <MenuItem onClick={createHandleMenuClick('Clear formatting')}>
                 Clear formatting
@@ -163,7 +163,7 @@ const MenuItem = styled(Menu.Item)(
   border-radius: 8px;
   cursor: default;
   user-select: none;
-  
+
   &:last-of-type {
     border-bottom: none;
   }

--- a/docs/src/app/(private)/experiments/popups/popups-in-popups.tsx
+++ b/docs/src/app/(private)/experiments/popups/popups-in-popups.tsx
@@ -128,7 +128,7 @@ function MenuDemo({ modal }: Props) {
               <Menu.Portal>
                 <Menu.Positioner align="start" side="right" sideOffset={12} render={<Positioner />}>
                   <MenuPopup>
-                    <Menu.Root>
+                    <Menu.SubmenuRoot>
                       <SubmenuTrigger>Heading</SubmenuTrigger>
                       <Menu.Portal>
                         <Menu.Positioner
@@ -150,7 +150,7 @@ function MenuDemo({ modal }: Props) {
                           </MenuPopup>
                         </Menu.Positioner>
                       </Menu.Portal>
-                    </Menu.Root>
+                    </Menu.SubmenuRoot>
                     <MenuItem onClick={createHandleMenuClick('Style/Paragraph')}>
                       Paragraph
                     </MenuItem>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Found more invalid submenu usage that throws error.
Related: https://github.com/mui/base-ui/pull/2648

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
