### PR TITLE
[all components] Clear highlight on pointer leave when item is clipped by scroll container

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
@@ -775,15 +775,19 @@ describe('useListNavigation', () => {
       await flushMicrotasks();
     });
 
-    it('does not clear the active item on pointer leave when the pointer is still within bounds', async () => {
+    it('clears the active item when the pointer leaves a clipped container while still within the item bounds', async () => {
       const spy = vi.fn();
       render(<App onNavigate={spy} />);
 
       fireEvent.click(screen.getByRole('button'));
 
+      const menu = screen.getByRole('menu');
       const item = screen.getByTestId('item-1');
 
-      vi.spyOn(item, 'getBoundingClientRect').mockReturnValue({
+      menu.style.overflow = 'auto';
+      menu.style.maxHeight = '40px';
+
+      vi.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
         x: 0,
         y: 0,
         top: 0,
@@ -797,24 +801,39 @@ describe('useListNavigation', () => {
         },
       });
 
-      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+      vi.spyOn(item, 'getBoundingClientRect').mockReturnValue({
+        x: 0,
+        y: 0,
+        top: 0,
+        right: 100,
+        bottom: 80,
+        left: 0,
+        width: 100,
+        height: 80,
+        toJSON() {
+          return {};
+        },
+      });
+
+      fireEvent.mouseMove(item);
 
       await waitFor(() => {
         expect(item).toHaveFocus();
       });
 
-      const callsBeforeLeave = spy.mock.calls.length;
-
       await act(async () => {
         fireEvent.pointerLeave(item, {
           clientX: 50,
-          clientY: 20,
+          clientY: 60,
           pointerType: 'mouse',
+          relatedTarget: document.body,
         });
       });
 
-      await flushMicrotasks();
-      expect(spy).toHaveBeenCalledTimes(callsBeforeLeave);
+      await waitFor(() => {
+        expect(item).toHaveAttribute('aria-selected', 'false');
+      });
+      expect(spy.mock.calls.at(-1)?.[0]).toBe(null);
     });
   });
 

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import { isHTMLElement } from '@floating-ui/utils/dom';
-import { isMouseWithinBounds } from '@base-ui/utils/isMouseWithinBounds';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
@@ -534,10 +533,6 @@ export function useListNavigation(
         forceSyncFocusRef.current = true;
 
         const relatedTarget = event.relatedTarget as HTMLElement | null;
-
-        if (isMouseWithinBounds(event)) {
-          return;
-        }
 
         if (!focusItemOnHover || listRef.current.includes(relatedTarget)) {
           return;

--- a/packages/utils/src/isMouseWithinBounds.ts
+++ b/packages/utils/src/isMouseWithinBounds.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated This utility is no longer used internally and will be removed in the next version.
+ */
 export function isMouseWithinBounds(
   event: React.MouseEvent<HTMLElement> | React.PointerEvent<HTMLElement>,
 ) {


### PR DESCRIPTION
Removing the shared `isMouseWithinBounds` guard lets `useListNavigation` clear hover highlight again when an item is partially clipped by a scroll container.

That guard was originally added as a Safari workaround for an older Select behavior (`alignItemWithTrigger` issue), but it does not seem to reproduce on the current path anymore. Keeping it in the shared hook now blocks legitimate `pointerleave` handling, so this change removes the extra guard instead of adding more conditions.

## Changes

- Remove the shared `isMouseWithinBounds` early return from `useListNavigation` item `onPointerLeave`.
- Add a regression test for a hovered item whose bounds extend past a clipped scrolling container.