### PR TITLE
[combobox][autocomplete] Improve JSDoc

### DIFF
--- a/docs/reference/generated/autocomplete-root.json
+++ b/docs/reference/generated/autocomplete-root.json
@@ -30,7 +30,7 @@
     },
     "open": {
       "type": "boolean",
-      "description": "Whether the popup is currently open.",
+      "description": "Whether the popup is currently open. Use when controlled.",
       "detailedType": "boolean | undefined"
     },
     "onOpenChange": {

--- a/docs/reference/generated/combobox-item.json
+++ b/docs/reference/generated/combobox-item.json
@@ -6,6 +6,11 @@
       "type": "any",
       "description": "A unique value that identifies this item."
     },
+    "onClick": {
+      "type": "MouseEventHandler<HTMLElement>",
+      "description": "An optional click handler for the item when selected.\nIt fires when clicking the item with the pointer, as well as when pressing `Enter` with the keyboard if the `Input` or `List` element has focus.",
+      "detailedType": "React.MouseEventHandler<HTMLElement> | undefined"
+    },
     "index": {
       "type": "number",
       "description": "The index of the item in the list. Improves performance when specified by avoiding the need to calculate the index automatically from the DOM.",

--- a/docs/reference/generated/combobox-root.json
+++ b/docs/reference/generated/combobox-root.json
@@ -30,7 +30,7 @@
     },
     "open": {
       "type": "boolean",
-      "description": "Whether the popup is currently open.",
+      "description": "Whether the popup is currently open. Use when controlled.",
       "detailedType": "boolean | undefined"
     },
     "onOpenChange": {
@@ -51,7 +51,7 @@
     },
     "defaultInputValue": {
       "type": "string | number | string[]",
-      "description": "The uncontrolled input value when initially rendered.",
+      "description": "The uncontrolled input value when initially rendered.\n\nTo render a controlled input, use the `inputValue` prop instead.",
       "detailedType": "string | number | string[] | undefined"
     },
     "filter": {
@@ -67,7 +67,7 @@
     },
     "inputValue": {
       "type": "string | number | string[]",
-      "description": "The input value of the combobox.",
+      "description": "The input value of the combobox. Use when controlled.",
       "detailedType": "string | number | string[] | undefined"
     },
     "isItemEqualToValue": {

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -208,6 +208,11 @@ export namespace ComboboxItem {
       Omit<BaseUIComponentProps<'div', State>, 'id'> {
     children?: React.ReactNode;
     /**
+     * An optional click handler for the item when selected.
+     * It fires when clicking the item with the pointer, as well as when pressing `Enter` with the keyboard if the `Input` or `List` element has focus.
+     */
+    onClick?: React.MouseEventHandler<HTMLElement>;
+    /**
      * The index of the item in the list. Improves performance when specified by avoiding the need to calculate the index automatically from the DOM.
      */
     index?: number;

--- a/packages/react/src/combobox/root/ComboboxRootInternal.tsx
+++ b/packages/react/src/combobox/root/ComboboxRootInternal.tsx
@@ -1183,7 +1183,7 @@ interface ComboboxRootProps<ItemValue> {
    */
   defaultOpen?: boolean;
   /**
-   * Whether the popup is currently open.
+   * Whether the popup is currently open. Use when controlled.
    */
   open?: boolean;
   /**
@@ -1205,7 +1205,7 @@ interface ComboboxRootProps<ItemValue> {
    */
   autoHighlight?: boolean;
   /**
-   * The input value of the combobox.
+   * The input value of the combobox. Use when controlled.
    */
   inputValue?: React.ComponentProps<'input'>['value'];
   /**
@@ -1217,6 +1217,8 @@ interface ComboboxRootProps<ItemValue> {
   ) => void;
   /**
    * The uncontrolled input value when initially rendered.
+   *
+   * To render a controlled input, use the `inputValue` prop instead.
    */
   defaultInputValue?: React.ComponentProps<'input'>['defaultValue'];
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

A few tweaks to match other components. 

The `onClick` handler is also documented for `Menu.Item`, which indicates it's used for click events (and not e.g. an alternative API like `onPress` or `onSelect`)