### PR TITLE
[docs] Fix invalid background showing on small screens

### DIFF
--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -79,6 +79,7 @@
   }
 
   .DemoToolbarActions {
+    position: relative;
     /* Apply sticky only on wider viewports to avoid actions taking up most of it */
     @media (min-width: 768px) {
       position: sticky;


### PR DESCRIPTION
Before:
<img width="382" height="299" alt="image" src="https://github.com/user-attachments/assets/c1dfe666-afad-4aa7-96a3-9de1433ec3a8" />

After:
<img width="387" height="282" alt="Screenshot 2026-01-16 121754" src="https://github.com/user-attachments/assets/cb836ae7-5799-4e78-afda-2c591355966d" />