### PR TITLE
[docs-infra] Fix Display of Long Demo Code Blocks

### DIFF
--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -242,6 +242,7 @@
     }
 
     & code .frame {
+      display: block;
       padding-left: 0.75rem;
       padding-right: 0.75rem;
     }


### PR DESCRIPTION
When there are multiple frames within a code block, it's displaying them as `flex-direction: row`

<img width="1634" height="1986" alt="Screenshot 2026-02-11 at 8 51 59 pm" src="https://github.com/user-attachments/assets/ee2a570d-72c1-4055-946d-0d95da65b9cb" />

The flex container should be moved upward where it only has a single child element.

[See Preview Deployment](https://deploy-preview-4046--base-ui.netlify.app/react/components/autocomplete#async:css-modules:index.tsx)