### PR TITLE
[all components] Only define  on event handlers typing that actually contain it (type safe using `satisfies`)

### DIFF
--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -47,8 +47,11 @@ export interface ButtonState {
   disabled: boolean;
 }
 
+export type ButtonPreventableEvents = useButton.PreventableEvents;
+
 export interface ButtonProps
-  extends NativeButtonProps, BaseUIComponentProps<'button', ButtonState> {
+  extends NativeButtonProps,
+    BaseUIComponentProps<'button', ButtonState, ButtonPreventableEvents> {
   /**
    * Whether the button should be focusable when disabled.
    * @default false
@@ -57,6 +60,7 @@ export interface ButtonProps
 }
 
 export namespace Button {
+  export type PreventableEvents = ButtonPreventableEvents;
   export type State = ButtonState;
   export type Props = ButtonProps;
 }

--- a/packages/react/src/merge-props/mergeProps.spec.ts
+++ b/packages/react/src/merge-props/mergeProps.spec.ts
@@ -1,0 +1,180 @@
+import * as React from 'react';
+import { expectType } from '#test-utils';
+import { mergeProps, type RequiredHandlers } from '@base-ui/react/merge-props';
+import type { BaseUIEvent } from '../utils/types';
+
+// =============================================================================
+// Test 1: Default (PE = string) — all event handlers get preventBaseUIHandler
+// This is the backward-compatible behavior.
+// =============================================================================
+{
+  const result = mergeProps<'button'>(
+    { onClick: () => {} },
+    { onKeyDown: () => {} },
+  );
+
+  // All event handlers should accept BaseUIEvent
+  result.onClick = (event: BaseUIEvent<React.MouseEvent<HTMLButtonElement>>) => {
+    event.preventBaseUIHandler();
+  };
+
+  result.onKeyDown = (event: BaseUIEvent<React.KeyboardEvent<HTMLButtonElement>>) => {
+    event.preventBaseUIHandler();
+  };
+}
+
+// =============================================================================
+// Test 2: Specific PE — only listed handlers get preventBaseUIHandler
+// =============================================================================
+{
+  const result = mergeProps<'button', 'onClick'>(
+    { onClick: () => {} },
+    {},
+  );
+
+  // onClick IS preventable — its event parameter has preventBaseUIHandler
+  result.onClick = (event) => {
+    event.preventBaseUIHandler();
+  };
+
+  // onKeyDown is NOT preventable — it receives a plain React event
+  result.onKeyDown = (event) => {
+    expectType<React.KeyboardEvent<HTMLButtonElement>, typeof event>(event);
+  };
+}
+
+// =============================================================================
+// Test 3: PE = never — no event handlers get preventBaseUIHandler
+// =============================================================================
+{
+  const result = mergeProps<'button', never>(
+    { onClick: () => {} },
+    {},
+  );
+
+  // onClick receives a plain React.MouseEvent, no BaseUIEvent wrapping
+  result.onClick = (event) => {
+    expectType<React.MouseEvent<HTMLButtonElement>, typeof event>(event);
+  };
+}
+
+// =============================================================================
+// Test 4: Negative test — preventBaseUIHandler is a TS error on non-PE handler
+// =============================================================================
+{
+  const result = mergeProps<'button', 'onClick'>({}, {});
+
+  result.onKeyDown = (event) => {
+    // @ts-expect-error preventBaseUIHandler does not exist on non-preventable events
+    event.preventBaseUIHandler();
+  };
+}
+
+// =============================================================================
+// Test 5: Negative test — preventBaseUIHandler is a TS error when PE = never
+// =============================================================================
+{
+  const result = mergeProps<'button', never>({}, {});
+
+  result.onClick = (event) => {
+    // @ts-expect-error preventBaseUIHandler does not exist when PE = never
+    event.preventBaseUIHandler();
+  };
+}
+
+// =============================================================================
+// Test 6: Non-event props are unchanged regardless of PE
+// =============================================================================
+{
+  const result = mergeProps<'button', 'onClick'>({}, {});
+
+  expectType<string | undefined, typeof result.className>(result.className);
+  expectType<string | undefined, typeof result.id>(result.id);
+}
+
+// =============================================================================
+// Test 7: Multiple PE events
+// =============================================================================
+{
+  const result = mergeProps<'button', 'onClick' | 'onKeyDown' | 'onFocus'>({}, {});
+
+  // All listed events should have preventBaseUIHandler
+  result.onClick = (event) => {
+    event.preventBaseUIHandler();
+  };
+  result.onKeyDown = (event) => {
+    event.preventBaseUIHandler();
+  };
+  result.onFocus = (event) => {
+    event.preventBaseUIHandler();
+  };
+
+  // Unlisted event should NOT have preventBaseUIHandler
+  result.onBlur = (event) => {
+    // @ts-expect-error preventBaseUIHandler does not exist on non-preventable events
+    event.preventBaseUIHandler();
+  };
+}
+
+// =============================================================================
+// Test 8: Props getter receives correctly-narrowed types
+// =============================================================================
+{
+  mergeProps<'button', 'onClick'>(
+    (props) => {
+      // The onClick handler in the props getter should have preventBaseUIHandler
+      props.onClick = (event) => {
+        event.preventBaseUIHandler();
+      };
+
+      // Non-PE handlers should NOT have preventBaseUIHandler
+      props.onKeyDown = (event) => {
+        // @ts-expect-error preventBaseUIHandler does not exist on non-preventable events
+        event.preventBaseUIHandler();
+      };
+
+      return props;
+    },
+    { onClick: () => {} },
+  );
+}
+
+// =============================================================================
+// Test 9: satisfies RequiredHandlers — catches missing handlers
+// =============================================================================
+{
+  mergeProps<'button', 'onClick' | 'onKeyDown'>(
+    {
+      onClick() {},
+      onKeyDown() {},
+    } satisfies RequiredHandlers<'onClick' | 'onKeyDown'>,
+    {},
+  );
+}
+
+// =============================================================================
+// Test 10: satisfies RequiredHandlers — errors on missing handler
+// =============================================================================
+{
+  mergeProps<'button', 'onClick' | 'onKeyDown'>(
+    {
+      onClick() {},
+      // @ts-expect-error onKeyDown is missing from RequiredHandlers
+    } satisfies RequiredHandlers<'onClick' | 'onKeyDown'>,
+    {},
+  );
+}
+
+// =============================================================================
+// Test 11: satisfies RequiredHandlers — allows extra non-handler props
+// =============================================================================
+{
+  mergeProps<'button', 'onClick'>(
+    {
+      id: 'test',
+      role: 'button' as const,
+      onClick() {},
+    } satisfies RequiredHandlers<'onClick'>,
+    {},
+  );
+}

--- a/packages/react/src/use-button/useButton.ts
+++ b/packages/react/src/use-button/useButton.ts
@@ -249,6 +249,12 @@ export interface UseButtonReturnValue {
 }
 
 export namespace useButton {
+  /**
+   * Event handler keys that useButton makes preventable via `makeEventPreventable`.
+   * Pass this type (or a union including it) as the `PreventableEvents` generic
+   * of `BaseUIComponentProps` for components that use `useButton`.
+   */
+  export type PreventableEvents = 'onClick' | 'onMouseDown' | 'onKeyDown' | 'onKeyUp' | 'onPointerDown';
   export type Parameters = UseButtonParameters;
   export type ReturnValue = UseButtonReturnValue;
 }

--- a/packages/react/src/utils/types.ts
+++ b/packages/react/src/utils/types.ts
@@ -20,22 +20,32 @@ type WithPreventBaseUIHandler<T> = T extends (event: infer E) => any
     : T;
 
 /**
- * Adds a `preventBaseUIHandler` method to all event handlers.
+ * Adds a `preventBaseUIHandler` method to event handlers whose key is in `PE`.
+ * - `string` (default): all event handlers get `preventBaseUIHandler` — backward compatible.
+ * - A concrete union (e.g. `'onClick' | 'onKeyDown'`): only those handlers get `preventBaseUIHandler`.
+ * - `never`: no handlers get `preventBaseUIHandler`.
  */
-export type WithBaseUIEvent<T> = {
-  [K in keyof T]: WithPreventBaseUIHandler<T[K]>;
+export type WithBaseUIEvent<T, PE extends string = string> = {
+  [K in keyof T]: K extends PE ? WithPreventBaseUIHandler<T[K]> : T[K];
 };
 
 /**
  * Props shared by all Base UI components.
  * Contains `className` (string or callback taking the component's state as an argument) and `render` (function to customize rendering).
+ *
+ * @template PreventableEvents Union of event handler keys (e.g. `'onClick' | 'onKeyDown'`) for which
+ *   `event.preventBaseUIHandler()` is available.
+ *   - `string` (default): all events get `preventBaseUIHandler` — backward compatibility for non-migrated components.
+ *   - `never`: no events get `preventBaseUIHandler` — for components with no internal event handlers.
+ *   - A concrete union: only those events get `preventBaseUIHandler`.
  */
 export type BaseUIComponentProps<
   ElementType extends React.ElementType,
   State,
+  PreventableEvents extends string = string,
   RenderFunctionProps = HTMLProps,
 > = Omit<
-  WithBaseUIEvent<React.ComponentPropsWithRef<ElementType>>,
+  WithBaseUIEvent<React.ComponentPropsWithRef<ElementType>, PreventableEvents>,
   'className' | 'color' | 'defaultValue' | 'defaultChecked'
 > & {
   /**


### PR DESCRIPTION
Alternative approach to #4089

Fixes #4088