### PR TITLE
[combobox] Add `toolbar` role to `<Combobox.Chips>` part

### DIFF
--- a/packages/react/src/combobox/chips/ComboboxChips.test.tsx
+++ b/packages/react/src/combobox/chips/ComboboxChips.test.tsx
@@ -1,5 +1,7 @@
 import { Combobox } from '@base-ui/react/combobox';
+import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
+import { expect } from 'chai';
 
 describe('<Combobox.Chips />', () => {
   const { render } = createRenderer();
@@ -10,4 +12,28 @@ describe('<Combobox.Chips />', () => {
       return render(<Combobox.Root>{node}</Combobox.Root>);
     },
   }));
+
+  it('does not set role="toolbar" when there are no chips', async () => {
+    await render(
+      <Combobox.Root multiple>
+        <Combobox.Chips data-testid="chips" />
+      </Combobox.Root>,
+    );
+
+    const chips = screen.getByTestId('chips');
+    expect(chips).not.to.have.attribute('role');
+  });
+
+  it('sets role="toolbar" when there is at least one chip', async () => {
+    await render(
+      <Combobox.Root multiple defaultValue={['apple']}>
+        <Combobox.Chips data-testid="chips">
+          <Combobox.Chip>apple</Combobox.Chip>
+        </Combobox.Chips>
+      </Combobox.Root>,
+    );
+
+    const chips = screen.getByTestId('chips');
+    expect(chips).to.have.attribute('role', 'toolbar');
+  });
 });

--- a/packages/react/src/combobox/chips/ComboboxChips.tsx
+++ b/packages/react/src/combobox/chips/ComboboxChips.tsx
@@ -7,6 +7,7 @@ import { ComboboxChipsContext } from './ComboboxChipsContext';
 import { CompositeList } from '../../composite/list/CompositeList';
 import { useComboboxRootContext } from '../root/ComboboxRootContext';
 import { selectors } from '../store';
+import { EMPTY_OBJECT } from '../../utils/constants';
 
 /**
  * A container for the chips in a multiselectable input.
@@ -21,6 +22,7 @@ export const ComboboxChips = React.forwardRef(function ComboboxChips(
   const store = useComboboxRootContext();
 
   const open = useStore(store, selectors.open);
+  const hasSelectionChips = useStore(store, selectors.hasSelectionChips);
 
   const [highlightedChipIndex, setHighlightedChipIndex] = React.useState<number | undefined>(
     undefined,
@@ -34,7 +36,9 @@ export const ComboboxChips = React.forwardRef(function ComboboxChips(
 
   const element = useRenderElement('div', componentProps, {
     ref: [forwardedRef, store.state.chipsContainerRef],
-    props: elementProps,
+    // NVDA enters browse mode instead of staying in focus mode when navigating with
+    // arrow keys inside a container unless it has a toolbar role.
+    props: [hasSelectionChips ? { role: 'toolbar' } : EMPTY_OBJECT, elementProps],
   });
 
   const contextValue: ComboboxChipsContext = React.useMemo(

--- a/packages/react/src/combobox/clear/ComboboxClear.tsx
+++ b/packages/react/src/combobox/clear/ComboboxClear.tsx
@@ -45,6 +45,7 @@ export const ComboboxClear = React.forwardRef(function ComboboxClear(
   const readOnly = useStore(store, selectors.readOnly);
   const open = useStore(store, selectors.open);
   const selectedValue = useStore(store, selectors.selectedValue);
+  const hasSelectionChips = useStore(store, selectors.hasSelectionChips);
 
   const inputValue = useComboboxInputValueContext();
 
@@ -54,7 +55,7 @@ export const ComboboxClear = React.forwardRef(function ComboboxClear(
   } else if (selectionMode === 'single') {
     visible = selectedValue != null;
   } else {
-    visible = Array.isArray(selectedValue) && selectedValue.length > 0;
+    visible = hasSelectionChips;
   }
 
   const disabled = fieldDisabled || comboboxDisabled || disabledProp;

--- a/packages/react/src/combobox/store.ts
+++ b/packages/react/src/combobox/store.ts
@@ -98,6 +98,10 @@ export const selectors = {
   items: createSelector((state: State) => state.items),
 
   selectedValue: createSelector((state: State) => state.selectedValue),
+  hasSelectionChips: createSelector((state: State) => {
+    const selectedValue = state.selectedValue;
+    return Array.isArray(selectedValue) && selectedValue.length > 0;
+  }),
 
   open: createSelector((state: State) => state.open),
   mounted: createSelector((state: State) => state.mounted),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This prevents NVDA from entering "browse" mode when navigating chips with arrow keys when it should stay in "focus" mode (NVDA otherwise swallows arrow keys and the user gets stuck, needing to press <kbd>Tab</kbd>). It is also more semantically correct as `<Combobox.Chips>` acts as a toolbar role wise when at least 1 chip is present.

I tested manually on Windows + NVDA

The ARIA guide says toolbars should only contain 3+ items (that means `Input` + at least two chips) however this is likely not a strict/hard rule, because it doesn't break behavior

Fixes #3629