### PR TITLE
[docs] Fix popover arrow border color

### DIFF
--- a/docs/src/components/TypeRef/TypeRef.css
+++ b/docs/src/components/TypeRef/TypeRef.css
@@ -53,7 +53,7 @@
   }
 
   .TypeRefArrowStroke {
-    fill: var(--gray-c2);
+    fill: var(--blackA-3);
   }
 
   .TypeRefArrowStrokeDark {


### PR DESCRIPTION
before
<img width="324" height="111" alt="Screenshot 2026-04-09 at 09 31 18" src="https://github.com/user-attachments/assets/25a7dbfe-daa8-4659-a6db-5c32d80872f3" />


after
<img width="324" height="85" alt="Screenshot 2026-04-09 at 09 31 07" src="https://github.com/user-attachments/assets/493f69a4-7692-4339-8438-998032175048" />
