### PR TITLE
[docs] Align the tooltip content with trigger aria-label

### DIFF
--- a/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-controlled/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-controlled/css-modules/index.tsx
@@ -19,15 +19,15 @@ export default function TooltipDetachedTriggersControlledDemo() {
       <div className={styles.Container}>
         <div className={styles.ButtonGroup}>
           <Tooltip.Trigger className={styles.IconButton} handle={demoTooltip} id="trigger-1">
-            <InfoIcon aria-label="Information 1" className={styles.Icon} />
+            <InfoIcon aria-label="Controlled tooltip" className={styles.Icon} />
           </Tooltip.Trigger>
 
           <Tooltip.Trigger className={styles.IconButton} handle={demoTooltip} id="trigger-2">
-            <InfoIcon aria-label="Information 2" className={styles.Icon} />
+            <InfoIcon aria-label="Controlled tooltip" className={styles.Icon} />
           </Tooltip.Trigger>
 
           <Tooltip.Trigger className={styles.IconButton} handle={demoTooltip} id="trigger-3">
-            <InfoIcon aria-label="Information 3" className={styles.Icon} />
+            <InfoIcon aria-label="Controlled tooltip" className={styles.Icon} />
           </Tooltip.Trigger>
         </div>
 

--- a/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-controlled/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-controlled/tailwind/index.tsx
@@ -32,7 +32,7 @@ export default function TooltipDetachedTriggersControlledDemo() {
             handle={demoTooltip}
             id="trigger-1"
           >
-            <InfoIcon aria-label="Information 1" />
+            <InfoIcon aria-label="Controlled tooltip" />
           </Tooltip.Trigger>
 
           <Tooltip.Trigger
@@ -49,7 +49,7 @@ export default function TooltipDetachedTriggersControlledDemo() {
             handle={demoTooltip}
             id="trigger-2"
           >
-            <InfoIcon aria-label="Information 2" />
+            <InfoIcon aria-label="Controlled tooltip" />
           </Tooltip.Trigger>
 
           <Tooltip.Trigger
@@ -66,7 +66,7 @@ export default function TooltipDetachedTriggersControlledDemo() {
             handle={demoTooltip}
             id="trigger-3"
           >
-            <InfoIcon aria-label="Information 3" />
+            <InfoIcon aria-label="Controlled tooltip" />
           </Tooltip.Trigger>
         </div>
 

--- a/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-full/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-full/css-modules/index.tsx
@@ -10,15 +10,15 @@ export default function TooltipDetachedTriggersFullDemo() {
     <Tooltip.Provider>
       <div className={styles.ButtonGroup}>
         <Tooltip.Trigger className={styles.Button} handle={demoTooltip} payload={InfoContent}>
-          <InfoIcon aria-label="Information" className={styles.Icon} />
+          <InfoIcon aria-label="This is information about the feature" className={styles.Icon} />
         </Tooltip.Trigger>
 
         <Tooltip.Trigger className={styles.Button} handle={demoTooltip} payload={HelpContent}>
-          <HelpIcon aria-label="Help" className={styles.Icon} />
+          <HelpIcon aria-label="Need help?" className={styles.Icon} />
         </Tooltip.Trigger>
 
         <Tooltip.Trigger className={styles.Button} handle={demoTooltip} payload={AlertContent}>
-          <AlertIcon aria-label="Alert" className={styles.Icon} />
+          <AlertIcon aria-label="Warning: This action cannot be undone" className={styles.Icon} />
         </Tooltip.Trigger>
       </div>
 

--- a/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-full/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-full/tailwind/index.tsx
@@ -23,7 +23,7 @@ export default function TooltipDetachedTriggersFullDemo() {
           handle={demoTooltip}
           payload={InfoContent}
         >
-          <InfoIcon aria-label="Information" className="size-5" />
+          <InfoIcon aria-label="This is information about the feature" className="size-5" />
         </Tooltip.Trigger>
 
         <Tooltip.Trigger
@@ -40,7 +40,7 @@ export default function TooltipDetachedTriggersFullDemo() {
           handle={demoTooltip}
           payload={HelpContent}
         >
-          <HelpIcon aria-label="Help" className="size-5" />
+          <HelpIcon aria-label="Need help?" className="size-5" />
         </Tooltip.Trigger>
 
         <Tooltip.Trigger
@@ -57,7 +57,7 @@ export default function TooltipDetachedTriggersFullDemo() {
           handle={demoTooltip}
           payload={AlertContent}
         >
-          <AlertIcon aria-label="Alert" className="size-5" />
+          <AlertIcon aria-label="Warning: This action cannot be undone" className="size-5" />
         </Tooltip.Trigger>
       </div>
 

--- a/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-simple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-simple/css-modules/index.tsx
@@ -9,7 +9,7 @@ export default function TooltipDetachedTriggersSimpleDemo() {
   return (
     <Tooltip.Provider>
       <Tooltip.Trigger className={styles.IconButton} handle={demoTooltip}>
-        <InfoIcon aria-label="Information" className={styles.Icon} />
+        <InfoIcon aria-label="This is a detached tooltip" className={styles.Icon} />
       </Tooltip.Trigger>
 
       <Tooltip.Root handle={demoTooltip}>

--- a/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-simple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-simple/tailwind/index.tsx
@@ -21,7 +21,7 @@ export default function TooltipDetachedTriggersSimpleDemo() {
           active:bg-gray-100"
         handle={demoTooltip}
       >
-        <InfoIcon aria-label="Information" />
+        <InfoIcon aria-label="This is a detached tooltip" />
       </Tooltip.Trigger>
 
       <Tooltip.Root handle={demoTooltip}>

--- a/docs/src/app/(docs)/react/components/tooltip/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/tooltip/demos/hero/css-modules/index.tsx
@@ -7,8 +7,8 @@ export default function ExampleTooltip() {
     <Tooltip.Provider>
       <div className={styles.Panel}>
         <Tooltip.Root>
-          <Tooltip.Trigger aria-label="Bold" className={styles.Button}>
-            <BoldIcon className={styles.Icon} />
+          <Tooltip.Trigger className={styles.Button}>
+            <BoldIcon className={styles.Icon} aria-label="Bold" />
           </Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Positioner sideOffset={10}>
@@ -23,8 +23,8 @@ export default function ExampleTooltip() {
         </Tooltip.Root>
 
         <Tooltip.Root>
-          <Tooltip.Trigger aria-label="Italic" className={styles.Button}>
-            <ItalicIcon className={styles.Icon} />
+          <Tooltip.Trigger className={styles.Button}>
+            <ItalicIcon className={styles.Icon} aria-label="Italic" />
           </Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Positioner sideOffset={10}>
@@ -39,8 +39,8 @@ export default function ExampleTooltip() {
         </Tooltip.Root>
 
         <Tooltip.Root>
-          <Tooltip.Trigger aria-label="Underline" className={styles.Button}>
-            <UnderlineIcon className={styles.Icon} />
+          <Tooltip.Trigger className={styles.Button}>
+            <UnderlineIcon className={styles.Icon} aria-label="Underline" />
           </Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Positioner sideOffset={10}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

- provided the same content in both tooltip trigger aria-label and tooltip content
- move aria-label from the trigger to the child in the main example
- add role="img' to the svg elements
