### PR TITLE
[popups] Fix touch `openMethod` when tapping outside element bounds on Safari

### DIFF
--- a/packages/react/src/utils/useOpenInteractionType.ts
+++ b/packages/react/src/utils/useOpenInteractionType.ts
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { InteractionType, useEnhancedClickHandler } from '@base-ui/utils/useEnhancedClickHandler';
+import { isIOS } from '@base-ui/utils/detectBrowser';
 
 /**
  * Determines the interaction type (keyboard, mouse, touch, etc.) that opened the component.
@@ -19,7 +20,7 @@ export function useOpenInteractionType(open: boolean) {
             // On iOS Safari, the hitslop around touch targets means tapping outside an element's
             // bounds does not fire `pointerdown` but does fire `mousedown`. The `interactionType`
             // will be "" in that case.
-            'touch',
+            (isIOS ? 'touch' : ''),
         );
       }
     },


### PR DESCRIPTION
- For Dialog, Menu, Popover, Combobox, and Autocomplete, this fixes `openType` not being `"touch"` in `initialFocus` when tapping outside an element's bounds but inside the hitslop area
- For Select, this fixes `alignItemWithTrigger` not being deactivated on touch when tapping outside the trigger's bounds but inside the hitslop area