### PR TITLE
Omit field item when implicitly labeling

### DIFF
--- a/docs/src/app/(private)/experiments/forms/button-controls.tsx
+++ b/docs/src/app/(private)/experiments/forms/button-controls.tsx
@@ -10,6 +10,57 @@ import { RadioGroup } from '@base-ui/react/radio-group';
 import styles from './form.module.css';
 import { CheckIcon } from './_icons';
 
+function ToppingsCheckboxGroup() {
+  return (
+    <Field.Root
+      name="toppings"
+      className={styles.Field}
+      validate={(value) => {
+        return (value as string[]).length === 0 ? 'Required' : null;
+      }}
+      render={
+        <Fieldset.Root
+          render={<CheckboxGroup defaultValue={[]} className={styles.CheckboxGroup} />}
+        />
+      }
+    >
+      <Fieldset.Legend className={styles.Legend}>Toppings</Fieldset.Legend>
+
+      <Field.Label className={styles.Label}>
+        <Checkbox.Root value="anchovies" className={styles.Checkbox}>
+          <Checkbox.Indicator className={styles.CheckboxIndicator}>
+            <CheckIcon className={styles.Icon} />
+          </Checkbox.Indicator>
+        </Checkbox.Root>
+        Anchovies
+      </Field.Label>
+
+      <Field.Label className={styles.Label}>
+        <Checkbox.Root value="sausage" className={styles.Checkbox}>
+          <Checkbox.Indicator className={styles.CheckboxIndicator}>
+            <CheckIcon className={styles.Icon} />
+          </Checkbox.Indicator>
+        </Checkbox.Root>
+        Sausage
+        <Field.Description className={styles.Description} style={{ marginLeft: -4 }}>
+          – very spicy, you have been warned
+        </Field.Description>
+      </Field.Label>
+
+      <Field.Label className={styles.Label}>
+        <Checkbox.Root value="broccolini" className={styles.Checkbox}>
+          <Checkbox.Indicator className={styles.CheckboxIndicator}>
+            <CheckIcon className={styles.Icon} />
+          </Checkbox.Indicator>
+        </Checkbox.Root>
+        Broccolini
+      </Field.Label>
+
+      <Field.Error className={styles.Error} />
+    </Field.Root>
+  );
+}
+
 function PullRequestsCheckboxGroup() {
   return (
     <Field.Root
@@ -186,9 +237,10 @@ export default function ButtonControlsForm() {
         fontFamily: 'var(--font-sans)',
       }}
     >
-      <PullRequestsCheckboxGroup />
-      <StickersRadioGroup />
-      <DmSpamRadioGroup />
+      <ToppingsCheckboxGroup />
+      {/*<StickersRadioGroup />*/}
+      {/*<PullRequestsCheckboxGroup />
+      <DmSpamRadioGroup />*/}
 
       <button type="submit" className={styles.Button}>
         Submit

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -141,7 +141,11 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
       return undefined;
     }
 
-    setControlId(inputId);
+    if (controlRef.current != null && controlRef.current.closest('label')) {
+      setControlId(null);
+    } else {
+      setControlId(inputId);
+    }
 
     return () => {
       setControlId(undefined);

--- a/packages/react/src/field/label/FieldLabel.tsx
+++ b/packages/react/src/field/label/FieldLabel.tsx
@@ -84,14 +84,16 @@ export const FieldLabel = React.forwardRef(function FieldLabel(
   }
 
   useIsoLayoutEffect(() => {
-    if (id) {
+    if (controlId == null) {
+      setLabelId(undefined);
+    } else if (id) {
       setLabelId(id);
     }
 
     return () => {
       setLabelId(undefined);
     };
-  }, [id, setLabelId]);
+  }, [id, setLabelId, controlId]);
 
   const element = useRenderElement('label', componentProps, {
     ref: [forwardedRef, labelRef],

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -89,7 +89,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
   const id = useBaseUiId();
   const inputId = useLabelableId({
     id: idProp,
-    implicit: false,
+    implicit: true,
     controlRef: radioRef,
   });
   const hiddenInputId = nativeButton ? undefined : inputId;


### PR DESCRIPTION
https://deploy-preview-3815--base-ui.netlify.app/experiments/forms/button-controls

It works but will trigger Chrome's `Duplicate form field id in the same form` error since the default id needs to be unset in an effect

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
