### PR TITLE
[select][combobox] Fix required form submission with multiple values

### DIFF
--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -1047,6 +1047,8 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     return stringifyAsValue(formValue, itemToStringValue);
   }, [formValue, itemToStringValue]);
 
+  const hasMultipleSelection = multiple && Array.isArray(selectedValue) && selectedValue.length > 0;
+
   const hiddenInputs = React.useMemo(() => {
     if (!multiple || !Array.isArray(selectedValue) || !name) {
       return null;
@@ -1132,7 +1134,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
           id,
           name: multiple || selectionMode === 'none' ? undefined : name,
           disabled,
-          required,
+          required: required && !hasMultipleSelection,
           readOnly,
           value: serializedValue,
           ref: hiddenInputRef,

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -1031,6 +1031,32 @@ describe('<Combobox.Root />', () => {
     });
   });
 
+  describe('prop: required', () => {
+    it('does not mark the hidden input as required when selection exists in multiple mode', async () => {
+      const { container } = await render(
+        <Combobox.Root multiple required name="languages" value={['a']}>
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      const hiddenInput = container.querySelector<HTMLInputElement>('input[aria-hidden="true"]');
+      expect(hiddenInput).not.to.equal(null);
+      expect(hiddenInput).not.to.have.attribute('required');
+    });
+
+    it('keeps the hidden input required when no selection exists in multiple mode', async () => {
+      const { container } = await render(
+        <Combobox.Root multiple required name="languages" value={[]}>
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      const hiddenInput = container.querySelector<HTMLInputElement>('input[aria-hidden="true"]');
+      expect(hiddenInput).not.to.equal(null);
+      expect(hiddenInput).to.have.attribute('required');
+    });
+  });
+
   describe('prop: readOnly', () => {
     it('should render readOnly state on all interactive components', async () => {
       const { user } = await render(

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -1011,7 +1011,7 @@ describe('<Combobox.Root />', () => {
     });
 
     it('should set disabled attribute on hidden input', async () => {
-       await render(
+      await render(
         <Combobox.Root disabled name="test">
           <Combobox.Input />
           <Combobox.Portal>
@@ -1033,7 +1033,7 @@ describe('<Combobox.Root />', () => {
 
   describe('prop: required', () => {
     it('does not mark the hidden input as required when selection exists in multiple mode', async () => {
-       await render(
+      await render(
         <Combobox.Root multiple required name="languages" value={['a']}>
           <Combobox.Input />
         </Combobox.Root>,
@@ -1045,7 +1045,7 @@ describe('<Combobox.Root />', () => {
     });
 
     it('keeps the hidden input required when no selection exists in multiple mode', async () => {
-     await render(
+      await render(
         <Combobox.Root multiple required name="languages" value={[]}>
           <Combobox.Input />
         </Combobox.Root>,

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -1011,7 +1011,7 @@ describe('<Combobox.Root />', () => {
     });
 
     it('should set disabled attribute on hidden input', async () => {
-      const { container } = await render(
+       await render(
         <Combobox.Root disabled name="test">
           <Combobox.Input />
           <Combobox.Portal>
@@ -1026,32 +1026,32 @@ describe('<Combobox.Root />', () => {
         </Combobox.Root>,
       );
 
-      const hiddenInput = container.querySelector('input[aria-hidden="true"]');
+      const hiddenInput = screen.getByRole('textbox', { hidden: true });
       expect(hiddenInput).to.have.attribute('disabled');
     });
   });
 
   describe('prop: required', () => {
     it('does not mark the hidden input as required when selection exists in multiple mode', async () => {
-      const { container } = await render(
+       await render(
         <Combobox.Root multiple required name="languages" value={['a']}>
           <Combobox.Input />
         </Combobox.Root>,
       );
 
-      const hiddenInput = container.querySelector<HTMLInputElement>('input[aria-hidden="true"]');
+      const hiddenInput = screen.getByRole('textbox', { hidden: true });
       expect(hiddenInput).not.to.equal(null);
       expect(hiddenInput).not.to.have.attribute('required');
     });
 
     it('keeps the hidden input required when no selection exists in multiple mode', async () => {
-      const { container } = await render(
+     await render(
         <Combobox.Root multiple required name="languages" value={[]}>
           <Combobox.Input />
         </Combobox.Root>,
       );
 
-      const hiddenInput = container.querySelector<HTMLInputElement>('input[aria-hidden="true"]');
+      const hiddenInput = screen.getByRole('textbox', { hidden: true });
       expect(hiddenInput).not.to.equal(null);
       expect(hiddenInput).to.have.attribute('required');
     });

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -2262,7 +2262,7 @@ describe('<Select.Root />', () => {
     });
 
     it('does not mark the hidden input as required when selection exists', async () => {
-      const { container } = await render(
+      await render(
         <Select.Root multiple required name="select" value={['a']}>
           <Select.Trigger>
             <Select.Value />
@@ -2270,13 +2270,13 @@ describe('<Select.Root />', () => {
         </Select.Root>,
       );
 
-      const hiddenInput = container.querySelector<HTMLInputElement>('input[aria-hidden="true"]');
+      const hiddenInput = screen.getByRole('textbox', { hidden: true });
       expect(hiddenInput).not.to.equal(null);
       expect(hiddenInput).not.to.have.attribute('required');
     });
 
     it('keeps the hidden input required when no selection exists', async () => {
-      const { container } = await render(
+       await render(
         <Select.Root multiple required name="select" value={[]}>
           <Select.Trigger>
             <Select.Value />
@@ -2284,7 +2284,7 @@ describe('<Select.Root />', () => {
         </Select.Root>,
       );
 
-      const hiddenInput = container.querySelector<HTMLInputElement>('input[aria-hidden="true"]');
+      const hiddenInput = screen.getByRole('textbox', { hidden: true });
       expect(hiddenInput).not.to.equal(null);
       expect(hiddenInput).to.have.attribute('required');
     });

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -2261,6 +2261,34 @@ describe('<Select.Root />', () => {
       expect(mainInput?.value).to.equal('');
     });
 
+    it('does not mark the hidden input as required when selection exists', async () => {
+      const { container } = await render(
+        <Select.Root multiple required name="select" value={['a']}>
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+        </Select.Root>,
+      );
+
+      const hiddenInput = container.querySelector<HTMLInputElement>('input[aria-hidden="true"]');
+      expect(hiddenInput).not.to.equal(null);
+      expect(hiddenInput).not.to.have.attribute('required');
+    });
+
+    it('keeps the hidden input required when no selection exists', async () => {
+      const { container } = await render(
+        <Select.Root multiple required name="select" value={[]}>
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+        </Select.Root>,
+      );
+
+      const hiddenInput = container.querySelector<HTMLInputElement>('input[aria-hidden="true"]');
+      expect(hiddenInput).not.to.equal(null);
+      expect(hiddenInput).to.have.attribute('required');
+    });
+
     it('should not close popup when selecting items in multiple mode', async () => {
       const { user } = await render(
         <Select.Root multiple>

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -2276,7 +2276,7 @@ describe('<Select.Root />', () => {
     });
 
     it('keeps the hidden input required when no selection exists', async () => {
-       await render(
+      await render(
         <Select.Root multiple required name="select" value={[]}>
           <Select.Trigger>
             <Select.Value />

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -85,6 +85,8 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     return stringifyAsValue(value, itemToStringValue);
   }, [isMultiple, value, itemToStringValue]);
 
+  const hasMultipleSelection = isMultiple && Array.isArray(value) && value.length > 0;
+
   const hiddenInputs = React.useMemo(() => {
     if (!isMultiple || !Array.isArray(value) || !rootContext.name) {
       return null;
@@ -155,7 +157,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
             name: isMultiple ? undefined : rootContext.name,
             value: serializedValue,
             disabled: rootContext.disabled,
-            required: rootContext.required,
+            required: rootContext.required && !hasMultipleSelection,
             readOnly: rootContext.readOnly,
             ref,
             style: visuallyHidden,


### PR DESCRIPTION
Since `multiple` modes on each use separate hidden inputs, the main hidden input needs to remove `required` when a value exists

Fixes #2913 (https://codesandbox.io/p/sandbox/ecstatic-fire-nzxvy9)