### PR TITLE
[menu] Fix submenus sometimes not appearing on hover

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
@@ -159,11 +159,8 @@ export function useHoverFloatingInteraction(
   React.useEffect(() => {
     return () => {
       cleanupMouseMoveHandler();
-      openChangeTimeout.clear();
-      restTimeout.clear();
-      interactedInsideRef.current = false;
     };
-  }, [cleanupMouseMoveHandler, openChangeTimeout, restTimeout, interactedInsideRef]);
+  }, [cleanupMouseMoveHandler]);
 
   React.useEffect(() => {
     return clearPointerEvents;


### PR DESCRIPTION
Fixed submenus not appearing when the trigger is hovered quickly (so that only mouseenter fires without mousemove).

The bug was caused by the splitting of useHover: previously, when useHover was placed on the root part, it was long-lived. Now, useHoverFloatingInteraction is placed on MenuPopup, which gets unmounted when menus close, and its effects are fired too often.