### PR TITLE
[menu][popover] Fix not opening on hover after click open

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingRootStore.ts
+++ b/packages/react/src/floating-ui-react/components/FloatingRootStore.ts
@@ -77,6 +77,15 @@ export class FloatingRootStore extends ReactStore<
       },
       selectors,
     );
+
+    // The open event is used to determine the interaction type that opened the popup.
+    // When the `open` state changes externally (e.g. controlled mode, or a synced store),
+    // `setOpen` isn't called, so we need to ensure it doesn't become stale after close.
+    this.observe('open', (open, oldOpen) => {
+      if (!open && oldOpen) {
+        this.context.dataRef.current.openEvent = undefined;
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes `openEvent` not being cleared after external `open` updates

This is a post-v1 regression from [this change](https://github.com/mui/base-ui/pull/3572/changes#diff-434d723ae523348ea8b7f7eec9e191614b57dabba8cbaacf5cf6db01b2a2b767), marked as internal