### PR TITLE
[docs] Label all demos and document labeling

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/page.mdx
+++ b/docs/src/app/(docs)/react/components/autocomplete/page.mdx
@@ -14,7 +14,7 @@ import { DemoAutocompleteHero } from './demos/hero';
 
 - **Avoid when selection state is needed**: Use [Combobox](/react/components/combobox) instead of Autocomplete if the selection should be remembered and the input value cannot be custom. Unlike Combobox, Autocomplete's input can contain free-form text, as its suggestions only _optionally_ autocomplete the text.
 - **Can be used for filterable command pickers**: The input can be used as a filter for command items that perform an action when clicked when rendered inside the popup.
-- **Form controls must have an accessible name**: The input must have a meaningful label. Prefer using [`<Field>`](/react/components/field) to provide a visible text label and description, or use the `aria-label` attribute as an alternative. See the [forms guide](/react/handbook/forms) for more on building form controls.
+- **Form controls must have an accessible name**: It can be created using a `<label>` element or the `Field` component. See the [forms guide](/react/handbook/forms).
 
 ## Anatomy
 

--- a/docs/src/app/(docs)/react/components/checkbox-group/page.mdx
+++ b/docs/src/app/(docs)/react/components/checkbox-group/page.mdx
@@ -12,7 +12,7 @@ import { DemoCheckboxGroupHero } from './demos/hero';
 
 ## Usage guidelines
 
-- **Form controls must have an accessible name**: Checkbox group and individual checkboxes must have a meaningful label. Prefer using [`<Fieldset>`](/react/components/fieldset) and [`<Field>`](/react/components/field) to provide visible text labels and descriptions, or use the `aria-label` attribute as an alternative. See the [forms guide](/react/handbook/forms) for more on building form controls.
+- **Form controls must have an accessible name**: It can be created using `<label>` elements, or the `Field` and `Fieldset` components. See [Labeling a checkbox group](#labeling-a-checkbox-group) and the [forms guide](/react/handbook/forms).
 
 ## Anatomy
 
@@ -28,6 +28,75 @@ import { CheckboxGroup } from '@base-ui/react/checkbox-group';
 ```
 
 ## Examples
+
+### Labeling a checkbox group
+
+A visible label for the group is created by specifying `aria-labelledby` on `<CheckboxGroup>` to reference the `id` of a sibling element that contains the group label text.
+
+```tsx title="Using aria-labelledby to label a checkbox group"
+<div id="protocols-label">Allowed network protocols</div>
+<CheckboxGroup aria-labelledby="protocols-label">{/* ... */}</CheckboxGroup>
+```
+
+For individual checkboxes, use an enclosing `<label>` element that wraps each `<Checkbox.Root>`. An enclosing label is announced to screen readers when focus is on the control, and ensures that clicking on any gaps between the label and checkbox still toggles it.
+
+```tsx title="Using an enclosing label to label a checkbox" {1,4}
+<label>
+  <Checkbox.Root value="http" />
+  HTTP
+</label>
+```
+
+The [Field](/react/components/field) and [Fieldset](/react/components/fieldset) components eliminate the need to track `id` or `aria-labelledby` associations manually. They support both enclosing and sibling labeling patterns, along with a UX improvement to prevent double clicks from selecting the label text.
+
+1. **Group label**: Since the group contains multiple controls, it can be labeled as a fieldset. Use [Fieldset](/react/components/fieldset) by replacing the `<Fieldset.Root>` element with `<CheckboxGroup>` via the `render` prop. `<Fieldset.Legend>` provides the visible label for the group.
+2. **Individual label**: Label an individual checkbox using an enclosing `<Field.Label>`. Enclosing labels ensure that clicking on any gaps between the label and checkbox still toggles it.
+
+```tsx title="Using Field and Fieldset to label a checkbox group"
+<Field.Root>
+  <Fieldset.Root render={<CheckboxGroup />}>
+    <Fieldset.Legend>Allowed network protocols</Fieldset.Legend>
+    <Field.Label>
+      <Checkbox.Root value="http" />
+      HTTP
+    </Field.Label>
+    <Field.Label>
+      <Checkbox.Root value="https" />
+      HTTPS
+    </Field.Label>
+    <Field.Label>
+      <Checkbox.Root value="ssh" />
+      SSH
+    </Field.Label>
+  </Fieldset.Root>
+</Field.Root>
+```
+
+### Form integration
+
+To use a checkbox group in a form, pass the checkbox group's `name` to `<Field.Root>`:
+
+```tsx title="Using Checkbox Group in a form" {2}
+<Form>
+  <Field.Root name="allowedNetworkProtocols">
+    <Fieldset.Root render={<CheckboxGroup />}>
+      <Fieldset.Legend>Allowed network protocols</Fieldset.Legend>
+      <Field.Label>
+        <Checkbox.Root value="http" />
+        HTTP
+      </Field.Label>
+      <Field.Label>
+        <Checkbox.Root value="https" />
+        HTTPS
+      </Field.Label>
+      <Field.Label>
+        <Checkbox.Root value="ssh" />
+        SSH
+      </Field.Label>
+    </Fieldset.Root>
+  </Field.Root>
+</Form>
+```
 
 ### Parent checkbox
 

--- a/docs/src/app/(docs)/react/components/checkbox/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/checkbox/demos/hero/css-modules/index.tsx
@@ -5,7 +5,7 @@ import styles from './index.module.css';
 export default function ExampleCheckbox() {
   return (
     <label className={styles.Label}>
-      <Checkbox.Root defaultChecked aria-label="Enable notifications" className={styles.Checkbox}>
+      <Checkbox.Root defaultChecked className={styles.Checkbox}>
         <Checkbox.Indicator className={styles.Indicator}>
           <CheckIcon className={styles.Icon} />
         </Checkbox.Indicator>

--- a/docs/src/app/(docs)/react/components/checkbox/page.mdx
+++ b/docs/src/app/(docs)/react/components/checkbox/page.mdx
@@ -12,7 +12,7 @@ import { DemoCheckboxBasic } from './demos/hero';
 
 ## Usage guidelines
 
-- **Form controls must have an accessible name**: The checkbox must have a meaningful label. Prefer using [`<Field>`](/react/components/field) to provide a visible text label and description, or use the `aria-label` attribute as an alternative. See the [forms guide](/react/handbook/forms) for more on building form controls.
+- **Form controls must have an accessible name**: It can be created using a `<label>` element or the `Field` component. See [Labeling a checkbox](#labeling-a-checkbox) and the [forms guide](/react/handbook/forms).
 
 ## Anatomy
 
@@ -28,11 +28,33 @@ import { Checkbox } from '@base-ui/react/checkbox';
 
 ## Examples
 
+### Labeling a checkbox
+
+Label a checkbox using an enclosing `<label>` element that wraps `<Checkbox.Root>`. An enclosing label is announced to screen readers when focus is on the control, and ensures that clicking on any gaps between the label and checkbox still toggles the control.
+
+```tsx title="Using an enclosing label to label a checkbox" {1,4}
+<label>
+  <Checkbox.Root />
+  Accept terms and conditions
+</label>
+```
+
+The [Field](/react/components/field) component eliminates the need to track `id` or `aria-label` associations manually. It supports both enclosing and sibling labeling patterns, along with a UX improvement to prevent double clicks from selecting the label text.
+
+```tsx title="Using the Field component to label a checkbox" {2,5}
+<Field.Root>
+  <Field.Label>
+    <Checkbox.Root />
+    Accept terms and conditions
+  </Field.Label>
+</Field.Root>
+```
+
 ### Form integration
 
-To use a single checkbox in a form, pass the checkbox's `name` to `<Field>` and use `<Field.Label>` to label the control.
+To use a single checkbox in a form, pass the checkbox's `name` to `<Field.Root>`:
 
-```tsx title="Using Checkbox in a form"
+```tsx title="Using Checkbox in a form" {2}
 <Form>
   <Field.Root name="stayLoggedIn">
     <Field.Label>

--- a/docs/src/app/(docs)/react/components/combobox/page.mdx
+++ b/docs/src/app/(docs)/react/components/combobox/page.mdx
@@ -15,7 +15,7 @@ import { DemoComboboxHero } from './demos/hero';
 - **Combobox is a filterable Select**: Use Combobox when the input is restricted to a set of predefined selectable items, similar to [Select](/react/components/select) but whose items are filterable using an input. Prefer using Combobox over Select when the number of items is sufficiently large to warrant filtering.
 - **Avoid for simple search widgets**: Combobox does not allow free-form text input. For search widgets, consider using [Autocomplete](/react/components/autocomplete) instead.
 - **Avoid when not rendering an input**: Use [Select](/react/components/select) instead of Combobox if no input is being rendered, which includes accessibility features specific to a listbox without an input.
-- **Form controls must have an accessible name**: The input must have a meaningful label. Prefer using [`<Field>`](/react/components/field) to provide a visible text label and description, or use the `aria-label` attribute as an alternative. See the [forms guide](/react/handbook/forms) for more on building form controls.
+- **Form controls must have an accessible name**: It can be created using a `<label>` element or the `Field` component. See the [forms guide](/react/handbook/forms).
 
 ## Anatomy
 

--- a/docs/src/app/(docs)/react/components/input/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/input/demos/hero/css-modules/index.module.css
@@ -1,10 +1,20 @@
+.Label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  color: var(--color-gray-900);
+}
+
 .Input {
   box-sizing: border-box;
   padding-left: 0.875rem;
   margin: 0;
   border: 1px solid var(--color-gray-200);
-  width: 100%;
-  max-width: 16rem;
+  width: 14rem;
   height: 2.5rem;
   border-radius: 0.375rem;
   font-family: inherit;

--- a/docs/src/app/(docs)/react/components/input/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/input/demos/hero/css-modules/index.tsx
@@ -2,5 +2,10 @@ import { Input } from '@base-ui/react/input';
 import styles from './index.module.css';
 
 export default function ExampleInput() {
-  return <Input placeholder="Name" className={styles.Input} />;
+  return (
+    <label className={styles.Label}>
+      Name
+      <Input placeholder="Enter your name" className={styles.Input} />
+    </label>
+  );
 }

--- a/docs/src/app/(docs)/react/components/input/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/input/demos/hero/tailwind/index.tsx
@@ -2,9 +2,12 @@ import { Input } from '@base-ui/react/input';
 
 export default function ExampleInput() {
   return (
-    <Input
-      placeholder="Name"
-      className="h-10 w-full max-w-64 rounded-md border border-gray-200 pl-3.5 text-base text-gray-900 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800"
-    />
+    <label className="flex flex-col items-start gap-1">
+      <span className="text-sm font-medium text-gray-900">Name</span>
+      <Input
+        placeholder="Enter your name"
+        className="h-10 w-56 rounded-md border border-gray-200 pl-3.5 text-base text-gray-900 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800"
+      />
+    </label>
   );
 }

--- a/docs/src/app/(docs)/react/components/input/page.mdx
+++ b/docs/src/app/(docs)/react/components/input/page.mdx
@@ -12,7 +12,7 @@ import { DemoInputHero } from './demos/hero';
 
 ## Usage guidelines
 
-- **Form controls must have an accessible name**: The input must have a meaningful label. Prefer using [`<Field>`](/react/components/field) to provide a visible text label and description, or use the `aria-label` attribute as an alternative. See the [forms guide](/react/handbook/forms) for more on building form controls.
+- **Form controls must have an accessible name**: It can be created using a `<label>` element or the `Field` component. See the [forms guide](/react/handbook/forms).
 
 ## Anatomy
 

--- a/docs/src/app/(docs)/react/components/number-field/page.mdx
+++ b/docs/src/app/(docs)/react/components/number-field/page.mdx
@@ -13,7 +13,7 @@ import { DemoNumberFieldHero } from './demos/hero';
 
 ## Usage guidelines
 
-- **Form controls must have an accessible name**: The input must have a meaningful label. Prefer using [`<Field>`](/react/components/field) to provide a visible text label and description, or use the `aria-label` attribute as an alternative. See the [forms guide](/react/handbook/forms) for more on building form controls.
+- **Form controls must have an accessible name**: It can be created using a `<label>` element or the `Field` component. See the [forms guide](/react/handbook/forms).
 
 ## Anatomy
 

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -221,6 +221,7 @@ An easily stylable checkbox component.
   - Usage guidelines
   - Anatomy
   - Examples
+    - Labeling a checkbox
     - Form integration
   - API reference
 - Exports:
@@ -248,6 +249,8 @@ Provides shared state to a series of checkboxes.
   - Usage guidelines
   - Anatomy
   - Examples
+    - Labeling a checkbox group
+    - Form integration
     - Parent checkbox
     - Nested parent checkbox
   - API reference
@@ -917,6 +920,9 @@ An easily stylable radio button component.
 - Sections:
   - Usage guidelines
   - Anatomy
+  - Examples
+    - Labeling a radio group
+    - Form integration
   - API reference
     - RadioGroup
 - Exports:
@@ -983,10 +989,12 @@ A common form component for choosing a predefined value in a dropdown menu.
 - Sections:
   - Usage guidelines
   - Anatomy
-  - TypeScript
   - Positioning
-  - Formatting the value
   - Examples
+    - Typed wrapper component
+    - Formatting the value
+    - Labeling a select
+    - Placeholder values
     - Multiple selection
     - Object values
   - API reference
@@ -1076,6 +1084,8 @@ An easily stylable range input.
   - Examples
     - Range slider
     - Thumb alignment
+    - Labeling a slider
+    - Form integration
   - API reference
 - Exports:
   - Slider - Root
@@ -1113,6 +1123,9 @@ A control that indicates whether a setting is on or off.
 - Sections:
   - Usage guidelines
   - Anatomy
+  - Examples
+    - Labeling a switch
+    - Form integration
   - API reference
 - Exports:
   - Switch - Root

--- a/docs/src/app/(docs)/react/components/radio/page.mdx
+++ b/docs/src/app/(docs)/react/components/radio/page.mdx
@@ -12,7 +12,7 @@ import { DemoRadioHero } from './demos/hero';
 
 ## Usage guidelines
 
-- **Form controls must have an accessible name**: Radio group and individual Radio elements must have a meaningful label. Prefer using [`<Fieldset>`](/react/components/fieldset) and [`<Field>`](/react/components/field) to provide visible text labels and descriptions, or use the `aria-label` attribute as an alternative. See the [forms guide](/react/handbook/forms) for more on building form controls.
+- **Form controls must have an accessible name**: It can be created using `<label>` elements, or the `Field` and `Fieldset` components. See [Labeling a radio group](#labeling-a-radio-group) and the [forms guide](/react/handbook/forms).
 
 ## Anatomy
 
@@ -27,6 +27,69 @@ import { RadioGroup } from '@base-ui/react/radio-group';
     <Radio.Indicator />
   </Radio.Root>
 </RadioGroup>;
+```
+
+## Examples
+
+### Labeling a radio group
+
+A visible label for the group is created by specifying `aria-labelledby` on `<RadioGroup>` to reference the `id` of a sibling element that contains the group label text.
+
+```tsx title="Using aria-labelledby to label a radio group"
+<div id="storage-type-label">Storage type</div>
+<RadioGroup aria-labelledby="storage-type-label">{/* ... */}</RadioGroup>
+```
+
+For individual radio buttons, use an enclosing `<label>` element that wraps each `<Radio.Root>`. An enclosing label is announced to screen readers when focus is on the control, and ensures that clicking on any gaps between the label and radio still toggles it.
+
+```tsx title="Using an enclosing label to label a radio button" {1,4}
+<label>
+  <Radio.Root value="ssd" />
+  SSD
+</label>
+```
+
+The [Field](/react/components/field) and [Fieldset](/react/components/fieldset) components eliminate the need to track `id` or `aria-labelledby` associations manually. They support both enclosing and sibling labeling patterns, along with a UX improvement to prevent double clicks from selecting the label text.
+
+1. **Group label**: Since the group contains multiple controls, it can be labeled as a fieldset. Use [Fieldset](/react/components/fieldset) by replacing the `<Fieldset.Root>` element with `<RadioGroup>` via the `render` prop. `<Fieldset.Legend>` provides the visible label for the group.
+2. **Individual label**: Label an individual radio using an enclosing `<Field.Label>`. Enclosing labels ensure that clicking on any gaps between the label and radio still toggles it.
+
+```tsx title="Using Field and Fieldset to label a radio group"
+<Field.Root>
+  <Fieldset.Root render={<RadioGroup />}>
+    <Fieldset.Legend>Storage type</Fieldset.Legend>
+    <Field.Label>
+      <Radio.Root value="ssd" />
+      SSD
+    </Field.Label>
+    <Field.Label>
+      <Radio.Root value="hdd" />
+      HDD
+    </Field.Label>
+  </Fieldset.Root>
+</Field.Root>
+```
+
+### Form integration
+
+To use a radio group in a form, pass the radio group's `name` to `<Field.Root>`:
+
+```tsx title="Using Radio Group in a form" {2}
+<Form>
+  <Field.Root name="storageType">
+    <Fieldset.Root render={<RadioGroup />}>
+      <Fieldset.Legend>Storage type</Fieldset.Legend>
+      <Field.Label>
+        <Radio.Root value="ssd" />
+        SSD
+      </Field.Label>
+      <Field.Label>
+        <Radio.Root value="hdd" />
+        HDD
+      </Field.Label>
+    </Fieldset.Root>
+  </Field.Root>
+</Form>
 ```
 
 ## API reference

--- a/docs/src/app/(docs)/react/components/select/page.mdx
+++ b/docs/src/app/(docs)/react/components/select/page.mdx
@@ -14,7 +14,7 @@ import { DemoSelectHero } from './demos/hero';
 
 - **Prefer Combobox for large lists**: Select is not filterable, aside from basic keyboard typeahead functionality to find items by focusing and highlighting them. Prefer [Combobox](/react/components/combobox) instead of Select when the number of items is sufficiently large to warrant filtering.
 - **Special positioning behavior**: The select popup by default overlaps its trigger so the selected item's text is aligned with the trigger's value text. This behavior [can be disabled or customized](/react/components/select#positioning).
-- **Form controls must have an accessible name**: The trigger must have a meaningful label. Prefer using [`<Field>`](/react/components/field) to provide a visible text label and description, or use the `aria-label` attribute as an alternative. See the [forms guide](/react/handbook/forms) for more on building form controls.
+- **Form controls must have an accessible name**: It can be created using the `Field` component. See the [forms guide](/react/handbook/forms).
 
 ## Anatomy
 
@@ -52,21 +52,6 @@ import { Select } from '@base-ui/react/select';
 </Select.Root>;
 ```
 
-## TypeScript
-
-The following example shows a typed wrapper around the Select component with correct type inference and type safety:
-
-```tsx title="Specifying generic type parameters"
-import * as React from 'react';
-import { Select } from '@base-ui/react/select';
-
-export function MySelect<Value, Multiple extends boolean | undefined = false>(
-  props: Select.Root.Props<Value, Multiple>,
-): React.JSX.Element {
-  return <Select.Root {...props}>{/* ... */}</Select.Root>;
-}
-```
-
 ## Positioning
 
 `<Select.Positioner>` has a special prop called `alignItemWithTrigger` which causes the positioning to act differently by default from other `Positioner` components.
@@ -83,7 +68,24 @@ When set to `true` (its default) there are a few important points to note about 
   Additionally, the trigger must be at least 20px from the edges of the top and bottom of the viewport, or it will also fall back.
 - **Other positioning props are ignored**: Props like `side` or `align` have no effect unless the prop is set to `false` or when in fallback mode.
 
-## Formatting the value
+## Examples
+
+### Typed wrapper component
+
+The following example shows a typed wrapper around the Select component with correct type inference and type safety:
+
+```tsx title="Specifying generic type parameters"
+import * as React from 'react';
+import { Select } from '@base-ui/react/select';
+
+export function MySelect<Value, Multiple extends boolean | undefined = false>(
+  props: Select.Root.Props<Value, Multiple>,
+): React.JSX.Element {
+  return <Select.Root {...props}>{/* ... */}</Select.Root>;
+}
+```
+
+### Formatting the value
 
 By default, the `<Select.Value>` component renders the raw `value`.
 
@@ -122,7 +124,49 @@ const items = {
 
 To avoid lookup, [object values](#object-values) for each item can also be used.
 
-## Examples
+### Labeling a select
+
+A select should have a visible label. Use the [Field](/react/components/field) component to provide a label for the select trigger:
+
+```tsx title="Using Field to label a select" {2}
+<Field.Root>
+  <Field.Label>Theme</Field.Label>
+  <Select.Root>{/* ... */}</Select.Root>
+</Field.Root>
+```
+
+The Field component ensures clicking on the label will focus the select trigger without opening it (matching native behavior), and hovering over the label will not activate CSS `:hover` on the trigger, unlike a native `<label>`.
+
+### Placeholder values
+
+To show a placeholder value, use the `placeholder` prop on `<Select.Value>`:
+
+```jsx title="Placeholder item" {8}
+const items = [
+  { value: 'system', label: 'System default' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+];
+
+<Select.Root items={items}>
+  <Select.Value placeholder="Select theme" />
+</Select.Root>;
+```
+
+With placeholders, users cannot clear selected values using the select itself. If the select value should be clearable from the popup (instead of an external "reset" button), use a `null` item rendered in the list itself:
+
+```jsx title="Clearable item" {2}
+const items = [
+  { value: null, label: 'Select theme' },
+  { value: 'system', label: 'System default' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+];
+
+<Select.Root items={items}>
+  <Select.Value />
+</Select.Root>;
+```
 
 ### Multiple selection
 

--- a/docs/src/app/(docs)/react/components/slider/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/hero/css-modules/index.tsx
@@ -7,7 +7,7 @@ export default function ExampleSlider() {
       <Slider.Control className={styles.Control}>
         <Slider.Track className={styles.Track}>
           <Slider.Indicator className={styles.Indicator} />
-          <Slider.Thumb className={styles.Thumb} />
+          <Slider.Thumb aria-label="Volume" className={styles.Thumb} />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(docs)/react/components/slider/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/hero/tailwind/index.tsx
@@ -6,7 +6,10 @@ export default function ExampleSlider() {
       <Slider.Control className="flex w-56 touch-none items-center py-3 select-none">
         <Slider.Track className="h-1 w-full rounded bg-gray-200 shadow-[inset_0_0_0_1px] shadow-gray-200 select-none">
           <Slider.Indicator className="rounded bg-gray-700 select-none" />
-          <Slider.Thumb className="size-4 rounded-full bg-white outline outline-1 outline-gray-300 select-none has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800" />
+          <Slider.Thumb
+            aria-label="Volume"
+            className="size-4 rounded-full bg-white outline outline-1 outline-gray-300 select-none has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800"
+          />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(docs)/react/components/slider/page.mdx
+++ b/docs/src/app/(docs)/react/components/slider/page.mdx
@@ -12,7 +12,7 @@ import { DemoSliderHero } from './demos/hero';
 
 ## Usage guidelines
 
-- **Form controls must have an accessible name**: The thumb must have a meaningful label. Prefer using [`<Field>`](/react/components/field) to provide visible text labels and descriptions, or [`<Fieldset>`](/react/components/fieldset) for multi-thumb range sliders. Otherwise, the `aria-label` attribute can be used as an alternative. See the [forms guide](/react/handbook/forms) for more on building form controls.
+- **Form controls must have an accessible name**: See [Labeling a slider](#labeling-a-slider) and the [forms guide](/react/handbook/forms).
 
 ## Anatomy
 
@@ -56,6 +56,105 @@ A client-only alternative `thumbAlignment="edge-client-only"` can be used to red
 import { DemoSliderEdgeAlignment } from './demos/edge-alignment';
 
 <DemoSliderEdgeAlignment compact />
+
+### Labeling a slider
+
+A single-thumb slider without a visible label (such as a volume control) can be labeled using `aria-label` on `<Slider.Thumb>`:
+
+```tsx title="Slider with invisible label" {5}
+<Slider.Root>
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb aria-label="Volume" />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>
+```
+
+A visible label can be created using `aria-labelledby` on `<Slider.Root>` that references the `id` of a sibling element, such as a `<div>`:
+
+```tsx title="Slider with visible label" {1,2}
+<div id="volume-label">Volume</div>
+<Slider.Root aria-labelledby="volume-label">
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>
+```
+
+For a multi-thumb range slider with a visible label, add `aria-label` on each `<Slider.Thumb>` to distinguish them:
+
+```tsx title="Labeling multi-thumb range sliders" {6-7}
+<div id="price-label">Price range</div>
+<Slider.Root defaultValue={[25, 75]} aria-labelledby="price-label">
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb index={0} aria-label="Minimum price" />
+      <Slider.Thumb index={1} aria-label="Maximum price" />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>
+```
+
+The [Field](/react/components/field) and [Fieldset](/react/components/fieldset) components can also be used to provide accessible labels for sliders, eliminating the need to track `id` or `aria-labelledby` associations manually. Field comes with a UX improvement to prevent double clicks from selecting the label text.
+
+For a single-thumb slider, use [Field](/react/components/field) to provide a visible label:
+
+```tsx title="Using Field to label a slider" {2}
+<Field.Root>
+  <Field.Label>Volume</Field.Label>
+  <Slider.Root>
+    <Slider.Control>
+      <Slider.Track>
+        <Slider.Indicator />
+        <Slider.Thumb />
+      </Slider.Track>
+    </Slider.Control>
+  </Slider.Root>
+</Field.Root>
+```
+
+For a multi-thumb range slider, use [Fieldset](/react/components/fieldset) by replacing the `<Fieldset.Root>` element with `<Slider.Root>` via the `render` prop. `<Fieldset.Legend>` provides the visible label for the group:
+
+```tsx title="Using Fieldset to label a multi-thumb slider" {2,3,7-8}
+<Field.Root>
+  <Fieldset.Root render={<Slider.Root />}>
+    <Fieldset.Legend>Price range</Fieldset.Legend>
+    <Slider.Control>
+      <Slider.Track>
+        <Slider.Indicator />
+        <Slider.Thumb index={0} aria-label="Minimum price" />
+        <Slider.Thumb index={1} aria-label="Maximum price" />
+      </Slider.Track>
+    </Slider.Control>
+  </Fieldset.Root>
+</Field.Root>
+```
+
+### Form integration
+
+To use a slider in a form, pass the slider's `name` to `<Field.Root>`:
+
+```tsx title="Using Slider in a form" {2}
+<Form>
+  <Field.Root name="volume">
+    <Field.Label>Volume</Field.Label>
+    <Slider.Root>
+      <Slider.Control>
+        <Slider.Track>
+          <Slider.Indicator />
+          <Slider.Thumb />
+        </Slider.Track>
+      </Slider.Control>
+    </Slider.Root>
+  </Field.Root>
+</Form>
+```
 
 ## API reference
 

--- a/docs/src/app/(docs)/react/components/switch/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/switch/demos/hero/css-modules/index.module.css
@@ -1,3 +1,12 @@
+.Label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: var(--color-gray-900);
+}
+
 .Switch {
   position: relative;
   display: flex;

--- a/docs/src/app/(docs)/react/components/switch/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/switch/demos/hero/css-modules/index.tsx
@@ -3,8 +3,11 @@ import styles from './index.module.css';
 
 export default function ExampleSwitch() {
   return (
-    <Switch.Root defaultChecked className={styles.Switch}>
-      <Switch.Thumb className={styles.Thumb} />
-    </Switch.Root>
+    <label className={styles.Label}>
+      <Switch.Root defaultChecked className={styles.Switch}>
+        <Switch.Thumb className={styles.Thumb} />
+      </Switch.Root>
+      Notifications
+    </label>
   );
 }

--- a/docs/src/app/(docs)/react/components/switch/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/switch/demos/hero/tailwind/index.tsx
@@ -2,11 +2,14 @@ import { Switch } from '@base-ui/react/switch';
 
 export default function ExampleSwitch() {
   return (
-    <Switch.Root
-      defaultChecked
-      className="relative flex h-6 w-10 rounded-full bg-gradient-to-r from-gray-700 from-35% to-gray-200 to-65% bg-[length:6.5rem_100%] bg-[100%_0%] bg-no-repeat p-px shadow-[inset_0_1.5px_2px] shadow-gray-200 outline outline-1 -outline-offset-1 outline-gray-200 transition-[background-position,box-shadow] duration-[125ms] ease-[cubic-bezier(0.26,0.75,0.38,0.45)] before:absolute before:rounded-full before:outline-offset-2 before:outline-blue-800 focus-visible:before:inset-0 focus-visible:before:outline focus-visible:before:outline-2 active:bg-gray-100 data-[checked]:bg-[0%_0%] data-[checked]:active:bg-gray-500 dark:from-gray-500 dark:shadow-black/75 dark:outline-white/15 dark:data-[checked]:shadow-none"
-    >
-      <Switch.Thumb className="aspect-square h-full rounded-full bg-white shadow-[0_0_1px_1px,0_1px_1px,1px_2px_4px_-1px] shadow-gray-100 transition-transform duration-150 data-[checked]:translate-x-4 dark:shadow-black/25" />
-    </Switch.Root>
+    <label className="flex items-center gap-2 text-base text-gray-900">
+      <Switch.Root
+        defaultChecked
+        className="relative flex h-6 w-10 rounded-full bg-gradient-to-r from-gray-700 from-35% to-gray-200 to-65% bg-[length:6.5rem_100%] bg-[100%_0%] bg-no-repeat p-px shadow-[inset_0_1.5px_2px] shadow-gray-200 outline outline-1 -outline-offset-1 outline-gray-200 transition-[background-position,box-shadow] duration-[125ms] ease-[cubic-bezier(0.26,0.75,0.38,0.45)] before:absolute before:rounded-full before:outline-offset-2 before:outline-blue-800 focus-visible:before:inset-0 focus-visible:before:outline focus-visible:before:outline-2 active:bg-gray-100 data-[checked]:bg-[0%_0%] data-[checked]:active:bg-gray-500 dark:from-gray-500 dark:shadow-black/75 dark:outline-white/15 dark:data-[checked]:shadow-none"
+      >
+        <Switch.Thumb className="aspect-square h-full rounded-full bg-white shadow-[0_0_1px_1px,0_1px_1px,1px_2px_4px_-1px] shadow-gray-100 transition-transform duration-150 data-[checked]:translate-x-4 dark:shadow-black/25" />
+      </Switch.Root>
+      Notifications
+    </label>
   );
 }

--- a/docs/src/app/(docs)/react/components/switch/page.mdx
+++ b/docs/src/app/(docs)/react/components/switch/page.mdx
@@ -12,7 +12,7 @@ import { DemoSwitchHero } from './demos/hero';
 
 ## Usage guidelines
 
-- **Form controls must have an accessible name**: The switch must have a meaningful label. Prefer using [`<Field>`](/react/components/field) to provide a visible text label and description, or use the `aria-label` attribute as an alternative. See the [forms guide](/react/handbook/forms) for more on building form controls.
+- **Form controls must have an accessible name**: It can be created using a `<label>` element or the `Field` component. See [Labeling a switch](#labeling-a-switch) and the [forms guide](/react/handbook/forms).
 
 ## Anatomy
 
@@ -24,6 +24,45 @@ import { Switch } from '@base-ui/react/switch';
 <Switch.Root>
   <Switch.Thumb />
 </Switch.Root>;
+```
+
+## Examples
+
+### Labeling a switch
+
+Label a switch using an enclosing `<label>` element that wraps `<Switch.Root>`. An enclosing label is announced to screen readers when focus is on the control, and ensures that clicking on any gaps between the label and switch still toggles the control.
+
+```tsx title="Using an enclosing label to label a switch" {1,4}
+<label>
+  <Switch.Root />
+  Notifications
+</label>
+```
+
+The [Field](/react/components/field) component eliminates the need to track `id` or `aria-label` associations manually. It supports both enclosing and sibling labeling patterns, along with a UX improvement to prevent double clicks from selecting the label text.
+
+```tsx title="Using the Field component to label a switch" {2,5}
+<Field.Root>
+  <Field.Label>
+    <Switch.Root />
+    Notifications
+  </Field.Label>
+</Field.Root>
+```
+
+### Form integration
+
+To use a switch in a form, pass the switch's `name` to `<Field.Root>`:
+
+```tsx title="Using Switch in a form" {2}
+<Form>
+  <Field.Root name="notifications">
+    <Field.Label>
+      <Switch.Root />
+      Notifications
+    </Field.Label>
+  </Field.Root>
+</Form>
 ```
 
 ## API reference


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Adds labels to all demos and detailed docs about how to label form components. 

Select demos are updated separately in https://github.com/mui/base-ui/pull/3604

- [Checkbox](https://deploy-preview-3635--base-ui.netlify.app/react/components/checkbox#labeling-a-checkbox)
- [Checkbox Group](https://deploy-preview-3635--base-ui.netlify.app/react/components/checkbox-group#labeling-a-checkbox-group)
- [Radio](https://deploy-preview-3635--base-ui.netlify.app/react/components/radio#labeling-a-radio-group)
- [Switch](https://deploy-preview-3635--base-ui.netlify.app/react/components/switch#labeling-a-switch)
- [Slider](https://deploy-preview-3635--base-ui.netlify.app/react/components/slider#labeling-a-slider)
- [Select](https://deploy-preview-3635--base-ui.netlify.app/react/components/select#labeling-a-select)

Combobox/Autocomplete/Number Field render visible `<input>`s so it's clearer how to label these (and is already done on the demos)

This documents both native and Field-based labeling. Native might be redundant given the hero demos already use that. If so, we can remove that to make the example text shorter to read