### PR TITLE
[checkbox] Document data-indeterminate attribute

### DIFF
--- a/docs/reference/generated/checkbox-indicator.json
+++ b/docs/reference/generated/checkbox-indicator.json
@@ -57,6 +57,9 @@
     "data-focused": {
       "description": "Present when the checkbox is focused (when wrapped in Field.Root)."
     },
+    "data-indeterminate": {
+      "description": "Present when the checkbox is in an indeterminate state."
+    },
     "data-starting-style": {
       "description": "Present when the checkbox indicator is animating in."
     },

--- a/docs/reference/generated/checkbox-root.json
+++ b/docs/reference/generated/checkbox-root.json
@@ -129,6 +129,9 @@
     },
     "data-focused": {
       "description": "Present when the checkbox is focused (when wrapped in Field.Root)."
+    },
+    "data-indeterminate": {
+      "description": "Present when the checkbox is in an indeterminate state."
     }
   },
   "cssVariables": {}

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -226,10 +226,10 @@ An easily stylable checkbox component.
 - Exports:
   - Checkbox - Root
     - Props: checked, className, defaultChecked, disabled, id, indeterminate, inputRef, name, nativeButton, onCheckedChange, parent, readOnly, render, required, style, uncheckedValue, value
-    - Data Attributes: data-checked, data-dirty, data-disabled, data-filled, data-focused, data-invalid, data-readonly, data-required, data-touched, data-unchecked, data-valid
+    - Data Attributes: data-checked, data-dirty, data-disabled, data-filled, data-focused, data-indeterminate, data-invalid, data-readonly, data-required, data-touched, data-unchecked, data-valid
   - Checkbox - Indicator
     - Props: className, keepMounted, render, style
-    - Data Attributes: data-checked, data-dirty, data-disabled, data-ending-style, data-filled, data-focused, data-invalid, data-readonly, data-required, data-starting-style, data-touched, data-unchecked, data-valid
+    - Data Attributes: data-checked, data-dirty, data-disabled, data-ending-style, data-filled, data-focused, data-indeterminate, data-invalid, data-readonly, data-required, data-starting-style, data-touched, data-unchecked, data-valid
 
 </details>
 

--- a/packages/react/src/checkbox/indicator/CheckboxIndicatorDataAttributes.ts
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicatorDataAttributes.ts
@@ -10,6 +10,10 @@ export enum CheckboxIndicatorDataAttributes {
    */
   unchecked = 'data-unchecked',
   /**
+   * Present when the checkbox is in an indeterminate state.
+   */
+  indeterminate = 'data-indeterminate',
+  /**
    * Present when the checkbox is disabled.
    */
   disabled = 'data-disabled',

--- a/packages/react/src/checkbox/root/CheckboxRootDataAttributes.ts
+++ b/packages/react/src/checkbox/root/CheckboxRootDataAttributes.ts
@@ -8,6 +8,10 @@ export enum CheckboxRootDataAttributes {
    */
   unchecked = 'data-unchecked',
   /**
+   * Present when the checkbox is in an indeterminate state.
+   */
+  indeterminate = 'data-indeterminate',
+  /**
    * Present when the checkbox is disabled.
    */
   disabled = 'data-disabled',


### PR DESCRIPTION
The `data-indeterminate` attribute was missing from the API reference documentation for Checkbox.Root and Checkbox.Indicator.