### PR TITLE
[combobox] Preserve inline input on Enter without highlight

### DIFF
--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -436,6 +436,10 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
             const nativeEvent = event.nativeEvent;
 
             if (activeIndex === null) {
+              if (inline) {
+                return;
+              }
+
               // Allow form submission when no item is highlighted.
               store.state.setOpen(false, createChangeEventDetails(REASONS.none, nativeEvent));
               return;

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -910,6 +910,33 @@ describe('<Combobox.Root />', () => {
       expect(onOuterKeyDown.callCount).to.equal(1);
     });
 
+    it('keeps input value on Enter when inline and no item is highlighted', async () => {
+      const { user } = await render(
+        <Combobox.Root inline items={['Apple', 'Banana']}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.List>
+            {(item: string) => (
+              <Combobox.Item key={item} value={item}>
+                {item}
+              </Combobox.Item>
+            )}
+          </Combobox.List>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+
+      await user.click(input);
+      await user.type(input, 'Ba');
+
+      expect(input).not.to.have.attribute('aria-activedescendant');
+      expect(input).to.have.value('Ba');
+
+      await user.keyboard('{Enter}');
+
+      expect(input).to.have.value('Ba');
+    });
+
     it('bubbles Escape key when list is empty and popup hidden with CSS', async () => {
       const onOuterKeyDown = spy();
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Pressing Enter with no highlighted item called `setOpen(false)`, which triggered close/reset behavior and cleared inline input text. The fix skips that close call in inline mode, so <kbd>Enter</kbd> now leaves the typed value unchanged unless an item is actually highlighted and selected.

Fixes #4204