### PR TITLE
[dialogs] Add iOS scroll lock elements

### DIFF
--- a/docs/reference/generated/dialog-viewport.json
+++ b/docs/reference/generated/dialog-viewport.json
@@ -2,6 +2,12 @@
   "name": "DialogViewport",
   "description": "A positioning container for the dialog popup that can be made scrollable.\nRenders a `<div>` element.",
   "props": {
+    "disableScrollLockElements": {
+      "type": "boolean",
+      "default": "false",
+      "description": "Whether the wrapper elements used for scroll locking on iOS should be disabled.\nThis can be useful if you want to implement your own scroll lock on iOS, or to customize the elements.",
+      "detailedType": "boolean | undefined"
+    },
     "className": {
       "type": "string | ((state: Dialog.Viewport.State) => string | undefined)",
       "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state.",

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/_index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/_index.module.css
@@ -83,6 +83,11 @@
   }
 }
 
+.Viewport {
+  position: fixed;
+  inset: 0;
+}
+
 .Title {
   margin-top: -0.375rem;
   margin-bottom: 0.25rem;

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
@@ -139,6 +139,11 @@
   }
 }
 
+.Viewport {
+  position: fixed;
+  inset: 0;
+}
+
 .Title {
   margin-top: -0.375rem;
   margin-bottom: 0.25rem;

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/css-modules/index.tsx
@@ -27,31 +27,33 @@ export default function ExampleDialog() {
       <Dialog.Trigger className={styles.Button}>Tweet</Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className={styles.Backdrop} />
-        <Dialog.Popup className={styles.Popup}>
-          <Dialog.Title className={styles.Title}>New tweet</Dialog.Title>
-          <form
-            className={styles.TextareaContainer}
-            onSubmit={(event) => {
-              event.preventDefault();
-              // Close the dialog when submitting
-              setDialogOpen(false);
-            }}
-          >
-            <textarea
-              required
-              className={styles.Textarea}
-              placeholder="What’s on your mind?"
-              value={textareaValue}
-              onChange={(event) => setTextareaValue(event.target.value)}
-            />
-            <div className={styles.Actions}>
-              <Dialog.Close className={styles.Button}>Cancel</Dialog.Close>
-              <button type="submit" className={styles.Button}>
-                Tweet
-              </button>
-            </div>
-          </form>
-        </Dialog.Popup>
+        <Dialog.Viewport className={styles.Viewport}>
+          <Dialog.Popup className={styles.Popup}>
+            <Dialog.Title className={styles.Title}>New tweet</Dialog.Title>
+            <form
+              className={styles.TextareaContainer}
+              onSubmit={(event) => {
+                event.preventDefault();
+                // Close the dialog when submitting
+                setDialogOpen(false);
+              }}
+            >
+              <textarea
+                required
+                className={styles.Textarea}
+                placeholder="What’s on your mind?"
+                value={textareaValue}
+                onChange={(event) => setTextareaValue(event.target.value)}
+              />
+              <div className={styles.Actions}>
+                <Dialog.Close className={styles.Button}>Cancel</Dialog.Close>
+                <button type="submit" className={styles.Button}>
+                  Tweet
+                </button>
+              </div>
+            </form>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
 
       {/* Confirmation dialog */}

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
@@ -28,36 +28,38 @@ export default function ExampleDialog() {
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-        <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-          <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">New tweet</Dialog.Title>
-          <form
-            className="mt-4 flex flex-col gap-6"
-            onSubmit={(event) => {
-              event.preventDefault();
-              // Close the dialog when submitting
-              setDialogOpen(false);
-            }}
-          >
-            <textarea
-              required
-              className="min-h-48 w-full rounded-md border border-gray-200 px-3.5 py-2 text-base text-gray-900 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800"
-              placeholder="What’s on your mind?"
-              value={textareaValue}
-              onChange={(event) => setTextareaValue(event.target.value)}
-            />
-            <div className="flex justify-end gap-4">
-              <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                Cancel
-              </Dialog.Close>
-              <button
-                type="submit"
-                className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100"
-              >
-                Tweet
-              </button>
-            </div>
-          </form>
-        </Dialog.Popup>
+        <Dialog.Viewport className="fixed inset-0">
+          <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+            <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">New tweet</Dialog.Title>
+            <form
+              className="mt-4 flex flex-col gap-6"
+              onSubmit={(event) => {
+                event.preventDefault();
+                // Close the dialog when submitting
+                setDialogOpen(false);
+              }}
+            >
+              <textarea
+                required
+                className="min-h-48 w-full rounded-md border border-gray-200 px-3.5 py-2 text-base text-gray-900 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800"
+                placeholder="What’s on your mind?"
+                value={textareaValue}
+                onChange={(event) => setTextareaValue(event.target.value)}
+              />
+              <div className="flex justify-end gap-4">
+                <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                  Cancel
+                </Dialog.Close>
+                <button
+                  type="submit"
+                  className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100"
+                >
+                  Tweet
+                </button>
+              </div>
+            </form>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
 
       {/* Confirmation dialog */}

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/detached-triggers-controlled/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/detached-triggers-controlled/css-modules/index.tsx
@@ -50,14 +50,16 @@ export default function DialogDetachedTriggersControlledDemo() {
         {({ payload }) => (
           <Dialog.Portal>
             <Dialog.Backdrop className={styles.Backdrop} />
-            <Dialog.Popup className={styles.Popup}>
-              {payload !== undefined && (
-                <Dialog.Title className={styles.Title}>Dialog {payload}</Dialog.Title>
-              )}
-              <div className={styles.Actions}>
-                <Dialog.Close className={styles.Button}>Close</Dialog.Close>
-              </div>
-            </Dialog.Popup>
+            <Dialog.Viewport className={styles.Viewport}>
+              <Dialog.Popup className={styles.Popup}>
+                {payload !== undefined && (
+                  <Dialog.Title className={styles.Title}>Dialog {payload}</Dialog.Title>
+                )}
+                <div className={styles.Actions}>
+                  <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+                </div>
+              </Dialog.Popup>
+            </Dialog.Viewport>
           </Dialog.Portal>
         )}
       </Dialog.Root>

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/detached-triggers-controlled/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/detached-triggers-controlled/tailwind/index.tsx
@@ -64,17 +64,19 @@ export default function DialogDetachedTriggersControlledDemo() {
         {({ payload }) => (
           <Dialog.Portal>
             <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-            <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-              <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
-                Dialog {payload}
-              </Dialog.Title>
+            <Dialog.Viewport className="fixed inset-0">
+              <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+                <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
+                  Dialog {payload}
+                </Dialog.Title>
 
-              <div className="flex justify-end gap-4">
-                <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                  Close
-                </Dialog.Close>
-              </div>
-            </Dialog.Popup>
+                <div className="flex justify-end gap-4">
+                  <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                    Close
+                  </Dialog.Close>
+                </div>
+              </Dialog.Popup>
+            </Dialog.Viewport>
           </Dialog.Portal>
         )}
       </Dialog.Root>

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/detached-triggers-simple/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/detached-triggers-simple/css-modules/index.tsx
@@ -15,15 +15,17 @@ export default function DialogDetachedTriggersSimpleDemo() {
       <Dialog.Root handle={demoDialog}>
         <Dialog.Portal>
           <Dialog.Backdrop className={styles.Backdrop} />
-          <Dialog.Popup className={styles.Popup}>
-            <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
-            <Dialog.Description className={styles.Description}>
-              You are all caught up. Good job!
-            </Dialog.Description>
-            <div className={styles.Actions}>
-              <Dialog.Close className={styles.Button}>Close</Dialog.Close>
-            </div>
-          </Dialog.Popup>
+          <Dialog.Viewport className={styles.Viewport}>
+            <Dialog.Popup className={styles.Popup}>
+              <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
+              <Dialog.Description className={styles.Description}>
+                You are all caught up. Good job!
+              </Dialog.Description>
+              <div className={styles.Actions}>
+                <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+              </div>
+            </Dialog.Popup>
+          </Dialog.Viewport>
         </Dialog.Portal>
       </Dialog.Root>
     </React.Fragment>

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/detached-triggers-simple/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/detached-triggers-simple/tailwind/index.tsx
@@ -17,17 +17,21 @@ export default function DialogDetachedTriggersSimpleDemo() {
       <Dialog.Root handle={demoDialog}>
         <Dialog.Portal>
           <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-          <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-            <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
-            <Dialog.Description className="mb-6 text-base text-gray-600">
-              You are all caught up. Good job!
-            </Dialog.Description>
-            <div className="flex justify-end gap-4">
-              <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                Close
-              </Dialog.Close>
-            </div>
-          </Dialog.Popup>
+          <Dialog.Viewport className="fixed inset-0">
+            <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+              <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
+                Notifications
+              </Dialog.Title>
+              <Dialog.Description className="mb-6 text-base text-gray-600">
+                You are all caught up. Good job!
+              </Dialog.Description>
+              <div className="flex justify-end gap-4">
+                <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                  Close
+                </Dialog.Close>
+              </div>
+            </Dialog.Popup>
+          </Dialog.Viewport>
         </Dialog.Portal>
       </Dialog.Root>
     </React.Fragment>

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.module.css
@@ -83,6 +83,11 @@
   }
 }
 
+.Viewport {
+  position: fixed;
+  inset: 0;
+}
+
 .Title {
   margin-top: -0.375rem;
   margin-bottom: 0.25rem;

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/css-modules/index.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Dialog } from '@base-ui-components/react/dialog';
 import styles from './index.module.css';
 
@@ -7,15 +8,17 @@ export default function ExampleDialog() {
       <Dialog.Trigger className={styles.Button}>View notifications</Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className={styles.Backdrop} />
-        <Dialog.Popup className={styles.Popup}>
-          <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
-          <Dialog.Description className={styles.Description}>
-            You are all caught up. Good job!
-          </Dialog.Description>
-          <div className={styles.Actions}>
-            <Dialog.Close className={styles.Button}>Close</Dialog.Close>
-          </div>
-        </Dialog.Popup>
+        <Dialog.Viewport className={styles.Viewport}>
+          <Dialog.Popup className={styles.Popup}>
+            <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
+            <Dialog.Description className={styles.Description}>
+              You are all caught up. Good job!
+            </Dialog.Description>
+            <div className={styles.Actions}>
+              <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/hero/tailwind/index.tsx
@@ -8,17 +8,19 @@ export default function ExampleDialog() {
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-        <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-          <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
-          <Dialog.Description className="mb-6 text-base text-gray-600">
-            You are all caught up. Good job!
-          </Dialog.Description>
-          <div className="flex justify-end gap-4">
-            <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-              Close
-            </Dialog.Close>
-          </div>
-        </Dialog.Popup>
+        <Dialog.Viewport className="fixed inset-0">
+          <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+            <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
+            <Dialog.Description className="mb-6 text-base text-gray-600">
+              You are all caught up. Good job!
+            </Dialog.Description>
+            <div className="flex justify-end gap-4">
+              <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                Close
+              </Dialog.Close>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/inside-scroll/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/inside-scroll/css-modules/index.module.css
@@ -57,6 +57,11 @@
 .Viewport {
   position: fixed;
   inset: 0;
+}
+
+.PopupContainer {
+  position: fixed;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/inside-scroll/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/inside-scroll/css-modules/index.tsx
@@ -10,32 +10,34 @@ export default function InsideScrollDialog() {
       <Dialog.Portal>
         <Dialog.Backdrop className={styles.Backdrop} />
         <Dialog.Viewport className={styles.Viewport}>
-          <Dialog.Popup className={styles.Popup}>
-            <div className={styles.PopupHeader}>
-              <Dialog.Title className={styles.Title}>Dialog</Dialog.Title>
-            </div>
-            <Dialog.Description className={styles.Description}>
-              This layout keeps the popup fully on screen while allowing its content to scroll.
-            </Dialog.Description>
-            <ScrollArea.Root className={styles.Body}>
-              <ScrollArea.Viewport className={styles.BodyViewport}>
-                <ScrollArea.Content className={styles.BodyContent}>
-                  {CONTENT_SECTIONS.map((item) => (
-                    <section key={item.title}>
-                      <h3 className={styles.SectionTitle}>{item.title}</h3>
-                      <p className={styles.SectionBody}>{item.body}</p>
-                    </section>
-                  ))}
-                </ScrollArea.Content>
-              </ScrollArea.Viewport>
-              <ScrollArea.Scrollbar className={styles.Scrollbar}>
-                <ScrollArea.Thumb className={styles.ScrollbarThumb} />
-              </ScrollArea.Scrollbar>
-            </ScrollArea.Root>
-            <div className={styles.Actions}>
-              <Dialog.Close className={styles.Button}>Close</Dialog.Close>
-            </div>
-          </Dialog.Popup>
+          <div className={styles.PopupContainer}>
+            <Dialog.Popup className={styles.Popup}>
+              <div className={styles.PopupHeader}>
+                <Dialog.Title className={styles.Title}>Dialog</Dialog.Title>
+              </div>
+              <Dialog.Description className={styles.Description}>
+                This layout keeps the popup fully on screen while allowing its content to scroll.
+              </Dialog.Description>
+              <ScrollArea.Root className={styles.Body}>
+                <ScrollArea.Viewport className={styles.BodyViewport}>
+                  <ScrollArea.Content className={styles.BodyContent}>
+                    {CONTENT_SECTIONS.map((item) => (
+                      <section key={item.title}>
+                        <h3 className={styles.SectionTitle}>{item.title}</h3>
+                        <p className={styles.SectionBody}>{item.body}</p>
+                      </section>
+                    ))}
+                  </ScrollArea.Content>
+                </ScrollArea.Viewport>
+                <ScrollArea.Scrollbar className={styles.Scrollbar}>
+                  <ScrollArea.Thumb className={styles.ScrollbarThumb} />
+                </ScrollArea.Scrollbar>
+              </ScrollArea.Root>
+              <div className={styles.Actions}>
+                <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+              </div>
+            </Dialog.Popup>
+          </div>
         </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/inside-scroll/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/inside-scroll/tailwind/index.tsx
@@ -10,41 +10,43 @@ export default function InsideScrollDialog() {
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-opacity duration-[250ms] ease-[cubic-bezier(0.45,1.005,0,1.005)] data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-        <Dialog.Viewport className="fixed inset-0 flex items-center justify-center overflow-hidden py-6 [@media(min-height:600px)]:pb-12 [@media(min-height:600px)]:pt-8">
-          <Dialog.Popup className="relative flex w-[min(40rem,calc(100vw-2rem))] max-h-full max-w-full min-h-0 flex-col overflow-hidden rounded-lg bg-[var(--color-gray-50)] p-8 text-[var(--color-gray-900)] shadow-[0_24px_45px_rgba(15,23,42,0.18)] outline outline-1 outline-[var(--color-gray-200)] transition-all duration-[300ms] ease-[cubic-bezier(0.45,1.005,0,1.005)] data-[starting-style]:scale-[0.98] data-[starting-style]:opacity-0 data-[ending-style]:scale-[0.98] data-[ending-style]:opacity-0 dark:outline-[var(--color-gray-300)]">
-            <div className="mb-2 flex items-start justify-between gap-3">
-              <Dialog.Title className="m-0 text-xl font-semibold leading-[1.875rem]">
-                Dialog
-              </Dialog.Title>
-            </div>
-            <Dialog.Description className="m-0 mb-4 text-base leading-[1.6rem] text-[var(--color-gray-600)]">
-              This layout keeps the popup fully on screen while allowing its content to scroll.
-            </Dialog.Description>
-            <ScrollArea.Root className="relative flex min-h-0 flex-1 overflow-hidden before:absolute before:top-0 before:h-px before:w-full before:bg-[var(--color-gray-200)] before:content-[''] after:absolute after:bottom-0 after:h-px after:w-full after:bg-[var(--color-gray-200)] after:content-['']">
-              <ScrollArea.Viewport className="flex-1 min-h-0 overflow-y-auto overscroll-contain py-6 pr-6 pl-1 focus-visible:outline focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-[var(--color-blue)]">
-                <ScrollArea.Content className="flex flex-col gap-6">
-                  {CONTENT_SECTIONS.map((item) => (
-                    <section key={item.title}>
-                      <h3 className="mb-[0.4rem] text-base font-semibold leading-6">
-                        {item.title}
-                      </h3>
-                      <p className="m-0 text-[0.95rem] leading-[1.55rem] text-[var(--color-gray-700)]">
-                        {item.body}
-                      </p>
-                    </section>
-                  ))}
-                </ScrollArea.Content>
-              </ScrollArea.Viewport>
-              <ScrollArea.Scrollbar className="pointer-events-none absolute m-1 flex w-[0.25rem] justify-center rounded-[1rem] opacity-0 transition-opacity duration-[250ms] data-[hovering]:pointer-events-auto data-[hovering]:opacity-100 data-[hovering]:duration-[75ms] data-[scrolling]:pointer-events-auto data-[scrolling]:opacity-100 data-[scrolling]:duration-[75ms] md:w-[0.325rem]">
-                <ScrollArea.Thumb className="w-full rounded-[inherit] bg-[var(--color-gray-500)] before:absolute before:left-1/2 before:top-1/2 before:h-[calc(100%+1rem)] before:w-[calc(100%+1rem)] before:-translate-x-1/2 before:-translate-y-1/2 before:content-['']" />
-              </ScrollArea.Scrollbar>
-            </ScrollArea.Root>
-            <div className="mt-4 flex justify-end gap-3">
-              <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                Close
-              </Dialog.Close>
-            </div>
-          </Dialog.Popup>
+        <Dialog.Viewport className="fixed inset-0">
+          <div className="fixed inset-0 flex items-center justify-center overflow-hidden py-6 [@media(min-height:600px)]:pb-12 [@media(min-height:600px)]:pt-8">
+            <Dialog.Popup className="relative flex w-[min(40rem,calc(100vw-2rem))] max-h-full max-w-full min-h-0 flex-col overflow-hidden rounded-lg bg-[var(--color-gray-50)] p-8 text-[var(--color-gray-900)] shadow-[0_24px_45px_rgba(15,23,42,0.18)] outline outline-1 outline-[var(--color-gray-200)] transition-all duration-[300ms] ease-[cubic-bezier(0.45,1.005,0,1.005)] data-[starting-style]:scale-[0.98] data-[starting-style]:opacity-0 data-[ending-style]:scale-[0.98] data-[ending-style]:opacity-0 dark:outline-[var(--color-gray-300)]">
+              <div className="mb-2 flex items-start justify-between gap-3">
+                <Dialog.Title className="m-0 text-xl font-semibold leading-[1.875rem]">
+                  Dialog
+                </Dialog.Title>
+              </div>
+              <Dialog.Description className="m-0 mb-4 text-base leading-[1.6rem] text-[var(--color-gray-600)]">
+                This layout keeps the popup fully on screen while allowing its content to scroll.
+              </Dialog.Description>
+              <ScrollArea.Root className="relative flex min-h-0 flex-1 overflow-hidden before:absolute before:top-0 before:h-px before:w-full before:bg-[var(--color-gray-200)] before:content-[''] after:absolute after:bottom-0 after:h-px after:w-full after:bg-[var(--color-gray-200)] after:content-['']">
+                <ScrollArea.Viewport className="flex-1 min-h-0 overflow-y-auto overscroll-contain py-6 pr-6 pl-1 focus-visible:outline focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-[var(--color-blue)]">
+                  <ScrollArea.Content className="flex flex-col gap-6">
+                    {CONTENT_SECTIONS.map((item) => (
+                      <section key={item.title}>
+                        <h3 className="mb-[0.4rem] text-base font-semibold leading-6">
+                          {item.title}
+                        </h3>
+                        <p className="m-0 text-[0.95rem] leading-[1.55rem] text-[var(--color-gray-700)]">
+                          {item.body}
+                        </p>
+                      </section>
+                    ))}
+                  </ScrollArea.Content>
+                </ScrollArea.Viewport>
+                <ScrollArea.Scrollbar className="pointer-events-none absolute m-1 flex w-[0.25rem] justify-center rounded-[1rem] opacity-0 transition-opacity duration-[250ms] data-[hovering]:pointer-events-auto data-[hovering]:opacity-100 data-[hovering]:duration-[75ms] data-[scrolling]:pointer-events-auto data-[scrolling]:opacity-100 data-[scrolling]:duration-[75ms] md:w-[0.325rem]">
+                  <ScrollArea.Thumb className="w-full rounded-[inherit] bg-[var(--color-gray-500)] before:absolute before:left-1/2 before:top-1/2 before:h-[calc(100%+1rem)] before:w-[calc(100%+1rem)] before:-translate-x-1/2 before:-translate-y-1/2 before:content-['']" />
+                </ScrollArea.Scrollbar>
+              </ScrollArea.Root>
+              <div className="mt-4 flex justify-end gap-3">
+                <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                  Close
+                </Dialog.Close>
+              </div>
+            </Dialog.Popup>
+          </div>
         </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.module.css
@@ -139,6 +139,11 @@
   }
 }
 
+.Viewport {
+  position: fixed;
+  inset: 0;
+}
+
 .Title {
   margin-top: -0.375rem;
   margin-bottom: 0.25rem;

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/css-modules/index.tsx
@@ -7,32 +7,38 @@ export default function ExampleDialog() {
       <Dialog.Trigger className={styles.Button}>View notifications</Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className={styles.Backdrop} />
-        <Dialog.Popup className={styles.Popup}>
-          <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
-          <Dialog.Description className={styles.Description}>
-            You are all caught up. Good job!
-          </Dialog.Description>
-          <div className={styles.Actions}>
-            <div className={styles.ActionsLeft}>
-              <Dialog.Root>
-                <Dialog.Trigger className={styles.GhostButton}>Customize</Dialog.Trigger>
-                <Dialog.Portal>
-                  <Dialog.Popup className={styles.Popup}>
-                    <Dialog.Title className={styles.Title}>Customize notifications</Dialog.Title>
-                    <Dialog.Description className={styles.Description}>
-                      Review your settings here.
-                    </Dialog.Description>
-                    <div className={styles.Actions}>
-                      <Dialog.Close className={styles.Button}>Close</Dialog.Close>
-                    </div>
-                  </Dialog.Popup>
-                </Dialog.Portal>
-              </Dialog.Root>
-            </div>
+        <Dialog.Viewport className={styles.Viewport}>
+          <Dialog.Popup className={styles.Popup}>
+            <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
+            <Dialog.Description className={styles.Description}>
+              You are all caught up. Good job!
+            </Dialog.Description>
+            <div className={styles.Actions}>
+              <div className={styles.ActionsLeft}>
+                <Dialog.Root>
+                  <Dialog.Trigger className={styles.GhostButton}>Customize</Dialog.Trigger>
+                  <Dialog.Portal>
+                    <Dialog.Viewport className={styles.Viewport}>
+                      <Dialog.Popup className={styles.Popup}>
+                        <Dialog.Title className={styles.Title}>
+                          Customize notifications
+                        </Dialog.Title>
+                        <Dialog.Description className={styles.Description}>
+                          Review your settings here.
+                        </Dialog.Description>
+                        <div className={styles.Actions}>
+                          <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+                        </div>
+                      </Dialog.Popup>
+                    </Dialog.Viewport>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              </div>
 
-            <Dialog.Close className={styles.Button}>Close</Dialog.Close>
-          </div>
-        </Dialog.Popup>
+              <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/nested/tailwind/index.tsx
@@ -8,40 +8,44 @@ export default function ExampleDialog() {
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-        <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-          <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
-          <Dialog.Description className="mb-6 text-base text-gray-600">
-            You are all caught up. Good job!
-          </Dialog.Description>
-          <div className="flex items-center justify-end gap-4">
-            <div className="mr-auto flex">
-              <Dialog.Root>
-                <Dialog.Trigger className="-mx-1.5 -my-0.5 flex items-center justify-center rounded-sm px-1.5 py-0.5 text-base font-medium text-blue-800 hover:bg-blue-800/5 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-blue-800/10 dark:hover:bg-blue-800/15 dark:active:bg-blue-800/25">
-                  Customize
-                </Dialog.Trigger>
-                <Dialog.Portal>
-                  <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-                    <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
-                      Customize notification
-                    </Dialog.Title>
-                    <Dialog.Description className="mb-6 text-base text-gray-600">
-                      Review your settings here.
-                    </Dialog.Description>
-                    <div className="flex items-center justify-end gap-4">
-                      <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                        Close
-                      </Dialog.Close>
-                    </div>
-                  </Dialog.Popup>
-                </Dialog.Portal>
-              </Dialog.Root>
-            </div>
+        <Dialog.Viewport className="fixed inset-0">
+          <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+            <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
+            <Dialog.Description className="mb-6 text-base text-gray-600">
+              You are all caught up. Good job!
+            </Dialog.Description>
+            <div className="flex items-center justify-end gap-4">
+              <div className="mr-auto flex">
+                <Dialog.Root>
+                  <Dialog.Trigger className="-mx-1.5 -my-0.5 flex items-center justify-center rounded-sm px-1.5 py-0.5 text-base font-medium text-blue-800 hover:bg-blue-800/5 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-blue-800/10 dark:hover:bg-blue-800/15 dark:active:bg-blue-800/25">
+                    Customize
+                  </Dialog.Trigger>
+                  <Dialog.Portal>
+                    <Dialog.Viewport className="fixed inset-0">
+                      <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+                        <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
+                          Customize notification
+                        </Dialog.Title>
+                        <Dialog.Description className="mb-6 text-base text-gray-600">
+                          Review your settings here.
+                        </Dialog.Description>
+                        <div className="flex items-center justify-end gap-4">
+                          <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                            Close
+                          </Dialog.Close>
+                        </div>
+                      </Dialog.Popup>
+                    </Dialog.Viewport>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              </div>
 
-            <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-              Close
-            </Dialog.Close>
-          </div>
-        </Dialog.Popup>
+              <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                Close
+              </Dialog.Close>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/uncontained/css-modules/index.module.css
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/uncontained/css-modules/index.module.css
@@ -62,6 +62,11 @@
 .Viewport {
   position: fixed;
   inset: 0;
+}
+
+.PopupContainer {
+  position: fixed;
+  inset: 0;
   display: grid;
   place-items: center;
   padding: 2.5rem 1rem;

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/uncontained/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/uncontained/css-modules/index.tsx
@@ -8,12 +8,14 @@ export default function ExampleUncontainedDialog() {
       <Dialog.Portal>
         <Dialog.Backdrop className={styles.Backdrop} />
         <Dialog.Viewport className={styles.Viewport}>
-          <Dialog.Popup className={styles.PopupRoot}>
-            <Dialog.Close className={styles.Close} aria-label="Close">
-              <XIcon className={styles.CloseIcon} />
-            </Dialog.Close>
-            <div className={styles.Popup} />
-          </Dialog.Popup>
+          <div className={styles.PopupContainer}>
+            <Dialog.Popup className={styles.PopupRoot}>
+              <Dialog.Close className={styles.Close} aria-label="Close">
+                <XIcon className={styles.CloseIcon} />
+              </Dialog.Close>
+              <div className={styles.Popup} />
+            </Dialog.Popup>
+          </div>
         </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>

--- a/docs/src/app/(public)/(content)/react/components/dialog/demos/uncontained/tailwind/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/dialog/demos/uncontained/tailwind/index.tsx
@@ -8,16 +8,18 @@ export default function ExampleUncontainedDialog() {
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-70 backdrop-blur-[2px] transition-[opacity,backdrop-filter] duration-150 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 supports-[-webkit-touch-callout:none]:absolute dark:opacity-70" />
-        <Dialog.Viewport className="fixed inset-0 grid place-items-center px-4 py-10 xl:py-6">
-          <Dialog.Popup className="group/popup flex h-full w-full justify-center pointer-events-none transition-opacity duration-150 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0">
-            <Dialog.Close
-              className="absolute right-3 top-2 flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-gray-50 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-gray-50 xl:right-3 xl:top-3 xl:h-10 xl:w-10 dark:text-gray-900 dark:focus-visible:outline-gray-900 pointer-events-auto"
-              aria-label="Close"
-            >
-              <XIcon className="h-8 w-8" />
-            </Dialog.Close>
-            <div className="pointer-events-auto box-border h-full w-full max-w-[70rem] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-transform duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] group-data-[starting-style]/popup:scale-110 dark:outline-gray-300" />
-          </Dialog.Popup>
+        <Dialog.Viewport className="fixed inset-0">
+          <div className="fixed inset-0 grid place-items-center px-4 py-10 xl:py-6">
+            <Dialog.Popup className="group/popup flex h-full w-full justify-center pointer-events-none transition-opacity duration-150 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0">
+              <Dialog.Close
+                className="absolute right-3 top-2 flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-gray-50 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-gray-50 xl:right-3 xl:top-3 xl:h-10 xl:w-10 dark:text-gray-900 dark:focus-visible:outline-gray-900 pointer-events-auto"
+                aria-label="Close"
+              >
+                <XIcon className="h-8 w-8" />
+              </Dialog.Close>
+              <div className="pointer-events-auto box-border h-full w-full max-w-[70rem] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-transform duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] group-data-[starting-style]/popup:scale-110 dark:outline-gray-300" />
+            </Dialog.Popup>
+          </div>
         </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #1893 

This solution seems to be robust in that it doesn't break input focus slide/have glitch issues with animations. 

## Drawbacks

1. Three-four extra wrapper elements are required just to get the behavior to work. I added `disableScrollLockElements` as a way to customize them
2. Trying to style `<Dialog.Viewport>` as a flex container for `<Dialog.Popup>` doesn't work because of the nesting, breaking expectations

Note that for Popover it doesn't solve the use case listed here #3100, they'd have to specify these elements manually. We could document this? `<Popover.Viewport>` is also conceptually different from `<Dialog.Viewport>` (cc: @colmtuite)

## Alternatives

1. Document "Locking scroll on iOS" as a separate section
2. Create a separate component on iOS called `<ScrollLock>` solely for the docs (copy-pasteable) so the users can edit the elements and see that `<Dialog.Viewport>` cannot be a flex container for `<Dialog.Popup>`. Reveals how to solve the Popover use case in #3100 as well.
3. Re-adopt [usePreventScroll](https://github.com/adobe/react-spectrum/commits/main/packages/%40react-aria/overlays/src/usePreventScroll.ts) from RA which seems to have fixed most related issues