### PR TITLE
[toast] Add focus option to move focus to toast on open

### DIFF
--- a/docs/src/app/(docs)/react/components/toast/demos/undo/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/toast/demos/undo/css-modules/index.tsx
@@ -24,6 +24,7 @@ function Form() {
       title: 'Action performed',
       description: 'You can undo this action.',
       type: 'success',
+      focus: true,
       actionProps: {
         children: 'Undo',
         onClick() {

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -106,6 +106,13 @@ type ToastRootToastObject<Data extends {} = any> = {
   onClose?: () => void;
   /** Callback function to be called when the toast is removed from the list after any animations are complete when closed. */
   onRemove?: () => void;
+  /**
+   * Whether to move focus to the toast when it opens.
+   * When `true`, the previously focused element is saved and restored when the toast closes.
+   * Timers are paused while the toast has focus.
+   * @default false
+   */
+  focus?: boolean;
   /** The props for the action button. */
   actionProps?: Omit<
     React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
@@ -565,6 +572,13 @@ type ToastObject<Data extends {}> = {
   onClose?: () => void;
   /** Callback function to be called when the toast is removed from the list after any animations are complete when closed. */
   onRemove?: () => void;
+  /**
+   * Whether to move focus to the toast when it opens.
+   * When `true`, the previously focused element is saved and restored when the toast closes.
+   * Timers are paused while the toast has focus.
+   * @default false
+   */
+  focus?: boolean;
   /** The props for the action button. */
   actionProps?: Omit<
     React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
@@ -629,6 +643,13 @@ type ToastManagerAddOptions<Data extends {}> = {
   onClose?: () => void;
   /** Callback function to be called when the toast is removed from the list after any animations are complete when closed. */
   onRemove?: () => void;
+  /**
+   * Whether to move focus to the toast when it opens.
+   * When `true`, the previously focused element is saved and restored when the toast closes.
+   * Timers are paused while the toast has focus.
+   * @default false
+   */
+  focus?: boolean;
   /** The props for the action button. */
   actionProps?: Omit<
     React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
@@ -849,6 +870,13 @@ type ToastManagerUpdateOptions<Data extends {}> = {
   onClose?: () => void;
   /** Callback function to be called when the toast is removed from the list after any animations are complete when closed. */
   onRemove?: () => void;
+  /**
+   * Whether to move focus to the toast when it opens.
+   * When `true`, the previously focused element is saved and restored when the toast closes.
+   * Timers are paused while the toast has focus.
+   * @default false
+   */
+  focus?: boolean;
   /** The props for the action button. */
   actionProps?: Omit<
     React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -746,4 +746,76 @@ describe('<Toast.Root />', () => {
       });
     });
   });
+
+  describe('focus option', () => {
+    it('moves focus to the toast when focus is true', async () => {
+      function AddButton() {
+        const { add } = Toast.useToastManager();
+        return (
+          <button
+            type="button"
+            data-testid="trigger"
+            onClick={() => {
+              add({
+                title: 'Focused toast',
+                focus: true,
+              });
+            }}
+          >
+            add
+          </button>
+        );
+      }
+
+      await render(
+        <Toast.Provider>
+          <AddButton />
+          <Toast.Viewport>
+            <List />
+          </Toast.Viewport>
+        </Toast.Provider>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        const toastRoot = screen.getByTestId('root');
+        expect(toastRoot).toHaveFocus();
+      });
+    });
+
+    it('does not move focus when focus is not set', async () => {
+      function AddButton() {
+        const { add } = Toast.useToastManager();
+        return (
+          <button
+            type="button"
+            data-testid="trigger"
+            onClick={() => {
+              add({ title: 'Normal toast' });
+            }}
+          >
+            add
+          </button>
+        );
+      }
+
+      await render(
+        <Toast.Provider>
+          <AddButton />
+          <Toast.Viewport>
+            <List />
+          </Toast.Viewport>
+        </Toast.Provider>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('root')).not.toHaveFocus();
+      });
+    });
+  });
 });

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -178,6 +178,19 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
 
   useIsoLayoutEffect(recalculateHeight, [recalculateHeight]);
 
+  React.useEffect(() => {
+    if (!toast.focus || !rootRef.current) {
+      return;
+    }
+
+    const doc = ownerDocument(rootRef.current);
+    store.setPrevFocusElement(activeElement(doc) as HTMLElement | null);
+    rootRef.current.focus({ preventScroll: true });
+    store.pauseTimers();
+    store.setFocused(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   function applyDirectionalDamping(deltaX: number, deltaY: number) {
     let newDeltaX = deltaX;
     let newDeltaY = deltaY;

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -87,6 +87,13 @@ export interface ToastObject<Data extends object> {
    */
   onRemove?: (() => void) | undefined;
   /**
+   * Whether to move focus to the toast when it opens.
+   * When `true`, the previously focused element is saved and restored when the toast closes.
+   * Timers are paused while the toast has focus.
+   * @default false
+   */
+  focus?: boolean | undefined;
+  /**
    * The props for the action button.
    */
   actionProps?: React.ComponentPropsWithoutRef<'button'> | undefined;


### PR DESCRIPTION
## Summary

Adds a `focus` option to `toastManager.add()` that moves focus to the toast when it opens. This enables keyboard and screen reader users to reach interactive actions (e.g. Undo) without relying on the F6 shortcut.

Closes #4253

## Changes

- **`useToastManager.ts`** — Add `focus?: boolean` to `ToastObject`
- **`ToastRoot.tsx`** — On mount, if `focus` is `true`: save `prevFocusElement`, focus the toast, pause timers, and set `focused` state (same pattern as F6 in `ToastViewport`)
- **`ToastRoot.test.tsx`** — Add tests for focus behavior
- **Undo demo** — Apply `focus: true` to demonstrate the pattern

## How it works

```
1. toastManager.add({ focus: true, ... })
2. Toast mounts → useEffect saves prevFocusElement, focuses the toast
3. Viewport's handleFocus pauses timers (existing infra)
4. User interacts (Undo/Close) or tabs away → timers resume (existing infra)
5. On close → handleFocusManagement restores focus (existing infra)
```

When `focus` is not set, behavior is identical to before — no breaking changes.

## Screenshot
| Tab → Undo → Click | Tab → Undo → Tab out → auto-dismiss |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/6bb401a0-099a-44e8-bbdc-c72127774430" /> | <img src="https://github.com/user-attachments/assets/f11a8bef-b223-44c9-bf6c-e258556c99a5" /> |




