### PR TITLE
[autocomplete][docs] Fix command palette footer dark mode

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
@@ -262,10 +262,10 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.625rem 0.75rem;
-  border-top: 1px solid var(--color-gray-100);
+  border-top: 1px solid var(--color-gray-200);
   font-size: 0.75rem;
-  color: var(--color-gray-500);
-  background-color: white;
+  color: var(--color-gray-600);
+  background-color: var(--color-gray-50);
   border-radius: 0 0 1rem 1rem;
 }
 
@@ -288,8 +288,8 @@
     ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
   font-weight: 500;
   line-height: 1;
-  color: var(--color-gray-600);
-  background-color: var(--color-gray-50);
+  color: var(--color-gray-700);
+  background-color: var(--color-gray-100);
   border: 1px solid var(--color-gray-300);
   border-radius: 0.25rem;
 }

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/tailwind/index.tsx
@@ -78,19 +78,19 @@ export default function ExampleAutocompleteCommandPalette() {
                 </ScrollArea.Scrollbar>
               </ScrollArea.Root>
 
-              <div className="flex items-center justify-between border-t border-gray-100 bg-white px-3 py-2.5 text-xs text-gray-500">
+              <div className="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-3 py-2.5 text-xs text-gray-600">
                 <div className="flex items-center gap-2">
                   <span>Activate</span>
-                  <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded border border-gray-300 bg-gray-50 px-1 text-[0.625rem] font-medium text-gray-600">
+                  <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded border border-gray-300 bg-gray-100 px-1 text-[0.625rem] font-medium text-gray-700">
                     Enter
                   </kbd>
                 </div>
                 <div className="flex items-center gap-2">
                   <span>Actions</span>
-                  <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded border border-gray-300 bg-gray-50 px-1 text-[0.625rem] font-medium text-gray-600">
+                  <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded border border-gray-300 bg-gray-100 px-1 text-[0.625rem] font-medium text-gray-700">
                     Cmd
                   </kbd>
-                  <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded border border-gray-300 bg-gray-50 px-1 text-[0.625rem] font-medium text-gray-600">
+                  <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded border border-gray-300 bg-gray-100 px-1 text-[0.625rem] font-medium text-gray-700">
                     K
                   </kbd>
                 </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The bottom bar was incorrectly hardcoded for light mode

![img](https://media.discordapp.net/attachments/1287295829887025224/1471620996065792260/Captura_de_pantalla_2026-02-12_a_las_4.34.56_p.m..png?ex=698f995a&is=698e47da&hm=64d680d45b8316ec60cffa4eaefd6a0af34d1d6cd723b326588f6478a232f442&=&format=webp&quality=lossless&width=2368&height=1914)

After:
<img width="548" height="583" alt="Screenshot 2026-02-13 at 10 43 24 am" src="https://github.com/user-attachments/assets/90bc9752-03e6-410f-998b-8f55a7dd8cc6" />
