### PR TITLE
[docs] Reduce recalculate when block overlay scroll

### DIFF
--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -231,8 +231,6 @@
 
 @layer all {
   html {
-    /* Stable scrollbar */
-    overflow-y: scroll;
     word-break: break-word;
   }
 
@@ -240,6 +238,8 @@
     font-synthesis: none;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    /* Stable scrollbar */
+    overflow-y: scroll;
   }
 
   /* Debugging red text? You just forgot to set or inherit color in your demo. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Related
#3531

### Cause

This issue occurs only in Chromium versions <= **143**

When child elements use certain relative length units, changing the styles of the `html` element triggers a full tree style recalculation.


[relative length units mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/length)
In repo
> https://github.com/mui/base-ui/blob/139af29ecd8d3d70396dda5289da596a56304fd9/docs/src/components/Demo/Demo.css#L224

### Solve
Move overflow: html → body.

### Limitations

- Inset block scrollbar still trigger excessive style recalculation.
- This works correctly in recent Chromium versions.

As the issue is fixed in recent Chromium versions, please let me know if this PR is no longer needed

### Result

As a result, page performance can be improved when using scroll-blocking components (e.g., dialogs, navigation buttons).

**[chromium 143 master branch]**
<img width="538" height="476" alt="Screenshot 2026-01-20 at 2 49 33 AM" src="https://github.com/user-attachments/assets/07fc2e3b-bc6a-400b-9783-97bac268d2e4" />

---

**[chromium 143 this branch] , [chromium 144 master]**
<img width="510" height="457" alt="Screenshot 2026-01-20 at 2 51 19 AM" src="https://github.com/user-attachments/assets/286af206-95a9-4f97-ad6e-4ac5b8ef0195" />
>


