### PR TITLE
[combobox][autocomplete] Fix controlled input value updates

### DIFF
--- a/packages/react/src/autocomplete/value/AutocompleteValue.tsx
+++ b/packages/react/src/autocomplete/value/AutocompleteValue.tsx
@@ -1,8 +1,6 @@
 'use client';
 import * as React from 'react';
-import { useStore } from '@base-ui-components/utils/store';
-import { useComboboxRootContext } from '../../combobox/root/ComboboxRootContext';
-import { selectors } from '../../combobox/store';
+import { useComboboxInputValueContext } from '../../combobox/root/ComboboxRootContext';
 
 /**
  * The current value of the autocomplete.
@@ -13,9 +11,7 @@ import { selectors } from '../../combobox/store';
 export function AutocompleteValue(props: AutocompleteValue.Props) {
   const { children } = props;
 
-  const store = useComboboxRootContext();
-
-  const inputValue = useStore(store, selectors.inputValue);
+  const inputValue = useComboboxInputValueContext();
 
   if (typeof children === 'function') {
     return children(String(inputValue));

--- a/packages/react/src/combobox/clear/ComboboxClear.tsx
+++ b/packages/react/src/combobox/clear/ComboboxClear.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useStore } from '@base-ui-components/utils/store';
-import { useComboboxRootContext } from '../root/ComboboxRootContext';
+import { useComboboxInputValueContext, useComboboxRootContext } from '../root/ComboboxRootContext';
 import type { BaseUIComponentProps, NativeButtonProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { selectors } from '../store';
@@ -45,7 +45,8 @@ export const ComboboxClear = React.forwardRef(function ComboboxClear(
   const clearRef = useStore(store, selectors.clearRef);
   const open = useStore(store, selectors.open);
   const selectedValue = useStore(store, selectors.selectedValue);
-  const inputValue = useStore(store, selectors.inputValue);
+
+  const inputValue = useComboboxInputValueContext();
 
   let visible = false;
   if (selectionMode === 'none') {

--- a/packages/react/src/combobox/root/ComboboxRootContext.tsx
+++ b/packages/react/src/combobox/root/ComboboxRootContext.tsx
@@ -15,6 +15,10 @@ export const ComboboxFloatingContext = React.createContext<FloatingRootContext |
 export const ComboboxDerivedItemsContext = React.createContext<
   ComboboxDerivedItemsContext | undefined
 >(undefined);
+// `inputValue` can't be placed in the store.
+// https://github.com/mui/base-ui/issues/2703
+export const ComboboxInputValueContext =
+  React.createContext<React.ComponentProps<'input'>['value']>('');
 
 export function useComboboxRootContext() {
   const context = React.useContext(ComboboxRootContext) as ComboboxStore | undefined;
@@ -44,4 +48,8 @@ export function useComboboxDerivedItemsContext() {
     );
   }
   return context;
+}
+
+export function useComboboxInputValueContext() {
+  return React.useContext(ComboboxInputValueContext);
 }

--- a/packages/react/src/combobox/root/ComboboxRootInternal.tsx
+++ b/packages/react/src/combobox/root/ComboboxRootInternal.tsx
@@ -27,6 +27,7 @@ import {
   ComboboxFloatingContext,
   ComboboxDerivedItemsContext,
   ComboboxRootContext,
+  ComboboxInputValueContext,
 } from './ComboboxRootContext';
 import { selectors, type State as StoreState } from '../store';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
@@ -1027,13 +1028,15 @@ export function ComboboxRootInternal<Value = any, Mode extends SelectionMode = '
     <ComboboxRootContext.Provider value={store}>
       <ComboboxFloatingContext.Provider value={floatingRootContext}>
         <ComboboxDerivedItemsContext.Provider value={itemsContextValue}>
-          {virtualized ? (
-            children
-          ) : (
-            <CompositeList elementsRef={listRef} labelsRef={items ? undefined : labelsRef}>
-              {children}
-            </CompositeList>
-          )}
+          <ComboboxInputValueContext.Provider value={inputValue}>
+            {virtualized ? (
+              children
+            ) : (
+              <CompositeList elementsRef={listRef} labelsRef={items ? undefined : labelsRef}>
+                {children}
+              </CompositeList>
+            )}
+          </ComboboxInputValueContext.Provider>
         </ComboboxDerivedItemsContext.Provider>
       </ComboboxFloatingContext.Provider>
     </ComboboxRootContext.Provider>

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -6,7 +6,7 @@ import { useTimeout } from '@base-ui-components/utils/useTimeout';
 import { BaseUIComponentProps, NativeButtonProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useButton } from '../../use-button';
-import { useComboboxRootContext } from '../root/ComboboxRootContext';
+import { useComboboxInputValueContext, useComboboxRootContext } from '../root/ComboboxRootContext';
 import { selectors } from '../store';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { pressableTriggerOpenStateMapping } from '../../utils/popupStateMapping';
@@ -57,7 +57,8 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
   const inputInsidePopup = useStore(store, selectors.inputInsidePopup);
   const open = useStore(store, selectors.open);
   const selectedValue = useStore(store, selectors.selectedValue);
-  const inputValue = useStore(store, selectors.inputValue);
+
+  const inputValue = useComboboxInputValueContext();
 
   const disabled = fieldDisabled || comboboxDisabled || disabledProp;
 


### PR DESCRIPTION
Fixes #2703

Previously:

1. `store.state.setInputValue(...)`
2. Return value from useControlled
3. `React.useEffect` + `store.apply({ inputValue })`
4. `inputValue` updates too late - it must be sync for the caret position to be preserved.

```js
function Bug() {
  const [value, setValue] = React.useState('');
  return (
    <input
      value={value}
      onChange={(event) => {
        const value = event.target.value;
        // This is similar to what we're doing; the onChange sets the value from useControlled,
        // which returns a value that is updated asynchronously (with useEffect) to apply to the store,
        // which then informs useStore subscribers. But this happens too late and doesn't work for onChange.
        queueMicrotask(() => {
          setValue(value);
        });
      }}
    />
  );
}
```

Now:

1. `store.state.setInputValue(...)`
2. Return `inputValue` from `useControlled`
3. No synchronizing to the store with an effect; updates are sync through a derived context value

cc: @romgrk maybe you know of a better way to update the store based on derived values from other hooks, or perhaps a new context provider is required just for this special case.