### PR TITLE
[internal][combobox] Remove unnecessary TS Omit and rename prop

### DIFF
--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -63,17 +63,17 @@ import { INITIAL_LAST_HIGHLIGHT, NO_ACTIVE_VALUE } from './utils/constants';
  * @internal
  */
 export function AriaCombobox<Value, Mode extends SelectionMode = 'none'>(
-  props: Omit<ComboboxRootConditionalProps<Value, Mode>, 'items'> & {
+  props: Omit<AriaComboboxProps<Value, Mode>, 'items'> & {
     items: readonly Group<any>[];
   },
 ): React.JSX.Element;
 export function AriaCombobox<Value, Mode extends SelectionMode = 'none'>(
-  props: Omit<ComboboxRootConditionalProps<Value, Mode>, 'items'> & {
+  props: Omit<AriaComboboxProps<Value, Mode>, 'items'> & {
     items?: readonly any[] | undefined;
   },
 ): React.JSX.Element;
 export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
-  props: ComboboxRootConditionalProps<Value, Mode>,
+  props: AriaComboboxProps<Value, Mode>,
 ): React.JSX.Element {
   const {
     id: idProp,
@@ -1499,7 +1499,7 @@ interface ComboboxRootProps<ItemValue> {
   fillInputOnItemPress?: boolean | undefined;
 }
 
-export type ComboboxRootConditionalProps<
+export type AriaComboboxProps<
   Value,
   Mode extends SelectionMode = 'none',
 > = ComboboxRootProps<Value> & {
@@ -1533,10 +1533,7 @@ export type ComboboxRootConditionalProps<
 };
 
 export namespace AriaCombobox {
-  export type Props<Value, Mode extends SelectionMode = 'none'> = ComboboxRootConditionalProps<
-    Value,
-    Mode
-  >;
+  export type Props<Value, Mode extends SelectionMode = 'none'> = AriaComboboxProps<Value, Mode>;
 
   export interface State {}
 


### PR DESCRIPTION
Remove unnecessary TS Omit. 

`ComboboxRootProps` does not contain these props. These props are of AriaCombobox.