### PR TITLE
[useButton] Prevent `Space` default on valid anchor keydown

### DIFF
--- a/packages/react/src/use-button/useButton.ts
+++ b/packages/react/src/use-button/useButton.ts
@@ -119,21 +119,22 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
             }
 
             const shouldClick =
-              event.target === event.currentTarget &&
-              !isNativeButton &&
-              !isValidLink() &&
-              !disabled;
+              event.target === event.currentTarget && !isNativeButton && !disabled;
             const isEnterKey = event.key === 'Enter';
             const isSpaceKey = event.key === ' ';
 
             // Keyboard accessibility for non interactive elements
             if (shouldClick) {
-              if (isSpaceKey || isEnterKey) {
-                event.preventDefault();
-              }
+              if (!isValidLink()) {
+                if (isSpaceKey || isEnterKey) {
+                  event.preventDefault();
+                }
 
-              if (isEnterKey) {
-                externalOnClick?.(event);
+                if (isEnterKey) {
+                  externalOnClick?.(event);
+                }
+              } else if (isSpaceKey) {
+                event.preventDefault();
               }
             }
           },


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR fixes an issue where pressing the `Space` key on a valid anchor (`<a href="…">`) did not call `preventDefault()`, causing the page to scroll.
The logic is updated to ensure the `Space` key behavior on valid links matches expected button-like interaction and prevents unintended scrolling.