### PR TITLE
[docs] Fix Recalculate style regression

### DIFF
--- a/docs/src/app/(docs)/layout.css
+++ b/docs/src/app/(docs)/layout.css
@@ -15,7 +15,7 @@
     color: var(--color-foreground);
   }
 
-  body:has(.RootLayout) ::selection {
+  .RootLayout ::selection {
     background-color: var(--color-selection);
   }
 }


### PR DESCRIPTION
I was browsing the docs and felt that it was noticeably slower than it used to be. So, out of curiosity, I opened my dev tool. As it turned out, this is a regression from #3493. We introduced a complex CSS selector that breaks the CSS performance on the page:
```css
body:has(.RootLayout) ::selection {
```

Two ways to reproduce the problem:

### Open Select

https://github.com/user-attachments/assets/2674133f-39e6-43c9-9898-d4f2caf531a7

- [HEAD](https://693ae9e6a41ca30008471aaf--base-ui.netlify.app/react/components/select): **99ms**
<img width="385" height="404" alt="SCR-20251213-clwn" src="https://github.com/user-attachments/assets/c07d3aaa-54ee-4c99-a1e5-b15b66bdfc3a" />

- [PR](https://deploy-preview-3531--base-ui.netlify.app/react/components/select): **26ms**
<img width="449" height="374" alt="SCR-20251213-cmes" src="https://github.com/user-attachments/assets/32cb4fd5-4c4b-49d3-bea5-c776e143276c" />

### Page transition

https://github.com/user-attachments/assets/e93c0c95-dfe6-4a1f-bbad-5956393293ce

- [HEAD](https://693ae9e6a41ca30008471aaf--base-ui.netlify.app/react/components/select): **340ms**
<img width="340" height="362" alt="SCR-20251213-cnmx" src="https://github.com/user-attachments/assets/b1cc105a-c0da-42ba-9245-16126778596a" />

- [PR](https://deploy-preview-3531--base-ui.netlify.app/react/components/select): **54ms**
<img width="505" height="358" alt="SCR-20251213-cnjl" src="https://github.com/user-attachments/assets/7a638ecc-cfb9-4fc5-9503-a919833d12ce" />

---

A must-watch on the topic: https://www.youtube.com/watch?v=nWcexTnvIKI. In our case: 

<img width="978" height="127" alt="SCR-20251213-cojp" src="https://github.com/user-attachments/assets/89a6bd0d-a490-4aff-bf29-6723889b5836" />

My small contribution to v1 🎁. There is still stuff that feels slow, but one step at a time 😁