### PR TITLE
[collapsible] Fix open state when keepMounted with no transitions

### DIFF
--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -56,6 +56,52 @@ describe('<Collapsible.Panel />', () => {
       expect(screen.queryByText(PANEL_CONTENT)).not.toBeVisible();
       expect(screen.queryByText(PANEL_CONTENT)).toHaveAttribute('data-closed');
     });
+
+    it.skipIf(isJSDOM)(
+      'hides the panel after external controlled close when true and no animations are applied',
+      async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+
+          return (
+            <React.Fragment>
+              <Collapsible.Root open={open} onOpenChange={setOpen}>
+                <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+                <Collapsible.Panel keepMounted>{PANEL_CONTENT}</Collapsible.Panel>
+              </Collapsible.Root>
+
+              <button type="button" onClick={() => setOpen(!open)}>
+                toggle externally
+              </button>
+            </React.Fragment>
+          );
+        }
+
+        const { user } = await render(<App />);
+
+        const trigger = screen.getByRole('button', { name: 'Trigger' });
+        const externalTrigger = screen.getByRole('button', { name: 'toggle externally' });
+        const panel = screen.getByText(PANEL_CONTENT);
+
+        expect(trigger).toHaveAttribute('aria-expanded', 'false');
+        expect(panel).toHaveAttribute('hidden');
+        expect(panel).toHaveAttribute('data-closed');
+        expect(panel).not.toHaveAttribute('data-ending-style');
+
+        await user.click(externalTrigger);
+
+        expect(trigger).toHaveAttribute('aria-expanded', 'true');
+        expect(panel).not.toHaveAttribute('hidden');
+        expect(panel).toHaveAttribute('data-open');
+
+        await user.click(externalTrigger);
+
+        expect(trigger).toHaveAttribute('aria-expanded', 'false');
+        expect(panel).toHaveAttribute('hidden');
+        expect(panel).toHaveAttribute('data-closed');
+        expect(panel).not.toHaveAttribute('data-ending-style');
+      },
+    );
   });
 
   // we test firefox in browserstack which does not support this yet

--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -436,7 +436,9 @@ export interface UseCollapsiblePanelParameters {
    */
   keepMounted: boolean;
   /**
-   * Whether the collapsible panel is currently mounted.
+   * Whether the collapsible panel is mounted for transition and hidden-state
+   * purposes. This can be `false` while the element remains in the DOM when
+   * `keepMounted` or `hiddenUntilFound` is enabled.
    */
   mounted: boolean;
   onOpenChange: (open: boolean, eventDetails: CollapsibleRoot.ChangeEventDetails) => void;

--- a/packages/react/src/collapsible/root/useCollapsibleRoot.ts
+++ b/packages/react/src/collapsible/root/useCollapsibleRoot.ts
@@ -94,13 +94,14 @@ export function useCollapsibleRoot(
 
   useIsoLayoutEffect(() => {
     /**
-     * Unmount immediately when closing in controlled mode and keepMounted={false}
-     * and no CSS animations or transitions are applied
+     * Close immediately in controlled mode when no CSS animations or
+     * transitions are applied. `keepMounted` only keeps the element in the
+     * DOM; `mounted` must still become `false` so the panel regains `hidden`.
      */
-    if (isControlled && animationTypeRef.current === 'none' && !keepMounted && !open) {
+    if (isControlled && animationTypeRef.current === 'none' && !open) {
       setMounted(false);
     }
-  }, [isControlled, keepMounted, open, openParam, setMounted]);
+  }, [isControlled, open, openParam, setMounted]);
 
   return React.useMemo(
     () => ({
@@ -189,7 +190,9 @@ export interface UseCollapsibleRootReturnValue {
    */
   height: number | undefined;
   /**
-   * Whether the collapsible panel is currently mounted.
+   * Whether the collapsible panel is mounted for transition and hidden-state
+   * purposes. This can be `false` while the element remains in the DOM when
+   * `keepMounted` or `hiddenUntilFound` is enabled.
    */
   mounted: boolean;
   /**
@@ -202,7 +205,7 @@ export interface UseCollapsibleRootReturnValue {
   setDimensions: React.Dispatch<React.SetStateAction<Dimensions>>;
   setHiddenUntilFound: React.Dispatch<React.SetStateAction<boolean>>;
   setKeepMounted: React.Dispatch<React.SetStateAction<boolean>>;
-  setMounted: (open: boolean) => void;
+  setMounted: (nextMounted: boolean) => void;
   setOpen: (open: boolean) => void;
   setPanelIdState: (id: string | undefined) => void;
   setVisible: React.Dispatch<React.SetStateAction<boolean>>;


### PR DESCRIPTION
Demo: https://stackblitz.com/edit/vitejs-vite-ton1ipyx?file=package.json

Fixes https://github.com/mui/base-ui/issues/4553

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
