### PR TITLE
[field] Refactor field usage

### DIFF
--- a/packages/react/src/checkbox-group/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.tsx
@@ -11,7 +11,6 @@ import { useLabelableContext } from '../labelable-provider/LabelableContext';
 import type { BaseUIComponentProps } from '../utils/types';
 import { fieldValidityMapping } from '../field/utils/constants';
 import { useField } from '../field/useField';
-import { useFieldControlValidation } from '../field/control/useFieldControlValidation';
 import { PARENT_CHECKBOX } from '../checkbox/root/CheckboxRoot';
 import { useCheckboxGroupParent } from './useCheckboxGroupParent';
 import { BaseUIChangeEventDetails } from '../utils/createBaseUIEventDetails';
@@ -37,12 +36,15 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
     ...elementProps
   } = componentProps;
 
-  const { disabled: fieldDisabled, name: fieldName, state: fieldState } = useFieldRootContext();
+  const {
+    disabled: fieldDisabled,
+    name: fieldName,
+    state: fieldState,
+    validation,
+  } = useFieldRootContext();
   const { labelId } = useLabelableContext();
 
   const disabled = fieldDisabled || disabledProp;
-
-  const fieldControlValidation = useFieldControlValidation();
 
   const [value, setValueUnwrapped] = useControlled({
     controlled: externalValue,
@@ -82,7 +84,7 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
   useField({
     enabled: !!fieldName,
     id,
-    commitValidation: fieldControlValidation.commitValidation,
+    commit: validation.commit,
     value,
     controlRef,
     name: fieldName,
@@ -105,19 +107,10 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
       setValue,
       parent,
       disabled,
-      fieldControlValidation,
+      validation,
       registerControlRef,
     }),
-    [
-      allValues,
-      value,
-      defaultValue,
-      setValue,
-      parent,
-      disabled,
-      fieldControlValidation,
-      registerControlRef,
-    ],
+    [allValues, value, defaultValue, setValue, parent, disabled, validation, registerControlRef],
   );
 
   const element = useRenderElement('div', componentProps, {

--- a/packages/react/src/checkbox-group/CheckboxGroupContext.ts
+++ b/packages/react/src/checkbox-group/CheckboxGroupContext.ts
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { useFieldControlValidation } from '../field/control/useFieldControlValidation';
+import type { UseFieldValidationReturnValue } from '../field/root/useFieldValidation';
 import { useCheckboxGroupParent } from './useCheckboxGroupParent';
 import { BaseUIChangeEventDetails } from '../utils/createBaseUIEventDetails';
 
@@ -11,7 +11,7 @@ export interface CheckboxGroupContext {
   allValues: string[] | undefined;
   parent: useCheckboxGroupParent.ReturnValue;
   disabled: boolean;
-  fieldControlValidation: useFieldControlValidation.ReturnValue;
+  validation: UseFieldValidationReturnValue;
   registerControlRef: (element: HTMLButtonElement | null) => void;
 }
 

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -16,7 +16,6 @@ import { useButton } from '../../use-button/useButton';
 import type { FieldRoot } from '../../field/root/FieldRoot';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useFieldItemContext } from '../../field/item/FieldItemContext';
-import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
 import { useField } from '../../field/useField';
 import { useFormContext } from '../../form/FormContext';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
@@ -70,6 +69,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     validationMode,
     validityData,
     shouldValidateOnChange,
+    validation: localValidation,
   } = useFieldRootContext();
   const fieldItemContext = useFieldItemContext();
   const { labelId, controlId, setControlId, getDescriptionProps } = useLabelableContext();
@@ -117,9 +117,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     native: nativeButton,
   });
 
-  const localFieldControlValidation = useFieldControlValidation();
-  const fieldControlValidation =
-    groupContext?.fieldControlValidation ?? localFieldControlValidation;
+  const validation = groupContext?.validation ?? localValidation;
 
   const [checked, setCheckedState] = useControlled({
     controlled: value && groupValue && !parent ? groupValue.includes(value) : groupChecked,
@@ -154,7 +152,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
   useField({
     enabled: !groupContext,
     id,
-    commitValidation: fieldControlValidation.commitValidation,
+    commit: validation.commit,
     value: checked,
     controlRef,
     name,
@@ -162,7 +160,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
   });
 
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const mergedInputRef = useMergedRefs(inputRefProp, inputRef, fieldControlValidation.inputRef);
+  const mergedInputRef = useMergedRefs(inputRefProp, inputRef, validation.inputRef);
 
   useIsoLayoutEffect(() => {
     if (inputRef.current) {
@@ -187,7 +185,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     setFocused(false);
 
     if (validationMode === 'onBlur') {
-      fieldControlValidation.commitValidation(groupContext ? groupValue : element.checked);
+      validation.commit(groupContext ? groupValue : element.checked);
     }
   }
 
@@ -241,9 +239,9 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
           setFilled(nextChecked);
 
           if (shouldValidateOnChange()) {
-            fieldControlValidation.commitValidation(nextChecked);
+            validation.commit(nextChecked);
           } else {
-            fieldControlValidation.commitValidation(nextChecked, true);
+            validation.commit(nextChecked, true);
           }
         }
 
@@ -256,9 +254,9 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
           setFilled(nextGroupValue.length > 0);
 
           if (shouldValidateOnChange()) {
-            fieldControlValidation.commitValidation(nextGroupValue);
+            validation.commit(nextGroupValue);
           } else {
-            fieldControlValidation.commitValidation(nextGroupValue, true);
+            validation.commit(nextGroupValue, true);
           }
         }
       },
@@ -272,9 +270,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
       ? { value: (groupContext ? checked && valueProp : valueProp) || '' }
       : EMPTY_OBJECT,
     getDescriptionProps,
-    groupContext
-      ? fieldControlValidation.getValidationProps
-      : fieldControlValidation.getInputValidationProps,
+    groupContext ? validation.getValidationProps : validation.getInputValidationProps,
   );
 
   const computedChecked = isGroupedWithParent ? Boolean(groupChecked) : checked;
@@ -320,7 +316,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
         onClick,
       },
       getDescriptionProps,
-      fieldControlValidation.getValidationProps,
+      validation.getValidationProps,
       elementProps,
       otherGroupProps,
       getButtonProps,

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -54,6 +54,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
     setTouched,
     setFocused,
     validationMode,
+    validation,
   } = useFieldRootContext();
   const { labelId } = useLabelableContext();
   const comboboxChipsContext = useComboboxChipsContext();
@@ -66,7 +67,6 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
 
   const comboboxDisabled = useStore(store, selectors.disabled);
   const readOnly = useStore(store, selectors.readOnly);
-  const fieldControlValidation = useStore(store, selectors.fieldControlValidation);
   const openOnInputClick = useStore(store, selectors.openOnInputClick);
   const name = useStore(store, selectors.name);
   const selectionMode = useStore(store, selectors.selectionMode);
@@ -200,7 +200,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
 
           if (validationMode === 'onBlur') {
             const valueToValidate = selectionMode === 'none' ? inputValue : selectedValue;
-            fieldControlValidation?.commitValidation(valueToValidate);
+            validation.commit(valueToValidate);
           }
         },
         onCompositionStart(event) {
@@ -428,9 +428,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
           store.state.keyboardActiveRef.current = false;
         },
       },
-      fieldControlValidation
-        ? fieldControlValidation.getValidationProps(elementProps)
-        : elementProps,
+      validation ? validation.getValidationProps(elementProps) : elementProps,
     ],
     stateAttributesMapping,
   });

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -34,7 +34,6 @@ import {
 import { selectors, type State as StoreState } from '../store';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
-import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
 import { useField } from '../../field/useField';
 import { useFormContext } from '../../form/FormContext';
 import { useLabelableId } from '../../labelable-provider/useLabelableId';
@@ -119,15 +118,15 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     setFilled,
     name: fieldName,
     disabled: fieldDisabled,
+    validation,
   } = useFieldRootContext();
-  const fieldControlValidation = useFieldControlValidation();
   const id = useLabelableId({ id: idProp });
 
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
   const multiple = selectionMode === 'multiple';
   const hasInputValue = inputValueProp !== undefined || defaultInputValueProp !== undefined;
-  const commitValidation = fieldControlValidation.commitValidation;
+  const commit = validation.commit;
 
   let autoHighlightMode: false | 'input-change' | 'always';
   if (autoHighlight === 'always') {
@@ -340,7 +339,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         disabled,
         readOnly,
         required,
-        fieldControlValidation,
         grid,
         isGrouped,
         virtualized,
@@ -433,7 +431,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
   useField({
     id,
-    commitValidation,
+    commit,
     value: formValue,
     controlRef: inputInsidePopup ? triggerRef : inputRef,
     name,
@@ -870,10 +868,10 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     }
 
     clearErrors(name);
-    commitValidation?.(selectedValue, true);
+    commit?.(selectedValue, true);
 
     if (shouldValidateOnChange()) {
-      commitValidation?.(selectedValue);
+      commit?.(selectedValue);
     }
 
     updateValue(selectedValue);
@@ -905,10 +903,10 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     }
 
     clearErrors(name);
-    commitValidation?.(inputValue, true);
+    commit?.(inputValue, true);
 
     if (shouldValidateOnChange()) {
-      commitValidation?.(inputValue);
+      commit?.(inputValue);
     }
 
     updateValue(inputValue);
@@ -1111,7 +1109,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       disabled,
       readOnly,
       required,
-      fieldControlValidation,
       grid,
       isGrouped,
       virtualized,
@@ -1144,7 +1141,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     disabled,
     readOnly,
     required,
-    fieldControlValidation,
+    validation,
     grid,
     isGrouped,
     virtualized,
@@ -1159,7 +1156,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     autoHighlightMode,
   ]);
 
-  const hiddenInputRef = useMergedRefs(inputRefProp, fieldControlValidation.inputRef);
+  const hiddenInputRef = useMergedRefs(inputRefProp, validation.inputRef);
 
   const itemsContextValue: ComboboxDerivedItemsContext = React.useMemo(
     () => ({
@@ -1201,7 +1198,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     <React.Fragment>
       {props.children}
       <input
-        {...fieldControlValidation.getInputValidationProps({
+        {...validation.getInputValidationProps({
           // Move focus when the hidden input is focused.
           onFocus() {
             if (inputInsidePopup) {
@@ -1231,7 +1228,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
                 setInputValue(nextValue, details);
 
                 if (shouldValidateOnChange()) {
-                  fieldControlValidation.commitValidation(nextValue);
+                  validation.commit(nextValue);
                 }
                 return;
               }
@@ -1249,7 +1246,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
                 setSelectedValue?.(matchingValue, details);
 
                 if (shouldValidateOnChange()) {
-                  fieldControlValidation.commitValidation(matchingValue);
+                  validation.commit(matchingValue);
                 }
               }
             }
@@ -1261,17 +1258,17 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
               queueMicrotask(handleChange);
             }
           },
-          id,
-          name: multiple || selectionMode === 'none' ? undefined : name,
-          disabled,
-          required: required && !hasMultipleSelection,
-          readOnly,
-          value: serializedValue,
-          ref: hiddenInputRef,
-          style: visuallyHidden,
-          tabIndex: -1,
-          'aria-hidden': true,
         })}
+        id={id}
+        name={multiple || selectionMode === 'none' ? undefined : name}
+        disabled={disabled}
+        required={required && !hasMultipleSelection}
+        readOnly={readOnly}
+        value={serializedValue}
+        ref={hiddenInputRef}
+        style={visuallyHidden}
+        tabIndex={-1}
+        aria-hidden
       />
       {hiddenInputs}
     </React.Fragment>

--- a/packages/react/src/combobox/store.ts
+++ b/packages/react/src/combobox/store.ts
@@ -2,7 +2,6 @@ import { Store, createSelector } from '@base-ui-components/utils/store';
 import type { InteractionType } from '@base-ui-components/utils/useEnhancedClickHandler';
 import type { TransitionStatus } from '../utils/useTransitionStatus';
 import type { HTMLProps } from '../utils/types';
-import type { useFieldControlValidation } from '../field/control/useFieldControlValidation';
 import type { Side } from '../utils/useAnchorPositioning';
 import { compareItemEquality } from '../utils/itemEquality';
 import type { AriaCombobox } from './root/AriaCombobox';
@@ -76,7 +75,6 @@ export type State = {
   disabled: boolean;
   readOnly: boolean;
   required: boolean;
-  fieldControlValidation: ReturnType<typeof useFieldControlValidation>;
   grid: boolean;
   isGrouped: boolean;
   virtualized: boolean;
@@ -152,7 +150,6 @@ export const selectors = {
   disabled: createSelector((state: State) => state.disabled),
   readOnly: createSelector((state: State) => state.readOnly),
   required: createSelector((state: State) => state.required),
-  fieldControlValidation: createSelector((state: State) => state.fieldControlValidation),
   grid: createSelector((state: State) => state.grid),
   isGrouped: createSelector((state: State) => state.isGrouped),
   virtualized: createSelector((state: State) => state.virtualized),

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -44,12 +44,12 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
     setTouched,
     setFocused,
     validationMode,
+    validation,
   } = useFieldRootContext();
   const { labelId } = useLabelableContext();
   const store = useComboboxRootContext();
 
   const selectionMode = useStore(store, selectors.selectionMode);
-  const fieldControlValidation = useStore(store, selectors.fieldControlValidation);
   const comboboxDisabled = useStore(store, selectors.disabled);
   const readOnly = useStore(store, selectors.readOnly);
   const listElement = useStore(store, selectors.listElement);
@@ -121,7 +121,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
 
           if (validationMode === 'onBlur') {
             const valueToValidate = selectionMode === 'none' ? inputValue : selectedValue;
-            fieldControlValidation.commitValidation(valueToValidate);
+            validation.commit(valueToValidate);
           }
         },
         onMouseDown(event) {
@@ -166,9 +166,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
           }
         },
       },
-      fieldControlValidation
-        ? fieldControlValidation.getValidationProps(elementProps)
-        : elementProps,
+      validation ? validation.getValidationProps(elementProps) : elementProps,
       getButtonProps,
     ],
     stateAttributesMapping,

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -9,14 +9,12 @@ import { useFormContext } from '../../form/FormContext';
 import { LabelableProvider } from '../../labelable-provider';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
+import { useFieldValidation } from './useFieldValidation';
 
 /**
- * Groups all parts of the field.
- * Renders a `<div>` element.
- *
- * Documentation: [Base UI Field](https://base-ui.com/react/components/field)
+ * @internal
  */
-export const FieldRoot = React.forwardRef(function FieldRoot(
+const FieldRootInner = React.forwardRef(function FieldRootInner(
   componentProps: FieldRoot.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
@@ -102,6 +100,18 @@ export const FieldRoot = React.forwardRef(function FieldRoot(
     [disabled, touched, dirty, valid, filled, focused],
   );
 
+  const validation = useFieldValidation({
+    setValidityData,
+    validate,
+    validityData,
+    validationDebounceTime,
+    invalid,
+    markedDirtyRef,
+    state,
+    name,
+    shouldValidateOnChange,
+  });
+
   const contextValue: FieldRootContext = React.useMemo(
     () => ({
       invalid,
@@ -123,6 +133,7 @@ export const FieldRoot = React.forwardRef(function FieldRoot(
       shouldValidateOnChange,
       state,
       markedDirtyRef,
+      validation,
     }),
     [
       invalid,
@@ -142,6 +153,7 @@ export const FieldRoot = React.forwardRef(function FieldRoot(
       validationDebounceTime,
       shouldValidateOnChange,
       state,
+      validation,
     ],
   );
 
@@ -152,9 +164,22 @@ export const FieldRoot = React.forwardRef(function FieldRoot(
     stateAttributesMapping: fieldValidityMapping,
   });
 
+  return <FieldRootContext.Provider value={contextValue}>{element}</FieldRootContext.Provider>;
+});
+
+/**
+ * Groups all parts of the field.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Field](https://base-ui.com/react/components/field)
+ */
+export const FieldRoot = React.forwardRef(function FieldRoot(
+  componentProps: FieldRoot.Props,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
+) {
   return (
     <LabelableProvider>
-      <FieldRootContext.Provider value={contextValue}>{element}</FieldRootContext.Provider>
+      <FieldRootInner {...componentProps} ref={forwardedRef} />
     </LabelableProvider>
   );
 });

--- a/packages/react/src/field/root/FieldRootContext.ts
+++ b/packages/react/src/field/root/FieldRootContext.ts
@@ -4,6 +4,9 @@ import { NOOP } from '../../utils/noop';
 import { DEFAULT_VALIDITY_STATE } from '../utils/constants';
 import type { FieldRoot, FieldValidityData } from './FieldRoot';
 import type { Form } from '../../form';
+import type { UseFieldValidationReturnValue } from './useFieldValidation';
+import type { HTMLProps } from '../../utils/types';
+import { EMPTY_OBJECT } from '../../utils/constants';
 
 export interface FieldRootContext {
   invalid: boolean | undefined;
@@ -28,6 +31,7 @@ export interface FieldRootContext {
   shouldValidateOnChange: () => boolean;
   state: FieldRoot.State;
   markedDirtyRef: React.MutableRefObject<boolean>;
+  validation: UseFieldValidationReturnValue;
 }
 
 export const FieldRootContext = React.createContext<FieldRootContext>({
@@ -63,6 +67,12 @@ export const FieldRootContext = React.createContext<FieldRootContext>({
     focused: false,
   },
   markedDirtyRef: { current: false },
+  validation: {
+    getValidationProps: (props: HTMLProps = EMPTY_OBJECT) => props,
+    getInputValidationProps: (props: HTMLProps = EMPTY_OBJECT) => props,
+    inputRef: { current: null },
+    commit: async () => {},
+  },
 });
 
 export function useFieldRootContext(optional = true) {

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -3,13 +3,13 @@ import * as React from 'react';
 import { EMPTY_OBJECT } from '@base-ui-components/utils/empty';
 import { useTimeout } from '@base-ui-components/utils/useTimeout';
 import { useStableCallback } from '@base-ui-components/utils/useStableCallback';
-import { useFieldRootContext } from '../root/FieldRootContext';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
 import { mergeProps } from '../../merge-props';
 import { DEFAULT_VALIDITY_STATE } from '../utils/constants';
 import { useFormContext } from '../../form/FormContext';
 import { getCombinedFieldValidityData } from '../utils/getCombinedFieldValidityData';
 import type { HTMLProps } from '../../utils/types';
+import type { FieldValidityData, FieldRootState } from './FieldRoot';
 
 const validityKeys = Object.keys(DEFAULT_VALIDITY_STATE) as Array<keyof ValidityState>;
 
@@ -35,7 +35,9 @@ function isOnlyValueMissing(state: Record<keyof ValidityState, boolean> | undefi
   return onlyValueMissing;
 }
 
-export function useFieldControlValidation() {
+export function useFieldValidation(
+  params: UseFieldValidationParameters,
+): UseFieldValidationReturnValue {
   const { formRef, clearErrors } = useFormContext();
 
   const {
@@ -48,14 +50,14 @@ export function useFieldControlValidation() {
     state,
     name,
     shouldValidateOnChange,
-  } = useFieldRootContext();
+  } = params;
 
   const { controlId, getDescriptionProps } = useLabelableContext();
 
   const timeout = useTimeout();
   const inputRef = React.useRef<HTMLInputElement | null>(null);
 
-  const commitValidation = useStableCallback(async (value: unknown, revalidate = false) => {
+  const commit = useStableCallback(async (value: unknown, revalidate = false) => {
     const element = inputRef.current;
     if (!element) {
       return;
@@ -166,8 +168,8 @@ export function useFieldControlValidation() {
       // - native constraint validations passed, custom validity check is next
       const formValues = Array.from(formRef.current.fields.values()).reduce(
         (acc, field) => {
-          if (field.name && field.getValueRef) {
-            acc[field.name] = field.getValueRef.current?.();
+          if (field.name) {
+            acc[field.name] = field.getValue();
           }
           return acc;
         },
@@ -255,7 +257,7 @@ export function useFieldControlValidation() {
             clearErrors(name);
 
             if (!shouldValidateOnChange()) {
-              commitValidation(event.currentTarget.value, true);
+              commit(event.currentTarget.value, true);
               return;
             }
 
@@ -267,7 +269,7 @@ export function useFieldControlValidation() {
 
             if (element.value === '') {
               // Ignore the debounce time for empty values.
-              commitValidation(element.value);
+              commit(element.value);
               return;
             }
 
@@ -275,10 +277,10 @@ export function useFieldControlValidation() {
 
             if (validationDebounceTime) {
               timeout.start(validationDebounceTime, () => {
-                commitValidation(element.value);
+                commit(element.value);
               });
             } else {
-              commitValidation(element.value);
+              commit(element.value);
             }
           },
         },
@@ -289,7 +291,7 @@ export function useFieldControlValidation() {
       clearErrors,
       name,
       timeout,
-      commitValidation,
+      commit,
       invalid,
       validationDebounceTime,
       shouldValidateOnChange,
@@ -301,19 +303,30 @@ export function useFieldControlValidation() {
       getValidationProps,
       getInputValidationProps,
       inputRef,
-      commitValidation,
+      commit,
     }),
-    [getValidationProps, getInputValidationProps, commitValidation],
+    [getValidationProps, getInputValidationProps, commit],
   );
 }
 
-export interface UseFieldControlValidationReturnValue {
-  getValidationProps: (props?: HTMLProps) => HTMLProps;
-  getInputValidationProps: (props?: HTMLProps) => HTMLProps;
-  inputRef: React.MutableRefObject<any>;
-  commitValidation: (value: unknown, revalidate?: boolean) => void;
+export interface UseFieldValidationParameters {
+  setValidityData: (data: FieldValidityData) => void;
+  validate: (
+    value: unknown,
+    formValues: Record<string, unknown>,
+  ) => string | string[] | null | Promise<string | string[] | null>;
+  validityData: FieldValidityData;
+  validationDebounceTime: number;
+  invalid: boolean;
+  markedDirtyRef: React.RefObject<boolean>;
+  state: FieldRootState;
+  name: string | undefined;
+  shouldValidateOnChange: () => boolean;
 }
 
-export namespace useFieldControlValidation {
-  export type ReturnValue = UseFieldControlValidationReturnValue;
+export interface UseFieldValidationReturnValue {
+  getValidationProps: (props?: HTMLProps) => HTMLProps;
+  getInputValidationProps: (props?: HTMLProps) => HTMLProps;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  commit: (value: unknown, revalidate?: boolean) => Promise<void>;
 }

--- a/packages/react/src/form/FormContext.ts
+++ b/packages/react/src/form/FormContext.ts
@@ -17,7 +17,7 @@ export interface FormContext {
         validate: () => void;
         validityData: FieldValidityData;
         controlRef: React.RefObject<HTMLElement | null>;
-        getValueRef: React.RefObject<(() => unknown) | undefined>;
+        getValue: () => unknown;
       }
     >;
   }>;

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -5,7 +5,6 @@ import { stopEvent } from '../../floating-ui-react/utils';
 import { useNumberFieldRootContext } from '../root/NumberFieldRootContext';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
-import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
 import { fieldValidityMapping } from '../../field/utils/constants';
 import { useField } from '../../field/useField';
 import { useFormContext } from '../../form/FormContext';
@@ -87,22 +86,16 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
   } = useNumberFieldRootContext();
 
   const { clearErrors } = useFormContext();
-  const { validationMode, setTouched, setFocused, invalid, shouldValidateOnChange } =
+  const { validationMode, setTouched, setFocused, invalid, shouldValidateOnChange, validation } =
     useFieldRootContext();
   const { labelId } = useLabelableContext();
-
-  const {
-    getInputValidationProps,
-    commitValidation,
-    inputRef: inputValidationRef,
-  } = useFieldControlValidation();
 
   const hasTouchedInputRef = React.useRef(false);
   const blockRevalidationRef = React.useRef(false);
 
   useField({
     id,
-    commitValidation,
+    commit: validation.commit,
     value,
     controlRef: inputRef,
     name,
@@ -120,9 +113,9 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
     clearErrors(name);
 
     if (shouldValidateOnChange()) {
-      commitValidation(value);
+      validation.commit(value);
     }
-  }, [value, inputValue, name, clearErrors, shouldValidateOnChange, commitValidation]);
+  }, [value, inputValue, name, clearErrors, shouldValidateOnChange, validation]);
 
   useIsoLayoutEffect(() => {
     if (prevValueRef.current === value || shouldValidateOnChange()) {
@@ -133,8 +126,8 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       blockRevalidationRef.current = false;
       return;
     }
-    commitValidation(value, true);
-  }, [commitValidation, shouldValidateOnChange, value]);
+    validation.commit(value, true);
+  }, [shouldValidateOnChange, validation, value]);
 
   useIsoLayoutEffect(() => {
     prevValueRef.current = value;
@@ -188,7 +181,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       if (inputValue.trim() === '') {
         setValue(null);
         if (validationMode === 'onBlur') {
-          commitValidation(null);
+          validation.commit(null);
         }
         onValueCommitted(null, createGenericEventDetails('none', event.nativeEvent));
         return;
@@ -218,7 +211,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       const shouldCommit = hadManualInput || shouldUpdateValue || hadPendingProgrammaticChange;
 
       if (validationMode === 'onBlur') {
-        commitValidation(committed);
+        validation.commit(committed);
       }
       if (shouldUpdateValue) {
         setValue(committed, event.nativeEvent);
@@ -426,9 +419,9 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
   };
 
   const element = useRenderElement('input', componentProps, {
-    ref: [forwardedRef, inputRef, inputValidationRef],
+    ref: [forwardedRef, inputRef, validation.inputRef],
     state,
-    props: [inputProps, getInputValidationProps(), elementProps],
+    props: [inputProps, validation.getInputValidationProps(), elementProps],
     stateAttributesMapping,
   });
 

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -75,7 +75,6 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
   const {
     setDirty,
     validityData,
-    setValidityData,
     disabled: fieldDisabled,
     setFilled,
     invalid,
@@ -133,12 +132,6 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
   const allowInputSyncRef = React.useRef(true);
   const lastChangedValueRef = React.useRef<number | null>(null);
   const unsubscribeFromGlobalContextMenuRef = React.useRef<() => void>(() => {});
-
-  useIsoLayoutEffect(() => {
-    if (validityData.initialValue === null && value !== validityData.initialValue) {
-      setValidityData((prev) => ({ ...prev, initialValue: value }));
-    }
-  }, [setValidityData, validityData.initialValue, value]);
 
   // During SSR, the value is formatted on the server, whose locale may differ from the client's
   // locale. This causes a hydration mismatch, which we manually suppress. This is preferable to

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -14,7 +14,6 @@ import { useFormContext } from '../form/FormContext';
 import { useField } from '../field/useField';
 import { useFieldRootContext } from '../field/root/FieldRootContext';
 import { useLabelableContext } from '../labelable-provider/LabelableContext';
-import { useFieldControlValidation } from '../field/control/useFieldControlValidation';
 import { fieldValidityMapping } from '../field/utils/constants';
 import type { FieldRoot } from '../field/root/FieldRoot';
 import { mergeProps } from '../merge-props';
@@ -57,9 +56,9 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
     name: fieldName,
     disabled: fieldDisabled,
     state: fieldState,
+    validation,
   } = useFieldRootContext();
   const { labelId } = useLabelableContext();
-  const fieldControlValidation = useFieldControlValidation();
   const { clearErrors } = useFormContext();
 
   const disabled = fieldDisabled || disabledProp;
@@ -96,7 +95,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
 
   useField({
     id,
-    commitValidation: fieldControlValidation.commitValidation,
+    commit: validation.commit,
     value: checkedValue,
     controlRef,
     name,
@@ -113,18 +112,11 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
     clearErrors(name);
 
     if (shouldValidateOnChange()) {
-      fieldControlValidation.commitValidation(checkedValue);
+      validation.commit(checkedValue);
     } else {
-      fieldControlValidation.commitValidation(checkedValue, true);
+      validation.commit(checkedValue, true);
     }
-  }, [
-    name,
-    clearErrors,
-    shouldValidateOnChange,
-    validationMode,
-    checkedValue,
-    fieldControlValidation,
-  ]);
+  }, [name, clearErrors, shouldValidateOnChange, validationMode, checkedValue, validation]);
 
   useIsoLayoutEffect(() => {
     prevValueRef.current = checkedValue;
@@ -138,7 +130,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
       setFocused(false);
 
       if (validationMode === 'onBlur') {
-        fieldControlValidation.commitValidation(checkedValue);
+        validation.commit(checkedValue);
       }
     }
   });
@@ -161,7 +153,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
     return JSON.stringify(checkedValue);
   }, [checkedValue]);
 
-  const mergedInputRef = useMergedRefs(fieldControlValidation.inputRef, inputRefProp);
+  const mergedInputRef = useMergedRefs(validation.inputRef, inputRefProp);
 
   const inputProps = mergeProps<'input'>(
     {
@@ -179,7 +171,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
         controlRef.current?.focus();
       },
     },
-    fieldControlValidation.getInputValidationProps,
+    validation.getInputValidationProps,
   );
 
   const state: RadioGroup.State = React.useMemo(
@@ -197,7 +189,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
       ...fieldState,
       checkedValue,
       disabled,
-      fieldControlValidation,
+      validation,
       name,
       onValueChange,
       readOnly,
@@ -210,7 +202,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
     [
       checkedValue,
       disabled,
-      fieldControlValidation,
+      validation,
       fieldState,
       name,
       onValueChange,
@@ -242,7 +234,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
         render={render}
         className={className}
         state={state}
-        props={[defaultProps, fieldControlValidation.getValidationProps, elementProps]}
+        props={[defaultProps, validation.getValidationProps, elementProps]}
         refs={[forwardedRef]}
         stateAttributesMapping={fieldValidityMapping}
         enableHomeAndEndKeys={false}

--- a/packages/react/src/radio-group/RadioGroupContext.ts
+++ b/packages/react/src/radio-group/RadioGroupContext.ts
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { NOOP } from '../utils/noop';
-import { useFieldControlValidation } from '../field/control/useFieldControlValidation';
+import type { UseFieldValidationReturnValue } from '../field/root/useFieldValidation';
 import type { BaseUIChangeEventDetails } from '../utils/createBaseUIEventDetails';
 
 export interface RadioGroupContext {
@@ -14,7 +14,7 @@ export interface RadioGroupContext {
   onValueChange: (value: unknown, eventDetails: BaseUIChangeEventDetails<'none'>) => void;
   touched: boolean;
   setTouched: React.Dispatch<React.SetStateAction<boolean>>;
-  fieldControlValidation?: ReturnType<typeof useFieldControlValidation>;
+  validation?: UseFieldValidationReturnValue;
   registerControlRef: (element: HTMLElement | null) => void;
 }
 

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -52,7 +52,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
     setCheckedValue,
     touched,
     setTouched,
-    fieldControlValidation,
+    validation,
     registerControlRef,
   } = useRadioGroupContext();
 
@@ -200,7 +200,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
   const props = [
     rootProps,
     getDescriptionProps,
-    fieldControlValidation?.getValidationProps ?? EMPTY_OBJECT,
+    validation?.getValidationProps ?? EMPTY_OBJECT,
     elementProps,
     getButtonProps,
   ];

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -78,7 +78,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   const { setDirty, shouldValidateOnChange, validityData } = useFieldRootContext();
   const { controlId } = useLabelableContext();
 
-  const ref = useMergedRefs(inputRef, rootContext.fieldControlValidation.inputRef);
+  const ref = useMergedRefs(inputRef, rootContext.validation.inputRef);
 
   const serializedValue = React.useMemo(() => {
     if (isMultiple && Array.isArray(value) && value.length === 0) {
@@ -112,13 +112,13 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
       <SelectFloatingContext.Provider value={floatingContext}>
         {children}
         <input
-          {...rootContext.fieldControlValidation.getInputValidationProps({
+          {...rootContext.validation.getInputValidationProps({
             onFocus() {
               // Move focus to the trigger element when the hidden input is focused.
               store.state.triggerElement?.focus();
             },
             // Handle browser autofill.
-            onChange(event: React.ChangeEvent<HTMLSelectElement>) {
+            onChange(event: React.ChangeEvent<HTMLInputElement>) {
               // Workaround for https://github.com/facebook/react/issues/9023
               if (event.nativeEvent.defaultPrevented) {
                 return;
@@ -147,7 +147,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
                   rootContext.setValue?.(matchingValue, details);
 
                   if (shouldValidateOnChange()) {
-                    rootContext.fieldControlValidation.commitValidation(matchingValue);
+                    rootContext.validation.commit(matchingValue);
                   }
                 }
               }
@@ -155,17 +155,17 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
               store.set('forceMount', true);
               queueMicrotask(handleChange);
             },
-            id: id || controlId || undefined,
-            name: isMultiple ? undefined : rootContext.name,
-            value: serializedValue,
-            disabled: rootContext.disabled,
-            required: rootContext.required && !hasMultipleSelection,
-            readOnly: rootContext.readOnly,
-            ref,
-            style: visuallyHidden,
-            tabIndex: -1,
-            'aria-hidden': true,
           })}
+          id={id || controlId || undefined}
+          name={isMultiple ? undefined : rootContext.name}
+          value={serializedValue}
+          disabled={rootContext.disabled}
+          required={rootContext.required && !hasMultipleSelection}
+          readOnly={rootContext.readOnly}
+          ref={ref}
+          style={visuallyHidden}
+          tabIndex={-1}
+          aria-hidden
         />
         {hiddenInputs}
       </SelectFloatingContext.Provider>

--- a/packages/react/src/select/root/SelectRootContext.ts
+++ b/packages/react/src/select/root/SelectRootContext.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useFloatingRootContext, type FloatingRootContext } from '../../floating-ui-react';
 import type { SelectStore } from '../store';
-import type { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
+import type { UseFieldValidationReturnValue } from '../../field/root/useFieldValidation';
 import type { HTMLProps } from '../../utils/types';
 import type { SelectRoot } from './SelectRoot';
 
@@ -32,7 +32,7 @@ export interface SelectRootContext {
     allowSelectedMouseUp: boolean;
   }>;
   selectedItemTextRef: React.MutableRefObject<HTMLSpanElement | null>;
-  fieldControlValidation: ReturnType<typeof useFieldControlValidation>;
+  validation: UseFieldValidationReturnValue;
   /**
    * Called by each <Select.Item> when it knows its stable list index.
    * Allows the root to map option values to their DOM positions.

--- a/packages/react/src/select/root/useSelectRoot.ts
+++ b/packages/react/src/select/root/useSelectRoot.ts
@@ -16,7 +16,6 @@ import {
   useTypeahead,
   FloatingRootContext,
 } from '../../floating-ui-react';
-import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useLabelableId } from '../../labelable-provider/useLabelableId';
 import { useTransitionStatus } from '../../utils/useTransitionStatus';
@@ -57,8 +56,8 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
     setFilled,
     name: fieldName,
     disabled: fieldDisabled,
+    validation,
   } = useFieldRootContext();
-  const fieldControlValidation = useFieldControlValidation();
 
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
@@ -144,11 +143,11 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
   const positionerElement = useStore(store, selectors.positionerElement);
 
   const controlRef = useValueAsRef(store.state.triggerElement);
-  const commitValidation = fieldControlValidation.commitValidation;
+  const commit = validation.commit;
 
   useField({
     id,
-    commitValidation,
+    commit,
     value,
     controlRef,
     name,
@@ -198,14 +197,14 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
 
     clearErrors(name);
     setDirty(value !== validityData.initialValue);
-    commitValidation(value, !shouldValidateOnChange());
+    commit(value, !shouldValidateOnChange());
 
     if (shouldValidateOnChange()) {
-      commitValidation(value);
+      commit(value);
     }
   }, [
     value,
-    commitValidation,
+    commit,
     clearErrors,
     name,
     shouldValidateOnChange,
@@ -511,7 +510,7 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
       typingRef,
       selectionRef,
       selectedItemTextRef,
-      fieldControlValidation,
+      validation,
       registerItemIndex,
       onOpenChangeComplete,
       keyboardActiveRef,
@@ -540,7 +539,7 @@ export function useSelectRoot<Value, Multiple extends boolean | undefined>(
       typingRef,
       selectionRef,
       selectedItemTextRef,
-      fieldControlValidation,
+      validation,
       registerItemIndex,
       onOpenChangeComplete,
       keyboardActiveRef,

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -60,7 +60,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
     store,
     setOpen,
     selectionRef,
-    fieldControlValidation,
+    validation,
     readOnly,
     alignItemWithTriggerActiveRef,
     disabled: selectDisabled,
@@ -164,7 +164,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
         setFocused(false);
 
         if (validationMode === 'onBlur') {
-          fieldControlValidation.commitValidation(value);
+          validation.commit(value);
         }
       },
       onPointerMove({ pointerType }) {
@@ -220,7 +220,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
         });
       },
     },
-    fieldControlValidation.getValidationProps,
+    validation.getValidationProps,
     elementProps,
     getButtonProps,
   );

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -80,7 +80,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
   const {
     disabled,
     dragging,
-    fieldControlValidation,
+    validation,
     inset,
     lastChangedValueRef,
     max,
@@ -278,7 +278,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
       return;
     }
 
-    fieldControlValidation.commitValidation(lastChangedValueRef.current ?? finger.value);
+    validation.commit(lastChangedValueRef.current ?? finger.value);
     onValueCommitted(
       lastChangedValueRef.current ?? finger.value,
       createGenericEventDetails('none', nativeEvent),

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -21,7 +21,6 @@ import { activeElement } from '../../floating-ui-react/utils';
 import { CompositeList, type CompositeMetadata } from '../../composite/list/CompositeList';
 import type { FieldRoot } from '../../field/root/FieldRoot';
 import { useField } from '../../field/useField';
-import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
 import { useFormContext } from '../../form/FormContext';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
@@ -100,10 +99,9 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     setDirty,
     validityData,
     shouldValidateOnChange,
+    validation,
   } = useFieldRootContext();
   const { labelId } = useLabelableContext();
-
-  const fieldControlValidation = useFieldControlValidation();
 
   const ariaLabelledby = ariaLabelledByProp ?? labelId;
   const disabled = fieldDisabled || disabledProp;
@@ -148,7 +146,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
 
   useField({
     id,
-    commitValidation: fieldControlValidation.commitValidation,
+    commit: validation.commit,
     value: valueUnwrapped,
     controlRef,
     name,
@@ -203,9 +201,9 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
       setValueUnwrapped(newValue as Value);
       clearErrors(name);
       if (shouldValidateOnChange()) {
-        fieldControlValidation.commitValidation(newValue);
+        validation.commit(newValue);
       } else {
-        fieldControlValidation.commitValidation(newValue, true);
+        validation.commit(newValue, true);
       }
     },
   );
@@ -225,9 +223,9 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
         clearErrors(name);
 
         if (shouldValidateOnChange()) {
-          fieldControlValidation.commitValidation(nextValue ?? newValue);
+          validation.commit(nextValue ?? newValue);
         } else {
-          fieldControlValidation.commitValidation(nextValue ?? newValue, true);
+          validation.commit(nextValue ?? newValue, true);
         }
       }
     },
@@ -286,7 +284,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
       controlRef,
       disabled,
       dragging,
-      fieldControlValidation,
+      validation,
       formatOptionsRef,
       handleInputChange,
       indicatorPosition,
@@ -322,7 +320,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
       ariaLabelledby,
       disabled,
       dragging,
-      fieldControlValidation,
+      validation,
       formatOptionsRef,
       handleInputChange,
       indicatorPosition,
@@ -361,7 +359,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
         id,
         role: 'group',
       },
-      fieldControlValidation.getValidationProps,
+      validation.getValidationProps,
       elementProps,
     ],
     stateAttributesMapping: sliderStateAttributesMapping,

--- a/packages/react/src/slider/root/SliderRootContext.ts
+++ b/packages/react/src/slider/root/SliderRootContext.ts
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import type { Orientation } from '../../utils/types';
 import type { CompositeMetadata } from '../../composite/list/CompositeList';
-import type { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
+import type { UseFieldValidationReturnValue } from '../../field/root/useFieldValidation';
 import type { ThumbMetadata } from '../thumb/SliderThumb';
 import type { SliderRoot } from './SliderRoot';
 
@@ -14,7 +14,7 @@ export interface SliderRootContext {
   controlRef: React.RefObject<HTMLElement | null>;
   dragging: boolean;
   disabled: boolean;
-  fieldControlValidation: useFieldControlValidation.ReturnValue;
+  validation: UseFieldValidationReturnValue;
   formatOptionsRef: React.RefObject<Intl.NumberFormatOptions | undefined>;
   handleInputChange: (
     valueInput: number,

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -115,7 +115,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
     active: activeIndex,
     controlRef,
     disabled: contextDisabled,
-    fieldControlValidation,
+    validation,
     formatOptionsRef,
     handleInputChange,
     inset,
@@ -301,9 +301,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
         setFocused(false);
 
         if (validationMode === 'onBlur') {
-          fieldControlValidation.commitValidation(
-            getSliderValue(thumbValue, index, min, max, range, sliderValues),
-          );
+          validation.commit(getSliderValue(thumbValue, index, min, max, range, sliderValues));
         }
       },
       onKeyDown(event: React.KeyboardEvent) {
@@ -386,10 +384,10 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
       type: 'range',
       value: thumbValue ?? '',
     },
-    fieldControlValidation.getInputValidationProps,
+    validation.getInputValidationProps,
   );
 
-  const mergedInputRef = useMergedRefs(inputRef, fieldControlValidation.inputRef, inputRefProp);
+  const mergedInputRef = useMergedRefs(inputRef, validation.inputRef, inputRefProp);
 
   const element = useRenderElement('div', componentProps, {
     state,

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -14,7 +14,6 @@ import { stateAttributesMapping } from '../stateAttributesMapping';
 import { useField } from '../../field/useField';
 import type { FieldRoot } from '../../field/root/FieldRoot';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
-import { useFieldControlValidation } from '../../field/control/useFieldControlValidation';
 import { useFormContext } from '../../form/FormContext';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
 import { useLabelableId } from '../../labelable-provider/useLabelableId';
@@ -59,6 +58,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     validationMode,
     disabled: fieldDisabled,
     name: fieldName,
+    validation,
   } = useFieldRootContext();
 
   const { labelId } = useLabelableContext();
@@ -66,17 +66,10 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
 
-  const {
-    getValidationProps,
-    getInputValidationProps,
-    inputRef: inputValidationRef,
-    commitValidation,
-  } = useFieldControlValidation();
-
   const onCheckedChange = useStableCallback(onCheckedChangeProp);
 
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const handleInputRef = useMergedRefs(inputRef, externalInputRef, inputValidationRef);
+  const handleInputRef = useMergedRefs(inputRef, externalInputRef, validation.inputRef);
 
   const switchRef = React.useRef<HTMLButtonElement | null>(null);
 
@@ -95,7 +88,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
 
   useField({
     id,
-    commitValidation,
+    commit: validation.commit,
     value: checked,
     controlRef: switchRef,
     name,
@@ -133,7 +126,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
       setFocused(false);
 
       if (validationMode === 'onBlur') {
-        commitValidation(element.checked);
+        validation.commit(element.checked);
       }
     },
     onClick(event) {
@@ -181,20 +174,18 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
             setCheckedState(nextChecked);
 
             if (shouldValidateOnChange()) {
-              commitValidation(nextChecked);
+              validation.commit(nextChecked);
             } else {
-              commitValidation(nextChecked, true);
+              validation.commit(nextChecked, true);
             }
           },
         },
-        getInputValidationProps,
+        validation.getInputValidationProps,
       ),
     [
       checked,
       clearErrors,
-      commitValidation,
       disabled,
-      getInputValidationProps,
       handleInputRef,
       id,
       name,
@@ -204,6 +195,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
       setDirty,
       setFilled,
       shouldValidateOnChange,
+      validation,
       validityData.initialValue,
     ],
   );
@@ -222,7 +214,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
   const element = useRenderElement('button', componentProps, {
     state,
     ref: [forwardedRef, switchRef, buttonRef],
-    props: [rootProps, getValidationProps, elementProps, getButtonProps],
+    props: [rootProps, validation.getValidationProps, elementProps, getButtonProps],
     stateAttributesMapping,
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Moves (and renames) `useFieldControlValidation` so it's called from within `FieldRoot`, allowing the code to be removed by bundlers when `Field` is not being used