### PR TITLE
[form controls] Clear `data-focused` when disabled

### DIFF
--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -1453,36 +1453,99 @@ describe('<Autocomplete.Root />', () => {
       });
     });
 
-    it('[data-focused]', async () => {
-      await render(
-        <Field.Root>
-          <Autocomplete.Root>
-            <Autocomplete.Input data-testid="input" />
-            <Autocomplete.Portal>
-              <Autocomplete.Positioner>
-                <Autocomplete.Popup>
-                  <Autocomplete.List>
-                    <Autocomplete.Item value="">Select</Autocomplete.Item>
-                    <Autocomplete.Item value="1">Option 1</Autocomplete.Item>
-                  </Autocomplete.List>
-                </Autocomplete.Popup>
-              </Autocomplete.Positioner>
-            </Autocomplete.Portal>
-          </Autocomplete.Root>
-        </Field.Root>,
-      );
+    describe('[data-focused]', () => {
+      it('sets [data-focused] when focused', async () => {
+        await render(
+          <Field.Root>
+            <Autocomplete.Root>
+              <Autocomplete.Input data-testid="input" />
+              <Autocomplete.Portal>
+                <Autocomplete.Positioner>
+                  <Autocomplete.Popup>
+                    <Autocomplete.List>
+                      <Autocomplete.Item value="">Select</Autocomplete.Item>
+                      <Autocomplete.Item value="1">Option 1</Autocomplete.Item>
+                    </Autocomplete.List>
+                  </Autocomplete.Popup>
+                </Autocomplete.Positioner>
+              </Autocomplete.Portal>
+            </Autocomplete.Root>
+          </Field.Root>,
+        );
 
-      const input = screen.getByTestId('input');
+        const input = screen.getByTestId('input');
 
-      expect(input).not.to.have.attribute('data-focused');
+        expect(input).not.to.have.attribute('data-focused');
 
-      fireEvent.focus(input);
+        fireEvent.focus(input);
 
-      expect(input).to.have.attribute('data-focused', '');
+        expect(input).to.have.attribute('data-focused', '');
 
-      fireEvent.blur(input);
+        fireEvent.blur(input);
 
-      expect(input).not.to.have.attribute('data-focused');
+        expect(input).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove [data-focused] when the field becomes disabled', async () => {
+        const { setProps } = await render(
+          <Field.Root>
+            <Autocomplete.Root>
+              <Autocomplete.Input data-testid="input" />
+              <Autocomplete.Portal>
+                <Autocomplete.Positioner>
+                  <Autocomplete.Popup>
+                    <Autocomplete.List>
+                      <Autocomplete.Item value="">Select</Autocomplete.Item>
+                      <Autocomplete.Item value="1">Option 1</Autocomplete.Item>
+                    </Autocomplete.List>
+                  </Autocomplete.Popup>
+                </Autocomplete.Positioner>
+              </Autocomplete.Portal>
+            </Autocomplete.Root>
+          </Field.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+        expect(input).not.to.have.attribute('data-focused');
+
+        fireEvent.focus(input);
+        expect(input).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(input).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove [data-focused] when the input becomes disabled', async () => {
+        function App({ disabled }: { disabled: boolean }) {
+          return (
+            <Field.Root>
+              <Autocomplete.Root>
+                <Autocomplete.Input data-testid="input" disabled={disabled} />
+                <Autocomplete.Portal>
+                  <Autocomplete.Positioner>
+                    <Autocomplete.Popup>
+                      <Autocomplete.List>
+                        <Autocomplete.Item value="">Select</Autocomplete.Item>
+                        <Autocomplete.Item value="1">Option 1</Autocomplete.Item>
+                      </Autocomplete.List>
+                    </Autocomplete.Popup>
+                  </Autocomplete.Positioner>
+                </Autocomplete.Portal>
+              </Autocomplete.Root>
+            </Field.Root>
+          );
+        }
+        const { setProps } = await render(<App disabled={false} />);
+
+        const input = screen.getByTestId('input');
+        expect(input).not.to.have.attribute('data-focused');
+
+        fireEvent.focus(input);
+        expect(input).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(input).not.to.have.attribute('data-focused');
+      });
     });
 
     it('[data-invalid]', async () => {

--- a/packages/react/src/checkbox-group/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.tsx
@@ -93,6 +93,7 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
 
   useField({
     enabled: !!fieldName,
+    disabled,
     id,
     commit: validation.commit,
     value,

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -742,24 +742,71 @@ describe('<Checkbox.Root />', () => {
       });
     });
 
-    it('[data-focused]', async () => {
-      await render(
-        <Field.Root>
-          <Checkbox.Root data-testid="button" />
-        </Field.Root>,
-      );
+    describe('[data-focused]', () => {
+      it('sets [data-focused] when focused', async () => {
+        await render(
+          <Field.Root>
+            <Checkbox.Root data-testid="button" />
+          </Field.Root>,
+        );
 
-      const button = screen.getByTestId('button');
+        const button = screen.getByTestId('button');
 
-      expect(button).not.to.have.attribute('data-focused');
+        expect(button).not.to.have.attribute('data-focused');
 
-      fireEvent.focus(button);
+        fireEvent.focus(button);
 
-      expect(button).to.have.attribute('data-focused', '');
+        expect(button).to.have.attribute('data-focused', '');
 
-      fireEvent.blur(button);
+        fireEvent.blur(button);
 
-      expect(button).not.to.have.attribute('data-focused');
+        expect(button).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove data-focused when the field becomes disabled', async () => {
+        const { setProps } = await render(
+          <Field.Root data-testid="root">
+            <Checkbox.Root />
+          </Field.Root>,
+        );
+
+        const root = screen.getByTestId('root');
+        const checkbox = screen.getByRole('checkbox');
+
+        fireEvent.focus(checkbox);
+
+        expect(root).to.have.attribute('data-focused', '');
+        expect(checkbox).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+
+        expect(root).not.to.have.attribute('data-focused', '');
+        expect(checkbox).not.to.have.attribute('data-focused', '');
+      });
+
+      it('should remove data-focused when the checkbox becomes disabled', async () => {
+        function App({ disabled }: { disabled: boolean }) {
+          return (
+            <Field.Root data-testid="root">
+              <Checkbox.Root disabled={disabled} />
+            </Field.Root>
+          );
+        }
+        const { setProps } = await render(<App disabled={false} />);
+
+        const root = screen.getByTestId('root');
+        const checkbox = screen.getByRole('checkbox');
+
+        fireEvent.focus(checkbox);
+
+        expect(root).to.have.attribute('data-focused', '');
+        expect(checkbox).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+
+        expect(root).not.to.have.attribute('data-focused', '');
+        expect(checkbox).not.to.have.attribute('data-focused', '');
+      });
     });
 
     it('[data-invalid]', async () => {

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -165,6 +165,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
 
   useField({
     enabled: !groupContext,
+    disabled,
     id,
     commit: validation.commit,
     value: checked,
@@ -184,12 +185,6 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
       }
     }
   }, [checked, groupIndeterminate, setFilled]);
-
-  useIsoLayoutEffect(() => {
-    if (disabled) {
-      setFocused(false);
-    }
-  }, [disabled, setFocused]);
 
   useValueChanged(checked, () => {
     if (groupContext && !parent) {

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -185,6 +185,12 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     }
   }, [checked, groupIndeterminate, setFilled]);
 
+  useIsoLayoutEffect(() => {
+    if (disabled) {
+      setFocused(false);
+    }
+  }, [disabled, setFocused]);
+
   useValueChanged(checked, () => {
     if (groupContext && !parent) {
       return;

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import { useStore } from '@base-ui/utils/store';
-import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { isAndroid, isFirefox } from '@base-ui/utils/detectBrowser';
 import { BaseUIComponentProps } from '../../utils/types';
@@ -16,6 +15,7 @@ import { triggerStateAttributesMapping } from '../utils/stateAttributesMapping';
 import { selectors } from '../store';
 import type { FieldRoot } from '../../field/root/FieldRoot';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
+import { useClearFocusWhenDisabled } from '../../field/useField';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
 import { useComboboxChipsContext } from '../chips/ComboboxChipsContext';
 import { stopEvent } from '../../floating-ui-react/utils';
@@ -102,11 +102,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
     });
   });
 
-  useIsoLayoutEffect(() => {
-    if (disabled) {
-      setFocused(false);
-    }
-  }, [disabled, setFocused]);
+  useClearFocusWhenDisabled(disabled);
 
   const state: ComboboxInput.State = {
     ...fieldState,

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useStore } from '@base-ui/utils/store';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { isAndroid, isFirefox } from '@base-ui/utils/detectBrowser';
 import { BaseUIComponentProps } from '../../utils/types';
@@ -100,6 +101,12 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
       inputInsidePopup: nextIsInsidePopup,
     });
   });
+
+  useIsoLayoutEffect(() => {
+    if (disabled) {
+      setFocused(false);
+    }
+  }, [disabled, setFocused]);
 
   const state: ComboboxInput.State = {
     ...fieldState,

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -432,6 +432,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   } = useOpenInteractionType(open);
 
   useField({
+    disabled,
     id,
     name,
     commit: validation.commit,

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -4798,41 +4798,160 @@ describe('<Combobox.Root />', () => {
       });
     });
 
-    it('[data-focused]', async () => {
-      await render(
-        <Field.Root>
-          <Combobox.Root>
-            <Combobox.Input data-testid="input" />
-            <Combobox.Trigger data-testid="trigger" />
-            <Combobox.Portal>
-              <Combobox.Positioner>
-                <Combobox.Popup>
-                  <Combobox.List>
-                    <Combobox.Item value="">Select</Combobox.Item>
-                    <Combobox.Item value="1">Option 1</Combobox.Item>
-                  </Combobox.List>
-                </Combobox.Popup>
-              </Combobox.Positioner>
-            </Combobox.Portal>
-          </Combobox.Root>
-        </Field.Root>,
-      );
+    describe('[data-focused]', () => {
+      it('[data-focused]', async () => {
+        await render(
+          <Field.Root>
+            <Combobox.Root>
+              <Combobox.Input data-testid="input" />
+              <Combobox.Trigger data-testid="trigger" />
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.List>
+                      <Combobox.Item value="">Select</Combobox.Item>
+                      <Combobox.Item value="1">Option 1</Combobox.Item>
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          </Field.Root>,
+        );
 
-      const input = screen.getByTestId('input');
-      const trigger = screen.getByTestId('trigger');
+        const input = screen.getByTestId('input');
+        const trigger = screen.getByTestId('trigger');
 
-      expect(input).not.to.have.attribute('data-focused');
-      expect(trigger).not.to.have.attribute('data-focused');
+        expect(input).not.to.have.attribute('data-focused');
+        expect(trigger).not.to.have.attribute('data-focused');
 
-      fireEvent.focus(input);
+        fireEvent.focus(input);
 
-      expect(input).to.have.attribute('data-focused', '');
-      expect(trigger).to.have.attribute('data-focused', '');
+        expect(input).to.have.attribute('data-focused', '');
+        expect(trigger).to.have.attribute('data-focused', '');
 
-      fireEvent.blur(input);
+        fireEvent.blur(input);
 
-      expect(input).not.to.have.attribute('data-focused');
-      expect(trigger).not.to.have.attribute('data-focused');
+        expect(input).not.to.have.attribute('data-focused');
+        expect(trigger).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove data-focused when the field becomes disabled', async () => {
+        const { setProps } = await render(
+          <Field.Root>
+            <Combobox.Root>
+              <Combobox.Input data-testid="input" />
+              <Combobox.Trigger data-testid="trigger" />
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.List>
+                      <Combobox.Item value="">Select</Combobox.Item>
+                      <Combobox.Item value="1">Option 1</Combobox.Item>
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          </Field.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+        const trigger = screen.getByTestId('trigger');
+
+        expect(input).not.to.have.attribute('data-focused');
+        expect(trigger).not.to.have.attribute('data-focused');
+
+        fireEvent.focus(input);
+
+        expect(input).to.have.attribute('data-focused', '');
+        expect(trigger).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+
+        expect(input).not.to.have.attribute('data-focused');
+        expect(trigger).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove data-focused when the trigger becomes disabled', async () => {
+        function App({ disabled }: { disabled: boolean }) {
+          return (
+            <Field.Root>
+              <Combobox.Root>
+                <Combobox.Input data-testid="input" />
+                <Combobox.Trigger data-testid="trigger" disabled={disabled} />
+                <Combobox.Portal>
+                  <Combobox.Positioner>
+                    <Combobox.Popup>
+                      <Combobox.List>
+                        <Combobox.Item value="">Select</Combobox.Item>
+                        <Combobox.Item value="1">Option 1</Combobox.Item>
+                      </Combobox.List>
+                    </Combobox.Popup>
+                  </Combobox.Positioner>
+                </Combobox.Portal>
+              </Combobox.Root>
+            </Field.Root>
+          );
+        }
+        const { setProps } = await render(<App disabled={false} />);
+
+        const input = screen.getByTestId('input');
+        const trigger = screen.getByTestId('trigger');
+
+        expect(input).not.to.have.attribute('data-focused');
+        expect(trigger).not.to.have.attribute('data-focused');
+
+        fireEvent.focus(input);
+
+        expect(input).to.have.attribute('data-focused', '');
+        expect(trigger).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+
+        expect(input).not.to.have.attribute('data-focused');
+        expect(trigger).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove data-focused when the input becomes disabled', async () => {
+        function App({ disabled }: { disabled: boolean }) {
+          return (
+            <Field.Root>
+              <Combobox.Root>
+                <Combobox.Input data-testid="input" disabled={disabled} />
+                <Combobox.Trigger data-testid="trigger" />
+                <Combobox.Portal>
+                  <Combobox.Positioner>
+                    <Combobox.Popup>
+                      <Combobox.List>
+                        <Combobox.Item value="">Select</Combobox.Item>
+                        <Combobox.Item value="1">Option 1</Combobox.Item>
+                      </Combobox.List>
+                    </Combobox.Popup>
+                  </Combobox.Positioner>
+                </Combobox.Portal>
+              </Combobox.Root>
+            </Field.Root>
+          );
+        }
+        const { setProps } = await render(<App disabled={false} />);
+
+        const input = screen.getByTestId('input');
+        const trigger = screen.getByTestId('trigger');
+
+        expect(input).not.to.have.attribute('data-focused');
+        expect(trigger).not.to.have.attribute('data-focused');
+
+        fireEvent.focus(input);
+
+        expect(input).to.have.attribute('data-focused', '');
+        expect(trigger).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+
+        expect(input).not.to.have.attribute('data-focused');
+        expect(trigger).not.to.have.attribute('data-focused');
+      });
     });
 
     it('does not mark as touched when focus moves into the popup', async () => {

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -125,12 +125,12 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
     event: 'mousedown',
   });
 
-  const { buttonRef, getButtonProps } = useButton({
+  const { buttonRef, getButtonProps, focusableWhenDisabled } = useButton({
     native: nativeButton,
     disabled,
   });
 
-  useClearFocusWhenDisabled(disabled);
+  useClearFocusWhenDisabled(disabled, focusableWhenDisabled);
 
   const state: ComboboxTrigger.State = {
     ...fieldState,

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { useStore } from '@base-ui/utils/store';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useTimeout } from '@base-ui/utils/useTimeout';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { BaseUIComponentProps, NativeButtonProps } from '../../utils/types';
@@ -128,6 +129,12 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
     native: nativeButton,
     disabled,
   });
+
+  useIsoLayoutEffect(() => {
+    if (disabled) {
+      setFocused(false);
+    }
+  }, [disabled, setFocused]);
 
   const state: ComboboxTrigger.State = {
     ...fieldState,

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { useStore } from '@base-ui/utils/store';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useTimeout } from '@base-ui/utils/useTimeout';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { BaseUIComponentProps, NativeButtonProps } from '../../utils/types';
@@ -17,6 +16,7 @@ import {
 import { triggerStateAttributesMapping } from '../utils/stateAttributesMapping';
 import { selectors } from '../store';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
+import { useClearFocusWhenDisabled } from '../../field/useField';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
 import { stopEvent, contains, getTarget } from '../../floating-ui-react/utils';
 import { getPseudoElementBounds } from '../../utils/getPseudoElementBounds';
@@ -130,11 +130,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
     disabled,
   });
 
-  useIsoLayoutEffect(() => {
-    if (disabled) {
-      setFocused(false);
-    }
-  }, [disabled, setFocused]);
+  useClearFocusWhenDisabled(disabled);
 
   const state: ComboboxTrigger.State = {
     ...fieldState,

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -80,10 +80,12 @@ export const FieldControl = React.forwardRef(function FieldControl(
   const inputRef = React.useRef<HTMLElement>(null);
 
   useIsoLayoutEffect(() => {
-    if (autoFocus && inputRef.current === activeElement(ownerDocument(inputRef.current))) {
+    if (disabled) {
+      setFocused(false);
+    } else if (autoFocus && inputRef.current === activeElement(ownerDocument(inputRef.current))) {
       setFocused(true);
     }
-  }, [autoFocus, setFocused]);
+  }, [disabled, autoFocus, setFocused]);
 
   const [valueUnwrapped] = useControlled({
     controlled: valueProp,

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -80,12 +80,10 @@ export const FieldControl = React.forwardRef(function FieldControl(
   const inputRef = React.useRef<HTMLElement>(null);
 
   useIsoLayoutEffect(() => {
-    if (disabled) {
-      setFocused(false);
-    } else if (autoFocus && inputRef.current === activeElement(ownerDocument(inputRef.current))) {
+    if (autoFocus && inputRef.current === activeElement(ownerDocument(inputRef.current))) {
       setFocused(true);
     }
-  }, [disabled, autoFocus, setFocused]);
+  }, [autoFocus, setFocused]);
 
   const [valueUnwrapped] = useControlled({
     controlled: valueProp,
@@ -98,6 +96,7 @@ export const FieldControl = React.forwardRef(function FieldControl(
   const value = isControlled ? valueUnwrapped : undefined;
 
   useField({
+    disabled,
     id,
     name,
     commit: validation.commit,

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -1029,13 +1029,41 @@ describe('<Field.Root />', () => {
       });
     });
 
-    it('should remove data-focused when disabled', async () => {
+    it('should remove data-focused when the field becomes disabled', async () => {
       const { setProps } = await render(
         <Field.Root data-testid="root">
           <Field.Control data-testid="control" />
           <Field.Label data-testid="label" />
         </Field.Root>,
       );
+
+      const root = screen.getByTestId('root');
+      const control = screen.getByTestId('control');
+      const label = screen.getByTestId('label');
+
+      fireEvent.focus(control);
+
+      expect(root).to.have.attribute('data-focused', '');
+      expect(control).to.have.attribute('data-focused', '');
+      expect(label).to.have.attribute('data-focused', '');
+
+      await setProps({ disabled: true });
+
+      expect(root).not.to.have.attribute('data-focused');
+      expect(control).not.to.have.attribute('data-focused');
+      expect(label).not.to.have.attribute('data-focused');
+    });
+
+    it('should remove data-focused when the control becomes disabled', async () => {
+      function App({ disabled }: { disabled: boolean }) {
+        return (
+          <Field.Root data-testid="root">
+            <Field.Control data-testid="control" disabled={disabled} />
+            <Field.Label data-testid="label" />
+          </Field.Root>
+        );
+      }
+      const { setProps } = await render(<App />);
 
       const root = screen.getByTestId('root');
       const control = screen.getByTestId('control');

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -1028,6 +1028,31 @@ describe('<Field.Root />', () => {
         expect(description).not.to.have.attribute('data-focused');
       });
     });
+
+    it('should remove data-focused when disabled', async () => {
+      const { setProps } = await render(
+        <Field.Root data-testid="root">
+          <Field.Control data-testid="control" />
+          <Field.Label data-testid="label" />
+        </Field.Root>,
+      );
+
+      const root = screen.getByTestId('root');
+      const control = screen.getByTestId('control');
+      const label = screen.getByTestId('label');
+
+      fireEvent.focus(control);
+
+      expect(root).to.have.attribute('data-focused', '');
+      expect(control).to.have.attribute('data-focused', '');
+      expect(label).to.have.attribute('data-focused', '');
+
+      await setProps({ disabled: true });
+
+      expect(root).not.to.have.attribute('data-focused');
+      expect(control).not.to.have.attribute('data-focused');
+      expect(label).not.to.have.attribute('data-focused');
+    });
   });
 
   describe('defaultValue behavior', () => {

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -1063,7 +1063,7 @@ describe('<Field.Root />', () => {
           </Field.Root>
         );
       }
-      const { setProps } = await render(<App />);
+      const { setProps } = await render(<App disabled={false} />);
 
       const root = screen.getByTestId('root');
       const control = screen.getByTestId('control');

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -96,7 +96,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
       dirty,
       valid,
       filled,
-      focused,
+      focused: disabled ? false : focused,
     }),
     [disabled, touched, dirty, valid, filled, focused],
   );

--- a/packages/react/src/field/useField.ts
+++ b/packages/react/src/field/useField.ts
@@ -7,18 +7,27 @@ import { useFormContext } from '../form/FormContext';
 import { useFieldRootContext } from './root/FieldRootContext';
 
 // exported for subcomponents that have their own disabled prop e.g. SelectTrigger
-export function useClearFocusWhenDisabled(disabled: boolean) {
+export function useClearFocusWhenDisabled(disabled: boolean, focusableWhenDisabled = false) {
   const { setFocused } = useFieldRootContext();
 
   useIsoLayoutEffect(() => {
-    if (disabled) {
+    if (disabled && !focusableWhenDisabled) {
       setFocused(false);
     }
-  }, [disabled, setFocused]);
+  }, [disabled, focusableWhenDisabled, setFocused]);
 }
 
 export function useField(params: UseFieldParameters) {
-  const { enabled = true, disabled = false, value, id, name, controlRef, commit } = params;
+  const {
+    enabled = true,
+    disabled = false,
+    focusableWhenDisabled = false,
+    value,
+    id,
+    name,
+    controlRef,
+    commit,
+  } = params;
 
   const { formRef } = useFormContext();
   const { invalid, markedDirtyRef, validityData, setValidityData } = useFieldRootContext();
@@ -80,7 +89,7 @@ export function useField(params: UseFieldParameters) {
     value,
   ]);
 
-  useClearFocusWhenDisabled(disabled);
+  useClearFocusWhenDisabled(disabled, focusableWhenDisabled);
 
   useIsoLayoutEffect(() => {
     const fields = formRef.current.fields;
@@ -94,12 +103,8 @@ export function useField(params: UseFieldParameters) {
 
 export interface UseFieldParameters {
   enabled?: boolean | undefined;
-  /**
-   * Whether the component should ignore user interaction.
-   * When `true`, the field's focused state is cleared.
-   * @default false
-   */
   disabled?: boolean | undefined;
+  focusableWhenDisabled?: boolean | undefined;
   value: unknown;
   getValue?: (() => unknown) | undefined;
   id: string | undefined;

--- a/packages/react/src/field/useField.ts
+++ b/packages/react/src/field/useField.ts
@@ -6,8 +6,19 @@ import { getCombinedFieldValidityData } from './utils/getCombinedFieldValidityDa
 import { useFormContext } from '../form/FormContext';
 import { useFieldRootContext } from './root/FieldRootContext';
 
+// exported for subcomponents that have their own disabled prop e.g. SelectTrigger
+export function useClearFocusWhenDisabled(disabled: boolean) {
+  const { setFocused } = useFieldRootContext();
+
+  useIsoLayoutEffect(() => {
+    if (disabled) {
+      setFocused(false);
+    }
+  }, [disabled, setFocused]);
+}
+
 export function useField(params: UseFieldParameters) {
-  const { enabled = true, value, id, name, controlRef, commit } = params;
+  const { enabled = true, disabled = false, value, id, name, controlRef, commit } = params;
 
   const { formRef } = useFormContext();
   const { invalid, markedDirtyRef, validityData, setValidityData } = useFieldRootContext();
@@ -69,6 +80,8 @@ export function useField(params: UseFieldParameters) {
     value,
   ]);
 
+  useClearFocusWhenDisabled(disabled);
+
   useIsoLayoutEffect(() => {
     const fields = formRef.current.fields;
     return () => {
@@ -81,6 +94,12 @@ export function useField(params: UseFieldParameters) {
 
 export interface UseFieldParameters {
   enabled?: boolean | undefined;
+  /**
+   * Whether the component should ignore user interaction.
+   * When `true`, the field's focused state is cleared.
+   * @default false
+   */
+  disabled?: boolean | undefined;
   value: unknown;
   getValue?: (() => unknown) | undefined;
   id: string | undefined;

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { stopEvent } from '../../floating-ui-react/utils';
 import { useNumberFieldRootContext } from '../root/NumberFieldRootContext';
 import type { BaseUIComponentProps } from '../../utils/types';
@@ -98,6 +97,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
   const blockRevalidationRef = React.useRef(false);
 
   useField({
+    disabled,
     id,
     commit: validation.commit,
     value,
@@ -126,12 +126,6 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
 
     validation.commit(value, true);
   });
-
-  useIsoLayoutEffect(() => {
-    if (disabled) {
-      setFocused(false);
-    }
-  }, [disabled, setFocused]);
 
   const inputProps: React.ComponentProps<'input'> = {
     id,

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { stopEvent } from '../../floating-ui-react/utils';
 import { useNumberFieldRootContext } from '../root/NumberFieldRootContext';
 import type { BaseUIComponentProps } from '../../utils/types';
@@ -57,11 +58,11 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
   componentProps: NumberFieldInput.Props,
   forwardedRef: React.ForwardedRef<HTMLInputElement>,
 ) {
-  const { render, className, ...elementProps } = componentProps;
+  const { render, className, disabled: disabledProp, ...elementProps } = componentProps;
 
   const {
     allowInputSyncRef,
-    disabled,
+    disabled: contextDisabled,
     formatOptionsRef,
     getAllowedNonNumericKeys,
     getStepAmount,
@@ -85,6 +86,8 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
     hasPendingCommitRef,
     valueRef,
   } = useNumberFieldRootContext();
+
+  const disabled = disabledProp || contextDisabled;
 
   const { clearErrors } = useFormContext();
   const { validationMode, setTouched, setFocused, invalid, shouldValidateOnChange, validation } =
@@ -123,6 +126,12 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
 
     validation.commit(value, true);
   });
+
+  useIsoLayoutEffect(() => {
+    if (disabled) {
+      setFocused(false);
+    }
+  }, [disabled, setFocused]);
 
   const inputProps: React.ComponentProps<'input'> = {
     id,

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -1361,47 +1361,90 @@ describe('<NumberField />', () => {
       });
     });
 
-    it('[data-filled]', async () => {
-      await render(
-        <Field.Root>
-          <NumberFieldBase.Root>
-            <NumberFieldBase.Input data-testid="input" />
-          </NumberFieldBase.Root>
-        </Field.Root>,
-      );
+    describe('[data-focused]', () => {
+      it('sets [data-focused] when focused', async () => {
+        await render(
+          <Field.Root>
+            <NumberFieldBase.Root>
+              <NumberFieldBase.Input data-testid="input" />
+            </NumberFieldBase.Root>
+          </Field.Root>,
+        );
 
-      const input = screen.getByTestId('input');
+        const input = screen.getByTestId('input');
 
-      expect(input).not.to.have.attribute('data-focused');
+        expect(input).not.to.have.attribute('data-focused');
 
-      fireEvent.focus(input);
+        fireEvent.focus(input);
 
-      expect(input).to.have.attribute('data-focused', '');
+        expect(input).to.have.attribute('data-focused', '');
 
-      fireEvent.blur(input);
+        fireEvent.blur(input);
 
-      expect(input).not.to.have.attribute('data-focused');
-    });
+        expect(input).not.to.have.attribute('data-focused');
+      });
 
-    it('adds [data-focused] attribute on every focus', async () => {
-      await render(
-        <Field.Root>
-          <NumberFieldBase.Root>
-            <NumberFieldBase.Input data-testid="input" />
-          </NumberFieldBase.Root>
-        </Field.Root>,
-      );
+      it('adds [data-focused] attribute on every focus', async () => {
+        await render(
+          <Field.Root>
+            <NumberFieldBase.Root>
+              <NumberFieldBase.Input data-testid="input" />
+            </NumberFieldBase.Root>
+          </Field.Root>,
+        );
 
-      const input = screen.getByTestId('input');
+        const input = screen.getByTestId('input');
 
-      fireEvent.focus(input);
-      expect(input).to.have.attribute('data-focused', '');
+        fireEvent.focus(input);
+        expect(input).to.have.attribute('data-focused', '');
 
-      fireEvent.blur(input);
-      expect(input).not.to.have.attribute('data-focused');
+        fireEvent.blur(input);
+        expect(input).not.to.have.attribute('data-focused');
 
-      fireEvent.focus(input);
-      expect(input).to.have.attribute('data-focused', '');
+        fireEvent.focus(input);
+        expect(input).to.have.attribute('data-focused', '');
+      });
+
+      it('should remove [data-focused] when the field becomes disabled', async () => {
+        const { setProps } = await render(
+          <Field.Root>
+            <NumberFieldBase.Root>
+              <NumberFieldBase.Input data-testid="input" />
+            </NumberFieldBase.Root>
+          </Field.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+        expect(input).not.to.have.attribute('data-focused');
+
+        fireEvent.focus(input);
+        expect(input).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(input).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove [data-focused] when the input becomes disabled', async () => {
+        function App({ disabled }: { disabled: boolean }) {
+          return (
+            <Field.Root>
+              <NumberFieldBase.Root>
+                <NumberFieldBase.Input data-testid="input" disabled={disabled} />
+              </NumberFieldBase.Root>
+            </Field.Root>
+          );
+        }
+        const { setProps } = await render(<App disabled={false} />);
+
+        const input = screen.getByTestId('input');
+        expect(input).not.to.have.attribute('data-focused');
+
+        fireEvent.focus(input);
+        expect(input).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(input).not.to.have.attribute('data-focused');
+      });
     });
 
     it('prop: validate', async () => {

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -581,6 +581,71 @@ describe('<RadioGroup />', () => {
       expect(b).to.have.attribute('data-unchecked', '');
       expect(indicatorB).to.have.attribute('data-unchecked', '');
     });
+
+    describe('[data-focused]', () => {
+      it('sets [data-focused] when focused', async () => {
+        const { user } = await render(
+          <Field.Root>
+            <RadioGroup>
+              <Radio.Root value="a" />
+              <Radio.Root value="b" />
+            </RadioGroup>
+          </Field.Root>,
+        );
+
+        const [radioA] = screen.getAllByRole('radio');
+        expect(radioA).not.to.have.attribute('data-focused');
+
+        await user.keyboard('{Tab}');
+        expect(radioA).to.have.attribute('data-focused', '');
+
+        await user.keyboard('{Tab}');
+        expect(radioA).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove [data-focused] when the field becomes disabled', async () => {
+        const { user, setProps } = await render(
+          <Field.Root>
+            <RadioGroup>
+              <Radio.Root value="a" />
+              <Radio.Root value="b" />
+            </RadioGroup>
+          </Field.Root>,
+        );
+
+        const [radioA] = screen.getAllByRole('radio');
+        expect(radioA).not.to.have.attribute('data-focused');
+
+        await user.keyboard('{Tab}');
+        expect(radioA).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(radioA).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove [data-focused] when the radio group becomes disabled', async () => {
+        function App({ disabled }: { disabled: boolean }) {
+          return (
+            <Field.Root>
+              <RadioGroup disabled={disabled}>
+                <Radio.Root value="a" />
+                <Radio.Root value="b" />
+              </RadioGroup>
+            </Field.Root>
+          );
+        }
+        const { user, setProps } = await render(<App disabled={false} />);
+
+        const [radioA] = screen.getAllByRole('radio');
+        expect(radioA).not.to.have.attribute('data-focused');
+
+        await user.keyboard('{Tab}');
+        expect(radioA).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(radioA).not.to.have.attribute('data-focused');
+      });
+    });
   });
 
   it('does not forward `value` prop', async () => {

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { useControlled } from '@base-ui/utils/useControlled';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import type { BaseUIComponentProps, HTMLProps } from '../utils/types';
 import { useBaseUiId } from '../utils/useBaseUiId';
 import { contains } from '../floating-ui-react/utils';
@@ -147,6 +146,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
   });
 
   useField({
+    disabled,
     id,
     commit: validation.commit,
     value: checkedValue,
@@ -172,12 +172,6 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
       setInputRef(fallbackInput);
     }
   });
-
-  useIsoLayoutEffect(() => {
-    if (disabled) {
-      setFocused(false);
-    }
-  }, [disabled, setFocused]);
 
   const [touched, setTouched] = React.useState(false);
 

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { useControlled } from '@base-ui/utils/useControlled';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import type { BaseUIComponentProps, HTMLProps } from '../utils/types';
 import { useBaseUiId } from '../utils/useBaseUiId';
 import { contains } from '../floating-ui-react/utils';
@@ -171,6 +172,12 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
       setInputRef(fallbackInput);
     }
   });
+
+  useIsoLayoutEffect(() => {
+    if (disabled) {
+      setFocused(false);
+    }
+  }, [disabled, setFocused]);
 
   const [touched, setTouched] = React.useState(false);
 

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -1621,34 +1621,120 @@ describe('<Select.Root />', () => {
       });
     });
 
-    it('[data-focused]', async () => {
-      await render(
-        <Field.Root>
-          <Select.Root>
-            <Select.Trigger data-testid="trigger" />
-            <Select.Portal>
-              <Select.Positioner>
-                <Select.Popup>
-                  <Select.Item value="">Select</Select.Item>
-                  <Select.Item value="1">Option 1</Select.Item>
-                </Select.Popup>
-              </Select.Positioner>
-            </Select.Portal>
-          </Select.Root>
-        </Field.Root>,
-      );
+    describe('[data-focused]', () => {
+      it('sets [data-focused] when focused', async () => {
+        await render(
+          <Field.Root>
+            <Select.Root>
+              <Select.Trigger data-testid="trigger" />
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    <Select.Item value="">Select</Select.Item>
+                    <Select.Item value="1">Option 1</Select.Item>
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </Field.Root>,
+        );
 
-      const trigger = screen.getByTestId('trigger');
+        const trigger = screen.getByTestId('trigger');
+        expect(trigger).not.to.have.attribute('data-focused');
 
-      expect(trigger).not.to.have.attribute('data-focused');
+        fireEvent.focus(trigger);
+        expect(trigger).to.have.attribute('data-focused', '');
 
-      fireEvent.focus(trigger);
+        fireEvent.blur(trigger);
+        expect(trigger).not.to.have.attribute('data-focused');
+      });
 
-      expect(trigger).to.have.attribute('data-focused', '');
+      it('should remove data-focused when the field becomes disabled', async () => {
+        const { setProps } = await render(
+          <Field.Root>
+            <Select.Root>
+              <Select.Trigger data-testid="trigger" />
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    <Select.Item value="">Select</Select.Item>
+                    <Select.Item value="1">Option 1</Select.Item>
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </Field.Root>,
+        );
 
-      fireEvent.blur(trigger);
+        const trigger = screen.getByTestId('trigger');
+        expect(trigger).not.to.have.attribute('data-focused');
 
-      expect(trigger).not.to.have.attribute('data-focused');
+        fireEvent.focus(trigger);
+        expect(trigger).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(trigger).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove data-focused when the root becomes disabled', async () => {
+        function App({ disabled }: { disabled: boolean }) {
+          return (
+            <Field.Root>
+              <Select.Root disabled={disabled}>
+                <Select.Trigger data-testid="trigger" />
+                <Select.Portal>
+                  <Select.Positioner>
+                    <Select.Popup>
+                      <Select.Item value="">Select</Select.Item>
+                      <Select.Item value="1">Option 1</Select.Item>
+                    </Select.Popup>
+                  </Select.Positioner>
+                </Select.Portal>
+              </Select.Root>
+            </Field.Root>
+          );
+        }
+        const { setProps } = await render(<App disabled={false} />);
+
+        const trigger = screen.getByTestId('trigger');
+        expect(trigger).not.to.have.attribute('data-focused');
+
+        fireEvent.focus(trigger);
+        expect(trigger).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(trigger).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove data-focused when the trigger becomes disabled', async () => {
+        function App({ disabled }: { disabled: boolean }) {
+          return (
+            <Field.Root>
+              <Select.Root>
+                <Select.Trigger data-testid="trigger" disabled={disabled} />
+                <Select.Portal>
+                  <Select.Positioner>
+                    <Select.Popup>
+                      <Select.Item value="">Select</Select.Item>
+                      <Select.Item value="1">Option 1</Select.Item>
+                    </Select.Popup>
+                  </Select.Positioner>
+                </Select.Portal>
+              </Select.Root>
+            </Field.Root>
+          );
+        }
+        const { setProps } = await render(<App disabled={false} />);
+
+        const trigger = screen.getByTestId('trigger');
+        expect(trigger).not.to.have.attribute('data-focused');
+
+        fireEvent.focus(trigger);
+        expect(trigger).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(trigger).not.to.have.attribute('data-focused');
+      });
     });
 
     it('does not mark as touched when focus moves into the popup', async () => {

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -179,6 +179,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   const controlRef = useValueAsRef(store.state.triggerElement);
 
   useField({
+    disabled,
     id: generatedId,
     commit: validation.commit,
     value,

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { useTimeout } from '@base-ui/utils/useTimeout';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
@@ -84,6 +85,12 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const hasSelectedValue = useStore(store, selectors.hasSelectedValue);
   const shouldCheckNullItemLabel = !hasSelectedValue && open;
   const hasNullItemLabel = useStore(store, selectors.hasNullItemLabel, shouldCheckNullItemLabel);
+
+  useIsoLayoutEffect(() => {
+    if (disabled) {
+      setFocused(false);
+    }
+  }, [disabled, setFocused]);
 
   const id = idProp ?? rootId;
   useLabelableId({ id });

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { useTimeout } from '@base-ui/utils/useTimeout';
-import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
@@ -10,6 +9,7 @@ import { useStore } from '@base-ui/utils/store';
 import { useSelectRootContext } from '../root/SelectRootContext';
 import { BaseUIComponentProps, HTMLProps, NativeButtonProps } from '../../utils/types';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
+import { useClearFocusWhenDisabled } from '../../field/useField';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
 import { pressableTriggerOpenStateMapping } from '../../utils/popupStateMapping';
 import { fieldValidityMapping } from '../../field/utils/constants';
@@ -86,11 +86,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const shouldCheckNullItemLabel = !hasSelectedValue && open;
   const hasNullItemLabel = useStore(store, selectors.hasNullItemLabel, shouldCheckNullItemLabel);
 
-  useIsoLayoutEffect(() => {
-    if (disabled) {
-      setFocused(false);
-    }
-  }, [disabled, setFocused]);
+  useClearFocusWhenDisabled(disabled);
 
   const id = idProp ?? rootId;
   useLabelableId({ id });

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -86,7 +86,12 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const shouldCheckNullItemLabel = !hasSelectedValue && open;
   const hasNullItemLabel = useStore(store, selectors.hasNullItemLabel, shouldCheckNullItemLabel);
 
-  useClearFocusWhenDisabled(disabled);
+  const { getButtonProps, buttonRef, focusableWhenDisabled } = useButton({
+    disabled,
+    native: nativeButton,
+  });
+
+  useClearFocusWhenDisabled(disabled, focusableWhenDisabled);
 
   const id = idProp ?? rootId;
   useLabelableId({ id });
@@ -94,11 +99,6 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const positionerRef = useValueAsRef(positionerElement);
 
   const triggerRef = React.useRef<HTMLElement | null>(null);
-
-  const { getButtonProps, buttonRef } = useButton({
-    disabled,
-    native: nativeButton,
-  });
 
   const setTriggerElement = useStableCallback((element) => {
     store.set('triggerElement', element);

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -2170,29 +2170,78 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
       expect(root).to.have.attribute('data-dirty', '');
     });
 
-    it('[data-focused]', async () => {
-      await render(
-        <Field.Root>
-          <Slider.Root data-testid="root">
-            <Slider.Control>
-              <Slider.Thumb />
-            </Slider.Control>
-          </Slider.Root>
-        </Field.Root>,
-      );
+    describe('[data-focused]', () => {
+      it('sets [data-focused] when focused', async () => {
+        await render(
+          <Field.Root>
+            <Slider.Root data-testid="root">
+              <Slider.Control>
+                <Slider.Thumb />
+              </Slider.Control>
+            </Slider.Root>
+          </Field.Root>,
+        );
 
-      const root = screen.getByTestId('root');
-      const input = screen.getByRole('slider');
+        const root = screen.getByTestId('root');
+        const input = screen.getByRole('slider');
 
-      expect(root).not.to.have.attribute('data-focused');
+        expect(root).not.to.have.attribute('data-focused');
 
-      fireEvent.focus(input);
+        fireEvent.focus(input);
+        expect(root).to.have.attribute('data-focused', '');
 
-      expect(root).to.have.attribute('data-focused', '');
+        fireEvent.blur(input);
+        expect(root).not.to.have.attribute('data-focused');
+      });
 
-      fireEvent.blur(input);
+      it('should remove [data-focused] when the field becomes disabled', async () => {
+        const { setProps } = await render(
+          <Field.Root>
+            <Slider.Root data-testid="root">
+              <Slider.Control>
+                <Slider.Thumb />
+              </Slider.Control>
+            </Slider.Root>
+          </Field.Root>,
+        );
 
-      expect(root).not.to.have.attribute('data-focused');
+        const root = screen.getByTestId('root');
+        const input = screen.getByRole('slider');
+
+        expect(root).not.to.have.attribute('data-focused');
+
+        fireEvent.focus(input);
+        expect(root).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(root).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove [data-focused] when the slider becomes disabled', async () => {
+        function App({ disabled }: { disabled: boolean }) {
+          return (
+            <Field.Root>
+              <Slider.Root data-testid="root" disabled={disabled}>
+                <Slider.Control>
+                  <Slider.Thumb />
+                </Slider.Control>
+              </Slider.Root>
+            </Field.Root>
+          );
+        }
+        const { setProps } = await render(<App disabled={false} />);
+
+        const root = screen.getByTestId('root');
+        const input = screen.getByRole('slider');
+
+        expect(root).not.to.have.attribute('data-focused');
+
+        fireEvent.focus(input);
+        expect(root).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(root).not.to.have.attribute('data-focused');
+      });
     });
 
     describe('prop: validate', () => {

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -104,6 +104,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     state: fieldState,
     disabled: fieldDisabled,
     name: fieldName,
+    setFocused,
     setTouched,
     setDirty,
     validityData,
@@ -273,14 +274,17 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   }
 
   useIsoLayoutEffect(() => {
-    const activeEl = activeElement(ownerDocument(sliderRef.current));
-    if (disabled && activeEl && sliderRef.current?.contains(activeEl)) {
-      // This is necessary because Firefox and Safari will keep focus
-      // on a disabled element:
-      // https://codesandbox.io/p/sandbox/mui-pr-22247-forked-h151h?file=/src/App.js
-      (activeEl as HTMLElement).blur();
+    if (disabled) {
+      setFocused(false);
+      const activeEl = activeElement(ownerDocument(sliderRef.current));
+      if (activeEl && sliderRef.current?.contains(activeEl)) {
+        // This is necessary because Firefox and Safari will keep focus
+        // on a disabled element:
+        // https://codesandbox.io/p/sandbox/mui-pr-22247-forked-h151h?file=/src/App.js
+        (activeEl as HTMLElement).blur();
+      }
     }
-  }, [disabled]);
+  }, [disabled, setFocused]);
 
   if (disabled && active !== -1) {
     setActive(-1);

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -104,7 +104,6 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     state: fieldState,
     disabled: fieldDisabled,
     name: fieldName,
-    setFocused,
     setTouched,
     setDirty,
     validityData,
@@ -166,6 +165,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   });
 
   useField({
+    disabled,
     id,
     commit: validation.commit,
     value: valueUnwrapped,
@@ -275,7 +275,6 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
 
   useIsoLayoutEffect(() => {
     if (disabled) {
-      setFocused(false);
       const activeEl = activeElement(ownerDocument(sliderRef.current));
       if (activeEl && sliderRef.current?.contains(activeEl)) {
         // This is necessary because Firefox and Safari will keep focus
@@ -284,7 +283,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
         (activeEl as HTMLElement).blur();
       }
     }
-  }, [disabled, setFocused]);
+  }, [disabled]);
 
   if (disabled && active !== -1) {
     setActive(-1);

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -631,24 +631,60 @@ describe('<Switch.Root />', () => {
       });
     });
 
-    it('[data-focused]', async () => {
-      await render(
-        <Field.Root>
-          <Switch.Root data-testid="button" />
-        </Field.Root>,
-      );
+    describe('[data-focused]', () => {
+      it('[data-focused]', async () => {
+        await render(
+          <Field.Root>
+            <Switch.Root data-testid="button" />
+          </Field.Root>,
+        );
 
-      const button = screen.getByTestId('button');
+        const button = screen.getByTestId('button');
+        expect(button).not.to.have.attribute('data-focused');
 
-      expect(button).not.to.have.attribute('data-focused');
+        fireEvent.focus(button);
+        expect(button).to.have.attribute('data-focused', '');
 
-      fireEvent.focus(button);
+        fireEvent.blur(button);
+        expect(button).not.to.have.attribute('data-focused');
+      });
 
-      expect(button).to.have.attribute('data-focused', '');
+      it('should remove data-focused when the field becomes disabled', async () => {
+        const { user, setProps } = await render(
+          <Field.Root>
+            <Switch.Root />
+          </Field.Root>,
+        );
 
-      fireEvent.blur(button);
+        const switchEl = screen.getByRole('switch');
+        expect(switchEl).not.to.have.attribute('data-focused');
 
-      expect(button).not.to.have.attribute('data-focused');
+        await user.keyboard('{Tab}');
+        expect(switchEl).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(switchEl).not.to.have.attribute('data-focused');
+      });
+
+      it('should remove data-focused when the switch becomes disabled', async () => {
+        function App({ disabled }: { disabled: boolean }) {
+          return (
+            <Field.Root>
+              <Switch.Root disabled={disabled} />
+            </Field.Root>
+          );
+        }
+        const { user, setProps } = await render(<App disabled={false} />);
+
+        const switchEl = screen.getByRole('switch');
+        expect(switchEl).not.to.have.attribute('data-focused');
+
+        await user.keyboard('{Tab}');
+        expect(switchEl).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+        expect(switchEl).not.to.have.attribute('data-focused');
+      });
     });
 
     it('prop: validationMode=onSubmit', async () => {

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -95,6 +95,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
   });
 
   useField({
+    disabled,
     id,
     commit: validation.commit,
     value: checked,
@@ -108,12 +109,6 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
       setFilled(inputRef.current.checked);
     }
   }, [inputRef, setFilled]);
-
-  useIsoLayoutEffect(() => {
-    if (disabled) {
-      setFocused(false);
-    }
-  }, [disabled, setFocused]);
 
   useValueChanged(checked, () => {
     clearErrors(name);

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -109,6 +109,12 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     }
   }, [inputRef, setFilled]);
 
+  useIsoLayoutEffect(() => {
+    if (disabled) {
+      setFocused(false);
+    }
+  }, [disabled, setFocused]);
+
   useValueChanged(checked, () => {
     clearErrors(name);
     setDirty(checked !== validityData.initialValue);

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -94,8 +94,14 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     state: 'checked',
   });
 
+  const { getButtonProps, buttonRef, focusableWhenDisabled } = useButton({
+    disabled,
+    native: nativeButton,
+  });
+
   useField({
     disabled,
+    focusableWhenDisabled,
     id,
     commit: validation.commit,
     value: checked,
@@ -120,11 +126,6 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     } else {
       validation.commit(checked, true);
     }
-  });
-
-  const { getButtonProps, buttonRef } = useButton({
-    disabled,
-    native: nativeButton,
   });
 
   const rootProps: React.ComponentPropsWithRef<'span'> = {

--- a/packages/react/src/toolbar/button/ToolbarButton.test.tsx
+++ b/packages/react/src/toolbar/button/ToolbarButton.test.tsx
@@ -8,6 +8,7 @@ import { AlertDialog } from '@base-ui/react/alert-dialog';
 import { Popover } from '@base-ui/react/popover';
 import { Toggle } from '@base-ui/react/toggle';
 import { ToggleGroup } from '@base-ui/react/toggle-group';
+import { Field } from '@base-ui/react/field';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { NOOP } from '../../utils/noop';
@@ -213,6 +214,37 @@ describe('<Toolbar.Button />', () => {
         await user.click(switchElement);
         expect(handleCheckedChange).toHaveBeenCalledTimes(0);
         expect(handleClick).toHaveBeenCalledTimes(0);
+      });
+
+      it('keeps [data-focused] when disabled while remaining focusable', async () => {
+        function App({ disabled }: { disabled: boolean }) {
+          return (
+            <Toolbar.Root>
+              <Field.Root data-testid="field">
+                <Toolbar.Button
+                  nativeButton={false}
+                  render={<Switch.Root data-testid="switch" />}
+                  disabled={disabled}
+                />
+              </Field.Root>
+            </Toolbar.Root>
+          );
+        }
+
+        const { user, setProps } = await render(<App disabled={false} />);
+
+        const field = screen.getByTestId('field');
+        const switchElement = screen.getByTestId('switch');
+
+        await user.keyboard('[Tab]');
+
+        expect(field).to.have.attribute('data-focused', '');
+        expect(switchElement).to.have.attribute('data-focused', '');
+
+        await setProps({ disabled: true });
+
+        expect(field).to.have.attribute('data-focused', '');
+        expect(switchElement).to.have.attribute('data-focused', '');
       });
     });
 

--- a/packages/react/src/use-button/useButton.ts
+++ b/packages/react/src/use-button/useButton.ts
@@ -27,13 +27,14 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
     return Boolean(element?.tagName === 'A' && (element as HTMLAnchorElement)?.href);
   });
 
-  const { props: focusableWhenDisabledProps } = useFocusableWhenDisabled({
-    focusableWhenDisabled,
-    disabled,
-    composite: isCompositeItem,
-    tabIndex,
-    isNativeButton,
-  });
+  const { props: focusableWhenDisabledProps, focusableWhenDisabled: isFocusableWhenDisabled } =
+    useFocusableWhenDisabled({
+      focusableWhenDisabled,
+      disabled,
+      composite: isCompositeItem,
+      tabIndex,
+      isNativeButton,
+    });
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -193,6 +194,7 @@ export function useButton(parameters: useButton.Parameters = {}): useButton.Retu
   return {
     getButtonProps,
     buttonRef,
+    focusableWhenDisabled: isFocusableWhenDisabled,
   };
 }
 
@@ -246,6 +248,7 @@ export interface UseButtonReturnValue {
    * It is not a part of the props returned by `getButtonProps`.
    */
   buttonRef: React.Ref<HTMLElement>;
+  focusableWhenDisabled: boolean;
 }
 
 export namespace useButton {

--- a/packages/react/src/utils/useFocusableWhenDisabled.ts
+++ b/packages/react/src/utils/useFocusableWhenDisabled.ts
@@ -14,6 +14,7 @@ export function useFocusableWhenDisabled(
 
   const isFocusableComposite = composite && focusableWhenDisabled !== false;
   const isNonFocusableComposite = composite && focusableWhenDisabled === false;
+  const isFocusableWhenDisabled = Boolean(focusableWhenDisabled) || isFocusableComposite;
 
   // we can't explicitly assign `undefined` to any of these props because it
   // would otherwise prevent subsequently merged props from setting them
@@ -57,7 +58,10 @@ export function useFocusableWhenDisabled(
     tabIndexProp,
   ]);
 
-  return { props };
+  return {
+    props,
+    focusableWhenDisabled: isFocusableWhenDisabled,
+  };
 }
 
 interface FocusableWhenDisabledProps {
@@ -94,6 +98,7 @@ export interface UseFocusableWhenDisabledParameters {
 
 export interface UseFocusableWhenDisabledReturnValue {
   props: FocusableWhenDisabledProps;
+  focusableWhenDisabled: boolean;
 }
 
 export namespace useFocusableWhenDisabled {


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/issues/3987

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
