### PR TITLE
[popover] Prevent disabling focus manager with `openOnHover` prop

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useHoverReferenceInteraction.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverReferenceInteraction.ts
@@ -379,7 +379,17 @@ export function useHoverReferenceInteraction(
         restTimeout.clear();
 
         function handleMouseMove() {
-          if (!blockMouseMoveRef.current && (!currentOpen || isOverInactiveTrigger)) {
+          restTimeoutPendingRef.current = false;
+
+          // A delayed hover open should not override a click-like open that happened
+          // while the hover delay was pending.
+          if (isClickLikeOpenEvent()) {
+            return;
+          }
+
+          const latestOpen = store.select('open');
+
+          if (!blockMouseMoveRef.current && (!latestOpen || isOverInactiveTrigger)) {
             store.setOpen(
               true,
               createChangeEventDetails(REASONS.triggerHover, nativeEvent, trigger),
@@ -401,6 +411,7 @@ export function useHoverReferenceInteraction(
     };
   }, [
     blockMouseMoveRef,
+    isClickLikeOpenEvent,
     mouseOnly,
     store,
     pointerTypeRef,

--- a/packages/react/src/popover/popup/PopoverPopup.test.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.test.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
-import { act, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { createRenderer, describeConformance, isJSDOM, waitSingleFrame } from '#test-utils';
 
 describe('<Popover.Popup />', () => {
-  const { render } = createRenderer();
+  const { render, clock } = createRenderer();
 
   describeConformance(<Popover.Popup />, () => ({
     refInstanceof: window.HTMLDivElement,
@@ -299,6 +299,47 @@ describe('<Popover.Popup />', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('popup')).toHaveFocus();
+    });
+  });
+
+  describe('openOnHover: delay + click', () => {
+    clock.withFakeTimers();
+
+    it('returns focus to the trigger if opened by click before the hover delay completes', async () => {
+      await render(
+        <Popover.Root>
+          <Popover.Trigger openOnHover delay={300}>
+            Open
+          </Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup>
+                <Popover.Close>Close</Popover.Close>
+              </Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>,
+      );
+
+      const trigger = screen.getByText('Open');
+
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
+
+      clock.tick(100);
+
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      expect(screen.getByText('Close')).not.to.equal(null);
+
+      clock.tick(1000);
+      await flushMicrotasks();
+
+      fireEvent.click(screen.getByText('Close'));
+      await flushMicrotasks();
+
+      expect(trigger).toHaveFocus();
     });
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

When `<Popover.Trigger>` specifies `openOnHover` and a click occurs before the hover delay completes, `<FloatingFocusManager>` would be disabled incorrectly.