### PR TITLE
[docs] Fix Tailwind StackBlitz class pre-injection

### DIFF
--- a/docs/src/utils/demoExportOptions.test.ts
+++ b/docs/src/utils/demoExportOptions.test.ts
@@ -43,6 +43,17 @@ function getInjectedClassAttribute(headTemplate: string) {
 }
 
 describe('exportOpts Tailwind class injection', () => {
+  it('uses the Tailwind v4 browser runtime for StackBlitz exports', () => {
+    const headTemplate = getTailwindHeadTemplate(`
+      export default function Demo() {
+        return <div className="outline-1 outline-gray-200">Demo</div>;
+      }
+    `);
+
+    expect(headTemplate).toContain('https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4');
+    expect(headTemplate).not.toContain('https://cdn.tailwindcss.com');
+  });
+
   it('injects classes referenced via concatenated className constants', () => {
     const source = `
       const popupClassName =

--- a/docs/src/utils/demoExportOptions.ts
+++ b/docs/src/utils/demoExportOptions.ts
@@ -30,14 +30,7 @@ const htmlHeadWithCssModulesTheme: ExportConfig['headTemplate'] = () => themeSty
 // Tailwind CSS Setup
 const tailwindSetup = `
 <!-- Check out the Tailwind CSS' installation guide for setting it up: https://tailwindcss.com/docs/installation/framework-guides -->
-<script src="https://cdn.tailwindcss.com"></script>
-<script>
-  tailwind.config = {
-    theme: {
-      extend: {},
-    },
-  }
-</script>`;
+<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>`;
 const tailwindNote = `
 
 <!-- Inject classes used so that Tailwind loaded from the CDN can pre-render them. -->


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


Updates StackBlitz Tailwind class pre-injection logic to include classes referenced via `className={identifier}` string constants, not just inline literals.

I noticed the nested Drawer stack example's enter animation was broken on first mount in Tailwind in Stackblitz. This should also fix issues like this: https://github.com/mui/base-ui/pull/3974