### PR TITLE
[checkbox group] Fix parent checkbox ignoring custom `id` prop

### DIFF
--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.test.tsx
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.test.tsx
@@ -159,6 +159,57 @@ describe('useCheckboxGroupParent', () => {
     expect(parent).to.have.attribute('aria-controls', allValues.map((v) => `${id}-${v}`).join(' '));
   });
 
+  it('should honor custom id on parent checkbox', () => {
+    function App() {
+      const [value, setValue] = React.useState<string[]>([]);
+      return (
+        <CheckboxGroup value={value} onValueChange={setValue} allValues={allValues}>
+          <Checkbox.Root parent id="custom-parent-id" data-testid="parent" />
+          <Checkbox.Root value="a" />
+          <Checkbox.Root value="b" />
+          <Checkbox.Root value="c" />
+        </CheckboxGroup>
+      );
+    }
+
+    render(<App />);
+
+    const parent = screen.getByTestId('parent');
+
+    expect(parent).to.have.attribute('id', 'custom-parent-id');
+    expect(parent).to.have.attribute(
+      'aria-controls',
+      allValues.map((v) => `custom-parent-id-${v}`).join(' '),
+    );
+  });
+
+  it('should allow label association via htmlFor with custom id', () => {
+    function App() {
+      const [value, setValue] = React.useState<string[]>([]);
+      return (
+        <CheckboxGroup value={value} onValueChange={setValue} allValues={allValues}>
+          <label htmlFor="parent-checkbox-id">Select All</label>
+          <Checkbox.Root parent id="parent-checkbox-id" data-testid="parent" />
+          <Checkbox.Root value="a" />
+          <Checkbox.Root value="b" />
+          <Checkbox.Root value="c" />
+        </CheckboxGroup>
+      );
+    }
+
+    render(<App />);
+
+    const parent = screen.getByTestId('parent');
+    const label = screen.getByText('Select All');
+
+    expect(parent).to.have.attribute('id', 'parent-checkbox-id');
+    expect(label).to.have.attribute('for', 'parent-checkbox-id');
+
+    // Click the label should toggle the parent checkbox
+    fireEvent.click(label);
+    expect(parent).to.have.attribute('aria-checked', 'true');
+  });
+
   it('preserves initial state if mixed when parent is clicked', () => {
     function App() {
       const [value, setValue] = React.useState<string[]>([]);

--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.test.tsx
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.test.tsx
@@ -210,6 +210,33 @@ describe('useCheckboxGroupParent', () => {
     expect(parent).to.have.attribute('aria-checked', 'true');
   });
 
+  it('should allow label association via htmlFor with custom id on child checkbox', () => {
+    function App() {
+      const [value, setValue] = React.useState<string[]>([]);
+      return (
+        <CheckboxGroup value={value} onValueChange={setValue} allValues={allValues}>
+          <Checkbox.Root parent data-testid="parent" />
+          <label htmlFor="child-checkbox-a">Option A</label>
+          <Checkbox.Root value="a" id="child-checkbox-a" data-testid="child-a" />
+          <Checkbox.Root value="b" />
+          <Checkbox.Root value="c" />
+        </CheckboxGroup>
+      );
+    }
+
+    render(<App />);
+
+    const childA = screen.getByTestId('child-a');
+    const label = screen.getByText('Option A');
+
+    expect(childA).to.have.attribute('id', 'child-checkbox-a');
+    expect(label).to.have.attribute('for', 'child-checkbox-a');
+
+    // Click the label should toggle the child checkbox
+    fireEvent.click(label);
+    expect(childA).to.have.attribute('aria-checked', 'true');
+  });
+
   it('preserves initial state if mixed when parent is clicked', () => {
     function App() {
       const [value, setValue] = React.useState<string[]>([]);

--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
@@ -23,11 +23,10 @@ export function useCheckboxGroupParent(
   const onValueChange = useEventCallback(onValueChangeProp);
 
   const getParentProps: useCheckboxGroupParent.ReturnValue['getParentProps'] = React.useCallback(
-    () => ({
-      id,
+    (parentId?: string) => ({
       indeterminate,
       checked,
-      'aria-controls': allValues.map((v) => `${id}-${v}`).join(' '),
+      'aria-controls': allValues.map((v) => `${parentId ?? id}-${v}`).join(' '),
       onCheckedChange(_, eventDetails) {
         const uncontrolledState = uncontrolledStateRef.current;
 
@@ -114,8 +113,7 @@ export namespace useCheckboxGroupParent {
     id: string | undefined;
     indeterminate: boolean;
     disabledStatesRef: React.RefObject<Map<string, boolean>>;
-    getParentProps: () => {
-      id: string | undefined;
+    getParentProps: (parentId?: string) => {
       indeterminate: boolean;
       checked: boolean;
       'aria-controls': string;

--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
@@ -71,9 +71,9 @@ export function useCheckboxGroupParent(
   );
 
   const getChildProps: useCheckboxGroupParent.ReturnValue['getChildProps'] = React.useCallback(
-    (name: string) => ({
+    (name: string, childId?: string) => ({
       name,
-      id: `${id}-${name}`,
+      id: childId ?? `${id}-${name}`,
       checked: value.includes(name),
       onCheckedChange(nextChecked, eventDetails) {
         const newValue = value.slice();
@@ -119,7 +119,7 @@ export namespace useCheckboxGroupParent {
       'aria-controls': string;
       onCheckedChange: (checked: boolean, eventDetails: BaseUIChangeEventDetails<'none'>) => void;
     };
-    getChildProps: (name: string) => {
+    getChildProps: (name: string, childId?: string) => {
       name: string;
       id: string;
       checked: boolean;

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -85,7 +85,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     if (parent) {
       groupProps = groupContext.parent.getParentProps(id);
     } else if (value) {
-      groupProps = groupContext.parent.getChildProps(value);
+      groupProps = groupContext.parent.getChildProps(value, id);
     }
   }
 

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -78,10 +78,12 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
   const name = fieldName ?? nameProp;
   const value = valueProp ?? name;
 
+  const id = useBaseUiId(idProp);
+
   let groupProps: Partial<Omit<CheckboxRoot.Props, 'className'>> = {};
   if (isGrouped) {
     if (parent) {
-      groupProps = groupContext.parent.getParentProps();
+      groupProps = groupContext.parent.getParentProps(id);
     } else if (value) {
       groupProps = groupContext.parent.getChildProps(value);
     }
@@ -118,8 +120,6 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     name: 'Checkbox',
     state: 'checked',
   });
-
-  const id = useBaseUiId(idProp);
 
   useIsoLayoutEffect(() => {
     const element = controlRef?.current;


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/issues/2691

## Context

In the "parent checkbox" use case of CheckboxGroup, the consumer-specified `id` on `Checkbox.Root` was being ignored. This made it impossible to associate a label to the checkbox using `htmlFor`.

The issue occurred because `useCheckboxGroupParent` was returning its own generated `id` in `getParentProps()`, which overrode the user-provided `id` prop.

## Summary

- Modified `getParentProps()` to accept an optional `parentId` parameter
- `CheckboxRoot` now passes its`id` to `getParentProps()` for parent checkboxes
- This ensures custom `id` props are honored and `aria-controls` uses the correct id

## Test plan
- Added test to verify custom `id` is respected on parent checkbox
- Added test to verify label association via `htmlFor` works correctly
- All existing tests pass"

I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
