### PR TITLE
[select] Fix default formating with Select multiple

### DIFF
--- a/packages/react/src/select/value/SelectValue.test.tsx
+++ b/packages/react/src/select/value/SelectValue.test.tsx
@@ -479,7 +479,7 @@ describe('<Select.Value />', () => {
         </Select.Root>,
       );
 
-      expect(screen.getByTestId('value')).to.have.text('sans, serif');
+      expect(screen.getByTestId('value')).to.have.text('Sans-serif, Serif');
     });
 
     it('displays comma-separated values for multiple values with items array', async () => {

--- a/packages/react/src/select/value/SelectValue.tsx
+++ b/packages/react/src/select/value/SelectValue.tsx
@@ -44,7 +44,7 @@ export const SelectValue = React.forwardRef(function SelectValue(
       ? childrenProp(value)
       : (childrenProp ??
         (Array.isArray(value)
-          ? resolveMultipleLabels(value, itemToStringLabel)
+          ? resolveMultipleLabels(value, items, itemToStringLabel)
           : resolveSelectedLabel(value, items, itemToStringLabel)));
 
   const element = useRenderElement('span', componentProps, {

--- a/packages/react/src/utils/resolveValueLabel.tsx
+++ b/packages/react/src/utils/resolveValueLabel.tsx
@@ -113,10 +113,11 @@ export function resolveSelectedLabel(
 
 export function resolveMultipleLabels(
   values: any[] | undefined,
+  items: ItemsInput,
   itemToStringLabel?: (item: any) => string,
 ): string {
   if (!Array.isArray(values) || values.length === 0) {
     return '';
   }
-  return values.map((v) => stringifyAsLabel(v, itemToStringLabel)).join(', ');
+  return values.map((value) => resolveSelectedLabel(value, items, itemToStringLabel)).join(', ');
 }


### PR DESCRIPTION
I was having a look at the [most upvotes issues](https://github.com/shadcn-ui/ui/issues?q=is%3Aissue%20state%3Aopen%20sort%3Areactions-%2B1-desc), and [most upvotes discussions](https://github.com/shadcn-ui/ui/discussions?discussions_q=is%3Aopen+sort%3Atop) of Shadcn UI. Leaving comments about the multi-select problem being a solved problem with Base UI, e.g., https://github.com/shadcn-ui/ui/issues/66#issuecomment-3708651206. But the default formatting seems buggy; at least, I don't expect adding `multiple` to change the way the default formatting behaves.

**Before**:
<img width="189" height="92" alt="SCR-20260105-dbfk" src="https://github.com/user-attachments/assets/f5b9eb01-e7d2-4503-955d-3aed3da45d04" />

**After**:
<img width="187" height="93" alt="SCR-20260105-dbhi" src="https://github.com/user-attachments/assets/5752d74b-848c-4336-a179-96423f6497cc" />

Relates to #3229.

----

**Off-topic**. While I was at it, I compared the two versions, Base UI and Radix, side by side:

<img width="507" height="191" alt="SCR-20260105-dalf" src="https://github.com/user-attachments/assets/302cba33-fef8-4bc8-b0b5-390d4a30cdb9" />

The only thing where we seem to have regressed is bundle size: https://www.notion.so/mui-org/2026-Shadcn-Radix-vs-Base-UI-demo-2dfcbfe7b6608090b851c5f6e1f60e95. Base UI seems to demand about +25kB gzipped more than Radix for the same features; I suspect most of it is unnecessary 🐳. Solving this could give an extra incentive for people to migrate.

Edit: moved to #3688