### PR TITLE
[combobox] Fix initial closed typeahead

### DIFF
--- a/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
@@ -324,4 +324,41 @@ describe('<Combobox.Trigger />', () => {
       expect(trigger).to.have.attribute('aria-controls', listbox.id);
     });
   });
+
+  describe('typeahead', () => {
+    it('selects item when typing on focused trigger (input inside popup)', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['apple', 'banana', 'cherry']}>
+          <Combobox.Trigger data-testid="trigger">
+            <Combobox.Value data-testid="value" />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+
+      expect(trigger).not.to.have.text('apple');
+
+      await act(async () => {
+        trigger.focus();
+      });
+      await user.keyboard('a');
+
+      expect(trigger).to.have.text('apple');
+      expect(screen.queryByRole('listbox')).to.equal(null);
+    });
+  });
 });

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -105,6 +105,12 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
         onPointerEnter: trackPointerType,
         onFocus() {
           setFocused(true);
+
+          if (disabled || readOnly) {
+            return;
+          }
+
+          focusTimeout.start(0, store.state.forceMount);
         },
         onBlur() {
           setTouched(true);
@@ -112,14 +118,8 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
 
           if (validationMode === 'onBlur') {
             const valueToValidate = selectionMode === 'none' ? inputValue : selectedValue;
-            fieldControlValidation?.commitValidation(valueToValidate);
+            fieldControlValidation.commitValidation(valueToValidate);
           }
-
-          if (disabled || readOnly) {
-            return;
-          }
-
-          focusTimeout.start(0, () => store.state.forceMount());
         },
         onMouseDown(event) {
           if (disabled || readOnly) {


### PR DESCRIPTION
This handler belongs in `onFocus` to mount the list for first typeahead, same as with Select.