### PR TITLE
[slider] Fix name propagation logic

### DIFF
--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -104,7 +104,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
 
   const ariaLabelledby = ariaLabelledByProp ?? labelId;
   const disabled = fieldDisabled || disabledProp;
-  const name = fieldName || nameProp;
+  const name = fieldName ?? nameProp;
 
   // The internal value is potentially unsorted, e.g. to support frozen arrays
   // https://github.com/mui/material-ui/pull/28472


### PR DESCRIPTION
A quick continuation of #2728. The issue can be seen in https://stackblitz.com/edit/vitejs-vite-nrku5ear?file=package.json,src%2FApp.tsx,src%2FApp.module.css&terminal=dev.

```jsx
        <Field.Root name={0} className={styles.Field}>
          <Slider.Root defaultValue={25} className={styles.Slider}>
            <Field.Label className={styles.Label}>Volume</Field.Label>
            <Slider.Value className={styles.SliderValue} />
            <Slider.Control className={styles.SliderControl}>
              <Slider.Track className={styles.SliderTrack}>
                <Slider.Indicator className={styles.SliderIndicator} />
                <Slider.Thumb className={styles.SliderThumb} />
              </Slider.Track>
            </Slider.Control>
          </Slider.Root>
          <Field.Error className={styles.Error} />
        </Field.Root>
```

Even though, number are not accepted for `name`, it feels like this should apply for the sake of easing prototyping.