### PR TITLE
[autocomplete] Fix filter method's `useMemo` dependency

### DIFF
--- a/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
@@ -87,7 +87,7 @@ export function AutocompleteRoot<ItemValue>(
     return (item, query, toString) => {
       return collator.contains(stringifyAsLabel(item, toString), query);
     };
-  }, [other, collator]);
+  }, [other.filter, collator]);
 
   const resolvedQuery = String(isControlled ? value : internalValue).trim();
 


### PR DESCRIPTION
This memo would run on every render because `other` is a new object every render (because of `{...other}` via props destructuring). This PR fixes the dependency.