### PR TITLE
[navigation menu] Make link close on click configurable

### DIFF
--- a/docs/reference/generated/navigation-menu-link.json
+++ b/docs/reference/generated/navigation-menu-link.json
@@ -2,6 +2,12 @@
   "name": "NavigationMenuLink",
   "description": "A link in the navigation menu that can be used to navigate to a different page or section.\nRenders an `<a>` element.",
   "props": {
+    "closeOnClick": {
+      "type": "boolean",
+      "default": "false",
+      "description": "Whether to close the navigation menu when the link is clicked.",
+      "detailedType": "boolean | undefined"
+    },
     "active": {
       "type": "boolean",
       "default": "false",

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { NavigationMenu } from '@base-ui-components/react/navigation-menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -18,41 +18,86 @@ describe('<NavigationMenu.Link />', () => {
     },
   }));
 
-  it.skipIf(!isJSDOM)('closes the menu when clicking a link', async () => {
-    const { user } = await render(
-      <NavigationMenu.Root>
-        <NavigationMenu.List>
-          <NavigationMenu.Item value="item-1">
-            <NavigationMenu.Trigger data-testid="trigger-1">Item 1</NavigationMenu.Trigger>
-            <NavigationMenu.Content data-testid="popup-1">
-              <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
-            </NavigationMenu.Content>
-          </NavigationMenu.Item>
-        </NavigationMenu.List>
+  describe.skipIf(!isJSDOM)('prop: closeOnClick', () => {
+    it('closes the menu when clicking a link when true', async () => {
+      const { user } = await render(
+        <NavigationMenu.Root>
+          <NavigationMenu.List>
+            <NavigationMenu.Item value="item-1">
+              <NavigationMenu.Trigger data-testid="trigger-1">Item 1</NavigationMenu.Trigger>
+              <NavigationMenu.Content data-testid="popup-1">
+                <NavigationMenu.Link href="#link-1" closeOnClick>
+                  Link 1
+                </NavigationMenu.Link>
+              </NavigationMenu.Content>
+            </NavigationMenu.Item>
+          </NavigationMenu.List>
 
-        <NavigationMenu.Portal>
-          <NavigationMenu.Positioner>
-            <NavigationMenu.Popup>
-              <NavigationMenu.Viewport />
-            </NavigationMenu.Popup>
-          </NavigationMenu.Positioner>
-        </NavigationMenu.Portal>
-      </NavigationMenu.Root>,
-    );
+          <NavigationMenu.Portal>
+            <NavigationMenu.Positioner>
+              <NavigationMenu.Popup>
+                <NavigationMenu.Viewport />
+              </NavigationMenu.Popup>
+            </NavigationMenu.Positioner>
+          </NavigationMenu.Portal>
+        </NavigationMenu.Root>,
+      );
 
-    const trigger = screen.getByTestId('trigger-1');
+      const trigger = screen.getByTestId('trigger-1');
 
-    await user.click(trigger);
-    await flushMicrotasks();
+      await user.click(trigger);
 
-    expect(screen.queryByTestId('popup-1')).not.to.equal(null);
-    expect(trigger).to.have.attribute('aria-expanded', 'true');
+      await waitFor(() => {
+        expect(screen.queryByTestId('popup-1')).not.to.equal(null);
+      });
+      expect(trigger).to.have.attribute('aria-expanded', 'true');
 
-    const link = screen.getByRole('link', { name: 'Link 1' });
-    await user.click(link);
+      const link = screen.getByRole('link', { name: 'Link 1' });
+      await user.click(link);
 
-    await waitFor(() => expect(screen.queryByTestId('popup-1')).to.equal(null));
-    expect(trigger).to.have.attribute('aria-expanded', 'false');
+      await waitFor(() => expect(screen.queryByTestId('popup-1')).to.equal(null));
+      expect(trigger).to.have.attribute('aria-expanded', 'false');
+    });
+
+    it('does not close the menu when clicking a link when false', async () => {
+      const { user } = await render(
+        <NavigationMenu.Root>
+          <NavigationMenu.List>
+            <NavigationMenu.Item value="item-1">
+              <NavigationMenu.Trigger data-testid="trigger-1">Item 1</NavigationMenu.Trigger>
+              <NavigationMenu.Content data-testid="popup-1">
+                <NavigationMenu.Link href="#link-1" closeOnClick={false}>
+                  Link 1
+                </NavigationMenu.Link>
+              </NavigationMenu.Content>
+            </NavigationMenu.Item>
+          </NavigationMenu.List>
+
+          <NavigationMenu.Portal>
+            <NavigationMenu.Positioner>
+              <NavigationMenu.Popup>
+                <NavigationMenu.Viewport />
+              </NavigationMenu.Popup>
+            </NavigationMenu.Positioner>
+          </NavigationMenu.Portal>
+        </NavigationMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger-1');
+
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('popup-1')).not.to.equal(null);
+      });
+      expect(trigger).to.have.attribute('aria-expanded', 'true');
+
+      const link = screen.getByRole('link', { name: 'Link 1' });
+      await user.click(link);
+
+      await waitFor(() => expect(screen.queryByTestId('popup-1')).not.to.equal(null));
+      expect(trigger).to.have.attribute('aria-expanded', 'true');
+    });
   });
 
   describe('prop: active', () => {

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
@@ -20,7 +20,13 @@ export const NavigationMenuLink = React.forwardRef(function NavigationMenuLink(
   componentProps: NavigationMenuLink.Props,
   forwardedRef: React.ForwardedRef<HTMLAnchorElement>,
 ) {
-  const { className, render, active = false, ...elementProps } = componentProps;
+  const {
+    className,
+    render,
+    active = false,
+    closeOnClick = false,
+    ...elementProps
+  } = componentProps;
 
   const { setValue, popupElement, positionerElement, rootRef } = useNavigationMenuRootContext();
   const nodeId = useNavigationMenuTreeContext();
@@ -37,7 +43,9 @@ export const NavigationMenuLink = React.forwardRef(function NavigationMenuLink(
     'aria-current': active ? 'page' : undefined,
     tabIndex: undefined,
     onClick(event) {
-      setValue(null, createBaseUIEventDetails('link-press', event.nativeEvent));
+      if (closeOnClick) {
+        setValue(null, createBaseUIEventDetails('link-press', event.nativeEvent));
+      }
     },
     onBlur(event) {
       if (
@@ -82,5 +90,10 @@ export namespace NavigationMenuLink {
      * @default false
      */
     active?: boolean;
+    /**
+     * Whether to close the navigation menu when the link is clicked.
+     * @default false
+     */
+    closeOnClick?: boolean;
   }
 }


### PR DESCRIPTION
This needs to be configurable for a couple of reasons:

1. External links shouldn't close the menu, only client-side ones. Stripe and Apple leave theirs open as they act as external links.
2. Nested menus shouldn't close their menu since they're meant to be always-open

This API matches regular `Menu` but `false` by default