### PR TITLE
[collapsible] Fix opening transition regression

### DIFF
--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -175,15 +175,18 @@ export function useCollapsiblePanel(
     }
 
     if (open) {
-      const originalStyles = {
+      const originalLayoutStyles = {
         'justify-content': panel.style.justifyContent,
         'align-items': panel.style.alignItems,
+        'align-content': panel.style.alignContent,
+        'justify-items': panel.style.justifyItems,
       };
 
       /* opening */
       panel.style.setProperty('display', getComputedStyle(panel).display || 'block', 'important');
-      panel.style.setProperty('justify-content', 'unset', 'important');
-      panel.style.setProperty('align-items', 'unset', 'important');
+      Object.keys(originalLayoutStyles).forEach((key) => {
+        panel.style.setProperty(key, 'initial', 'important');
+      });
 
       /**
        * When `keepMounted={false}` and the panel is initially closed, the very
@@ -200,7 +203,7 @@ export function useCollapsiblePanel(
 
       resizeFrame = AnimationFrame.request(() => {
         panel.style.removeProperty('display');
-        Object.entries(originalStyles).forEach(([key, value]) => {
+        Object.entries(originalLayoutStyles).forEach(([key, value]) => {
           if (value === '') {
             panel.style.removeProperty(key);
           } else {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The change to respect the `display` property has some quirks. If `justify-content: end` is being used (which is necessary so that the `border-radius` of the bottom edge doesn't get clipped while transitioning), the `.scrollHeight` is `0` initially. We need to manually unset the `justify-content`/`align-items` values. 

Also the computed styles object is "live" so it should be recalculated on every access. It was empty `""` after the first open.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
