### PR TITLE
[toast][docs] Fix Toast component docs

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/toast/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/toast/page.mdx
@@ -129,6 +129,8 @@ The `data-swipe-direction` attribute can be used to determine the swipe directio
   &[data-swipe-direction='down'] {
     transform: translateY(calc(var(--toast-swipe-movement-y) + 150%));
   }
+  /* Note: --offset-y is defined locally in these examples and derives from
+   --toast-offset-y, --toast-index, and swipe movement values */
   &[data-swipe-direction='left'] {
     transform: translateX(calc(var(--toast-swipe-movement-x) - 150%)) translateY(var(--offset-y));
   }


### PR DESCRIPTION
Noticed while looking through the docs for integration with Material UI Snackbar.

You can't use `+` between transform functions in CSS. It should be a space-separated list of functions.

Preview: https://deploy-preview-3320--base-ui.netlify.app/react/components/toast
