### PR TITLE
[docs] Fix layout trashing scrollable

### DIFF
--- a/docs/src/utils/observeScrollableInner.ts
+++ b/docs/src/utils/observeScrollableInner.ts
@@ -1,22 +1,36 @@
 // Observe whether the inner node is scrollable and set a "[data-scrollable]"
 // attribute on the parent node. We are rawdogging the DOM changes here to skip unnecessary renders.
-export function observeScrollableInner(node: HTMLElement | null) {
-  if (!node) {
-    return;
+export function observeScrollableInner(ref: HTMLElement | null) {
+  if (!ref) {
+    return undefined;
   }
 
-  const inner = node.children[0] as HTMLElement;
+  const inner = ref.children[0] as HTMLElement;
+  let raf: ReturnType<typeof requestAnimationFrame> | null = null;
   const observer = new ResizeObserver(() => {
-    if (inner.scrollWidth > inner.offsetWidth) {
-      node.setAttribute('data-scrollable', '');
-    } else {
-      node.removeAttribute('data-scrollable');
-    }
+    const isScrollable = inner.scrollWidth > inner.offsetWidth;
+
+    // Schedule the DOM update to happen in the next frame to avoid layout trashing.
+    raf = requestAnimationFrame(() => {
+      if (isScrollable) {
+        ref.setAttribute('data-scrollable', '');
+      } else {
+        ref.removeAttribute('data-scrollable');
+      }
+      raf = null;
+    });
   });
 
   if (inner) {
     observer.observe(inner);
-  } else {
+  } else if (process.env.NODE_ENV !== 'production') {
     console.warn('Expected to find an inner element');
   }
+
+  return () => {
+    observer.disconnect();
+    if (raf !== null) {
+      cancelAnimationFrame(raf);
+    }
+  };
 }


### PR DESCRIPTION
Visible from #3531. The problems were introduced in #866.

**Before**

1. We .observe() but we never .disconnect() -> memory leak
2. We console.warn() but shouldn't this be dev only, we don't need that bundle size in production
3. We layout trash x200 in a loop. https://www.youtube.com/watch?v=nWcexTnvIKI explains it all.

<img width="734" height="367" alt="SCR-20251213-ndjh" src="https://github.com/user-attachments/assets/310bbc77-38d5-4620-93f0-48769eba3d4e" />

https://693ae9e6a41ca30008471aaf--base-ui.netlify.app/react/components/select

**After**

1. Fixed
2. Fixed
3. Fixed 12ms -> 0ms. So 12ms saved from a page transition that takes 179ms. It's 7% faster, cool.

<img width="750" height="345" alt="SCR-20251213-ndln" src="https://github.com/user-attachments/assets/349c018e-4ef0-49fe-96fe-fd77db4ab922" />

https://deploy-preview-3535--base-ui.netlify.app/react/components/select

And yes, the style seems to still work:

<img width="150" height="196" alt="SCR-20251213-niel" src="https://github.com/user-attachments/assets/895cbcb9-e600-41df-81c3-0fe58d437b65" />
