### PR TITLE
[combobox][autocomplete] Restore item `onClick` on keypress

### DIFF
--- a/packages/react/src/autocomplete/item/AutocompleteItem.test.tsx
+++ b/packages/react/src/autocomplete/item/AutocompleteItem.test.tsx
@@ -39,7 +39,7 @@ describe('<Autocomplete.Item />', () => {
       expect(handleClick.callCount).to.equal(1);
     });
 
-    it('does not call onClick when selected with Enter key', async () => {
+    it('calls onClick when selected with Enter key (via root interaction)', async () => {
       const handleClick = spy();
       const { user } = await render(
         <Autocomplete.Root items={['one', 'two']} openOnInputClick>
@@ -69,7 +69,7 @@ describe('<Autocomplete.Item />', () => {
       await user.keyboard('{ArrowDown}');
       await user.keyboard('{Enter}');
 
-      expect(handleClick.callCount).to.equal(0);
+      expect(handleClick.callCount).to.equal(1);
     });
   });
 });

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -354,22 +354,35 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
           }
 
           if (event.key === 'Enter' && open) {
-            const hasActive = store.state.activeIndex !== null;
-            if (!hasActive) {
-              store.state.setOpen(false, createBaseUIEventDetails('none', event.nativeEvent));
+            const activeIndex = store.state.activeIndex;
+            const nativeEvent = event.nativeEvent;
+
+            if (activeIndex === null) {
+              store.state.setOpen(false, createBaseUIEventDetails('none', nativeEvent));
               return;
             }
 
+            const selectActiveItem = () => {
+              const listItem = store.state.listRef.current[activeIndex];
+
+              if (listItem) {
+                store.state.selectionEventRef.current = nativeEvent;
+                listItem.click();
+                store.state.selectionEventRef.current = null;
+                return;
+              }
+
+              store.state.handleSelection(nativeEvent);
+            };
+
             if (store.state.alwaysSubmitOnEnter) {
               // Commit the input value update synchronously so the form reads the committed value.
-              ReactDOM.flushSync(() => {
-                store.state.handleSelection(event.nativeEvent);
-              });
+              ReactDOM.flushSync(selectActiveItem);
               return;
             }
 
             stopEvent(event);
-            store.state.handleSelection(event.nativeEvent);
+            selectActiveItem();
           }
         },
         onPointerMove() {

--- a/packages/react/src/combobox/item/ComboboxItem.test.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.test.tsx
@@ -71,7 +71,7 @@ describe('<Combobox.Item />', () => {
       expect(handleClick.callCount).to.equal(1);
     });
 
-    it('does not call onClick when selected with Enter key (handled by root)', async () => {
+    it('calls onClick when selected with Enter key (via root interaction)', async () => {
       const handleClick = spy();
       const { user } = await render(
         <Combobox.Root items={['one', 'two']} openOnInputClick>
@@ -99,7 +99,7 @@ describe('<Combobox.Item />', () => {
       await user.keyboard('{ArrowDown}');
       await user.keyboard('{Enter}');
 
-      expect(handleClick.callCount).to.equal(0);
+      expect(handleClick.callCount).to.equal(1);
     });
   });
 

--- a/packages/react/src/combobox/list/ComboboxList.tsx
+++ b/packages/react/src/combobox/list/ComboboxList.tsx
@@ -81,13 +81,26 @@ export const ComboboxList = React.forwardRef(function ComboboxList(
           }
 
           if (event.key === 'Enter') {
-            if (store.state.activeIndex == null) {
+            const activeIndex = store.state.activeIndex;
+
+            if (activeIndex == null) {
               // Allow form submission when no item is highlighted.
               return;
             }
 
             stopEvent(event);
-            store.state.handleSelection(event.nativeEvent);
+
+            const nativeEvent = event.nativeEvent;
+            const listItem = store.state.listRef.current[activeIndex];
+
+            if (listItem) {
+              store.state.selectionEventRef.current = nativeEvent;
+              listItem.click();
+              store.state.selectionEventRef.current = null;
+              return;
+            }
+
+            store.state.handleSelection(nativeEvent);
           }
         },
         onKeyDownCapture() {

--- a/packages/react/src/combobox/root/ComboboxRootInternal.tsx
+++ b/packages/react/src/combobox/root/ComboboxRootInternal.tsx
@@ -274,6 +274,7 @@ export function ComboboxRootInternal<Value = any, Mode extends SelectionMode = '
   const hadInputClearRef = React.useRef(false);
   const chipsContainerRef = React.useRef<HTMLDivElement | null>(null);
   const clearRef = React.useRef<HTMLButtonElement | null>(null);
+  const selectionEventRef = React.useRef<MouseEvent | PointerEvent | KeyboardEvent | null>(null);
 
   /**
    * Contains the currently visible list of item values post-filtering.
@@ -307,6 +308,7 @@ export function ComboboxRootInternal<Value = any, Mode extends SelectionMode = '
         clearRef,
         valuesRef,
         allValuesRef,
+        selectionEventRef,
         name,
         disabled,
         readOnly,
@@ -676,7 +678,9 @@ export function ComboboxRootInternal<Value = any, Mode extends SelectionMode = '
       }
 
       const targetEl = getTarget(event) as HTMLElement | null;
-      const eventDetails = createBaseUIEventDetails('item-press', event);
+      const overrideEvent = selectionEventRef.current ?? event;
+      selectionEventRef.current = null;
+      const eventDetails = createBaseUIEventDetails('item-press', overrideEvent);
 
       // Let the link handle the click.
       const href = targetEl?.closest('a')?.getAttribute('href');

--- a/packages/react/src/combobox/store.ts
+++ b/packages/react/src/combobox/store.ts
@@ -51,6 +51,7 @@ export type State = {
   clearRef: React.RefObject<HTMLButtonElement | null>;
   valuesRef: React.RefObject<Array<any>>;
   allValuesRef: React.RefObject<Array<any>>;
+  selectionEventRef: React.RefObject<MouseEvent | PointerEvent | KeyboardEvent | null>;
 
   setOpen: (open: boolean, eventDetails: ComboboxRootInternal.ChangeEventDetails) => void;
   setInputValue: (value: string, eventDetails: ComboboxRootInternal.ChangeEventDetails) => void;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Undoes the breaking change from https://github.com/mui/base-ui/pull/2682 (marked internal since it was a post-release change)

Pressing <kbd>Enter</kbd> on `Input` or `List` should continue to fire `onClick` on `Item`, since the logic may be entirely contained in there (particularly for command palette patterns, or anything that avoids a surrounding `form`)

This change also ensures the correct event is still passed as part of `eventDetails`, unlike before