### PR TITLE
[all components] Fix error about `props.ref` access in React <=18

### DIFF
--- a/packages/utils/src/getReactElementRef.ts
+++ b/packages/utils/src/getReactElementRef.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { isReactVersionAtLeast } from './reactVersion';
 
 /**
  * Extracts the `ref` from a React element, handling different React versions.
@@ -10,7 +11,6 @@ export function getReactElementRef(element: unknown): React.Ref<unknown> | null 
 
   const reactElement = element as React.ReactElement & { ref?: React.Ref<unknown> };
   const propsWithRef = reactElement.props as { ref?: React.Ref<unknown> } | undefined;
-  const refFromProps = propsWithRef?.ref;
 
-  return refFromProps ?? reactElement.ref ?? null;
+  return (isReactVersionAtLeast(19) ? propsWithRef?.ref : reactElement.ref) ?? null;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/base-ui/issues/3248#issuecomment-3544166244