### PR TITLE
[docs] Remove TW radius vars from CSS modules demos

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
@@ -253,7 +253,7 @@
     display: block;
     height: 100%;
     width: 0.25rem;
-    border-radius: var(--radius-sm);
+    border-radius: 0.25rem;
     background-color: var(--color-gray-400);
   }
 }

--- a/docs/src/app/(docs)/react/components/toolbar/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toolbar/demos/hero/css-modules/index.module.css
@@ -85,7 +85,7 @@
   &:focus-visible {
     outline: 2px solid var(--color-blue);
     outline-offset: -2px;
-    border-radius: var(--radius-sm);
+    border-radius: 0.25rem;
   }
 
   @media (hover: hover) {


### PR DESCRIPTION
CSS Modules demos shouldn't use Tailwind CSS vars (since they are not available when opening in StackBlitz), so this PR removes radius CSS vars that were used in a couple of demos.