### PR TITLE
[menu] Fix stealing focus from dialogs on close

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -524,7 +524,11 @@ export function useListNavigation(
         }
       },
       onPointerLeave(event) {
-        if (!isPointerModalityRef.current || event.pointerType === 'touch') {
+        if (
+          !latestOpenRef.current ||
+          !isPointerModalityRef.current ||
+          event.pointerType === 'touch'
+        ) {
           return;
         }
 


### PR DESCRIPTION
Fixes two scenarios:

1. When `autoFocus` is specified on an input inside a dialog, the `onPointerLeave` handler's focus call used on `Menu.Item` steals the focus to set on the menu popup. This occurs due to `pointer-events: none` on the closing menu or the Dialog's backdrop as it opens
2. In Firefox only, `onPointerLeave` fires later than the `initialFocus` call of the dialog, so the menu steals focus away from the dialog. Chrome and Safari fire earlier so that doesn't happen

https://codesandbox.io/p/sandbox/inspiring-bassi-8d5k5x