### PR TITLE
[internal] Performance: use raw `useSyncExternalStore`

### DIFF
--- a/packages/utils/src/store/Store.ts
+++ b/packages/utils/src/store/Store.ts
@@ -104,3 +104,5 @@ export class Store<State> {
     Store.prototype.setState.call(this, newState);
   }
 }
+
+export type ReadonlyStore<State> = Pick<Store<State>, 'getSnapshot' | 'subscribe' | 'state'>;

--- a/packages/utils/src/store/useStore.ts
+++ b/packages/utils/src/store/useStore.ts
@@ -3,62 +3,72 @@ import * as React from 'react';
  * More info: https://github.com/mui/mui-x/issues/18303#issuecomment-2958392341 */
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
-import type { Store } from './Store';
+import { isReactVersionAtLeast } from '../reactVersion';
+import type { ReadonlyStore } from './Store';
 
-const majorVersion = parseInt(React.version, 10);
-const canUseRawUseSyncExternalStore = majorVersion >= 19;
+/* Some tests fail in R18 with the raw useSyncExternalStore. It may be possible to make it work
+ * but for now we only enable it for R19+. */
+const canUseRawUseSyncExternalStore = isReactVersionAtLeast(19);
+const useStoreImplementation = canUseRawUseSyncExternalStore ? useStoreR19 : useStoreLegacy;
 
 export function useStore<State, Value>(
-  store: Store<State>,
+  store: ReadonlyStore<State>,
   selector: (state: State) => Value,
 ): Value;
 export function useStore<State, Value, A1>(
-  store: Store<State>,
+  store: ReadonlyStore<State>,
   selector: (state: State, a1: A1) => Value,
   a1: A1,
 ): Value;
 export function useStore<State, Value, A1, A2>(
-  store: Store<State>,
+  store: ReadonlyStore<State>,
   selector: (state: State, a1: A1, a2: A2) => Value,
   a1: A1,
   a2: A2,
 ): Value;
 export function useStore<State, Value, A1, A2, A3>(
-  store: Store<State>,
+  store: ReadonlyStore<State>,
   selector: (state: State, a1: A1, a2: A2, a3: A3) => Value,
   a1: A1,
   a2: A2,
   a3: A3,
 ): Value;
-/**
- * Returns a value from the store. The value is derived from the store's state using the provided selector function.
- * Updates to the store's other properties will not cause re-renders.
- *
- * @param store The Store instance to read from.
- * @param selector A function that selects a value from the store's state.
- * @param a1 Optional first argument for the selector function.
- * @param a2 Optional second argument for the selector function.
- * @param a3 Optional third argument for the selector function.
- */
 export function useStore(
-  store: Store<unknown>,
+  store: ReadonlyStore<unknown>,
   selector: Function,
   a1?: unknown,
   a2?: unknown,
   a3?: unknown,
 ): unknown {
-  if (canUseRawUseSyncExternalStore) {
-    const getSelection = React.useMemo(
-      () => () => selector(store.getSnapshot(), a1, a2, a3),
-      [store, selector, a1, a2, a3],
-    );
-    return useSyncExternalStore(store.subscribe, getSelection, getSelection);
-  } else {
-    return useSyncExternalStoreWithSelector(
-      store.subscribe,
-      store.getSnapshot,
-      store.getSnapshot,
-      (state) => selector(state, a1, a2, a3),
-    );
-  }
+  return useStoreImplementation(store, selector, a1, a2, a3);
+}
+
+function useStoreR19(
+  store: ReadonlyStore<unknown>,
+  selector: Function,
+  a1?: unknown,
+  a2?: unknown,
+  a3?: unknown,
+): unknown {
+  const getSelection = React.useCallback(
+    () => selector(store.getSnapshot(), a1, a2, a3),
+    [store, selector, a1, a2, a3],
+  );
+
+  return useSyncExternalStore(store.subscribe, getSelection, getSelection);
+}
+
+function useStoreLegacy(
+  store: ReadonlyStore<unknown>,
+  selector: Function,
+  a1?: unknown,
+  a2?: unknown,
+  a3?: unknown,
+): unknown {
+  return useSyncExternalStoreWithSelector(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+    (state) => selector(state, a1, a2, a3),
+  );
 }


### PR DESCRIPTION
See https://github.com/mui/mui-x/pull/20447