### PR TITLE
[combobox][select] Docs for typed wrappers

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/typed/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/typed/css-modules/index.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { Combobox } from '@base-ui-components/react/combobox';
+
+export default function App() {
+  return <MyCombobox />;
+}
+
+export function MyCombobox<Value, Multiple extends boolean | undefined = false>(
+  props: ComboboxRootControlledProps<Value, Multiple>,
+): React.JSX.Element;
+export function MyCombobox<Value, Multiple extends boolean | undefined = false>(
+  props: ComboboxRootUncontrolledProps<Value, Multiple>,
+): React.JSX.Element;
+export function MyCombobox<Value, Multiple extends boolean | undefined = false>(
+  props: Combobox.Root.Props<Value, Multiple>,
+): React.JSX.Element {
+  return <Combobox.Root<any, any> {...props} />;
+}
+
+type ComboboxValueType<Value, Multiple extends boolean | undefined> = Multiple extends true
+  ? Value[]
+  : Value;
+
+type ComboboxRootControlledProps<Value, Multiple extends boolean | undefined> = Combobox.Root.Props<
+  Value,
+  Multiple
+> & {
+  /**
+   * The selected value of the combobox. Use when controlled.
+   */
+  value: ComboboxValueType<Value, Multiple>;
+  /**
+   * Event handler called when the selected value of the combobox changes.
+   */
+  onValueChange?: (
+    value: ComboboxValueType<Value, Multiple>,
+    eventDetails: Combobox.Root.ChangeEventDetails,
+  ) => void;
+};
+
+type ComboboxRootUncontrolledProps<
+  Value,
+  Multiple extends boolean | undefined,
+> = Combobox.Root.Props<Value, Multiple> & {
+  /**
+   * The selected value of the combobox. Use when controlled.
+   */
+  value?: any;
+  /**
+   * Event handler called when the selected value of the combobox changes.
+   */
+  onValueChange?: (
+    value: ComboboxValueType<Value, Multiple> | (Multiple extends true ? never : null),
+    eventDetails: Combobox.Root.ChangeEventDetails,
+  ) => void;
+};

--- a/docs/src/app/(public)/(content)/react/components/combobox/demos/typed/index.ts
+++ b/docs/src/app/(public)/(content)/react/components/combobox/demos/typed/index.ts
@@ -1,0 +1,6 @@
+import { createDemoWithVariants } from 'docs/src/utils/createDemo';
+import CssModules from './css-modules';
+
+export const DemoComboboxTyped = createDemoWithVariants(import.meta.url, {
+  CssModules,
+});

--- a/docs/src/app/(public)/(content)/react/components/combobox/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/combobox/page.mdx
@@ -74,6 +74,14 @@ When not specifying value props, the parameter's type must be explicitly specifi
 
 ## Examples
 
+### Typed wrapper
+
+The following example shows a typed wrapper around the Combobox component with correct type inference and type safety.
+
+import { DemoComboboxTyped } from './demos/typed';
+
+<DemoComboboxTyped />
+
 ### Multiple select
 
 The combobox can allow multiple selections by adding the `multiple` prop to `<Combobox.Root>`.

--- a/docs/src/app/(public)/(content)/react/components/select/demos/typed/css-modules/index.tsx
+++ b/docs/src/app/(public)/(content)/react/components/select/demos/typed/css-modules/index.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { Select } from '@base-ui-components/react/select';
+
+export default function App() {
+  return <MySelect />;
+}
+
+export function MySelect<Value, Multiple extends boolean | undefined = false>(
+  props: SelectRootControlledProps<Value, Multiple>,
+): React.JSX.Element;
+export function MySelect<Value, Multiple extends boolean | undefined = false>(
+  props: SelectRootUncontrolledProps<Value, Multiple>,
+): React.JSX.Element;
+export function MySelect<Value, Multiple extends boolean | undefined = false>(
+  props: Select.Root.Props<Value, Multiple>,
+): React.JSX.Element {
+  return <Select.Root<any, any> {...props} />;
+}
+
+type SelectValueType<Value, Multiple extends boolean | undefined> = Multiple extends true
+  ? Value[]
+  : Value;
+
+type SelectRootBaseProps<Value, Multiple extends boolean | undefined> = Omit<
+  Select.Root.Props<Value>,
+  'multiple' | 'value' | 'defaultValue' | 'onValueChange'
+> & {
+  /**
+   * Whether multiple items can be selected.
+   * @default false
+   */
+  multiple?: Multiple;
+  /**
+   * The uncontrolled value of the select when it’s initially rendered.
+   *
+   * To render a controlled select, use the `value` prop instead.
+   * @default null
+   */
+  defaultValue?: SelectValueType<Value, Multiple> | null;
+};
+
+type SelectRootControlledProps<Value, Multiple extends boolean | undefined> = SelectRootBaseProps<
+  Value,
+  Multiple
+> & {
+  /**
+   * The value of the select. Use when controlled.
+   */
+  value: SelectValueType<Value, Multiple>;
+  /**
+   * Event handler called when the value of the select changes.
+   */
+  onValueChange?: (
+    value: SelectValueType<Value, Multiple>,
+    eventDetails: Select.Root.ChangeEventDetails,
+  ) => void;
+};
+
+type SelectRootUncontrolledProps<Value, Multiple extends boolean | undefined> = SelectRootBaseProps<
+  Value,
+  Multiple
+> & {
+  /**
+   * The value of the select. Use when controlled.
+   */
+  value?: any;
+  /**
+   * Event handler called when the value of the select changes.
+   */
+  onValueChange?: (
+    value: SelectValueType<Value, Multiple> | (Multiple extends true ? never : null),
+    eventDetails: Select.Root.ChangeEventDetails,
+  ) => void;
+};

--- a/docs/src/app/(public)/(content)/react/components/select/demos/typed/index.ts
+++ b/docs/src/app/(public)/(content)/react/components/select/demos/typed/index.ts
@@ -1,0 +1,6 @@
+import { createDemoWithVariants } from 'docs/src/utils/createDemo';
+import CssModules from './css-modules';
+
+export const DemoSelectTyped = createDemoWithVariants(import.meta.url, {
+  CssModules,
+});

--- a/docs/src/app/(public)/(content)/react/components/select/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/select/page.mdx
@@ -109,6 +109,14 @@ To avoid lookup, [object values](#object-values) for each item can also be used.
 
 ## Examples
 
+### Typed wrapper
+
+The following example shows a typed wrapper around the Select component with correct type inference and type safety.
+
+import { DemoSelectTyped } from './demos/typed';
+
+<DemoSelectTyped />
+
 ### Multiple selection
 
 Add the `multiple` prop to the `<Select.Root>` component to allow multiple selections.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The type setup required to satisfy all the type spec tests for [Select](https://github.com/mui/base-ui/blob/eb7e80b12c3bbd3e4db922753f57b65941235880/packages/react/src/select/root/SelectRoot.spec.tsx) and [Combobox](https://github.com/mui/base-ui/blob/eb7e80b12c3bbd3e4db922753f57b65941235880/packages/react/src/combobox/root/ComboboxRoot.spec.tsx) is now quite complex, so creating wrappers that inherit the root's props is not straightforward. These demos display copy-pasteable starting points for wrappers to use

- We could export `UncontrolledProps` & `ControlledProps` on the root to further simplify types
- There may be a way to avoid overloads while letting all the type tests pass, but I didn't find a way how to do it (would be ideal)