### PR TITLE
[number field] Improve symbol replacement logic

### DIFF
--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -300,8 +300,11 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       const isAllSelected = selectionStart === 0 && selectionEnd === inputValue.length;
 
       // Normalize handling of plus/minus signs via precomputed regexes
-      const selectionIsExactlyCharAt = (index: number) =>
-        selectionStart === index && selectionEnd === index + 1;
+      const selectionContainsIndex = (index: number) =>
+        selectionStart != null &&
+        selectionEnd != null &&
+        index >= selectionStart &&
+        index < selectionEnd;
 
       if (
         ANY_MINUS_DETECT_RE.test(event.key) &&
@@ -310,7 +313,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
         // Only allow one sign unless replacing the existing one or all text is selected
         const existingIndex = inputValue.search(ANY_MINUS_RE);
         const isReplacingExisting =
-          existingIndex != null && existingIndex !== -1 && selectionIsExactlyCharAt(existingIndex);
+          existingIndex != null && existingIndex !== -1 && selectionContainsIndex(existingIndex);
         isAllowedNonNumericKey =
           !(ANY_MINUS_DETECT_RE.test(inputValue) || ANY_PLUS_DETECT_RE.test(inputValue)) ||
           isAllSelected ||
@@ -322,7 +325,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       ) {
         const existingIndex = inputValue.search(ANY_PLUS_RE);
         const isReplacingExisting =
-          existingIndex != null && existingIndex !== -1 && selectionIsExactlyCharAt(existingIndex);
+          existingIndex != null && existingIndex !== -1 && selectionContainsIndex(existingIndex);
         isAllowedNonNumericKey =
           !(ANY_MINUS_DETECT_RE.test(inputValue) || ANY_PLUS_DETECT_RE.test(inputValue)) ||
           isAllSelected ||
@@ -333,8 +336,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       [decimal, currency, percentSign].forEach((symbol) => {
         if (event.key === symbol) {
           const symbolIndex = inputValue.indexOf(symbol);
-          const isSymbolHighlighted =
-            selectionStart === symbolIndex && selectionEnd === symbolIndex + 1;
+          const isSymbolHighlighted = selectionContainsIndex(symbolIndex);
           isAllowedNonNumericKey =
             !inputValue.includes(symbol) || isAllSelected || isSymbolHighlighted;
         }

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -316,6 +316,24 @@ describe('<NumberField />', () => {
       expect(onValueCommitted.firstCall.args[0]).to.equal(-1.5);
     });
 
+    it('allows typing a decimal while replacing a selection', async () => {
+      await render(<NumberField defaultValue={12.3} locale="en-US" />);
+      const input = screen.getByRole<HTMLInputElement>('textbox');
+
+      await act(async () => {
+        input.focus();
+      });
+
+      const decimalIndex = input.value.indexOf('.');
+      expect(decimalIndex).to.be.greaterThan(-1);
+      await act(async () => {
+        input.setSelectionRange(1, decimalIndex + 2);
+      });
+
+      const keydownResult = fireEvent.keyDown(input, { key: '.' });
+      expect(keydownResult).to.equal(true);
+    });
+
     it('accepts grouping while typing and parses progressively', async () => {
       const onValueChange = spy();
       const onValueCommitted = spy();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Loosens text selection behavior when replacing symbols (e.g. a decimal point `.`) that only appear once in the input, matching native input behavior