### PR TITLE
[accordion][collapsible] Add data-hidden attribute to collapsible and accordion when they are not open

### DIFF
--- a/docs/reference/generated/accordion-panel.json
+++ b/docs/reference/generated/accordion-panel.json
@@ -39,6 +39,9 @@
     "data-disabled": {
       "description": "Present when the accordion item is disabled."
     },
+    "data-hidden": {
+      "description": "Present when the panel is hidden."
+    },
     "data-index": {
       "description": "Indicates the index of the accordion item.",
       "type": "number"

--- a/docs/reference/generated/collapsible-panel.json
+++ b/docs/reference/generated/collapsible-panel.json
@@ -36,6 +36,9 @@
     "data-closed": {
       "description": "Present when the collapsible panel is closed."
     },
+    "data-hidden": {
+      "description": "Present when the panel is hidden."
+    },
     "data-starting-style": {
       "description": "Present when the panel is animating in."
     },

--- a/packages/react/src/accordion/panel/AccordionPanel.tsx
+++ b/packages/react/src/accordion/panel/AccordionPanel.tsx
@@ -132,8 +132,9 @@ export const AccordionPanel = React.forwardRef(function AccordionPanel(
     () => ({
       ...state,
       transitionStatus,
+      hidden: !open,
     }),
-    [state, transitionStatus],
+    [state, transitionStatus, open],
   );
 
   const element = useRenderElement('div', componentProps, {

--- a/packages/react/src/accordion/panel/AccordionPanel.tsx
+++ b/packages/react/src/accordion/panel/AccordionPanel.tsx
@@ -14,6 +14,23 @@ import { AccordionPanelCssVars } from './AccordionPanelCssVars';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useRenderElement } from '../../utils/useRenderElement';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
+import type { StateAttributesMapping } from '../../utils/getStateAttributesProps';
+import { AccordionPanelDataAttributes } from './AccordionPanelDataAttributes';
+
+const stateAttributesMapping: StateAttributesMapping<AccordionPanel.State> = {
+  ...accordionStateAttributesMapping,
+  open: (open) => {
+    const hidden = !open;
+    const itemMapping = accordionStateAttributesMapping.open?.(open) ?? {};
+    if (hidden) {
+      return {
+        ...itemMapping,
+        [AccordionPanelDataAttributes.hidden]: '',
+      };
+    }
+    return itemMapping;
+  },
+};
 
 /**
  * A collapsible panel with the accordion item contents.
@@ -132,9 +149,8 @@ export const AccordionPanel = React.forwardRef(function AccordionPanel(
     () => ({
       ...state,
       transitionStatus,
-      hidden: !open,
     }),
-    [state, transitionStatus, open],
+    [state, transitionStatus],
   );
 
   const element = useRenderElement('div', componentProps, {
@@ -154,7 +170,7 @@ export const AccordionPanel = React.forwardRef(function AccordionPanel(
       },
       elementProps,
     ],
-    stateAttributesMapping: accordionStateAttributesMapping,
+    stateAttributesMapping,
   });
 
   const shouldRender = keepMounted || hiddenUntilFound || (!keepMounted && mounted);

--- a/packages/react/src/accordion/panel/AccordionPanelDataAttributes.ts
+++ b/packages/react/src/accordion/panel/AccordionPanelDataAttributes.ts
@@ -26,4 +26,8 @@ export enum AccordionPanelDataAttributes {
    * Present when the panel is animating out.
    */
   endingStyle = TransitionStatusDataAttributes.endingStyle,
+  /**
+   * Present when the panel is hidden.
+   */
+  hidden = 'data-hidden',
 }

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
@@ -124,9 +124,10 @@ export const CollapsiblePanel = React.forwardRef(function CollapsiblePanel(
   const panelState: CollapsiblePanel.State = React.useMemo(
     () => ({
       ...state,
+      hidden: !open,
       transitionStatus,
     }),
-    [state, transitionStatus],
+    [state, transitionStatus, open],
   );
 
   const element = useRenderElement('div', componentProps, {
@@ -158,6 +159,7 @@ export const CollapsiblePanel = React.forwardRef(function CollapsiblePanel(
 
 export interface CollapsiblePanelState extends CollapsibleRoot.State {
   transitionStatus: TransitionStatus;
+  hidden: boolean;
 }
 
 export interface CollapsiblePanelProps extends BaseUIComponentProps<'div', CollapsiblePanel.State> {

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
@@ -6,12 +6,18 @@ import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useCollapsibleRootContext } from '../root/CollapsibleRootContext';
 import type { CollapsibleRoot } from '../root/CollapsibleRoot';
-import { collapsibleStateAttributesMapping } from '../root/stateAttributesMapping';
+import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
+import { panelOpenStateMapping } from '../../utils/collapsibleOpenStateMapping';
 import { useCollapsiblePanel } from './useCollapsiblePanel';
 import { CollapsiblePanelCssVars } from './CollapsiblePanelCssVars';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
+import type { StateAttributesMapping } from '../../utils/getStateAttributesProps';
 
+const stateAttributesMapping: StateAttributesMapping<CollapsiblePanel.State> = {
+  ...panelOpenStateMapping,
+  ...transitionStatusMapping,
+};
 /**
  * A panel with the collapsible contents.
  * Renders a `<div>` element.
@@ -124,10 +130,9 @@ export const CollapsiblePanel = React.forwardRef(function CollapsiblePanel(
   const panelState: CollapsiblePanel.State = React.useMemo(
     () => ({
       ...state,
-      hidden: !open,
       transitionStatus,
     }),
-    [state, transitionStatus, open],
+    [state, transitionStatus],
   );
 
   const element = useRenderElement('div', componentProps, {
@@ -145,7 +150,7 @@ export const CollapsiblePanel = React.forwardRef(function CollapsiblePanel(
       },
       elementProps,
     ],
-    stateAttributesMapping: collapsibleStateAttributesMapping,
+    stateAttributesMapping,
   });
 
   const shouldRender = keepMounted || hiddenUntilFound || (!keepMounted && mounted);
@@ -159,7 +164,6 @@ export const CollapsiblePanel = React.forwardRef(function CollapsiblePanel(
 
 export interface CollapsiblePanelState extends CollapsibleRoot.State {
   transitionStatus: TransitionStatus;
-  hidden: boolean;
 }
 
 export interface CollapsiblePanelProps extends BaseUIComponentProps<'div', CollapsiblePanel.State> {

--- a/packages/react/src/collapsible/panel/CollapsiblePanelDataAttributes.ts
+++ b/packages/react/src/collapsible/panel/CollapsiblePanelDataAttributes.ts
@@ -17,4 +17,8 @@ export enum CollapsiblePanelDataAttributes {
    * Present when the panel is animating out.
    */
   endingStyle = TransitionStatusDataAttributes.endingStyle,
+  /**
+   * Present when the panel is hidden.
+   */
+  hidden = 'data-hidden'
 }

--- a/packages/react/src/utils/collapsibleOpenStateMapping.ts
+++ b/packages/react/src/utils/collapsibleOpenStateMapping.ts
@@ -33,3 +33,21 @@ export const collapsibleOpenStateMapping = {
 } satisfies StateAttributesMapping<{
   open: boolean;
 }>;
+
+export const panelOpenStateMapping = {
+  open: (open) => {
+    const panelHidden = !open;
+    const collapsibleStateMapping = collapsibleOpenStateMapping.open(open);
+
+    if (panelHidden) {
+      return {
+        ...collapsibleStateMapping,
+        [CollapsiblePanelDataAttributes.hidden]: '',
+      };
+    }
+
+    return collapsibleStateMapping;
+  },
+} satisfies StateAttributesMapping<{
+  open: boolean;
+}>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Adds a data-hidden attribute to collapsible and accordion when they are not open to match the behavior in tabs (which sets this attribute). 

Attached is a screenshot from an accordion component where data-hidden is now applied!

<img width="428" height="187" alt="image" src="https://github.com/user-attachments/assets/3c34745a-e82f-40c9-9e93-941599012f05" />
