### PR TITLE
[number field] Remove `event.isTrusted` 

### DIFF
--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -239,8 +239,8 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
         return;
       }
 
-      // For trusted user typing, update the input text immediately and only fire onValueChange
-      // if the typed value is currently parseable into a number. This preserves good UX for IME
+      // Update the input text immediately and only fire onValueChange if the typed value is
+      // currently parseable into a number. This preserves good UX for IME
       // composition/partial input while still providing live numeric updates when possible.
       const allowedNonNumericKeys = getAllowedNonNumericKeys();
       const isValidCharacterString = Array.from(targetValue).every((ch) => {
@@ -265,19 +265,11 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
         return;
       }
 
-      if (event.isTrusted) {
-        setInputValue(targetValue);
-        const parsedValue = parseNumber(targetValue, locale, formatOptionsRef.current);
-        if (parsedValue !== null) {
-          setValue(parsedValue, createChangeEventDetails(REASONS.inputChange, event.nativeEvent));
-        }
-        return;
-      }
-
       const parsedValue = parseNumber(targetValue, locale, formatOptionsRef.current);
 
+      setInputValue(targetValue);
+
       if (parsedValue !== null) {
-        setInputValue(targetValue);
         setValue(parsedValue, createChangeEventDetails(REASONS.inputChange, event.nativeEvent));
       }
     },

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -573,17 +573,16 @@ describe('<NumberField />', () => {
       expect(onValueChange.firstCall.args[0]).to.equal(12.34);
     });
 
-    // In JSDOM, change events are not trusted; input text state is not updated for invalid
-    // partials (like "."). We cover browser behavior here.
-    it.skipIf(isJSDOM)('does not commit on blur for invalid input', async () => {
+    it('does not commit on blur for invalid input', async () => {
       const onValueCommitted = spy();
       await render(<NumberField onValueCommitted={onValueCommitted} />);
       const input = screen.getByRole('textbox');
 
       fireEvent.change(input, { target: { value: '.' } });
+      expect(input).to.have.value('.');
       fireEvent.blur(input);
 
-      expect(onValueCommitted.firstCall.args[0]).to.equal(null);
+      expect(onValueCommitted.callCount).to.equal(0);
     });
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Simplifies testing in JSDOM env.

Codex review:
> Behavior‑wise, it mattered mostly for non‑trusted change events (tests and any code that manually dispatches change events). Those used to be blocked from showing partial/invalid input; now they’re allowed (but `onValueChange` still only fires for parseable values).
> For real users in browsers, the UX is effectively the same (they already hit the "trusted" path).
> So the practical impact is: more predictable in tests and more permissive for programmatic events; the numeric value still won’t change unless parseable.
