### PR TITLE
[docs] Update select styles

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/select/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/select/demos/hero/css-modules/index.module.css
@@ -212,16 +212,20 @@
   }
 
   &[data-direction='up'] {
-    &::before {
-      top: -100%;
+    &[data-side='none'] {
+      &::before {
+        top: -100%;
+      }
     }
   }
 
   &[data-direction='down'] {
     bottom: 0;
 
-    &::before {
-      bottom: -100%;
+    &[data-side='none'] {
+      &::before {
+        bottom: -100%;
+      }
     }
   }
 }

--- a/docs/src/app/(public)/(content)/react/components/select/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/select/demos/hero/tailwind/index.tsx
@@ -21,7 +21,7 @@ export default function ExampleSelect() {
       <Select.Portal>
         <Select.Positioner className="outline-none select-none z-10" sideOffset={8}>
           <Select.Popup className="group origin-[var(--transform-origin)] bg-clip-padding rounded-md bg-[canvas] text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[side=none]:data-[ending-style]:transition-none data-[starting-style]:scale-90 data-[starting-style]:opacity-0 data-[side=none]:data-[starting-style]:scale-100 data-[side=none]:data-[starting-style]:opacity-100 data-[side=none]:data-[starting-style]:transition-none dark:shadow-none dark:outline-gray-300">
-            <Select.ScrollUpArrow className="top-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:top-[-100%] before:left-0 before:h-full before:w-full before:content-[''] data-[direction=down]:bottom-0 data-[direction=down]:before:bottom-[-100%]" />
+            <Select.ScrollUpArrow className="top-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute data-[side=none]:before:top-[-100%] before:left-0 before:h-full before:w-full before:content-['']" />
             <Select.List className="relative py-1 scroll-py-6 overflow-y-auto max-h-[var(--available-height)]">
               {fonts.map(({ label, value }) => (
                 <Select.Item
@@ -36,7 +36,7 @@ export default function ExampleSelect() {
                 </Select.Item>
               ))}
             </Select.List>
-            <Select.ScrollDownArrow className="bottom-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:top-[-100%] before:left-0 before:h-full before:w-full before:content-[''] data-[direction=down]:bottom-0 data-[direction=down]:before:bottom-[-100%]" />
+            <Select.ScrollDownArrow className="bottom-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:left-0 before:h-full before:w-full before:content-[''] bottom-0 data-[side=none]:before:bottom-[-100%]" />
           </Select.Popup>
         </Select.Positioner>
       </Select.Portal>

--- a/docs/src/app/(public)/(content)/react/components/select/demos/object-values/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/select/demos/object-values/css-modules/index.module.css
@@ -217,16 +217,20 @@
   }
 
   &[data-direction='up'] {
-    &::before {
-      top: -100%;
+    &[data-side='none'] {
+      &::before {
+        top: -100%;
+      }
     }
   }
 
   &[data-direction='down'] {
     bottom: 0;
 
-    &::before {
-      bottom: -100%;
+    &[data-side='none'] {
+      &::before {
+        bottom: -100%;
+      }
     }
   }
 }

--- a/docs/src/app/(public)/(content)/react/components/select/demos/object-values/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/select/demos/object-values/tailwind/index.tsx
@@ -22,7 +22,7 @@ export default function ObjectValueSelect() {
       <Select.Portal>
         <Select.Positioner className="outline-none select-none z-10" sideOffset={8}>
           <Select.Popup className="group origin-[var(--transform-origin)] bg-clip-padding rounded-md bg-[canvas] text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[side=none]:data-[ending-style]:transition-none data-[starting-style]:scale-90 data-[starting-style]:opacity-0 data-[side=none]:data-[starting-style]:scale-100 data-[side=none]:data-[starting-style]:opacity-100 data-[side=none]:data-[starting-style] :transition-none dark:shadow-none dark:outline-gray-300">
-            <Select.ScrollUpArrow className="top-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:top-[-100%] before:left-0 before:h-full before:w-full before:content-[''] data-[direction=down]:bottom-0 data-[direction=down]:before:bottom-[-100%]" />
+            <Select.ScrollUpArrow className="top-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute data-[side=none]:before:top-[-100%] before:left-0 before:h-full before:w-full before:content-['']" />
             <Select.List className="relative py-1 scroll-py-6 overflow-y-auto max-h-[var(--available-height)]">
               {shippingMethods.map((method) => (
                 <Select.Item
@@ -42,7 +42,7 @@ export default function ObjectValueSelect() {
                 </Select.Item>
               ))}
             </Select.List>
-            <Select.ScrollDownArrow className="bottom-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:top-[-100%] before:left-0 before:h-full before:w-full before:content-[''] data-[direction=down]:bottom-0 data-[direction=down]:before:bottom-[-100%]" />
+            <Select.ScrollDownArrow className="bottom-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:left-0 before:h-full before:w-full before:content-[''] bottom-0 data-[side=none]:before:bottom-[-100%]" />
           </Select.Popup>
         </Select.Positioner>
       </Select.Portal>

--- a/docs/src/app/(public)/(content)/react/components/toolbar/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/toolbar/demos/hero/tailwind/index.tsx
@@ -54,7 +54,6 @@ export default function ExampleToolbar() {
         </Toolbar.Button>
         <Select.Portal>
           <Select.Positioner className="outline-none select-none" sideOffset={8}>
-            <Select.ScrollUpArrow className="top-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:top-[-100%] before:left-0 before:h-full before:w-full before:content-[''] data-[direction=down]:bottom-0 data-[direction=down]:before:bottom-[-100%]" />
             <Select.Popup className="group max-h-[var(--available-height)] origin-[var(--transform-origin)] overflow-y-auto rounded-md bg-[canvas] py-1 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[side=none]:data-[ending-style]:transition-none data-[starting-style]:scale-90 data-[starting-style]:opacity-0 data-[side=none]:data-[starting-style]:scale-100 data-[side=none]:data-[starting-style]:opacity-100 data-[side=none]:data-[starting-style]:transition-none dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300">
               <Select.Item
                 value="Helvetica"
@@ -75,7 +74,6 @@ export default function ExampleToolbar() {
                 <Select.ItemText className="col-start-2 text-sm">Arial</Select.ItemText>
               </Select.Item>
             </Select.Popup>
-            <Select.ScrollDownArrow className="bottom-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:top-[-100%] before:left-0 before:h-full before:w-full before:content-[''] data-[direction=down]:bottom-0 data-[direction=down]:before:bottom-[-100%]" />
           </Select.Positioner>
         </Select.Portal>
       </Select.Root>


### PR DESCRIPTION
- Removes the extended hit area for the scroll arrows when `data-side` is not `none` to prevent it from overlapping the trigger and activating too early while hovering.
- Removes stale `ScrollArea` JSX from Toolbar demo