### PR TITLE
[number field] Fix hidden input focus on submit

### DIFF
--- a/docs/reference/generated/number-field-root.json
+++ b/docs/reference/generated/number-field-root.json
@@ -38,10 +38,10 @@
       "detailedType": "boolean | undefined"
     },
     "step": {
-      "type": "number",
+      "type": "number | 'any'",
       "default": "1",
-      "description": "Amount to increment and decrement with the buttons and arrow keys, or to scrub with pointer movement in the scrub area.\nTo enable step validation on form submission, specify the `min` prop explicitly.",
-      "detailedType": "number | undefined"
+      "description": "Amount to increment and decrement with the buttons and arrow keys, or to scrub with pointer movement in the scrub area.\nTo always enable step validation on form submission, specify the `min` prop explicitly in conjunction with this prop.\nSpecify `step=\"any\"` to always disable step validation.",
+      "detailedType": "number | 'any' | undefined"
     },
     "smallStep": {
       "type": "number",

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -98,33 +98,55 @@ describe('<NumberField />', () => {
     expect(form.checkValidity()).to.equal(false);
   });
 
-  it.skipIf(isJSDOM)(
-    'does not block submission when step mismatch occurs with undefined step',
-    async () => {
-      await render(
-        <form data-testid="form">
-          <NumberFieldBase.Root name="quantity" min={0}>
-            <NumberFieldBase.Group>
-              <NumberFieldBase.Input />
-            </NumberFieldBase.Group>
-          </NumberFieldBase.Root>
-          <button type="submit">Submit</button>
-        </form>,
-      );
+  it.skipIf(isJSDOM)('blocks submission when step mismatch occurs with default step', async () => {
+    await render(
+      <form data-testid="form">
+        <NumberFieldBase.Root name="quantity" min={0}>
+          <NumberFieldBase.Group>
+            <NumberFieldBase.Input />
+          </NumberFieldBase.Group>
+        </NumberFieldBase.Root>
+        <button type="submit">Submit</button>
+      </form>,
+    );
 
-      const input = screen.getByRole('textbox');
-      fireEvent.change(input, { target: { value: '0.11' } });
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '0.11' } });
 
-      const hiddenInput = document.querySelector(
-        'input[type="number"][name="quantity"]',
-      ) as HTMLInputElement;
-      expect(hiddenInput).not.to.equal(null);
-      expect(hiddenInput.validity.stepMismatch).to.equal(false);
+    const hiddenInput = document.querySelector(
+      'input[type="number"][name="quantity"]',
+    ) as HTMLInputElement;
+    expect(hiddenInput).not.to.equal(null);
+    expect(hiddenInput.validity.stepMismatch).to.equal(true);
 
-      const form = screen.getByTestId<HTMLFormElement>('form');
-      expect(form.checkValidity()).to.equal(true);
-    },
-  );
+    const form = screen.getByTestId<HTMLFormElement>('form');
+    expect(form.checkValidity()).to.equal(false);
+  });
+
+  it('does not block submission when step="any"', async () => {
+    await render(
+      <form data-testid="form">
+        <NumberFieldBase.Root name="quantity" min={0} step="any">
+          <NumberFieldBase.Group>
+            <NumberFieldBase.Input />
+          </NumberFieldBase.Group>
+        </NumberFieldBase.Root>
+        <button type="submit">Submit</button>
+      </form>,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '0.11' } });
+
+    const hiddenInput = document.querySelector(
+      'input[type="number"][name="quantity"]',
+    ) as HTMLInputElement;
+    expect(hiddenInput).not.to.equal(null);
+    expect(hiddenInput.validity.stepMismatch).to.equal(false);
+
+    const form = screen.getByTestId<HTMLFormElement>('form');
+    expect(form.checkValidity()).to.equal(true);
+  });
 
   describe('prop: onValueChange', () => {
     it('should be called when the value changes', async () => {

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -56,7 +56,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
     min,
     max,
     smallStep = 0.1,
-    step = 1,
+    step: stepProp = 1,
     largeStep = 10,
     required = false,
     disabled: disabledProp = false,
@@ -90,6 +90,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
 
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
+  const step = stepProp === 'any' ? 1 : stepProp;
 
   const [isScrubbing, setIsScrubbing] = React.useState(false);
 
@@ -547,7 +548,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
         max={max}
         // stepMismatch validation is broken unless an explicit `min` is added.
         // See https://github.com/facebook/react/issues/12334.
-        step={step}
+        step={stepProp}
         disabled={disabled}
         required={required}
         aria-hidden
@@ -582,10 +583,11 @@ export interface NumberFieldRootProps extends Omit<
   smallStep?: number;
   /**
    * Amount to increment and decrement with the buttons and arrow keys, or to scrub with pointer movement in the scrub area.
-   * To enable step validation on form submission, specify the `min` prop explicitly.
+   * To always enable step validation on form submission, specify the `min` prop explicitly in conjunction with this prop.
+   * Specify `step="any"` to always disable step validation.
    * @default 1
    */
-  step?: number;
+  step?: number | 'any';
   /**
    * The large step value of the input element when incrementing while the shift key is held. Snaps
    * to multiples of this value.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #3574

The main problem in the issue is that `stepMismatch` was sometimes occurring, and the hidden `<input type="number">` was being focused. This emitted an `aria-hidden` warning and appeared to "block submission" but the real issue is that the submission was (correctly) blocked from `stepMismatch`, just that focus wasn't being relocated to the right input.

Native `<input type="number">` supports `step="any"` to turn off step validation (while internal controls still assume `step={1}`), which I have added here for parity. If users want a custom step _without_ step validation, this would require another prop, which can likely wait until an issue is created.

<img width="804" height="638" alt="Screenshot 2025-12-28 at 5 44 10 pm" src="https://github.com/user-attachments/assets/4f67e681-fe8e-49f5-bbf1-9009923c2c7d" />


## Related

- `stepMismatch` validation is broken unless you add an explicit `min` like `min={0}`.  It's some kind of esoteric React bug with controlled number inputs? https://github.com/facebook/react/issues/12334. Syncing the `value` with `.setAttribute('value', ...)` doesn't seem to work in an effect. I've added this to the documentation for `step`.