### PR TITLE
[docs] Add ReUI to community page

### DIFF
--- a/docs/src/app/(docs)/react/overview/community/page.mdx
+++ b/docs/src/app/(docs)/react/overview/community/page.mdx
@@ -21,6 +21,7 @@ Here's a non-exhaustive list of open-source styled libraries built with Base UI
 - [Prototyper UI](https://prototyper-ui.com): components that agents can read, compose, and render.
 - [Lumi UI](https://www.lumiui.dev): composable React components.
 - [Olyx UI](https://www.olyxui.com): composable components styled with native CSS and HCT color system.
+- [ReUI](https://reui.io): a large collection of components and templates built on shadcn/ui.
 
 ## Unofficial ports
 


### PR DESCRIPTION
Add [ReUI](https://reui.io) to the styled libraries list on the community page.

Preview: https://deploy-preview-4589--base-ui.netlify.app/react/overview/community
Ref: https://github.com/mui/base-ui/pull/4580#issuecomment-4231914042