### PR TITLE
[docs][experiments] Avoid unanchoring menu

### DIFF
--- a/docs/src/app/(private)/experiments/menu/menu-fully-featured.tsx
+++ b/docs/src/app/(private)/experiments/menu/menu-fully-featured.tsx
@@ -44,7 +44,7 @@ export default function MenuFullyFeatured() {
         >
           Menu <ChevronDownIcon className={classes.ButtonIcon} />
         </Menu.Trigger>
-        <Menu.Portal keepMounted>
+        <Menu.Portal>
           <Menu.Positioner
             className={classes.Positioner}
             sideOffset={8}


### PR DESCRIPTION
Tiny fix to avoid unanchoring the menu if `Trigger as <span>` is clicked in settings.
<img width="1142" height="429" alt="Screenshot 2026-01-20 at 17 04 24" src="https://github.com/user-attachments/assets/11155fec-a201-4d34-beed-bf12008278b4" />
