### PR TITLE
[popover] Fix some tests not running with detached triggers

### DIFF
--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -114,7 +114,7 @@ describe('<Popover.Root />', () => {
 
           return (
             <dialog open ref={handleDialogRef}>
-              <ContainedTriggerPopover
+              <TestPopover
                 portalProps={{ container: dialogNode ?? undefined }}
                 popupProps={{
                   children: (
@@ -167,7 +167,7 @@ describe('<Popover.Root />', () => {
 
           return (
             <dialog open ref={handleDialogRef}>
-              <ContainedTriggerPopover
+              <TestPopover
                 portalProps={{ container: dialogNode ?? undefined }}
                 popupProps={{
                   children: (
@@ -209,25 +209,25 @@ describe('<Popover.Root />', () => {
 
     describe('prop: defaultOpen', () => {
       it('should open when the component is rendered', async () => {
-        await render(<ContainedTriggerPopover rootProps={{ defaultOpen: true }} />);
+        await render(<TestPopover rootProps={{ defaultOpen: true }} />);
 
         expect(screen.getByText('Content')).not.to.equal(null);
       });
 
       it('should not open when the component is rendered and open is controlled', async () => {
-        await render(<ContainedTriggerPopover rootProps={{ defaultOpen: true, open: false }} />);
+        await render(<TestPopover rootProps={{ defaultOpen: true, open: false }} />);
 
         expect(screen.queryByText('Content')).to.equal(null);
       });
 
       it('should not close when the component is rendered and open is controlled', async () => {
-        await render(<ContainedTriggerPopover rootProps={{ defaultOpen: true, open: true }} />);
+        await render(<TestPopover rootProps={{ defaultOpen: true, open: true }} />);
 
         expect(screen.getByText('Content')).not.to.equal(null);
       });
 
       it('should remain uncontrolled', async () => {
-        await render(<ContainedTriggerPopover rootProps={{ defaultOpen: true }} />);
+        await render(<TestPopover rootProps={{ defaultOpen: true }} />);
 
         expect(screen.getByText('Content')).not.to.equal(null);
 
@@ -243,9 +243,9 @@ describe('<Popover.Root />', () => {
       clock.withFakeTimers();
 
       it('should open after delay with rest type by default', async () => {
-        await render(<ContainedTriggerPopover triggerProps={{ openOnHover: true, delay: 100 }} />);
+        await render(<TestPopover triggerProps={{ openOnHover: true, delay: 100 }} />);
 
-        const anchor = screen.getByRole('button');
+        const anchor = screen.getByRole('button', { name: 'Toggle' });
 
         fireEvent.mouseEnter(anchor);
         fireEvent.mouseMove(anchor);
@@ -266,11 +266,9 @@ describe('<Popover.Root />', () => {
       clock.withFakeTimers();
 
       it('should close after delay', async () => {
-        await render(
-          <ContainedTriggerPopover triggerProps={{ openOnHover: true, closeDelay: 100 }} />,
-        );
+        await render(<TestPopover triggerProps={{ openOnHover: true, closeDelay: 100 }} />);
 
-        const anchor = screen.getByRole('button');
+        const anchor = screen.getByRole('button', { name: 'Toggle' });
 
         fireEvent.mouseEnter(anchor);
         fireEvent.mouseMove(anchor);
@@ -296,7 +294,7 @@ describe('<Popover.Root />', () => {
     describe('BaseUIChangeEventDetails', () => {
       it('onOpenChange cancel() prevents opening while uncontrolled', async () => {
         await render(
-          <ContainedTriggerPopover
+          <TestPopover
             rootProps={{
               onOpenChange: (nextOpen, eventDetails) => {
                 if (nextOpen) {
@@ -307,7 +305,7 @@ describe('<Popover.Root />', () => {
           />,
         );
 
-        const trigger = screen.getByRole('button');
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
         fireEvent.click(trigger);
         await flushMicrotasks();
 
@@ -320,7 +318,7 @@ describe('<Popover.Root />', () => {
         const { user } = await render(
           <div>
             <input type="text" />
-            <ContainedTriggerPopover
+            <TestPopover
               portalProps={{ keepMounted: true }}
               popupProps={{ children: <Popover.Close>Close</Popover.Close> }}
             />
@@ -347,7 +345,7 @@ describe('<Popover.Root />', () => {
 
       it('does not move focus to the popover when opened with hover', async () => {
         const { user } = await render(
-          <ContainedTriggerPopover
+          <TestPopover
             triggerProps={{ openOnHover: true, delay: 0 }}
             popupProps={{ children: <Popover.Close>Close</Popover.Close> }}
           />,
@@ -386,7 +384,7 @@ describe('<Popover.Root />', () => {
             {/* eslint-disable-next-line react/no-danger */}
             <style dangerouslySetInnerHTML={{ __html: style }} />
             <input type="text" data-testid="first-input" />
-            <ContainedTriggerPopover
+            <TestPopover
               triggerProps={{ openOnHover: true, delay: 0, closeDelay: 0 }}
               popupProps={{ className: 'popup', children: null }}
             />
@@ -418,10 +416,10 @@ describe('<Popover.Root />', () => {
           const { user } = await render(
             <div>
               <input />
-              <ContainedTriggerPopover
+              <TestPopover
                 rootProps={{ defaultOpen: true }}
                 popupProps={{ children: <input data-testid="input-inside" /> }}
-                afterPortal={<input data-testid="focus-target" />}
+                afterTrigger={<input data-testid="focus-target" />}
               />
               <input />
             </div>,
@@ -445,7 +443,7 @@ describe('<Popover.Root />', () => {
             const { user } = await render(
               <div>
                 <input />
-                <ContainedTriggerPopover
+                <TestPopover
                   rootProps={{ defaultOpen: true }}
                   popupProps={{ children: <input data-testid="input-inside" /> }}
                 />
@@ -460,7 +458,7 @@ describe('<Popover.Root />', () => {
             await user.tab({ shift: true });
 
             await waitFor(() => {
-              expect(screen.getByRole('button')).toHaveFocus();
+              expect(screen.getByRole('button', { name: 'Toggle' })).toHaveFocus();
             });
 
             await waitFor(() => {
@@ -481,9 +479,9 @@ describe('<Popover.Root />', () => {
           const { user } = await render(
             <div>
               <input />
-              <ContainedTriggerPopover
+              <TestPopover
                 rootProps={{ defaultOpen: true }}
-                betweenTriggerAndPortal={<input data-testid="focus-target" />}
+                afterTrigger={<input data-testid="focus-target" />}
                 popupProps={{ children: <input data-testid="input-inside" /> }}
               />
               <input />
@@ -510,9 +508,9 @@ describe('<Popover.Root />', () => {
             const { user } = await render(
               <div>
                 <input />
-                <ContainedTriggerPopover
+                <TestPopover
                   rootProps={{ defaultOpen: true }}
-                  betweenTriggerAndPortal={<input />}
+                  afterTrigger={<input />}
                   popupProps={{ children: <input data-testid="input-inside" /> }}
                 />
                 <input />
@@ -525,7 +523,7 @@ describe('<Popover.Root />', () => {
             await user.tab({ shift: true });
 
             await waitFor(() => {
-              expect(screen.getByRole('button')).toHaveFocus();
+              expect(screen.getByRole('button', { name: 'Toggle' })).toHaveFocus();
             });
 
             await waitFor(() => {
@@ -547,11 +545,11 @@ describe('<Popover.Root />', () => {
           const { user } = await render(
             <div>
               <input />
-              <ContainedTriggerPopover
+              <TestPopover
                 rootProps={{ defaultOpen: true }}
                 triggerPlacement="after-content"
                 popupProps={{ children: <input data-testid="input-inside" /> }}
-                afterPortal={<input data-testid="focus-target" />}
+                afterTrigger={<input data-testid="focus-target" />}
               />
               <input />
             </div>,
@@ -575,7 +573,7 @@ describe('<Popover.Root />', () => {
             const { user } = await render(
               <div>
                 <input />
-                <ContainedTriggerPopover
+                <TestPopover
                   rootProps={{ defaultOpen: true }}
                   triggerPlacement="after-content"
                   popupProps={{ children: <input data-testid="input-inside" /> }}
@@ -591,7 +589,7 @@ describe('<Popover.Root />', () => {
             await user.tab({ shift: true });
 
             await waitFor(() => {
-              expect(screen.getByRole('button')).toHaveFocus();
+              expect(screen.getByRole('button', { name: 'Toggle' })).toHaveFocus();
             });
 
             await waitFor(() => {
@@ -614,9 +612,9 @@ describe('<Popover.Root />', () => {
         const handleOpenChange = spy();
 
         await render(
-          <ContainedTriggerPopover
+          <TestPopover
             rootProps={{ defaultOpen: true, onOpenChange: handleOpenChange }}
-            portalChildren={<Popover.Backdrop data-testid="backdrop" />}
+            portalProps={{ children: <Popover.Backdrop data-testid="backdrop" /> }}
           />,
         );
 
@@ -637,7 +635,7 @@ describe('<Popover.Root />', () => {
         const handleOpenChange = spy();
 
         await render(
-          <ContainedTriggerPopover
+          <TestPopover
             rootProps={{ defaultOpen: true, onOpenChange: handleOpenChange, modal: true }}
           />,
         );
@@ -661,7 +659,7 @@ describe('<Popover.Root />', () => {
         function TestCase() {
           return (
             <React.Fragment>
-              <ContainedTriggerPopover
+              <TestPopover
                 rootProps={{ defaultOpen: true }}
                 popupProps={{ children: <button data-testid="inside">Inside</button> }}
               />
@@ -696,7 +694,7 @@ describe('<Popover.Root />', () => {
         function Test() {
           const [showButton, setShowButton] = React.useState(true);
           return (
-            <ContainedTriggerPopover
+            <TestPopover
               rootProps={{ defaultOpen: true, modal: 'trap-focus' }}
               popupProps={{
                 children: showButton && (
@@ -740,7 +738,7 @@ describe('<Popover.Root />', () => {
         };
 
         const { user } = await render(
-          <ContainedTriggerPopover
+          <TestPopover
             rootProps={{
               actionsRef,
               onOpenChange: (open, details) => {
@@ -772,7 +770,7 @@ describe('<Popover.Root />', () => {
 
       it('closes the popover when the `close` method is called', async () => {
         const actionsRef = React.createRef<Popover.Root.Actions>();
-        await render(<ContainedTriggerPopover rootProps={{ defaultOpen: true, actionsRef }} />);
+        await render(<TestPopover rootProps={{ defaultOpen: true, actionsRef }} />);
 
         await act(async () => {
           actionsRef.current!.close();
@@ -788,7 +786,7 @@ describe('<Popover.Root />', () => {
       it('should render an internal backdrop when `true`', async () => {
         const { user } = await render(
           <div>
-            <ContainedTriggerPopover rootProps={{ modal: true }} />
+            <TestPopover rootProps={{ modal: true }} />
             <button>Outside</button>
           </div>,
         );
@@ -809,7 +807,7 @@ describe('<Popover.Root />', () => {
       it('should not render an internal backdrop when `false`', async () => {
         const { user } = await render(
           <div>
-            <ContainedTriggerPopover rootProps={{ modal: false }} />
+            <TestPopover rootProps={{ modal: false }} />
             <button>Outside</button>
           </div>,
         );
@@ -837,7 +835,7 @@ describe('<Popover.Root />', () => {
           return (
             <div>
               <button onClick={() => setOpen(false)}>Close</button>
-              <ContainedTriggerPopover
+              <TestPopover
                 rootProps={{ open, onOpenChangeComplete }}
                 popupProps={{ children: null }}
               />
@@ -883,7 +881,7 @@ describe('<Popover.Root />', () => {
               {/* eslint-disable-next-line react/no-danger */}
               <style dangerouslySetInnerHTML={{ __html: style }} />
               <button onClick={() => setOpen(false)}>Close</button>
-              <ContainedTriggerPopover
+              <TestPopover
                 rootProps={{ open, onOpenChangeComplete }}
                 popupProps={{ className: 'animation-test-indicator', children: null }}
               />
@@ -918,7 +916,7 @@ describe('<Popover.Root />', () => {
           return (
             <div>
               <button onClick={() => setOpen(true)}>Open</button>
-              <ContainedTriggerPopover
+              <TestPopover
                 rootProps={{ open, onOpenChangeComplete }}
                 popupProps={{ children: null }}
               />
@@ -964,7 +962,7 @@ describe('<Popover.Root />', () => {
               {/* eslint-disable-next-line react/no-danger */}
               <style dangerouslySetInnerHTML={{ __html: style }} />
               <button onClick={() => setOpen(true)}>Open</button>
-              <ContainedTriggerPopover
+              <TestPopover
                 rootProps={{
                   open,
                   onOpenChange: (nextOpen) => setOpen(nextOpen),
@@ -993,10 +991,7 @@ describe('<Popover.Root />', () => {
         const onOpenChangeComplete = spy();
 
         await render(
-          <ContainedTriggerPopover
-            rootProps={{ onOpenChangeComplete }}
-            popupProps={{ children: null }}
-          />,
+          <TestPopover rootProps={{ onOpenChangeComplete }} popupProps={{ children: null }} />,
         );
 
         expect(onOpenChangeComplete.callCount).to.equal(0);
@@ -1009,7 +1004,7 @@ describe('<Popover.Root />', () => {
         async () => {
           const fruits = Array.from({ length: 50 }, (_, i) => i);
           await render(
-            <ContainedTriggerPopover
+            <TestPopover
               rootProps={{ defaultOpen: true }}
               popupProps={{
                 children: (
@@ -1086,7 +1081,7 @@ describe('<Popover.Root />', () => {
 
       it('should close child popover when clicking parent popover', async () => {
         const { user } = await render(
-          <ContainedTriggerPopover
+          <TestPopover
             triggerProps={{ 'data-testid': 'parent-trigger' } as Popover.Trigger.Props}
             popupProps={
               {
@@ -1139,11 +1134,9 @@ type TestPopoverProps = {
   portalProps?: Popover.Portal.Props;
   positionerProps?: Popover.Positioner.Props;
   popupProps?: Popover.Popup.Props;
-  portalChildren?: React.ReactNode;
   triggerPlacement?: 'before-content' | 'after-content';
-  betweenTriggerAndPortal?: React.ReactNode;
   beforeTrigger?: React.ReactNode;
-  afterPortal?: React.ReactNode;
+  afterTrigger?: React.ReactNode;
   includeTrigger?: boolean;
 };
 
@@ -1154,19 +1147,17 @@ function ContainedTriggerPopover(props: TestPopoverProps) {
     portalProps,
     positionerProps,
     popupProps,
-    portalChildren,
     triggerPlacement = 'before-content',
-    betweenTriggerAndPortal,
-    beforeTrigger,
-    afterPortal,
+    afterTrigger,
     includeTrigger = true,
   } = props;
 
   const { children: triggerChildren, ...restTriggerProps } = triggerProps ?? {};
   const { children: popupChildren, ...restPopupProps } = popupProps ?? {};
+  const { children: portalChildren, ...restPortalProps } = portalProps ?? {};
 
   const renderPortal = () => (
-    <Popover.Portal {...portalProps}>
+    <Popover.Portal {...restPortalProps}>
       {portalChildren}
       <Popover.Positioner data-testid="positioner" {...positionerProps}>
         <Popover.Popup data-testid="popover-popup" {...restPopupProps}>
@@ -1184,56 +1175,60 @@ function ContainedTriggerPopover(props: TestPopoverProps) {
 
   return (
     <Popover.Root {...rootProps}>
-      {beforeTrigger}
       {triggerPlacement === 'before-content' ? (
         <React.Fragment>
           {triggerElement}
-          {betweenTriggerAndPortal}
+          {afterTrigger}
           {renderPortal()}
         </React.Fragment>
       ) : (
         <React.Fragment>
           {renderPortal()}
-          {betweenTriggerAndPortal}
           {triggerElement}
+          {afterTrigger}
         </React.Fragment>
       )}
-      {afterPortal}
     </Popover.Root>
   );
 }
 
 function DetachedTriggerPopover(props: TestPopoverProps) {
   const {
+    rootProps,
     triggerProps,
+    portalProps,
+    positionerProps,
+    popupProps,
     triggerPlacement = 'before-content',
-    betweenTriggerAndPortal,
-    ...rest
+    afterTrigger,
   } = props;
+
+  const { children: triggerChildren, ...restTriggerProps } = triggerProps ?? {};
   const popoverHandle = useRefWithInit(() => Popover.createHandle()).current;
 
   return (
     <React.Fragment>
       {triggerPlacement === 'before-content' && (
         <React.Fragment>
-          <Popover.Trigger data-testid="trigger" handle={popoverHandle} {...triggerProps}>
-            {triggerProps?.children ?? 'Toggle'}
+          <Popover.Trigger data-testid="trigger" handle={popoverHandle} {...restTriggerProps}>
+            {triggerChildren ?? 'Toggle'}
           </Popover.Trigger>
-
-          {betweenTriggerAndPortal}
+          {afterTrigger}
         </React.Fragment>
       )}
       <ContainedTriggerPopover
-        {...rest}
-        rootProps={{ ...rest.rootProps, handle: popoverHandle }}
+        rootProps={{ ...rootProps, handle: popoverHandle }}
+        portalProps={portalProps}
+        positionerProps={positionerProps}
+        popupProps={popupProps}
         includeTrigger={false}
       />
       {triggerPlacement === 'after-content' && (
         <React.Fragment>
-          {betweenTriggerAndPortal}
-          <Popover.Trigger data-testid="trigger" handle={popoverHandle} {...triggerProps}>
-            {triggerProps?.children ?? 'Toggle'}
+          <Popover.Trigger data-testid="trigger" handle={popoverHandle} {...restTriggerProps}>
+            {triggerChildren ?? 'Toggle'}
           </Popover.Trigger>
+          {afterTrigger}
         </React.Fragment>
       )}
     </React.Fragment>
@@ -1242,43 +1237,41 @@ function DetachedTriggerPopover(props: TestPopoverProps) {
 
 function MultipleDetachedTriggersPopover(props: TestPopoverProps) {
   const {
+    rootProps,
     triggerProps,
+    portalProps,
+    positionerProps,
+    popupProps,
+    afterTrigger,
     triggerPlacement = 'before-content',
-    betweenTriggerAndPortal,
-    ...rest
   } = props;
+
+  const { children: triggerChildren, ...restTriggerProps } = triggerProps ?? {};
   const popoverHandle = useRefWithInit(() => Popover.createHandle()).current;
+
+  const renderTriggers = () => (
+    <React.Fragment>
+      <Popover.Trigger data-testid="trigger" handle={popoverHandle} {...restTriggerProps}>
+        {triggerChildren ?? 'Toggle'}
+      </Popover.Trigger>
+      {afterTrigger}
+      <Popover.Trigger data-testid="trigger-2" handle={popoverHandle}>
+        Toggle another
+      </Popover.Trigger>
+    </React.Fragment>
+  );
 
   return (
     <React.Fragment>
-      {triggerPlacement === 'before-content' && (
-        <React.Fragment>
-          <Popover.Trigger data-testid="trigger" handle={popoverHandle} {...triggerProps}>
-            {triggerProps?.children ?? 'Toggle'}
-          </Popover.Trigger>
-          <Popover.Trigger data-testid="trigger-2" handle={popoverHandle}>
-            Toggle another
-          </Popover.Trigger>
-
-          {betweenTriggerAndPortal}
-        </React.Fragment>
-      )}
+      {triggerPlacement === 'before-content' && <React.Fragment>{renderTriggers()}</React.Fragment>}
       <ContainedTriggerPopover
-        {...rest}
-        rootProps={{ ...rest.rootProps, handle: popoverHandle }}
+        rootProps={{ ...rootProps, handle: popoverHandle }}
+        portalProps={portalProps}
+        positionerProps={positionerProps}
+        popupProps={popupProps}
         includeTrigger={false}
       />
-      {triggerPlacement === 'after-content' && (
-        <React.Fragment>
-          {betweenTriggerAndPortal}
-          <Popover.Trigger data-testid="trigger" handle={popoverHandle} {...triggerProps}>
-            {triggerProps?.children ?? 'Toggle'}
-          </Popover.Trigger>
-          <Popover.Trigger data-testid="trigger-2" handle={popoverHandle}>
-            Toggle another
-          </Popover.Trigger>
-        </React.Fragment>
-      )}
+      {triggerPlacement === 'after-content' && <React.Fragment>{renderTriggers()}</React.Fragment>}
     </React.Fragment>
   );
 }


### PR DESCRIPTION
In https://github.com/mui/base-ui/pull/3421 I made a mistake - not all tests (in fact, just a couple of them) were run with detached/multiple triggers. Instead, the contained triggers tests were running 3 times.
This fixes it and updates the test logic. Fortunately no component logic had to be fixed.