### PR TITLE
[combobox][test] Check for popup close when chip receives focus

### DIFF
--- a/packages/react/src/combobox/chip-remove/ComboboxChipRemove.test.tsx
+++ b/packages/react/src/combobox/chip-remove/ComboboxChipRemove.test.tsx
@@ -117,7 +117,7 @@ describe('<Combobox.ChipRemove />', () => {
       const remove = screen.getByTestId('remove');
 
       // Should be focusable
-      act(() => {
+      await act(async () => {
         remove.focus();
       });
       expect(remove).toHaveFocus();
@@ -225,7 +225,7 @@ describe('<Combobox.ChipRemove />', () => {
 
       const remove = screen.getByTestId('remove');
 
-      act(() => {
+      await act(async () => {
         remove.focus();
       });
       await user.keyboard('{Enter}');

--- a/packages/react/src/combobox/chip/ComboboxChip.test.tsx
+++ b/packages/react/src/combobox/chip/ComboboxChip.test.tsx
@@ -46,7 +46,7 @@ describe('<Combobox.Chip />', () => {
       const chipApple = screen.getByTestId('chip-apple');
 
       // Focus the chip manually (simulating navigation)
-      act(() => {
+      await act(async () => {
         chipApple.focus();
       });
 
@@ -77,7 +77,7 @@ describe('<Combobox.Chip />', () => {
       const chipApple = screen.getByTestId('chip-apple');
 
       // Focus the chip manually
-      act(() => {
+      await act(async () => {
         chipApple.focus();
       });
 
@@ -141,7 +141,7 @@ describe('<Combobox.Chip />', () => {
       const chipApple = screen.getByTestId('chip-apple');
 
       // Focus the chip manually
-      act(() => {
+      await act(async () => {
         chipApple.focus();
       });
 
@@ -166,7 +166,7 @@ describe('<Combobox.Chip />', () => {
       const chipApple = screen.getByTestId('chip-apple');
 
       // Focus the first chip
-      act(() => {
+      await act(async () => {
         chipApple.focus();
       });
 
@@ -235,7 +235,7 @@ describe('<Combobox.Chip />', () => {
 
       await user.click(input);
       const chipApple = screen.getByTestId('chip-apple');
-      act(() => {
+      await act(async () => {
         chipApple.focus();
       });
 
@@ -260,7 +260,7 @@ describe('<Combobox.Chip />', () => {
       const input = screen.getByTestId('input');
 
       // Focus the first chip
-      act(() => {
+      await act(async () => {
         chipApple.focus();
       });
 
@@ -277,7 +277,7 @@ describe('<Combobox.Chip />', () => {
       expect(input).toHaveFocus();
 
       // Navigate left from first chip should also focus input
-      act(() => {
+      await act(async () => {
         chipApple.focus();
       });
       await user.keyboard('{ArrowLeft}');
@@ -303,7 +303,7 @@ describe('<Combobox.Chip />', () => {
       const chipApple = screen.getByTestId('chip-apple');
 
       // Focus the chip and delete it
-      act(() => {
+      await act(async () => {
         chipApple.focus();
       });
       await user.keyboard('{Backspace}');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Adds a test to verify the popup closes when a chip receives focus (`focusout` of popup)

---

(Edit: this no longer reproduces on master, so changes have been removed from this PR)

With changes to focus management, the popup should explicitly close when a chip receives focus. This fixes the ability to escape the popup on iOS VoiceOver (`aria-hidden` on "outside" elements gets removed). This is a post-v1.1.0 regression