### PR TITLE
[navigation menu] Fix reverse shift-tab submenu re-entry

### DIFF
--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -1571,6 +1571,36 @@ describe('<NavigationMenu.Root />', () => {
       expect(screen.queryByTestId('popup-1')).toBe(null);
     });
 
+    it('returns to the last submenu item when shift+tabbing after tabbing out of it', async () => {
+      const { user } = await render(
+        <div>
+          <button data-testid="first" />
+          <TestNavigationMenu />
+          <button data-testid="last" />
+        </div>,
+      );
+      const trigger = screen.getByTestId('trigger-1');
+
+      await act(async () => trigger.focus());
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('popup-1')).not.toBe(null);
+      expect(trigger).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByText('Link 1')).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByText('Link 2')).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByTestId('trigger-2')).toHaveFocus();
+
+      await user.tab({ shift: true });
+      expect(screen.getByText('Link 2')).toHaveFocus();
+    });
+
     it('closes the menu when tabbing back out', async () => {
       const { user } = await render(
         <div>
@@ -2764,6 +2794,29 @@ describe('<NavigationMenu.Root />', () => {
 
         await user.tab();
         expect(screen.getByText('Engineering Leads')).toHaveFocus();
+      });
+
+      it('returns to the last inline submenu item when shift+tabbing after leaving it', async () => {
+        const { user } = await render(<TestInlineNestedNavigationMenuTabFlow />);
+        const triggerProduct = screen.getByTestId('trigger-product');
+
+        await user.click(triggerProduct);
+        await flushMicrotasks();
+
+        await user.tab();
+        expect(screen.getByTestId('nested-trigger-developers')).toHaveFocus();
+
+        await user.tab();
+        expect(screen.getByTestId('nested-link-get-started')).toHaveFocus();
+
+        await user.tab();
+        expect(screen.getByTestId('nested-link-composition')).toHaveFocus();
+
+        await user.tab();
+        expect(screen.getByTestId('nested-trigger-design-systems')).toHaveFocus();
+
+        await user.tab({ shift: true });
+        expect(screen.getByTestId('nested-link-composition')).toHaveFocus();
       });
     });
   });

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -26,7 +26,6 @@ import {
   getTabbableAfterElement,
   getNextTabbable,
   getPreviousTabbable,
-  isTabbable,
   isOutsideEvent,
   stopEvent,
 } from '../../floating-ui-react/utils';

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -804,10 +804,10 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
             ref={afterOutsideRef}
             onFocus={(event) => {
               if (referenceElement && isOutsideEvent(event, referenceElement)) {
-                const elementToFocus =
-                  afterInsideRef.current && isTabbable(afterInsideRef.current)
-                    ? afterInsideRef.current
-                    : triggerElement;
+                ReactDOM.flushSync(() => {
+                  setViewportInert(false);
+                });
+                const elementToFocus = afterInsideRef.current || triggerElement;
                 elementToFocus?.focus();
               } else {
                 let nextTabbable = getNextTabbable(triggerElement);


### PR DESCRIPTION
Fixes #4463

This fixes reverse tab re-entry in Navigation Menu submenus so focus returns to the last submenu item instead of falling back to the trigger or disappearing in inline nested submenus.

## Changes

- Update the `afterOutside` focus guard to re-enter the submenu through the inside guard and synchronously clear inline viewport inert state before redirecting focus.
- Add regression coverage for reverse tab re-entry in both portaled and inline nested submenu flows.