### PR TITLE
[form controls] Fix visually hidden input styles

### DIFF
--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -5,7 +5,7 @@ import { useControlled } from '@base-ui/utils/useControlled';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
-import { visuallyHidden } from '@base-ui/utils/visuallyHidden';
+import { visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import { NOOP } from '../../utils/noop';
 import { useStateAttributesMapping } from '../utils/useStateAttributesMapping';
 import { useRenderElement } from '../../utils/useRenderElement';
@@ -196,7 +196,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
       id: inputId ?? undefined,
       required,
       ref: mergedInputRef,
-      style: visuallyHidden,
+      style: visuallyHiddenInput,
       tabIndex: -1,
       type: 'checkbox',
       'aria-hidden': true,

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -5,7 +5,7 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useOnFirstRender } from '@base-ui/utils/useOnFirstRender';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
-import { visuallyHidden } from '@base-ui/utils/visuallyHidden';
+import { visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { Store, useStore } from '@base-ui/utils/store';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
@@ -1290,7 +1290,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         readOnly={readOnly}
         value={serializedValue}
         ref={hiddenInputRef}
-        style={visuallyHidden}
+        style={visuallyHiddenInput}
         tabIndex={-1}
         aria-hidden
       />

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -8,7 +8,7 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { useForcedRerendering } from '@base-ui/utils/useForcedRerendering';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
-import { visuallyHidden } from '@base-ui/utils/visuallyHidden';
+import { visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import { ownerDocument, ownerWindow } from '@base-ui/utils/owner';
 import { isIOS } from '@base-ui/utils/detectBrowser';
 import { InputMode, NumberFieldRootContext } from './NumberFieldRootContext';
@@ -547,7 +547,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
         required={required}
         aria-hidden
         tabIndex={-1}
-        style={visuallyHidden}
+        style={visuallyHiddenInput}
       />
     </NumberFieldRootContext.Provider>
   );

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useControlled } from '@base-ui/utils/useControlled';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { visuallyHidden } from '@base-ui/utils/visuallyHidden';
+import { visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import { NOOP } from '../utils/noop';
 import type { BaseUIComponentProps, HTMLProps } from '../utils/types';
 import { useBaseUiId } from '../utils/useBaseUiId';
@@ -166,7 +166,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
       'aria-labelledby': elementProps['aria-labelledby'] ?? fieldsetContext?.legendId,
       'aria-hidden': true,
       tabIndex: -1,
-      style: visuallyHidden,
+      style: visuallyHiddenInput,
       onChange: NOOP, // suppress a Next.js error
       onFocus() {
         controlRef.current?.focus();

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { visuallyHidden } from '@base-ui/utils/visuallyHidden';
+import { visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import type { BaseUIComponentProps, NonNativeButtonProps } from '../../utils/types';
 import { createChangeEventDetails } from '../../utils/createBaseUIEventDetails';
 import { REASONS } from '../../utils/reasons';
@@ -76,6 +76,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
 
   const radioRef = React.useRef<HTMLElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
+
   const mergedInputRef = useMergedRefs(inputRefProp, inputRef);
 
   useIsoLayoutEffect(() => {
@@ -131,58 +132,42 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
     native: nativeButton,
   });
 
-  const inputProps: React.ComponentPropsWithRef<'input'> = React.useMemo(
-    () => ({
-      type: 'radio',
-      ref: mergedInputRef,
-      id: inputId,
-      tabIndex: -1,
-      style: visuallyHidden,
-      'aria-hidden': true,
-      disabled,
-      checked,
-      required,
-      readOnly,
-      onChange(event) {
-        // Workaround for https://github.com/facebook/react/issues/9023
-        if (event.nativeEvent.defaultPrevented) {
-          return;
-        }
+  const inputProps: React.ComponentPropsWithRef<'input'> = {
+    type: 'radio',
+    ref: mergedInputRef,
+    id: inputId,
+    tabIndex: -1,
+    style: visuallyHiddenInput,
+    'aria-hidden': true,
+    disabled,
+    checked,
+    required,
+    readOnly,
+    onChange(event) {
+      // Workaround for https://github.com/facebook/react/issues/9023
+      if (event.nativeEvent.defaultPrevented) {
+        return;
+      }
 
-        if (disabled || readOnly || value === undefined) {
-          return;
-        }
+      if (disabled || readOnly || value === undefined) {
+        return;
+      }
 
-        const details = createChangeEventDetails(REASONS.none, event.nativeEvent);
+      const details = createChangeEventDetails(REASONS.none, event.nativeEvent);
 
-        if (details.isCanceled) {
-          return;
-        }
+      if (details.isCanceled) {
+        return;
+      }
 
-        setFieldTouched(true);
-        setDirty(value !== validityData.initialValue);
-        setFilled(true);
-        setCheckedValue(value, details);
-      },
-      onFocus() {
-        radioRef.current?.focus();
-      },
-    }),
-    [
-      checked,
-      disabled,
-      inputId,
-      mergedInputRef,
-      readOnly,
-      required,
-      setCheckedValue,
-      setDirty,
-      setFieldTouched,
-      setFilled,
-      validityData.initialValue,
-      value,
-    ],
-  );
+      setFieldTouched(true);
+      setDirty(value !== validityData.initialValue);
+      setFilled(true);
+      setCheckedValue(value, details);
+    },
+    onFocus() {
+      radioRef.current?.focus();
+    },
+  };
 
   const state: RadioRoot.State = React.useMemo(
     () => ({
@@ -246,6 +231,7 @@ export interface RadioRootState extends FieldRoot.State {
   /** Whether the user must choose a value before submitting a form. */
   required: boolean;
 }
+
 export interface RadioRootProps
   extends NonNativeButtonProps, Omit<BaseUIComponentProps<'span', RadioRoot.State>, 'value'> {
   /** The unique identifying value of the radio in a group. */

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { visuallyHidden } from '@base-ui/utils/visuallyHidden';
+import { visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { useOnFirstRender } from '@base-ui/utils/useOnFirstRender';
@@ -552,7 +552,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
           required={required && !hasMultipleSelection}
           readOnly={readOnly}
           ref={ref}
-          style={visuallyHidden}
+          style={visuallyHiddenInput}
           tabIndex={-1}
           aria-hidden
         />

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -4,7 +4,7 @@ import { useControlled } from '@base-ui/utils/useControlled';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { visuallyHidden } from '@base-ui/utils/visuallyHidden';
+import { visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import { useRenderElement } from '../../utils/useRenderElement';
 import type { BaseUIComponentProps, NonNativeButtonProps } from '../../utils/types';
 import { mergeProps } from '../../merge-props';
@@ -167,7 +167,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
           id: inputId,
           name,
           required,
-          style: visuallyHidden,
+          style: visuallyHiddenInput,
           tabIndex: -1,
           type: 'checkbox',
           'aria-hidden': true,

--- a/packages/utils/src/visuallyHidden.ts
+++ b/packages/utils/src/visuallyHidden.ts
@@ -1,15 +1,24 @@
 import * as React from 'react';
 
-export const visuallyHidden: React.CSSProperties = {
-  clip: 'rect(0 0 0 0)',
+const visuallyHiddenBase: React.CSSProperties = {
+  clipPath: 'inset(50%)',
   overflow: 'hidden',
   whiteSpace: 'nowrap',
-  position: 'fixed',
-  top: 0,
-  left: 0,
   border: 0,
   padding: 0,
   width: 1,
   height: 1,
   margin: -1,
+};
+
+export const visuallyHidden: React.CSSProperties = {
+  ...visuallyHiddenBase,
+  position: 'fixed',
+  top: 0,
+  left: 0,
+};
+
+export const visuallyHiddenInput: React.CSSProperties = {
+  ...visuallyHiddenBase,
+  position: 'absolute',
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `visuallyHidden` util isn't suitable for hidden inputs in form controls because native validation popups won't point to them (since the hidden input is at the top-left of the screen currently). They instead should be positioned where the control is. 

Affects:

- `NumberField`
- `Radio`
- `Checkbox`
- `Switch`
- `Select`
- `Combobox`

`Slider` already handled this correctly

---

The main issue when not adding `top`/`left` is stray overflow (since the visually hidden input takes up layout size) however this should not be a concern for form inputs specifically

