### PR TITLE
[docs-infra] Preload Local Fonts

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -5,6 +5,29 @@ export default function Layout({ children }: React.PropsWithChildren) {
   return (
     // Use suppressHydrationWarning to avoid https://github.com/facebook/react/issues/24430
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <link
+          rel="preload"
+          href={new URL('../fonts/regular.woff2', import.meta.url).toString()}
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preload"
+          href={new URL('../fonts/medium.woff2', import.meta.url).toString()}
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preload"
+          href={new URL('../fonts/bold.woff2', import.meta.url).toString()}
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
+      </head>
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
We should preload our [local fonts](https://github.com/mui/base-ui/blob/master/docs/src/fonts/index.css), so they start loading right away instead of after the first css file loads.

Before:

<img width="445" height="383" alt="image" src="https://github.com/user-attachments/assets/73cde756-a68d-40fe-afee-7ce07ae81b29" />

After:

<img width="340" height="427" alt="image" src="https://github.com/user-attachments/assets/1a644331-f762-41f5-aa13-4cb8bded35ff" />

<img width="1411" height="94" alt="Screenshot From 2025-11-07 08-40-56" src="https://github.com/user-attachments/assets/3bff18c7-ba89-4286-ad9d-c6d427e4bf0a" />

<img width="1403" height="146" alt="image" src="https://github.com/user-attachments/assets/0ef7e9d6-0d94-4420-aadc-179f44a33741" />

Also seems to fix the issue where the page renders without any text:
<img width="383" height="294" alt="image" src="https://github.com/user-attachments/assets/571fe64e-3fbe-4a68-810d-16ea6493afc6" />

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
