### PR TITLE
[radio] Rely on individual radio hidden inputs

### DIFF
--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -1,10 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useControlled } from '@base-ui/utils/useControlled';
-import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
-import { NOOP } from '../utils/noop';
 import type { BaseUIComponentProps, HTMLProps } from '../utils/types';
 import { useBaseUiId } from '../utils/useBaseUiId';
 import { contains } from '../floating-ui-react/utils';
@@ -17,7 +14,6 @@ import type { FieldRoot } from '../field/root/FieldRoot';
 import { useFieldsetRootContext } from '../fieldset/root/FieldsetRootContext';
 import { useFormContext } from '../form/FormContext';
 import { useLabelableContext } from '../labelable-provider/LabelableContext';
-import { mergeProps } from '../merge-props';
 import { useValueChanged } from '../utils/useValueChanged';
 import { RadioGroupContext } from './RadioGroupContext';
 import type { BaseUIChangeEventDetails } from '../utils/createBaseUIEventDetails';
@@ -93,10 +89,60 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
   );
 
   const controlRef = React.useRef<HTMLElement>(null);
-  const registerControlRef = useStableCallback((element: HTMLElement | null) => {
-    if (controlRef.current == null && element != null) {
-      controlRef.current = element;
+  const groupInputRef = React.useRef<HTMLInputElement | null>(null);
+  const firstEnabledInputRef = React.useRef<HTMLInputElement | null>(null);
+
+  function setInputRef(hiddenInput: HTMLInputElement | null) {
+    let cleanup: void | (() => void) | undefined = undefined;
+
+    if (inputRefProp) {
+      if (typeof inputRefProp === 'function') {
+        cleanup = inputRefProp(hiddenInput);
+      } else {
+        inputRefProp.current = hiddenInput;
+      }
     }
+
+    groupInputRef.current = hiddenInput;
+    validation.inputRef.current = hiddenInput;
+
+    return cleanup;
+  }
+
+  const registerControlRef = useStableCallback(
+    (element: HTMLElement | null, isDisabled = false) => {
+      if (!element) {
+        return;
+      }
+
+      if (isDisabled) {
+        if (controlRef.current === element) {
+          controlRef.current = null;
+        }
+        return;
+      }
+
+      if (controlRef.current == null) {
+        controlRef.current = element;
+      }
+    },
+  );
+
+  const registerInputRef = useStableCallback((input: HTMLInputElement | null) => {
+    if (!input || input.disabled) {
+      return undefined;
+    }
+
+    if (!firstEnabledInputRef.current) {
+      firstEnabledInputRef.current = input;
+    }
+
+    const currentInput = groupInputRef.current;
+    if (input.checked || currentInput == null || currentInput.disabled) {
+      return setInputRef(input);
+    }
+
+    return undefined;
   });
 
   useField({
@@ -119,61 +165,16 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
     } else {
       validation.commit(checkedValue, true);
     }
+
+    const fallbackInput = firstEnabledInputRef.current;
+    if (checkedValue == null && fallbackInput && !fallbackInput.disabled) {
+      setInputRef(fallbackInput);
+    }
   });
 
   const [touched, setTouched] = React.useState(false);
 
-  const onBlur = useStableCallback((event) => {
-    if (!contains(event.currentTarget, event.relatedTarget)) {
-      setFieldTouched(true);
-      setFocused(false);
-
-      if (validationMode === 'onBlur') {
-        validation.commit(checkedValue);
-      }
-    }
-  });
-
-  const onKeyDownCapture = useStableCallback((event) => {
-    if (event.key.startsWith('Arrow')) {
-      setFieldTouched(true);
-      setTouched(true);
-      setFocused(true);
-    }
-  });
-
-  const serializedCheckedValue = React.useMemo(() => {
-    if (checkedValue == null) {
-      return ''; // avoid uncontrolled -> controlled error
-    }
-    if (typeof checkedValue === 'string') {
-      return checkedValue;
-    }
-    return JSON.stringify(checkedValue);
-  }, [checkedValue]);
-
-  const mergedInputRef = useMergedRefs(validation.inputRef, inputRefProp);
-
-  const inputProps = mergeProps<'input'>(
-    {
-      value: serializedCheckedValue,
-      ref: mergedInputRef,
-      id,
-      name: serializedCheckedValue ? name : undefined,
-      disabled,
-      readOnly,
-      required,
-      'aria-labelledby': elementProps['aria-labelledby'] ?? fieldsetContext?.legendId,
-      'aria-hidden': true,
-      tabIndex: -1,
-      style: name ? visuallyHiddenInput : visuallyHidden,
-      onChange: NOOP, // suppress a Next.js error
-      onFocus() {
-        controlRef.current?.focus();
-      },
-    },
-    validation.getInputValidationProps,
-  );
+  const ariaLabelledby = elementProps['aria-labelledby'] ?? labelId ?? fieldsetContext?.legendId;
 
   const state: RadioGroup.State = {
     ...fieldState,
@@ -192,6 +193,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
       onValueChange,
       readOnly,
       registerControlRef,
+      registerInputRef,
       required,
       setCheckedValue,
       setTouched,
@@ -206,6 +208,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
       onValueChange,
       readOnly,
       registerControlRef,
+      registerInputRef,
       required,
       setCheckedValue,
       setTouched,
@@ -218,12 +221,27 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
     'aria-required': required || undefined,
     'aria-disabled': disabled || undefined,
     'aria-readonly': readOnly || undefined,
-    'aria-labelledby': labelId,
+    'aria-labelledby': ariaLabelledby,
     onFocus() {
       setFocused(true);
     },
-    onBlur,
-    onKeyDownCapture,
+    onBlur(event) {
+      if (!contains(event.currentTarget, event.relatedTarget)) {
+        setFieldTouched(true);
+        setFocused(false);
+
+        if (validationMode === 'onBlur') {
+          validation.commit(checkedValue);
+        }
+      }
+    },
+    onKeyDownCapture(event) {
+      if (event.key.startsWith('Arrow')) {
+        setFieldTouched(true);
+        setTouched(true);
+        setFocused(true);
+      }
+    },
   };
 
   return (
@@ -238,7 +256,6 @@ export const RadioGroup = React.forwardRef(function RadioGroup(
         enableHomeAndEndKeys={false}
         modifierKeys={MODIFIER_KEYS}
       />
-      <input {...inputProps} />
     </RadioGroupContext.Provider>
   );
 });

--- a/packages/react/src/radio-group/RadioGroupContext.ts
+++ b/packages/react/src/radio-group/RadioGroupContext.ts
@@ -22,7 +22,8 @@ export interface RadioGroupContext {
   touched: boolean;
   setTouched: React.Dispatch<React.SetStateAction<boolean>>;
   validation?: UseFieldValidationReturnValue | undefined;
-  registerControlRef: (element: HTMLElement | null) => void;
+  registerControlRef: (element: HTMLElement | null, disabled?: boolean) => void;
+  registerInputRef: (element: HTMLInputElement | null) => void;
 }
 
 export const RadioGroupContext = React.createContext<RadioGroupContext>({
@@ -36,6 +37,7 @@ export const RadioGroupContext = React.createContext<RadioGroupContext>({
   touched: false,
   setTouched: NOOP,
   registerControlRef: NOOP,
+  registerInputRef: NOOP,
 });
 
 export function useRadioGroupContext() {

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import type { BaseUIComponentProps, NonNativeButtonProps } from '../../utils/types';
 import { createChangeEventDetails } from '../../utils/createBaseUIEventDetails';
@@ -20,6 +21,7 @@ import { useFieldItemContext } from '../../field/item/FieldItemContext';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
 import { useLabelableId } from '../../labelable-provider/useLabelableId';
 import { useRadioGroupContext } from '../../radio-group/RadioGroupContext';
+import { serializeValue } from '../../utils/serializeValue';
 import { RadioRootContext } from './RadioRootContext';
 
 /**
@@ -55,6 +57,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
     setTouched,
     validation,
     registerControlRef,
+    registerInputRef,
     name,
   } = useRadioGroupContext();
 
@@ -74,17 +77,43 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
   const required = requiredGroup || requiredProp;
 
   const checked = checkedValue === value;
+  const serializedValue = React.useMemo(() => serializeValue(value), [value]);
 
   const radioRef = React.useRef<HTMLElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
-  const mergedInputRef = useMergedRefs(inputRefProp, inputRef);
+  const handleControlRef = useStableCallback((element: HTMLElement | null) => {
+    if (!element) {
+      return;
+    }
+
+    registerControlRef(element, disabled);
+  });
+
+  const mergedInputRef = useMergedRefs(inputRefProp, inputRef, registerInputRef);
 
   useIsoLayoutEffect(() => {
     if (inputRef.current?.checked) {
       setFilled(true);
     }
   }, [setFilled]);
+
+  useIsoLayoutEffect(() => {
+    if (!inputRef.current) {
+      return;
+    }
+
+    if (disabled && checked) {
+      registerInputRef(null);
+      return;
+    }
+
+    if (radioRef.current) {
+      registerControlRef(radioRef.current, disabled);
+    }
+
+    registerInputRef(inputRef.current);
+  }, [checked, disabled, registerControlRef, registerInputRef]);
 
   const id = useBaseUiId();
   const inputId = useLabelableId({
@@ -136,9 +165,11 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
     type: 'radio',
     ref: mergedInputRef,
     id: hiddenInputId,
+    name,
     tabIndex: -1,
     style: name ? visuallyHiddenInput : visuallyHidden,
     'aria-hidden': true,
+    ...(value !== undefined ? { value: serializedValue } : EMPTY_OBJECT),
     disabled,
     checked,
     required,
@@ -184,7 +215,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
 
   const isRadioGroup = setCheckedValue !== NOOP;
 
-  const refs = [forwardedRef, registerControlRef, radioRef, buttonRef];
+  const refs = [forwardedRef, radioRef, buttonRef, handleControlRef];
   const props = [
     rootProps,
     getDescriptionProps,
@@ -222,27 +253,45 @@ export const RadioRoot = React.forwardRef(function RadioRoot(
 });
 
 export interface RadioRootState extends FieldRoot.State {
-  /** Whether the radio button is currently selected. */
+  /**
+   * Whether the radio button is currently selected.
+   */
   checked: boolean;
-  /** Whether the component should ignore user interaction. */
+  /**
+   * Whether the component should ignore user interaction.
+   */
   disabled: boolean;
-  /** Whether the user should be unable to select the radio button. */
+  /**
+   * Whether the user should be unable to select the radio button.
+   */
   readOnly: boolean;
-  /** Whether the user must choose a value before submitting a form. */
+  /**
+   * Whether the user must choose a value before submitting a form.
+   */
   required: boolean;
 }
 
 export interface RadioRootProps
   extends NonNativeButtonProps, Omit<BaseUIComponentProps<'span', RadioRoot.State>, 'value'> {
-  /** The unique identifying value of the radio in a group. */
+  /**
+   * The unique identifying value of the radio in a group.
+   */
   value: any;
-  /** Whether the component should ignore user interaction. */
+  /**
+   * Whether the component should ignore user interaction.
+   */
   disabled?: boolean | undefined;
-  /** Whether the user must choose a value before submitting a form. */
+  /**
+   * Whether the user must choose a value before submitting a form.
+   */
   required?: boolean | undefined;
-  /** Whether the user should be unable to select the radio button. */
+  /**
+   * Whether the user should be unable to select the radio button.
+   */
   readOnly?: boolean | undefined;
-  /** A ref to access the hidden input element. */
+  /**
+   * A ref to access the hidden input element.
+   */
   inputRef?: React.Ref<HTMLInputElement> | undefined;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This removes the `<RadioGroup>`'s internal hidden input to instead rely on the individual radio buttons' inputs, aligning with native behavior. This also makes native validation bubbles position better by default, and uses the native radio validation message instead of `<input type="text">`: "Please select one of these options" instead of "Please fill in this field"

The group's `inputRef` is forwarded to the `controlRef` input for backward compatibility.

⚠️ Test expectations for the hidden input change here, but considering this was an implementation detail for testing, I think it's acceptable to change