### PR TITLE
[test] Fix flaky tooltip tests

### DIFF
--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -1422,6 +1422,7 @@ describe('<Tooltip.Root />', () => {
       const triggerId = randomStringValue();
       await render(
         <React.Fragment>
+          <button type="button" aria-label="Initial focus" autoFocus />
           <Tooltip.Trigger handle={testTooltip} payload={1}>
             Trigger 1
           </Tooltip.Trigger>


### PR DESCRIPTION
Another attempt at fixing flaky Tooltip tests.
Added a focus target before the tested components to prevent the trigger from being initially focused.