### PR TITLE
[docs] Reduce table headers weight

### DIFF
--- a/docs/src/components/Accordion.css
+++ b/docs/src/components/Accordion.css
@@ -28,7 +28,7 @@
   .AccordionHeaderCell {
     padding: 0.5rem 0.75rem;
     font-size: var(--text-sm);
-    font-weight: 700;
+    font-weight: 400;
     color: var(--color-foreground);
   }
 

--- a/docs/src/components/Table.css
+++ b/docs/src/components/Table.css
@@ -27,7 +27,7 @@
 
   .TableColumnHeader {
     text-align: initial;
-    font-weight: 700;
+    font-weight: 400;
     color: var(--color-foreground);
     background-color: var(--color-gray-50);
     border-bottom: 1px solid var(--color-gray-200);


### PR DESCRIPTION
Preview: https://deploy-preview-4443--base-ui.netlify.app/react/components/accordion#header

|before|after|
|---|---|
|<img width="700" height="373" alt="Screenshot 2026-03-25 at 14 36 21" src="https://github.com/user-attachments/assets/a3f6d1bc-5f38-4103-b4ad-d0bb4a045605" />|<img width="702" height="382" alt="Screenshot 2026-03-25 at 14 35 59" src="https://github.com/user-attachments/assets/b643d0c8-c82d-43ef-b57c-5e9ed82d5782" />|

🧘‍♂️