### PR TITLE
[popover] Update the handle API

### DIFF
--- a/docs/reference/generated/popover-root.json
+++ b/docs/reference/generated/popover-root.json
@@ -29,7 +29,7 @@
       "detailedType": "string | null | undefined"
     },
     "handle": {
-      "type": "PopoverStore<Payload>",
+      "type": "PopoverHandle<Payload>",
       "description": "A handle to associate the popover with a trigger.\nIf specified, allows external triggers to control the popover's open state.",
       "detailedType": "{} | undefined"
     },

--- a/docs/reference/generated/popover-trigger.json
+++ b/docs/reference/generated/popover-trigger.json
@@ -3,7 +3,7 @@
   "description": "A button that opens the popover.\nRenders a `<button>` element.",
   "props": {
     "handle": {
-      "type": "PopoverStore<Payload>",
+      "type": "PopoverHandle<Payload>",
       "description": "A handle to associate the trigger with a popover.",
       "detailedType": "{} | undefined"
     },

--- a/docs/src/app/(private)/experiments/popover/popovers.tsx
+++ b/docs/src/app/(private)/experiments/popover/popovers.tsx
@@ -177,6 +177,15 @@ export default function Popovers() {
         >
           Open externally (2nd trigger)
         </button>
+        <button
+          type="button"
+          className={styles.Button}
+          onClick={() => {
+            popover2.open('detached-second-trigger');
+          }}
+        >
+          Open via handle (2nd trigger)
+        </button>
       </div>
     </div>
   );
@@ -210,12 +219,12 @@ function StyledPopover(props: StyledPopoverProps<number>) {
 
   return (
     <Popover.Root handle={handle} open={open} onOpenChange={onOpenChange} triggerId={triggerId}>
-      {({ payload }) => payload !== undefined && renderPopoverContent(payload, settings)}
+      {({ payload }) => renderPopoverContent(payload, settings)}
     </Popover.Root>
   );
 }
 
-function renderPopoverContent(contentIndex: number, settings: Settings) {
+function renderPopoverContent(contentIndex: number | undefined, settings: Settings) {
   return (
     <Popover.Portal keepMounted={settings.keepMounted}>
       <Popover.Positioner sideOffset={8} className={demoStyles.Positioner} side={settings.side}>
@@ -224,14 +233,20 @@ function renderPopoverContent(contentIndex: number, settings: Settings) {
             <ArrowSvg />
           </Popover.Arrow>
           <Popover.Viewport className={demoStyles.Viewport}>
-            <Popover.Title className={demoStyles.Title}>Popover {contentIndex}</Popover.Title>
-            <div>
-              <div className={styles.PopoverSection}>{contents[contentIndex]}</div>
+            {contentIndex !== undefined ? (
+              <React.Fragment>
+                <Popover.Title className={demoStyles.Title}>Popover {contentIndex}</Popover.Title>
+                <div>
+                  <div className={styles.PopoverSection}>{contents[contentIndex]}</div>
 
-              <div className={styles.PopoverSection}>
-                <StatefulComponent key={contentIndex} />
-              </div>
-            </div>
+                  <div className={styles.PopoverSection}>
+                    <StatefulComponent key={contentIndex} />
+                  </div>
+                </div>
+              </React.Fragment>
+            ) : (
+              <p className={styles.PopoverSection}>No content for this trigger.</p>
+            )}
           </Popover.Viewport>
         </Popover.Popup>
       </Popover.Positioner>

--- a/docs/src/error-codes.json
+++ b/docs/src/error-codes.json
@@ -72,10 +72,11 @@
   "71": "Base UI: TooltipPositionerContext is missing. TooltipPositioner parts must be placed within <Tooltip.Positioner>.",
   "72": "Base UI: TooltipRootContext is missing. Tooltip parts must be placed within <Tooltip.Root>.",
   "73": "Base UI: useToastManager must be used within <Toast.Provider>.",
-  "74": "Base UI: PopoverTrigger must be either used within a PopoverRoot component or have the `handle` prop set.",
+  "74": "Base UI: <Popover.Trigger> must be either used within a <Popover.Root> component or provided with a handle.",
   "75": "Base UI: PopoverTrigger must have an `id` prop specified.",
   "76": "Base UI: selectors are required to call useState.",
   "77": "Base UI: Trigger must have an `id` prop specified.",
   "78": "Base UI: <AlertDialog.Trigger> must be used within <AlertDialog.Root> or provided with a handle.",
-  "79": "Base UI: <Dialog.Trigger> must be used within <Dialog.Root> or provided with a handle."
+  "79": "Base UI: <Dialog.Trigger> must be used within <Dialog.Root> or provided with a handle.",
+  "80": "Base UI: PopoverHandle.open: No trigger found with id \"%s\"."
 }

--- a/packages/react/src/popover/index.parts.ts
+++ b/packages/react/src/popover/index.parts.ts
@@ -9,4 +9,4 @@ export { PopoverTitle as Title } from './title/PopoverTitle';
 export { PopoverDescription as Description } from './description/PopoverDescription';
 export { PopoverClose as Close } from './close/PopoverClose';
 export { PopoverViewport as Viewport } from './viewport/PopoverViewport';
-export { createPopoverHandle as createHandle } from './PopoverStore';
+export { createPopoverHandle as createHandle } from './store/PopoverHandle';

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -1586,4 +1586,85 @@ describe('<Popover.Root />', () => {
       expect(screen.getByTestId('popup').textContent).to.equal('2');
     });
   });
+
+  describe.skipIf(isJSDOM)('imperative actions on the handle', () => {
+    it('opens and closes the dialog', async () => {
+      const popover = Popover.createHandle();
+      await render(
+        <div>
+          <Popover.Trigger handle={popover} id="trigger">
+            Trigger
+          </Popover.Trigger>
+          <Popover.Root handle={popover}>
+            <Popover.Portal>
+              <Popover.Positioner>
+                <Popover.Popup data-testid="content">Content</Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          </Popover.Root>
+        </div>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      expect(screen.queryByRole('dialog')).to.equal(null);
+
+      await act(() => popover.open('trigger'));
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.to.equal(null);
+      });
+
+      expect(screen.getByTestId('content').textContent).to.equal('Content');
+      expect(trigger).to.have.attribute('aria-expanded', 'true');
+
+      await act(() => popover.close());
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).to.equal(null);
+      });
+
+      expect(trigger).to.have.attribute('aria-expanded', 'false');
+    });
+
+    it('sets the payload assosiated with the trigger', async () => {
+      const popover = Popover.createHandle<number>();
+      await render(
+        <div>
+          <Popover.Trigger handle={popover} id="trigger1" payload={1}>
+            Trigger 1
+          </Popover.Trigger>
+          <Popover.Trigger handle={popover} id="trigger2" payload={2}>
+            Trigger 2
+          </Popover.Trigger>
+          <Popover.Root handle={popover}>
+            {({ payload }: { payload: number | undefined }) => (
+              <Popover.Portal>
+                <Popover.Positioner>
+                  <Popover.Popup data-testid="content">{payload}</Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            )}
+          </Popover.Root>
+        </div>,
+      );
+
+      const trigger1 = screen.getByRole('button', { name: 'Trigger 1' });
+      const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
+      expect(screen.queryByRole('dialog')).to.equal(null);
+
+      await act(() => popover.open('trigger2'));
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.to.equal(null);
+      });
+
+      expect(screen.getByTestId('content').textContent).to.equal('2');
+      expect(trigger2).to.have.attribute('aria-expanded', 'true');
+      expect(trigger1).not.to.have.attribute('aria-expanded', 'true');
+
+      await act(() => popover.close());
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).to.equal(null);
+      });
+
+      expect(trigger2).to.have.attribute('aria-expanded', 'false');
+    });
+  });
 });

--- a/packages/react/src/popover/root/PopoverRoot.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.tsx
@@ -18,7 +18,8 @@ import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { PATIENT_CLICK_THRESHOLD } from '../../utils/constants';
 import { useScrollLock } from '../../utils/useScrollLock';
 import { PopoverRootContext, usePopoverRootContext } from './PopoverRootContext';
-import { PopoverStore } from '../PopoverStore';
+import { PopoverStore } from '../store/PopoverStore';
+import { PopoverHandle } from '../store/PopoverHandle';
 import {
   createChangeEventDetails,
   type BaseUIChangeEventDetails,
@@ -44,7 +45,7 @@ function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Pay
   let floatingEvents: ReturnType<typeof useFloatingRootContext>['events'];
   const store = useRefWithInit(() => {
     return (
-      handle ||
+      handle?.store ??
       new PopoverStore<Payload>({
         open: openProp ?? defaultOpenProp,
         modal,
@@ -347,7 +348,7 @@ export interface PopoverRootProps<Payload = unknown> {
    * A handle to associate the popover with a trigger.
    * If specified, allows external triggers to control the popover's open state.
    */
-  handle?: PopoverStore<Payload>;
+  handle?: PopoverHandle<Payload>;
   /**
    * The content of the popover.
    * This can be a regular React node or a render function that receives the `payload` of the active trigger.

--- a/packages/react/src/popover/root/PopoverRootContext.ts
+++ b/packages/react/src/popover/root/PopoverRootContext.ts
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import type { PopoverStore } from '../PopoverStore';
+import type { PopoverStore } from '../store/PopoverStore';
 
 export interface PopoverRootContext<Payload = unknown> {
   store: PopoverStore<Payload>;

--- a/packages/react/src/popover/store/PopoverHandle.ts
+++ b/packages/react/src/popover/store/PopoverHandle.ts
@@ -1,0 +1,56 @@
+import { createChangeEventDetails } from '../../utils/createBaseUIEventDetails';
+import { PopoverStore } from './PopoverStore';
+
+export class PopoverHandle<Payload> {
+  /**
+   * Internal store holding the popover's state.
+   * @internal
+   */
+  public readonly store: PopoverStore<Payload>;
+
+  constructor() {
+    this.store = new PopoverStore<Payload>();
+  }
+
+  /**
+   * Opens the popover and associates it with the trigger with the given id.
+   * The trigger must be a Popover.Trigger component with this handle passed as a prop.
+   *
+   * @param triggerId ID of the trigger to associate with the popover.
+   */
+  open(triggerId: string) {
+    const triggerElement = triggerId
+      ? (this.store.state.triggers.get(triggerId) ?? undefined)
+      : undefined;
+
+    if (process.env.NODE_ENV !== 'production' && triggerId && !triggerElement) {
+      throw new Error(`Base UI: PopoverHandle.open: No trigger found with id "${triggerId}".`);
+    }
+
+    this.store.setOpen(
+      true,
+      createChangeEventDetails('imperative-action', undefined, triggerElement),
+    );
+  }
+
+  /**
+   * Closes the popover.
+   */
+  close() {
+    this.store.setOpen(false, createChangeEventDetails('imperative-action', undefined, undefined));
+  }
+
+  /**
+   * Indicates whether the popover is currently open.
+   */
+  get isOpen() {
+    return this.store.state.open;
+  }
+}
+
+/**
+ * Creates a new handle to connect a Popover.Root with detached Popover.Trigger components.
+ */
+export function createPopoverHandle<Payload>(): PopoverHandle<Payload> {
+  return new PopoverHandle<Payload>();
+}

--- a/packages/react/src/popover/store/PopoverHandle.ts
+++ b/packages/react/src/popover/store/PopoverHandle.ts
@@ -23,7 +23,7 @@ export class PopoverHandle<Payload> {
       ? (this.store.state.triggers.get(triggerId) ?? undefined)
       : undefined;
 
-    if (process.env.NODE_ENV !== 'production' && triggerId && !triggerElement) {
+    if (triggerId && !triggerElement) {
       throw new Error(`Base UI: PopoverHandle.open: No trigger found with id "${triggerId}".`);
     }
 

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { ReactStore, createSelector } from '@base-ui-components/utils/store';
 import { type InteractionType } from '@base-ui-components/utils/useEnhancedClickHandler';
 import { EMPTY_OBJECT } from '@base-ui-components/utils/empty';
-import { type FloatingRootContext } from '../floating-ui-react';
-import { type TransitionStatus } from '../utils/useTransitionStatus';
-import { type HTMLProps } from '../utils/types';
-import { getEmptyContext } from '../floating-ui-react/hooks/useFloatingRootContext';
-import { PopoverRoot } from './root/PopoverRoot';
-import { PopupTriggerMap } from '../utils/popupStoreUtils';
+import { type FloatingRootContext } from '../../floating-ui-react';
+import { type TransitionStatus } from '../../utils/useTransitionStatus';
+import { type HTMLProps } from '../../utils/types';
+import { getEmptyContext } from '../../floating-ui-react/hooks/useFloatingRootContext';
+import { PopoverRoot } from './../root/PopoverRoot';
+import { PopupTriggerMap } from '../../utils/popupStoreUtils';
 
 export type State<Payload> = {
   open: boolean;
@@ -125,10 +125,6 @@ export class PopoverStore<Payload> extends ReactStore<State<Payload>, Context, S
   ) {
     this.state.floatingRootContext.events.emit('setOpen', { open, eventDetails });
   }
-}
-
-export function createPopoverHandle<Payload>(): PopoverStore<Payload> {
-  return new PopoverStore<Payload>();
 }
 
 type Selectors = typeof selectors;

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -1,13 +1,19 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { ReactStore, createSelector } from '@base-ui-components/utils/store';
+import { Timeout } from '@base-ui-components/utils/useTimeout';
+import { useRefWithInit } from '@base-ui-components/utils/useRefWithInit';
+import { useOnMount } from '@base-ui-components/utils/useOnMount';
 import { type InteractionType } from '@base-ui-components/utils/useEnhancedClickHandler';
 import { EMPTY_OBJECT } from '@base-ui-components/utils/empty';
 import { type FloatingRootContext } from '../../floating-ui-react';
 import { type TransitionStatus } from '../../utils/useTransitionStatus';
-import { type HTMLProps } from '../../utils/types';
+import { FloatingUIOpenChangeDetails, type HTMLProps } from '../../utils/types';
 import { getEmptyContext } from '../../floating-ui-react/hooks/useFloatingRootContext';
 import { PopoverRoot } from './../root/PopoverRoot';
 import { PopupTriggerMap } from '../../utils/popupStoreUtils';
+import { PATIENT_CLICK_THRESHOLD } from '../../utils/constants';
 
 export type State<Payload> = {
   open: boolean;
@@ -18,6 +24,7 @@ export type State<Payload> = {
   openMethod: InteractionType | null;
   openReason: PopoverRoot.ChangeEventReason | null;
   stickIfOpen: boolean;
+  nested: boolean;
 
   titleElementId: string | undefined;
   descriptionElementId: string | undefined;
@@ -43,6 +50,8 @@ type Context = {
   onOpenChangeComplete: ((open: boolean) => void) | undefined;
   triggerFocusTargetRef: React.RefObject<HTMLElement | null>;
   beforeContentFocusGuardRef: React.RefObject<HTMLElement | null>;
+  preventUnmountingRef: React.RefObject<boolean>;
+  stickIfOpenTimeout: Timeout;
 };
 
 function createInitialState<Payload>(): State<Payload> {
@@ -66,6 +75,7 @@ function createInitialState<Payload>(): State<Payload> {
     inactiveTriggerProps: EMPTY_OBJECT as HTMLProps,
     popupProps: EMPTY_OBJECT as HTMLProps,
     stickIfOpen: true,
+    nested: false,
   };
 }
 
@@ -114,17 +124,96 @@ export class PopoverStore<Payload> extends ReactStore<State<Payload>, Context, S
         onOpenChangeComplete: undefined,
         triggerFocusTargetRef: React.createRef<HTMLElement>(),
         beforeContentFocusGuardRef: React.createRef<HTMLElement>(),
+        preventUnmountingRef: { current: false },
+        stickIfOpenTimeout: new Timeout(),
       },
       selectors,
     );
   }
 
-  setOpen(
-    open: boolean,
+  setOpen = (
+    nextOpen: boolean,
     eventDetails: Omit<PopoverRoot.ChangeEventDetails, 'preventUnmountOnClose'>,
+  ) => {
+    const isHover = eventDetails.reason === 'trigger-hover';
+    const isKeyboardClick =
+      eventDetails.reason === 'trigger-press' && (eventDetails.event as MouseEvent).detail === 0;
+    const isDismissClose =
+      !nextOpen && (eventDetails.reason === 'escape-key' || eventDetails.reason == null);
+
+    (eventDetails as PopoverRoot.ChangeEventDetails).preventUnmountOnClose = () => {
+      this.context.preventUnmountingRef.current = true;
+    };
+
+    this.context.onOpenChange?.(nextOpen, eventDetails as PopoverRoot.ChangeEventDetails);
+
+    if (eventDetails.isCanceled) {
+      return;
+    }
+
+    const details: FloatingUIOpenChangeDetails = {
+      open: nextOpen,
+      nativeEvent: eventDetails.event,
+      reason: eventDetails.reason,
+      nested: this.state.nested,
+      triggerElement: eventDetails.trigger,
+    };
+
+    const floatingEvents = this.state.floatingRootContext.events;
+    floatingEvents?.emit('openchange', details);
+
+    const changeState = () => {
+      this.set('open', nextOpen);
+
+      if (nextOpen) {
+        this.set('openReason', eventDetails.reason ?? null);
+      }
+
+      // If a popup is closing, the `trigger` may be null.
+      // We want to keep the previous value so that exit animations are played and focus is returned correctly.
+      const newTriggerId = eventDetails.trigger?.id ?? null;
+      if (newTriggerId || nextOpen) {
+        this.set('activeTriggerId', newTriggerId);
+      }
+    };
+
+    if (isHover) {
+      // Only allow "patient" clicks to close the popover if it's open.
+      // If they clicked within 500ms of the popover opening, keep it open.
+      this.set('stickIfOpen', true);
+      this.context.stickIfOpenTimeout.start(PATIENT_CLICK_THRESHOLD, () => {
+        this.set('stickIfOpen', false);
+      });
+
+      ReactDOM.flushSync(changeState);
+    } else {
+      changeState();
+    }
+
+    if (isKeyboardClick || isDismissClose) {
+      this.set('instantType', isKeyboardClick ? 'click' : 'dismiss');
+    } else if (eventDetails.reason === 'focus-out') {
+      this.set('instantType', 'focus');
+    } else {
+      this.set('instantType', undefined);
+    }
+  };
+
+  public static useStore<Payload>(
+    externalStore: PopoverStore<Payload> | undefined,
+    initialState: Partial<State<Payload>>,
   ) {
-    this.state.floatingRootContext.events.emit('setOpen', { open, eventDetails });
+    const store = useRefWithInit(() => {
+      return externalStore ?? new PopoverStore<Payload>(initialState);
+    }).current;
+
+    useOnMount(store.disposeEffect);
+    return store;
   }
+
+  private disposeEffect = () => {
+    return this.context.stickIfOpenTimeout.disposeEffect();
+  };
 }
 
 type Selectors = typeof selectors;

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -17,7 +17,7 @@ import { CLICK_TRIGGER_IDENTIFIER } from '../../utils/constants';
 import { safePolygon, useClick, useHover, useInteractions } from '../../floating-ui-react';
 import { OPEN_DELAY } from '../utils/constants';
 import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
-import { PopoverStore } from '../PopoverStore';
+import { PopoverHandle } from '../store/PopoverHandle';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { FocusGuard } from '../../utils/FocusGuard';
 import {
@@ -56,15 +56,10 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
 
   const rootContext = usePopoverRootContext(true);
 
-  let store: PopoverStore<unknown>;
-
-  if (handle) {
-    store = handle;
-  } else if (rootContext) {
-    store = rootContext.store;
-  } else {
+  const store = handle?.store ?? rootContext?.store;
+  if (!store) {
     throw new Error(
-      'Base UI: PopoverTrigger must be either used within a PopoverRoot component or have the `handle` prop set.',
+      'Base UI: <Popover.Trigger> must be either used within a <Popover.Root> component or provided with a handle.',
     );
   }
 
@@ -257,7 +252,7 @@ export type PopoverTriggerProps<Payload = unknown> = NativeButtonProps &
     /**
      * A handle to associate the trigger with a popover.
      */
-    handle?: PopoverStore<Payload>;
+    handle?: PopoverHandle<Payload>;
     /**
      * A payload to pass to the popover when it is opened.
      */


### PR DESCRIPTION
Updated the handle API to match the shape introduced for Dialog: PopoverHandle is now a separate class and contains methods for imperative interaction with the API. I didn't include the ability to open a Popover without associating it with any trigger as this would require more changes in the internals and is likely less common than in dialogs.

I also moved the `setOpen` method to the store, to make it consistent with the Dialog and avoid indirect calling via the event system.