### PR TITLE
[docs-infra] Fix Docs Analytics

### DIFF
--- a/docs/src/app/(docs)/layout.tsx
+++ b/docs/src/app/(docs)/layout.tsx
@@ -38,56 +38,57 @@ export default function Layout({ children }: React.PropsWithChildren) {
         />
       </head>
       <body suppressHydrationWarning>
-        <DocsProviders>
-          <div className="RootLayout">
-            <div className="RootLayoutContainer">
-              <div className="RootLayoutContent">
-                <div className="ContentLayoutRoot">
-                  <Header />
-                  <SideNav.Root>
-                    {sitemap &&
-                      Object.entries(
-                        sitemap.data as Record<
-                          string,
-                          {
-                            title?: string;
-                            prefix?: string;
-                            pages: { title: string; tags?: string[]; path: string }[];
-                          }
-                        >,
-                      ).map(([name, section]) => (
-                        <SideNav.Section key={name}>
-                          <SideNav.Heading>{name}</SideNav.Heading>
-                          <SideNav.List>
-                            {section.pages.map((page) => (
-                              <SideNav.Item
-                                key={page.title}
-                                href={
-                                  page.path.startsWith('./')
-                                    ? `${section.prefix}${page.path.replace(/^\.\//, '').replace(/\/page\.mdx$/, '')}`
-                                    : page.path
-                                }
-                                external={page.tags?.includes('External')}
-                              >
-                                {titleMap[page.title] || page.title}
-                                {page.tags?.includes('New') && <SideNav.Badge>New</SideNav.Badge>}
-                              </SideNav.Item>
-                            ))}
-                          </SideNav.List>
-                        </SideNav.Section>
-                      ))}
-                  </SideNav.Root>
+        <GoogleAnalytics>
+          <DocsProviders>
+            <div className="RootLayout">
+              <div className="RootLayoutContainer">
+                <div className="RootLayoutContent">
+                  <div className="ContentLayoutRoot">
+                    <Header />
+                    <SideNav.Root>
+                      {sitemap &&
+                        Object.entries(
+                          sitemap.data as Record<
+                            string,
+                            {
+                              title?: string;
+                              prefix?: string;
+                              pages: { title: string; tags?: string[]; path: string }[];
+                            }
+                          >,
+                        ).map(([name, section]) => (
+                          <SideNav.Section key={name}>
+                            <SideNav.Heading>{name}</SideNav.Heading>
+                            <SideNav.List>
+                              {section.pages.map((page) => (
+                                <SideNav.Item
+                                  key={page.title}
+                                  href={
+                                    page.path.startsWith('./')
+                                      ? `${section.prefix}${page.path.replace(/^\.\//, '').replace(/\/page\.mdx$/, '')}`
+                                      : page.path
+                                  }
+                                  external={page.tags?.includes('External')}
+                                >
+                                  {titleMap[page.title] || page.title}
+                                  {page.tags?.includes('New') && <SideNav.Badge>New</SideNav.Badge>}
+                                </SideNav.Item>
+                              ))}
+                            </SideNav.List>
+                          </SideNav.Section>
+                        ))}
+                    </SideNav.Root>
 
-                  <main className="ContentLayoutMain" id={MAIN_CONTENT_ID}>
-                    <QuickNav.Container>{children}</QuickNav.Container>
-                  </main>
+                    <main className="ContentLayoutMain" id={MAIN_CONTENT_ID}>
+                      <QuickNav.Container>{children}</QuickNav.Container>
+                    </main>
+                  </div>
                 </div>
+                <span className="RootLayoutFooter" />
               </div>
-              <span className="RootLayoutFooter" />
             </div>
-          </div>
-          <GoogleAnalytics />
-        </DocsProviders>
+          </DocsProviders>
+        </GoogleAnalytics>
       </body>
     </html>
   );

--- a/docs/src/app/(website)/layout.tsx
+++ b/docs/src/app/(website)/layout.tsx
@@ -11,68 +11,72 @@ export default function Layout({ children }: React.PropsWithChildren) {
     // Use suppressHydrationWarning to avoid https://github.com/facebook/react/issues/24430
     <html lang="en">
       <body suppressHydrationWarning className="Body p-6 bp2:py-7 bp2:px-9">
-        <div
-          className="bs-bb d-g gtc-8 g-8 bp2:g-9"
-          style={{ maxWidth: '1480px', marginInline: 'auto' }}
-        >
-          <header className="d-c">
-            <div className="gcs-1 gce-4">
-              <Logo aria-label="Base UI" />
-            </div>
-            <nav
-              className="d-f fd-c g-2 gcs-5 gce-8 bp2:gcs-5 bp2:gce-9 bp3:gcs-5 bp3:gce-7"
-              aria-label="social links"
-            >
-              <a className="Text size-1 Link" href="https://x.com/base_ui">
-                X
-              </a>
-              <a className="Text size-1 Link" href="https://github.com/mui/base-ui">
-                GitHub
-              </a>
-              <a className="Text size-1 Link" href="https://discord.com/invite/g6C3hUtuxz">
-                Discord
-              </a>
-            </nav>
-            <div className="d-n bp3:d-b gcs-7 gce-9">
-              <Link className="Text size-1 Link" href="/react/components/accordion">
-                Components
-              </Link>
-            </div>
-          </header>
-          <main id="main" className="d-c">
-            {children}
-          </main>
-          <div className="gcs-1 gce-9 bp3:gcs-3">
-            <div className="Separator" role="separator" aria-hidden="true"></div>
-          </div>
-          <footer className="d-c">
-            <div className="gcs-1 gce-9 bp2:gce-3">
-              <span className="Text size-1">© Base UI</span>
-            </div>
-            <nav className="d-f fd-c g-2 gcs-1 gce-9 bp2:gcs-3 bp4:gce-7" aria-label="social links">
-              <a className="Text size-1 Link" href="https://x.com/base_ui">
-                X
-              </a>
-              <a className="Text size-1 Link" href="https://github.com/mui/base-ui">
-                GitHub
-              </a>
-              <a className="Text size-1 Link" href="https://discord.com/invite/g6C3hUtuxz">
-                Discord
-              </a>
-              <a className="Text size-1 Link" href="https://www.npmjs.com/package/@base-ui/react">
-                npm
-              </a>
-              <a
-                className="Text size-1 Link"
-                href="https://bsky.app/profile/did:plc:nwr6peuxqzdzlbi72qr5kldc"
+        <GoogleAnalytics>
+          <div
+            className="bs-bb d-g gtc-8 g-8 bp2:g-9"
+            style={{ maxWidth: '1480px', marginInline: 'auto' }}
+          >
+            <header className="d-c">
+              <div className="gcs-1 gce-4">
+                <Logo aria-label="Base UI" />
+              </div>
+              <nav
+                className="d-f fd-c g-2 gcs-5 gce-8 bp2:gcs-5 bp2:gce-9 bp3:gcs-5 bp3:gce-7"
+                aria-label="social links"
               >
-                Bluesky
-              </a>
-            </nav>
-          </footer>
-        </div>
+                <a className="Text size-1 Link" href="https://x.com/base_ui">
+                  X
+                </a>
+                <a className="Text size-1 Link" href="https://github.com/mui/base-ui">
+                  GitHub
+                </a>
+                <a className="Text size-1 Link" href="https://discord.com/invite/g6C3hUtuxz">
+                  Discord
+                </a>
+              </nav>
+              <div className="d-n bp3:d-b gcs-7 gce-9">
+                <Link className="Text size-1 Link" href="/react/components/accordion">
+                  Components
+                </Link>
+              </div>
+            </header>
+            <main id="main" className="d-c">
+              {children}
+            </main>
+            <div className="gcs-1 gce-9 bp3:gcs-3">
+              <div className="Separator" role="separator" aria-hidden="true"></div>
+            </div>
+            <footer className="d-c">
+              <div className="gcs-1 gce-9 bp2:gce-3">
+                <span className="Text size-1">© Base UI</span>
+              </div>
+              <nav
+                className="d-f fd-c g-2 gcs-1 gce-9 bp2:gcs-3 bp4:gce-7"
+                aria-label="social links"
+              >
+                <a className="Text size-1 Link" href="https://x.com/base_ui">
+                  X
+                </a>
+                <a className="Text size-1 Link" href="https://github.com/mui/base-ui">
+                  GitHub
+                </a>
+                <a className="Text size-1 Link" href="https://discord.com/invite/g6C3hUtuxz">
+                  Discord
+                </a>
+                <a className="Text size-1 Link" href="https://www.npmjs.com/package/@base-ui/react">
+                  npm
+                </a>
+                <a
+                  className="Text size-1 Link"
+                  href="https://bsky.app/profile/did:plc:nwr6peuxqzdzlbi72qr5kldc"
+                >
+                  Bluesky
+                </a>
+              </nav>
+            </footer>
+          </div>
+        </GoogleAnalytics>
       </body>
-      <GoogleAnalytics />
     </html>
   );
 }

--- a/docs/src/components/Accordion.tsx
+++ b/docs/src/components/Accordion.tsx
@@ -137,7 +137,8 @@ export function Item({
       open={open || undefined}
       className={clsx('AccordionItem', props.className)}
       onToggle={(event) => {
-        if (gaCategory && event.currentTarget.open) {
+        props.onToggle?.(event);
+        if (gaCategory && event.currentTarget.open && event.nativeEvent.isTrusted) {
           ga?.trackEvent({
             category: gaCategory,
             action: 'expand',

--- a/docs/src/components/Accordion.tsx
+++ b/docs/src/components/Accordion.tsx
@@ -138,6 +138,7 @@ export function Item({
       className={clsx('AccordionItem', props.className)}
       onToggle={(event) => {
         props.onToggle?.(event);
+        setOpen(event.currentTarget.open);
         if (gaCategory && event.currentTarget.open && event.nativeEvent.isTrusted) {
           ga?.trackEvent({
             category: gaCategory,

--- a/docs/src/components/Accordion.tsx
+++ b/docs/src/components/Accordion.tsx
@@ -106,8 +106,13 @@ export function Trigger({
 export function Item({
   gaCategory,
   gaLabel,
+  gaParams,
   ...props
-}: React.ComponentProps<'details'> & { gaCategory?: string; gaLabel?: string }) {
+}: React.ComponentProps<'details'> & {
+  gaCategory?: string;
+  gaLabel?: string;
+  gaParams?: Record<string, string | number | boolean>;
+}) {
   const [open, setOpen] = React.useState<boolean>(false);
   const ga = useGoogleAnalytics();
   // in Chrome, the <details> opens automatically when the hash part of a URL
@@ -133,7 +138,12 @@ export function Item({
       className={clsx('AccordionItem', props.className)}
       onToggle={(event) => {
         if (gaCategory && event.currentTarget.open) {
-          ga?.trackEvent({ category: gaCategory, action: 'expand', label: gaLabel });
+          ga?.trackEvent({
+            category: gaCategory,
+            action: 'expand',
+            label: gaLabel,
+            params: gaParams,
+          });
         }
       }}
     />

--- a/docs/src/components/Accordion.tsx
+++ b/docs/src/components/Accordion.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import { useGoogleAnalytics } from 'docs/src/blocks/GoogleAnalyticsProvider';
 import { observeScrollableInner } from '../utils/observeScrollableInner';
 
 const ARROW_UP = 'ArrowUp';
@@ -102,8 +103,13 @@ export function Trigger({
   );
 }
 
-export function Item(props: React.ComponentProps<'details'>) {
+export function Item({
+  gaCategory,
+  gaLabel,
+  ...props
+}: React.ComponentProps<'details'> & { gaCategory?: string; gaLabel?: string }) {
   const [open, setOpen] = React.useState<boolean>(false);
+  const ga = useGoogleAnalytics();
   // in Chrome, the <details> opens automatically when the hash part of a URL
   // matches the `id` on <summary> but needs to be manually handled for Safari
   // and Firefox
@@ -125,6 +131,11 @@ export function Item(props: React.ComponentProps<'details'>) {
       ref={handleRef}
       open={open || undefined}
       className={clsx('AccordionItem', props.className)}
+      onToggle={(event) => {
+        if (gaCategory && event.currentTarget.open) {
+          ga?.trackEvent({ category: gaCategory, action: 'expand', label: gaLabel });
+        }
+      }}
     />
   );
 }

--- a/docs/src/components/CodeBlock.tsx
+++ b/docs/src/components/CodeBlock.tsx
@@ -45,7 +45,7 @@ export function Panel({ className, children, ...other }: React.ComponentPropsWit
           if (code) {
             await copy(code);
             ga?.trackEvent({
-              category: 'code-block',
+              category: 'code_block',
               action: 'copy',
               label: document.getElementById(titleId)?.textContent ?? undefined,
             });

--- a/docs/src/components/CodeBlock.tsx
+++ b/docs/src/components/CodeBlock.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import copy from 'clipboard-copy';
 import clsx from 'clsx';
+import { usePathname } from 'next/navigation';
 import { useGoogleAnalytics } from 'docs/src/blocks/GoogleAnalyticsProvider';
 import * as ScrollArea from './ScrollArea';
 import { CopyIcon } from '../icons/CopyIcon';
@@ -30,6 +31,7 @@ export function Panel({ className, children, ...other }: React.ComponentPropsWit
   const { codeId, titleId } = React.useContext(CodeBlockContext);
   const [copyTimeout, setCopyTimeout] = React.useState<number>(0);
   const ga = useGoogleAnalytics();
+  const pathname = usePathname();
 
   return (
     <div className={clsx('CodeBlockPanel', className)} {...other}>
@@ -44,10 +46,13 @@ export function Panel({ className, children, ...other }: React.ComponentPropsWit
 
           if (code) {
             await copy(code);
+            const title = document.getElementById(titleId)?.textContent ?? undefined;
+            const codeBlockId = title ? `${pathname}#${title}` : pathname;
             ga?.trackEvent({
               category: 'code_block',
               action: 'copy',
-              label: document.getElementById(titleId)?.textContent ?? undefined,
+              label: codeBlockId,
+              params: { copy: codeBlockId, slug: title || '' },
             });
             /* eslint-disable no-restricted-syntax */
             const newTimeout = window.setTimeout(() => {

--- a/docs/src/components/CodeBlock.tsx
+++ b/docs/src/components/CodeBlock.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import copy from 'clipboard-copy';
 import clsx from 'clsx';
+import { useGoogleAnalytics } from 'docs/src/blocks/GoogleAnalyticsProvider';
 import * as ScrollArea from './ScrollArea';
 import { CopyIcon } from '../icons/CopyIcon';
 import { CheckIcon } from '../icons/CheckIcon';
@@ -28,6 +29,7 @@ export function Root(props: React.ComponentPropsWithoutRef<'div'>) {
 export function Panel({ className, children, ...other }: React.ComponentPropsWithoutRef<'div'>) {
   const { codeId, titleId } = React.useContext(CodeBlockContext);
   const [copyTimeout, setCopyTimeout] = React.useState<number>(0);
+  const ga = useGoogleAnalytics();
 
   return (
     <div className={clsx('CodeBlockPanel', className)} {...other}>
@@ -42,6 +44,11 @@ export function Panel({ className, children, ...other }: React.ComponentPropsWit
 
           if (code) {
             await copy(code);
+            ga?.trackEvent({
+              category: 'code-block',
+              action: 'copy',
+              label: document.getElementById(titleId)?.textContent ?? undefined,
+            });
             /* eslint-disable no-restricted-syntax */
             const newTimeout = window.setTimeout(() => {
               window.clearTimeout(newTimeout);

--- a/docs/src/components/GoogleAnalytics.tsx
+++ b/docs/src/components/GoogleAnalytics.tsx
@@ -1,32 +1,34 @@
 'use client';
 import * as React from 'react';
 import { usePathname } from 'next/navigation';
+import { usePreference } from '@mui/internal-docs-infra/usePreference';
+import { GoogleAnalyticsProvider } from 'docs/src/blocks/GoogleAnalyticsProvider';
 import { DemoVariantSelectorContext } from './Demo/DemoVariantSelectorProvider';
-import { PackageManagerSnippetContext } from '../blocks/PackageManagerSnippet/PackageManagerSnippetProvider';
-import { GoogleAnalytics as BaseGoogleAnalytics } from '../blocks/GoogleAnalytics';
 import { GoogleTagManager } from '../blocks/GoogleTagManager';
 
 const PRODUCTION_GA =
   process.env.DEPLOY_ENV === 'production' || process.env.DEPLOY_ENV === 'staging';
 const GOOGLE_ANALYTICS_ID_V4 = PRODUCTION_GA ? 'G-FE5XQBD0BH' : 'G-LSE9X5R2CN';
 
-export function GoogleAnalytics() {
+export function GoogleAnalytics({ children }: { children?: React.ReactNode }) {
   const currentRoute = usePathname();
   const demoVariantSelectorContext = React.useContext(DemoVariantSelectorContext);
-  const packageManagerSnippetContext = React.useContext(PackageManagerSnippetContext);
+  const [stylingVariant] = usePreference('variant', 'CssModules:Tailwind', 'CssModules');
 
   return (
     <React.Fragment>
       <GoogleTagManager id={GOOGLE_ANALYTICS_ID_V4} />
-      <BaseGoogleAnalytics
+      <GoogleAnalyticsProvider
+        id={GOOGLE_ANALYTICS_ID_V4}
         productId="base-ui"
         productCategoryId="core"
         currentRoute={currentRoute}
         codeLanguage={demoVariantSelectorContext?.selectedLanguage ?? 'ts'}
-        codeStylingVariant={demoVariantSelectorContext?.selectedVariant ?? null}
-        packageManager={packageManagerSnippetContext?.packageManager ?? 'npm'}
+        codeStylingVariant={stylingVariant}
         userLanguage="en"
-      />
+      >
+        {children}
+      </GoogleAnalyticsProvider>
     </React.Fragment>
   );
 }

--- a/docs/src/components/QuickNav/QuickNav.tsx
+++ b/docs/src/components/QuickNav/QuickNav.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
+import { useGoogleAnalytics } from 'docs/src/blocks/GoogleAnalyticsProvider';
 
 export function Container({ className, ...props }: React.ComponentProps<'div'>) {
   return <div className={clsx('QuickNavContainer', className)} {...props} />;
@@ -279,6 +280,23 @@ export function Item({ className, ...props }: React.ComponentProps<'li'>) {
   return <li className={clsx('QuickNavItem', className)} {...props} />;
 }
 
-export function Link({ className, ...props }: React.ComponentProps<'a'>) {
-  return <a className={clsx('QuickNavLink', className)} {...props} />;
+export function Link({ className, onClick, ...props }: React.ComponentProps<'a'>) {
+  const ga = useGoogleAnalytics();
+
+  const handleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      ga?.trackEvent({
+        category: 'Table of contents',
+        action: 'click',
+        label: props.href ?? undefined,
+      });
+      onClick?.(event);
+    },
+    [ga, props.href, onClick],
+  );
+
+  // The anchor element is interactive via `href` from `...props`, but the
+  // lint rules can't see through the spread to know that.
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+  return <a className={clsx('QuickNavLink', className)} {...props} onClick={handleClick} />;
 }

--- a/docs/src/components/QuickNav/QuickNav.tsx
+++ b/docs/src/components/QuickNav/QuickNav.tsx
@@ -286,7 +286,7 @@ export function Link({ className, onClick, ...props }: React.ComponentProps<'a'>
   const handleClick = React.useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
       ga?.trackEvent({
-        category: 'Table of contents',
+        category: 'table_of_contents',
         action: 'click',
         label: props.href ?? undefined,
       });

--- a/docs/src/components/QuickNav/QuickNav.tsx
+++ b/docs/src/components/QuickNav/QuickNav.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
+import { usePathname } from 'next/navigation';
 import { useGoogleAnalytics } from 'docs/src/blocks/GoogleAnalyticsProvider';
 
 export function Container({ className, ...props }: React.ComponentProps<'div'>) {
@@ -282,17 +283,21 @@ export function Item({ className, ...props }: React.ComponentProps<'li'>) {
 
 export function Link({ className, onClick, ...props }: React.ComponentProps<'a'>) {
   const ga = useGoogleAnalytics();
+  const pathname = usePathname();
 
   const handleClick = React.useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
+      const slug = props.href ?? undefined;
+      const tocId = slug ? `${pathname}${slug}` : pathname;
       ga?.trackEvent({
         category: 'table_of_contents',
         action: 'click',
-        label: props.href ?? undefined,
+        label: tocId,
+        params: { click: tocId, slug: slug || '' },
       });
       onClick?.(event);
     },
-    [ga, props.href, onClick],
+    [ga, props.href, onClick, pathname],
   );
 
   // The anchor element is interactive via `href` from `...props`, but the

--- a/docs/src/components/ReferenceTable/AttributesReferenceTable.tsx
+++ b/docs/src/components/ReferenceTable/AttributesReferenceTable.tsx
@@ -40,7 +40,7 @@ export async function AttributesReferenceTable({
           return (
             <Accordion.Item
               key={name}
-              gaCategory="Reference"
+              gaCategory="reference"
               gaLabel={`Attribute: ${partName ? `${partName}-` : ''}${name}`}
             >
               <Accordion.Trigger index={index}>

--- a/docs/src/components/ReferenceTable/AttributesReferenceTable.tsx
+++ b/docs/src/components/ReferenceTable/AttributesReferenceTable.tsx
@@ -42,6 +42,11 @@ export async function AttributesReferenceTable({
               key={name}
               gaCategory="reference"
               gaLabel={`Attribute: ${partName ? `${partName}-` : ''}${name}`}
+              gaParams={{
+                type: 'attribute',
+                slug: `${partName ? `${partName}-` : ''}${name}`,
+                part_name: partName || '',
+              }}
             >
               <Accordion.Trigger index={index}>
                 <TableCode className="text-navy">{name}</TableCode>

--- a/docs/src/components/ReferenceTable/AttributesReferenceTable.tsx
+++ b/docs/src/components/ReferenceTable/AttributesReferenceTable.tsx
@@ -10,6 +10,7 @@ import { TableCode } from '../TableCode';
 
 interface AttributesReferenceTableProps extends React.ComponentProps<typeof Table.Root> {
   data: Record<string, AttributeDef>;
+  name?: string;
 }
 
 const CREATE_MDX_OPTIONS = {
@@ -17,7 +18,11 @@ const CREATE_MDX_OPTIONS = {
   useMDXComponents: () => inlineMdxComponents,
 };
 
-export async function AttributesReferenceTable({ data, ...props }: AttributesReferenceTableProps) {
+export async function AttributesReferenceTable({
+  data,
+  name: partName,
+  ...props
+}: AttributesReferenceTableProps) {
   return (
     <React.Fragment>
       <Accordion.Root {...props} className={clsx(props.className, 'xs:hidden')}>
@@ -33,7 +38,11 @@ export async function AttributesReferenceTable({ data, ...props }: AttributesRef
           );
 
           return (
-            <Accordion.Item key={name}>
+            <Accordion.Item
+              key={name}
+              gaCategory="Reference"
+              gaLabel={`Attribute: ${partName ? `${partName}-` : ''}${name}`}
+            >
               <Accordion.Trigger index={index}>
                 <TableCode className="text-navy">{name}</TableCode>
                 <svg

--- a/docs/src/components/ReferenceTable/CssVariablesReferenceTable.tsx
+++ b/docs/src/components/ReferenceTable/CssVariablesReferenceTable.tsx
@@ -40,7 +40,7 @@ export async function CssVariablesReferenceTable({
           return (
             <Accordion.Item
               key={name}
-              gaCategory="Reference"
+              gaCategory="reference"
               gaLabel={`CSS variable: ${partName ? `${partName}-` : ''}${name}`}
             >
               <Accordion.Trigger index={index}>

--- a/docs/src/components/ReferenceTable/CssVariablesReferenceTable.tsx
+++ b/docs/src/components/ReferenceTable/CssVariablesReferenceTable.tsx
@@ -10,6 +10,7 @@ import { TableCode } from '../TableCode';
 
 interface CssVariablesReferenceTableProps extends React.ComponentProps<typeof Table.Root> {
   data: Record<string, CssVariableDef>;
+  name?: string;
 }
 
 const CREATE_MDX_OPTIONS = {
@@ -19,6 +20,7 @@ const CREATE_MDX_OPTIONS = {
 
 export async function CssVariablesReferenceTable({
   data,
+  name: partName,
   ...props
 }: CssVariablesReferenceTableProps) {
   return (
@@ -36,7 +38,11 @@ export async function CssVariablesReferenceTable({
           );
 
           return (
-            <Accordion.Item key={name}>
+            <Accordion.Item
+              key={name}
+              gaCategory="Reference"
+              gaLabel={`CSS variable: ${partName ? `${partName}-` : ''}${name}`}
+            >
               <Accordion.Trigger index={index}>
                 <TableCode className="text-navy">{name}</TableCode>
                 <svg

--- a/docs/src/components/ReferenceTable/CssVariablesReferenceTable.tsx
+++ b/docs/src/components/ReferenceTable/CssVariablesReferenceTable.tsx
@@ -42,6 +42,11 @@ export async function CssVariablesReferenceTable({
               key={name}
               gaCategory="reference"
               gaLabel={`CSS variable: ${partName ? `${partName}-` : ''}${name}`}
+              gaParams={{
+                type: 'css_variable',
+                slug: `${partName ? `${partName}-` : ''}${name}`,
+                part_name: partName || '',
+              }}
             >
               <Accordion.Trigger index={index}>
                 <TableCode className="text-navy">{name}</TableCode>

--- a/docs/src/components/ReferenceTable/ReferenceAccordion.tsx
+++ b/docs/src/components/ReferenceTable/ReferenceAccordion.tsx
@@ -179,7 +179,7 @@ export async function ReferenceAccordion({
         const id = `${partName}-${name}`;
 
         return (
-          <Accordion.Item key={name}>
+          <Accordion.Item key={name} gaCategory="Reference" gaLabel={`${nameLabel}: ${id}`}>
             <Accordion.Trigger
               id={id}
               index={index}

--- a/docs/src/components/ReferenceTable/ReferenceAccordion.tsx
+++ b/docs/src/components/ReferenceTable/ReferenceAccordion.tsx
@@ -179,7 +179,12 @@ export async function ReferenceAccordion({
         const id = `${partName}-${name}`;
 
         return (
-          <Accordion.Item key={name} gaCategory="reference" gaLabel={`${nameLabel}: ${id}`}>
+          <Accordion.Item
+            key={name}
+            gaCategory="reference"
+            gaLabel={`${nameLabel}: ${id}`}
+            gaParams={{ type: nameLabel.toLowerCase(), slug: id, part_name: partName }}
+          >
             <Accordion.Trigger
               id={id}
               index={index}

--- a/docs/src/components/ReferenceTable/ReferenceAccordion.tsx
+++ b/docs/src/components/ReferenceTable/ReferenceAccordion.tsx
@@ -179,7 +179,7 @@ export async function ReferenceAccordion({
         const id = `${partName}-${name}`;
 
         return (
-          <Accordion.Item key={name} gaCategory="Reference" gaLabel={`${nameLabel}: ${id}`}>
+          <Accordion.Item key={name} gaCategory="reference" gaLabel={`${nameLabel}: ${id}`}>
             <Accordion.Trigger
               id={id}
               index={index}

--- a/docs/src/components/ReferenceTable/ReturnValueReferenceTable.tsx
+++ b/docs/src/components/ReferenceTable/ReturnValueReferenceTable.tsx
@@ -67,6 +67,11 @@ export async function ReturnValueReferenceTable({
               key={name}
               gaCategory="reference"
               gaLabel={`Return value: ${partName ? `${partName}-` : ''}${name}`}
+              gaParams={{
+                type: 'return_value',
+                slug: `${partName ? `${partName}-` : ''}${name}`,
+                part_name: partName || '',
+              }}
             >
               <Accordion.Trigger index={index}>
                 {ReturnType ? (

--- a/docs/src/components/ReferenceTable/ReturnValueReferenceTable.tsx
+++ b/docs/src/components/ReferenceTable/ReturnValueReferenceTable.tsx
@@ -10,6 +10,7 @@ import type { PropDef } from './types';
 
 interface ReturnValueReferenceTableProps extends React.ComponentProps<typeof Table.Root> {
   data: Record<string, PropDef>;
+  name?: string;
 }
 
 const TYPE_MDX_OPTIONS = {
@@ -37,6 +38,7 @@ function getDescription(def: PropDef, name: string, includeName: boolean) {
 
 export async function ReturnValueReferenceTable({
   data,
+  name: partName,
   ...props
 }: ReturnValueReferenceTableProps) {
   const entries = Object.entries(data);
@@ -61,7 +63,11 @@ export async function ReturnValueReferenceTable({
             : null;
 
           return (
-            <Accordion.Item key={name}>
+            <Accordion.Item
+              key={name}
+              gaCategory="Reference"
+              gaLabel={`Return value: ${partName ? `${partName}-` : ''}${name}`}
+            >
               <Accordion.Trigger index={index}>
                 {ReturnType ? (
                   <ReturnType />

--- a/docs/src/components/ReferenceTable/ReturnValueReferenceTable.tsx
+++ b/docs/src/components/ReferenceTable/ReturnValueReferenceTable.tsx
@@ -65,7 +65,7 @@ export async function ReturnValueReferenceTable({
           return (
             <Accordion.Item
               key={name}
-              gaCategory="Reference"
+              gaCategory="reference"
               gaLabel={`Return value: ${partName ? `${partName}-` : ''}${name}`}
             >
               <Accordion.Trigger index={index}>

--- a/docs/src/components/ReferenceTable/rehypeReference.mjs
+++ b/docs/src/components/ReferenceTable/rehypeReference.mjs
@@ -155,7 +155,10 @@ function describeComponents(componentDefs, referenceName, parts, asParam) {
       subtree.push(
         createMdxElement({
           name: ATTRIBUTES_TABLE,
-          props: { data: def.dataAttributes },
+          props: {
+            name: def.name,
+            data: def.dataAttributes,
+          },
         }),
       );
     }
@@ -164,7 +167,10 @@ function describeComponents(componentDefs, referenceName, parts, asParam) {
       subtree.push(
         createMdxElement({
           name: CSS_VARIABLES_TABLE,
-          props: { data: def.cssVariables },
+          props: {
+            name: def.name,
+            data: def.cssVariables,
+          },
         }),
       );
     }

--- a/docs/src/components/Search/SearchBar.tsx
+++ b/docs/src/components/Search/SearchBar.tsx
@@ -165,7 +165,7 @@ export function SearchBar({
       clearTimeout(queryDebounceRef.current);
       queryDebounceRef.current = null;
     }
-    ga?.trackEvent({ category: 'Search', action: 'open' });
+    ga?.trackEvent({ category: 'search', action: 'open' });
     setDialogOpen(true);
   }, [ga]);
 
@@ -181,7 +181,7 @@ export function SearchBar({
         // Fire final search event for the current query
         if (searchQueryRef.current) {
           ga?.trackEvent({
-            category: 'Search',
+            category: 'search',
             action: selectedResultRef.current ? 'select' : 'dismiss',
             label: searchQueryRef.current,
             params: {
@@ -256,7 +256,7 @@ export function SearchBar({
         queryDebounceRef.current = setTimeout(() => {
           if (searchQueryRef.current && searchQueryRef.current !== lastTrackedQueryRef.current) {
             ga?.trackEvent({
-              category: 'Search',
+              category: 'search',
               action: 'query',
               label: searchQueryRef.current,
               params: {

--- a/docs/src/components/Search/SearchBar.tsx
+++ b/docs/src/components/Search/SearchBar.tsx
@@ -252,10 +252,11 @@ export function SearchBar({
         queryDebounceRef.current = null;
       }
 
+      const previousLength = searchQueryRef.current?.length ?? 0;
       searchQueryRef.current = value;
       if (value) {
-        // Increment attempt when starting a new query (first char after empty)
-        if (value.length === 1) {
+        // Increment attempt when starting a new query (transition from empty to non-empty)
+        if (previousLength === 0 && value.length > 0) {
           attemptRef.current += 1;
         }
 

--- a/docs/src/components/Search/SearchBar.tsx
+++ b/docs/src/components/Search/SearchBar.tsx
@@ -13,6 +13,7 @@ import { Dialog } from '@base-ui/react/dialog';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { isMac } from '@base-ui/utils/detectBrowser';
 import { CornerDownLeft, Search } from 'lucide-react';
+import { useGoogleAnalytics } from 'docs/src/blocks/GoogleAnalyticsProvider';
 import { stringToUrl } from '../QuickNav/rehypeSlug.mjs';
 import './SearchBar.css';
 
@@ -101,6 +102,24 @@ export function SearchBar({
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
   const popupRef = React.useRef<HTMLDivElement>(null);
+  const ga = useGoogleAnalytics();
+
+  // Search session tracking
+  const searchQueryRef = React.useRef('');
+  const resultCountRef = React.useRef(0);
+  const attemptRef = React.useRef(0);
+  const selectedResultRef = React.useRef(false);
+  const lastTrackedQueryRef = React.useRef('');
+  const queryDebounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up pending debounce on unmount
+  React.useEffect(() => {
+    return () => {
+      if (queryDebounceRef.current) {
+        clearTimeout(queryDebounceRef.current);
+      }
+    };
+  }, []);
 
   // Use the generic search hook with Base UI specific configuration
   const { results, search, defaultResults, buildResultUrl } = useSearch({
@@ -117,6 +136,10 @@ export function SearchBar({
   const [searchResults, setSearchResults] =
     React.useState<ReturnType<typeof useSearch>['results']>(defaultResults);
   React.useEffect(() => {
+    // Track result count for the current query
+    const totalResults = results.results.reduce((sum, group) => sum + group.items.length, 0);
+    resultCountRef.current = totalResults;
+
     const updateResults = () => {
       setSearchResults(results);
     };
@@ -132,12 +155,44 @@ export function SearchBar({
   }, [results]);
 
   const handleOpenDialog = React.useCallback(() => {
+    // Reset search session tracking
+    searchQueryRef.current = '';
+    resultCountRef.current = 0;
+    attemptRef.current = 0;
+    selectedResultRef.current = false;
+    lastTrackedQueryRef.current = '';
+    if (queryDebounceRef.current) {
+      clearTimeout(queryDebounceRef.current);
+      queryDebounceRef.current = null;
+    }
+    ga?.trackEvent({ category: 'Search', action: 'open' });
     setDialogOpen(true);
-  }, []);
+  }, [ga]);
 
   const handleCloseDialog = React.useCallback(
     (open: boolean) => {
       if (!open) {
+        // Cancel any pending debounced query event
+        if (queryDebounceRef.current) {
+          clearTimeout(queryDebounceRef.current);
+          queryDebounceRef.current = null;
+        }
+
+        // Fire final search event for the current query
+        if (searchQueryRef.current) {
+          ga?.trackEvent({
+            category: 'Search',
+            action: selectedResultRef.current ? 'select' : 'dismiss',
+            label: searchQueryRef.current,
+            params: {
+              search_term: searchQueryRef.current,
+              result_count: resultCountRef.current,
+              attempt: attemptRef.current,
+            },
+          });
+          lastTrackedQueryRef.current = searchQueryRef.current;
+        }
+
         setDialogOpen(false);
 
         // Wait for the closing animation to complete before resetting state
@@ -148,7 +203,7 @@ export function SearchBar({
         handleOpenDialog();
       }
     },
-    [handleOpenDialog, defaultResults],
+    [handleOpenDialog, defaultResults, ga],
   );
 
   const handleAutocompleteEscape = React.useCallback(
@@ -184,14 +239,45 @@ export function SearchBar({
 
   const handleValueChange = React.useCallback(
     async (value: string) => {
+      // Cancel any pending debounced query event
+      if (queryDebounceRef.current) {
+        clearTimeout(queryDebounceRef.current);
+        queryDebounceRef.current = null;
+      }
+
+      searchQueryRef.current = value;
+      if (value) {
+        // Increment attempt when starting a new query (first char after empty)
+        if (value.length === 1) {
+          attemptRef.current += 1;
+        }
+
+        // Fire a debounced 'query' event when the user pauses typing
+        queryDebounceRef.current = setTimeout(() => {
+          if (searchQueryRef.current && searchQueryRef.current !== lastTrackedQueryRef.current) {
+            ga?.trackEvent({
+              category: 'Search',
+              action: 'query',
+              label: searchQueryRef.current,
+              params: {
+                search_term: searchQueryRef.current,
+                result_count: resultCountRef.current,
+                attempt: attemptRef.current,
+              },
+            });
+            lastTrackedQueryRef.current = searchQueryRef.current;
+          }
+        }, 1500);
+      }
       await search(value, { groupBy: { properties: ['group'], maxResult: 5 } });
     },
-    [search],
+    [search, ga],
   );
 
   const highlightedResultRef = React.useRef<SearchResult | undefined>(undefined);
 
   const handleItemClick = React.useCallback(() => {
+    selectedResultRef.current = true;
     handleCloseDialog(false);
   }, [handleCloseDialog]);
 

--- a/docs/src/components/Search/SearchBar.tsx
+++ b/docs/src/components/Search/SearchBar.tsx
@@ -108,7 +108,7 @@ export function SearchBar({
   const searchQueryRef = React.useRef('');
   const resultCountRef = React.useRef(0);
   const attemptRef = React.useRef(0);
-  const selectedResultRef = React.useRef(false);
+  const selectedResultRef = React.useRef<SearchResult | null>(null);
   const lastTrackedQueryRef = React.useRef('');
   const queryDebounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -159,7 +159,7 @@ export function SearchBar({
     searchQueryRef.current = '';
     resultCountRef.current = 0;
     attemptRef.current = 0;
-    selectedResultRef.current = false;
+    selectedResultRef.current = null;
     lastTrackedQueryRef.current = '';
     if (queryDebounceRef.current) {
       clearTimeout(queryDebounceRef.current);
@@ -180,14 +180,21 @@ export function SearchBar({
 
         // Fire final search event for the current query
         if (searchQueryRef.current) {
+          const selected = selectedResultRef.current;
           ga?.trackEvent({
             category: 'search',
-            action: selectedResultRef.current ? 'select' : 'dismiss',
+            action: selected ? 'select' : 'dismiss',
             label: searchQueryRef.current,
             params: {
               search_term: searchQueryRef.current,
               result_count: resultCountRef.current,
               attempt: attemptRef.current,
+              ...(selected
+                ? {
+                    selected_result: selected.title || selected.slug,
+                    selected_type: selected.type || '',
+                  }
+                : { failed: searchQueryRef.current }),
             },
           });
           lastTrackedQueryRef.current = searchQueryRef.current;
@@ -277,7 +284,7 @@ export function SearchBar({
   const highlightedResultRef = React.useRef<SearchResult | undefined>(undefined);
 
   const handleItemClick = React.useCallback(() => {
-    selectedResultRef.current = true;
+    selectedResultRef.current = highlightedResultRef.current ?? null;
     handleCloseDialog(false);
   }, [handleCloseDialog]);
 


### PR DESCRIPTION
Fixes the Google Analytics configuration.

See what events are logged using [Tag Assistant](https://chromewebstore.google.com/detail/tag-assistant/kejbdjndbnbjgmefkgdddjlbokphdefk?hl=en)

Adds the following events:
| Category | Action | Label | Extra Params | Trigger |
|---|---|---|---|---|
| `demo` | `expand` | `{pathname}#{demoSlug}` | `expand`, `slug` | Expand demo code |
| `demo` | `collapse` | `{pathname}#{demoSlug}` | `collapse`, `slug` | Collapse demo code |
| `demo` | `interaction` | `{pathname}#{demoSlug}` | `interaction`, `slug` | First playground interaction |
| `demo` | `copy` | `{pathname}#{demoSlug}` | `copy`, `slug` | Copy demo code |
| `demo` | `file_select` | `{pathname}#{demoSlug}` | `file_select`, `slug` | Switch file tab in multi-file demo |
| `code_block` | `copy` | `{pathname}#{title}` | `copy`, `slug` | Copy code block |
| `reference` | `expand` | `{Type}: {id}` | `type`, `slug`, `part_name` | Expand reference accordion row |
| `search` | `open` | — | — | Open search dialog |
| `search` | `query` | search text | `search_term`, `result_count`, `attempt` | Pause typing for 1.5s |
| `search` | `select` | search text | `search_term`, `result_count`, `attempt`, `selected_result`, `selected_type` | Pick a search result |
| `search` | `dismiss` | search text | `search_term`, `result_count`, `attempt`, `failed` | Close search without picking |
| `table_of_contents` | `click` | `{pathname}{href}` | `click`, `slug` | Click TOC link |

Work on https://github.com/mui/mui-public/issues/269