### PR TITLE
[drawer] Unmark Drawer preview

### DIFF
--- a/docs/src/app/(docs)/react/components/drawer/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/hero/css-modules/index.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import styles from './index.module.css';
 
 export default function ExampleDrawer() {

--- a/docs/src/app/(docs)/react/components/drawer/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/hero/tailwind/index.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 
 export default function ExampleDrawer() {
   return (

--- a/docs/src/app/(docs)/react/components/drawer/demos/indent-provider/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/indent-provider/css-modules/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import styles from './index.module.css';
 
 export default function ExampleDrawer() {

--- a/docs/src/app/(docs)/react/components/drawer/demos/indent-provider/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/indent-provider/tailwind/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 
 export default function ExampleDrawer() {
   const [portalContainer, setPortalContainer] = React.useState<HTMLDivElement | null>(null);

--- a/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/css-modules/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import styles from './index.module.css';
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/tailwind/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 
 const ITEMS = [

--- a/docs/src/app/(docs)/react/components/drawer/demos/nested/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/nested/css-modules/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import styles from './index.module.css';
 
 export default function ExampleDrawerNested() {

--- a/docs/src/app/(docs)/react/components/drawer/demos/nested/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/nested/tailwind/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 
 export default function ExampleDrawerNested() {
   return (

--- a/docs/src/app/(docs)/react/components/drawer/demos/non-modal/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/non-modal/css-modules/index.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import styles from './index.module.css';
 
 export default function ExampleDrawer() {

--- a/docs/src/app/(docs)/react/components/drawer/demos/non-modal/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/non-modal/tailwind/index.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 
 export default function ExampleDrawer() {
   return (

--- a/docs/src/app/(docs)/react/components/drawer/demos/position/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/position/css-modules/index.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import styles from './index.module.css';
 
 export default function ExampleDrawer() {

--- a/docs/src/app/(docs)/react/components/drawer/demos/position/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/position/tailwind/index.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 
 export default function ExampleDrawer() {
   return (

--- a/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import styles from './index.module.css';
 
 const TOP_MARGIN_REM = 1;

--- a/docs/src/app/(docs)/react/components/drawer/demos/snap-points/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/snap-points/tailwind/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 
 const TOP_MARGIN_REM = 1;
 const VISIBLE_SNAP_POINTS_REM = [30];

--- a/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/css-modules/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import styles from './index.module.css';
 
 export default function ExampleDrawerSwipeArea() {

--- a/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/tailwind/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 
 export default function ExampleDrawerSwipeArea() {
   const [portalContainer, setPortalContainer] = React.useState<HTMLDivElement | null>(null);

--- a/docs/src/app/(docs)/react/components/drawer/demos/uncontained/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/uncontained/css-modules/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import styles from './index.module.css';
 
 const ACTIONS = ['Unfollow', 'Mute', 'Add to Favourites', 'Add to Close Friends', 'Restrict'];

--- a/docs/src/app/(docs)/react/components/drawer/demos/uncontained/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/drawer/demos/uncontained/tailwind/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 
 const ACTIONS = ['Unfollow', 'Mute', 'Add to Favourites', 'Add to Close Friends', 'Restrict'];
 

--- a/docs/src/app/(docs)/react/components/drawer/page.mdx
+++ b/docs/src/app/(docs)/react/components/drawer/page.mdx
@@ -8,8 +8,6 @@
 
 import { DemoDrawerHero } from './demos/hero';
 
-**Note**: `Drawer` is in preview for a temporary period and receives breaking changes in minor versions. `DrawerPreview` will be renamed to `Drawer` when it exits preview.
-
 <DemoDrawerHero />
 
 ## Usage guidelines
@@ -21,7 +19,7 @@ import { DemoDrawerHero } from './demos/hero';
 Import the component and assemble its parts:
 
 ```jsx title="Anatomy"
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 
 <Drawer.Provider>
   <Drawer.IndentBackground />

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -14,7 +14,7 @@
 - Combobox - ([Outline](#combobox), [Contents](./combobox/page.mdx))
 - Context Menu - ([Outline](#context-menu), [Contents](./context-menu/page.mdx))
 - Dialog - ([Outline](#dialog), [Contents](./dialog/page.mdx))
-- Drawer [Preview] - ([Outline](#drawer), [Contents](./drawer/page.mdx))
+- Drawer [New] - ([Outline](#drawer), [Contents](./drawer/page.mdx))
 - Field - ([Outline](#field), [Contents](./field/page.mdx))
 - Fieldset - ([Outline](#fieldset), [Contents](./fieldset/page.mdx))
 - Form - ([Outline](#form), [Contents](./form/page.mdx))

--- a/docs/src/app/(private)/experiments/drawer-slider.tsx
+++ b/docs/src/app/(private)/experiments/drawer-slider.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import { Slider } from '@base-ui/react/slider';
 import styles from './drawer-slider.module.css';
 

--- a/docs/src/app/(private)/experiments/drawer/cross-axis-scroll.tsx
+++ b/docs/src/app/(private)/experiments/drawer/cross-axis-scroll.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import clsx from 'clsx';
 import heroStyles from 'docs/src/app/(docs)/react/components/drawer/demos/hero/css-modules/index.module.css';
 import positionStyles from 'docs/src/app/(docs)/react/components/drawer/demos/position/css-modules/index.module.css';

--- a/docs/src/app/(private)/experiments/drawer/drawer-controlled-opening.tsx
+++ b/docs/src/app/(private)/experiments/drawer/drawer-controlled-opening.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 
 export default function ControlledOpening() {
   const [open, setOpen] = React.useState(false);

--- a/docs/src/app/(private)/experiments/drawer/touch-ignore.tsx
+++ b/docs/src/app/(private)/experiments/drawer/touch-ignore.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 
 type EventName = 'plain div click' | 'ignored div click' | 'native button click' | 'drawer closed';
 

--- a/packages/react/src/drawer/content/DrawerContent.test.tsx
+++ b/packages/react/src/drawer/content/DrawerContent.test.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import { screen } from '@mui/internal-test-utils';
 import { describe, expect, it } from 'vitest';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/drawer/indent-background/DrawerIndentBackground.test.tsx
+++ b/packages/react/src/drawer/indent-background/DrawerIndentBackground.test.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import { screen } from '@mui/internal-test-utils';
 import { expect } from 'vitest';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/drawer/indent/DrawerIndent.test.tsx
+++ b/packages/react/src/drawer/indent/DrawerIndent.test.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import { screen } from '@mui/internal-test-utils';
 import { describe, expect, it } from 'vitest';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/drawer/index.ts
+++ b/packages/react/src/drawer/index.ts
@@ -1,4 +1,4 @@
-export * as DrawerPreview from './index.parts';
+export * as Drawer from './index.parts';
 
 export type * from './root/DrawerRoot';
 export type * from './provider/DrawerProvider';

--- a/packages/react/src/drawer/popup/DrawerPopup.test.tsx
+++ b/packages/react/src/drawer/popup/DrawerPopup.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import { act, screen, waitFor } from '@mui/internal-test-utils';
 import { describe, expect, it } from 'vitest';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/drawer/root/DrawerRoot.spec.tsx
+++ b/packages/react/src/drawer/root/DrawerRoot.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expectType } from '#test-utils';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import { REASONS } from '../../utils/reasons';
 
 type DrawerChangeHandler = NonNullable<Drawer.Root.Props['onOpenChange']>;

--- a/packages/react/src/drawer/root/DrawerRoot.test.tsx
+++ b/packages/react/src/drawer/root/DrawerRoot.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { createRenderer, isJSDOM, waitSingleFrame } from '#test-utils';

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -1,4 +1,4 @@
-import { DrawerPreview as Drawer } from '@base-ui/react/drawer';
+import { Drawer } from '@base-ui/react/drawer';
 import { Slider } from '@base-ui/react/slider';
 import { fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { beforeAll, describe, expect, it, vi } from 'vitest';


### PR DESCRIPTION
## Summary
- Promote the drawer namespace to stable `Drawer`.
- Remove `DrawerPreview` entirely as a breaking API change.
- Remove preview wording from the docs and update drawer examples and tests to use the stable import.
