### PR TITLE
[combobox][select] Fix inconsistent `isItemEqualToValue` argument order

### DIFF
--- a/docs/reference/generated/combobox-root.json
+++ b/docs/reference/generated/combobox-root.json
@@ -98,9 +98,9 @@
       "detailedType": "boolean | undefined"
     },
     "isItemEqualToValue": {
-      "type": "((itemValue: Value, selectedValue: Value) => boolean)",
+      "type": "((itemValue: Value, value: Value) => boolean)",
       "description": "Custom comparison logic used to determine if a combobox item value matches the current selected value. Useful when item values are objects without matching referentially.\nDefaults to `Object.is` comparison.",
-      "detailedType": "| ((itemValue: Value, selectedValue: Value) => boolean)\n| undefined"
+      "detailedType": "| ((itemValue: Value, value: Value) => boolean)\n| undefined"
     },
     "itemToStringLabel": {
       "type": "((itemValue: Value) => string)",

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -31,7 +31,7 @@ export const ComboboxItem = React.memo(
     const {
       render,
       className,
-      value = null,
+      value: itemValue = null,
       index: indexProp,
       disabled = false,
       nativeButton = false,
@@ -59,12 +59,14 @@ export const ComboboxItem = React.memo(
     const selectable = selectionMode !== 'none';
     const index =
       indexProp ??
-      (virtualized ? findItemIndex(flatFilteredItems, value, isItemEqualToValue) : listItem.index);
+      (virtualized
+        ? findItemIndex(flatFilteredItems, itemValue, isItemEqualToValue)
+        : listItem.index);
     const hasRegistered = listItem.index !== -1;
 
     const rootId = useStore(store, selectors.id);
     const highlighted = useStore(store, selectors.isActive, index);
-    const matchesSelectedValue = useStore(store, selectors.isSelected, value);
+    const matchesSelectedValue = useStore(store, selectors.isSelected, itemValue);
     const getItemProps = useStore(store, selectors.getItemProps);
 
     const itemRef = React.useRef<HTMLDivElement | null>(null);
@@ -92,19 +94,19 @@ export const ComboboxItem = React.memo(
       }
 
       const visibleMap = store.state.valuesRef.current;
-      visibleMap[index] = value;
+      visibleMap[index] = itemValue;
 
       // Stable registry that doesn't depend on filtering. Assume that no
       // filtering had occurred at this point; otherwise, an `items` prop is
       // required.
       if (selectionMode !== 'none') {
-        store.state.allValuesRef.current.push(value);
+        store.state.allValuesRef.current.push(itemValue);
       }
 
       return () => {
         delete visibleMap[index];
       };
-    }, [hasRegistered, hasItems, index, value, store, selectionMode]);
+    }, [hasRegistered, hasItems, index, itemValue, store, selectionMode]);
 
     useIsoLayoutEffect(() => {
       if (!open) {
@@ -121,10 +123,10 @@ export const ComboboxItem = React.memo(
         ? selectedValue[selectedValue.length - 1]
         : selectedValue;
 
-      if (compareItemEquality(lastSelectedValue, value, isItemEqualToValue)) {
+      if (compareItemEquality(itemValue, lastSelectedValue, isItemEqualToValue)) {
         store.set('selectedIndex', index);
       }
-    }, [hasRegistered, hasItems, open, store, index, value, isItemEqualToValue]);
+    }, [hasRegistered, hasItems, open, store, index, itemValue, isItemEqualToValue]);
 
     const state: ComboboxItem.State = {
       disabled,
@@ -144,7 +146,7 @@ export const ComboboxItem = React.memo(
 
     function commitSelection(nativeEvent: MouseEvent) {
       function selectItem() {
-        store.state.handleSelection(nativeEvent, value);
+        store.state.handleSelection(nativeEvent, itemValue);
       }
 
       if (store.state.submitOnItemClick) {

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -5315,6 +5315,54 @@ describe('<Combobox.Root />', () => {
       });
     });
 
+    it('passes item as the first comparator argument in multiple mode', async () => {
+      const users = [
+        { id: 1, name: 'Alice', source: 'item' },
+        { id: 2, name: 'Bob', source: 'item' },
+      ];
+
+      await render(
+        <Combobox.Root
+          items={users}
+          defaultValue={[{ id: 2, name: 'Bob', source: 'selected' }]}
+          itemToStringLabel={(item) => item.name}
+          itemToStringValue={(item) => String(item.id)}
+          isItemEqualToValue={(item, value) =>
+            item.id === value.id && item.source === 'item' && value.source === 'selected'
+          }
+          defaultOpen
+          multiple
+        >
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item) => (
+                    <Combobox.Item key={item.id} value={item}>
+                      {item.name}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const option = screen.getByRole('option', { name: 'Bob' });
+      expect(option).to.have.attribute('aria-selected', 'true');
+
+      fireEvent.click(option);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Bob' })).to.have.attribute(
+          'aria-selected',
+          'false',
+        );
+      });
+    });
+
     it('does not call comparator with null when clearing the value', async () => {
       const users = [
         { id: 1, name: 'Alice' },

--- a/packages/react/src/combobox/root/ComboboxRoot.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.tsx
@@ -98,7 +98,7 @@ export type ComboboxRootProps<Value, Multiple extends boolean | undefined = fals
    * Custom comparison logic used to determine if a combobox item value matches the current selected value. Useful when item values are objects without matching referentially.
    * Defaults to `Object.is` comparison.
    */
-  isItemEqualToValue?: ((itemValue: Value, selectedValue: Value) => boolean) | undefined;
+  isItemEqualToValue?: ((itemValue: Value, value: Value) => boolean) | undefined;
   /**
    * The uncontrolled selected value of the combobox when it's initially rendered.
    *

--- a/packages/react/src/combobox/store.ts
+++ b/packages/react/src/combobox/store.ts
@@ -82,7 +82,7 @@ export type State = {
   onOpenChangeComplete: (open: boolean) => void;
   openOnInputClick: boolean;
   itemToStringLabel?: ((item: any) => string) | undefined;
-  isItemEqualToValue: (item: any, value: any) => boolean;
+  isItemEqualToValue: (itemValue: any, selectedValue: any) => boolean;
   modal: boolean;
   autoHighlight: false | 'always' | 'input-change';
   submitOnItemClick: boolean;
@@ -128,13 +128,15 @@ export const selectors = {
   activeIndex: createSelector((state: State) => state.activeIndex),
   selectedIndex: createSelector((state: State) => state.selectedIndex),
   isActive: createSelector((state: State, index: number) => state.activeIndex === index),
-  isSelected: createSelector((state: State, candidate: any) => {
+  isSelected: createSelector((state: State, itemValue: any) => {
     const comparer = state.isItemEqualToValue;
     const selectedValue = state.selectedValue;
     if (Array.isArray(selectedValue)) {
-      return selectedValue.some((value) => compareItemEquality(value, candidate, comparer));
+      return selectedValue.some((selectedItem) =>
+        compareItemEquality(itemValue, selectedItem, comparer),
+      );
     }
-    return compareItemEquality(selectedValue, candidate, comparer);
+    return compareItemEquality(itemValue, selectedValue, comparer);
   }),
 
   transitionStatus: createSelector((state: State) => state.transitionStatus),

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -33,7 +33,7 @@ export const SelectItem = React.memo(
     const {
       render,
       className,
-      value = null,
+      value: itemValue = null,
       label,
       disabled = false,
       nativeButton = false,
@@ -63,7 +63,7 @@ export const SelectItem = React.memo(
     const highlightTimeout = useTimeout();
 
     const highlighted = useStore(store, selectors.isActive, listItem.index);
-    const selected = useStore(store, selectors.isSelected, listItem.index, value);
+    const selected = useStore(store, selectors.isSelected, listItem.index, itemValue);
     const selectedByFocus = useStore(store, selectors.isSelectedByFocus, listItem.index);
     const isItemEqualToValue = useStore(store, selectors.isItemEqualToValue);
 
@@ -79,12 +79,12 @@ export const SelectItem = React.memo(
       }
 
       const values = valuesRef.current;
-      values[index] = value;
+      values[index] = itemValue;
 
       return () => {
         delete values[index];
       };
-    }, [hasRegistered, index, value, valuesRef]);
+    }, [hasRegistered, index, itemValue, valuesRef]);
 
     useIsoLayoutEffect(() => {
       if (!hasRegistered) {
@@ -93,16 +93,19 @@ export const SelectItem = React.memo(
 
       const selectedValue = store.state.value;
 
-      let candidate = selectedValue;
+      let selectedCandidate = selectedValue;
       if (multiple && Array.isArray(selectedValue) && selectedValue.length > 0) {
-        candidate = selectedValue[selectedValue.length - 1];
+        selectedCandidate = selectedValue[selectedValue.length - 1];
       }
 
-      if (candidate !== undefined && compareItemEquality(candidate, value, isItemEqualToValue)) {
+      if (
+        selectedCandidate !== undefined &&
+        compareItemEquality(itemValue, selectedCandidate, isItemEqualToValue)
+      ) {
         store.set('selectedIndex', index);
       }
       return undefined;
-    }, [hasRegistered, index, multiple, isItemEqualToValue, store, value]);
+    }, [hasRegistered, index, multiple, isItemEqualToValue, store, itemValue]);
 
     const state: SelectItem.State = {
       disabled,
@@ -131,11 +134,11 @@ export const SelectItem = React.memo(
       if (multiple) {
         const currentValue = Array.isArray(selectedValue) ? selectedValue : [];
         const nextValue = selected
-          ? removeItem(currentValue, value, isItemEqualToValue)
-          : [...currentValue, value];
+          ? removeItem(currentValue, itemValue, isItemEqualToValue)
+          : [...currentValue, itemValue];
         setValue(nextValue, createChangeEventDetails(REASONS.itemPress, event));
       } else {
-        setValue(value, createChangeEventDetails(REASONS.itemPress, event));
+        setValue(itemValue, createChangeEventDetails(REASONS.itemPress, event));
         setOpen(false, createChangeEventDetails(REASONS.itemPress, event));
       }
     }

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -19,7 +19,7 @@ import { clearStyles } from '../popup/utils';
 import { selectors } from '../store';
 import { createChangeEventDetails } from '../../utils/createBaseUIEventDetails';
 import { REASONS } from '../../utils/reasons';
-import { findItemIndex, itemIncludes } from '../../utils/itemEquality';
+import { findItemIndex, selectedValueIncludes } from '../../utils/itemEquality';
 
 const FIXED: React.CSSProperties = { position: 'fixed' };
 
@@ -183,12 +183,13 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
       const eventDetails = createChangeEventDetails(REASONS.none);
 
       if (prevSize !== 0 && !store.state.multiple && value !== null) {
-        const valueIndex = findItemIndex(valuesRef.current, value, isItemEqualToValue);
-        if (valueIndex === -1) {
-          const initial = initialValueRef.current;
+        const selectedValueIndex = findItemIndex(valuesRef.current, value, isItemEqualToValue);
+        if (selectedValueIndex === -1) {
+          const initialSelectedValue = initialValueRef.current;
           const hasInitial =
-            initial != null && itemIncludes(valuesRef.current, initial, isItemEqualToValue);
-          const nextValue = hasInitial ? initial : null;
+            initialSelectedValue != null &&
+            findItemIndex(valuesRef.current, initialSelectedValue, isItemEqualToValue) !== -1;
+          const nextValue = hasInitial ? initialSelectedValue : null;
           setValue(nextValue, eventDetails);
 
           if (nextValue === null) {
@@ -199,12 +200,15 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
       }
 
       if (prevSize !== 0 && store.state.multiple && Array.isArray(value)) {
-        const nextValue = value.filter((v) =>
-          itemIncludes(valuesRef.current, v, isItemEqualToValue),
-        );
+        const hasVisibleItem = (selectedItemValue: unknown) =>
+          findItemIndex(valuesRef.current, selectedItemValue, isItemEqualToValue) !== -1;
+        const nextValue = value.filter((selectedItemValue) => hasVisibleItem(selectedItemValue));
         if (
           nextValue.length !== value.length ||
-          nextValue.some((v) => !itemIncludes(value, v, isItemEqualToValue))
+          nextValue.some(
+            (selectedItemValue) =>
+              !selectedValueIncludes(value, selectedItemValue, isItemEqualToValue),
+          )
         ) {
           setValue(nextValue, eventDetails);
 

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -3018,6 +3018,50 @@ describe('<Select.Root />', () => {
         expect(screen.getByRole('option', { name: 'Bob' })).to.have.attribute('data-selected', '');
       });
     });
+
+    it('passes item as the first comparator argument in multiple mode', async () => {
+      const users = [
+        { id: 1, name: 'Alice', source: 'item' },
+        { id: 2, name: 'Bob', source: 'item' },
+      ];
+
+      await render(
+        <Select.Root
+          multiple
+          defaultOpen
+          defaultValue={[{ id: 2, name: 'Bob', source: 'selected' }]}
+          itemToStringLabel={(item) => item.name}
+          itemToStringValue={(item) => String(item.id)}
+          isItemEqualToValue={(item, value) =>
+            item.id === value.id && item.source === 'item' && value.source === 'selected'
+          }
+        >
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                {users.map((user) => (
+                  <Select.Item key={user.id} value={user}>
+                    {user.name}
+                  </Select.Item>
+                ))}
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const option = screen.getByRole('option', { name: 'Bob' });
+      expect(option).to.have.attribute('data-selected', '');
+
+      fireEvent.click(option);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Bob' })).not.to.have.attribute('data-selected');
+      });
+    });
   });
 
   describe('prop: highlightItemOnHover', () => {

--- a/packages/react/src/select/store.ts
+++ b/packages/react/src/select/store.ts
@@ -16,7 +16,7 @@ export type State = {
     | undefined;
   itemToStringLabel: ((item: any) => string) | undefined;
   itemToStringValue: ((item: any) => string) | undefined;
-  isItemEqualToValue: (item: any, value: any) => boolean;
+  isItemEqualToValue: (itemValue: any, selectedValue: any) => boolean;
 
   value: any;
 
@@ -81,14 +81,14 @@ export const selectors = {
   selectedIndex: createSelector((state: State) => state.selectedIndex),
   isActive: createSelector((state: State, index: number) => state.activeIndex === index),
 
-  isSelected: createSelector((state: State, index: number, candidate: any) => {
+  isSelected: createSelector((state: State, index: number, itemValue: any) => {
     const comparer = state.isItemEqualToValue;
     const storeValue = state.value;
 
     if (state.multiple) {
       return (
         Array.isArray(storeValue) &&
-        storeValue.some((item) => compareItemEquality(item, candidate, comparer))
+        storeValue.some((selectedItem) => compareItemEquality(itemValue, selectedItem, comparer))
       );
     }
 
@@ -98,7 +98,7 @@ export const selectors = {
       return true;
     }
 
-    return compareItemEquality(storeValue, candidate, comparer);
+    return compareItemEquality(itemValue, storeValue, comparer);
   }),
   isSelectedByFocus: createSelector((state: State, index: number) => {
     return state.selectedIndex === index;

--- a/packages/react/src/utils/itemEquality.ts
+++ b/packages/react/src/utils/itemEquality.ts
@@ -1,54 +1,60 @@
-export type ItemEqualityComparer<Item = any, Value = Item> = (item: Item, value: Value) => boolean;
+export type ItemEqualityComparer<Item = any, Value = Item> = (
+  itemValue: Item,
+  selectedValue: Value,
+) => boolean;
 
-export const defaultItemEquality: ItemEqualityComparer = (item, value) => Object.is(item, value);
+export const defaultItemEquality: ItemEqualityComparer = (itemValue, selectedValue) =>
+  Object.is(itemValue, selectedValue);
 
 export function compareItemEquality<Item, Value>(
-  item: Item,
-  value: Value,
+  itemValue: Item,
+  selectedValue: Value,
   comparer: ItemEqualityComparer<Item, Value>,
 ): boolean {
-  if (item == null || value == null) {
-    return Object.is(item, value);
+  if (itemValue == null || selectedValue == null) {
+    return Object.is(itemValue, selectedValue);
   }
-  return comparer(item, value);
+  return comparer(itemValue, selectedValue);
 }
 
-export function itemIncludes<Item, Value>(
-  collection: readonly Item[] | undefined | null,
-  value: Value,
-  comparer: ItemEqualityComparer<Item, Value>,
+export function selectedValueIncludes<Item, Value>(
+  selectedValues: readonly Item[] | undefined | null,
+  itemValue: Value,
+  comparer: ItemEqualityComparer<Value, Item>,
 ): boolean {
-  if (!collection || collection.length === 0) {
+  if (!selectedValues || selectedValues.length === 0) {
     return false;
   }
-  return collection.some((item) => {
-    if (item === undefined) {
+  return selectedValues.some((selectedValue) => {
+    if (selectedValue === undefined) {
       return false;
     }
-    return compareItemEquality(item, value, comparer);
+    return compareItemEquality(itemValue, selectedValue, comparer);
   });
 }
 
 export function findItemIndex<Item, Value>(
-  collection: readonly Item[] | undefined | null,
-  value: Value,
+  itemValues: readonly Item[] | undefined | null,
+  selectedValue: Value,
   comparer: ItemEqualityComparer<Item, Value>,
 ): number {
-  if (!collection || collection.length === 0) {
+  if (!itemValues || itemValues.length === 0) {
     return -1;
   }
-  return collection.findIndex((item) => {
-    if (item === undefined) {
+  return itemValues.findIndex((itemValue) => {
+    if (itemValue === undefined) {
       return false;
     }
-    return compareItemEquality(item, value, comparer);
+    return compareItemEquality(itemValue, selectedValue, comparer);
   });
 }
 
 export function removeItem<Item, Value>(
-  collection: readonly Item[],
-  value: Value,
-  comparer: ItemEqualityComparer<Item, Value>,
+  selectedValues: readonly Item[],
+  itemValue: Value,
+  comparer: ItemEqualityComparer<Value, Item>,
 ): Item[] {
-  return collection.filter((item) => !compareItemEquality(item, value, comparer));
+  return selectedValues.filter(
+    (selectedValue) => !compareItemEquality(itemValue, selectedValue, comparer),
+  );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The order of args was sometimes inconsistent here and did not match the types.