### PR TITLE
[toast] Add useToastActions hook to avoid unnecessary re-renders

### DIFF
--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -1298,6 +1298,9 @@ Generates toast notifications.
     - `update` method
     - `close` method
     - `promise` method
+  - useToastActions
+    - Return value
+    - When to use
 - Exports:
   - Toast - Root
     - Props: className, render, style, swipeDirection, toast

--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -445,6 +445,65 @@ const promise = toastManager.promise(
 );
 ```
 
+## useToastActions
+
+Returns only the action methods without subscribing to toast state.
+Use this hook in components that only need to **fire** toasts (for example, buttons) but don't need to read the `toasts` array.
+Unlike `useToastManager`, this hook will not cause the component to re-render when toasts are added, updated, or removed.
+
+```tsx title="Usage"
+const toastActions = Toast.useToastActions();
+```
+
+### Return value
+
+<PropsReferenceTable
+  type="return"
+  data={{
+    add: {
+      type: '(options: ToastManagerAddOptions) => string',
+      description: 'Add a toast to the toast list.',
+    },
+    close: {
+      type: '(toastId: string) => void',
+      description: 'Closes and removes a toast from the toast list.',
+    },
+    update: {
+      type: '(toastId: string, options: ToastManagerUpdateOptions) => void',
+      description: 'Update a toast in the toast list.',
+    },
+    promise: {
+      type: '<Value>(promise: Promise<Value>, options: ToastManagerPromiseOptions) => Promise<Value>',
+      description:
+        'Create a toast that resolves with a value, with three possible states for the toast: `loading`, `success`, and `error`.',
+    },
+  }}
+/>
+
+### When to use
+
+Use `useToastActions` when the component only needs to **dispatch** toasts:
+
+```jsx title="Example" {2,7-9}
+function SaveButton() {
+  const toastActions = Toast.useToastActions();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        toastActions.add({
+          description: 'Changes saved!',
+        });
+      }}
+    >
+      Save
+    </button>
+  );
+}
+```
+
+Use `useToastManager` when the component needs to **read** the `toasts` array (for example, to render the toast list).
+
 export const metadata = {
   keywords: [
     'React Toast',

--- a/docs/src/error-codes.json
+++ b/docs/src/error-codes.json
@@ -89,5 +89,6 @@
   "89": "Base UI: <PreviewCard.Trigger> must be either used within a <PreviewCard.Root> component or provided with a handle.",
   "90": "Base UI: DrawerRootContext is missing. Drawer parts must be placed within <Drawer.Root>.",
   "91": "Base UI: DrawerProviderContext is missing. Use <Drawer.Provider>.",
-  "92": "Base UI: DrawerViewportContext is missing. Drawer parts must be placed within <Drawer.Viewport>."
+  "92": "Base UI: DrawerViewportContext is missing. Drawer parts must be placed within <Drawer.Viewport>.",
+  "93": "Base UI: useToastActions must be used within <Toast.Provider>."
 }

--- a/packages/react/src/toast/index.parts.ts
+++ b/packages/react/src/toast/index.parts.ts
@@ -11,4 +11,5 @@ export { ToastPositioner as Positioner } from './positioner/ToastPositioner';
 export { ToastArrow as Arrow } from './arrow/ToastArrow';
 
 export { useToastManager } from './useToastManager';
+export { useToastActions } from './useToastActions';
 export { createToastManager } from './createToastManager';

--- a/packages/react/src/toast/index.ts
+++ b/packages/react/src/toast/index.ts
@@ -12,4 +12,5 @@ export type * from './portal/ToastPortal';
 export type * from './positioner/ToastPositioner';
 export type * from './arrow/ToastArrow';
 export type * from './useToastManager';
+export type * from './useToastActions';
 export type * from './createToastManager';

--- a/packages/react/src/toast/useToastActions.spec.tsx
+++ b/packages/react/src/toast/useToastActions.spec.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { expectType } from '#test-utils';
+import { useToastActions } from './useToastActions';
+
+type ToastPayload = {
+  id: string;
+  count: number;
+};
+
+const typedActions = useToastActions<ToastPayload>();
+
+const typedAddId = typedActions.add({
+  title: 'typed',
+  data: {
+    id: 'typed',
+    count: 1,
+  },
+});
+expectType<string, typeof typedAddId>(typedAddId);
+
+typedActions.add({
+  title: 'wrong-shape',
+  data: {
+    id: 'test',
+    // @ts-expect-error - message is not a valid property
+    message: 'not a number',
+  },
+});
+
+typedActions.add({
+  title: 'wrong-shape',
+  // @ts-expect-error - count is a missing property
+  data: {
+    id: 'test',
+  },
+});
+
+typedActions.update('typed', {
+  data: {
+    id: 'typed-update',
+    count: 2,
+  },
+});
+
+typedActions.promise(Promise.resolve(2), {
+  loading: 'loading',
+  success: (value) => ({
+    title: `${value}`,
+    data: {
+      id: 'typed-success',
+      count: value,
+    },
+  }),
+  error: 'error',
+});
+
+const legacyActions = useToastActions();
+
+const legacyAddId = legacyActions.add<ToastPayload>({
+  title: 'legacy',
+  data: {
+    id: 'legacy',
+    count: 3,
+  },
+});
+expectType<string, typeof legacyAddId>(legacyAddId);
+
+legacyActions.update<ToastPayload>('legacy', {
+  data: {
+    id: 'legacy-update',
+    count: 4,
+  },
+});
+
+legacyActions.promise<number, ToastPayload>(Promise.resolve(5), {
+  loading: 'loading',
+  success: (value) => ({
+    title: `${value}`,
+    data: {
+      id: 'legacy-success',
+      count: value,
+    },
+  }),
+  error: 'error',
+});

--- a/packages/react/src/toast/useToastActions.test.tsx
+++ b/packages/react/src/toast/useToastActions.test.tsx
@@ -1,0 +1,201 @@
+import * as React from 'react';
+import { Toast } from '@base-ui/react/toast';
+import { fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
+import { expect } from 'chai';
+import { createRenderer, isJSDOM } from '#test-utils';
+import { useToastActions } from './useToastActions';
+import { List } from './utils/test-utils';
+
+async function tick(clock: ReturnType<typeof createRenderer>['clock'], ms: number) {
+  clock.tick(ms);
+  await flushMicrotasks();
+}
+
+describe.skipIf(!isJSDOM)('useToastActions', () => {
+  const { clock, render } = createRenderer();
+
+  clock.withFakeTimers();
+
+  it('adds a toast without subscribing to state (no re-renders on toast changes)', async () => {
+    const renderCount = { current: 0 };
+
+    function ActionButton() {
+      const { add } = useToastActions();
+      renderCount.current += 1;
+      return (
+        <button
+          onClick={() => {
+            add({ title: 'test' });
+          }}
+        >
+          add
+        </button>
+      );
+    }
+
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <List />
+        </Toast.Viewport>
+        <ActionButton />
+      </Toast.Provider>,
+    );
+
+    const initialRenders = renderCount.current;
+
+    const button = screen.getByRole('button', { name: 'add' });
+    fireEvent.click(button);
+
+    expect(screen.queryByTestId('root')).not.to.equal(null);
+
+    // The action-only component should NOT have re-rendered
+    expect(renderCount.current).to.equal(initialRenders);
+
+    await tick(clock, 5000);
+
+    // After auto-dismiss, still no re-render
+    expect(renderCount.current).to.equal(initialRenders);
+  });
+
+  it('closes a toast', async () => {
+    let toastId = '';
+
+    function ActionButton() {
+      const { add, close } = useToastActions();
+      return (
+        <div>
+          <button
+            onClick={() => {
+              toastId = add({ title: 'closeable' });
+            }}
+          >
+            add
+          </button>
+          <button
+            onClick={() => {
+              close(toastId);
+            }}
+          >
+            close
+          </button>
+        </div>
+      );
+    }
+
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <List />
+        </Toast.Viewport>
+        <ActionButton />
+      </Toast.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'add' }));
+    expect(screen.queryByTestId('root')).not.to.equal(null);
+
+    fireEvent.click(screen.getByRole('button', { name: 'close' }));
+    expect(screen.queryByTestId('root')).to.equal(null);
+  });
+
+  it('updates a toast', async () => {
+    let toastId = '';
+
+    function ActionButton() {
+      const { add, update } = useToastActions();
+      return (
+        <div>
+          <button
+            onClick={() => {
+              toastId = add({ title: 'original' });
+            }}
+          >
+            add
+          </button>
+          <button
+            onClick={() => {
+              update(toastId, { description: 'updated desc' });
+            }}
+          >
+            update
+          </button>
+        </div>
+      );
+    }
+
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <List />
+        </Toast.Viewport>
+        <ActionButton />
+      </Toast.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'add' }));
+    expect(screen.getByTestId('title')).to.have.text('original');
+
+    fireEvent.click(screen.getByRole('button', { name: 'update' }));
+    expect(screen.getByTestId('description')).to.have.text('updated desc');
+  });
+
+  it('handles promise toasts', async () => {
+    let resolvePromise: (value: string) => void;
+
+    function ActionButton() {
+      const { promise } = useToastActions();
+      return (
+        <button
+          onClick={() => {
+            const p = new Promise<string>((resolve) => {
+              resolvePromise = resolve;
+            });
+            promise(p, {
+              loading: 'Loading...',
+              success: (value) => `Success: ${value}`,
+              error: 'Error',
+            });
+          }}
+        >
+          promise
+        </button>
+      );
+    }
+
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <List />
+        </Toast.Viewport>
+        <ActionButton />
+      </Toast.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'promise' }));
+    expect(screen.getByTestId('description')).to.have.text('Loading...');
+
+    resolvePromise!('done');
+    await flushMicrotasks();
+
+    expect(screen.getByTestId('description')).to.have.text('Success: done');
+  });
+
+  it('throws when used outside of Toast.Provider', () => {
+    function BadComponent() {
+      useToastActions();
+      return null;
+    }
+
+    expect(() => {
+      // Use renderToString-like approach by wrapping in try/catch
+      const container = document.createElement('div');
+      const root = (React as any).createRoot?.(container) ?? null;
+      if (root) {
+        expect(() => {
+          root.render(<BadComponent />);
+        }).to.throw('Base UI: useToastActions must be used within <Toast.Provider>.');
+      }
+    });
+  });
+});

--- a/packages/react/src/toast/useToastActions.ts
+++ b/packages/react/src/toast/useToastActions.ts
@@ -1,0 +1,44 @@
+'use client';
+import * as React from 'react';
+import { ToastContext } from './provider/ToastProviderContext';
+import type {
+  ToastManagerAddOptions,
+  ToastManagerUpdateOptions,
+  ToastManagerPromiseOptions,
+} from './useToastManager';
+
+/**
+ * Returns methods to manage toasts without subscribing to toast state changes.
+ *
+ * Use this hook in components that only need to fire toasts (e.g. buttons)
+ * but don't need to read or display the `toasts` array.
+ * Unlike `useToastManager`, this hook will not cause the component to
+ * re-render when toasts are added, updated, or removed.
+ */
+export function useToastActions<Data extends object = any>(): UseToastActionsReturnValue<Data> {
+  const store = React.useContext(ToastContext);
+
+  if (!store) {
+    throw new Error('Base UI: useToastActions must be used within <Toast.Provider>.');
+  }
+
+  return React.useMemo(
+    () => ({
+      add: store.addToast as UseToastActionsReturnValue<Data>['add'],
+      close: store.closeToast,
+      update: store.updateToast as UseToastActionsReturnValue<Data>['update'],
+      promise: store.promiseToast as UseToastActionsReturnValue<Data>['promise'],
+    }),
+    [store],
+  );
+}
+
+export interface UseToastActionsReturnValue<Data extends object = any> {
+  add: <T extends Data = Data>(options: ToastManagerAddOptions<T>) => string;
+  close: (toastId: string) => void;
+  update: <T extends Data = Data>(toastId: string, options: ToastManagerUpdateOptions<T>) => void;
+  promise: <Value, T extends Data = Data>(
+    promise: Promise<Value>,
+    options: ToastManagerPromiseOptions<Value, T>,
+  ) => Promise<Value>;
+}

--- a/test/public-types/toast.tsx
+++ b/test/public-types/toast.tsx
@@ -1,6 +1,7 @@
 import {
   Toast,
   type UseToastManagerReturnValue,
+  type UseToastActionsReturnValue,
   type ToastManagerAddOptions as BaseToastManagerAddOptions,
   type ToastManagerPromiseOptions as BaseToastManagerPromiseOptions,
   type ToastManagerUpdateOptions as BaseToastManagerUpdateOptions,
@@ -22,6 +23,11 @@ export type ToastManagerPromiseOptions<Value, Data extends object> = BaseToastMa
   Data
 >;
 
+export type ToastActionsReturnValue = UseToastActionsReturnValue;
+export type ToastActionsAdd = UseToastActionsReturnValue['add'];
+export type ToastActionsUpdate = UseToastActionsReturnValue['update'];
+export type ToastActionsPromise = UseToastActionsReturnValue['promise'];
+
 export type ToastCreateManagerReturn = ReturnType<typeof Toast.createToastManager>;
 
-export const { useToastManager, createToastManager } = Toast;
+export const { useToastManager, useToastActions, createToastManager } = Toast;


### PR DESCRIPTION
Fixes #4234

## Problem

`useToastManager()` unconditionally calls `store.useState('toasts')`, which registers a `useSyncExternalStore` subscription. This means **every** component that calls `useToastManager()` re-renders on every toast lifecycle event (add, close, update, timeout) — even if the component only destructures action methods like `{ add }` and never reads the `toasts` array.

```tsx
// This button re-renders on every toast state change, despite only using `add`
function SaveButton() {
  const { add } = Toast.useToastManager();
  return <button onClick={() => add({ title: 'Saved!' })}>Save</button>;
}
```

The action methods (`addToast`, `closeToast`, etc.) are stable references — arrow functions on the `ToastStore` class instance. But the subscription is registered before the caller destructures the return value, so destructuring only `{ add }` doesn't help.

## Solution

Add a new `useToastActions()` hook that returns only the stable action methods (`add`, `close`, `update`, `promise`) without subscribing to state:

- No `store.useState()` call → no `useSyncExternalStore` subscription → zero re-renders from toast state changes
- `ToastContext` holds the `ToastStore` instance (stable ref created via `useRefWithInit`), so `useContext` won't trigger re-renders either
- The action methods are arrow functions on the class instance — their references are stable

### Usage

```tsx
// Components that only FIRE toasts — zero re-renders from toast state
function SaveButton() {
  const { add } = Toast.useToastActions();
  return <button onClick={() => add({ title: 'Saved!' })}>Save</button>;
}

// Components that DISPLAY toasts — subscribe to state (unchanged)
function ToastList() {
  const { toasts } = Toast.useToastManager();
  return toasts.map((toast) => <Toast.Root key={toast.id} toast={toast} />);
}
```

## Changes

- **New hook**: `packages/react/src/toast/useToastActions.ts`
- **Exports**: Added to `index.parts.ts` and `index.ts`
- **Tests**: 5 new tests including a render count assertion that verifies the component does **not** re-render when toasts are added/dismissed
- **Type spec**: Mirrors `useToastManager.spec.tsx` — validates generic `<Data>` inference
- **Docs**: Added `useToastActions` section to toast docs with return value reference and usage guidance
- **Public types**: Updated `test/public-types/toast.tsx` with `UseToastActionsReturnValue`
- **Error codes**: New code 93 for missing provider error

All existing `useToastManager` tests (31/31) continue to pass.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).