### PR TITLE
[collapsible] Fix CollapsiblePanel type to use its own state

### DIFF
--- a/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
@@ -161,7 +161,7 @@ export namespace CollapsiblePanel {
     transitionStatus: TransitionStatus;
   }
 
-  export interface Props extends BaseUIComponentProps<'div', CollapsibleRoot.State> {
+  export interface Props extends BaseUIComponentProps<'div', State> {
     /**
      * Allows the browser’s built-in page search to find and expand the panel contents.
      *


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This is a very minor PR to fix the type declaration. It current misses the `transitionStatus` field.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
