### PR TITLE
[menubar] Mark disabled in Menubar Context as required

### DIFF
--- a/packages/react/src/menubar/MenubarContext.ts
+++ b/packages/react/src/menubar/MenubarContext.ts
@@ -4,7 +4,7 @@ import { type MenuRoot } from '../menu/root/MenuRoot';
 
 export interface MenubarContext {
   modal: boolean;
-  disabled?: boolean;
+  disabled: boolean;
   contentElement: HTMLElement | null;
   setContentElement: (element: HTMLElement | null) => void;
   hasSubmenuOpen: boolean;


### PR DESCRIPTION
Make `disabled` in `MenubarContext` required (default is `false`) for clearer typing. Noticed in https://github.com/mui/base-ui/pull/2736.
