### PR TITLE
[select] Fix support for individual transform animations when `alignItemWithTrigger` is active

### DIFF
--- a/packages/react/src/select/popup/SelectPopup.test.tsx
+++ b/packages/react/src/select/popup/SelectPopup.test.tsx
@@ -88,4 +88,39 @@ describe('<Select.Popup />', () => {
     expect(trigger).to.have.attribute('aria-expanded', 'true');
     expect(trigger).to.have.attribute('aria-haspopup', 'listbox');
   });
+
+  it('restores transform-related inline styles after measurement', async () => {
+    let popupElement: HTMLElement | null = null;
+
+    await render(
+      <Select.Root open>
+        <Select.Trigger>Trigger</Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup
+              ref={(node) => {
+                if (node) {
+                  node.style.setProperty('transform', 'translateX(10px)');
+                  node.style.setProperty('scale', '0.8');
+                  node.style.setProperty('translate', '1px 2px');
+                }
+                popupElement = node;
+              }}
+            >
+              <Select.Item value="1">
+                <Select.ItemText>Item 1</Select.ItemText>
+              </Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    await new Promise<void>(queueMicrotask);
+
+    expect(popupElement).not.to.equal(null);
+    expect(popupElement!.style.getPropertyValue('transform')).to.equal('translateX(10px)');
+    expect(popupElement!.style.getPropertyValue('scale')).to.equal('0.8');
+    expect(popupElement!.style.getPropertyValue('translate')).to.equal('1px 2px');
+  });
 });

--- a/packages/react/src/select/popup/SelectPopup.tsx
+++ b/packages/react/src/select/popup/SelectPopup.tsx
@@ -43,7 +43,7 @@ const stateAttributesMapping: StateAttributesMapping<SelectPopup.State> = {
  */
 export const SelectPopup = React.forwardRef(function SelectPopup(
   componentProps: SelectPopup.Props,
-  forwardedRef: React.ForwardedRef<Element>,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { render, className, ...elementProps } = componentProps;
 
@@ -244,8 +244,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     queueMicrotask(() => {
       // Ensure we remove any transforms that can affect the location of the popup
       // and therefore the calculations.
-      const originalTransform = popupElement.style.transform;
-      popupElement.style.transform = 'none';
+      const restoreTransformStyles = unsetTransformStyles(popupElement);
       popupElement.style.removeProperty('--transform-origin');
 
       try {
@@ -371,11 +370,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
           initialPlacedRef.current = true;
         });
       } finally {
-        if (originalTransform) {
-          popupElement.style.transform = originalTransform;
-        } else {
-          popupElement.style.removeProperty('transform');
-        }
+        restoreTransformStyles();
       }
     });
   }, [
@@ -501,4 +496,43 @@ export interface SelectPopupState {
 export namespace SelectPopup {
   export type Props = SelectPopupProps;
   export type State = SelectPopupState;
+}
+
+const UNSET_TRANSFORM_STYLES = {
+  transform: 'none',
+  scale: '1',
+  translate: '0 0',
+} as const;
+
+type TransformStyleProperty = keyof typeof UNSET_TRANSFORM_STYLES;
+
+function restoreInlineStyleProperty(
+  style: CSSStyleDeclaration,
+  property: TransformStyleProperty,
+  value: string,
+) {
+  if (value) {
+    style.setProperty(property, value);
+  } else {
+    style.removeProperty(property);
+  }
+}
+
+function unsetTransformStyles(popupElement: HTMLElement) {
+  const { style } = popupElement;
+
+  const originalStyles = {} as Record<TransformStyleProperty, string>;
+
+  const props = Object.keys(UNSET_TRANSFORM_STYLES) as TransformStyleProperty[];
+
+  for (const prop of props) {
+    originalStyles[prop] = style.getPropertyValue(prop);
+    style.setProperty(prop, UNSET_TRANSFORM_STYLES[prop]);
+  }
+
+  return () => {
+    for (const prop of props) {
+      restoreInlineStyleProperty(style, prop, originalStyles[prop]);
+    }
+  };
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Extension to https://github.com/mui/base-ui/pull/3532. TW uses these new properties (`scale`/`translate`) by default instead of `transform`

https://stackblitz.com/edit/z72vh5ef?file=src%2FApp.tsx