### PR TITLE
[docs] Add description to useFilter() return types

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/types.md
+++ b/docs/src/app/(docs)/react/components/autocomplete/types.md
@@ -950,8 +950,11 @@ type ReturnValue = T[];
 
 ```typescript
 type AutocompleteFilter = {
+  /** Returns whether the item matches the query anywhere. */
   contains: <Item>(item: Item, query: string, itemToString?: (item: Item) => string) => boolean;
+  /** Returns whether the item starts with the query. */
   startsWith: <Item>(item: Item, query: string, itemToString?: (item: Item) => string) => boolean;
+  /** Returns whether the item ends with the query. */
   endsWith: <Item>(item: Item, query: string, itemToString?: (item: Item) => string) => boolean;
 };
 ```

--- a/docs/src/app/(docs)/react/components/combobox/types.md
+++ b/docs/src/app/(docs)/react/components/combobox/types.md
@@ -1108,8 +1108,11 @@ type ReturnValue = T[];
 
 ```typescript
 type ComboboxFilter = {
+  /** Returns whether the item matches the query anywhere. */
   contains: <Item>(item: Item, query: string, itemToString?: (item: Item) => string) => boolean;
+  /** Returns whether the item starts with the query. */
   startsWith: <Item>(item: Item, query: string, itemToString?: (item: Item) => string) => boolean;
+  /** Returns whether the item ends with the query. */
   endsWith: <Item>(item: Item, query: string, itemToString?: (item: Item) => string) => boolean;
 };
 ```

--- a/packages/react/src/combobox/root/utils/useFilter.ts
+++ b/packages/react/src/combobox/root/utils/useFilter.ts
@@ -12,8 +12,17 @@ export interface UseFilterOptions extends Intl.CollatorOptions {
 }
 
 export interface Filter {
+  /**
+   * Returns whether the item matches the query anywhere.
+   */
   contains: <Item>(item: Item, query: string, itemToString?: (item: Item) => string) => boolean;
+  /**
+   * Returns whether the item starts with the query.
+   */
   startsWith: <Item>(item: Item, query: string, itemToString?: (item: Item) => string) => boolean;
+  /**
+   * Returns whether the item ends with the query.
+   */
   endsWith: <Item>(item: Item, query: string, itemToString?: (item: Item) => string) => boolean;
 }
 


### PR DESCRIPTION
Adds a JSDoc description to `useFilter()` for Combobox and Autocomplete components.

[Combobox](https://deploy-preview-4542--base-ui.netlify.app/react/components/combobox#ComboboxuseFilter-contains)
[Autocomplete](https://deploy-preview-4542--base-ui.netlify.app/react/components/autocomplete#AutocompleteuseFilter-contains)