### PR TITLE
[docs][separator] Add data attributes documentation

### DIFF
--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -1619,6 +1619,7 @@ A separator element accessible to screen readers.
 - Exports:
   - Separator
     - Props: className, orientation, render, style
+    - Data Attributes: data-orientation
 - Types: Separator.Props, Separator.State
 
 </details>

--- a/docs/src/app/(docs)/react/components/separator/types.md
+++ b/docs/src/app/(docs)/react/components/separator/types.md
@@ -18,6 +18,12 @@ Renders a `<div>` element.
 | style       | `React.CSSProperties \| ((state: Separator.State) => React.CSSProperties \| undefined)` | -              | Style applied to the element, or a function that&#xA;returns a style object based on the component's state.                                                                                   |
 | render      | `ReactElement \| ((props: HTMLProps, state: Separator.State) => ReactElement)`          | -              | Allows you to replace the component's HTML element&#xA;with a different tag, or compose it with another component. Accepts a `ReactElement` or a function that returns the element to render. |
 
+**Separator Data Attributes:**
+
+| Attribute        | Type                         | Description                                 |
+| :--------------- | :--------------------------- | :------------------------------------------ |
+| data-orientation | `'horizontal' \| 'vertical'` | Indicates the orientation of the separator. |
+
 ### Separator.Props
 
 Re-export of [Separator](#separator) props.

--- a/packages/react/src/separator/SeparatorDataAttributes.ts
+++ b/packages/react/src/separator/SeparatorDataAttributes.ts
@@ -1,0 +1,7 @@
+export enum SeparatorDataAttributes {
+  /**
+   * Indicates the orientation of the separator.
+   * @type {'horizontal' | 'vertical'}
+   */
+  orientation = 'data-orientation',
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR just adds missing data attributes documentation for the Separator component.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
