### PR TITLE
[docs-infra] Flatten MDX link component

### DIFF
--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -20,7 +20,7 @@ interface MDXComponents {
 
 // Maintain spacing between MDX components here
 export const mdxComponents: MDXComponents = {
-  a: (props) => <Link {...props} />,
+  a: Link,
   code: (props) => <Code className="data-[inline]:mx-[0.1em]" {...props} />,
   h1: (props) => (
     // Do not wrap heading tags in divs, that confuses Safari Reader


### PR DESCRIPTION
A small one. Each component adds about 10% of rendering slowness overhead.

Preview: https://deploy-preview-2781--base-ui.netlify.app/react/overview/quick-start