### PR TITLE
[autocomplete] Remove unnecessary double stringification of item in filtering logic

### DIFF
--- a/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
@@ -84,9 +84,7 @@ export function AutocompleteRoot<ItemValue>(
     if (other.filter) {
       return other.filter;
     }
-    return (item, query, toString) => {
-      return collator.contains(item, query, toString);
-    };
+    return collator.contains;
   }, [other.filter, collator]);
 
   const resolvedQuery = String(isControlled ? value : internalValue).trim();


### PR DESCRIPTION
`contains` method already stringify the item as label. Avoid double doing it.