### PR TITLE
[all components] Fix forwarded ref types

### DIFF
--- a/packages/react/src/accordion/trigger/AccordionTrigger.tsx
+++ b/packages/react/src/accordion/trigger/AccordionTrigger.tsx
@@ -49,7 +49,7 @@ function getActiveTriggers(accordionItemRefs: { current: (HTMLElement | null)[] 
 
 export const AccordionTrigger = React.forwardRef(function AccordionTrigger(
   componentProps: AccordionTrigger.Props,
-  forwardedRef: React.ForwardedRef<Element>,
+  forwardedRef: React.ForwardedRef<HTMLElement>,
 ) {
   const {
     disabled: disabledProp,

--- a/packages/react/src/field/label/FieldLabel.tsx
+++ b/packages/react/src/field/label/FieldLabel.tsx
@@ -18,7 +18,7 @@ import { useRenderElement } from '../../utils/useRenderElement';
  */
 export const FieldLabel = React.forwardRef(function FieldLabel(
   componentProps: FieldLabel.Props,
-  forwardedRef: React.ForwardedRef<any>,
+  forwardedRef: React.ForwardedRef<HTMLElement>,
 ) {
   const { render, className, id: idProp, ...elementProps } = componentProps;
 

--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
@@ -23,7 +23,7 @@ import type { MenuRoot } from '../root/MenuRoot';
  */
 export const MenuCheckboxItem = React.forwardRef(function MenuCheckboxItem(
   componentProps: MenuCheckboxItem.Props,
-  forwardedRef: React.ForwardedRef<Element>,
+  forwardedRef: React.ForwardedRef<HTMLElement>,
 ) {
   const {
     render,

--- a/packages/react/src/menu/group/MenuGroup.tsx
+++ b/packages/react/src/menu/group/MenuGroup.tsx
@@ -12,7 +12,7 @@ import { MenuGroupContext } from './MenuGroupContext';
  */
 export const MenuGroup = React.forwardRef(function MenuGroup(
   componentProps: MenuGroup.Props,
-  forwardedRef: React.ForwardedRef<Element>,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { render, className, ...elementProps } = componentProps;
 

--- a/packages/react/src/menu/item/MenuItem.tsx
+++ b/packages/react/src/menu/item/MenuItem.tsx
@@ -16,7 +16,7 @@ import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
  */
 export const MenuItem = React.forwardRef(function MenuItem(
   componentProps: MenuItem.Props,
-  forwardedRef: React.ForwardedRef<Element>,
+  forwardedRef: React.ForwardedRef<HTMLElement>,
 ) {
   const {
     render,

--- a/packages/react/src/menu/popup/MenuPopup.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.tsx
@@ -32,7 +32,7 @@ const stateAttributesMapping: StateAttributesMapping<MenuPopup.State> = {
  */
 export const MenuPopup = React.forwardRef(function MenuPopup(
   componentProps: MenuPopup.Props,
-  forwardedRef: React.ForwardedRef<Element>,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { render, className, finalFocus, ...elementProps } = componentProps;
 

--- a/packages/react/src/menu/radio-group/MenuRadioGroup.tsx
+++ b/packages/react/src/menu/radio-group/MenuRadioGroup.tsx
@@ -16,7 +16,7 @@ import type { MenuRoot } from '../root/MenuRoot';
 export const MenuRadioGroup = React.memo(
   React.forwardRef(function MenuRadioGroup(
     componentProps: MenuRadioGroup.Props,
-    forwardedRef: React.ForwardedRef<Element>,
+    forwardedRef: React.ForwardedRef<HTMLDivElement>,
   ) {
     const {
       render,

--- a/packages/react/src/menu/radio-item/MenuRadioItem.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.tsx
@@ -22,7 +22,7 @@ import { REASONS } from '../../utils/reasons';
  */
 export const MenuRadioItem = React.forwardRef(function MenuRadioItem(
   componentProps: MenuRadioItem.Props,
-  forwardedRef: React.ForwardedRef<Element>,
+  forwardedRef: React.ForwardedRef<HTMLElement>,
 ) {
   const {
     render,

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -42,7 +42,7 @@ import { useTriggerDataForwarding } from '../../utils/popups';
  */
 export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
   componentProps: PopoverTrigger.Props,
-  forwardedRef: React.ForwardedRef<any>,
+  forwardedRef: React.ForwardedRef<HTMLElement>,
 ) {
   const {
     render,

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -28,7 +28,7 @@ import { compareItemEquality, removeItem } from '../../utils/itemEquality';
 export const SelectItem = React.memo(
   React.forwardRef(function SelectItem(
     componentProps: SelectItem.Props,
-    forwardedRef: React.ForwardedRef<HTMLDivElement>,
+    forwardedRef: React.ForwardedRef<HTMLElement>,
   ) {
     const {
       render,

--- a/packages/react/src/slider/track/SliderTrack.tsx
+++ b/packages/react/src/slider/track/SliderTrack.tsx
@@ -14,7 +14,7 @@ import { sliderStateAttributesMapping } from '../root/stateAttributesMapping';
  */
 export const SliderTrack = React.forwardRef(function SliderTrack(
   componentProps: SliderTrack.Props,
-  forwardedRef: React.ForwardedRef<HTMLElement>,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { render, className, ...elementProps } = componentProps;
 

--- a/packages/react/src/tabs/tab/TabsTab.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.tsx
@@ -23,7 +23,7 @@ import { activeElement, contains } from '../../floating-ui-react/utils';
  */
 export const TabsTab = React.forwardRef(function TabsTab(
   componentProps: TabsTab.Props,
-  forwardedRef: React.ForwardedRef<Element>,
+  forwardedRef: React.ForwardedRef<HTMLElement>,
 ) {
   const {
     className,

--- a/packages/react/src/toolbar/group/ToolbarGroup.tsx
+++ b/packages/react/src/toolbar/group/ToolbarGroup.tsx
@@ -14,7 +14,7 @@ import { ToolbarGroupContext } from './ToolbarGroupContext';
  */
 export const ToolbarGroup = React.forwardRef(function ToolbarGroup(
   componentProps: ToolbarGroup.Props,
-  forwardedRef: React.ForwardedRef<HTMLElement>,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { className, disabled: disabledProp = false, render, ...elementProps } = componentProps;
 

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -20,7 +20,7 @@ import { OPEN_DELAY } from '../utils/constants';
  */
 export const TooltipTrigger = React.forwardRef(function TooltipTrigger(
   componentProps: TooltipTrigger.Props,
-  forwardedRef: React.ForwardedRef<any>,
+  forwardedRef: React.ForwardedRef<Element>,
 ) {
   const {
     className,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This loosens or restricts the type of the `ref` for some components

Some rules:
- Non-button `<div>` elements should not be polymorphic (as in rendered as another tag, not replaced with a same-tag component), so these have strict `HTMLDivElement`
- Button `<div>` elements (e.g. composite items) can be polymorphic (e.g. rendered as an anchor tag), so use `HTMLElement`
- `<Tooltip.Trigger>` could be a non-HTML element (e.g. using SVG elements), so I've replaced instances of `Element` with `HTMLElement` where applicable, except for `<Tooltip.Trigger>`, where I made `any` stricter

---

This doesn't solve `event.currentTarget` typesafety in event handlers, yet. Also, some button components which are unlikely to be polymorphic (but technically allow it via `nativeButton={false}`) still use strict `HTMLButtonElement` instead of `HTMLElement`. Changing them to be looser could be ok, if worth it.