### PR TITLE
[internal] Fix link to MDN docs

### DIFF
--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -1480,7 +1480,7 @@ interface ComboboxRootProps<ItemValue> {
   autoComplete?: ('list' | 'both' | 'inline' | 'none') | undefined;
   /**
    * Provides a hint to the browser for autofill on the hidden input element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete
    */
   formAutoComplete?: string | undefined;
   /**

--- a/packages/react/src/combobox/root/ComboboxRoot.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.tsx
@@ -70,7 +70,7 @@ export type ComboboxRootProps<Value, Multiple extends boolean | undefined = fals
   multiple?: Multiple | undefined;
   /**
    * Provides a hint to the browser for autofill.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete
    */
   autoComplete?: string | undefined;
   /**

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -599,7 +599,7 @@ export interface SelectRootProps<Value, Multiple extends boolean | undefined = f
   name?: string | undefined;
   /**
    * Provides a hint to the browser for autofill.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete
    */
   autoComplete?: string | undefined;
   /**


### PR DESCRIPTION
A quick one I noticed in #4005. The problem is that 301 could break in the future, and is also slower to resolve.

<img width="1301" height="180" alt="SCR-20260209-szkb" src="https://github.com/user-attachments/assets/282d3a30-a837-41ba-ac9e-79c694280cb2" />

---

**Off-topic**. Our docs doesn't render those `@see` in Base UI, but it does in Material UI, that look like a regression. Compare https://deploy-preview-4030--base-ui.netlify.app/react/components/combobox#ComboboxRoot-autoComplete to https://mui.com/x/api/charts/bar-chart/#bar-chart-prop-axisHighlight. cc @dav-is for awareness.