### PR TITLE
[form controls] Fix hidden input `id` and `required` props

### DIFF
--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -1245,6 +1245,21 @@ describe('<Autocomplete.Root />', () => {
 
     clock.withFakeTimers();
 
+    it('sets `required` on the visible input', async () => {
+      await render(
+        <Field.Root>
+          <Autocomplete.Root required>
+            <Autocomplete.Input data-testid="input" />
+            <Autocomplete.Portal>
+              <Autocomplete.Positioner />
+            </Autocomplete.Portal>
+          </Autocomplete.Root>
+        </Field.Root>,
+      );
+
+      expect(screen.getByTestId('input')).to.have.attribute('required');
+    });
+
     it('[data-touched]', async () => {
       await render(
         <Field.Root>

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -299,6 +299,30 @@ describe('<Checkbox.Root />', () => {
       fireEvent.click(screen.getByTestId('label'));
       expect(checkbox).to.have.attribute('aria-checked', 'true');
     });
+
+    it('should associate `id` with the native button when `nativeButton=true`', async () => {
+      await render(
+        <div>
+          <label data-testid="label" htmlFor="myCheckbox">
+            Toggle
+          </label>
+
+          <Checkbox.Root id="myCheckbox" nativeButton render={<button />} />
+        </div>,
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).to.have.attribute('id', 'myCheckbox');
+
+      const hiddenInputs = screen.getAllByRole<HTMLInputElement>('checkbox', { hidden: true });
+      const hiddenInput = hiddenInputs.find((input) => input !== checkbox);
+      expect(hiddenInput).not.to.equal(undefined);
+      expect(hiddenInput).not.to.have.attribute('id', 'myCheckbox');
+
+      expect(checkbox).to.have.attribute('aria-checked', 'false');
+      fireEvent.click(screen.getByTestId('label'));
+      expect(checkbox).to.have.attribute('aria-checked', 'true');
+    });
   });
 
   describe('Form', () => {

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -192,8 +192,9 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
       disabled,
       // parent checkboxes unset `name` to be excluded from form submission
       name: parent ? undefined : name,
-      // Set `id` to stop Chrome warning about an unassociated input
-      id: inputId ?? undefined,
+      // Set `id` to stop Chrome warning about an unassociated input.
+      // When using a native button, the `id` is applied to the button instead.
+      id: nativeButton ? undefined : (inputId ?? undefined),
       required,
       ref: mergedInputRef,
       style: visuallyHiddenInput,
@@ -269,7 +270,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     ref: [buttonRef, controlRef, forwardedRef, groupContext?.registerControlRef],
     props: [
       {
-        id,
+        id: nativeButton ? (inputId ?? undefined) : id,
         role: 'checkbox',
         'aria-checked': groupIndeterminate ? 'mixed' : checked,
         'aria-readonly': readOnly || undefined,

--- a/packages/react/src/combobox/input/ComboboxInput.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.test.tsx
@@ -173,6 +173,19 @@ describe('<Combobox.Input />', () => {
     });
   });
 
+  describe('prop: required', () => {
+    it('sets aria-required attribute when required', async () => {
+      await render(
+        <Combobox.Root required>
+          <Combobox.Input data-testid="input" />
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      expect(input).to.have.attribute('aria-required', 'true');
+    });
+  });
+
   describe('interaction behavior', () => {
     it('clears selected value when input text is cleared (single selection)', async () => {
       const { user } = await render(

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -57,8 +57,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
   // `inputValue` can't be placed in the store.
   // https://github.com/mui/base-ui/issues/2703
   const inputValue = useComboboxInputValueContext();
-
-  const id = useBaseUiId(idProp);
+  const required = useStore(store, selectors.required);
   const direction = useDirection();
 
   const comboboxDisabled = useStore(store, selectors.disabled);
@@ -78,6 +77,8 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
   const popupSide = mounted && positionerElement ? popupSideValue : null;
   const disabled = fieldDisabled || comboboxDisabled || disabledProp;
   const listEmpty = filteredItems.length === 0;
+
+  const id = useBaseUiId(idProp);
 
   const [composingValue, setComposingValue] = React.useState<string | null>(null);
   const isComposingRef = React.useRef(false);
@@ -176,9 +177,11 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
         type: 'text',
         value: componentProps.value ?? composingValue ?? inputValue,
         'aria-readonly': readOnly || undefined,
+        'aria-required': required || undefined,
         'aria-labelledby': labelId,
         disabled,
         readOnly,
+        required: selectionMode === 'none' ? required : undefined,
         ...(selectionMode === 'none' && name && { name }),
         id,
         onFocus() {

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
@@ -466,6 +466,29 @@ describe('<Combobox.Trigger />', () => {
   });
 
   describe('aria attributes', () => {
+    it('sets aria-required attribute when required (input inside popup)', async () => {
+      await render(
+        <Combobox.Root required>
+          <Combobox.Trigger data-testid="trigger" />
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      expect(trigger).to.have.attribute('aria-required', 'true');
+    });
+
+    it('does not set aria-required attribute when the input is outside the popup', async () => {
+      await render(
+        <Combobox.Root required>
+          <Combobox.Input />
+          <Combobox.Trigger data-testid="trigger" />
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      expect(trigger).not.to.have.attribute('aria-required');
+    });
+
     it('sets all aria attributes on the input when closed', async () => {
       await render(
         <Combobox.Root>

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -58,6 +58,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
   const selectionMode = useStore(store, selectors.selectionMode);
   const comboboxDisabled = useStore(store, selectors.disabled);
   const readOnly = useStore(store, selectors.readOnly);
+  const required = useStore(store, selectors.required);
   const mounted = useStore(store, selectors.mounted);
   const popupSideValue = useStore(store, selectors.popupSide);
   const positionerElement = useStore(store, selectors.positionerElement);
@@ -150,6 +151,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
         'aria-haspopup': inputInsidePopup ? 'dialog' : 'listbox',
         'aria-controls': open ? listElement?.id : undefined,
         'aria-readonly': readOnly || undefined,
+        'aria-required': inputInsidePopup ? required || undefined : undefined,
         'aria-labelledby': labelId,
         onPointerDown: trackPointerType,
         onPointerEnter: trackPointerType,

--- a/packages/react/src/radio/root/RadioRoot.test.tsx
+++ b/packages/react/src/radio/root/RadioRoot.test.tsx
@@ -39,4 +39,44 @@ describe('<Radio.Root />', () => {
     fireEvent.click(radioA);
     expect(radioNull).to.have.attribute('aria-checked', 'false');
   });
+
+  it('associates `id` with the native button when `nativeButton=true`', async () => {
+    await render(
+      <div>
+        <label data-testid="label" htmlFor="myRadio">
+          A
+        </label>
+
+        <RadioGroup defaultValue="b">
+          <Radio.Root value="a" id="myRadio" nativeButton render={<button />} data-testid="a" />
+          <Radio.Root value="b" data-testid="b" />
+        </RadioGroup>
+      </div>,
+    );
+
+    const radioA = screen.getByTestId('a');
+    expect(radioA).to.have.attribute('id', 'myRadio');
+
+    const hiddenInput = radioA.nextElementSibling as HTMLInputElement | null;
+    expect(hiddenInput?.tagName).to.equal('INPUT');
+    expect(hiddenInput).not.to.have.attribute('id', 'myRadio');
+
+    expect(radioA).to.have.attribute('aria-checked', 'false');
+    fireEvent.click(screen.getByTestId('label'));
+    expect(radioA).to.have.attribute('aria-checked', 'true');
+  });
+
+  describe('prop: disabled', () => {
+    it('uses aria-disabled instead of HTML disabled', async () => {
+      await render(
+        <RadioGroup>
+          <Radio.Root value="a" disabled data-testid="radio" />
+        </RadioGroup>,
+      );
+
+      const radio = screen.getByTestId('radio');
+      expect(radio).to.not.have.attribute('disabled');
+      expect(radio).to.have.attribute('aria-disabled', 'true');
+    });
+  });
 });

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -91,15 +91,16 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
     implicit: false,
     controlRef: radioRef,
   });
+  const hiddenInputId = nativeButton ? undefined : inputId;
 
-  const rootProps: React.ComponentProps<'button'> = {
+  const rootProps: React.ComponentPropsWithRef<'span'> = {
     role: 'radio',
     'aria-checked': checked,
     'aria-required': required || undefined,
     'aria-readonly': readOnly || undefined,
     'aria-labelledby': labelId,
     [ACTIVE_COMPOSITE_ITEM as string]: checked ? '' : undefined,
-    id,
+    id: nativeButton ? inputId : id,
     onKeyDown(event) {
       if (event.key === 'Enter') {
         event.preventDefault();
@@ -133,7 +134,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
   const inputProps: React.ComponentPropsWithRef<'input'> = {
     type: 'radio',
     ref: mergedInputRef,
-    id: inputId,
+    id: hiddenInputId,
     tabIndex: -1,
     style: visuallyHiddenInput,
     'aria-hidden': true,

--- a/packages/react/src/select/trigger/SelectTrigger.test.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.test.tsx
@@ -177,4 +177,17 @@ describe('<Select.Trigger />', () => {
       expect(trigger).to.have.attribute('data-pressed');
     });
   });
+
+  describe('prop: required', () => {
+    it('sets aria-required attribute when required', async () => {
+      await render(
+        <Select.Root required>
+          <Select.Trigger data-testid="trigger" />
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      expect(trigger).to.have.attribute('aria-required', 'true');
+    });
+  });
 });

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -63,6 +63,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
     selectionRef,
     validation,
     readOnly,
+    required,
     alignItemWithTriggerActiveRef,
     disabled: selectDisabled,
     keyboardActiveRef,
@@ -143,6 +144,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
       'aria-controls': open ? ariaControlsId : undefined,
       'aria-labelledby': labelId,
       'aria-readonly': readOnly || undefined,
+      'aria-required': required || undefined,
       tabIndex: disabled ? -1 : 0,
       ref: mergedRef,
       onFocus(event) {

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -175,6 +175,18 @@ describe('<Switch.Root />', () => {
     });
   });
 
+  describe('prop: required', () => {
+    it('should have the `aria-required` attribute', async () => {
+      await render(<Switch.Root required />);
+      expect(screen.getByRole('switch')).to.have.attribute('aria-required', 'true');
+    });
+
+    it('should not have the aria attribute when `required` is not set', async () => {
+      await render(<Switch.Root />);
+      expect(screen.getByRole('switch')).not.to.have.attribute('aria-required');
+    });
+  });
+
   describe('prop: inputRef', () => {
     it('should be able to access the native input', async () => {
       const inputRef = React.createRef<HTMLInputElement>();
@@ -255,6 +267,28 @@ describe('<Switch.Root />', () => {
       const switchElement = screen.getByRole('switch');
       expect(switchElement).to.have.attribute('aria-checked', 'false');
 
+      await user.click(screen.getByTestId('label'));
+      expect(switchElement).to.have.attribute('aria-checked', 'true');
+    });
+
+    it('should associate `id` with the native button when `nativeButton=true`', async () => {
+      const { user } = await render(
+        <div>
+          <label data-testid="label" htmlFor="mySwitch">
+            Toggle
+          </label>
+
+          <Switch.Root id="mySwitch" nativeButton render={<button />} />
+        </div>,
+      );
+
+      const switchElement = screen.getByRole('switch');
+      expect(switchElement).to.have.attribute('id', 'mySwitch');
+
+      const hiddenInput = screen.getByRole('checkbox', { hidden: true });
+      expect(hiddenInput).not.to.have.attribute('id', 'mySwitch');
+
+      expect(switchElement).to.have.attribute('aria-checked', 'false');
       await user.click(screen.getByTestId('label'));
       expect(switchElement).to.have.attribute('aria-checked', 'true');
     });

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -78,11 +78,12 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
 
   const id = useBaseUiId();
 
-  const inputId = useLabelableId({
+  const controlId = useLabelableId({
     id: idProp,
     implicit: false,
     controlRef: switchRef,
   });
+  const hiddenInputId = nativeButton ? undefined : controlId;
 
   const [checked, setCheckedState] = useControlled({
     controlled: checkedProp,
@@ -124,10 +125,11 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
   });
 
   const rootProps: React.ComponentPropsWithRef<'span'> = {
-    id,
+    id: nativeButton ? controlId : id,
     role: 'switch',
     'aria-checked': checked,
     'aria-readonly': readOnly || undefined,
+    'aria-required': required || undefined,
     'aria-labelledby': labelId,
     onFocus() {
       if (!disabled) {
@@ -164,7 +166,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
         {
           checked,
           disabled,
-          id: inputId,
+          id: hiddenInputId,
           name,
           required,
           style: visuallyHiddenInput,
@@ -199,7 +201,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
       checked,
       disabled,
       handleInputRef,
-      inputId,
+      hiddenInputId,
       name,
       onCheckedChange,
       required,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

1. In Switch, Checkbox, and Radio, when rendering a `<button>` element, the `id` will point to the `<button>` control instead of the hidden `<input>`, matching Radix and native behavior. Enclosing labels in this format creates invalid HTML, but sibling labels will work correctly by default. Closes #3263

2. In Autocomplete, the `required` prop is also forwarded to the visible `Input` part, matching Number Field (but does not apply to Combobox). Also adds `aria-required` for missing controls (as is currently applied to Checkbox/Radio)