### PR TITLE
[toast] Fix `<Toast.Close>` emitting `aria-hidden` warning on click

### DIFF
--- a/packages/react/src/toast/close/ToastClose.tsx
+++ b/packages/react/src/toast/close/ToastClose.tsx
@@ -21,6 +21,8 @@ export const ToastClose = React.forwardRef(function ToastClose(
   const { close, expanded } = useToastContext();
   const { toast } = useToastRootContext();
 
+  const [hasFocus, setHasFocus] = React.useState(false);
+
   const { getButtonProps, buttonRef } = useButton({
     disabled,
     native: nativeButton,
@@ -38,9 +40,15 @@ export const ToastClose = React.forwardRef(function ToastClose(
     state,
     props: [
       {
-        'aria-hidden': !expanded,
+        'aria-hidden': !expanded && !hasFocus,
         onClick() {
           close(toast.id);
+        },
+        onFocus() {
+          setHasFocus(true);
+        },
+        onBlur() {
+          setHasFocus(false);
         },
       },
       elementProps,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

`expanded` can get set to `false` while focus is on the Toast close button and it's the last toast in the viewport, so `aria-hidden`  gets added. Blocking the attribute while it has focus is a simple workaround to avoid the warning.

Fixes #3466 