### PR TITLE
[docs] Remove Tailwind theme font overrides

### DIFF
--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/_index.module.css
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/_index.module.css
@@ -92,7 +92,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
 }
 

--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
@@ -92,7 +92,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
 }
 

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/grouped/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/grouped/tailwind/index.tsx
@@ -23,7 +23,7 @@ export default function ExampleGroupAutocomplete() {
             <Autocomplete.List className="outline-0 overflow-y-auto scroll-pt-[2.25rem] scroll-pb-[0.5rem] overscroll-contain max-h-[min(22.5rem,var(--available-height))] data-[empty]:p-0">
               {(group: TagGroup) => (
                 <Autocomplete.Group key={group.value} items={group.items} className="block pb-2">
-                  <Autocomplete.GroupLabel className="sticky top-0 z-[1] mb-0 mr-2 mt-0 ml-0 w-[calc(100%-0.5rem)] bg-[canvas] px-4 pb-1 pt-2 text-xs font-bold uppercase tracking-wider">
+                  <Autocomplete.GroupLabel className="sticky top-0 z-[1] mb-0 mr-2 mt-0 ml-0 w-[calc(100%-0.5rem)] bg-[canvas] px-4 pb-1 pt-2 text-xs font-bold uppercase tracking-wide">
                     {group.value}
                   </Autocomplete.GroupLabel>
                   <Autocomplete.Collection>

--- a/docs/src/app/(docs)/react/components/combobox/demos/creatable/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/combobox/demos/creatable/css-modules/index.module.css
@@ -286,7 +286,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
 }
 

--- a/docs/src/app/(docs)/react/components/dialog/demos/_index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/_index.module.css
@@ -88,7 +88,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
 }
 

--- a/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
@@ -100,7 +100,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
 }
 

--- a/docs/src/app/(docs)/react/components/dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/hero/css-modules/index.module.css
@@ -90,7 +90,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
 }
 

--- a/docs/src/app/(docs)/react/components/dialog/demos/nested/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/nested/css-modules/index.module.css
@@ -144,7 +144,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
 }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/hero/css-modules/index.module.css
@@ -135,7 +135,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
 }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/indent-provider/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/indent-provider/css-modules/index.module.css
@@ -176,7 +176,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
   text-align: center;
 }

--- a/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/css-modules/index.module.css
@@ -228,7 +228,6 @@
   margin: 0 0 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
 }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/nested/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/nested/css-modules/index.module.css
@@ -239,7 +239,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
   text-align: center;
 }

--- a/docs/src/app/(docs)/react/components/drawer/demos/non-modal/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/non-modal/css-modules/index.module.css
@@ -145,7 +145,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
 }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/position/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/position/css-modules/index.module.css
@@ -126,7 +126,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
   text-align: center;
 }

--- a/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.module.css
@@ -167,7 +167,6 @@
   margin: 0;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
   text-align: center;
   cursor: default;

--- a/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/css-modules/index.module.css
@@ -194,7 +194,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 700;
 }
 

--- a/docs/src/app/(docs)/react/components/fieldset/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/fieldset/demos/hero/css-modules/index.module.css
@@ -15,7 +15,6 @@
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   color: var(--color-gray-900);
 }
 

--- a/docs/src/app/(docs)/react/components/select/demos/object-values/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/select/demos/object-values/css-modules/index.module.css
@@ -65,7 +65,7 @@
 }
 
 .ValueSecondary {
-  font-size: 0.825rem;
+  font-size: 0.75rem;
   line-height: 1rem;
   color: var(--color-gray-600);
 }
@@ -205,7 +205,7 @@
 }
 
 .ItemDescription {
-  font-size: 0.825rem;
+  font-size: 0.75rem;
   line-height: 1rem;
   opacity: 0.8;
 }

--- a/docs/src/app/(private)/docs-theme/page.tsx
+++ b/docs/src/app/(private)/docs-theme/page.tsx
@@ -13,7 +13,7 @@ const allCoreRows = [...coreColorRows, ...accentColorRows];
 const typefaces = [
   { token: 'font-sans', sample: 'Die Grotesk A for UI copy' },
   { token: 'font-sans-b', sample: 'Die Grotesk B for headings' },
-  { token: 'font-mono', sample: 'Söhne Mono for code and data' },
+  { token: 'font-mono', sample: 'Paper Mono for code and data' },
   { token: 'font-serif', sample: 'Georgia for editorial accents' },
 ] as const;
 

--- a/docs/src/app/(private)/experiments/_components/ExperimentRoot.module.css
+++ b/docs/src/app/(private)/experiments/_components/ExperimentRoot.module.css
@@ -47,7 +47,7 @@
 .sidebar {
   box-sizing: border-box;
   width: var(--sidebar-width);
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   position: fixed;
   top: 0;
   bottom: 0;

--- a/docs/src/app/(private)/experiments/_components/Input.module.css
+++ b/docs/src/app/(private)/experiments/_components/Input.module.css
@@ -6,7 +6,7 @@
   height: 1.75rem;
   border-radius: 0.375rem;
   font-family: inherit;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   font-weight: normal;
   background-color: transparent;
   color: var(--color-gray-900);

--- a/docs/src/app/(private)/experiments/_components/Select.module.css
+++ b/docs/src/app/(private)/experiments/_components/Select.module.css
@@ -12,7 +12,7 @@
   border: 1px solid var(--color-gray-200);
   border-radius: 0.375rem;
   font-family: inherit;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   line-height: 1.5rem;
   color: var(--color-gray-900);
   cursor: default;
@@ -124,7 +124,7 @@
 .Item {
   box-sizing: border-box;
   outline: 0;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   line-height: 1rem;
   padding-block: 0.5rem;
   padding-left: 0.625rem;

--- a/docs/src/app/(private)/experiments/_components/Sidebar.module.css
+++ b/docs/src/app/(private)/experiments/_components/Sidebar.module.css
@@ -5,7 +5,7 @@
   & h2 {
     text-transform: uppercase;
     font-weight: bold;
-    font-size: var(--text-xs);
+    font-size: 0.8125rem;
     color: var(--color-gray-500);
   }
 }

--- a/docs/src/app/(private)/experiments/combobox-composition.module.css
+++ b/docs/src/app/(private)/experiments/combobox-composition.module.css
@@ -7,8 +7,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 500;
   color: var(--color-gray-900);
 }
@@ -20,8 +20,8 @@
   border-radius: 0.375rem;
   background: canvas;
   padding-left: 0.875rem;
-  font-size: var(--text-base);
-  line-height: var(--text-base--line-height);
+  font-size: 1rem;
+  line-height: 1.5rem;
   font-weight: 400;
   color: var(--color-gray-900);
 }

--- a/docs/src/app/(private)/experiments/combobox/creatable-tags.module.css
+++ b/docs/src/app/(private)/experiments/combobox/creatable-tags.module.css
@@ -43,8 +43,8 @@
   border-radius: 0.375rem;
   background: var(--color-gray-100);
   padding: 0.2rem 0.375rem;
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-gray-900);
   outline: none;
 }
@@ -73,8 +73,8 @@
   border-radius: 0.375rem;
   background: transparent;
   padding-left: 0.5rem;
-  font-size: var(--text-base);
-  line-height: var(--text-base--line-height);
+  font-size: 1rem;
+  line-height: 1.5rem;
   color: var(--color-gray-900);
   outline: none;
 }
@@ -117,7 +117,7 @@
   gap: 0.5rem;
   cursor: default;
   padding: 0.5rem 2rem 0.5rem 1rem;
-  font-size: var(--text-base);
+  font-size: 1rem;
   line-height: 1rem;
   outline: none;
   user-select: none;

--- a/docs/src/app/(private)/experiments/combobox/dialog-combobox.module.css
+++ b/docs/src/app/(private)/experiments/combobox/dialog-combobox.module.css
@@ -91,7 +91,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 500;
 }
 

--- a/docs/src/app/(private)/experiments/combobox/priority-combobox.module.css
+++ b/docs/src/app/(private)/experiments/combobox/priority-combobox.module.css
@@ -9,8 +9,8 @@
   background: canvas;
   background-clip: padding-box;
   padding: 0 0.75rem;
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-gray-900);
   user-select: none;
 }
@@ -78,8 +78,8 @@
   width: 100%;
   height: 2rem;
   padding-left: 0.875rem;
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 400;
   color: var(--color-gray-900);
 }
@@ -141,7 +141,7 @@
   gap: 0.5rem;
   cursor: default;
   padding: 0.5rem 1rem;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   line-height: 1rem;
   user-select: none;
   outline: none;

--- a/docs/src/app/(private)/experiments/context-menu.module.css
+++ b/docs/src/app/(private)/experiments/context-menu.module.css
@@ -20,8 +20,8 @@
 
 .SectionTitle {
   margin: 0 0 1rem;
-  font-size: var(--text-xl);
-  line-height: var(--text-xl--line-height);
+  font-size: 1.3125rem;
+  line-height: 1.625rem;
   font-weight: 600;
 }
 
@@ -59,7 +59,7 @@
 .Item {
   cursor: default;
   padding: 0.5rem 0.75rem;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
 }
 
 .Item:hover {
@@ -76,7 +76,7 @@
   justify-content: space-between;
   cursor: default;
   padding: 0.5rem 0.75rem;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
 }
 
 .SubmenuTrigger:hover {
@@ -157,8 +157,8 @@
 
 .LabelSecondary {
   display: block;
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
 }
 
 .BluePrimary {
@@ -257,7 +257,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  font-size: var(--text-base);
+  font-size: 1rem;
   color: var(--color-gray-600);
 }
 
@@ -269,7 +269,7 @@
   border: 1px solid var(--color-gray-300);
   border-radius: 0.375rem;
   padding: 0.375rem 0.75rem;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   color: var(--color-gray-800);
 }
 
@@ -302,8 +302,8 @@
 }
 
 .DisabledLabel {
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-gray-700);
 }
 
@@ -329,7 +329,7 @@
   cursor: default;
   padding: 0.5rem 0.75rem;
   text-align: left;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
 }
 
 .SpecialTrigger:hover {

--- a/docs/src/app/(private)/experiments/drawer-slider.module.css
+++ b/docs/src/app/(private)/experiments/drawer-slider.module.css
@@ -17,8 +17,8 @@
   border: 1px solid var(--color-gray-200);
   background-color: var(--color-gray-50);
   color: var(--color-gray-900);
-  font-size: var(--text-base);
-  line-height: var(--text-base--line-height);
+  font-size: 1rem;
+  line-height: 1.5rem;
   font-weight: 500;
   user-select: none;
 }
@@ -125,8 +125,8 @@
   margin-top: -0.375rem;
   margin-bottom: 0.25rem;
   text-align: center;
-  font-size: var(--text-lg);
-  line-height: var(--text-lg--line-height);
+  font-size: 1.125rem;
+  line-height: 1.75rem;
   font-weight: 500;
 }
 
@@ -134,8 +134,8 @@
   margin-bottom: 1.5rem;
   text-align: center;
   color: var(--color-gray-600);
-  font-size: var(--text-base);
-  line-height: var(--text-base--line-height);
+  font-size: 1rem;
+  line-height: 1.5rem;
 }
 
 .SliderSection {

--- a/docs/src/app/(private)/experiments/drawer/cross-axis-scroll.module.css
+++ b/docs/src/app/(private)/experiments/drawer/cross-axis-scroll.module.css
@@ -10,7 +10,6 @@
   margin: 0;
   font-size: 1.5rem;
   line-height: 2rem;
-  letter-spacing: -0.01em;
 }
 
 .Description {

--- a/docs/src/app/(private)/experiments/menu/menu.module.css
+++ b/docs/src/app/(private)/experiments/menu/menu.module.css
@@ -12,9 +12,9 @@
   border-radius: 0.375rem;
   background-color: var(--color-gray-50);
   font-family: inherit;
-  font-size: var(--text-base);
+  font-size: 1rem;
   font-weight: 500;
-  line-height: var(--text-base--line-height);
+  line-height: 1.5rem;
   color: var(--color-gray-900);
   user-select: none;
 
@@ -141,7 +141,7 @@
   padding-left: 1rem;
   padding-right: 2rem;
   display: flex;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   line-height: 1rem;
 
   &[data-highlighted] {
@@ -214,7 +214,7 @@
   padding-block: 0.5rem;
   padding-left: 0.625rem;
   padding-right: 2rem;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   line-height: 1rem;
   display: grid;
   gap: 0.5rem;
@@ -269,7 +269,7 @@
   padding-block: 0.5rem;
   padding-left: 1.875rem;
   padding-right: 2rem;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   line-height: 1rem;
   color: var(--color-gray-600);
 }
@@ -304,8 +304,8 @@
 
 .SectionTitle {
   margin: 0 0 1rem;
-  font-size: var(--text-xl);
-  line-height: var(--text-xl--line-height);
+  font-size: 1.3125rem;
+  line-height: 1.625rem;
   font-weight: 600;
 }
 
@@ -338,7 +338,7 @@
 .DialogTitle {
   margin: 0 0 1rem;
   font-size: 1.25rem;
-  line-height: var(--text-lg--line-height);
+  line-height: 1.75rem;
   font-weight: 600;
 }
 

--- a/docs/src/app/(private)/experiments/mobile-scroll-lock.module.css
+++ b/docs/src/app/(private)/experiments/mobile-scroll-lock.module.css
@@ -82,7 +82,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 500;
 }
 

--- a/docs/src/app/(private)/experiments/navigation-menu.module.css
+++ b/docs/src/app/(private)/experiments/navigation-menu.module.css
@@ -12,16 +12,16 @@
 
 .ExperimentTitle {
   margin: 0 0 0.5rem;
-  font-size: var(--text-lg);
-  line-height: var(--text-lg--line-height);
+  font-size: 1.125rem;
+  line-height: 1.75rem;
   font-weight: 600;
   color: var(--color-gray-900);
 }
 
 .ExperimentDescription {
   margin: 0 0 1rem;
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-gray-600);
   max-width: 52rem;
 }
@@ -48,9 +48,9 @@
   border-radius: 0.375rem;
   background-color: var(--color-gray-50);
   font-family: inherit;
-  font-size: var(--text-base);
+  font-size: 1rem;
   font-weight: 500;
-  line-height: var(--text-base--line-height);
+  line-height: 1.5rem;
   color: var(--color-gray-900);
   user-select: none;
   text-decoration: none;
@@ -268,8 +268,8 @@
   border-radius: 0.5rem;
   background: transparent;
   font-family: inherit;
-  font-size: var(--text-base);
-  line-height: var(--text-base--line-height);
+  font-size: 1rem;
+  line-height: 1.5rem;
   font-weight: 500;
   color: var(--color-gray-900);
   text-align: left;
@@ -294,8 +294,8 @@
 }
 
 .InlineNestedHint {
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 400;
   color: var(--color-gray-500);
 }
@@ -322,16 +322,16 @@
 
 .SectionTitle {
   margin: 0 0 0.375rem;
-  font-size: var(--text-lg);
-  line-height: var(--text-lg--line-height);
+  font-size: 1.125rem;
+  line-height: 1.75rem;
   font-weight: 600;
   color: var(--color-gray-900);
 }
 
 .SectionDescription {
   margin: 0;
-  font-size: var(--text-sm);
-  line-height: var(--text-base--line-height);
+  font-size: 0.875rem;
+  line-height: 1.5rem;
   color: var(--color-gray-600);
 }
 
@@ -356,8 +356,8 @@
   border-radius: 0.5rem;
   background: var(--color-gray-50);
   font-family: inherit;
-  font-size: var(--text-base);
-  line-height: var(--text-base--line-height);
+  font-size: 1rem;
+  line-height: 1.5rem;
   font-weight: 500;
   color: var(--color-gray-900);
   text-align: left;
@@ -442,15 +442,15 @@
 
 .LinkTitle {
   margin: 0 0 4px;
-  font-size: var(--text-base);
+  font-size: 1rem;
   font-weight: 500;
-  line-height: var(--text-sm--line-height);
+  line-height: 1.25rem;
 }
 
 .LinkDescription {
   margin: 0;
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-gray-500);
 }
 
@@ -505,8 +505,8 @@
   border-radius: 0.375rem;
   background: var(--color-gray-50);
   padding: 0 0.875rem;
-  font-size: var(--text-base);
-  line-height: var(--text-base--line-height);
+  font-size: 1rem;
+  line-height: 1.5rem;
   font-weight: 500;
   color: var(--color-gray-900);
   user-select: none;
@@ -574,15 +574,15 @@
 
 .ModalTitle {
   margin: -0.375rem 0 0.25rem;
-  font-size: var(--text-lg);
-  line-height: var(--text-lg--line-height);
+  font-size: 1.125rem;
+  line-height: 1.75rem;
   font-weight: 500;
 }
 
 .ModalDescription {
   margin: 0 0 1.5rem;
-  font-size: var(--text-base);
-  line-height: var(--text-base--line-height);
+  font-size: 1rem;
+  line-height: 1.5rem;
   color: var(--color-gray-600);
 }
 

--- a/docs/src/app/(private)/experiments/popup-tabbing.module.css
+++ b/docs/src/app/(private)/experiments/popup-tabbing.module.css
@@ -3,16 +3,16 @@
 }
 
 .Title {
-  font-size: var(--text-lg);
-  line-height: var(--text-lg--line-height);
+  font-size: 1.125rem;
+  line-height: 1.75rem;
   font-weight: 600;
   color: var(--color-gray-900);
 }
 
 .Description {
   margin-top: 0.25rem;
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: var(--color-gray-600);
 }
 
@@ -21,8 +21,8 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 500;
   color: var(--color-gray-900);
 }
@@ -75,7 +75,7 @@
 
 .SectionTitle {
   margin-bottom: 0.75rem;
-  font-size: var(--text-base);
+  font-size: 1rem;
   font-weight: 600;
   color: var(--color-gray-900);
 }
@@ -96,7 +96,7 @@
   border-radius: 0.375rem;
   background: var(--color-gray-50);
   padding: 0 0.875rem;
-  font-size: var(--text-base);
+  font-size: 1rem;
   font-weight: 500;
   color: var(--color-gray-900);
 }
@@ -212,7 +212,7 @@
   display: flex;
   cursor: default;
   padding: 0.5rem 2rem 0.5rem 1rem;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   line-height: 1rem;
   user-select: none;
   outline: none;
@@ -242,8 +242,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 500;
   color: var(--color-gray-900);
 }
@@ -260,7 +260,7 @@
   background: canvas;
   padding-left: 0.875rem;
   padding-right: 2rem;
-  font-size: var(--text-base);
+  font-size: 1rem;
   color: var(--color-gray-900);
 }
 
@@ -340,7 +340,7 @@
   display: flex;
   cursor: default;
   padding: 0.5rem 2rem 0.5rem 1rem;
-  font-size: var(--text-base);
+  font-size: 1rem;
   line-height: 1rem;
   user-select: none;
   outline: none;
@@ -360,13 +360,13 @@
 }
 
 .InnerTitle {
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   font-weight: 500;
 }
 
 .InnerDescription {
   margin-top: 0.25rem;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   color: var(--color-gray-600);
 }
 

--- a/docs/src/app/(private)/experiments/popups/popups-in-popups.module.css
+++ b/docs/src/app/(private)/experiments/popups/popups-in-popups.module.css
@@ -122,7 +122,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 500;
 }
 
@@ -236,7 +235,6 @@
   margin-bottom: 0.25rem;
   font-size: 1.125rem;
   line-height: 1.75rem;
-  letter-spacing: -0.0025em;
   font-weight: 500;
   text-align: center;
 }

--- a/docs/src/app/(private)/experiments/storeWithControlledValues.module.css
+++ b/docs/src/app/(private)/experiments/storeWithControlledValues.module.css
@@ -5,8 +5,8 @@
 
 .Heading {
   margin-bottom: 1rem;
-  font-size: var(--text-lg);
-  line-height: var(--text-lg--line-height);
+  font-size: 1.125rem;
+  line-height: 1.75rem;
 }
 
 .Row {

--- a/docs/src/app/(private)/experiments/tooltip/prevent-open.module.css
+++ b/docs/src/app/(private)/experiments/tooltip/prevent-open.module.css
@@ -51,7 +51,7 @@
   border-radius: var(--radius-md);
   background-color: canvas;
   padding: 0.25rem 0.5rem;
-  font-size: var(--text-sm);
+  font-size: 0.875rem;
   box-shadow: var(--shadow-lg);
   outline: 1px solid var(--color-gray-200);
   transition:

--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -101,7 +101,6 @@
   /* Typography */
   --font-mono: 'Paper Mono', monospace;
   --font-sans: 'die grotesk a', system-ui, sans-serif;
-  --font-sans-b: 'die grotesk b', system-ui, sans-serif;
   --font-serif: Georgia, 'Times New Roman', Times, 'Noto Serif', 'DejaVu Serif', serif;
 }
 
@@ -175,6 +174,9 @@
     --color-navy: oklch(31% 25% 264deg);
     --color-green: oklch(46% 30% 150deg);
     --color-violet: oklch(40% 60% 300deg);
+
+    /* Font family */
+    --font-sans-b: 'die grotesk b', system-ui, sans-serif;
 
     /* Font size */
     --font-size-13: 0.8125rem; /* 13px */

--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -103,46 +103,6 @@
   --font-sans: 'die grotesk a', system-ui, sans-serif;
   --font-sans-b: 'die grotesk b', system-ui, sans-serif;
   --font-serif: Georgia, 'Times New Roman', Times, 'Noto Serif', 'DejaVu Serif', serif;
-
-  --text-xs: 0.8125rem;
-  --text-xs--line-height: 1.25rem;
-  --text-xs--letter-spacing: 0.001em;
-
-  --text-sm: 0.875rem;
-  --text-sm--line-height: 1.25rem;
-  --text-sm--letter-spacing: 0.016em;
-
-  --text-base: 1rem;
-  --text-base--line-height: 1.5rem;
-  --text-base--letter-spacing: 0em;
-
-  --text-lg: 1.125rem;
-  --text-lg--line-height: 1.75rem;
-  --text-lg--letter-spacing: -0.0025em;
-
-  --text-xl: 1.3125rem;
-  --text-xl--line-height: 1.625rem;
-  --text-xl--letter-spacing: -0.005em;
-
-  --text-2xl: 1.5rem;
-  --text-2xl--line-height: 1.25;
-  --text-2xl--letter-spacing: -0.0125em;
-
-  --text-3xl: 1.875rem;
-  --text-3xl--line-height: 1.2;
-  --text-3xl--letter-spacing: -0.015em;
-
-  --text-4xl: 2.25rem;
-  --text-4xl--line-height: 2.5rem;
-  --text-4xl--letter-spacing: -0.015em;
-
-  --text-5xl: 3rem;
-  --text-5xl--line-height: 1;
-  --text-5xl--letter-spacing: -0.015em;
-
-  --text-6xl: 3.75rem;
-  --text-6xl--line-height: 0.95;
-  --text-6xl--letter-spacing: -0.015em;
 }
 
 /* ═══ Demo isolation ═══ */
@@ -157,11 +117,6 @@
 
   [data-demo]:not([data-demo='tailwind']) * {
     all: revert-layer;
-  }
-
-  [data-demo='tailwind'] {
-    --text-sm--letter-spacing: 0em;
-    --text-md--letter-spacing: 0em;
   }
 }
 


### PR DESCRIPTION
Review strategy: the most important bit is taking a look at what changed on demo visual regression tests ([Argos](https://app.argos-ci.com/mui/base-ui/builds/25196)).

Changes included:
- Removes custom font theme values from Tailwind's config.
- Removes unnecessary `letter-spacing` instances from demos and experiments.
- Removes all `--text-*` Tailwind's CSS var instances from experiments.