### PR TITLE
[typescript] Fix type references to internal types

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,7 +68,7 @@
     "./types": "./src/types/index.ts",
     "./unstable-use-media-query": "./src/unstable-use-media-query/index.ts",
     "./use-render": "./src/use-render/index.ts",
-    "./utils/types": "./src/utils/types.ts"
+    "./utils/types": "./src/types/types.ts"
   },
   "imports": {
     "#test-utils": "./test/index.ts",

--- a/packages/react/src/types/types.ts
+++ b/packages/react/src/types/types.ts
@@ -1,0 +1,1 @@
+export type { HTMLProps, BaseUIEvent, ComponentRenderFn } from '../utils/types';


### PR DESCRIPTION
https://stackblitz.com/edit/bf5bx4pd-byucm7h5?file=src%2FApp.tsx

Not sure if there are better ways but this seems to make `import("@base-ui/react/utils/types").BaseUIEvent` work without exposing all the internal types

Options that didn't work:
- Re-exporting from `src/types/index`: `export type { BaseUIEvent } from '../utils/types'`
- Exporting a duplicate `BaseUIEvent` from `src/types/index` directly, TS throws with an error about duplicate exports

Fixes https://github.com/mui/base-ui/issues/3937

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
