### PR TITLE
[popups] Fix mount transitions on `Positioner` in Firefox

### DIFF
--- a/packages/react/src/utils/useTransitionStatus.ts
+++ b/packages/react/src/utils/useTransitionStatus.ts
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { useIsoLayoutEffect } from '@base-ui-components/utils/useIsoLayoutEffect';
 import { AnimationFrame } from '@base-ui-components/utils/useAnimationFrame';
 
@@ -54,9 +53,9 @@ export function useTransitionStatus(
     }
 
     const frame = AnimationFrame.request(() => {
-      ReactDOM.flushSync(() => {
-        setTransitionStatus(undefined);
-      });
+      // Avoid `flushSync` here due to Firefox.
+      // See https://github.com/mui/base-ui/pull/3424
+      setTransitionStatus(undefined);
     });
 
     return () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #3419 

It seems like Firefox needs an extra delay before changing the `'starting'` transition state so the `getDisabledMountTransitionStyles` lingers for the correct amount of time.

Navigation Menu: https://deploy-preview-3424--base-ui.netlify.app/react/components/navigation-menu
Side animations also fixed: https://deploy-preview-3424--base-ui.netlify.app/experiments/anchor-side-animations