### PR TITLE
[popups] Fix click and drag outside nested popup from closing parents

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useDismiss.ts
+++ b/packages/react/src/floating-ui-react/hooks/useDismiss.ts
@@ -631,6 +631,7 @@ export function useDismiss(
       });
 
       compositionTimeout.clear();
+      endedOrStartedInsideRef.current = false;
     };
   }, [
     dataRef,
@@ -686,6 +687,15 @@ export function useDismiss(
     endedOrStartedInsideRef.current = true;
   });
 
+  const markPressStartedInsideReactTree = useStableCallback(
+    (event: React.PointerEvent | React.MouseEvent) => {
+      if (!open || !enabled || event.button !== 0) {
+        return;
+      }
+      endedOrStartedInsideRef.current = true;
+    },
+  );
+
   const floating: ElementProps['floating'] = React.useMemo(
     () => ({
       onKeyDown: closeOnEscapeKeyDown,
@@ -698,13 +708,24 @@ export function useDismiss(
       onMouseUp: handlePressedInside,
 
       onClickCapture: markInsideReactTree,
-      onMouseDownCapture: markInsideReactTree,
-      onPointerDownCapture: markInsideReactTree,
+      onMouseDownCapture(event) {
+        markInsideReactTree();
+        markPressStartedInsideReactTree(event);
+      },
+      onPointerDownCapture(event) {
+        markInsideReactTree();
+        markPressStartedInsideReactTree(event);
+      },
       onMouseUpCapture: markInsideReactTree,
       onTouchEndCapture: markInsideReactTree,
       onTouchMoveCapture: markInsideReactTree,
     }),
-    [closeOnEscapeKeyDown, handlePressedInside, markInsideReactTree],
+    [
+      closeOnEscapeKeyDown,
+      handlePressedInside,
+      markInsideReactTree,
+      markPressStartedInsideReactTree,
+    ],
   );
 
   return React.useMemo(

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -1032,6 +1032,55 @@ describe('<Popover.Root />', () => {
     });
 
     describe('nested popup interactions', () => {
+      it('keeps the parent popover open when press starts in nested popover and ends outside', async () => {
+        function Test() {
+          return (
+            <div>
+              <button type="button" data-testid="outside">
+                Outside
+              </button>
+
+              <Popover.Root defaultOpen>
+                <Popover.Trigger>Parent</Popover.Trigger>
+                <Popover.Portal>
+                  <Popover.Positioner>
+                    <Popover.Popup data-testid="parent-popup">
+                      <Popover.Root>
+                        <Popover.Trigger>Child</Popover.Trigger>
+                        <Popover.Portal>
+                          <Popover.Positioner>
+                            <Popover.Popup data-testid="child-popup">Child content</Popover.Popup>
+                          </Popover.Positioner>
+                        </Popover.Portal>
+                      </Popover.Root>
+                    </Popover.Popup>
+                  </Popover.Positioner>
+                </Popover.Portal>
+              </Popover.Root>
+            </div>
+          );
+        }
+
+        await render(<Test />);
+
+        expect(screen.queryByTestId('parent-popup')).not.to.equal(null);
+
+        const childTrigger = screen.getByRole('button', { name: 'Child' });
+
+        fireEvent.click(childTrigger);
+
+        const childPopup = await screen.findByTestId('child-popup');
+        const outside = screen.getByTestId('outside');
+
+        fireEvent.pointerDown(childPopup, { pointerType: 'mouse', button: 0 });
+        fireEvent.click(outside);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('parent-popup')).not.to.equal(null);
+        });
+        expect(screen.queryByTestId('child-popup')).not.to.equal(null);
+      });
+
       it.skipIf(isJSDOM)(
         'should not close popover when scrolling nested popup on touch',
         async () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

We need to mark that a press occurred inside any nested (portaled) children. This ensures dragging on a nested open popover and releasing outside doesn't close the parent.

Repro: https://stackblitz.com/edit/ufqitdie?file=src%2FApp.tsx 
Press down inside nested popover, drag outside, release pointer up - parent does not close.