### PR TITLE
[toast] Allow collapsed state on mouseleave

### DIFF
--- a/packages/react/src/toast/viewport/ToastViewport.test.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.test.tsx
@@ -99,6 +99,53 @@ describe('<Toast.Viewport />', () => {
     expect(button).toHaveFocus();
   });
 
+  it('removes expanded on mouseleave when focus-visible not inside', async () => {
+    const { user } = await render(
+      <Toast.Provider>
+        <Toast.Viewport data-testid="viewport">
+          <List />
+        </Toast.Viewport>
+        <Button />
+      </Toast.Provider>,
+    );
+
+    const button = screen.getByRole('button', { name: 'add' });
+
+    await user.click(button);
+    const root = await screen.findByTestId('root');
+    const viewport = screen.getByTestId('viewport');
+
+    fireEvent.mouseEnter(root);
+    expect(viewport).to.have.attribute('data-expanded');
+
+    fireEvent.mouseLeave(root);
+    expect(viewport).to.not.have.attribute('data-expanded');
+  });
+
+  it('keeps expanded on mouseleave when focus-visible is inside', async () => {
+    const { user } = await render(
+      <Toast.Provider>
+        <Toast.Viewport data-testid="viewport">
+          <List />
+        </Toast.Viewport>
+        <Button />
+      </Toast.Provider>,
+    );
+
+    const button = screen.getByRole('button', { name: 'add' });
+    await user.click(button);
+    const root = await screen.findByTestId('root');
+    const viewport = screen.getByTestId('viewport');
+
+    await user.keyboard('{F6}');
+    await user.tab();
+
+    fireEvent.mouseEnter(root);
+    expect(viewport).to.have.attribute('data-expanded');
+    fireEvent.mouseLeave(root);
+    expect(viewport).to.have.attribute('data-expanded');
+  });
+
   describe('timers', () => {
     const { render: renderFakeTimers, clock } = createRenderer();
 

--- a/packages/react/src/toast/viewport/ToastViewport.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.tsx
@@ -159,11 +159,6 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
   }
 
   function handleMouseLeave() {
-    const activeEl = activeElement(ownerDocument(viewportRef.current));
-    if (contains(viewportRef.current, activeEl) && isFocusVisible(activeEl)) {
-      return;
-    }
-
     resumeTimers();
     setHovering(false);
   }
@@ -178,16 +173,14 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
       return;
     }
 
-    // If the window was previously blurred, the focus must be visible to
-    // pause the timers, since for pointers it's unexpected that focus is
-    // considered inside the viewport at this point.
+    // Only set focused when the active element inside is focus-visible.
+    // This prevents the viewport from staying expanded when clicking
+    // inside without keyboard navigation.
     const activeEl = activeElement(ownerDocument(viewportRef.current));
-    if (!windowFocusedRef.current && !isFocusVisible(activeEl)) {
-      return;
+    if (contains(viewportRef.current, activeEl) && isFocusVisible(activeEl)) {
+      setFocused(true);
+      pauseTimers();
     }
-
-    setFocused(true);
-    pauseTimers();
   }
 
   function handleBlur(event: React.FocusEvent) {


### PR DESCRIPTION
Changes the `data-expanded` state for pointers to make the toast expanded state feel less sticky