### PR TITLE
[dialog] Add iOS scroll lock elements to `Viewport` by default

### DIFF
--- a/docs/reference/generated/dialog-viewport.json
+++ b/docs/reference/generated/dialog-viewport.json
@@ -1,6 +1,6 @@
 {
   "name": "DialogViewport",
-  "description": "A positioning container for the dialog popup that can be made scrollable.\nRenders a `<div>` element.",
+  "description": "A positioning container for the dialog popup that can be made scrollable.\nThis part also robustly locks the scroll on iOS devices.\nRenders a `<div>` element.",
   "props": {
     "className": {
       "type": "string | ((state: Dialog.Viewport.State) => string | undefined)",

--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/_index.module.css
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/_index.module.css
@@ -60,12 +60,17 @@
   }
 }
 
+.Viewport {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1rem;
+}
+
 .Popup {
   box-sizing: border-box;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   width: 24rem;
   max-width: calc(100vw - 3rem);
   margin-top: -2rem;
@@ -83,7 +88,7 @@
   &[data-starting-style],
   &[data-ending-style] {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.9);
+    transform: scale(0.9);
   }
 }
 

--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/detached-triggers-controlled/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/detached-triggers-controlled/css-modules/index.tsx
@@ -67,20 +67,22 @@ export default function AlertDialogDetachedTriggersControlledDemo() {
         {({ payload }) => (
           <AlertDialog.Portal>
             <AlertDialog.Backdrop className={styles.Backdrop} />
-            <AlertDialog.Popup className={styles.Popup}>
-              <AlertDialog.Title className={styles.Title}>
-                {payload?.message ?? 'Are you sure?'}
-              </AlertDialog.Title>
-              <AlertDialog.Description className={styles.Description}>
-                This action cannot be undone.
-              </AlertDialog.Description>
-              <div className={styles.Actions}>
-                <AlertDialog.Close className={styles.Button}>Cancel</AlertDialog.Close>
-                <AlertDialog.Close className={`${styles.Button} ${styles.DangerButton}`}>
-                  Confirm
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
+            <AlertDialog.Viewport className={styles.Viewport}>
+              <AlertDialog.Popup className={styles.Popup}>
+                <AlertDialog.Title className={styles.Title}>
+                  {payload?.message ?? 'Are you sure?'}
+                </AlertDialog.Title>
+                <AlertDialog.Description className={styles.Description}>
+                  This action cannot be undone.
+                </AlertDialog.Description>
+                <div className={styles.Actions}>
+                  <AlertDialog.Close className={styles.Button}>Cancel</AlertDialog.Close>
+                  <AlertDialog.Close className={`${styles.Button} ${styles.DangerButton}`}>
+                    Confirm
+                  </AlertDialog.Close>
+                </div>
+              </AlertDialog.Popup>
+            </AlertDialog.Viewport>
           </AlertDialog.Portal>
         )}
       </AlertDialog.Root>

--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/detached-triggers-controlled/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/detached-triggers-controlled/tailwind/index.tsx
@@ -66,22 +66,24 @@ export default function AlertDialogDetachedTriggersControlledDemo() {
         {({ payload }) => (
           <AlertDialog.Portal>
             <AlertDialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-            <AlertDialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-              <AlertDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
-                {payload?.message ?? 'Are you sure?'}
-              </AlertDialog.Title>
-              <AlertDialog.Description className="mb-6 text-base text-gray-600">
-                This action cannot be undone.
-              </AlertDialog.Description>
-              <div className="flex justify-end gap-4">
-                <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-red-800 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                  Confirm
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
+            <AlertDialog.Viewport className="fixed inset-0 flex items-center justify-center px-4 py-10">
+              <AlertDialog.Popup className="-mt-8 w-96 max-w-[calc(100vw-3rem)] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+                <AlertDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
+                  {payload?.message ?? 'Are you sure?'}
+                </AlertDialog.Title>
+                <AlertDialog.Description className="mb-6 text-base text-gray-600">
+                  This action cannot be undone.
+                </AlertDialog.Description>
+                <div className="flex justify-end gap-4">
+                  <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                    Cancel
+                  </AlertDialog.Close>
+                  <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-red-800 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                    Confirm
+                  </AlertDialog.Close>
+                </div>
+              </AlertDialog.Popup>
+            </AlertDialog.Viewport>
           </AlertDialog.Portal>
         )}
       </AlertDialog.Root>

--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/detached-triggers-simple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/detached-triggers-simple/css-modules/index.tsx
@@ -18,18 +18,20 @@ export default function AlertDialogDetachedTriggersSimpleDemo() {
       <AlertDialog.Root handle={demoAlertDialog}>
         <AlertDialog.Portal>
           <AlertDialog.Backdrop className={styles.Backdrop} />
-          <AlertDialog.Popup className={styles.Popup}>
-            <AlertDialog.Title className={styles.Title}>Discard draft?</AlertDialog.Title>
-            <AlertDialog.Description className={styles.Description}>
-              This action cannot be undone.
-            </AlertDialog.Description>
-            <div className={styles.Actions}>
-              <AlertDialog.Close className={styles.Button}>Cancel</AlertDialog.Close>
-              <AlertDialog.Close className={`${styles.Button} ${styles.DangerButton}`}>
-                Discard
-              </AlertDialog.Close>
-            </div>
-          </AlertDialog.Popup>
+          <AlertDialog.Viewport className={styles.Viewport}>
+            <AlertDialog.Popup className={styles.Popup}>
+              <AlertDialog.Title className={styles.Title}>Discard draft?</AlertDialog.Title>
+              <AlertDialog.Description className={styles.Description}>
+                This action cannot be undone.
+              </AlertDialog.Description>
+              <div className={styles.Actions}>
+                <AlertDialog.Close className={styles.Button}>Cancel</AlertDialog.Close>
+                <AlertDialog.Close className={`${styles.Button} ${styles.DangerButton}`}>
+                  Discard
+                </AlertDialog.Close>
+              </div>
+            </AlertDialog.Popup>
+          </AlertDialog.Viewport>
         </AlertDialog.Portal>
       </AlertDialog.Root>
     </React.Fragment>

--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/detached-triggers-simple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/detached-triggers-simple/tailwind/index.tsx
@@ -17,22 +17,24 @@ export default function AlertDialogDetachedTriggersSimpleDemo() {
       <AlertDialog.Root handle={demoAlertDialog}>
         <AlertDialog.Portal>
           <AlertDialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-          <AlertDialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-            <AlertDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
-              Discard draft?
-            </AlertDialog.Title>
-            <AlertDialog.Description className="mb-6 text-base text-gray-600">
-              This action cannot be undone.
-            </AlertDialog.Description>
-            <div className="flex justify-end gap-4">
-              <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                Cancel
-              </AlertDialog.Close>
-              <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-red-800 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                Discard
-              </AlertDialog.Close>
-            </div>
-          </AlertDialog.Popup>
+          <AlertDialog.Viewport className="fixed inset-0 flex items-center justify-center px-4 py-10">
+            <AlertDialog.Popup className="-mt-8 w-96 max-w-[calc(100vw-3rem)] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+              <AlertDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
+                Discard draft?
+              </AlertDialog.Title>
+              <AlertDialog.Description className="mb-6 text-base text-gray-600">
+                This action cannot be undone.
+              </AlertDialog.Description>
+              <div className="flex justify-end gap-4">
+                <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                  Cancel
+                </AlertDialog.Close>
+                <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-red-800 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                  Discard
+                </AlertDialog.Close>
+              </div>
+            </AlertDialog.Popup>
+          </AlertDialog.Viewport>
         </AlertDialog.Portal>
       </AlertDialog.Root>
     </React.Fragment>

--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
@@ -60,12 +60,17 @@
   }
 }
 
+.Viewport {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1rem;
+}
+
 .Popup {
   box-sizing: border-box;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   width: 24rem;
   max-width: calc(100vw - 3rem);
   margin-top: -2rem;
@@ -83,7 +88,7 @@
   &[data-starting-style],
   &[data-ending-style] {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.9);
+    transform: scale(0.9);
   }
 }
 

--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/hero/css-modules/index.tsx
@@ -9,18 +9,20 @@ export default function ExampleAlertDialog() {
       </AlertDialog.Trigger>
       <AlertDialog.Portal>
         <AlertDialog.Backdrop className={styles.Backdrop} />
-        <AlertDialog.Popup className={styles.Popup}>
-          <AlertDialog.Title className={styles.Title}>Discard draft?</AlertDialog.Title>
-          <AlertDialog.Description className={styles.Description}>
-            You can't undo this action.
-          </AlertDialog.Description>
-          <div className={styles.Actions}>
-            <AlertDialog.Close className={styles.Button}>Cancel</AlertDialog.Close>
-            <AlertDialog.Close data-color="red" className={styles.Button}>
-              Discard
-            </AlertDialog.Close>
-          </div>
-        </AlertDialog.Popup>
+        <AlertDialog.Viewport className={styles.Viewport}>
+          <AlertDialog.Popup className={styles.Popup}>
+            <AlertDialog.Title className={styles.Title}>Discard draft?</AlertDialog.Title>
+            <AlertDialog.Description className={styles.Description}>
+              You can't undo this action.
+            </AlertDialog.Description>
+            <div className={styles.Actions}>
+              <AlertDialog.Close className={styles.Button}>Cancel</AlertDialog.Close>
+              <AlertDialog.Close data-color="red" className={styles.Button}>
+                Discard
+              </AlertDialog.Close>
+            </div>
+          </AlertDialog.Popup>
+        </AlertDialog.Viewport>
       </AlertDialog.Portal>
     </AlertDialog.Root>
   );

--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/hero/tailwind/index.tsx
@@ -8,22 +8,24 @@ export default function ExampleAlertDialog() {
       </AlertDialog.Trigger>
       <AlertDialog.Portal>
         <AlertDialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-        <AlertDialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-          <AlertDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
-            Discard draft?
-          </AlertDialog.Title>
-          <AlertDialog.Description className="mb-6 text-base text-gray-600">
-            You can’t undo this action.
-          </AlertDialog.Description>
-          <div className="flex justify-end gap-4">
-            <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-              Cancel
-            </AlertDialog.Close>
-            <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-red-800 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-              Discard
-            </AlertDialog.Close>
-          </div>
-        </AlertDialog.Popup>
+        <AlertDialog.Viewport className="fixed inset-0 flex items-center justify-center px-4 py-10">
+          <AlertDialog.Popup className="-mt-8 w-96 max-w-[calc(100vw-3rem)] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+            <AlertDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
+              Discard draft?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="mb-6 text-base text-gray-600">
+              You can’t undo this action.
+            </AlertDialog.Description>
+            <div className="flex justify-end gap-4">
+              <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                Cancel
+              </AlertDialog.Close>
+              <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-red-800 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                Discard
+              </AlertDialog.Close>
+            </div>
+          </AlertDialog.Popup>
+        </AlertDialog.Viewport>
       </AlertDialog.Portal>
     </AlertDialog.Root>
   );

--- a/docs/src/app/(docs)/react/components/dialog/demos/_index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/_index.module.css
@@ -56,12 +56,17 @@
   }
 }
 
+.Viewport {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1rem;
+}
+
 .Popup {
   box-sizing: border-box;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   width: 24rem;
   max-width: calc(100vw - 3rem);
   margin-top: -2rem;
@@ -79,7 +84,7 @@
   &[data-starting-style],
   &[data-ending-style] {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.9);
+    transform: scale(0.9);
   }
 }
 

--- a/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
@@ -100,14 +100,20 @@
   }
 }
 
+.Viewport {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1rem;
+}
+
 .Popup {
   box-sizing: border-box;
-  position: fixed;
-  top: 50%;
-  left: 50%;
   width: 24rem;
   max-width: calc(100vw - 3rem);
-  margin-top: -2rem;
+  margin-top: calc(-2rem + 3rem * var(--nested-dialogs));
   padding: 1.5rem;
   border-radius: 0.5rem;
   outline: 1px solid var(--color-gray-200);
@@ -115,8 +121,7 @@
   color: var(--color-gray-900);
   transition: all 150ms;
 
-  transform: translate(-50%, -50%) scale(calc(1 - 0.1 * var(--nested-dialogs)));
-  translate: 0 calc(0px + 1.25rem * var(--nested-dialogs));
+  transform: scale(calc(1 - 0.1 * var(--nested-dialogs)));
 
   @media (prefers-color-scheme: dark) {
     outline: 1px solid var(--color-gray-300);
@@ -135,7 +140,7 @@
   &[data-starting-style],
   &[data-ending-style] {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.9);
+    transform: scale(0.9);
   }
 }
 

--- a/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/css-modules/index.tsx
@@ -27,55 +27,59 @@ export default function ExampleDialog() {
       <Dialog.Trigger className={styles.Button}>Tweet</Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className={styles.Backdrop} />
-        <Dialog.Popup className={styles.Popup}>
-          <Dialog.Title className={styles.Title}>New tweet</Dialog.Title>
-          <form
-            className={styles.TextareaContainer}
-            onSubmit={(event) => {
-              event.preventDefault();
-              // Close the dialog when submitting
-              setDialogOpen(false);
-            }}
-          >
-            <textarea
-              required
-              className={styles.Textarea}
-              placeholder="What’s on your mind?"
-              value={textareaValue}
-              onChange={(event) => setTextareaValue(event.target.value)}
-            />
-            <div className={styles.Actions}>
-              <Dialog.Close className={styles.Button}>Cancel</Dialog.Close>
-              <button type="submit" className={styles.Button}>
-                Tweet
-              </button>
-            </div>
-          </form>
-        </Dialog.Popup>
+        <Dialog.Viewport className={styles.Viewport}>
+          <Dialog.Popup className={styles.Popup}>
+            <Dialog.Title className={styles.Title}>New tweet</Dialog.Title>
+            <form
+              className={styles.TextareaContainer}
+              onSubmit={(event) => {
+                event.preventDefault();
+                // Close the dialog when submitting
+                setDialogOpen(false);
+              }}
+            >
+              <textarea
+                required
+                className={styles.Textarea}
+                placeholder="What’s on your mind?"
+                value={textareaValue}
+                onChange={(event) => setTextareaValue(event.target.value)}
+              />
+              <div className={styles.Actions}>
+                <Dialog.Close className={styles.Button}>Cancel</Dialog.Close>
+                <button type="submit" className={styles.Button}>
+                  Tweet
+                </button>
+              </div>
+            </form>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
 
       {/* Confirmation dialog */}
       <AlertDialog.Root open={confirmationOpen} onOpenChange={setConfirmationOpen}>
         <AlertDialog.Portal>
-          <AlertDialog.Popup className={styles.Popup}>
-            <AlertDialog.Title className={styles.Title}>Discard tweet?</AlertDialog.Title>
-            <AlertDialog.Description className={styles.Description}>
-              Your tweet will be lost.
-            </AlertDialog.Description>
-            <div className={styles.Actions}>
-              <AlertDialog.Close className={styles.Button}>Go back</AlertDialog.Close>
-              <button
-                type="button"
-                className={styles.Button}
-                onClick={() => {
-                  setConfirmationOpen(false);
-                  setDialogOpen(false);
-                }}
-              >
-                Discard
-              </button>
-            </div>
-          </AlertDialog.Popup>
+          <AlertDialog.Viewport className={styles.Viewport}>
+            <AlertDialog.Popup className={styles.Popup}>
+              <AlertDialog.Title className={styles.Title}>Discard tweet?</AlertDialog.Title>
+              <AlertDialog.Description className={styles.Description}>
+                Your tweet will be lost.
+              </AlertDialog.Description>
+              <div className={styles.Actions}>
+                <AlertDialog.Close className={styles.Button}>Go back</AlertDialog.Close>
+                <button
+                  type="button"
+                  className={styles.Button}
+                  onClick={() => {
+                    setConfirmationOpen(false);
+                    setDialogOpen(false);
+                  }}
+                >
+                  Discard
+                </button>
+              </div>
+            </AlertDialog.Popup>
+          </AlertDialog.Viewport>
         </AlertDialog.Portal>
       </AlertDialog.Root>
     </Dialog.Root>

--- a/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
@@ -28,64 +28,68 @@ export default function ExampleDialog() {
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-        <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-          <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">New tweet</Dialog.Title>
-          <form
-            className="mt-4 flex flex-col gap-6"
-            onSubmit={(event) => {
-              event.preventDefault();
-              // Close the dialog when submitting
-              setDialogOpen(false);
-            }}
-          >
-            <textarea
-              required
-              className="min-h-48 w-full rounded-md border border-gray-200 px-3.5 py-2 text-base text-gray-900 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800"
-              placeholder="What’s on your mind?"
-              value={textareaValue}
-              onChange={(event) => setTextareaValue(event.target.value)}
-            />
-            <div className="flex justify-end gap-4">
-              <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                Cancel
-              </Dialog.Close>
-              <button
-                type="submit"
-                className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100"
-              >
-                Tweet
-              </button>
-            </div>
-          </form>
-        </Dialog.Popup>
+        <Dialog.Viewport className="fixed inset-0 flex items-center justify-center px-4 py-10">
+          <Dialog.Popup className="mt-[calc(-2rem+3rem*var(--nested-dialogs))] w-96 max-w-[calc(100vw-3rem)] scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+            <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">New tweet</Dialog.Title>
+            <form
+              className="mt-4 flex flex-col gap-6"
+              onSubmit={(event) => {
+                event.preventDefault();
+                // Close the dialog when submitting
+                setDialogOpen(false);
+              }}
+            >
+              <textarea
+                required
+                className="min-h-48 w-full rounded-md border border-gray-200 px-3.5 py-2 text-base text-gray-900 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800"
+                placeholder="What’s on your mind?"
+                value={textareaValue}
+                onChange={(event) => setTextareaValue(event.target.value)}
+              />
+              <div className="flex justify-end gap-4">
+                <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                  Cancel
+                </Dialog.Close>
+                <button
+                  type="submit"
+                  className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100"
+                >
+                  Tweet
+                </button>
+              </div>
+            </form>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
 
       {/* Confirmation dialog */}
       <AlertDialog.Root open={confirmationOpen} onOpenChange={setConfirmationOpen}>
         <AlertDialog.Portal>
-          <AlertDialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-            <AlertDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
-              Discard tweet?
-            </AlertDialog.Title>
-            <AlertDialog.Description className="mb-6 text-base text-gray-600">
-              Your tweet will be lost.
-            </AlertDialog.Description>
-            <div className="flex items-center justify-end gap-4">
-              <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                Go back
-              </AlertDialog.Close>
-              <button
-                type="button"
-                className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100"
-                onClick={() => {
-                  setConfirmationOpen(false);
-                  setDialogOpen(false);
-                }}
-              >
-                Discard
-              </button>
-            </div>
-          </AlertDialog.Popup>
+          <AlertDialog.Viewport className="fixed inset-0 flex items-center justify-center px-4 py-10">
+            <AlertDialog.Popup className="mt-[calc(-2rem+3rem*var(--nested-dialogs))] w-96 max-w-[calc(100vw-3rem)] scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+              <AlertDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
+                Discard tweet?
+              </AlertDialog.Title>
+              <AlertDialog.Description className="mb-6 text-base text-gray-600">
+                Your tweet will be lost.
+              </AlertDialog.Description>
+              <div className="flex items-center justify-end gap-4">
+                <AlertDialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                  Go back
+                </AlertDialog.Close>
+                <button
+                  type="button"
+                  className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100"
+                  onClick={() => {
+                    setConfirmationOpen(false);
+                    setDialogOpen(false);
+                  }}
+                >
+                  Discard
+                </button>
+              </div>
+            </AlertDialog.Popup>
+          </AlertDialog.Viewport>
         </AlertDialog.Portal>
       </AlertDialog.Root>
     </Dialog.Root>

--- a/docs/src/app/(docs)/react/components/dialog/demos/detached-triggers-controlled/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/detached-triggers-controlled/css-modules/index.tsx
@@ -50,14 +50,16 @@ export default function DialogDetachedTriggersControlledDemo() {
         {({ payload }) => (
           <Dialog.Portal>
             <Dialog.Backdrop className={styles.Backdrop} />
-            <Dialog.Popup className={styles.Popup}>
-              {payload !== undefined && (
-                <Dialog.Title className={styles.Title}>Dialog {payload}</Dialog.Title>
-              )}
-              <div className={styles.Actions}>
-                <Dialog.Close className={styles.Button}>Close</Dialog.Close>
-              </div>
-            </Dialog.Popup>
+            <Dialog.Viewport className={styles.Viewport}>
+              <Dialog.Popup className={styles.Popup}>
+                {payload !== undefined && (
+                  <Dialog.Title className={styles.Title}>Dialog {payload}</Dialog.Title>
+                )}
+                <div className={styles.Actions}>
+                  <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+                </div>
+              </Dialog.Popup>
+            </Dialog.Viewport>
           </Dialog.Portal>
         )}
       </Dialog.Root>

--- a/docs/src/app/(docs)/react/components/dialog/demos/detached-triggers-controlled/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/detached-triggers-controlled/tailwind/index.tsx
@@ -64,17 +64,19 @@ export default function DialogDetachedTriggersControlledDemo() {
         {({ payload }) => (
           <Dialog.Portal>
             <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-            <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-              <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
-                Dialog {payload}
-              </Dialog.Title>
+            <Dialog.Viewport className="fixed inset-0 flex items-center justify-center px-4 py-10">
+              <Dialog.Popup className="-mt-8 w-96 max-w-[calc(100vw-3rem)] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+                <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
+                  Dialog {payload}
+                </Dialog.Title>
 
-              <div className="flex justify-end gap-4">
-                <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                  Close
-                </Dialog.Close>
-              </div>
-            </Dialog.Popup>
+                <div className="flex justify-end gap-4">
+                  <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                    Close
+                  </Dialog.Close>
+                </div>
+              </Dialog.Popup>
+            </Dialog.Viewport>
           </Dialog.Portal>
         )}
       </Dialog.Root>

--- a/docs/src/app/(docs)/react/components/dialog/demos/detached-triggers-simple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/detached-triggers-simple/css-modules/index.tsx
@@ -15,15 +15,17 @@ export default function DialogDetachedTriggersSimpleDemo() {
       <Dialog.Root handle={demoDialog}>
         <Dialog.Portal>
           <Dialog.Backdrop className={styles.Backdrop} />
-          <Dialog.Popup className={styles.Popup}>
-            <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
-            <Dialog.Description className={styles.Description}>
-              You are all caught up. Good job!
-            </Dialog.Description>
-            <div className={styles.Actions}>
-              <Dialog.Close className={styles.Button}>Close</Dialog.Close>
-            </div>
-          </Dialog.Popup>
+          <Dialog.Viewport className={styles.Viewport}>
+            <Dialog.Popup className={styles.Popup}>
+              <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
+              <Dialog.Description className={styles.Description}>
+                You are all caught up. Good job!
+              </Dialog.Description>
+              <div className={styles.Actions}>
+                <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+              </div>
+            </Dialog.Popup>
+          </Dialog.Viewport>
         </Dialog.Portal>
       </Dialog.Root>
     </React.Fragment>

--- a/docs/src/app/(docs)/react/components/dialog/demos/detached-triggers-simple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/detached-triggers-simple/tailwind/index.tsx
@@ -17,17 +17,21 @@ export default function DialogDetachedTriggersSimpleDemo() {
       <Dialog.Root handle={demoDialog}>
         <Dialog.Portal>
           <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-          <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-            <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
-            <Dialog.Description className="mb-6 text-base text-gray-600">
-              You are all caught up. Good job!
-            </Dialog.Description>
-            <div className="flex justify-end gap-4">
-              <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                Close
-              </Dialog.Close>
-            </div>
-          </Dialog.Popup>
+          <Dialog.Viewport className="fixed inset-0 flex items-center justify-center px-4 py-10">
+            <Dialog.Popup className="-mt-8 w-96 max-w-[calc(100vw-3rem)] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+              <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
+                Notifications
+              </Dialog.Title>
+              <Dialog.Description className="mb-6 text-base text-gray-600">
+                You are all caught up. Good job!
+              </Dialog.Description>
+              <div className="flex justify-end gap-4">
+                <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                  Close
+                </Dialog.Close>
+              </div>
+            </Dialog.Popup>
+          </Dialog.Viewport>
         </Dialog.Portal>
       </Dialog.Root>
     </React.Fragment>

--- a/docs/src/app/(docs)/react/components/dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/hero/css-modules/index.module.css
@@ -56,12 +56,17 @@
   }
 }
 
+.Viewport {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1rem;
+}
+
 .Popup {
   box-sizing: border-box;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   width: 24rem;
   max-width: calc(100vw - 3rem);
   margin-top: -2rem;
@@ -79,7 +84,7 @@
   &[data-starting-style],
   &[data-ending-style] {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.9);
+    transform: scale(0.9);
   }
 }
 

--- a/docs/src/app/(docs)/react/components/dialog/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/hero/css-modules/index.tsx
@@ -7,15 +7,17 @@ export default function ExampleDialog() {
       <Dialog.Trigger className={styles.Button}>View notifications</Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className={styles.Backdrop} />
-        <Dialog.Popup className={styles.Popup}>
-          <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
-          <Dialog.Description className={styles.Description}>
-            You are all caught up. Good job!
-          </Dialog.Description>
-          <div className={styles.Actions}>
-            <Dialog.Close className={styles.Button}>Close</Dialog.Close>
-          </div>
-        </Dialog.Popup>
+        <Dialog.Viewport className={styles.Viewport}>
+          <Dialog.Popup className={styles.Popup}>
+            <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
+            <Dialog.Description className={styles.Description}>
+              You are all caught up. Good job!
+            </Dialog.Description>
+            <div className={styles.Actions}>
+              <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/docs/src/app/(docs)/react/components/dialog/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/hero/tailwind/index.tsx
@@ -8,17 +8,19 @@ export default function ExampleDialog() {
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-        <Dialog.Popup className="fixed top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-          <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
-          <Dialog.Description className="mb-6 text-base text-gray-600">
-            You are all caught up. Good job!
-          </Dialog.Description>
-          <div className="flex justify-end gap-4">
-            <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-              Close
-            </Dialog.Close>
-          </div>
-        </Dialog.Popup>
+        <Dialog.Viewport className="fixed inset-0 flex items-center justify-center px-4 py-10">
+          <Dialog.Popup className="-mt-8 w-96 max-w-[calc(100vw-3rem)] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+            <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
+            <Dialog.Description className="mb-6 text-base text-gray-600">
+              You are all caught up. Good job!
+            </Dialog.Description>
+            <div className="flex justify-end gap-4">
+              <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                Close
+              </Dialog.Close>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/docs/src/app/(docs)/react/components/dialog/demos/nested/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/nested/css-modules/index.module.css
@@ -100,14 +100,20 @@
   }
 }
 
+.Viewport {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1rem;
+}
+
 .Popup {
   box-sizing: border-box;
-  position: fixed;
-  top: 50%;
-  left: 50%;
   width: 24rem;
   max-width: calc(100vw - 3rem);
-  margin-top: -2rem;
+  margin-top: calc(-2rem + 3rem * var(--nested-dialogs));
   padding: 1.5rem;
   border-radius: 0.5rem;
   outline: 1px solid var(--color-gray-200);
@@ -115,8 +121,7 @@
   color: var(--color-gray-900);
   transition: all 150ms;
 
-  transform: translate(-50%, -50%) scale(calc(1 - 0.1 * var(--nested-dialogs)));
-  translate: 0 calc(0px + 1.25rem * var(--nested-dialogs));
+  transform: scale(calc(1 - 0.1 * var(--nested-dialogs)));
 
   @media (prefers-color-scheme: dark) {
     outline: 1px solid var(--color-gray-300);
@@ -135,7 +140,7 @@
   &[data-starting-style],
   &[data-ending-style] {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.9);
+    transform: scale(0.9);
   }
 }
 

--- a/docs/src/app/(docs)/react/components/dialog/demos/nested/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/nested/css-modules/index.tsx
@@ -7,32 +7,38 @@ export default function ExampleDialog() {
       <Dialog.Trigger className={styles.Button}>View notifications</Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className={styles.Backdrop} />
-        <Dialog.Popup className={styles.Popup}>
-          <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
-          <Dialog.Description className={styles.Description}>
-            You are all caught up. Good job!
-          </Dialog.Description>
-          <div className={styles.Actions}>
-            <div className={styles.ActionsLeft}>
-              <Dialog.Root>
-                <Dialog.Trigger className={styles.GhostButton}>Customize</Dialog.Trigger>
-                <Dialog.Portal>
-                  <Dialog.Popup className={styles.Popup}>
-                    <Dialog.Title className={styles.Title}>Customize notifications</Dialog.Title>
-                    <Dialog.Description className={styles.Description}>
-                      Review your settings here.
-                    </Dialog.Description>
-                    <div className={styles.Actions}>
-                      <Dialog.Close className={styles.Button}>Close</Dialog.Close>
-                    </div>
-                  </Dialog.Popup>
-                </Dialog.Portal>
-              </Dialog.Root>
-            </div>
+        <Dialog.Viewport className={styles.Viewport}>
+          <Dialog.Popup className={styles.Popup}>
+            <Dialog.Title className={styles.Title}>Notifications</Dialog.Title>
+            <Dialog.Description className={styles.Description}>
+              You are all caught up. Good job!
+            </Dialog.Description>
+            <div className={styles.Actions}>
+              <div className={styles.ActionsLeft}>
+                <Dialog.Root>
+                  <Dialog.Trigger className={styles.GhostButton}>Customize</Dialog.Trigger>
+                  <Dialog.Portal>
+                    <Dialog.Viewport className={styles.Viewport}>
+                      <Dialog.Popup className={styles.Popup}>
+                        <Dialog.Title className={styles.Title}>
+                          Customize notifications
+                        </Dialog.Title>
+                        <Dialog.Description className={styles.Description}>
+                          Review your settings here.
+                        </Dialog.Description>
+                        <div className={styles.Actions}>
+                          <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+                        </div>
+                      </Dialog.Popup>
+                    </Dialog.Viewport>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              </div>
 
-            <Dialog.Close className={styles.Button}>Close</Dialog.Close>
-          </div>
-        </Dialog.Popup>
+              <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/docs/src/app/(docs)/react/components/dialog/demos/nested/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/nested/tailwind/index.tsx
@@ -8,40 +8,44 @@ export default function ExampleDialog() {
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
-        <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-          <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
-          <Dialog.Description className="mb-6 text-base text-gray-600">
-            You are all caught up. Good job!
-          </Dialog.Description>
-          <div className="flex items-center justify-end gap-4">
-            <div className="mr-auto flex">
-              <Dialog.Root>
-                <Dialog.Trigger className="-mx-1.5 -my-0.5 flex items-center justify-center rounded-sm px-1.5 py-0.5 text-base font-medium text-blue-800 hover:bg-blue-800/5 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-blue-800/10 dark:hover:bg-blue-800/15 dark:active:bg-blue-800/25">
-                  Customize
-                </Dialog.Trigger>
-                <Dialog.Portal>
-                  <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-                    <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
-                      Customize notification
-                    </Dialog.Title>
-                    <Dialog.Description className="mb-6 text-base text-gray-600">
-                      Review your settings here.
-                    </Dialog.Description>
-                    <div className="flex items-center justify-end gap-4">
-                      <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                        Close
-                      </Dialog.Close>
-                    </div>
-                  </Dialog.Popup>
-                </Dialog.Portal>
-              </Dialog.Root>
-            </div>
+        <Dialog.Viewport className="fixed inset-0 flex items-center justify-center px-4 py-10">
+          <Dialog.Popup className="mt-[calc(-2rem+3rem*var(--nested-dialogs))] w-96 max-w-[calc(100vw-3rem)] scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+            <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">Notifications</Dialog.Title>
+            <Dialog.Description className="mb-6 text-base text-gray-600">
+              You are all caught up. Good job!
+            </Dialog.Description>
+            <div className="flex items-center justify-end gap-4">
+              <div className="mr-auto flex">
+                <Dialog.Root>
+                  <Dialog.Trigger className="-mx-1.5 -my-0.5 flex items-center justify-center rounded-sm px-1.5 py-0.5 text-base font-medium text-blue-800 hover:bg-blue-800/5 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-blue-800/10 dark:hover:bg-blue-800/15 dark:active:bg-blue-800/25">
+                    Customize
+                  </Dialog.Trigger>
+                  <Dialog.Portal>
+                    <Dialog.Viewport className="fixed inset-0 flex items-center justify-center px-4 py-10">
+                      <Dialog.Popup className="mt-[calc(-2rem+3rem*var(--nested-dialogs))] w-96 max-w-[calc(100vw-3rem)] scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+                        <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
+                          Customize notification
+                        </Dialog.Title>
+                        <Dialog.Description className="mb-6 text-base text-gray-600">
+                          Review your settings here.
+                        </Dialog.Description>
+                        <div className="flex items-center justify-end gap-4">
+                          <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                            Close
+                          </Dialog.Close>
+                        </div>
+                      </Dialog.Popup>
+                    </Dialog.Viewport>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              </div>
 
-            <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-              Close
-            </Dialog.Close>
-          </div>
-        </Dialog.Popup>
+              <Dialog.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
+                Close
+              </Dialog.Close>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/docs/src/app/(docs)/react/components/dialog/demos/uncontained/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/uncontained/css-modules/index.module.css
@@ -62,8 +62,9 @@
 .Viewport {
   position: fixed;
   inset: 0;
-  display: grid;
-  place-items: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 2.5rem 1rem;
 
   @media (min-width: 80rem) {

--- a/docs/src/app/(docs)/react/components/dialog/demos/uncontained/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/uncontained/tailwind/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleUncontainedDialog() {
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-70 backdrop-blur-[2px] transition-[opacity,backdrop-filter] duration-150 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 supports-[-webkit-touch-callout:none]:absolute dark:opacity-70" />
-        <Dialog.Viewport className="fixed inset-0 grid place-items-center px-4 py-10 xl:py-6">
+        <Dialog.Viewport className="fixed inset-0 flex items-center justify-center px-4 py-10 xl:py-6">
           <Dialog.Popup className="group/popup flex h-full w-full justify-center pointer-events-none transition-opacity duration-150 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0">
             <Dialog.Close
               className="absolute right-3 top-2 flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-gray-50 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-gray-50 xl:right-3 xl:top-3 xl:h-10 xl:w-10 dark:text-gray-900 dark:focus-visible:outline-gray-900 pointer-events-auto"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #1893 

- [x] Update all dialog demos to use `<Dialog.Viewport>`

### Downsides

- Users cannot edit these wrapper nodes (easily). One solution to that is to make this opt-out or opt-in with a prop.
- The wrapper nodes may cause layout issues in certain scenarios. However, I didn't see any issues on the docs for the existing dialogs that used the Viewport part
- Some users want to lock document scroll for `Popover` as well when it isn't scrollable (#3098), but this only applies to Dialog

### Alternatives

The alternative is to document scroll lock on iOS (which also lets users know how to do it for Popover, though I haven't tried to do it for that component yet to see if it's viable). However, not adding it by default means it will probably be ignored in many cases.