### PR TITLE
[docs] Use loose list in TypeScript guide

### DIFF
--- a/docs/src/app/(public)/(content)/react/handbook/typescript/page.mdx
+++ b/docs/src/app/(public)/(content)/react/handbook/typescript/page.mdx
@@ -68,5 +68,7 @@ Depending on the component API, other types are also exported on component parts
 The following list is non-exhaustive, and each of these are documented where necessary.
 
 - Popups have an `actionsRef` prop to access imperative methods. For example, `Menu.Root.Actions` gives access to the shape of the `actionsRef` object prop on `Menu.Root`.
+
 - The `toast` object on `Toast.Root` is a complex object with many properties. `Toast.Root.ToastObject` gives access to this interface.
+
 - Components that have a `render` prop have an extended `React.ComponentProps` type, enhanced with a `render` prop. The `useRender.ComponentProps` type on the function gives access to this interface.


### PR DESCRIPTION
*Context: I noticed this while reading #2719.*

Ohh, I think we have more use cases for #2187 😁. This feels odd: https://deploy-preview-2719--base-ui.netlify.app/react/handbook/typescript#other-accessible-types.

cc @mapache-salvaje for awareness