### PR TITLE
[select] Fire onClick during drag-to-select

### DIFF
--- a/packages/react/src/select/item/SelectItem.test.tsx
+++ b/packages/react/src/select/item/SelectItem.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { expect } from 'chai';
+import { expect, vi } from 'vitest';
 
 describe('<Select.Item />', () => {
   const { render } = createRenderer();
@@ -260,6 +260,81 @@ describe('<Select.Item />', () => {
       await waitFor(() => {
         expect(value.textContent).to.equal('Select font');
       });
+    });
+
+    it('should call onClick when selecting via drag-to-select (mousedown on trigger, mouseup on item)', async () => {
+      const handleClick = vi.fn();
+
+      await renderFakeTimers(
+        <Select.Root>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" placeholder="Select font" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="one" onClick={handleClick}>
+                  one
+                </Select.Item>
+                <Select.Item value="two">two</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.mouseDown(trigger);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.to.equal(null));
+
+      const option = screen.getByRole('option', { name: 'one' });
+      fireEvent.pointerEnter(option, { pointerType: 'mouse' });
+      fireEvent.pointerMove(option, { pointerType: 'mouse' });
+
+      // Wait past the delay gates and release the mouse over the option
+      await clock.tickAsync(500);
+      fireEvent.mouseUp(option);
+
+      await waitFor(() => expect(screen.getByTestId('value').textContent).to.equal('one'));
+      expect(handleClick).toHaveBeenCalledOnce();
+    });
+
+    it('should not select item when onClick calls preventBaseUIHandler during drag-to-select', async () => {
+      const handleClick = vi.fn((event) => event.preventBaseUIHandler());
+
+      await renderFakeTimers(
+        <Select.Root>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" placeholder="Select font" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="one" onClick={handleClick}>
+                  one
+                </Select.Item>
+                <Select.Item value="two">two</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.mouseDown(trigger);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.to.equal(null));
+
+      const option = screen.getByRole('option', { name: 'one' });
+      fireEvent.pointerEnter(option, { pointerType: 'mouse' });
+      fireEvent.pointerMove(option, { pointerType: 'mouse' });
+
+      // Wait past the delay gates and release the mouse over the option
+      await clock.tickAsync(500);
+      fireEvent.mouseUp(option);
+
+      expect(handleClick).toHaveBeenCalledOnce();
+      expect(screen.getByTestId('value').textContent).to.equal('Select font');
+      expect(screen.queryByRole('listbox')).not.to.equal(null);
     });
   });
 

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -10,7 +10,13 @@ import {
   useCompositeListItem,
   IndexGuessBehavior,
 } from '../../composite/list/useCompositeListItem';
-import type { BaseUIComponentProps, HTMLProps, NonNativeButtonProps } from '../../utils/types';
+import type {
+  BaseUIComponentProps,
+  BaseUIEvent,
+  HTMLProps,
+  NonNativeButtonProps,
+} from '../../utils/types';
+import { makeEventPreventable } from '../../merge-props';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { SelectItemContext } from './SelectItemContext';
 import { selectors } from '../store';
@@ -37,6 +43,7 @@ export const SelectItem = React.memo(
       label,
       disabled = false,
       nativeButton = false,
+      onClick: onClickProp,
       ...elementProps
     } = componentProps;
 
@@ -208,7 +215,7 @@ export const SelectItem = React.memo(
         pointerTypeRef.current = event.pointerType;
         didPointerDownRef.current = true;
       },
-      onMouseUp(event) {
+      onMouseUp(event: BaseUIEvent<React.MouseEvent<HTMLDivElement>>) {
         if (disabled) {
           return;
         }
@@ -229,7 +236,12 @@ export const SelectItem = React.memo(
           return;
         }
 
-        commitSelection(event.nativeEvent);
+        makeEventPreventable(event);
+        onClickProp?.(event);
+
+        if (!event.baseUIHandlerPrevented) {
+          commitSelection(event.nativeEvent);
+        }
       },
     };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The drag-to-select behavior which was originally introduced in #541 (mousedown on trigger → drag to item → mouseup to select) bypasses the item's `onClick` handler since the browser doesn't fire a `click` event when mousedown and mouseup occur on different elements. This is inconsistent with the other ways to select an item: both regular clicks and keyboard selection both invoke `onClick` already.

This PR calls `onClick` from `onMouseUp` before committing the selection, allowing `preventBaseUIHandler()` to cancel the selection.

Includes tests.