### PR TITLE
[typescript] Fix type resolution in docs

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -30,6 +30,11 @@
         "name": "next"
       }
     ],
+    "paths": {
+      "@base-ui/react": ["../packages/react/src"],
+      "@base-ui/react/*": ["../packages/react/src/*"],
+      "@base-ui/utils/*": ["../packages/utils/src/*"]
+    },
     "strictNullChecks": true,
     "jsx": "preserve"
   },


### PR DESCRIPTION
After the removal of `baseUrl` in https://github.com/mui/base-ui/pull/3687, the docs app started behaving oddly - refusing to resolve modules that exist (to be precise - it failed on modules that were recently added, such as PreviewCard.createHandle in https://app.netlify.com/projects/base-ui/deploys/695e1ee9405d3100081196ce). It turns out that without `baseUrl`, `paths` point to incorrect locations (`tsc -p tsconfig.json --showConfig` for docs shows that paths are not transformed).

I opened an [issue](https://github.com/andrewbranch/ts5to6/issues/7) asking for clarification and assistance, but in the meantime, specifying the paths explicitly seems to fix the problem.