### PR TITLE
[navigation menu] Remove invalid aria-orientation

### DIFF
--- a/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
+++ b/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
@@ -66,9 +66,7 @@ export const NavigationMenuList = React.forwardRef(function NavigationMenuList(
   // but we want to block it in this case.
   // When nested, skip this handler so arrow keys can reach the parent CompositeRoot.
   const defaultProps: HTMLProps = nested
-    ? {
-        'aria-orientation': orientation,
-      }
+    ? EMPTY_OBJECT
     : {
         onKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
           const shouldStop =
@@ -82,7 +80,12 @@ export const NavigationMenuList = React.forwardRef(function NavigationMenuList(
         },
       };
 
-  const props = [dismissProps?.floating || EMPTY_OBJECT, defaultProps, elementProps];
+  const props = [
+    dismissProps?.floating || EMPTY_OBJECT,
+    defaultProps,
+    { 'aria-orientation': undefined },
+    elementProps,
+  ];
 
   // When nested, skip the CompositeRoot wrapper so that triggers can participate
   // in the parent Content's composite navigation context. Also skip the onKeyDown

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -831,18 +831,18 @@ describe('<NavigationMenu.Root />', () => {
     },
   }));
 
-  it('applies aria-orientation to the top-level list instead of the root element', async () => {
+  it('does not apply aria-orientation to the top-level list or root element', async () => {
     await render(<TestNavigationMenuOrientationAttributes />);
 
     expect(screen.getByTestId('top-level-root')).not.toHaveAttribute('aria-orientation');
-    expect(screen.getByTestId('top-level-list')).toHaveAttribute('aria-orientation', 'vertical');
+    expect(screen.getByTestId('top-level-list')).not.toHaveAttribute('aria-orientation');
   });
 
-  it('applies aria-orientation to nested lists instead of nested root elements', async () => {
+  it('does not apply aria-orientation to nested lists or root elements', async () => {
     await render(<TestNavigationMenuOrientationAttributes />);
 
     expect(screen.getByTestId('nested-root')).not.toHaveAttribute('aria-orientation');
-    expect(screen.getByTestId('nested-list')).toHaveAttribute('aria-orientation', 'vertical');
+    expect(screen.getByTestId('nested-list')).not.toHaveAttribute('aria-orientation');
   });
 
   describe('interactions', () => {


### PR DESCRIPTION
Fixes #4349

## Summary

NavigationMenu.List currently renders `aria-orientation` on a plain `ul`, which triggers accessibility checks because that implicit role does not support the attribute. This change stops Navigation Menu from outputting `aria-orientation` on either top-level or nested lists.

## Changes

- Override the list props so `NavigationMenu.List` does not render `aria-orientation`.
- Update the Navigation Menu root tests to assert the attribute is absent on both top-level and nested lists.

## Notes

- After rebasing onto `upstream/master`, `pnpm test:jsdom NavigationMenuRoot --no-watch` fails before running tests because Vite cannot resolve `date-fns/addDays` from `packages/react/src/temporal-adapter-date-fns/TemporalAdapterDateFns.ts`.
- `pnpm exec eslint packages/react/src/navigation-menu/list/NavigationMenuList.tsx packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx` passes.