### PR TITLE
[combobox] Fix misleading `item-press` reason in `onInputValueChange`

### DIFF
--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -283,9 +283,10 @@ describe('<Combobox.Root />', () => {
 
       it('should reset input value to selected value when popup closes without selection', async () => {
         const items = ['apple', 'banana', 'cherry'];
+        const onInputValueChange = spy();
 
         const { user } = await render(
-          <Combobox.Root items={items} defaultValue="apple">
+          <Combobox.Root items={items} defaultValue="apple" onInputValueChange={onInputValueChange}>
             <Combobox.Input data-testid="input" />
             <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
             <Combobox.Portal>
@@ -319,7 +320,9 @@ describe('<Combobox.Root />', () => {
 
         await user.click(document.body);
 
-        expect(input).to.have.value('apple');
+        await waitFor(() => expect(input).to.have.value('apple'));
+        expect(onInputValueChange.lastCall.args[0]).to.equal('apple');
+        expect(onInputValueChange.lastCall.args[1].reason).to.equal('none');
       });
 
       it('should not auto-close during browser autofill', async () => {

--- a/packages/react/src/combobox/root/ComboboxRootInternal.tsx
+++ b/packages/react/src/combobox/root/ComboboxRootInternal.tsx
@@ -766,7 +766,7 @@ export function ComboboxRootInternal<Value = any, Mode extends SelectionMode = '
         const stringVal = stringifyAsLabel(selectedValue, itemToStringLabel);
         if (inputRef.current && inputRef.current.value !== stringVal) {
           // If no selection was made, treat this as clearing the typed filter.
-          const reason = stringVal === '' ? 'input-clear' : 'item-press';
+          const reason = stringVal === '' ? 'input-clear' : 'none';
           setInputValue(stringVal, createBaseUIEventDetails(reason));
         }
       }


### PR DESCRIPTION
`item-press` could be emitted in this input value restoration case (e.g. select value, type something, press <kbd>Esc</kbd>) which is misleading as it isn't linked with item clicks.