### PR TITLE
[tooltip] Prevent opening when focusing a disabled Trigger

### DIFF
--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -618,6 +618,17 @@ describe('<Tooltip.Root />', () => {
         expect(screen.queryByText('Content')).to.equal(null);
       });
 
+      it('should not open on focus when the trigger is disabled', async () => {
+        await render(<TestTooltip triggerProps={{ disabled: true, delay: 0 }} />);
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        await act(async () => trigger.focus());
+        await flushMicrotasks();
+
+        expect(screen.queryByText('Content')).to.equal(null);
+      });
+
       it('should close if open when becoming disabled', async () => {
         function App() {
           const [disabled, setDisabled] = React.useState(false);

--- a/packages/react/src/tooltip/root/TooltipRoot.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.tsx
@@ -4,7 +4,7 @@ import { fastComponent } from '@base-ui/utils/fastHooks';
 import { useOnFirstRender } from '@base-ui/utils/useOnFirstRender';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { TooltipRootContext } from './TooltipRootContext';
-import { useClientPoint, useDismiss, useFocus, useInteractions } from '../../floating-ui-react';
+import { useClientPoint, useDismiss, useInteractions } from '../../floating-ui-react';
 import {
   type BaseUIChangeEventDetails,
   createChangeEventDetails,
@@ -134,7 +134,6 @@ export const TooltipRoot = fastComponent(function TooltipRoot<Payload>(
 
   const floatingRootContext = store.useState('floatingRootContext');
 
-  const focus = useFocus(floatingRootContext, { enabled: !disabled });
   const dismiss = useDismiss(floatingRootContext, { enabled: !disabled, referencePress: true });
   const clientPoint = useClientPoint(floatingRootContext, {
     enabled: !disabled && trackCursorAxis !== 'none',
@@ -142,7 +141,6 @@ export const TooltipRoot = fastComponent(function TooltipRoot<Payload>(
   });
 
   const { getReferenceProps, getFloatingProps, getTriggerProps } = useInteractions([
-    focus,
     dismiss,
     clientPoint,
   ]);

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -9,7 +9,12 @@ import { useTriggerDataForwarding } from '../../utils/popups';
 import { useBaseUiId } from '../../utils/useBaseUiId';
 import { TooltipHandle } from '../store/TooltipHandle';
 import { useTooltipProviderContext } from '../provider/TooltipProviderContext';
-import { safePolygon, useDelayGroup, useHoverReferenceInteraction } from '../../floating-ui-react';
+import {
+  safePolygon,
+  useDelayGroup,
+  useFocus,
+  useHoverReferenceInteraction,
+} from '../../floating-ui-react';
 
 import { OPEN_DELAY } from '../utils/constants';
 
@@ -112,6 +117,8 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
     isActiveTrigger: isTriggerActive,
   });
 
+  const focusProps = useFocus(floatingRootContext, { enabled: !disabled }).reference;
+
   const state: TooltipTrigger.State = { open: isOpenedByThisTrigger };
 
   const rootTriggerProps = store.useState('triggerProps', isMountedByThisTrigger);
@@ -119,7 +126,7 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
   const element = useRenderElement('button', componentProps, {
     state,
     ref: [forwardedRef, registerTrigger, triggerElementRef],
-    props: [hoverProps, rootTriggerProps, { id: thisTriggerId }, elementProps],
+    props: [hoverProps, focusProps, rootTriggerProps, { id: thisTriggerId }, elementProps],
     stateAttributesMapping: triggerOpenStateMapping,
   });
 


### PR DESCRIPTION
When the `disabled` prop is set on the Trigger, it's still possible to open the tooltip by focusing the trigger. This PR fixes it, making it consistent with the behavior on hover.

Fixes #3468