### PR TITLE
[navigation menu] Fix delayed trigger switches in Safari

### DIFF
--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.webkit.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.webkit.test.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
+import { vi } from 'vitest';
+import { NavigationMenu } from '@base-ui/react/navigation-menu';
+import { createRenderer } from '#test-utils';
+import { OPEN_DELAY } from '../utils/constants';
+
+vi.mock('@base-ui/utils/detectBrowser', async () => {
+  const actual = await vi.importActual<typeof import('@base-ui/utils/detectBrowser')>(
+    '@base-ui/utils/detectBrowser',
+  );
+
+  return {
+    ...actual,
+    isWebKit: true,
+  };
+});
+
+function TestNavigationMenu() {
+  return (
+    <NavigationMenu.Root>
+      <NavigationMenu.List data-testid="top-level-list">
+        <NavigationMenu.Item value="item-1">
+          <NavigationMenu.Trigger data-testid="trigger-1">Item 1</NavigationMenu.Trigger>
+          <NavigationMenu.Content data-testid="popup-1">
+            <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
+          </NavigationMenu.Content>
+        </NavigationMenu.Item>
+      </NavigationMenu.List>
+
+      <NavigationMenu.Portal>
+        <NavigationMenu.Positioner>
+          <NavigationMenu.Popup>
+            <NavigationMenu.Viewport />
+          </NavigationMenu.Popup>
+        </NavigationMenu.Positioner>
+      </NavigationMenu.Portal>
+    </NavigationMenu.Root>
+  );
+}
+
+function TestInlineNestedNavigationMenu() {
+  return (
+    <NavigationMenu.Root>
+      <NavigationMenu.List>
+        <NavigationMenu.Item value="item-1">
+          <NavigationMenu.Trigger data-testid="trigger-1">Item 1</NavigationMenu.Trigger>
+          <NavigationMenu.Content data-testid="popup-1">
+            <NavigationMenu.Root defaultValue="nested-item-1">
+              <NavigationMenu.List data-testid="inline-nested-list">
+                <NavigationMenu.Item value="nested-item-1">
+                  <NavigationMenu.Trigger data-testid="nested-trigger-1">
+                    Nested Item 1
+                  </NavigationMenu.Trigger>
+                  <NavigationMenu.Content data-testid="nested-popup-1">
+                    <NavigationMenu.Link href="#nested-link-1">Nested Link 1</NavigationMenu.Link>
+                  </NavigationMenu.Content>
+                </NavigationMenu.Item>
+              </NavigationMenu.List>
+
+              <NavigationMenu.Viewport data-testid="inline-nested-viewport" />
+            </NavigationMenu.Root>
+          </NavigationMenu.Content>
+        </NavigationMenu.Item>
+      </NavigationMenu.List>
+
+      <NavigationMenu.Portal>
+        <NavigationMenu.Positioner>
+          <NavigationMenu.Popup>
+            <NavigationMenu.Viewport />
+          </NavigationMenu.Popup>
+        </NavigationMenu.Positioner>
+      </NavigationMenu.Portal>
+    </NavigationMenu.Root>
+  );
+}
+
+function mockBoundingClientRect(
+  element: Element,
+  rect: { x: number; y: number; width: number; height: number },
+) {
+  const domRect = {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+    top: rect.y,
+    left: rect.x,
+    right: rect.x + rect.width,
+    bottom: rect.y + rect.height,
+    toJSON: () => ({}),
+  } satisfies DOMRect;
+
+  vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(domRect);
+}
+
+describe('<NavigationMenu.Root /> (Safari)', () => {
+  const { render, clock } = createRenderer();
+
+  clock.withFakeTimers();
+
+  it('does not mutate top-level pointer events for hover-open menus', async () => {
+    await render(<TestNavigationMenu />);
+    const trigger = screen.getByTestId('trigger-1');
+
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseMove(trigger);
+    clock.tick(OPEN_DELAY);
+    await flushMicrotasks();
+
+    const topLevelList = screen.getByTestId('top-level-list');
+
+    expect(screen.queryByTestId('popup-1')).not.to.equal(null);
+    expect(topLevelList.style.pointerEvents).to.equal('');
+    expect(document.body.style.pointerEvents).to.equal('');
+  });
+
+  it('keeps nested safePolygon pointer events scoped on WebKit', async () => {
+    await render(<TestInlineNestedNavigationMenu />);
+    const trigger1 = screen.getByTestId('trigger-1');
+
+    fireEvent.mouseEnter(trigger1);
+    fireEvent.mouseMove(trigger1);
+    clock.tick(OPEN_DELAY);
+    await flushMicrotasks();
+
+    const nestedList = screen.getByTestId('inline-nested-list');
+    const nestedTrigger1 = screen.getByTestId('nested-trigger-1');
+    const nestedViewport = screen.getByTestId('inline-nested-viewport');
+
+    mockBoundingClientRect(nestedTrigger1, { x: 0, y: 40, width: 100, height: 40 });
+    mockBoundingClientRect(nestedViewport, { x: 200, y: 0, width: 300, height: 300 });
+    fireEvent.mouseEnter(nestedTrigger1);
+
+    expect(nestedList.style.pointerEvents).to.equal('none');
+    expect(document.body.style.pointerEvents).to.equal('');
+  });
+});

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -9,6 +9,7 @@ import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useTimeout } from '@base-ui/utils/useTimeout';
 import { useAnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
+import { isWebKit } from '@base-ui/utils/detectBrowser';
 import {
   safePolygon,
   useClick,
@@ -112,6 +113,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   const allowFocusRef = React.useRef(false);
   const prevSizeRef = React.useRef(DEFAULT_SIZE);
   const animationAbortControllerRef = React.useRef<AbortController | null>(null);
+  const skipAutoSizeSyncRef = React.useRef(false);
 
   const isActiveItem = open && value === itemValue;
   const isActiveItemRef = useValueAsRef(isActiveItem);
@@ -327,6 +329,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
       sizeFrame.cancel();
       animationAbortControllerRef.current?.abort();
       animationAbortControllerRef.current = null;
+      skipAutoSizeSyncRef.current = false;
       setPointerType('');
     }
   }, [stickIfOpenTimeout, open, mutationFrame, resizeFrame, sizeFrame]);
@@ -441,13 +444,20 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
 
   useIsoLayoutEffect(() => {
     if (isActiveItemRef.current && open && popupElement) {
-      const hasNestedMenu = currentContentRef.current?.querySelector('[data-nested]') != null;
+      if (transitionStatus === 'starting') {
+        const hasNestedMenu = currentContentRef.current?.querySelector('[data-nested]') != null;
 
-      if (transitionStatus === 'starting' && hasNestedMenu) {
-        sizeFrame.request(syncCurrentSize);
-        return () => {
-          sizeFrame.cancel();
-        };
+        if (hasNestedMenu) {
+          sizeFrame.request(syncCurrentSize);
+          return () => {
+            sizeFrame.cancel();
+          };
+        }
+      }
+
+      if (skipAutoSizeSyncRef.current) {
+        skipAutoSizeSyncRef.current = false;
+        return undefined;
       }
 
       handleValueChange(0, 0);
@@ -540,10 +550,6 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   });
 
   function getScope() {
-    if (!nested || positionerElement) {
-      return null;
-    }
-
     return triggerElementRef.current?.closest('ul') ?? null;
   }
 
@@ -551,7 +557,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     enabled: hoverInteractionsEnabled,
     move: false,
     handleClose: safePolygon({
-      blockPointerEvents: pointerType !== 'touch',
+      blockPointerEvents: pointerType !== 'touch' && (!isWebKit || nested),
       getScope,
     }),
     restMs: mounted && positionerElement ? 0 : delay,
@@ -646,8 +652,15 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     }
 
     const { width, height } = getCssDimensions(popupElement);
+    const shouldSkipAutoSizeSync =
+      value != null && value !== itemValue && (event.type === 'click' || pointerType !== 'touch');
 
     handleActivation(event);
+
+    if (shouldSkipAutoSizeSync) {
+      skipAutoSizeSyncRef.current = true;
+    }
+
     handleValueChange(width, height);
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Summary

This improves Navigation Menu hover performance during trigger-to-trigger switching.

### What changed

- Keep `safePolygon` pointer-events blocking enabled for non-WebKit browsers.
- Disable top-level pointer-events blocking on WebKit, which avoids the Safari hover delay when switching triggers.
- Keep nested Navigation Menu blocking behavior intact.
- Reduce redundant size-sync work during trigger switches by skipping an extra auto-size pass when the trigger event already handled the size transition.
- Add a regression test asserting top-level hover pointer-events mutations stay scoped to the list rather than `document.body`.

### Why

Safari could intermittently delay hover activation when moving directly between top-level triggers. Entering the popup first consistently cleared the issue, which pointed to the top-level pointer-events mutation path rather than `safePolygon` geometry. Disabling that mutation on WebKit fixes the delay while preserving the better non-WebKit behavior.