### PR TITLE
[popups] Apply `data-base-ui-inert` to highest level node

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -624,13 +624,13 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
     function IframeApp() {
       React.useEffect(() => {
         function createIframe() {
-          const container = document.querySelector('#innerRoot');
+          const innerRoot = document.querySelector('#innerRoot');
           const iframe = document.createElement('iframe');
           iframe.setAttribute('data-testid', 'iframe');
           iframe.src = 'about:blank';
           iframe.style.height = '300px';
 
-          container?.appendChild(iframe);
+          innerRoot?.appendChild(iframe);
 
           // Properly open, write, and close the iframe document.
           const iframeDoc = iframe.contentWindow?.document;
@@ -940,7 +940,7 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
               ref={refs.setReference}
               onClick={() => setIsOpen((v) => !v)}
             />
-            <div>
+            <div data-testid="outside-wrapper">
               <div data-testid="aria-live" aria-live="polite" />
               <button data-testid="btn-1" />
               <button data-testid="btn-2" />
@@ -988,7 +988,7 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
               ref={refs.setReference}
               onClick={() => setIsOpen((v) => !v)}
             />
-            <div>
+            <div data-testid="outside-wrapper">
               <div data-testid="aria-live" aria-live="polite" />
               <button data-testid="btn-1" />
               <button data-testid="btn-2" />
@@ -1012,14 +1012,73 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
       expect(screen.getByTestId('btn-1')).not.toHaveAttribute('inert');
       expect(screen.getByTestId('btn-2')).not.toHaveAttribute('inert');
       expect(screen.getByTestId('reference')).toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('btn-1')).toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('btn-2')).toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('outside-wrapper')).toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
 
       fireEvent.click(screen.getByTestId('reference'));
 
       expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('outside-wrapper')).not.toHaveAttribute('data-base-ui-inert');
       expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
       expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
+    });
+
+    test('false - keeps marker on top-level outside ancestor when reference has siblings', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
+        const { refs, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        return (
+          <>
+            <div data-testid="outside-wrapper">
+              <input
+                data-testid="reference"
+                ref={refs.setReference}
+                onClick={() => setIsOpen((v) => !v)}
+              />
+              <button data-testid="btn-1" />
+              <button data-testid="btn-2" />
+              <div data-testid="nested-wrapper">
+                <button data-testid="nested-btn" />
+              </div>
+            </div>
+            <div data-testid="outside-sibling" />
+            {isOpen && (
+              <FloatingFocusManager context={context} modal={false}>
+                <div role="listbox" ref={refs.setFloating} data-testid="floating" />
+              </FloatingFocusManager>
+            )}
+          </>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.click(screen.getByTestId('reference'));
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('floating')).not.toHaveAttribute('inert');
+      expect(screen.getByTestId('outside-wrapper')).toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('outside-sibling')).toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('nested-wrapper')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('nested-btn')).not.toHaveAttribute('data-base-ui-inert');
+
+      fireEvent.click(screen.getByTestId('reference'));
+
+      expect(screen.getByTestId('outside-wrapper')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('outside-sibling')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('nested-wrapper')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('nested-btn')).not.toHaveAttribute('data-base-ui-inert');
     });
   });
 
@@ -1192,6 +1251,49 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
 
       expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
       expect(screen.getByTestId('last')).toHaveFocus();
+    });
+
+    test('does not mark reference siblings due to outside focus guards', async () => {
+      function App() {
+        const [open, setOpen] = React.useState(false);
+        const { refs, context } = useFloating({
+          open,
+          onOpenChange: setOpen,
+        });
+
+        return (
+          <>
+            <div data-testid="reference-wrapper">
+              <button
+                data-testid="reference"
+                ref={refs.setReference}
+                onClick={() => setOpen(true)}
+              />
+              <span data-testid="reference-sibling-1" />
+              <span data-testid="reference-sibling-2" />
+            </div>
+            <FloatingPortal>
+              {open && (
+                <FloatingFocusManager context={context} modal={false}>
+                  <div data-testid="floating" ref={refs.setFloating}>
+                    <span tabIndex={0} data-testid="inside" />
+                  </div>
+                </FloatingFocusManager>
+              )}
+            </FloatingPortal>
+          </>
+        );
+      }
+
+      render(<App />);
+
+      await userEvent.click(screen.getByTestId('reference'));
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('floating')).toBeInTheDocument();
+      expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('reference-sibling-1')).not.toHaveAttribute('data-base-ui-inert');
+      expect(screen.getByTestId('reference-sibling-2')).not.toHaveAttribute('data-base-ui-inert');
     });
 
     test('shift+tab', async () => {

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -292,8 +292,6 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
   const tree = useFloatingTree(externalTree);
   const portalContext = usePortalContext();
 
-  const startDismissButtonRef = React.useRef<HTMLButtonElement>(null);
-  const endDismissButtonRef = React.useRef<HTMLButtonElement>(null);
   const preventReturnFocusRef = React.useRef(false);
   const isPointerDownRef = React.useRef(false);
   const pointerDownOutsideRef = React.useRef(false);
@@ -638,22 +636,34 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
       isTypeableCombobox(node.context?.elements.domReference || null),
     )?.context?.elements.domReference;
 
-    const insideElements = [
+    const controlInsideElements = [
       floating,
-      rootAncestorComboboxDomReference,
       ...portalNodes,
-      startDismissButtonRef.current,
-      endDismissButtonRef.current,
       beforeGuardRef.current,
       afterGuardRef.current,
       portalContext?.beforeOutsideRef.current,
       portalContext?.afterOutsideRef.current,
+    ];
+    const insideElements = [
+      ...controlInsideElements,
+      rootAncestorComboboxDomReference,
       resolveRef(previousFocusableElement),
       resolveRef(nextFocusableElement),
       isUntrappedTypeableCombobox ? domReference : null,
     ].filter((x): x is Element => x != null);
 
-    return markOthers(insideElements, modal || isUntrappedTypeableCombobox);
+    const ariaHiddenCleanup = markOthers(insideElements, {
+      ariaHidden: modal || isUntrappedTypeableCombobox,
+      mark: false,
+    });
+
+    const markerInsideElements = [floating, ...portalNodes].filter((x): x is Element => x != null);
+    const markerCleanup = markOthers(markerInsideElements);
+
+    return () => {
+      markerCleanup();
+      ariaHiddenCleanup();
+    };
   }, [
     open,
     disabled,

--- a/packages/react/src/floating-ui-react/utils/markOthers.test.ts
+++ b/packages/react/src/floating-ui-react/utils/markOthers.test.ts
@@ -1,0 +1,401 @@
+import { markOthers } from './markOthers';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+test('single call', () => {
+  const other = document.createElement('div');
+  document.body.appendChild(other);
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+
+  const cleanup = markOthers([target], { ariaHidden: true });
+
+  expect(other.getAttribute('aria-hidden')).toBe('true');
+
+  cleanup();
+
+  expect(other.getAttribute('aria-hidden')).toBe(null);
+});
+
+test('multiple calls', () => {
+  const other = document.createElement('div');
+  document.body.appendChild(other);
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+
+  const cleanup = markOthers([target], { ariaHidden: true });
+
+  expect(other.getAttribute('aria-hidden')).toBe('true');
+
+  const nextTarget = document.createElement('div');
+  document.body.appendChild(nextTarget);
+
+  const nextCleanup = markOthers([nextTarget], { ariaHidden: true });
+
+  expect(target.getAttribute('aria-hidden')).toBe('true');
+  expect(nextTarget.getAttribute('aria-hidden')).toBe(null);
+
+  document.body.removeChild(nextTarget);
+
+  nextCleanup();
+
+  expect(target.getAttribute('aria-hidden')).toBe(null);
+  expect(other.getAttribute('aria-hidden')).toBe('true');
+
+  cleanup();
+
+  expect(other.getAttribute('aria-hidden')).toBe(null);
+
+  document.body.appendChild(nextTarget);
+});
+
+test('out of order cleanup', () => {
+  const other = document.createElement('div');
+  document.body.appendChild(other);
+  const target = document.createElement('div');
+  target.setAttribute('data-testid', '');
+  document.body.appendChild(target);
+
+  const cleanup = markOthers([target], { ariaHidden: true });
+
+  expect(other.getAttribute('aria-hidden')).toBe('true');
+
+  const nextTarget = document.createElement('div');
+  document.body.appendChild(nextTarget);
+
+  const nextCleanup = markOthers([nextTarget], { ariaHidden: true });
+
+  expect(target.getAttribute('aria-hidden')).toBe('true');
+  expect(nextTarget.getAttribute('aria-hidden')).toBe(null);
+
+  cleanup();
+
+  expect(nextTarget.getAttribute('aria-hidden')).toBe(null);
+  expect(target.getAttribute('aria-hidden')).toBe('true');
+  expect(other.getAttribute('aria-hidden')).toBe('true');
+
+  nextCleanup();
+
+  expect(nextTarget.getAttribute('aria-hidden')).toBe(null);
+  expect(other.getAttribute('aria-hidden')).toBe(null);
+  expect(target.getAttribute('aria-hidden')).toBe(null);
+});
+
+test('multiple cleanups with differing controlAttribute', () => {
+  const other = document.createElement('div');
+  document.body.appendChild(other);
+  const target = document.createElement('div');
+  target.setAttribute('data-testid', '1');
+  document.body.appendChild(target);
+
+  const cleanup = markOthers([target], { ariaHidden: true });
+
+  expect(other.getAttribute('aria-hidden')).toBe('true');
+
+  const target2 = document.createElement('div');
+  target2.setAttribute('data-testid', '2');
+  document.body.appendChild(target2);
+
+  const cleanup2 = markOthers([target2]);
+
+  expect(target.getAttribute('aria-hidden')).not.toBe('true');
+  expect(target.getAttribute('data-base-ui-inert')).toBe('');
+
+  cleanup();
+
+  expect(other.getAttribute('aria-hidden')).toBe(null);
+
+  cleanup2();
+
+  expect(target.getAttribute('data-base-ui-inert')).toBe(null);
+});
+
+test('mixed controlAttribute usage (aria-hidden/inert/none)', () => {
+  const other = document.createElement('div');
+  document.body.appendChild(other);
+
+  const A = document.createElement('div');
+  A.setAttribute('data-testid', 'A');
+  document.body.appendChild(A);
+
+  const B = document.createElement('div');
+  B.setAttribute('data-testid', 'B');
+  document.body.appendChild(B);
+
+  const C = document.createElement('div');
+  C.setAttribute('data-testid', 'C');
+  document.body.appendChild(C);
+
+  const cleanupA = markOthers([A], { ariaHidden: true });
+
+  expect(other.getAttribute('aria-hidden')).toBe('true');
+  expect(other.hasAttribute('inert')).toBe(false);
+  expect(other.getAttribute('data-base-ui-inert')).toBe('');
+
+  const cleanupB = markOthers([B], { inert: true });
+
+  expect(other.getAttribute('aria-hidden')).toBe('true');
+  expect(other.getAttribute('inert')).toBe('');
+  expect(other.getAttribute('data-base-ui-inert')).toBe('');
+
+  const cleanupC = markOthers([C]);
+
+  expect(other.getAttribute('aria-hidden')).toBe('true');
+  expect(other.getAttribute('inert')).toBe('');
+  expect(other.getAttribute('data-base-ui-inert')).toBe('');
+
+  cleanupC();
+
+  expect(other.getAttribute('aria-hidden')).toBe('true');
+  expect(other.getAttribute('inert')).toBe('');
+  expect(other.getAttribute('data-base-ui-inert')).toBe('');
+
+  cleanupB();
+
+  expect(other.getAttribute('aria-hidden')).toBe('true');
+  expect(other.hasAttribute('inert')).toBe(false);
+  expect(other.getAttribute('data-base-ui-inert')).toBe('');
+
+  cleanupA();
+
+  expect(other.hasAttribute('aria-hidden')).toBe(false);
+  expect(other.hasAttribute('inert')).toBe(false);
+  expect(other.hasAttribute('data-base-ui-inert')).toBe(false);
+});
+
+test('tracks externally controlled attributes per control attribute', () => {
+  const container = document.createElement('div');
+  const keep = document.createElement('div');
+  const outside = document.createElement('div');
+
+  outside.setAttribute('inert', '');
+  container.append(keep, outside);
+  document.body.append(container);
+
+  let cleanupInert: (() => void) | undefined;
+  let cleanupAriaHidden: (() => void) | undefined;
+
+  try {
+    cleanupInert = markOthers([keep], { inert: true });
+    cleanupAriaHidden = markOthers([keep], { ariaHidden: true });
+
+    expect(outside).toHaveAttribute('inert');
+    expect(outside).toHaveAttribute('aria-hidden', 'true');
+
+    cleanupAriaHidden();
+    cleanupAriaHidden = undefined;
+
+    expect(outside).toHaveAttribute('inert');
+    expect(outside).not.toHaveAttribute('aria-hidden');
+
+    cleanupInert();
+    cleanupInert = undefined;
+
+    expect(outside).toHaveAttribute('inert');
+    expect(outside).not.toHaveAttribute('aria-hidden');
+  } finally {
+    cleanupAriaHidden?.();
+    cleanupInert?.();
+  }
+});
+
+test('ignores marker elements without affecting aria-hidden', () => {
+  const floating = document.createElement('div');
+  document.body.appendChild(floating);
+
+  const reference = document.createElement('div');
+  document.body.appendChild(reference);
+
+  const outside = document.createElement('div');
+  document.body.appendChild(outside);
+
+  const cleanup = markOthers([floating], {
+    ariaHidden: true,
+    markerIgnoreElements: [reference],
+  });
+
+  expect(outside.getAttribute('data-base-ui-inert')).toBe('');
+  expect(reference.getAttribute('data-base-ui-inert')).toBe(null);
+  expect(reference.getAttribute('aria-hidden')).toBe('true');
+
+  cleanup();
+
+  expect(outside.getAttribute('data-base-ui-inert')).toBe(null);
+  expect(reference.getAttribute('aria-hidden')).toBe(null);
+});
+
+test('keeps marker on top-level outside node with nested markerIgnoreElements', () => {
+  const floating = document.createElement('div');
+  document.body.appendChild(floating);
+
+  const outsideWrapper = document.createElement('div');
+  const ariaLive = document.createElement('div');
+  ariaLive.setAttribute('aria-live', 'polite');
+  const sibling = document.createElement('button');
+  outsideWrapper.append(ariaLive, sibling);
+  document.body.append(outsideWrapper);
+
+  const cleanup = markOthers([floating], {
+    ariaHidden: true,
+    markerIgnoreElements: [ariaLive],
+  });
+
+  expect(outsideWrapper).toHaveAttribute('data-base-ui-inert');
+  expect(ariaLive).not.toHaveAttribute('data-base-ui-inert');
+  expect(ariaLive).not.toHaveAttribute('aria-hidden');
+  expect(sibling).not.toHaveAttribute('data-base-ui-inert');
+  expect(sibling).toHaveAttribute('aria-hidden', 'true');
+
+  cleanup();
+
+  expect(outsideWrapper).not.toHaveAttribute('data-base-ui-inert');
+  expect(sibling).not.toHaveAttribute('aria-hidden');
+});
+
+test('keeps marker top-level when ignored descendant is nested in a branch', () => {
+  const floating = document.createElement('div');
+  document.body.appendChild(floating);
+
+  const outsideRoot = document.createElement('div');
+  const ignoredBranch = document.createElement('div');
+  const ignoredParent = document.createElement('div');
+  const ignoredDescendant = document.createElement('div');
+  ignoredDescendant.setAttribute('aria-live', 'polite');
+  ignoredParent.append(ignoredDescendant);
+  ignoredBranch.append(ignoredParent);
+
+  const siblingBranch = document.createElement('div');
+  const siblingLeaf = document.createElement('button');
+  siblingBranch.append(siblingLeaf);
+
+  outsideRoot.append(ignoredBranch, siblingBranch);
+  document.body.append(outsideRoot);
+
+  const cleanup = markOthers([floating], {
+    ariaHidden: true,
+    markerIgnoreElements: [ignoredDescendant],
+  });
+
+  expect(outsideRoot).toHaveAttribute('data-base-ui-inert');
+  expect(ignoredBranch).not.toHaveAttribute('data-base-ui-inert');
+  expect(ignoredParent).not.toHaveAttribute('data-base-ui-inert');
+  expect(ignoredDescendant).not.toHaveAttribute('data-base-ui-inert');
+  expect(ignoredDescendant).not.toHaveAttribute('aria-hidden');
+  expect(siblingBranch).not.toHaveAttribute('data-base-ui-inert');
+  expect(siblingBranch).toHaveAttribute('aria-hidden', 'true');
+  expect(siblingLeaf).not.toHaveAttribute('data-base-ui-inert');
+
+  cleanup();
+
+  expect(outsideRoot).not.toHaveAttribute('data-base-ui-inert');
+  expect(siblingBranch).not.toHaveAttribute('aria-hidden');
+});
+
+test('preserves externally owned aria-hidden during concurrent aria-hidden and inert overlaps', () => {
+  const keep = document.createElement('div');
+  const outside = document.createElement('div');
+  outside.setAttribute('aria-hidden', 'true');
+  document.body.append(keep, outside);
+
+  let cleanupAriaHidden: (() => void) | undefined;
+  let cleanupInert: (() => void) | undefined;
+
+  try {
+    cleanupAriaHidden = markOthers([keep], { ariaHidden: true, mark: false });
+    cleanupInert = markOthers([keep], { inert: true, mark: false });
+
+    expect(outside).toHaveAttribute('aria-hidden', 'true');
+    expect(outside).toHaveAttribute('inert');
+
+    cleanupInert();
+    cleanupInert = undefined;
+
+    expect(outside).toHaveAttribute('aria-hidden', 'true');
+    expect(outside).not.toHaveAttribute('inert');
+
+    cleanupAriaHidden();
+    cleanupAriaHidden = undefined;
+
+    expect(outside).toHaveAttribute('aria-hidden', 'true');
+    expect(outside).not.toHaveAttribute('inert');
+  } finally {
+    cleanupInert?.();
+    cleanupAriaHidden?.();
+  }
+});
+
+test('does not let mark-only overlap disturb control cleanup bookkeeping', () => {
+  const keep = document.createElement('div');
+  const outside = document.createElement('div');
+  document.body.append(keep, outside);
+
+  let cleanupMarkOnly: (() => void) | undefined;
+  let cleanupControlOnly: (() => void) | undefined;
+
+  try {
+    cleanupMarkOnly = markOthers([keep], { mark: true });
+    cleanupControlOnly = markOthers([keep], { ariaHidden: true, mark: false });
+
+    expect(outside).toHaveAttribute('data-base-ui-inert');
+    expect(outside).toHaveAttribute('aria-hidden', 'true');
+
+    cleanupMarkOnly();
+    cleanupMarkOnly = undefined;
+
+    expect(outside).not.toHaveAttribute('data-base-ui-inert');
+    expect(outside).toHaveAttribute('aria-hidden', 'true');
+
+    cleanupControlOnly();
+    cleanupControlOnly = undefined;
+
+    expect(outside).not.toHaveAttribute('data-base-ui-inert');
+    expect(outside).not.toHaveAttribute('aria-hidden');
+  } finally {
+    cleanupControlOnly?.();
+    cleanupMarkOnly?.();
+  }
+});
+
+test('does not recurse infinitely with target inside anchor in shadow root', () => {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  const anchor = document.createElement('a');
+  anchor.href = 'https://floating-ui.com';
+
+  const target = document.createElement('button');
+  anchor.appendChild(target);
+  shadowRoot.appendChild(anchor);
+
+  const cleanup = markOthers([target], { ariaHidden: true });
+
+  cleanup();
+});
+
+test('uses shadow root host as avoid element when parent chain includes anchor', () => {
+  const outside = document.createElement('div');
+  document.body.appendChild(outside);
+
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  const anchor = document.createElement('a');
+  anchor.href = 'https://floating-ui.com';
+
+  const target = document.createElement('button');
+  anchor.appendChild(target);
+  shadowRoot.appendChild(anchor);
+
+  const cleanup = markOthers([target], { ariaHidden: true });
+
+  expect(outside.getAttribute('aria-hidden')).toBe('true');
+  expect(host.getAttribute('aria-hidden')).toBe(null);
+
+  cleanup();
+
+  expect(outside.getAttribute('aria-hidden')).toBe(null);
+});

--- a/packages/react/src/floating-ui-react/utils/markOthers.ts
+++ b/packages/react/src/floating-ui-react/utils/markOthers.ts
@@ -1,35 +1,46 @@
 // Modified to add conditional `aria-hidden` support:
 // https://github.com/theKashey/aria-hidden/blob/9220c8f4a4fd35f63bee5510a9f41a37264382d4/src/index.ts
-import { getNodeName } from '@floating-ui/utils/dom';
+import { getNodeName, isShadowRoot } from '@floating-ui/utils/dom';
 import { ownerDocument } from '@base-ui/utils/owner';
 
 type Undo = () => void;
 
+interface MarkOthersOptions {
+  ariaHidden?: boolean | undefined;
+  inert?: boolean | undefined;
+  mark?: boolean | undefined;
+  markerIgnoreElements?: Element[] | undefined;
+}
+
 const counters = {
   inert: new WeakMap<Element, number>(),
   'aria-hidden': new WeakMap<Element, number>(),
-  none: new WeakMap<Element, number>(),
 };
 
-function getCounterMap(control: 'inert' | 'aria-hidden' | null) {
-  if (control === 'inert') {
-    return counters.inert;
-  }
-  if (control === 'aria-hidden') {
-    return counters['aria-hidden'];
-  }
-  return counters.none;
-}
+const markerName = 'data-base-ui-inert';
+type ControlAttribute = keyof typeof counters;
 
-let uncontrolledElementsSet = new WeakSet<Element>();
-let markerMap: Record<string, WeakMap<Element, number>> = {};
+const uncontrolledElementsSets: Record<ControlAttribute, WeakSet<Element>> = {
+  inert: new WeakSet<Element>(),
+  'aria-hidden': new WeakSet<Element>(),
+};
+let markerCounterMap = new WeakMap<Element, number>();
 let lockCount = 0;
+
+function getUncontrolledElementsSet(controlAttribute: ControlAttribute) {
+  return uncontrolledElementsSets[controlAttribute];
+}
 
 export const supportsInert = (): boolean =>
   typeof HTMLElement !== 'undefined' && 'inert' in HTMLElement.prototype;
 
-const unwrapHost = (node: Element | ShadowRoot): Element | null =>
-  node && ((node as ShadowRoot).host || unwrapHost(node.parentNode as Element));
+function unwrapHost(node: Node | null): Element | null {
+  if (!node) {
+    return null;
+  }
+
+  return isShadowRoot(node) ? node.host : unwrapHost(node.parentNode);
+}
 
 const correctElements = (parent: HTMLElement, targets: Element[]): Element[] =>
   targets
@@ -48,75 +59,117 @@ const correctElements = (parent: HTMLElement, targets: Element[]): Element[] =>
     })
     .filter((x): x is Element => x != null);
 
+const buildKeepSet = (targets: Element[]): Set<Node> => {
+  const keep = new Set<Node>();
+
+  targets.forEach((target) => {
+    let node: Node | null = target;
+    while (node && !keep.has(node)) {
+      keep.add(node);
+      node = node.parentNode;
+    }
+  });
+
+  return keep;
+};
+
+const collectOutsideElements = (
+  root: HTMLElement,
+  keepElements: Set<Node>,
+  stopElements: Set<Node>,
+): Element[] => {
+  const outside: Element[] = [];
+
+  const walk = (parent: Element | null) => {
+    if (!parent || stopElements.has(parent)) {
+      return;
+    }
+
+    Array.from(parent.children).forEach((node: Element) => {
+      if (getNodeName(node) === 'script') {
+        return;
+      }
+
+      if (keepElements.has(node)) {
+        walk(node);
+      } else {
+        outside.push(node);
+      }
+    });
+  };
+
+  walk(root);
+
+  return outside;
+};
+
 function applyAttributeToOthers(
   uncorrectedAvoidElements: Element[],
   body: HTMLElement,
   ariaHidden: boolean,
   inert: boolean,
+  { mark = true, markerIgnoreElements = [] }: MarkOthersOptions,
 ): Undo {
-  const markerName = 'data-base-ui-inert';
   // eslint-disable-next-line no-nested-ternary
   const controlAttribute = inert ? 'inert' : ariaHidden ? 'aria-hidden' : null;
+  let counterMap: WeakMap<Element, number> | null = null;
+  let uncontrolledElementsSet: WeakSet<Element> | null = null;
   const avoidElements = correctElements(body, uncorrectedAvoidElements);
-  const elementsToKeep = new Set<Node>();
-  const elementsToStop = new Set<Node>(avoidElements);
+  const markerIgnoreTargets = mark ? correctElements(body, markerIgnoreElements) : [];
+  const markerIgnoreSet = new Set<Node>(markerIgnoreTargets);
+  const markerTargets = mark
+    ? collectOutsideElements(
+        body,
+        buildKeepSet(avoidElements),
+        new Set<Node>(avoidElements),
+      ).filter((target) => !markerIgnoreSet.has(target))
+    : [];
   const hiddenElements: Element[] = [];
+  const markedElements: Element[] = [];
 
-  if (!markerMap[markerName]) {
-    markerMap[markerName] = new WeakMap();
-  }
+  if (controlAttribute) {
+    const map = counters[controlAttribute];
+    const currentUncontrolledElementsSet = getUncontrolledElementsSet(controlAttribute);
+    uncontrolledElementsSet = currentUncontrolledElementsSet;
+    counterMap = map;
+    const ariaLiveElements = correctElements(
+      body,
+      Array.from(body.querySelectorAll('[aria-live]')),
+    );
+    const controlElements = avoidElements.concat(ariaLiveElements);
+    const controlTargets = collectOutsideElements(
+      body,
+      buildKeepSet(controlElements),
+      new Set<Node>(controlElements),
+    );
 
-  const markerCounter = markerMap[markerName];
+    controlTargets.forEach((node) => {
+      const attr = node.getAttribute(controlAttribute);
+      const alreadyHidden = attr !== null && attr !== 'false';
+      const counterValue = (map.get(node) || 0) + 1;
 
-  avoidElements.forEach(keep);
-  deep(body);
-  elementsToKeep.clear();
+      map.set(node, counterValue);
+      hiddenElements.push(node);
 
-  function keep(el: Node | undefined) {
-    if (!el || elementsToKeep.has(el)) {
-      return;
-    }
-
-    elementsToKeep.add(el);
-    if (el.parentNode) {
-      keep(el.parentNode);
-    }
-  }
-
-  function deep(parent: Element | null) {
-    if (!parent || elementsToStop.has(parent)) {
-      return;
-    }
-
-    [].forEach.call(parent.children, (node: Element) => {
-      if (getNodeName(node) === 'script') {
-        return;
+      if (counterValue === 1 && alreadyHidden) {
+        currentUncontrolledElementsSet.add(node);
       }
 
-      if (elementsToKeep.has(node)) {
-        deep(node);
-      } else {
-        const attr = controlAttribute ? node.getAttribute(controlAttribute) : null;
-        const alreadyHidden = attr !== null && attr !== 'false';
-        const counterMap = getCounterMap(controlAttribute);
-        const counterValue = (counterMap.get(node) || 0) + 1;
-        const markerValue = (markerCounter.get(node) || 0) + 1;
+      if (!alreadyHidden) {
+        node.setAttribute(controlAttribute, controlAttribute === 'inert' ? '' : 'true');
+      }
+    });
+  }
 
-        counterMap.set(node, counterValue);
-        markerCounter.set(node, markerValue);
-        hiddenElements.push(node);
+  if (mark) {
+    markerTargets.forEach((node) => {
+      const markerValue = (markerCounterMap.get(node) || 0) + 1;
 
-        if (counterValue === 1 && alreadyHidden) {
-          uncontrolledElementsSet.add(node);
-        }
+      markerCounterMap.set(node, markerValue);
+      markedElements.push(node);
 
-        if (markerValue === 1) {
-          node.setAttribute(markerName, '');
-        }
-
-        if (!alreadyHidden && controlAttribute) {
-          node.setAttribute(controlAttribute, controlAttribute === 'inert' ? '' : 'true');
-        }
+      if (markerValue === 1) {
+        node.setAttribute(markerName, '');
       }
     });
   }
@@ -124,46 +177,51 @@ function applyAttributeToOthers(
   lockCount += 1;
 
   return () => {
-    hiddenElements.forEach((element) => {
-      const counterMap = getCounterMap(controlAttribute);
-      const currentCounterValue = counterMap.get(element) || 0;
-      const counterValue = currentCounterValue - 1;
-      const markerValue = (markerCounter.get(element) || 0) - 1;
+    if (counterMap) {
+      hiddenElements.forEach((element) => {
+        const currentCounterValue = counterMap.get(element) || 0;
+        const counterValue = currentCounterValue - 1;
+        counterMap.set(element, counterValue);
 
-      counterMap.set(element, counterValue);
-      markerCounter.set(element, markerValue);
+        if (!counterValue) {
+          if (!uncontrolledElementsSet?.has(element) && controlAttribute) {
+            element.removeAttribute(controlAttribute);
+          }
 
-      if (!counterValue) {
-        if (!uncontrolledElementsSet.has(element) && controlAttribute) {
-          element.removeAttribute(controlAttribute);
+          uncontrolledElementsSet?.delete(element);
         }
+      });
+    }
 
-        uncontrolledElementsSet.delete(element);
-      }
+    if (mark) {
+      markedElements.forEach((element) => {
+        const markerValue = (markerCounterMap.get(element) || 0) - 1;
 
-      if (!markerValue) {
-        element.removeAttribute(markerName);
-      }
-    });
+        markerCounterMap.set(element, markerValue);
+
+        if (!markerValue) {
+          element.removeAttribute(markerName);
+        }
+      });
+    }
 
     lockCount -= 1;
 
     if (!lockCount) {
       counters.inert = new WeakMap();
       counters['aria-hidden'] = new WeakMap();
-      counters.none = new WeakMap();
-      uncontrolledElementsSet = new WeakSet();
-      markerMap = {};
+      uncontrolledElementsSets.inert = new WeakSet();
+      uncontrolledElementsSets['aria-hidden'] = new WeakSet();
+      markerCounterMap = new WeakMap();
     }
   };
 }
 
-export function markOthers(avoidElements: Element[], ariaHidden = false, inert = false): Undo {
+export function markOthers(avoidElements: Element[], options: MarkOthersOptions = {}): Undo {
+  const { ariaHidden = false, inert = false, mark = true, markerIgnoreElements = [] } = options;
   const body = ownerDocument(avoidElements[0]).body;
-  return applyAttributeToOthers(
-    avoidElements.concat(Array.from(body.querySelectorAll('[aria-live]'))),
-    body,
-    ariaHidden,
-    inert,
-  );
+  return applyAttributeToOthers(avoidElements, body, ariaHidden, inert, {
+    mark,
+    markerIgnoreElements,
+  });
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #3950

This should avoid interfering with nodes inside editors while continuing to support 3rd party extension elements (as it's assumed they're portaled to `<body>`), and improves perf as well since a smaller number of elements are mutated (with the common portaled popup case)