### PR TITLE
[docs][select] Add placeholder styles

### DIFF
--- a/docs/src/app/(docs)/react/components/select/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/select/demos/hero/css-modules/index.module.css
@@ -36,6 +36,10 @@
   }
 }
 
+.SelectValue[data-placeholder] {
+  color: var(--color-gray-500);
+}
+
 .SelectIcon {
   display: flex;
 }

--- a/docs/src/app/(docs)/react/components/select/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/select/demos/hero/css-modules/index.tsx
@@ -14,7 +14,7 @@ export default function ExampleSelect() {
   return (
     <Select.Root items={fonts}>
       <Select.Trigger className={styles.Select}>
-        <Select.Value />
+        <Select.Value className={styles.SelectValue} />
         <Select.Icon className={styles.SelectIcon}>
           <ChevronUpDownIcon />
         </Select.Icon>

--- a/docs/src/app/(docs)/react/components/select/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/select/demos/hero/tailwind/index.tsx
@@ -13,7 +13,7 @@ export default function ExampleSelect() {
   return (
     <Select.Root items={fonts}>
       <Select.Trigger className="flex h-10 min-w-36 items-center justify-between gap-3 rounded-md border border-gray-200 pr-3 pl-3.5 text-base bg-[canvas] text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 data-[popup-open]:bg-gray-100">
-        <Select.Value />
+        <Select.Value className="data-[placeholder]:text-gray-500" />
         <Select.Icon className="flex">
           <ChevronUpDownIcon />
         </Select.Icon>

--- a/docs/src/app/(docs)/react/components/select/demos/multiple/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/select/demos/multiple/css-modules/index.module.css
@@ -35,6 +35,10 @@
   }
 }
 
+.SelectValue[data-placeholder] {
+  color: var(--color-gray-500);
+}
+
 .SelectIcon {
   display: flex;
 }

--- a/docs/src/app/(docs)/react/components/select/demos/multiple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/select/demos/multiple/css-modules/index.tsx
@@ -34,7 +34,7 @@ export default function MultiSelectExample() {
   return (
     <Select.Root multiple defaultValue={['javascript', 'typescript']}>
       <Select.Trigger className={styles.Select}>
-        <Select.Value>{renderValue}</Select.Value>
+        <Select.Value className={styles.SelectValue}>{renderValue}</Select.Value>
         <Select.Icon className={styles.SelectIcon}>
           <ChevronUpDownIcon />
         </Select.Icon>

--- a/docs/src/app/(docs)/react/components/select/demos/multiple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/select/demos/multiple/tailwind/index.tsx
@@ -33,7 +33,7 @@ export default function MultiSelectExample() {
   return (
     <Select.Root multiple defaultValue={['javascript', 'typescript']}>
       <Select.Trigger className="flex h-10 min-w-[14rem] items-center justify-between gap-3 rounded-md border border-gray-200 pr-3 pl-3.5 text-base bg-[canvas] text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 data-[popup-open]:bg-gray-100">
-        <Select.Value>{renderValue}</Select.Value>
+        <Select.Value className="data-[placeholder]:text-gray-500">{renderValue}</Select.Value>
         <Select.Icon className="flex">
           <ChevronUpDownIcon />
         </Select.Icon>


### PR DESCRIPTION
Adjusts the color of the value when the `data-placeholder` attribute is present. Since there are no specific docs around placeholders, I think it's a good way of documenting how to deal with placeholder styles without adding a specific demo.

|before|after|
|---|---|
|<img width="155" height="53" alt="Screenshot 2025-12-17 at 12 53 02" src="https://github.com/user-attachments/assets/3f071c4e-89dc-4284-84ae-d0208019cf9d" />|<img width="156" height="57" alt="Screenshot 2025-12-17 at 12 52 47" src="https://github.com/user-attachments/assets/c129aefe-0d9c-49b3-9367-80833a4ec0fd" />|
