### PR TITLE
[docs] Show explicit aria props in demos for i18n

### DIFF
--- a/docs/src/app/(docs)/react/components/number-field/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/number-field/demos/hero/css-modules/index.tsx
@@ -16,11 +16,11 @@ export default function ExampleNumberField() {
       </NumberField.ScrubArea>
 
       <NumberField.Group className={styles.Group}>
-        <NumberField.Decrement className={styles.Decrement}>
+        <NumberField.Decrement aria-label="Decrease" className={styles.Decrement}>
           <MinusIcon />
         </NumberField.Decrement>
-        <NumberField.Input className={styles.Input} />
-        <NumberField.Increment className={styles.Increment}>
+        <NumberField.Input aria-roledescription="Number field" className={styles.Input} />
+        <NumberField.Increment aria-label="Increase" className={styles.Increment}>
           <PlusIcon />
         </NumberField.Increment>
       </NumberField.Group>

--- a/docs/src/app/(docs)/react/components/number-field/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/number-field/demos/hero/tailwind/index.tsx
@@ -15,11 +15,20 @@ export default function ExampleNumberField() {
       </NumberField.ScrubArea>
 
       <NumberField.Group className="flex">
-        <NumberField.Decrement className="flex size-10 items-center justify-center rounded-tl-md rounded-bl-md border border-gray-200 bg-gray-50 bg-clip-padding text-gray-900 select-none hover:bg-gray-100 active:bg-gray-100">
+        <NumberField.Decrement
+          aria-label="Decrease"
+          className="flex size-10 items-center justify-center rounded-tl-md rounded-bl-md border border-gray-200 bg-gray-50 bg-clip-padding text-gray-900 select-none hover:bg-gray-100 active:bg-gray-100"
+        >
           <MinusIcon />
         </NumberField.Decrement>
-        <NumberField.Input className="h-10 w-24 border-t border-b border-gray-200 text-center text-base text-gray-900 tabular-nums focus:z-1 focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800" />
-        <NumberField.Increment className="flex size-10 items-center justify-center rounded-tr-md rounded-br-md border border-gray-200 bg-gray-50 bg-clip-padding text-gray-900 select-none hover:bg-gray-100 active:bg-gray-100">
+        <NumberField.Input
+          aria-roledescription="Number field"
+          className="h-10 w-24 border-t border-b border-gray-200 text-center text-base text-gray-900 tabular-nums focus:z-1 focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800"
+        />
+        <NumberField.Increment
+          aria-label="Increase"
+          className="flex size-10 items-center justify-center rounded-tr-md rounded-br-md border border-gray-200 bg-gray-50 bg-clip-padding text-gray-900 select-none hover:bg-gray-100 active:bg-gray-100"
+        >
           <PlusIcon />
         </NumberField.Increment>
       </NumberField.Group>

--- a/docs/src/app/(docs)/react/components/slider/demos/range-slider/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/range-slider/css-modules/index.tsx
@@ -7,8 +7,8 @@ export default function RangeSlider() {
       <Slider.Control className={styles.Control}>
         <Slider.Track className={styles.Track}>
           <Slider.Indicator className={styles.Indicator} />
-          <Slider.Thumb index={0} className={styles.Thumb} />
-          <Slider.Thumb index={1} className={styles.Thumb} />
+          <Slider.Thumb index={0} aria-label="Minimum value" className={styles.Thumb} />
+          <Slider.Thumb index={1} aria-label="Maximum value" className={styles.Thumb} />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(docs)/react/components/slider/demos/range-slider/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/range-slider/tailwind/index.tsx
@@ -8,10 +8,12 @@ export default function RangeSlider() {
           <Slider.Indicator className="rounded-sm bg-gray-700 select-none" />
           <Slider.Thumb
             index={0}
+            aria-label="Minimum value"
             className="size-4 rounded-full bg-white outline-1 outline-gray-300 select-none has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800"
           />
           <Slider.Thumb
             index={1}
+            aria-label="Maximum value"
             className="size-4 rounded-full bg-white outline-1 outline-gray-300 select-none has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-800"
           />
         </Slider.Track>

--- a/docs/src/app/(docs)/react/components/toast/demos/anchored/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/toast/demos/anchored/css-modules/index.tsx
@@ -90,7 +90,7 @@ function AnchoredToasts() {
   const { toasts } = Toast.useToastManager();
   return (
     <Toast.Portal>
-      <Toast.Viewport className={styles.AnchoredViewport}>
+      <Toast.Viewport aria-label="Notifications" className={styles.AnchoredViewport}>
         {toasts.map((toast) => (
           <Toast.Positioner key={toast.id} toast={toast} className={styles.AnchoredPositioner}>
             <Toast.Root toast={toast} className={styles.AnchoredToast}>
@@ -112,7 +112,7 @@ function StackedToasts() {
   const { toasts } = Toast.useToastManager();
   return (
     <Toast.Portal>
-      <Toast.Viewport className={styles.StackedViewport}>
+      <Toast.Viewport aria-label="Notifications" className={styles.StackedViewport}>
         {toasts.map((toast) => (
           <Toast.Root key={toast.id} toast={toast} className={styles.StackedToast}>
             <Toast.Content className={styles.Content}>

--- a/docs/src/app/(docs)/react/components/toast/demos/anchored/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/toast/demos/anchored/tailwind/index.tsx
@@ -93,7 +93,7 @@ function AnchoredToasts() {
   const { toasts } = Toast.useToastManager();
   return (
     <Toast.Portal>
-      <Toast.Viewport className="outline-0">
+      <Toast.Viewport aria-label="Notifications" className="outline-0">
         {toasts.map((toast) => (
           <Toast.Positioner
             key={toast.id}
@@ -122,7 +122,10 @@ function StackedToasts() {
   const { toasts } = Toast.useToastManager();
   return (
     <Toast.Portal>
-      <Toast.Viewport className="fixed z-10 top-auto right-[1rem] bottom-[1rem] mx-auto flex w-[250px] sm:right-[2rem] sm:bottom-[2rem] sm:w-[300px]">
+      <Toast.Viewport
+        aria-label="Notifications"
+        className="fixed z-10 top-auto right-[1rem] bottom-[1rem] mx-auto flex w-[250px] sm:right-[2rem] sm:bottom-[2rem] sm:w-[300px]"
+      >
         {toasts.map((toast) => (
           <Toast.Root
             key={toast.id}

--- a/docs/src/app/(docs)/react/components/toast/demos/custom/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/toast/demos/custom/css-modules/index.tsx
@@ -18,7 +18,7 @@ export default function CustomToastExample() {
     <Toast.Provider>
       <CustomToast />
       <Toast.Portal>
-        <Toast.Viewport className={styles.Viewport}>
+        <Toast.Viewport aria-label="Notifications" className={styles.Viewport}>
           <ToastList />
         </Toast.Viewport>
       </Toast.Portal>

--- a/docs/src/app/(docs)/react/components/toast/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/toast/demos/hero/css-modules/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleToast() {
     <Toast.Provider>
       <ToastButton />
       <Toast.Portal>
-        <Toast.Viewport className={styles.Viewport}>
+        <Toast.Viewport aria-label="Notifications" className={styles.Viewport}>
           <ToastList />
         </Toast.Viewport>
       </Toast.Portal>

--- a/docs/src/app/(docs)/react/components/toast/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/toast/demos/hero/tailwind/index.tsx
@@ -7,7 +7,10 @@ export default function ExampleToast() {
     <Toast.Provider>
       <ToastButton />
       <Toast.Portal>
-        <Toast.Viewport className="fixed z-10 top-auto right-[1rem] bottom-[1rem] mx-auto flex w-[250px] sm:right-[2rem] sm:bottom-[2rem] sm:w-[300px]">
+        <Toast.Viewport
+          aria-label="Notifications"
+          className="fixed z-10 top-auto right-[1rem] bottom-[1rem] mx-auto flex w-[250px] sm:right-[2rem] sm:bottom-[2rem] sm:w-[300px]"
+        >
           <ToastList />
         </Toast.Viewport>
       </Toast.Portal>

--- a/docs/src/app/(docs)/react/components/toast/demos/position/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/toast/demos/position/css-modules/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleToast() {
     <Toast.Provider>
       <ToastButton />
       <Toast.Portal>
-        <Toast.Viewport className={styles.Viewport}>
+        <Toast.Viewport aria-label="Notifications" className={styles.Viewport}>
           <ToastList />
         </Toast.Viewport>
       </Toast.Portal>

--- a/docs/src/app/(docs)/react/components/toast/demos/position/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/toast/demos/position/tailwind/index.tsx
@@ -7,7 +7,10 @@ export default function ExampleToast() {
     <Toast.Provider>
       <ToastButton />
       <Toast.Portal>
-        <Toast.Viewport className="fixed z-10 top-[1rem] right-0 bottom-auto left-0 mx-auto flex w-full max-w-[300px]">
+        <Toast.Viewport
+          aria-label="Notifications"
+          className="fixed z-10 top-[1rem] right-0 bottom-auto left-0 mx-auto flex w-full max-w-[300px]"
+        >
           <ToastList />
         </Toast.Viewport>
       </Toast.Portal>

--- a/docs/src/app/(docs)/react/components/toast/demos/promise/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/toast/demos/promise/css-modules/index.tsx
@@ -8,7 +8,7 @@ export default function PromiseToastExample() {
     <Toast.Provider>
       <PromiseDemo />
       <Toast.Portal>
-        <Toast.Viewport className={styles.Viewport}>
+        <Toast.Viewport aria-label="Notifications" className={styles.Viewport}>
           <ToastList />
         </Toast.Viewport>
       </Toast.Portal>

--- a/docs/src/app/(docs)/react/components/toast/demos/undo/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/toast/demos/undo/css-modules/index.tsx
@@ -8,7 +8,7 @@ export default function UndoToastExample() {
     <Toast.Provider>
       <Form />
       <Toast.Portal>
-        <Toast.Viewport className={styles.Viewport}>
+        <Toast.Viewport aria-label="Notifications" className={styles.Viewport}>
           <ToastList />
         </Toast.Viewport>
       </Toast.Portal>

--- a/docs/src/app/(docs)/react/components/toast/demos/varying-heights/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/toast/demos/varying-heights/css-modules/index.tsx
@@ -8,7 +8,7 @@ export default function VaryingHeightsToast() {
     <Toast.Provider>
       <ToastButton />
       <Toast.Portal>
-        <Toast.Viewport className={styles.Viewport}>
+        <Toast.Viewport aria-label="Notifications" className={styles.Viewport}>
           <ToastList />
         </Toast.Viewport>
       </Toast.Portal>

--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -20,7 +20,7 @@ import { Toast } from '@base-ui/react/toast';
 
 <Toast.Provider>
   <Toast.Portal>
-    <Toast.Viewport>
+    <Toast.Viewport aria-label="Notifications">
       {/* Stacked toasts */}
       <Toast.Root>
         <Toast.Content>
@@ -174,7 +174,7 @@ function AnchoredToasts() {
   const { toasts } = Toast.useToastManager();
   return (
     <Toast.Portal>
-      <Toast.Viewport>
+      <Toast.Viewport aria-label="Notifications">
         {toasts.map((toast) => (
           <Toast.Positioner key={toast.id} toast={toast}>
             <Toast.Root toast={toast}>{/* ... */}</Toast.Root>
@@ -189,7 +189,7 @@ function StackedToasts() {
   const { toasts } = Toast.useToastManager();
   return (
     <Toast.Portal>
-      <Toast.Viewport>
+      <Toast.Viewport aria-label="Notifications">
         {toasts.map((toast) => (
           <Toast.Root key={toast.id} toast={toast}>
             {/* ... */}

--- a/docs/src/app/(docs)/react/components/toolbar/page.mdx
+++ b/docs/src/app/(docs)/react/components/toolbar/page.mdx
@@ -84,9 +84,9 @@ return (
   <Toolbar.Root>
     <NumberField.Root>
       <NumberField.Group>
-        <NumberField.Decrement />
-        <Toolbar.Input render={<NumberField.Input />} />
-        <NumberField.Increment />
+        <NumberField.Decrement aria-label="Decrease" />
+        <Toolbar.Input render={<NumberField.Input aria-roledescription="Number field" />} />
+        <NumberField.Increment aria-label="Increase" />
       </NumberField.Group>
     </NumberField.Root>
   </Toolbar.Root>;

--- a/docs/src/app/(docs)/react/handbook/customization/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/customization/page.mdx
@@ -80,6 +80,7 @@ To prevent Base UI from handling a React event like `onClick`, you can use the 
 
 ```tsx title="Prevent Base UI's default behavior"
 <NumberField.Input
+  aria-roledescription="Number field"
   onPaste={(event) => {
     event.preventBaseUIHandler();
   }}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/number-field.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/number-field.tsx
@@ -30,6 +30,7 @@ export const Input = React.forwardRef<HTMLInputElement, NumberField.Input.Props>
 ) {
   return (
     <NumberField.Input
+      aria-roledescription="Number field"
       ref={forwardedRef}
       className={clsx(
         'h-10 w-24 border-t border-b border-gray-200 text-center text-base text-gray-900 tabular-nums focus:z-1 focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800',

--- a/docs/src/app/(docs)/react/handbook/forms/demos/components/toast.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/components/toast.tsx
@@ -36,7 +36,10 @@ export function ToastProvider(props: { children: React.ReactNode }) {
     <Toast.Provider limit={1}>
       {props.children}
       <Toast.Portal>
-        <Toast.Viewport className="fixed z-10 top-auto right-[1rem] bottom-[1rem] mx-auto flex w-[250px] sm:right-[2rem] sm:bottom-[2rem] sm:w-[360px]">
+        <Toast.Viewport
+          aria-label="Notifications"
+          className="fixed z-10 top-auto right-[1rem] bottom-[1rem] mx-auto flex w-[250px] sm:right-[2rem] sm:bottom-[2rem] sm:w-[360px]"
+        >
           <Toasts />
         </Toast.Viewport>
       </Toast.Portal>

--- a/docs/src/app/(docs)/react/handbook/forms/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/hero/tailwind/index.tsx
@@ -149,11 +149,11 @@ function ExampleForm() {
         <NumberField.Root defaultValue={undefined} min={1} max={64} required>
           <Field.Label>Number of instances</Field.Label>
           <NumberField.Group>
-            <NumberField.Decrement>
+            <NumberField.Decrement aria-label="Decrease">
               <Minus className="size-4" />
             </NumberField.Decrement>
-            <NumberField.Input className="!w-16" />
-            <NumberField.Increment>
+            <NumberField.Input aria-roledescription="Number field" className="!w-16" />
+            <NumberField.Increment aria-label="Increase">
               <Plus className="size-4" />
             </NumberField.Increment>
           </NumberField.Group>
@@ -184,8 +184,8 @@ function ExampleForm() {
           <Slider.Control>
             <Slider.Track>
               <Slider.Indicator />
-              <Slider.Thumb index={0} />
-              <Slider.Thumb index={1} />
+              <Slider.Thumb index={0} aria-label="Minimum scaling threshold" />
+              <Slider.Thumb index={1} aria-label="Maximum scaling threshold" />
             </Slider.Track>
           </Slider.Control>
         </Fieldset.Root>

--- a/docs/src/app/(docs)/react/handbook/forms/demos/react-hook-form/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/react-hook-form/tailwind/index.tsx
@@ -240,11 +240,16 @@ function ReactHookForm() {
             <NumberField.Root value={value} min={1} max={64} onValueChange={onChange}>
               <Field.Label>Number of instances</Field.Label>
               <NumberField.Group>
-                <NumberField.Decrement>
+                <NumberField.Decrement aria-label="Decrease">
                   <Minus className="size-4" />
                 </NumberField.Decrement>
-                <NumberField.Input className="!w-16" ref={ref} onBlur={onBlur} />
-                <NumberField.Increment>
+                <NumberField.Input
+                  aria-roledescription="Number field"
+                  className="!w-16"
+                  ref={ref}
+                  onBlur={onBlur}
+                />
+                <NumberField.Increment aria-label="Increase">
                   <Plus className="size-4" />
                 </NumberField.Increment>
               </NumberField.Group>
@@ -286,8 +291,13 @@ function ReactHookForm() {
               <Slider.Control>
                 <Slider.Track>
                   <Slider.Indicator />
-                  <Slider.Thumb index={0} onBlur={onBlur} inputRef={ref} />
-                  <Slider.Thumb index={1} onBlur={onBlur} />
+                  <Slider.Thumb
+                    index={0}
+                    aria-label="Minimum scaling threshold"
+                    onBlur={onBlur}
+                    inputRef={ref}
+                  />
+                  <Slider.Thumb index={1} aria-label="Maximum scaling threshold" onBlur={onBlur} />
                 </Slider.Track>
               </Slider.Control>
             </Fieldset.Root>

--- a/docs/src/app/(docs)/react/handbook/forms/demos/tanstack-form/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/tanstack-form/tailwind/index.tsx
@@ -290,11 +290,15 @@ function TanstackForm() {
               >
                 <Field.Label>Number of instances</Field.Label>
                 <NumberField.Group>
-                  <NumberField.Decrement>
+                  <NumberField.Decrement aria-label="Decrease">
                     <Minus className="size-4" />
                   </NumberField.Decrement>
-                  <NumberField.Input className="!w-16" onBlur={field.handleBlur} />
-                  <NumberField.Increment>
+                  <NumberField.Input
+                    aria-roledescription="Number field"
+                    className="!w-16"
+                    onBlur={field.handleBlur}
+                  />
+                  <NumberField.Increment aria-label="Increase">
                     <Plus className="size-4" />
                   </NumberField.Increment>
                 </NumberField.Group>
@@ -341,8 +345,16 @@ function TanstackForm() {
                 <Slider.Control>
                   <Slider.Track>
                     <Slider.Indicator />
-                    <Slider.Thumb index={0} onBlur={field.handleBlur} />
-                    <Slider.Thumb index={1} onBlur={field.handleBlur} />
+                    <Slider.Thumb
+                      index={0}
+                      aria-label="Minimum scaling threshold"
+                      onBlur={field.handleBlur}
+                    />
+                    <Slider.Thumb
+                      index={1}
+                      aria-label="Maximum scaling threshold"
+                      onBlur={field.handleBlur}
+                    />
                   </Slider.Track>
                 </Slider.Control>
               </Fieldset.Root>

--- a/docs/src/app/(docs)/react/handbook/forms/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/forms/page.mdx
@@ -65,8 +65,8 @@ import { Slider } from '@base-ui/react/slider';
       <Fieldset.Legend>Price range</Fieldset.Legend>
       <Slider.Control>
         <Slider.Track>
-          <Slider.Thumb />
-          <Slider.Thumb />
+          <Slider.Thumb index={0} aria-label="Minimum price" />
+          <Slider.Thumb index={1} aria-label="Maximum price" />
         </Slider.Track>
       </Slider.Control>
     </Fieldset.Root>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #2245
Closes #4226

The API table shows this can be customized in special cases, but the demos having it in-built is clearer by default.

ARIA translation works okay (but not fully reliably if the app isn't i18n'd): https://adrianroselli.com/2019/11/aria-label-does-not-translate.html#Update07. So the internal English labels are better than nothing to work with auto-translation in browsers. One issue is in buttons if the icon descendant has the `aria-label` instead of the button, our source code may unexpectedly override that with the English internal label


### Caveat

Range-slider demos rely on Slider’s default internal `aria-valuetext` for multi-thumb text ("start range" / "end range"). So while thumb names (`aria-label`) are explicit, the demos do not currently demonstrate customizing/localizing `aria-valuetext` via `getAriaValueText`. I've omitted it since this otherwise makes the demos awkward and often the valuetext duplicates the label anyway