### PR TITLE
[docs][checkbox group] Remove unnecessary `name` attribute from parent checkbox demo

### DIFF
--- a/docs/src/app/(docs)/react/components/checkbox-group/demos/parent/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/checkbox-group/demos/parent/css-modules/index.tsx
@@ -20,7 +20,7 @@ export default function ExampleCheckboxGroup() {
       style={{ marginLeft: '1rem' }}
     >
       <label className={styles.Item} id={id} style={{ marginLeft: '-1rem' }}>
-        <Checkbox.Root className={styles.Checkbox} name="apples" parent>
+        <Checkbox.Root className={styles.Checkbox} parent>
           <Checkbox.Indicator
             className={styles.Indicator}
             render={(props, state) => (


### PR DESCRIPTION
In the Parent checkbox demo, the `name="apples"` is probably unnecessary (and maybe misleading).

I also saw in the `CheckboxRoot` implementation that the `name` attribute is excluded from parent checkbox. `name` attribute is used for forms.

Preview: https://deploy-preview-3803--base-ui.netlify.app/react/components/checkbox-group#parent-checkbox