### PR TITLE
[combobox] Preserve inline always highlight on blur

### DIFF
--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -385,6 +385,58 @@ describe('<Autocomplete.Root />', () => {
       expect(input).to.have.attribute('aria-activedescendant', firstOption.id);
       expect(firstOption).to.have.attribute('data-highlighted');
     });
+
+    it('keeps the latest pointer highlight on outside blur when behavior is "always"', async () => {
+      const { user } = await render(
+        <React.Fragment>
+          <Autocomplete.Root
+            items={['apple', 'banana', 'cherry']}
+            autoHighlight="always"
+            keepHighlight
+            open
+            inline
+          >
+            <Autocomplete.Input data-testid="input" />
+            <Autocomplete.List>
+              {(item: string) => (
+                <Autocomplete.Item key={item} value={item}>
+                  {item}
+                </Autocomplete.Item>
+              )}
+            </Autocomplete.List>
+          </Autocomplete.Root>
+          <button data-testid="outside">outside</button>
+        </React.Fragment>,
+      );
+
+      const input = screen.getByTestId<HTMLInputElement>('input');
+      const banana = screen.getByRole('option', { name: 'banana' });
+
+      await act(async () => {
+        input.focus();
+      });
+
+      await user.hover(banana);
+
+      await waitFor(() => {
+        expect(input).to.have.attribute('aria-activedescendant', banana.id);
+        expect(banana).to.have.attribute('data-highlighted');
+      });
+
+      const outside = screen.getByTestId('outside');
+      fireEvent.pointerDown(outside);
+      fireEvent.blur(input, { relatedTarget: outside });
+      fireEvent.focus(outside);
+
+      await waitFor(() => {
+        expect(input).to.have.attribute('aria-activedescendant', banana.id);
+        expect(banana).to.have.attribute('data-highlighted');
+      });
+
+      expect(screen.getByRole('option', { name: 'apple' })).not.to.have.attribute(
+        'data-highlighted',
+      );
+    });
   });
 
   describe('prop: keepHighlight', () => {

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -211,7 +211,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
           setFocused(false);
 
           const activeIndex = store.state.activeIndex;
-          if (inline && activeIndex !== null) {
+          if (inline && activeIndex !== null && autoHighlightMode !== 'always') {
             lastActiveIndexRef.current = activeIndex;
             shouldRestoreActiveIndexRef.current = true;
             store.state.setIndices({ activeIndex: null });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Prevents the highlight from restoring to index 0 when the input loses focus / is blurred when `autoHighlight="always"`, such as in the cmdk menu on the docs when clicking outside the dialog. Regression from https://github.com/mui/base-ui/pull/3973.