### PR TITLE
[code-infra] Remove `NODE_ENV=test`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,9 +81,6 @@ export default defineConfig(
       'react-hooks/immutability': 'off',
       'react-hooks/incompatible-library': 'off',
       'react-hooks/refs': 'off',
-
-      // TODO (@Janpot) REconfigure test env to not use production guard
-      'mui/consistent-production-guard': 'off',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:regressions:dev": "vite --config test/regressions/vite.config.mjs --port 5173",
     "test:regressions:run": "cross-env VITEST_ENV=chromium vitest run --project regressions",
     "test:regressions:server": "serve test/regressions -p 5173",
-    "test:_unit": "cross-env NODE_ENV=test vitest --project @base-ui/react --project @base-ui/utils --project docs",
+    "test:_unit": "cross-env vitest --project @base-ui/react --project @base-ui/utils --project docs",
     "test:jsdom": "cross-env VITEST_ENV=jsdom pnpm test:_unit",
     "test:jsdom:coverage": "pnpm test:jsdom --coverage",
     "test:chromium": "cross-env VITEST_ENV=chromium pnpm test:_unit",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,7 +79,7 @@
     "build": "code-infra build --ignore \"**/*.template.js\" --copy .npmignore",
     "test:package": "publint --pack pnpm && attw --pack ./build --exclude-entrypoints package.json --exclude-entrypoints esm --exclude-entrypoints cjs",
     "release": "pnpm build && pnpm publish",
-    "test": "cross-env NODE_ENV=test VITEST_ENV=jsdom vitest",
+    "test": "cross-env VITEST_ENV=jsdom vitest",
     "typescript": "tsc -b tsconfig.json"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,7 +21,7 @@
     "build": "code-infra build --copy .npmignore",
     "test:package": "publint --pack pnpm run ./build && attw --pack ./build --exclude-entrypoints package.json --exclude-entrypoints esm --exclude-entrypoints cjs",
     "release": "pnpm build && pnpm publish",
-    "test": "cross-env NODE_ENV=test VITEST_ENV=jsdom vitest",
+    "test": "cross-env VITEST_ENV=jsdom vitest",
     "typescript": "tsc -b tsconfig.json"
   },
   "dependencies": {


### PR DESCRIPTION
It was unused and we started disallowing it in eslint