### PR TITLE
[docs] Fix `children` prop displayed with wrong height

### DIFF
--- a/docs/src/components/ReferenceTable/PropsReferenceAccordion.tsx
+++ b/docs/src/components/ReferenceTable/PropsReferenceAccordion.tsx
@@ -8,7 +8,7 @@ import { Link } from 'docs/src/components/Link';
 import * as Accordion from '../Accordion';
 import * as DescriptionList from '../DescriptionList';
 import type { PropDef as BasePropDef } from './types';
-import { TableCode } from '../TableCode';
+import { TableCode, type TableCodeProps } from '../TableCode';
 import * as ReferenceTableTooltip from './ReferenceTableTooltip';
 
 function ExpandedCode(props: React.ComponentProps<'code'>) {
@@ -138,7 +138,11 @@ export async function PropsReferenceAccordion({
 
         const ShortPropType = await createMdxComponent(`\`${shortPropTypeName}\``, {
           rehypePlugins: rehypeSyntaxHighlighting,
-          useMDXComponents: () => ({ code: TableCode }),
+          useMDXComponents: () => ({
+            code: (codeProps: TableCodeProps) => (
+              <TableCode {...codeProps} printWidth={name === 'children' ? 999 : undefined} />
+            ),
+          }),
         });
 
         const PropDefault = await createMdxComponent(`\`${prop.default}\``, {

--- a/docs/src/components/TableCode.tsx
+++ b/docs/src/components/TableCode.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { Code } from './Code';
 import { getChildrenText } from '../utils/getChildrenText';
 
-interface TableCodeProps extends React.ComponentProps<'code'> {
+export interface TableCodeProps extends React.ComponentProps<'code'> {
   printWidth?: number;
 }
 


### PR DESCRIPTION
The height of the `children` is wrong when it's long, e.g. https://master--base-ui.netlify.app/react/components/combobox#ComboboxValue-children

<img width="600" alt="Screenshot 2025-09-30 at 9 24 48 PM" src="https://github.com/user-attachments/assets/0029579c-60da-4cd9-af9d-8e72181d7dc6" />

Fixed version: https://deploy-preview-2866--base-ui.netlify.app/react/components/combobox#value

<img width="600" alt="Screenshot 2025-09-30 at 9 38 39 PM" src="https://github.com/user-attachments/assets/bf08a5b5-93dc-46c1-a8ce-cd3d2a89438a" />



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
