### PR TITLE
[button] Remove unnecessary `Boolean` coercion

### DIFF
--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -17,13 +17,11 @@ export const Button = React.forwardRef(function Button(
   const {
     render,
     className,
-    disabled: disabledProp = false,
+    disabled = false,
     focusableWhenDisabled = false,
     nativeButton = true,
     ...elementProps
   } = componentProps;
-
-  const disabled = Boolean(disabledProp);
 
   const { getButtonProps, buttonRef } = useButton({
     disabled,


### PR DESCRIPTION
`disabled` prop is of type `boolean`. I guess in #2363, `disabled` prop was initially `disabled?: boolean | 'focusable';` but was later changed and thus it was forgotten to remove the coercion.