### PR TITLE
[calendar] Fix start and end of month navigation with `Home` and `End`

### DIFF
--- a/packages/react/src/calendar/day-grid-body/CalendarDayGridBody.keyboard.test.tsx
+++ b/packages/react/src/calendar/day-grid-body/CalendarDayGridBody.keyboard.test.tsx
@@ -317,13 +317,6 @@ describe('<Calendar.DayGridBody /> - keyboard navigation', () => {
 
   // ---------------------------------------------------------------------------
   // Home / End
-  //
-  // February 2025 grid (en-US locale, weeks start Sunday):
-  //   Week 1: Jan 26(disabled, idx 0) … Jan 31(disabled, idx 5), Feb 1(Sat, idx 6)
-  //   Week 2: Feb 2(Sun, idx 7)  … Feb 8(Sat, idx 13)
-  //   Week 3: Feb 9(Sun, idx 14) … Feb 14(Fri, idx 19), Feb 15(Sat, idx 20)
-  //   Week 4: Feb 16(Sun, idx 21) … Feb 22(Sat, idx 27)
-  //   Week 5: Feb 23(Sun, idx 28) … Feb 28(Fri, idx 33), Mar 1(disabled, idx 34)
   // ---------------------------------------------------------------------------
 
   describe('Home', () => {
@@ -352,6 +345,18 @@ describe('<Calendar.DayGridBody /> - keyboard navigation', () => {
 
       expect(getDayButton(feb1)).toHaveFocus();
     });
+
+    it('should move focus to the first day of the week when pressing Home from the first week of the month and first day is not the first day of the week', async () => {
+      const apr4 = adapter.date('2025-04-04', 'default');
+      const { user } = renderCalendar(adapter.startOfMonth(apr4));
+
+      await act(async () => {
+        getDayButton(apr4).focus();
+      });
+      await user.keyboard('{Home}');
+
+      expect(getDayButton(adapter.date('2025-04-01', 'default'))).toHaveFocus();
+    });
   });
 
   describe('End', () => {
@@ -379,6 +384,18 @@ describe('<Calendar.DayGridBody /> - keyboard navigation', () => {
       await user.keyboard('{End}');
 
       expect(getDayButton(feb28)).toHaveFocus();
+    });
+
+    it('should move focus to the last day of the week when pressing End from the last week of the month and last day is not the last day of the week', async () => {
+      const mar30 = adapter.date('2025-03-30', 'default');
+      const { user } = renderCalendar(adapter.startOfMonth(mar30));
+
+      await act(async () => {
+        getDayButton(mar30).focus();
+      });
+      await user.keyboard('{End}');
+
+      expect(getDayButton(mar31)).toHaveFocus();
     });
   });
 

--- a/packages/react/src/calendar/day-grid-body/useSharedCalendarDayGridBody.ts
+++ b/packages/react/src/calendar/day-grid-body/useSharedCalendarDayGridBody.ts
@@ -185,7 +185,7 @@ export function useSharedCalendarDayGridBody(
         focusNextNonDisabledElement({
           elements: items,
           newHighlightedIndex,
-          decrement: eventKey === HOME,
+          decrement: eventKey === END,
           amount: 1,
         });
         break;


### PR DESCRIPTION
## Summary

- Fix <kbd>Home</kbd>/<kbd>End</kbd> keyboard navigation in the calendar day grid when the first/last cell of the week row is an outside-month (disabled) day
- When pressing Home on a week that starts with disabled outside-month days (e.g., Apr 4 → Home should land on Apr 1, not Mar 30), the fallback search now correctly moves **forward** into the week to find the first focusable day
- Likewise, pressing End on a week that ends with disabled outside-month days now searches **backward** to find the last focusable in-month day

## Test plan

- Added keyboard navigation tests for Home/End on weeks with leading/trailing outside-month days


Also removed stale test navigation comment