### PR TITLE
[docs] Set explicit height in virtualized demos, avoid deferred value flickers

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/autocomplete/demos/virtualized/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/autocomplete/demos/virtualized/css-modules/index.tsx
@@ -14,9 +14,12 @@ export default function ExampleVirtualizedAutocomplete() {
 
   const { contains } = Autocomplete.useFilter();
 
+  const resolvedSearchValue =
+    searchValue === '' || deferredSearchValue === '' ? searchValue : deferredSearchValue;
+
   const filteredItems = React.useMemo(() => {
-    return virtualizedItems.filter((item) => contains(item, deferredSearchValue, getItemLabel));
-  }, [contains, deferredSearchValue]);
+    return virtualizedItems.filter((item) => contains(item, resolvedSearchValue, getItemLabel));
+  }, [contains, resolvedSearchValue]);
 
   const virtualizer = useVirtualizer({
     enabled: open,
@@ -41,7 +44,6 @@ export default function ExampleVirtualizedAutocomplete() {
   );
 
   const totalSize = virtualizer.getTotalSize();
-  const totalSizePx = `${totalSize}px`;
 
   return (
     <Autocomplete.Root
@@ -84,12 +86,12 @@ export default function ExampleVirtualizedAutocomplete() {
                   role="presentation"
                   ref={handleScrollElementRef}
                   className={styles.Scroller}
-                  style={{ '--total-size': totalSizePx } as React.CSSProperties}
+                  style={{ '--total-size': `${totalSize}px` } as React.CSSProperties}
                 >
                   <div
                     role="presentation"
                     className={styles.VirtualizedPlaceholder}
-                    style={{ height: totalSizePx }}
+                    style={{ height: totalSize }}
                   >
                     {virtualizer.getVirtualItems().map((virtualItem) => {
                       const item = filteredItems[virtualItem.index];
@@ -112,6 +114,7 @@ export default function ExampleVirtualizedAutocomplete() {
                             top: 0,
                             left: 0,
                             width: '100%',
+                            height: virtualItem.size,
                             transform: `translateY(${virtualItem.start}px)`,
                           }}
                         >

--- a/docs/src/app/(public)/(content)/react/components/autocomplete/demos/virtualized/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/autocomplete/demos/virtualized/tailwind/index.tsx
@@ -13,9 +13,12 @@ export default function ExampleVirtualizedAutocomplete() {
 
   const { contains } = Autocomplete.useFilter();
 
+  const resolvedSearchValue =
+    searchValue === '' || deferredSearchValue === '' ? searchValue : deferredSearchValue;
+
   const filteredItems = React.useMemo(() => {
-    return virtualizedItems.filter((item) => contains(item, deferredSearchValue, getItemLabel));
-  }, [contains, deferredSearchValue]);
+    return virtualizedItems.filter((item) => contains(item, resolvedSearchValue, getItemLabel));
+  }, [contains, resolvedSearchValue]);
 
   const virtualizer = useVirtualizer({
     enabled: open,
@@ -40,7 +43,6 @@ export default function ExampleVirtualizedAutocomplete() {
   );
 
   const totalSize = virtualizer.getTotalSize();
-  const totalSizePx = `${totalSize}px`;
 
   return (
     <Autocomplete.Root
@@ -86,12 +88,12 @@ export default function ExampleVirtualizedAutocomplete() {
                   role="presentation"
                   ref={handleScrollElementRef}
                   className="h-[min(22rem,var(--total-size))] max-h-[var(--available-height)] overflow-auto overscroll-contain scroll-p-2"
-                  style={{ '--total-size': totalSizePx } as React.CSSProperties}
+                  style={{ '--total-size': `${totalSize}px` } as React.CSSProperties}
                 >
                   <div
                     role="presentation"
                     className="relative w-full"
-                    style={{ height: totalSizePx }}
+                    style={{ height: totalSize }}
                   >
                     {virtualizer.getVirtualItems().map((virtualItem) => {
                       const item = filteredItems[virtualItem.index];
@@ -114,6 +116,7 @@ export default function ExampleVirtualizedAutocomplete() {
                             top: 0,
                             left: 0,
                             width: '100%',
+                            height: virtualItem.size,
                             transform: `translateY(${virtualItem.start}px)`,
                           }}
                         >

--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/virtualized/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/virtualized/css-modules/index.tsx
@@ -15,9 +15,12 @@ export default function ExampleVirtualizedCombobox() {
 
   const { contains } = Combobox.useFilter({ value });
 
+  const resolvedSearchValue =
+    searchValue === '' || deferredSearchValue === '' ? searchValue : deferredSearchValue;
+
   const filteredItems = React.useMemo(() => {
-    return virtualizedItems.filter((item) => contains(item, deferredSearchValue, getItemLabel));
-  }, [contains, deferredSearchValue]);
+    return virtualizedItems.filter((item) => contains(item, resolvedSearchValue, getItemLabel));
+  }, [contains, resolvedSearchValue]);
 
   const virtualizer = useVirtualizer({
     enabled: open,
@@ -42,7 +45,6 @@ export default function ExampleVirtualizedCombobox() {
   );
 
   const totalSize = virtualizer.getTotalSize();
-  const totalSizePx = `${totalSize}px`;
 
   return (
     <Combobox.Root
@@ -87,12 +89,12 @@ export default function ExampleVirtualizedCombobox() {
                   role="presentation"
                   ref={handleScrollElementRef}
                   className={styles.Scroller}
-                  style={{ '--total-size': totalSizePx } as React.CSSProperties}
+                  style={{ '--total-size': `${totalSize}px` } as React.CSSProperties}
                 >
                   <div
                     role="presentation"
                     className={styles.VirtualizedPlaceholder}
-                    style={{ height: totalSizePx }}
+                    style={{ height: totalSize }}
                   >
                     {virtualizer.getVirtualItems().map((virtualItem) => {
                       const item = filteredItems[virtualItem.index];
@@ -115,6 +117,7 @@ export default function ExampleVirtualizedCombobox() {
                             top: 0,
                             left: 0,
                             width: '100%',
+                            height: virtualItem.size,
                             transform: `translateY(${virtualItem.start}px)`,
                           }}
                         >

--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/virtualized/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/virtualized/tailwind/index.tsx
@@ -14,9 +14,12 @@ export default function ExampleVirtualizedCombobox() {
 
   const { contains } = Combobox.useFilter({ value });
 
+  const resolvedSearchValue =
+    searchValue === '' || deferredSearchValue === '' ? searchValue : deferredSearchValue;
+
   const filteredItems = React.useMemo(() => {
-    return virtualizedItems.filter((item) => contains(item, deferredSearchValue, getItemLabel));
-  }, [contains, deferredSearchValue]);
+    return virtualizedItems.filter((item) => contains(item, resolvedSearchValue, getItemLabel));
+  }, [contains, resolvedSearchValue]);
 
   const virtualizer = useVirtualizer({
     enabled: open,
@@ -41,7 +44,6 @@ export default function ExampleVirtualizedCombobox() {
   );
 
   const totalSize = virtualizer.getTotalSize();
-  const totalSizePx = `${totalSize}px`;
 
   return (
     <Combobox.Root
@@ -88,12 +90,12 @@ export default function ExampleVirtualizedCombobox() {
                   role="presentation"
                   ref={handleScrollElementRef}
                   className="h-[min(22rem,var(--total-size))] max-h-[var(--available-height)] overflow-auto overscroll-contain scroll-p-2"
-                  style={{ '--total-size': totalSizePx } as React.CSSProperties}
+                  style={{ '--total-size': `${totalSize}px` } as React.CSSProperties}
                 >
                   <div
                     role="presentation"
                     className="relative w-full"
-                    style={{ height: totalSizePx }}
+                    style={{ height: totalSize }}
                   >
                     {virtualizer.getVirtualItems().map((virtualItem) => {
                       const item = filteredItems[virtualItem.index];
@@ -116,6 +118,7 @@ export default function ExampleVirtualizedCombobox() {
                             top: 0,
                             left: 0,
                             width: '100%',
+                            height: virtualItem.size,
                             transform: `translateY(${virtualItem.start}px)`,
                           }}
                         >


### PR DESCRIPTION
- `height` still needs to be specified for each virtualized item (which was removed in https://github.com/mui/base-ui/pull/3130); when selecting e.g. the 10th item, the next open doesn't scroll to the item correctly otherwise
- Fixed flickers related to `React.useDeferredValue` by using the non-deferred value when either is an empty string (added in https://github.com/mui/base-ui/pull/3068):
  - Selecting an item, selecting all text and pressing <kbd>Backspace</kbd> would briefly show the selected item alone in the list before revealing all options again
  - Tabbing into input and typing <kbd>f</kbd> to show the empty state would briefly show all items before the empty state is shown