### PR TITLE
[docs][slider] Fix a11y issues in demos

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/slider/demos/edge-alignment/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/slider/demos/edge-alignment/css-modules/index.tsx
@@ -8,7 +8,7 @@ export default function EdgeAlignedThumb() {
       <Slider.Control className={styles.Control}>
         <Slider.Track className={styles.Track}>
           <Slider.Indicator className={styles.Indicator} />
-          <Slider.Thumb className={styles.Thumb} />
+          <Slider.Thumb getAriaLabel={() => 'edge-aligned-thumb'} className={styles.Thumb} />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(public)/(content)/react/components/slider/demos/edge-alignment/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/slider/demos/edge-alignment/tailwind/index.tsx
@@ -7,7 +7,10 @@ export default function EdgeAlignedThumb() {
       <Slider.Control className="flex w-56 touch-none items-center py-3 select-none">
         <Slider.Track className="h-1 w-full rounded bg-gray-200 shadow-[inset_0_0_0_1px] shadow-gray-200 select-none">
           <Slider.Indicator className="rounded bg-gray-700 select-none" />
-          <Slider.Thumb className="size-4 rounded-full bg-white outline outline-1 outline-gray-300 select-none has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800" />
+          <Slider.Thumb
+            getAriaLabel={() => 'edge-aligned-thumb'}
+            className="size-4 rounded-full bg-white outline outline-1 outline-gray-300 select-none has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800"
+          />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(public)/(content)/react/components/slider/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/slider/demos/hero/css-modules/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleSlider() {
       <Slider.Control className={styles.Control}>
         <Slider.Track className={styles.Track}>
           <Slider.Indicator className={styles.Indicator} />
-          <Slider.Thumb className={styles.Thumb} />
+          <Slider.Thumb getAriaLabel={() => 'slider-thumb'} className={styles.Thumb} />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(public)/(content)/react/components/slider/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/slider/demos/hero/tailwind/index.tsx
@@ -7,7 +7,10 @@ export default function ExampleSlider() {
       <Slider.Control className="flex w-56 touch-none items-center py-3 select-none">
         <Slider.Track className="h-1 w-full rounded bg-gray-200 shadow-[inset_0_0_0_1px] shadow-gray-200 select-none">
           <Slider.Indicator className="rounded bg-gray-700 select-none" />
-          <Slider.Thumb className="size-4 rounded-full bg-white outline outline-1 outline-gray-300 select-none has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800" />
+          <Slider.Thumb
+            getAriaLabel={() => 'slider-thumb'}
+            className="size-4 rounded-full bg-white outline outline-1 outline-gray-300 select-none has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800"
+          />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(public)/(content)/react/components/slider/demos/range-slider/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/slider/demos/range-slider/css-modules/index.tsx
@@ -8,8 +8,16 @@ export default function RangeSlider() {
       <Slider.Control className={styles.Control}>
         <Slider.Track className={styles.Track}>
           <Slider.Indicator className={styles.Indicator} />
-          <Slider.Thumb index={0} className={styles.Thumb} />
-          <Slider.Thumb index={1} className={styles.Thumb} />
+          <Slider.Thumb
+            getAriaLabel={(index) => `range-slider-thumb-${index}`}
+            index={0}
+            className={styles.Thumb}
+          />
+          <Slider.Thumb
+            getAriaLabel={(index) => `range-slider-thumb-${index}`}
+            index={1}
+            className={styles.Thumb}
+          />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(public)/(content)/react/components/slider/demos/range-slider/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/slider/demos/range-slider/tailwind/index.tsx
@@ -9,10 +9,12 @@ export default function RangeSlider() {
           <Slider.Indicator className="rounded bg-gray-700 select-none" />
           <Slider.Thumb
             index={0}
+            aria-label="range-slider"
             className="size-4 rounded-full bg-white outline outline-1 outline-gray-300 select-none has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800"
           />
           <Slider.Thumb
             index={1}
+            aria-label="range-slider"
             className="size-4 rounded-full bg-white outline outline-1 outline-gray-300 select-none has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800"
           />
         </Slider.Track>


### PR DESCRIPTION
Closes #2545

Preview: https://deploy-preview-2988--base-ui.netlify.app/react/components/slider

### Before
<img width="941" height="463" alt="image" src="https://github.com/user-attachments/assets/680adbb1-c797-43af-8a91-726b582eab7b" />


### After
<img width="878" height="427" alt="image" src="https://github.com/user-attachments/assets/702cdbce-5b54-483b-9954-68aa8cf6ed47" />
