### PR TITLE
[composite] Change focus to sync

### DIFF
--- a/packages/react/src/composite/list/CompositeList.tsx
+++ b/packages/react/src/composite/list/CompositeList.tsx
@@ -52,11 +52,7 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     disableEslintWarning(mapTick);
 
     const newMap = new Map<Element, CompositeMetadata<Metadata>>();
-    // Filter out disconnected elements before sorting to avoid inconsistent
-    // compareDocumentPosition results when elements are detached from the DOM.
-    const sortedNodes = Array.from(map.keys())
-      .filter((node) => node.isConnected)
-      .sort(sortByDocumentPosition);
+    const sortedNodes = getOrderedNodes(map);
 
     sortedNodes.forEach((node, index) => {
       const metadata = map.get(node) ?? ({} as CompositeMetadata<Metadata>);
@@ -94,6 +90,20 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
       mutationObserver.disconnect();
     };
   }, [sortedMap]);
+
+  useIsoLayoutEffect(() => {
+    const sortedNodes = getOrderedNodes(map);
+
+    if (
+      sortedNodes.length === elementsRef.current.length &&
+      sortedNodes.every((node, index) => elementsRef.current[index] === node)
+    ) {
+      return;
+    }
+
+    lastTickRef.current += 1;
+    setMapTick(lastTickRef.current);
+  });
 
   useIsoLayoutEffect(() => {
     const shouldUpdateLengths = lastTickRef.current === mapTick;
@@ -168,6 +178,12 @@ function sortByDocumentPosition(a: Element, b: Element) {
   }
 
   return 0;
+}
+
+function getOrderedNodes(map: Map<Element, unknown>) {
+  // Filter out disconnected elements before sorting to avoid inconsistent
+  // compareDocumentPosition results when elements are detached from the DOM.
+  return Array.from(map.keys()).filter((node) => node.isConnected).sort(sortByDocumentPosition);
 }
 
 function disableEslintWarning(_: any) {}

--- a/packages/react/src/composite/list/CompositeList.tsx
+++ b/packages/react/src/composite/list/CompositeList.tsx
@@ -47,12 +47,15 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     setMapTick(lastTickRef.current);
   });
 
-  const sortedMap = React.useMemo(() => {
+  const sortedNodes = React.useMemo(() => {
     // `mapTick` is the `useMemo` trigger as `map` is stable.
     disableEslintWarning(mapTick);
 
+    return getOrderedNodes(map);
+  }, [map, mapTick]);
+
+  const sortedMap = React.useMemo(() => {
     const newMap = new Map<Element, CompositeMetadata<Metadata>>();
-    const sortedNodes = getOrderedNodes(map);
 
     sortedNodes.forEach((node, index) => {
       const metadata = map.get(node) ?? ({} as CompositeMetadata<Metadata>);
@@ -60,7 +63,7 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     });
 
     return newMap;
-  }, [map, mapTick]);
+  }, [map, sortedNodes]);
 
   useIsoLayoutEffect(() => {
     if (typeof MutationObserver !== 'function' || sortedMap.size === 0) {
@@ -92,18 +95,15 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
   }, [sortedMap]);
 
   useIsoLayoutEffect(() => {
-    const sortedNodes = getOrderedNodes(map);
+    const nextSortedNodes = getOrderedNodes(map);
 
-    if (
-      sortedNodes.length === elementsRef.current.length &&
-      sortedNodes.every((node, index) => elementsRef.current[index] === node)
-    ) {
+    if (areSameNodes(nextSortedNodes, sortedNodes)) {
       return;
     }
 
     lastTickRef.current += 1;
     setMapTick(lastTickRef.current);
-  });
+  }, [children, map, sortedNodes]);
 
   useIsoLayoutEffect(() => {
     const shouldUpdateLengths = lastTickRef.current === mapTick;
@@ -186,6 +186,10 @@ function getOrderedNodes(map: Map<Element, unknown>) {
   return Array.from(map.keys())
     .filter((node) => node.isConnected)
     .sort(sortByDocumentPosition);
+}
+
+function areSameNodes(a: Element[], b: Element[]) {
+  return a.length === b.length && a.every((node, index) => node === b[index]);
 }
 
 function disableEslintWarning(_: any) {}

--- a/packages/react/src/composite/list/CompositeList.tsx
+++ b/packages/react/src/composite/list/CompositeList.tsx
@@ -34,6 +34,7 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
   // `mapTick` uses a counter rather than objects for low precision-loss risk and better memory efficiency
   const [mapTick, setMapTick] = React.useState(0);
   const lastTickRef = React.useRef(mapTick);
+  const sortedNodesRef = React.useRef<Element[]>([]);
 
   const register = useStableCallback((node: Element, metadata: Metadata) => {
     map.set(node, metadata ?? null);
@@ -47,15 +48,12 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     setMapTick(lastTickRef.current);
   });
 
-  const sortedNodes = React.useMemo(() => {
+  const sortedMap = React.useMemo(() => {
     // `mapTick` is the `useMemo` trigger as `map` is stable.
     disableEslintWarning(mapTick);
 
-    return getOrderedNodes(map);
-  }, [map, mapTick]);
-
-  const sortedMap = React.useMemo(() => {
     const newMap = new Map<Element, CompositeMetadata<Metadata>>();
+    const sortedNodes = getOrderedNodes(map);
 
     sortedNodes.forEach((node, index) => {
       const metadata = map.get(node) ?? ({} as CompositeMetadata<Metadata>);
@@ -63,9 +61,11 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     });
 
     return newMap;
-  }, [map, sortedNodes]);
+  }, [map, mapTick]);
 
   useIsoLayoutEffect(() => {
+    sortedNodesRef.current = Array.from(sortedMap.keys());
+
     if (typeof MutationObserver !== 'function' || sortedMap.size === 0) {
       return undefined;
     }
@@ -96,14 +96,18 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
 
   useIsoLayoutEffect(() => {
     const nextSortedNodes = getOrderedNodes(map);
+    const previousSortedNodes = sortedNodesRef.current;
 
-    if (areSameNodes(nextSortedNodes, sortedNodes)) {
+    if (
+      nextSortedNodes.length === previousSortedNodes.length &&
+      nextSortedNodes.every((node, index) => node === previousSortedNodes[index])
+    ) {
       return;
     }
 
     lastTickRef.current += 1;
     setMapTick(lastTickRef.current);
-  }, [children, map, sortedNodes]);
+  }, [children, map]);
 
   useIsoLayoutEffect(() => {
     const shouldUpdateLengths = lastTickRef.current === mapTick;
@@ -186,10 +190,6 @@ function getOrderedNodes(map: Map<Element, unknown>) {
   return Array.from(map.keys())
     .filter((node) => node.isConnected)
     .sort(sortByDocumentPosition);
-}
-
-function areSameNodes(a: Element[], b: Element[]) {
-  return a.length === b.length && a.every((node, index) => node === b[index]);
 }
 
 function disableEslintWarning(_: any) {}

--- a/packages/react/src/composite/list/CompositeList.tsx
+++ b/packages/react/src/composite/list/CompositeList.tsx
@@ -183,7 +183,9 @@ function sortByDocumentPosition(a: Element, b: Element) {
 function getOrderedNodes(map: Map<Element, unknown>) {
   // Filter out disconnected elements before sorting to avoid inconsistent
   // compareDocumentPosition results when elements are detached from the DOM.
-  return Array.from(map.keys()).filter((node) => node.isConnected).sort(sortByDocumentPosition);
+  return Array.from(map.keys())
+    .filter((node) => node.isConnected)
+    .sort(sortByDocumentPosition);
 }
 
 function disableEslintWarning(_: any) {}

--- a/packages/react/src/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/composite/root/CompositeRoot.test.tsx
@@ -1,6 +1,6 @@
 import { expect } from 'vitest';
 import * as React from 'react';
-import { act, createRenderer, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { isJSDOM } from '#test-utils';
 import { DirectionProvider } from '../../direction-provider';
 import { CompositeItem } from '../item/CompositeItem';
@@ -10,7 +10,7 @@ describe('Composite', () => {
   const { render } = createRenderer();
 
   describe('list', () => {
-    it('controlled mode', async () => {
+    it('controlled mode', () => {
       function App() {
         const [highlightedIndex, setHighlightedIndex] = React.useState(0);
         return (
@@ -36,31 +36,27 @@ describe('Composite', () => {
       expect(item1).toHaveAttribute('tabindex', '0');
 
       fireEvent.keyDown(item1, { key: 'ArrowDown' });
-      await flushMicrotasks();
 
       expect(item2).toHaveAttribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowDown' });
-      await flushMicrotasks();
 
       expect(item3).toHaveAttribute('tabindex', '0');
       expect(item3).toHaveFocus();
 
       fireEvent.keyDown(item3, { key: 'ArrowUp' });
-      await flushMicrotasks();
 
       expect(item2).toHaveAttribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowUp' });
-      await flushMicrotasks();
 
       expect(item1).toHaveAttribute('tabindex', '0');
       expect(item1).toHaveFocus();
     });
 
-    it('uncontrolled mode', async () => {
+    it('uncontrolled mode', () => {
       render(
         <CompositeRoot>
           <CompositeItem data-testid="1">1</CompositeItem>
@@ -76,28 +72,44 @@ describe('Composite', () => {
       act(() => item1.focus());
 
       fireEvent.keyDown(item1, { key: 'ArrowDown' });
-      await flushMicrotasks();
 
       expect(item2).toHaveAttribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowDown' });
-      await flushMicrotasks();
 
       expect(item3).toHaveAttribute('tabindex', '0');
       expect(item3).toHaveFocus();
 
       fireEvent.keyDown(item3, { key: 'ArrowUp' });
-      await flushMicrotasks();
 
       expect(item2).toHaveAttribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowUp' });
-      await flushMicrotasks();
 
       expect(item1).toHaveAttribute('tabindex', '0');
       expect(item1).toHaveFocus();
+    });
+
+    it('moves focus synchronously on arrow navigation', () => {
+      render(
+        <CompositeRoot>
+          <CompositeItem data-testid="1">1</CompositeItem>
+          <CompositeItem data-testid="2">2</CompositeItem>
+          <CompositeItem data-testid="3">3</CompositeItem>
+        </CompositeRoot>,
+      );
+
+      const item1 = screen.getByTestId('1');
+      const item2 = screen.getByTestId('2');
+
+      act(() => item1.focus());
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown' });
+
+      expect(item2).toHaveAttribute('tabindex', '0');
+      expect(item2).toHaveFocus();
     });
 
     it.skipIf(isJSDOM)('updates the order of items', async () => {
@@ -124,7 +136,7 @@ describe('Composite', () => {
     });
 
     describe('Home and End keys', () => {
-      it('Home key moves focus to the first item', async () => {
+      it('Home key moves focus to the first item', () => {
         render(
           <CompositeRoot enableHomeAndEndKeys>
             <CompositeItem data-testid="1">1</CompositeItem>
@@ -139,13 +151,12 @@ describe('Composite', () => {
         act(() => item3.focus());
 
         fireEvent.keyDown(item3, { key: 'Home' });
-        await flushMicrotasks();
 
         expect(item1).toHaveAttribute('tabindex', '0');
         expect(item1).toHaveFocus();
       });
 
-      it('End key moves focus to the last item', async () => {
+      it('End key moves focus to the last item', () => {
         render(
           <CompositeRoot enableHomeAndEndKeys>
             <CompositeItem data-testid="1">1</CompositeItem>
@@ -160,7 +171,6 @@ describe('Composite', () => {
         act(() => item1.focus());
 
         fireEvent.keyDown(item1, { key: 'End' });
-        await flushMicrotasks();
 
         expect(item3).toHaveAttribute('tabindex', '0');
         expect(item3).toHaveFocus();
@@ -168,7 +178,7 @@ describe('Composite', () => {
     });
 
     describe.skipIf(isJSDOM)('rtl', () => {
-      it('horizontal orientation', async () => {
+      it('horizontal orientation', () => {
         render(
           <div dir="rtl">
             <DirectionProvider direction="rtl">
@@ -188,41 +198,35 @@ describe('Composite', () => {
         act(() => item1.focus());
 
         fireEvent.keyDown(item1, { key: 'ArrowDown' });
-        await flushMicrotasks();
 
         fireEvent.keyDown(item1, { key: 'ArrowLeft' });
-        await flushMicrotasks();
 
         expect(item2).toHaveAttribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowLeft' });
-        await flushMicrotasks();
 
         expect(item3).toHaveAttribute('tabindex', '0');
         expect(item3).toHaveFocus();
 
         fireEvent.keyDown(item3, { key: 'ArrowRight' });
-        await flushMicrotasks();
 
         expect(item2).toHaveAttribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowRight' });
-        await flushMicrotasks();
 
         expect(item1).toHaveAttribute('tabindex', '0');
         expect(item1).toHaveFocus();
 
         // loop backward
         fireEvent.keyDown(item1, { key: 'ArrowRight' });
-        await flushMicrotasks();
 
         expect(item3).toHaveAttribute('tabindex', '0');
         expect(item3).toHaveFocus();
       });
 
-      it('both horizontal and vertical orientation', async () => {
+      it('both horizontal and vertical orientation', () => {
         render(
           <div dir="rtl">
             <DirectionProvider direction="rtl">
@@ -242,37 +246,31 @@ describe('Composite', () => {
         act(() => item1.focus());
 
         fireEvent.keyDown(item1, { key: 'ArrowLeft' });
-        await flushMicrotasks();
 
         expect(item2).toHaveAttribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowLeft' });
-        await flushMicrotasks();
 
         expect(item3).toHaveAttribute('tabindex', '0');
         expect(item3).toHaveFocus();
 
         fireEvent.keyDown(item3, { key: 'ArrowRight' });
-        await flushMicrotasks();
 
         expect(item2).toHaveAttribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowRight' });
-        await flushMicrotasks();
 
         expect(item1).toHaveAttribute('tabindex', '0');
         expect(item1).toHaveFocus();
 
         fireEvent.keyDown(item1, { key: 'ArrowDown' });
-        await flushMicrotasks();
 
         expect(item2).toHaveAttribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowDown' });
-        await flushMicrotasks();
 
         expect(item3).toHaveAttribute('tabindex', '0');
         expect(item3).toHaveFocus();
@@ -300,53 +298,45 @@ describe('Composite', () => {
       act(() => screen.getByTestId('1').focus());
 
       fireEvent.keyDown(screen.getByTestId('1'), { key: 'ArrowDown' });
-      await flushMicrotasks();
 
       expect(screen.getByTestId('4')).toHaveAttribute('tabindex', '0');
       expect(screen.getByTestId('4')).toHaveFocus();
 
       fireEvent.keyDown(screen.getByTestId('4'), { key: 'ArrowRight' });
-      await flushMicrotasks();
 
       expect(screen.getByTestId('5')).toHaveAttribute('tabindex', '0');
       expect(screen.getByTestId('5')).toHaveFocus();
 
       fireEvent.keyDown(screen.getByTestId('5'), { key: 'ArrowDown' });
-      await flushMicrotasks();
 
       expect(screen.getByTestId('8')).toHaveAttribute('tabindex', '0');
       expect(screen.getByTestId('8')).toHaveFocus();
 
       fireEvent.keyDown(screen.getByTestId('8'), { key: 'ArrowLeft' });
-      await flushMicrotasks();
 
       expect(screen.getByTestId('7')).toHaveAttribute('tabindex', '0');
       expect(screen.getByTestId('7')).toHaveFocus();
 
       fireEvent.keyDown(screen.getByTestId('7'), { key: 'ArrowUp' });
-      await flushMicrotasks();
 
       expect(screen.getByTestId('4')).toHaveAttribute('tabindex', '0');
       expect(screen.getByTestId('4')).toHaveFocus();
 
       act(() => screen.getByTestId('9').focus());
-      await flushMicrotasks();
 
       expect(screen.getByTestId('9')).toHaveAttribute('tabindex', '0');
 
       fireEvent.keyDown(screen.getByTestId('9'), { key: 'Home' });
-      await flushMicrotasks();
 
       expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
 
       fireEvent.keyDown(screen.getByTestId('1'), { key: 'End' });
-      await flushMicrotasks();
 
       expect(screen.getByTestId('9')).toHaveAttribute('tabindex', '0');
     });
 
     describe.skipIf(isJSDOM)('rtl', () => {
-      it('horizontal orientation', async () => {
+      it('horizontal orientation', () => {
         render(
           <div dir="rtl">
             <DirectionProvider direction="rtl">
@@ -364,36 +354,30 @@ describe('Composite', () => {
         act(() => screen.getByTestId('1').focus());
 
         fireEvent.keyDown(screen.getByTestId('1'), { key: 'ArrowLeft' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
         expect(screen.getByTestId('2')).toHaveFocus();
 
         fireEvent.keyDown(screen.getByTestId('2'), { key: 'ArrowLeft' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '0');
         expect(screen.getByTestId('3')).toHaveFocus();
 
         fireEvent.keyDown(screen.getByTestId('3'), { key: 'ArrowLeft' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('4')).toHaveAttribute('tabindex', '0');
         expect(screen.getByTestId('4')).toHaveFocus();
 
         fireEvent.keyDown(screen.getByTestId('4'), { key: 'ArrowLeft' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('5')).toHaveAttribute('tabindex', '0');
         expect(screen.getByTestId('5')).toHaveFocus();
 
         fireEvent.keyDown(screen.getByTestId('5'), { key: 'Home' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
 
         fireEvent.keyDown(screen.getByTestId('1'), { key: 'End' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('9')).toHaveAttribute('tabindex', '0');
       });
@@ -416,49 +400,42 @@ describe('Composite', () => {
         act(() => screen.getByTestId('1').focus());
 
         fireEvent.keyDown(screen.getByTestId('1'), { key: 'ArrowDown' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('4')).toHaveAttribute('tabindex', '0');
         expect(screen.getByTestId('4')).toHaveFocus();
 
         fireEvent.keyDown(screen.getByTestId('4'), { key: 'ArrowLeft' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('5')).toHaveAttribute('tabindex', '0');
         expect(screen.getByTestId('5')).toHaveFocus();
 
         fireEvent.keyDown(screen.getByTestId('5'), { key: 'ArrowDown' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('8')).toHaveAttribute('tabindex', '0');
         expect(screen.getByTestId('8')).toHaveFocus();
 
         fireEvent.keyDown(screen.getByTestId('8'), { key: 'ArrowRight' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('7')).toHaveAttribute('tabindex', '0');
         expect(screen.getByTestId('7')).toHaveFocus();
 
         fireEvent.keyDown(screen.getByTestId('7'), { key: 'ArrowUp' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('4')).toHaveAttribute('tabindex', '0');
         expect(screen.getByTestId('4')).toHaveFocus();
 
         fireEvent.keyDown(screen.getByTestId('4'), { key: 'End' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('9')).toHaveAttribute('tabindex', '0');
 
         fireEvent.keyDown(screen.getByTestId('9'), { key: 'Home' });
-        await flushMicrotasks();
 
         expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
       });
     });
 
     describe('prop: disabledIndices', () => {
-      it('disables navigating item when their index is included', async () => {
+      it('disables navigating item when their index is included', () => {
         function App() {
           const [highlightedIndex, setHighlightedIndex] = React.useState(0);
           return (
@@ -482,13 +459,11 @@ describe('Composite', () => {
         act(() => item1.focus());
 
         fireEvent.keyDown(item1, { key: 'ArrowDown' });
-        await flushMicrotasks();
 
         expect(item3).toHaveAttribute('tabindex', '0');
         expect(item3).toHaveFocus();
 
         fireEvent.keyDown(item3, { key: 'ArrowUp' });
-        await flushMicrotasks();
 
         expect(item1).toHaveAttribute('tabindex', '0');
         expect(item1).toHaveFocus();
@@ -533,25 +508,21 @@ describe('Composite', () => {
         act(() => item1.focus());
 
         fireEvent.keyDown(item1, { key: 'ArrowDown' });
-        await flushMicrotasks();
 
         expect(item2).toHaveAttribute('tabindex', '0');
         expect(item2).toHaveFocus();
 
         fireEvent.keyDown(item2, { key: 'ArrowDown' });
-        await flushMicrotasks();
 
         expect(item3).toHaveAttribute('tabindex', '0');
         expect(item3).toHaveFocus();
 
         fireEvent.keyDown(item3, { key: 'ArrowDown' });
-        await flushMicrotasks();
 
         expect(item1).toHaveAttribute('tabindex', '0');
         expect(item1).toHaveFocus();
 
         fireEvent.keyDown(item1, { key: 'ArrowUp' });
-        await flushMicrotasks();
 
         expect(item3).toHaveAttribute('tabindex', '0');
         expect(item3).toHaveFocus();
@@ -560,7 +531,7 @@ describe('Composite', () => {
   });
 
   describe('prop: disabledIndices', () => {
-    it('disables navigating item when their index is included', async () => {
+    it('disables navigating item when their index is included', () => {
       function App() {
         const [highlightedIndex, setHighlightedIndex] = React.useState(0);
         return (
@@ -584,13 +555,11 @@ describe('Composite', () => {
       act(() => item1.focus());
 
       fireEvent.keyDown(item1, { key: 'ArrowDown' });
-      await flushMicrotasks();
 
       expect(item3).toHaveAttribute('tabindex', '0');
       expect(item3).toHaveFocus();
 
       fireEvent.keyDown(item3, { key: 'ArrowUp' });
-      await flushMicrotasks();
 
       expect(item1).toHaveAttribute('tabindex', '0');
       expect(item1).toHaveFocus();
@@ -635,25 +604,21 @@ describe('Composite', () => {
       act(() => item1.focus());
 
       fireEvent.keyDown(item1, { key: 'ArrowDown' });
-      await flushMicrotasks();
 
       expect(item2).toHaveAttribute('tabindex', '0');
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowDown' });
-      await flushMicrotasks();
 
       expect(item3).toHaveAttribute('tabindex', '0');
       expect(item3).toHaveFocus();
 
       fireEvent.keyDown(item3, { key: 'ArrowDown' });
-      await flushMicrotasks();
 
       expect(item1).toHaveAttribute('tabindex', '0');
       expect(item1).toHaveFocus();
 
       fireEvent.keyDown(item1, { key: 'ArrowUp' });
-      await flushMicrotasks();
 
       expect(item3).toHaveAttribute('tabindex', '0');
       expect(item3).toHaveFocus();
@@ -661,7 +626,7 @@ describe('Composite', () => {
   });
 
   describe('prop: modifierKeys', () => {
-    it('prevents arrow key navigation when any modifier key is pressed by default', async () => {
+    it('prevents arrow key navigation when any modifier key is pressed by default', () => {
       render(
         <CompositeRoot>
           <CompositeItem data-testid="1">1</CompositeItem>
@@ -676,23 +641,19 @@ describe('Composite', () => {
       expect(item1).toHaveFocus();
 
       fireEvent.keyDown(item1, { key: 'ArrowDown', shiftKey: true });
-      await flushMicrotasks();
       expect(item1).toHaveFocus();
 
       fireEvent.keyDown(item1, { key: 'ArrowDown', ctrlKey: true });
-      await flushMicrotasks();
       expect(item1).toHaveFocus();
 
       fireEvent.keyDown(item1, { key: 'ArrowDown', altKey: true });
-      await flushMicrotasks();
       expect(item1).toHaveFocus();
 
       fireEvent.keyDown(item1, { key: 'ArrowDown', metaKey: true });
-      await flushMicrotasks();
       expect(item1).toHaveFocus();
     });
 
-    it('specifies allowed modifier keys that do not prevent arrow key navigation when pressed', async () => {
+    it('specifies allowed modifier keys that do not prevent arrow key navigation when pressed', () => {
       render(
         <CompositeRoot modifierKeys={['Alt', 'Meta']}>
           <CompositeItem data-testid="1">1</CompositeItem>
@@ -710,19 +671,15 @@ describe('Composite', () => {
       expect(item1).toHaveFocus();
 
       fireEvent.keyDown(item1, { key: 'ArrowDown', shiftKey: true });
-      await flushMicrotasks();
       expect(item1).toHaveFocus();
 
       fireEvent.keyDown(item1, { key: 'ArrowDown', ctrlKey: true });
-      await flushMicrotasks();
       expect(item1).toHaveFocus();
 
       fireEvent.keyDown(item1, { key: 'ArrowDown', altKey: true });
-      await flushMicrotasks();
       expect(item2).toHaveFocus();
 
       fireEvent.keyDown(item2, { key: 'ArrowDown', metaKey: true });
-      await flushMicrotasks();
       expect(item3).toHaveFocus();
     });
   });

--- a/packages/react/src/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/composite/root/useCompositeRoot.ts
@@ -340,11 +340,7 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
             event.preventDefault();
           }
           onHighlightedIndexChange(nextIndex, true);
-
-          // Wait for FocusManager `returnFocus` to execute.
-          queueMicrotask(() => {
-            elementsRef.current[nextIndex]?.focus();
-          });
+          elementsRef.current[nextIndex]?.focus();
         }
       },
     }),

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -174,7 +174,13 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     }
   });
 
-  const [touched, setTouched] = React.useState(false);
+  const [touched, setTouchedState] = React.useState(false);
+  const touchedRef = React.useRef(touched);
+
+  const setTouched = useStableCallback<React.Dispatch<React.SetStateAction<boolean>>>((value) => {
+    touchedRef.current = typeof value === 'function' ? value(touchedRef.current) : value;
+    setTouchedState(touchedRef.current);
+  });
 
   const ariaLabelledby = elementProps['aria-labelledby'] ?? labelId ?? fieldsetContext?.legendId;
 
@@ -201,6 +207,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
       setCheckedValue,
       setTouched,
       touched,
+      touchedRef,
     }),
     [
       checkedValue,
@@ -217,6 +224,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
       setCheckedValue,
       setTouched,
       touched,
+      touchedRef,
     ],
   );
 

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -174,12 +174,10 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     }
   });
 
-  const [touched, setTouchedState] = React.useState(false);
-  const touchedRef = React.useRef(touched);
+  const touchedRef = React.useRef(false);
 
   const setTouched = useStableCallback<React.Dispatch<React.SetStateAction<boolean>>>((value) => {
     touchedRef.current = typeof value === 'function' ? value(touchedRef.current) : value;
-    setTouchedState(touchedRef.current);
   });
 
   const ariaLabelledby = elementProps['aria-labelledby'] ?? labelId ?? fieldsetContext?.legendId;
@@ -206,7 +204,6 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
       required,
       setCheckedValue,
       setTouched,
-      touched,
       touchedRef,
     }),
     [
@@ -223,7 +220,6 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
       required,
       setCheckedValue,
       setTouched,
-      touched,
       touchedRef,
     ],
   );

--- a/packages/react/src/radio-group/RadioGroupContext.ts
+++ b/packages/react/src/radio-group/RadioGroupContext.ts
@@ -20,6 +20,7 @@ export interface RadioGroupContext<Value> {
     eventDetails: BaseUIChangeEventDetails<BaseUIEventReasons['none']>,
   ) => void;
   touched: boolean;
+  touchedRef: React.RefObject<boolean>;
   setTouched: React.Dispatch<React.SetStateAction<boolean>>;
   validation?: UseFieldValidationReturnValue | undefined;
   registerControlRef: (element: HTMLElement | null, disabled?: boolean) => void;

--- a/packages/react/src/radio-group/RadioGroupContext.ts
+++ b/packages/react/src/radio-group/RadioGroupContext.ts
@@ -19,7 +19,6 @@ export interface RadioGroupContext<Value> {
     value: Value,
     eventDetails: BaseUIChangeEventDetails<BaseUIEventReasons['none']>,
   ) => void;
-  touched: boolean;
   touchedRef: React.RefObject<boolean>;
   setTouched: React.Dispatch<React.SetStateAction<boolean>>;
   validation?: UseFieldValidationReturnValue | undefined;

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -59,6 +59,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
     form: formGroup,
     checkedValue,
     touched = false,
+    touchedRef,
     validation,
     name,
   } = groupContext ?? {};
@@ -168,7 +169,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
       );
     },
     onFocus(event) {
-      if (event.defaultPrevented || disabled || readOnly || !touched) {
+      if (event.defaultPrevented || disabled || readOnly || !(touchedRef?.current ?? touched)) {
         return;
       }
 

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -58,7 +58,6 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
     required: requiredGroup,
     form: formGroup,
     checkedValue,
-    touched = false,
     touchedRef,
     validation,
     name,
@@ -169,7 +168,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
       );
     },
     onFocus(event) {
-      if (event.defaultPrevented || disabled || readOnly || !(touchedRef?.current ?? touched)) {
+      if (event.defaultPrevented || disabled || readOnly || !touchedRef?.current) {
         return;
       }
 


### PR DESCRIPTION
Fixes #828

This removes Composite's extra focus microtask now that floating focus return is already async, and preserves radio group selection behavior when arrow navigation moves focus synchronously.

## Changes

- Focus the next composite item synchronously during keyboard navigation.
- Keep radio group arrow navigation selecting the focused radio in the same event turn.
- Remove obsolete `flushMicrotasks()` noise from the Composite root tests and add direct coverage for synchronous focus.
