### PR TITLE
[menu] Allow `onKeyDown` handlers to be called at `Group` level during typeahead

### DIFF
--- a/packages/react/src/menu/group/MenuGroup.test.tsx
+++ b/packages/react/src/menu/group/MenuGroup.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@mui/internal-test-utils';
-import { expect } from 'chai';
+import { expect, vi } from 'vitest';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -14,5 +14,82 @@ describe('<Menu.Group />', () => {
   it('renders a div with the `group` role', async () => {
     await render(<Menu.Group />);
     expect(screen.getByRole('group')).toBeVisible();
+  });
+
+  it('calls the group keydown handler without triggering parent typeahead in an open submenu', async () => {
+    const handleKeyDown = vi.fn();
+
+    const { user } = await render(
+      <Menu.Root open>
+        <Menu.Portal>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Group onKeyDown={handleKeyDown}>
+                <Menu.Item>Apple</Menu.Item>
+                <Menu.Item>Banana</Menu.Item>
+                <Menu.SubmenuRoot open>
+                  <Menu.SubmenuTrigger>More</Menu.SubmenuTrigger>
+                  <Menu.Portal>
+                    <Menu.Positioner>
+                      <Menu.Popup>
+                        <Menu.Item closeOnClick={false}>Sub item</Menu.Item>
+                      </Menu.Popup>
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.SubmenuRoot>
+              </Menu.Group>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>,
+    );
+
+    const parentMatchItem = screen.getByRole('menuitem', { name: 'Banana' });
+    const subItem = screen.getByRole('menuitem', { name: 'Sub item' });
+    expect(parentMatchItem).not.toHaveAttribute('data-highlighted');
+
+    await user.click(subItem);
+    await user.keyboard('b');
+
+    expect(handleKeyDown).toHaveBeenCalled();
+    expect(parentMatchItem).not.toHaveAttribute('data-highlighted');
+  });
+
+  it('does not bubble typeahead keydown events above the menu root from an open submenu', async () => {
+    const handleGroupKeyDown = vi.fn();
+    const handleRootKeyDown = vi.fn();
+
+    const { user } = await render(
+      <div onKeyDown={handleRootKeyDown}>
+        <Menu.Root open>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Group onKeyDown={handleGroupKeyDown}>
+                  <Menu.Item>Parent item</Menu.Item>
+                  <Menu.SubmenuRoot open>
+                    <Menu.SubmenuTrigger>More</Menu.SubmenuTrigger>
+                    <Menu.Portal>
+                      <Menu.Positioner>
+                        <Menu.Popup>
+                          <Menu.Item closeOnClick={false}>Sub item</Menu.Item>
+                        </Menu.Popup>
+                      </Menu.Positioner>
+                    </Menu.Portal>
+                  </Menu.SubmenuRoot>
+                </Menu.Group>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
+      </div>,
+    );
+
+    const subItem = screen.getByRole('menuitem', { name: 'Sub item' });
+    await user.click(subItem);
+    await user.keyboard('s');
+
+    expect(handleGroupKeyDown).toHaveBeenCalled();
+    expect(handleRootKeyDown).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -470,6 +470,9 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     listRef: store.context.itemLabels,
     activeIndex,
     resetMs: TYPEAHEAD_RESET_MS,
+    // Let nested menu keydowns bubble through the menu tree (e.g. Group handlers),
+    // then stop them at the menu root so they don't reach higher-level listeners.
+    stopPropagation: parent.type !== 'menu' && parent.type !== 'nested-context-menu',
     onMatch: (index) => {
       if (open && index !== activeIndex) {
         store.set('activeIndex', index);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Listeners that execute on keydown around Group level should allow to be called and not be blocked by typeahead, as in Radix.
