### PR TITLE
[toolbar] Drop `cols` prop

### DIFF
--- a/docs/reference/generated/toolbar-root.json
+++ b/docs/reference/generated/toolbar-root.json
@@ -2,12 +2,6 @@
   "name": "ToolbarRoot",
   "description": "A container for grouping a set of controls, such as buttons, toggle groups, or menus.\nRenders a `<div>` element.",
   "props": {
-    "cols": {
-      "type": "number",
-      "default": "1",
-      "description": "The number of columns. When greater than 1, the toolbar is arranged into\na grid.",
-      "detailedType": "number | undefined"
-    },
     "style": {
       "type": "CSSProperties | ((state: Toolbar.Root.State) => CSSProperties | undefined)",
       "detailedType": "| React.CSSProperties\n| ((state: Toolbar.Root.State) => CSSProperties | undefined)\n| undefined"

--- a/packages/react/src/toolbar/root/ToolbarRoot.tsx
+++ b/packages/react/src/toolbar/root/ToolbarRoot.tsx
@@ -16,7 +16,6 @@ export const ToolbarRoot = React.forwardRef(function ToolbarRoot(
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const {
-    cols = 1,
     disabled = false,
     loop = true,
     orientation = 'horizontal',
@@ -63,7 +62,6 @@ export const ToolbarRoot = React.forwardRef(function ToolbarRoot(
         state={state}
         refs={[forwardedRef]}
         props={[defaultProps, elementProps]}
-        cols={cols}
         disabledIndices={disabledIndices}
         loop={loop}
         onMapChange={setItemMap}
@@ -85,12 +83,6 @@ export interface ToolbarRootState {
 }
 
 export interface ToolbarRootProps extends BaseUIComponentProps<'div', ToolbarRoot.State> {
-  /**
-   * The number of columns. When greater than 1, the toolbar is arranged into
-   * a grid.
-   * @default 1
-   */
-  cols?: number;
   disabled?: boolean;
   /**
    * The orientation of the toolbar.


### PR DESCRIPTION
This was probably a mistake to expose `cols` since a component with grid-style navigation would need `role="grid"` etc. Also the [ARIA pattern](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/#aboutthispattern) describes a long row that wraps which is not the same as a grid:
> In toolbars with multiple rows of controls, Left Arrow and Right Arrow can provide navigation that wraps from row to row, leaving the option of reserving vertical arrow keys for operating controls

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
