### PR TITLE
[combobox][autocomplete] Fix `Home`/`End` Input scroll in Chrome/Safari

### DIFF
--- a/packages/react/src/combobox/input/ComboboxInput.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Combobox } from '@base-ui-components/react/combobox';
-import { createRenderer, describeConformance } from '#test-utils';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { Field } from '@base-ui-components/react/field';
@@ -394,6 +394,41 @@ describe('<Combobox.Input />', () => {
       expect(input.selectionStart).to.equal(input.value.length);
       expect(input.selectionEnd).to.equal(input.value.length);
     });
+
+    it.skipIf(isJSDOM)(
+      'scrolls to the start and end when pressing Home/End on overflowing input',
+      async () => {
+        const { user } = await render(
+          <Combobox.Root>
+            <Combobox.Input style={{ width: 64, fontSize: 20 }} />
+          </Combobox.Root>,
+        );
+
+        const input = screen.getByRole<HTMLInputElement>('combobox');
+        input.focus();
+
+        await user.type(input, 'this is a very long combobox value');
+
+        expect(input.scrollWidth).to.be.greaterThan(input.clientWidth);
+
+        const expectedScroll = input.scrollWidth - input.clientWidth;
+
+        expect(expectedScroll).to.be.greaterThan(0);
+
+        input.scrollLeft = expectedScroll;
+        input.setSelectionRange(input.value.length, input.value.length);
+
+        await user.keyboard('{Home}');
+        expect(input.selectionStart).to.equal(0);
+        expect(input.selectionEnd).to.equal(0);
+        expect(input.scrollLeft).to.equal(0);
+
+        await user.keyboard('{End}');
+        expect(input.selectionStart).to.equal(input.value.length);
+        expect(input.selectionEnd).to.equal(input.value.length);
+        expect(input.scrollLeft).to.be.closeTo(expectedScroll, 2);
+      },
+    );
 
     it('preserves caret position when controlled and inserting in the middle', async () => {
       function Controlled() {

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -16,6 +16,7 @@ import type { FieldRoot } from '../../field/root/FieldRoot';
 import { stopEvent } from '../../floating-ui-react/utils';
 import { useComboboxPositionerContext } from '../positioner/ComboboxPositionerContext';
 import { createChangeEventDetails } from '../../utils/createBaseUIEventDetails';
+import { useDirection } from '../../direction-provider/DirectionContext';
 
 const stateAttributesMapping: StateAttributesMapping<ComboboxInput.State> = {
   ...pressableTriggerOpenStateMapping,
@@ -43,6 +44,8 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
   const comboboxChipsContext = useComboboxChipsContext();
   const hasPositionerParent = Boolean(useComboboxPositionerContext(true));
   const store = useComboboxRootContext();
+
+  const direction = useDirection();
 
   const comboboxDisabled = useStore(store, selectors.disabled);
   const readOnly = useStore(store, selectors.readOnly);
@@ -292,17 +295,21 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
           }
 
           store.state.keyboardActiveRef.current = true;
+          const input = event.currentTarget;
+          const scrollAmount = input.scrollWidth - input.clientWidth;
 
           if (event.key === 'Home') {
             stopEvent(event);
-            event.currentTarget.setSelectionRange(0, 0);
+            input.setSelectionRange(0, 0);
+            input.scrollLeft = 0;
             return;
           }
 
           if (event.key === 'End') {
             stopEvent(event);
-            const length = event.currentTarget.value.length;
-            event.currentTarget.setSelectionRange(length, length);
+            const length = input.value.length;
+            input.setSelectionRange(length, length);
+            input.scrollLeft = direction === 'rtl' ? -scrollAmount : scrollAmount;
             return;
           }
 
@@ -328,7 +335,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
           if (
             comboboxChipsContext &&
             event.key === 'Backspace' &&
-            event.currentTarget.value === '' &&
+            input.value === '' &&
             comboboxChipsContext.highlightedChipIndex === undefined &&
             Array.isArray(selectedValue) &&
             selectedValue.length > 0

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { useStore } from '@base-ui-components/utils/store';
 import { useEventCallback } from '@base-ui-components/utils/useEventCallback';
+import { isFirefox } from '@base-ui-components/utils/detectBrowser';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useComboboxInputValueContext, useComboboxRootContext } from '../root/ComboboxRootContext';
@@ -297,19 +298,21 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
           store.state.keyboardActiveRef.current = true;
           const input = event.currentTarget;
           const scrollAmount = input.scrollWidth - input.clientWidth;
+          const isRTL = direction === 'rtl';
 
           if (event.key === 'Home') {
             stopEvent(event);
-            input.setSelectionRange(0, 0);
+            const cursor = isFirefox && isRTL ? input.value.length : 0;
+            input.setSelectionRange(cursor, cursor);
             input.scrollLeft = 0;
             return;
           }
 
           if (event.key === 'End') {
             stopEvent(event);
-            const length = input.value.length;
-            input.setSelectionRange(length, length);
-            input.scrollLeft = direction === 'rtl' ? -scrollAmount : scrollAmount;
+            const cursor = isFirefox && isRTL ? 0 : input.value.length;
+            input.setSelectionRange(cursor, cursor);
+            input.scrollLeft = isRTL ? -scrollAmount : scrollAmount;
             return;
           }
 


### PR DESCRIPTION
Firefox automatically scrolls an overflowing input, but Chrome/Safari do not 

Fixes #2882

https://codesandbox.io/p/sandbox/heuristic-platform-8r3n93