### PR TITLE
[preview card] Fix `PreviewCardTrigger` updates delay refs on every render

### DIFF
--- a/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
+++ b/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
@@ -22,7 +22,7 @@ export const PreviewCardTrigger = React.forwardRef(function PreviewCardTrigger(
 
   useIsoLayoutEffect(() => {
     writeDelayRefs({ delay, closeDelay });
-  });
+  }, [writeDelayRefs, delay, closeDelay]);
 
   const state: PreviewCardTrigger.State = React.useMemo(() => ({ open }), [open]);
 


### PR DESCRIPTION
Noticed in #3182. Because there's no dependency array passed, this runs every render. This is just an improvement.