### PR TITLE
[navigation-menu] Fix transition width when reopening (#3073)

### DIFF
--- a/docs/src/app/(private)/experiments/navigation-menu.tsx
+++ b/docs/src/app/(private)/experiments/navigation-menu.tsx
@@ -208,6 +208,105 @@ export default function ExampleNavigationMenu() {
         </NavigationMenu.Portal>
       </NavigationMenu.Root>
 
+      <NavigationMenu.Root className={styles.Root} style={{ marginTop: '2rem' }}>
+        <NavigationMenu.List className={styles.List}>
+          <NavigationMenu.Item>
+            <NavigationMenu.Trigger className={styles.Trigger}>
+              Overview
+              <NavigationMenu.Icon className={styles.Icon}>
+                <ChevronDownIcon />
+              </NavigationMenu.Icon>
+            </NavigationMenu.Trigger>
+            <NavigationMenu.Content className={styles.Content}>
+              <table role="presentation">
+                <tbody>
+                  <tr>
+                    <td>
+                      <ul className={styles.GridLinkList}>
+                        {overviewLinks.map((item) => (
+                          <li key={item.href}>
+                            <Link className={styles.LinkCard} href={item.href}>
+                              <h3 className={styles.LinkTitle}>{item.title}</h3>
+                              <p className={styles.LinkDescription}>{item.description}</p>
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </td>
+                    <td>
+                      <ul className={styles.FlexLinkList}>
+                        <li>
+                          <Link className={styles.LinkCard} href="/react/components">
+                            <h3 className={styles.LinkTitle}>Components</h3>
+                            <p className={styles.LinkDescription}>
+                              Browse primitives for building product UI.
+                            </p>
+                          </Link>
+                        </li>
+                        <li>
+                          <Link className={styles.LinkCard} href="/react/hooks">
+                            <h3 className={styles.LinkTitle}>Hooks</h3>
+                            <p className={styles.LinkDescription}>
+                              Use shared behavior without adopting styles.
+                            </p>
+                          </Link>
+                        </li>
+                      </ul>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+
+          <NavigationMenu.Item>
+            <Link className={styles.Trigger} href="https://github.com/mui/base-ui">
+              GitHub
+            </Link>
+          </NavigationMenu.Item>
+
+          <NavigationMenu.Item>
+            <NavigationMenu.Trigger className={styles.Trigger}>
+              Handbook
+              <NavigationMenu.Icon className={styles.Icon}>
+                <ChevronDownIcon />
+              </NavigationMenu.Icon>
+            </NavigationMenu.Trigger>
+            <NavigationMenu.Content className={styles.Content}>
+              <ul className={styles.FlexLinkList}>
+                {handbookLinks.map((item) => (
+                  <li key={item.href}>
+                    <Link className={styles.LinkCard} href={item.href}>
+                      <h3 className={styles.LinkTitle}>{item.title}</h3>
+                      <p className={styles.LinkDescription}>{item.description}</p>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+        </NavigationMenu.List>
+
+        <NavigationMenu.Portal>
+          <NavigationMenu.Positioner
+            className={styles.Positioner}
+            sideOffset={10}
+            collisionPadding={{ top: 5, bottom: 5, left: 20, right: 20 }}
+            style={{
+              ['--duration' as string]: '1.25s',
+              ['--easing' as string]: 'linear',
+            }}
+          >
+            <NavigationMenu.Popup className={styles.Popup}>
+              <NavigationMenu.Arrow className={styles.Arrow}>
+                <ArrowSvg />
+              </NavigationMenu.Arrow>
+              <NavigationMenu.Viewport className={styles.Viewport} />
+            </NavigationMenu.Popup>
+          </NavigationMenu.Positioner>
+        </NavigationMenu.Portal>
+      </NavigationMenu.Root>
+
       <NavigationMenu.Root className={styles.Root} style={{ position: 'absolute', bottom: 100 }}>
         <NavigationMenu.List className={styles.List}>
           <NavigationMenu.Item>

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -2791,7 +2791,9 @@ describe('<NavigationMenu.Root />', () => {
             await flushMicrotasks();
           });
 
-          const popupWidthCalls = popupWidthSpy.mock.calls
+          const popupWidthCalls = (
+            popupWidthSpy.mock.calls as Array<[property: string, value: string, priority?: string]>
+          )
             .filter((call) => call[0] === '--popup-width')
             .map((call) => call[1]);
           const exitingWidthIndex = popupWidthCalls.indexOf('675px');

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -73,6 +73,96 @@ function TestNavigationMenuWithTopLevelLink(props: NavigationMenu.Root.Props = {
   );
 }
 
+const scopedPopupAnimationStyles = `
+  .test-navigation-menu-popup {
+    transition-property: opacity, transform, width, height;
+    transition-duration: 350ms;
+    transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .test-navigation-menu-popup[data-starting-style],
+  .test-navigation-menu-popup[data-ending-style] {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+
+  .test-navigation-menu-popup[data-ending-style] {
+    transition-property: opacity, transform;
+    transition-duration: 150ms;
+    transition-timing-function: ease;
+  }
+
+  .test-navigation-menu-content {
+    transition:
+      opacity 175ms ease,
+      transform 350ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .test-navigation-menu-content[data-starting-style],
+  .test-navigation-menu-content[data-ending-style] {
+    opacity: 0;
+  }
+
+  .test-navigation-menu-content[data-starting-style][data-activation-direction='left'] {
+    transform: translateX(-2rem);
+  }
+
+  .test-navigation-menu-content[data-starting-style][data-activation-direction='right'] {
+    transform: translateX(2rem);
+  }
+
+  .test-navigation-menu-content[data-ending-style] {
+    transition-duration: 175ms;
+    transition-timing-function: ease;
+  }
+
+  .test-navigation-menu-content[data-ending-style][data-activation-direction='left'] {
+    transform: translateX(2rem);
+  }
+
+  .test-navigation-menu-content[data-ending-style][data-activation-direction='right'] {
+    transform: translateX(-2rem);
+  }
+`;
+
+function TestNavigationMenuWithTopLevelLinkScopedPopupAnimation() {
+  return (
+    <NavigationMenu.Root>
+      {/* eslint-disable-next-line react/no-danger */}
+      <style dangerouslySetInnerHTML={{ __html: scopedPopupAnimationStyles }} />
+      <NavigationMenu.List>
+        <NavigationMenu.Item value="item-1">
+          <NavigationMenu.Trigger data-testid="trigger-product">Product</NavigationMenu.Trigger>
+          <NavigationMenu.Content className="test-navigation-menu-content">
+            <div style={{ width: 675, height: 220 }}>Product panel</div>
+          </NavigationMenu.Content>
+        </NavigationMenu.Item>
+
+        <NavigationMenu.Item>
+          <NavigationMenu.Link href="#top-level-link" data-testid="top-level-link">
+            Top level link
+          </NavigationMenu.Link>
+        </NavigationMenu.Item>
+
+        <NavigationMenu.Item value="item-2">
+          <NavigationMenu.Trigger data-testid="trigger-learn">Learn</NavigationMenu.Trigger>
+          <NavigationMenu.Content className="test-navigation-menu-content">
+            <div style={{ width: 500, height: 180 }}>Learn panel</div>
+          </NavigationMenu.Content>
+        </NavigationMenu.Item>
+      </NavigationMenu.List>
+
+      <NavigationMenu.Portal keepMounted>
+        <NavigationMenu.Positioner data-testid="positioner">
+          <NavigationMenu.Popup className="test-navigation-menu-popup" data-testid="popup-root">
+            <NavigationMenu.Viewport />
+          </NavigationMenu.Popup>
+        </NavigationMenu.Positioner>
+      </NavigationMenu.Portal>
+    </NavigationMenu.Root>
+  );
+}
+
 function TestNestedNavigationMenu(props: NavigationMenu.Root.Props = {}) {
   return (
     <NavigationMenu.Root {...props}>
@@ -485,62 +575,11 @@ function TestNavigationMenuWithScopedPopupExitAnimation(
   } = {},
 ) {
   const { onOpenChangeComplete } = props;
-  const style = `
-    .test-navigation-menu-popup {
-      transition-property: opacity, transform, width, height;
-      transition-duration: 350ms;
-      transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
-    }
-
-    .test-navigation-menu-popup[data-starting-style],
-    .test-navigation-menu-popup[data-ending-style] {
-      opacity: 0;
-      transform: scale(0.9);
-    }
-
-    .test-navigation-menu-popup[data-ending-style] {
-      transition-property: opacity, transform;
-      transition-duration: 150ms;
-      transition-timing-function: ease;
-    }
-
-    .test-navigation-menu-content {
-      transition:
-        opacity 175ms ease,
-        transform 350ms cubic-bezier(0.4, 0, 0.2, 1);
-    }
-
-    .test-navigation-menu-content[data-starting-style],
-    .test-navigation-menu-content[data-ending-style] {
-      opacity: 0;
-    }
-
-    .test-navigation-menu-content[data-starting-style][data-activation-direction='left'] {
-      transform: translateX(-2rem);
-    }
-
-    .test-navigation-menu-content[data-starting-style][data-activation-direction='right'] {
-      transform: translateX(2rem);
-    }
-
-    .test-navigation-menu-content[data-ending-style] {
-      transition-duration: 175ms;
-      transition-timing-function: ease;
-    }
-
-    .test-navigation-menu-content[data-ending-style][data-activation-direction='left'] {
-      transform: translateX(2rem);
-    }
-
-    .test-navigation-menu-content[data-ending-style][data-activation-direction='right'] {
-      transform: translateX(-2rem);
-    }
-  `;
 
   return (
     <NavigationMenu.Root onOpenChangeComplete={onOpenChangeComplete}>
       {/* eslint-disable-next-line react/no-danger */}
-      <style dangerouslySetInnerHTML={{ __html: style }} />
+      <style dangerouslySetInnerHTML={{ __html: scopedPopupAnimationStyles }} />
       <NavigationMenu.List>
         <NavigationMenu.Item value="item-1">
           <NavigationMenu.Trigger data-testid="trigger-product">Product</NavigationMenu.Trigger>
@@ -2661,6 +2700,116 @@ describe('<NavigationMenu.Root />', () => {
         } finally {
           globalThis.BASE_UI_ANIMATIONS_DISABLED = previousAnimationsDisabled;
           restoreResizeObserver();
+        }
+      });
+
+      it('seeds the popup width from the exiting panel when reopening after hovering a top-level link', async () => {
+        const previousAnimationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        let popupWidthSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+        try {
+          function waitForAnimationFrame() {
+            return new Promise<void>((resolve) => {
+              requestAnimationFrame(() => {
+                resolve();
+              });
+            });
+          }
+
+          await render(<TestNavigationMenuWithTopLevelLinkScopedPopupAnimation />);
+
+          const triggerProduct = screen.getByTestId('trigger-product');
+          const triggerLearn = screen.getByTestId('trigger-learn');
+          const topLevelLink = screen.getByTestId('top-level-link');
+          const popupRoot = screen.getByTestId('popup-root');
+          const positioner = screen.getByTestId('positioner');
+          const animations = mockAnimations(popupRoot);
+
+          let nextPanelWidth = 675;
+          let nextPanelHeight = 220;
+
+          Object.defineProperty(popupRoot, 'offsetWidth', {
+            configurable: true,
+            get: () => {
+              const fixedWidth = popupRoot.style.getPropertyValue('--popup-width');
+              return fixedWidth && fixedWidth !== 'auto'
+                ? parseInt(fixedWidth, 10)
+                : nextPanelWidth;
+            },
+          });
+          Object.defineProperty(popupRoot, 'offsetHeight', {
+            configurable: true,
+            get: () => {
+              const fixedHeight = popupRoot.style.getPropertyValue('--popup-height');
+              return fixedHeight && fixedHeight !== 'auto'
+                ? parseInt(fixedHeight, 10)
+                : nextPanelHeight;
+            },
+          });
+
+          const openAnimation = animations.start();
+          fireEvent.mouseEnter(triggerProduct);
+          fireEvent.mouseMove(triggerProduct);
+          clock.tick(OPEN_DELAY);
+          await flushMicrotasks();
+
+          await act(async () => {
+            await animations.finish(openAnimation);
+            await flushMicrotasks();
+          });
+
+          await waitFor(() => {
+            expect(triggerProduct).toHaveAttribute('aria-expanded', 'true');
+            expect(popupRoot.style.getPropertyValue('--popup-width')).toBe('auto');
+          });
+
+          const closeAnimation = animations.start();
+          fireEvent.mouseLeave(triggerProduct, { relatedTarget: topLevelLink });
+          fireEvent.mouseEnter(topLevelLink);
+          fireEvent.mouseMove(topLevelLink);
+          clock.tick(OPEN_DELAY);
+          await flushMicrotasks();
+
+          await waitFor(() => {
+            expect(triggerProduct).toHaveAttribute('aria-expanded', 'false');
+          });
+
+          nextPanelWidth = 500;
+          nextPanelHeight = 180;
+          popupWidthSpy = vi.spyOn(popupRoot.style, 'setProperty');
+
+          const reopenAnimation = animations.start();
+          fireEvent.mouseEnter(triggerLearn);
+          fireEvent.mouseMove(triggerLearn);
+          clock.tick(OPEN_DELAY);
+          await flushMicrotasks();
+
+          await act(async () => {
+            await waitForAnimationFrame();
+            await flushMicrotasks();
+          });
+
+          const popupWidthCalls = popupWidthSpy.mock.calls
+            .filter((call) => call[0] === '--popup-width')
+            .map((call) => call[1]);
+          const exitingWidthIndex = popupWidthCalls.indexOf('675px');
+          const reopeningWidthIndex = popupWidthCalls.lastIndexOf('500px');
+
+          expect(triggerLearn).toHaveAttribute('aria-expanded', 'true');
+          expect(positioner.style.getPropertyValue('--positioner-width')).toBe('500px');
+          expect(exitingWidthIndex).toBeGreaterThan(-1);
+          expect(reopeningWidthIndex).toBeGreaterThan(exitingWidthIndex);
+
+          await act(async () => {
+            await animations.finish(closeAnimation);
+            await animations.finish(reopenAnimation);
+            await flushMicrotasks();
+          });
+        } finally {
+          popupWidthSpy?.mockRestore();
+          globalThis.BASE_UI_ANIMATIONS_DISABLED = previousAnimationsDisabled;
         }
       });
 

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -487,8 +487,8 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
         skipAutoSizeSyncRef.current = false;
         return undefined;
       }
-
-      handleValueChange(0, 0);
+      const { width, height } = getCssDimensions(popupElement);
+      handleValueChange(width, height);
     }
     return undefined;
   }, [


### PR DESCRIPTION
fixes #3073

This happened in this sequence:
`open: true` → `open: false` while the closing animation is still running → `open: true`

During that path:
1. `--popup-width` is removed, so `width: var(--popup-width)` resolves to `auto`.
2. Layout reflow is triggered. (`getComputedStyle `)
3. `--popup-width` is set to the next width.

In this flow, the width transition does not start.

### test
https://deploy-preview-4587--base-ui.netlify.app/experiments/navigation-menu


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
