### PR TITLE
[code-infra] Build packages with react compiler enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,19 @@ default-context: &default-context
 #   restore_cache:
 #     key: v1-repo-{{ .Branch }}-{{ .Revision }}
 
+commands:
+  build-with-compiler:
+    description: 'Build packages with React Compiler'
+    steps:
+      - run:
+          name: Add compiler package
+          command: pnpm -F "./packages/*" add react-compiler-runtime
+      - run:
+          name: Build with compiler
+          command: pnpm -F "./packages/*" build --enableReactCompiler
+          environment:
+            MUI_REACT_COMPILER_MODE: 'infer'
+
 jobs:
   test_unit:
     <<: *default-job
@@ -197,6 +210,33 @@ jobs:
           command: pnpm -r test:package
       - code-infra/upload-size-snapshot
 
+  test_unit_compiler:
+    <<: *default-job
+    steps:
+      - checkout
+      - code-infra/install-deps
+      - build-with-compiler
+      - run:
+          name: Run tests on JSDOM
+          command: pnpm test:jsdom:coverage
+          environment:
+            MUI_DISABLE_WORKSPACE_ALIASES: 1
+
+  test_browser_compiler:
+    <<: *default-job
+    executor:
+      name: code-infra/mui-node-browser
+      playwright-img-version: v1.56.1-noble
+    steps:
+      - checkout
+      - code-infra/install-deps
+      - build-with-compiler
+      - run:
+          name: Run tests on headless Chromium
+          command: pnpm test:chromium --coverage
+          environment:
+            MUI_DISABLE_WORKSPACE_ALIASES: 1
+
 workflows:
   pipeline:
     when:
@@ -226,6 +266,12 @@ workflows:
       - test_package:
           <<: *default-context
           name: 'Package verification'
+      - test_unit_compiler:
+          <<: *default-context
+          name: 'JSDOM tests (React Compiler)'
+      - test_browser_compiler:
+          <<: *default-context
+          name: 'Browser tests (React Compiler)'
   react-18:
     when:
       equal: [pipeline, << pipeline.parameters.workflow >>]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -77,7 +77,6 @@
   "scripts": {
     "prebuild": "rimraf --glob build build-tests \"*.tsbuildinfo\"",
     "build": "code-infra build --ignore \"**/*.template.js\" --copy .npmignore",
-    "build:stable": "code-infra build --bundle esm --ignore \"**/*.template.js\" --buildTypes false",
     "test:package": "publint --pack pnpm && attw --pack ./build --exclude-entrypoints package.json --exclude-entrypoints esm --exclude-entrypoints cjs",
     "release": "pnpm build && pnpm publish",
     "test": "cross-env NODE_ENV=test VITEST_ENV=jsdom vitest",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "prebuild": "rimraf --glob build build-tests \"*.tsbuildinfo\"",
     "build": "code-infra build --copy .npmignore",
-    "build:stable": "code-infra build --bundle esm --buildTypes false",
     "test:package": "publint --pack pnpm run ./build && attw --pack ./build --exclude-entrypoints package.json --exclude-entrypoints esm --exclude-entrypoints cjs",
     "release": "pnpm build && pnpm publish",
     "test": "cross-env NODE_ENV=test VITEST_ENV=jsdom vitest",

--- a/test/vite.shared.config.mjs
+++ b/test/vite.shared.config.mjs
@@ -2,13 +2,19 @@ import * as path from 'path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const shouldDisableWorkspaceAliases = Boolean(process.env.MUI_DISABLE_WORKSPACE_ALIASES);
+
 export default defineConfig({
   mode: process.env.NODE_ENV || 'development',
   plugins: [react()],
   resolve: {
     alias: {
-      '@base-ui-components/react': path.join(process.cwd(), 'packages/react/src'),
-      '@base-ui-components/utils': path.join(process.cwd(), 'packages/utils/src'),
+      ...(shouldDisableWorkspaceAliases
+        ? undefined
+        : {
+            '@base-ui-components/react': path.join(process.cwd(), 'packages/react/src'),
+            '@base-ui-components/utils': path.join(process.cwd(), 'packages/utils/src'),
+          }),
       './fonts': path.join(process.cwd(), '/docs/src/fonts'),
       docs: path.join(process.cwd(), '/docs'),
       stream: null,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Added tests with React compiler enabled solely on CI to make sure building with react compiler doesn't break any component.

The two new jobs (`test_unit_compiler` and `test_browser_compiler`) perform the build with full react compiler transform and then run the tests without aliasing to the source files.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
