### PR TITLE
[menubar] Fix menubar ARIA structure to satisfy aria-required-children

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -254,7 +254,7 @@ export const FloatingPortal = React.forwardRef(function FloatingPortal(
           />
         )}
         {shouldRenderGuards && portalNode && (
-          <span aria-owns={portalNode.id} style={ownerVisuallyHidden} />
+          <span aria-owns={portalNode.id} style={ownerVisuallyHidden} aria-hidden />
         )}
         {portalNode && ReactDOM.createPortal(children, portalNode)}
         {shouldRenderGuards && portalNode && (


### PR DESCRIPTION
Closes #4004

Tested with Lighthouse

Before: https://base-ui.com/react/components/menubar

<img width="1835" height="976" alt="Screenshot (66)" src="https://github.com/user-attachments/assets/637ed02a-2b8f-4e2d-8776-49bbcce124a8" />

----

After: https://deploy-preview-4027--base-ui.netlify.app/react/components/menubar

<img width="1852" height="977" alt="Screenshot (68)" src="https://github.com/user-attachments/assets/ada7702f-a871-4371-9dbe-ce597fa6b376" />

----

Also, tested it with NVDA screen-reader and nothing is announced wrongly atleast to me.

Used `aria-hidden` even though it is visually hidden, because it doesn't have the following styles as mentioned in the [docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden):
```markdown
`aria-hidden="true"` should not be added when:

- The HTML `hidden` attribute is present
- The element or the element's ancestor is hidden with `display: none`
- The element or the element's ancestor is hidden with `visibility: hidden`
```