### PR TITLE
[docs][select] Remove placeholders

### DIFF
--- a/docs/src/app/(docs)/react/components/select/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/select/demos/hero/css-modules/index.tsx
@@ -3,7 +3,6 @@ import { Select } from '@base-ui/react/select';
 import styles from './index.module.css';
 
 const fonts = [
-  { label: 'Select font', value: null },
   { label: 'Sans-serif', value: 'sans' },
   { label: 'Serif', value: 'serif' },
   { label: 'Monospace', value: 'mono' },
@@ -12,7 +11,7 @@ const fonts = [
 
 export default function ExampleSelect() {
   return (
-    <Select.Root items={fonts}>
+    <Select.Root items={fonts} defaultValue="sans">
       <Select.Trigger className={styles.Select}>
         <Select.Value />
         <Select.Icon className={styles.SelectIcon}>

--- a/docs/src/app/(docs)/react/components/select/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/select/demos/hero/tailwind/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Select } from '@base-ui/react/select';
 
 const fonts = [
-  { label: 'Select font', value: null },
   { label: 'Sans-serif', value: 'sans' },
   { label: 'Serif', value: 'serif' },
   { label: 'Monospace', value: 'mono' },
@@ -11,7 +10,7 @@ const fonts = [
 
 export default function ExampleSelect() {
   return (
-    <Select.Root items={fonts}>
+    <Select.Root items={fonts} defaultValue="sans">
       <Select.Trigger className="flex h-10 min-w-36 items-center justify-between gap-3 rounded-md border border-gray-200 pr-3 pl-3.5 text-base bg-[canvas] text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 data-[popup-open]:bg-gray-100">
         <Select.Value />
         <Select.Icon className="flex">

--- a/docs/src/app/(docs)/react/components/select/demos/multiple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/select/demos/multiple/css-modules/index.tsx
@@ -22,7 +22,7 @@ const values = Object.keys(languages) as Language[];
 
 function renderValue(value: Language[]) {
   if (value.length === 0) {
-    return 'Select languages...';
+    return '';
   }
 
   const firstLanguage = languages[value[0]];

--- a/docs/src/app/(docs)/react/components/select/demos/multiple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/select/demos/multiple/tailwind/index.tsx
@@ -21,7 +21,7 @@ const values = Object.keys(languages) as Language[];
 
 function renderValue(value: Language[]) {
   if (value.length === 0) {
-    return 'Select languages...';
+    return '';
   }
 
   const firstLanguage = languages[value[0]];

--- a/docs/src/app/(docs)/react/components/select/page.mdx
+++ b/docs/src/app/(docs)/react/components/select/page.mdx
@@ -91,7 +91,6 @@ Passing the `items` prop to `<Select.Root>` instead renders the matching label f
 
 ```jsx title="items prop" "items"1,3
 const items = [
-  { value: null, label: 'Select theme' },
   { value: 'system', label: 'System default' },
   { value: 'light', label: 'Light' },
   { value: 'dark', label: 'Dark' },

--- a/docs/src/app/(docs)/react/handbook/animation/demos/animated-select-motion/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/animation/demos/animated-select-motion/css-modules/index.tsx
@@ -5,7 +5,6 @@ import { AnimatePresence, motion } from 'motion/react';
 import styles from './index.module.css';
 
 const fonts = [
-  { label: 'Select font', value: null },
   { label: 'Sans-serif', value: 'sans' },
   { label: 'Serif', value: 'serif' },
   { label: 'Monospace', value: 'mono' },
@@ -42,7 +41,7 @@ export default function AnimatedSelectMotionDemo() {
   );
 
   return (
-    <Select.Root items={fonts} open={open} onOpenChange={setOpen}>
+    <Select.Root items={fonts} open={open} onOpenChange={setOpen} defaultValue="sans">
       <Select.Trigger className={styles.Select}>
         <Select.Value />
         <Select.Icon className={styles.SelectIcon}>

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/select.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/select.tsx
@@ -10,7 +10,7 @@ export function Trigger({ className, ...props }: Select.Trigger.Props) {
   return (
     <Select.Trigger
       className={clsx(
-        'flex h-10 min-w-36 items-center justify-between gap-3 rounded-md border border-gray-200 pr-3 pl-3.5 text-base text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 data-[popup-open]:bg-gray-100 cursor-default not-[[data-filled]]:text-gray-500 bg-[canvas]',
+        'flex h-10 min-w-36 items-center justify-between gap-3 rounded-md border border-gray-200 pr-3 pl-3.5 text-base text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 data-[popup-open]:bg-gray-100 cursor-default bg-[canvas]',
         className,
       )}
       {...props}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/hero/tailwind/index.tsx
@@ -278,10 +278,7 @@ const IMAGES: Image[] = ['nginx:1.29-alpine', 'node:22-slim', 'postgres:18', 're
   name,
 }));
 
-const SERVER_TYPES = [
-  { label: 'Select server type', value: null },
-  ...cartesian(['t', 'm'], ['1', '2'], ['small', 'medium', 'large']).map((part) => {
-    const value = part.join('.').replace('.', '');
-    return { label: value, value };
-  }),
-];
+const SERVER_TYPES = cartesian(['t', 'm'], ['1', '2'], ['small', 'medium', 'large']).map((part) => {
+  const value = part.join('.').replace('.', '');
+  return { label: value, value };
+});

--- a/docs/src/app/(docs)/react/handbook/forms/demos/react-hook-form/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/react-hook-form/tailwind/index.tsx
@@ -427,10 +427,7 @@ const IMAGES: Image[] = ['nginx:1.29-alpine', 'node:22-slim', 'postgres:18', 're
   name,
 }));
 
-const SERVER_TYPES = [
-  { label: 'Select server type', value: null },
-  ...cartesian(['t', 'm'], ['1', '2'], ['small', 'medium', 'large']).map((part) => {
-    const value = part.join('.').replace('.', '');
-    return { label: value, value };
-  }),
-];
+const SERVER_TYPES = cartesian(['t', 'm'], ['1', '2'], ['small', 'medium', 'large']).map((part) => {
+  const value = part.join('.').replace('.', '');
+  return { label: value, value };
+});

--- a/docs/src/app/(docs)/react/handbook/forms/demos/tanstack-form/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/tanstack-form/tailwind/index.tsx
@@ -506,10 +506,7 @@ const IMAGES: Image[] = ['nginx:1.29-alpine', 'node:22-slim', 'postgres:18', 're
   name,
 }));
 
-const SERVER_TYPES = [
-  { label: 'Select server type', value: null },
-  ...cartesian(['t', 'm'], ['1', '2'], ['small', 'medium', 'large']).map((part) => {
-    const value = part.join('.').replace('.', '');
-    return { label: value, value };
-  }),
-];
+const SERVER_TYPES = cartesian(['t', 'm'], ['1', '2'], ['small', 'medium', 'large']).map((part) => {
+  const value = part.join('.').replace('.', '');
+  return { label: value, value };
+});


### PR DESCRIPTION
Select placeholders don't add value and are not required in the vast majority of use cases. This PR removes all placeholders from Select demos so we don't promote its usage.

- In single selection demos, options with `null` value have been removed and a `defaultValue` has been added instead.
- In the multiple selection demo, the placeholder has been removed altogether because it already had a `defaultValue`.

Updated demos:
- Select
  - [Hero](https://deploy-preview-3580--base-ui.netlify.app/react/components/select)
  - [Multiple selection](https://deploy-preview-3580--base-ui.netlify.app/react/components/select#multiple-selection)
  - [Formatting the value](https://deploy-preview-3580--base-ui.netlify.app/react/components/select#formatting-the-value) (code snippet)
- Forms (handbook)
  - [Hero](https://deploy-preview-3580--base-ui.netlify.app/react/handbook/forms)
  - [React Hook Form](https://deploy-preview-3580--base-ui.netlify.app/react/handbook/forms#react-hook-form)
  - [TanStack Form](https://deploy-preview-3580--base-ui.netlify.app/react/handbook/forms#tanstack-form)
- [Animation](https://deploy-preview-3580--base-ui.netlify.app/react/handbook/animation#animating-select-component-with-motion) (handbook)

Note: Ideally all Selects should have a proper label, but I assume we don't want to add noise when showcasing individual components demos.