### PR TITLE
[toast] Fix `flushSync` dev error when toast is added

### DIFF
--- a/packages/react/src/toast/content/ToastContent.tsx
+++ b/packages/react/src/toast/content/ToastContent.tsx
@@ -33,8 +33,8 @@ export const ToastContent = React.forwardRef(function ToastContent(
       return undefined;
     }
 
-    const resizeObserver = new ResizeObserver(recalculateHeight);
-    const mutationObserver = new MutationObserver(recalculateHeight);
+    const resizeObserver = new ResizeObserver(() => recalculateHeight(true));
+    const mutationObserver = new MutationObserver(() => recalculateHeight(true));
 
     resizeObserver.observe(node);
     mutationObserver.observe(node, { childList: true, subtree: true, characterData: true });

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -146,7 +146,12 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     },
   });
 
-  const recalculateHeight = useStableCallback(() => {
+  /**
+   * Recalculates the natural height of the toast and updates it in the toast manager.
+   * @param flushSync Whether to flush the update synchronously. Use in observer
+   * callbacks to avoid visual flickers.
+   */
+  const recalculateHeight = useStableCallback((flushSync: boolean = false) => {
     const element = rootRef.current;
     if (!element) {
       return;
@@ -157,7 +162,7 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     const height = element.offsetHeight;
     element.style.height = previousHeight;
 
-    ReactDOM.flushSync(() => {
+    function update() {
       setToasts((prev) =>
         prev.map((t) =>
           t.id === toast.id
@@ -170,7 +175,13 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
             : t,
         ),
       );
-    });
+    }
+
+    if (flushSync) {
+      ReactDOM.flushSync(update);
+    } else {
+      update();
+    }
   });
 
   useIsoLayoutEffect(recalculateHeight, [recalculateHeight]);

--- a/packages/react/src/toast/root/ToastRootContext.ts
+++ b/packages/react/src/toast/root/ToastRootContext.ts
@@ -13,7 +13,7 @@ export interface ToastRootContext {
   index: number;
   visibleIndex: number;
   expanded: boolean;
-  recalculateHeight: () => void;
+  recalculateHeight: (flushSync?: boolean) => void;
 }
 
 export const ToastRootContext = React.createContext<ToastRootContext | undefined>(undefined);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #3442. `flushSync` should only be called in observer callbacks to prevent flickers but not inside the layout effect directly.