### PR TITLE
[docs] Improve `style` prop type

### DIFF
--- a/docs/src/components/ReferenceTable/PropsReferenceAccordion.tsx
+++ b/docs/src/components/ReferenceTable/PropsReferenceAccordion.tsx
@@ -56,6 +56,10 @@ function getShortPropType(name: string, type: string | undefined) {
     return { type: 'string | function', detailedType: true };
   }
 
+  if (name === 'style') {
+    return { type: 'React.CSSProperties | function', detailedType: true };
+  }
+
   if (name === 'render') {
     return { type: 'ReactElement | function', detailedType: true };
   }


### PR DESCRIPTION
Improve `style` prop to show `React.CSSProperties | function` instead of `Union`.

Should we shorthand it to only `CSSProperties`, like with other `React.` items?


### Before
https://master--base-ui.netlify.app/react/components/autocomplete#AutocompleteInput-style

<img width="1069" height="412" alt="Screenshot 2025-10-23 at 17 47 26" src="https://github.com/user-attachments/assets/e8cddf36-a122-4b20-b1a8-658b91671ede" />

### After
https://deploy-preview-3046--base-ui.netlify.app/react/components/autocomplete#AutocompleteInput-style

<img width="1066" height="351" alt="Screenshot 2025-10-23 at 17 47 46" src="https://github.com/user-attachments/assets/f02b49fd-e4d4-40b4-8692-61c28a29ec19" />
