### PR TITLE
[useButton] Update disabled prop of the button when ref changes

### DIFF
--- a/packages/react/src/dialog/close/useDialogClose.ts
+++ b/packages/react/src/dialog/close/useDialogClose.ts
@@ -58,6 +58,6 @@ export namespace useDialogClose {
      * Resolver for the root element props.
      */
     getRootProps: (externalProps: React.HTMLAttributes<any>) => React.HTMLAttributes<any>;
-    ref: React.RefObject<HTMLElement | null>;
+    ref: React.Ref<HTMLElement>;
   }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

As put in the title, this PR updates `useButton` hook to update `disabled` property also when element itself changes. Without this, it becomes disabled when ref changes and `focusableWhenDisabled` stops working properly.

Ref can change especially when using `render` prop and custom components: https://codesandbox.io/p/sandbox/2756-l3j4xk

To solve it, this PR updates `buttonRef` to a callback and update the option manually. We can use `useState` as the ref, but it forces re-render which I think is not necessary at the moment.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
