### PR TITLE
[scroll area] Fix CSS vars inheritance on Safari

### DIFF
--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { useStableCallback } from '@base-ui-components/utils/useStableCallback';
 import { useIsoLayoutEffect } from '@base-ui-components/utils/useIsoLayoutEffect';
+import { isWebKit } from '@base-ui-components/utils/detectBrowser';
 import { useTimeout } from '@base-ui-components/utils/useTimeout';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useScrollAreaRootContext } from '../root/ScrollAreaRootContext';
@@ -31,7 +32,12 @@ let scrollAreaOverflowVarsRegistered = false;
  * under the "Improving CSS variable performance" section.
  */
 function removeCSSVariableInheritance() {
-  if (scrollAreaOverflowVarsRegistered) {
+  if (
+    scrollAreaOverflowVarsRegistered ||
+    // When `inherits: false`, specifying `inherit` on child elements doesn't work
+    // in Safari. To let CSS features work correctly, this optimization must be skipped.
+    isWebKit
+  ) {
     return;
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

There doesn't seem to be a solution for this, Safari is just buggy. Unfortunately, this means complex scroll areas in Safari will have worse perf (compared to Chrome/Firefox) though I'm not sure how major this will be in practice

Couple alternate solutions - these will be non-breaking, so we can add them if necessary in the future:

1. Allow the CSS vars to be disabled if perf is crucial, instead leveraging the `render` prop (where the state variables exist) to apply it to an element directly instead of relying on CSS vars
2. Allow refs to be specified so users can create `.ViewportStart`/`.ViewportEnd` elements where our code will apply the variables to instead