### PR TITLE
[select] Apply id to hidden input and deprecate Select.Root id prop

### DIFF
--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -1114,29 +1114,6 @@ describe('<Select.Root />', () => {
     });
   });
 
-  describe('prop: id', () => {
-    it('sets the id on the trigger', async () => {
-      await render(
-        <Select.Root id="test-id">
-          <Select.Trigger>
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByRole('combobox');
-      expect(trigger).to.have.attribute('id', 'test-id');
-    });
-  });
-
   describe('with Field.Root parent', () => {
     it('should receive disabled prop from Field.Root', async () => {
       await render(
@@ -2002,7 +1979,7 @@ describe('<Select.Root />', () => {
       );
     });
 
-    it('Field.Label links to trigger and focuses it', async () => {
+    it("Field.Label links to select's hidden input and focuses it", async () => {
       const { user } = await render(
         <Field.Root>
           <Field.Label data-testid="label">Font</Field.Label>
@@ -2023,14 +2000,14 @@ describe('<Select.Root />', () => {
       );
 
       const label = screen.getByTestId<HTMLLabelElement>('label');
-      const trigger = screen.getByTestId('trigger');
+      const hiddenInput = screen.getByRole('textbox', { hidden: true });
+      const hiddenInputId = hiddenInput.getAttribute('id');
 
-      expect(label).to.have.attribute('for', trigger.id);
-      expect(trigger).to.have.attribute('id', label?.htmlFor);
+      expect(label.htmlFor).to.equal(hiddenInputId);
 
       await user.click(label);
 
-      expect(screen.getByRole('listbox')).toHaveFocus();
+      expect(screen.getByRole('combob')).toHaveFocus();
     });
 
     it('Field.Label links to trigger when trigger has an explicit id', async () => {
@@ -2054,15 +2031,10 @@ describe('<Select.Root />', () => {
       );
 
       const label = screen.getByTestId<HTMLLabelElement>('label');
-      const trigger = screen.getByTestId('trigger');
-
-      expect(trigger).to.have.attribute('id', 'x-id');
-      expect(label).to.have.attribute('for', 'x-id');
-      expect(trigger).to.have.attribute('id', label?.htmlFor);
 
       await user.click(label);
 
-      expect(screen.getByRole('listbox')).toHaveFocus();
+      expect(screen.getByRole('combobox')).toHaveFocus();
     });
 
     it('Field.Description', async () => {
@@ -3150,6 +3122,31 @@ describe('<Select.Root />', () => {
       await waitFor(() => {
         expect(optionA).to.have.attribute('data-highlighted');
       });
+    });
+  });
+
+  describe('iO zoom issue', () => {
+    it('should apply a font size of at least 16px to the hidden input to prevent the iOS zoom issue', async () => {
+      await render(
+        <Select.Root>
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const hiddenInput = screen.getByRole('textbox', { hidden: true });
+      const fontSize = parseFloat(getComputedStyle(hiddenInput).fontSize);
+      expect(fontSize).to.be.greaterThanOrEqual(16);
     });
   });
 });

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -31,7 +31,7 @@ import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useFormContext } from '../../form/FormContext';
 import { useField } from '../../field/useField';
 import { stringifyAsValue } from '../../utils/resolveValueLabel';
-import { EMPTY_ARRAY, EMPTY_OBJECT } from '../../utils/constants';
+import { EMPTY_ARRAY } from '../../utils/constants';
 import { defaultItemEquality, findItemIndex } from '../../utils/itemEquality';
 import { useValueChanged } from '../../utils/useValueChanged';
 import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
@@ -390,12 +390,8 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   ]);
 
   const mergedTriggerProps = React.useMemo(() => {
-    return mergeProps(
-      getReferenceProps(),
-      interactionTypeProps,
-      generatedId ? { id: generatedId } : EMPTY_OBJECT,
-    );
-  }, [getReferenceProps, interactionTypeProps, generatedId]);
+    return mergeProps(getReferenceProps(), interactionTypeProps);
+  }, [getReferenceProps, interactionTypeProps]);
 
   useOnFirstRender(() => {
     store.update({
@@ -566,6 +562,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
               queueMicrotask(handleChange);
             },
           })}
+          id={generatedId}
           name={multiple ? undefined : name}
           autoComplete={autoComplete}
           value={serializedValue}
@@ -604,6 +601,7 @@ export interface SelectRootProps<Value, Multiple extends boolean | undefined = f
   autoComplete?: string | undefined;
   /**
    * The id of the Select.
+   * @deprecated use the `id` prop on the `<Select.Trigger>` component instead.
    */
   id?: string | undefined;
   /**

--- a/packages/react/src/select/trigger/SelectTrigger.test.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.test.tsx
@@ -206,4 +206,28 @@ describe('<Select.Trigger />', () => {
       expect(trigger).to.have.attribute('aria-required', 'true');
     });
   });
+
+  describe('prop: id', () => {
+    it('should not be set the id attribute on the trigger when not provided', async () => {
+      await render(
+        <Select.Root>
+          <Select.Trigger />
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).not.to.have.attribute('id');
+    });
+
+    it('should set the id attribute on the trigger when provided', async () => {
+      await render(
+        <Select.Root>
+          <Select.Trigger id="trigger" />
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).to.have.attribute('id', 'trigger');
+    });
+  });
 });

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -22,7 +22,6 @@ import { useButton } from '../../use-button';
 import type { FieldRoot } from '../../field/root/FieldRoot';
 import { createChangeEventDetails } from '../../utils/createBaseUIEventDetails';
 import { REASONS } from '../../utils/reasons';
-import { useLabelableId } from '../../labelable-provider/useLabelableId';
 
 const BOUNDARY_OFFSET = 2;
 const SELECTED_DELAY = 400;
@@ -47,7 +46,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const {
     render,
     className,
-    id: idProp,
+    id,
     disabled: disabledProp = false,
     nativeButton = true,
     ...elementProps
@@ -80,13 +79,9 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const triggerProps = useStore(store, selectors.triggerProps);
   const positionerElement = useStore(store, selectors.positionerElement);
   const listElement = useStore(store, selectors.listElement);
-  const rootId = useStore(store, selectors.id);
   const hasSelectedValue = useStore(store, selectors.hasSelectedValue);
   const shouldCheckNullItemLabel = !hasSelectedValue && open;
   const hasNullItemLabel = useStore(store, selectors.hasNullItemLabel, shouldCheckNullItemLabel);
-
-  const id = idProp ?? rootId;
-  useLabelableId({ id });
 
   const positionerRef = useValueAsRef(positionerElement);
 

--- a/packages/utils/src/visuallyHidden.ts
+++ b/packages/utils/src/visuallyHidden.ts
@@ -9,6 +9,7 @@ const visuallyHiddenBase: React.CSSProperties = {
   width: 1,
   height: 1,
   margin: -1,
+  fontSize: 16,
 };
 
 export const visuallyHidden: React.CSSProperties = {


### PR DESCRIPTION

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Problem
1. id prop of `<Select.Root />` is confusing
The id prop on Select.Root is confusing because it's unclear which element it should be applied to.
Currently, it is passed down to the trigger.

However, developers can already provide an id directly to <Select.Trigger id="..." />.
Because of this, the Select.Root id prop seems unnecessary.


## Changes

### 1. Pass the id to hidden input instead of `Select.Trigger`

I've checked up the PR that fix zoom issue on iOS. (ref. https://github.com/mui/base-ui/pull/3722)
Passed the id of label to `Select.Trigger` to avoid iOS zoom in that PR.

But, It occurs the warning from html



### 3. Set hidden input font-size (e.g. 16px) to prevent iOS zoom on focus.

Number 1 changes occur the iOS zoom issue again.
So, I set the font-size to 16px in visiuallyHiddenBase.
It prevents to zoom on iOS when label click for focus the input.

### 2. Deprecate the id prop of `Select.Root`


