### PR TITLE
[dialog] Fix `Maximum update depth exceeded` error with Suspense

### DIFF
--- a/packages/react/src/dialog/portal/DialogPortal.test.tsx
+++ b/packages/react/src/dialog/portal/DialogPortal.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Dialog } from '@base-ui/react/dialog';
 import { createRenderer, describeConformance } from '#test-utils';
+import { expect } from 'vitest';
+import { screen } from '@mui/internal-test-utils';
 
 describe('<Dialog.Portal />', () => {
   const { render } = createRenderer();
@@ -11,4 +13,30 @@ describe('<Dialog.Portal />', () => {
       return render(<Dialog.Root open>{node}</Dialog.Root>);
     },
   }));
+
+  describe('Suspense integration', () => {
+    // Issue #3695
+    it('should not throw "Maximum update depth exceeded" when Suspense boundary is outside Portal', async () => {
+      const promise = Promise.resolve('Greetings');
+
+      function Message({ messagePromise }: { messagePromise: Promise<string> }) {
+        const value = React.use(messagePromise);
+        return <p>{value}</p>;
+      }
+
+      await render(
+        <React.Suspense fallback="Loading...">
+          <Dialog.Root open>
+            <Dialog.Portal>
+              <Dialog.Popup>
+                <Message messagePromise={promise} />
+              </Dialog.Popup>
+            </Dialog.Portal>
+          </Dialog.Root>
+        </React.Suspense>,
+      );
+
+      expect(screen.getByText('Greetings')).not.to.equal(null);
+    });
+  });
 });

--- a/packages/react/src/dialog/portal/DialogPortal.tsx
+++ b/packages/react/src/dialog/portal/DialogPortal.tsx
@@ -22,6 +22,7 @@ export const DialogPortal = React.forwardRef(function DialogPortal(
   const { store } = useDialogRootContext();
   const mounted = store.useState('mounted');
   const modal = store.useState('modal');
+  const open = store.useState('open');
 
   const shouldRender = mounted || keepMounted;
   if (!shouldRender) {

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -4,6 +4,7 @@ import * as ReactDOM from 'react-dom';
 import { isNode } from '@floating-ui/utils/dom';
 import { useId } from '@base-ui/utils/useId';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { FocusGuard } from '../../utils/FocusGuard';
 import {
   enableFocusInside,
@@ -72,6 +73,14 @@ export function useFloatingPortalNode(
     null,
   );
   const [portalNode, setPortalNode] = React.useState<HTMLElement | null>(null);
+  const setPortalNodeRef = useStableCallback((node: HTMLElement | null) => {
+    if (node !== null) {
+      // the useIsoLayoutEffect below watching containerProp / parentPortalNode
+      // sets setPortalNode(null) when the container becomes null or changes.
+      // So even though the ref callback now ignores null, the portal node still gets cleared.
+      setPortalNode(node);
+    }
+  });
 
   const containerRef = React.useRef<HTMLElement | ShadowRoot | null>(null);
 
@@ -113,7 +122,7 @@ export function useFloatingPortalNode(
   }, [containerProp, parentPortalNode, uniqueId]);
 
   const portalElement = useRenderElement('div', componentProps, {
-    ref: [ref, setPortalNode],
+    ref: [ref, setPortalNodeRef],
     state: elementState,
     props: [
       {


### PR DESCRIPTION
Adjusted the portal node ref handling in FloatingPortal to avoid state updates during ref cleanup, which prevents the Suspense hide/show loop while still clearing the portal node via container changes.

Also added a missing `open` state getter in DialogPortal.

Fixes #3695
