### PR TITLE
[docs] Fix header links on Firefox

### DIFF
--- a/docs/src/components/Header.css
+++ b/docs/src/components/Header.css
@@ -71,6 +71,8 @@
   }
 
   .HeaderLink {
+    flex-shrink: 0;
+
     @media (hover: hover) {
       &:hover {
         text-decoration: underline;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

<img width="307" height="56" alt="Screenshot 2025-12-15 at 12 28 19 pm" src="https://github.com/user-attachments/assets/7c724d98-dabf-45f5-98da-ee330d89938c" />
