### PR TITLE
[checkbox][switch] Match native off state in form submission

### DIFF
--- a/docs/reference/generated/checkbox-root.json
+++ b/docs/reference/generated/checkbox-root.json
@@ -48,6 +48,11 @@
       "description": "Whether the checkbox controls a group of child checkboxes.\n\nMust be used in a [Checkbox Group](https://base-ui.com/react/components/checkbox-group).",
       "detailedType": "boolean | undefined"
     },
+    "uncheckedValue": {
+      "type": "string",
+      "description": "The value submitted with the form when the checkbox is unchecked.\nBy default, unchecked checkboxes do not submit any value, matching native checkbox behavior.",
+      "detailedType": "string | undefined"
+    },
     "disabled": {
       "type": "boolean",
       "default": "false",

--- a/docs/reference/generated/switch-root.json
+++ b/docs/reference/generated/switch-root.json
@@ -29,6 +29,11 @@
       "description": "Whether the component renders a native `<button>` element when replacing it\nvia the `render` prop.\nSet to `true` if the rendered element is a native button.",
       "detailedType": "boolean | undefined"
     },
+    "uncheckedValue": {
+      "type": "string",
+      "description": "The value submitted with the form when the switch is off.\nBy default, unchecked switches do not submit any value, matching native checkbox behavior.",
+      "detailedType": "string | undefined"
+    },
     "disabled": {
       "type": "boolean",
       "default": "false",

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -481,6 +481,89 @@ describe('<Checkbox.Root />', () => {
       await customUser.click(customSubmitButton);
       expect(customSubmitSpy.lastCall.returnValue.get).to.equal('on');
     });
+
+    it.skipIf(isJSDOM)(
+      'should submit uncheckedValue when checkbox is unchecked and uncheckedValue is specified',
+      async () => {
+        const submitSpy = spy((event) => {
+          event.preventDefault();
+          const formData = new FormData(event.currentTarget);
+          return formData.get('test-checkbox');
+        });
+
+        await render(
+          <Form onSubmit={submitSpy}>
+            <Field.Root name="test-checkbox">
+              <Checkbox.Root uncheckedValue="off" />
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>,
+        );
+
+        const checkbox = screen.getByRole('checkbox');
+        const submitButton = screen.getByRole('button')!;
+
+        submitButton.click();
+
+        expect(submitSpy.callCount).to.equal(1);
+        expect(submitSpy.lastCall.returnValue).to.equal('off');
+
+        await act(async () => {
+          checkbox.click();
+        });
+
+        submitButton.click();
+
+        expect(submitSpy.callCount).to.equal(2);
+        expect(submitSpy.lastCall.returnValue).to.equal('on');
+
+        await act(async () => {
+          checkbox.click();
+        });
+
+        submitButton.click();
+
+        expect(submitSpy.callCount).to.equal(3);
+        expect(submitSpy.lastCall.returnValue).to.equal('off');
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'should submit custom uncheckedValue when checkbox is unchecked',
+      async () => {
+        const submitSpy = spy((event) => {
+          event.preventDefault();
+          const formData = new FormData(event.currentTarget);
+          return formData.get('test-checkbox');
+        });
+
+        await render(
+          <Form onSubmit={submitSpy}>
+            <Field.Root name="test-checkbox">
+              <Checkbox.Root uncheckedValue="false" value="true" />
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>,
+        );
+
+        const checkbox = screen.getByRole('checkbox');
+        const submitButton = screen.getByRole('button')!;
+
+        submitButton.click();
+
+        expect(submitSpy.callCount).to.equal(1);
+        expect(submitSpy.lastCall.returnValue).to.equal('false');
+
+        await act(async () => {
+          checkbox.click();
+        });
+
+        submitButton.click();
+
+        expect(submitSpy.callCount).to.equal(2);
+        expect(submitSpy.lastCall.returnValue).to.equal('true');
+      },
+    );
   });
 
   describe('Field', () => {

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -54,6 +54,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     readOnly = false,
     render,
     required = false,
+    uncheckedValue,
     value: valueProp,
     nativeButton = false,
     ...elementProps
@@ -313,6 +314,9 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
   return (
     <CheckboxRootContext.Provider value={state}>
       {element}
+      {!checked && !groupContext && name && !parent && uncheckedValue !== undefined && (
+        <input type="hidden" name={name} value={uncheckedValue} />
+      )}
       <input {...inputProps} />
     </CheckboxRootContext.Provider>
   );
@@ -402,6 +406,11 @@ export interface CheckboxRootProps
    * @default false
    */
   parent?: boolean;
+  /**
+   * The value submitted with the form when the checkbox is unchecked.
+   * By default, unchecked checkboxes do not submit any value, matching native checkbox behavior.
+   */
+  uncheckedValue?: string;
   /**
    * The value of the selected checkbox.
    */

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -354,6 +354,77 @@ describe('<Switch.Root />', () => {
       expect(customSubmitSpy.lastCall.returnValue.get).to.equal('on');
     });
 
+    it.skipIf(isJSDOM)(
+      'should submit uncheckedValue when switch is off and uncheckedValue is specified',
+      async () => {
+        const submitSpy = spy((event) => {
+          event.preventDefault();
+          const formData = new FormData(event.currentTarget);
+          return formData.get('test-switch');
+        });
+
+        const { user } = await render(
+          <Form onSubmit={submitSpy}>
+            <Field.Root name="test-switch">
+              <Switch.Root uncheckedValue="off" />
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>,
+        );
+
+        const switchElement = screen.getByRole('switch');
+        const submitButton = screen.getByRole('button')!;
+
+        await user.click(submitButton);
+
+        expect(submitSpy.callCount).to.equal(1);
+        expect(submitSpy.lastCall.returnValue).to.equal('off');
+
+        await user.click(switchElement);
+        await user.click(submitButton);
+
+        expect(submitSpy.callCount).to.equal(2);
+        expect(submitSpy.lastCall.returnValue).to.equal('on');
+
+        await user.click(switchElement);
+        await user.click(submitButton);
+
+        expect(submitSpy.callCount).to.equal(3);
+        expect(submitSpy.lastCall.returnValue).to.equal('off');
+      },
+    );
+
+    it.skipIf(isJSDOM)('should submit custom uncheckedValue when switch is off', async () => {
+      const submitSpy = spy((event) => {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+        return formData.get('test-switch');
+      });
+
+      const { user } = await render(
+        <Form onSubmit={submitSpy}>
+          <Field.Root name="test-switch">
+            <Switch.Root uncheckedValue="false" />
+          </Field.Root>
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      const switchElement = screen.getByRole('switch');
+      const submitButton = screen.getByRole('button')!;
+
+      await user.click(submitButton);
+
+      expect(submitSpy.callCount).to.equal(1);
+      expect(submitSpy.lastCall.returnValue).to.equal('false');
+
+      await user.click(switchElement);
+      await user.click(submitButton);
+
+      expect(submitSpy.callCount).to.equal(2);
+      expect(submitSpy.lastCall.returnValue).to.equal('on');
+    });
+
     it('triggers native HTML validation on submit', async () => {
       const { user } = await render(
         <Form>

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -46,6 +46,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     required = false,
     disabled: disabledProp = false,
     render,
+    uncheckedValue,
     ...elementProps
   } = componentProps;
 
@@ -228,6 +229,9 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
   return (
     <SwitchRootContext.Provider value={state}>
       {element}
+      {!checked && name && uncheckedValue !== undefined && (
+        <input type="hidden" name={name} value={uncheckedValue} />
+      )}
       <input {...inputProps} />
     </SwitchRootContext.Provider>
   );
@@ -251,6 +255,7 @@ export interface SwitchRootState extends FieldRoot.State {
    */
   required: boolean;
 }
+
 export interface SwitchRootProps
   extends NonNativeButtonProps,
     Omit<BaseUIComponentProps<'span', SwitchRoot.State>, 'onChange'> {
@@ -298,7 +303,13 @@ export interface SwitchRootProps
    * @default false
    */
   required?: boolean;
+  /**
+   * The value submitted with the form when the switch is off.
+   * By default, unchecked switches do not submit any value, matching native checkbox behavior.
+   */
+  uncheckedValue?: string;
 }
+
 export type SwitchRootChangeEventReason = typeof REASONS.none;
 export type SwitchRootChangeEventDetails = BaseUIChangeEventDetails<SwitchRoot.ChangeEventReason>;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #3239

**Breaking:** In form submission data, Checkbox and Switch no longer have an `"off"` value when unchecked to match native behavior. 

A new prop, `uncheckedValue`, has been added [if you want a value submitted when they're unchecked](https://stackoverflow.com/questions/1809494/post-unchecked-html-checkboxes).