### PR TITLE
[triggers] Fix `ref: HTMLElement` type

### DIFF
--- a/packages/react/src/popover/trigger/PopoverTrigger.spec.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.spec.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Popover as BasePopover } from '@base-ui/react/popover';
+
+function TriggerWithElementRef() {
+  const triggerRef = React.useRef<HTMLElement>(null);
+
+  return <BasePopover.Trigger ref={triggerRef} />;
+}
+
+const ForwardRefWrapper = React.forwardRef<HTMLElement, BasePopover.Trigger.Props>((props, ref) => (
+  <BasePopover.Trigger {...props} ref={ref} />
+));
+
+<TriggerWithElementRef />;
+<ForwardRefWrapper />;

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -41,7 +41,7 @@ import { useTriggerDataForwarding } from '../../utils/popups';
  * Documentation: [Base UI Popover](https://base-ui.com/react/components/popover)
  */
 export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
-  componentProps: PopoverTrigger.Props,
+  componentProps: PopoverTriggerPropsInternal,
   forwardedRef: React.ForwardedRef<HTMLElement>,
 ) {
   const {
@@ -236,7 +236,8 @@ export interface PopoverTriggerState {
 }
 
 export type PopoverTriggerProps<Payload = unknown> = NativeButtonProps &
-  BaseUIComponentProps<'button', PopoverTriggerState> & {
+  Omit<BaseUIComponentProps<'button', PopoverTriggerState>, 'ref'> & {
+    ref?: React.Ref<HTMLElement> | undefined;
     /**
      * Whether the component renders a native `<button>` element when replacing it
      * via the `render` prop.
@@ -278,6 +279,9 @@ export type PopoverTriggerProps<Payload = unknown> = NativeButtonProps &
      */
     closeDelay?: number | undefined;
   };
+
+type PopoverTriggerPropsInternal<Payload = unknown> = Omit<PopoverTriggerProps<Payload>, 'ref'> &
+  BaseUIComponentProps<'button', PopoverTriggerState>;
 
 export namespace PopoverTrigger {
   export type State = PopoverTriggerState;


### PR DESCRIPTION
Fixes a type error with trigger's that redeclare their ref as HTMLElement, repro:
```tsx
const triggerRef = React.useRef<HTMLElement>(null);
 // Type 'RefObject<HTMLElement | null>' is not assignable to type '((((instance: HTMLButtonElement | null) => void |…
<Popover.Trigger ref={triggerRef} />;
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
