### PR TITLE
[avatar] Add `aria-hidden` to `AvatarFallback`

### DIFF
--- a/packages/react/src/avatar/fallback/AvatarFallback.tsx
+++ b/packages/react/src/avatar/fallback/AvatarFallback.tsx
@@ -40,7 +40,10 @@ export const AvatarFallback = React.forwardRef(function AvatarFallback(
   const element = useRenderElement('span', componentProps, {
     state,
     ref: forwardedRef,
-    props: elementProps,
+    props: {
+      'aria-hidden': true,
+      ...elementProps
+    },
     stateAttributesMapping: avatarStateAttributesMapping,
     enabled: imageLoadingStatus !== 'loaded' && delayPassed,
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Rationale

`AvatarFallback` is purely presentational and doesn’t convey meaningful information. Marking it with `aria-hidden="true"` prevents redundant or confusing announcements.

When an avatar is used inside an interactive element (e.g., a button or link), that element (I think) should provide an accessible name using `aria-label` or a similar attribute.

### Concerns / Questions

Are there cases where the avatar fallback is the *only* identifier for an entity (user, group, etc.)?  

If so, should `aria-hidden` be applied, depending on whether an `aria-label` is present?