### PR TITLE
Bump `chai` to latest major

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -74,7 +74,7 @@
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@types/unist": "^3.0.3",
-    "chai": "^5.3.3",
+    "chai": "^6.2.0",
     "mdast-util-mdx-jsx": "^3.2.0",
     "motion": "^12.23.22",
     "prettier": "^3.6.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -74,7 +74,7 @@
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@types/unist": "^3.0.3",
-    "chai": "^4.5.0",
+    "chai": "^5.3.3",
     "mdast-util-mdx-jsx": "^3.2.0",
     "motion": "^12.23.22",
     "prettier": "^3.6.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -67,7 +67,7 @@
     "@mui/internal-scripts": "^2.0.10",
     "@mui/internal-test-utils": "^2.0.10",
     "@tailwindcss/postcss": "4.1.13",
-    "@types/chai": "^4.3.20",
+    "@types/chai": "^5.2.2",
     "@types/gtag.js": "^0.0.20",
     "@types/hast": "^3.0.4",
     "@types/node": "^22.18.8",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -94,7 +94,7 @@
     "@mui/internal-test-utils": "^2.0.10",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@types/chai": "^4.3.20",
+    "@types/chai": "^5.2.2",
     "@types/chai-dom": "^1.11.3",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -100,7 +100,7 @@
     "@types/react-dom": "^19.1.9",
     "@types/sinon": "^17.0.4",
     "@types/use-sync-external-store": "^1.5.0",
-    "chai": "^4.5.0",
+    "chai": "^5.3.3",
     "clsx": "^2.1.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -100,7 +100,7 @@
     "@types/react-dom": "^19.1.9",
     "@types/sinon": "^17.0.4",
     "@types/use-sync-external-store": "^1.5.0",
-    "chai": "^5.3.3",
+    "chai": "^6.2.0",
     "clsx": "^2.1.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,7 +32,7 @@
     "@mui/internal-test-utils": "^2.0.9",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@types/chai": "^4.3.20",
+    "@types/chai": "^5.2.2",
     "@types/chai-dom": "^1.11.3",
     "@types/react": "^19.1.13",
     "@types/sinon": "^17.0.4",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,7 +37,7 @@
     "@types/react": "^19.1.13",
     "@types/sinon": "^17.0.4",
     "@types/use-sync-external-store": "^1.5.0",
-    "chai": "^5.3.3",
+    "chai": "^6.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "sinon": "^21.0.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,7 +37,7 @@
     "@types/react": "^19.1.13",
     "@types/sinon": "^17.0.4",
     "@types/use-sync-external-store": "^1.5.0",
-    "chai": "^4.5.0",
+    "chai": "^5.3.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "sinon": "^21.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         version: 0.0.3-canary.19(eslint@9.36.0(jiti@2.5.1))(postcss@8.5.6)(prettier@3.6.2)(stylelint@16.24.0(typescript@5.9.2))(typescript@5.9.2)
       '@mui/internal-test-utils':
         specifier: ^2.0.10
-        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@6.2.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/monorepo':
         specifier: github:mui/material-ui#v7.3.2
         version: https://codeload.github.com/mui/material-ui/tar.gz/7e308aba71a669964313244a94c1f9d4d5a5f533(@babel/core@7.28.4)(@types/express@5.0.3)(encoding@0.1.13)(rollup@4.50.1)
@@ -72,7 +72,7 @@ importers:
         version: 3.12.0
       chai-dom:
         specifier: ^1.12.1
-        version: 1.12.1(chai@5.3.3)
+        version: 1.12.1(chai@6.2.0)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -313,7 +313,7 @@ importers:
         version: 2.0.13
       '@mui/internal-test-utils':
         specifier: ^2.0.10
-        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@6.2.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tailwindcss/postcss':
         specifier: 4.1.13
         version: 4.1.13
@@ -339,8 +339,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       chai:
-        specifier: ^5.3.3
-        version: 5.3.3
+        specifier: ^6.2.0
+        version: 6.2.0
       mdast-util-mdx-jsx:
         specifier: ^3.2.0
         version: 3.2.0
@@ -456,7 +456,7 @@ importers:
     devDependencies:
       '@mui/internal-test-utils':
         specifier: ^2.0.10
-        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@6.2.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -482,8 +482,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       chai:
-        specifier: ^5.3.3
-        version: 5.3.3
+        specifier: ^6.2.0
+        version: 6.2.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -527,7 +527,7 @@ importers:
     devDependencies:
       '@mui/internal-test-utils':
         specifier: ^2.0.9
-        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@6.2.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -550,8 +550,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       chai:
-        specifier: ^5.3.3
-        version: 5.3.3
+        specifier: ^6.2.0
+        version: 6.2.0
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -597,7 +597,7 @@ importers:
         version: link:../packages/react/build
       '@mui/internal-test-utils':
         specifier: ^2.0.10
-        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@6.2.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@playwright/test':
         specifier: 1.55.1
         version: 1.55.1
@@ -623,8 +623,8 @@ importers:
         specifier: ^17.0.4
         version: 17.0.4
       chai:
-        specifier: ^5.3.3
-        version: 5.3.3
+        specifier: ^6.2.0
+        version: 6.2.0
       docs:
         specifier: workspace:^
         version: link:../docs
@@ -4958,6 +4958,10 @@ packages:
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chai@6.2.0:
+    resolution: {integrity: sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==}
     engines: {node: '>=18'}
 
   chainsaw@0.1.0:
@@ -12406,7 +12410,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mui/internal-test-utils@2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@mui/internal-test-utils@2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@6.2.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.4)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
@@ -12418,8 +12422,8 @@ snapshots:
       '@testing-library/dom': 10.4.1
       '@testing-library/react': 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      chai: 5.3.3
-      chai-dom: 1.12.1(chai@5.3.3)
+      chai: 6.2.0
+      chai-dom: 1.12.1(chai@6.2.0)
       dom-accessibility-api: 0.7.0
       format-util: 1.0.5
       fs-extra: 11.3.1
@@ -15641,9 +15645,9 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai-dom@1.12.1(chai@5.3.3):
+  chai-dom@1.12.1(chai@6.2.0):
     dependencies:
-      chai: 5.3.3
+      chai: 6.2.0
 
   chai@5.3.3:
     dependencies:
@@ -15652,6 +15656,8 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+
+  chai@6.2.0: {}
 
   chainsaw@0.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,7 +313,7 @@ importers:
         version: 2.0.13
       '@mui/internal-test-utils':
         specifier: ^2.0.10
-        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@4.5.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tailwindcss/postcss':
         specifier: 4.1.13
         version: 4.1.13
@@ -339,8 +339,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       chai:
-        specifier: ^4.5.0
-        version: 4.5.0
+        specifier: ^5.3.3
+        version: 5.3.3
       mdast-util-mdx-jsx:
         specifier: ^3.2.0
         version: 3.2.0
@@ -456,7 +456,7 @@ importers:
     devDependencies:
       '@mui/internal-test-utils':
         specifier: ^2.0.10
-        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@4.5.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -482,8 +482,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       chai:
-        specifier: ^4.5.0
-        version: 4.5.0
+        specifier: ^5.3.3
+        version: 5.3.3
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -527,7 +527,7 @@ importers:
     devDependencies:
       '@mui/internal-test-utils':
         specifier: ^2.0.9
-        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@4.5.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -550,8 +550,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       chai:
-        specifier: ^4.5.0
-        version: 4.5.0
+        specifier: ^5.3.3
+        version: 5.3.3
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -597,7 +597,7 @@ importers:
         version: link:../packages/react/build
       '@mui/internal-test-utils':
         specifier: ^2.0.10
-        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@4.5.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@playwright/test':
         specifier: 1.55.1
         version: 1.55.1
@@ -623,8 +623,8 @@ importers:
         specifier: ^17.0.4
         version: 17.0.4
       chai:
-        specifier: ^4.5.0
-        version: 4.5.0
+        specifier: ^5.3.3
+        version: 5.3.3
       docs:
         specifier: workspace:^
         version: link:../docs
@@ -4694,9 +4694,6 @@ packages:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
 
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -4959,10 +4956,6 @@ packages:
     peerDependencies:
       chai: '>= 3'
 
-  chai@4.5.0:
-    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
-    engines: {node: '>=4'}
-
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -5008,9 +5001,6 @@ packages:
 
   chardet@2.1.0:
     resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
-
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -5448,10 +5438,6 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
-
-  deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
-    engines: {node: '>=6'}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -6278,9 +6264,6 @@ packages:
   get-east-asian-width@1.3.1:
     resolution: {integrity: sha512-R1QfovbPsKmosqTnPoRFiJ7CF9MLRgb53ChvMZm+r4p76/+8yKDy17qLL2PKInORy2RkZZekuK0efYgmzTkXyQ==}
     engines: {node: '>=18'}
-
-  get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -7334,9 +7317,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
-
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -8337,9 +8317,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -12429,39 +12406,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mui/internal-test-utils@2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@4.5.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.4)
-      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
-      '@babel/register': 7.28.3(@babel/core@7.28.4)
-      '@babel/runtime': 7.28.4
-      '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@19.1.13)(react@19.1.1)
-      '@playwright/test': 1.55.1
-      '@testing-library/dom': 10.4.1
-      '@testing-library/react': 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      chai: 4.5.0
-      chai-dom: 1.12.1(chai@4.5.0)
-      dom-accessibility-api: 0.7.0
-      format-util: 1.0.5
-      fs-extra: 11.3.1
-      jsdom: 26.1.0
-      lodash: 4.17.21
-      mocha: 11.7.2
-      prop-types: 15.8.1
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-      sinon: 21.0.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/react'
-      - '@types/react-dom'
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
-
   '@mui/internal-test-utils@2.0.13(@babel/core@7.28.4)(@playwright/test@1.55.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(chai@5.3.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.4)
@@ -15426,8 +15370,6 @@ snapshots:
 
   arrify@2.0.1: {}
 
-  assertion-error@1.1.0: {}
-
   assertion-error@2.0.1: {}
 
   ast-module-types@6.0.1: {}
@@ -15699,23 +15641,9 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai-dom@1.12.1(chai@4.5.0):
-    dependencies:
-      chai: 4.5.0
-
   chai-dom@1.12.1(chai@5.3.3):
     dependencies:
       chai: 5.3.3
-
-  chai@4.5.0:
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
 
   chai@5.3.3:
     dependencies:
@@ -15758,10 +15686,6 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   chardet@2.1.0: {}
-
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
 
   check-error@2.1.1: {}
 
@@ -16193,10 +16117,6 @@ snapshots:
   dedent@1.5.3(babel-plugin-macros@3.1.0):
     optionalDependencies:
       babel-plugin-macros: 3.1.0
-
-  deep-eql@4.1.4:
-    dependencies:
-      type-detect: 4.1.0
 
   deep-eql@5.0.2: {}
 
@@ -17217,8 +17137,6 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.3.1: {}
-
-  get-func-name@2.0.2: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -18429,10 +18347,6 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
-
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
 
   loupe@3.2.1: {}
 
@@ -19867,8 +19781,6 @@ snapshots:
   path-type@6.0.0: {}
 
   pathe@2.0.3: {}
-
-  pathval@1.1.1: {}
 
   pathval@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,8 +318,8 @@ importers:
         specifier: 4.1.13
         version: 4.1.13
       '@types/chai':
-        specifier: ^4.3.20
-        version: 4.3.20
+        specifier: ^5.2.2
+        version: 5.2.2
       '@types/gtag.js':
         specifier: ^0.0.20
         version: 0.0.20
@@ -464,8 +464,8 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/chai':
-        specifier: ^4.3.20
-        version: 4.3.20
+        specifier: ^5.2.2
+        version: 5.2.2
       '@types/chai-dom':
         specifier: ^1.11.3
         version: 1.11.3
@@ -535,8 +535,8 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/chai':
-        specifier: ^4.3.20
-        version: 4.3.20
+        specifier: ^5.2.2
+        version: 5.2.2
       '@types/chai-dom':
         specifier: ^1.11.3
         version: 1.11.3
@@ -608,8 +608,8 @@ importers:
         specifier: ^6.6.4
         version: 6.8.0
       '@types/chai':
-        specifier: ^4.3.20
-        version: 4.3.20
+        specifier: ^5.2.2
+        version: 5.2.2
       '@types/chai-dom':
         specifier: ^1.11.3
         version: 1.11.3
@@ -4017,9 +4017,6 @@ packages:
 
   '@types/chai-dom@1.11.3':
     resolution: {integrity: sha512-EUEZI7uID4ewzxnU7DJXtyvykhQuwe+etJ1wwOiJyQRTH/ifMWKX+ghiXkxCUvNJ6IQDodf0JXhuP6zZcy2qXQ==}
-
-  '@types/chai@4.3.20':
-    resolution: {integrity: sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -14560,9 +14557,7 @@ snapshots:
 
   '@types/chai-dom@1.11.3':
     dependencies:
-      '@types/chai': 4.3.20
-
-  '@types/chai@4.3.20': {}
+      '@types/chai': 5.2.2
 
   '@types/chai@5.2.2':
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -20,11 +20,6 @@
       "groupName": "MUI public packages",
       "matchPackageNames": ["@mui/*", "!@mui/internal-*", "!@mui/docs"],
       "allowedVersions": "!/-dev/"
-    },
-    {
-      "groupName": "chai - incompatible versions",
-      "matchPackageNames": ["chai", "@types/chai"],
-      "allowedVersions": "< 5.0.0"
     }
   ]
 }

--- a/test/package.json
+++ b/test/package.json
@@ -15,7 +15,7 @@
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "@types/sinon": "^17.0.4",
-    "chai": "^5.3.3",
+    "chai": "^6.2.0",
     "docs": "workspace:^",
     "es-toolkit": "^1.39.10",
     "is-wsl": "^3.1.0",

--- a/test/package.json
+++ b/test/package.json
@@ -10,7 +10,7 @@
     "@playwright/test": "1.55.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.4",
-    "@types/chai": "^4.3.20",
+    "@types/chai": "^5.2.2",
     "@types/chai-dom": "^1.11.3",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",

--- a/test/package.json
+++ b/test/package.json
@@ -15,7 +15,7 @@
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "@types/sinon": "^17.0.4",
-    "chai": "^4.5.0",
+    "chai": "^5.3.3",
     "docs": "workspace:^",
     "es-toolkit": "^1.39.10",
     "is-wsl": "^3.1.0",


### PR DESCRIPTION
- Bump `chai` and `@types/chai` packages to the latest version
- Remove `renovate` group limiting these package updates