### PR TITLE
[menu] Do not import client components from MenuStore

### DIFF
--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -3,7 +3,7 @@ import { createSelector, ReactStore } from '@base-ui-components/utils/store';
 import { EMPTY_OBJECT } from '@base-ui-components/utils/empty';
 import { useRefWithInit } from '@base-ui-components/utils/useRefWithInit';
 import { MenuParent, MenuRoot } from '../root/MenuRoot';
-import { FloatingTreeStore } from '../../floating-ui-react';
+import { FloatingTreeStore } from '../../floating-ui-react/components/FloatingTreeStore';
 import { HTMLProps } from '../../utils/types';
 import {
   createInitialPopupStoreState,

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -16,8 +16,8 @@ import {
   useInteractions,
   useFloatingNodeId,
   useFloatingParentNodeId,
-  FloatingTreeStore,
 } from '../../floating-ui-react';
+import { FloatingTreeStore } from '../../floating-ui-react/components/FloatingTreeStore';
 import {
   contains,
   getNextTabbable,


### PR DESCRIPTION
MenuStore (not marked as client-only) imported FloatingTreeStore from the root Floating UI barrel file (which contains client-only imports). This changes the import to point to client+server module, preventing a bug on some RSC environments
