### PR TITLE
[internal] Fix use of ellipses

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.tsx
@@ -28,7 +28,7 @@ export default function ExampleAutocompleteCommandPalette() {
             >
               <Autocomplete.Input
                 className={styles.Input}
-                placeholder="Search for apps and commands..."
+                placeholder="Search for apps and commands…"
               />
               <Dialog.Close className={styles.VisuallyHiddenClose}>
                 Close command palette

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/tailwind/index.tsx
@@ -32,7 +32,7 @@ export default function ExampleAutocompleteCommandPalette() {
             >
               <Autocomplete.Input
                 className="w-full border-0 border-b border-gray-100 bg-transparent p-4 text-base font-normal tracking-[0.016em] text-gray-900 placeholder:text-gray-500 outline-none"
-                placeholder="Search for apps and commands..."
+                placeholder="Search for apps and commands…"
               />
               <Dialog.Close className="sr-only">Close command palette</Dialog.Close>
 

--- a/docs/src/app/(docs)/react/components/select/demos/multiple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/select/demos/multiple/css-modules/index.tsx
@@ -22,7 +22,7 @@ const values = Object.keys(languages) as Language[];
 
 function renderValue(value: Language[]) {
   if (value.length === 0) {
-    return 'Select languages…';
+    return 'Select languages';
   }
 
   const firstLanguage = languages[value[0]];

--- a/docs/src/app/(docs)/react/components/select/demos/multiple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/select/demos/multiple/tailwind/index.tsx
@@ -21,7 +21,7 @@ const values = Object.keys(languages) as Language[];
 
 function renderValue(value: Language[]) {
   if (value.length === 0) {
-    return 'Select languages…';
+    return 'Select languages';
   }
 
   const firstLanguage = languages[value[0]];

--- a/docs/src/app/(private)/experiments/combobox/creatable-tags.tsx
+++ b/docs/src/app/(private)/experiments/combobox/creatable-tags.tsx
@@ -44,7 +44,7 @@ export default function Experiment() {
         onCreate={(label) => {
           setItems((prev) => [...prev, label].sort());
         }}
-        placeholder="Red, Green, Blue..."
+        placeholder="Red, Green, Blue…"
       />
     </div>
   );

--- a/docs/src/app/(private)/experiments/combobox/priority-combobox.tsx
+++ b/docs/src/app/(private)/experiments/combobox/priority-combobox.tsx
@@ -20,7 +20,7 @@ function CustomCombobox(props: { items: Priority[] }) {
         <Combobox.Positioner align="start" sideOffset={4} disableAnchorTracking={true}>
           <Combobox.Popup className={styles.Popup} aria-label="Select priority">
             <div className={styles.InputRow}>
-              <Combobox.Input placeholder="Set priority to..." className={styles.Input} />
+              <Combobox.Input placeholder="Set priority to…" className={styles.Input} />
               <div className={styles.ShortcutKey}>P</div>
             </div>
             <Combobox.Separator className={styles.Separator} />

--- a/docs/src/app/(private)/experiments/popover/vertical.tsx
+++ b/docs/src/app/(private)/experiments/popover/vertical.tsx
@@ -115,7 +115,7 @@ function DiscussionPanel() {
     <div className={styles.DiscussionPanel}>
       <Popover.Title className={styles.Title}>Discussion</Popover.Title>
       <p className={styles.NoComments}>There aren't any comments yet.</p>
-      <textarea className={styles.TextArea} placeholder="Write a comment..." />
+      <textarea className={styles.TextArea} placeholder="Write a comment…" />
       <div className={styles.Actions}>
         <button className={styles.Button} type="button">
           Post

--- a/packages/react/src/dialog/portal/DialogPortal.test.tsx
+++ b/packages/react/src/dialog/portal/DialogPortal.test.tsx
@@ -37,7 +37,7 @@ describe('<Dialog.Portal />', () => {
       const { LazyComponent, resolve } = createLazyComponent();
 
       await render(
-        <React.Suspense fallback="Loading...">
+        <React.Suspense fallback="Loading…">
           <Dialog.Root open>
             <Dialog.Portal>
               <Dialog.Popup>
@@ -48,7 +48,7 @@ describe('<Dialog.Portal />', () => {
         </React.Suspense>,
       );
 
-      expect(await screen.findByText('Loading...')).not.toBe(null);
+      expect(await screen.findByText('Loading…')).not.toBe(null);
       resolve({ default: () => <p>Greetings</p> });
       expect(await screen.findByText('Greetings')).not.toBe(null);
     });


### PR DESCRIPTION
Finish the work from https://github.com/mui/base-ui/pull/3633#discussion_r2650903166 (I have 5 other PRs open across the codebase 😁).

1. Fix a few more `...` to `…`
2. Remove … for the [multi-select ](https://base-ui.com/react/components/select#multiple-selection) to be consistent with the other demos on the page https://base-ui.com/react/components/select.

There is a larger discussion on whether we want to change the current standard: placeholders have no … to match with https://vercel.com/design/guidelines#placeholders-signal-emptiness. However, Vercel's UI or Shadcn UI is not even following this. Overall, it feels like we should stick to the current practice: avoid … whenever it's redundant, only for:

- There is an action in progress
- There is another action to take, and that is not very obvious from the other clues.

Similar assets:

- https://developer.apple.com/design/human-interface-guidelines/menus#Labels:~:text=commands%20it%20contains.-,Append%20an%20ellipsis,-to%20a%20menu
- https://learn.microsoft.com/en-us/windows/win32/uxguide/cmd-menus#using-ellipses
- https://m3.material.io/foundations/content-design/style-guide/grammar-and-punctuation#20caa5d9-e816-4bea-8cc9-85c97b606ceb