### PR TITLE
[docs-infra] Skip adding markdown link in prod error page

### DIFF
--- a/docs/src/app/(public)/(content)/production-error/page.mdx
+++ b/docs/src/app/(public)/(content)/production-error/page.mdx
@@ -3,7 +3,7 @@ import ErrorDisplay from './ErrorDisplay';
 
 # Production error #<ErrorCode />
 
-<Subtitle>Explanation for minified production error message.</Subtitle>
+<Subtitle skipMarkdownLink>Explanation for minified production error message.</Subtitle>
 <Meta
   name="description"
   content="In the production build, error messages are minified to keep your application lightweight."

--- a/docs/src/components/Subtitle/Subtitle.tsx
+++ b/docs/src/components/Subtitle/Subtitle.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { MarkdownLink } from './MarkdownLink';
 
-export function Subtitle({ className, ...props }: React.ComponentProps<'p'>) {
+export function Subtitle({
+  className,
+  skipMarkdownLink = false,
+  ...props
+}: React.ComponentProps<'p'> & { skipMarkdownLink?: boolean }) {
   return (
     <div
       className={clsx(
@@ -11,7 +15,7 @@ export function Subtitle({ className, ...props }: React.ComponentProps<'p'>) {
       )}
     >
       <p {...props} />
-      <MarkdownLink />
+      {!skipMarkdownLink && <MarkdownLink />}
     </div>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The link doesn't make sense here.

<img width="1000" height="288" alt="Screenshot 2025-11-19 at 9 39 48 AM" src="https://github.com/user-attachments/assets/f49fcc21-7ff3-4166-a8ca-54a1284ef6c7" />

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
