### PR TITLE
Revert "[docs] Fix backdrops on iOS 26 (#2848)"

### DIFF
--- a/docs/src/app/(private)/experiments/dialog.module.css
+++ b/docs/src/app/(private)/experiments/dialog.module.css
@@ -131,11 +131,10 @@
 }
 
 .backdrop {
-  position: absolute;
   background: radial-gradient(#cecdcf36, #8b94ab47);
   z-index: 0;
+  position: fixed;
   inset: 0;
-  min-height: 100dvh;
 
   &.withTransitions {
     transition:

--- a/docs/src/app/(private)/experiments/menu/complex-nesting.tsx
+++ b/docs/src/app/(private)/experiments/menu/complex-nesting.tsx
@@ -57,7 +57,7 @@ export default function MenuComplexNestingExperiment() {
                   </Menu.Item>
 
                   <Dialog.Portal>
-                    <Dialog.Backdrop className="absolute inset-0 min-h-dvh bg-black/50" />
+                    <Dialog.Backdrop className="fixed inset-0 bg-black/50" />
                     <Dialog.Popup className="fixed top-1/2 left-1/2 w-[500px] max-w-[90vw] -translate-x-1/2 -translate-y-1/2 transform rounded-lg bg-white p-6 shadow-xl">
                       <Dialog.Title className="mb-4 text-xl font-semibold">
                         Settings (Nested Dialog)

--- a/docs/src/app/(private)/experiments/mobile-scroll-lock.module.css
+++ b/docs/src/app/(private)/experiments/mobile-scroll-lock.module.css
@@ -34,12 +34,11 @@
 }
 
 .Backdrop {
-  position: absolute;
+  position: fixed;
   inset: 0;
   background-color: black;
   opacity: 0.2;
   transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
-  min-height: 100dvh;
 
   @media (prefers-color-scheme: dark) {
     opacity: 0.7;

--- a/docs/src/app/(private)/experiments/modality.module.css
+++ b/docs/src/app/(private)/experiments/modality.module.css
@@ -229,9 +229,8 @@
 
 .Backdrop {
   background: rgb(0 0 0 / 0.35);
-  position: absolute;
+  position: fixed;
   inset: 0;
   backdrop-filter: blur(4px);
   z-index: 2000;
-  min-height: 100dvh;
 }

--- a/docs/src/app/(private)/experiments/popups/popups-in-popups.module.css
+++ b/docs/src/app/(private)/experiments/popups/popups-in-popups.module.css
@@ -319,8 +319,7 @@
 
 .Backdrop {
   background: rgb(0 0 0 / 0.35);
-  position: absolute;
+  position: fixed;
   inset: 0;
   backdrop-filter: blur(4px);
-  min-height: 100dvh;
 }

--- a/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
@@ -38,9 +38,8 @@
 }
 
 .Backdrop {
-  position: absolute;
+  position: fixed;
   inset: 0;
-  min-height: 100dvh;
   background-color: black;
   opacity: 0.2;
   transition: opacity 150ms;

--- a/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/tailwind/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleAlertDialog() {
         Discard draft
       </AlertDialog.Trigger>
       <AlertDialog.Portal>
-        <AlertDialog.Backdrop className="absolute inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
+        <AlertDialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
         <AlertDialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <AlertDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
             Discard draft?

--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/css-modules/index.module.css
@@ -220,9 +220,8 @@
 
 /* Dialog styles (reused from dialog hero demo) */
 .Backdrop {
-  position: absolute;
+  position: fixed;
   inset: 0;
-  min-height: 100dvh;
   background-color: black;
   opacity: 0.2;
   transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);

--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/tailwind/index.tsx
@@ -190,7 +190,7 @@ export default function ExampleCreatableCombobox() {
 
       <Dialog.Root open={openDialog} onOpenChange={setOpenDialog}>
         <Dialog.Portal>
-          <Dialog.Backdrop className="absolute inset-0 min-h-dvh bg-black opacity-20 transition-opacity dark:opacity-70 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0" />
+          <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-opacity dark:opacity-70 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0" />
           <Dialog.Popup
             className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 mt-[-2rem] w-[24rem] max-w-[calc(100vw-3rem)] rounded-lg bg-[canvas] p-6 text-gray-900 outline-1 outline-gray-200 transition-all data-[starting-style]:opacity-0 data-[starting-style]:scale-90 data-[ending-style]:opacity-0 data-[ending-style]:scale-90 dark:-outline-offset-1 dark:outline-gray-300"
             initialFocus={createInputRef}

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
@@ -78,9 +78,8 @@
 }
 
 .Backdrop {
-  position: absolute;
+  position: fixed;
   inset: 0;
-  min-height: 100dvh;
   background-color: black;
   opacity: 0.2;
   transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
@@ -26,7 +26,7 @@ export default function ExampleDialog() {
         Tweet
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Backdrop className="absolute inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
+        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
         <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">New tweet</Dialog.Title>
           <form

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.module.css
@@ -34,9 +34,8 @@
 }
 
 .Backdrop {
-  position: absolute;
+  position: fixed;
   inset: 0;
-  min-height: 100dvh;
   background-color: black;
   opacity: 0.2;
   transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/tailwind/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleDialog() {
         View notifications
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Backdrop className="absolute inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
+        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
         <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
           <Dialog.Description className="mb-6 text-base text-gray-600">

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.module.css
@@ -78,9 +78,8 @@
 }
 
 .Backdrop {
-  position: absolute;
+  position: fixed;
   inset: 0;
-  min-height: 100dvh;
   background-color: black;
   opacity: 0.2;
   transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/tailwind/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleDialog() {
         View notifications
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Backdrop className="absolute inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
+        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
         <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
           <Dialog.Description className="mb-6 text-base text-gray-600">

--- a/docs/src/app/(public)/(content)/react/overview/quick-start/page.mdx
+++ b/docs/src/app/(public)/(content)/react/overview/quick-start/page.mdx
@@ -13,9 +13,7 @@ npm i @base-ui-components/react
 
 All components are included in a single package. Base UI is tree-shakeable, so your app bundle will contain only the components that you actually use.
 
-## Set up
-
-### Portals
+## Set up portals
 
 Base UI uses portals for components that render popups, such as Dialog and Popover.
 To make portalled components always appear on top of the entire page, add the following style to your application layout root:
@@ -37,16 +35,6 @@ To make portalled components always appear on top of the entire page, add the fo
 
 This style creates a separate stacking context for your application's `.root` element.
 This way, popups will always appear above the page contents, and any `z-index` property in your styles won't interfere with them.
-
-### iOS Safari
-
-Backdrops must use `position: absolute` instead of `position: fixed` in order to cover the entire visible viewport on iOS 26. For this to work after scrolling, `position: relative` must be set on the `<body>`.
-
-```css title="styles.css"
-body {
-  position: relative;
-}
-```
 
 ## Assemble a component
 

--- a/docs/src/app/(public)/layout.css
+++ b/docs/src/app/(public)/layout.css
@@ -6,7 +6,6 @@
   }
 
   body {
-    position: relative; /* iOS 26 backdrops */
     min-width: 320px;
     line-height: 1.5;
     /* It's also the iOS footer overscroll background */

--- a/docs/src/components/MobileNav.css
+++ b/docs/src/components/MobileNav.css
@@ -1,8 +1,8 @@
 @layer components {
   .MobileNavBackdrop {
-    position: absolute;
+    position: fixed;
     inset: 0;
-    min-height: 100dvh;
+    height: 100dvh;
 
     transition-duration: 600ms;
     transition-property: -webkit-backdrop-filter, backdrop-filter, opacity;


### PR DESCRIPTION
This reverts commit 94470c056dad5aef46d6c8e7d4eacd0ca1e334a1.

The scroll lock used with inset scrollbar poses problems with `position: absolute`. Different technique is needed here.