### PR TITLE
[toast][test] Skip `createToastManager` browser tests

### DIFF
--- a/packages/react/src/toast/createToastManager.test.tsx
+++ b/packages/react/src/toast/createToastManager.test.tsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { createRenderer, isJSDOM } from '#test-utils';
 import { List } from './utils/test-utils';
 
-describe.skipIf(!isJSDOM)('Manager', () => {
+describe.skipIf(!isJSDOM)('createToastManager', () => {
   const { render, clock } = createRenderer();
 
   clock.withFakeTimers();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

These `createToastManager` tests seem to be flaky in the browser as toast removal can occur after animation frames and other work complete. Since running them in the browser doesn't verify anything critical on top of JSDOM, they can be skipped