### PR TITLE
[context menu] Block mouseup at initial cursor point

### DIFF
--- a/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
+++ b/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
@@ -76,5 +76,102 @@ describe('<ContextMenu.Root />', () => {
       expect(rootOnOpenChange.lastCall?.args[0]).to.equal(false);
       expect(rootOnOpenChange.lastCall?.args[1].reason).to.equal(REASONS.itemPress);
     });
+
+    it('ignores mouseup directly under the cursor when the context menu spawns there', async () => {
+      const onOpenChange = spy();
+
+      await render(
+        <ContextMenu.Root onOpenChange={onOpenChange}>
+          <ContextMenu.Trigger data-testid="context-trigger">Surface</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner alignOffset={0}>
+              <ContextMenu.Popup data-testid="context-popup">
+                <ContextMenu.Item data-testid="context-item">Action</ContextMenu.Item>
+              </ContextMenu.Popup>
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('context-trigger');
+
+      fireEvent.contextMenu(trigger, { clientX: 12, clientY: 12, button: 2 });
+
+      await screen.findByTestId('context-popup');
+      const item = screen.getByTestId('context-item');
+
+      fireEvent.mouseUp(item, { button: 2, clientX: 12, clientY: 12 });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('context-popup')).not.to.equal(null);
+      });
+
+      expect(onOpenChange.callCount).to.equal(1);
+    });
+
+    it('ignores mouseup directly under the cursor when alignOffset is negative', async () => {
+      const onOpenChange = spy();
+
+      await render(
+        <ContextMenu.Root onOpenChange={onOpenChange}>
+          <ContextMenu.Trigger data-testid="context-trigger">Surface</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner alignOffset={-5}>
+              <ContextMenu.Popup data-testid="context-popup">
+                <ContextMenu.Item data-testid="context-item">Action</ContextMenu.Item>
+              </ContextMenu.Popup>
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('context-trigger');
+
+      fireEvent.contextMenu(trigger, { clientX: 18, clientY: 18, button: 2 });
+
+      await screen.findByTestId('context-popup');
+      const item = screen.getByTestId('context-item');
+
+      fireEvent.mouseUp(item, { button: 2, clientX: 18, clientY: 18 });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('context-popup')).not.to.equal(null);
+      });
+
+      expect(onOpenChange.callCount).to.equal(1);
+    });
+
+    it('allows mouseup after leaving the initial cursor point', async () => {
+      const onOpenChange = spy();
+
+      await render(
+        <ContextMenu.Root onOpenChange={onOpenChange}>
+          <ContextMenu.Trigger data-testid="context-trigger">Surface</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner alignOffset={0}>
+              <ContextMenu.Popup data-testid="context-popup">
+                <ContextMenu.Item data-testid="context-item">Action</ContextMenu.Item>
+              </ContextMenu.Popup>
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('context-trigger');
+
+      fireEvent.contextMenu(trigger, { clientX: 20, clientY: 20, button: 2 });
+
+      await screen.findByTestId('context-popup');
+      const item = screen.getByTestId('context-item');
+
+      fireEvent.pointerMove(document.body, { clientX: 24, clientY: 24 });
+      fireEvent.mouseUp(item, { button: 2, clientX: 24, clientY: 24 });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('context-popup')).to.equal(null);
+      });
+
+      expect(onOpenChange.lastCall?.args[0]).to.equal(false);
+    });
   });
 });

--- a/packages/react/src/context-menu/root/ContextMenuRoot.tsx
+++ b/packages/react/src/context-menu/root/ContextMenuRoot.tsx
@@ -25,6 +25,7 @@ export function ContextMenuRoot(props: ContextMenuRoot.Props) {
   const actionsRef: ContextMenuRootContext['actionsRef'] = React.useRef(null);
   const positionerRef = React.useRef<HTMLElement | null>(null);
   const allowMouseUpTriggerRef = React.useRef(true);
+  const initialCursorPointRef = React.useRef<{ x: number; y: number } | null>(null);
   const id = useId();
 
   const contextValue: ContextMenuRootContext = React.useMemo(
@@ -36,6 +37,7 @@ export function ContextMenuRoot(props: ContextMenuRoot.Props) {
       internalBackdropRef,
       positionerRef,
       allowMouseUpTriggerRef,
+      initialCursorPointRef,
       rootId: id,
     }),
     [anchor, id],

--- a/packages/react/src/context-menu/root/ContextMenuRootContext.ts
+++ b/packages/react/src/context-menu/root/ContextMenuRootContext.ts
@@ -11,6 +11,7 @@ export interface ContextMenuRootContext {
   } | null>;
   positionerRef: React.RefObject<HTMLElement | null>;
   allowMouseUpTriggerRef: React.RefObject<boolean>;
+  initialCursorPointRef: React.RefObject<{ x: number; y: number } | null>;
   rootId: string | undefined;
 }
 

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
@@ -33,6 +33,7 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
     backdropRef,
     positionerRef,
     allowMouseUpTriggerRef,
+    initialCursorPointRef,
     rootId,
   } = useContextMenuRootContext(false);
 
@@ -47,6 +48,8 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
 
   function handleLongPress(x: number, y: number, event: MouseEvent | TouchEvent) {
     const isTouchEvent = event.type.startsWith('touch');
+
+    initialCursorPointRef.current = { x, y };
 
     setAnchor({
       getBoundingClientRect() {

--- a/packages/react/src/menu/item/useMenuItem.ts
+++ b/packages/react/src/menu/item/useMenuItem.ts
@@ -72,6 +72,19 @@ export function useMenuItem(params: useMenuItem.Parameters): useMenuItem.ReturnV
             }
           },
           onMouseUp(event) {
+            if (contextMenuContext) {
+              const initialCursorPoint = contextMenuContext.initialCursorPointRef.current;
+              contextMenuContext.initialCursorPointRef.current = null;
+              if (
+                isContextMenu &&
+                initialCursorPoint &&
+                Math.abs(event.clientX - initialCursorPoint.x) <= 1 &&
+                Math.abs(event.clientY - initialCursorPoint.y) <= 1
+              ) {
+                return;
+              }
+            }
+
             if (
               itemRef.current &&
               store.context.allowMouseUpTriggerRef.current &&
@@ -97,6 +110,7 @@ export function useMenuItem(params: useMenuItem.Parameters): useMenuItem.ReturnV
       menuEvents,
       store,
       isContextMenu,
+      contextMenuContext,
       itemMetadata,
       nodeId,
     ],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #3224

This blocks the `mouseup` on the item if the mouseup occurred 1px or less from the the right click