### PR TITLE
fix(popover): prevent scroll on initial focus

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -746,7 +746,10 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
       elToFocus = elToFocus || getDefaultFocusElement();
 
       enqueueFocus(elToFocus, {
-        preventScroll: elToFocus === floatingFocusElement,
+        // Opening a portal-backed floating element should not unexpectedly scroll
+        // the page to reveal the focused element. This is especially visible for
+        // popovers rendered at the end of <body>.
+        preventScroll: true,
       });
     });
   }, [

--- a/packages/react/src/popover/popup/PopoverPopup.test.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.test.tsx
@@ -44,7 +44,7 @@ describe('<Popover.Popup />', () => {
       Object.defineProperty(HTMLElement.prototype, 'focus', {
         configurable: true,
         writable: true,
-        value(options) {
+        value(options?: FocusOptions) {
           lastPreventScroll = options?.preventScroll;
           return originalFocus.call(this, options);
         },

--- a/packages/react/src/popover/popup/PopoverPopup.test.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.test.tsx
@@ -37,6 +37,51 @@ describe('<Popover.Popup />', () => {
   });
 
   describe('prop: initialFocus', () => {
+    it('should prevent page scroll when default initial focus lands on a tabbable element', async () => {
+      const originalFocus = HTMLElement.prototype.focus;
+      let lastPreventScroll;
+
+      Object.defineProperty(HTMLElement.prototype, 'focus', {
+        configurable: true,
+        writable: true,
+        value(options) {
+          lastPreventScroll = options?.preventScroll;
+          return originalFocus.call(this, options);
+        },
+      });
+
+      try {
+        await render(
+          <div>
+            <Popover.Root>
+              <Popover.Trigger>Open</Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Positioner>
+                  <Popover.Popup>
+                    <input data-testid="popover-input" />
+                    <button>Close</button>
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
+          </div>,
+        );
+
+        const trigger = screen.getByText('Open');
+        await act(async () => {
+          trigger.click();
+        });
+
+        await waitFor(() => {
+          expect(screen.getByTestId('popover-input')).toHaveFocus();
+        });
+
+        expect(lastPreventScroll).to.equal(true);
+      } finally {
+        HTMLElement.prototype.focus = originalFocus;
+      }
+    });
+
     it('should focus the first focusable element within the popup by default', async () => {
       await render(
         <div>


### PR DESCRIPTION
## Summary
- prevent initial focus from scrolling the page when a popover opens
- add a regression test covering default initial focus on a tabbable element inside the popup

## What changed
When the popover opens, `FloatingFocusManager` can move focus to the first tabbable element inside the popup. Because the popup is rendered through a portal, that focus move can scroll the page unexpectedly. This change applies `preventScroll: true` to the initial focus enqueue path so opening the popover doesn't jump the page.

## Testing
- `pnpm vitest packages/react/src/popover/popup/PopoverPopup.test.tsx --run`

Fixes #4520