### PR TITLE
[useScrollLock] Simplify behavior when `scrollbar-gutter` is supported

### DIFF
--- a/docs/src/app/(private)/experiments/scroll-lock.tsx
+++ b/docs/src/app/(private)/experiments/scroll-lock.tsx
@@ -7,7 +7,7 @@ export default function ScrollLock() {
   const [bodyScrollY, setBodyScrollY] = React.useState(false);
   const [longContent, setLongContent] = React.useState(true);
 
-  useScrollLock({ enabled, mounted: enabled, open: enabled });
+  useScrollLock(enabled);
 
   React.useEffect(() => {
     document.body.style.overflowY = bodyScrollY ? 'scroll' : '';

--- a/docs/src/components/MobileNav.tsx
+++ b/docs/src/components/MobileNav.tsx
@@ -41,7 +41,7 @@ function PopupImpl(props: React.PropsWithChildren) {
   const [forceScrollLock, setForceScrollLock] = React.useState(false);
   const setOpen = React.useContext(MobileNavStateCallback);
   const rem = React.useRef(16);
-  useScrollLock({ enabled: forceScrollLock, open: forceScrollLock, mounted: forceScrollLock });
+  useScrollLock(forceScrollLock);
 
   React.useEffect(() => {
     rem.current = parseFloat(getComputedStyle(document.documentElement).fontSize);

--- a/packages/react/src/combobox/positioner/ComboboxPositioner.tsx
+++ b/packages/react/src/combobox/positioner/ComboboxPositioner.tsx
@@ -81,12 +81,7 @@ export const ComboboxPositioner = React.forwardRef(function ComboboxPositioner(
     lazyFlip: true,
   });
 
-  useScrollLock({
-    enabled: open && modal && openMethod !== 'touch',
-    mounted,
-    open,
-    referenceElement: triggerElement,
-  });
+  useScrollLock(open && modal && openMethod !== 'touch', triggerElement);
 
   const defaultProps: HTMLProps = React.useMemo(() => {
     const style: React.CSSProperties = {

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -154,12 +154,7 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
     escapeKey: isTopmost,
   });
 
-  useScrollLock({
-    enabled: open && modal === true,
-    mounted,
-    open,
-    referenceElement: popupElement,
-  });
+  useScrollLock(open && modal === true, popupElement);
 
   const { getReferenceProps, getFloatingProps, getTriggerProps } = useInteractions([role, dismiss]);
 

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -175,13 +175,10 @@ export const MenuRoot: React.FC<MenuRoot.Props> = function MenuRoot(props) {
     reset: resetOpenInteractionType,
   } = useOpenInteractionType(open);
 
-  useScrollLock({
-    enabled:
-      open && modal && lastOpenChangeReason !== REASONS.triggerHover && openMethod !== 'touch',
-    mounted,
-    open,
-    referenceElement: positionerElement,
-  });
+  useScrollLock(
+    open && modal && lastOpenChangeReason !== REASONS.triggerHover && openMethod !== 'touch',
+    positionerElement,
+  );
 
   useIsoLayoutEffect(() => {
     if (!open && !hoverEnabled) {

--- a/packages/react/src/menubar/Menubar.tsx
+++ b/packages/react/src/menubar/Menubar.tsx
@@ -51,12 +51,7 @@ export const Menubar = React.forwardRef(function Menubar(
     }
   }, [hasSubmenuOpen, resetOpenInteractionType]);
 
-  useScrollLock({
-    enabled: modal && hasSubmenuOpen && openMethod !== 'touch',
-    open: hasSubmenuOpen,
-    mounted: hasSubmenuOpen,
-    referenceElement: contentElement,
-  });
+  useScrollLock(modal && hasSubmenuOpen && openMethod !== 'touch', contentElement);
 
   const id = useBaseUiId(idProp);
 

--- a/packages/react/src/popover/root/PopoverRoot.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.tsx
@@ -82,13 +82,10 @@ function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Pay
     }
   }, [store, resolvedTriggerId, open]);
 
-  useScrollLock({
-    enabled:
-      open && modal === true && openReason !== REASONS.triggerHover && openMethod !== 'touch',
-    mounted,
-    open,
-    referenceElement: positionerElement,
-  });
+  useScrollLock(
+    open && modal === true && openReason !== REASONS.triggerHover && openMethod !== 'touch',
+    positionerElement,
+  );
 
   React.useEffect(() => {
     if (!open) {

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -97,12 +97,7 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
 
   React.useImperativeHandle(alignItemWithTriggerActiveRef, () => alignItemWithTriggerActive);
 
-  useScrollLock({
-    enabled: (alignItemWithTriggerActive || modal) && open && !touchModality,
-    mounted,
-    open,
-    referenceElement: triggerElement,
-  });
+  useScrollLock((alignItemWithTriggerActive || modal) && open && !touchModality, triggerElement);
 
   const positioning = useAnchorPositioning({
     anchor,

--- a/packages/react/src/utils/useScrollLock.d.ts
+++ b/packages/react/src/utils/useScrollLock.d.ts
@@ -2,10 +2,6 @@
  * Locks the scroll of the document when enabled.
  *
  * @param enabled - Whether to enable the scroll lock.
+ * @param referenceElement - Element to use as a reference for lock calculations.
  */
-export declare function useScrollLock(params: {
-  enabled: boolean;
-  mounted: boolean;
-  open: boolean;
-  referenceElement?: Element | null;
-}): void;
+export declare function useScrollLock(enabled?: boolean, referenceElement?: Element | null): void;

--- a/packages/react/src/utils/useScrollLock.ts
+++ b/packages/react/src/utils/useScrollLock.ts
@@ -234,31 +234,9 @@ const SCROLL_LOCKER = new ScrollLocker();
  * Locks the scroll of the document when enabled.
  *
  * @param enabled - Whether to enable the scroll lock.
+ * @param referenceElement - Element to use as a reference for lock calculations.
  */
-export function useScrollLock(params: {
-  enabled: boolean;
-  mounted: boolean;
-  open: boolean;
-  referenceElement?: Element | null;
-}) {
-  const { enabled = true, mounted, open, referenceElement = null } = params;
-
-  // https://github.com/mui/base-ui/issues/1135
-  useIsoLayoutEffect(() => {
-    if (enabled && isWebKit && mounted && !open) {
-      const doc = ownerDocument(referenceElement);
-      const originalUserSelect = doc.body.style.userSelect;
-      const originalWebkitUserSelect = doc.body.style.webkitUserSelect;
-      doc.body.style.userSelect = 'none';
-      doc.body.style.webkitUserSelect = 'none';
-      return () => {
-        doc.body.style.userSelect = originalUserSelect;
-        doc.body.style.webkitUserSelect = originalWebkitUserSelect;
-      };
-    }
-    return undefined;
-  }, [enabled, mounted, open, referenceElement]);
-
+export function useScrollLock(enabled: boolean = true, referenceElement: Element | null = null) {
   useIsoLayoutEffect(() => {
     if (!enabled) {
       return undefined;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #3180
Fixes https://github.com/mui/base-ui/issues/2126 (https://codesandbox.io/p/sandbox/kind-tu-yp2qtf)
Fixes https://github.com/mui/base-ui/issues/3189
Closes https://github.com/mui/base-ui/issues/2598 (simplified signature for `/utils` package which people can use)

This removes the special `height` handling set on the body which breaks custom scroll updates. Only old Safari is likely to be an issue here (before 18.2) which is why I've kept the old logic still. We can probably remove the logic entirely in a year or so when Safari 27 is released, given a "last two-three versions" support guide

## Breaking change

The `useScrollLock` utility signature was simplified to `useScrollLock(enabled: boolean, referenceElement?: Element | null)`