### PR TITLE
[docs][drawer] Remove next/link from demo

### DIFF
--- a/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/css-modules/index.tsx
@@ -54,9 +54,9 @@ export default function ExampleDrawerMobileNav() {
                         <ul className={styles.List}>
                           {ITEMS.map((item) => (
                             <li key={item.label} className={styles.Item}>
-                              <Link className={styles.Link} href={item.href}>
+                              <a className={styles.Link} href={item.href}>
                                 {item.label}
-                              </Link>
+                              </a>
                             </li>
                           ))}
                         </ul>
@@ -64,9 +64,9 @@ export default function ExampleDrawerMobileNav() {
                         <ul className={styles.LongList} aria-label="Long list">
                           {LONG_LIST.map((item) => (
                             <li key={item.label} className={styles.Item}>
-                              <Link className={styles.Link} href={item.href}>
+                              <a className={styles.Link} href={item.href}>
                                 {item.label}
-                              </Link>
+                              </a>
                             </li>
                           ))}
                         </ul>
@@ -84,9 +84,4 @@ export default function ExampleDrawerMobileNav() {
       </Drawer.Portal>
     </Drawer.Root>
   );
-}
-
-// Replace with your router's Link component
-function Link({ href, ...props }: React.ComponentProps<'a'>) {
-  return <a {...props} href={href} onClick={(event) => event.preventDefault()} />;
 }

--- a/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/tailwind/index.tsx
@@ -66,12 +66,12 @@ export default function ExampleDrawerMobileNav() {
                         <ul className="grid list-none gap-1 p-0 m-0">
                           {ITEMS.map((item) => (
                             <li key={item.label} className="flex">
-                              <Link
+                              <a
                                 className="w-full rounded-xl bg-gray-100 px-4 py-3 text-gray-900 no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-800 focus-visible:-outline-offset-1"
                                 href={item.href}
                               >
                                 {item.label}
-                              </Link>
+                              </a>
                             </li>
                           ))}
                         </ul>
@@ -79,12 +79,12 @@ export default function ExampleDrawerMobileNav() {
                         <ul aria-label="Long list" className="mt-6 grid list-none gap-1 p-0 m-0">
                           {LONG_LIST.map((item) => (
                             <li key={item.label} className="flex">
-                              <Link
+                              <a
                                 className="w-full rounded-xl bg-gray-100 px-4 py-3 text-gray-900 no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-800 focus-visible:-outline-offset-1"
                                 href={item.href}
                               >
                                 {item.label}
-                              </Link>
+                              </a>
                             </li>
                           ))}
                         </ul>
@@ -102,9 +102,4 @@ export default function ExampleDrawerMobileNav() {
       </Drawer.Portal>
     </Drawer.Root>
   );
-}
-
-// Replace with your router's Link component
-function Link({ href, ...props }: React.ComponentProps<'a'>) {
-  return <a {...props} href={href} onClick={(event) => event.preventDefault()} />;
 }


### PR DESCRIPTION
Preview: https://deploy-preview-4115--base-ui.netlify.app/react/components/drawer#mobile-navigation

Using `next/link` in demos makes demos non-runnable outside of the docs (e.g. when opening the demo in Stackblitz, see screenshot below).

<img width="767" height="221" alt="image" src="https://github.com/user-attachments/assets/1efb3a9d-e843-4675-8164-6ca0bcce0d48" />

 