### PR TITLE
[menu][popover][combobox] Fix focus guard handling

### DIFF
--- a/docs/src/app/(private)/experiments/popup-tabbing.tsx
+++ b/docs/src/app/(private)/experiments/popup-tabbing.tsx
@@ -1,0 +1,321 @@
+'use client';
+import * as React from 'react';
+import { Combobox } from '@base-ui/react/combobox';
+import { Menu } from '@base-ui/react/menu';
+import { Popover } from '@base-ui/react/popover';
+import { Switch } from '@base-ui/react/switch';
+
+function ExampleMenu() {
+  return (
+    <Menu.Root>
+      <Menu.Trigger
+        openOnHover
+        className="flex h-10 items-center justify-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100 data-[popup-open]:bg-gray-100"
+      >
+        Song <ChevronDownIcon className="-mr-1" />
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner className="outline-none" sideOffset={8}>
+          <Menu.Popup className="origin-[var(--transform-origin)] rounded-md bg-[canvas] py-1 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300">
+            <Menu.Arrow className="data-[side=bottom]:top-[-8px] data-[side=left]:right-[-13px] data-[side=left]:rotate-90 data-[side=right]:left-[-13px] data-[side=right]:-rotate-90 data-[side=top]:bottom-[-8px] data-[side=top]:rotate-180">
+              <ArrowSvg />
+            </Menu.Arrow>
+            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+              Add to Library
+            </Menu.Item>
+            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+              Add to Playlist
+            </Menu.Item>
+            <Menu.Separator className="mx-4 my-1.5 h-px bg-gray-200" />
+            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+              Play Next
+            </Menu.Item>
+            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+              Play Last
+            </Menu.Item>
+            <Menu.Separator className="mx-4 my-1.5 h-px bg-gray-200" />
+            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+              Favorite
+            </Menu.Item>
+            <Menu.Item className="flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900">
+              Share
+            </Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}
+
+function ExamplePopoverInPopover() {
+  return (
+    <Popover.Root>
+      <Popover.Trigger className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800">
+        Inner popover
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner sideOffset={8}>
+          <Popover.Popup className="origin-[var(--transform-origin)] w-72 rounded-lg bg-[canvas] p-4 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0">
+            <div className="text-sm font-medium">Inner content</div>
+            <div className="mt-1 text-sm text-gray-600">Try Tab / Shift+Tab out of here.</div>
+            <button
+              type="button"
+              className="mt-3 inline-flex h-9 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3 text-sm font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+            >
+              Inner button
+            </button>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+const fruits = ['Apple', 'Banana', 'Orange', 'Grape', 'Mango', 'Strawberry'];
+
+function ExampleCombobox() {
+  const id = React.useId();
+
+  return (
+    <Combobox.Root items={fruits}>
+      <div className="relative flex flex-col gap-1 text-sm leading-5 font-medium text-gray-900">
+        <label htmlFor={id}>Choose a fruit</label>
+        <div className="relative">
+          <Combobox.Input
+            placeholder="e.g. Apple"
+            id={id}
+            className="h-10 w-64 rounded-md font-normal border border-gray-200 pl-3.5 pr-[calc(0.5rem+1.5rem)] text-base text-gray-900 bg-[canvas] focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800"
+          />
+          <div className="absolute right-2 bottom-0 flex h-10 items-center justify-center text-gray-600">
+            <Combobox.Trigger
+              className="flex h-10 w-6 items-center justify-center rounded bg-transparent p-0"
+              aria-label="Open popup"
+            >
+              <ChevronDownIcon className="size-4" />
+            </Combobox.Trigger>
+          </div>
+        </div>
+      </div>
+
+      <Combobox.Portal>
+        <Combobox.Positioner className="outline-none" sideOffset={4}>
+          <Combobox.Popup className="w-[var(--anchor-width)] max-h-[min(var(--available-height),23rem)] max-w-[var(--available-width)] origin-[var(--transform-origin)] overflow-y-auto scroll-pt-2 scroll-pb-2 overscroll-contain rounded-md bg-[canvas] py-2 text-gray-900 shadow-lg shadow-gray-200 outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 dark:shadow-none dark:-outline-offset-1 dark:outline-gray-300">
+            <Combobox.Empty className="px-4 py-2 text-[0.925rem] leading-4 text-gray-600 empty:m-0 empty:p-0">
+              No fruits found.
+            </Combobox.Empty>
+            <Combobox.List>
+              {(item: string) => (
+                <Combobox.Item
+                  key={item}
+                  value={item}
+                  className="flex cursor-default py-2 pr-8 pl-4 text-base leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-2 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900"
+                >
+                  {item}
+                </Combobox.Item>
+              )}
+            </Combobox.List>
+          </Combobox.Popup>
+        </Combobox.Positioner>
+      </Combobox.Portal>
+    </Combobox.Root>
+  );
+}
+
+export default function PopupTabbing() {
+  const [renderInsideButtons, setRenderInsideButtons] = React.useState(true);
+
+  return (
+    <div className="p-6">
+      <h1 className="text-lg font-semibold text-gray-900">popup-tabbing</h1>
+      <p className="mt-1 text-sm text-gray-600">
+        Repros for tab order and focus handoff between nested popups.
+      </p>
+
+      <label className="mt-4 flex items-center gap-2 text-sm font-medium text-gray-900">
+        <Switch.Root
+          checked={renderInsideButtons}
+          onCheckedChange={setRenderInsideButtons}
+          className="relative flex h-5 w-9 rounded-full bg-gray-200 p-px outline outline-1 -outline-offset-1 outline-gray-300 transition-colors focus-visible:outline-2 focus-visible:outline-blue-800 data-[checked]:bg-gray-900 data-[checked]:outline-gray-900"
+        >
+          <Switch.Thumb className="h-full aspect-square rounded-full bg-white transition-transform data-[checked]:translate-x-4" />
+        </Switch.Root>
+        Render inside before/after buttons
+      </label>
+
+      <div className="mt-6 space-y-10">
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold text-gray-900">Combobox inside Popover</h2>
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+            >
+              Outside before
+            </button>
+
+            <Popover.Root>
+              <Popover.Trigger className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800">
+                Outer popover
+              </Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Positioner sideOffset={8}>
+                  <Popover.Popup className="origin-[var(--transform-origin)] flex flex-col gap-3 rounded-lg bg-[canvas] p-4 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0">
+                    {renderInsideButtons ? (
+                      <button
+                        type="button"
+                        className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+                      >
+                        Inside before
+                      </button>
+                    ) : null}
+
+                    <ExampleCombobox />
+
+                    {renderInsideButtons ? (
+                      <button
+                        type="button"
+                        className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+                      >
+                        Inside after
+                      </button>
+                    ) : null}
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
+
+            <button
+              type="button"
+              className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+            >
+              Outside after
+            </button>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold text-gray-900">Menu inside Popover</h2>
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+            >
+              Outside before
+            </button>
+
+            <Popover.Root>
+              <Popover.Trigger className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800">
+                Outer popover
+              </Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Positioner sideOffset={8}>
+                  <Popover.Popup className="origin-[var(--transform-origin)] flex items-center gap-3 rounded-lg bg-[canvas] p-4 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0">
+                    {renderInsideButtons ? (
+                      <button
+                        type="button"
+                        className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+                      >
+                        Inside before
+                      </button>
+                    ) : null}
+                    <ExampleMenu />
+                    {renderInsideButtons ? (
+                      <button
+                        type="button"
+                        className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+                      >
+                        Inside after
+                      </button>
+                    ) : null}
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
+
+            <button
+              type="button"
+              className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+            >
+              Outside after
+            </button>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold text-gray-900">Popover inside Popover</h2>
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+            >
+              Outside before
+            </button>
+
+            <Popover.Root>
+              <Popover.Trigger className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800">
+                Outer popover
+              </Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Positioner sideOffset={8}>
+                  <Popover.Popup className="origin-[var(--transform-origin)] flex flex-col gap-3 rounded-lg bg-[canvas] p-4 text-gray-900 shadow-lg shadow-gray-200 outline outline-1 outline-gray-200 transition-[transform,scale,opacity] data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0">
+                    {renderInsideButtons ? (
+                      <button
+                        type="button"
+                        className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+                      >
+                        Inside before
+                      </button>
+                    ) : null}
+                    <ExamplePopoverInPopover />
+                    {renderInsideButtons ? (
+                      <button
+                        type="button"
+                        className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+                      >
+                        Inside after
+                      </button>
+                    ) : null}
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
+
+            <button
+              type="button"
+              className="inline-flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800"
+            >
+              Outside after
+            </button>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function ArrowSvg(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg width="20" height="10" viewBox="0 0 20 10" fill="none" {...props}>
+      <path
+        d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
+        className="fill-[canvas]"
+      />
+      <path
+        d="M8.99542 1.85876C9.75604 1.17425 10.9106 1.17422 11.6713 1.85878L16.5281 6.22989C17.0789 6.72568 17.7938 7.00001 18.5349 7.00001L15.89 7L11.0023 2.60207C10.622 2.2598 10.0447 2.2598 9.66436 2.60207L4.77734 7L2.13171 7.00001C2.87284 7.00001 3.58774 6.72568 4.13861 6.22989L8.99542 1.85876Z"
+        className="fill-gray-200 dark:fill-none"
+      />
+      <path
+        d="M10.3333 3.34539L5.47654 7.71648C4.55842 8.54279 3.36693 9 2.13172 9H0V8H2.13172C3.11989 8 4.07308 7.63423 4.80758 6.97318L9.66437 2.60207C10.0447 2.25979 10.622 2.2598 11.0023 2.60207L15.8591 6.97318C16.5936 7.63423 17.5468 8 18.5349 8H20V9H18.5349C17.2998 9 16.1083 8.54278 15.1901 7.71648L10.3333 3.34539Z"
+        className="dark:fill-gray-300"
+      />
+    </svg>
+  );
+}
+
+function ChevronDownIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" {...props}>
+      <path d="M1 3.5L5 7.5L9 3.5" stroke="currentcolor" strokeWidth="1.5" />
+    </svg>
+  );
+}

--- a/packages/react/src/combobox/popup/ComboboxPopup.tsx
+++ b/packages/react/src/combobox/popup/ComboboxPopup.tsx
@@ -47,6 +47,7 @@ export const ComboboxPopup = React.forwardRef(function ComboboxPopup(
   const transitionStatus = useStore(store, selectors.transitionStatus);
   const inputInsidePopup = useStore(store, selectors.inputInsidePopup);
   const inputElement = useStore(store, selectors.inputElement);
+  const modal = useStore(store, selectors.modal);
 
   const empty = filteredItems.length === 0;
 
@@ -117,7 +118,7 @@ export const ComboboxPopup = React.forwardRef(function ComboboxPopup(
     <FloatingFocusManager
       context={floatingRootContext}
       disabled={!mounted}
-      modal={!inputInsidePopup}
+      modal={inputInsidePopup ? modal : false}
       openInteractionType={openMethod}
       initialFocus={resolvedInitialFocus}
       returnFocus={resolvedFinalFocus}

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -193,7 +193,7 @@ export const FloatingPortal = React.forwardRef(function FloatingPortal(
     // portal has already been focused, either by tabbing into a focus trap
     // element outside or using the mouse.
     function onFocus(event: FocusEvent) {
-      if (portalNode && isOutsideEvent(event)) {
+      if (portalNode && event.relatedTarget && isOutsideEvent(event)) {
         const focusing = event.type === 'focusin';
         const manageFocus = focusing ? enableFocusInside : disableFocusInside;
         manageFocus(portalNode);

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -207,7 +207,7 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
   });
 
   const focus = useFocus(floatingRootContext, {
-    enabled: !disabled && ((!isInMenubar && isOpenedByThisTrigger) || parentMenubarHasSubmenuOpen),
+    enabled: !disabled && parentMenubarHasSubmenuOpen,
   });
 
   const mixedToggleHandlers = useMixedToggleClickHandler({
@@ -292,12 +292,11 @@ export const MenuTrigger = React.forwardRef(function MenuTrigger(
         );
       });
 
-      let nextTabbable = getTabbableAfterElement(triggerElementRef.current);
+      let nextTabbable = getTabbableAfterElement(
+        store.context.triggerFocusTargetRef.current || triggerElementRef.current,
+      );
 
-      while (
-        (nextTabbable !== null && contains(currentPositionerElement, nextTabbable)) ||
-        nextTabbable?.hasAttribute('aria-hidden')
-      ) {
+      while (nextTabbable !== null && contains(currentPositionerElement, nextTabbable)) {
         const prevTabbable = nextTabbable;
         nextTabbable = getNextTabbable(nextTabbable);
         if (nextTabbable === prevTabbable) {

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -460,6 +460,98 @@ describe('<Popover.Root />', () => {
           });
         });
 
+        it('closes a nested combobox popup when tabbing out of the popover', async () => {
+          const { user } = await render(
+            <div>
+              <TestPopover
+                rootProps={{ defaultOpen: true }}
+                portalProps={{ keepMounted: true }}
+                popupProps={{
+                  children: (
+                    <Combobox.Root items={['a', 'b']}>
+                      <Combobox.Input data-testid="combobox-input" />
+                      <Combobox.Portal>
+                        <Combobox.Positioner>
+                          <Combobox.Popup>
+                            <Combobox.List>
+                              <Combobox.Item value="a">a</Combobox.Item>
+                              <Combobox.Item value="b">b</Combobox.Item>
+                            </Combobox.List>
+                          </Combobox.Popup>
+                        </Combobox.Positioner>
+                      </Combobox.Portal>
+                    </Combobox.Root>
+                  ),
+                }}
+                afterTrigger={<input data-testid="focus-target" />}
+              />
+            </div>,
+          );
+
+          const comboboxInput = screen.getByTestId('combobox-input');
+          await user.click(comboboxInput);
+          await flushMicrotasks();
+
+          expect(screen.getByRole('listbox')).toBeVisible();
+
+          await user.tab();
+
+          expect(screen.getByTestId('focus-target')).toHaveFocus();
+
+          await waitFor(() => {
+            expect(screen.getByTestId('popover-popup')).to.have.attribute('data-closed');
+          });
+
+          await waitFor(() => {
+            expect(screen.queryByRole('listbox')).to.equal(null);
+          });
+        });
+
+        it('closes a nested combobox popup when tabbing backward to the trigger', async () => {
+          const { user } = await render(
+            <div>
+              <TestPopover
+                rootProps={{ defaultOpen: true }}
+                portalProps={{ keepMounted: true }}
+                popupProps={{
+                  children: (
+                    <Combobox.Root items={['a', 'b']}>
+                      <Combobox.Input data-testid="combobox-input" />
+                      <Combobox.Portal>
+                        <Combobox.Positioner>
+                          <Combobox.Popup>
+                            <Combobox.List>
+                              <Combobox.Item value="a">a</Combobox.Item>
+                              <Combobox.Item value="b">b</Combobox.Item>
+                            </Combobox.List>
+                          </Combobox.Popup>
+                        </Combobox.Positioner>
+                      </Combobox.Portal>
+                    </Combobox.Root>
+                  ),
+                }}
+              />
+            </div>,
+          );
+
+          const comboboxInput = screen.getByTestId('combobox-input');
+          await user.click(comboboxInput);
+          await flushMicrotasks();
+
+          expect(screen.getByRole('listbox')).toBeVisible();
+
+          const trigger = screen.getByTestId('trigger');
+          expect(trigger).not.to.have.attribute('aria-hidden', 'true');
+
+          await user.tab({ shift: true });
+
+          expect(screen.getByRole('button', { name: 'Toggle' })).toHaveFocus();
+
+          await waitFor(() => {
+            expect(screen.queryByRole('listbox')).to.equal(null);
+          });
+        });
+
         it.skipIf(isJSDOM)(
           'moves focus to the trigger when tabbing backward from the open popup then to the popup when tabbing forward',
           async () => {
@@ -711,6 +803,55 @@ describe('<Popover.Root />', () => {
 
         expect(screen.queryByRole('dialog')).to.equal(null);
       });
+
+      it.skipIf(isJSDOM)(
+        'moves focus to the next element when tabbing out of a nested menu inside the popover',
+        async () => {
+          const { user } = await render(
+            <div>
+              <TestPopover
+                rootProps={{ defaultOpen: true }}
+                portalProps={{ keepMounted: true }}
+                popupProps={{
+                  children: (
+                    <React.Fragment>
+                      <button type="button" data-testid="before">
+                        Before
+                      </button>
+                      <Menu.Root>
+                        <Menu.Trigger>Menu</Menu.Trigger>
+                        <Menu.Portal>
+                          <Menu.Positioner>
+                            <Menu.Popup>
+                              <Menu.Item>Item</Menu.Item>
+                            </Menu.Popup>
+                          </Menu.Positioner>
+                        </Menu.Portal>
+                      </Menu.Root>
+                      <button type="button" data-testid="after">
+                        After
+                      </button>
+                    </React.Fragment>
+                  ),
+                }}
+              />
+            </div>,
+          );
+
+          await user.click(screen.getByRole('button', { name: 'Menu' }));
+
+          const menu = await screen.findByRole('menu');
+          await waitFor(() => {
+            expect(menu).toHaveFocus();
+          });
+
+          await user.tab();
+
+          expect(screen.getByTestId('after')).toHaveFocus();
+          expect(screen.queryByRole('menu')).to.equal(null);
+          expect(screen.getByTestId('popover-popup')).toBeVisible();
+        },
+      );
     });
 
     describe.skipIf(isJSDOM)('pointerdown removal', () => {

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -187,12 +187,11 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
         );
       });
 
-      let nextTabbable = getTabbableAfterElement(triggerElementRef.current);
+      let nextTabbable = getTabbableAfterElement(
+        store.context.triggerFocusTargetRef.current || triggerElementRef.current,
+      );
 
-      while (
-        (nextTabbable !== null && contains(positionerElement, nextTabbable)) ||
-        nextTabbable?.hasAttribute('aria-hidden')
-      ) {
+      while (nextTabbable !== null && contains(positionerElement, nextTabbable)) {
         const prevTabbable = nextTabbable;
         nextTabbable = getNextTabbable(nextTabbable);
         if (nextTabbable === prevTabbable) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes a few issues with the focus guards:

- Tabbing out of a Popover gets stuck on the focus guard in Safari  (or moving virtual cursor out of a Popover on iOS)
- Tabbing out of a Menu inside a Popover incorrectly restores focus to the popover container instead of the next tabbable
- Tabbing out of a Combobox input whose popover is open should close the popup when focus lands on the Popover trigger (when it's the first tabbable element or the last one, when tabbing forward)

https://deploy-preview-3654--base-ui.netlify.app/experiments/popup-tabbing