### PR TITLE
[docs] Enable alternate R and slashed zero for Die Grotesk

### DIFF
--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -152,8 +152,9 @@
 /* Undo `tailwindcss/preflight` in non-Tailwind demos. */
 
 @layer base {
-  [data-demo] {
-    /* Undo Die Grotesk OpenType features */
+  /* Undo Die Grotesk OpenType features in demos and regression tests */
+  [data-demo],
+  [data-testid='testcase'] {
     font-feature-settings: normal;
   }
 


### PR DESCRIPTION
Preview: https://deploy-preview-4442--base-ui.netlify.app/react/components/radio

|before|after|
|---|---|
|<img width="133" height="60" alt="Screenshot 2026-03-25 at 14 08 31" src="https://github.com/user-attachments/assets/c2d2a4dc-0b96-44d7-bae7-649c505b79bb" />|<img width="126" height="55" alt="Screenshot 2026-03-25 at 14 08 18" src="https://github.com/user-attachments/assets/bdf6d244-6148-46cd-bdf4-2422ee9ef923" />|
