### PR TITLE
[docs] Fix link to license

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -40,8 +40,7 @@ Future plans and high-priority features and enhancements can be found in the [ro
 
 ## License
 
-This project is licensed under the terms of the
-[MIT license](/LICENSE).
+This project is licensed under the terms of the [MIT license](../../LICENSE).
 
 ## Security
 


### PR DESCRIPTION
Go to https://www.npmjs.com/package/@base-ui/react, try every links, see that this one is broken.