### PR TITLE
[docs] Serif for italics

### DIFF
--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -102,6 +102,7 @@
   --font-mono: 'SF Mono', 'Menlo', 'DejaVu Sans Mono', 'Consolas', 'Inconsolata', monospace;
   --font-sans: 'Die Grotesk A', system-ui, sans-serif;
   --font-sans-b: 'Die Grotesk B', system-ui, sans-serif;
+  --font-serif: Georgia, 'Times New Roman', Times, 'Noto Serif', 'DejaVu Serif', serif;
 
   --text-xs: 0.8125rem;
   --text-xs--line-height: 1.25rem;

--- a/docs/src/css/mdx-components.css
+++ b/docs/src/css/mdx-components.css
@@ -90,4 +90,10 @@
     margin-top: 1.25rem;
     margin-bottom: 1.5rem;
   }
+
+  .MdEm {
+    font-family: var(--font-serif);
+    /* Adjust to visually match the sans-serif font */
+    font-size: 1.06em;
+  }
 }

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -21,6 +21,7 @@ interface MDXComponents {
 // Maintain spacing between MDX components here
 export const mdxComponents: MDXComponents = {
   a: Link,
+  em: (props) => <em className="MdEm" {...props} />,
   code: (props) => <Code className="MdInlineCode" {...props} />,
   h1: (props) => (
     // Do not wrap heading tags in divs, that confuses Safari Reader


### PR DESCRIPTION
Preview: https://deploy-preview-4415--base-ui.netlify.app/react/utils/csp-provider#inline-style-attributes (search for "inline style attributes in addition to elements")

Italics had no different styles because we don't load italics font faces for Die Grotesk, and previously we didn't for Unica 77, so this has been broken since forever, but we only use italics in a couple of places. This PR adds a new entry to mdx-components so `<em>` tags render with a class name. `<em>` tags now use the serif font.

