### PR TITLE
[docs][combobox] Fix popup height style for inside-popup demo

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/input-inside-popup/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/input-inside-popup/css-modules/index.module.css
@@ -95,7 +95,7 @@
     transform 150ms,
     opacity 150ms;
   max-width: var(--available-width);
-  max-height: min(24rem, var(--available-height));
+  max-height: 24rem;
 
   &[data-starting-style],
   &[data-ending-style] {

--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/input-inside-popup/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/input-inside-popup/tailwind/index.tsx
@@ -13,7 +13,7 @@ export default function ExamplePopoverCombobox() {
       <Combobox.Portal>
         <Combobox.Positioner align="start" sideOffset={4}>
           <Combobox.Popup
-            className="[--input-container-height:3rem] origin-[var(--transform-origin)] max-w-[var(--available-width)] max-h-[min(24rem,var(--available-height))] rounded-lg bg-[canvas] shadow-lg shadow-gray-200 text-gray-900 outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300"
+            className="[--input-container-height:3rem] origin-[var(--transform-origin)] max-w-[var(--available-width)] max-h-[24rem] rounded-lg bg-[canvas] shadow-lg shadow-gray-200 text-gray-900 outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300"
             aria-label="Select country"
           >
             <div className="w-80 h-[var(--input-container-height)] text-center p-2">


### PR DESCRIPTION
This is a really minor, but weird, issue in the docs style for the `input-inside-popup` demo.

Even if there was enough space on the bottom to position the popup there, it would choose to flip to the top if there was **more** space there. Kind of like `autoPlacement()` in Floating UI instead of `flip()` (even though it's not being used.)

`var(--available-height)` is already handled by `List`, so there aren't any visual changes.

### Fix

With the fix, it correctly chooses the bottom if it can. Previously it was choose the top (shown with the arrow) in this particular scenario. The viewport height and scroll position need to be specific enough for the issue to be reproduced.

<img width="392" height="764" alt="Screenshot 2025-10-02 at 4 21 33 pm" src="https://github.com/user-attachments/assets/01e11939-2ad9-4986-823a-4497bc40f57e" />
