### PR TITLE
[dialog] Improve `onOpenChange` prop description

### DIFF
--- a/docs/reference/generated/alert-dialog-root.json
+++ b/docs/reference/generated/alert-dialog-root.json
@@ -15,7 +15,7 @@
     },
     "onOpenChange": {
       "type": "((open: boolean, eventDetails: AlertDialog.Root.ChangeEventDetails) => void)",
-      "description": "Event handler called when the dialog's open state changes internally.\nOnly fires in uncontrolled mode (when using `defaultOpen`).",
+      "description": "Event handler called when the dialog's open state changes internally.\nOnly fires in uncontrolled mode (when the `open` prop is not provided).",
       "detailedType": "| ((\n    open: boolean,\n    eventDetails: AlertDialog.Root.ChangeEventDetails,\n  ) => void)\n| undefined"
     },
     "actionsRef": {

--- a/docs/reference/generated/dialog-root.json
+++ b/docs/reference/generated/dialog-root.json
@@ -15,7 +15,7 @@
     },
     "onOpenChange": {
       "type": "((open: boolean, eventDetails: Dialog.Root.ChangeEventDetails) => void)",
-      "description": "Event handler called when the dialog's open state changes internally.\nOnly fires in uncontrolled mode (when using `defaultOpen`).",
+      "description": "Event handler called when the dialog's open state changes internally.\nOnly fires in uncontrolled mode (when the `open` prop is not provided).",
       "detailedType": "| ((\n    open: boolean,\n    eventDetails: Dialog.Root.ChangeEventDetails,\n  ) => void)\n| undefined"
     },
     "actionsRef": {

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.tsx
@@ -69,7 +69,7 @@ export interface AlertDialogRootProps
   extends Omit<DialogRoot.Props, 'modal' | 'dismissible' | 'onOpenChange' | 'actionsRef'> {
   /**
    * Event handler called when the dialog's open state changes internally.
-   * Only fires in uncontrolled mode (when using `defaultOpen`).
+   * Only fires in uncontrolled mode (when the `open` prop is not provided).
    */
   onOpenChange?: (open: boolean, eventDetails: AlertDialogRoot.ChangeEventDetails) => void;
   /**

--- a/packages/react/src/dialog/root/DialogRoot.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.tsx
@@ -89,7 +89,7 @@ export interface DialogRootProps {
   modal?: boolean | 'trap-focus';
   /**
    * Event handler called when the dialog's open state changes internally.
-   * Only fires in uncontrolled mode (when using `defaultOpen`).
+   * Only fires in uncontrolled mode (when the `open` prop is not provided).
    */
   onOpenChange?: (open: boolean, eventDetails: DialogRoot.ChangeEventDetails) => void;
   /**


### PR DESCRIPTION
related to https://github.com/mui/base-ui/issues/3007

The current description of `onOpenChange` doesn’t clearly specify that it triggers only in `uncontrolled mode`. Updated the description to explicitly mention that it runs only in `uncontrolled mode`.