### PR TITLE
[FocusGuard] Set tabindex to -1 for non-Safari browsers

### DIFF
--- a/packages/react/src/utils/FocusGuard.tsx
+++ b/packages/react/src/utils/FocusGuard.tsx
@@ -24,10 +24,10 @@ export const FocusGuard = React.forwardRef(function FocusGuard(
 
   const restProps = {
     ref,
-    tabIndex: 0,
     // Role is only for VoiceOver
     role,
     'aria-hidden': role ? undefined : true,
+    tabIndex: role ? 0 : -1,
     style: visuallyHidden,
   };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus?application=axeAPI

Elements with `aria-hidden="true"` should not be focusable. Therefore, tabIndex is set to -1 when role is undefined.