### PR TITLE
[popups] Prevent sticking after hover when pressing `<a>` tag

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useHover.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHover.ts
@@ -24,7 +24,7 @@ import { getEmptyRootContext } from '../utils/getEmptyRootContext';
 import { TYPEABLE_SELECTOR } from '../utils/constants';
 
 const safePolygonIdentifier = createAttribute('safe-polygon');
-const interactiveSelector = `button,a,[role="button"],select,[tabindex]:not([tabindex="-1"]),${TYPEABLE_SELECTOR}`;
+const interactiveSelector = `button,[role="button"],select,[tabindex]:not([tabindex="-1"]),${TYPEABLE_SELECTOR}`;
 
 function isInteractiveElement(element: Element | null) {
   return element ? Boolean(element.closest(interactiveSelector)) : false;


### PR DESCRIPTION
Small tweak to prevent the navigation menu from sticking when pressing (but not clicking) an `<a>` tag. This should only apply to buttons or input text elements.