### PR TITLE
[toast] Ensure toast is frozen at its current visual transform while swiping

### DIFF
--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -474,10 +474,9 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     const deltaY = dragOffset.y - initialTransform.y;
 
     return {
-      // While swiping, freeze the element at its current visual transform
-      // so it doesn't snap to the end position.
-      // The computed transform is applied inline during the swipe.
       transition: isSwiping ? 'none' : undefined,
+      // While swiping, freeze the element at its current visual transform so it doesn't snap to the
+      // end position.
       transform: isSwiping
         ? `translateX(${dragOffset.x}px) translateY(${dragOffset.y}px) scale(${initialTransform.scale})`
         : undefined,


### PR DESCRIPTION
Previously, it would incorrectly snap down to its end state; a lot more noticeable with lengthy transitions of course.

This is with the fix:

https://github.com/user-attachments/assets/2d17eecd-1761-47a3-a281-9b52aaa1b929

