### PR TITLE
[portals] Ensure `container` is reactive from `undefined` transitions

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
@@ -1,13 +1,14 @@
-import { fireEvent, flushMicrotasks, render, screen } from '@mui/internal-test-utils';
 import * as React from 'react';
-
+import { fireEvent, flushMicrotasks, render, screen } from '@mui/internal-test-utils';
 import { isJSDOM } from '@base-ui-components/utils/detectBrowser';
 import { FloatingPortal, useFloating } from '../index';
+import type { UseFloatingPortalNodeProps } from './FloatingPortal';
 
-function App(props: {
-  root?: HTMLElement | null | React.RefObject<HTMLElement | null>;
-  id?: string;
-}) {
+interface AppProps {
+  root?: UseFloatingPortalNodeProps['root'];
+}
+
+function App(props: AppProps) {
   const [open, setOpen] = React.useState(false);
   const { refs } = useFloating({
     open,
@@ -25,30 +26,6 @@ function App(props: {
 }
 
 describe.skipIf(!isJSDOM)('FloatingPortal', () => {
-  test('creates a custom id node', async () => {
-    render(<App id="custom-id" />);
-    await flushMicrotasks();
-    expect(document.querySelector('#custom-id')).toBeInTheDocument();
-  });
-
-  test('uses a custom id node as the root', async () => {
-    const customRoot = document.createElement('div');
-    customRoot.id = 'custom-root';
-    document.body.appendChild(customRoot);
-    render(<App id="custom-root" />);
-    fireEvent.click(screen.getByTestId('reference'));
-    await flushMicrotasks();
-    expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(customRoot);
-    customRoot.remove();
-  });
-
-  test('creates a custom id node as the root', async () => {
-    render(<App id="custom-id" />);
-    fireEvent.click(screen.getByTestId('reference'));
-    await flushMicrotasks();
-    expect(screen.getByTestId('floating').parentElement?.parentElement?.id).toBe('custom-id');
-  });
-
   test('allows custom roots', async () => {
     const customRoot = document.createElement('div');
     customRoot.id = 'custom-root';
@@ -89,7 +66,7 @@ describe.skipIf(!isJSDOM)('FloatingPortal', () => {
       return (
         <React.Fragment>
           {renderRoot && <div ref={setRoot} data-testid="root" />}
-          <App root={root} />;
+          <App root={root} />
         </React.Fragment>
       );
     }
@@ -102,5 +79,44 @@ describe.skipIf(!isJSDOM)('FloatingPortal', () => {
     const subRoot = screen.getByTestId('floating').parentElement;
     const root = screen.getByTestId('root');
     expect(root).toBe(subRoot?.parentElement);
+  });
+
+  test('reattaches the portal when the root changes', async () => {
+    const customRoot = document.createElement('div');
+    document.body.appendChild(customRoot);
+
+    try {
+      function RootSwitcher() {
+        const [root, setRoot] = React.useState<UseFloatingPortalNodeProps['root']>(undefined);
+
+        return (
+          <React.Fragment>
+            <App root={root} />
+            <button onClick={() => setRoot(undefined)} data-testid="use-undefined" />
+            <button onClick={() => setRoot(customRoot)} data-testid="use-element" />
+          </React.Fragment>
+        );
+      }
+
+      render(<RootSwitcher />);
+
+      fireEvent.click(screen.getByTestId('reference'));
+
+      expect((await screen.findByTestId('floating')).parentElement?.parentElement).toBe(
+        document.body,
+      );
+
+      fireEvent.click(screen.getByTestId('use-element'));
+
+      expect((await screen.findByTestId('floating')).parentElement?.parentElement).toBe(customRoot);
+
+      fireEvent.click(screen.getByTestId('use-undefined'));
+
+      const floatingInBodyAgain = await screen.findByTestId('floating');
+      expect(floatingInBodyAgain.parentElement?.parentElement).toBe(document.body);
+      expect(customRoot.contains(floatingInBodyAgain)).toBe(false);
+    } finally {
+      customRoot.remove();
+    }
   });
 });


### PR DESCRIPTION
Fixes #2780

Also removed support for `id` as we don't need it.

https://codesandbox.io/p/sandbox/kind-moon-fstqzf