### PR TITLE
[combobox] Add `getValueFromItem` prop

### DIFF
--- a/docs/reference/generated/combobox-root.json
+++ b/docs/reference/generated/combobox-root.json
@@ -85,6 +85,11 @@
       "description": "Filtered items to display in the list.\nWhen provided, the list will use these items instead of filtering the `items` prop internally.\nUse when you want to control filtering logic externally with the `useFilter()` hook.",
       "detailedType": "any[] | Group[] | undefined"
     },
+    "getValueFromItem": {
+      "type": "GetValueFromItemFn<Value, any[] | Group[] | undefined>",
+      "description": "Maps each item in the `items` array to the selected value shape.\nUseful when `items` are objects while `value` / `defaultValue` are primitive values.\nWhen omitted, the full item is used as the selected value.",
+      "detailedType": "| ((item: GroupItem | Item | any) => Value)\n| undefined"
+    },
     "grid": {
       "type": "boolean",
       "default": "false",
@@ -113,7 +118,7 @@
       "detailedType": "((itemValue: Value) => string) | undefined"
     },
     "items": {
-      "type": "any[] | Group[]",
+      "type": "any[] | Group[] | undefined",
       "description": "The items to be displayed in the list.\nCan be either a flat array of items or an array of groups with items.",
       "detailedType": "any[] | Group[] | undefined"
     },

--- a/docs/reference/generated/combobox-root.json
+++ b/docs/reference/generated/combobox-root.json
@@ -76,9 +76,9 @@
       "detailedType": "string | undefined"
     },
     "filter": {
-      "type": "((itemValue: Value, query: string, itemToString: ((itemValue: Value) => string) | undefined) => boolean) | null",
+      "type": "((itemValue: Value | GroupItem | Item | any, query: string, itemToString: ((itemValue: Value | GroupItem | Item | any) => string) | undefined) => boolean) | null",
       "description": "Filter function used to match items vs input query.",
-      "detailedType": "| ((\n    itemValue: Value,\n    query: string,\n    itemToString:\n      | ((itemValue: Value) => string)\n      | undefined,\n  ) => boolean)\n| null\n| undefined"
+      "detailedType": "| ((\n    itemValue: Value | GroupItem | Item | any,\n    query: string,\n    itemToString:\n      | ((\n          itemValue: Value | GroupItem | Item | any,\n        ) => string)\n      | undefined,\n  ) => boolean)\n| null\n| undefined"
     },
     "filteredItems": {
       "type": "any[] | Group[]",

--- a/docs/reference/generated/combobox-root.json
+++ b/docs/reference/generated/combobox-root.json
@@ -76,9 +76,9 @@
       "detailedType": "string | undefined"
     },
     "filter": {
-      "type": "((itemValue: Value | GroupItem | Item | any, query: string, itemToString: ((itemValue: Value | GroupItem | Item | any) => string) | undefined) => boolean) | null",
+      "type": "((itemValue: Value | Item | any, query: string, itemToString: ((itemValue: Value | Item | any) => string) | undefined) => boolean) | null",
       "description": "Filter function used to match items vs input query.",
-      "detailedType": "| ((\n    itemValue: Value | GroupItem | Item | any,\n    query: string,\n    itemToString:\n      | ((\n          itemValue: Value | GroupItem | Item | any,\n        ) => string)\n      | undefined,\n  ) => boolean)\n| null\n| undefined"
+      "detailedType": "| ((\n    itemValue: Value | Item | any,\n    query: string,\n    itemToString:\n      | ((itemValue: Value | Item | any) => string)\n      | undefined,\n  ) => boolean)\n| null\n| undefined"
     },
     "filteredItems": {
       "type": "any[] | Group[]",
@@ -88,7 +88,7 @@
     "getValueFromItem": {
       "type": "GetValueFromItemFn<Value, any[] | Group[] | undefined>",
       "description": "Maps each item in the `items` array to the selected value shape.\nUseful when `items` are objects while `value` / `defaultValue` are primitive values.\nWhen omitted, the full item is used as the selected value.",
-      "detailedType": "| ((item: GroupItem | Item | any) => Value)\n| undefined"
+      "detailedType": "((item: Item | any) => Value) | undefined"
     },
     "grid": {
       "type": "boolean",

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -329,7 +329,7 @@ An input combined with a list of predefined items to select.
     - Return value
 - Exports:
   - Combobox - Root
-    - Props: actionsRef, autoComplete, autoHighlight, children, defaultInputValue, defaultOpen, defaultValue, disabled, filter, filteredItems, grid, highlightItemOnHover, id, inline, inputRef, inputValue, isItemEqualToValue, itemToStringLabel, itemToStringValue, items, limit, locale, loopFocus, modal, multiple, name, onInputValueChange, onItemHighlighted, onOpenChange, onOpenChangeComplete, onValueChange, open, openOnInputClick, readOnly, required, value, virtualized
+    - Props: actionsRef, autoComplete, autoHighlight, children, defaultInputValue, defaultOpen, defaultValue, disabled, filter, filteredItems, getValueFromItem, grid, highlightItemOnHover, id, inline, inputRef, inputValue, isItemEqualToValue, itemToStringLabel, itemToStringValue, items, limit, locale, loopFocus, modal, multiple, name, onInputValueChange, onItemHighlighted, onOpenChange, onOpenChangeComplete, onValueChange, open, openOnInputClick, readOnly, required, value, virtualized
   - Combobox - Trigger
     - Props: className, disabled, nativeButton, render, style
     - Data Attributes: data-dirty, data-disabled, data-filled, data-focused, data-invalid, data-list-empty, data-placeholder, data-popup-open, data-popup-side, data-pressed, data-readonly, data-required, data-touched, data-valid

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
@@ -159,6 +159,7 @@ export interface AutocompleteRootProps<ItemValue> extends Omit<
   | 'onSelectedValueChange'
   | 'fillInputOnItemPress'
   | 'itemToStringValue'
+  | 'getValueFromItem'
   | 'isItemEqualToValue'
   // Different names
   | 'inputValue' // value

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -31,7 +31,7 @@ export const ComboboxItem = React.memo(
     const {
       render,
       className,
-      value: itemValue = null,
+      value: itemValueProp = null,
       index: indexProp,
       disabled = false,
       nativeButton = false,
@@ -54,14 +54,37 @@ export const ComboboxItem = React.memo(
     const selectionMode = useStore(store, selectors.selectionMode);
     const readOnly = useStore(store, selectors.readOnly);
     const virtualized = useStore(store, selectors.virtualized);
+    const getValueFromItem = useStore(store, selectors.getValueFromItem);
     const isItemEqualToValue = useStore(store, selectors.isItemEqualToValue);
 
+    const itemValue =
+      hasItems && getValueFromItem && itemValueProp != null && typeof itemValueProp === 'object'
+        ? getValueFromItem(itemValueProp)
+        : itemValueProp;
+
     const selectable = selectionMode !== 'none';
-    const index =
-      indexProp ??
-      (virtualized
-        ? findItemIndex(flatFilteredItems, itemValue, isItemEqualToValue)
-        : listItem.index);
+    let index = indexProp;
+    if (index == null) {
+      if (virtualized) {
+        if (hasItems && getValueFromItem) {
+          const mappedIndex = findItemIndex(
+            flatFilteredItems,
+            itemValue,
+            isItemEqualToValue,
+            getValueFromItem,
+          );
+          index =
+            mappedIndex > -1
+              ? mappedIndex
+              : findItemIndex(flatFilteredItems, itemValueProp, isItemEqualToValue);
+        } else {
+          index = findItemIndex(flatFilteredItems, itemValueProp, isItemEqualToValue);
+        }
+      } else {
+        index = listItem.index;
+      }
+    }
+
     const hasRegistered = listItem.index !== -1;
 
     const rootId = useStore(store, selectors.id);

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -66,20 +66,10 @@ export const ComboboxItem = React.memo(
     let index = indexProp;
     if (index == null) {
       if (virtualized) {
-        if (hasItems && getValueFromItem) {
-          const mappedIndex = findItemIndex(
-            flatFilteredItems,
-            itemValue,
-            isItemEqualToValue,
-            getValueFromItem,
-          );
-          index =
-            mappedIndex > -1
-              ? mappedIndex
-              : findItemIndex(flatFilteredItems, itemValueProp, isItemEqualToValue);
-        } else {
-          index = findItemIndex(flatFilteredItems, itemValueProp, isItemEqualToValue);
-        }
+        index =
+          hasItems && getValueFromItem
+            ? findItemIndex(flatFilteredItems, itemValue, isItemEqualToValue, getValueFromItem)
+            : findItemIndex(flatFilteredItems, itemValue, isItemEqualToValue);
       } else {
         index = listItem.index;
       }

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -46,6 +46,7 @@ import { HTMLProps } from '../../utils/types';
 import { useValueChanged } from '../../utils/useValueChanged';
 import { NOOP } from '../../utils/noop';
 import {
+  resolveSelectedLabelString,
   stringifyAsLabel,
   stringifyAsValue,
   Group,
@@ -102,6 +103,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     loopFocus = true,
     itemToStringLabel,
     itemToStringValue,
+    getValueFromItem,
     isItemEqualToValue = defaultItemEquality,
     virtualized = false,
     inline: inlineProp = false,
@@ -166,6 +168,43 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   const hasInputValue = inputValueProp !== undefined || defaultInputValueProp !== undefined;
   const hasItems = items !== undefined;
   const hasFilteredItemsProp = filteredItemsProp !== undefined;
+  const isGrouped = isGroupedItems(items);
+
+  const flatItems: readonly any[] = React.useMemo(() => {
+    if (!items) {
+      return EMPTY_ARRAY;
+    }
+
+    if (isGrouped) {
+      return items.flatMap((group) => group.items);
+    }
+
+    return items;
+  }, [items, isGrouped]);
+
+  function resolveSelectedInputLabel(value: any): string {
+    if (!getValueFromItem || !hasItems) {
+      return resolveSelectedLabelString(value, items, itemToStringLabel);
+    }
+
+    const matchingItem = flatItems.find((item) =>
+      compareItemEquality(getValueFromItem(item), value, isItemEqualToValue),
+    );
+
+    if (matchingItem !== undefined) {
+      if (itemToStringLabel && value != null) {
+        return itemToStringLabel(value) ?? '';
+      }
+
+      return stringifyAsLabel(matchingItem);
+    }
+
+    return resolveSelectedLabelString(
+      value,
+      items,
+      value && typeof value === 'object' ? itemToStringLabel : undefined,
+    );
+  }
 
   let autoHighlightMode: false | 'input-change' | 'always';
   if (autoHighlight === 'always') {
@@ -202,7 +241,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         return defaultInputValueProp ?? '';
       }
       if (single) {
-        return stringifyAsLabel(selectedValue, itemToStringLabel);
+        return resolveSelectedInputLabel(selectedValue);
       }
       return '';
     },
@@ -222,10 +261,9 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     state: 'open',
   });
 
-  const isGrouped = isGroupedItems(items);
   const query = closeQuery ?? (inputValue === '' ? '' : String(inputValue).trim());
 
-  const selectedLabelString = single ? stringifyAsLabel(selectedValue, itemToStringLabel) : '';
+  const selectedLabelString = single ? resolveSelectedInputLabel(selectedValue) : '';
 
   const shouldBypassFiltering =
     single &&
@@ -237,18 +275,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
   const filterQuery = shouldBypassFiltering ? '' : query;
   const shouldIgnoreExternalFiltering = hasItems && hasFilteredItemsProp && shouldBypassFiltering;
-
-  const flatItems: readonly any[] = React.useMemo(() => {
-    if (!items) {
-      return EMPTY_ARRAY;
-    }
-
-    if (isGrouped) {
-      return items.flatMap((group) => group.items);
-    }
-
-    return items;
-  }, [items, isGrouped]);
 
   const filteredItems: Value[] | Group<Value>[] = React.useMemo(() => {
     if (filteredItemsProp && !shouldIgnoreExternalFiltering) {
@@ -364,6 +390,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         virtualized,
         openOnInputClick,
         itemToStringLabel,
+        getValueFromItem,
         isItemEqualToValue,
         modal,
         autoHighlight: autoHighlightMode,
@@ -606,7 +633,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
       if (shouldFillInput) {
         setInputValue(
-          stringifyAsLabel(nextValue, itemToStringLabel),
+          resolveSelectedInputLabel(nextValue),
           createChangeEventDetails(eventDetails.reason, eventDetails.event),
         );
       }
@@ -721,7 +748,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
           setInputValue('', createChangeEventDetails(REASONS.inputClear));
         }
       } else {
-        const stringVal = stringifyAsLabel(selectedValue, itemToStringLabel);
+        const stringVal = resolveSelectedInputLabel(selectedValue);
         if (inputRef.current && inputRef.current.value !== stringVal) {
           // If no selection was made, treat this as clearing the typed filter.
           const reason = stringVal === '' ? REASONS.inputClear : REASONS.none;
@@ -761,15 +788,25 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         return;
       }
 
-      const registry = items ? flatItems : allValuesRef.current;
+      const findSelectedIndex = (value: any) => {
+        if (!items) {
+          return findItemIndex(allValuesRef.current, value, isItemEqualToValue);
+        }
+
+        if (getValueFromItem) {
+          return findItemIndex(flatItems, value, isItemEqualToValue, getValueFromItem);
+        }
+
+        return findItemIndex(flatItems, value, isItemEqualToValue);
+      };
 
       if (multiple) {
         const currentValue = Array.isArray(selectedValue) ? selectedValue : [];
         const lastValue = currentValue[currentValue.length - 1];
-        const lastIndex = findItemIndex(registry, lastValue, isItemEqualToValue);
+        const lastIndex = findSelectedIndex(lastValue);
         setIndices({ selectedIndex: lastIndex === -1 ? null : lastIndex });
       } else {
-        const index = findItemIndex(registry, selectedValue, isItemEqualToValue);
+        const index = findSelectedIndex(selectedValue);
         setIndices({ selectedIndex: index === -1 ? null : index });
       }
     },
@@ -781,16 +818,19 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       flatItems,
       multiple,
       isItemEqualToValue,
+      getValueFromItem,
       setIndices,
     ],
   );
 
   useIsoLayoutEffect(() => {
     if (items) {
-      valuesRef.current = flatFilteredItems;
+      valuesRef.current = getValueFromItem
+        ? flatFilteredItems.map((item) => getValueFromItem(item))
+        : (flatFilteredItems as Value[]);
       listRef.current.length = flatFilteredItems.length;
     }
-  }, [items, flatFilteredItems]);
+  }, [items, flatFilteredItems, getValueFromItem]);
 
   useIsoLayoutEffect(() => {
     const pendingHighlight = pendingQueryHighlightRef.current;
@@ -840,7 +880,11 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       return;
     }
 
-    const itemValue = candidateItems[storeActiveIndex];
+    let itemValue = candidateItems[storeActiveIndex];
+    if (shouldUseFlatFilteredItems) {
+      const candidateItem = flatFilteredItems[storeActiveIndex];
+      itemValue = hasItems && getValueFromItem ? getValueFromItem(candidateItem) : candidateItem;
+    }
     const previouslyHighlightedItemValue = lastHighlightRef.current.value;
     const isSameItem =
       previouslyHighlightedItemValue !== NO_ACTIVE_VALUE &&
@@ -863,6 +907,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     hasFilteredItemsProp,
     hasItems,
     flatFilteredItems,
+    getValueFromItem,
     inline,
     open,
     store,
@@ -908,7 +953,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     }
 
     if (single && !hasInputValue && !inputInsidePopup) {
-      const nextInputValue = stringifyAsLabel(selectedValue, itemToStringLabel);
+      const nextInputValue = resolveSelectedInputLabel(selectedValue);
 
       if (inputValue !== nextInputValue) {
         setInputValue(nextInputValue, createChangeEventDetails(REASONS.none));
@@ -936,7 +981,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       return;
     }
 
-    const nextInputValue = stringifyAsLabel(selectedValue, itemToStringLabel);
+    const nextInputValue = resolveSelectedInputLabel(selectedValue);
 
     if (inputValue !== nextInputValue) {
       setInputValue(nextInputValue, createChangeEventDetails(REASONS.none));
@@ -1109,6 +1154,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       onOpenChangeComplete,
       openOnInputClick,
       itemToStringLabel,
+      getValueFromItem,
       modal,
       autoHighlight: autoHighlightMode,
       isItemEqualToValue,
@@ -1141,6 +1187,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     onOpenChangeComplete,
     openOnInputClick,
     itemToStringLabel,
+    getValueFromItem,
     modal,
     isItemEqualToValue,
     submitOnItemClick,
@@ -1444,6 +1491,12 @@ interface ComboboxRootProps<ItemValue> {
    * If the shape of the object is `{ value, label }`, the value will be used automatically without needing to specify this prop.
    */
   itemToStringValue?: ((itemValue: ItemValue) => string) | undefined;
+  /**
+   * Maps each item in `items` to the selected value shape.
+   * Useful when `items` are objects while `selectedValue` / `defaultSelectedValue` are primitives.
+   * When omitted, the full item is used as the selected value.
+   */
+  getValueFromItem?: ((item: any) => ItemValue) | undefined;
   /**
    * Custom comparison logic used to determine if a combobox item value matches the current selected value. Useful when item values are objects without matching referentially.
    * Defaults to `Object.is` comparison.

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -182,21 +182,92 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     return items;
   }, [items, isGrouped]);
 
+  const itemToStringForItem = React.useMemo(() => {
+    if (!itemToStringLabel) {
+      return undefined;
+    }
+
+    if (!getValueFromItem) {
+      return itemToStringLabel;
+    }
+
+    return (item: any) => {
+      const mappedValue = getValueFromItem(item);
+
+      if (mappedValue == null) {
+        return stringifyAsLabel(item);
+      }
+
+      return itemToStringLabel(mappedValue) ?? '';
+    };
+  }, [getValueFromItem, itemToStringLabel]);
+
+  const flatItemValues: readonly any[] = React.useMemo(() => {
+    if (!hasItems) {
+      return EMPTY_ARRAY;
+    }
+
+    return getValueFromItem ? flatItems.map((item) => getValueFromItem(item)) : flatItems;
+  }, [flatItems, getValueFromItem, hasItems]);
+
+  const selectedValueLookup = React.useMemo(() => {
+    if (!hasItems || isItemEqualToValue !== defaultItemEquality) {
+      return null;
+    }
+
+    const itemByValue = new Map<any, any>();
+    const indexByValue = new Map<any, number>();
+
+    flatItemValues.forEach((itemValue, index) => {
+      if (itemValue === undefined || itemByValue.has(itemValue)) {
+        return;
+      }
+
+      itemByValue.set(itemValue, flatItems[index]);
+      indexByValue.set(itemValue, index);
+    });
+
+    return { itemByValue, indexByValue };
+  }, [flatItems, flatItemValues, hasItems, isItemEqualToValue]);
+
+  function findMatchingItem(value: any) {
+    if (!hasItems) {
+      return undefined;
+    }
+
+    if (selectedValueLookup) {
+      return selectedValueLookup.itemByValue.get(value);
+    }
+
+    const index = findItemIndex(flatItemValues, value, isItemEqualToValue);
+    return index === -1 ? undefined : flatItems[index];
+  }
+
+  function findSelectedIndex(value: any): number {
+    if (!items) {
+      return findItemIndex(allValuesRef.current, value, isItemEqualToValue);
+    }
+
+    if (selectedValueLookup) {
+      return selectedValueLookup.indexByValue.get(value) ?? -1;
+    }
+
+    return findItemIndex(flatItemValues, value, isItemEqualToValue);
+  }
+
   function resolveSelectedInputLabel(value: any): string {
     if (!getValueFromItem || !hasItems) {
       return resolveSelectedLabelString(value, items, itemToStringLabel);
     }
 
-    const matchingItem = flatItems.find((item) =>
-      compareItemEquality(getValueFromItem(item), value, isItemEqualToValue),
-    );
+    const matchingItem = findMatchingItem(value);
 
     if (matchingItem !== undefined) {
       if (itemToStringLabel && value != null) {
         return itemToStringLabel(value) ?? '';
       }
 
-      return stringifyAsLabel(matchingItem);
+      return stringifyAsLabel(matchingItem, itemToStringForItem);
     }
 
     return resolveSelectedLabelString(
@@ -225,13 +296,26 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       return () => true;
     }
     if (filterProp !== undefined) {
-      return filterProp;
+      return (item: Value, query: string) => filterProp(item, query, itemToStringForItem);
     }
     if (single && !queryChangedAfterOpen) {
-      return createSingleSelectionCollatorFilter(collatorFilter, itemToStringLabel, selectedValue);
+      return createSingleSelectionCollatorFilter(
+        collatorFilter,
+        itemToStringForItem,
+        selectedValue,
+        itemToStringLabel,
+      );
     }
-    return createCollatorItemFilter(collatorFilter, itemToStringLabel);
-  }, [filterProp, single, selectedValue, queryChangedAfterOpen, collatorFilter, itemToStringLabel]);
+    return createCollatorItemFilter(collatorFilter, itemToStringForItem);
+  }, [
+    collatorFilter,
+    filterProp,
+    itemToStringForItem,
+    itemToStringLabel,
+    queryChangedAfterOpen,
+    selectedValue,
+    single,
+  ]);
 
   // If neither inputValue nor defaultInputValue are provided, derive it from the
   // selected value for single mode so the input reflects the selection on mount.
@@ -298,7 +382,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         const candidateItems =
           filterQuery === ''
             ? group.items
-            : group.items.filter((item) => filter(item, filterQuery, itemToStringLabel));
+            : group.items.filter((item) => filter(item, filterQuery));
 
         if (candidateItems.length === 0) {
           continue;
@@ -334,7 +418,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       if (limit > -1 && limitedItems.length >= limit) {
         break;
       }
-      if (filter(item, filterQuery, itemToStringLabel)) {
+      if (filter(item, filterQuery)) {
         limitedItems.push(item);
       }
     }
@@ -467,7 +551,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     if (items) {
       // Ensure typeahead works on a closed list.
       labelsRef.current = flatFilteredItems.map((item) =>
-        stringifyAsLabel(item, itemToStringLabel),
+        stringifyAsLabel(item, itemToStringForItem),
       );
     } else {
       store.set('forceMounted', true);
@@ -788,18 +872,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         return;
       }
 
-      const findSelectedIndex = (value: any) => {
-        if (!items) {
-          return findItemIndex(allValuesRef.current, value, isItemEqualToValue);
-        }
-
-        if (getValueFromItem) {
-          return findItemIndex(flatItems, value, isItemEqualToValue, getValueFromItem);
-        }
-
-        return findItemIndex(flatItems, value, isItemEqualToValue);
-      };
-
       if (multiple) {
         const currentValue = Array.isArray(selectedValue) ? selectedValue : [];
         const lastValue = currentValue[currentValue.length - 1];
@@ -815,22 +887,30 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       selectedValue,
       items,
       selectionMode,
-      flatItems,
       multiple,
-      isItemEqualToValue,
-      getValueFromItem,
       setIndices,
+      flatItemValues,
+      isItemEqualToValue,
+      selectedValueLookup,
     ],
   );
 
+  const flatFilteredItemValues: readonly any[] = React.useMemo(() => {
+    if (!hasItems) {
+      return EMPTY_ARRAY;
+    }
+
+    return getValueFromItem
+      ? flatFilteredItems.map((item) => getValueFromItem(item))
+      : flatFilteredItems;
+  }, [flatFilteredItems, getValueFromItem, hasItems]);
+
   useIsoLayoutEffect(() => {
     if (items) {
-      valuesRef.current = getValueFromItem
-        ? flatFilteredItems.map((item) => getValueFromItem(item))
-        : (flatFilteredItems as Value[]);
+      valuesRef.current = flatFilteredItemValues as Value[];
       listRef.current.length = flatFilteredItems.length;
     }
-  }, [items, flatFilteredItems, getValueFromItem]);
+  }, [flatFilteredItemValues, flatFilteredItems.length, items]);
 
   useIsoLayoutEffect(() => {
     const pendingHighlight = pendingQueryHighlightRef.current;
@@ -850,7 +930,11 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     }
 
     const shouldUseFlatFilteredItems = hasItems || hasFilteredItemsProp;
-    const candidateItems = shouldUseFlatFilteredItems ? flatFilteredItems : valuesRef.current;
+    const candidateItems = shouldUseFlatFilteredItems
+      ? hasItems
+        ? flatFilteredItemValues
+        : flatFilteredItems
+      : valuesRef.current;
     const storeActiveIndex = store.state.activeIndex;
 
     if (storeActiveIndex == null) {
@@ -880,11 +964,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       return;
     }
 
-    let itemValue = candidateItems[storeActiveIndex];
-    if (shouldUseFlatFilteredItems) {
-      const candidateItem = flatFilteredItems[storeActiveIndex];
-      itemValue = hasItems && getValueFromItem ? getValueFromItem(candidateItem) : candidateItem;
-    }
+    const itemValue = candidateItems[storeActiveIndex];
     const previouslyHighlightedItemValue = lastHighlightRef.current.value;
     const isSameItem =
       previouslyHighlightedItemValue !== NO_ACTIVE_VALUE &&
@@ -907,7 +987,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     hasFilteredItemsProp,
     hasItems,
     flatFilteredItems,
-    getValueFromItem,
+    flatFilteredItemValues,
     inline,
     open,
     store,

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -167,6 +167,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   const single = selectionMode === 'single';
   const hasInputValue = inputValueProp !== undefined || defaultInputValueProp !== undefined;
   const hasItems = items !== undefined;
+  const hasMappedItems = hasItems && getValueFromItem !== undefined;
   const hasFilteredItemsProp = filteredItemsProp !== undefined;
   const isGrouped = isGroupedItems(items);
 
@@ -203,15 +204,15 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   }, [getValueFromItem, itemToStringLabel]);
 
   const flatItemValues: readonly any[] = React.useMemo(() => {
-    if (!hasItems) {
+    if (!hasMappedItems) {
       return EMPTY_ARRAY;
     }
 
-    return getValueFromItem ? flatItems.map((item) => getValueFromItem(item)) : flatItems;
-  }, [flatItems, getValueFromItem, hasItems]);
+    return flatItems.map((item) => getValueFromItem(item));
+  }, [flatItems, getValueFromItem, hasMappedItems]);
 
   const selectedValueToIndex = React.useMemo(() => {
-    if (!hasItems || isItemEqualToValue !== defaultItemEquality) {
+    if (!hasMappedItems || isItemEqualToValue !== defaultItemEquality) {
       return null;
     }
 
@@ -226,7 +227,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     });
 
     return valueToIndex;
-  }, [flatItemValues, hasItems, isItemEqualToValue]);
+  }, [flatItemValues, hasMappedItems, isItemEqualToValue]);
 
   function resolveSelectedLabelAsString(
     value: any,
@@ -251,16 +252,20 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         return findItemIndex(allValuesRef.current, value, isItemEqualToValue);
       }
 
+      if (!hasMappedItems) {
+        return findItemIndex(flatItems, value, isItemEqualToValue);
+      }
+
       return (
         selectedValueToIndex?.get(value) ?? findItemIndex(flatItemValues, value, isItemEqualToValue)
       );
     },
-    [flatItemValues, hasItems, isItemEqualToValue, selectedValueToIndex],
+    [flatItemValues, flatItems, hasItems, hasMappedItems, isItemEqualToValue, selectedValueToIndex],
   );
 
   function resolveSelectedInputLabel(value: any): string {
-    if (!getValueFromItem || !hasItems) {
-      return resolveSelectedLabelAsString(value, itemToStringLabel);
+    if (!hasMappedItems) {
+      return stringifyAsLabel(value, itemToStringLabel);
     }
 
     const index = findSelectedIndex(value);

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -243,18 +243,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     return index === -1 ? undefined : flatItems[index];
   }
 
-  function findSelectedIndex(value: any): number {
-    if (!items) {
-      return findItemIndex(allValuesRef.current, value, isItemEqualToValue);
-    }
-
-    if (selectedValueLookup) {
-      return selectedValueLookup.indexByValue.get(value) ?? -1;
-    }
-
-    return findItemIndex(flatItemValues, value, isItemEqualToValue);
-  }
-
   function resolveSelectedInputLabel(value: any): string {
     if (!getValueFromItem || !hasItems) {
       return resolveSelectedLabelString(value, items, itemToStringLabel);
@@ -432,7 +420,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     filterQuery,
     limit,
     filter,
-    itemToStringLabel,
     flatItems,
   ]);
 
@@ -872,6 +859,18 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         return;
       }
 
+      const findSelectedIndex = (value: any) => {
+        if (!items) {
+          return findItemIndex(allValuesRef.current, value, isItemEqualToValue);
+        }
+
+        if (selectedValueLookup) {
+          return selectedValueLookup.indexByValue.get(value) ?? -1;
+        }
+
+        return findItemIndex(flatItemValues, value, isItemEqualToValue);
+      };
+
       if (multiple) {
         const currentValue = Array.isArray(selectedValue) ? selectedValue : [];
         const lastValue = currentValue[currentValue.length - 1];
@@ -930,11 +929,10 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     }
 
     const shouldUseFlatFilteredItems = hasItems || hasFilteredItemsProp;
-    const candidateItems = shouldUseFlatFilteredItems
-      ? hasItems
-        ? flatFilteredItemValues
-        : flatFilteredItems
-      : valuesRef.current;
+    let candidateItems = valuesRef.current;
+    if (shouldUseFlatFilteredItems) {
+      candidateItems = hasItems ? flatFilteredItemValues : flatFilteredItems;
+    }
     const storeActiveIndex = store.state.activeIndex;
 
     if (storeActiveIndex == null) {

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -46,7 +46,7 @@ import { HTMLProps } from '../../utils/types';
 import { useValueChanged } from '../../utils/useValueChanged';
 import { NOOP } from '../../utils/noop';
 import {
-  resolveSelectedLabelString,
+  resolveSelectedLabel,
   stringifyAsLabel,
   stringifyAsValue,
   Group,
@@ -210,57 +210,71 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     return getValueFromItem ? flatItems.map((item) => getValueFromItem(item)) : flatItems;
   }, [flatItems, getValueFromItem, hasItems]);
 
-  const selectedValueLookup = React.useMemo(() => {
+  const selectedValueToIndex = React.useMemo(() => {
     if (!hasItems || isItemEqualToValue !== defaultItemEquality) {
       return null;
     }
 
-    const itemByValue = new Map<any, any>();
-    const indexByValue = new Map<any, number>();
+    const valueToIndex = new Map<any, number>();
 
     flatItemValues.forEach((itemValue, index) => {
-      if (itemValue === undefined || itemByValue.has(itemValue)) {
+      if (itemValue === undefined || valueToIndex.has(itemValue)) {
         return;
       }
 
-      itemByValue.set(itemValue, flatItems[index]);
-      indexByValue.set(itemValue, index);
+      valueToIndex.set(itemValue, index);
     });
 
-    return { itemByValue, indexByValue };
-  }, [flatItems, flatItemValues, hasItems, isItemEqualToValue]);
+    return valueToIndex;
+  }, [flatItemValues, hasItems, isItemEqualToValue]);
 
-  function findMatchingItem(value: any) {
-    if (!hasItems) {
-      return undefined;
+  function resolveSelectedLabelAsString(
+    value: any,
+    selectedItemToStringLabel?: (item: any) => string,
+  ): string {
+    const label = resolveSelectedLabel(value, items, selectedItemToStringLabel);
+
+    if (label == null || typeof label === 'boolean') {
+      return '';
     }
 
-    if (selectedValueLookup) {
-      return selectedValueLookup.itemByValue.get(value);
+    if (typeof label === 'string' || typeof label === 'number') {
+      return String(label);
     }
 
-    const index = findItemIndex(flatItemValues, value, isItemEqualToValue);
-    return index === -1 ? undefined : flatItems[index];
+    return stringifyAsLabel(value);
   }
+
+  const findSelectedIndex = React.useCallback(
+    (value: any) => {
+      if (!hasItems) {
+        return findItemIndex(allValuesRef.current, value, isItemEqualToValue);
+      }
+
+      return (
+        selectedValueToIndex?.get(value) ?? findItemIndex(flatItemValues, value, isItemEqualToValue)
+      );
+    },
+    [flatItemValues, hasItems, isItemEqualToValue, selectedValueToIndex],
+  );
 
   function resolveSelectedInputLabel(value: any): string {
     if (!getValueFromItem || !hasItems) {
-      return resolveSelectedLabelString(value, items, itemToStringLabel);
+      return resolveSelectedLabelAsString(value, itemToStringLabel);
     }
 
-    const matchingItem = findMatchingItem(value);
+    const index = findSelectedIndex(value);
 
-    if (matchingItem !== undefined) {
+    if (index !== -1) {
       if (itemToStringLabel && value != null) {
         return itemToStringLabel(value) ?? '';
       }
 
-      return stringifyAsLabel(matchingItem, itemToStringForItem);
+      return stringifyAsLabel(flatItems[index], itemToStringForItem);
     }
 
-    return resolveSelectedLabelString(
+    return resolveSelectedLabelAsString(
       value,
-      items,
       value && typeof value === 'object' ? itemToStringLabel : undefined,
     );
   }
@@ -859,57 +873,26 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         return;
       }
 
-      const findSelectedIndex = (value: any) => {
-        if (!items) {
-          return findItemIndex(allValuesRef.current, value, isItemEqualToValue);
-        }
+      const currentValue = Array.isArray(selectedValue) ? selectedValue : [];
+      const nextSelectedIndex = multiple
+        ? findSelectedIndex(currentValue[currentValue.length - 1])
+        : findSelectedIndex(selectedValue);
 
-        if (selectedValueLookup) {
-          return selectedValueLookup.indexByValue.get(value) ?? -1;
-        }
-
-        return findItemIndex(flatItemValues, value, isItemEqualToValue);
-      };
-
-      if (multiple) {
-        const currentValue = Array.isArray(selectedValue) ? selectedValue : [];
-        const lastValue = currentValue[currentValue.length - 1];
-        const lastIndex = findSelectedIndex(lastValue);
-        setIndices({ selectedIndex: lastIndex === -1 ? null : lastIndex });
-      } else {
-        const index = findSelectedIndex(selectedValue);
-        setIndices({ selectedIndex: index === -1 ? null : index });
-      }
+      setIndices({ selectedIndex: nextSelectedIndex === -1 ? null : nextSelectedIndex });
     },
-    [
-      open,
-      selectedValue,
-      items,
-      selectionMode,
-      multiple,
-      setIndices,
-      flatItemValues,
-      isItemEqualToValue,
-      selectedValueLookup,
-    ],
+    [findSelectedIndex, multiple, open, selectedValue, selectionMode, setIndices],
   );
-
-  const flatFilteredItemValues: readonly any[] = React.useMemo(() => {
-    if (!hasItems) {
-      return EMPTY_ARRAY;
-    }
-
-    return getValueFromItem
-      ? flatFilteredItems.map((item) => getValueFromItem(item))
-      : flatFilteredItems;
-  }, [flatFilteredItems, getValueFromItem, hasItems]);
 
   useIsoLayoutEffect(() => {
     if (items) {
-      valuesRef.current = flatFilteredItemValues as Value[];
+      valuesRef.current = (
+        getValueFromItem
+          ? flatFilteredItems.map((item) => getValueFromItem(item))
+          : flatFilteredItems
+      ) as Value[];
       listRef.current.length = flatFilteredItems.length;
     }
-  }, [flatFilteredItemValues, flatFilteredItems.length, items]);
+  }, [flatFilteredItems, getValueFromItem, items]);
 
   useIsoLayoutEffect(() => {
     const pendingHighlight = pendingQueryHighlightRef.current;
@@ -928,11 +911,8 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       return;
     }
 
-    const shouldUseFlatFilteredItems = hasItems || hasFilteredItemsProp;
-    let candidateItems = valuesRef.current;
-    if (shouldUseFlatFilteredItems) {
-      candidateItems = hasItems ? flatFilteredItemValues : flatFilteredItems;
-    }
+    const candidateItems =
+      hasItems || !hasFilteredItemsProp ? valuesRef.current : flatFilteredItems;
     const storeActiveIndex = store.state.activeIndex;
 
     if (storeActiveIndex == null) {
@@ -985,7 +965,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     hasFilteredItemsProp,
     hasItems,
     flatFilteredItems,
-    flatFilteredItemValues,
     inline,
     open,
     store,

--- a/packages/react/src/combobox/root/ComboboxRoot.spec.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.spec.tsx
@@ -14,6 +14,12 @@ const objectItemsReadonly = [
   { value: 'c', label: 'cherry' },
 ] as const;
 
+const numberObjectItems = [
+  { value: 1, label: 'one' },
+  { value: 2, label: 'two' },
+  { value: 3, label: 'three' },
+] as const;
+
 const groupItemsReadonly = [
   {
     value: 'fruits',
@@ -60,6 +66,7 @@ const groupItemsReadonly = [
 <Combobox.Root
   items={objectItems}
   defaultValue="a"
+  getValueFromItem={(item) => item.value}
   onValueChange={(value) => {
     // @ts-expect-error - possibly null
     value.startsWith('a');
@@ -70,6 +77,7 @@ const groupItemsReadonly = [
 <Combobox.Root
   items={objectItemsReadonly}
   defaultValue="a"
+  getValueFromItem={(item) => item.value}
   onValueChange={(value) => {
     // @ts-expect-error - possibly null
     value.startsWith('a');
@@ -80,6 +88,7 @@ const groupItemsReadonly = [
 <Combobox.Root
   items={objectItems}
   value="a"
+  getValueFromItem={(item) => item.value}
   onValueChange={(value) => {
     // @ts-expect-error - possibly null
     value.startsWith('a');
@@ -93,6 +102,90 @@ const groupItemsReadonly = [
     // @ts-expect-error - possibly null
     value.label;
   }}
+/>;
+
+// @ts-expect-error - primitive selected values with object items require `getValueFromItem`
+<Combobox.Root items={objectItems} defaultValue="a" />;
+
+// @ts-expect-error - primitive selected values with object items require `getValueFromItem`
+<Combobox.Root items={objectItems} value="a" />;
+
+// @ts-expect-error - primitive selected values with object items require `getValueFromItem`
+<Combobox.Root items={numberObjectItems} defaultValue={1} />;
+
+// @ts-expect-error - primitive selected values with object items require `getValueFromItem`
+<Combobox.Root items={numberObjectItems} value={1} />;
+
+<Combobox.Root
+  items={objectItems}
+  defaultValue="a"
+  getValueFromItem={(item) => {
+    // @ts-expect-error
+    item.nonexistent;
+    return item.value;
+  }}
+  onValueChange={(value) => {
+    value?.startsWith('a');
+  }}
+/>;
+
+<Combobox.Root
+  items={objectItemsReadonly}
+  value="a"
+  getValueFromItem={(item) => item.value}
+  onValueChange={(value) => {
+    value?.startsWith('a');
+  }}
+/>;
+
+<Combobox.Root
+  items={numberObjectItems}
+  defaultValue={1}
+  getValueFromItem={(item) => item.value}
+  onValueChange={(value) => {
+    value?.toFixed(2);
+    // @ts-expect-error
+    value?.toUpperCase();
+  }}
+/>;
+
+<Combobox.Root
+  items={objectItems}
+  defaultValue={['a', 'b']}
+  multiple
+  getValueFromItem={(item) => item.value}
+  onValueChange={(value) => {
+    value.pop();
+    // @ts-expect-error
+    value.startsWith('a');
+  }}
+/>;
+
+type ObjectItem = (typeof objectItems)[number];
+
+const stringItemToValue: NonNullable<
+  Combobox.Root.Props<string, false, readonly ObjectItem[]>['getValueFromItem']
+> = (item) => {
+  return item.value;
+};
+
+// @ts-expect-error - getValueFromItem must return the selected value type
+const invalidStringItemToValue: NonNullable<
+  Combobox.Root.Props<string, false, readonly ObjectItem[]>['getValueFromItem']
+> = (_item) => {
+  return 123;
+};
+
+<Combobox.Root<string, false, readonly ObjectItem[]>
+  items={objectItems}
+  defaultValue="a"
+  getValueFromItem={stringItemToValue}
+/>;
+
+<Combobox.Root
+  items={groupItemsReadonly}
+  defaultValue="a"
+  getValueFromItem={(item) => item.value}
 />;
 
 <Combobox.Root
@@ -277,3 +370,145 @@ export function Wrapper<Value, Multiple extends boolean | undefined = false>(
 ) {
   return <Combobox.Root {...props} />;
 }
+
+type OptionData = Record<string, any> | any[] | string | boolean | number | null | undefined;
+
+type Option<TData extends OptionData = any> = {
+  value: string | number;
+  label: string;
+  data?: TData;
+};
+
+type GroupedOptions<TData extends OptionData = any> = {
+  title?: React.ReactNode;
+  items: Option<TData>[];
+}[];
+
+const groupedOptions: GroupedOptions = [
+  { title: 'Fruits', items: objectItems },
+  { title: 'Other', items: objectItems },
+];
+
+interface SelectProps<
+  Data extends OptionData = any,
+  Multiple extends boolean | undefined = false,
+> extends Omit<
+  Combobox.Root.Props<Option['value'], Multiple>,
+  'isItemEqualToValue' | 'getValueFromItem' | 'items' | 'children'
+> {
+  items: Option<Data>[] | GroupedOptions<Data>;
+}
+
+function Select<Data extends OptionData, Multiple extends boolean | undefined = false>({
+  items,
+  ...rest
+}: SelectProps<Data, Multiple>) {
+  return <Combobox.Root items={items} getValueFromItem={(item) => item.value} {...rest} />;
+}
+
+<Select items={objectItems} />;
+
+<Select items={groupedOptions} />;
+
+type Primitive = string | number;
+
+type RootGetValueFromItem<Item, Value extends Primitive> = NonNullable<
+  Combobox.Root.Props<Value, false, readonly Item[]>['getValueFromItem']
+>;
+
+function asRootGetValueFromItem<Item, Value extends Primitive>(
+  getItemValue: (item: Item) => Value,
+): RootGetValueFromItem<Item, Value> {
+  return getItemValue as RootGetValueFromItem<Item, Value>;
+}
+
+type ValueObjectComboboxProps<Item, Value extends Primitive> = Omit<
+  Combobox.Root.Props<Value, false, readonly Item[]>,
+  'items' | 'children' | 'getValueFromItem' | 'itemToStringLabel'
+> & {
+  items: readonly Item[];
+  getItemValue: (item: Item) => Value;
+  getItemLabel: (item: Item) => string;
+  renderItem?: (item: Item) => React.ReactNode;
+};
+
+function ValueObjectCombobox<Item, Value extends Primitive>({
+  items,
+  getItemValue,
+  getItemLabel,
+  renderItem,
+  ...rootProps
+}: ValueObjectComboboxProps<Item, Value>) {
+  const rootGetValueFromItem = asRootGetValueFromItem(getItemValue);
+
+  return (
+    <Combobox.Root<Value, false, readonly Item[]>
+      {...rootProps}
+      items={items}
+      getValueFromItem={rootGetValueFromItem}
+      itemToStringLabel={(value) => {
+        const matchingItem = items.find((item) => Object.is(getItemValue(item), value));
+        return matchingItem ? getItemLabel(matchingItem) : String(value);
+      }}
+    >
+      <Combobox.Input />
+      <Combobox.Portal>
+        <Combobox.Positioner>
+          <Combobox.Popup>
+            <Combobox.List>
+              {(item) => {
+                const value = getItemValue(item);
+                return (
+                  <Combobox.Item key={value} value={value}>
+                    {renderItem?.(item) ?? getItemLabel(item)}
+                  </Combobox.Item>
+                );
+              }}
+            </Combobox.List>
+          </Combobox.Popup>
+        </Combobox.Positioner>
+      </Combobox.Portal>
+    </Combobox.Root>
+  );
+}
+
+<ValueObjectCombobox
+  items={objectItems}
+  getItemValue={(item) => item.value}
+  getItemLabel={(item) => item.label}
+  defaultValue={objectItems[0].value}
+  onValueChange={(value) => {
+    value?.startsWith('a');
+    // @ts-expect-error - possibly null
+    value.startsWith('a');
+  }}
+/>;
+
+<ValueObjectCombobox
+  items={numberObjectItems}
+  getItemValue={(item): number => item.value}
+  getItemLabel={(item) => item.label}
+  value={1}
+  onValueChange={(value) => {
+    value?.toFixed(1);
+    // @ts-expect-error - number value
+    value?.startsWith('1');
+  }}
+/>;
+
+const peopleItems = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+] as const;
+
+<ValueObjectCombobox
+  items={peopleItems}
+  getItemValue={(item): number => item.id}
+  getItemLabel={(item) => item.name}
+  defaultValue={1}
+  onValueChange={(value) => {
+    value?.toFixed(1);
+    // @ts-expect-error - number value
+    value?.startsWith('1');
+  }}
+/>;

--- a/packages/react/src/combobox/root/ComboboxRoot.spec.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.spec.tsx
@@ -190,6 +190,28 @@ const invalidStringItemToValue: NonNullable<
 
 <Combobox.Root
   items={objectItems}
+  defaultValue="a"
+  getValueFromItem={(item) => item.value}
+  filter={(item, query, itemToString) => {
+    item.label;
+    // @ts-expect-error - item is the raw item shape when `items` are provided
+    item.toUpperCase();
+    return itemToString?.(item)?.startsWith(query) ?? false;
+  }}
+/>;
+
+<Combobox.Root
+  defaultValue="a"
+  filter={(item, query, itemToString) => {
+    item.toUpperCase();
+    // @ts-expect-error - primitive values do not expose item fields
+    item.label;
+    return itemToString?.(item)?.startsWith(query) ?? false;
+  }}
+/>;
+
+<Combobox.Root
+  items={objectItems}
   defaultValue={objectItems[0]}
   itemToStringLabel={(item) => {
     return item.label;
@@ -393,7 +415,7 @@ interface SelectProps<
   Data extends OptionData = any,
   Multiple extends boolean | undefined = false,
 > extends Omit<
-  Combobox.Root.Props<Option['value'], Multiple>,
+  Combobox.Root.Props<Option['value'], Multiple, Option<Data>[] | GroupedOptions<Data>>,
   'isItemEqualToValue' | 'getValueFromItem' | 'items' | 'children'
 > {
   items: Option<Data>[] | GroupedOptions<Data>;

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -5797,6 +5797,20 @@ describe('<Combobox.Root />', () => {
       },
     ];
 
+    interface PersonItem {
+      id: string;
+      name: string;
+    }
+
+    const personItems: PersonItem[] = [
+      { id: 'alice', name: 'Alice' },
+      { id: 'bob', name: 'Bob' },
+      { id: 'charlie', name: 'Charlie' },
+    ];
+
+    const getPersonLabel = (value: string) =>
+      personItems.find((item) => item.id === value)?.name ?? value;
+
     it('derives input value from matching item label on first mount (single)', async () => {
       await render(
         <Combobox.Root items={items} defaultValue="banana" getValueFromItem={(item) => item.value}>
@@ -5955,6 +5969,120 @@ describe('<Combobox.Root />', () => {
       });
 
       expect(onValueChange.lastCall.args[0]).to.equal('banana');
+    });
+
+    it('filters non-default item shapes using labels derived from mapped primitive values', async () => {
+      const { user } = await render(
+        <Combobox.Root
+          items={personItems}
+          getValueFromItem={(item) => item.id}
+          itemToStringLabel={getPersonLabel}
+        >
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: PersonItem) => (
+                    <Combobox.Item key={item.id} value={item.id}>
+                      {item.name}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('Bo');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: 'Bob' })).not.to.equal(null);
+      });
+
+      expect(screen.queryByRole('option', { name: 'Alice' })).to.equal(null);
+      expect(screen.queryByRole('option', { name: 'Charlie' })).to.equal(null);
+    });
+
+    it('passes derived item labels to custom filter functions when getValueFromItem is set', async () => {
+      const { user } = await render(
+        <Combobox.Root
+          items={personItems}
+          getValueFromItem={(item) => item.id}
+          itemToStringLabel={getPersonLabel}
+          filter={(item, query, itemToString) =>
+            itemToString?.(item)?.toLowerCase().includes(query.toLowerCase()) ?? false
+          }
+        >
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: PersonItem) => (
+                    <Combobox.Item key={item.id} value={item.id}>
+                      {item.name}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('Bo');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: 'Bob' })).not.to.equal(null);
+      });
+
+      expect(screen.queryByRole('option', { name: 'Alice' })).to.equal(null);
+      expect(screen.queryByRole('option', { name: 'Charlie' })).to.equal(null);
+    });
+
+    it('uses derived item labels in closed trigger typeahead for non-default item shapes', async () => {
+      const onValueChange = spy();
+      const { user } = await render(
+        <Combobox.Root
+          items={personItems}
+          getValueFromItem={(item) => item.id}
+          itemToStringLabel={getPersonLabel}
+          onValueChange={onValueChange}
+        >
+          <Combobox.Trigger data-testid="people-trigger">
+            <Combobox.Value />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: PersonItem) => (
+                    <Combobox.Item key={item.id} value={item.id}>
+                      {item.name}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('people-trigger');
+      await act(async () => {
+        trigger.focus();
+      });
+      await user.keyboard('b');
+
+      await waitFor(() => {
+        expect(onValueChange.callCount).to.be.greaterThan(0);
+      });
+
+      expect(onValueChange.lastCall.args[0]).to.equal('bob');
     });
 
     it('normalizes clicked object item values through getValueFromItem', async () => {

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -5778,6 +5778,398 @@ describe('<Combobox.Root />', () => {
     });
   });
 
+  describe('primitive string values with object items', () => {
+    interface FruitItem {
+      value: string;
+      label: string;
+    }
+
+    const items: FruitItem[] = [
+      { value: 'apple', label: 'Apple' },
+      { value: 'banana', label: 'Banana' },
+      { value: 'cherry', label: 'Cherry' },
+    ];
+
+    const groupedItems = [
+      {
+        value: 'fruits',
+        items,
+      },
+    ];
+
+    it('derives input value from matching item label on first mount (single)', async () => {
+      await render(
+        <Combobox.Root items={items} defaultValue="banana" getValueFromItem={(item) => item.value}>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: FruitItem) => (
+                    <Combobox.Item key={item.value} value={item.value}>
+                      {item.label}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByRole('combobox')).to.have.value('Banana');
+    });
+
+    it('derives input value from matching grouped item label on first mount (single)', async () => {
+      await render(
+        <Combobox.Root
+          items={groupedItems}
+          defaultValue="banana"
+          getValueFromItem={(item) => item.value}
+        >
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Group items={groupedItems[0].items}>
+                    <Combobox.Collection>
+                      {(item: FruitItem) => (
+                        <Combobox.Item key={item.value} value={item.value}>
+                          {item.label}
+                        </Combobox.Item>
+                      )}
+                    </Combobox.Collection>
+                  </Combobox.Group>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByRole('combobox')).to.have.value('Banana');
+    });
+
+    it('syncs selectedIndex for primitive string selected value when closed', async () => {
+      await render(
+        <Combobox.Root items={items} defaultValue="banana" getValueFromItem={(item) => item.value}>
+          <SelectedIndexProbe />
+        </Combobox.Root>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('selected-index')).to.have.text('1');
+      });
+    });
+
+    it('syncs selectedIndex for primitive string selected values in multiple mode when closed', async () => {
+      await render(
+        <Combobox.Root
+          items={items}
+          multiple
+          defaultValue={['apple', 'banana']}
+          getValueFromItem={(item) => item.value}
+        >
+          <SelectedIndexProbe />
+        </Combobox.Root>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('selected-index')).to.have.text('1');
+      });
+    });
+
+    it('emits primitive highlighted values when navigating with keyboard', async () => {
+      const onItemHighlighted = spy();
+      const { user } = await render(
+        <Combobox.Root
+          items={items}
+          defaultOpen
+          getValueFromItem={(item) => item.value}
+          onItemHighlighted={onItemHighlighted}
+        >
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: FruitItem) => (
+                    <Combobox.Item key={item.value} value={item.value}>
+                      {item.label}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(onItemHighlighted.callCount).to.be.greaterThan(0);
+      });
+
+      expect(onItemHighlighted.lastCall.args[0]).to.equal('apple');
+    });
+
+    it('uses primitive item values in closed trigger typeahead selection', async () => {
+      const onValueChange = spy();
+      const { user } = await render(
+        <Combobox.Root
+          items={items}
+          getValueFromItem={(item) => item.value}
+          onValueChange={onValueChange}
+        >
+          <Combobox.Trigger data-testid="trigger">
+            <Combobox.Value />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: FruitItem) => (
+                    <Combobox.Item key={item.value} value={item.value}>
+                      {item.label}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      await act(async () => {
+        trigger.focus();
+      });
+      await user.keyboard('b');
+
+      await waitFor(() => {
+        expect(onValueChange.callCount).to.be.greaterThan(0);
+      });
+
+      expect(onValueChange.lastCall.args[0]).to.equal('banana');
+    });
+
+    it('normalizes clicked object item values through getValueFromItem', async () => {
+      const onValueChange = spy();
+      const { user } = await render(
+        <Combobox.Root
+          items={items}
+          getValueFromItem={(item) => item.value}
+          onValueChange={onValueChange}
+        >
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: FruitItem) => (
+                    <Combobox.Item key={item.value} value={item}>
+                      {item.label}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByRole('option', { name: 'Banana' }));
+
+      await waitFor(() => {
+        expect(onValueChange.callCount).to.be.greaterThan(0);
+      });
+
+      expect(onValueChange.lastCall.args[0]).to.equal('banana');
+    });
+
+    it('normalizes clicked object item values without coupling to item index order', async () => {
+      const onValueChange = spy();
+      const renderedItems = [...items].reverse();
+      const { user } = await render(
+        <Combobox.Root
+          items={items}
+          getValueFromItem={(item) => item.value}
+          onValueChange={onValueChange}
+        >
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {renderedItems.map((item) => (
+                    <Combobox.Item key={item.value} value={item}>
+                      {item.label}
+                    </Combobox.Item>
+                  ))}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByRole('option', { name: 'Apple' }));
+
+      await waitFor(() => {
+        expect(onValueChange.callCount).to.be.greaterThan(0);
+      });
+
+      expect(onValueChange.lastCall.args[0]).to.equal('apple');
+    });
+
+    it('updates derived input label when item labels change for a controlled primitive string value', async () => {
+      const initialItems = [
+        { value: 'apple', label: 'Apple' },
+        { value: 'banana', label: 'Banana' },
+      ];
+
+      const nextItems = [
+        { value: 'apple', label: 'Apricot' },
+        { value: 'banana', label: 'Blue Java Banana' },
+      ];
+
+      function App() {
+        const [list, setList] = React.useState(initialItems);
+
+        return (
+          <div>
+            <button onClick={() => setList(nextItems)}>update</button>
+            <Combobox.Root items={list} value="banana" getValueFromItem={(item) => item.value}>
+              <Combobox.Input />
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.List>
+                      {(item: FruitItem) => (
+                        <Combobox.Item key={item.value} value={item.value}>
+                          {item.label}
+                        </Combobox.Item>
+                      )}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      expect(input).to.have.value('Banana');
+
+      await user.click(screen.getByRole('button', { name: 'update' }));
+      expect(input).to.have.value('Blue Java Banana');
+    });
+
+    it('calls itemToStringLabel with the selected primitive when an item matches', async () => {
+      await render(
+        <Combobox.Root
+          items={items}
+          defaultValue="banana"
+          getValueFromItem={(item) => item.value}
+          itemToStringLabel={(value) => value.toUpperCase()}
+        >
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: FruitItem) => (
+                    <Combobox.Item key={item.value} value={item.value}>
+                      {item.label}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByRole('combobox')).to.have.value('BANANA');
+    });
+
+    it('does not call itemToStringLabel with selected primitives when no item matches', async () => {
+      const itemToStringLabel = spy((value: string) => value.toUpperCase());
+
+      await render(
+        <Combobox.Root
+          items={items}
+          defaultValue="durian"
+          getValueFromItem={(item) => item.value}
+          itemToStringLabel={itemToStringLabel}
+        >
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: FruitItem) => (
+                    <Combobox.Item key={item.value} value={item.value}>
+                      {item.label}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(itemToStringLabel.callCount).to.equal(0);
+      expect(screen.getByRole('combobox')).to.have.value('durian');
+    });
+  });
+
+  describe('primitive number values with object items', () => {
+    interface NumberItem {
+      value: number;
+      label: string;
+    }
+
+    const items: NumberItem[] = [
+      { value: 1, label: 'One' },
+      { value: 2, label: 'Two' },
+      { value: 3, label: 'Three' },
+    ];
+
+    it('derives input value from matching item label on first mount (single)', async () => {
+      await render(
+        <Combobox.Root items={items} defaultValue={2} getValueFromItem={(item) => item.value}>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: NumberItem) => (
+                    <Combobox.Item key={item.value} value={item.value}>
+                      {item.label}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByRole('combobox')).to.have.value('Two');
+    });
+  });
+
   describe('prop: loopFocus', () => {
     it('loops focus from last to first item with ArrowDown by default', async () => {
       const { user } = await render(

--- a/packages/react/src/combobox/root/ComboboxRoot.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import { AriaCombobox, type AriaComboboxState } from './AriaCombobox';
+import type { Group } from '../../utils/resolveValueLabel';
 
 /**
  * Groups all parts of the combobox.
@@ -8,9 +9,14 @@ import { AriaCombobox, type AriaComboboxState } from './AriaCombobox';
  *
  * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
  */
-export function ComboboxRoot<Value, Multiple extends boolean | undefined = false>(
-  props: ComboboxRoot.Props<Value, Multiple>,
-): React.JSX.Element {
+export function ComboboxRoot<
+  Value,
+  Multiple extends boolean | undefined = false,
+  Items extends readonly any[] | readonly Group<any>[] | undefined =
+    | readonly Value[]
+    | readonly Group<Value>[]
+    | undefined,
+>(props: ComboboxRoot.Props<Value, Multiple, Items>): React.JSX.Element {
   const {
     multiple = false as Multiple,
     defaultValue,
@@ -40,7 +46,74 @@ type ComboboxValueType<Value, Multiple extends boolean | undefined> = Multiple e
   ? Value[]
   : Value;
 
-export type ComboboxRootProps<Value, Multiple extends boolean | undefined = false> = Omit<
+type ItemFromItemsProp<Items extends readonly any[] | readonly Group<any>[] | undefined> =
+  Items extends readonly (infer Item)[]
+    ? Item extends { items: readonly (infer GroupItem)[] }
+      ? GroupItem
+      : Item extends { items: (infer GroupItem)[] }
+        ? GroupItem
+        : Item
+    : never;
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+type IsUnknown<T> =
+  IsAny<T> extends true
+    ? false
+    : unknown extends T
+      ? [T] extends [unknown]
+        ? true
+        : false
+      : false;
+
+type IsDefaultItemsShape<
+  Value,
+  Items extends readonly any[] | readonly Group<any>[] | undefined,
+> = [Items] extends [readonly Value[] | readonly Group<Value>[] | undefined] ? true : false;
+
+type GetValueFromItemFn<Value, Items extends readonly any[] | readonly Group<any>[] | undefined> = (
+  item: ItemFromItemsProp<NonNullable<Items>>,
+) => Value;
+
+type ShouldRequireGetValueFromItem<
+  Value,
+  Items extends readonly any[] | readonly Group<any>[] | undefined,
+> = [Items] extends [undefined]
+  ? false
+  : IsDefaultItemsShape<Value, Items> extends true
+    ? false
+    : [ItemFromItemsProp<NonNullable<Items>>] extends [never]
+      ? false
+      : IsAny<ItemFromItemsProp<NonNullable<Items>>> extends true
+        ? false
+        : IsUnknown<Value> extends true
+          ? false
+          : [NonNullable<Value>] extends [never]
+            ? false
+            : ItemFromItemsProp<NonNullable<Items>> extends object
+              ? [NonNullable<Value>] extends [ItemFromItemsProp<NonNullable<Items>>]
+                ? false
+                : true
+              : false;
+
+type RequireGetValueFromItemConstraint<
+  Value,
+  Items extends readonly any[] | readonly Group<any>[] | undefined,
+> =
+  ShouldRequireGetValueFromItem<Value, Items> extends true
+    ? {
+        getValueFromItem: GetValueFromItemFn<Value, Items>;
+      }
+    : {};
+
+export type ComboboxRootProps<
+  Value,
+  Multiple extends boolean | undefined = false,
+  Items extends readonly any[] | readonly Group<any>[] | undefined =
+    | readonly Value[]
+    | readonly Group<Value>[]
+    | undefined,
+> = Omit<
   AriaCombobox.Props<Value, ModeFromMultiple<Multiple>>,
   | 'fillInputOnItemPress'
   | 'autoComplete'
@@ -51,6 +124,8 @@ export type ComboboxRootProps<Value, Multiple extends boolean | undefined = fals
   | 'highlightItemOnHover'
   | 'itemToStringLabel'
   | 'itemToStringValue'
+  | 'items'
+  | 'getValueFromItem'
   | 'isItemEqualToValue'
   // Different names
   | 'selectionMode'
@@ -85,6 +160,11 @@ export type ComboboxRootProps<Value, Multiple extends boolean | undefined = fals
    */
   highlightItemOnHover?: boolean | undefined;
   /**
+   * The items to be displayed in the list.
+   * Can be either a flat array of items or an array of groups with items.
+   */
+  items?: Items | undefined;
+  /**
    * When the item values are objects (`<Combobox.Item value={object}>`), this function converts the object value to a string representation for display in the input.
    * If the shape of the object is `{ value, label }`, the label will be used automatically without needing to specify this prop.
    */
@@ -94,6 +174,12 @@ export type ComboboxRootProps<Value, Multiple extends boolean | undefined = fals
    * If the shape of the object is `{ value, label }`, the value will be used automatically without needing to specify this prop.
    */
   itemToStringValue?: ((itemValue: Value) => string) | undefined;
+  /**
+   * Maps each item in the `items` array to the selected value shape.
+   * Useful when `items` are objects while `value` / `defaultValue` are primitive values.
+   * When omitted, the full item is used as the selected value.
+   */
+  getValueFromItem?: GetValueFromItemFn<Value, Items> | undefined;
   /**
    * Custom comparison logic used to determine if a combobox item value matches the current selected value. Useful when item values are objects without matching referentially.
    * Defaults to `Object.is` comparison.
@@ -151,7 +237,7 @@ export type ComboboxRootProps<Value, Multiple extends boolean | undefined = fals
         eventDetails: ComboboxRoot.ChangeEventDetails,
       ) => void)
     | undefined;
-};
+} & RequireGetValueFromItemConstraint<Value, Items>;
 
 export interface ComboboxRootState extends AriaComboboxState {}
 
@@ -164,10 +250,14 @@ export type ComboboxRootHighlightEventReason = AriaCombobox.HighlightEventReason
 export type ComboboxRootHighlightEventDetails = AriaCombobox.HighlightEventDetails;
 
 export namespace ComboboxRoot {
-  export type Props<Value, Multiple extends boolean | undefined = false> = ComboboxRootProps<
+  export type Props<
     Value,
-    Multiple
-  >;
+    Multiple extends boolean | undefined = false,
+    Items extends readonly any[] | readonly Group<any>[] | undefined =
+      | readonly Value[]
+      | readonly Group<Value>[]
+      | undefined,
+  > = ComboboxRootProps<Value, Multiple, Items>;
   export type State = ComboboxRootState;
   export type Actions = ComboboxRootActions;
   export type ChangeEventReason = ComboboxRootChangeEventReason;

--- a/packages/react/src/combobox/root/ComboboxRoot.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.tsx
@@ -47,13 +47,11 @@ type ComboboxValueType<Value, Multiple extends boolean | undefined> = Multiple e
   : Value;
 
 type ItemFromItemsProp<Items extends readonly any[] | readonly Group<any>[] | undefined> =
-  Items extends readonly (infer Item)[]
-    ? Item extends { items: readonly (infer GroupItem)[] }
-      ? GroupItem
-      : Item extends { items: (infer GroupItem)[] }
-        ? GroupItem
-        : Item
-    : never;
+  Items extends readonly Group<infer Item>[]
+    ? Item
+    : Items extends readonly (infer Item)[]
+      ? Item
+      : never;
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
 

--- a/packages/react/src/combobox/root/ComboboxRoot.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.tsx
@@ -75,6 +75,11 @@ type GetValueFromItemFn<Value, Items extends readonly any[] | readonly Group<any
   item: ItemFromItemsProp<NonNullable<Items>>,
 ) => Value;
 
+type FilterItemFromItemsProp<
+  Value,
+  Items extends readonly any[] | readonly Group<any>[] | undefined,
+> = [Items] extends [undefined] ? Value : ItemFromItemsProp<NonNullable<Items>>;
+
 type ShouldRequireGetValueFromItem<
   Value,
   Items extends readonly any[] | readonly Group<any>[] | undefined,
@@ -119,6 +124,7 @@ export type ComboboxRootProps<
   | 'autoComplete'
   | 'formAutoComplete'
   | 'submitOnItemClick'
+  | 'filter'
   | 'autoHighlight'
   | 'keepHighlight'
   | 'highlightItemOnHover'
@@ -164,6 +170,17 @@ export type ComboboxRootProps<
    * Can be either a flat array of items or an array of groups with items.
    */
   items?: Items | undefined;
+  /**
+   * Filter function used to match items vs input query.
+   */
+  filter?:
+    | null
+    | ((
+        itemValue: FilterItemFromItemsProp<Value, Items>,
+        query: string,
+        itemToString?: ((itemValue: FilterItemFromItemsProp<Value, Items>) => string) | undefined,
+      ) => boolean)
+    | undefined;
   /**
    * When the item values are objects (`<Combobox.Item value={object}>`), this function converts the object value to a string representation for display in the input.
    * If the shape of the object is `{ value, label }`, the label will be used automatically without needing to specify this prop.

--- a/packages/react/src/combobox/root/utils/index.ts
+++ b/packages/react/src/combobox/root/utils/index.ts
@@ -28,6 +28,7 @@ export function createSingleSelectionCollatorFilter(
   collatorFilter: Filter,
   itemToStringLabel?: (item: any) => string,
   selectedValue?: any,
+  selectedValueToString?: (selectedValue: any) => string,
 ) {
   return (item: any, query: string) => {
     if (item == null) {
@@ -39,7 +40,9 @@ export function createSingleSelectionCollatorFilter(
 
     const itemString = stringifyAsLabel(item, itemToStringLabel);
     const selectedString =
-      selectedValue != null ? stringifyAsLabel(selectedValue, itemToStringLabel) : '';
+      selectedValue != null
+        ? stringifyAsLabel(selectedValue, selectedValueToString ?? itemToStringLabel)
+        : '';
 
     // Handle case-insensitive matching consistently
     if (

--- a/packages/react/src/combobox/store.ts
+++ b/packages/react/src/combobox/store.ts
@@ -82,6 +82,7 @@ export type State = {
   onOpenChangeComplete: (open: boolean) => void;
   openOnInputClick: boolean;
   itemToStringLabel?: ((item: any) => string) | undefined;
+  getValueFromItem?: ((item: any) => any) | undefined;
   isItemEqualToValue: (itemValue: any, selectedValue: any) => boolean;
   modal: boolean;
   autoHighlight: false | 'always' | 'input-change';
@@ -178,6 +179,7 @@ export const selectors = {
   onOpenChangeComplete: createSelector((state: State) => state.onOpenChangeComplete),
   openOnInputClick: createSelector((state: State) => state.openOnInputClick),
   itemToStringLabel: createSelector((state: State) => state.itemToStringLabel),
+  getValueFromItem: createSelector((state: State) => state.getValueFromItem),
   isItemEqualToValue: createSelector((state: State) => state.isItemEqualToValue),
   modal: createSelector((state: State) => state.modal),
   autoHighlight: createSelector((state: State) => state.autoHighlight),

--- a/packages/react/src/utils/itemEquality.ts
+++ b/packages/react/src/utils/itemEquality.ts
@@ -37,6 +37,18 @@ export function findItemIndex<Item, Value>(
   itemValues: readonly Item[] | undefined | null,
   selectedValue: Value,
   comparer: ItemEqualityComparer<Item, Value>,
+): number;
+export function findItemIndex<Item, Value, Candidate>(
+  itemValues: readonly Item[] | undefined | null,
+  selectedValue: Value,
+  comparer: ItemEqualityComparer<Candidate, Value>,
+  getItemValue: (itemValue: Item) => Candidate,
+): number;
+export function findItemIndex<Item, Value, Candidate = Item>(
+  itemValues: readonly Item[] | undefined | null,
+  selectedValue: Value,
+  comparer: ItemEqualityComparer<Candidate, Value>,
+  getItemValue?: ((itemValue: Item) => Candidate) | undefined,
 ): number {
   if (!itemValues || itemValues.length === 0) {
     return -1;
@@ -45,7 +57,10 @@ export function findItemIndex<Item, Value>(
     if (itemValue === undefined) {
       return false;
     }
-    return compareItemEquality(itemValue, selectedValue, comparer);
+    const candidateValue = getItemValue
+      ? getItemValue(itemValue)
+      : (itemValue as unknown as Candidate);
+    return compareItemEquality(candidateValue, selectedValue, comparer);
   });
 }
 

--- a/packages/react/src/utils/resolveValueLabel.tsx
+++ b/packages/react/src/utils/resolveValueLabel.tsx
@@ -132,6 +132,24 @@ export function resolveSelectedLabel(
   return fallback();
 }
 
+export function resolveSelectedLabelString(
+  value: any,
+  items: ItemsInput,
+  itemToStringLabel?: (item: any) => string,
+): string {
+  const label = resolveSelectedLabel(value, items, itemToStringLabel);
+
+  if (label == null || typeof label === 'boolean') {
+    return '';
+  }
+
+  if (typeof label === 'string' || typeof label === 'number') {
+    return String(label);
+  }
+
+  return stringifyAsLabel(value);
+}
+
 export function resolveMultipleLabels(
   values: any[],
   items: ItemsInput,

--- a/packages/react/src/utils/resolveValueLabel.tsx
+++ b/packages/react/src/utils/resolveValueLabel.tsx
@@ -132,24 +132,6 @@ export function resolveSelectedLabel(
   return fallback();
 }
 
-export function resolveSelectedLabelString(
-  value: any,
-  items: ItemsInput,
-  itemToStringLabel?: (item: any) => string,
-): string {
-  const label = resolveSelectedLabel(value, items, itemToStringLabel);
-
-  if (label == null || typeof label === 'boolean') {
-    return '';
-  }
-
-  if (typeof label === 'string' || typeof label === 'number') {
-    return String(label);
-  }
-
-  return stringifyAsLabel(value);
-}
-
 export function resolveMultipleLabels(
   values: any[],
   items: ItemsInput,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/base-ui/issues/3865
Fixes https://github.com/mui/base-ui/issues/3951
Closes https://github.com/mui/base-ui/issues/3853

Smaller and more flexible alternative to #3954. This explicitly supports object `items` with primitive `value`.

`<Combobox.Root>` needs to know what is passed to `<Combobox.Item value={...}>` — `value` could be a primitive `string` or `number`, or the whole item object (when `items` is an array of objects). This new prop `getValueFromItem` lets it know explicitly.

This can't be inferred automatically except in two cases:

- `{ value, label }` is the shape of the `items` objects
- `defaultValue`/`value` aren't `null`

`getValueFromItem` supports arbitrary object shapes and the initial `null` value.

`<Combobox.Root>` will error if `getValueFromItem` is missing and `value`/`defaultValue` don't match the shape of `items`:

```tsx
// @ts-expect-error - primitive selected values with object items require `getValueFromItem`
<Combobox.Root items={objectItems} defaultValue="a" />;
// @ts-expect-error - primitive selected values with object items require `getValueFromItem`
<Combobox.Root items={objectItems} value="a" />;
// @ts-expect-error - primitive selected values with object items require `getValueFromItem`
<Combobox.Root items={numberObjectItems} defaultValue={1} />;
// @ts-expect-error - primitive selected values with object items require `getValueFromItem`
<Combobox.Root items={numberObjectItems} value={1} />;
```

This does require synchronizing `<Combobox.Item value={...}` and `getValueFromItem` together. I added a wrapper example in the spec file. 

The `getValueFromItem` name is differentiated from the other mappers (`itemToStringValue`, `itemToStringLabel`) as those ones operate on item values, not item objects.

---

Explanation why this is needed:

- `Combobox.Root` owns the selection state and matching logic (`selectedIndex`, highlight, input label), so it must know the **selected value shape** before items are interacted with.
- `items` can be objects, but the selected value can be either:
  - the full object, or
  - a primitive extracted from it (`id`, `value`, etc.).
  Root cannot guess which contract you intend.
- `Combobox.Item value={...}` is not a reliable source for automatic inference at Root level: values can be dynamic, transformed, grouped, virtualized, or rendered in different order.
- In single mode, initial `value/defaultValue` can be `null`, so type/value-shape cannot be inferred from those props at mount time.
- The `{ value, label }` object shape is the only safe convention Base UI can special-case automatically; arbitrary object shapes are not inferable.
- `getValueFromItem` gives Root an explicit mapping from item object -> selected value, so all internal comparisons and label resolution stay consistent.
- It also improves TypeScript correctness: the mapper’s return type defines the selected value type and catches mismatches early.