### PR TITLE
[docs][toolbar] Remove `data-highlighted`

### DIFF
--- a/docs/reference/generated/toolbar-button.json
+++ b/docs/reference/generated/toolbar-button.json
@@ -36,9 +36,6 @@
     }
   },
   "dataAttributes": {
-    "data-highlighted": {
-      "description": "Present when the button is the active item in the toolbar."
-    },
     "data-orientation": {
       "description": "Indicates the orientation of the toolbar.",
       "type": "'horizontal' | 'vertical'"

--- a/docs/reference/generated/toolbar-input.json
+++ b/docs/reference/generated/toolbar-input.json
@@ -34,9 +34,6 @@
     }
   },
   "dataAttributes": {
-    "data-highlighted": {
-      "description": "Present when the input is the active item in the toolbar."
-    },
     "data-orientation": {
       "description": "Indicates the orientation of the toolbar.",
       "type": "'horizontal' | 'vertical'"

--- a/docs/reference/generated/toolbar-link.json
+++ b/docs/reference/generated/toolbar-link.json
@@ -18,9 +18,6 @@
     }
   },
   "dataAttributes": {
-    "data-highlighted": {
-      "description": "Present when the link is the active item in the toolbar."
-    },
     "data-orientation": {
       "description": "Indicates the orientation of the toolbar.",
       "type": "'horizontal' | 'vertical'"

--- a/packages/react/src/toolbar/button/ToolbarButtonDataAttributes.ts
+++ b/packages/react/src/toolbar/button/ToolbarButtonDataAttributes.ts
@@ -12,8 +12,4 @@ export enum ToolbarButtonDataAttributes {
    * Present when the button remains focusable when disabled.
    */
   focusable = 'data-focusable',
-  /**
-   * Present when the button is the active item in the toolbar.
-   */
-  highlighted = 'data-highlighted',
 }

--- a/packages/react/src/toolbar/input/ToolbarInputDataAttributes.ts
+++ b/packages/react/src/toolbar/input/ToolbarInputDataAttributes.ts
@@ -12,8 +12,4 @@ export enum ToolbarInputDataAttributes {
    * Present when the input remains focusable when disabled.
    */
   focusable = 'data-focusable',
-  /**
-   * Present when the input is the active item in the toolbar.
-   */
-  highlighted = 'data-highlighted',
 }

--- a/packages/react/src/toolbar/link/ToolbarLinkDataAttributes.ts
+++ b/packages/react/src/toolbar/link/ToolbarLinkDataAttributes.ts
@@ -4,8 +4,4 @@ export enum ToolbarLinkDataAttributes {
    * @type {'horizontal' | 'vertical'}
    */
   orientation = 'data-orientation',
-  /**
-   * Present when the link is the active item in the toolbar.
-   */
-  highlighted = 'data-highlighted',
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #3094

It could be useful to add `[data-highlighted]` for Toolbar if we detect it's inside `Popover`/`Dialog`, for cases where the user wants to create a Menu-like widget that has complex non-menu items (e.g. #3017), though usually they don't want focus to be stolen while hovering in such cases