### PR TITLE
[docs] Add useFilter API to Autocomplete docs

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/autocomplete/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/autocomplete/page.mdx
@@ -64,6 +64,44 @@ import { Autocomplete } from '@base-ui-components/react/autocomplete';
   parts="Input, Trigger, Icon, Clear, List, Portal, Backdrop, Positioner, Popup, Arrow, Status, Empty, Collection, Row, Item, Group, GroupLabel, Separator"
 />
 
+## useFilter
+
+Matches items against a query using `Intl.Collator` for robust string matching.
+This hook is used when externally filtering items.
+
+### Input parameters
+
+Accepts all `Intl.CollatorOptions`, plus the following option:
+
+<PropsReferenceTable
+  data={{
+    locale: {
+      type: 'Intl.LocalesArgument',
+      description: 'The locale to use for string comparison.',
+    },
+  }}
+/>
+
+### Return value
+
+<PropsReferenceTable
+  type="return"
+  data={{
+    contains: {
+      type: '(itemValue: any, query: string) => boolean',
+      description: 'Returns whether the item matches the query anywhere.',
+    },
+    startsWith: {
+      type: '(itemValue: any, query: string) => boolean',
+      description: 'Returns whether the item starts with the query.',
+    },
+    endsWith: {
+      type: '(itemValue: any, query: string) => boolean',
+      description: 'Returns whether the item ends with the query.',
+    },
+  }}
+/>
+
 ## TypeScript inference
 
 Autocomplete infers the item type from the `items` prop passed to `<Autocomplete.Root>`.


### PR DESCRIPTION
Resolves comment https://github.com/mui/base-ui/issues/2933#issuecomment-3386184122

Should we also add a demo for non-matching list items like shown in the codesandbox in this comment: https://github.com/mui/base-ui/issues/2933#issuecomment-3380166752? 
