### PR TITLE
[internal] Remove deprecated baseUrl TypeScript option

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -30,6 +30,12 @@
         "name": "next"
       }
     ],
+    "paths": {
+      "@base-ui-components/react": ["../packages/react/src"],
+      "@base-ui-components/react/*": ["../packages/react/src/*"],
+      "@base-ui-components/utils/*": ["../packages/utils/src/*"],
+      "docs/*": ["./*"]
+    },
     "strictNullChecks": true
   },
   "exclude": ["node_modules"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,6 @@
     "strict": true,
     "noEmit": true,
     "experimentalDecorators": true,
-    "baseUrl": "./",
     "allowSyntheticDefaultImports": true,
     "noErrorTruncation": false,
     "allowJs": true,


### PR DESCRIPTION
It's not 100% https://www.notion.so/mui-org/KPIs-Engineering-165cbfe7b66080c4bc5dec28d3175c09?source=copy_link#1b4cbfe7b6608067a435cb844061274f

<img width="480" height="180" alt="SCR-20251011-ukdr" src="https://github.com/user-attachments/assets/78fa1bf2-acbd-431c-81b4-94cb51ecbe11" />

Example of a fail: https://app.circleci.com/pipelines/github/mui/base-ui/15235/workflows/80dcf95f-f162-4db5-9c53-4ba13dacceae/jobs/156108.

This one seems quick-in. See https://github.com/microsoft/TypeScript/issues/62508#issuecomment-3348649259 for context.