### PR TITLE
add tooltip role and aria-describedby to Tooltip for screenreaders

### DIFF
--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -41,6 +41,38 @@ describe('<Tooltip.Root />', () => {
     { name: 'detached triggers', Component: DetachedTriggerTooltip },
     { name: 'multiple detached triggers', Component: MultipleDetachedTriggersTooltip },
   ])('when using $name', ({ Component: TestTooltip }) => {
+    describe('ARIA attributes', () => {
+      clock.withFakeTimers();
+
+      it('should have role="tooltip" on the popup', async () => {
+        await render(<TestTooltip rootProps={{ open: true }} />);
+
+        expect(screen.getByRole('tooltip')).not.to.equal(null);
+      });
+
+      it('should have aria-describedby on the trigger pointing to the popup', async () => {
+        await render(
+          <TestTooltip
+            rootProps={{ open: true, triggerId: 'test-trigger' }}
+            triggerProps={{ id: 'test-trigger' }}
+          />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+        const popup = screen.getByRole('tooltip');
+
+        expect(trigger.getAttribute('aria-describedby')).to.equal(popup.id);
+      });
+
+      it('should not have aria-describedby on the trigger when closed', async () => {
+        await render(<TestTooltip />);
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        expect(trigger.getAttribute('aria-describedby')).to.equal(null);
+      });
+    });
+
     describe('uncontrolled open', () => {
       clock.withFakeTimers();
 

--- a/packages/react/src/tooltip/root/TooltipRoot.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.tsx
@@ -4,7 +4,13 @@ import { fastComponent } from '@base-ui/utils/fastHooks';
 import { useOnFirstRender } from '@base-ui/utils/useOnFirstRender';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { TooltipRootContext } from './TooltipRootContext';
-import { useClientPoint, useDismiss, useFocus, useInteractions } from '../../floating-ui-react';
+import {
+  useClientPoint,
+  useDismiss,
+  useFocus,
+  useInteractions,
+  useRole,
+} from '../../floating-ui-react';
 import {
   type BaseUIChangeEventDetails,
   createChangeEventDetails,
@@ -140,11 +146,13 @@ export const TooltipRoot = fastComponent(function TooltipRoot<Payload>(
     enabled: !disabled && trackCursorAxis !== 'none',
     axis: trackCursorAxis === 'none' ? undefined : trackCursorAxis,
   });
+  const role = useRole(floatingRootContext, { role: 'tooltip' });
 
   const { getReferenceProps, getFloatingProps, getTriggerProps } = useInteractions([
     focus,
     dismiss,
     clientPoint,
+    role,
   ]);
 
   const activeTriggerProps = React.useMemo(() => getReferenceProps(), [getReferenceProps]);


### PR DESCRIPTION
- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Used the built-in `useRole` hookt to add role of 'tooltip' to the Tooltip Content so the contents of the popup are announced by the screenreader when focusing the TooltipTrigger using aria-describedby