### PR TITLE
[docs-infra] Silence hydration errors at top level from plugins

### DIFF
--- a/docs/src/app/(docs)/layout.tsx
+++ b/docs/src/app/(docs)/layout.tsx
@@ -13,7 +13,7 @@ import './layout.css';
 export default function Layout({ children }: React.PropsWithChildren) {
   return (
     // Use suppressHydrationWarning to avoid https://github.com/facebook/react/issues/24430
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en">
       <head>
         <link
           rel="preload"
@@ -37,7 +37,7 @@ export default function Layout({ children }: React.PropsWithChildren) {
           crossOrigin="anonymous"
         />
       </head>
-      <body>
+      <body suppressHydrationWarning>
         <DocsProviders>
           <div className="RootLayout">
             <div className="RootLayoutContainer">

--- a/docs/src/app/(private)/layout.tsx
+++ b/docs/src/app/(private)/layout.tsx
@@ -6,7 +6,7 @@ import './layout.css';
 export default function Layout({ children }: React.PropsWithChildren) {
   return (
     // Use suppressHydrationWarning to avoid https://github.com/facebook/react/issues/24430
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en">
       <head>
         <link
           rel="preload"
@@ -30,7 +30,7 @@ export default function Layout({ children }: React.PropsWithChildren) {
           crossOrigin="anonymous"
         />
       </head>
-      <body>{children}</body>
+      <body suppressHydrationWarning>{children}</body>
     </html>
   );
 }

--- a/docs/src/app/(website)/layout.tsx
+++ b/docs/src/app/(website)/layout.tsx
@@ -8,8 +8,9 @@ import './css/index.css';
 
 export default function Layout({ children }: React.PropsWithChildren) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className="Body p-6 bp2:py-7 bp2:px-9">
+    // Use suppressHydrationWarning to avoid https://github.com/facebook/react/issues/24430
+    <html lang="en">
+      <body suppressHydrationWarning className="Body p-6 bp2:py-7 bp2:px-9">
         <div
           className="bs-bb d-g gtc-8 g-8 bp2:g-9"
           style={{ maxWidth: '1480px', marginInline: 'auto' }}


### PR DESCRIPTION
A v2 of #2433. I suspect that something changed in React since that PR, the logs https://github.com/facebook/react/releases.

The `suppressHydrationWarning` prop behaves more correctly now. Before, you could add suppressHydrationWarning to the `<html>`, and it would silence the error on the `<body>` too. Now, it behaves as the docs say, the prop only impacts the element it's applied to, and since the problem was always with the body, we can move the prop to that element.