### PR TITLE
[typescript] Fix CSS module resolution in TS@next

### DIFF
--- a/docs/types.d.ts
+++ b/docs/types.d.ts
@@ -7,9 +7,4 @@ declare module '*.mdx' {
   export default MDXComponent;
 }
 
-declare module '*.module.css' {
-  const classes: { readonly [key: string]: string };
-  export default classes;
-}
-
 declare module '*.css';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "allowImportingTsExtensions": true,
+    "noUncheckedSideEffectImports": true,
     "paths": {
       "@base-ui/react": ["./packages/react/src"],
       "@base-ui/react/*": ["./packages/react/src/*"],


### PR DESCRIPTION
In https://github.com/mui/base-ui/pull/3687 I missed one error - in TypeScript 6, CSS modules are not resolved correctly without an explicit module definition. TS 5 seems to pick up the module definition from Next.js, while 6.0, for some reason, doesn't. I copied the module definition from Next.js to our code.

To test it, I ran:

```sh
pnpm dlx @mui/internal-code-infra@canary set-version-overrides --pkg typescript@next
pnpm typescript
```

No errors were reported.
