### PR TITLE
[toast] Allow `React.ReactNode` for `title`/`description` properties

### DIFF
--- a/docs/reference/generated/toast-root.json
+++ b/docs/reference/generated/toast-root.json
@@ -12,7 +12,7 @@
       "type": "Toast.Root.ToastObject<any>",
       "required": true,
       "description": "The toast to render.",
-      "detailedType": "id: string\n  ref?: RefObject<HTMLElement | null>\n  title?: string\n  type?: string\n  description?: string\n  timeout?: number\n  priority?: 'high' | 'low'\n  transitionStatus?: 'starting' | 'ending'\n  limited?: boolean\n  height?: number\n  onClose?: () => void\n  onRemove?: () => void\n  actionProps?: Omit<\n    DetailedHTMLProps<\n      ButtonHTMLAttributes<HTMLButtonElement>,\n      HTMLButtonElement\n    >,\n    'ref'\n  >\n  data?: any\n}"
+      "detailedType": "id: string\n  ref?: RefObject<HTMLElement | null>\n  title?: ReactNode\n  type?: string\n  description?: ReactNode\n  timeout?: number\n  priority?: 'high' | 'low'\n  transitionStatus?: 'starting' | 'ending'\n  limited?: boolean\n  height?: number\n  onClose?: () => void\n  onRemove?: () => void\n  actionProps?: Omit<\n    DetailedHTMLProps<\n      ButtonHTMLAttributes<HTMLButtonElement>,\n      HTMLButtonElement\n    >,\n    'ref'\n  >\n  data?: any\n}"
     },
     "className": {
       "type": "string | ((state: Toast.Root.State) => string)",

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -64,7 +64,7 @@ export interface ToastObject<Data extends object> {
   /**
    * The title of the toast.
    */
-  title?: string;
+  title?: React.ReactNode;
   /**
    * The type of the toast. Used to conditionally style the toast,
    * including conditionally rendering elements based on the type.
@@ -73,7 +73,7 @@ export interface ToastObject<Data extends object> {
   /**
    * The description of the toast.
    */
-  description?: string;
+  description?: React.ReactNode;
   /**
    * The amount of time (in ms) before the toast is auto dismissed.
    * A value of `0` will prevent the toast from being dismissed automatically.


### PR DESCRIPTION
Closes #2888; already works at runtime