### PR TITLE
[all components] Reset openMethod on close transition

### DIFF
--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -425,11 +425,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   const triggerRef = useValueAsRef(triggerElement);
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
-  const {
-    openMethod,
-    triggerProps,
-    reset: resetOpenInteractionType,
-  } = useOpenInteractionType(open);
+  const { openMethod, triggerProps } = useOpenInteractionType(open);
 
   useField({
     id,
@@ -696,7 +692,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     setMounted(false);
     onOpenChangeComplete?.(false);
     setQueryChangedAfterOpen(false);
-    resetOpenInteractionType();
     setCloseQuery(null);
 
     if (selectionMode === 'none') {

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -24,16 +24,10 @@ export function useDialogRoot(params: useDialogRoot.Parameters): useDialogRoot.R
   const modal = store.useState('modal');
   const popupElement = store.useState('popupElement');
 
-  const {
-    openMethod,
-    triggerProps,
-    reset: resetOpenInteractionType,
-  } = useOpenInteractionType(open);
+  const { openMethod, triggerProps } = useOpenInteractionType(open);
 
   useImplicitActiveTrigger(store);
-  const { forceUnmount } = useOpenStateTransitions(open, store, () => {
-    resetOpenInteractionType();
-  });
+  const { forceUnmount } = useOpenStateTransitions(open, store);
 
   const createDialogEventDetails = useStableCallback((reason: DialogRoot.ChangeEventReason) => {
     const details: DialogRoot.ChangeEventDetails =

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -191,16 +191,11 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     rootId: useId(),
   });
 
-  const {
-    openMethod,
-    triggerProps: interactionTypeProps,
-    reset: resetOpenInteractionType,
-  } = useOpenInteractionType(open);
+  const { openMethod, triggerProps: interactionTypeProps } = useOpenInteractionType(open);
 
   useImplicitActiveTrigger(store);
   const { forceUnmount } = useOpenStateTransitions(open, store, () => {
     store.update({ allowMouseEnter: false, stickIfOpen: true });
-    resetOpenInteractionType();
   });
 
   const allowOutsidePressDismissalRef = React.useRef(parent.type !== 'context-menu');

--- a/packages/react/src/menubar/Menubar.tsx
+++ b/packages/react/src/menubar/Menubar.tsx
@@ -47,17 +47,7 @@ export const Menubar = React.forwardRef(function Menubar(
   const [contentElement, setContentElement] = React.useState<HTMLElement | null>(null);
   const [hasSubmenuOpen, setHasSubmenuOpen] = React.useState(false);
 
-  const {
-    openMethod,
-    triggerProps: interactionTypeProps,
-    reset: resetOpenInteractionType,
-  } = useOpenInteractionType(hasSubmenuOpen);
-
-  React.useEffect(() => {
-    if (!hasSubmenuOpen) {
-      resetOpenInteractionType();
-    }
-  }, [hasSubmenuOpen, resetOpenInteractionType]);
+  const { openMethod, triggerProps: interactionTypeProps } = useOpenInteractionType(hasSubmenuOpen);
 
   useScrollLock(modal && hasSubmenuOpen && openMethod !== 'touch', contentElement);
 

--- a/packages/react/src/popover/root/PopoverRoot.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.tsx
@@ -67,16 +67,11 @@ function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Pay
   store.useContextCallback('onOpenChange', onOpenChange);
   store.useContextCallback('onOpenChangeComplete', onOpenChangeComplete);
 
-  const {
-    openMethod,
-    triggerProps: interactionTypeTriggerProps,
-    reset: resetOpenInteractionType,
-  } = useOpenInteractionType(open);
+  const { openMethod, triggerProps: interactionTypeTriggerProps } = useOpenInteractionType(open);
 
   useImplicitActiveTrigger(store);
   const { forceUnmount } = useOpenStateTransitions(open, store, () => {
     store.update({ stickIfOpen: true, openChangeReason: null });
-    resetOpenInteractionType();
   });
 
   useScrollLock(

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -11,7 +11,7 @@ import {
   reactMajor,
 } from '@mui/internal-test-utils';
 import { createRenderer, isJSDOM, popupConformanceTests, wait } from '#test-utils';
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { spy } from 'sinon';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
@@ -721,6 +721,126 @@ describe('<Select.Root />', () => {
       const positioner = screen.getByTestId('positioner');
 
       expect(positioner.previousElementSibling).to.equal(null);
+    });
+  });
+
+  describe.skipIf(isJSDOM)('interaction type tracking (openMethod)', () => {
+    it('keeps touch interaction type when reopening quickly after close', async ({
+      onTestFinished,
+    }) => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+      let nextFrameId = 0;
+      const frameCallbacks = new Map<number, FrameRequestCallback>();
+
+      const requestAnimationFrameSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback: FrameRequestCallback) => {
+          nextFrameId += 1;
+          frameCallbacks.set(nextFrameId, callback);
+          return nextFrameId;
+        });
+      const cancelAnimationFrameSpy = vi
+        .spyOn(window, 'cancelAnimationFrame')
+        .mockImplementation((id: number) => {
+          frameCallbacks.delete(id);
+        });
+
+      onTestFinished(() => {
+        requestAnimationFrameSpy.mockRestore();
+        cancelAnimationFrameSpy.mockRestore();
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+      });
+
+      const style = `
+        @keyframes select-close-test {
+          to {
+            opacity: 0;
+          }
+        }
+
+        .animation-test-indicator[data-ending-style] {
+          animation: select-close-test 20ms linear;
+        }
+      `;
+
+      await render(
+        <div>
+          {/* eslint-disable-next-line react/no-danger */}
+          <style dangerouslySetInnerHTML={{ __html: style }} />
+          <Select.Root modal>
+            <Select.Trigger>Open</Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup className="animation-test-indicator">
+                  <Select.Item>Item</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        </div>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+
+      const isScrollLocked = () =>
+        trigger.ownerDocument.documentElement.style.overflow === 'hidden' ||
+        trigger.ownerDocument.documentElement.hasAttribute('data-base-ui-scroll-locked') ||
+        trigger.ownerDocument.body.style.overflow === 'hidden';
+
+      function fireTouchPress() {
+        fireEvent.pointerDown(trigger, { pointerType: 'touch' });
+        fireEvent.mouseDown(trigger);
+      }
+
+      function flushAnimationFrames() {
+        let iterations = 0;
+        while (frameCallbacks.size > 0) {
+          if (iterations > 20) {
+            throw new Error('Exceeded maximum animation frame flush iterations.');
+          }
+
+          const pending = Array.from(frameCallbacks.values());
+          frameCallbacks.clear();
+          pending.forEach((callback) => {
+            callback(0);
+          });
+          iterations += 1;
+        }
+      }
+
+      fireTouchPress();
+      await act(async () => {
+        flushAnimationFrames();
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.to.equal(null);
+      });
+
+      fireTouchPress();
+
+      await act(async () => {
+        flushAnimationFrames();
+      });
+
+      await waitFor(() => {
+        expect(trigger).to.have.attribute('aria-expanded', 'false');
+      });
+
+      // Re-open while the previous close animation is still pending.
+      fireTouchPress();
+
+      await act(async () => {
+        flushAnimationFrames();
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.to.equal(null);
+      });
+
+      await wait(30);
+
+      expect(isScrollLocked()).to.equal(false);
     });
   });
 

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -122,11 +122,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   const alignItemWithTriggerActiveRef = React.useRef(false);
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
-  const {
-    openMethod,
-    triggerProps: interactionTypeProps,
-    reset: resetOpenInteractionType,
-  } = useOpenInteractionType(open);
+  const { openMethod, triggerProps: interactionTypeProps } = useOpenInteractionType(open);
 
   const store = useRefWithInit(
     () =>
@@ -278,7 +274,6 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   const handleUnmount = useStableCallback(() => {
     setMounted(false);
     store.set('activeIndex', null);
-    resetOpenInteractionType();
     onOpenChangeComplete?.(false);
   });
 

--- a/packages/react/src/utils/useOpenInteractionType.ts
+++ b/packages/react/src/utils/useOpenInteractionType.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { InteractionType, useEnhancedClickHandler } from '@base-ui/utils/useEnhancedClickHandler';
 import { isIOS } from '@base-ui/utils/detectBrowser';
+import { useValueChanged } from './useValueChanged';
 
 /**
  * Determines the interaction type (keyboard, mouse, touch, etc.) that opened the component.
@@ -26,21 +27,22 @@ export function useOpenInteractionType(open: boolean) {
     },
   );
 
-  const reset = React.useCallback(() => {
-    setOpenMethod(null);
-  }, []);
+  useValueChanged(open, (previousOpen) => {
+    if (previousOpen && !open) {
+      setOpenMethod(null);
+    }
+  });
 
   const { onClick, onPointerDown } = useEnhancedClickHandler(handleTriggerClick);
 
   return React.useMemo(
     () => ({
       openMethod,
-      reset,
       triggerProps: {
         onClick,
         onPointerDown,
       },
     }),
-    [openMethod, reset, onClick, onPointerDown],
+    [openMethod, onClick, onPointerDown],
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes a race condition due to `useClick`'s `mousedown` being deferred in a rAF and the reset happening on close complete. Concrete bug: tapping the Select trigger quickly repeatedly sometimes had a `null` `openMethod` incorrectly.