### PR TITLE
[code-infra] Enable pkg.pr.new compact urls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,4 @@ jobs:
         uses: mui/mui-public/.github/actions/ci-publish@master
         with:
           pr-comment: true
+          use-compact-url: true


### PR DESCRIPTION
Enable [compact urls](https://github.com/stackblitz-labs/pkg.pr.new?tab=readme-ov-file#:~:text=Compact%20URLs%20are%20the%20default) for pkg.pr.new URLS

Non-compact urls look like this:
https://pkg.pr.new/mui/base-ui/@base-ui/react@3713


Compact urls look like this:
https://pkg.pr.new/@base-ui/react@3713

---

To see it working, see this comment in this very PR https://github.com/mui/base-ui/pull/4055#issuecomment-3890191256
