### PR TITLE
[menu] Fix submenu stuck glitch

### DIFF
--- a/docs/src/app/(private)/experiments/menu/menu-submenus.tsx
+++ b/docs/src/app/(private)/experiments/menu/menu-submenus.tsx
@@ -1,0 +1,162 @@
+'use client';
+import * as React from 'react';
+import { Menu } from '@base-ui/react/menu';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import {
+  SettingsMetadata,
+  useExperimentSettings,
+} from '../../../../components/Experiments/SettingsPanel';
+import '../../../../demo-theme.css';
+import classes from './menu.module.css';
+
+interface Settings {
+  customAnchor: boolean;
+  modal: boolean;
+  openOnHover: boolean;
+  disabled: boolean;
+  customTriggerElement: boolean;
+  side: Menu.Positioner.Props['side'];
+  align: Menu.Positioner.Props['align'];
+}
+
+export default function MenuSubmenus() {
+  const { settings } = useExperimentSettings<Settings>();
+
+  const anchorRef = React.useRef<HTMLDivElement>(null);
+
+  const triggerRender = React.useMemo(
+    () => (settings.customTriggerElement ? <span /> : undefined),
+    [settings.customTriggerElement],
+  );
+
+  const handleItemClick = useStableCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    console.log(`${event.currentTarget.textContent} clicked`);
+  });
+
+  return (
+    <div>
+      <h1>Many adjacent submenus</h1>
+      <Menu.Root modal={settings.modal} disabled={settings.disabled}>
+        <Menu.Trigger
+          className={classes.Button}
+          render={triggerRender}
+          nativeButton={triggerRender === undefined}
+          openOnHover={settings.openOnHover}
+        >
+          Menu <ChevronDownIcon className={classes.ButtonIcon} />
+        </Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner
+            className={classes.Positioner}
+            sideOffset={8}
+            anchor={settings.customAnchor ? anchorRef : undefined}
+            side={settings.side}
+            align={settings.align}
+          >
+            <Menu.Popup
+              className={classes.Popup}
+              style={{ maxHeight: 'var(--available-height)', overflowY: 'scroll' }}
+            >
+              {Array.from({ length: 50 }).map((_, submenuIndex) => (
+                <Menu.SubmenuRoot key={submenuIndex}>
+                  <Menu.SubmenuTrigger className={classes.SubmenuTrigger}>
+                    Submenu test index {submenuIndex + 1}
+                    <ChevronRightIcon />
+                  </Menu.SubmenuTrigger>
+                  <Menu.Portal>
+                    <Menu.Positioner className={classes.Positioner} sideOffset={8}>
+                      <Menu.Popup className={classes.Popup}>
+                        {Array.from({ length: 12 }).map((__, itemIndex) => (
+                          <Menu.SubmenuRoot key={itemIndex}>
+                            <Menu.SubmenuTrigger className={classes.SubmenuTrigger}>
+                              Submenu test index {submenuIndex + 1} - Item {itemIndex + 1}
+                              <ChevronRightIcon />
+                            </Menu.SubmenuTrigger>
+                            <Menu.Portal>
+                              <Menu.Positioner className={classes.Positioner} sideOffset={8}>
+                                <Menu.Popup className={classes.Popup}>
+                                  {Array.from({ length: 8 }).map((___, nestedIndex) => (
+                                    <Menu.Item
+                                      key={nestedIndex}
+                                      className={classes.Item}
+                                      onClick={handleItemClick}
+                                    >
+                                      Nested submenu {submenuIndex + 1}.{itemIndex + 1} - Item{' '}
+                                      {nestedIndex + 1}
+                                    </Menu.Item>
+                                  ))}
+                                </Menu.Popup>
+                              </Menu.Positioner>
+                            </Menu.Portal>
+                          </Menu.SubmenuRoot>
+                        ))}
+                      </Menu.Popup>
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.SubmenuRoot>
+              ))}
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
+
+      {settings.customAnchor && (
+        <div className={classes.CustomAnchor} ref={anchorRef}>
+          Menu will be anchored here
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const settingsMetadata: SettingsMetadata<Settings> = {
+  customAnchor: {
+    type: 'boolean',
+    label: 'Custom anchor',
+  },
+  modal: {
+    type: 'boolean',
+    label: 'Modal',
+    default: true,
+  },
+  openOnHover: {
+    type: 'boolean',
+    label: 'Open on hover',
+  },
+  disabled: {
+    type: 'boolean',
+    label: 'Disabled',
+  },
+  customTriggerElement: {
+    type: 'boolean',
+    label: 'Trigger as <span>',
+  },
+  side: {
+    type: 'string',
+    label: 'Side',
+    options: ['top', 'right', 'bottom', 'left'],
+    default: 'bottom',
+  },
+  align: {
+    type: 'string',
+    label: 'Align',
+    options: ['start', 'center', 'end'],
+    default: 'center',
+  },
+};
+
+function ChevronDownIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" {...props}>
+      <path d="M1 3.5L5 7.5L9 3.5" stroke="currentcolor" strokeWidth="1.5" />
+    </svg>
+  );
+}
+
+function ChevronRightIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" {...props}>
+      <path d="M3.5 9L7.5 5L3.5 1" stroke="currentcolor" strokeWidth="1.5" />
+    </svg>
+  );
+}

--- a/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
@@ -79,20 +79,17 @@ export function useHoverFloatingInteraction(
     return type?.includes('mouse') && type !== 'mousedown';
   });
 
-  const closeWithDelay = React.useCallback(
-    (event: MouseEvent, runElseBranch = true) => {
-      const closeDelay = getDelay(closeDelayProp, pointerTypeRef.current);
-      if (closeDelay && !handlerRef.current) {
-        openChangeTimeout.start(closeDelay, () =>
-          store.setOpen(false, createChangeEventDetails(REASONS.triggerHover, event)),
-        );
-      } else if (runElseBranch) {
-        openChangeTimeout.clear();
-        store.setOpen(false, createChangeEventDetails(REASONS.triggerHover, event));
-      }
-    },
-    [closeDelayProp, handlerRef, store, pointerTypeRef, openChangeTimeout],
-  );
+  const closeWithDelay = useStableCallback((event: MouseEvent, runElseBranch = true) => {
+    const closeDelay = getDelay(closeDelayProp, pointerTypeRef.current);
+    if (closeDelay && !handlerRef.current) {
+      openChangeTimeout.start(closeDelay, () =>
+        store.setOpen(false, createChangeEventDetails(REASONS.triggerHover, event)),
+      );
+    } else if (runElseBranch) {
+      openChangeTimeout.clear();
+      store.setOpen(false, createChangeEventDetails(REASONS.triggerHover, event));
+    }
+  });
 
   const cleanupMouseMoveHandler = useStableCallback(() => {
     unbindMouseMoveRef.current();
@@ -251,7 +248,19 @@ export function useHoverFloatingInteraction(
         floating.removeEventListener('pointerdown', handleInteractInside, true);
       }
     };
-  });
+  }, [
+    enabled,
+    floatingElement,
+    store,
+    dataRef,
+    isClickLikeOpenEvent,
+    closeWithDelay,
+    clearPointerEvents,
+    cleanupMouseMoveHandler,
+    handleInteractInside,
+    openChangeTimeout,
+    handlerRef,
+  ]);
 }
 
 export function getDelay(

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -1149,10 +1149,11 @@ describe('<Menu.Root />', () => {
 
         const submenuTrigger = screen.getByTestId('submenu-trigger');
 
-        fireEvent.mouseEnter(submenuTrigger);
-        fireEvent.mouseMove(submenuTrigger);
+        await userEvent.hover(submenuTrigger);
 
-        expect(screen.queryByTestId('submenu')).not.to.equal(null);
+        await waitFor(() => {
+          expect(screen.queryByTestId('submenu')).not.to.equal(null);
+        });
       });
 
       it('should not close when submenu is hovered after root menu is hovered', async () => {

--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -57,11 +57,7 @@ const selectors = {
       (state.modal ?? true),
   ),
 
-  allowMouseEnter: createSelector((state: State<unknown>): boolean =>
-    state.parent.type === 'menu'
-      ? state.parent.store.select('allowMouseEnter')
-      : state.allowMouseEnter,
-  ),
+  allowMouseEnter: createSelector((state: State<unknown>) => state.allowMouseEnter),
   stickIfOpen: createSelector((state: State<unknown>) => state.stickIfOpen),
   parent: createSelector((state: State<unknown>) => state.parent),
   rootId: createSelector((state: State<unknown>): string | undefined => {
@@ -127,18 +123,6 @@ export class MenuStore<Payload> extends ReactStore<
       selectors,
     );
 
-    // Sync `allowMouseEnter` with parent menu if applicable.
-    this.observe(
-      createSelector((state) => state.allowMouseEnter),
-      (allowMouseEnter, oldValue) => {
-        // The allowMouseEnter !== oldValue check prevent calling parent store's set
-        // on intialization. Without it, React might complain about updating one component during rendering another.
-        if (this.state.parent.type === 'menu' && allowMouseEnter !== oldValue) {
-          this.state.parent.store.set('allowMouseEnter', allowMouseEnter);
-        }
-      },
-    );
-
     // Set up propagation of state from parent menu if applicable.
     this.unsubscribeParentListener = this.observe('parent', (parent) => {
       this.unsubscribeParentListener?.();
@@ -184,7 +168,7 @@ function createInitialState<Payload>(): State<Payload> {
     ...createInitialPopupStoreState(),
     disabled: false,
     modal: true,
-    allowMouseEnter: true,
+    allowMouseEnter: false,
     stickIfOpen: true,
     parent: {
       type: undefined,

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -112,15 +112,15 @@ export const MenuSubmenuTrigger = React.forwardRef(function SubmenuTriggerCompon
   });
 
   const hoverEnabled = store.useState('hoverEnabled');
-  const allowMouseEnter = store.useState('allowMouseEnter');
+  const allowMouseEnter = parentMenuStore.useState('allowMouseEnter');
 
   const hoverProps = useHoverReferenceInteraction(floatingRootContext, {
-    enabled: hoverEnabled && openOnHover && !disabled && allowMouseEnter,
+    enabled: hoverEnabled && openOnHover && !disabled,
     handleClose: safePolygon({ blockPointerEvents: true }),
     mouseOnly: true,
     move: true,
     restMs: delay,
-    delay: { open: delay, close: closeDelay },
+    delay: allowMouseEnter ? { open: delay, close: closeDelay } : 0,
     triggerElementRef,
     externalTree: floatingTreeRoot,
   });


### PR DESCRIPTION
The `allowMouseEnter` condition is part of the `useHoverReferenceInteraction` `enabled` state in `<Menu.Trigger>`. This can undesirably switch to `false` while hovering submenu triggers, which causes the event listener registration effect to cleanup then re-execute. During this phase (high CPU load/many submenu triggers makes it more obvious), `mouseleave` may not fire since the event listener is temporarily not registered - this prevents the `mousemove` listener for `safePolygon()` from registering, leaving `pointer-events: none;` stuck since it gets cleaned up/removed by that module.

Fixes #3774. The performance issue seems ~related to this but performance is somewhat subjective here as to how it should feel, at least without comparison with other libraries

https://deploy-preview-3783--base-ui.netlify.app/experiments/menu/menu-submenus