### PR TITLE
[code-infra] Remove `vscode-styled-components` from recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,18 +1,19 @@
 {
   "recommendations": [
-    // Formating
+    // Formatting
     "esbenp.prettier-vscode", // Prettier
     "editorconfig.editorconfig", // EditorConfig
 
-    // Highlighting
+    // Language support
     "bradlc.vscode-tailwindcss", // Tailwind CSS
     "unifiedjs.vscode-mdx", // MDX
-    "styled-components.vscode-styled-components", // styled()
 
-    // Lint
+    // Linting
     "dbaeumer.vscode-eslint", // ESLint
-    "yoavbls.pretty-ts-errors", // TypeScript
     "stylelint.vscode-stylelint", // Stylelint
-    "davidanson.vscode-markdownlint" // markdownlint
+    "davidanson.vscode-markdownlint", // markdownlint
+
+    // Misc
+    "yoavbls.pretty-ts-errors" // TypeScript errors readability
   ]
 }


### PR DESCRIPTION
Removed `vscode-styled-components` from VSCode recommended extensions, fixed a typo, and slightly reorganized the extension list. We don't use Styled Components/Emotion anywhere in the repo anymore.