### PR TITLE
[combobox] Clear single value on input clear

### DIFF
--- a/packages/react/src/combobox/input/ComboboxInput.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.test.tsx
@@ -174,6 +174,43 @@ describe('<Combobox.Input />', () => {
   });
 
   describe('interaction behavior', () => {
+    it('clears selected value when input text is cleared (single selection)', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['apple', 'banana']} defaultValue="apple">
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+
+      expect(input.value).to.equal('apple');
+
+      await user.clear(input);
+
+      expect(input.value).to.equal('');
+
+      await user.type(input, 'a');
+      await waitFor(() => expect(screen.getByRole('listbox')).not.to.equal(null));
+
+      const options = screen.getAllByRole('option');
+      options.forEach((opt) => {
+        expect(opt).to.not.have.attribute('aria-selected', 'true');
+      });
+    });
+
     it('should open popup on typing when enabled', async () => {
       const { user } = await render(
         <Combobox.Root>

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -236,8 +236,17 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
             createChangeEventDetails('input-change', event.nativeEvent),
           );
 
-          if (event.currentTarget.value === '' && !openOnInputClick && !hasPositionerParent) {
-            store.state.setOpen(false, createChangeEventDetails('input-clear', event.nativeEvent));
+          const empty = event.currentTarget.value === '';
+          const clearDetails = createChangeEventDetails('input-clear', event.nativeEvent);
+
+          if (empty && !hasPositionerParent) {
+            if (selectionMode === 'single') {
+              store.state.setSelectedValue(null, clearDetails);
+            }
+
+            if (!openOnInputClick) {
+              store.state.setOpen(false, clearDetails);
+            }
           }
 
           if (!readOnly && !disabled) {

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -314,9 +314,8 @@ describe('<Combobox.Root />', () => {
         expect(input).to.have.value('apple');
 
         await user.click(trigger);
-        await user.clear(input);
         await user.type(input, 'xyz');
-        expect(input).to.have.value('xyz');
+        expect(input).to.have.value('applexyz');
 
         await user.click(document.body);
 


### PR DESCRIPTION
Retaining the value in a single-select combobox when clearing the input is somewhat unexpected behavior

Preview: https://deploy-preview-2860--base-ui.netlify.app/react/components/combobox