### PR TITLE
[tooltip][popover] Refactor popup auto resize logic

### DIFF
--- a/packages/react/src/popover/popup/PopoverPopup.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.tsx
@@ -2,11 +2,7 @@
 import * as React from 'react';
 import { InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import { isHTMLElement } from '@floating-ui/utils/dom';
-import {
-  Dimensions,
-  FloatingFocusManager,
-  useHoverFloatingInteraction,
-} from '../../floating-ui-react';
+import { FloatingFocusManager, useHoverFloatingInteraction } from '../../floating-ui-react';
 import { usePopoverRootContext } from '../root/PopoverRootContext';
 import { usePopoverPositionerContext } from '../positioner/PopoverPositionerContext';
 import type { Side, Align } from '../../utils/useAnchorPositioning';
@@ -18,8 +14,6 @@ import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { REASONS } from '../../utils/reasons';
-import { usePopupAutoResize } from '../../utils/usePopupAutoResize';
-import { useDirection } from '../../direction-provider/DirectionContext';
 import { COMPOSITE_KEYS } from '../../composite/composite';
 import { useToolbarRootContext } from '../../toolbar/root/ToolbarRootContext';
 import { getDisabledMountTransitionStyles } from '../../utils/getDisabledMountTransitionStyles';
@@ -45,7 +39,6 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
 
   const positioner = usePopoverPositionerContext();
   const insideToolbar = useToolbarRootContext(true) != null;
-  const direction = useDirection();
 
   const open = store.useState('open');
   const openMethod = store.useState('openMethod');
@@ -57,9 +50,6 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
   const modal = store.useState('modal');
   const mounted = store.useState('mounted');
   const openReason = store.useState('openChangeReason');
-  const popupElement = store.useState('popupElement');
-  const payload = store.useState('payload');
-  const positionerElement = store.useState('positionerElement');
   const activeTriggerElement = store.useState('activeTriggerElement');
   const floatingContext = store.useState('floatingRootContext');
 
@@ -108,39 +98,6 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
     },
     [store],
   );
-
-  function handleMeasureLayout() {
-    floatingContext.context.events.emit('measure-layout');
-  }
-
-  function handleMeasureLayoutComplete(
-    previousDimensions: Dimensions | null,
-    nextDimensions: Dimensions,
-  ) {
-    floatingContext.context.events.emit('measure-layout-complete', {
-      previousDimensions,
-      nextDimensions,
-    });
-  }
-
-  // If there's just one trigger, we can skip the auto-resize logic as
-  // the popover will always be anchored to the same position.
-  const autoresizeEnabled = React.useCallback(
-    () => store.context.triggerElements.size > 1,
-    [store],
-  );
-
-  usePopupAutoResize({
-    popupElement,
-    positionerElement,
-    mounted,
-    content: payload,
-    enabled: autoresizeEnabled,
-    onMeasureLayout: handleMeasureLayout,
-    onMeasureLayoutComplete: handleMeasureLayoutComplete,
-    side: positioner.side,
-    direction,
-  });
 
   const element = useRenderElement('div', componentProps, {
     state,

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -58,6 +58,7 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
   const positionerElement = store.useState('positionerElement');
   const instantType = store.useState('instantType');
   const transitionStatus = store.useState('transitionStatus');
+  const hasViewport = store.useState('hasViewport');
 
   const prevTriggerElementRef = React.useRef<Element | null>(null);
 
@@ -80,7 +81,7 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     keepMounted,
     nodeId,
     collisionAvoidance,
-    adaptiveOrigin,
+    adaptiveOrigin: hasViewport ? adaptiveOrigin : undefined,
   });
 
   const defaultProps: HTMLProps = React.useMemo(() => {

--- a/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
@@ -430,16 +430,18 @@ describe('<Popover.Root />', () => {
       expect(screen.getByTestId('content').textContent).to.equal('1');
 
       await waitFor(() => {
-        expect(screen.getByTestId('positioner').getBoundingClientRect().left).to.equal(
+        expect(screen.getByTestId('positioner').getBoundingClientRect().left).to.be.closeTo(
           trigger1.getBoundingClientRect().left,
+          1,
         );
       });
 
       await user.click(screen.getByRole('button', { name: 'Open Trigger 2' }));
       expect(screen.getByTestId('content').textContent).to.equal('2');
       await waitFor(() => {
-        expect(screen.getByTestId('positioner').getBoundingClientRect().left).to.equal(
+        expect(screen.getByTestId('positioner').getBoundingClientRect().left).to.be.closeTo(
           trigger2.getBoundingClientRect().left,
+          1,
         );
       });
 

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -30,6 +30,7 @@ export type State<Payload> = PopupStoreState<Payload> & {
   descriptionElementId: string | undefined;
   openOnHover: boolean;
   closeDelay: number;
+  hasViewport: boolean;
 };
 
 type Context = PopupStoreContext<PopoverRoot.ChangeEventDetails> & {
@@ -55,6 +56,7 @@ function createInitialState<Payload>(): State<Payload> {
     nested: false,
     openOnHover: false,
     closeDelay: 0,
+    hasViewport: false,
   };
 }
 
@@ -70,6 +72,7 @@ const selectors = {
   descriptionElementId: createSelector((state: State<unknown>) => state.descriptionElementId),
   openOnHover: createSelector((state: State<unknown>) => state.openOnHover),
   closeDelay: createSelector((state: State<unknown>) => state.closeDelay),
+  hasViewport: createSelector((state: State<unknown>) => state.hasViewport),
 };
 
 export class PopoverStore<Payload> extends ReactStore<

--- a/packages/react/src/popover/viewport/PopoverViewport.tsx
+++ b/packages/react/src/popover/viewport/PopoverViewport.tsx
@@ -6,12 +6,15 @@ import { usePreviousValue } from '@base-ui/utils/usePreviousValue';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { usePopoverRootContext } from '../root/PopoverRootContext';
+import { usePopoverPositionerContext } from '../positioner/PopoverPositionerContext';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
+import { usePopupAutoResize } from '../../utils/usePopupAutoResize';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { StateAttributesMapping } from '../../utils/getStateAttributesProps';
 import { Dimensions } from '../../floating-ui-react/types';
 import { PopoverViewportCssVars } from './PopoverViewportCssVars';
+import { useDirection } from '../../direction-provider/DirectionContext';
 
 const stateAttributesMapping: StateAttributesMapping<PopoverViewport.State> = {
   activationDirection: (value) =>
@@ -36,10 +39,15 @@ export const PopoverViewport = React.forwardRef(function PopoverViewport(
 ) {
   const { render, className, children, ...elementProps } = componentProps;
   const { store } = usePopoverRootContext();
+  const positioner = usePopoverPositionerContext();
+  const direction = useDirection();
 
   const activeTrigger = store.useState('activeTriggerElement');
   const open = store.useState('open');
-  const floatingContext = store.useState('floatingRootContext');
+  const mounted = store.useState('mounted');
+  const payload = store.useState('payload');
+  const popupElement = store.useState('popupElement');
+  const positionerElement = store.useState('positionerElement');
 
   const previousActiveTrigger = usePreviousValue(open ? activeTrigger : null);
 
@@ -60,6 +68,13 @@ export const PopoverViewport = React.forwardRef(function PopoverViewport(
   } | null>(null);
 
   const [showStartingStyleAttribute, setShowStartingStyleAttribute] = React.useState(false);
+
+  useIsoLayoutEffect(() => {
+    store.set('hasViewport', true);
+    return () => {
+      store.set('hasViewport', false);
+    };
+  }, [store]);
 
   // Capture a clone of the current content DOM subtree when not transitioning.
   // We can't store previous React nodes as they may be stateful; instead we capture DOM clones for visual continuity.
@@ -90,31 +105,16 @@ export const PopoverViewport = React.forwardRef(function PopoverViewport(
     previousContainerRef.current?.style.setProperty('display', 'none');
   });
 
-  type MeasureLayoutCompleteData = {
-    previousDimensions: Dimensions | null;
-    nextDimensions: Dimensions;
-  };
-
-  const handleMeasureLayoutComplete = useStableCallback((data: MeasureLayoutCompleteData) => {
+  const handleMeasureLayoutComplete = useStableCallback((previousDimensions: Dimensions | null) => {
     currentContainerRef.current?.style.removeProperty('animation');
     currentContainerRef.current?.style.removeProperty('transition');
 
     previousContainerRef.current?.style.removeProperty('display');
 
-    if (data.previousDimensions) {
-      setPreviousContentDimensions(data.previousDimensions);
+    if (previousDimensions) {
+      setPreviousContentDimensions(previousDimensions);
     }
   });
-
-  React.useEffect(() => {
-    floatingContext.context.events.on('measure-layout', handleMeasureLayout);
-    floatingContext.context.events.on('measure-layout-complete', handleMeasureLayoutComplete);
-
-    return () => {
-      floatingContext.context.events.off('measure-layout', handleMeasureLayout);
-      floatingContext.context.events.off('measure-layout-complete', handleMeasureLayoutComplete);
-    };
-  }, [floatingContext, handleMeasureLayout, handleMeasureLayoutComplete]);
 
   const lastHandledTriggerRef = React.useRef<Element | null>(null);
 
@@ -203,6 +203,17 @@ export const PopoverViewport = React.forwardRef(function PopoverViewport(
 
     container.replaceChildren(...Array.from(previousContentNode.childNodes));
   }, [previousContentNode]);
+
+  usePopupAutoResize({
+    popupElement,
+    positionerElement,
+    mounted,
+    content: payload,
+    onMeasureLayout: handleMeasureLayout,
+    onMeasureLayoutComplete: handleMeasureLayoutComplete,
+    side: positioner.side,
+    direction,
+  });
 
   const state = React.useMemo(() => {
     return {

--- a/packages/react/src/tooltip/popup/TooltipPopup.tsx
+++ b/packages/react/src/tooltip/popup/TooltipPopup.tsx
@@ -10,10 +10,8 @@ import type { TransitionStatus } from '../../utils/useTransitionStatus';
 import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useRenderElement } from '../../utils/useRenderElement';
-import { usePopupAutoResize } from '../../utils/usePopupAutoResize';
 import { getDisabledMountTransitionStyles } from '../../utils/getDisabledMountTransitionStyles';
 import { useHoverFloatingInteraction } from '../../floating-ui-react';
-import { useDirection } from '../../direction-provider';
 
 const stateAttributesMapping: StateAttributesMapping<TooltipPopup.State> = {
   ...baseMapping,
@@ -36,15 +34,10 @@ export const TooltipPopup = React.forwardRef(function TooltipPopup(
   const { side, align } = useTooltipPositionerContext();
 
   const open = store.useState('open');
-  const mounted = store.useState('mounted');
   const instantType = store.useState('instantType');
   const transitionStatus = store.useState('transitionStatus');
   const popupProps = store.useState('popupProps');
-  const payload = store.useState('payload');
-  const popupElement = store.useState('popupElement');
-  const positionerElement = store.useState('positionerElement');
   const floatingContext = store.useState('floatingRootContext');
-  const direction = useDirection();
 
   useOpenChangeComplete({
     open,
@@ -54,39 +47,6 @@ export const TooltipPopup = React.forwardRef(function TooltipPopup(
         store.context.onOpenChangeComplete?.(true);
       }
     },
-  });
-
-  function handleMeasureLayout() {
-    floatingContext.context.events.emit('measure-layout');
-  }
-
-  function handleMeasureLayoutComplete(
-    previousDimensions: { width: number; height: number } | null,
-    nextDimensions: { width: number; height: number },
-  ) {
-    floatingContext.context.events.emit('measure-layout-complete', {
-      previousDimensions,
-      nextDimensions,
-    });
-  }
-
-  // If there's just one trigger, we can skip the auto-resize logic as
-  // the tooltip will always be anchored to the same position.
-  const autoresizeEnabled = React.useCallback(
-    () => store.context.triggerElements.size > 1,
-    [store],
-  );
-
-  usePopupAutoResize({
-    popupElement,
-    positionerElement,
-    mounted,
-    content: payload,
-    enabled: autoresizeEnabled,
-    onMeasureLayout: handleMeasureLayout,
-    onMeasureLayoutComplete: handleMeasureLayoutComplete,
-    side,
-    direction,
   });
 
   const disabled = store.useState('disabled');

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { screen } from '@mui/internal-test-utils';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -48,8 +48,10 @@ describe('<Tooltip.Positioner />', () => {
         </Tooltip.Root>,
       );
 
-      expect(screen.getByTestId('positioner').style.left).to.equal(`${baselineX}px`);
-      expect(screen.getByTestId('positioner').style.top).to.equal(`${baselineY + sideOffset}px`);
+      expect(screen.getByTestId('positioner').getBoundingClientRect()).to.include({
+        x: baselineX,
+        y: baselineY + sideOffset,
+      });
     });
 
     it('offsets the side when a function is specified', async () => {
@@ -67,10 +69,10 @@ describe('<Tooltip.Positioner />', () => {
         </Tooltip.Root>,
       );
 
-      expect(screen.getByTestId('positioner').style.left).to.equal(`${baselineX}px`);
-      expect(screen.getByTestId('positioner').style.top).to.equal(
-        `${baselineY + popupWidth + anchorWidth}px`,
-      );
+      expect(screen.getByTestId('positioner').getBoundingClientRect()).to.include({
+        x: baselineX,
+        y: baselineY + popupWidth + anchorWidth,
+      });
     });
 
     it('can read the latest side inside sideOffset', async () => {
@@ -161,8 +163,10 @@ describe('<Tooltip.Positioner />', () => {
         </Tooltip.Root>,
       );
 
-      expect(screen.getByTestId('positioner').style.left).to.equal(`${baselineX + alignOffset}px`);
-      expect(screen.getByTestId('positioner').style.top).to.equal(`${baselineY}px`);
+      expect(screen.getByTestId('positioner').getBoundingClientRect()).to.include({
+        x: baselineX + alignOffset,
+        y: baselineY,
+      });
     });
 
     it('offsets the align when a function is specified', async () => {
@@ -180,8 +184,10 @@ describe('<Tooltip.Positioner />', () => {
         </Tooltip.Root>,
       );
 
-      expect(screen.getByTestId('positioner').style.left).to.equal(`${baselineX + popupWidth}px`);
-      expect(screen.getByTestId('positioner').style.top).to.equal(`${baselineY}px`);
+      expect(screen.getByTestId('positioner').getBoundingClientRect()).to.include({
+        x: baselineX + popupWidth,
+        y: baselineY,
+      });
     });
 
     it('can read the latest side inside alignOffset', async () => {
@@ -255,6 +261,42 @@ describe('<Tooltip.Positioner />', () => {
 
       // correctly flips the side in the browser
       expect(side).to.equal('inline-end');
+    });
+  });
+
+  it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
+    await render(
+      <Tooltip.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Positioner data-testid="positioner">
+            <Tooltip.Popup style={popupStyle}>Popup</Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>,
+    );
+
+    const positioner = screen.getByTestId('positioner');
+    expect(positioner.style.transform).not.to.equal('');
+  });
+
+  it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
+    await render(
+      <Tooltip.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Positioner data-testid="positioner">
+            <Tooltip.Popup style={popupStyle}>
+              <Tooltip.Viewport>Popup</Tooltip.Viewport>
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>,
+    );
+
+    const positioner = screen.getByTestId('positioner');
+    await waitFor(() => {
+      expect(positioner.style.transform).to.equal('');
     });
   });
 });

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
@@ -49,6 +49,7 @@ export const TooltipPositioner = React.forwardRef(function TooltipPositioner(
   const floatingRootContext = store.useState('floatingRootContext');
   const instantType = store.useState('instantType');
   const transitionStatus = store.useState('transitionStatus');
+  const hasViewport = store.useState('hasViewport');
 
   const positioning = useAnchorPositioning({
     anchor,
@@ -66,7 +67,7 @@ export const TooltipPositioner = React.forwardRef(function TooltipPositioner(
     disableAnchorTracking,
     keepMounted,
     collisionAvoidance,
-    adaptiveOrigin,
+    adaptiveOrigin: hasViewport ? adaptiveOrigin : undefined,
   });
 
   const defaultProps: HTMLProps = React.useMemo(() => {

--- a/packages/react/src/tooltip/store/TooltipStore.ts
+++ b/packages/react/src/tooltip/store/TooltipStore.ts
@@ -21,6 +21,7 @@ export type State<Payload> = PopupStoreState<Payload> & {
   disableHoverablePopup: boolean;
   openChangeReason: TooltipRoot.ChangeEventReason | null;
   closeDelay: number;
+  hasViewport: boolean;
 };
 
 export type Context = PopupStoreContext<TooltipRoot.ChangeEventDetails> & {
@@ -36,6 +37,7 @@ const selectors = {
   disableHoverablePopup: createSelector((state: State<unknown>) => state.disableHoverablePopup),
   lastOpenChangeReason: createSelector((state: State<unknown>) => state.openChangeReason),
   closeDelay: createSelector((state: State<unknown>) => state.closeDelay),
+  hasViewport: createSelector((state: State<unknown>) => state.hasViewport),
 };
 
 export class TooltipStore<Payload> extends ReactStore<
@@ -142,5 +144,6 @@ function createInitialState<Payload>(): State<Payload> {
     disableHoverablePopup: false,
     openChangeReason: null,
     closeDelay: 0,
+    hasViewport: false,
   };
 }

--- a/packages/react/src/tooltip/viewport/TooltipViewport.tsx
+++ b/packages/react/src/tooltip/viewport/TooltipViewport.tsx
@@ -6,12 +6,15 @@ import { usePreviousValue } from '@base-ui/utils/usePreviousValue';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useTooltipRootContext } from '../root/TooltipRootContext';
+import { useTooltipPositionerContext } from '../positioner/TooltipPositionerContext';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useAnimationsFinished } from '../../utils/useAnimationsFinished';
+import { usePopupAutoResize } from '../../utils/usePopupAutoResize';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { StateAttributesMapping } from '../../utils/getStateAttributesProps';
 import { Dimensions } from '../../floating-ui-react/types';
 import { TooltipViewportCssVars } from './TooltipViewportCssVars';
+import { useDirection } from '../../direction-provider';
 
 const stateAttributesMapping: StateAttributesMapping<TooltipViewport.State> = {
   activationDirection: (value) =>
@@ -36,11 +39,16 @@ export const TooltipViewport = React.forwardRef(function TooltipViewport(
 ) {
   const { render, className, children, ...elementProps } = componentProps;
   const store = useTooltipRootContext();
+  const positioner = useTooltipPositionerContext();
+  const direction = useDirection();
 
   const activeTrigger = store.useState('activeTriggerElement');
   const open = store.useState('open');
-  const floatingContext = store.useState('floatingRootContext');
   const instantType = store.useState('instantType');
+  const mounted = store.useState('mounted');
+  const payload = store.useState('payload');
+  const popupElement = store.useState('popupElement');
+  const positionerElement = store.useState('positionerElement');
 
   const previousActiveTrigger = usePreviousValue(open ? activeTrigger : null);
 
@@ -62,6 +70,13 @@ export const TooltipViewport = React.forwardRef(function TooltipViewport(
 
   const [showStartingStyleAttribute, setShowStartingStyleAttribute] = React.useState(false);
 
+  useIsoLayoutEffect(() => {
+    store.set('hasViewport', true);
+    return () => {
+      store.set('hasViewport', false);
+    };
+  }, [store]);
+
   const handleMeasureLayout = useStableCallback(() => {
     currentContainerRef.current?.style.setProperty('animation', 'none');
     currentContainerRef.current?.style.setProperty('transition', 'none');
@@ -69,31 +84,16 @@ export const TooltipViewport = React.forwardRef(function TooltipViewport(
     previousContainerRef.current?.style.setProperty('display', 'none');
   });
 
-  type MeasureLayoutCompleteData = {
-    previousDimensions: Dimensions | null;
-    nextDimensions: Dimensions;
-  };
-
-  const handleMeasureLayoutComplete = useStableCallback((data: MeasureLayoutCompleteData) => {
+  const handleMeasureLayoutComplete = useStableCallback((previousDimensions: Dimensions | null) => {
     currentContainerRef.current?.style.removeProperty('animation');
     currentContainerRef.current?.style.removeProperty('transition');
 
     previousContainerRef.current?.style.removeProperty('display');
 
-    if (data.previousDimensions) {
-      setPreviousContentDimensions(data.previousDimensions);
+    if (previousDimensions) {
+      setPreviousContentDimensions(previousDimensions);
     }
   });
-
-  React.useEffect(() => {
-    floatingContext.context.events.on('measure-layout', handleMeasureLayout);
-    floatingContext.context.events.on('measure-layout-complete', handleMeasureLayoutComplete);
-
-    return () => {
-      floatingContext.context.events.off('measure-layout', handleMeasureLayout);
-      floatingContext.context.events.off('measure-layout-complete', handleMeasureLayoutComplete);
-    };
-  }, [floatingContext, handleMeasureLayout, handleMeasureLayoutComplete]);
 
   const lastHandledTriggerRef = React.useRef<Element | null>(null);
 
@@ -204,6 +204,17 @@ export const TooltipViewport = React.forwardRef(function TooltipViewport(
 
     container.replaceChildren(...Array.from(previousContentNode.childNodes));
   }, [previousContentNode]);
+
+  usePopupAutoResize({
+    popupElement,
+    positionerElement,
+    mounted,
+    content: payload,
+    onMeasureLayout: handleMeasureLayout,
+    onMeasureLayoutComplete: handleMeasureLayoutComplete,
+    side: positioner.side,
+    direction,
+  });
 
   const state = React.useMemo(() => {
     return {


### PR DESCRIPTION
- Moves `usePopupAutoResize()` into `Viewport` part for treeshaking when it's not being used.
- Ensures `translate()` positioning is used instead of `top`/`left` if the `Viewport` part is missing. This should solve things like this https://x.com/sajadevo_/status/2004063902636945842 (I have no way to verify though) because it rounds to the device's subpixel grid instead of being totally unrounded. This also ensures you can use detached triggers without needing to specify `--popup-width/--positioner-width` etc. variables as it's explicitly opt-in.
