### PR TITLE
[docs] Fix typo on popover page

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/popover/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/popover/page.mdx
@@ -159,4 +159,3 @@ Inside the `Viewport`, the content is further wrapped in `div`s with data attrib
 You can use these attributes to style the enter and exit animations.
 
 <Demo path="./demos/detached-triggers-full" />
-```


### PR DESCRIPTION
Noticed this on master:
<img width="800" alt="Screenshot 2025-10-10 at 2 29 39 PM" src="https://github.com/user-attachments/assets/7a7dfb06-0cda-4219-867d-54894f906baf" />

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
