### PR TITLE
[docs-infra] Add robots `noindex, nofollow` on private layout

### DIFF
--- a/docs/src/app/(private)/layout.tsx
+++ b/docs/src/app/(private)/layout.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
 import 'docs/src/styles.css';
 import './layout.css';
+import { Metadata } from 'next';
 
 export default function Layout({ children }: React.PropsWithChildren) {
   return children;
 }
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Added robots `noindex, nofollow` meta tag to prevent any private pages from being crawled and indexed.

<img width="692" height="100" alt="CleanShot 2025-12-04 at 12 02 19@2x" src="https://github.com/user-attachments/assets/5558d210-25e7-4b6d-ac95-5cdd58cca2da" />
