### PR TITLE
[popover] Fix trapping focus when modal is true

### DIFF
--- a/packages/react/src/popover/popup/PopoverPopup.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.tsx
@@ -120,7 +120,7 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
     <FloatingFocusManager
       context={floatingContext}
       openInteractionType={openMethod}
-      modal={modal === 'trap-focus'}
+      modal={modal !== false}
       disabled={!mounted || openReason === REASONS.triggerHover}
       initialFocus={resolvedInitialFocus}
       returnFocus={finalFocus}


### PR DESCRIPTION
Update modal handling logic to allow trapping focus when `modal` is set to `true`


### Before
https://stackblitz.com/edit/gchds8cz?file=src%2FApp.tsx

### After
https://stackblitz.com/edit/sehut9n6?file=src%2FApp.tsx

