### PR TITLE
[number field] Fix Field focused state

### DIFF
--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -142,12 +142,17 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
     // causing a hydration mismatch.
     suppressHydrationWarning: true,
     onFocus(event) {
-      if (event.defaultPrevented || readOnly || disabled || hasTouchedInputRef.current) {
+      if (event.defaultPrevented || readOnly || disabled) {
+        return;
+      }
+
+      setFocused(true);
+
+      if (hasTouchedInputRef.current) {
         return;
       }
 
       hasTouchedInputRef.current = true;
-      setFocused(true);
 
       // Browsers set selection at the start of the input field by default. We want to set it at
       // the end for the first focus.

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -1229,6 +1229,27 @@ describe('<NumberField />', () => {
       expect(input).not.to.have.attribute('data-focused');
     });
 
+    it('adds [data-focused] attribute on every focus', async () => {
+      await render(
+        <Field.Root>
+          <NumberFieldBase.Root>
+            <NumberFieldBase.Input data-testid="input" />
+          </NumberFieldBase.Root>
+        </Field.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+
+      fireEvent.focus(input);
+      expect(input).to.have.attribute('data-focused', '');
+
+      fireEvent.blur(input);
+      expect(input).not.to.have.attribute('data-focused');
+
+      fireEvent.focus(input);
+      expect(input).to.have.attribute('data-focused', '');
+    });
+
     it('prop: validate', async () => {
       await render(
         <Field.Root validationMode="onBlur" validate={() => 'error'}>


### PR DESCRIPTION
Fixes #3560. Early touched state return blocked new `setFocused(true)` calls.