### PR TITLE
[context-menu] Right click on menu item closes context menu on Windows

### DIFF
--- a/packages/react/src/menu/item/useMenuItem.ts
+++ b/packages/react/src/menu/item/useMenuItem.ts
@@ -72,6 +72,13 @@ export function useMenuItem(params: useMenuItem.Parameters): useMenuItem.ReturnV
             }
           },
           onMouseUp(event) {
+            // On MacOS right click does not invoke onMouseUp, however on Windows it does
+            // This checks makes sure we are consistent behavior and ignore the logic below
+            // on right click
+            if (event.button === 2) {
+              return;
+            }
+
             if (contextMenuContext) {
               const initialCursorPoint = contextMenuContext.initialCursorPointRef.current;
               contextMenuContext.initialCursorPointRef.current = null;
@@ -85,11 +92,7 @@ export function useMenuItem(params: useMenuItem.Parameters): useMenuItem.ReturnV
               }
             }
 
-            if (
-              itemRef.current &&
-              store.context.allowMouseUpTriggerRef.current &&
-              (!isContextMenu || event.button === 2)
-            ) {
+            if (itemRef.current && store.context.allowMouseUpTriggerRef.current && !isContextMenu) {
               // This fires whenever the user clicks on the trigger, moves the cursor, and releases it over the item.
               // We trigger the click and override the `closeOnClick` preference to always close the menu.
               if (itemMetadata.type === 'regular-item') {


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/issues/3595

The issue is that https://github.com/mui/base-ui/blob/master/packages/react/src/menu/item/useMenuItem.ts#L75 fires on Windows, but not on MacOS. Apperantly on MacOS the operating system intercepts the event to show the context menu.

I added a check at the beginning of the handler to ignore the code if it comes from right-click, this way we can have coherent behavior between Windows and other OSs.

----

There is another difference that I noticed between Windows and MacOS, on Windows the context menu opens on mouse up, while on MacOs it opens on mouse down.