### PR TITLE
Store refactor

### DIFF
--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -71,7 +71,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
       store.state.setInputValue('', createChangeEventDetails('none'));
     }
 
-    store.apply({
+    store.update({
       inputElement: element,
       inputInsidePopup: hasPositionerParent,
     });

--- a/packages/react/src/combobox/root/ComboboxRootInternal.tsx
+++ b/packages/react/src/combobox/root/ComboboxRootInternal.tsx
@@ -539,7 +539,7 @@ export function ComboboxRootInternal<Value = any, Mode extends SelectionMode = '
       selectedIndex?: number | null;
       type?: 'none' | 'keyboard' | 'pointer';
     }) => {
-      store.apply(options);
+      store.update(options);
       const type: ComboboxRootInternal.HighlightEventReason = options.type || 'none';
 
       if (options.activeIndex === undefined) {
@@ -937,7 +937,7 @@ export function ComboboxRootInternal<Value = any, Mode extends SelectionMode = '
   ]);
 
   useOnFirstRender(() => {
-    store.apply({
+    store.update({
       popupProps: getFloatingProps(),
       inputProps: getReferenceProps(),
       triggerProps,
@@ -954,7 +954,7 @@ export function ComboboxRootInternal<Value = any, Mode extends SelectionMode = '
   });
 
   useIsoLayoutEffect(() => {
-    store.apply({
+    store.update({
       id,
       selectedValue,
       inputValue,

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -203,7 +203,7 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
     }
 
     if (open && alignItemWithTriggerActive) {
-      store.apply({
+      store.update({
         scrollUpArrowVisible: false,
         scrollDownArrowVisible: false,
       });

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -191,13 +191,13 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
       // Store the last selected index for later use when closing the popup.
       lastSelectedIndexRef.current = lastIndex === -1 ? null : lastIndex;
 
-      store.apply({
+      store.update({
         label: labels.join(', '),
       });
     } else {
       const index = findItemIndex(valuesRef.current, value as Value, isItemEqualToValue);
 
-      store.apply({
+      store.update({
         selectedIndex: index === -1 ? null : index,
         label: labelsRef.current[index] ?? '',
       });
@@ -323,7 +323,7 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
         computedSelectedIndex = lastIndex === -1 ? null : lastIndex;
       }
 
-      store.apply({
+      store.update({
         selectedIndex: computedSelectedIndex,
         label: labels.join(', '),
       });
@@ -332,7 +332,7 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
       const hasIndex = index !== -1;
 
       if (hasIndex || value === null) {
-        store.apply({
+        store.update({
           selectedIndex: hasIndex ? index : null,
           label: hasIndex ? (labelsRef.current[index] ?? '') : '',
         });
@@ -453,14 +453,14 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
   useOnFirstRender(() => {
     // These should be initialized at store creation, but there is an interdependency
     // between some values used in floating hooks above.
-    store.apply({
+    store.update({
       popupProps: getFloatingProps(),
       triggerProps: getReferenceProps(),
     });
   });
 
   useIsoLayoutEffect(() => {
-    store.apply({
+    store.update({
       id,
       modal,
       multiple,

--- a/packages/utils/src/store/ReactStore.test.tsx
+++ b/packages/utils/src/store/ReactStore.test.tsx
@@ -45,14 +45,14 @@ describe('ReactStore', () => {
     expect(store.state.value).to.equal(1);
 
     act(() => {
-      store.apply({ value: 3, label: 'y' });
+      store.update({ value: 3, label: 'y' });
     });
     expect(store.state.value).to.equal(1);
     // Non-controlled keys still update
     expect(store.state.label).to.equal('y');
 
     act(() => {
-      store.update({ value: 4, label: 'x' });
+      store.setState({ value: 4, label: 'x' });
     });
     expect(store.state.value).to.equal(1);
     // Non-controlled keys still update
@@ -83,12 +83,12 @@ describe('ReactStore', () => {
     expect(store.state.value).to.equal(2);
 
     act(() => {
-      store.apply({ value: 3 });
+      store.update({ value: 3 });
     });
     expect(store.state.value).to.equal(3);
 
     act(() => {
-      store.update({ value: 4, label: 'updated' });
+      store.setState({ value: 4, label: 'updated' });
     });
     expect(store.state.value).to.equal(4);
     expect(store.state.label).to.equal('updated');

--- a/packages/utils/src/store/ReactStore.ts
+++ b/packages/utils/src/store/ReactStore.ts
@@ -12,7 +12,7 @@ import { NOOP } from '../empty';
  *
  * - Keys registered through {@link useControlledProp} become controlled when a non-undefined
  *   value is provided. Controlled keys mirror the incoming value and ignore local writes
- *   (via {@link set}, {@link apply}, or {@link update}).
+ *   (via {@link set}, {@link update}, or {@link setState}).
  * - When a key is uncontrolled, an optional default value is written once on first render.
  * - Use {@link useSyncedValue} and {@link useSyncedValues} to synchronize external values/props into the
  *   store during a layout phase using {@link useIsoLayoutEffect}.
@@ -79,7 +79,7 @@ export class ReactStore<
    */
   public useSyncedValues(props: Partial<State>) {
     useIsoLayoutEffect(() => {
-      this.apply(props);
+      this.update(props);
     }, [props]);
   }
 
@@ -113,14 +113,14 @@ export class ReactStore<
       this.controlledValues.set(key, isControlled);
 
       if (!isControlled && !Object.is(this.state[key], defaultValue)) {
-        super.update({ ...(this.state as State), [key]: defaultValue } as State);
+        super.setState({ ...(this.state as State), [key]: defaultValue } as State);
       }
     }
 
     useIsoLayoutEffect(() => {
       if (isControlled && !Object.is(this.state[key], controlled)) {
         // Set the internal state to match the controlled value.
-        super.update({ ...(this.state as State), [key]: controlled } as State);
+        super.setState({ ...(this.state as State), [key]: controlled } as State);
       }
     }, [key, controlled, defaultValue, isControlled]);
   }
@@ -148,7 +148,7 @@ export class ReactStore<
    *
    * @param values An object containing the changes to apply to the current state.
    */
-  public apply(values: Partial<State>): void {
+  public update(values: Partial<State>): void {
     const newValues = { ...values };
     for (const key in newValues) {
       if (this.controlledValues.get(key) === true) {
@@ -157,7 +157,7 @@ export class ReactStore<
       }
     }
 
-    super.apply(newValues);
+    super.update(newValues);
   }
 
   /**
@@ -166,7 +166,7 @@ export class ReactStore<
    *
    * @param newState The new state to set for the store.
    */
-  public update(newState: State) {
+  public setState(newState: State) {
     const newValues = { ...newState };
     for (const key in newValues) {
       if (this.controlledValues.get(key) === true) {
@@ -175,7 +175,7 @@ export class ReactStore<
       }
     }
 
-    super.update({ ...this.state, ...newValues });
+    super.setState({ ...this.state, ...newValues });
   }
 
   /**

--- a/packages/utils/src/store/Store.ts
+++ b/packages/utils/src/store/Store.ts
@@ -7,7 +7,7 @@ type Listener<T> = (state: T) => void;
 export class Store<State> {
   /**
    * The current state of the store.
-   * This property is updated immediately when the state changes as a result of calling {@link update}, {@link apply}, or {@link set}.
+   * This property is updated immediately when the state changes as a result of calling {@link setState}, {@link update}, or {@link set}.
    * To subscribe to state changes, use the {@link useState} method. The value returned by {@link useState} is updated after the component renders (similarly to React's useState).
    * The values can be used directly (to avoid subscribing to the store) in effects or event handlers.
    *
@@ -17,9 +17,13 @@ export class Store<State> {
 
   private listeners: Set<Listener<State>>;
 
+  // Internal state to handle recursive `setState()` calls
+  private updateTick: number;
+
   constructor(state: State) {
     this.state = state;
     this.listeners = new Set();
+    this.updateTick = 0;
   }
 
   /**
@@ -47,10 +51,26 @@ export class Store<State> {
    *
    * @param newState The new state to set for the store.
    */
-  public update(newState: State) {
-    if (this.state !== newState) {
-      this.state = newState;
-      this.listeners.forEach((l) => l(newState));
+  public setState(newState: State) {
+    if (this.state === newState) {
+      return;
+    }
+
+    this.state = newState;
+    this.updateTick += 1;
+
+    const currentTick = this.updateTick;
+
+    const it = this.listeners.values();
+    let result;
+    while (((result = it.next()), !result.done)) {
+      if (currentTick !== this.updateTick) {
+        // If the tick has changed, a recursive `setState` call has been made,
+        // and it has already notified all listeners.
+        return;
+      }
+      const listener = result.value;
+      listener(newState);
     }
   }
 
@@ -59,10 +79,10 @@ export class Store<State> {
    *
    * @param changes An object containing the changes to apply to the current state.
    */
-  public apply(changes: Partial<State>) {
+  public update(changes: Partial<State>) {
     for (const key in changes) {
       if (!Object.is(this.state[key], changes[key])) {
-        this.update({ ...this.state, ...changes });
+        this.setState({ ...this.state, ...changes });
         return;
       }
     }
@@ -76,7 +96,7 @@ export class Store<State> {
    */
   public set<T>(key: keyof State, value: T) {
     if (!Object.is(this.state[key], value)) {
-      this.update({ ...this.state, [key]: value });
+      this.setState({ ...this.state, [key]: value });
     }
   }
 }


### PR DESCRIPTION
Import changes from the X version:
 - Support recursive state updates efficiently
 - Rename `.update()` to `.setState()`: this naming seems more explicit about what happens
 - Rename `.apply()` to `.update()`: `.update(partialState)` seems more readable than `.apply(partialState)`, "apply" is already used by `Function#apply` for a different purpose