### PR TITLE
[popups] Split portal node hook from focus portal

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -37,7 +37,7 @@ import { REASONS } from '../../utils/reasons';
 import { createAttribute } from '../utils/createAttribute';
 import { enqueueFocus } from '../utils/enqueueFocus';
 import { markOthers } from '../utils/markOthers';
-import { usePortalContext } from './FloatingPortal';
+import { usePortalContext } from './useFloatingPortalNode';
 import { useFloatingTree } from './FloatingTree';
 import { FloatingTreeStore } from '../components/FloatingTreeStore';
 import { CLICK_TRIGGER_IDENTIFIER } from '../../utils/constants';

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, flushMicrotasks, render, screen } from '@mui/internal-test-u
 import { isJSDOM } from '@base-ui/utils/detectBrowser';
 import { FloatingPortal, useFloating } from '../index';
 import { FloatingPortalLite } from '../../utils/FloatingPortalLite';
-import type { UseFloatingPortalNodeProps } from './FloatingPortal';
+import type { UseFloatingPortalNodeProps } from './useFloatingPortalNode';
 
 interface AppProps {
   container?: UseFloatingPortalNodeProps['container'];

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -1,10 +1,6 @@
 'use client';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { isNode } from '@floating-ui/utils/dom';
-import { useId } from '@base-ui/utils/useId';
-import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { FocusGuard } from '../../utils/FocusGuard';
 import {
   enableFocusInside,
@@ -15,139 +11,14 @@ import {
 } from '../utils/tabbable';
 import { createChangeEventDetails } from '../../utils/createBaseUIEventDetails';
 import { REASONS } from '../../utils/reasons';
-import { createAttribute } from '../utils/createAttribute';
-import {
-  useRenderElement,
-  type UseRenderElementComponentProps,
-} from '../../utils/useRenderElement';
-import { EMPTY_OBJECT, ownerVisuallyHidden } from '../../utils/constants';
+import { ownerVisuallyHidden } from '../../utils/constants';
 import type { BaseUIComponentProps } from '../../utils/types';
-
-type FocusManagerState = null | {
-  modal: boolean;
-  open: boolean;
-  onOpenChange(
-    open: boolean,
-    data?: { reason?: string | undefined; event?: Event | undefined },
-  ): void;
-  domReference: Element | null;
-  closeOnFocusOut: boolean;
-};
-
-const PortalContext = React.createContext<null | {
-  portalNode: HTMLElement | null;
-  setFocusManagerState: React.Dispatch<React.SetStateAction<FocusManagerState>>;
-  beforeInsideRef: React.RefObject<HTMLSpanElement | null>;
-  afterInsideRef: React.RefObject<HTMLSpanElement | null>;
-  beforeOutsideRef: React.RefObject<HTMLSpanElement | null>;
-  afterOutsideRef: React.RefObject<HTMLSpanElement | null>;
-}>(null);
-
-export const usePortalContext = () => React.useContext(PortalContext);
-
-const attr = createAttribute('portal');
-
-export interface UseFloatingPortalNodeProps {
-  ref?: React.Ref<HTMLDivElement> | undefined;
-  container?:
-    | HTMLElement
-    | ShadowRoot
-    | null
-    | React.RefObject<HTMLElement | ShadowRoot | null>
-    | undefined;
-  componentProps?: UseRenderElementComponentProps<any> | undefined;
-  elementProps?: React.HTMLAttributes<HTMLDivElement> | undefined;
-}
-
-export interface UseFloatingPortalNodeResult {
-  portalNode: HTMLElement | null;
-  portalSubtree: React.ReactPortal | null;
-}
-
-export function useFloatingPortalNode(
-  props: UseFloatingPortalNodeProps = {},
-): UseFloatingPortalNodeResult {
-  const { ref, container: containerProp, componentProps = EMPTY_OBJECT, elementProps } = props;
-
-  const uniqueId = useId();
-  const portalContext = usePortalContext();
-  const parentPortalNode = portalContext?.portalNode;
-
-  const [containerElement, setContainerElement] = React.useState<HTMLElement | ShadowRoot | null>(
-    null,
-  );
-  const [portalNode, setPortalNode] = React.useState<HTMLElement | null>(null);
-  const setPortalNodeRef = useStableCallback((node: HTMLElement | null) => {
-    if (node !== null) {
-      // the useIsoLayoutEffect below watching containerProp / parentPortalNode
-      // sets setPortalNode(null) when the container becomes null or changes.
-      // So even though the ref callback now ignores null, the portal node still gets cleared.
-      setPortalNode(node);
-    }
-  });
-
-  const containerRef = React.useRef<HTMLElement | ShadowRoot | null>(null);
-
-  useIsoLayoutEffect(() => {
-    // Wait for the container to be resolved if explicitly `null`.
-    if (containerProp === null) {
-      if (containerRef.current) {
-        containerRef.current = null;
-        setPortalNode(null);
-        setContainerElement(null);
-      }
-      return;
-    }
-
-    // React 17 does not use React.useId().
-    if (uniqueId == null) {
-      return;
-    }
-
-    const resolvedContainer =
-      (containerProp && (isNode(containerProp) ? containerProp : containerProp.current)) ??
-      parentPortalNode ??
-      document.body;
-
-    if (resolvedContainer == null) {
-      if (containerRef.current) {
-        containerRef.current = null;
-        setPortalNode(null);
-        setContainerElement(null);
-      }
-      return;
-    }
-
-    if (containerRef.current !== resolvedContainer) {
-      containerRef.current = resolvedContainer;
-      setPortalNode(null);
-      setContainerElement(resolvedContainer);
-    }
-  }, [containerProp, parentPortalNode, uniqueId]);
-
-  const portalElement = useRenderElement('div', componentProps, {
-    ref: [ref, setPortalNodeRef],
-    props: [
-      {
-        id: uniqueId,
-        [attr]: '',
-      },
-      elementProps,
-    ],
-  });
-
-  // This `createPortal` call injects `portalElement` into the `container`.
-  // Another call inside `FloatingPortal`/`FloatingPortalLite` then injects the children into `portalElement`.
-  const portalSubtree =
-    containerElement && portalElement
-      ? ReactDOM.createPortal(portalElement, containerElement)
-      : null;
-
-  return {
-    portalNode,
-    portalSubtree,
-  };
-}
+import {
+  PortalContext,
+  type PortalFocusManagerState,
+  type UseFloatingPortalNodeProps,
+  useFloatingPortalNode,
+} from './useFloatingPortalNode';
 
 /**
  * Portals the floating element into a given container element — by default,
@@ -177,7 +48,7 @@ export const FloatingPortal = React.forwardRef(function FloatingPortal(
   const beforeInsideRef = React.useRef<HTMLSpanElement>(null);
   const afterInsideRef = React.useRef<HTMLSpanElement>(null);
 
-  const [focusManagerState, setFocusManagerState] = React.useState<FocusManagerState>(null);
+  const [focusManagerState, setFocusManagerState] = React.useState<PortalFocusManagerState>(null);
   const focusInsideDisabledRef = React.useRef(false);
 
   const modal = focusManagerState?.modal;

--- a/packages/react/src/floating-ui-react/components/useFloatingPortalNode.tsx
+++ b/packages/react/src/floating-ui-react/components/useFloatingPortalNode.tsx
@@ -1,0 +1,141 @@
+'use client';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { isNode } from '@floating-ui/utils/dom';
+import { useId } from '@base-ui/utils/useId';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import { createAttribute } from '../utils/createAttribute';
+import {
+  useRenderElement,
+  type UseRenderElementComponentProps,
+} from '../../utils/useRenderElement';
+import { EMPTY_OBJECT } from '../../utils/constants';
+
+export type PortalFocusManagerState = null | {
+  modal: boolean;
+  open: boolean;
+  onOpenChange(
+    open: boolean,
+    data?: { reason?: string | undefined; event?: Event | undefined },
+  ): void;
+  domReference: Element | null;
+  closeOnFocusOut: boolean;
+};
+
+export type PortalContextValue = {
+  portalNode: HTMLElement | null;
+  setFocusManagerState: React.Dispatch<React.SetStateAction<PortalFocusManagerState>>;
+  beforeInsideRef: React.RefObject<HTMLSpanElement | null>;
+  afterInsideRef: React.RefObject<HTMLSpanElement | null>;
+  beforeOutsideRef: React.RefObject<HTMLSpanElement | null>;
+  afterOutsideRef: React.RefObject<HTMLSpanElement | null>;
+};
+
+export const PortalContext = React.createContext<PortalContextValue | null>(null);
+
+export const usePortalContext = () => React.useContext(PortalContext);
+
+const attr = createAttribute('portal');
+
+export interface UseFloatingPortalNodeProps {
+  ref?: React.Ref<HTMLDivElement> | undefined;
+  container?:
+    | HTMLElement
+    | ShadowRoot
+    | null
+    | React.RefObject<HTMLElement | ShadowRoot | null>
+    | undefined;
+  componentProps?: UseRenderElementComponentProps<any> | undefined;
+  elementProps?: React.HTMLAttributes<HTMLDivElement> | undefined;
+}
+
+export interface UseFloatingPortalNodeResult {
+  portalNode: HTMLElement | null;
+  portalSubtree: React.ReactPortal | null;
+}
+
+export function useFloatingPortalNode(
+  props: UseFloatingPortalNodeProps = {},
+): UseFloatingPortalNodeResult {
+  const { ref, container: containerProp, componentProps = EMPTY_OBJECT, elementProps } = props;
+
+  const uniqueId = useId();
+  const portalContext = usePortalContext();
+  const parentPortalNode = portalContext?.portalNode;
+
+  const [containerElement, setContainerElement] = React.useState<HTMLElement | ShadowRoot | null>(
+    null,
+  );
+  const [portalNode, setPortalNode] = React.useState<HTMLElement | null>(null);
+  const setPortalNodeRef = useStableCallback((node: HTMLElement | null) => {
+    if (node !== null) {
+      // the useIsoLayoutEffect below watching containerProp / parentPortalNode
+      // sets setPortalNode(null) when the container becomes null or changes.
+      // So even though the ref callback now ignores null, the portal node still gets cleared.
+      setPortalNode(node);
+    }
+  });
+
+  const containerRef = React.useRef<HTMLElement | ShadowRoot | null>(null);
+
+  useIsoLayoutEffect(() => {
+    // Wait for the container to be resolved if explicitly `null`.
+    if (containerProp === null) {
+      if (containerRef.current) {
+        containerRef.current = null;
+        setPortalNode(null);
+        setContainerElement(null);
+      }
+      return;
+    }
+
+    // React 17 does not use React.useId().
+    if (uniqueId == null) {
+      return;
+    }
+
+    const resolvedContainer =
+      (containerProp && (isNode(containerProp) ? containerProp : containerProp.current)) ??
+      parentPortalNode ??
+      document.body;
+
+    if (resolvedContainer == null) {
+      if (containerRef.current) {
+        containerRef.current = null;
+        setPortalNode(null);
+        setContainerElement(null);
+      }
+      return;
+    }
+
+    if (containerRef.current !== resolvedContainer) {
+      containerRef.current = resolvedContainer;
+      setPortalNode(null);
+      setContainerElement(resolvedContainer);
+    }
+  }, [containerProp, parentPortalNode, uniqueId]);
+
+  const portalElement = useRenderElement('div', componentProps, {
+    ref: [ref, setPortalNodeRef],
+    props: [
+      {
+        id: uniqueId,
+        [attr]: '',
+      },
+      elementProps,
+    ],
+  });
+
+  // This `createPortal` call injects `portalElement` into the `container`.
+  // Another call inside `FloatingPortal`/`FloatingPortalLite` then injects the children into `portalElement`.
+  const portalSubtree =
+    containerElement && portalElement
+      ? ReactDOM.createPortal(portalElement, containerElement)
+      : null;
+
+  return {
+    portalNode,
+    portalSubtree,
+  };
+}

--- a/packages/react/src/floating-ui-react/index.ts
+++ b/packages/react/src/floating-ui-react/index.ts
@@ -1,6 +1,7 @@
 export { FloatingDelayGroup, useDelayGroup } from './components/FloatingDelayGroup';
 export { FloatingFocusManager } from './components/FloatingFocusManager';
-export { FloatingPortal, useFloatingPortalNode } from './components/FloatingPortal';
+export { FloatingPortal } from './components/FloatingPortal';
+export { useFloatingPortalNode } from './components/useFloatingPortalNode';
 export {
   FloatingNode,
   FloatingTree,

--- a/packages/react/src/floating-ui-react/types.ts
+++ b/packages/react/src/floating-ui-react/types.ts
@@ -13,7 +13,7 @@ import type { FloatingRootStore } from './components/FloatingRootStore';
 export * from '.';
 export type { FloatingDelayGroupProps } from './components/FloatingDelayGroup';
 export type { FloatingFocusManagerProps } from './components/FloatingFocusManager';
-export type { UseFloatingPortalNodeProps } from './components/FloatingPortal';
+export type { UseFloatingPortalNodeProps } from './components/useFloatingPortalNode';
 export type { UseClientPointProps } from './hooks/useClientPoint';
 export type { UseDismissProps } from './hooks/useDismiss';
 export type { UseFocusProps } from './hooks/useFocus';

--- a/packages/react/src/utils/FloatingPortalLite.tsx
+++ b/packages/react/src/utils/FloatingPortalLite.tsx
@@ -1,7 +1,8 @@
 'use client';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { useFloatingPortalNode, type FloatingPortal } from '../floating-ui-react';
+import type { FloatingPortal } from '../floating-ui-react';
+import { useFloatingPortalNode } from '../floating-ui-react/components/useFloatingPortalNode';
 
 /**
  * `FloatingPortal` includes tabbable logic handling for focus management.


### PR DESCRIPTION
This splits the lightweight portal node hook away from the full focus-management portal so popup components only pull the code they actually need.

The main effect is that `Tooltip.Portal` and other lightweight popup paths stop retaining tabbable-related focus management through the shared portal module.

## Changes

- Extract `useFloatingPortalNode` and the shared portal context into a dedicated module.
- Point `FloatingPortalLite` at that split module so it no longer pulls in the full `FloatingPortal` implementation.
- Update the related internal imports and tests to use the new module boundary.