### PR TITLE
[code-infra] Support custom npm dist tags during release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
         default: true
       dist-tag:
-        description: 'NPM dist tag to publish to'
+        description: 'npm dist tag to publish to'
         required: false
         type: string
         default: 'latest'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: true
+      dist-tag:
+        description: 'NPM dist tag to publish to'
+        required: false
+        type: string
+        default: 'latest'
 
 permissions: {}
 
@@ -47,6 +52,9 @@ jobs:
           fi
           if [ "${{ inputs.github-release }}" = "true" ]; then
             ARGS="$ARGS --github-release"
+          fi
+          if [ -n "${{ inputs.dist-tag }}" ]; then
+            ARGS="$ARGS --tag ${{ inputs.dist-tag }}"
           fi
 
           pnpm code-infra publish $ARGS

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
     "build": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build",
     "build:clean": "rimraf .next && pnpm build",
     "dev": "next dev --port 3005",
-    "deploy": "git push -f upstream master:docs-v1",
+    "deploy": "git fetch upstream master && git push -f upstream FETCH_HEAD:docs-v1",
     "serve": "serve ./export -l 3010",
     "typescript": "tsc -b tsconfig.json",
     "link-check": "tsx ./scripts/reportBrokenLinks.mts",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@arethetypeswrong/cli": "^0.18.2",
     "@babel/plugin-transform-react-constant-elements": "^7.27.1",
     "@base-ui-components/monorepo-tests": "workspace:*",
-    "@mui/internal-code-infra": "^0.0.3-canary.17",
+    "@mui/internal-code-infra": "^0.0.3-canary.19",
     "@mui/internal-test-utils": "^2.0.10",
     "@mui/monorepo": "github:mui/material-ui#v7.3.2",
     "@octokit/rest": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: workspace:*
         version: link:test
       '@mui/internal-code-infra':
-        specifier: ^0.0.3-canary.17
-        version: 0.0.3-canary.17(eslint@9.36.0(jiti@2.5.1))(postcss@8.5.6)(prettier@3.6.2)(stylelint@16.24.0(typescript@5.9.2))(typescript@5.9.2)
+        specifier: ^0.0.3-canary.19
+        version: 0.0.3-canary.19(eslint@9.36.0(jiti@2.5.1))(postcss@8.5.6)(prettier@3.6.2)(stylelint@16.24.0(typescript@5.9.2))(typescript@5.9.2)
       '@mui/internal-test-utils':
         specifier: ^2.0.10
         version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -2133,8 +2133,8 @@ packages:
     resolution: {integrity: sha512-9hqDvOezGxIztw/9FdWmg+M+jzM8fspsR/MqssBUHYUvLxYUy3P0MO3iTy/GJHkZvvL53hJTI3XD6NjSuaeIgw==}
     hasBin: true
 
-  '@mui/internal-code-infra@0.0.3-canary.17':
-    resolution: {integrity: sha512-+9R21uphQTbFQIVmjMz+SqioYjGs6N7fgLaLgCdUykmqUFsLp/MeJuv+91l94MFAt7TYUrOD/3OzK4mCq4BcaQ==}
+  '@mui/internal-code-infra@0.0.3-canary.19':
+    resolution: {integrity: sha512-LMQAy+0XWTaXTbMtacB2QaQPqFhKwJnfIZ0k0yUBXdHizfKKAobJyifBS+YBErGNrkoW9GOMrJcuLM3h92gPcA==}
     hasBin: true
     peerDependencies:
       eslint: ^9.0.0
@@ -12406,7 +12406,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@mui/internal-code-infra@0.0.3-canary.17(eslint@9.36.0(jiti@2.5.1))(postcss@8.5.6)(prettier@3.6.2)(stylelint@16.24.0(typescript@5.9.2))(typescript@5.9.2)':
+  '@mui/internal-code-infra@0.0.3-canary.19(eslint@9.36.0(jiti@2.5.1))(postcss@8.5.6)(prettier@3.6.2)(stylelint@16.24.0(typescript@5.9.2))(typescript@5.9.2)':
     dependencies:
       '@argos-ci/core': 4.1.5
       '@babel/cli': 7.28.3(@babel/core@7.28.4)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,7 +39,7 @@ A typical release goes like this:
    > - **Commit SHA to release from:** the commit that contains the merged release on master. This commit is linked to the GitHub release.
    > - **Run in dry-run mode:** Used for debugging.
    > - **Create GitHub release:** Keep selected if you want a GitHub release to be automatically created from the changelog.
-   > - **NPM dist tag to publish to** Use to publish legacy or canary versions.
+   > - **npm dist tag to publish to** Use to publish legacy or canary versions.
 
 3. Click "Run workflow"
 4. Refresh the page to see the newly created workflow, and click it.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,10 +35,11 @@ A typical release goes like this:
 1. Go to the [publish action](https://github.com/mui/base-ui/actions/workflows/publish.yml).
 2. Choose "Run workflow" dropdown
 
-> **Branch:** master
-> **Commit SHA to release from:** the commit that contains the merged release on master. This commit is linked to the GitHub release.
-> **Run in dry-run mode:** Used for debugging.
-> **Create GitHub release:** Keep selected if you want a GitHub release to be automatically created from the changelog.
+   > - **Branch:** master
+   > - **Commit SHA to release from:** the commit that contains the merged release on master. This commit is linked to the GitHub release.
+   > - **Run in dry-run mode:** Used for debugging.
+   > - **Create GitHub release:** Keep selected if you want a GitHub release to be automatically created from the changelog.
+   > - **NPM dist tag to publish to** Use to publish legacy or canary versions.
 
 3. Click "Run workflow"
 4. Refresh the page to see the newly created workflow, and click it.


### PR DESCRIPTION
* Allow publishing to different dist tag than "latest"
* Tweak docs deploy to fetch latest master first, like https://github.com/mui/material-ui/pull/47018