### PR TITLE
[triggers] Fix React 17 support

### DIFF
--- a/packages/react/src/utils/popupStoreUtils.ts
+++ b/packages/react/src/utils/popupStoreUtils.ts
@@ -17,9 +17,6 @@ export function useTriggerRegistration<State extends { triggers: PopupTriggerMap
 
   useIsoLayoutEffect(() => {
     if (id == null) {
-      if (element != null) {
-        throw new Error('Base UI: Trigger must have an `id` prop specified.');
-      }
       return;
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #3300

The `id` should always exist from the `useBaseUiId` util, so this throw doesn't need to happen following the switch to the effect instead of callback ref.