### PR TITLE
[code-infra] Setup flat build for packages

### DIFF
--- a/babel.config.mjs
+++ b/babel.config.mjs
@@ -17,6 +17,7 @@ export default function getBabelConfig(api) {
         runtimeModule: '#formatErrorMessage',
         detection: 'opt-out',
         errorCodesPath,
+        outExtension: process.env.MUI_OUT_FILE_EXTENSION ?? undefined,
       },
     ],
   ];

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -77,7 +77,7 @@
   "type": "commonjs",
   "scripts": {
     "prebuild": "rimraf --glob build build-tests \"*.tsbuildinfo\"",
-    "build": "code-infra build --ignore \"**/*.template.js\" --copy .npmignore",
+    "build": "code-infra build --flat --ignore \"**/*.template.js\" --copy .npmignore",
     "test:package": "publint --pack pnpm && attw --pack ./build --exclude-entrypoints package.json --exclude-entrypoints esm --exclude-entrypoints cjs",
     "release": "pnpm build && pnpm publish",
     "test": "cross-env VITEST_ENV=jsdom vitest",

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -10,7 +10,7 @@
     "moduleResolution": "bundler",
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "build/esm"
+    "outDir": "build"
   },
   "include": ["src/**/*.ts*"],
   "exclude": ["src/**/*.spec.ts*", "src/**/*.test.ts*"],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,7 @@
   "type": "commonjs",
   "scripts": {
     "prebuild": "rimraf --glob build build-tests \"*.tsbuildinfo\"",
-    "build": "code-infra build --copy .npmignore",
+    "build": "code-infra build --flat --copy .npmignore",
     "test:package": "publint --pack pnpm run ./build && attw --pack ./build --exclude-entrypoints package.json --exclude-entrypoints esm --exclude-entrypoints cjs",
     "release": "pnpm build && pnpm publish",
     "test": "cross-env VITEST_ENV=jsdom vitest",

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -10,7 +10,7 @@
     "moduleResolution": "bundler",
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "build/esm",
+    "outDir": "build",
     "lib": ["ES2022", "DOM"]
   },
   "include": ["src/**/*.ts*", "src/**/*.tsx"],


### PR DESCRIPTION
1. No more `esm` subdirectory inside `build` for es files
2. Output is as per package.json's type value
3. For module, js files corresponds to esm and cjs files correspond to commonjs.
4. For commonjs or no value, js files are cjs and mjs files correspond to module/esm.

### Parcel's bundle size comparison -

<table>
  <thead>
    <tr>
      <th>Structure</th>
      <th><code>packageExports</code></th>
      <th>Files Used</th>
      <th>Bundle Size</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Current</td>
      <td><code>false</code></td>
      <td>CJS</td>
      <td>456.28 kB</td>
    </tr>
    <tr>
      <td>Current</td>
      <td><code>true</code></td>
      <td>ESM</td>
      <td>352.45 kB</td>
    </tr>
    <tr>
      <td>New</td>
      <td><code>false</code></td>
      <td>ESM</td>
      <td>355.1 kB</td>
    </tr>
    <tr>
      <td>New</td>
      <td><code>true</code></td>
      <td>ESM</td>
      <td>354.46 kB</td>
    </tr>
  </tbody>
</table>

There's significant reduction in the size with default parcel configuration but around 2kb increase if `packageExports` is `true` between the structures.

### Bundle Size Comparison: @base-ui/react                                                                                                                                                                            
                                                                                                                                                                                                                         
   **Reference:** [`@09a9a9b`](https://pkg.pr.new/mui/base-ui/@base-ui/react@09a9a9b)                                                                                                                                    
   **Change:** [`@af45823`](https://pkg.pr.new/mui/base-ui/@base-ui/react@af45823)                                                                                                                                       
                                                                                                                                                                                                                         
   #### Vendor-Base-UI Chunk Size                                                                                                                                                                                        
                                                                                                                                                                                                                         
   | Bundler | Old (Minified) | New (Minified) | Diff (Minified) | Old (Gzipped) | New (Gzipped) | Diff (Gzipped) |                                                                                                      
   | :--- | :--- | :--- | :--- | :--- | :--- | :--- |                                                                                                                                                                    
   | **rolldown** | 113.7 KB | 114.0 KB | **+0.3 KB** | 36.9 KB | 36.9 KB | **0.0 KB** |                                                                                                                                 
   | **vite-swc** | 115.1 KB | 115.3 KB | **+0.2 KB** | 38.3 KB | 38.4 KB | **+0.1 KB** |                                                                                                                                
   | **rsbuild** | 124.6 KB | 124.9 KB | **+0.3 KB** | 41.3 KB | 41.4 KB | **+0.1 KB** |                                                                                                                                 
   | **webpack-5** | 126.8 KB | 127.2 KB | **+0.4 KB** | 41.6 KB | 41.7 KB | **+0.1 KB** |                                                                                                                               
   | **vite*** | 296.5 KB | 297.4 KB | **+0.9 KB** | 60.3 KB | 60.3 KB | **0.0 KB** |                                                                                                                                    
   | **webpack-4** | 359.6 KB | 360.0 KB | **+0.4 KB** | 73.4 KB | 73.5 KB | **+0.1 KB** |                                                                                                                               
                                                                                                                                                                                                                         
   > \* _Note: `vite` (default) and `webpack-4` configurations in this test suite produce larger bundles due to less aggressive tree-shaking settings, but the delta remains consistent._                                
                                                                                                                                                                                                                         
   #### Total Bundle Size (Single Bundle)                                                                                                                                                                                
                                                                                                                                                                                                                         
   For bundlers configured to output a single file:                                                                                                                                                                      
                                                                                                                                                                                                                         
   | Bundler | Old (Minified) | New (Minified) | Diff (Minified) | Old (Gzipped) | New (Gzipped) | Diff (Gzipped) |                                                                                                      
   | :--- | :--- | :--- | :--- | :--- | :--- | :--- |                                                                                                                                                                    
   | **esbuild** | 352.5 KB | 352.8 KB | **+0.3 KB** | 113.5 KB | 113.6 KB | **+0.1 KB** |                                                                                                                               
   | **parcel** | 346.1 KB | 346.1 KB | **0.0 KB** | 110.6 KB | 110.6 KB | **0.0 KB** |                                                                                                                                  
                                                                                                                                                                                                                         
   #### Summary                                                                                                                                                                                                          
   *   **Minified Increase:** Consistently **~0.2 KB - 0.4 KB** across most modern bundlers.                                                                                                                             
   *   **Gzipped Increase:** Negligible increase of **~0.1 KB** (approx. 100 bytes).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
