### PR TITLE
[docs] Forms guide visual improvements

### DIFF
--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/autocomplete.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/autocomplete.tsx
@@ -14,7 +14,7 @@ export const Input = React.forwardRef<HTMLInputElement, Autocomplete.Input.Props
     <Autocomplete.Input
       ref={forwardedRef}
       className={clsx(
-        'bg-[canvas] h-10 w-[16rem] md:w-[20rem] font-normal rounded-md border border-gray-200 pl-3.5 text-base text-gray-900 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800',
+        'h-9 w-full rounded-md text-sm border border-gray-300 pl-3 my-1 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800 data-[invalid]:border-red-500',
         className,
       )}
       {...props}
@@ -56,7 +56,7 @@ export function Item({ className, ...props }: Autocomplete.Item.Props) {
   return (
     <Autocomplete.Item
       className={clsx(
-        'flex flex-col gap-0.25 cursor-default py-2 pr-8 pl-4 text-base leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-2 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded data-[highlighted]:before:bg-gray-900',
+        'flex flex-col gap-0.25 cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-2 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded data-[highlighted]:before:bg-gray-900',
         className,
       )}
       {...props}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/checkbox-group.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/checkbox-group.tsx
@@ -5,7 +5,7 @@ import { CheckboxGroup as BaseCheckboxGroup } from '@base-ui/react/checkbox-grou
 export function CheckboxGroup({ className, ...props }: BaseCheckboxGroup.Props) {
   return (
     <BaseCheckboxGroup
-      className={clsx('flex flex-col items-start gap-1 text-gray-900', className)}
+      className={clsx('flex flex-col items-start gap-2 text-gray-900', className)}
       {...props}
     />
   );

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/checkbox.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/checkbox.tsx
@@ -6,7 +6,7 @@ export function Root({ className, ...props }: Checkbox.Root.Props) {
   return (
     <Checkbox.Root
       className={clsx(
-        'flex size-5 items-center justify-center rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-800 data-[checked]:bg-gray-900 data-[unchecked]:border data-[unchecked]:border-gray-300',
+        'flex size-4 items-center justify-center rounded-[4px] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-800 data-[checked]:bg-gray-900 data-[unchecked]:border data-[unchecked]:border-gray-300',
         className,
       )}
       {...props}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/combobox.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/combobox.tsx
@@ -15,7 +15,7 @@ export const Input = React.forwardRef<HTMLInputElement, Combobox.Input.Props>(fu
     <Combobox.Input
       ref={forwardedRef}
       className={clsx(
-        'h-10 w-64 rounded-md font-normal border border-gray-200 pl-3.5 text-base text-gray-900 bg-[canvas] focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800',
+        'h-9 w-full pl-3 text-sm border border-gray-300 rounded-md my-1 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800 data-[invalid]:border-red-500',
         className,
       )}
       {...props}
@@ -27,7 +27,7 @@ export function Clear({ className, ...props }: Combobox.Clear.Props) {
   return (
     <Combobox.Clear
       className={clsx(
-        'combobox-clear flex h-10 w-6 items-center justify-center rounded bg-transparent p-0',
+        'combobox-clear flex items-center justify-center rounded bg-transparent p-0',
         className,
       )}
       {...props}
@@ -40,10 +40,7 @@ export function Clear({ className, ...props }: Combobox.Clear.Props) {
 export function Trigger({ className, ...props }: Combobox.Trigger.Props) {
   return (
     <Combobox.Trigger
-      className={clsx(
-        'flex h-10 w-6 items-center justify-center rounded bg-transparent p-0',
-        className,
-      )}
+      className={clsx('flex items-center justify-center rounded bg-transparent p-0', className)}
       {...props}
     />
   );
@@ -96,7 +93,7 @@ export function Item({ className, ...props }: Combobox.Item.Props) {
   return (
     <Combobox.Item
       className={clsx(
-        'grid cursor-default grid-cols-[0.75rem_1fr] items-center gap-2 py-2 pr-8 pl-4 text-base leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-2 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900',
+        'grid cursor-default grid-cols-[0.75rem_1fr] items-center gap-2 py-2 pr-8 pl-4 text-sm leading-4 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-2 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900',
         className,
       )}
       {...props}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/field.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/field.tsx
@@ -31,7 +31,7 @@ export const Control = React.forwardRef<HTMLInputElement, Field.Control.Props>(
       <Field.Control
         ref={forwardedRef}
         className={clsx(
-          'h-10 w-full max-w-xs rounded-md bg-[canvas] border border-gray-200 pl-3.5 text-base text-gray-900 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800',
+          'h-9 w-full rounded-md text-sm border border-gray-300 pl-3 my-1 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800 data-[invalid]:border-red-500',
           className,
         )}
         {...props}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/form.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/form.tsx
@@ -5,7 +5,10 @@ import { Form as BaseForm } from '@base-ui/react/form';
 export function Form({ className, ...props }: BaseForm.Props) {
   return (
     <BaseForm
-      className={clsx('flex w-full max-w-3xs sm:max-w-[20rem] flex-col gap-5', className)}
+      className={clsx(
+        'flex w-full max-w-3xs sm:max-w-[20rem] flex-col gap-5 text-sm text-gray-900',
+        className,
+      )}
       {...props}
     />
   );

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/number-field.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/number-field.tsx
@@ -9,14 +9,14 @@ export function Root({ className, ...props }: NumberField.Root.Props) {
 }
 
 export function Group({ className, ...props }: NumberField.Group.Props) {
-  return <NumberField.Group className={clsx('flex', className)} {...props} />;
+  return <NumberField.Group className={clsx('relative flex my-1', className)} {...props} />;
 }
 
 export function Decrement({ className, ...props }: NumberField.Decrement.Props) {
   return (
     <NumberField.Decrement
       className={clsx(
-        'flex size-10 items-center justify-center rounded-tl-md rounded-bl-md border border-gray-200 bg-gray-50 bg-clip-padding text-gray-900 select-none hover:bg-gray-100 active:bg-gray-100',
+        'flex items-center justify-center select-none h-1/2 px-2 rounded-br-md hover:bg-gray-100 active:bg-gray-100',
         className,
       )}
       {...props}
@@ -32,7 +32,7 @@ export const Input = React.forwardRef<HTMLInputElement, NumberField.Input.Props>
     <NumberField.Input
       ref={forwardedRef}
       className={clsx(
-        'h-10 w-24 border-t border-b border-gray-200 text-center text-base text-gray-900 tabular-nums focus:z-1 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800',
+        'w-20 p-3 h-9 rounded-md border border-gray-300 focus:outline focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800',
         className,
       )}
       {...props}
@@ -44,7 +44,7 @@ export function Increment({ className, ...props }: NumberField.Increment.Props) 
   return (
     <NumberField.Increment
       className={clsx(
-        'flex size-10 items-center justify-center rounded-tr-md rounded-br-md border border-gray-200 bg-gray-50 bg-clip-padding text-gray-900 select-none hover:bg-gray-100 active:bg-gray-100',
+        'flex items-center justify-center select-none h-1/2 px-2 rounded-tr-md hover:bg-gray-100 active:bg-gray-100',
         className,
       )}
       {...props}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/radio-group.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/radio-group.tsx
@@ -3,10 +3,5 @@ import clsx from 'clsx';
 import { RadioGroup as BaseRadioGroup } from '@base-ui/react/radio-group';
 
 export function RadioGroup({ className, ...props }: BaseRadioGroup.Props) {
-  return (
-    <BaseRadioGroup
-      className={clsx('w-full flex flex-row items-start gap-1 text-gray-900', className)}
-      {...props}
-    />
-  );
+  return <BaseRadioGroup className={clsx('w-full', className)} {...props} />;
 }

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/radio.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/radio.tsx
@@ -6,7 +6,7 @@ export function Root({ className, ...props }: Radio.Root.Props) {
   return (
     <Radio.Root
       className={clsx(
-        'flex size-5 items-center justify-center rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-800 data-[checked]:bg-gray-900 data-[unchecked]:border data-[unchecked]:border-gray-300',
+        'flex size-4 items-center justify-center rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-800 data-[checked]:bg-gray-900 data-[unchecked]:border data-[unchecked]:border-gray-300',
         className,
       )}
       {...props}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/select.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/select.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { Select } from '@base-ui/react/select';
 
 export function Root(props: Select.Root.Props<any>) {
@@ -10,7 +11,7 @@ export function Trigger({ className, ...props }: Select.Trigger.Props) {
   return (
     <Select.Trigger
       className={clsx(
-        'flex h-10 min-w-36 items-center justify-between gap-3 rounded-md border border-gray-200 pr-3 pl-3.5 text-base text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 data-[popup-open]:bg-gray-100 cursor-default not-[[data-filled]]:text-gray-500 bg-[canvas]',
+        'flex items-center justify-between h-9 w-full rounded-md text-sm border border-gray-300 px-3 my-1 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 data-[popup-open]:bg-gray-100 cursor-default data-[invalid]:border-red-500',
         className,
       )}
       {...props}
@@ -56,11 +57,13 @@ export function ScrollUpArrow({ className, ...props }: Select.ScrollUpArrow.Prop
   return (
     <Select.ScrollUpArrow
       className={clsx(
-        "top-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute data-[side=none]:before:top-[-100%] before:left-0 before:h-full before:w-full before:content-['']",
+        "top-0 z-[1] flex h-6 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute data-[side=none]:before:top-[-100%] before:left-0 before:h-full before:w-full before:content-['']",
         className,
       )}
       {...props}
-    />
+    >
+      <ChevronUp className="size-4" />
+    </Select.ScrollUpArrow>
   );
 }
 
@@ -68,11 +71,13 @@ export function ScrollDownArrow({ className, ...props }: Select.ScrollDownArrow.
   return (
     <Select.ScrollDownArrow
       className={clsx(
-        "bottom-0 z-[1] flex h-4 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:left-0 before:h-full before:w-full before:content-[''] data-[side=none]:before:bottom-[-100%]",
+        "bottom-0 z-[1] flex h-6 w-full cursor-default items-center justify-center rounded-md bg-[canvas] text-center text-xs before:absolute before:left-0 before:h-full before:w-full before:content-[''] data-[side=none]:before:bottom-[-100%]",
         className,
       )}
       {...props}
-    />
+    >
+      <ChevronDown className="size-4" />
+    </Select.ScrollDownArrow>
   );
 }
 
@@ -92,7 +97,7 @@ export function Item({ className, ...props }: Select.Item.Props) {
   return (
     <Select.Item
       className={clsx(
-        'grid min-w-[var(--anchor-width)] cursor-default grid-cols-[0.75rem_1fr] items-center gap-3 py-2 pr-4 pl-2.5 text-sm leading-4 outline-none select-none group-data-[side=none]:min-w-[calc(var(--anchor-width)+1rem)] group-data-[side=none]:pr-12 group-data-[side=none]:text-base group-data-[side=none]:leading-4 data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900 pointer-coarse:py-2.5 pointer-coarse:text-[0.925rem]',
+        'grid min-w-[var(--anchor-width)+4*var(--spacing)] cursor-default grid-cols-[0.75rem_1fr] items-center gap-3 py-2 pr-4 pl-2.5 text-sm leading-4 outline-none select-none group-data-[side=none]:min-w-[calc(var(--anchor-width)+4*var(--spacing)+1rem)] group-data-[side=none]:pr-12 group-data-[side=none]:text-sm group-data-[side=none]:leading-4 data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900 pointer-coarse:py-2.5 pointer-coarse:text-[0.925rem]',
         className,
       )}
       {...props}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/slider.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/slider.tsx
@@ -2,20 +2,18 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { Slider } from '@base-ui/react/slider';
 
-export function Root({ className, ...props }: Slider.Root.Props<any>) {
-  return <Slider.Root className={clsx('grid grid-cols-2', className)} {...props} />;
+export function Root(props: Slider.Root.Props<any>) {
+  return <Slider.Root {...props} />;
 }
 
 export function Value({ className, ...props }: Slider.Value.Props) {
-  return (
-    <Slider.Value className={clsx('text-sm font-medium text-gray-900', className)} {...props} />
-  );
+  return <Slider.Value className={clsx('text-gray-600', className)} {...props} />;
 }
 
 export function Control({ className, ...props }: Slider.Control.Props) {
   return (
     <Slider.Control
-      className={clsx('flex col-span-2 touch-none items-center py-3 select-none', className)}
+      className={clsx('flex col-span-2 touch-none items-center py-3 select-none mt-2', className)}
       {...props}
     />
   );
@@ -25,7 +23,7 @@ export function Track({ className, ...props }: Slider.Track.Props) {
   return (
     <Slider.Track
       className={clsx(
-        'h-1 w-full rounded bg-gray-200 shadow-[inset_0_0_0_1px] shadow-gray-200 select-none',
+        'h-1.5 w-full rounded bg-gray-200 shadow-[inset_0_0_0_1px] outline outline-1 -outline-offset-1 outline-gray-900/[5%] shadow-gray-200 select-none',
         className,
       )}
       {...props}
@@ -35,7 +33,7 @@ export function Track({ className, ...props }: Slider.Track.Props) {
 
 export function Indicator({ className, ...props }: Slider.Indicator.Props) {
   return (
-    <Slider.Indicator className={clsx('rounded bg-gray-700 select-none', className)} {...props} />
+    <Slider.Indicator className={clsx('rounded bg-gray-900 select-none', className)} {...props} />
   );
 }
 
@@ -43,7 +41,7 @@ export function Thumb({ className, ...props }: Slider.Thumb.Props) {
   return (
     <Slider.Thumb
       className={clsx(
-        'size-4 rounded-full bg-white outline outline-gray-300 select-none has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800',
+        'size-5 rounded-full bg-white outline outline-1 outline-gray-900/20 select-none has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800',
         className,
       )}
       {...props}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/switch.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/switch.tsx
@@ -6,7 +6,7 @@ export function Root({ className, ...props }: Switch.Root.Props) {
   return (
     <Switch.Root
       className={clsx(
-        'relative flex h-6 w-10 rounded-full bg-gradient-to-r from-gray-700 from-35% to-gray-200 to-65% bg-[length:6.5rem_100%] bg-[100%_0%] bg-no-repeat p-px shadow-[inset_0_1.5px_2px] shadow-gray-200 outline outline-1 -outline-offset-1 outline-gray-200 transition-[background-position,box-shadow] duration-[125ms] ease-[cubic-bezier(0.26,0.75,0.38,0.45)] before:absolute before:rounded-full before:outline-offset-2 before:outline-blue-800 focus-visible:before:inset-0 focus-visible:before:outline focus-visible:before:outline-2 active:bg-gray-100 data-[checked]:bg-[0%_0%] data-[checked]:active:bg-gray-500 dark:from-gray-500 dark:shadow-black/75 dark:outline-white/15 dark:data-[checked]:shadow-none',
+        'relative flex h-5 w-9 rounded-full bg-gray-200 p-px outline outline-1 -outline-offset-1 outline-gray-900/10 before:absolute before:rounded-full before:outline-offset-2 before:outline-blue-800 focus-visible:before:inset-0 focus-visible:before:outline focus-visible:before:outline-2 active:bg-gray-100 data-[checked]:bg-gray-900 data-[checked]:active:bg-gray-700 dark:from-gray-500 dark:shadow-black/75 dark:outline-white/15 dark:data-[checked]:shadow-none',
         className,
       )}
       {...props}
@@ -18,7 +18,7 @@ export function Thumb({ className, ...props }: Switch.Thumb.Props) {
   return (
     <Switch.Thumb
       className={clsx(
-        'aspect-square h-full rounded-full bg-white shadow-[0_0_1px_1px,0_1px_1px,1px_2px_4px_-1px] shadow-gray-100 transition-transform duration-150 data-[checked]:translate-x-4 dark:shadow-black/25',
+        'aspect-square h-full rounded-full bg-white outline outline-1 outline-gray-900/[15%] transition-transform duration-150 data-[checked]:translate-x-4 dark:shadow-black/25',
         className,
       )}
       {...props}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/hero/tailwind/index.tsx
@@ -31,24 +31,34 @@ function ExampleForm() {
       }}
     >
       <Field.Root name="serverName">
-        <Field.Label>Server name</Field.Label>
+        <div className="flex gap-1">
+          <Field.Label>Server name</Field.Label>
+          <span className="text-sm text-red-800">*</span>
+        </div>
+        <Field.Description>Must be 3 or more characters long</Field.Description>
         <Field.Control
           defaultValue=""
-          placeholder="e.g. api-server-01"
+          placeholder="api-server-01"
           required
           minLength={3}
           pattern=".*[A-Za-z].*"
         />
-        <Field.Description>Must be 3 or more characters long</Field.Description>
-        <Field.Error />
+        <Field.Error match="valueMissing">This field is required</Field.Error>
+        <Field.Error match="tooShort">This field must be at least 3 characters long</Field.Error>
+        <Field.Error match="patternMismatch">
+          This field must contain at least one letter
+        </Field.Error>
       </Field.Root>
 
       <Field.Root name="region">
         <Combobox.Root items={REGIONS} required>
-          <div className="relative flex flex-col gap-1 text-sm leading-5 font-medium text-gray-900">
+          <div className="flex gap-1">
             <Field.Label>Region</Field.Label>
-            <Combobox.Input placeholder="e.g. eu-central-1" />
-            <div className="absolute right-2 bottom-0 flex h-10 items-center justify-center text-gray-600">
+            <span className="text-sm text-red-800">*</span>
+          </div>
+          <div className="relative w-full text-gray-900">
+            <Combobox.Input placeholder="eu-central-1" />
+            <div className="absolute right-3 top-0 bottom-0 flex gap-1 items-center justify-center">
               <Combobox.Clear />
               <Combobox.Trigger>
                 <ChevronDown className="size-4" />
@@ -75,7 +85,7 @@ function ExampleForm() {
             </Combobox.Positioner>
           </Combobox.Portal>
         </Combobox.Root>
-        <Field.Error />
+        <Field.Error match="valueMissing">This field is required</Field.Error>
       </Field.Root>
 
       <Field.Root name="containerImage">
@@ -85,9 +95,12 @@ function ExampleForm() {
           itemToStringValue={(itemValue: Image) => itemValue.url}
           required
         >
-          <Field.Label>Container image</Field.Label>
-          <Autocomplete.Input placeholder="e.g. docker.io/library/node:latest" />
+          <div className="flex gap-1">
+            <Field.Label>Container image</Field.Label>
+            <span className="text-sm text-red-800">*</span>
+          </div>
           <Field.Description>Enter a registry URL with optional tags</Field.Description>
+          <Autocomplete.Input placeholder="docker.io/library/node:latest" />
           <Autocomplete.Portal>
             <Autocomplete.Positioner>
               <Autocomplete.Popup>
@@ -95,7 +108,7 @@ function ExampleForm() {
                   {(image: Image) => {
                     return (
                       <Autocomplete.Item key={image.url} value={image}>
-                        <span className="text-base leading-6">{image.name}</span>
+                        <span className="text-sm leading-6">{image.name}</span>
                         <span className="font-mono whitespace-nowrap text-xs leading-4 opacity-80">
                           {image.url}
                         </span>
@@ -107,15 +120,18 @@ function ExampleForm() {
             </Autocomplete.Positioner>
           </Autocomplete.Portal>
         </Autocomplete.Root>
-        <Field.Error />
+        <Field.Error match="valueMissing">This field is required</Field.Error>
       </Field.Root>
 
       <Field.Root name="serverType">
-        <Field.Label className="cursor-default" nativeLabel={false} render={<div />}>
-          Server type
-        </Field.Label>
-        <Select.Root items={SERVER_TYPES} required>
-          <Select.Trigger className="w-48">
+        <div className="flex gap-1">
+          <Field.Label className="cursor-default" nativeLabel={false} render={<div />}>
+            Server type
+          </Field.Label>
+          <span className="text-sm text-red-800">*</span>
+        </div>
+        <Select.Root items={SERVER_TYPES} defaultValue={SERVER_TYPES[0].value} required>
+          <Select.Trigger>
             <Select.Value />
             <Select.Icon>
               <ChevronsUpDown className="size-4" />
@@ -142,23 +158,7 @@ function ExampleForm() {
             </Select.Positioner>
           </Select.Portal>
         </Select.Root>
-        <Field.Error />
-      </Field.Root>
-
-      <Field.Root name="numOfInstances">
-        <NumberField.Root defaultValue={undefined} min={1} max={64} required>
-          <Field.Label>Number of instances</Field.Label>
-          <NumberField.Group>
-            <NumberField.Decrement>
-              <Minus className="size-4" />
-            </NumberField.Decrement>
-            <NumberField.Input className="!w-16" />
-            <NumberField.Increment>
-              <Plus className="size-4" />
-            </NumberField.Increment>
-          </NumberField.Group>
-        </NumberField.Root>
-        <Field.Error />
+        <Field.Error match="valueMissing">This field is required</Field.Error>
       </Field.Root>
 
       <Field.Root name="scalingThreshold">
@@ -175,12 +175,14 @@ function ExampleForm() {
                 minimumFractionDigits: 0,
                 maximumFractionDigits: 0,
               }}
-              className="w-98/100 gap-y-2"
+              className="w-full"
             />
           }
         >
-          <Fieldset.Legend>Scaling threshold</Fieldset.Legend>
-          <Slider.Value className="col-start-2 text-end" />
+          <div className="flex justify-between">
+            <Fieldset.Legend>Scaling threshold</Fieldset.Legend>
+            <Slider.Value />
+          </div>
           <Slider.Control>
             <Slider.Track>
               <Slider.Indicator />
@@ -191,48 +193,68 @@ function ExampleForm() {
         </Fieldset.Root>
       </Field.Root>
 
+      <Field.Root name="numOfInstances">
+        <NumberField.Root defaultValue={1} min={1} max={64} required>
+          <div className="flex gap-1">
+            <Field.Label>Number of instances</Field.Label>
+            <span className="text-sm text-red-800">*</span>
+          </div>
+          <Field.Description>Must be between 1 and 64</Field.Description>
+          <NumberField.Group>
+            <NumberField.Input />
+            <div className="absolute right-0 top-0 bottom-0 border-l border-gray-300 flex flex-col items-center justify-center">
+              <NumberField.Increment>
+                <Plus className="size-3" />
+              </NumberField.Increment>
+              <div className="w-full h-px bg-gray-300" />
+              <NumberField.Decrement>
+                <Minus className="size-3" />
+              </NumberField.Decrement>
+            </div>
+          </NumberField.Group>
+        </NumberField.Root>
+        <Field.Error match="valueMissing">This field is required</Field.Error>
+        <Field.Error match="rangeOverflow">This field must be less than 64</Field.Error>
+        <Field.Error match="rangeUnderflow">This field must be greater than 1</Field.Error>
+      </Field.Root>
+
       <Field.Root name="storageType">
-        <Fieldset.Root render={<RadioGroup className="gap-4" defaultValue="ssd" />}>
-          <Fieldset.Legend className="-mt-px">Storage type</Fieldset.Legend>
-          <Field.Item>
-            <Field.Label>
-              <Radio.Root value="ssd">
-                <Radio.Indicator />
-              </Radio.Root>
-              SSD
-            </Field.Label>
-          </Field.Item>
-          <Field.Item>
-            <Field.Label>
-              <Radio.Root value="hdd">
-                <Radio.Indicator />
-              </Radio.Root>
-              HDD
-            </Field.Label>
-          </Field.Item>
+        <Fieldset.Root render={<RadioGroup className="flex flex-col gap-2" defaultValue="ssd" />}>
+          <Fieldset.Legend>Storage type</Fieldset.Legend>
+          <div className="flex flex-col gap-1">
+            <Field.Item>
+              <Field.Label>
+                <Radio.Root value="ssd">
+                  <Radio.Indicator />
+                </Radio.Root>
+                SSD
+              </Field.Label>
+            </Field.Item>
+            <Field.Item>
+              <Field.Label>
+                <Radio.Root value="hdd">
+                  <Radio.Indicator />
+                </Radio.Root>
+                HDD
+              </Field.Label>
+            </Field.Item>
+          </div>
         </Fieldset.Root>
       </Field.Root>
 
-      <Field.Root name="restartOnFailure">
-        <Field.Label className="gap-4">
-          Restart on failure
-          <Switch.Root defaultChecked>
-            <Switch.Thumb />
-          </Switch.Root>
-        </Field.Label>
-      </Field.Root>
-
       <Field.Root name="allowedNetworkProtocols">
-        <Fieldset.Root render={<CheckboxGroup defaultValue={[]} />}>
-          <Fieldset.Legend className="mb-2">Allowed network protocols</Fieldset.Legend>
-          <div className="flex gap-4">
-            {['http', 'https', 'ssh'].map((val) => {
+        <Fieldset.Root
+          render={<CheckboxGroup defaultValue={['https']} className="flex flex-col gap-2" />}
+        >
+          <Fieldset.Legend>Allowed network protocols</Fieldset.Legend>
+          <div className="flex flex-col gap-1">
+            {['https', 'http', 'ssh'].map((val) => {
               return (
                 <Field.Item key={val}>
-                  <Field.Label className="uppercase">
+                  <Field.Label className="uppercase font-normal">
                     <Checkbox.Root value={val}>
                       <Checkbox.Indicator>
-                        <Check className="size-3" />
+                        <Check className="size-3.5" />
                       </Checkbox.Indicator>
                     </Checkbox.Root>
                     {val}
@@ -242,6 +264,15 @@ function ExampleForm() {
             })}
           </div>
         </Fieldset.Root>
+      </Field.Root>
+
+      <Field.Root name="restartOnFailure">
+        <Field.Label className="gap-2">
+          <Switch.Root defaultChecked>
+            <Switch.Thumb />
+          </Switch.Root>
+          Restart on failure
+        </Field.Label>
       </Field.Root>
 
       <Button type="submit" className="mt-3">
@@ -281,7 +312,6 @@ const IMAGES: Image[] = ['nginx:1.29-alpine', 'node:22-slim', 'postgres:18', 're
 }));
 
 const SERVER_TYPES = [
-  { label: 'Select server type', value: null },
   ...cartesian(['t', 'm'], ['1', '2'], ['small', 'medium', 'large']).map((part) => {
     const value = part.join('.').replace('.', '');
     return { label: value, value };


### PR DESCRIPTION
The Forms guide could use several visual improvements to make a better impression on users with higher design expectations.

This is a proposal of some things we could improve:

([Preview](https://deploy-preview-3817--base-ui.netlify.app/react/handbook/forms))

- Add required field indicators
- Add error
- Improve descriptions
- Improve layout and sizes, use full-width on input-like fields, use a smaller text size.
- Add error messages for native validation. Without this, the browser shows the default message, which might be in the user's language, but the labels and descriptions will still be in English. This could be confusing, so I think it's better to have the same approach for all text.

| Before | After |
|--------|-------|
| ![Forms guide without PR changes](https://github.com/user-attachments/assets/65c30909-0135-40ee-84b6-fe96783b6171) | ![Forms guide after PR changes](https://github.com/user-attachments/assets/733f893c-0ddd-4b9c-960a-580088dce60a) |
| ![Errors in forms guide without PR changes](https://github.com/user-attachments/assets/cf4eeccb-2e76-4274-b31d-e2e4d7f8b470) | ![Errors in forms guide after PR changes](https://github.com/user-attachments/assets/f7fb215d-a328-466c-9cb6-fdbda28e7744) |

