### PR TITLE
[autocomplete] Export `UseFilterOptions` type

### DIFF
--- a/packages/react/src/autocomplete/index.ts
+++ b/packages/react/src/autocomplete/index.ts
@@ -53,3 +53,8 @@ export type {
   ComboboxStatusState as AutocompleteStatusState,
 } from '../combobox/status/ComboboxStatus';
 export type { ComboboxCollectionProps as AutocompleteCollectionProps } from '../combobox/collection/ComboboxCollection';
+
+export type {
+  Filter as AutocompleteFilter,
+  UseFilterOptions as AutocompleteFilterOptions,
+} from '../combobox/root/utils/useFilter';

--- a/packages/react/src/combobox/index.ts
+++ b/packages/react/src/combobox/index.ts
@@ -23,3 +23,8 @@ export type * from './chip-remove/ComboboxChipRemove';
 export type * from './clear/ComboboxClear';
 export type * from './status/ComboboxStatus';
 export type * from './collection/ComboboxCollection';
+
+export type {
+  Filter as ComboboxFilter,
+  UseComboboxFilterOptions as ComboboxFilterOptions,
+} from '../combobox/root/utils/useFilter';

--- a/packages/react/src/combobox/root/utils/useFilter.ts
+++ b/packages/react/src/combobox/root/utils/useFilter.ts
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { createCollatorItemFilter, createSingleSelectionCollatorFilter } from './index';
 
-interface FilterOptions extends Intl.CollatorOptions {
+export interface UseFilterOptions extends Intl.CollatorOptions {
   /**
    * The locale to use for string comparison.
    * Defaults to the user's runtime locale.
@@ -18,7 +18,7 @@ export interface Filter {
 
 const filterCache = new Map<string, Filter>();
 
-function getFilter(options: FilterOptions = {}): Filter {
+function getFilter(options: UseFilterOptions = {}): Filter {
   const mergedOptions: Intl.CollatorOptions = {
     usage: 'search',
     sensitivity: 'base',
@@ -78,7 +78,7 @@ function getFilter(options: FilterOptions = {}): Filter {
  */
 export const useCoreFilter = getFilter;
 
-export type UseComboboxFilterOptions = FilterOptions & {
+export interface UseComboboxFilterOptions extends UseFilterOptions {
   /**
    * Whether the combobox is in multiple selection mode.
    * @default false
@@ -88,7 +88,7 @@ export type UseComboboxFilterOptions = FilterOptions & {
    * The current value of the combobox.
    */
   value?: any;
-};
+}
 
 /**
  * Matches items against a query using `Intl.Collator` for robust string matching.

--- a/packages/react/src/toast/createToastManager.ts
+++ b/packages/react/src/toast/createToastManager.ts
@@ -1,11 +1,6 @@
 import { generateId } from '@base-ui-components/utils/generateId';
 import { type ToastObject, useToastManager } from './useToastManager';
 
-export interface ToastManagerEvent {
-  action: 'add' | 'close' | 'update' | 'promise';
-  options: any;
-}
-
 /**
  * Creates a new toast manager.
  */
@@ -84,7 +79,7 @@ export function createToastManager(): createToastManager.ToastManager {
   };
 }
 
-export interface CreateToastManagerToastManager {
+export interface CreateToastManager {
   ' subscribe': (listener: (data: ToastManagerEvent) => void) => () => void;
   add: <Data extends object>(options: useToastManager.AddOptions<Data>) => string;
   close: (id: string) => void;
@@ -96,5 +91,10 @@ export interface CreateToastManagerToastManager {
 }
 
 export namespace createToastManager {
-  export type ToastManager = CreateToastManagerToastManager;
+  export type ToastManager = CreateToastManager;
+}
+
+export interface ToastManagerEvent {
+  action: 'add' | 'close' | 'update' | 'promise';
+  options: any;
 }

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -9,7 +9,7 @@ export function useToastManager(): useToastManager.ReturnValue {
   const context = React.useContext(ToastContext);
 
   if (!context) {
-    throw new Error('Base UI: useToast must be used within <Toast.Provider>.');
+    throw new Error('Base UI: useToastManager must be used within <Toast.Provider>.');
   }
 
   const { toasts, add, close, update, promise } = context;

--- a/test/public-types/autocomplete.tsx
+++ b/test/public-types/autocomplete.tsx
@@ -8,6 +8,8 @@ export type AutocompleteChangeEventReason = Autocomplete.Root.ChangeEventReason;
 export type AutocompleteHighlightEventDetails = Autocomplete.Root.HighlightEventDetails;
 export type AutocompleteHighlightEventReason = Autocomplete.Root.HighlightEventReason;
 
+export const { useFilter } = Autocomplete;
+
 export interface SimpleAutocompleteProps extends Omit<Autocomplete.Root.Props<string>, 'children'> {
   items: readonly string[];
 }

--- a/test/public-types/combobox.tsx
+++ b/test/public-types/combobox.tsx
@@ -11,6 +11,8 @@ export type ComboboxChangeEventReason = Combobox.Root.ChangeEventReason;
 export type ComboboxHighlightEventDetails = Combobox.Root.HighlightEventDetails;
 export type ComboboxHighlightEventReason = Combobox.Root.HighlightEventReason;
 
+export const { useFilter } = Combobox;
+
 export interface SimpleComboboxProps extends Omit<Combobox.Root.Props<string, false>, 'children'> {
   items: readonly string[];
 }

--- a/test/public-types/toast.tsx
+++ b/test/public-types/toast.tsx
@@ -18,3 +18,5 @@ export type ToastManagerPromiseOptions<
 > = Toast.useToastManager.PromiseOptions<Value, Data>;
 
 export type ToastCreateManagerReturn = ReturnType<typeof Toast.createToastManager>;
+
+export const { useToastManager, createToastManager } = Toast;


### PR DESCRIPTION
The case in #2629 needs the filter options exported too, which was missed in the main PR. Also cleans up a Toast issue.