### PR TITLE
[docs][scroll area] Fix hijacking scroll when using touch

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/scroll-area/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/scroll-area/demos/hero/css-modules/index.module.css
@@ -42,12 +42,14 @@
   margin: 0.5rem;
   opacity: 0;
   transition: opacity 150ms 300ms;
+  pointer-events: none;
 
   &[data-hovering],
   &[data-scrolling] {
     opacity: 1;
     transition-duration: 75ms;
     transition-delay: 0ms;
+    pointer-events: auto;
   }
 
   &::before {

--- a/docs/src/app/(public)/(content)/react/components/scroll-area/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/scroll-area/demos/hero/tailwind/index.tsx
@@ -27,7 +27,7 @@ export default function ExampleScrollArea() {
           </p>
         </div>
       </ScrollArea.Viewport>
-      <ScrollArea.Scrollbar className="m-2 flex w-1 justify-center rounded bg-gray-200 opacity-0 transition-opacity delay-300 data-[hovering]:opacity-100 data-[hovering]:delay-0 data-[hovering]:duration-75 data-[scrolling]:opacity-100 data-[scrolling]:delay-0 data-[scrolling]:duration-75">
+      <ScrollArea.Scrollbar className="m-2 flex w-1 justify-center rounded bg-gray-200 opacity-0 transition-opacity delay-300 pointer-events-none data-[hovering]:opacity-100 data-[hovering]:delay-0 data-[hovering]:duration-75 data-[hovering]:pointer-events-auto data-[scrolling]:opacity-100 data-[scrolling]:delay-0 data-[scrolling]:duration-75 data-[scrolling]:pointer-events-auto">
         <ScrollArea.Thumb className="w-full rounded bg-gray-500" />
       </ScrollArea.Scrollbar>
     </ScrollArea.Root>

--- a/docs/src/components/ScrollArea.css
+++ b/docs/src/components/ScrollArea.css
@@ -17,6 +17,12 @@
 
     opacity: 0;
     transition: opacity 150ms 300ms;
+    pointer-events: none;
+
+    &[data-hovering],
+    &[data-scrolling] {
+      pointer-events: auto;
+    }
 
     &[data-scrolling] {
       opacity: 1;


### PR DESCRIPTION
Fixes #2825

This prevents pointer interactions from taking effect unless you start scrolling on touch, at which point you can grab the thumb like on iOS.

Preview: https://deploy-preview-2827--base-ui.netlify.app/react/components/scroll-area