### PR TITLE
[useRender] Export missing types

### DIFF
--- a/packages/react/src/use-render/index.ts
+++ b/packages/react/src/use-render/index.ts
@@ -1,1 +1,2 @@
 export * from './useRender';
+export type { HTMLProps, ComponentRenderFn } from '../utils/types';


### PR DESCRIPTION
Exports internal types referenced by a publicly exported `useRender.ComponentProps`, solving https://github.com/mui/joy-ui/pull/437#discussion_r2569875597