### PR TITLE
[select] Fix hover highlight after scroll arrow hover

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
@@ -698,6 +698,18 @@ describe('useListNavigation', () => {
       await flushMicrotasks();
     });
 
+    it('true - syncs an item on hover when activeIndex is null but selectedIndex matches', async () => {
+      const spy = vi.fn();
+      render(<App focusItemOnOpen={false} selectedIndex={1} onNavigate={(index) => spy(index)} />);
+
+      fireEvent.click(screen.getByRole('button'));
+      fireEvent.mouseMove(screen.getByTestId('item-1'));
+
+      expect(screen.getByTestId('item-1')).toHaveFocus();
+      expect(spy).toHaveBeenCalledWith(1);
+      await flushMicrotasks();
+    });
+
     it('false - does not focus item on hover and does not sync the active index', async () => {
       const spy = vi.fn();
       render(<App onNavigate={spy} focusItemOnOpen={false} focusItemOnHover={false} />);

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -495,18 +495,19 @@ export function useListNavigation(
 
   const hasActiveIndex = activeIndex != null;
 
-  const item = React.useMemo(() => {
-    function syncCurrentTarget(event: React.SyntheticEvent<any>) {
-      if (!latestOpenRef.current) {
-        return;
-      }
-      const index = listRef.current.indexOf(event.currentTarget);
-      if (index !== -1 && indexRef.current !== index) {
-        indexRef.current = index;
-        onNavigate(event);
-      }
+  const syncCurrentTarget = useStableCallback((event: React.SyntheticEvent<any>) => {
+    if (!latestOpenRef.current) {
+      return;
     }
 
+    const index = listRef.current.indexOf(event.currentTarget);
+    if (index !== -1 && (indexRef.current !== index || activeIndex !== index)) {
+      indexRef.current = index;
+      onNavigate(event);
+    }
+  });
+
+  const item = React.useMemo(() => {
     const itemProps: ElementProps['item'] = {
       onFocus(event) {
         forceSyncFocusRef.current = true;
@@ -562,6 +563,7 @@ export function useListNavigation(
 
     return itemProps;
   }, [
+    syncCurrentTarget,
     latestOpenRef,
     floatingFocusElementRef,
     focusItemOnHover,


### PR DESCRIPTION
Select clears `activeIndex` while hover-scrolling a scroll arrow. After the custom hover handlers were removed, `useListNavigation` still kept its internal `indexRef` on the previously hovered item, so moving back over that same item was treated as a no-op and the highlight did not return.

This change makes hover synchronization re-run when the controlled `activeIndex` has been cleared, and adds a regression test for that path.

## To Reproduce

- Visit [Select](https://deploy-preview-4573--base-ui.netlify.app/react/components/select)
- Ensure the trigger is ~150px from the top of the viewport
- Click trigger, select Pink Lady (last item)
- Reopen, hover scroll arrow
- Attempt to select first item after a mousemove

## Changes

- Update `useListNavigation` to resync hover navigation when its internal index still matches but the controlled `activeIndex` no longer does.
- Add a regression test covering hover re-entry when `activeIndex` is `null` but `selectedIndex` still points at the same item.