### PR TITLE
[docs] Fix search trigger active bg color

### DIFF
--- a/docs/src/components/Search/SearchBar.css
+++ b/docs/src/components/Search/SearchBar.css
@@ -105,7 +105,7 @@
   }
 
   .SearchTrigger:active::before {
-    background-color: var(--color-gray-200);
+    background-color: var(--color-gray-50);
   }
 
   .SearchTrigger:focus-visible {


### PR DESCRIPTION


|before|after|
|---|---|
|<img width="92" height="42" alt="Screenshot 2026-03-17 at 13 00 02" src="https://github.com/user-attachments/assets/094040b6-f00d-40a3-b185-8b5aae538013" />|<img width="90" height="44" alt="Screenshot 2026-03-17 at 12 59 22" src="https://github.com/user-attachments/assets/5b595745-06b4-4eda-bee4-802fb2381010" />|
