### PR TITLE
[docs-infra] Add `og:url` tag

### DIFF
--- a/docs/src/app/(public)/layout.tsx
+++ b/docs/src/app/(public)/layout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { Metadata, Viewport } from 'next/types';
+import type { Viewport } from 'next';
 import { GoogleAnalytics } from 'docs/src/components/GoogleAnalytics';
 import { DocsProviders } from 'docs/src/components/DocsProviders';
 import 'docs/src/styles.css';
@@ -18,13 +18,6 @@ export default function Layout({ children }: React.PropsWithChildren) {
     </DocsProviders>
   );
 }
-
-export const metadata: Metadata = {
-  metadataBase: new URL('https://base-ui.com'),
-  alternates: {
-    canonical: './',
-  },
-};
 
 export const viewport: Viewport = {
   themeColor: [

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -39,6 +39,7 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://base-ui.com'),
   title: {
     template: '%s · Base UI',
     default: 'Base UI',
@@ -47,7 +48,11 @@ export const metadata: Metadata = {
     site: '@base_ui',
     card: 'summary_large_image',
   },
+  alternates: {
+    canonical: './',
+  },
   openGraph: {
+    url: './',
     type: 'website',
     locale: 'en_US',
     title: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

see https://github.com/mui/base-ui/issues/1615, closes https://github.com/mui/mui-public/issues/561

Continuation of https://github.com/mui/base-ui/pull/3388:

- configured meta `og:url` tags for all pages
- collocated `metadataBase` to the root layout

<img width="956" height="102" alt="CleanShot 2025-12-04 at 11 58 04@2x" src="https://github.com/user-attachments/assets/83612c5c-67b7-45d9-81e1-aef53005b869" />
