### PR TITLE
[docs] Fix CSS layer order in 404 page

### DIFF
--- a/docs/src/app/(docs)/layout.tsx
+++ b/docs/src/app/(docs)/layout.tsx
@@ -1,4 +1,4 @@
-// Keep CSS imports first to ensure layers are declared before component styles
+// Keep CSS imports first to ensure CSS layer order is correct
 import 'docs/src/css/index.css';
 import './layout.css';
 

--- a/docs/src/app/(website)/layout.tsx
+++ b/docs/src/app/(website)/layout.tsx
@@ -104,13 +104,13 @@ export default function Layout({ children }: React.PropsWithChildren) {
                 >
                   npm
                 </Link>
-                <a
-                  className="Text sz-1 Link"
+                <Link
+                  className="Text sz-1"
                   href="https://bsky.app/profile/did:plc:nwr6peuxqzdzlbi72qr5kldc"
                   rel="noopener noreferrer"
                 >
                   Bluesky
-                </a>
+                </Link>
               </nav>
             </footer>
           </div>

--- a/docs/src/app/(website)/layout.tsx
+++ b/docs/src/app/(website)/layout.tsx
@@ -1,4 +1,4 @@
-// Keep CSS imports first to ensure layers are declared before component styles
+// Keep CSS imports first to ensure CSS layer order is correct
 import 'docs/src/css/index.css';
 import './css/index.css';
 

--- a/docs/src/app/global-not-found.tsx
+++ b/docs/src/app/global-not-found.tsx
@@ -1,5 +1,6 @@
-import { Link } from 'docs/src/components/Link';
 import Layout from './(website)/layout';
+// eslint-disable-next-line import/order -- We import the layout first to ensure the CSS layer order is correct
+import { Link } from 'docs/src/components/Link';
 
 export default function NotFoundPage() {
   return (


### PR DESCRIPTION
Preview: https://deploy-preview-4599--base-ui.netlify.app/whooooops

|before|after|
|---|---|
|<img width="2840" height="972" alt="base-ui com_asd" src="https://github.com/user-attachments/assets/ff134422-2a98-46ba-8478-6a95ffe2b697" />|<img width="2840" height="972" alt="localhost_3005_asd" src="https://github.com/user-attachments/assets/0febdab3-85d2-4667-8027-2baadb09c24d" />|