### PR TITLE
[scroll area] Perf improvements

### DIFF
--- a/packages/react/src/scroll-area/content/ScrollAreaContent.tsx
+++ b/packages/react/src/scroll-area/content/ScrollAreaContent.tsx
@@ -30,7 +30,16 @@ export const ScrollAreaContent = React.forwardRef(function ScrollAreaContent(
       return undefined;
     }
 
-    const ro = new ResizeObserver(computeThumbPosition);
+    let hasInitialized = false;
+    const ro = new ResizeObserver(() => {
+      // ResizeObserver fires once upon observing, so we skip the initial call
+      // to avoid double-calculating the thumb position on mount.
+      if (!hasInitialized) {
+        hasInitialized = true;
+        return;
+      }
+      computeThumbPosition();
+    });
 
     if (contentWrapperRef.current) {
       ro.observe(contentWrapperRef.current);

--- a/packages/react/src/scroll-area/corner/ScrollAreaCorner.tsx
+++ b/packages/react/src/scroll-area/corner/ScrollAreaCorner.tsx
@@ -34,7 +34,7 @@ export const ScrollAreaCorner = React.forwardRef(function ScrollAreaCorner(
     ],
   });
 
-  if (hiddenState.cornerHidden) {
+  if (hiddenState.corner) {
     return null;
   }
 

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
@@ -14,21 +14,15 @@ import { useBaseUiId } from '../../utils/useBaseUiId';
 import { scrollAreaStateAttributesMapping } from './stateAttributes';
 import { contains } from '../../floating-ui-react/utils';
 
-interface Size {
-  width: number;
-  height: number;
-}
+const DEFAULT_COORDS = { x: 0, y: 0 };
+const DEFAULT_SIZE = { width: 0, height: 0 };
+const DEFAULT_OVERFLOW_EDGES = { xStart: false, xEnd: false, yStart: false, yEnd: false };
+const DEFAULT_HIDDEN_STATE = { x: false, y: false, corner: false };
 
-const DEFAULT_SIZE = {
-  width: 0,
-  height: 0,
-};
-const DEFAULT_OVERFLOW_EDGES = {
-  xStart: false,
-  xEnd: false,
-  yStart: false,
-  yEnd: false,
-};
+export type HiddenState = typeof DEFAULT_HIDDEN_STATE;
+export type OverflowEdges = typeof DEFAULT_OVERFLOW_EDGES;
+export type Size = typeof DEFAULT_SIZE;
+export type Coords = typeof DEFAULT_COORDS;
 
 /**
  * Groups all parts of the scroll area.
@@ -47,15 +41,21 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
     ...elementProps
   } = componentProps;
 
+  const overflowEdgeThreshold = normalizeOverflowEdgeThreshold(overflowEdgeThresholdProp);
+
+  const rootId = useBaseUiId();
+
+  const scrollYTimeout = useTimeout();
+  const scrollXTimeout = useTimeout();
+
   const [hovering, setHovering] = React.useState(false);
   const [scrollingX, setScrollingX] = React.useState(false);
   const [scrollingY, setScrollingY] = React.useState(false);
+  const [touchModality, setTouchModality] = React.useState(false);
   const [cornerSize, setCornerSize] = React.useState<Size>(DEFAULT_SIZE);
   const [thumbSize, setThumbSize] = React.useState<Size>(DEFAULT_SIZE);
-  const [touchModality, setTouchModality] = React.useState(false);
   const [overflowEdges, setOverflowEdges] = React.useState(DEFAULT_OVERFLOW_EDGES);
-
-  const rootId = useBaseUiId();
+  const [hiddenState, setHiddenState] = React.useState(DEFAULT_HIDDEN_STATE);
 
   const rootRef = React.useRef<HTMLDivElement | null>(null);
   const viewportRef = React.useRef<HTMLDivElement | null>(null);
@@ -71,19 +71,9 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
   const startScrollTopRef = React.useRef(0);
   const startScrollLeftRef = React.useRef(0);
   const currentOrientationRef = React.useRef<'vertical' | 'horizontal'>('vertical');
-  const scrollYTimeout = useTimeout();
-  const scrollXTimeout = useTimeout();
-  const scrollPositionRef = React.useRef({ x: 0, y: 0 });
+  const scrollPositionRef = React.useRef(DEFAULT_COORDS);
 
-  const [hiddenState, setHiddenState] = React.useState({
-    scrollbarYHidden: false,
-    scrollbarXHidden: false,
-    cornerHidden: false,
-  });
-
-  const overflowEdgeThreshold = normalizeOverflowEdgeThreshold(overflowEdgeThresholdProp);
-
-  const handleScroll = useStableCallback((scrollPosition: { x: number; y: number }) => {
+  const handleScroll = useStableCallback((scrollPosition: Coords) => {
     const offsetX = scrollPosition.x - scrollPositionRef.current.x;
     const offsetY = scrollPosition.y - scrollPositionRef.current.y;
     scrollPositionRef.current = scrollPosition;
@@ -200,12 +190,14 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
     }
   });
 
+  function handleTouchModalityChange(event: React.PointerEvent) {
+    setTouchModality(event.pointerType === 'touch');
+  }
+
   function handlePointerEnterOrMove(event: React.PointerEvent) {
-    const isTouch = event.pointerType === 'touch';
+    handleTouchModalityChange(event);
 
-    setTouchModality(isTouch);
-
-    if (!isTouch) {
+    if (event.pointerType !== 'touch') {
       const isTargetRootChild = contains(rootRef.current, event.target as Element);
       setHovering(isTargetRootChild);
     }
@@ -213,29 +205,22 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
 
   const state: ScrollAreaRoot.State = React.useMemo(
     () => ({
-      hasOverflowX: !hiddenState.scrollbarXHidden,
-      hasOverflowY: !hiddenState.scrollbarYHidden,
+      hasOverflowX: !hiddenState.x,
+      hasOverflowY: !hiddenState.y,
       overflowXStart: overflowEdges.xStart,
       overflowXEnd: overflowEdges.xEnd,
       overflowYStart: overflowEdges.yStart,
       overflowYEnd: overflowEdges.yEnd,
-      cornerHidden: hiddenState.cornerHidden,
+      cornerHidden: hiddenState.corner,
     }),
-    [
-      hiddenState.scrollbarXHidden,
-      hiddenState.scrollbarYHidden,
-      hiddenState.cornerHidden,
-      overflowEdges,
-    ],
+    [hiddenState.x, hiddenState.y, hiddenState.corner, overflowEdges],
   );
 
   const props: HTMLProps = {
     role: 'presentation',
     onPointerEnter: handlePointerEnterOrMove,
     onPointerMove: handlePointerEnterOrMove,
-    onPointerDown({ pointerType }) {
-      setTouchModality(pointerType === 'touch');
-    },
+    onPointerDown: handleTouchModalityChange,
     onPointerLeave() {
       setHovering(false);
     },
@@ -293,19 +278,12 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
       cornerSize,
       thumbSize,
       touchModality,
-      cornerRef,
       scrollingX,
       setScrollingX,
       scrollingY,
       setScrollingY,
       hovering,
       setHovering,
-      viewportRef,
-      rootRef,
-      scrollbarYRef,
-      scrollbarXRef,
-      thumbYRef,
-      thumbXRef,
       rootId,
       hiddenState,
       overflowEdges,
@@ -338,6 +316,7 @@ export interface ScrollAreaRootState {
   /** Whether the scrollbar corner is hidden. */
   cornerHidden: boolean;
 }
+
 export interface ScrollAreaRootProps extends BaseUIComponentProps<'div', ScrollAreaRoot.State> {
   /**
    * The threshold in pixels that must be passed before the overflow edge attributes are applied.
@@ -352,6 +331,11 @@ export interface ScrollAreaRootProps extends BaseUIComponentProps<'div', ScrollA
         yStart: number;
         yEnd: number;
       }>;
+}
+
+export namespace ScrollAreaRoot {
+  export type State = ScrollAreaRootState;
+  export type Props = ScrollAreaRootProps;
 }
 
 function normalizeOverflowEdgeThreshold(
@@ -373,9 +357,4 @@ function normalizeOverflowEdgeThreshold(
     yStart: Math.max(0, threshold?.yStart || 0),
     yEnd: Math.max(0, threshold?.yEnd || 0),
   };
-}
-
-export namespace ScrollAreaRoot {
-  export type State = ScrollAreaRootState;
-  export type Props = ScrollAreaRootProps;
 }

--- a/packages/react/src/scroll-area/root/ScrollAreaRootContext.ts
+++ b/packages/react/src/scroll-area/root/ScrollAreaRootContext.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import type { ScrollAreaRoot } from './ScrollAreaRoot';
+import type { Coords, HiddenState, OverflowEdges, ScrollAreaRoot, Size } from './ScrollAreaRoot';
 
 export interface ScrollAreaRootContext {
-  cornerSize: { width: number; height: number };
-  setCornerSize: React.Dispatch<React.SetStateAction<{ width: number; height: number }>>;
-  thumbSize: { width: number; height: number };
-  setThumbSize: React.Dispatch<React.SetStateAction<{ width: number; height: number }>>;
+  cornerSize: Size;
+  setCornerSize: React.Dispatch<React.SetStateAction<Size>>;
+  thumbSize: Size;
+  setThumbSize: React.Dispatch<React.SetStateAction<Size>>;
   touchModality: boolean;
   hovering: boolean;
   setHovering: React.Dispatch<React.SetStateAction<boolean>>;
@@ -23,34 +23,12 @@ export interface ScrollAreaRootContext {
   handlePointerDown: (event: React.PointerEvent) => void;
   handlePointerMove: (event: React.PointerEvent) => void;
   handlePointerUp: (event: React.PointerEvent) => void;
-  handleScroll: (scrollPosition: { x: number; y: number }) => void;
+  handleScroll: (scrollPosition: Coords) => void;
   rootId: string | undefined;
-  hiddenState: {
-    scrollbarYHidden: boolean;
-    scrollbarXHidden: boolean;
-    cornerHidden: boolean;
-  };
-  setHiddenState: React.Dispatch<
-    React.SetStateAction<{
-      scrollbarYHidden: boolean;
-      scrollbarXHidden: boolean;
-      cornerHidden: boolean;
-    }>
-  >;
-  overflowEdges: {
-    xStart: boolean;
-    xEnd: boolean;
-    yStart: boolean;
-    yEnd: boolean;
-  };
-  setOverflowEdges: React.Dispatch<
-    React.SetStateAction<{
-      xStart: boolean;
-      xEnd: boolean;
-      yStart: boolean;
-      yEnd: boolean;
-    }>
-  >;
+  hiddenState: HiddenState;
+  setHiddenState: React.Dispatch<React.SetStateAction<HiddenState>>;
+  overflowEdges: OverflowEdges;
+  setOverflowEdges: React.Dispatch<React.SetStateAction<OverflowEdges>>;
   viewportState: ScrollAreaRoot.State;
   overflowEdgeThreshold: {
     xStart: number;

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
@@ -54,13 +54,13 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
         vertical: scrollingY,
       }[orientation],
       orientation,
-      hasOverflowX: !hiddenState.scrollbarXHidden,
-      hasOverflowY: !hiddenState.scrollbarYHidden,
+      hasOverflowX: !hiddenState.x,
+      hasOverflowY: !hiddenState.y,
       overflowXStart: overflowEdges.xStart,
       overflowXEnd: overflowEdges.xEnd,
       overflowYStart: overflowEdges.yStart,
       overflowYEnd: overflowEdges.yEnd,
-      cornerHidden: hiddenState.cornerHidden,
+      cornerHidden: hiddenState.corner,
     }),
     [hovering, scrollingX, scrollingY, orientation, hiddenState, overflowEdges],
   );
@@ -217,8 +217,7 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
 
   const contextValue = React.useMemo(() => ({ orientation }), [orientation]);
 
-  const isHidden =
-    orientation === 'vertical' ? hiddenState.scrollbarYHidden : hiddenState.scrollbarXHidden;
+  const isHidden = orientation === 'vertical' ? hiddenState.y : hiddenState.x;
 
   const shouldRender = keepMounted || !isHidden;
   if (!shouldRender) {

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { isWebKit } from '@base-ui/utils/detectBrowser';
@@ -83,6 +82,7 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     thumbYRef,
     thumbXRef,
     cornerRef,
+    cornerSize,
     setCornerSize,
     setThumbSize,
     rootId,
@@ -98,10 +98,11 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
   const direction = useDirection();
 
   const programmaticScrollRef = React.useRef(true);
+
   const scrollEndTimeout = useTimeout();
   const waitForAnimationsTimeout = useTimeout();
 
-  function computeThumbPositionHandler() {
+  const computeThumbPosition = useStableCallback(() => {
     const viewportEl = viewportRef.current;
     const scrollbarYEl = scrollbarYRef.current;
     const scrollbarXEl = scrollbarXRef.current;
@@ -147,6 +148,19 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     const nextWidth = scrollbarXHidden ? 0 : viewportWidth;
     const nextHeight = scrollbarYHidden ? 0 : viewportHeight;
 
+    let nextCornerWidth = 0;
+    let nextCornerHeight = 0;
+    if (!scrollbarXHidden && !scrollbarYHidden) {
+      nextCornerWidth = scrollbarYEl?.offsetWidth || 0;
+      nextCornerHeight = scrollbarXEl?.offsetHeight || 0;
+    }
+
+    // Only subtract corner size from scrollbar dimensions if the corner hasn't been sized yet.
+    // Once sized, the layout will already account for it.
+    const cornerNotYetSized = cornerSize.width === 0 && cornerSize.height === 0;
+    const cornerWidthOffset = cornerNotYetSized ? nextCornerWidth : 0;
+    const cornerHeightOffset = cornerNotYetSized ? nextCornerHeight : 0;
+
     const scrollbarXOffset = getOffset(scrollbarXEl, 'padding', 'x');
     const scrollbarYOffset = getOffset(scrollbarYEl, 'padding', 'y');
     const thumbXOffset = getOffset(thumbXEl, 'margin', 'x');
@@ -156,10 +170,10 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     const idealNextHeight = nextHeight - scrollbarYOffset - thumbYOffset;
 
     const maxNextWidth = scrollbarXEl
-      ? Math.min(scrollbarXEl.offsetWidth, idealNextWidth)
+      ? Math.min(scrollbarXEl.offsetWidth - cornerWidthOffset, idealNextWidth)
       : idealNextWidth;
     const maxNextHeight = scrollbarYEl
-      ? Math.min(scrollbarYEl.offsetHeight, idealNextHeight)
+      ? Math.min(scrollbarYEl.offsetHeight - cornerHeightOffset, idealNextHeight)
       : idealNextHeight;
 
     const clampedNextWidth = Math.max(MIN_THUMB_SIZE, maxNextWidth * ratioX);
@@ -227,9 +241,7 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
       if (scrollbarXHidden || scrollbarYHidden) {
         setCornerSize({ width: 0, height: 0 });
       } else if (!scrollbarXHidden && !scrollbarYHidden) {
-        const width = scrollbarYEl?.offsetWidth || 0;
-        const height = scrollbarXEl?.offsetHeight || 0;
-        setCornerSize({ width, height });
+        setCornerSize({ width: nextCornerWidth, height: nextCornerHeight });
       }
     }
 
@@ -237,17 +249,17 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
       const cornerHidden = scrollbarYHidden || scrollbarXHidden;
 
       if (
-        prevState.scrollbarYHidden === scrollbarYHidden &&
-        prevState.scrollbarXHidden === scrollbarXHidden &&
-        prevState.cornerHidden === cornerHidden
+        prevState.y === scrollbarYHidden &&
+        prevState.x === scrollbarXHidden &&
+        prevState.corner === cornerHidden
       ) {
         return prevState;
       }
 
       return {
-        scrollbarYHidden,
-        scrollbarXHidden,
-        cornerHidden,
+        y: scrollbarYHidden,
+        x: scrollbarXHidden,
+        corner: cornerHidden,
       };
     });
 
@@ -269,10 +281,6 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
       }
       return nextOverflowEdges;
     });
-  }
-
-  const computeThumbPosition = useStableCallback(() => {
-    ReactDOM.flushSync(computeThumbPositionHandler);
   });
 
   useIsoLayoutEffect(() => {
@@ -282,8 +290,14 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
 
     removeCSSVariableInheritance();
 
-    const cleanup = onVisible(viewportRef.current, computeThumbPosition);
-    return cleanup;
+    let hasInitialized = false;
+    return onVisible(viewportRef.current, () => {
+      if (!hasInitialized) {
+        hasInitialized = true;
+        return;
+      }
+      computeThumbPosition();
+    });
   }, [computeThumbPosition, viewportRef]);
 
   useIsoLayoutEffect(() => {
@@ -305,7 +319,16 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
       return undefined;
     }
 
-    const ro = new ResizeObserver(computeThumbPosition);
+    let hasInitialized = false;
+    const ro = new ResizeObserver(() => {
+      // ResizeObserver fires once upon observing, so we skip the initial call
+      // to avoid double-calculating the thumb position on mount.
+      if (!hasInitialized) {
+        hasInitialized = true;
+        return;
+      }
+      computeThumbPosition();
+    });
 
     ro.observe(viewport);
 
@@ -317,7 +340,12 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     // We assume the user is using `onOpenChangeComplete` to hide the scrollbar
     // until animations complete because otherwise the scrollbar would show the thumb resizing mid-animation.
     waitForAnimationsTimeout.start(0, () => {
-      Promise.all(viewport.getAnimations({ subtree: true }).map((animation) => animation.finished))
+      const animations = viewport.getAnimations({ subtree: true });
+      if (animations.length === 0) {
+        return;
+      }
+
+      Promise.all(animations.map((animation) => animation.finished))
         .then(computeThumbPosition)
         .catch(() => {});
     });
@@ -336,7 +364,7 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     role: 'presentation',
     ...(rootId && { 'data-id': `${rootId}-viewport` }),
     // https://accessibilityinsights.io/info-examples/web/scrollable-region-focusable/
-    ...((!hiddenState.scrollbarXHidden || !hiddenState.scrollbarYHidden) && { tabIndex: 0 }),
+    ...((!hiddenState.x || !hiddenState.y) && { tabIndex: 0 }),
     className: styleDisableScrollbar.className,
     style: {
       overflow: 'scroll',
@@ -374,20 +402,15 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
 
   const viewportState: ScrollAreaViewport.State = React.useMemo(
     () => ({
-      hasOverflowX: !hiddenState.scrollbarXHidden,
-      hasOverflowY: !hiddenState.scrollbarYHidden,
+      hasOverflowX: !hiddenState.x,
+      hasOverflowY: !hiddenState.y,
       overflowXStart: overflowEdges.xStart,
       overflowXEnd: overflowEdges.xEnd,
       overflowYStart: overflowEdges.yStart,
       overflowYEnd: overflowEdges.yEnd,
-      cornerHidden: hiddenState.cornerHidden,
+      cornerHidden: hiddenState.corner,
     }),
-    [
-      hiddenState.scrollbarXHidden,
-      hiddenState.scrollbarYHidden,
-      hiddenState.cornerHidden,
-      overflowEdges,
-    ],
+    [hiddenState.x, hiddenState.y, hiddenState.corner, overflowEdges],
   );
 
   const element = useRenderElement('div', componentProps, {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Help with #3534 @oliviertassinari 

The key issue causing the "flicker" from what I found is that the `<Corner>` element's size wasn't being taken into account during the first calculation of the thumb position. Once the corner has its size rendered, then the thumb calculation was correct. Since multiple calculations were happening on mount, this caused a visible flicker that was masked with a sync state update.

- Prevented `computeThumbPosition` being called unnecessarily on mount (even though state updates were typically discarded) by blocking initial updates in observer callbacks and removing redundant effects
- Made some variable names smaller for bundle size
- Removed some memory allocations
- Removed refs inserted into the context memo dep array unnecessarily

Also cleaned up the code a bit to remove duplication and grouped some hook calls more precisely

Preview: https://deploy-preview-3536--base-ui.netlify.app/react/components/select