### PR TITLE
[dialog][alert dialog][popover] Fix focus management for children with positive tabindex

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -755,7 +755,12 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
             <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
             {open && (
               <FloatingFocusManager context={context} modal initialFocus={priorityRef}>
-                <div role="dialog" ref={refs.setFloating} {...getFloatingProps()} data-testid="floating">
+                <div
+                  role="dialog"
+                  ref={refs.setFloating}
+                  {...getFloatingProps()}
+                  data-testid="floating"
+                >
                   <button ref={priorityRef} tabIndex={1} data-testid="priority">
                     Priority
                   </button>

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -359,13 +359,37 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
 
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === 'Tab') {
+        const activeEl = activeElement(getDocument(floatingFocusElement));
         // The focus guards have nothing to focus, so we need to stop the event.
         if (
-          contains(floatingFocusElement, activeElement(getDocument(floatingFocusElement))) &&
+          contains(floatingFocusElement, activeEl) &&
           getTabbableContent().length === 0 &&
           !isUntrappedTypeableCombobox
         ) {
           stopEvent(event);
+        }
+
+        const tabbableContent = getTabbableContent() as Array<FocusableElement>;
+        if (
+          contains(floatingFocusElement, activeEl) &&
+          !isUntrappedTypeableCombobox &&
+          tabbableContent.some((element) => element.tabIndex > 0)
+        ) {
+          // Positive tabIndex content can jump ahead of the focus guards in the browser's
+          // global tab order, so manually cycle within the floating element to preserve
+          // the focus trap.
+          stopEvent(event);
+          const activeIndex = tabbableContent.indexOf(activeEl as FocusableElement);
+          let nextIndex = 0;
+          if (event.shiftKey) {
+            nextIndex = activeIndex <= 0 ? tabbableContent.length - 1 : activeIndex - 1;
+          } else {
+            nextIndex =
+              activeIndex === -1 || activeIndex === tabbableContent.length - 1
+                ? 0
+                : activeIndex + 1;
+          }
+          enqueueFocus(tabbableContent[nextIndex] ?? null, { sync: true });
         }
       }
     }

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -990,6 +990,51 @@ describe('<Popover.Root />', () => {
         expect(positioner.previousElementSibling).to.equal(null);
       });
 
+      it('keeps focus trapped when content includes a positive tabIndex', async () => {
+        function Test() {
+          const priorityRef = React.useRef<HTMLButtonElement>(null);
+
+          return (
+            <div>
+              <TestPopover
+                rootProps={{ modal: 'trap-focus' }}
+                popupProps={{
+                  initialFocus: priorityRef,
+                  children: (
+                    <React.Fragment>
+                      <button ref={priorityRef} tabIndex={1}>
+                        Priority
+                      </button>
+                      <button>Close</button>
+                    </React.Fragment>
+                  ),
+                }}
+              />
+              <button>Outside</button>
+            </div>
+          );
+        }
+
+        const { user } = await render(<Test />);
+
+        await user.click(screen.getByRole('button', { name: 'Toggle' }));
+        await waitFor(() => {
+          expect(screen.queryByTestId('popover-popup')).not.to.equal(null);
+        });
+
+        const priorityButton = screen.getByRole('button', { name: 'Priority' });
+        await waitFor(() => {
+          expect(priorityButton).toHaveFocus();
+        });
+
+        await user.keyboard('[Tab]');
+        expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus();
+
+        await user.keyboard('[Tab]');
+        expect(priorityButton).toHaveFocus();
+        expect(screen.getByText('Outside')).not.toHaveFocus();
+      });
+
       describe('with openOnHover', () => {
         clock.withFakeTimers();
 


### PR DESCRIPTION
Fixed modal focus trapping when Dialogs or Popovers contain positive tabIndex elements by adding manual <kbd>Tab</kbd> cycling in FloatingFocusManager.

Fixes #3844