### PR TITLE
[all components] Skip CSS-hidden composite items in keyboard navigation

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { tabbable, isTabbable, focusable, type FocusableElement } from 'tabbable';
-import { getComputedStyle, getNodeName, isHTMLElement } from '@floating-ui/utils/dom';
+import { getNodeName, isHTMLElement } from '@floating-ui/utils/dom';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
@@ -28,6 +28,7 @@ import {
   isOutsideEvent,
   getNextTabbable,
   getPreviousTabbable,
+  isElementVisible,
   isTypeableElement,
 } from '../utils';
 import type { FloatingContext, FloatingRootContext } from '../types';
@@ -112,7 +113,7 @@ function isFocusable(element: Element | null) {
     return element.checkVisibility();
   }
 
-  return getComputedStyle(element).display !== 'none';
+  return isElementVisible(element);
 }
 
 function handleTabIndex(

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
@@ -16,9 +16,12 @@ import { HorizontalMenu } from '../../../test/floating-ui-tests/MenuOrientation'
 /* eslint-disable testing-library/no-unnecessary-act */
 
 function App(
-  inProps: Omit<Partial<UseListNavigationProps>, 'listRef'> & { disableFirstItem?: boolean } = {},
+  inProps: Omit<Partial<UseListNavigationProps>, 'listRef'> & {
+    disableFirstItem?: boolean;
+    hideFirstItem?: boolean;
+  } = {},
 ) {
-  const { disableFirstItem, ...props } = inProps;
+  const { disableFirstItem, hideFirstItem, ...props } = inProps;
   const [open, setOpen] = React.useState(false);
   const listRef = React.useRef<Array<HTMLLIElement | null>>([]);
   const [activeIndex, setActiveIndex] = React.useState<null | number>(null);
@@ -51,6 +54,7 @@ function App(
                 data-testid={`item-${index}`}
                 aria-selected={activeIndex === index}
                 key={string}
+                style={hideFirstItem && index === 0 ? { display: 'none' } : undefined}
                 tabIndex={-1}
                 aria-disabled={
                   (disableFirstItem && index === 0) ||
@@ -79,11 +83,13 @@ function VirtualizedGridRows({
   initialActiveIndex = 0,
   loopFocus = true,
   disabledIndices,
+  hiddenIndices,
 }: {
   totalItems?: number;
   initialActiveIndex?: number;
   loopFocus?: boolean;
   disabledIndices?: UseListNavigationProps['disabledIndices'];
+  hiddenIndices?: number[];
 }) {
   const COLUMNS = 5;
   const VISIBLE_ROWS = 3;
@@ -139,6 +145,7 @@ function VirtualizedGridRows({
                     key={itemIndex}
                     type="button"
                     role="gridcell"
+                    style={hiddenIndices?.includes(itemIndex) ? { display: 'none' } : undefined}
                     data-active={activeIndex === itemIndex ? '' : undefined}
                     {...getItemProps({
                       ref(node: HTMLButtonElement | null) {
@@ -254,6 +261,21 @@ describe('useListNavigation', () => {
     fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowUp' });
     await waitFor(() => {
       expect(screen.getByTestId('item-0')).toHaveFocus();
+    });
+  });
+
+  it('skips items hidden with CSS in navigation', async () => {
+    render(<App hideFirstItem loopFocus disabledIndices={[]} />);
+
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('item-1')).toHaveFocus();
+    });
+
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowUp' });
+    await waitFor(() => {
+      expect(screen.getByTestId('item-2')).toHaveFocus();
     });
   });
 
@@ -965,6 +987,24 @@ describe('useListNavigation', () => {
         expect(screen.getByTestId('virtual-grid-active-index')).toHaveAttribute(
           'data-active-index',
           '96',
+        );
+      });
+    });
+
+    it('falls back left when the preferred candidate is hidden', async () => {
+      render(<VirtualizedGridRows initialActiveIndex={9} hiddenIndices={[14]} />);
+
+      const reference = screen.getByTestId('virtual-grid-reference');
+      await act(async () => {
+        reference.focus();
+      });
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('virtual-grid-active-index')).toHaveAttribute(
+          'data-active-index',
+          '13',
         );
       });
     });

--- a/packages/react/src/floating-ui-react/hooks/useTypeahead.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useTypeahead.test.tsx
@@ -72,6 +72,58 @@ function Combobox(
   );
 }
 
+function ComboboxWithElementsRef(
+  props: Pick<UseTypeaheadProps, 'onMatch'> & {
+    list?: Array<string>;
+    hiddenIndices?: Array<number>;
+  },
+) {
+  const [activeIndex, setActiveIndex] = React.useState<null | number>(null);
+  const [open, setOpen] = React.useState(true);
+  const { refs, context } = useFloating({
+    open,
+    onOpenChange: setOpen,
+  });
+  const listRef = React.useRef(props.list ?? ['apple', 'apricot', 'banana']);
+  const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
+  const typeahead = useTypeahead(context, {
+    listRef,
+    elementsRef,
+    activeIndex,
+    onMatch(index) {
+      setActiveIndex(index);
+      props.onMatch?.(index);
+    },
+  });
+
+  const { getReferenceProps, getFloatingProps, getItemProps } = useInteractions([typeahead]);
+
+  return (
+    <React.Fragment>
+      <input {...getReferenceProps({ role: 'combobox', ref: refs.setReference })} />
+      {open && (
+        <div {...getFloatingProps({ role: 'listbox', ref: refs.setFloating })}>
+          {listRef.current.map((value, index) => (
+            <div
+              key={value}
+              role="option"
+              aria-selected={activeIndex === index}
+              style={props.hiddenIndices?.includes(index) ? { display: 'none' } : undefined}
+              {...getItemProps({
+                ref(node) {
+                  elementsRef.current[index] = node;
+                },
+              })}
+            >
+              {value}
+            </div>
+          ))}
+        </div>
+      )}
+    </React.Fragment>
+  );
+}
+
 describe('useTypeahead', () => {
   it('rapidly focuses list items when they start with the same letter', async () => {
     const spy = vi.fn();
@@ -222,5 +274,15 @@ describe('useTypeahead', () => {
     vi.advanceTimersByTime(750);
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy).toHaveBeenCalledWith(false);
+  });
+
+  it('skips hidden items when matching with elementsRef', async () => {
+    const spy = vi.fn();
+    render(<ComboboxWithElementsRef onMatch={spy} hiddenIndices={[0]} />);
+
+    await userEvent.click(screen.getByRole('combobox'));
+
+    await userEvent.keyboard('a');
+    expect(spy).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/react/src/floating-ui-react/hooks/useTypeahead.ts
+++ b/packages/react/src/floating-ui-react/hooks/useTypeahead.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useTimeout } from '@base-ui/utils/useTimeout';
-import { contains, stopEvent } from '../utils';
+import { contains, isElementVisible, stopEvent } from '../utils';
 
 import type { ElementProps, FloatingContext, FloatingRootContext } from '../types';
 
@@ -23,6 +23,12 @@ export interface UseTypeaheadProps {
    * Callback invoked with the matching index if found as the user types.
    */
   onMatch?: ((index: number) => void) | undefined;
+  /**
+   * Optional list of item elements that correspond to `listRef` indices.
+   * When an element exists for an index, typeahead skips it if it is hidden
+   * via CSS (`display: none`).
+   */
+  elementsRef?: React.RefObject<Array<HTMLElement | null>> | undefined;
   /**
    * Callback invoked with the typing state as the user types.
    */
@@ -59,6 +65,7 @@ export function useTypeahead(
   const open = store.useState('open');
   const {
     listRef,
+    elementsRef,
     activeIndex,
     onMatch: onMatchProp,
     onTypingChange,
@@ -105,16 +112,28 @@ export function useTypeahead(
   });
 
   const onKeyDown = useStableCallback((event: React.KeyboardEvent) => {
-    function getMatchingIndex(
-      list: Array<string | null>,
-      orderedList: Array<string | null>,
-      string: string,
-    ) {
-      const str = orderedList.find(
-        (text) => text?.toLocaleLowerCase().indexOf(string.toLocaleLowerCase()) === 0,
-      );
+    function isVisible(index: number) {
+      const element = elementsRef?.current[index];
+      return !element || isElementVisible(element);
+    }
 
-      return str ? list.indexOf(str) : -1;
+    function getMatchingIndex(list: Array<string | null>, string: string, startIndex = 0) {
+      if (list.length === 0) {
+        return -1;
+      }
+
+      const normalizedStartIndex = ((startIndex % list.length) + list.length) % list.length;
+      const lowerString = string.toLocaleLowerCase();
+
+      for (let offset = 0; offset < list.length; offset += 1) {
+        const index = (normalizedStartIndex + offset) % list.length;
+        const text = list[index];
+        if (!text?.toLocaleLowerCase().startsWith(lowerString) || !isVisible(index)) {
+          continue;
+        }
+        return index;
+      }
+      return -1;
     }
 
     const listContent = listRef.current;
@@ -126,10 +145,7 @@ export function useTypeahead(
     }
 
     if (stringRef.current.length > 0 && stringRef.current[0] !== ' ') {
-      if (
-        getMatchingIndex(listContent, listContent, stringRef.current) === -1 &&
-        event.key !== ' '
-      ) {
+      if (getMatchingIndex(listContent, stringRef.current) === -1 && event.key !== ' ') {
         setTypingChange(false);
       }
     }
@@ -181,12 +197,9 @@ export function useTypeahead(
     // If this is a new typing session (string is empty), base it on the current
     // selection/active item; otherwise continue from the last matched index.
     const prevIndex = isNewSession ? (selectedIndex ?? activeIndex ?? -1) : prevIndexRef.current;
+    const startIndex = (prevIndex ?? 0) + 1;
 
-    const index = getMatchingIndex(
-      listContent,
-      [...listContent.slice((prevIndex || 0) + 1), ...listContent.slice(0, (prevIndex || 0) + 1)],
-      stringRef.current,
-    );
+    const index = getMatchingIndex(listContent, stringRef.current, startIndex);
 
     if (index !== -1) {
       onMatchProp?.(index);

--- a/packages/react/src/floating-ui-react/utils/composite.ts
+++ b/packages/react/src/floating-ui-react/utils/composite.ts
@@ -1,4 +1,5 @@
 import { floor } from '@floating-ui/utils';
+import { getComputedStyle } from '@floating-ui/utils/dom';
 
 import type { Dimensions } from '../types';
 import { stopEvent } from './event';
@@ -443,11 +444,13 @@ export function isListIndexDisabled(
   index: number,
   disabledIndices?: DisabledIndices,
 ) {
-  if (typeof disabledIndices === 'function') {
-    return disabledIndices(index);
-  }
-  if (disabledIndices) {
-    return disabledIndices.includes(index);
+  const isExplicitlyDisabled =
+    typeof disabledIndices === 'function'
+      ? disabledIndices(index)
+      : (disabledIndices?.includes(index) ?? false);
+
+  if (isExplicitlyDisabled) {
+    return true;
   }
 
   const element = listRef.current[index];
@@ -455,5 +458,16 @@ export function isListIndexDisabled(
     return false;
   }
 
-  return element.hasAttribute('disabled') || element.getAttribute('aria-disabled') === 'true';
+  if (!isElementVisible(element)) {
+    return true;
+  }
+
+  return (
+    !disabledIndices &&
+    (element.hasAttribute('disabled') || element.getAttribute('aria-disabled') === 'true')
+  );
+}
+
+export function isElementVisible(element: Element) {
+  return getComputedStyle(element).display !== 'none';
 }

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -145,6 +145,50 @@ describe('<Menu.Root />', () => {
         expect(disabledItem3).to.have.attribute('aria-disabled', 'true');
       });
 
+      it.skipIf(isJSDOM)('skips items hidden with CSS during keyboard navigation', async () => {
+        await render(
+          <TestMenu
+            popupProps={{
+              children: (
+                <React.Fragment>
+                  <Menu.Item data-testid="item-1" style={{ display: 'none' }}>
+                    Item 1
+                  </Menu.Item>
+                  <Menu.Item data-testid="item-2">Item 2</Menu.Item>
+                  <Menu.Item data-testid="item-3">Item 3</Menu.Item>
+                </React.Fragment>
+              ),
+            }}
+          />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+        await act(async () => {
+          trigger.focus();
+        });
+
+        await userEvent.keyboard('[Enter]');
+
+        const hiddenItem = screen.getByTestId('item-1');
+        const item2 = screen.getByTestId('item-2');
+        const item3 = screen.getByTestId('item-3');
+
+        await waitFor(() => {
+          expect(item2).toHaveFocus();
+        });
+        expect(hiddenItem).to.have.attribute('tabindex', '-1');
+
+        await userEvent.keyboard('{ArrowDown}');
+        await waitFor(() => {
+          expect(item3).toHaveFocus();
+        });
+
+        await userEvent.keyboard('{ArrowUp}');
+        await waitFor(() => {
+          expect(item2).toHaveFocus();
+        });
+      });
+
       describe('text navigation', () => {
         it.skipIf(isJSDOM)('changes the highlighted item', async () => {
           const itemElements = [
@@ -179,6 +223,39 @@ describe('<Menu.Root />', () => {
           });
 
           expect(screen.getByText('Cd')).to.have.attribute('tabindex', '0');
+        });
+
+        it.skipIf(isJSDOM)('skips items hidden with CSS in text navigation', async () => {
+          const itemElements = [
+            <Menu.Item key="hidden" data-testid="item-hidden" style={{ display: 'none' }}>
+              Apple
+            </Menu.Item>,
+            <Menu.Item key="apricot" data-testid="item-apricot">
+              Apricot
+            </Menu.Item>,
+            <Menu.Item key="banana" data-testid="item-banana">
+              Banana
+            </Menu.Item>,
+          ];
+
+          const { user } = await render(
+            <TestMenu rootProps={{ open: true }} popupProps={{ children: itemElements }} />,
+          );
+
+          const hiddenItem = screen.getByTestId('item-hidden');
+          const apricotItem = screen.getByTestId('item-apricot');
+          const bananaItem = screen.getByTestId('item-banana');
+
+          await act(async () => {
+            bananaItem.focus();
+          });
+
+          await user.keyboard('a');
+          await waitFor(() => {
+            expect(apricotItem).toHaveFocus();
+          });
+
+          expect(hiddenItem).to.have.attribute('tabindex', '-1');
         });
 
         it.skipIf(!isJSDOM)(

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -463,6 +463,7 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
 
   const typeahead = useTypeahead(floatingRootContext, {
     listRef: store.context.itemLabels,
+    elementsRef: store.context.itemDomElements,
     activeIndex,
     resetMs: TYPEAHEAD_RESET_MS,
     onMatch: (index) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Note on perf: this check only happens in events (measured <0.1ms increase per event on a slow device) or on open for focus sync where the cost is O(k) depending on how many items are disabled (the items need to be scanned to find the first enabled/non-hidden item) but `k` is very low in practice. So overhead is ~nonexistent.

Fixes #4193