### PR TITLE
[toast] Support type extension via module augmentation

### DIFF
--- a/packages/react/src/toast/action/ToastAction.tsx
+++ b/packages/react/src/toast/action/ToastAction.tsx
@@ -4,6 +4,7 @@ import type { BaseUIComponentProps, NativeButtonProps } from '../../utils/types'
 import { useToastRootContext } from '../root/ToastRootContext';
 import { useButton } from '../../use-button/useButton';
 import { useRenderElement } from '../../utils/useRenderElement';
+import { ToastType } from '../useToastManager';
 
 /**
  * Performs an action when clicked.
@@ -55,7 +56,7 @@ export interface ToastActionState {
   /**
    * The type of the toast.
    */
-  type: string | undefined;
+  type: ToastType
 }
 
 export interface ToastActionProps

--- a/packages/react/src/toast/action/ToastAction.tsx
+++ b/packages/react/src/toast/action/ToastAction.tsx
@@ -56,7 +56,7 @@ export interface ToastActionState {
   /**
    * The type of the toast.
    */
-  type: ToastType
+  type: ToastType;
 }
 
 export interface ToastActionProps

--- a/packages/react/src/toast/close/ToastClose.tsx
+++ b/packages/react/src/toast/close/ToastClose.tsx
@@ -5,6 +5,7 @@ import { useToastRootContext } from '../root/ToastRootContext';
 import { useToastContext } from '../provider/ToastProviderContext';
 import { useButton } from '../../use-button/useButton';
 import { useRenderElement } from '../../utils/useRenderElement';
+import { ToastType } from '../useToastManager';
 
 /**
  * Closes the toast when clicked.
@@ -60,7 +61,7 @@ export interface ToastCloseState {
   /**
    * The type of the toast.
    */
-  type: string | undefined;
+  type: ToastType
 }
 
 export interface ToastCloseProps

--- a/packages/react/src/toast/close/ToastClose.tsx
+++ b/packages/react/src/toast/close/ToastClose.tsx
@@ -61,7 +61,7 @@ export interface ToastCloseState {
   /**
    * The type of the toast.
    */
-  type: ToastType
+  type: ToastType;
 }
 
 export interface ToastCloseProps

--- a/packages/react/src/toast/description/ToastDescription.tsx
+++ b/packages/react/src/toast/description/ToastDescription.tsx
@@ -5,6 +5,7 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useToastRootContext } from '../root/ToastRootContext';
 import { useRenderElement } from '../../utils/useRenderElement';
+import { ToastType } from '../useToastManager';
 
 /**
  * A description that describes the toast.
@@ -66,7 +67,7 @@ export interface ToastDescriptionState {
   /**
    * The type of the toast.
    */
-  type: string | undefined;
+  type: ToastType
 }
 
 export interface ToastDescriptionProps extends BaseUIComponentProps<'p', ToastDescription.State> {}

--- a/packages/react/src/toast/description/ToastDescription.tsx
+++ b/packages/react/src/toast/description/ToastDescription.tsx
@@ -67,7 +67,7 @@ export interface ToastDescriptionState {
   /**
    * The type of the toast.
    */
-  type: ToastType
+  type: ToastType;
 }
 
 export interface ToastDescriptionProps extends BaseUIComponentProps<'p', ToastDescription.State> {}

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -589,7 +589,7 @@ export interface ToastRootState {
   /** Whether the toast was removed due to exceeding the limit. */
   limited: boolean;
   /** The type of the toast. */
-  type: ToastType
+  type: ToastType;
   /** Whether the toast is being swiped. */
   swiping: boolean;
   /** The direction the toast is being swiped. */

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -7,7 +7,7 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { activeElement, contains, getTarget } from '../../floating-ui-react/utils';
 import type { BaseUIComponentProps, HTMLProps } from '../../utils/types';
-import type { ToastObject as ToastObjectType } from '../useToastManager';
+import type { ToastObject as ToastObjectType, ToastType } from '../useToastManager';
 import { ToastRootContext } from './ToastRootContext';
 import { transitionStatusMapping } from '../../utils/stateAttributesMapping';
 import type { TransitionStatus } from '../../utils/useTransitionStatus';
@@ -589,7 +589,7 @@ export interface ToastRootState {
   /** Whether the toast was removed due to exceeding the limit. */
   limited: boolean;
   /** The type of the toast. */
-  type: string | undefined;
+  type: ToastType
   /** Whether the toast is being swiped. */
   swiping: boolean;
   /** The direction the toast is being swiped. */

--- a/packages/react/src/toast/title/ToastTitle.tsx
+++ b/packages/react/src/toast/title/ToastTitle.tsx
@@ -5,6 +5,7 @@ import { useId } from '@base-ui/utils/useId';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useToastRootContext } from '../root/ToastRootContext';
 import { useRenderElement } from '../../utils/useRenderElement';
+import { ToastType } from '../useToastManager';
 
 /**
  * A title that labels the toast.
@@ -65,7 +66,7 @@ export interface ToastTitleState {
   /**
    * The type of the toast.
    */
-  type: string | undefined;
+  type: ToastType;
 }
 
 export interface ToastTitleProps extends BaseUIComponentProps<'h2', ToastTitle.State> {}

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -26,8 +26,17 @@ export function useToastManager<Data extends object = any>(): UseToastManagerRet
     [toasts, add, close, update, promise],
   );
 }
+export interface UserToastObject {}
 
-export interface ToastObject<Data extends object> {
+interface BaseToastType {
+  /**
+   * The type of the toast. Used to conditionally style the toast,
+   * including conditionally rendering elements based on the type.
+   */
+  type?: string | undefined;
+}
+
+interface BaseToastObject<Data extends object> {
   /**
    * The unique identifier for the toast.
    */
@@ -40,11 +49,6 @@ export interface ToastObject<Data extends object> {
    * The title of the toast.
    */
   title?: React.ReactNode;
-  /**
-   * The type of the toast. Used to conditionally style the toast,
-   * including conditionally rendering elements based on the type.
-   */
-  type?: string | undefined;
   /**
    * The description of the toast.
    */
@@ -96,6 +100,15 @@ export interface ToastObject<Data extends object> {
   data?: Data | undefined;
 }
 
+type ToastTypeObject = keyof UserToastObject extends never
+  ? BaseToastType
+  : UserToastObject extends BaseToastType
+    ? UserToastObject
+    : BaseToastType;
+
+export type ToastType = ToastTypeObject['type'];
+
+export type ToastObject<Data extends object> = BaseToastObject<Data> & ToastTypeObject;
 export interface ToastManagerPositionerProps extends Omit<
   ToastPositionerProps,
   'anchor' | 'toast'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

fixes #3437

How about allowing users to define their own `toast` types via `module augmentation`?

I implemented a rough version of it. If you think this approach looks good, I can continue refining it.