### PR TITLE
[docs] Style inline code parameters with background to distinguish from links

### DIFF
--- a/docs/src/syntax-highlighting/index.css
+++ b/docs/src/syntax-highlighting/index.css
@@ -4,6 +4,7 @@
   --syntax-constant: var(--color-blue);
   --syntax-entity: var(--color-violet);
   --syntax-parameter: var(--color-navy);
+  --syntax-parameter-background: var(--color-inline-highlight);
   --syntax-tag: var(--color-green);
   --syntax-keyword: var(--color-red);
   --syntax-string: var(--color-navy);
@@ -31,6 +32,14 @@
   --syntax-keyword: var(--color-blue);
   --syntax-string: var(--color-blue);
   --syntax-nullish: var(--color-blue);
+}
+
+/* Highlight inline code parameters */
+[data-inline][data-syntax='parameter']:not([data-table-code]) {
+  color: var(--syntax-parameter);
+  background-color: var(--syntax-parameter-background);
+  border-radius: calc((0.5px + 0.2em));
+  padding: 0.05em 0.2em;
 }
 
 /* Recover some of the syntax highlighting colors in tables */

--- a/docs/src/syntax-highlighting/rehypeInlineCode.mjs
+++ b/docs/src/syntax-highlighting/rehypeInlineCode.mjs
@@ -34,6 +34,11 @@ export function rehypeInlineCode() {
         }
       });
 
+      // Mark inline code that contains a parameter token for code highlighting
+      if (node.children?.some((part) => part.properties?.style?.includes('--syntax-parameter'))) {
+        node.properties['data-syntax'] = 'parameter';
+      }
+
       // Tweak `<tag>` highlights to paint the bracket with the tag highlight color
       if (toString(node).match(/^<.+>$/)) {
         const keyNode = node.children?.find(


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Summary

Inline terms like `mergeProps` were styled in blue without a background, so they looked like links. This change gives inline code that represents parameters a padded, colored background so it reads as code instead of a link, improving clarity and accessibility.

### Changes

- Added `--syntax-parameter-background` and a rule for `[data-inline][data-syntax='parameter']` so inline parameter code gets a background, border-radius, and padding.
- Inline code nodes that contain a parameter token are marked with `data-syntax="parameter"` so the new styles apply.

![Captura de tela 2026-02-11 030711](https://github.com/user-attachments/assets/b702c7b3-32e2-429d-8d74-fb38bdde55d9)
![Captura de tela 2026-02-11 030639](https://github.com/user-attachments/assets/7f75070d-03cb-4d1a-b5f8-68790c2790a7)

Closes: #4009 