### PR TITLE
[internal] Do not use default import from chai

### DIFF
--- a/test/setupVitest.ts
+++ b/test/setupVitest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable vars-on-top */
 import { beforeAll, afterAll } from 'vitest';
-import chai from 'chai';
+import * as chai from 'chai';
 import chaiDom from 'chai-dom';
 import chaiPlugin from '@mui/internal-test-utils/chaiPlugin';
 


### PR DESCRIPTION
As chai was updated in code-infra packages, it no longer exports a default value.
Surprisingly, tests were still working on CI, but failing for me locally.