### PR TITLE
[popover] Add `updatePosition` method to handle

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -73,6 +73,7 @@
     "@wooorm/starry-night": "3.9.0",
     "baseline-browser-mapping": "2.10.12",
     "cross-env": "10.1.0",
+    "maplibre-gl": "^5.22.0",
     "mdast-util-mdx-jsx": "3.2.0",
     "motion": "12.38.0",
     "prettier": "3.8.1",

--- a/docs/src/app/(docs)/react/components/popover/types.md
+++ b/docs/src/app/(docs)/react/components/popover/types.md
@@ -538,6 +538,14 @@ function close(): void;
 
 Closes the popover.
 
+```typescript
+function updatePosition(): void;
+```
+
+Re-positions the popover.
+Useful for anchors whose position changes outside of React's lifecycle,
+such as virtual anchors during canvas animations.
+
 ## External Types
 
 ### PayloadChildRenderFunction

--- a/docs/src/app/(private)/experiments/popover/virtual-anchor.module.css
+++ b/docs/src/app/(private)/experiments/popover/virtual-anchor.module.css
@@ -1,0 +1,33 @@
+.map {
+  position: relative;
+  width: 100%;
+  height: 500px;
+  overflow: hidden;
+  margin-block: 1rem;
+}
+
+.popup {
+  background: white;
+  color: #333;
+  padding: 8px 12px;
+  font-size: 14px;
+  max-width: 220px;
+}
+
+.popup h3 {
+  margin: 0 0 4px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.popup p {
+  margin: 0;
+  color: #666;
+  font-size: 12px;
+}
+
+.info {
+  margin-top: 16px;
+  font-size: 13px;
+  line-height: 1.5;
+}

--- a/docs/src/app/(private)/experiments/popover/virtual-anchor.tsx
+++ b/docs/src/app/(private)/experiments/popover/virtual-anchor.tsx
@@ -1,0 +1,354 @@
+'use client';
+import * as React from 'react';
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { Popover } from '@base-ui/react/popover';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
+import { ownerDocument } from '@base-ui/utils/owner';
+import styles from './virtual-anchor.module.css';
+
+/**
+ * Real MapLibre GL JS reproduction of the virtual anchor repositioning problem.
+ *
+ * A popover is anchored to a geographic coordinate via a virtual element whose
+ * getBoundingClientRect() calls map.project(lngLat) to get the screen position.
+ *
+ * Demo 1 (Broken): Pan or zoom — the popover stays stuck at its initial screen
+ * position because autoUpdate never re-reads getBoundingClientRect().
+ *
+ * Demo 2 (State workaround): Recreates the virtual anchor object through React
+ * state on every map move so Base UI notices a new anchor identity and
+ * repositions. This works, but forces React rerenders during interaction.
+ *
+ * Demo 3 (Fixed): Same stable virtual anchor as Demo 1, but map movement calls
+ * PopoverHandle.updatePosition() so floating-ui re-reads the anchor rect
+ * without rerendering. The portal is mounted inside the map container so the
+ * map clips the popup at its edges.
+ */
+
+type RectSnapshot = Pick<
+  DOMRectReadOnly,
+  'x' | 'y' | 'width' | 'height' | 'top' | 'left' | 'right' | 'bottom'
+>;
+
+const MARKER_LNG_LAT: [number, number] = [139.7798, 35.5494]; // Haneda Airport
+
+const MAP_STYLE: maplibregl.StyleSpecification = {
+  version: 8,
+  sources: {
+    osm: {
+      type: 'raster',
+      tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+      tileSize: 256,
+      attribution: '&copy; OpenStreetMap contributors',
+    },
+  },
+  layers: [{ id: 'osm', type: 'raster', source: 'osm' }],
+};
+
+const ZERO_RECT: RectSnapshot = {
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+};
+
+const DISABLE_COLLISION_AVOIDANCE = {
+  side: 'none',
+  align: 'none',
+  fallbackAxisSide: 'none',
+} as const;
+
+function PopupContent() {
+  return (
+    <React.Fragment>
+      <h3>Haneda Airport</h3>
+      <p>35.5494 N, 139.7798 E</p>
+    </React.Fragment>
+  );
+}
+
+function createMarkerElement(container: HTMLElement) {
+  const el = ownerDocument(container).createElement('div');
+  el.style.cssText =
+    'width:20px;height:20px;border-radius:50%;background:#e53935;border:3px solid white;box-shadow:0 2px 6px rgba(0,0,0,.3)';
+  return el;
+}
+
+function projectMarker(map: maplibregl.Map) {
+  return map.project(MARKER_LNG_LAT);
+}
+
+function projectToScreen(map: maplibregl.Map): RectSnapshot {
+  const { x, y } = projectMarker(map);
+  const rect = map.getContainer().getBoundingClientRect();
+  const screenX = rect.left + x;
+  const screenY = rect.top + y;
+  return {
+    x: screenX,
+    y: screenY,
+    width: 0,
+    height: 0,
+    top: screenY,
+    left: screenX,
+    right: screenX,
+    bottom: screenY,
+  };
+}
+
+function createVirtualAnchor(mapRef: React.RefObject<maplibregl.Map | null>) {
+  return {
+    getBoundingClientRect() {
+      const map = mapRef.current;
+      return map ? projectToScreen(map) : ZERO_RECT;
+    },
+  };
+}
+
+function useMap(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  onReady?: (map: maplibregl.Map) => void | (() => void),
+) {
+  const mapRef = React.useRef<maplibregl.Map | null>(null);
+  const onReadyRef = React.useRef(onReady);
+  onReadyRef.current = onReady;
+
+  useIsoLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    const map = new maplibregl.Map({
+      container,
+      style: MAP_STYLE,
+      center: MARKER_LNG_LAT,
+      zoom: 14,
+    });
+
+    new maplibregl.Marker({ element: createMarkerElement(container) })
+      .setLngLat(MARKER_LNG_LAT)
+      .addTo(map);
+
+    mapRef.current = map;
+    let cleanupMapListeners: (() => void) | undefined;
+    map.once('idle', () => {
+      const nextCleanup = onReadyRef.current?.(map);
+      cleanupMapListeners = typeof nextCleanup === 'function' ? nextCleanup : undefined;
+    });
+
+    return () => {
+      cleanupMapListeners?.();
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [containerRef]);
+
+  return mapRef;
+}
+
+function DemoSection(props: {
+  title: React.ReactNode;
+  description: React.ReactNode;
+  info: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const { title, description, info, children } = props;
+
+  return (
+    <div>
+      <h2>{title}</h2>
+      <p>{description}</p>
+      {children}
+      <p>{info}</p>
+    </div>
+  );
+}
+
+// ─── Demo 1: Broken ──────────────────────────────────────────────────────
+function BrokenDemo() {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const mapRef = useMap(containerRef);
+
+  // Stable virtual anchor — same object identity forever.
+  // getBoundingClientRect() always returns the marker's current screen position
+  // by calling map.project(), but floating-ui never re-reads it.
+  const virtualAnchor = React.useRef({
+    getBoundingClientRect() {
+      const map = mapRef.current;
+      return map ? projectToScreen(map) : ZERO_RECT;
+    },
+  }).current;
+
+  return (
+    <DemoSection
+      title="Broken: popover does not track the marker"
+      description="Pan or zoom the map. The marker moves with the map but the popover stays stuck at its initial screen position."
+      info={
+        <React.Fragment>
+          <strong>Why it&apos;s broken:</strong> <code>autoUpdate</code> only uses{' '}
+          <code>ResizeObserver</code> + <code>IntersectionObserver</code>. Neither fires for a
+          virtual element. The anchor object identity never changes (same ref), so the anchor
+          identity check in <code>useAnchorPositioning</code> also doesn&apos;t trigger. Result:
+          popover positions once on mount, then never updates.
+        </React.Fragment>
+      }
+    >
+      <div ref={containerRef} className={styles.map} />
+      <Popover.Root open>
+        <Popover.Portal>
+          <Popover.Positioner
+            anchor={virtualAnchor}
+            side="top"
+            sideOffset={12}
+            positionMethod="fixed"
+          >
+            <Popover.Popup className={styles.popup}>
+              <PopupContent />
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>
+    </DemoSection>
+  );
+}
+
+// ─── Demo 2: State workaround — recreate anchor via React state ──────────
+function StateWorkaroundDemo() {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const mapRef = React.useRef<maplibregl.Map | null>(null);
+  const [virtualAnchor, setVirtualAnchor] = React.useState(() => createVirtualAnchor(mapRef));
+
+  useMap(containerRef, (map) => {
+    mapRef.current = map;
+
+    const update = () => {
+      setVirtualAnchor(createVirtualAnchor(mapRef));
+    };
+
+    update();
+    map.on('move', update);
+
+    return () => {
+      map.off('move', update);
+      mapRef.current = null;
+    };
+  });
+
+  return (
+    <DemoSection
+      title="Workaround: recreate the virtual anchor through React state"
+      description={
+        <React.Fragment>
+          The map&apos;s <code>move</code> event increments React state, which recreates the virtual
+          anchor object on every update. That changes the anchor identity, so Base UI re-registers
+          it and floating-ui repositions the popup.
+        </React.Fragment>
+      }
+      info={
+        <React.Fragment>
+          <strong>Tradeoff:</strong> This works with today&apos;s public API, but every map move now
+          goes through React state and rerenders the popover subtree.
+        </React.Fragment>
+      }
+    >
+      <div ref={containerRef} className={styles.map} />
+      <Popover.Root open>
+        <Popover.Portal container={containerRef}>
+          <Popover.Positioner
+            anchor={virtualAnchor}
+            side="top"
+            sideOffset={12}
+            collisionAvoidance={DISABLE_COLLISION_AVOIDANCE}
+            positionMethod="absolute"
+          >
+            <Popover.Popup className={styles.popup}>
+              <PopupContent />
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>
+    </DemoSection>
+  );
+}
+
+// ─── Demo 3: Fixed — stable virtual anchor + imperative reposition ───────
+function FixedDemo() {
+  const popover = useRefWithInit(() => Popover.createHandle()).current;
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const mapRef = useMap(containerRef, (map) => {
+    const update = () => popover.updatePosition();
+    update();
+    map.on('move', update);
+
+    return () => {
+      map.off('move', update);
+    };
+  });
+
+  const virtualAnchor = React.useRef({
+    getBoundingClientRect() {
+      const map = mapRef.current;
+      return map ? projectToScreen(map) : ZERO_RECT;
+    },
+  }).current;
+
+  return (
+    <DemoSection
+      title="Fixed: call `handle.updatePosition()` on map movement"
+      description={
+        <React.Fragment>
+          Same stable virtual anchor as the broken demo, but the map&apos;s <code>move</code> event
+          calls <code>handle.updatePosition()</code>. The popover now tracks the marker without
+          recreating the anchor object or rerendering on every frame.
+        </React.Fragment>
+      }
+      info={
+        <React.Fragment>
+          <strong>How it works:</strong> <code>Popover.createHandle()</code> exposes an imperative{' '}
+          <code>updatePosition()</code> method. Calling it makes floating-ui re-read the existing
+          virtual anchor&apos;s <code>getBoundingClientRect()</code>, so the popover follows the
+          marker while keeping the same anchor object identity. The portal is mounted inside the map
+          container, so the map clips any portion of the popup that would otherwise extend beyond
+          its edge.
+        </React.Fragment>
+      }
+    >
+      <div ref={containerRef} className={styles.map} />
+      <Popover.Root open handle={popover}>
+        <Popover.Portal container={containerRef}>
+          <Popover.Positioner
+            anchor={virtualAnchor}
+            side="top"
+            sideOffset={12}
+            collisionAvoidance={DISABLE_COLLISION_AVOIDANCE}
+            positionMethod="absolute"
+          >
+            <Popover.Popup className={styles.popup}>
+              <PopupContent />
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>
+    </DemoSection>
+  );
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────
+export default function VirtualAnchorExperiment() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 32, padding: 24 }}>
+      <h1>Virtual Anchor Repositioning (MapLibre)</h1>
+      <BrokenDemo />
+      <hr />
+      <StateWorkaroundDemo />
+      <hr />
+      <FixedDemo />
+    </div>
+  );
+}

--- a/examples/vite-css/handle-fix.html
+++ b/examples/vite-css/handle-fix.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Handle Fix</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/mount-handle-fix.tsx"></script>
+  </body>
+</html>

--- a/examples/vite-css/package.json
+++ b/examples/vite-css/package.json
@@ -5,13 +5,15 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "vite build",
+    "build:profile": "cross-env REACT_PROFILING=1 vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },
   "dependencies": {
     "@base-ui/react": "latest",
     "clsx": "^2.1.1",
+    "maplibre-gl": "^5.22.0",
     "react": "^19",
     "react-dom": "^19"
   },
@@ -20,6 +22,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.1",
+    "cross-env": "10.1.0",
     "eslint": "^10.1.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/examples/vite-css/src/handle-fix.tsx
+++ b/examples/vite-css/src/handle-fix.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { Popover } from '@base-ui/react/popover';
+import { ZERO_RECT, DISABLE_COLLISION_AVOIDANCE, projectToScreen, useMap } from './map-utils';
+import './map-popover.css';
+
+export default function HandleFix() {
+  const [popover] = React.useState(() => Popover.createHandle());
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const mapRef = useMap(containerRef, (map) => {
+    const update = () => popover.updatePosition();
+    update();
+    map.on('move', update);
+
+    return () => {
+      map.off('move', update);
+    };
+  });
+
+  const [virtualAnchor] = React.useState(() => ({
+    getBoundingClientRect() {
+      const map = mapRef.current;
+      return map ? projectToScreen(map) : ZERO_RECT;
+    },
+  }));
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>Fixed: handle.updatePosition()</h1>
+      <p>
+        Same stable virtual anchor, but map movement calls <code>handle.updatePosition()</code>. No
+        rerenders during interaction.
+      </p>
+      <div ref={containerRef} className="map" />
+      <Popover.Root open handle={popover}>
+        <Popover.Portal container={containerRef}>
+          <Popover.Positioner
+            anchor={virtualAnchor}
+            side="top"
+            sideOffset={12}
+            collisionAvoidance={DISABLE_COLLISION_AVOIDANCE}
+            positionMethod="absolute"
+          >
+            <Popover.Popup className="popup">
+              <h3>Haneda Airport</h3>
+              <p>35.5494 N, 139.7798 E</p>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>
+    </div>
+  );
+}

--- a/examples/vite-css/src/map-popover.css
+++ b/examples/vite-css/src/map-popover.css
@@ -1,0 +1,27 @@
+.map {
+  position: relative;
+  width: 100%;
+  height: 500px;
+  overflow: hidden;
+  margin-block: 1rem;
+}
+
+.popup {
+  background: white;
+  color: #333;
+  padding: 8px 12px;
+  font-size: 14px;
+  max-width: 220px;
+}
+
+.popup h3 {
+  margin: 0 0 4px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.popup p {
+  margin: 0;
+  color: #666;
+  font-size: 12px;
+}

--- a/examples/vite-css/src/map-utils.ts
+++ b/examples/vite-css/src/map-utils.ts
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import maplibregl from 'maplibre-gl';
+
+export type RectSnapshot = Pick<
+  DOMRectReadOnly,
+  'x' | 'y' | 'width' | 'height' | 'top' | 'left' | 'right' | 'bottom'
+>;
+
+export const MARKER_LNG_LAT: [number, number] = [139.7798, 35.5494]; // Haneda Airport
+
+export const MAP_STYLE: maplibregl.StyleSpecification = {
+  version: 8,
+  sources: {
+    osm: {
+      type: 'raster',
+      tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+      tileSize: 256,
+      attribution: '&copy; OpenStreetMap contributors',
+    },
+  },
+  layers: [{ id: 'osm', type: 'raster', source: 'osm' }],
+};
+
+export const ZERO_RECT: RectSnapshot = {
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+};
+
+export const DISABLE_COLLISION_AVOIDANCE = {
+  side: 'none',
+  align: 'none',
+  fallbackAxisSide: 'none',
+} as const;
+
+export function createMarkerElement() {
+  const el = document.createElement('div');
+  el.style.cssText =
+    'width:20px;height:20px;border-radius:50%;background:#e53935;border:3px solid white;box-shadow:0 2px 6px rgba(0,0,0,.3)';
+  return el;
+}
+
+export function projectToScreen(map: maplibregl.Map): RectSnapshot {
+  const { x, y } = map.project(MARKER_LNG_LAT);
+  const rect = map.getContainer().getBoundingClientRect();
+  const screenX = rect.left + x;
+  const screenY = rect.top + y;
+  return {
+    x: screenX,
+    y: screenY,
+    width: 0,
+    height: 0,
+    top: screenY,
+    left: screenX,
+    right: screenX,
+    bottom: screenY,
+  };
+}
+
+export function createVirtualAnchor(mapRef: React.RefObject<maplibregl.Map | null>) {
+  return {
+    getBoundingClientRect() {
+      const map = mapRef.current;
+      return map ? projectToScreen(map) : ZERO_RECT;
+    },
+  };
+}
+
+export function useMap(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  onReady?: (map: maplibregl.Map) => void | (() => void),
+) {
+  const mapRef = React.useRef<maplibregl.Map | null>(null);
+  const onReadyRef = React.useRef(onReady);
+  React.useEffect(() => {
+    onReadyRef.current = onReady;
+  });
+
+  React.useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    const map = new maplibregl.Map({
+      container,
+      style: MAP_STYLE,
+      center: MARKER_LNG_LAT,
+      zoom: 14,
+    });
+
+    new maplibregl.Marker({ element: createMarkerElement() }).setLngLat(MARKER_LNG_LAT).addTo(map);
+
+    mapRef.current = map;
+    let cleanupMapListeners: (() => void) | undefined;
+    map.once('idle', () => {
+      const nextCleanup = onReadyRef.current?.(map);
+      cleanupMapListeners = typeof nextCleanup === 'function' ? nextCleanup : undefined;
+    });
+
+    return () => {
+      cleanupMapListeners?.();
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [containerRef]);
+
+  return mapRef;
+}

--- a/examples/vite-css/src/mount-handle-fix.tsx
+++ b/examples/vite-css/src/mount-handle-fix.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom/client';
+import HandleFix from './handle-fix';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <HandleFix />
+  </React.StrictMode>,
+);

--- a/examples/vite-css/src/mount-state-workaround.tsx
+++ b/examples/vite-css/src/mount-state-workaround.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom/client';
+import StateWorkaround from './state-workaround';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <StateWorkaround />
+  </React.StrictMode>,
+);

--- a/examples/vite-css/src/state-workaround.tsx
+++ b/examples/vite-css/src/state-workaround.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { Popover } from '@base-ui/react/popover';
+import { DISABLE_COLLISION_AVOIDANCE, ZERO_RECT, createVirtualAnchor, useMap } from './map-utils';
+import './map-popover.css';
+
+function MapPopover({ containerRef }: { containerRef: React.RefObject<HTMLDivElement | null> }) {
+  const mapRef = React.useRef<import('maplibre-gl').Map | null>(null);
+  const [virtualAnchor, setVirtualAnchor] = React.useState(() => ({
+    getBoundingClientRect: () => ZERO_RECT,
+  }));
+
+  useMap(containerRef, (map) => {
+    mapRef.current = map;
+
+    const update = () => {
+      setVirtualAnchor(createVirtualAnchor(mapRef));
+    };
+
+    update();
+    map.on('move', update);
+
+    return () => {
+      map.off('move', update);
+      mapRef.current = null;
+    };
+  });
+
+  return (
+    <Popover.Root open>
+      <Popover.Portal container={containerRef}>
+        <Popover.Positioner
+          anchor={virtualAnchor}
+          side="top"
+          sideOffset={12}
+          collisionAvoidance={DISABLE_COLLISION_AVOIDANCE}
+          positionMethod="absolute"
+        >
+          <Popover.Popup className="popup">
+            <h3>Haneda Airport</h3>
+            <p>35.5494 N, 139.7798 E</p>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+export default function StateWorkaround() {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>State workaround</h1>
+      <p>
+        Recreates the virtual anchor object via React state on every map move. The popover tracks
+        correctly but forces rerenders on every frame.
+      </p>
+      <div ref={containerRef} className="map" />
+      <MapPopover containerRef={containerRef} />
+    </div>
+  );
+}

--- a/examples/vite-css/state-workaround.html
+++ b/examples/vite-css/state-workaround.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>State Workaround</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/mount-state-workaround.tsx"></script>
+  </body>
+</html>

--- a/examples/vite-css/tsconfig.app.json
+++ b/examples/vite-css/tsconfig.app.json
@@ -10,18 +10,17 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "paths": {
+      "@base-ui/react/*": ["../../packages/react/src/*"],
+      "@base-ui/utils/*": ["../../packages/utils/src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/examples/vite-css/vite.config.ts
+++ b/examples/vite-css/vite.config.ts
@@ -1,7 +1,26 @@
+import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
+const isProfile = process.env.REACT_PROFILING === '1';
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@base-ui/react': resolve(__dirname, '..', '..', 'packages', 'react', 'src'),
+      '@base-ui/utils': resolve(__dirname, '..', '..', 'packages', 'utils', 'src'),
+      ...(isProfile ? { 'react-dom/client': 'react-dom/profiling' } : {}),
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        'state-workaround': resolve(__dirname, 'state-workaround.html'),
+        'handle-fix': resolve(__dirname, 'handle-fix.html'),
+      },
+    },
+  },
 });

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -120,6 +120,19 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
 
     return undefined;
   }, [domReference, runOnceAnimationsFinish, store]);
+
+  useIsoLayoutEffect(() => {
+    // This needs cleanup when the positioner unmounts, so use a local effect
+    // instead of `store.useContextCallback`, which is intended for root-lived callbacks.
+    store.context.updatePosition = positioning.update;
+
+    return () => {
+      if (store.context.updatePosition === positioning.update) {
+        store.context.updatePosition = undefined;
+      }
+    };
+  }, [positioning.update, store]);
+
   const state: PopoverPositionerState = {
     open,
     side: positioning.side,

--- a/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
@@ -11,6 +11,12 @@ describe('<Popover.Root />', () => {
 
   const { render } = createRenderer();
 
+  it('treats updatePosition as a no-op when no positioner is mounted', () => {
+    const popover = Popover.createHandle();
+
+    expect(() => popover.updatePosition()).not.toThrow();
+  });
+
   describe.skipIf(isJSDOM)('multiple triggers within Root', () => {
     type NumberPayload = { payload: number | undefined };
 
@@ -736,6 +742,72 @@ describe('<Popover.Root />', () => {
   });
 
   describe.skipIf(isJSDOM)('imperative actions on the handle', () => {
+    it('updates the position when requested imperatively', async () => {
+      const popover = Popover.createHandle();
+      let anchorRect = {
+        x: 100,
+        y: 120,
+        width: 0,
+        height: 0,
+        top: 120,
+        left: 100,
+        right: 100,
+        bottom: 120,
+      };
+      const virtualAnchor = {
+        getBoundingClientRect: () => anchorRect,
+      };
+
+      await render(
+        <div>
+          <Popover.Trigger handle={popover} id="trigger">
+            Trigger
+          </Popover.Trigger>
+          <Popover.Root handle={popover}>
+            <Popover.Portal>
+              <Popover.Positioner
+                anchor={virtualAnchor}
+                align="start"
+                data-testid="positioner"
+                positionMethod="fixed"
+              >
+                <Popover.Popup style={{ width: 40, height: 20 }}>Content</Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          </Popover.Root>
+        </div>,
+      );
+
+      await act(() => popover.open('trigger'));
+
+      const positioner = await screen.findByTestId('positioner');
+      const initialLeft = positioner.getBoundingClientRect().left;
+
+      await waitFor(() => {
+        expect(positioner.getBoundingClientRect().left).toBe(initialLeft);
+      });
+
+      anchorRect = {
+        ...anchorRect,
+        x: 220,
+        left: 220,
+        right: 220,
+      };
+      const expectedDelta = anchorRect.left - 100;
+
+      expect(Math.abs(positioner.getBoundingClientRect().left - initialLeft)).toBeLessThanOrEqual(
+        1,
+      );
+
+      await act(() => popover.updatePosition());
+
+      await waitFor(() => {
+        expect(
+          Math.abs(positioner.getBoundingClientRect().left - (initialLeft + expectedDelta)),
+        ).toBeLessThanOrEqual(1);
+      });
+    });
+
     it('opens and closes the dialog', async () => {
       const popover = Popover.createHandle();
       await render(

--- a/packages/react/src/popover/store/PopoverHandle.ts
+++ b/packages/react/src/popover/store/PopoverHandle.ts
@@ -49,6 +49,15 @@ export class PopoverHandle<Payload> {
   }
 
   /**
+   * Re-positions the popover.
+   * Useful for anchors whose position changes outside of React's lifecycle,
+   * such as virtual anchors during canvas animations.
+   */
+  updatePosition() {
+    this.store.context.updatePosition?.();
+  }
+
+  /**
    * Indicates whether the popover is currently open.
    */
   get isOpen() {

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -40,6 +40,7 @@ type Context = PopupStoreContext<PopoverRoot.ChangeEventDetails> & {
   readonly triggerFocusTargetRef: React.RefObject<HTMLElement | null>;
   readonly beforeContentFocusGuardRef: React.RefObject<HTMLElement | null>;
   readonly stickIfOpenTimeout: Timeout;
+  updatePosition?: (() => void) | undefined;
 };
 
 function createInitialState<Payload>(): State<Payload> {
@@ -100,6 +101,7 @@ export class PopoverStore<Payload> extends ReactStore<
         triggerFocusTargetRef: React.createRef<HTMLElement>(),
         beforeContentFocusGuardRef: React.createRef<HTMLElement>(),
         stickIfOpenTimeout: new Timeout(),
+        updatePosition: undefined,
         triggerElements: new PopupTriggerMap(),
       },
       selectors,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      maplibre-gl:
+        specifier: ^5.22.0
+        version: 5.22.0
       react:
         specifier: ^19
         version: 19.2.4
@@ -452,6 +455,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.18.13)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      cross-env:
+        specifier: 10.1.0
+        version: 10.1.0
       eslint:
         specifier: ^10.1.0
         version: 10.2.0(jiti@2.6.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       cross-env:
         specifier: 10.1.0
         version: 10.1.0
+      maplibre-gl:
+        specifier: ^5.22.0
+        version: 5.22.0
       mdast-util-mdx-jsx:
         specifier: 3.2.0
         version: 3.2.0
@@ -2180,6 +2183,42 @@ packages:
 
   '@ltd/j-toml@1.38.0':
     resolution: {integrity: sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw==}
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2':
+    resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
+    engines: {node: '>= 0.6'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.0.7':
+    resolution: {integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/vector-tile@2.0.4':
+    resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@5.0.4':
+    resolution: {integrity: sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==}
+
+  '@maplibre/geojson-vt@6.0.4':
+    resolution: {integrity: sha512-HYv3POhMRCdhP3UPPATM/hfcy6/WuVIf5FKboH8u/ZuFMTnAIcSVlq5nfOqroLokd925w2QtE7YwquFOIacwVQ==}
+
+  '@maplibre/maplibre-gl-style-spec@24.8.1':
+    resolution: {integrity: sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.8':
+    resolution: {integrity: sha512-8vtfYGidr1rNkv5IwIoU2lfe3Oy+Wa8HluzQYcQi9cveU9K3pweAal/poQj4GJ0K/EW4bTQp2wVAs09g2yDRZg==}
+
+  '@maplibre/vt-pbf@4.3.0':
+    resolution: {integrity: sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==}
 
   '@mdn/browser-compat-data@5.7.6':
     resolution: {integrity: sha512-7xdrMX0Wk7grrTZQwAoy1GkvPMFoizStUoL+VmtUkAxegbCCec+3FKwOM6yc/uGU5+BEczQHXAlWiqvM8JeENg==}
@@ -4216,6 +4255,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/gtag.js@0.0.20':
     resolution: {integrity: sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==}
 
@@ -4263,6 +4305,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -5521,6 +5566,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -6208,6 +6256,9 @@ packages:
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -6892,6 +6943,9 @@ packages:
   json-stringify-nice@1.1.4:
     resolution: {integrity: sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -6942,6 +6996,9 @@ packages:
   katex@0.16.45:
     resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
     hasBin: true
+
+  kdbush@4.0.2:
+    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
   kebab-case@2.0.2:
     resolution: {integrity: sha512-NhIP7vecGtqJfNZ85ct0yRQfx//gCJHapJCBZP6/BBcBw/U218Jw7YX7rO6TI5/cCp5dJvlIjN3vbcRTqq7nWA==}
@@ -7192,6 +7249,10 @@ packages:
   map-obj@4.3.0:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
+
+  maplibre-gl@5.22.0:
+    resolution: {integrity: sha512-nc8YA+YSEioMZg5W0cb6Cf3wQ8aJge66dsttyBgpOArOnlmFJO1Kc5G32kYVPeUYhLpBja83T99uanmJvYAIyQ==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -7570,6 +7631,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -8003,6 +8067,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pbf@4.0.1:
+    resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+    hasBin: true
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -8098,6 +8166,9 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -8176,6 +8247,9 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  protocol-buffers-schema@3.6.0:
+    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
@@ -8217,6 +8291,9 @@ packages:
   quick-lru@7.3.0:
     resolution: {integrity: sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==}
     engines: {node: '>=18'}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -8484,6 +8561,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   resolve.exports@2.0.3:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
     engines: {node: '>=10'}
@@ -8550,6 +8630,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -8947,6 +9030,9 @@ packages:
     resolution: {integrity: sha512-BWnYJElmHbYZ/zKevy+TG+SsyoFCmRPDHJbR1MzLxkPOv1Jp/4hGhVUtP98s+wZBsBsHwCXvPTP0x287/WMjGg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -9058,6 +9144,9 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -11224,6 +11313,52 @@ snapshots:
       '@braidai/lang': 1.1.2
 
   '@ltd/j-toml@1.38.0': {}
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.0.7': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/vector-tile@2.0.4':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.1
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@5.0.4': {}
+
+  '@maplibre/geojson-vt@6.0.4':
+    dependencies:
+      kdbush: 4.0.2
+
+  '@maplibre/maplibre-gl-style-spec@24.8.1':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      rw: 1.3.3
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.8':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.0':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/vector-tile': 2.0.4
+      '@maplibre/geojson-vt': 5.0.4
+      '@types/geojson': 7946.0.16
+      '@types/supercluster': 7.1.3
+      pbf: 4.0.1
+      supercluster: 8.0.1
 
   '@mdn/browser-compat-data@5.7.6': {}
 
@@ -13516,6 +13651,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/gtag.js@0.0.20': {}
 
   '@types/hast@3.0.4':
@@ -13557,6 +13694,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/unist@2.0.11': {}
 
@@ -14972,6 +15113,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  earcut@3.0.2: {}
+
   eastasianwidth@0.2.0: {}
 
   ejs@3.1.10:
@@ -15871,6 +16014,8 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
+  gl-matrix@3.4.4: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -16562,6 +16707,8 @@ snapshots:
 
   json-stringify-nice@1.1.4: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json-stringify-safe@5.0.1: {}
 
   json-with-bigint@3.5.8: {}
@@ -16604,6 +16751,8 @@ snapshots:
   katex@0.16.45:
     dependencies:
       commander: 8.3.0
+
+  kdbush@4.0.2: {}
 
   kebab-case@2.0.2: {}
 
@@ -16925,6 +17074,28 @@ snapshots:
   map-obj@1.0.1: {}
 
   map-obj@4.3.0: {}
+
+  maplibre-gl@5.22.0:
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.0.7
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 6.0.4
+      '@maplibre/maplibre-gl-style-spec': 24.8.1
+      '@maplibre/mlt': 1.1.8
+      '@maplibre/vt-pbf': 4.3.0
+      '@types/geojson': 7946.0.16
+      earcut: 3.0.2
+      gl-matrix: 3.4.4
+      kdbush: 4.0.2
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
 
   markdown-extensions@2.0.0: {}
 
@@ -17616,6 +17787,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  murmurhash-js@1.0.0: {}
+
   mute-stream@2.0.0: {}
 
   mute-stream@3.0.0: {}
@@ -18170,6 +18343,10 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -18262,6 +18439,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@2.1.0: {}
+
   powershell-utils@0.1.0: {}
 
   powershell-utils@0.2.0: {}
@@ -18337,6 +18516,8 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  protocol-buffers-schema@3.6.0: {}
+
   protocols@2.0.2: {}
 
   proxy-from-env@1.1.0: {}
@@ -18376,6 +18557,8 @@ snapshots:
   quick-lru@4.0.1: {}
 
   quick-lru@7.3.0: {}
+
+  quickselect@3.0.0: {}
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -18779,6 +18962,10 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.0
+
   resolve.exports@2.0.3: {}
 
   resolve@1.22.11:
@@ -18859,6 +19046,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -19360,6 +19549,10 @@ snapshots:
       escape-string-regexp: 5.0.0
       unique-string: 3.0.0
 
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.0.2
+
   supports-color@10.2.2: {}
 
   supports-color@7.2.0:
@@ -19467,6 +19660,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyqueue@3.0.0: {}
 
   tinyrainbow@3.1.0: {}
 


### PR DESCRIPTION
Demo: https://deploy-preview-4537--base-ui.netlify.app/experiments/popover/virtual-anchor

Closes https://github.com/mui/base-ui/issues/4534

Exposes the `update` method from `useAnchorPositioning`/Floating UI via popover handle

```jsx
const handle = Popover.createHandle();

handle.updatePosition();
```

This allows the popover to be repositioned imperatively when a virtual anchor moves outside of React, e.g. canvas animations

Using this, React performance in devtools shows less synchronous work in ~1 second of map panning compared to putting a virtual anchor in state

Using state (6x slowdown):
<img width="1440" height="1244" alt="state-6x" src="https://github.com/user-attachments/assets/9032332b-b24c-46ae-8b75-8128911508ef" />

Using `handle.updatePosition` (6x slowdown):
<img width="1441" height="1273" alt="handle-6x" src="https://github.com/user-attachments/assets/cc5db6de-8a0c-4d9b-87ee-db1247c46753" />


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
