### PR TITLE
[select] Fix `items` type definition for groups

### DIFF
--- a/docs/reference/generated/select-root.json
+++ b/docs/reference/generated/select-root.json
@@ -65,10 +65,10 @@
       "detailedType": "((itemValue: Value) => string) | undefined"
     },
     "items": {
-      "type": "Record<string, ReactNode> | ({ label: ReactNode, value: any })[]",
+      "type": "Record<string, ReactNode> | Group[] | ({ label: ReactNode, value: any })[] | (Group<{ label: ReactNode, value: any }>)[]",
       "description": "Data structure of the items rendered in the select popup.\nWhen specified, `<Select.Value>` renders the label of the selected item instead of the raw value.",
       "example": "```tsx\nconst items = {\n  sans: 'Sans-serif',\n  serif: 'Serif',\n  mono: 'Monospace',\n  cursive: 'Cursive',\n};\n<Select.Root items={items} />\n```",
-      "detailedType": "| Record<string, ReactNode>\n| { label: ReactNode; value: any }[]\n| undefined"
+      "detailedType": "| Record<string, ReactNode>\n| Group[]\n| { label: ReactNode; value: any }[]\n| Group<{ label: ReactNode; value: any }>[]\n| undefined"
     },
     "modal": {
       "type": "boolean",

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -30,7 +30,7 @@ import { REASONS } from '../../utils/reasons';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useFormContext } from '../../form/FormContext';
 import { useField } from '../../field/useField';
-import { stringifyAsValue } from '../../utils/resolveValueLabel';
+import { Group, stringifyAsValue } from '../../utils/resolveValueLabel';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from '../../utils/constants';
 import { defaultItemEquality, findItemIndex } from '../../utils/itemEquality';
 import { useValueChanged } from '../../utils/useValueChanged';
@@ -673,7 +673,10 @@ export interface SelectRootProps<Value, Multiple extends boolean | undefined = f
    * ```
    */
   items?:
-    | (Record<string, React.ReactNode> | ReadonlyArray<{ label: React.ReactNode; value: any }>)
+    | Record<string, React.ReactNode>
+    | ReadonlyArray<{ label: React.ReactNode; value: any }>
+    | ReadonlyArray<Group<any>>
+    | ReadonlyArray<Group<{ label: React.ReactNode; value: any }>>
     | undefined;
   /**
    * When the item values are objects (`<Select.Item value={object}>`), this function converts the object value to a string representation for display in the trigger.

--- a/packages/react/src/select/store.ts
+++ b/packages/react/src/select/store.ts
@@ -3,7 +3,7 @@ import { type InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import type { TransitionStatus } from '../utils/useTransitionStatus';
 import type { HTMLProps } from '../utils/types';
 import { compareItemEquality } from '../utils/itemEquality';
-import { hasNullItemLabel, stringifyAsValue } from '../utils/resolveValueLabel';
+import { Group, hasNullItemLabel, stringifyAsValue } from '../utils/resolveValueLabel';
 
 export type State = {
   id: string | undefined;
@@ -13,6 +13,8 @@ export type State = {
   items:
     | Record<string, React.ReactNode>
     | ReadonlyArray<{ label: React.ReactNode; value: any }>
+    | ReadonlyArray<Group<any>>
+    | ReadonlyArray<Group<{ label: React.ReactNode; value: any }>>
     | undefined;
   itemToStringLabel: ((item: any) => string) | undefined;
   itemToStringValue: ((item: any) => string) | undefined;

--- a/packages/react/src/utils/resolveValueLabel.tsx
+++ b/packages/react/src/utils/resolveValueLabel.tsx
@@ -6,6 +6,7 @@ type ItemRecord = Record<string, React.ReactNode>;
 type ItemsInput =
   | ItemRecord
   | ReadonlyArray<LabeledItem>
+  | ReadonlyArray<Group<any>>
   | ReadonlyArray<Group<LabeledItem>>
   | undefined;
 


### PR DESCRIPTION
While adding a grouped demo in the Select docs (https://github.com/mui/base-ui/pull/3884), I realized the `items` prop didn't accept an array of groups.

This change expands the `items` type to also accept an array of groups with these shapes:

```ts
const groups1 = [
  {
    value: 'Fruits',
    items: ['Apple', 'Banana']
  },
  {
    value: 'Vegetables',
    items: ['Broccoli', 'Carrot']
  }
];

const groups2 = [
  {
    value: 'Fruits',
    items: [
      { value: 'apple', label: 'Apple' },
      { value: 'banana', label: 'Banana' }
    ]
  },
  {
    value: 'Vegetables',
    items: [
      { value: 'broccoli', label: 'Broccoli' },
      { value: 'carrot', label: 'Carrot' }
    ]
  }
];
```
