### PR TITLE
[combobox] Accept autoHighlight="always" in Combobox.Root

### DIFF
--- a/docs/reference/generated/combobox-root.json
+++ b/docs/reference/generated/combobox-root.json
@@ -54,10 +54,10 @@
       "detailedType": "| ((\n    open: boolean,\n    eventDetails: Combobox.Root.ChangeEventDetails,\n  ) => void)\n| undefined"
     },
     "autoHighlight": {
-      "type": "boolean",
+      "type": "boolean | 'always'",
       "default": "false",
-      "description": "Whether the first matching item is highlighted automatically while filtering.",
-      "detailedType": "boolean | undefined"
+      "description": "Whether the first matching item is highlighted automatically.\n- `true`: highlight after the user types and keep the highlight while the query changes.\n- `'always'`: highlight the first item as soon as the list opens.",
+      "detailedType": "boolean | 'always' | undefined"
     },
     "highlightItemOnHover": {
       "type": "boolean",

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -2738,6 +2738,33 @@ describe('<Combobox.Root />', () => {
       expect(input).not.to.have.attribute('aria-activedescendant');
     });
 
+    it('highlights the first item immediately when behavior is "always"', async () => {
+      await render(
+        <Combobox.Root items={['alpha', 'beta', 'gamma']} autoHighlight="always" defaultOpen>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      const firstOption = screen.getByRole('option', { name: 'alpha' });
+
+      expect(input).to.have.attribute('aria-activedescendant', firstOption.id);
+      expect(firstOption).to.have.attribute('data-highlighted');
+    });
+
     it('shows the selected item as selected on initial open (no active highlight)', async () => {
       await render(
         <Combobox.Root

--- a/packages/react/src/combobox/root/ComboboxRoot.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.tsx
@@ -74,10 +74,12 @@ export type ComboboxRootProps<Value, Multiple extends boolean | undefined = fals
    */
   autoComplete?: string | undefined;
   /**
-   * Whether the first matching item is highlighted automatically while filtering.
+   * Whether the first matching item is highlighted automatically.
+   * - `true`: highlight after the user types and keep the highlight while the query changes.
+   * - `'always'`: highlight the first item as soon as the list opens.
    * @default false
    */
-  autoHighlight?: boolean | undefined;
+  autoHighlight?: boolean | 'always' | undefined;
   /**
    * Whether moving the pointer over items should highlight them.
    * Disabling this prop allows CSS `:hover` to be differentiated from the `:focus` (`data-highlighted`) state.


### PR DESCRIPTION
## Summary
- Expose `autoHighlight="always"` in `Combobox.Root` public typing and JSDoc so the API matches supported runtime behavior.
- Add a regression test verifying that `autoHighlight="always"` highlights the first item immediately on open.
- Regenerate API reference output for `Combobox.Root`.

## Testing
- `pnpm test:jsdom ComboboxRoot --no-watch`
- `pnpm test:chromium ComboboxRoot --no-watch`

Fixes #4188