### PR TITLE
[docs] Fix iOS 26 site header

### DIFF
--- a/docs/src/app/(public)/layout.css
+++ b/docs/src/app/(public)/layout.css
@@ -3,14 +3,12 @@
 @layer base {
   html {
     color-scheme: light dark;
-
-    /* macOS overscroll background */
-    background-color: var(--color-gray-50);
   }
 
   body {
     min-width: 320px;
     line-height: 1.5;
+    /* It's also the iOS footer overscroll background */
     background-color: var(--color-background);
     color: var(--color-foreground);
   }

--- a/docs/src/app/(public)/page.css
+++ b/docs/src/app/(public)/page.css
@@ -1,3 +1,16 @@
+@import 'docs/src/breakpoints.css';
+
+@layer base {
+  body {
+    /* iOS overscroll background */
+    background-color: var(--color-content);
+
+    @media (--lg) {
+      background-color: var(--color-background);
+    }
+  }
+}
+
 @layer components {
   .HomepageRoot {
     display: flex;

--- a/docs/src/components/Header.css
+++ b/docs/src/components/Header.css
@@ -19,6 +19,7 @@
     top: 0;
     inset-inline: 0;
     box-shadow: inset 0 -1px var(--color-gridline);
+    /* It's also the iOS header overscroll background */
     background-color: var(--color-gray-50);
     z-index: 1;
 


### PR DESCRIPTION
Another step on #2794. iOS 26 removed the support for theme-color (on Android, it stays supported, but the OS doesn't really respect the theme-color value provided)https://www.reddit.com/r/webdev/comments/1ni74bd/redesigned_safari_has_dropped_support_for/. Now, iOS uses the background color to fill the rest of the space. 

Before
<img width="972" height="488" alt="SCR-20250921-bqkl" src="https://github.com/user-attachments/assets/fae31814-944c-4b15-becd-26adbd5b0a2e" />

After
<img width="974" height="459" alt="SCR-20250921-bqmc" src="https://github.com/user-attachments/assets/5ee68c7e-aa4a-4078-8b3a-2fe594df7a44" />