### PR TITLE
[docs] Fix iOS 26+ backdrops

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
@@ -39,6 +39,7 @@
 
 .Backdrop {
   position: fixed;
+  min-height: 100dvh;
   inset: 0;
   background-color: black;
   opacity: 0.2;
@@ -47,7 +48,6 @@
   /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
   @supports (-webkit-touch-callout: none) {
     position: absolute;
-    min-height: 100dvh;
   }
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
@@ -44,6 +44,12 @@
   opacity: 0.2;
   transition: opacity 150ms;
 
+  /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
+  @supports (-webkit-touch-callout: none) {
+    position: absolute;
+    min-height: 100dvh;
+  }
+
   @media (prefers-color-scheme: dark) {
     opacity: 0.7;
   }

--- a/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/tailwind/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleAlertDialog() {
         Discard draft
       </AlertDialog.Trigger>
       <AlertDialog.Portal>
-        <AlertDialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
+        <AlertDialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute supports-[-webkit-touch-callout:none]:min-h-[100dvh]" />
         <AlertDialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <AlertDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
             Discard draft?

--- a/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/alert-dialog/demos/hero/tailwind/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleAlertDialog() {
         Discard draft
       </AlertDialog.Trigger>
       <AlertDialog.Portal>
-        <AlertDialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute supports-[-webkit-touch-callout:none]:min-h-[100dvh]" />
+        <AlertDialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
         <AlertDialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <AlertDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
             Discard draft?

--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/css-modules/index.module.css
@@ -226,6 +226,12 @@
   opacity: 0.2;
   transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
 
+  /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
+  @supports (-webkit-touch-callout: none) {
+    position: absolute;
+    min-height: 100dvh;
+  }
+
   @media (prefers-color-scheme: dark) {
     opacity: 0.7;
   }

--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/css-modules/index.module.css
@@ -221,6 +221,7 @@
 /* Dialog styles (reused from dialog hero demo) */
 .Backdrop {
   position: fixed;
+  min-height: 100dvh;
   inset: 0;
   background-color: black;
   opacity: 0.2;
@@ -229,7 +230,6 @@
   /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
   @supports (-webkit-touch-callout: none) {
     position: absolute;
-    min-height: 100dvh;
   }
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/tailwind/index.tsx
@@ -190,7 +190,7 @@ export default function ExampleCreatableCombobox() {
 
       <Dialog.Root open={openDialog} onOpenChange={setOpenDialog}>
         <Dialog.Portal>
-          <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-opacity dark:opacity-70 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0" />
+          <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-opacity dark:opacity-70 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 supports-[-webkit-touch-callout:none]:absolute supports-[-webkit-touch-callout:none]:min-h-[100dvh]" />
           <Dialog.Popup
             className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 mt-[-2rem] w-[24rem] max-w-[calc(100vw-3rem)] rounded-lg bg-[canvas] p-6 text-gray-900 outline-1 outline-gray-200 transition-all data-[starting-style]:opacity-0 data-[starting-style]:scale-90 data-[ending-style]:opacity-0 data-[ending-style]:scale-90 dark:-outline-offset-1 dark:outline-gray-300"
             initialFocus={createInputRef}

--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/creatable/tailwind/index.tsx
@@ -190,7 +190,7 @@ export default function ExampleCreatableCombobox() {
 
       <Dialog.Root open={openDialog} onOpenChange={setOpenDialog}>
         <Dialog.Portal>
-          <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-opacity dark:opacity-70 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 supports-[-webkit-touch-callout:none]:absolute supports-[-webkit-touch-callout:none]:min-h-[100dvh]" />
+          <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-opacity dark:opacity-70 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 supports-[-webkit-touch-callout:none]:absolute" />
           <Dialog.Popup
             className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 mt-[-2rem] w-[24rem] max-w-[calc(100vw-3rem)] rounded-lg bg-[canvas] p-6 text-gray-900 outline-1 outline-gray-200 transition-all data-[starting-style]:opacity-0 data-[starting-style]:scale-90 data-[ending-style]:opacity-0 data-[ending-style]:scale-90 dark:-outline-offset-1 dark:outline-gray-300"
             initialFocus={createInputRef}

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
@@ -84,6 +84,12 @@
   opacity: 0.2;
   transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
 
+  /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
+  @supports (-webkit-touch-callout: none) {
+    position: absolute;
+    min-height: 100dvh;
+  }
+
   @media (prefers-color-scheme: dark) {
     opacity: 0.7;
   }

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
@@ -79,6 +79,7 @@
 
 .Backdrop {
   position: fixed;
+  min-height: 100dvh;
   inset: 0;
   background-color: black;
   opacity: 0.2;
@@ -87,7 +88,6 @@
   /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
   @supports (-webkit-touch-callout: none) {
     position: absolute;
-    min-height: 100dvh;
   }
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
@@ -26,7 +26,7 @@ export default function ExampleDialog() {
         Tweet
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
+        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute supports-[-webkit-touch-callout:none]:min-h-[100dvh]" />
         <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">New tweet</Dialog.Title>
           <form

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
@@ -26,7 +26,7 @@ export default function ExampleDialog() {
         Tweet
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute supports-[-webkit-touch-callout:none]:min-h-[100dvh]" />
+        <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
         <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">New tweet</Dialog.Title>
           <form

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.module.css
@@ -40,6 +40,12 @@
   opacity: 0.2;
   transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
 
+  /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
+  @supports (-webkit-touch-callout: none) {
+    position: absolute;
+    min-height: 100dvh;
+  }
+
   @media (prefers-color-scheme: dark) {
     opacity: 0.7;
   }

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.module.css
@@ -35,6 +35,7 @@
 
 .Backdrop {
   position: fixed;
+  min-height: 100dvh;
   inset: 0;
   background-color: black;
   opacity: 0.2;
@@ -43,7 +44,6 @@
   /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
   @supports (-webkit-touch-callout: none) {
     position: absolute;
-    min-height: 100dvh;
   }
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/tailwind/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleDialog() {
         View notifications
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
+        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute supports-[-webkit-touch-callout:none]:min-h-[100dvh]" />
         <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
           <Dialog.Description className="mb-6 text-base text-gray-600">

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/tailwind/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleDialog() {
         View notifications
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute supports-[-webkit-touch-callout:none]:min-h-[100dvh]" />
+        <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
         <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
           <Dialog.Description className="mb-6 text-base text-gray-600">

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.module.css
@@ -84,6 +84,12 @@
   opacity: 0.2;
   transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
 
+  /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
+  @supports (-webkit-touch-callout: none) {
+    position: absolute;
+    min-height: 100dvh;
+  }
+
   @media (prefers-color-scheme: dark) {
     opacity: 0.7;
   }

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.module.css
@@ -79,6 +79,7 @@
 
 .Backdrop {
   position: fixed;
+  min-height: 100dvh;
   inset: 0;
   background-color: black;
   opacity: 0.2;
@@ -87,7 +88,6 @@
   /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
   @supports (-webkit-touch-callout: none) {
     position: absolute;
-    min-height: 100dvh;
   }
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/tailwind/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleDialog() {
         View notifications
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute supports-[-webkit-touch-callout:none]:min-h-[100dvh]" />
+        <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
         <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
           <Dialog.Description className="mb-6 text-base text-gray-600">

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/tailwind/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleDialog() {
         View notifications
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
+        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute supports-[-webkit-touch-callout:none]:min-h-[100dvh]" />
         <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
           <Dialog.Description className="mb-6 text-base text-gray-600">

--- a/docs/src/app/(public)/(content)/react/overview/quick-start/page.mdx
+++ b/docs/src/app/(public)/(content)/react/overview/quick-start/page.mdx
@@ -13,7 +13,9 @@ npm i @base-ui-components/react
 
 All components are included in a single package. Base UI is tree-shakeable, so your app bundle will contain only the components that you actually use.
 
-## Set up portals
+## Set up
+
+### Portals
 
 Base UI uses portals for components that render popups, such as Dialog and Popover.
 To make portalled components always appear on top of the entire page, add the following style to your application layout root:
@@ -35,6 +37,16 @@ To make portalled components always appear on top of the entire page, add the fo
 
 This style creates a separate stacking context for your application's `.root` element.
 This way, popups will always appear above the page contents, and any `z-index` property in your styles won't interfere with them.
+
+### iOS 26+ Safari
+
+Starting in iOS 26, Safari allows content beneath the UI chrome to be visible. Backdrops such as those used by dialogs must use `position: absolute` instead of `position: fixed` to cover the entire visual viewport. For this to work after the page was scrolled, the following style must be added to your global styles:
+
+```css title="styles.css"
+body {
+  position: relative;
+}
+```
 
 ## Assemble a component
 

--- a/docs/src/app/(public)/(content)/react/overview/quick-start/page.mdx
+++ b/docs/src/app/(public)/(content)/react/overview/quick-start/page.mdx
@@ -40,7 +40,7 @@ This way, popups will always appear above the page contents, and any `z-index` p
 
 ### iOS 26+ Safari
 
-Starting in iOS 26, Safari allows content beneath the UI chrome to be visible. Backdrops such as those used by dialogs must use `position: absolute` instead of `position: fixed` to cover the entire visual viewport. For this to work after the page was scrolled, the following style must be added to your global styles:
+Starting with iOS 26, Safari allows content beneath the UI chrome to be visible. Backdrops such as those used by dialogs must use `position: absolute` instead of `position: fixed` to cover the entire visual viewport. For this to work after the page was scrolled, the following style must be added to your global styles:
 
 ```css title="styles.css"
 body {

--- a/docs/src/app/(public)/layout.css
+++ b/docs/src/app/(public)/layout.css
@@ -6,6 +6,7 @@
   }
 
   body {
+    position: relative; /* iOS 26 `position: absolute` backdrops */
     min-width: 320px;
     line-height: 1.5;
     /* It's also the iOS footer overscroll background */

--- a/docs/src/components/MobileNav.css
+++ b/docs/src/components/MobileNav.css
@@ -2,13 +2,18 @@
   .MobileNavBackdrop {
     position: fixed;
     inset: 0;
-    height: 100dvh;
+    min-height: 100dvh;
 
     transition-duration: 600ms;
     transition-property: -webkit-backdrop-filter, backdrop-filter, opacity;
     transition-timing-function: var(--ease-out-fast);
     backdrop-filter: blur(1.5px);
     background-image: linear-gradient(to bottom, transparent 2rem, rgb(0 0 0 / 5%) 50%);
+
+    /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
+    @supports (-webkit-touch-callout: none) {
+      position: absolute;
+    }
 
     @media (prefers-color-scheme: dark) {
       background-image: linear-gradient(to bottom, transparent, rgb(0 0 0 / 25%) 6rem);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Third attempt at fixing this...

This one instead only targets iOS Safari. Caveat: if other mobile browsers start allowing content to be seen beneath the viewport, it'll fail for them. 

### Second alternative

To avoid the caveat, we'd need to target the `data-base-ui-scroll-locked` attr placed on the `<html>` tag, which is **only** applied if there are inset scrollbars. The scroll lock for inset scrollbars is special and breaks `position: absolute` backdrops because it sets a fixed height on the body.

This one avoids breaking the inset scrollbar scroll lock, while allowing non-iOS mobile browser UIs to also work if they change. Presumably, browsers with inset scrollbars will never face this issue given it's a mobile/overlay-scrollbar type of UI paradigm 


```css
.Backdrop {
  position: absolute;
  min-height: 100dvh;
  inset: 0;

  [data-base-ui-scroll-locked] & {
    position: fixed;
  }
}
```

This could be renamed to something different, or add an attribute on the `.Backdrop` element itself to avoid the parent > child selector (which is quite awful in Tailwind)