### PR TITLE
[internal] Update the doc to use internal-code-infra to change React version

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -184,7 +184,7 @@ Alternatively, you might want to open `http://localhost:5173` (while `pnpm test:
 
 ### Testing multiple versions of React
 
-You can check integration of different versions of React (for example different [release channels](https://react.dev/community/versioning-policy) or PRs to React) by running `pnpm dlx @mui/internal-code-infra set-version-overrides --pkg react@<version>`.
+You can check integration of different versions of React (for example different [release channels](https://react.dev/community/versioning-policy) or PRs to React) by running `pnpm dlx @mui/internal-code-infra@canary set-version-overrides --pkg react@<version>`.
 
 Possible values for `version`:
 


### PR DESCRIPTION
Since #3020 removed `useReactVersion` script, this PR updates the doc to use `internal-code-infra` to change React version.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
