### PR TITLE
[docs] Wrap keyboard keys in `kbd` element

### DIFF
--- a/docs/reference/generated/tabs-list.json
+++ b/docs/reference/generated/tabs-list.json
@@ -5,7 +5,7 @@
     "activateOnFocus": {
       "type": "boolean",
       "default": "false",
-      "description": "Whether to automatically change the active tab on arrow key focus.\nOtherwise, tabs will be activated using Enter or Spacebar key press.",
+      "description": "Whether to automatically change the active tab on arrow key focus.\nOtherwise, tabs will be activated using <kbd>Enter</kbd> or <kbd>Space</kbd> key press.",
       "detailedType": "boolean | undefined"
     },
     "loopFocus": {

--- a/packages/react/src/tabs/list/TabsList.tsx
+++ b/packages/react/src/tabs/list/TabsList.tsx
@@ -201,7 +201,7 @@ export interface TabsListState extends TabsRoot.State {}
 export interface TabsListProps extends BaseUIComponentProps<'div', TabsList.State> {
   /**
    * Whether to automatically change the active tab on arrow key focus.
-   * Otherwise, tabs will be activated using Enter or Spacebar key press.
+   * Otherwise, tabs will be activated using <kbd>Enter</kbd> or <kbd>Space</kbd> key press.
    * @default false
    */
   activateOnFocus?: boolean;


### PR DESCRIPTION
Tiny JSDoc/Doc improvement.

Side note: Docs API entries could also use the `Kbd` class application to keep conssitency between `mdx`:
<img width="812" height="194" alt="Screenshot 2025-11-13 at 11 27 12" src="https://github.com/user-attachments/assets/c9a9b841-4635-453c-9d0b-13f4eee06ac4" />
