### PR TITLE
[select] Fix `highlightItemOnHover` not being respected

### DIFF
--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -148,7 +148,11 @@ export const SelectItem = React.memo(
         store.set('activeIndex', index);
       },
       onMouseEnter() {
-        if (!keyboardActiveRef.current && store.state.selectedIndex === null) {
+        if (
+          !keyboardActiveRef.current &&
+          store.state.selectedIndex === null &&
+          highlightItemOnHover
+        ) {
           store.set('activeIndex', index);
         }
       },

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -2911,7 +2911,7 @@ describe('<Select.Root />', () => {
 
   describe('prop: highlightItemOnHover', () => {
     it('highlights an item on mouse move by default', async () => {
-      await render(
+      const { user } = await render(
         <Select.Root defaultOpen>
           <Select.Trigger data-testid="trigger">
             <Select.Value />
@@ -2929,7 +2929,7 @@ describe('<Select.Root />', () => {
       );
 
       const optionB = screen.getByRole('option', { name: 'b' });
-      fireEvent.mouseMove(optionB);
+      await user.hover(optionB);
 
       await waitFor(() => {
         expect(optionB).to.have.attribute('data-highlighted');
@@ -2937,7 +2937,7 @@ describe('<Select.Root />', () => {
     });
 
     it('does not highlight items from mouse movement when disabled', async () => {
-      await render(
+      const { user } = await render(
         <Select.Root defaultOpen highlightItemOnHover={false}>
           <Select.Trigger data-testid="trigger">
             <Select.Value />
@@ -2955,7 +2955,7 @@ describe('<Select.Root />', () => {
       );
 
       const optionB = screen.getByRole('option', { name: 'b' });
-      fireEvent.mouseMove(optionB);
+      await user.hover(optionB);
 
       await flushMicrotasks();
 
@@ -2981,7 +2981,7 @@ describe('<Select.Root />', () => {
       );
 
       const optionA = screen.getByRole('option', { name: 'a' });
-      fireEvent.mouseMove(optionA);
+      await user.hover(optionA);
 
       await user.keyboard('{ArrowDown}');
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

When `highlightItemOnHover` is `false`, `data-highlighted` should not be applied to `Select.Item`'s. Adding condition to `onMouseEnter` fixes it.

Unit tests did not fail as they were using `fireEvent.mouseMove`, `UserEvent` should trigger `mouseEnter` and `mouseMove`.

Fixes #3867 