### PR TITLE
[combobox] Fix Field control ref when input is inside popup

### DIFF
--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -8,6 +8,7 @@ import { useMergedRefs } from '@base-ui-components/utils/useMergedRefs';
 import { visuallyHidden } from '@base-ui-components/utils/visuallyHidden';
 import { useRefWithInit } from '@base-ui-components/utils/useRefWithInit';
 import { Store, useStore } from '@base-ui-components/utils/store';
+import { useLatestRef } from '@base-ui-components/utils/useLatestRef';
 import {
   ElementProps,
   useDismiss,
@@ -384,6 +385,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   const queryRef = React.useRef(query);
   const selectedValueRef = React.useRef(selectedValue);
   const inputValueRef = React.useRef(inputValue);
+  const triggerRef = useLatestRef(triggerElement);
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
   const {
@@ -422,7 +424,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     id,
     commitValidation,
     value: formValue,
-    controlRef: inputRef,
+    controlRef: inputInsidePopup ? triggerRef : inputRef,
     name,
     getValue: () => formValue,
   });

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -2845,6 +2845,61 @@ describe('<Combobox.Root />', () => {
       expect(error).to.have.text('required');
     });
 
+    it('focuses trigger and surfaces errors when input is inside popup', async () => {
+      let submittedCalls = 0;
+
+      const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+        event.preventDefault();
+        submittedCalls += 1;
+      };
+
+      const { user } = await render(
+        <Form onSubmit={handleSubmit}>
+          <Field.Root name="combobox">
+            <Combobox.Root required>
+              <Combobox.Trigger data-testid="trigger">
+                <Combobox.Value />
+              </Combobox.Trigger>
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.Input data-testid="input" />
+                    <Combobox.List>
+                      <Combobox.Item value="a">a</Combobox.Item>
+                      <Combobox.Item value="b">b</Combobox.Item>
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+            <Field.Error match="valueMissing" data-testid="error">
+              required
+            </Field.Error>
+          </Field.Root>
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      expect(screen.queryByTestId('error')).to.equal(null);
+
+      await user.click(screen.getByText('Submit'));
+
+      expect(submittedCalls).to.equal(0);
+
+      const trigger = screen.getByTestId('trigger');
+
+      await waitFor(() => expect(trigger).toHaveFocus());
+      expect(trigger).to.have.attribute('data-invalid', '');
+
+      const error = screen.getByTestId('error');
+      expect(error).to.have.text('required');
+
+      await user.click(trigger);
+
+      const input = await screen.findByTestId('input');
+      expect(input).to.have.attribute('data-invalid', '');
+    });
+
     it('clears errors on change', async () => {
       function App() {
         const [errors, setErrors] = React.useState<Record<string, string | string[]>>({

--- a/packages/react/src/form/Form.tsx
+++ b/packages/react/src/form/Form.tsx
@@ -23,7 +23,10 @@ export const Form = React.forwardRef(function Form(
   });
   const submittedRef = React.useRef(false);
 
-  const focusControl = useEventCallback((control: HTMLElement) => {
+  const focusControl = useEventCallback((control: HTMLElement | null) => {
+    if (!control) {
+      return;
+    }
     control.focus();
     if (control.tagName === 'INPUT') {
       (control as HTMLInputElement).select();

--- a/packages/react/src/form/FormContext.ts
+++ b/packages/react/src/form/FormContext.ts
@@ -15,7 +15,7 @@ export interface FormContext {
         name: string | undefined;
         validate: () => void;
         validityData: FieldValidityData;
-        controlRef: React.RefObject<HTMLElement>;
+        controlRef: React.RefObject<HTMLElement | null>;
         getValueRef: React.RefObject<(() => unknown) | undefined>;
       }
     >;


### PR DESCRIPTION
Fixes #2968

When the input is inside the popup, the field control is the trigger, not the input. Furthermore, the ref type was lying about the control always being defined as an element in Form, so updated it to safeguard from errors. 