### PR TITLE
[docs] Fix mobile header z-index

### DIFF
--- a/docs/src/components/Header.css
+++ b/docs/src/components/Header.css
@@ -21,7 +21,7 @@
     box-shadow: inset 0 -1px var(--color-gridline);
     /* It's also the iOS header overscroll background */
     background-color: var(--color-gray-50);
-    z-index: 1;
+    z-index: 2;
 
     @media (--show-side-nav) {
       position: static;


### PR DESCRIPTION
Fixes certain elements (with explicit `z-index: 1`) covering the mobile navigation header.
Considered removing the explicit `z-index: 1` in those particular cases, but I'm not sure if I'm missing certain cases why they were added for, so, I thought that this is the less "evil" solution. 🤷 

Issues:

https://github.com/user-attachments/assets/38147a73-b5f8-4e15-8086-53ba177a565d

