### PR TITLE
[docs] Add `canonical` link tag

### DIFF
--- a/docs/src/app/(public)/layout.tsx
+++ b/docs/src/app/(public)/layout.tsx
@@ -21,6 +21,9 @@ export default function Layout({ children }: React.PropsWithChildren) {
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://base-ui.com'),
+  alternates: {
+    canonical: './',
+  },
 };
 
 export const viewport: Viewport = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

See #1615

> 1. We are missing the canonical links on all the pages. This is important so Google knows to not duplicate the pages

This PR follows up on an older SEO issues and adds canonical link tags for all public pages. 

This should fix all, if not most, google search console errors for duplicate canonical. So any URL with a hash or query param (https://base-ui.com/react/overview/quick-start#install-the-library, https://base-ui.com/react/overview/quick-start#portals, etc) will be indexed only once under the base url of the given page (https://base-ui.com/react/overview/quick-start).

<img width="1076" height="156" alt="CleanShot 2025-12-01 at 22 05 39@2x" src="https://github.com/user-attachments/assets/8a052adb-de60-447b-bc62-d1496e2e952b" />







