### PR TITLE
[autocomplete][combobox] Support external items mapping

### DIFF
--- a/docs/reference/generated/combobox-empty.json
+++ b/docs/reference/generated/combobox-empty.json
@@ -1,6 +1,6 @@
 {
   "name": "ComboboxEmpty",
-  "description": "Renders its children only when the list is empty.\nRequires the `items` prop on the root component.\nAnnounces changes politely to screen readers.\nRenders a `<div>` element.",
+  "description": "Renders its children only when the list is empty.\nAnnounces changes politely to screen readers.\nRenders a `<div>` element.",
   "props": {
     "className": {
       "type": "string | ((state: Combobox.Empty.State) => string | undefined)",

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -574,6 +574,85 @@ describe('<Autocomplete.Root />', () => {
       expect(screen.getAllByRole('option')).toHaveLength(2);
     });
 
+    it('mode="list": filters when rendering items as children (no `items` prop)', async () => {
+      const tags = [
+        { id: 'apple', value: 'apple' },
+        { id: 'banana', value: 'banana' },
+        { id: 'cherry', value: 'cherry' },
+      ];
+
+      const { user } = await render(
+        <Autocomplete.Root mode="list">
+          <Autocomplete.Input data-testid="input" />
+          <Autocomplete.Portal>
+            <Autocomplete.Positioner>
+              <Autocomplete.Popup>
+                <Autocomplete.List>
+                  {tags.map((tag) => (
+                    <Autocomplete.Item key={tag.id} value={tag}>
+                      {tag.value}
+                    </Autocomplete.Item>
+                  ))}
+                </Autocomplete.List>
+              </Autocomplete.Popup>
+            </Autocomplete.Positioner>
+          </Autocomplete.Portal>
+        </Autocomplete.Root>,
+      );
+
+      const input = screen.getByTestId<HTMLInputElement>('input');
+
+      await user.click(input);
+      await user.type(input, 'ch');
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('option')).to.have.length(1);
+      });
+      expect(screen.getByRole('option', { name: 'cherry' })).not.to.equal(null);
+    });
+
+    it('mode="list": arrow navigation skips filtered-out children (no `items` prop)', async () => {
+      const tags = [
+        { id: 'apple', value: 'apple' },
+        { id: 'banana', value: 'banana' },
+        { id: 'cherry', value: 'cherry' },
+      ];
+
+      const { user } = await render(
+        <Autocomplete.Root mode="list">
+          <Autocomplete.Input data-testid="input" />
+          <Autocomplete.Portal>
+            <Autocomplete.Positioner>
+              <Autocomplete.Popup>
+                <Autocomplete.List>
+                  {tags.map((tag) => (
+                    <Autocomplete.Item key={tag.id} value={tag}>
+                      {tag.value}
+                    </Autocomplete.Item>
+                  ))}
+                </Autocomplete.List>
+              </Autocomplete.Popup>
+            </Autocomplete.Positioner>
+          </Autocomplete.Portal>
+        </Autocomplete.Root>,
+      );
+
+      const input = screen.getByTestId<HTMLInputElement>('input');
+
+      await user.click(input);
+      await user.type(input, 'ch');
+
+      const option = await screen.findByRole('option', { name: 'cherry' });
+      expect(option).not.to.equal(null);
+
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(option).to.have.attribute('data-highlighted');
+      });
+      expect(input.getAttribute('aria-activedescendant')).to.equal(option.id);
+    });
+
     it('mode="both": inline overlay + autocomplete handles filtering', async () => {
       const items = ['apple', 'banana', 'cherry'];
 

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -13,6 +13,52 @@ describe('<Autocomplete.Root />', () => {
 
   const { render } = createRenderer();
 
+  it('supports <Autocomplete.Empty /> when `items` is omitted', async () => {
+    const tags = [
+      { id: 't1', value: 'feature' },
+      { id: 't2', value: 'fix' },
+      { id: 't3', value: 'bug' },
+    ];
+
+    const { user } = await render(
+      <Autocomplete.Root openOnInputClick>
+        <Autocomplete.Input />
+        <Autocomplete.Portal>
+          <Autocomplete.Positioner>
+            <Autocomplete.Popup>
+              <Autocomplete.Empty>No tags found.</Autocomplete.Empty>
+              <Autocomplete.List>
+                {tags.map((tag) => (
+                  <Autocomplete.Item key={tag.id} value={tag}>
+                    {tag.value}
+                  </Autocomplete.Item>
+                ))}
+              </Autocomplete.List>
+            </Autocomplete.Popup>
+          </Autocomplete.Positioner>
+        </Autocomplete.Portal>
+      </Autocomplete.Root>,
+    );
+
+    const input = screen.getByRole<HTMLInputElement>('combobox');
+
+    await user.click(input);
+    await user.type(input, 'zzz');
+
+    await waitFor(() => {
+      expect(screen.queryByText('No tags found.')).not.to.equal(null);
+    });
+
+    await user.clear(input);
+    await user.type(input, 'fea');
+
+    await waitFor(() => {
+      expect(screen.queryByText('No tags found.')).to.equal(null);
+    });
+
+    expect(await screen.findByRole('option', { name: 'feature' })).not.to.equal(null);
+  });
+
   describe('keyboard interactions', () => {
     it('closes popup on Tab after selecting with Enter and typing again', async () => {
       const { user } = await render(
@@ -62,6 +108,54 @@ describe('<Autocomplete.Root />', () => {
       await waitFor(() => {
         expect(screen.queryByRole('listbox')).toBe(null);
       });
+    });
+
+    it('resets highlight after selecting and reopening quickly (no `items` prop)', async () => {
+      const tags = ['alpha', 'alpine', 'beta'];
+
+      const { user } = await render(
+        <Autocomplete.Root mode="list" openOnInputClick>
+          <Autocomplete.Input />
+          <Autocomplete.Portal>
+            <Autocomplete.Positioner>
+              <Autocomplete.Popup>
+                <Autocomplete.List>
+                  {tags.map((item) => (
+                    <Autocomplete.Item key={item} value={item}>
+                      {item}
+                    </Autocomplete.Item>
+                  ))}
+                </Autocomplete.List>
+              </Autocomplete.Popup>
+            </Autocomplete.Positioner>
+          </Autocomplete.Portal>
+        </Autocomplete.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+
+      await user.click(input);
+      await user.type(input, 'al');
+
+      const firstOption = await screen.findByRole('option', { name: 'alpha' });
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(firstOption).to.have.attribute('data-highlighted');
+      });
+
+      // Select and close.
+      await user.keyboard('{Enter}');
+
+      // Immediately reopen.
+      await user.click(input);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.to.equal(null);
+      });
+
+      // No stale highlight should be carried over.
+      expect(document.querySelector('[data-highlighted]')).to.equal(null);
     });
   });
 

--- a/packages/react/src/combobox/empty/ComboboxEmpty.tsx
+++ b/packages/react/src/combobox/empty/ComboboxEmpty.tsx
@@ -1,15 +1,13 @@
 'use client';
 import * as React from 'react';
+import { useStore } from '@base-ui/utils/store';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
-import {
-  useComboboxDerivedItemsContext,
-  useComboboxRootContext,
-} from '../root/ComboboxRootContext';
+import { useComboboxRootContext } from '../root/ComboboxRootContext';
+import { selectors } from '../store';
 
 /**
  * Renders its children only when the list is empty.
- * Requires the `items` prop on the root component.
  * Announces changes politely to screen readers.
  * Renders a `<div>` element.
  */
@@ -19,10 +17,10 @@ export const ComboboxEmpty = React.forwardRef(function ComboboxEmpty(
 ) {
   const { render, className, children: childrenProp, ...elementProps } = componentProps;
 
-  const { filteredItems } = useComboboxDerivedItemsContext();
   const store = useComboboxRootContext();
+  const visibleItemCount = useStore(store, selectors.visibleItemCount);
 
-  const children = filteredItems.length === 0 ? childrenProp : null;
+  const children = visibleItemCount === 0 ? childrenProp : null;
 
   return useRenderElement('div', componentProps, {
     ref: [forwardedRef, store.state.emptyRef],

--- a/packages/react/src/combobox/group/ComboboxGroup.tsx
+++ b/packages/react/src/combobox/group/ComboboxGroup.tsx
@@ -1,9 +1,16 @@
 'use client';
 import * as React from 'react';
+import { useStore } from '@base-ui/utils/store';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { ComboboxGroupContext } from './ComboboxGroupContext';
 import { GroupCollectionProvider } from '../collection/GroupCollectionContext';
+import {
+  useComboboxDerivedItemsContext,
+  useComboboxRootContext,
+} from '../root/ComboboxRootContext';
+import { selectors } from '../store';
 
 /**
  * Groups related items with the corresponding label.
@@ -13,17 +20,34 @@ export const ComboboxGroup = React.forwardRef(function ComboboxGroup(
   componentProps: ComboboxGroup.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { render, className, items, ...elementProps } = componentProps;
+  const { render, className, items: groupItems, ...elementProps } = componentProps;
+
+  const store = useComboboxRootContext();
+  const { filterQuery } = useComboboxDerivedItemsContext();
+  const items = useStore(store, selectors.items);
+  const hasFilteredItemsProp = useStore(store, selectors.hasFilteredItemsProp);
+  const shouldFilterByQuery = !items && !hasFilteredItemsProp;
 
   const [labelId, setLabelId] = React.useState<string | undefined>();
+  const [visibleItemCount, setVisibleItemCount] = React.useState(0);
+
+  const registerVisibleItem = useStableCallback(() => {
+    setVisibleItemCount((count) => count + 1);
+    return () => {
+      setVisibleItemCount((count) => Math.max(0, count - 1));
+    };
+  });
+
+  const shouldRenderGroup = !shouldFilterByQuery || filterQuery === '' || visibleItemCount > 0;
 
   const contextValue = React.useMemo(
     () => ({
       labelId,
       setLabelId,
-      items,
+      items: groupItems,
+      registerVisibleItem,
     }),
-    [labelId, setLabelId, items],
+    [labelId, setLabelId, groupItems, registerVisibleItem],
   );
 
   const element = useRenderElement('div', componentProps, {
@@ -32,6 +56,7 @@ export const ComboboxGroup = React.forwardRef(function ComboboxGroup(
       {
         role: 'group',
         'aria-labelledby': labelId,
+        hidden: !shouldRenderGroup,
       },
       elementProps,
     ],
@@ -41,8 +66,8 @@ export const ComboboxGroup = React.forwardRef(function ComboboxGroup(
     <ComboboxGroupContext.Provider value={contextValue}>{element}</ComboboxGroupContext.Provider>
   );
 
-  if (items) {
-    return <GroupCollectionProvider items={items}>{wrappedElement}</GroupCollectionProvider>;
+  if (groupItems) {
+    return <GroupCollectionProvider items={groupItems}>{wrappedElement}</GroupCollectionProvider>;
   }
 
   return wrappedElement;

--- a/packages/react/src/combobox/group/ComboboxGroupContext.ts
+++ b/packages/react/src/combobox/group/ComboboxGroupContext.ts
@@ -9,6 +9,7 @@ export interface ComboboxGroupContext {
    * collections to render group-specific items.
    */
   items?: readonly any[] | undefined;
+  registerVisibleItem?: () => () => void;
 }
 
 export const ComboboxGroupContext = React.createContext<ComboboxGroupContext | undefined>(

--- a/packages/react/src/combobox/group/ComboboxGroupContext.ts
+++ b/packages/react/src/combobox/group/ComboboxGroupContext.ts
@@ -9,7 +9,7 @@ export interface ComboboxGroupContext {
    * collections to render group-specific items.
    */
   items?: readonly any[] | undefined;
-  registerVisibleItem?: () => () => void;
+  registerVisibleItem?: (() => () => void) | undefined;
 }
 
 export const ComboboxGroupContext = React.createContext<ComboboxGroupContext | undefined>(

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -6,11 +6,7 @@ import { isAndroid, isFirefox } from '@base-ui/utils/detectBrowser';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useRenderElement } from '../../utils/useRenderElement';
-import {
-  useComboboxDerivedItemsContext,
-  useComboboxInputValueContext,
-  useComboboxRootContext,
-} from '../root/ComboboxRootContext';
+import { useComboboxInputValueContext, useComboboxRootContext } from '../root/ComboboxRootContext';
 import { triggerStateAttributesMapping } from '../utils/stateAttributesMapping';
 import { selectors } from '../store';
 import type { FieldRootState } from '../../field/root/FieldRoot';
@@ -56,7 +52,6 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
   const positioning = useComboboxPositionerContext(true);
   const hasPositionerParent = Boolean(positioning);
   const store = useComboboxRootContext();
-  const { filteredItems } = useComboboxDerivedItemsContext();
   // `inputValue` can't be placed in the store.
   // https://github.com/mui/base-ui/issues/2703
   const inputValue = useComboboxInputValueContext();
@@ -79,11 +74,12 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
   const rootId = useStore(store, selectors.id);
   const inline = useStore(store, selectors.inline);
   const modal = useStore(store, selectors.modal);
+  const visibleItemCount = useStore(store, selectors.visibleItemCount);
 
   const autoHighlightEnabled = Boolean(autoHighlightMode);
   const popupSide = mounted && positionerElement ? popupSideValue : null;
   const disabled = fieldDisabled || comboboxDisabled || disabledProp;
-  const listEmpty = filteredItems.length === 0;
+  const listEmpty = visibleItemCount === 0;
 
   const isInsidePopup = hasPositionerParent || inline;
   const focusManagerModal = !isInsidePopup || modal;

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -18,6 +18,7 @@ import { selectors } from '../store';
 import { useButton } from '../../use-button';
 import { useComboboxRowContext } from '../row/ComboboxRowContext';
 import { compareItemEquality, findItemIndex } from '../../utils/itemEquality';
+import { ComboboxGroupContext } from '../group/ComboboxGroupContext';
 
 /**
  * An individual item in the list.
@@ -40,15 +41,17 @@ export const ComboboxItem = React.memo(
 
     const didPointerDownRef = React.useRef(false);
     const textRef = React.useRef<HTMLElement | null>(null);
-    const listItem = useCompositeListItem({
+    const listItem = useCompositeListItem<{ value: any }>({
       index: indexProp,
+      metadata: { value: itemValue },
       textRef,
       indexGuessBehavior: IndexGuessBehavior.GuessFromOrder,
     });
 
     const store = useComboboxRootContext();
     const isRow = useComboboxRowContext();
-    const { query, flatFilteredItems } = useComboboxDerivedItemsContext();
+    const { filterQuery, flatFilteredItems } = useComboboxDerivedItemsContext();
+    const groupContext = React.useContext(ComboboxGroupContext);
 
     const open = useStore(store, selectors.open);
     const selectionMode = useStore(store, selectors.selectionMode);
@@ -56,6 +59,7 @@ export const ComboboxItem = React.memo(
     const readOnly = useStore(store, selectors.readOnly);
     const virtualized = useStore(store, selectors.virtualized);
     const isItemEqualToValue = useStore(store, selectors.isItemEqualToValue);
+    const hasFilteredItemsProp = useStore(store, selectors.hasFilteredItemsProp);
 
     const selectable = selectionMode !== 'none';
     const index =
@@ -76,30 +80,12 @@ export const ComboboxItem = React.memo(
     const id = rootId != null && hasRegistered ? `${rootId}-${index}` : undefined;
     const selected = matchesSelectedValue && selectable;
 
-    const shouldFilterByQuery = selectionMode === 'none' && !items;
+    const shouldFilterByQuery = !items && !hasFilteredItemsProp;
     const matchesQuery =
-      !shouldFilterByQuery || itemValue == null || query === '' || filter(itemValue, query);
-
-    const prevItemElementRef = React.useRef<HTMLDivElement | null>(null);
-    const handleItemRef = React.useCallback(
-      (node: HTMLDivElement | null) => {
-        itemRef.current = node;
-
-        const prevNode = prevItemElementRef.current;
-        if (prevNode && prevNode !== node) {
-          store.state.itemValueMapRef.current.delete(prevNode);
-        }
-
-        prevItemElementRef.current = node;
-
-        if (!node || !shouldFilterByQuery) {
-          return;
-        }
-
-        store.state.itemValueMapRef.current.set(node, itemValue);
-      },
-      [shouldFilterByQuery, store, itemValue],
-    );
+      !shouldFilterByQuery ||
+      itemValue == null ||
+      filterQuery === '' ||
+      filter(itemValue, filterQuery);
 
     useIsoLayoutEffect(() => {
       const shouldRun = matchesQuery && hasRegistered && (virtualized || indexProp != null);
@@ -115,23 +101,20 @@ export const ComboboxItem = React.memo(
       };
     }, [matchesQuery, hasRegistered, virtualized, index, indexProp, store]);
 
+    const shouldRegisterValue = shouldFilterByQuery && (virtualized || indexProp != null);
+
     useIsoLayoutEffect(() => {
-      if (!matchesQuery || !hasRegistered || items || selectionMode === 'none') {
+      if (!shouldRegisterValue || !matchesQuery || !hasRegistered) {
         return undefined;
       }
 
       const visibleMap = store.state.valuesRef.current;
       visibleMap[index] = itemValue;
 
-      // Stable registry that doesn't depend on filtering. Assume that no
-      // filtering had occurred at this point; otherwise, an `items` prop is
-      // required.
-      store.state.allValuesRef.current.push(itemValue);
-
       return () => {
         delete visibleMap[index];
       };
-    }, [matchesQuery, hasRegistered, items, index, itemValue, store, selectionMode]);
+    }, [shouldRegisterValue, matchesQuery, hasRegistered, index, itemValue, store]);
 
     useIsoLayoutEffect(() => {
       if (!open) {
@@ -139,7 +122,9 @@ export const ComboboxItem = React.memo(
         return;
       }
 
-      if (!hasRegistered || items) {
+      // When the user starts filtering, avoid syncing `selectedIndex` from the selected value.
+      // Otherwise list navigation can restore the active highlight to the selected item after input edits.
+      if (!hasRegistered || items || selectionMode === 'none' || filterQuery !== '') {
         return;
       }
 
@@ -151,7 +136,16 @@ export const ComboboxItem = React.memo(
       if (compareItemEquality(lastSelectedValue, itemValue, isItemEqualToValue)) {
         store.set('selectedIndex', index);
       }
-    }, [hasRegistered, items, open, store, index, itemValue, isItemEqualToValue]);
+    }, [hasRegistered, items, open, store, index, itemValue, isItemEqualToValue, selectionMode, filterQuery]);
+
+    useIsoLayoutEffect(() => {
+      const registerItem = groupContext?.registerVisibleItem;
+      if (!registerItem || !matchesQuery) {
+        return undefined;
+      }
+
+      return registerItem();
+    }, [groupContext?.registerVisibleItem, matchesQuery]);
 
     const state: ComboboxItemState = {
       disabled,
@@ -215,7 +209,7 @@ export const ComboboxItem = React.memo(
     };
 
     const element = useRenderElement('div', componentProps, {
-      ref: [buttonRef, forwardedRef, listItem.ref, handleItemRef],
+      ref: [buttonRef, forwardedRef, listItem.ref, itemRef],
       state,
       props: [rootProps, defaultProps, elementProps, getButtonProps],
     });

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -48,10 +48,11 @@ export const ComboboxItem = React.memo(
 
     const store = useComboboxRootContext();
     const isRow = useComboboxRowContext();
-    const { flatFilteredItems, hasItems } = useComboboxDerivedItemsContext();
+    const { query, flatFilteredItems } = useComboboxDerivedItemsContext();
 
     const open = useStore(store, selectors.open);
     const selectionMode = useStore(store, selectors.selectionMode);
+    const filter = useStore(store, selectors.filter);
     const readOnly = useStore(store, selectors.readOnly);
     const virtualized = useStore(store, selectors.virtualized);
     const isItemEqualToValue = useStore(store, selectors.isItemEqualToValue);
@@ -67,6 +68,7 @@ export const ComboboxItem = React.memo(
     const rootId = useStore(store, selectors.id);
     const highlighted = useStore(store, selectors.isActive, index);
     const matchesSelectedValue = useStore(store, selectors.isSelected, itemValue);
+    const items = useStore(store, selectors.items);
     const getItemProps = useStore(store, selectors.getItemProps);
 
     const itemRef = React.useRef<HTMLDivElement | null>(null);
@@ -74,8 +76,33 @@ export const ComboboxItem = React.memo(
     const id = rootId != null && hasRegistered ? `${rootId}-${index}` : undefined;
     const selected = matchesSelectedValue && selectable;
 
+    const shouldFilterByQuery = selectionMode === 'none' && !items;
+    const matchesQuery =
+      !shouldFilterByQuery || itemValue == null || query === '' || filter(itemValue, query);
+
+    const prevItemElementRef = React.useRef<HTMLDivElement | null>(null);
+    const handleItemRef = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        itemRef.current = node;
+
+        const prevNode = prevItemElementRef.current;
+        if (prevNode && prevNode !== node) {
+          store.state.itemValueMapRef.current.delete(prevNode);
+        }
+
+        prevItemElementRef.current = node;
+
+        if (!node || !shouldFilterByQuery) {
+          return;
+        }
+
+        store.state.itemValueMapRef.current.set(node, itemValue);
+      },
+      [shouldFilterByQuery, store, itemValue],
+    );
+
     useIsoLayoutEffect(() => {
-      const shouldRun = hasRegistered && (virtualized || indexProp != null);
+      const shouldRun = matchesQuery && hasRegistered && (virtualized || indexProp != null);
       if (!shouldRun) {
         return undefined;
       }
@@ -86,10 +113,10 @@ export const ComboboxItem = React.memo(
       return () => {
         delete list[index];
       };
-    }, [hasRegistered, virtualized, index, indexProp, store]);
+    }, [matchesQuery, hasRegistered, virtualized, index, indexProp, store]);
 
     useIsoLayoutEffect(() => {
-      if (!hasRegistered || hasItems) {
+      if (!matchesQuery || !hasRegistered || items || selectionMode === 'none') {
         return undefined;
       }
 
@@ -99,14 +126,12 @@ export const ComboboxItem = React.memo(
       // Stable registry that doesn't depend on filtering. Assume that no
       // filtering had occurred at this point; otherwise, an `items` prop is
       // required.
-      if (selectionMode !== 'none') {
-        store.state.allValuesRef.current.push(itemValue);
-      }
+      store.state.allValuesRef.current.push(itemValue);
 
       return () => {
         delete visibleMap[index];
       };
-    }, [hasRegistered, hasItems, index, itemValue, store, selectionMode]);
+    }, [matchesQuery, hasRegistered, items, index, itemValue, store, selectionMode]);
 
     useIsoLayoutEffect(() => {
       if (!open) {
@@ -114,7 +139,7 @@ export const ComboboxItem = React.memo(
         return;
       }
 
-      if (!hasRegistered || hasItems) {
+      if (!hasRegistered || items) {
         return;
       }
 
@@ -123,10 +148,10 @@ export const ComboboxItem = React.memo(
         ? selectedValue[selectedValue.length - 1]
         : selectedValue;
 
-      if (compareItemEquality(itemValue, lastSelectedValue, isItemEqualToValue)) {
+      if (compareItemEquality(lastSelectedValue, itemValue, isItemEqualToValue)) {
         store.set('selectedIndex', index);
       }
-    }, [hasRegistered, hasItems, open, store, index, itemValue, isItemEqualToValue]);
+    }, [hasRegistered, items, open, store, index, itemValue, isItemEqualToValue]);
 
     const state: ComboboxItemState = {
       disabled,
@@ -190,7 +215,7 @@ export const ComboboxItem = React.memo(
     };
 
     const element = useRenderElement('div', componentProps, {
-      ref: [buttonRef, forwardedRef, listItem.ref, itemRef],
+      ref: [buttonRef, forwardedRef, listItem.ref, handleItemRef],
       state,
       props: [rootProps, defaultProps, elementProps, getButtonProps],
     });
@@ -202,6 +227,10 @@ export const ComboboxItem = React.memo(
       }),
       [selected, textRef],
     );
+
+    if (!matchesQuery) {
+      return null;
+    }
 
     return (
       <ComboboxItemContext.Provider value={contextValue}>{element}</ComboboxItemContext.Provider>

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -136,7 +136,17 @@ export const ComboboxItem = React.memo(
       if (compareItemEquality(lastSelectedValue, itemValue, isItemEqualToValue)) {
         store.set('selectedIndex', index);
       }
-    }, [hasRegistered, items, open, store, index, itemValue, isItemEqualToValue, selectionMode, filterQuery]);
+    }, [
+      hasRegistered,
+      items,
+      open,
+      store,
+      index,
+      itemValue,
+      isItemEqualToValue,
+      selectionMode,
+      filterQuery,
+    ]);
 
     useIsoLayoutEffect(() => {
       const registerItem = groupContext?.registerVisibleItem;

--- a/packages/react/src/combobox/list/ComboboxList.tsx
+++ b/packages/react/src/combobox/list/ComboboxList.tsx
@@ -33,6 +33,7 @@ export const ComboboxList = React.forwardRef(function ComboboxList(
   const items = useStore(store, selectors.items);
   const labelsRef = useStore(store, selectors.labelsRef);
   const listRef = useStore(store, selectors.listRef);
+  const valuesRef = useStore(store, selectors.valuesRef);
   const selectionMode = useStore(store, selectors.selectionMode);
   const grid = useStore(store, selectors.grid);
   const popupProps = useStore(store, selectors.popupProps);
@@ -115,12 +116,31 @@ export const ComboboxList = React.forwardRef(function ComboboxList(
     ],
   });
 
+  const handleMapChange = useStableCallback((map: Map<Element, any>) => {
+    if (items || selectionMode !== 'none') {
+      return;
+    }
+
+    const nextValues: any[] = [];
+    const itemValueMap = store.state.itemValueMapRef.current;
+
+    map.forEach((_metadata, node) => {
+      nextValues.push(itemValueMap.get(node));
+    });
+
+    valuesRef.current = nextValues;
+  });
+
   if (virtualized) {
     return element;
   }
 
   return (
-    <CompositeList elementsRef={listRef} labelsRef={items ? undefined : labelsRef}>
+    <CompositeList
+      elementsRef={listRef}
+      labelsRef={items ? undefined : labelsRef}
+      onMapChange={handleMapChange}
+    >
       {element}
     </CompositeList>
   );

--- a/packages/react/src/combobox/list/ComboboxList.tsx
+++ b/packages/react/src/combobox/list/ComboboxList.tsx
@@ -14,6 +14,9 @@ import { selectors } from '../store';
 import { ComboboxCollection } from '../collection/ComboboxCollection';
 import { CompositeList } from '../../composite/list/CompositeList';
 import { stopEvent } from '../../floating-ui-react/utils';
+import { createChangeEventDetails } from '../../utils/createBaseUIEventDetails';
+import { REASONS } from '../../utils/reasons';
+import { itemIncludes } from '../../utils/itemEquality';
 
 /**
  * A list container for the items.
@@ -26,11 +29,13 @@ export const ComboboxList = React.forwardRef(function ComboboxList(
   const { render, className, children, ...elementProps } = componentProps;
 
   const store = useComboboxRootContext();
+  const { filterQuery } = useComboboxDerivedItemsContext();
   const floatingRootContext = useComboboxFloatingContext();
   const hasPositionerContext = Boolean(useComboboxPositionerContext(true));
-  const { filteredItems } = useComboboxDerivedItemsContext();
 
   const items = useStore(store, selectors.items);
+  const hasFilteredItemsProp = useStore(store, selectors.hasFilteredItemsProp);
+  const visibleItemCount = useStore(store, selectors.visibleItemCount);
   const labelsRef = useStore(store, selectors.labelsRef);
   const listRef = useStore(store, selectors.listRef);
   const valuesRef = useStore(store, selectors.valuesRef);
@@ -42,7 +47,7 @@ export const ComboboxList = React.forwardRef(function ComboboxList(
   const virtualized = useStore(store, selectors.virtualized);
 
   const multiple = selectionMode === 'multiple';
-  const empty = filteredItems.length === 0;
+  const empty = visibleItemCount === 0;
 
   const setPositionerElement = useStableCallback((element) => {
     store.set('positionerElement', element);
@@ -116,19 +121,60 @@ export const ComboboxList = React.forwardRef(function ComboboxList(
     ],
   });
 
+  const prevMapSizeRef = React.useRef(0);
+
   const handleMapChange = useStableCallback((map: Map<Element, any>) => {
-    if (items || selectionMode !== 'none') {
+    if (items || hasFilteredItemsProp) {
       return;
     }
 
     const nextValues: any[] = [];
-    const itemValueMap = store.state.itemValueMapRef.current;
-
-    map.forEach((_metadata, node) => {
-      nextValues.push(itemValueMap.get(node));
+    const nextList: Array<HTMLElement | null> = [];
+    map.forEach((metadata, node) => {
+      nextValues.push(metadata?.value);
+      nextList.push(node as HTMLElement);
     });
 
     valuesRef.current = nextValues;
+    listRef.current = nextList;
+    store.set('visibleItemCount', nextValues.length);
+
+    const shouldUpdateAllValues =
+      filterQuery === '' || store.state.allValuesRef.current.length === 0;
+    if (shouldUpdateAllValues) {
+      store.state.allValuesRef.current = nextValues.slice();
+    }
+
+    if (filterQuery !== '' || selectionMode === 'none') {
+      return;
+    }
+
+    const prevSize = prevMapSizeRef.current;
+    prevMapSizeRef.current = map.size;
+
+    if (prevSize === 0 || map.size === prevSize) {
+      return;
+    }
+
+    const eventDetails = createChangeEventDetails(REASONS.none);
+    const comparer = store.state.isItemEqualToValue;
+    const currentSelectedValue = store.state.selectedValue;
+
+    if (selectionMode === 'multiple') {
+      const current = Array.isArray(currentSelectedValue) ? currentSelectedValue : [];
+      const next = current.filter((value) => itemIncludes(nextValues, value, comparer));
+      if (next.length !== current.length) {
+        store.state.setSelectedValue(next, eventDetails);
+      }
+      return;
+    }
+
+    if (currentSelectedValue != null && !itemIncludes(nextValues, currentSelectedValue, comparer)) {
+      const fallback = store.state.defaultSelectedValue;
+      const nextValue =
+        fallback != null && itemIncludes(nextValues, fallback, comparer) ? fallback : null;
+      store.state.setSelectedValue(nextValue, eventDetails);
+    }
   });
 
   if (virtualized) {

--- a/packages/react/src/combobox/list/ComboboxList.tsx
+++ b/packages/react/src/combobox/list/ComboboxList.tsx
@@ -16,7 +16,7 @@ import { CompositeList } from '../../composite/list/CompositeList';
 import { stopEvent } from '../../floating-ui-react/utils';
 import { createChangeEventDetails } from '../../utils/createBaseUIEventDetails';
 import { REASONS } from '../../utils/reasons';
-import { itemIncludes } from '../../utils/itemEquality';
+import { findItemIndex } from '../../utils/itemEquality';
 
 /**
  * A list container for the items.
@@ -162,17 +162,20 @@ export const ComboboxList = React.forwardRef(function ComboboxList(
 
     if (selectionMode === 'multiple') {
       const current = Array.isArray(currentSelectedValue) ? currentSelectedValue : [];
-      const next = current.filter((value) => itemIncludes(nextValues, value, comparer));
+      const next = current.filter((value) => findItemIndex(nextValues, value, comparer) !== -1);
       if (next.length !== current.length) {
         store.state.setSelectedValue(next, eventDetails);
       }
       return;
     }
 
-    if (currentSelectedValue != null && !itemIncludes(nextValues, currentSelectedValue, comparer)) {
+    if (
+      currentSelectedValue != null &&
+      findItemIndex(nextValues, currentSelectedValue, comparer) === -1
+    ) {
       const fallback = store.state.defaultSelectedValue;
       const nextValue =
-        fallback != null && itemIncludes(nextValues, fallback, comparer) ? fallback : null;
+        fallback != null && findItemIndex(nextValues, fallback, comparer) !== -1 ? fallback : null;
       store.state.setSelectedValue(nextValue, eventDetails);
     }
   });

--- a/packages/react/src/combobox/popup/ComboboxPopup.tsx
+++ b/packages/react/src/combobox/popup/ComboboxPopup.tsx
@@ -5,11 +5,7 @@ import { useStore } from '@base-ui/utils/store';
 import { FloatingFocusManager } from '../../floating-ui-react';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
-import {
-  useComboboxFloatingContext,
-  useComboboxRootContext,
-  useComboboxDerivedItemsContext,
-} from '../root/ComboboxRootContext';
+import { useComboboxFloatingContext, useComboboxRootContext } from '../root/ComboboxRootContext';
 import { selectors } from '../store';
 import { popupStateMapping } from '../../utils/popupStateMapping';
 import { useComboboxPositionerContext } from '../positioner/ComboboxPositionerContext';
@@ -40,7 +36,6 @@ export const ComboboxPopup = React.forwardRef(function ComboboxPopup(
   const store = useComboboxRootContext();
   const positioning = useComboboxPositionerContext();
   const floatingRootContext = useComboboxFloatingContext();
-  const { filteredItems } = useComboboxDerivedItemsContext();
 
   const mounted = useStore(store, selectors.mounted);
   const open = useStore(store, selectors.open);
@@ -49,8 +44,9 @@ export const ComboboxPopup = React.forwardRef(function ComboboxPopup(
   const inputInsidePopup = useStore(store, selectors.inputInsidePopup);
   const inputElement = useStore(store, selectors.inputElement);
   const modal = useStore(store, selectors.modal);
+  const visibleItemCount = useStore(store, selectors.visibleItemCount);
 
-  const empty = filteredItems.length === 0;
+  const empty = visibleItemCount === 0;
 
   useOpenChangeComplete({
     open,

--- a/packages/react/src/combobox/positioner/ComboboxPositioner.tsx
+++ b/packages/react/src/combobox/positioner/ComboboxPositioner.tsx
@@ -5,11 +5,7 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { inertValue } from '@base-ui/utils/inertValue';
 import { useScrollLock } from '@base-ui/utils/useScrollLock';
-import {
-  useComboboxFloatingContext,
-  useComboboxRootContext,
-  useComboboxDerivedItemsContext,
-} from '../root/ComboboxRootContext';
+import { useComboboxFloatingContext, useComboboxRootContext } from '../root/ComboboxRootContext';
 import { ComboboxPositionerContext } from './ComboboxPositionerContext';
 import {
   type Side,
@@ -53,7 +49,6 @@ export const ComboboxPositioner = React.forwardRef(function ComboboxPositioner(
   } = componentProps;
 
   const store = useComboboxRootContext();
-  const { filteredItems } = useComboboxDerivedItemsContext();
   const floatingRootContext = useComboboxFloatingContext();
   const keepMounted = useComboboxPortalContext();
 
@@ -66,8 +61,9 @@ export const ComboboxPositioner = React.forwardRef(function ComboboxPositioner(
   const inputGroupElement = useStore(store, selectors.inputGroupElement);
   const inputInsidePopup = useStore(store, selectors.inputInsidePopup);
   const transitionStatus = useStore(store, selectors.transitionStatus);
+  const visibleItemCount = useStore(store, selectors.visibleItemCount);
 
-  const empty = filteredItems.length === 0;
+  const empty = visibleItemCount === 0;
   const resolvedAnchor =
     anchor ?? (inputInsidePopup ? triggerElement : (inputGroupElement ?? inputElement));
 

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -149,6 +149,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   const selectionEventRef = React.useRef<MouseEvent | PointerEvent | KeyboardEvent | null>(null);
   const lastHighlightRef = React.useRef(INITIAL_LAST_HIGHLIGHT);
   const pendingQueryHighlightRef = React.useRef<null | { hasQuery: boolean }>(null);
+  const itemValueMapRef = React.useRef<WeakMap<HTMLElement, any>>(new WeakMap());
 
   /**
    * Contains the currently visible list of item values post-filtering.
@@ -360,6 +361,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         clearRef,
         valuesRef,
         allValuesRef,
+        itemValueMapRef,
         selectionEventRef,
         name,
         form,
@@ -1100,6 +1102,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       open,
       mounted,
       transitionStatus,
+      filter,
       items,
       inline: inlineProp,
       popupProps: getFloatingProps(),
@@ -1133,6 +1136,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     open,
     mounted,
     transitionStatus,
+    filter,
     items,
     getFloatingProps,
     getReferenceProps,

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -149,7 +149,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   const selectionEventRef = React.useRef<MouseEvent | PointerEvent | KeyboardEvent | null>(null);
   const lastHighlightRef = React.useRef(INITIAL_LAST_HIGHLIGHT);
   const pendingQueryHighlightRef = React.useRef<null | { hasQuery: boolean }>(null);
-  const itemValueMapRef = React.useRef<WeakMap<HTMLElement, any>>(new WeakMap());
+  const ignoreProgrammaticNavigationRef = React.useRef(false);
 
   /**
    * Contains the currently visible list of item values post-filtering.
@@ -348,6 +348,9 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         filter,
         query,
         items,
+        hasFilteredItemsProp,
+        defaultSelectedValue,
+        visibleItemCount: hasItems || hasFilteredItemsProp ? flatFilteredItems.length : 0,
         selectionMode,
         listRef,
         labelsRef,
@@ -361,7 +364,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         clearRef,
         valuesRef,
         allValuesRef,
-        itemValueMapRef,
         selectionEventRef,
         name,
         form,
@@ -448,6 +450,10 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   });
 
   const forceMount = useStableCallback(() => {
+    if (selectionMode === 'none') {
+      return;
+    }
+
     if (items) {
       // Ensure typeahead works on a closed list.
       labelsRef.current = flatFilteredItems.map((item) =>
@@ -517,6 +523,10 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
           event.type === 'compositionend' ||
           (inputType != null && inputType !== '' && inputType !== 'insertReplacementText');
         if (isTypedInput) {
+          if (!autoHighlightMode) {
+            ignoreProgrammaticNavigationRef.current = true;
+          }
+
           const hasQuery = next.trim() !== '';
           if (hasQuery) {
             setQueryChangedAfterOpen(true);
@@ -703,6 +713,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     onOpenChangeComplete?.(false);
     setQueryChangedAfterOpen(false);
     setCloseQuery(null);
+    ignoreProgrammaticNavigationRef.current = false;
 
     if (selectionMode === 'none') {
       setIndices({ activeIndex: null, selectedIndex: null });
@@ -796,11 +807,12 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   );
 
   useIsoLayoutEffect(() => {
-    if (items) {
+    if (items || hasFilteredItemsProp) {
       valuesRef.current = flatFilteredItems;
       listRef.current.length = flatFilteredItems.length;
+      store.set('visibleItemCount', flatFilteredItems.length);
     }
-  }, [items, flatFilteredItems]);
+  }, [items, hasFilteredItemsProp, flatFilteredItems, store]);
 
   useIsoLayoutEffect(() => {
     const pendingHighlight = pendingQueryHighlightRef.current;
@@ -1057,11 +1069,16 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         return;
       }
 
+      if (!event && ignoreProgrammaticNavigationRef.current && nextActiveIndex !== null) {
+        return;
+      }
+
       if (!event) {
         setIndices({
           activeIndex: nextActiveIndex,
         });
       } else {
+        ignoreProgrammaticNavigationRef.current = false;
         setIndices({
           activeIndex: nextActiveIndex,
           type: keyboardActiveRef.current ? 'keyboard' : 'pointer',
@@ -1104,6 +1121,8 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       transitionStatus,
       filter,
       items,
+      hasFilteredItemsProp,
+      defaultSelectedValue,
       inline: inlineProp,
       popupProps: getFloatingProps(),
       inputProps: getReferenceProps(),
@@ -1138,6 +1157,8 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     transitionStatus,
     filter,
     items,
+    hasFilteredItemsProp,
+    defaultSelectedValue,
     getFloatingProps,
     getReferenceProps,
     getItemProps,
@@ -1170,11 +1191,12 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   const itemsContextValue: ComboboxDerivedItemsContext = React.useMemo(
     () => ({
       query,
+      filterQuery,
       hasItems,
       filteredItems,
       flatFilteredItems,
     }),
-    [query, hasItems, filteredItems, flatFilteredItems],
+    [query, filterQuery, hasItems, filteredItems, flatFilteredItems],
   );
 
   const serializedValue = React.useMemo(() => {

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -79,6 +79,26 @@ function isElementOrAncestorInert(element: HTMLElement) {
   return false;
 }
 
+function ListCountsProbe() {
+  const store = useComboboxRootContext();
+  const visibleItemCount = useStore(store, selectors.visibleItemCount);
+  const [listCount, setListCount] = React.useState(0);
+  const [valuesCount, setValuesCount] = React.useState(0);
+
+  React.useEffect(() => {
+    setListCount(store.state.listRef.current.length);
+    setValuesCount(store.state.valuesRef.current.length);
+  }, [store, visibleItemCount]);
+
+  return (
+    <React.Fragment>
+      <div data-testid="visible-count">{visibleItemCount}</div>
+      <div data-testid="list-count">{listCount}</div>
+      <div data-testid="values-count">{valuesCount}</div>
+    </React.Fragment>
+  );
+}
+
 describe('<Combobox.Root />', () => {
   beforeEach(() => {
     globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
@@ -2959,6 +2979,610 @@ describe('<Combobox.Root />', () => {
 
       const [highlightedValue] = onItemHighlighted.mock.lastCall ?? [];
       expect(highlightedValue).toBe('Zucchini');
+    });
+  });
+
+  describe('without the items prop', () => {
+    it('filters items and updates list refs/empty state', async () => {
+      const fruits = ['Apple', 'Banana', 'Cherry'];
+
+      const { user } = await render(
+        <Combobox.Root openOnInputClick>
+          <Combobox.Input data-testid="input" />
+          <ListCountsProbe />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.Empty>No fruits found.</Combobox.Empty>
+                <Combobox.List>
+                  {fruits.map((fruit) => (
+                    <Combobox.Item key={fruit} value={fruit}>
+                      {fruit}
+                    </Combobox.Item>
+                  ))}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('visible-count')).to.have.text('3');
+      });
+      expect(screen.getByTestId('list-count')).to.have.text('3');
+      expect(screen.getByTestId('values-count')).to.have.text('3');
+
+      await user.type(input, 'ap');
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: 'Banana' })).to.equal(null);
+      });
+      expect(screen.queryByRole('option', { name: 'Apple' })).not.to.equal(null);
+      expect(screen.getByTestId('visible-count')).to.have.text('1');
+      expect(screen.getByTestId('list-count')).to.have.text('1');
+      expect(screen.getByTestId('values-count')).to.have.text('1');
+
+      await user.clear(input);
+      await user.type(input, 'zzz');
+      await waitFor(() => {
+        expect(screen.queryByText('No fruits found.')).not.to.equal(null);
+      });
+      expect(screen.getByTestId('visible-count')).to.have.text('0');
+      expect(screen.getByTestId('list-count')).to.have.text('0');
+      expect(screen.getByTestId('values-count')).to.have.text('0');
+
+      await user.clear(input);
+      await waitFor(() => {
+        expect(screen.getByTestId('visible-count')).to.have.text('3');
+      });
+      expect(screen.queryByText('No fruits found.')).to.equal(null);
+    });
+
+    it('clears highlight when typing after reopening with ArrowDown', async () => {
+      const { user } = await render(
+        <Combobox.Root>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value={{ value: 'pear', label: 'Pear' }}>Pear</Combobox.Item>
+                  <Combobox.Item value={{ value: 'banana', label: 'Banana' }}>Banana</Combobox.Item>
+                  <Combobox.Group>
+                    <Combobox.GroupLabel>Citrus</Combobox.GroupLabel>
+                    <Combobox.Item value={{ value: 'orange', label: 'Orange' }}>
+                      Orange
+                    </Combobox.Item>
+                    <Combobox.Item value={{ value: 'lemon', label: 'Lemon' }}>Lemon</Combobox.Item>
+                  </Combobox.Group>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+
+      await user.click(input);
+      const lemon = await screen.findByRole('option', { name: 'Lemon' });
+      await user.click(lemon);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).to.equal(null);
+      });
+
+      input.focus();
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.to.equal(null);
+      });
+
+      const reopenedLemon = screen.getByRole('option', { name: 'Lemon' });
+      await waitFor(() => {
+        expect(reopenedLemon).to.have.attribute('data-highlighted');
+      });
+      expect(input).to.have.attribute('aria-activedescendant', reopenedLemon.id);
+
+      await user.keyboard('{Backspace}');
+      await waitFor(() => {
+        expect(reopenedLemon).not.to.have.attribute('data-highlighted');
+      });
+      expect(input).not.to.have.attribute('aria-activedescendant');
+    });
+
+    it('does not restore highlight after clearing the input to empty', async () => {
+      const { user } = await render(
+        <Combobox.Root>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value={{ value: 'pear', label: 'Pear' }}>Pear</Combobox.Item>
+                  <Combobox.Item value={{ value: 'banana', label: 'Banana' }}>Banana</Combobox.Item>
+                  <Combobox.Item value={{ value: 'cherry', label: 'Cherry' }}>Cherry</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+
+      await user.click(input);
+      const pear = await screen.findByRole('option', { name: 'Pear' });
+      await user.click(pear);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).to.equal(null);
+      });
+
+      input.focus();
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.to.equal(null);
+      });
+
+      const reopenedPear = screen.getByRole('option', { name: 'Pear' });
+      await waitFor(() => {
+        expect(reopenedPear).to.have.attribute('data-highlighted');
+      });
+
+      await user.keyboard('{Control>}{KeyA}{/Control}{Backspace}');
+
+      await waitFor(() => {
+        expect(reopenedPear).not.to.have.attribute('data-highlighted');
+      });
+      expect(input).not.to.have.attribute('aria-activedescendant');
+
+      await act(() => flushMicrotasks());
+
+      expect(reopenedPear).not.to.have.attribute('data-highlighted');
+      expect(input).not.to.have.attribute('aria-activedescendant');
+    });
+
+    it('does not restore highlight after backspacing the input to empty', async () => {
+      const { user } = await render(
+        <Combobox.Root>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value={{ value: 'pear', label: 'Pear' }}>Pear</Combobox.Item>
+                  <Combobox.Item value={{ value: 'banana', label: 'Banana' }}>Banana</Combobox.Item>
+                  <Combobox.Item value={{ value: 'cherry', label: 'Cherry' }}>Cherry</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+
+      await user.click(input);
+      const pear = await screen.findByRole('option', { name: 'Pear' });
+      await user.click(pear);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).to.equal(null);
+      });
+
+      input.focus();
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.to.equal(null);
+      });
+
+      const reopenedPear = screen.getByRole('option', { name: 'Pear' });
+      await waitFor(() => {
+        expect(reopenedPear).to.have.attribute('data-highlighted');
+      });
+
+      await user.keyboard('{Backspace}{Backspace}{Backspace}{Backspace}');
+
+      await waitFor(() => {
+        expect(reopenedPear).not.to.have.attribute('data-highlighted');
+      });
+      expect(input).not.to.have.attribute('aria-activedescendant');
+
+      await act(() => flushMicrotasks());
+
+      expect(reopenedPear).not.to.have.attribute('data-highlighted');
+      expect(input).not.to.have.attribute('aria-activedescendant');
+    });
+
+    it('does not restore highlight after clearing the input when value is controlled', async () => {
+      const pearValue = { value: 'pear', label: 'Pear' };
+
+      const { user } = await render(
+        <Combobox.Root value={pearValue}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value={pearValue}>Pear</Combobox.Item>
+                  <Combobox.Item value={{ value: 'banana', label: 'Banana' }}>Banana</Combobox.Item>
+                  <Combobox.Item value={{ value: 'cherry', label: 'Cherry' }}>Cherry</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+
+      await user.click(input);
+      await user.keyboard('{ArrowDown}');
+
+      const listbox = screen.getByRole('listbox');
+      await waitFor(() => {
+        expect(listbox.querySelector('[data-highlighted]')).not.to.equal(null);
+      });
+
+      await user.keyboard('{Control>}{KeyA}{/Control}{Backspace}');
+
+      await waitFor(() => {
+        expect(listbox.querySelector('[data-highlighted]')).to.equal(null);
+      });
+      expect(input).not.to.have.attribute('aria-activedescendant');
+
+      await act(() => flushMicrotasks());
+
+      expect(listbox.querySelector('[data-highlighted]')).to.equal(null);
+      expect(input).not.to.have.attribute('aria-activedescendant');
+    });
+
+    it('hides groups when no items in the group match the query', async () => {
+      const { user } = await render(
+        <Combobox.Root openOnInputClick>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="Pear">Pear</Combobox.Item>
+                  <Combobox.Group>
+                    <Combobox.GroupLabel>Citrus</Combobox.GroupLabel>
+                    <Combobox.Item value="Orange">Orange</Combobox.Item>
+                    <Combobox.Item value="Lemon">Lemon</Combobox.Item>
+                  </Combobox.Group>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+
+      expect(screen.getByText('Citrus')).not.to.equal(null);
+
+      await user.type(input, 'pe');
+      await waitFor(() => {
+        const group = screen.getByText('Citrus').closest('[role="group"]');
+        expect(group).not.to.equal(null);
+        expect(group).to.have.attribute('hidden');
+      });
+
+      await user.clear(input);
+      await user.type(input, 'le');
+      await waitFor(() => {
+        expect(screen.getByText('Citrus')).not.to.equal(null);
+      });
+    });
+
+    it('keeps selection and highlight indices in sync after filtering', async () => {
+      const fruits = ['Apple', 'Banana', 'Cherry'];
+
+      const { user } = await render(
+        <Combobox.Root openOnInputClick>
+          <Combobox.Input data-testid="input" />
+          <SelectedIndexProbe />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {fruits.map((fruit) => (
+                    <Combobox.Item key={fruit} value={fruit}>
+                      {fruit}
+                    </Combobox.Item>
+                  ))}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+      await user.type(input, 'ba');
+
+      const banana = await screen.findByRole('option', { name: 'Banana' });
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(banana).to.have.attribute('data-highlighted');
+      });
+      expect(input).to.have.attribute('aria-activedescendant', banana.id);
+
+      await user.keyboard('{Enter}');
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).to.equal(null);
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('selected-index')).to.have.text('1');
+      });
+
+      await user.click(input);
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.to.equal(null);
+      });
+      expect(screen.getByRole('option', { name: 'Banana' })).to.have.attribute(
+        'aria-selected',
+        'true',
+      );
+    });
+
+    it('clears filtered results after close in multiple mode', async () => {
+      const fruits = ['Apple', 'Banana', 'Cherry'];
+
+      const { user } = await render(
+        <Combobox.Root multiple openOnInputClick>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {fruits.map((fruit) => (
+                    <Combobox.Item key={fruit} value={fruit}>
+                      {fruit}
+                    </Combobox.Item>
+                  ))}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+      await user.type(input, 'ap');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: 'Banana' })).to.equal(null);
+      });
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).to.equal(null);
+      });
+
+      await user.click(input);
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: 'Banana' })).not.to.equal(null);
+      });
+    });
+
+    it('maintains highlight indices after filtering and selection', async () => {
+      const fruits = ['Apple', 'Banana', 'Orange', 'Pineapple', 'Grape', 'Mango', 'Strawberry'];
+
+      const { user } = await render(
+        <Combobox.Root>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {fruits.map((fruit) => (
+                    <Combobox.Item key={fruit} value={fruit}>
+                      {fruit}
+                    </Combobox.Item>
+                  ))}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+      await user.type(input, 'apple');
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).to.equal(null);
+      });
+
+      await user.keyboard('{ArrowDown}');
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.to.equal(null);
+      });
+
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{ArrowDown}');
+
+      const mango = screen.getByRole('option', { name: 'Mango' });
+      await waitFor(() => {
+        expect(mango).to.have.attribute('data-highlighted');
+      });
+    });
+  });
+
+  describe('dynamic items without the items prop', () => {
+    it('unselects the removed item in controlled mode', async () => {
+      function DynamicCombobox() {
+        const [items, setItems] = React.useState(['a', 'b', 'c']);
+        const [selectedItem, setSelectedItem] = React.useState<string | null>('a');
+
+        return (
+          <div>
+            <button
+              onClick={() => {
+                setItems((prev) => prev.filter((item) => item !== 'a'));
+              }}
+            >
+              Remove
+            </button>
+            <button
+              onClick={() => {
+                setItems(['a', 'b', 'c']);
+              }}
+            >
+              Add
+            </button>
+            <div data-testid="value">{selectedItem ?? ''}</div>
+            <Combobox.Root value={selectedItem} onValueChange={setSelectedItem}>
+              <Combobox.Input data-testid="input" />
+              <Combobox.Portal keepMounted>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.List>
+                      {items.map((item) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      ))}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<DynamicCombobox />);
+      const input = screen.getByTestId('input');
+
+      await user.click(input);
+
+      expect(screen.getByRole('option', { name: 'a' })).to.have.attribute('data-selected', '');
+      expect(screen.getByTestId('value')).to.have.text('a');
+
+      await user.click(screen.getByText('Remove'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('value')).to.have.text('');
+      });
+
+      await user.click(screen.getByText('Add'));
+      await user.click(input);
+
+      expect(screen.getByRole('option', { name: 'a' })).not.to.have.attribute('data-selected');
+    });
+
+    it('falls back to the default value when the selection is removed', async () => {
+      function Test() {
+        const [items, setItems] = React.useState(['a', 'b', 'c']);
+        return (
+          <div>
+            <Combobox.Root defaultValue="b">
+              <Combobox.Input data-testid="input" />
+              <Combobox.Portal keepMounted>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.List>
+                      {items.map((item) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      ))}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+            <button
+              data-testid="remove-c"
+              onClick={() => setItems((prev) => prev.filter((i) => i !== 'c'))}
+            >
+              Remove C
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+      const input = screen.getByTestId('input');
+
+      await user.click(input);
+      await user.click(screen.getByRole('option', { name: 'c' }));
+
+      await user.click(input);
+      await waitFor(() => {
+        expect(screen.getByRole('listbox')).not.to.equal(null);
+      });
+
+      await user.click(screen.getByTestId('remove-c'));
+
+      await waitFor(() => {
+        expect(input).to.have.value('b');
+      });
+    });
+
+    it('drops removed selections in multiple mode', async () => {
+      function Test() {
+        const [items, setItems] = React.useState(['a', 'b', 'c']);
+        const [value, setValue] = React.useState<string[]>(['a', 'c']);
+        return (
+          <div>
+            <Combobox.Root multiple value={value} onValueChange={setValue}>
+              <Combobox.Input data-testid="input" />
+              <Combobox.Portal keepMounted>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.List>
+                      {items.map((item) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      ))}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+            <button
+              data-testid="remove-c"
+              onClick={() => setItems((prev) => prev.filter((i) => i !== 'c'))}
+            >
+              Remove C
+            </button>
+            <div data-testid="value">{value.join(',')}</div>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+      const input = screen.getByTestId('input');
+
+      await user.click(input);
+
+      await user.click(screen.getByTestId('remove-c'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('value')).to.have.text('a');
+      });
     });
   });
 

--- a/packages/react/src/combobox/root/ComboboxRootContext.tsx
+++ b/packages/react/src/combobox/root/ComboboxRootContext.tsx
@@ -5,6 +5,7 @@ import type { FloatingRootContext } from '../../floating-ui-react';
 
 export interface ComboboxDerivedItemsContext {
   query: string;
+  filterQuery: string;
   hasItems: boolean;
   filteredItems: any[];
   flatFilteredItems: any[];

--- a/packages/react/src/combobox/store.ts
+++ b/packages/react/src/combobox/store.ts
@@ -17,6 +17,12 @@ export type State = {
 
   items: readonly any[] | undefined;
 
+  hasFilteredItemsProp: boolean;
+
+  visibleItemCount: number;
+
+  defaultSelectedValue: any;
+
   selectedValue: any;
 
   open: boolean;
@@ -58,7 +64,6 @@ export type State = {
   clearRef: React.RefObject<HTMLButtonElement | null>;
   valuesRef: React.RefObject<Array<any>>;
   allValuesRef: React.RefObject<Array<any>>;
-  itemValueMapRef: React.RefObject<WeakMap<Element, any>>;
   selectionEventRef: React.RefObject<MouseEvent | PointerEvent | KeyboardEvent | null>;
 
   setOpen: (open: boolean, eventDetails: AriaCombobox.ChangeEventDetails) => void;
@@ -105,6 +110,9 @@ export const selectors = {
   filter: createSelector((state: State) => state.filter),
 
   items: createSelector((state: State) => state.items),
+  hasFilteredItemsProp: createSelector((state: State) => state.hasFilteredItemsProp),
+
+  visibleItemCount: createSelector((state: State) => state.visibleItemCount),
 
   selectedValue: createSelector((state: State) => state.selectedValue),
   hasSelectionChips: createSelector((state: State) => {

--- a/packages/react/src/combobox/store.ts
+++ b/packages/react/src/combobox/store.ts
@@ -58,6 +58,7 @@ export type State = {
   clearRef: React.RefObject<HTMLButtonElement | null>;
   valuesRef: React.RefObject<Array<any>>;
   allValuesRef: React.RefObject<Array<any>>;
+  itemValueMapRef: React.RefObject<WeakMap<Element, any>>;
   selectionEventRef: React.RefObject<MouseEvent | PointerEvent | KeyboardEvent | null>;
 
   setOpen: (open: boolean, eventDetails: AriaCombobox.ChangeEventDetails) => void;
@@ -101,6 +102,7 @@ export const selectors = {
   labelId: createSelector((state: State) => state.labelId),
 
   query: createSelector((state: State) => state.query),
+  filter: createSelector((state: State) => state.filter),
 
   items: createSelector((state: State) => state.items),
 

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -9,7 +9,6 @@ import { useRenderElement } from '../../utils/useRenderElement';
 import { useButton } from '../../use-button';
 import {
   useComboboxFloatingContext,
-  useComboboxDerivedItemsContext,
   useComboboxInputValueContext,
   useComboboxRootContext,
 } from '../root/ComboboxRootContext';
@@ -56,7 +55,6 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
   } = useFieldRootContext();
   const { labelId: fieldLabelId } = useLabelableContext();
   const store = useComboboxRootContext();
-  const { filteredItems } = useComboboxDerivedItemsContext();
 
   const selectionMode = useStore(store, selectors.selectionMode);
   const comboboxDisabled = useStore(store, selectors.disabled);
@@ -76,6 +74,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
   const activeIndex = useStore(store, selectors.activeIndex);
   const selectedIndex = useStore(store, selectors.selectedIndex);
   const hasSelectedValue = useStore(store, selectors.hasSelectedValue);
+  const visibleItemCount = useStore(store, selectors.visibleItemCount);
 
   const floatingRootContext = useComboboxFloatingContext();
   const inputValue = useComboboxInputValueContext();
@@ -83,7 +82,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
   const focusTimeout = useTimeout();
 
   const disabled = fieldDisabled || comboboxDisabled || disabledProp;
-  const listEmpty = filteredItems.length === 0;
+  const listEmpty = visibleItemCount === 0;
   const popupSide = mounted && positionerElement ? popupSideValue : null;
 
   useLabelableId({ id: inputInsidePopup ? idProp : undefined });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This adds support for the cmdk-style composition pattern without requiring `items` on `Root`, and without forcing the filtering/rendering to happen through a function child:

```jsx
<Combobox.Root>
  <Combobox.Input />
  <Combobox.Portal>
    <Combobox.Positioner>
      <Combobox.Popup>
        <Combobox.List>
          {fruits.map((item) => (
            <Combobox.Item key={item} value={item}>
              <Combobox.ItemIndicator>
                <CheckIcon />
              </Combobox.ItemIndicator>
              <div>{item}</div>
            </Combobox.Item>
          ))}
        </Combobox.List>
      </Combobox.Popup>
    </Combobox.Positioner>
  </Combobox.Portal>
</Combobox.Root>
```

Before this, `Autocomplete` could support this shape reasonably well, but filtering had to happen externally. `Combobox` only had partial support and did not keep selection/highlight/empty-state behavior in sync.

## Implementation

- `Combobox.Item` filters itself and returns `null` when it should not be shown.
- `Combobox.Group` uses `hidden` instead of unmounting its children so item registration effects can still run.
- The rebased version simplifies the bookkeeping a bit by reusing `CompositeList` metadata for item values instead of maintaining a separate DOM-node-to-value map.

## Pros

- Works with a more composition-oriented API, including server-component-friendly usage where a function child would otherwise need to be hoisted into a client component.
- TS inference stays natural because the item type comes from the surrounding array.
- Rendering/order are fully controlled by user composition.

## Tradeoffs

### Real

- This is still more internal complexity than the `items`-driven path.
- For selection modes with no `items`, Combobox still needs to force-mount the popup on interaction so labels and selected indices can be registered from the rendered tree.
- Virtualization still requires `items` or `filteredItems`, because unrendered rows are otherwise unknowable.

### Not really new / overstated

- Strings already work fine. Objects are only needed when the value/label are distinct, which is the same existing `itemToStringLabel` story rather than a new requirement introduced by this approach.
- Some of the implementation overhead was incidental rather than fundamental; the rebased version trims part of it by removing extra value-mapping plumbing.

## Validation

- `pnpm test:jsdom ComboboxRoot --no-watch`
- `pnpm test:jsdom AutocompleteRoot --no-watch`
- `pnpm typescript`
- `pnpm eslint docs/reference/generated/combobox-empty.json packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx packages/react/src/combobox/empty/ComboboxEmpty.tsx packages/react/src/combobox/group/ComboboxGroup.tsx packages/react/src/combobox/group/ComboboxGroupContext.ts packages/react/src/combobox/input/ComboboxInput.tsx packages/react/src/combobox/item/ComboboxItem.tsx packages/react/src/combobox/list/ComboboxList.tsx packages/react/src/combobox/popup/ComboboxPopup.tsx packages/react/src/combobox/positioner/ComboboxPositioner.tsx packages/react/src/combobox/root/AriaCombobox.tsx packages/react/src/combobox/root/ComboboxRoot.test.tsx packages/react/src/combobox/root/ComboboxRootContext.tsx packages/react/src/combobox/store.ts packages/react/src/combobox/trigger/ComboboxTrigger.tsx packages/react/src/composite/list/useCompositeListItem.ts`
