### PR TITLE
[tooltip][popover][preview card] Fix broken scale transition with detached triggers

### DIFF
--- a/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
@@ -604,6 +604,60 @@ describe('<Popover.Root />', () => {
       expect(screen.getByTestId('popup').textContent).to.equal('2');
     });
 
+    it('should not have inline scale style after switching triggers', async () => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+      const testPopover = Popover.createHandle<number>();
+
+      function Test() {
+        return (
+          <React.Fragment>
+            <Popover.Trigger handle={testPopover} payload={1}>
+              Trigger 1
+            </Popover.Trigger>
+            <Popover.Trigger handle={testPopover} payload={2}>
+              Trigger 2
+            </Popover.Trigger>
+
+            <Popover.Root handle={testPopover}>
+              {({ payload }: NumberPayload) => (
+                <Popover.Portal>
+                  <Popover.Positioner>
+                    <Popover.Popup data-testid="popup">
+                      <Popover.Viewport>
+                        <span data-testid="content">{payload}</span>
+                      </Popover.Viewport>
+                    </Popover.Popup>
+                  </Popover.Positioner>
+                </Popover.Portal>
+              )}
+            </Popover.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const trigger1 = screen.getByRole('button', { name: 'Trigger 1' });
+      const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
+
+      // Open with Trigger 1
+      await user.click(trigger1);
+      await waitFor(() => {
+        expect(screen.getByTestId('content').textContent).to.equal('1');
+      });
+
+      // Switch to Trigger 2
+      await user.click(trigger2);
+      await waitFor(() => {
+        expect(screen.getByTestId('content').textContent).to.equal('2');
+      });
+
+      // The popup should not have an inline scale style that would override CSS transitions
+      const popup = screen.getByTestId('popup');
+      expect(popup.style.scale).to.equal('');
+    });
+
     it('keeps positioning correct when conditional triggers unmount and the tree remounts', async () => {
       const testPopover = Popover.createHandle();
 

--- a/packages/react/src/tooltip/root/TooltipRoot.detached-triggers.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.detached-triggers.test.tsx
@@ -584,6 +584,62 @@ describe('<Tooltip.Root />', () => {
         expect(screen.getByTestId('popup').textContent).to.equal('2');
       });
     });
+
+    it('should not have inline scale style after switching triggers', async () => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+      const testTooltip = Tooltip.createHandle<number>();
+
+      function Test() {
+        return (
+          <React.Fragment>
+            <button type="button" aria-label="Initial focus" autoFocus />
+            <Tooltip.Trigger handle={testTooltip} payload={1} delay={0}>
+              Trigger 1
+            </Tooltip.Trigger>
+            <Tooltip.Trigger handle={testTooltip} payload={2} delay={0}>
+              Trigger 2
+            </Tooltip.Trigger>
+
+            <Tooltip.Root handle={testTooltip}>
+              {({ payload }: NumberPayload) => (
+                <Tooltip.Portal>
+                  <Tooltip.Positioner>
+                    <Tooltip.Popup data-testid="popup">
+                      <Tooltip.Viewport>
+                        <span data-testid="content">{payload}</span>
+                      </Tooltip.Viewport>
+                    </Tooltip.Popup>
+                  </Tooltip.Positioner>
+                </Tooltip.Portal>
+              )}
+            </Tooltip.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const trigger1 = screen.getByRole('button', { name: 'Trigger 1' });
+      const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
+
+      // Open with Trigger 1
+      await user.hover(trigger1);
+      await waitFor(() => {
+        expect(screen.getByTestId('content').textContent).to.equal('1');
+      });
+
+      // Switch to Trigger 2
+      await user.unhover(trigger1);
+      await user.hover(trigger2);
+      await waitFor(() => {
+        expect(screen.getByTestId('content').textContent).to.equal('2');
+      });
+
+      // The popup should not have an inline scale style that would override CSS transitions
+      const popup = screen.getByTestId('popup');
+      expect(popup.style.scale).to.equal('');
+    });
   });
 
   describe.skipIf(isJSDOM)('imperative actions on the handle', () => {

--- a/packages/react/src/utils/usePopupAutoResize.ts
+++ b/packages/react/src/utils/usePopupAutoResize.ts
@@ -164,7 +164,7 @@ export function usePopupAutoResize(parameters: UsePopupAutoResizeParameters) {
     }
 
     setPopupCssSize(popupElement, previousDimensions);
-    restoreMeasurementOverrides();
+    restoreMeasurementOverridesIncludingScale();
     onMeasureLayoutComplete?.(previousDimensions, newDimensions);
 
     setPositionerCssSize(positionerElement, newDimensions);


### PR DESCRIPTION
Fixed restoration of `scale` after it's forcibly set to `1` when measuring content dimensions in `usePopupAutoresize`.

Closes #3804