### PR TITLE
[popups] Fix trigger registration loop

### DIFF
--- a/packages/react/src/utils/popupStoreUtils.test.tsx
+++ b/packages/react/src/utils/popupStoreUtils.test.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Store } from '@base-ui-components/utils/store';
+import { useTriggerRegistration, PopupTriggerMap } from './popupStoreUtils';
+
+type TestStoreState = {
+  triggers: PopupTriggerMap;
+};
+
+function createStore() {
+  return new Store<TestStoreState>({
+    triggers: new Map(),
+  });
+}
+
+function TestTrigger({
+  id,
+  store,
+  element,
+  repeat = 1,
+}: {
+  id: string;
+  store: Store<TestStoreState>;
+  element: HTMLElement;
+  repeat?: number;
+}) {
+  const register = useTriggerRegistration(id, store);
+
+  React.useLayoutEffect(() => {
+    for (let i = 0; i < repeat; i += 1) {
+      register(element);
+    }
+    return () => {
+      register(null);
+    };
+  }, [register, repeat, element]);
+
+  return null;
+}
+
+describe('useTriggerRegistration', () => {
+  it('does not update the store when the same element is provided repeatedly', () => {
+    const store = createStore();
+    const spy = vi.spyOn(store, 'set');
+    const element = document.createElement('button');
+
+    const { unmount } = render(
+      <TestTrigger id="trigger" store={store} element={element} repeat={3} />,
+    );
+
+    expect(store.state.triggers.get('trigger')).to.equal(element);
+    expect(spy).toHaveBeenCalledTimes(1); // only first call
+
+    unmount();
+    expect(spy).toHaveBeenCalledTimes(2); // unregister
+    expect(store.state.triggers.size).to.equal(0);
+  });
+
+  it('updates the store when the trigger id changes', () => {
+    const store = createStore();
+    const spy = vi.spyOn(store, 'set');
+    const element = document.createElement('button');
+
+    const { rerender, unmount } = render(
+      <TestTrigger id="first" store={store} element={element} />,
+    );
+
+    expect(store.state.triggers.has('first')).to.equal(true);
+    expect(store.state.triggers.get('first')).to.equal(element);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    rerender(<TestTrigger id="second" store={store} element={element} />);
+
+    expect(store.state.triggers.has('first')).to.equal(false);
+    expect(store.state.triggers.get('second')).to.equal(element);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    unmount();
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(store.state.triggers.size).to.equal(0);
+  });
+});

--- a/packages/react/src/utils/popupStoreUtils.ts
+++ b/packages/react/src/utils/popupStoreUtils.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Store } from '@base-ui-components/utils/store';
+import { useIsoLayoutEffect } from '@base-ui-components/utils/useIsoLayoutEffect';
 
 /**
  * Returns a callback ref that registers/unregisters the trigger element in the store.
@@ -11,27 +12,69 @@ export function useTriggerRegistration<State extends { triggers: PopupTriggerMap
   id: string | undefined,
   store: Store<State>,
 ) {
-  const registeredIdRef = React.useRef<string>(null);
+  const registeredIdRef = React.useRef<string | null>(null);
+  const [element, setElement] = React.useState<HTMLElement | null>(null);
 
-  return React.useCallback(
-    (triggerElement: HTMLElement | null) => {
-      if (id == null) {
+  useIsoLayoutEffect(() => {
+    if (id == null) {
+      if (element != null) {
         throw new Error('Base UI: Trigger must have an `id` prop specified.');
       }
+      return;
+    }
 
-      const triggers = new Map(store.state.triggers);
-      if (triggerElement != null) {
-        triggers.set(id, triggerElement);
-        // Keeping track of the registered id in case it changes.
-        registeredIdRef.current = id;
-      } else if (registeredIdRef.current != null) {
-        triggers.delete(registeredIdRef.current);
-        registeredIdRef.current = null;
+    const prevId = registeredIdRef.current;
+    const triggers = store.state.triggers;
+
+    if (element) {
+      const existing = triggers.get(id);
+
+      if (existing === element && prevId === id) {
+        return;
       }
-      store.set('triggers', triggers);
-    },
-    [store, id],
-  );
+
+      const next = new Map(triggers);
+
+      if (prevId != null && prevId !== id) {
+        next.delete(prevId);
+      }
+
+      next.set(id, element);
+      registeredIdRef.current = id;
+      store.set('triggers', next);
+    } else {
+      const keyToRemove = prevId ?? id;
+      if (!triggers.has(keyToRemove)) {
+        return;
+      }
+
+      const next = new Map(triggers);
+      next.delete(keyToRemove);
+      registeredIdRef.current = null;
+      store.set('triggers', next);
+    }
+  }, [element, id, store]);
+
+  useIsoLayoutEffect(() => {
+    return () => {
+      const prevId = registeredIdRef.current;
+      if (prevId == null) {
+        return;
+      }
+
+      const triggers = store.state.triggers;
+      if (!triggers.has(prevId)) {
+        return;
+      }
+
+      const next = new Map(triggers);
+      next.delete(prevId);
+      registeredIdRef.current = null;
+      store.set('triggers', next);
+    };
+  }, [store]);
+
+  return setElement;
 }
 
 export type PayloadChildRenderFunction<Payload> = (arg: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Composing the trigger with some components can cause a loop of registrations.

When the trigger is a host element (`<button>`), React only fires the ref callback when the node mounts/unmounts, so we take that one store write - but RR (or TanStack, etc) `<Link>` calls the forwarded ref on every re-render (it renders an `<a>` and executes whatever ref it was given after each commit). As soon as `registerTrigger` stores the element, the store update makes TooltipTrigger re-render, which makes `<Link>` re-render, which invokes the forwarded ref again, which calls `store.set('triggers', …)` again, and so on

By moving from a callback ref to a layout effect, we can properly check the current state

Fixes #3245 

https://stackblitz.com/edit/we9fwsbd-ig7fodmj