### PR TITLE
[navigation menu] Fix positioner regression

### DIFF
--- a/packages/utils/src/store/ReactStore.ts
+++ b/packages/utils/src/store/ReactStore.ts
@@ -51,13 +51,11 @@ export class ReactStore<
     value: Value,
   ) {
     React.useDebugValue(key);
-    // eslint-disable-next-line consistent-this
-    const store = this;
     useIsoLayoutEffect(() => {
-      if (store.state[key] !== value) {
-        store.set(key, value);
+      if (this.state[key] !== value) {
+        this.set(key, value);
       }
-    }, [store, key, value]);
+    }, [key, value]);
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Making the `useSyncedValue` effect reactive to the store (from #3724) prevents the positioner from updating when hovering a new trigger.