### PR TITLE
[navigation-menu] Fix StackBlitz demo styling 

### DIFF
--- a/docs/src/app/(docs)/react/components/navigation-menu/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/navigation-menu/demos/hero/tailwind/index.tsx
@@ -128,7 +128,7 @@ const triggerClassName =
   'focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 focus-visible:relative';
 
 const contentClassName =
-  'w-[calc(100vw_-_40px)] h-full p-6 [@media(min-width:32rem)]:w-max [@media(min-width:32rem)]:min-w-[400px] [@media(min-width:32rem)]:w-max ' +
+  'w-[calc(100vw_-_40px)] h-full p-6 [@media(min-width:32rem)]:w-max [@media(min-width:32rem)]:min-w-[400px] ' +
   'transition-[opacity,transform,translate] duration-[var(--duration)] ease-[var(--easing)] ' +
   'data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 ' +
   'data-[starting-style]:data-[activation-direction=left]:translate-x-[-50%] ' +

--- a/docs/src/app/(docs)/react/components/navigation-menu/demos/nested/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/navigation-menu/demos/nested/tailwind/index.tsx
@@ -156,7 +156,7 @@ const triggerClassName =
   'focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 focus-visible:relative';
 
 const contentClassName =
-  'w-[calc(100vw_-_40px)] h-full p-6 [@media(min-width:32rem)]:w-max [@media(min-width:32rem)]:min-w-[400px] [@media(min-width:32rem)]:w-max ' +
+  'w-[calc(100vw_-_40px)] h-full p-6 [@media(min-width:32rem)]:w-max [@media(min-width:32rem)]:min-w-[400px] ' +
   'transition-[opacity,transform,translate] duration-[var(--duration)] ease-[var(--easing)] ' +
   'data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 ' +
   'data-[starting-style]:data-[activation-direction=left]:translate-x-[-50%] ' +


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Summary
Fixes styling issues when opening the Navigation Menu Tailwind demos (hero and nested) in StackBlitz so the code example matches the rendered demo on the docs site.

### Problem (reported on Discord)

https://discord.com/channels/1287292451308048406/1287292451308048409/1468332847197720617

Users reported that the example on the docs site does not match what the code produces when opened in StackBlitz:


![Captura de tela 2026-02-04 031140](https://github.com/user-attachments/assets/0c333036-b5df-4cb8-8c93-c8d75a7d3319)

> why is the example navigation-menu on the docs website not represented by the example code shown below it? the behavior of the dropdown content is entirely different on the rendered demo vs what the code creates (see the stack blitz link right next to it)  
> — https://base-ui.com/react/components/navigation-menu

**Root causes:**

1. **Missing `xs` breakpoint** – The demos use a custom `xs:` breakpoint (`32rem`), but the Tailwind config in the exported StackBlitz setup did not define it, so `xs:` utilities had no effect and layout/behavior differed from the docs.
2. **Classes not prefetched** – Trigger, content, and link class names were in `const` variables. The Tailwind CDN only scans for class names in the source, so those classes were not included, causing wrong popup width and other styling in StackBlitz.
3. **Arbitrary breakpoint restrictions (by design since Tailwind v3, 2022)** – Tailwind intentionally restricted certain arbitrary breakpoint syntaxes such as min-[32rem] starting in v3. Tailwind recommends using explicit media-query arbitrary variants instead, e.g. [@media(min-width:32rem)]:...

References:

> Hey! Going to close this issue since this was by design in v3 and we likely won't change that behavior now that Tailwind CSS v4 is out. In Tailwind CSS v4 we did improve this behavior — instead you define a value for each breakpoint (https://tailwindcss.com/docs/responsive-design#using-custom-breakpoints
> ). There is no concept of min, max, and raw breakpoints anymore.

https://github.com/tailwindlabs/tailwindcss/pull/9558#user-content-restrictions
https://github.com/tailwindlabs/tailwindcss/issues/12489

### Solution
- **Inline Tailwind classes** in the hero and nested Tailwind demos so all classes appear as string literals in the JSX and are included in the CDN prefetch, fixing popup width and layout in StackBlitz.
- **Replace `xs:` with arbitrary `@media` variant** – Use `[@media(min-width:32rem)]:` instead of a custom `xs` breakpoint so the demos work in the exported StackBlitz setup without extending `theme.screens`. No changes to `demoExportOptions.ts` Tailwind config are required.


### Related
https://github.com/mui/base-ui/pull/3962
https://github.com/mui/base-ui/pull/3961