### PR TITLE
[internal] Iterate on resolveMultipleLabels in one loop

### DIFF
--- a/packages/react/src/utils/resolveValueLabel.tsx
+++ b/packages/react/src/utils/resolveValueLabel.tsx
@@ -116,16 +116,15 @@ export function resolveMultipleLabels(
   items: ItemsInput,
   itemToStringLabel?: (item: any) => string,
 ): React.ReactNode {
-  const labels = values.map((v) => resolveSelectedLabel(v, items, itemToStringLabel));
-
-  const nodes: React.ReactNode[] = [];
-
-  labels.forEach((label, index) => {
+  return values.reduce((acc, value, index) => {
     if (index > 0) {
-      nodes.push(', ');
+      acc.push(', ');
     }
-    nodes.push(<React.Fragment key={index}>{label}</React.Fragment>);
-  });
-
-  return nodes;
+    acc.push(
+      <React.Fragment key={index}>
+        {resolveSelectedLabel(value, items, itemToStringLabel)}
+      </React.Fragment>,
+    );
+    return acc;
+  }, []);
 }


### PR DESCRIPTION
Iterate on #3314.

Use a bit fewer byles:
<img width="376" height="84" alt="SCR-20260109-kxnx" src="https://github.com/user-attachments/assets/f368e6b2-d98f-4dc1-beb4-1b31d533474c" />

and fewer CPU cycles by moving from looping twice on the data to once. It's a classic performance win that Romain had a lot of success with on the data grid codebase.