### PR TITLE
[autocomplete][docs] Add command palette search icon and stronger highlight

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
@@ -99,12 +99,27 @@
   }
 }
 
+.InputRow {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-gray-100);
+}
+
+.InputIcon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  color: var(--color-gray-500);
+}
+
 .Input {
   box-sizing: border-box;
-  padding: 1rem;
+  padding: 0;
   margin: 0;
   border: none;
-  border-bottom: 1px solid var(--color-gray-100);
   width: 100%;
   height: auto;
   border-radius: 0;
@@ -120,7 +135,6 @@
   }
 
   &:focus {
-    border-bottom-color: var(--color-gray-100);
     outline: none;
   }
 }
@@ -198,7 +212,19 @@
   font-weight: 400;
 
   &[data-highlighted] {
-    background-color: var(--color-gray-100);
+    z-index: 0;
+    position: relative;
+    color: var(--color-gray-50);
+  }
+
+  &[data-highlighted]::before {
+    content: '';
+    z-index: -1;
+    position: absolute;
+    inset-block: 0;
+    inset-inline: 0.25rem;
+    border-radius: 0.25rem;
+    background-color: var(--color-gray-900);
   }
 }
 
@@ -217,7 +243,8 @@
   white-space: nowrap;
 
   [data-highlighted] & {
-    color: var(--color-gray-700);
+    color: var(--color-gray-50);
+    opacity: 0.8;
   }
 }
 

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.tsx
@@ -26,10 +26,13 @@ export default function ExampleAutocompleteCommandPalette() {
               autoHighlight="always"
               keepHighlight
             >
-              <Autocomplete.Input
-                className={styles.Input}
-                placeholder="Search for apps and commands..."
-              />
+              <div className={styles.InputRow}>
+                <SearchIcon className={styles.InputIcon} aria-hidden />
+                <Autocomplete.Input
+                  className={styles.Input}
+                  placeholder="Search for apps and commands..."
+                />
+              </div>
               <Dialog.Close className={styles.VisuallyHiddenClose}>
                 Close command palette
               </Dialog.Close>
@@ -92,6 +95,24 @@ export default function ExampleAutocompleteCommandPalette() {
         </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>
+  );
+}
+
+function SearchIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
   );
 }
 

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/tailwind/index.tsx
@@ -30,10 +30,13 @@ export default function ExampleAutocompleteCommandPalette() {
               autoHighlight="always"
               keepHighlight
             >
-              <Autocomplete.Input
-                className="w-full border-0 border-b border-gray-100 bg-transparent p-4 text-base tracking-[0.016em] text-gray-900 placeholder:text-gray-500 outline-none"
-                placeholder="Search for apps and commands..."
-              />
+              <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3">
+                <SearchIcon className="h-4 w-4 shrink-0 text-gray-500" aria-hidden />
+                <Autocomplete.Input
+                  className="w-full border-0 bg-transparent p-0 text-base tracking-[0.016em] text-gray-900 placeholder:text-gray-500 outline-none"
+                  placeholder="Search for apps and commands..."
+                />
+              </div>
               <Dialog.Close className="sr-only">Close command palette</Dialog.Close>
 
               <ScrollArea.Root className="relative flex max-h-[min(60dvh,24rem)] min-h-0 flex-[0_1_auto] overflow-hidden">
@@ -59,10 +62,10 @@ export default function ExampleAutocompleteCommandPalette() {
                                 key={item.value}
                                 value={item}
                                 onClick={handleItemClick}
-                                className="grid min-h-8 cursor-default grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-md pl-9 pr-3 text-[0.9375rem] tracking-[0.016em] font-normal leading-[1.25] select-none outline-none [scroll-margin-block:0.25rem] data-[highlighted]:bg-gray-100"
+                                className="grid min-h-8 cursor-default grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-md pl-9 pr-3 text-[0.9375rem] tracking-[0.016em] font-normal leading-[1.25] text-gray-900 select-none outline-none [scroll-margin-block:0.25rem] data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-y-0 data-[highlighted]:before:inset-x-1 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-xs data-[highlighted]:before:bg-gray-900 data-[highlighted]:[&_span:last-child]:text-gray-50 data-[highlighted]:[&_span:last-child]:opacity-80"
                               >
                                 <span className="truncate font-normal">{item.label}</span>
-                                <span className="shrink-0 whitespace-nowrap text-[0.875rem] tracking-[0.00625em] text-gray-500 data-[highlighted]:text-gray-700">
+                                <span className="shrink-0 whitespace-nowrap text-[0.875rem] tracking-[0.00625em] text-gray-500">
                                   {group.value === 'Suggestions' ? 'Application' : 'Command'}
                                 </span>
                               </Autocomplete.Item>
@@ -100,6 +103,24 @@ export default function ExampleAutocompleteCommandPalette() {
         </Dialog.Viewport>
       </Dialog.Portal>
     </Dialog.Root>
+  );
+}
+
+function SearchIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
   );
 }
 

--- a/docs/src/components/Search/SearchBar.css
+++ b/docs/src/components/Search/SearchBar.css
@@ -191,7 +191,8 @@
   }
 
   .SearchBreadcrumbSeparator {
-    color: var(--color-gray-300);
+    color: currentColor;
+    opacity: 0.4;
   }
 
   .SearchScore {
@@ -278,7 +279,7 @@
   }
 
   .SearchOptionItem[data-highlighted] {
-    background: var(--color-gray-100);
+    background: var(--color-gray-200);
   }
 
   .SearchBackdrop {

--- a/docs/src/components/Search/SearchBar.css
+++ b/docs/src/components/Search/SearchBar.css
@@ -279,7 +279,7 @@
   }
 
   .SearchOptionItem[data-highlighted] {
-    background: var(--color-blue);
+    background: var(--color-highlight);
     color: white;
   }
 

--- a/docs/src/components/Search/SearchBar.css
+++ b/docs/src/components/Search/SearchBar.css
@@ -279,7 +279,8 @@
   }
 
   .SearchOptionItem[data-highlighted] {
-    background: var(--color-gray-200);
+    background: var(--color-blue);
+    color: white;
   }
 
   .SearchBackdrop {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/base-ui/issues/4182
Fixes https://github.com/mui/base-ui/issues/4183

For the highlight, I updated the SearchBar (cmdk) search on the docs to use `--color-blue` highlight, same as the style Select in code blocks and what macOS uses for Spotlight.

<img width="838" height="550" alt="Screenshot 2026-03-03 at 12 53 44 pm" src="https://github.com/user-attachments/assets/95f360ef-6cb1-4c27-b761-43bfcfcb8bf0" />

The highlight background needs to have a contrast ratio of `3:1` with non-highlight backgrounds if there is no focus-only style — an outline for `:focus` would work otherwise, but we don't have a data state attribute to do this unless you use `highlightItemOnHover={false}` to differentiate `:hover` from `:focus`, similar to Chrome's omnibox. @colmtuite 

---

Command Palette uses the black highlight, same as other demos, and adds a search icon:

<img width="493" height="524" alt="Screenshot 2026-03-03 at 12 54 07 pm" src="https://github.com/user-attachments/assets/aed94690-44d0-4c72-8401-59cf7026c7f5" />

(imo all demos should use `--color-blue` as the highlight, but that's a different fix for the docs overhaul)

