### PR TITLE
[drawer] Align default initial focus with other dialogs

### DIFF
--- a/packages/react/src/drawer/popup/DrawerPopup.test.tsx
+++ b/packages/react/src/drawer/popup/DrawerPopup.test.tsx
@@ -18,7 +18,7 @@ describe('<Drawer.Popup />', () => {
     },
   }));
 
-  it('defaults initial focus to the popup element', async () => {
+  it('defaults initial focus behavior to first tabbable element', async () => {
     await render(
       <div>
         <input />
@@ -40,8 +40,8 @@ describe('<Drawer.Popup />', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('popup')).toHaveFocus();
-      expect(screen.getByTestId('popup-input')).not.toHaveFocus();
+      expect(screen.getByTestId('popup-input')).toHaveFocus();
+      expect(screen.getByTestId('popup')).not.toHaveFocus();
     });
   });
 

--- a/packages/react/src/drawer/popup/DrawerPopup.tsx
+++ b/packages/react/src/drawer/popup/DrawerPopup.tsx
@@ -284,7 +284,17 @@ export const DrawerPopup = React.forwardRef(function DrawerPopup(
     },
   });
 
-  const resolvedInitialFocus = initialFocus === undefined ? store.context.popupRef : initialFocus;
+  // Default initial focus logic:
+  // If opened by touch, focus the popup element to prevent the virtual keyboard from opening
+  // (this is required for Android specifically as iOS handles this automatically).
+  function defaultInitialFocus(interactionType: InteractionType) {
+    if (interactionType === 'touch') {
+      return store.context.popupRef.current;
+    }
+    return true;
+  }
+
+  const resolvedInitialFocus = initialFocus === undefined ? defaultInitialFocus : initialFocus;
 
   const state: DrawerPopupState = {
     open,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Align `Drawer.Popup` initial focus with other dialogs; previous difference might not have been intentional, so behavior is now consistent.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
