### PR TITLE
[internal] Use combined window listeners

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useFocus.ts
+++ b/packages/react/src/floating-ui-react/hooks/useFocus.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { getWindow, isElement, isHTMLElement } from '@floating-ui/utils/dom';
+import * as windowListener from '@base-ui-components/utils/windowListener';
 import { isMac, isSafari } from '@base-ui-components/utils/detectBrowser';
 import { useTimeout } from '@base-ui-components/utils/useTimeout';
 import {
@@ -81,19 +82,19 @@ export function useFocus(
       keyboardModalityRef.current = false;
     }
 
-    win.addEventListener('blur', onBlur);
+    windowListener.add(win, 'blur', onBlur);
 
     if (isMacSafari) {
-      win.addEventListener('keydown', onKeyDown, true);
-      win.addEventListener('pointerdown', onPointerDown, true);
+      windowListener.add(win, 'keydown', onKeyDown, true);
+      windowListener.add(win, 'pointerdown', onPointerDown, true);
     }
 
     return () => {
-      win.removeEventListener('blur', onBlur);
+      windowListener.remove(win, 'blur', onBlur);
 
       if (isMacSafari) {
-        win.removeEventListener('keydown', onKeyDown, true);
-        win.removeEventListener('pointerdown', onPointerDown, true);
+        windowListener.remove(win, 'keydown', onKeyDown, true);
+        windowListener.remove(win, 'pointerdown', onPointerDown, true);
       }
     };
   }, [store, enabled]);

--- a/packages/react/src/select/popup/SelectPopup.tsx
+++ b/packages/react/src/select/popup/SelectPopup.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { useTimeout } from '@base-ui-components/utils/useTimeout';
 import { isWebKit } from '@base-ui-components/utils/detectBrowser';
+import * as windowListener from '@base-ui-components/utils/windowListener';
 import { useStableCallback } from '@base-ui-components/utils/useStableCallback';
 import { ownerDocument, ownerWindow } from '@base-ui-components/utils/owner';
 import { isMouseWithinBounds } from '@base-ui-components/utils/isMouseWithinBounds';
@@ -366,10 +367,10 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
       setOpen(false, createChangeEventDetails(REASONS.windowResize, event));
     }
 
-    win.addEventListener('resize', handleResize);
+    windowListener.add(win, 'resize', handleResize);
 
     return () => {
-      win.removeEventListener('resize', handleResize);
+      windowListener.remove(win, 'resize', handleResize);
     };
   }, [setOpen, alignItemWithTriggerActive, positionerElement, mounted]);
 

--- a/packages/react/src/utils/interactions/useFocusWithDelay.ts
+++ b/packages/react/src/utils/interactions/useFocusWithDelay.ts
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { getWindow, isHTMLElement } from '@floating-ui/utils/dom';
 import { useTimeout } from '@base-ui-components/utils/useTimeout';
+import * as windowListener from '@base-ui-components/utils/windowListener';
 import type { FloatingRootContext, ElementProps } from '../../floating-ui-react';
 import { createChangeEventDetails } from '../createBaseUIEventDetails';
 import { REASONS } from '../reasons';
@@ -42,9 +43,9 @@ export function useFocusWithDelay(
       }
     }
 
-    win.addEventListener('blur', handleBlur);
+    windowListener.add(win, 'blur', handleBlur);
     return () => {
-      win.removeEventListener('blur', handleBlur);
+      windowListener.remove(win, 'blur', handleBlur);
     };
   }, [store, domReference]);
 

--- a/packages/utils/src/windowListener.ts
+++ b/packages/utils/src/windowListener.ts
@@ -1,0 +1,80 @@
+type Events = keyof WindowEventMap;
+type Options = string;
+type State = ReturnType<typeof createState>;
+
+function createState() {
+  return new Map<Events, Map<Options, Set<Function>>>();
+}
+
+/**
+ * Adds an event listener to the window, ensuring that multiple listeners of the same
+ * type and options are not added more than once.
+ * WARNING: Event listeners are never removed from the window. Might not be suitable
+ * for events like 'mousemove'.
+ */
+export function add<K extends Events>(
+  win: Window,
+  type: K,
+  listener: (this: Window, ev: WindowEventMap[K]) => any,
+  options?: boolean | AddEventListenerOptions,
+) {
+  if ((win as any).baseUIListeners === undefined) {
+    Object.defineProperty(win, 'baseUIListeners', {
+      value: createState(),
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    });
+  }
+  const state = (win as any).baseUIListeners as State;
+  let eventState = state.get(type);
+  if (!eventState) {
+    eventState = new Map<Options, Set<Function>>();
+    state.set(type, eventState);
+  }
+  const optionKey = options ? JSON.stringify(options) : 'default';
+  let listeners = eventState.get(optionKey);
+  if (!listeners) {
+    listeners = new Set<Function>();
+    eventState.set(optionKey, listeners);
+  }
+  if (listeners.has(listener)) {
+    return;
+  }
+
+  if (listeners.size === 0) {
+    win.addEventListener(
+      type,
+      (event) => {
+        for (const listener of listeners) {
+          (listener as any).call(win, event);
+        }
+      },
+      options,
+    );
+  }
+
+  listeners.add(listener);
+}
+
+export function remove<K extends Events>(
+  win: Window,
+  type: K,
+  listener: (this: Window, ev: WindowEventMap[K]) => any,
+  options?: boolean | AddEventListenerOptions,
+) {
+  const state = (win as any).baseUIListeners as State;
+  if (!state) {
+    return;
+  }
+  const eventState = state.get(type);
+  if (!eventState) {
+    return;
+  }
+  const optionKey = options ? JSON.stringify(options) : 'default';
+  const listeners = eventState.get(optionKey);
+  if (!listeners) {
+    return;
+  }
+  listeners.delete(listener);
+}

--- a/packages/utils/src/windowListener.ts
+++ b/packages/utils/src/windowListener.ts
@@ -38,9 +38,6 @@ export function add<K extends Events>(
     listeners = new Set<Function>();
     eventState.set(optionKey, listeners);
   }
-  if (listeners.has(listener)) {
-    return;
-  }
 
   if (listeners.size === 0) {
     win.addEventListener(

--- a/packages/utils/src/windowListener.ts
+++ b/packages/utils/src/windowListener.ts
@@ -43,8 +43,8 @@ export function add<K extends Events>(
     win.addEventListener(
       type,
       (event) => {
-        for (const listener of listeners) {
-          (listener as any).call(win, event);
+        for (const l of listeners) {
+          (l as any).call(win, event);
         }
       },
       options,


### PR DESCRIPTION
Some components, amongst which tooltip triggers, add native event listeners on the `window`. Those native calls are slow, so we replace them with a combined listener that only attaches once.