### PR TITLE
[combobox] Prevent item taps from blurring input

### DIFF
--- a/packages/react/src/combobox/item/ComboboxItem.test.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.test.tsx
@@ -184,6 +184,67 @@ describe('<Combobox.Item />', () => {
     expect(screen.queryByRole('listbox')).toBe(null);
   });
 
+  it.skipIf(isJSDOM)('keeps the input focused after selecting an item with touch', async () => {
+    const { user } = await render(
+      <Combobox.Root defaultOpen>
+        <Combobox.Input data-testid="input" />
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                <Combobox.Item value="one">one</Combobox.Item>
+                <Combobox.Item value="two">two</Combobox.Item>
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    const input = screen.getByTestId('input');
+    await user.click(input);
+    expect(input).toHaveFocus();
+
+    const option = screen.getByRole('option', { name: 'two' });
+
+    await user.pointer([
+      { target: option, keys: '[TouchA>]', pointerName: 'touch' },
+      { target: option, keys: '[/TouchA]', pointerName: 'touch' },
+    ]);
+
+    await waitFor(() => expect(input).toHaveValue('two'));
+    expect(input).toHaveFocus();
+  });
+
+  it('prevents default on mousedown so pointer selection does not steal input focus', async () => {
+    await render(
+      <Combobox.Root defaultOpen>
+        <Combobox.Input data-testid="input" />
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                <Combobox.Item value="one">one</Combobox.Item>
+                <Combobox.Item value="two">two</Combobox.Item>
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    const option = screen.getByRole('option', { name: 'two' });
+    const mouseDown = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    });
+
+    option.dispatchEvent(mouseDown);
+
+    expect(mouseDown.defaultPrevented).toBe(true);
+  });
+
   it('multiple mode toggles selection and stays open', async () => {
     const { user } = await render(
       <Combobox.Root multiple>

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -173,6 +173,11 @@ export const ComboboxItem = React.memo(
         didPointerDownRef.current = true;
         event.preventDefault();
       },
+      onMouseDown(event) {
+        // iOS Safari can emit a synthetic mousedown for touch taps without a preceding
+        // pointerdown. Prevent default here too so tapping an item does not blur the input.
+        event.preventDefault();
+      },
       onClick(event) {
         if (disabled || readOnly) {
           return;


### PR DESCRIPTION
Tapping a combobox item on iOS (seems new in 26.4+) could still blur the input because the item only cancelled the `pointerdown` path. Safari can still deliver a synthetic `mousedown` for touch taps, which left a fallback path that could steal focus.

This keeps the existing `pointerdown` guard and also cancels `mousedown` on the shared item implementation, so the input stays focused while selection is committed. The shared change also covers `Autocomplete.Item`.

## Changes

- Prevent default on `mousedown` in `Combobox.Item` in addition to the existing `pointerdown` handling.
- Add regression coverage for touch selection focus retention and the `mousedown` fallback path.
