### PR TITLE
[select] Preserve touch exit animations

### DIFF
--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -861,6 +861,65 @@ describe('<Select.Root />', () => {
 
       expect(isScrollLocked()).toBe(false);
     });
+
+    it('keeps touch positioning during the close transition', async ({ onTestFinished }) => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+      onTestFinished(() => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+      });
+
+      const style = `
+        @keyframes select-close-test {
+          to {
+            opacity: 0;
+          }
+        }
+
+        .animation-test-popup[data-ending-style] {
+          animation: select-close-test 100ms linear;
+        }
+      `;
+
+      await render(
+        <div style={{ paddingTop: 80 }}>
+          {/* eslint-disable-next-line react/no-danger */}
+          <style dangerouslySetInnerHTML={{ __html: style }} />
+          <Select.Root>
+            <Select.Trigger>Open</Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup className="animation-test-popup">
+                  <Select.Item>Item</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        </div>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+
+      function fireTouchPress() {
+        fireEvent.pointerDown(trigger, { pointerType: 'touch' });
+        fireEvent.mouseDown(trigger);
+      }
+
+      fireTouchPress();
+
+      const popup = await screen.findByRole('listbox');
+      const positioner = popup.parentElement as HTMLElement;
+
+      expect(getComputedStyle(positioner).position).toBe('absolute');
+
+      fireTouchPress();
+
+      await waitFor(() => {
+        expect(popup).toHaveAttribute('data-ending-style');
+      });
+
+      expect(getComputedStyle(positioner).position).toBe('absolute');
+    });
   });
 
   describe('prop: actionsRef', () => {

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -4,6 +4,7 @@ import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidd
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { useOnFirstRender } from '@base-ui/utils/useOnFirstRender';
+import { usePreviousValue } from '@base-ui/utils/usePreviousValue';
 import { useControlled } from '@base-ui/utils/useControlled';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
@@ -159,6 +160,9 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   const triggerElement = useStore(store, selectors.triggerElement);
   const positionerElement = useStore(store, selectors.positionerElement);
 
+  const previousOpenMethod = usePreviousValue(openMethod);
+  const renderedOpenMethod = openMethod ?? previousOpenMethod;
+
   const serializedValue = React.useMemo(() => {
     if (multiple && Array.isArray(value) && value.length === 0) {
       return '';
@@ -274,7 +278,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
 
   const handleUnmount = useStableCallback(() => {
     setMounted(false);
-    store.set('activeIndex', null);
+    store.update({ activeIndex: null, openMethod: null });
     onOpenChangeComplete?.(false);
   });
 
@@ -413,7 +417,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
       itemToStringLabel,
       itemToStringValue,
       isItemEqualToValue,
-      openMethod,
+      openMethod: renderedOpenMethod,
     });
   }, [
     store,
@@ -430,7 +434,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     itemToStringLabel,
     itemToStringValue,
     isItemEqualToValue,
-    openMethod,
+    renderedOpenMethod,
   ]);
 
   const contextValue: SelectRootContext = React.useMemo(


### PR DESCRIPTION
## Summary

Fixes a Select regression where touch-triggered close animations could lose their exit styling during the close transition.

The change keeps the last non-null `openMethod` available through the close phase so touch-opened Selects do not switch layout modes mid-exit.

## Changes

- Preserve the previous `openMethod` during close using `usePreviousValue`.
- Clear the Select store's `openMethod` only after the popup fully unmounts.
- Add a Chromium regression test covering touch close transitions and `data-ending-style`.

## Notes

- This doesn't affect the `alignItemWithTrigger={false}` mode when explicitly set
- This also preserves the `null` openMethod bug fix from #4128