### PR TITLE
[tests] Pin en-US locale in Meter, Progress, and Slider format tests

### DIFF
--- a/packages/react/src/meter/root/MeterRoot.test.tsx
+++ b/packages/react/src/meter/root/MeterRoot.test.tsx
@@ -54,11 +54,11 @@ describe('<Meter.Root />', () => {
         currency: 'USD',
       };
       function formatValue(v: number) {
-        return new Intl.NumberFormat(undefined, format).format(v);
+        return new Intl.NumberFormat('en-US', format).format(v);
       }
 
       await render(
-        <Meter.Root value={30} format={format}>
+        <Meter.Root value={30} format={format} locale="en-US">
           <Meter.Value data-testid="value" />
           <Meter.Track>
             <Meter.Indicator />

--- a/packages/react/src/meter/value/MeterValue.test.tsx
+++ b/packages/react/src/meter/value/MeterValue.test.tsx
@@ -31,11 +31,11 @@ describe('<Meter.Value />', () => {
         currency: 'USD',
       };
       function formatValue(v: number) {
-        return new Intl.NumberFormat(undefined, format).format(v);
+        return new Intl.NumberFormat('en-US', format).format(v);
       }
 
       await render(
-        <Meter.Root value={30} format={format}>
+        <Meter.Root value={30} format={format} locale="en-US">
           <Meter.Value data-testid="value" />
         </Meter.Root>,
       );
@@ -51,10 +51,10 @@ describe('<Meter.Value />', () => {
         currency: 'USD',
       };
       function formatValue(v: number) {
-        return new Intl.NumberFormat(undefined, format).format(v);
+        return new Intl.NumberFormat('en-US', format).format(v);
       }
       await render(
-        <Meter.Root value={30} format={format}>
+        <Meter.Root value={30} format={format} locale="en-US">
           <Meter.Value data-testid="value">{renderSpy}</Meter.Value>
         </Meter.Root>,
       );

--- a/packages/react/src/progress/root/ProgressRoot.test.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.test.tsx
@@ -62,11 +62,11 @@ describe('<Progress.Root />', () => {
         currency: 'USD',
       };
       function formatValue(v: number) {
-        return new Intl.NumberFormat(undefined, format).format(v);
+        return new Intl.NumberFormat('en-US', format).format(v);
       }
 
       await render(
-        <Progress.Root value={30} format={format}>
+        <Progress.Root value={30} format={format} locale="en-US">
           <Progress.Value data-testid="value" />
           <Progress.Track>
             <Progress.Indicator />

--- a/packages/react/src/progress/value/ProgressValue.test.tsx
+++ b/packages/react/src/progress/value/ProgressValue.test.tsx
@@ -31,11 +31,11 @@ describe('<Progress.Value />', () => {
         currency: 'USD',
       };
       function formatValue(v: number) {
-        return new Intl.NumberFormat(undefined, format).format(v);
+        return new Intl.NumberFormat('en-US', format).format(v);
       }
 
       await render(
-        <Progress.Root value={30} format={format}>
+        <Progress.Root value={30} format={format} locale="en-US">
           <Progress.Value data-testid="value" />
         </Progress.Root>,
       );
@@ -52,10 +52,10 @@ describe('<Progress.Value />', () => {
           currency: 'USD',
         };
         function formatValue(v: number) {
-          return new Intl.NumberFormat(undefined, format).format(v);
+          return new Intl.NumberFormat('en-US', format).format(v);
         }
         await render(
-          <Progress.Root value={30} format={format}>
+          <Progress.Root value={30} format={format} locale="en-US">
             <Progress.Value data-testid="value">{renderSpy}</Progress.Value>
           </Progress.Root>,
         );

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -2033,10 +2033,10 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
   describe('prop: format', () => {
     it('formats the value', async () => {
       function formatValue(v: number) {
-        return new Intl.NumberFormat(undefined, USD_NUMBER_FORMAT).format(v);
+        return new Intl.NumberFormat('en-US', USD_NUMBER_FORMAT).format(v);
       }
 
-      await render(<TestSlider defaultValue={50} format={USD_NUMBER_FORMAT} />);
+      await render(<TestSlider defaultValue={50} format={USD_NUMBER_FORMAT} locale="en-US" />);
 
       const value = screen.getByTestId('value');
       const slider = screen.getByRole('slider');
@@ -2046,10 +2046,10 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
 
     it('formats range values', async () => {
       function formatValue(v: number) {
-        return new Intl.NumberFormat(undefined, USD_NUMBER_FORMAT).format(v);
+        return new Intl.NumberFormat('en-US', USD_NUMBER_FORMAT).format(v);
       }
 
-      await render(<TestRangeSlider defaultValue={[50, 75]} format={USD_NUMBER_FORMAT} />);
+      await render(<TestRangeSlider defaultValue={[50, 75]} format={USD_NUMBER_FORMAT} locale="en-US" />);
 
       const value = screen.getByTestId('value');
       expect(value).toHaveTextContent(`${formatValue(50)} – ${formatValue(75)}`);

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -2049,7 +2049,9 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
         return new Intl.NumberFormat('en-US', USD_NUMBER_FORMAT).format(v);
       }
 
-      await render(<TestRangeSlider defaultValue={[50, 75]} format={USD_NUMBER_FORMAT} locale="en-US" />);
+      await render(
+        <TestRangeSlider defaultValue={[50, 75]} format={USD_NUMBER_FORMAT} locale="en-US" />,
+      );
 
       const value = screen.getByTestId('value');
       expect(value).toHaveTextContent(`${formatValue(50)} – ${formatValue(75)}`);

--- a/packages/react/src/slider/value/SliderValue.test.tsx
+++ b/packages/react/src/slider/value/SliderValue.test.tsx
@@ -56,11 +56,11 @@ describe('<Slider.Value />', () => {
         currency: 'USD',
       };
       function formatValue(v: number) {
-        return new Intl.NumberFormat(undefined, format).format(v);
+        return new Intl.NumberFormat('en-US', format).format(v);
       }
       const renderSpy = vi.fn();
       await render(
-        <Slider.Root defaultValue={[40, 60]} format={format}>
+        <Slider.Root defaultValue={[40, 60]} format={format} locale="en-US">
           <Slider.Value data-testid="output">{renderSpy}</Slider.Value>
         </Slider.Root>,
       );


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

These tests were failing when the runtime default locale is not `en-US`, because `Intl.NumberFormat(undefined, …)` and components without an explicit `locale` follow the environment. Formatting for USD and grouped numbers then does not match the hard-coded expectations.

``` bash
FAIL   @base-ui/react (chromium)  src/meter/value/MeterValue.test.tsx > <Meter.Value /> > prop: children > renders a formatted value when a format is provided
Error: expect(element).toHaveTextContent()

Expected element to have text content:
  US$ 30,00
Received:
  US$ 30,00
 ❯ src/meter/value/MeterValue.test.tsx:44:20
     42|
     43|       const value = screen.getByTestId('value');
     44|       expect(value).toHaveTextContent(formatValue(30));
       |                    ^
     45|     });
     
 ```

This change pins `en-US` on `Intl.NumberFormat` and on the root `locale` prop in Meter, Progress, and Slider format-related tests so results are consistent in CI and on developer machines.