### PR TITLE
[useAnchorPositioning] Fix arrow shift offset

### DIFF
--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -276,11 +276,14 @@ export function useAnchorPositioning(
                       return {};
                     }
                     const { width, height } = arrowRef.current.getBoundingClientRect();
-                    const arrowSize = getSideAxis(limitData.placement) === 'y' ? width : height;
+                    const sideAxis = getSideAxis(getSide(limitData.placement));
+                    const arrowSize = sideAxis === 'y' ? width : height;
+                    const offsetAmount =
+                      sideAxis === 'y'
+                        ? collisionPadding.left + collisionPadding.right
+                        : collisionPadding.top + collisionPadding.bottom;
                     return {
-                      offset:
-                        arrowSize / 2 +
-                        (typeof collisionPadding === 'number' ? collisionPadding : 0),
+                      offset: arrowSize / 2 + offsetAmount / 2,
                     };
                   }),
           };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Continues fix from #2571 after Combobox PR made the `collisionPadding` always an object