### PR TITLE
[menu] Fix race conditions

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -566,6 +566,7 @@ export function useListNavigation(
           return;
         }
 
+        enqueueFocus(null, { sync: true });
         indexRef.current = -1;
         onNavigate(event);
 

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -139,14 +139,6 @@ export const MenuPositioner = React.forwardRef(function MenuPositioner(
         ) {
           store.setOpen(false, createChangeEventDetails(REASONS.siblingOpen));
         }
-      } else if (details.parentNodeId === floatingNodeId) {
-        // Re-enable hover on the parent when a child closes, except when the child
-        // closed due to hovering a different sibling item in this parent (sibling-open).
-        // Keeping hover disabled in that scenario prevents the parent from closing
-        // immediately when the pointer then leaves it.
-        if (details.reason !== REASONS.siblingOpen) {
-          store.set('hoverEnabled', true);
-        }
       }
     }
 

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -92,7 +92,9 @@ export const MenuSubmenuTrigger = React.forwardRef(function SubmenuTriggerCompon
   const itemMetadata = React.useMemo(
     () => ({
       type: 'submenu-trigger' as const,
-      setActive: () => parentMenuStore.set('activeIndex', listItem.index),
+      setActive() {
+        parentMenuStore.set('activeIndex', listItem.index);
+      },
     }),
     [parentMenuStore, listItem.index],
   );


### PR DESCRIPTION
Found a couple of these working on  #3783

1. Sometimes the highlight would remain stuck on an item despite the pointer leaving. `onFocus` gets called after `onPointerLeave` is called with `null` incorrectly.
2. Sometimes a submenu would incorrectly close on mouseleave despite being hovered over already  (where it should remain open).

Both are hard to reproduce; more frequent with CPU slowdown