### PR TITLE
[navigation menu] Fix missing starting transition on `Content`

### DIFF
--- a/packages/react/src/navigation-menu/content/NavigationMenuContent.tsx
+++ b/packages/react/src/navigation-menu/content/NavigationMenuContent.tsx
@@ -62,6 +62,12 @@ export const NavigationMenuContent = React.forwardRef(function NavigationMenuCon
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
 
+  // If the popup unmounts before the content's exit animation completes, reset the internal
+  // mounted state so the next open can re-enter via `transitionStatus="starting"`.
+  if (mounted && !popupMounted) {
+    setMounted(false);
+  }
+
   useOpenChangeComplete({
     ref,
     open,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Sometimes the content wouldn't have a starting transition, which occurred after #3558. This surfaced as the Content doesn't `setMounted(false)` before Popup unmounts.

On the hero demo:
1. Hover 'Overview'
2. Unhover
3. Hover 'Handbook'
4. Hover 'Overview'
5. 'Overview' content wouldn't have `[data-starting-style]`, now it does