### PR TITLE
[docs] Fix incorrect component import in docs

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/preview-card/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/preview-card/page.mdx
@@ -20,7 +20,7 @@
 Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
-import { PreviewCard } from '@base-ui-components/react/previewCard';
+import { PreviewCard } from '@base-ui-components/react/preview-card';
 
 <PreviewCard.Root>
   <PreviewCard.Trigger />


### PR DESCRIPTION
The import path for `PreviewCard` is incorrect in the docs. This PR fixes it.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
