### PR TITLE
[combobox] Fix input focus on close when clicking trigger

### DIFF
--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -35,6 +35,41 @@ describe('<Combobox.Root />', () => {
     combobox: true,
   });
 
+  it('does not focus input when closing via trigger click (input inside popup)', async () => {
+    const { user } = await render(
+      <Combobox.Root items={['One', 'Two', 'Three']}>
+        <Combobox.Trigger data-testid="trigger">
+          <Combobox.Value />
+        </Combobox.Trigger>
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup aria-label="Demo">
+              <Combobox.Input data-testid="input" />
+              <Combobox.List>
+                {(item: string) => (
+                  <Combobox.Item key={item} value={item}>
+                    {item}
+                  </Combobox.Item>
+                )}
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    await user.click(trigger);
+
+    expect(await screen.findByRole('listbox')).not.to.equal(null);
+
+    const input = await screen.findByRole('combobox');
+    expect(input).toHaveFocus();
+
+    await user.click(trigger);
+    expect(trigger).toHaveFocus();
+  });
+
   describe('selection behavior', () => {
     describe('single', () => {
       it('should auto-close popup after selection when open state is uncontrolled', async () => {

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -138,9 +138,13 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
             return;
           }
 
-          store.state.setOpen(!open, createBaseUIEventDetails('trigger-press', event.nativeEvent));
+          const nextOpen = !open;
+          store.state.setOpen(
+            nextOpen,
+            createBaseUIEventDetails('trigger-press', event.nativeEvent),
+          );
 
-          if (currentPointerTypeRef.current !== 'touch') {
+          if (nextOpen && currentPointerTypeRef.current !== 'touch') {
             store.state.inputRef.current?.focus();
           }
         },


### PR DESCRIPTION
Prevents the input from taking focus when clicking the trigger to close. In Safari, the page can scroll to the bottom when toggling with the trigger.