### PR TITLE
[docs] Remove incorrectly documented `data-required` and `data-readonly` state attributes from `Slider`

### DIFF
--- a/docs/reference/generated/slider-control.json
+++ b/docs/reference/generated/slider-control.json
@@ -28,12 +28,6 @@
     "data-disabled": {
       "description": "Present when the slider is disabled."
     },
-    "data-readonly": {
-      "description": "Present when the slider is readonly."
-    },
-    "data-required": {
-      "description": "Present when the slider is required."
-    },
     "data-valid": {
       "description": "Present when the slider is in valid state (when wrapped in Field.Root)."
     },

--- a/docs/reference/generated/slider-indicator.json
+++ b/docs/reference/generated/slider-indicator.json
@@ -28,12 +28,6 @@
     "data-disabled": {
       "description": "Present when the slider is disabled."
     },
-    "data-readonly": {
-      "description": "Present when the slider is readonly."
-    },
-    "data-required": {
-      "description": "Present when the slider is required."
-    },
     "data-valid": {
       "description": "Present when the slider is in valid state (when wrapped in Field.Root)."
     },

--- a/docs/reference/generated/slider-root.json
+++ b/docs/reference/generated/slider-root.json
@@ -117,12 +117,6 @@
     "data-disabled": {
       "description": "Present when the slider is disabled."
     },
-    "data-readonly": {
-      "description": "Present when the slider is readonly."
-    },
-    "data-required": {
-      "description": "Present when the slider is required."
-    },
     "data-valid": {
       "description": "Present when the slider is in valid state (when wrapped in Field.Root)."
     },

--- a/docs/reference/generated/slider-thumb.json
+++ b/docs/reference/generated/slider-thumb.json
@@ -70,12 +70,6 @@
     "data-disabled": {
       "description": "Present when the slider is disabled."
     },
-    "data-readonly": {
-      "description": "Present when the slider is readonly."
-    },
-    "data-required": {
-      "description": "Present when the slider is required."
-    },
     "data-valid": {
       "description": "Present when the slider is in valid state (when wrapped in Field.Root)."
     },

--- a/docs/reference/generated/slider-track.json
+++ b/docs/reference/generated/slider-track.json
@@ -28,12 +28,6 @@
     "data-disabled": {
       "description": "Present when the slider is disabled."
     },
-    "data-readonly": {
-      "description": "Present when the slider is readonly."
-    },
-    "data-required": {
-      "description": "Present when the slider is required."
-    },
     "data-valid": {
       "description": "Present when the slider is in valid state (when wrapped in Field.Root)."
     },

--- a/docs/reference/generated/slider-value.json
+++ b/docs/reference/generated/slider-value.json
@@ -32,12 +32,6 @@
     "data-disabled": {
       "description": "Present when the slider is disabled."
     },
-    "data-readonly": {
-      "description": "Present when the slider is readonly."
-    },
-    "data-required": {
-      "description": "Present when the slider is required."
-    },
     "data-valid": {
       "description": "Present when the slider is in valid state (when wrapped in Field.Root)."
     },

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -1090,22 +1090,22 @@ An easily stylable range input.
 - Exports:
   - Slider - Root
     - Props: className, defaultValue, disabled, format, largeStep, locale, max, min, minStepsBetweenValues, name, onValueChange, onValueCommitted, orientation, render, step, style, thumbAlignment, thumbCollisionBehavior, value
-    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-invalid, data-orientation, data-readonly, data-required, data-touched, data-valid
+    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-invalid, data-orientation, data-touched, data-valid
   - Slider - Value
     - Props: children, className, render, style
-    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-invalid, data-orientation, data-readonly, data-required, data-touched, data-valid
+    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-invalid, data-orientation, data-touched, data-valid
   - Slider - Control
     - Props: className, render, style
-    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-invalid, data-orientation, data-readonly, data-required, data-touched, data-valid
+    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-invalid, data-orientation, data-touched, data-valid
   - Slider - Track
     - Props: className, render, style
-    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-invalid, data-orientation, data-readonly, data-required, data-touched, data-valid
+    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-invalid, data-orientation, data-touched, data-valid
   - Slider - Thumb
     - Props: className, disabled, getAriaLabel, getAriaValueText, index, inputRef, onBlur, onFocus, render, style, tabIndex
-    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-index, data-invalid, data-orientation, data-readonly, data-required, data-touched, data-valid
+    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-index, data-invalid, data-orientation, data-touched, data-valid
   - Slider - Indicator
     - Props: className, render, style
-    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-invalid, data-orientation, data-readonly, data-required, data-touched, data-valid
+    - Data Attributes: data-dirty, data-disabled, data-dragging, data-focused, data-invalid, data-orientation, data-touched, data-valid
 
 </details>
 

--- a/packages/react/src/slider/control/SliderControlDataAttributes.ts
+++ b/packages/react/src/slider/control/SliderControlDataAttributes.ts
@@ -13,14 +13,6 @@ export enum SliderControlDataAttributes {
    */
   disabled = 'data-disabled',
   /**
-   * Present when the slider is readonly.
-   */
-  readonly = 'data-readonly',
-  /**
-   * Present when the slider is required.
-   */
-  required = 'data-required',
-  /**
    * Present when the slider is in valid state (when wrapped in Field.Root).
    */
   valid = 'data-valid',

--- a/packages/react/src/slider/indicator/SliderIndicatorDataAttributes.ts
+++ b/packages/react/src/slider/indicator/SliderIndicatorDataAttributes.ts
@@ -13,14 +13,6 @@ export enum SliderIndicatorDataAttributes {
    */
   disabled = 'data-disabled',
   /**
-   * Present when the slider is readonly.
-   */
-  readonly = 'data-readonly',
-  /**
-   * Present when the slider is required.
-   */
-  required = 'data-required',
-  /**
    * Present when the slider is in valid state (when wrapped in Field.Root).
    */
   valid = 'data-valid',

--- a/packages/react/src/slider/root/SliderRootDataAttributes.ts
+++ b/packages/react/src/slider/root/SliderRootDataAttributes.ts
@@ -13,14 +13,6 @@ export enum SliderRootDataAttributes {
    */
   disabled = 'data-disabled',
   /**
-   * Present when the slider is readonly.
-   */
-  readonly = 'data-readonly',
-  /**
-   * Present when the slider is required.
-   */
-  required = 'data-required',
-  /**
    * Present when the slider is in valid state (when wrapped in Field.Root).
    */
   valid = 'data-valid',

--- a/packages/react/src/slider/thumb/SliderThumbDataAttributes.ts
+++ b/packages/react/src/slider/thumb/SliderThumbDataAttributes.ts
@@ -17,14 +17,6 @@ export enum SliderThumbDataAttributes {
    */
   disabled = 'data-disabled',
   /**
-   * Present when the slider is readonly.
-   */
-  readonly = 'data-readonly',
-  /**
-   * Present when the slider is required.
-   */
-  required = 'data-required',
-  /**
    * Present when the slider is in valid state (when wrapped in Field.Root).
    */
   valid = 'data-valid',

--- a/packages/react/src/slider/track/SliderTrackDataAttributes.ts
+++ b/packages/react/src/slider/track/SliderTrackDataAttributes.ts
@@ -13,14 +13,6 @@ export enum SliderTrackDataAttributes {
    */
   disabled = 'data-disabled',
   /**
-   * Present when the slider is readonly.
-   */
-  readonly = 'data-readonly',
-  /**
-   * Present when the slider is required.
-   */
-  required = 'data-required',
-  /**
    * Present when the slider is in valid state (when wrapped in Field.Root).
    */
   valid = 'data-valid',

--- a/packages/react/src/slider/value/SliderValueDataAttributes.ts
+++ b/packages/react/src/slider/value/SliderValueDataAttributes.ts
@@ -13,14 +13,6 @@ export enum SliderValueDataAttributes {
    */
   disabled = 'data-disabled',
   /**
-   * Present when the slider is readonly.
-   */
-  readonly = 'data-readonly',
-  /**
-   * Present when the slider is required.
-   */
-  required = 'data-required',
-  /**
    * Present when the slider is in valid state (when wrapped in Field.Root).
    */
   valid = 'data-valid',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

According to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/range#additional_attributes), the `<input type="range" />` element does not support the `readonly` or `required` attributes. Therefore, the [`Slider`](https://base-ui.com/react/components/slider) component also lacks `readonly` and `required` props. However, the documentation states that `data-required` and `data-readonly` exist, so I have modified this accordingly.