### PR TITLE
[useListNavigation] Fix forceSyncFocus ref

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -383,7 +383,6 @@ export function useListNavigation(
       // we store and call the previous function.
       indexRef.current = -1;
       previousOnNavigateRef.current();
-      forceSyncFocusRef.current = false;
     }
   }, [enabled, open, elements.floating, selectedIndex, onNavigate]);
 
@@ -394,6 +393,7 @@ export function useListNavigation(
       return;
     }
     if (!open) {
+      forceSyncFocusRef.current = false;
       return;
     }
     if (!elements.floating) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

#2675 revealed a bug with `forceSyncFocus` staying `true` on close but it should be reset. Otherwise, the scroll will jump since it doesn't use a rAF from that point (and wait for the popup to be positioned).

Typing in the auto highlight demo (`react/components/autocomplete#auto-highlight`) reveals the issue:

- Type anything
- Close popup
- Type anything again (`forceSyncFocusRef.current === true` instead of `false`)
- Scroll jumped before; now it does not


Marked internal since it's a post-release regression fix.
