### PR TITLE
[internal] Add base-ui keyword to npm

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,6 +8,7 @@
     "react-component",
     "mui",
     "unstyled",
+    "base-ui",
     "a11y"
   ],
   "repository": {


### PR DESCRIPTION
See https://www.npmjs.com/search?q=keywords%3A%22base-ui%22, the community is publishing a bunch of npm packages under the Base UI ecosystem. It's standard practice to have the primary npm package "show the way" with the official npm keywords to use. For example https://www.npmjs.com/search?q=keywords:shadcn.

While I was at it, I noticed those too:

- https://github.com/shadcn-ui/ui/pull/10303.
- https://github.com/mui/base-ui-mosaic/pull/144
- https://github.com/mui/base-ui-charts/pull/188
- https://github.com/mui/base-ui-plus/pull/11

Next, we could optimize those npm keywords, but that's off topic for the problem this PR tries to solve => a different PR.