### PR TITLE
[docs] Support Cmd/Alt + Enter in search

### DIFF
--- a/docs/src/components/Search/SearchBar.tsx
+++ b/docs/src/components/Search/SearchBar.tsx
@@ -189,15 +189,9 @@ export function SearchBar({
     [search],
   );
 
-  const modifierPressedRef = React.useRef(false);
   const highlightedResultRef = React.useRef<SearchResult | undefined>(undefined);
 
   const handleItemClick = React.useCallback(() => {
-    // Don't close dialog if modifier was pressed
-    if (modifierPressedRef.current) {
-      modifierPressedRef.current = false;
-      return;
-    }
     handleCloseDialog(false);
   }, [handleCloseDialog]);
 
@@ -220,8 +214,6 @@ export function SearchBar({
       // Prevent the Input/List handlers from processing this
       event.preventDefault();
       event.stopPropagation();
-
-      modifierPressedRef.current = true;
 
       // Open in new tab
       const url = buildResultUrl(highlightedResult);


### PR DESCRIPTION
Adding support for opening search result links in new tab/new split using `Cmd + Enter` and `Alt + Enter` respectively so there's no need to grab the mouse to do so.

I'm not sure the implementation is the most straightforward one. My first idea was to do something in the `onClick` event in `<Autocomplete.Item render={<Link onNavigate={} onClick={} />}>` (Next.js prevents `onNavigate` when any modifier key is pressed), but the `onClick` event never runs when doing `Cmd/Alt + Enter`. AFAIK this is the piece of code responsible for `onClick` not running: `ComboboxList` component stops all `onKeyDown` events with `Enter` ([source](https://github.com/mui/base-ui/blob/v1.1.0/packages/react/src/combobox/list/ComboboxList.tsx#L85-L109)).