### PR TITLE
[slider] Fix input attributes

### DIFF
--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -110,8 +110,6 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
       expect(root).to.have.attribute('aria-labelledby', 'labelId');
 
       expect(slider).to.have.attribute('aria-valuenow', '30');
-      expect(slider).to.have.attribute('aria-valuemin', '0');
-      expect(slider).to.have.attribute('aria-valuemax', '100');
       expect(slider).to.have.attribute('aria-orientation', 'horizontal');
       expect(slider).to.have.attribute('aria-labelledby', 'labelId');
       expect(slider).to.have.attribute('step', '1');
@@ -455,9 +453,8 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
   });
 
   describe('prop: max', () => {
-    it('should set the max and aria-valuemax on the input', async () => {
+    it('sets the max attribute on the input', async () => {
       await render(<TestSlider defaultValue={150} step={100} max={750} />);
-      expect(screen.getByRole('slider')).to.have.attribute('aria-valuemax', '750');
       expect(screen.getByRole('slider')).to.have.attribute('max', '750');
     });
 
@@ -524,9 +521,8 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
   });
 
   describe('prop: min', () => {
-    it('should set the min and aria-valuemin on the input', async () => {
-      await render(<TestSlider defaultValue={150} step={100} min={150} />);
-      expect(screen.getByRole('slider')).to.have.attribute('aria-valuemin', '150');
+    it('sets the min attribute on the input', async () => {
+      await render(<TestSlider defaultValue={150} step={100} min={150} max={200} />);
       expect(screen.getByRole('slider')).to.have.attribute('min', '150');
     });
 

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -104,7 +104,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
 
   const ariaLabelledby = ariaLabelledByProp ?? labelId;
   const disabled = fieldDisabled || disabledProp;
-  const name = fieldName ?? nameProp ?? '';
+  const name = fieldName || nameProp;
 
   // The internal value is potentially unsorted, e.g. to support frozen arrays
   // https://github.com/mui/material-ui/pull/28472

--- a/packages/react/src/slider/root/SliderRootContext.ts
+++ b/packages/react/src/slider/root/SliderRootContext.ts
@@ -47,7 +47,7 @@ export interface SliderRootContext {
    * The minimum steps between values in a range slider.
    */
   minStepsBetweenValues: number;
-  name: string;
+  name: string | undefined;
   /**
    * Function to be called when drag ends and the pointer is released.
    */

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -199,8 +199,6 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
       'aria-labelledby': ariaLabelledByProp ?? labelId,
       'aria-describedby': ariaDescribedByProp,
       'aria-orientation': orientation,
-      'aria-valuemax': max,
-      'aria-valuemin': min,
       'aria-valuenow': thumbValue,
       'aria-valuetext':
         typeof getAriaValueTextProp === 'function'


### PR DESCRIPTION
Fixes:
- `aria-valuemin` and `aria-valuemax` aren't needed on `input type="range"`: https://w3c.github.io/html-aria/#att-max
- `name` attribute should not fall back to an empty string

From https://github.com/mui/base-ui/pull/2718#issue-3403364165

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
