### PR TITLE
[docs] Add accessible label to demo Dialog's textarea

### DIFF
--- a/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/css-modules/index.tsx
@@ -8,6 +8,7 @@ export default function ExampleDialog() {
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [confirmationOpen, setConfirmationOpen] = React.useState(false);
   const [textareaValue, setTextareaValue] = React.useState('');
+  const titleId = React.useId();
 
   return (
     <Dialog.Root
@@ -28,7 +29,9 @@ export default function ExampleDialog() {
       <Dialog.Portal>
         <Dialog.Backdrop className={styles.Backdrop} />
         <Dialog.Popup className={styles.Popup}>
-          <Dialog.Title className={styles.Title}>New tweet</Dialog.Title>
+          <Dialog.Title id={titleId} className={styles.Title}>
+            New tweet
+          </Dialog.Title>
           <form
             className={styles.TextareaContainer}
             onSubmit={(event) => {
@@ -38,6 +41,7 @@ export default function ExampleDialog() {
             }}
           >
             <textarea
+              aria-labelledby={titleId}
               required
               className={styles.Textarea}
               placeholder="What’s on your mind?"

--- a/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/tailwind/index.tsx
@@ -7,6 +7,7 @@ export default function ExampleDialog() {
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [confirmationOpen, setConfirmationOpen] = React.useState(false);
   const [textareaValue, setTextareaValue] = React.useState('');
+  const titleId = React.useId();
 
   return (
     <Dialog.Root
@@ -29,7 +30,9 @@ export default function ExampleDialog() {
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 min-h-dvh bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
         <Dialog.Popup className="fixed top-[calc(50%+1.25rem*var(--nested-dialogs))] left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 scale-[calc(1-0.1*var(--nested-dialogs))] rounded-lg bg-gray-50 p-6 text-gray-900 outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[nested-dialog-open]:after:absolute data-[nested-dialog-open]:after:inset-0 data-[nested-dialog-open]:after:rounded-[inherit] data-[nested-dialog-open]:after:bg-black/5 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
-          <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">New tweet</Dialog.Title>
+          <Dialog.Title id={titleId} className="-mt-1.5 mb-1 text-lg font-medium">
+            New tweet
+          </Dialog.Title>
           <form
             className="mt-4 flex flex-col gap-6"
             onSubmit={(event) => {
@@ -39,6 +42,7 @@ export default function ExampleDialog() {
             }}
           >
             <textarea
+              aria-labelledby={titleId}
               required
               className="min-h-48 w-full rounded-md border border-gray-200 px-3.5 py-2 text-base text-gray-900 focus:outline-2 focus:-outline-offset-1 focus:outline-blue-800"
               placeholder="What’s on your mind?"


### PR DESCRIPTION
Labels the Dialog's textarea in the https://deploy-preview-4279--base-ui.netlify.app/react/components/dialog#close-confirmation demo with the Title element

Closes https://github.com/mui/base-ui/issues/4251