### PR TITLE
[field] Prevent rerenders when control is uncontrolled

### DIFF
--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -1,9 +1,11 @@
-import { createRenderer } from '@mui/internal-test-utils';
+import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
+import { expect } from 'chai';
 import { describeConformance } from '../../../test/describeConformance';
 
 describe('<Field.Control />', () => {
   const { render } = createRenderer();
+  const { render: renderNonStrict } = createRenderer({ strict: false });
 
   describeConformance(<Field.Control />, () => ({
     refInstanceof: window.HTMLInputElement,
@@ -11,4 +13,31 @@ describe('<Field.Control />', () => {
       return render(<Field.Root>{node}</Field.Root>);
     },
   }));
+
+  it('avoids rerendering for uncontrolled input changes', async () => {
+    const renderCountRef = { current: 0 };
+
+    function RenderCountedControl() {
+      renderCountRef.current += 1;
+      return <Field.Control data-testid="control" />;
+    }
+
+    renderNonStrict(
+      <Field.Root>
+        <RenderCountedControl />
+      </Field.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+    const initialRenderCount = renderCountRef.current;
+
+    fireEvent.change(control, { target: { value: 'a' } });
+    const afterFirstChange = renderCountRef.current;
+
+    fireEvent.change(control, { target: { value: 'ab' } });
+    fireEvent.change(control, { target: { value: 'abc' } });
+
+    expect(renderCountRef.current).to.equal(afterFirstChange);
+    expect(afterFirstChange).to.be.at.most(initialRenderCount + 1);
+  });
 });

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useControlled } from '@base-ui/utils/useControlled';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { FieldRoot } from '../root/FieldRoot';
@@ -69,7 +68,7 @@ export const FieldControl = React.forwardRef(function FieldControl(
     }
   }, [validation.inputRef, setFilled, valueProp]);
 
-  const [value, setValueUnwrapped] = useControlled({
+  const [valueUnwrapped] = useControlled({
     controlled: valueProp,
     default: defaultValue,
     name: 'FieldControl',
@@ -77,18 +76,7 @@ export const FieldControl = React.forwardRef(function FieldControl(
   });
 
   const isControlled = valueProp !== undefined;
-
-  const setValue = useStableCallback(
-    (nextValue: string, eventDetails: FieldControl.ChangeEventDetails) => {
-      onValueChange?.(nextValue, eventDetails);
-
-      if (eventDetails.isCanceled) {
-        return;
-      }
-
-      setValueUnwrapped(nextValue);
-    },
-  );
+  const value = isControlled ? valueUnwrapped : undefined;
 
   useField({
     id,
@@ -112,7 +100,7 @@ export const FieldControl = React.forwardRef(function FieldControl(
         ...(isControlled ? { value } : { defaultValue }),
         onChange(event) {
           const inputValue = event.currentTarget.value;
-          setValue(inputValue, createChangeEventDetails(REASONS.none, event.nativeEvent));
+          onValueChange?.(inputValue, createChangeEventDetails(REASONS.none, event.nativeEvent));
           setDirty(inputValue !== validityData.initialValue);
           setFilled(inputValue !== '');
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `useControlled`/`setValue` wrapper was an unnecessary layer here

Fixes #3819