### PR TITLE
[field] Move field registration into Field.Root

### DIFF
--- a/packages/react/src/checkbox-group/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.tsx
@@ -7,10 +7,10 @@ import { useRenderElement } from '../utils/useRenderElement';
 import { CheckboxGroupContext } from './CheckboxGroupContext';
 import type { FieldRootState } from '../field/root/FieldRoot';
 import { useFieldRootContext } from '../field/root/FieldRootContext';
+import { useRegisterFieldControl } from '../field/root/useRegisterFieldControl';
 import { useLabelableContext } from '../labelable-provider/LabelableContext';
 import type { BaseUIComponentProps } from '../utils/types';
 import { fieldValidityMapping } from '../field/utils/constants';
-import { useField } from '../field/useField';
 import { PARENT_CHECKBOX } from '../checkbox/root/CheckboxRoot';
 import { useCheckboxGroupParent } from './useCheckboxGroupParent';
 import type { BaseUIChangeEventDetails } from '../utils/createBaseUIEventDetails';
@@ -92,14 +92,11 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
     }
   }, []);
 
-  useField({
+  useRegisterFieldControl({
     enabled: !!fieldName,
     id,
-    commit: validation.commit,
     value,
     controlRef,
-    name: fieldName,
-    getValue: () => value,
   });
 
   const resolvedValue = value ?? EMPTY_ARRAY;

--- a/packages/react/src/checkbox-group/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.tsx
@@ -92,11 +92,10 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
     }
   }, []);
 
-  useRegisterFieldControl({
+  useRegisterFieldControl(controlRef, {
     enabled: !!fieldName,
     id,
     value,
-    controlRef,
   });
 
   const resolvedValue = value ?? EMPTY_ARRAY;

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -167,11 +167,10 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     };
   }, [registerControlId, controlSourceRef]);
 
-  useRegisterFieldControl({
+  useRegisterFieldControl(controlRef, {
     enabled: !groupContext,
     id,
     value: checked,
-    controlRef,
   });
 
   const inputRef = React.useRef<HTMLInputElement>(null);

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -16,8 +16,8 @@ import { mergeProps } from '../../merge-props';
 import { useButton } from '../../use-button/useButton';
 import type { FieldRootState } from '../../field/root/FieldRoot';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
+import { useRegisterFieldControl } from '../../field/root/useRegisterFieldControl';
 import { useFieldItemContext } from '../../field/item/FieldItemContext';
-import { useField } from '../../field/useField';
 import { useFormContext } from '../../form/FormContext';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
 import { useAriaLabelledBy } from '../../labelable-provider/useAriaLabelledBy';
@@ -167,14 +167,11 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     };
   }, [registerControlId, controlSourceRef]);
 
-  useField({
+  useRegisterFieldControl({
     enabled: !groupContext,
     id,
-    commit: validation.commit,
     value: checked,
     controlRef,
-    name,
-    getValue: () => checked,
   });
 
   const inputRef = React.useRef<HTMLInputElement>(null);

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -437,11 +437,10 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   const { openMethod, triggerProps } = useOpenInteractionType(open);
   const getFieldValue = useStableCallback(() => fieldStringValue);
 
-  useRegisterFieldControl({
+  useRegisterFieldControl(inputInsidePopup ? triggerRef : inputRef, {
     id,
     value: fieldRawValue,
     getValue: getFieldValue,
-    controlRef: inputInsidePopup ? triggerRef : inputRef,
   });
 
   const forceMount = useStableCallback(() => {

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -34,7 +34,7 @@ import {
 import { selectors, type State as StoreState } from '../store';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
-import { useField } from '../../field/useField';
+import { useRegisterFieldControl } from '../../field/root/useRegisterFieldControl';
 import { useFormContext } from '../../form/FormContext';
 import { useLabelableId } from '../../labelable-provider/useLabelableId';
 import { createCollatorItemFilter, createSingleSelectionCollatorFilter } from './utils';
@@ -435,14 +435,13 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
   const { openMethod, triggerProps } = useOpenInteractionType(open);
+  const getFieldValue = useStableCallback(() => fieldStringValue);
 
-  useField({
+  useRegisterFieldControl({
     id,
-    name,
-    commit: validation.commit,
     value: fieldRawValue,
+    getValue: getFieldValue,
     controlRef: inputInsidePopup ? triggerRef : inputRef,
-    getValue: () => fieldStringValue,
   });
 
   const forceMount = useStableCallback(() => {

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -3,14 +3,15 @@ import * as React from 'react';
 import { useControlled } from '@base-ui/utils/useControlled';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { ownerDocument } from '@base-ui/utils/owner';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { type FieldRootState } from '../root/FieldRoot';
 import { useFieldRootContext } from '../root/FieldRootContext';
+import { useRegisterFieldControl } from '../root/useRegisterFieldControl';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
 import { useLabelableId } from '../../labelable-provider/useLabelableId';
 import { fieldValidityMapping } from '../utils/constants';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
-import { useField } from '../useField';
 import { createChangeEventDetails } from '../../utils/createBaseUIEventDetails';
 import { REASONS } from '../../utils/reasons';
 import type { BaseUIChangeEventDetails } from '../../utils/createBaseUIEventDetails';
@@ -95,13 +96,12 @@ export const FieldControl = React.forwardRef(function FieldControl(
 
   const isControlled = valueProp !== undefined;
   const value = isControlled ? valueUnwrapped : undefined;
+  const getFieldValue = useStableCallback(() => validation.inputRef.current?.value);
 
-  useField({
+  useRegisterFieldControl({
     id,
-    name,
-    commit: validation.commit,
     value,
-    getValue: () => validation.inputRef.current?.value,
+    getValue: getFieldValue,
     controlRef: validation.inputRef,
   });
 

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -98,11 +98,10 @@ export const FieldControl = React.forwardRef(function FieldControl(
   const value = isControlled ? valueUnwrapped : undefined;
   const getFieldValue = useStableCallback(() => validation.inputRef.current?.value);
 
-  useRegisterFieldControl({
+  useRegisterFieldControl(validation.inputRef, {
     id,
     value,
     getValue: getFieldValue,
-    controlRef: validation.inputRef,
   });
 
   const element = useRenderElement('input', componentProps, {

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -543,6 +543,94 @@ describe('<Field.Root />', () => {
         input2: 'two',
       });
     });
+
+    it('submits the replacement control value when swapping field-aware controls', async () => {
+      const handleSubmit = vi.fn();
+
+      function App() {
+        const [showSlider, setShowSlider] = React.useState(false);
+
+        return (
+          <Form onFormSubmit={handleSubmit}>
+            <Field.Root name="value">
+              {showSlider ? (
+                <Slider.Root defaultValue={12}>
+                  <Slider.Control />
+                </Slider.Root>
+              ) : (
+                <Select.Root defaultValue="sans">
+                  <Select.Trigger />
+                  <Select.Portal>
+                    <Select.Positioner>
+                      <Select.Popup>
+                        <Select.Item value="sans" />
+                      </Select.Popup>
+                    </Select.Positioner>
+                  </Select.Portal>
+                </Select.Root>
+              )}
+            </Field.Root>
+            <button type="button" onClick={() => setShowSlider(true)}>
+              Toggle
+            </button>
+            <button type="submit">submit</button>
+          </Form>
+        );
+      }
+
+      await render(<App />);
+
+      fireEvent.click(screen.getByText('submit'));
+
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+      expect(handleSubmit.mock.lastCall?.[0]).toEqual({ value: 'sans' });
+
+      fireEvent.click(screen.getByText('Toggle'));
+      fireEvent.click(screen.getByText('submit'));
+
+      expect(handleSubmit).toHaveBeenCalledTimes(2);
+      expect(handleSubmit.mock.lastCall?.[0]).toEqual({ value: 12 });
+    });
+
+    it('excludes registration-gated controls from onFormSubmit when their field name is removed', async () => {
+      const handleSubmit = vi.fn();
+
+      function App() {
+        const [name, setName] = React.useState<string | undefined>('fruits');
+
+        return (
+          <Form onFormSubmit={handleSubmit}>
+            <Field.Root name={name}>
+              <CheckboxGroup defaultValue={['apple']}>
+                <Field.Item>
+                  <Checkbox.Root value="apple" />
+                </Field.Item>
+                <Field.Item>
+                  <Checkbox.Root value="banana" />
+                </Field.Item>
+              </CheckboxGroup>
+            </Field.Root>
+            <button type="button" onClick={() => setName(undefined)}>
+              Clear name
+            </button>
+            <button type="submit">submit</button>
+          </Form>
+        );
+      }
+
+      await render(<App />);
+
+      fireEvent.click(screen.getByText('submit'));
+
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+      expect(handleSubmit.mock.lastCall?.[0]).toEqual({ fruits: ['apple'] });
+
+      fireEvent.click(screen.getByText('Clear name'));
+      fireEvent.click(screen.getByText('submit'));
+
+      expect(handleSubmit).toHaveBeenCalledTimes(2);
+      expect(handleSubmit.mock.lastCall?.[0]).toEqual({});
+    });
   });
 
   describe('prop: validationMode', () => {

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -10,6 +10,10 @@ import { LabelableProvider } from '../../labelable-provider';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useFieldValidation } from './useFieldValidation';
+import {
+  type FieldControlRegistration,
+  useFieldControlRegistration,
+} from './useFieldControlRegistration';
 
 /**
  * @internal
@@ -51,6 +55,9 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
   const touched = touchedProp ?? touchedState;
 
   const markedDirtyRef = React.useRef(false);
+  const fieldControlRegistrationsRef = React.useRef(new Map<symbol, FieldControlRegistration>());
+  const [registeredFieldControl, setRegisteredFieldControl] =
+    React.useState<FieldControlRegistration | null>(null);
 
   const setDirty: typeof setDirtyUnwrapped = useStableCallback((value) => {
     if (dirtyProp !== undefined) {
@@ -118,9 +125,33 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
     validation.commit(validityData.value);
   }, [validation, validityData]);
 
+  const registerFieldControl = useStableCallback(
+    (source: symbol, registration: FieldControlRegistration | undefined) => {
+      const registrations = fieldControlRegistrationsRef.current;
+
+      if (registration == null || registration.enabled === false) {
+        registrations.delete(source);
+      } else {
+        registrations.set(source, registration);
+      }
+
+      setRegisteredFieldControl(registrations.values().next().value ?? null);
+    },
+  );
+
   React.useImperativeHandle(actionsRef, () => ({ validate: handleImperativeValidate }), [
     handleImperativeValidate,
   ]);
+
+  useFieldControlRegistration({
+    registration: registeredFieldControl,
+    commit: validation.commit,
+    invalid,
+    markedDirtyRef,
+    name,
+    setValidityData,
+    validityData,
+  });
 
   const contextValue: FieldRootContext = React.useMemo(
     () => ({
@@ -143,6 +174,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
       shouldValidateOnChange,
       state,
       markedDirtyRef,
+      registerFieldControl,
       validation,
     }),
     [
@@ -163,6 +195,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
       validationDebounceTime,
       shouldValidateOnChange,
       state,
+      registerFieldControl,
       validation,
     ],
   );

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -10,10 +10,7 @@ import { LabelableProvider } from '../../labelable-provider';
 import { BaseUIComponentProps } from '../../utils/types';
 import { useRenderElement } from '../../utils/useRenderElement';
 import { useFieldValidation } from './useFieldValidation';
-import {
-  type FieldControlRegistration,
-  useFieldControlRegistration,
-} from './useFieldControlRegistration';
+import { useFieldControlRegistration } from './useFieldControlRegistration';
 
 /**
  * @internal
@@ -55,9 +52,6 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
   const touched = touchedProp ?? touchedState;
 
   const markedDirtyRef = React.useRef(false);
-  const activeFieldControlSourceRef = React.useRef<symbol | null>(null);
-  const [registeredFieldControl, setRegisteredFieldControl] =
-    React.useState<FieldControlRegistration | null>(null);
 
   const setDirty: typeof setDirtyUnwrapped = useStableCallback((value) => {
     if (dirtyProp !== undefined) {
@@ -125,26 +119,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
     validation.commit(validityData.value);
   }, [validation, validityData]);
 
-  const registerFieldControl = useStableCallback(
-    (source: symbol, registration: FieldControlRegistration | undefined) => {
-      if (registration == null) {
-        if (activeFieldControlSourceRef.current === source) {
-          activeFieldControlSourceRef.current = null;
-          setRegisteredFieldControl(null);
-        }
-      } else {
-        activeFieldControlSourceRef.current = source;
-        setRegisteredFieldControl(registration);
-      }
-    },
-  );
-
-  React.useImperativeHandle(actionsRef, () => ({ validate: handleImperativeValidate }), [
-    handleImperativeValidate,
-  ]);
-
-  useFieldControlRegistration({
-    registration: registeredFieldControl,
+  const registerFieldControl = useFieldControlRegistration({
     commit: validation.commit,
     invalid,
     markedDirtyRef,
@@ -152,6 +127,10 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
     setValidityData,
     validityData,
   });
+
+  React.useImperativeHandle(actionsRef, () => ({ validate: handleImperativeValidate }), [
+    handleImperativeValidate,
+  ]);
 
   const contextValue: FieldRootContext = React.useMemo(
     () => ({

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -55,7 +55,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
   const touched = touchedProp ?? touchedState;
 
   const markedDirtyRef = React.useRef(false);
-  const fieldControlRegistrationsRef = React.useRef(new Map<symbol, FieldControlRegistration>());
+  const activeFieldControlSourceRef = React.useRef<symbol | null>(null);
   const [registeredFieldControl, setRegisteredFieldControl] =
     React.useState<FieldControlRegistration | null>(null);
 
@@ -127,15 +127,15 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
 
   const registerFieldControl = useStableCallback(
     (source: symbol, registration: FieldControlRegistration | undefined) => {
-      const registrations = fieldControlRegistrationsRef.current;
-
-      if (registration == null || registration.enabled === false) {
-        registrations.delete(source);
+      if (registration == null) {
+        if (activeFieldControlSourceRef.current === source) {
+          activeFieldControlSourceRef.current = null;
+          setRegisteredFieldControl(null);
+        }
       } else {
-        registrations.set(source, registration);
+        activeFieldControlSourceRef.current = source;
+        setRegisteredFieldControl(registration);
       }
-
-      setRegisteredFieldControl(registrations.values().next().value ?? null);
     },
   );
 

--- a/packages/react/src/field/root/FieldRootContext.ts
+++ b/packages/react/src/field/root/FieldRootContext.ts
@@ -69,7 +69,7 @@ export const FieldRootContext = React.createContext<FieldRootContext>({
   shouldValidateOnChange: () => false,
   state: DEFAULT_FIELD_ROOT_STATE,
   markedDirtyRef: { current: false },
-  registerFieldControl: () => {},
+  registerFieldControl: NOOP,
   validation: {
     getValidationProps: (props: HTMLProps = EMPTY_OBJECT) => props,
     getInputValidationProps: (props: HTMLProps = EMPTY_OBJECT) => props,

--- a/packages/react/src/field/root/FieldRootContext.ts
+++ b/packages/react/src/field/root/FieldRootContext.ts
@@ -11,6 +11,7 @@ import type { Form } from '../../form';
 import type { UseFieldValidationReturnValue } from './useFieldValidation';
 import type { HTMLProps } from '../../utils/types';
 import { EMPTY_OBJECT } from '../../utils/constants';
+import type { FieldControlRegistration } from './useFieldControlRegistration';
 
 export interface FieldRootContext {
   invalid: boolean | undefined;
@@ -35,6 +36,10 @@ export interface FieldRootContext {
   shouldValidateOnChange: () => boolean;
   state: FieldRootState;
   markedDirtyRef: React.RefObject<boolean>;
+  registerFieldControl: (
+    source: symbol,
+    registration: FieldControlRegistration | undefined,
+  ) => void;
   validation: UseFieldValidationReturnValue;
 }
 
@@ -64,6 +69,7 @@ export const FieldRootContext = React.createContext<FieldRootContext>({
   shouldValidateOnChange: () => false,
   state: DEFAULT_FIELD_ROOT_STATE,
   markedDirtyRef: { current: false },
+  registerFieldControl: () => {},
   validation: {
     getValidationProps: (props: HTMLProps = EMPTY_OBJECT) => props,
     getInputValidationProps: (props: HTMLProps = EMPTY_OBJECT) => props,

--- a/packages/react/src/field/root/useFieldControlRegistration.ts
+++ b/packages/react/src/field/root/useFieldControlRegistration.ts
@@ -63,6 +63,7 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
         if (!flushSync) {
           commit(nextValue);
         } else {
+          // Synchronously update the validity state so the submit event can be prevented.
           ReactDOM.flushSync(() => commit(nextValue));
         }
       },

--- a/packages/react/src/field/root/useFieldControlRegistration.ts
+++ b/packages/react/src/field/root/useFieldControlRegistration.ts
@@ -1,18 +1,33 @@
 'use client';
+import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { getCombinedFieldValidityData } from './utils/getCombinedFieldValidityData';
-import { useFormContext } from '../form/FormContext';
-import { useFieldRootContext } from './root/FieldRootContext';
+import { getCombinedFieldValidityData } from '../utils/getCombinedFieldValidityData';
+import { useFormContext } from '../../form/FormContext';
+import type { FieldValidityData } from './FieldRoot';
 
-export function useField(params: UseFieldParameters) {
-  const { enabled = true, value, id, name, controlRef, commit } = params;
+export interface FieldControlRegistration {
+  controlRef: React.RefObject<any>;
+  enabled?: boolean | undefined;
+  getValue?: (() => unknown) | undefined;
+  id: string | undefined;
+  value: unknown;
+}
+
+export function useFieldControlRegistration(params: UseFieldControlRegistrationParameters) {
+  const { registration, commit, invalid, markedDirtyRef, name, setValidityData, validityData } =
+    params;
 
   const { formRef } = useFormContext();
-  const { invalid, markedDirtyRef, validityData, setValidityData } = useFieldRootContext();
 
-  const getValue = useStableCallback(params.getValue);
+  const fallbackControlRef = React.useRef<any>(null);
+
+  const enabled = registration == null ? false : (registration.enabled ?? true);
+  const id = registration?.id;
+  const value = registration?.value;
+  const controlRef = registration?.controlRef ?? fallbackControlRef;
+  const getValue = useStableCallback(registration?.getValue ?? (() => value));
 
   useIsoLayoutEffect(() => {
     if (!enabled) {
@@ -27,7 +42,7 @@ export function useField(params: UseFieldParameters) {
     if (validityData.initialValue === null && initialValue !== null) {
       setValidityData((prev) => ({ ...prev, initialValue }));
     }
-  }, [enabled, setValidityData, value, validityData.initialValue, getValue]);
+  }, [enabled, getValue, setValidityData, validityData.initialValue, value]);
 
   useIsoLayoutEffect(() => {
     if (!enabled || !id) {
@@ -50,7 +65,6 @@ export function useField(params: UseFieldParameters) {
         if (!flushSync) {
           commit(nextValue);
         } else {
-          // Synchronously update the validity state so the submit event can be prevented.
           ReactDOM.flushSync(() => commit(nextValue));
         }
       },
@@ -71,6 +85,7 @@ export function useField(params: UseFieldParameters) {
 
   useIsoLayoutEffect(() => {
     const fields = formRef.current.fields;
+
     return () => {
       if (id) {
         fields.delete(id);
@@ -79,16 +94,12 @@ export function useField(params: UseFieldParameters) {
   }, [formRef, id]);
 }
 
-export interface UseFieldParameters {
-  enabled?: boolean | undefined;
-  value: unknown;
-  getValue?: (() => unknown) | undefined;
-  id: string | undefined;
-  name?: string | undefined;
+export interface UseFieldControlRegistrationParameters {
   commit: (value: unknown) => void;
-  /**
-   * A ref to a focusable element that receives focus when the field fails
-   * validation during form submission.
-   */
-  controlRef: React.RefObject<any>;
+  invalid: boolean;
+  markedDirtyRef: React.RefObject<boolean>;
+  name: string | undefined;
+  registration: FieldControlRegistration | null;
+  setValidityData: React.Dispatch<React.SetStateAction<FieldValidityData>>;
+  validityData: FieldValidityData;
 }

--- a/packages/react/src/field/root/useFieldControlRegistration.ts
+++ b/packages/react/src/field/root/useFieldControlRegistration.ts
@@ -9,7 +9,6 @@ import type { FieldValidityData } from './FieldRoot';
 
 export interface FieldControlRegistration {
   controlRef: React.RefObject<any>;
-  enabled?: boolean | undefined;
   getValue?: (() => unknown) | undefined;
   id: string | undefined;
   value: unknown;
@@ -23,14 +22,13 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
 
   const fallbackControlRef = React.useRef<any>(null);
 
-  const enabled = registration == null ? false : (registration.enabled ?? true);
   const id = registration?.id;
   const value = registration?.value;
   const controlRef = registration?.controlRef ?? fallbackControlRef;
   const getValue = useStableCallback(registration?.getValue ?? (() => value));
 
   useIsoLayoutEffect(() => {
-    if (!enabled) {
+    if (registration == null) {
       return;
     }
 
@@ -42,10 +40,10 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
     if (validityData.initialValue === null && initialValue !== null) {
       setValidityData((prev) => ({ ...prev, initialValue }));
     }
-  }, [enabled, getValue, setValidityData, validityData.initialValue, value]);
+  }, [getValue, registration, setValidityData, validityData.initialValue, value]);
 
   useIsoLayoutEffect(() => {
-    if (!enabled || !id) {
+    if (registration == null || !id) {
       return;
     }
 
@@ -72,13 +70,13 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
   }, [
     commit,
     controlRef,
-    enabled,
     formRef,
     getValue,
     id,
     invalid,
     markedDirtyRef,
     name,
+    registration,
     validityData,
     value,
   ]);

--- a/packages/react/src/field/root/useFieldControlRegistration.ts
+++ b/packages/react/src/field/root/useFieldControlRegistration.ts
@@ -15,24 +15,76 @@ export interface FieldControlRegistration {
 }
 
 export function useFieldControlRegistration(params: UseFieldControlRegistrationParameters) {
-  const { registration, commit, invalid, markedDirtyRef, name, setValidityData, validityData } =
-    params;
+  const { commit, invalid, markedDirtyRef, name, setValidityData, validityData } = params;
 
   const { formRef } = useFormContext();
 
+  const activeFieldControlSourceRef = React.useRef<symbol | null>(null);
+  const registrationRef = React.useRef<FieldControlRegistration | null>(null);
   const fallbackControlRef = React.useRef<any>(null);
 
-  const id = registration?.id;
-  const value = registration?.value;
-  const controlRef = registration?.controlRef ?? fallbackControlRef;
-  const getValue = useStableCallback(registration?.getValue ?? (() => value));
+  const getValue = useStableCallback(() => {
+    const registration = registrationRef.current;
+    if (!registration) {
+      return undefined;
+    }
 
-  useIsoLayoutEffect(() => {
-    if (registration == null) {
+    if (registration.getValue) {
+      return registration.getValue();
+    }
+
+    return registration.value;
+  });
+
+  const validate = useStableCallback((flushSync = true) => {
+    const registration = registrationRef.current;
+    if (!registration) {
       return;
     }
 
-    let initialValue = value;
+    let nextValue = registration.value;
+    if (nextValue === undefined) {
+      nextValue = getValue();
+    }
+
+    markedDirtyRef.current = true;
+
+    if (!flushSync) {
+      commit(nextValue);
+    } else {
+      // Synchronously update the validity state so the submit event can be prevented.
+      ReactDOM.flushSync(() => commit(nextValue));
+    }
+  });
+
+  function refreshRegistration() {
+    const registration = registrationRef.current;
+    if (!registration || !registration.id) {
+      return;
+    }
+
+    formRef.current.fields.set(registration.id, {
+      getValue,
+      name,
+      controlRef: registration.controlRef ?? fallbackControlRef,
+      validityData: getCombinedFieldValidityData(validityData, invalid),
+      validate,
+    });
+  }
+
+  function deleteRegistration(id = registrationRef.current?.id) {
+    if (id) {
+      formRef.current.fields.delete(id);
+    }
+  }
+
+  function syncInitialValue() {
+    const registration = registrationRef.current;
+    if (!registration) {
+      return;
+    }
+
+    let initialValue = registration.value;
     if (initialValue === undefined) {
       initialValue = getValue();
     }
@@ -40,57 +92,56 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
     if (validityData.initialValue === null && initialValue !== null) {
       setValidityData((prev) => ({ ...prev, initialValue }));
     }
-  }, [getValue, registration, setValidityData, validityData.initialValue, value]);
+  }
 
   useIsoLayoutEffect(() => {
-    if (registration == null || !id) {
+    const registration = registrationRef.current;
+    if (!registration || !registration.id) {
       return;
     }
 
-    formRef.current.fields.set(id, {
+    formRef.current.fields.set(registration.id, {
       getValue,
       name,
-      controlRef,
+      controlRef: registration.controlRef ?? fallbackControlRef,
       validityData: getCombinedFieldValidityData(validityData, invalid),
-      validate(flushSync = true) {
-        let nextValue = value;
-        if (nextValue === undefined) {
-          nextValue = getValue();
-        }
-
-        markedDirtyRef.current = true;
-
-        if (!flushSync) {
-          commit(nextValue);
-        } else {
-          // Synchronously update the validity state so the submit event can be prevented.
-          ReactDOM.flushSync(() => commit(nextValue));
-        }
-      },
+      validate,
     });
-  }, [
-    commit,
-    controlRef,
-    formRef,
-    getValue,
-    id,
-    invalid,
-    markedDirtyRef,
-    name,
-    registration,
-    validityData,
-    value,
-  ]);
+  }, [formRef, getValue, invalid, name, validate, validityData]);
 
   useIsoLayoutEffect(() => {
     const fields = formRef.current.fields;
 
     return () => {
+      const id = registrationRef.current?.id;
       if (id) {
         fields.delete(id);
       }
     };
-  }, [formRef, id]);
+  }, [formRef]);
+
+  return useStableCallback((source: symbol, registration: FieldControlRegistration | undefined) => {
+    if (!registration) {
+      if (activeFieldControlSourceRef.current === source) {
+        activeFieldControlSourceRef.current = null;
+        deleteRegistration();
+        registrationRef.current = null;
+      }
+      return;
+    }
+
+    const previousId = registrationRef.current?.id;
+
+    activeFieldControlSourceRef.current = source;
+    registrationRef.current = registration;
+
+    if (previousId && previousId !== registration.id) {
+      deleteRegistration(previousId);
+    }
+
+    syncInitialValue();
+    refreshRegistration();
+  });
 }
 
 export interface UseFieldControlRegistrationParameters {
@@ -98,7 +149,6 @@ export interface UseFieldControlRegistrationParameters {
   invalid: boolean;
   markedDirtyRef: React.RefObject<boolean>;
   name: string | undefined;
-  registration: FieldControlRegistration | null;
   setValidityData: React.Dispatch<React.SetStateAction<FieldValidityData>>;
   validityData: FieldValidityData;
 }

--- a/packages/react/src/field/root/useRegisterFieldControl.ts
+++ b/packages/react/src/field/root/useRegisterFieldControl.ts
@@ -1,0 +1,38 @@
+'use client';
+import * as React from 'react';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useFieldRootContext } from './FieldRootContext';
+import type { FieldControlRegistration } from './useFieldControlRegistration';
+
+export interface UseRegisterFieldControlParameters extends FieldControlRegistration {}
+
+export function useRegisterFieldControl(params: UseRegisterFieldControlParameters) {
+  const { controlRef, enabled = true, getValue, id, value } = params;
+
+  const { registerFieldControl } = useFieldRootContext();
+  const sourceRef = React.useRef<symbol | null>(null);
+
+  if (sourceRef.current == null) {
+    sourceRef.current = Symbol();
+  }
+
+  useIsoLayoutEffect(() => {
+    const source = sourceRef.current;
+
+    if (source == null) {
+      return undefined;
+    }
+
+    registerFieldControl(source, {
+      controlRef,
+      enabled,
+      getValue,
+      id,
+      value,
+    });
+
+    return () => {
+      registerFieldControl(source, undefined);
+    };
+  }, [controlRef, enabled, getValue, id, registerFieldControl, value]);
+}

--- a/packages/react/src/field/root/useRegisterFieldControl.ts
+++ b/packages/react/src/field/root/useRegisterFieldControl.ts
@@ -8,8 +8,11 @@ export interface UseRegisterFieldControlParameters extends FieldControlRegistrat
   enabled?: boolean | undefined;
 }
 
-export function useRegisterFieldControl(params: UseRegisterFieldControlParameters) {
-  const { controlRef, enabled = true, getValue, id, value } = params;
+export function useRegisterFieldControl(
+  controlRef: FieldControlRegistration['controlRef'],
+  params: Omit<UseRegisterFieldControlParameters, 'controlRef'>,
+) {
+  const { enabled = true, getValue, id, value } = params;
 
   const { registerFieldControl } = useFieldRootContext();
   const sourceRef = React.useRef<symbol | null>(null);

--- a/packages/react/src/field/root/useRegisterFieldControl.ts
+++ b/packages/react/src/field/root/useRegisterFieldControl.ts
@@ -14,14 +14,14 @@ export function useRegisterFieldControl(params: UseRegisterFieldControlParameter
   const { registerFieldControl } = useFieldRootContext();
   const sourceRef = React.useRef<symbol | null>(null);
 
-  if (sourceRef.current == null) {
+  if (!sourceRef.current) {
     sourceRef.current = Symbol();
   }
 
   useIsoLayoutEffect(() => {
     const source = sourceRef.current;
 
-    if (source == null || !enabled) {
+    if (!source || !enabled) {
       return undefined;
     }
 

--- a/packages/react/src/field/root/useRegisterFieldControl.ts
+++ b/packages/react/src/field/root/useRegisterFieldControl.ts
@@ -4,7 +4,9 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useFieldRootContext } from './FieldRootContext';
 import type { FieldControlRegistration } from './useFieldControlRegistration';
 
-export interface UseRegisterFieldControlParameters extends FieldControlRegistration {}
+export interface UseRegisterFieldControlParameters extends FieldControlRegistration {
+  enabled?: boolean | undefined;
+}
 
 export function useRegisterFieldControl(params: UseRegisterFieldControlParameters) {
   const { controlRef, enabled = true, getValue, id, value } = params;
@@ -19,13 +21,12 @@ export function useRegisterFieldControl(params: UseRegisterFieldControlParameter
   useIsoLayoutEffect(() => {
     const source = sourceRef.current;
 
-    if (source == null) {
+    if (source == null || !enabled) {
       return undefined;
     }
 
     registerFieldControl(source, {
       controlRef,
-      enabled,
       getValue,
       id,
       value,

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -94,10 +94,9 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
   const hasTouchedInputRef = React.useRef(false);
   const blockRevalidationRef = React.useRef(false);
 
-  useRegisterFieldControl({
+  useRegisterFieldControl(inputRef, {
     id,
     value,
-    controlRef: inputRef,
   });
 
   useValueChanged(value, (previousValue) => {

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -4,8 +4,8 @@ import { stopEvent } from '../../floating-ui-react/utils';
 import { useNumberFieldRootContext } from '../root/NumberFieldRootContext';
 import type { BaseUIComponentProps } from '../../utils/types';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
+import { useRegisterFieldControl } from '../../field/root/useRegisterFieldControl';
 import { fieldValidityMapping } from '../../field/utils/constants';
-import { useField } from '../../field/useField';
 import { useFormContext } from '../../form/FormContext';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
 import { DEFAULT_STEP } from '../utils/constants';
@@ -94,13 +94,10 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
   const hasTouchedInputRef = React.useRef(false);
   const blockRevalidationRef = React.useRef(false);
 
-  useField({
+  useRegisterFieldControl({
     id,
-    commit: validation.commit,
     value,
     controlRef: inputRef,
-    name,
-    getValue: () => value ?? null,
   });
 
   useValueChanged(value, (previousValue) => {

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1003,6 +1003,27 @@ describe('<RadioGroup />', () => {
       expect(error).toHaveTextContent('required');
     });
 
+    it('submits null to onFormSubmit when no radio is selected', async () => {
+      const handleSubmit = vi.fn();
+
+      await renderFakeTimers(
+        <Form onFormSubmit={handleSubmit}>
+          <Field.Root name="test">
+            <RadioGroup name="group">
+              <Radio.Root value="a" data-testid="item-a" />
+              <Radio.Root value="b" data-testid="item-b" />
+            </RadioGroup>
+          </Field.Root>
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      fireEvent.click(screen.getByText('Submit'));
+
+      expect(handleSubmit.mock.calls.length).toBe(1);
+      expect(handleSubmit.mock.calls[0][0]).toEqual({ test: null });
+    });
+
     it('clears required validation when a value is selected', async () => {
       const { user } = await renderFakeTimers(
         <Form>

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -7,8 +7,8 @@ import { useBaseUiId } from '../utils/useBaseUiId';
 import { contains } from '../floating-ui-react/utils';
 import { SHIFT } from '../composite/composite';
 import { CompositeRoot } from '../composite/root/CompositeRoot';
-import { useField } from '../field/useField';
 import { useFieldRootContext } from '../field/root/FieldRootContext';
+import { useRegisterFieldControl } from '../field/root/useRegisterFieldControl';
 import { fieldValidityMapping } from '../field/utils/constants';
 import type { FieldRootState } from '../field/root/FieldRoot';
 import { useFieldsetRootContext } from '../fieldset/root/FieldsetRootContext';
@@ -147,13 +147,11 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     return undefined;
   });
 
-  useField({
+  useRegisterFieldControl({
     id,
-    commit: validation.commit,
     value: checkedValue,
-    controlRef,
-    name,
     getValue: () => checkedValue ?? null,
+    controlRef,
   });
 
   useValueChanged(checkedValue, () => {

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -147,10 +147,12 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     return undefined;
   });
 
+  const getFieldValue = useStableCallback(() => checkedValue ?? null);
+
   useRegisterFieldControl({
     id,
     value: checkedValue,
-    getValue: () => checkedValue ?? null,
+    getValue: getFieldValue,
     controlRef,
   });
 

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -149,11 +149,10 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
 
   const getFieldValue = useStableCallback(() => checkedValue ?? null);
 
-  useRegisterFieldControl({
+  useRegisterFieldControl(controlRef, {
     id,
     value: checkedValue,
     getValue: getFieldValue,
-    controlRef,
   });
 
   useValueChanged(checkedValue, () => {

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../floating-ui-react';
 import { SelectRootContext, SelectFloatingContext } from './SelectRootContext';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
+import { useRegisterFieldControl } from '../../field/root/useRegisterFieldControl';
 import { useLabelableId } from '../../labelable-provider/useLabelableId';
 import { useTransitionStatus } from '../../utils/useTransitionStatus';
 import { selectors, type State as StoreState } from '../store';
@@ -30,7 +31,6 @@ import {
 import { REASONS } from '../../utils/reasons';
 import { useOpenChangeComplete } from '../../utils/useOpenChangeComplete';
 import { useFormContext } from '../../form/FormContext';
-import { useField } from '../../field/useField';
 import { type Group, stringifyAsValue } from '../../utils/resolveValueLabel';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from '../../utils/constants';
 import { defaultItemEquality, findItemIndex } from '../../utils/itemEquality';
@@ -180,14 +180,13 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   }, [multiple, value, itemToStringValue]);
 
   const controlRef = useValueAsRef(store.state.triggerElement);
+  const getFieldValue = useStableCallback(() => fieldStringValue);
 
-  useField({
+  useRegisterFieldControl({
     id: generatedId,
-    commit: validation.commit,
     value,
+    getValue: getFieldValue,
     controlRef,
-    name,
-    getValue: () => fieldStringValue,
   });
 
   const initialValueRef = React.useRef(value);

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -182,11 +182,10 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   const controlRef = useValueAsRef(store.state.triggerElement);
   const getFieldValue = useStableCallback(() => fieldStringValue);
 
-  useRegisterFieldControl({
+  useRegisterFieldControl(controlRef, {
     id: generatedId,
     value,
     getValue: getFieldValue,
-    controlRef,
   });
 
   const initialValueRef = React.useRef(value);

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -169,10 +169,9 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     }
   });
 
-  useRegisterFieldControl({
+  useRegisterFieldControl(controlRef, {
     id,
     value: valueUnwrapped,
-    controlRef,
   });
 
   useValueChanged(valueUnwrapped, () => {

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -21,8 +21,8 @@ import { areArraysEqual } from '../../utils/areArraysEqual';
 import { activeElement, contains } from '../../floating-ui-react/utils';
 import { CompositeList, type CompositeMetadata } from '../../composite/list/CompositeList';
 import type { FieldRootState } from '../../field/root/FieldRoot';
-import { useField } from '../../field/useField';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
+import { useRegisterFieldControl } from '../../field/root/useRegisterFieldControl';
 import { useFormContext } from '../../form/FormContext';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
 import { resolveAriaLabelledBy, getDefaultLabelId } from '../../utils/resolveAriaLabelledBy';
@@ -169,13 +169,10 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     }
   });
 
-  useField({
+  useRegisterFieldControl({
     id,
-    commit: validation.commit,
     value: valueUnwrapped,
     controlRef,
-    name,
-    getValue: () => valueUnwrapped,
   });
 
   useValueChanged(valueUnwrapped, () => {

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -98,10 +98,9 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     state: 'checked',
   });
 
-  useRegisterFieldControl({
+  useRegisterFieldControl(switchRef, {
     id,
     value: checked,
-    controlRef: switchRef,
   });
 
   useIsoLayoutEffect(() => {

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -13,9 +13,9 @@ import { useBaseUiId } from '../../utils/useBaseUiId';
 import { useButton } from '../../use-button';
 import { SwitchRootContext } from './SwitchRootContext';
 import { stateAttributesMapping } from '../stateAttributesMapping';
-import { useField } from '../../field/useField';
 import type { FieldRootState } from '../../field/root/FieldRoot';
 import { useFieldRootContext } from '../../field/root/FieldRootContext';
+import { useRegisterFieldControl } from '../../field/root/useRegisterFieldControl';
 import { useFormContext } from '../../form/FormContext';
 import { useLabelableContext } from '../../labelable-provider/LabelableContext';
 import { useAriaLabelledBy } from '../../labelable-provider/useAriaLabelledBy';
@@ -98,13 +98,10 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     state: 'checked',
   });
 
-  useField({
+  useRegisterFieldControl({
     id,
-    commit: validation.commit,
     value: checked,
     controlRef: switchRef,
-    name,
-    getValue: () => checked,
   });
 
   useIsoLayoutEffect(() => {


### PR DESCRIPTION
This moves field registration ownership into `Field.Root` so field-aware controls only publish lightweight control descriptors through the field context.

The main tradeoff is that `Field` itself gets a bit bigger because it now owns the optional Base UI form-integration path. That is intentional: consumers who use controls like `Select`, `Slider`, `Checkbox`, `Switch`, `RadioGroup`, `Combobox`, and `NumberField` without Base UI `Field`/`Form` no longer pay for that registration logic by default.

The package-level bundle bot still reports a small increase for `@base-ui/react` because the root barrel exports `Field`, which now owns the shared registration path. That root-package number is a noisy aggregate for this change, and the more useful read is:

- `Field` itself got bigger because it now owns registration work that used to live in each control.
- The field-aware controls got smaller because they stopped each carrying that logic themselves.
- When `Field` is bundled together with those controls, the net effect is still smaller overall because the shared Field-owned path deduplicates better than the old per-control setup.

## Changes

- Move form registration out of each control and into `Field.Root` via `useFieldControlRegistration`.
- Add `useRegisterFieldControl` so the controls share one small registration publisher instead of repeating the same effect boilerplate.
- Remove the intermediate registration state hop in `Field.Root` and keep the active control registration in a ref-backed path.
- Preserve submit-time value normalization for controls that need it, including `Select`, `Combobox`, `Field.Control`, and unselected `RadioGroup`.
- Add a regression test for unselected `RadioGroup` values submitted through `Form.onFormSubmit`.
- Simplify the shared registration path so only the long-lived registry callbacks keep stable identity.

## Bundle impact

Bundle bot for the root barrel currently reports `@base-ui/react` at `+630 B` parsed and `+99 B` gzip.

Local bundle-size snapshot diff against fresh `upstream/master` for the narrower entrypoints affected by this refactor:

The last two rows below are real synthetic-bundle measurements where those entrypoint source files are imported together, rather than sums of the individual deltas.

| Entry | Parsed delta | Gzip delta |
| --- | ---: | ---: |
| `Field` | `+890 B` | `+194 B` |
| `Checkbox` | `-414 B` | `-154 B` |
| `CheckboxGroup` | `-482 B` | `-171 B` |
| `Combobox` | `-504 B` | `-175 B` |
| `NumberField` | `-418 B` | `-111 B` |
| `RadioGroup` | `-424 B` | `-159 B` |
| `Select` | `-503 B` | `-158 B` |
| `Slider` | `-452 B` | `-168 B` |
| `Switch` | `-445 B` | `-191 B` |
| Synthetic bundle: field-aware controls together | `-738 B` | `-270 B` |
| Synthetic bundle: field-aware controls + `Field` | `+541 B` | `+85 B` |

## Benchmark impact

Chromium production benchmark against `upstream/master` after removing the extra `Field.Root` registration state hop:

| Scenario | Master | This branch | Delta |
| --- | ---: | ---: | ---: |
| `Slider x400` without `Field` | `8.2 ms` | `7.3 ms` | `-0.9 ms` |
| `Slider x400` with `Field` | `12.8 ms` | `13.2 ms` | `+0.4 ms` |
| `Select x250` without `Field` | `22.4 ms` | `19.7 ms` | `-2.7 ms` |
| `Select x250` with `Field` | `30.2 ms` | `32.7 ms` | `+2.5 ms` |

So the final shape is:

- Controls used without `Field` are faster and slimmer.
- Wrapped cases are much closer to baseline after removing the extra registration state hop in `Field.Root`.
- The remaining runtime tradeoff is concentrated in the optional `Field` path rather than paid by every field-aware control by default.


