### PR TITLE
[code-infra] Disable automerge for MUI devDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchPackageNames": ["@mui/*"],
-      "automerge": true,
+      "automerge": false,
       "minimumReleaseAge": "1 minute"
     },
     {


### PR DESCRIPTION
Do not auto-merge code infra PRs. These should be owned and merged by the code-infra team