### PR TITLE
[internal] Remove redundant ref callback cleanup

### DIFF
--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -21,32 +21,23 @@ export function useTriggerRegistration<State extends PopupStoreState<any>>(
   store: ReactStore<State, PopupStoreContext<any>, PopupStoreSelectors>,
 ) {
   // Keep track of the currently registered element to unregister it on unmount or id change.
-  const registeredElementId = React.useRef<string | null>(null);
+  const registeredElementIdRef = React.useRef<string | null>(null);
 
   return React.useCallback(
     (element: Element | null) => {
       if (id === undefined) {
-        return undefined;
+        return;
       }
 
-      if (registeredElementId.current !== null) {
-        store.context.triggerElements.delete(registeredElementId.current);
-        registeredElementId.current = null;
+      if (registeredElementIdRef.current !== null) {
+        store.context.triggerElements.delete(registeredElementIdRef.current);
+        registeredElementIdRef.current = null;
       }
 
       if (element !== null) {
-        registeredElementId.current = id;
+        registeredElementIdRef.current = id;
         store.context.triggerElements.add(id, element);
-
-        return () => {
-          if (registeredElementId.current !== null) {
-            store.context.triggerElements.delete(registeredElementId.current);
-            registeredElementId.current = null;
-          }
-        };
       }
-
-      return undefined;
     },
     [store, id],
   );
@@ -71,7 +62,7 @@ export function useTriggerDataForwarding<State extends PopupStoreState<any>>(
   const baseRegisterTrigger = useTriggerRegistration(triggerId, store);
 
   const registerTrigger = useStableCallback((element: Element | null) => {
-    const cleanup = baseRegisterTrigger(element);
+    baseRegisterTrigger(element);
 
     if (element !== null && store.select('open') && store.select('activeTriggerId') == null) {
       // This runs when popup is open, but no active trigger is set.
@@ -84,8 +75,6 @@ export function useTriggerDataForwarding<State extends PopupStoreState<any>>(
         ...stateUpdates,
       } as Partial<State>);
     }
-
-    return cleanup;
   });
 
   useIsoLayoutEffect(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I noticed callback ref cleanup functions were being used here, but it looked like a bug given that isn't supported on React 17/18. However, there's already a cleanup happening when the ref callback gets called with `null`, which supports 17/18, so the cleanup looks redundant