### PR TITLE
[autocomplete][combobox] Fix controlled mode remounting input

### DIFF
--- a/packages/react/src/combobox/root/ComboboxRootInternal.tsx
+++ b/packages/react/src/combobox/root/ComboboxRootInternal.tsx
@@ -856,7 +856,6 @@ export function ComboboxRootInternal<Value = any, Mode extends SelectionMode = '
     store.apply({
       id,
       selectedValue,
-      inputValue,
       open,
       mounted,
       transitionStatus,
@@ -886,7 +885,6 @@ export function ComboboxRootInternal<Value = any, Mode extends SelectionMode = '
     store,
     id,
     selectedValue,
-    inputValue,
     open,
     mounted,
     transitionStatus,
@@ -912,6 +910,10 @@ export function ComboboxRootInternal<Value = any, Mode extends SelectionMode = '
     modal,
     autoHighlight,
   ]);
+
+  React.useEffect(() => {
+    store.apply({ inputValue });
+  }, [store, inputValue]);
 
   const hiddenInputRef = useMergedRefs(inputRefProp, fieldControlValidation.inputRef);
 


### PR DESCRIPTION
 Fixes #2703

@romgrk any insight into why this is necessary? I feel like a bunch of other values could also cause bugs due to this (and each needing their own independent effect) but creating new effects per prop to sync it feels really messy.