### PR TITLE
[docs] Update security page to cover v1

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ The versions of the project that are currently supported with security updates.
 | Base UI version | Release    | Supported                       |
 | --------------: | :--------- | :------------------------------ |
 |           1.0.0 | 2025-12-11 | :white_check_mark: Stable major |
-|          <1.0.0 | 2024-12-17 | :white_check_mark:              |
+|          <1.0.0 | 2024-12-17 | ❌                              |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
For https://github.com/mui/base-ui/security/policy

Now that we have reached v1, we can flag it as supported for security issues.

As for the pre-releases policy, since it's unstable, I think we should approach this simply: no coverage, incentive to upgrade.