### PR TITLE
[docs-infra] SEO Optimizations

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -148,6 +148,7 @@ const nextConfig = {
     // docs-infra
     LIB_VERSION: rootPackage.version,
     SOURCE_CODE_REPO: 'https://github.com/mui/base-ui',
+    BASE_URL: 'https://base-ui.com',
   },
   ...(process.env.NODE_ENV === 'production' && { distDir: 'export', output: 'export' }),
   devIndicators: false,

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,4 +1,4 @@
-/_next/*.js
+/_next/static/
   Cache-Control: public, max-age=31536000, immutable
 
 /static/favicon.ico

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -6,6 +6,9 @@
 # Playground SPA redirects
 /vite-playground/* /vite-playground/index.html 200
 
+# Shortlink to Netlify deploy previews
+/pr/:number https://deploy-preview-:number--base-ui.netlify.app/ 302
+
 # For links that we can't edit later on, for example hosted in the code published on npm
 /r/discord https://discord.com/invite/g6C3hUtuxz 302
 /r/invalid-render-prop /react/handbook/composition 302

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,4 +1,0 @@
-# Algolia-Crawler-Verif: 98C49CAFF7AEED76
-
-User-agent: *
-Allow: /

--- a/docs/src/app/(docs)/layout.tsx
+++ b/docs/src/app/(docs)/layout.tsx
@@ -110,15 +110,15 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
   },
   openGraph: {
-    type: 'website',
+    // 'article' is more semantically correct for documentation pages and
+    // unlocks article-specific OG properties.
+    type: 'article',
     locale: 'en_US',
-    title: {
-      template: '%s · Base UI',
-      default: 'Base UI',
-    },
+    url: './',
+    authors: ['https://base-ui.com'],
     ttl: 604800,
   },
-  metadataBase: new URL('https://base-ui.com'),
+  metadataBase: process.env.BASE_URL,
   alternates: {
     canonical: './',
   },

--- a/docs/src/app/(website)/layout.tsx
+++ b/docs/src/app/(website)/layout.tsx
@@ -39,13 +39,25 @@ export default function Layout({ children }: React.PropsWithChildren) {
                 className="bui-d-f bui-fd-c bui-g-2 bui-gcs-5 bui-gce-8 bp2:bui-gcs-5 bp2:bui-gce-9 bp3:bui-gcs-5 bp3:bui-gce-7"
                 aria-label="social links"
               >
-                <Link className="Text size-1" href="https://x.com/base_ui">
+                <Link
+                  className="Text size-1"
+                  href="https://x.com/base_ui"
+                  rel="noopener noreferrer"
+                >
                   X
                 </Link>
-                <Link className="Text size-1" href="https://github.com/mui/base-ui">
+                <Link
+                  className="Text size-1"
+                  href="https://github.com/mui/base-ui"
+                  rel="noopener noreferrer"
+                >
                   GitHub
                 </Link>
-                <Link className="Text size-1" href="https://discord.com/invite/g6C3hUtuxz">
+                <Link
+                  className="Text size-1"
+                  href="https://discord.com/invite/g6C3hUtuxz"
+                  rel="noopener noreferrer"
+                >
                   Discord
                 </Link>
               </nav>
@@ -69,21 +81,38 @@ export default function Layout({ children }: React.PropsWithChildren) {
                 className="bui-d-f bui-fd-c bui-g-2 bui-gcs-1 bui-gce-9 bp2:bui-gcs-3 bp4:bui-gce-7"
                 aria-label="social links"
               >
-                <Link className="Text size-1" href="https://x.com/base_ui">
+                <Link
+                  className="Text size-1"
+                  href="https://x.com/base_ui"
+                  rel="noopener noreferrer"
+                >
                   X
                 </Link>
-                <Link className="Text size-1" href="https://github.com/mui/base-ui">
+                <Link
+                  className="Text size-1"
+                  href="https://github.com/mui/base-ui"
+                  rel="noopener noreferrer"
+                >
                   GitHub
                 </Link>
-                <Link className="Text size-1" href="https://discord.com/invite/g6C3hUtuxz">
+                <Link
+                  className="Text size-1"
+                  href="https://discord.com/invite/g6C3hUtuxz"
+                  rel="noopener noreferrer"
+                >
                   Discord
                 </Link>
-                <Link className="Text size-1" href="https://www.npmjs.com/package/@base-ui/react">
+                <Link
+                  className="Text size-1"
+                  href="https://www.npmjs.com/package/@base-ui/react"
+                  rel="noopener noreferrer"
+                >
                   npm
                 </Link>
                 <a
                   className="Text size-1 Link"
                   href="https://bsky.app/profile/did:plc:nwr6peuxqzdzlbi72qr5kldc"
+                  rel="noopener noreferrer"
                 >
                   Bluesky
                 </a>
@@ -96,10 +125,12 @@ export default function Layout({ children }: React.PropsWithChildren) {
   );
 }
 
+const SITE_TITLE = 'Unstyled UI components for accessible design systems · Base UI';
+
 export const metadata: Metadata = {
   title: {
     template: '%s · Base UI',
-    default: 'Base UI',
+    default: SITE_TITLE,
   },
   twitter: {
     site: '@base_ui',
@@ -108,13 +139,14 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     locale: 'en_US',
+    url: './',
     title: {
       template: '%s · Base UI',
-      default: 'Base UI',
+      default: SITE_TITLE,
     },
     ttl: 604800,
   },
-  metadataBase: new URL('https://base-ui.com'),
+  metadataBase: process.env.BASE_URL,
   alternates: {
     canonical: './',
   },

--- a/docs/src/app/(website)/page.tsx
+++ b/docs/src/app/(website)/page.tsx
@@ -27,6 +27,28 @@ export default function Homepage() {
           }),
         }}
       />
+      {/* Organization schema for Google Knowledge Panel and entity recognition.
+          https://developers.google.com/search/docs/appearance/structured-data/organization */}
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'Organization',
+            name: 'Base UI',
+            url: process.env.BASE_URL,
+            logo: `${process.env.BASE_URL}/static/favicon.svg`,
+            sameAs: [
+              process.env.SOURCE_CODE_REPO,
+              'https://x.com/base_ui',
+              'https://www.npmjs.com/package/@base-ui/react',
+              'https://discord.com/invite/g6C3hUtuxz',
+              'https://bsky.app/profile/did:plc:nwr6peuxqzdzlbi72qr5kldc',
+            ],
+          }),
+        }}
+      />
 
       <section className="bui-d-c">
         <h1 className="Text size-3 bp2:size-4 bui-gcs-1 bui-gce-9 bp4:bui-gce-5">
@@ -191,33 +213,59 @@ export default function Homepage() {
           <h2 className="Text size-2">The fine print</h2>
         </div>
         <div className="bui-gcs-1 bui-gce-9 bp2:bui-gcs-3 bp4:bui-gce-7">
-          <Accordion.Root className="AccordionRoot">
-            <Accordion.Item className="AccordionItem">
+          <Accordion.Root
+            className="AccordionRoot"
+            itemScope
+            itemType="https://schema.org/FAQPage"
+            // Setting `keepMounted` so that the content of all panels is available in the DOM for search engines. This is especially important for the homepage, which contains important SEO content.
+            keepMounted
+          >
+            <Accordion.Item
+              className="AccordionItem"
+              itemScope
+              itemProp="mainEntity"
+              itemType="https://schema.org/Question"
+            >
               <Accordion.Header className="AccordionHeader">
-                <Accordion.Trigger className="AccordionTrigger Text size-2">
+                <Accordion.Trigger className="AccordionTrigger Text size-2" itemProp="name">
                   What is Base UI?
                   <PlusIcon className="AccordionIcon AccordionIconPlus" />
                   <MinusIcon className="AccordionIcon AccordionIconMinus" />
                 </Accordion.Trigger>
               </Accordion.Header>
-              <Accordion.Panel className="AccordionPanel">
-                <p className="Text size-2">
+              <Accordion.Panel
+                className="AccordionPanel"
+                itemScope
+                itemProp="acceptedAnswer"
+                itemType="https://schema.org/Answer"
+              >
+                <p className="Text size-2" itemProp="text">
                   Base UI is a library of unstyled UI components for building accessible component
                   libraries, user interfaces, web applications, and websites with React. Base UI
                   components are highly configurable, composable, and customizable.
                 </p>
               </Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item className="AccordionItem">
+            <Accordion.Item
+              className="AccordionItem"
+              itemScope
+              itemProp="mainEntity"
+              itemType="https://schema.org/Question"
+            >
               <Accordion.Header className="AccordionHeader">
-                <Accordion.Trigger className="AccordionTrigger Text size-2">
+                <Accordion.Trigger className="AccordionTrigger Text size-2" itemProp="name">
                   Does Base UI work with any styling library?
                   <PlusIcon className="AccordionIcon AccordionIconPlus" />
                   <MinusIcon className="AccordionIcon AccordionIconMinus" />
                 </Accordion.Trigger>
               </Accordion.Header>
-              <Accordion.Panel className="AccordionPanel">
-                <p className="Text size-2">
+              <Accordion.Panel
+                className="AccordionPanel"
+                itemScope
+                itemProp="acceptedAnswer"
+                itemType="https://schema.org/Answer"
+              >
+                <p className="Text size-2" itemProp="text">
                   Yes. Base UI works with Tailwind, CSS Modules, CSS-in-JS, plain CSS, and any other
                   styling library you prefer. It also works with JavaScript animation libraries like
                   Motion, or just plain CSS transitions. Base UI is an unstyled component library.
@@ -225,16 +273,26 @@ export default function Homepage() {
                 </p>
               </Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item className="AccordionItem">
+            <Accordion.Item
+              className="AccordionItem"
+              itemScope
+              itemProp="mainEntity"
+              itemType="https://schema.org/Question"
+            >
               <Accordion.Header className="AccordionHeader">
-                <Accordion.Trigger className="AccordionTrigger Text size-2">
+                <Accordion.Trigger className="AccordionTrigger Text size-2" itemProp="name">
                   Which accessibility standards does Base UI follow?
                   <PlusIcon className="AccordionIcon AccordionIconPlus" />
                   <MinusIcon className="AccordionIcon AccordionIconMinus" />
                 </Accordion.Trigger>
               </Accordion.Header>
-              <Accordion.Panel className="AccordionPanel">
-                <p className="Text size-2">
+              <Accordion.Panel
+                className="AccordionPanel"
+                itemScope
+                itemProp="acceptedAnswer"
+                itemType="https://schema.org/Answer"
+              >
+                <p className="Text size-2" itemProp="text">
                   When designing and speccing components, we follow{' '}
                   <Link href="https://www.w3.org/WAI/ARIA/apg/patterns/">
                     ARIA Authoring Practices Guide patterns
@@ -250,16 +308,26 @@ export default function Homepage() {
                 </p>
               </Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item className="AccordionItem">
+            <Accordion.Item
+              className="AccordionItem"
+              itemScope
+              itemProp="mainEntity"
+              itemType="https://schema.org/Question"
+            >
               <Accordion.Header className="AccordionHeader">
-                <Accordion.Trigger className="AccordionTrigger Text size-2">
+                <Accordion.Trigger className="AccordionTrigger Text size-2" itemProp="name">
                   How does Base UI differ from Radix UI?
                   <PlusIcon className="AccordionIcon AccordionIconPlus" />
                   <MinusIcon className="AccordionIcon AccordionIconMinus" />
                 </Accordion.Trigger>
               </Accordion.Header>
-              <Accordion.Panel className="AccordionPanel">
-                <div className="bui-d-f bui-fd-c bui-g-4">
+              <Accordion.Panel
+                className="AccordionPanel"
+                itemScope
+                itemProp="acceptedAnswer"
+                itemType="https://schema.org/Answer"
+              >
+                <div className="bui-d-f bui-fd-c bui-g-4" itemProp="text">
                   <p className="Text size-2">
                     In terms of API design, both libraries are very similar. We intentionally kept
                     our APIs close to Radix UI for an easier migration path. Base UI provides more
@@ -276,48 +344,78 @@ export default function Homepage() {
                 </div>
               </Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item className="AccordionItem">
+            <Accordion.Item
+              className="AccordionItem"
+              itemScope
+              itemProp="mainEntity"
+              itemType="https://schema.org/Question"
+            >
               <Accordion.Header className="AccordionHeader">
-                <Accordion.Trigger className="AccordionTrigger Text size-2">
+                <Accordion.Trigger className="AccordionTrigger Text size-2" itemProp="name">
                   Can I use Base UI without React?
                   <PlusIcon className="AccordionIcon AccordionIconPlus" />
                   <MinusIcon className="AccordionIcon AccordionIconMinus" />
                 </Accordion.Trigger>
               </Accordion.Header>
-              <Accordion.Panel className="AccordionPanel">
-                <p className="Text size-2">
+              <Accordion.Panel
+                className="AccordionPanel"
+                itemScope
+                itemProp="acceptedAnswer"
+                itemType="https://schema.org/Answer"
+              >
+                <p className="Text size-2" itemProp="text">
                   Base UI is a React library. It is not designed to be used without React. We may
                   consider supporting other libraries at some point, but for the foreseeable future,
                   React is our primary focus.
                 </p>
               </Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item className="AccordionItem">
+            <Accordion.Item
+              className="AccordionItem"
+              itemScope
+              itemProp="mainEntity"
+              itemType="https://schema.org/Question"
+            >
               <Accordion.Header className="AccordionHeader">
-                <Accordion.Trigger className="AccordionTrigger Text size-2">
+                <Accordion.Trigger className="AccordionTrigger Text size-2" itemProp="name">
                   Is Base UI free for commercial use?
                   <PlusIcon className="AccordionIcon AccordionIconPlus" />
                   <MinusIcon className="AccordionIcon AccordionIconMinus" />
                 </Accordion.Trigger>
               </Accordion.Header>
-              <Accordion.Panel className="AccordionPanel">
-                <p className="Text size-2">
+              <Accordion.Panel
+                className="AccordionPanel"
+                itemScope
+                itemProp="acceptedAnswer"
+                itemType="https://schema.org/Answer"
+              >
+                <p className="Text size-2" itemProp="text">
                   Yes. Base UI is licensed under the MIT license, and is free for commercial use.
                   You are free to use it in your commercial projects, and to modify it to suit your
                   needs.
                 </p>
               </Accordion.Panel>
             </Accordion.Item>
-            <Accordion.Item className="AccordionItem">
+            <Accordion.Item
+              className="AccordionItem"
+              itemScope
+              itemProp="mainEntity"
+              itemType="https://schema.org/Question"
+            >
               <Accordion.Header className="AccordionHeader">
-                <Accordion.Trigger className="AccordionTrigger Text size-2">
+                <Accordion.Trigger className="AccordionTrigger Text size-2" itemProp="name">
                   Do you offer enterprise SLAs?
                   <PlusIcon className="AccordionIcon AccordionIconPlus" />
                   <MinusIcon className="AccordionIcon AccordionIconMinus" />
                 </Accordion.Trigger>
               </Accordion.Header>
-              <Accordion.Panel className="AccordionPanel">
-                <p className="Text size-2">
+              <Accordion.Panel
+                className="AccordionPanel"
+                itemScope
+                itemProp="acceptedAnswer"
+                itemType="https://schema.org/Answer"
+              >
+                <p className="Text size-2" itemProp="text">
                   Not currently. We do provide dedicated support channels to some very large
                   enterprise companies who are working with us as design partners. But we do not
                   currently provide Service Level Agreements, guaranteed response times, issue
@@ -337,9 +435,13 @@ const description = 'Unstyled UI components for building accessible web apps and
 export const metadata: Metadata = {
   description,
   twitter: {
+    site: '@base_ui',
+    card: 'summary_large_image',
     description,
   },
   openGraph: {
+    type: 'website',
+    url: './',
     description,
   },
 };

--- a/docs/src/app/robots.txt
+++ b/docs/src/app/robots.txt
@@ -1,0 +1,8 @@
+# Algolia-Crawler-Verif: 98C49CAFF7AEED76
+
+User-agent: *
+Allow: /
+
+Disallow: /experiments/
+Disallow: /hydration-repro/
+Disallow: /playground/

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -76,9 +76,13 @@ export const mdxComponents: MDXComponents = {
   QuickNav,
   Meta: (props: React.ComponentProps<'meta'>) => {
     if (props.name === 'description' && String(props.content).length > 170) {
-      throw new Error('Meta description shouldn’t be longer than 170 chars');
+      throw new Error("Meta description shouldn't be longer than 170 chars");
     }
-    return <meta {...props} />;
+    // At build time, `transformMarkdownMetadata` extracts <Meta> attributes
+    // and injects them as `export const metadata = { ... }` into the compiled
+    // MDX. Next.js picks that export up and emits the <meta> tag itself, so
+    // rendering one here would produce a duplicate.
+    return null;
   },
   Subtitle: (props) => <Subtitle className="MdSubtitle" {...props} />,
 };

--- a/docs/types.d.ts
+++ b/docs/types.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="gtag.js" />
 
+declare namespace NodeJS {
+  interface ProcessEnv {
+    BASE_URL: string;
+    LIB_VERSION: string;
+    SOURCE_CODE_REPO: string;
+  }
+}
+
 declare module 'gtag.js';
 
 declare module '*.mdx' {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,9 @@ export default defineConfig(
           project: ['tsconfig.json'],
         },
       },
+      next: {
+        rootDir: 'docs',
+      },
     },
     /**
      * Sorted alphanumerically within each group. built-in and each plugin form


### PR DESCRIPTION
- Add sitemap generation from the existing docs infra sitemap for search. cc: @dav-is Unless you are already working on some primitive for sitemaps in docs-infra, this would be a good addition there. Unrelated, but moved `robots.txt` to `apps` directory instead of `public` so that it's not treated as a static asset. Could have been `robots.ts` instead with structured data if not for the algolia comment. We can move the Algolia validation to the home page `<meta>` tag.
  - Sitemap generation filters private pages and non-MDX entries (e.g. external links), and derives URL segments from `page.path` rather than `page.slug` to match actual directory names.
- Rename `app/sitemap/index.ts` → `app/computedSiteMap/index.ts` to avoid a naming conflict with Next.js's reserved `sitemap` route convention. Update webpack and Turbopack loader rules in `next.config.mjs` and all import sites (`Header.tsx`, `Search.tsx`, `(docs)/layout.tsx`) accordingly.
- Add `BASE_URL` env var to `next.config.mjs` and use it for `metadataBase` in both layout files instead of a hardcoded string.

Other SEO improvements to the homepage and docs:

- Add `FAQPage` microdata to the homepage accordion using HTML
  `itemscope`/`itemprop` attributes so Google can surface Q&As as rich
  results.

- Add `Organization` JSON-LD schema to the homepage with `logo` and
  `sameAs` links to GitHub, X, npm, Discord, and Bluesky

- Add `twitter:site` (`@base_ui`) to both the website and docs layouts

- Wrap the header logo in an `<a href="/">` with `aria-label="Base UI"`;
  move `aria-hidden` to the SVG so screen readers announce the link
correctly

- Add `rel="noopener noreferrer"` to all external social links in the
  website layout header and footer

- Update homepage `<title>` default from `"Base UI"` to
  `"Base UI · Unstyled UI components for building accessible web apps
and design systems` for better search engine signal. cc: @colmtuite . Some examples -
	- The Foundation for your Design System - shadcn/ui
	- React Router Official Documentation

- Fix `og:title` and `twitter:title` on docs pages always resolving to
  `"Base UI"` instead of the page title: remove the separate
  `openGraph.title` template from the docs layout so `og:title` inherits
  from `metadata.title` (populated per-page by the MDX pipeline)

  https://github.com/mui/mui-public/issues/561 

- Add `/_next/static/` immutable cache rule to `_headers`, replacing
the
  previous `/_next/*.js`-only rule to also cover CSS, fonts, and images

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
