### PR TITLE
[menubar] Fix submenu outside-press dismiss on touch

### DIFF
--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -406,7 +406,7 @@ export function MenuRoot<Payload>(props: MenuRoot.Props<Payload>) {
 
   const dismiss = useDismiss(floatingRootContext, {
     enabled: !disabled,
-    bubbles: closeParentOnEsc && parent.type === 'menu',
+    bubbles: { escapeKey: closeParentOnEsc && parent.type === 'menu' },
     outsidePress() {
       if (parent.type !== 'context-menu' || openEventRef.current?.type === 'contextmenu') {
         return true;

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM, wait } from '#test-utils';
 import { spy } from 'sinon';
 import { afterEach } from 'vitest';
@@ -629,6 +629,39 @@ describe('<Menubar />', () => {
         });
         await waitFor(() => {
           expect(screen.queryByTestId('edit-menu')).not.to.equal(null);
+        });
+      });
+    });
+
+    describe.skipIf(!isJSDOM)('touch interactions', () => {
+      it('closes the entire tree on a single outside press after opening a submenu', async () => {
+        await render(
+          <div>
+            <TestMenubar />
+            <button data-testid="outside">Outside</button>
+          </div>,
+        );
+
+        const fileTrigger = screen.getByTestId('file-trigger');
+
+        fireEvent.pointerDown(fileTrigger, { pointerType: 'touch' });
+        fireEvent.mouseDown(fileTrigger);
+
+        await screen.findByTestId('file-menu');
+
+        const shareTrigger = await screen.findByTestId('share-trigger');
+        fireEvent.pointerDown(shareTrigger, { pointerType: 'touch' });
+        fireEvent.mouseDown(shareTrigger);
+
+        await screen.findByTestId('share-menu');
+
+        const outside = screen.getByTestId('outside');
+        fireEvent.pointerDown(outside, { pointerType: 'touch' });
+        fireEvent.mouseDown(outside);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('share-menu')).to.equal(null);
+          expect(screen.queryByTestId('file-menu')).to.equal(null);
         });
       });
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

When using touch input, opening a submenu within a menubar and tapping outside should dismiss all open menus.