### PR TITLE
[docs] Use `pointer` cursor for Codesandbox external "link"

### DIFF
--- a/docs/src/components/Demo/CodeSandboxLink.tsx
+++ b/docs/src/components/Demo/CodeSandboxLink.tsx
@@ -108,7 +108,13 @@ export function CodeSandboxLink({ title, description, ...props }: CodeSandboxLin
   }, [files, language, name, title, description]);
 
   return (
-    <GhostButton aria-label="Open in CodeSandbox" type="button" onClick={handleClick} {...props}>
+    <GhostButton
+      aria-label="Open in CodeSandbox"
+      type="button"
+      onClick={handleClick}
+      className="ExternalLink"
+      {...props}
+    >
       CodeSandbox
       <ExternalLinkIcon />
     </GhostButton>

--- a/docs/src/components/GhostButton.css
+++ b/docs/src/components/GhostButton.css
@@ -11,6 +11,10 @@
     outline: 0;
     user-select: none;
 
+    &.ExternalLink {
+      cursor: pointer;
+    }
+
     &::before,
     &::after {
       content: '';


### PR DESCRIPTION
Given that we discussed that only external links should use the `pointer` cursor, I've added this style to the `CodeSandbox` "link".