### PR TITLE
[docs] Fix anatomy snippets

### DIFF
--- a/docs/src/app/(docs)/react/components/context-menu/page.mdx
+++ b/docs/src/app/(docs)/react/components/context-menu/page.mdx
@@ -27,16 +27,24 @@ import { ContextMenu } from '@base-ui/react/context-menu';
         <ContextMenu.Item />
         <ContextMenu.LinkItem />
         <ContextMenu.Separator />
-        <ContextMenu.Group>
-          <ContextMenu.GroupLabel />
-        </ContextMenu.Group>
-        <ContextMenu.RadioGroup>
-          <ContextMenu.RadioItem />
-        </ContextMenu.RadioGroup>
-        <ContextMenu.CheckboxItem />
+
         <ContextMenu.SubmenuRoot>
           <ContextMenu.SubmenuTrigger />
         </ContextMenu.SubmenuRoot>
+
+        <ContextMenu.Group>
+          <ContextMenu.GroupLabel />
+        </ContextMenu.Group>
+
+        <ContextMenu.RadioGroup>
+          <ContextMenu.RadioItem>
+            <ContextMenu.RadioItemIndicator />
+          </ContextMenu.RadioItem>
+        </ContextMenu.RadioGroup>
+
+        <ContextMenu.CheckboxItem>
+          <ContextMenu.CheckboxItemIndicator />
+        </ContextMenu.CheckboxItem>
       </ContextMenu.Popup>
     </ContextMenu.Positioner>
   </ContextMenu.Portal>

--- a/docs/src/app/(docs)/react/components/menu/page.mdx
+++ b/docs/src/app/(docs)/react/components/menu/page.mdx
@@ -24,21 +24,29 @@ import { Menu } from '@base-ui/react/menu';
     <Menu.Positioner>
       <Menu.Popup>
         <Menu.Arrow />
-        <Menu.Viewport>
-          <Menu.Item />
-          <Menu.LinkItem />
-          <Menu.Separator />
-          <Menu.Group>
-            <Menu.GroupLabel />
-          </Menu.Group>
-          <Menu.RadioGroup>
-            <Menu.RadioItem />
-          </Menu.RadioGroup>
-          <Menu.CheckboxItem />
-          <Menu.SubmenuRoot>
-            <Menu.SubmenuTrigger />
-          </Menu.SubmenuRoot>
-        </Menu.Viewport>
+        <Menu.Item />
+        <Menu.LinkItem />
+        <Menu.Separator />
+
+        <Menu.SubmenuRoot>
+          <Menu.SubmenuTrigger />
+        </Menu.SubmenuRoot>
+
+        <Menu.Group>
+          <Menu.GroupLabel />
+        </Menu.Group>
+
+        <Menu.RadioGroup>
+          <Menu.RadioItem>
+            <Menu.RadioItemIndicator />
+          </Menu.RadioItem>
+        </Menu.RadioGroup>
+
+        <Menu.CheckboxItem>
+          <Menu.CheckboxItemIndicator />
+        </Menu.CheckboxItem>
+
+        <Menu.Viewport />
       </Menu.Popup>
     </Menu.Positioner>
   </Menu.Portal>

--- a/docs/src/app/(docs)/react/components/menubar/page.mdx
+++ b/docs/src/app/(docs)/react/components/menubar/page.mdx
@@ -27,14 +27,28 @@ import { Menu } from '@base-ui/react/menu';
         <Menu.Popup>
           <Menu.Arrow />
           <Menu.Item />
+          <Menu.LinkItem />
           <Menu.Separator />
+
+          <Menu.SubmenuRoot>
+            <Menu.SubmenuTrigger />
+          </Menu.SubmenuRoot>
+
           <Menu.Group>
             <Menu.GroupLabel />
           </Menu.Group>
+
           <Menu.RadioGroup>
-            <Menu.RadioItem />
+            <Menu.RadioItem>
+              <Menu.RadioItemIndicator />
+            </Menu.RadioItem>
           </Menu.RadioGroup>
-          <Menu.CheckboxItem />
+
+          <Menu.CheckboxItem>
+            <Menu.CheckboxItemIndicator />
+          </Menu.CheckboxItem>
+
+          <Menu.Viewport />
         </Menu.Popup>
       </Menu.Positioner>
     </Menu.Portal>

--- a/docs/src/app/(docs)/react/components/otp-field/page.mdx
+++ b/docs/src/app/(docs)/react/components/otp-field/page.mdx
@@ -26,6 +26,7 @@ import { OTPFieldPreview as OTPField } from '@base-ui/react/otp-field';
 
 <OTPField.Root>
   <OTPField.Input />
+  <OTPField.Separator />
 </OTPField.Root>;
 ```
 

--- a/docs/src/app/(docs)/react/components/preview-card/page.mdx
+++ b/docs/src/app/(docs)/react/components/preview-card/page.mdx
@@ -35,6 +35,7 @@ import { PreviewCard } from '@base-ui/react/preview-card';
     <PreviewCard.Positioner>
       <PreviewCard.Popup>
         <PreviewCard.Arrow />
+        <PreviewCard.Viewport />
       </PreviewCard.Popup>
     </PreviewCard.Positioner>
   </PreviewCard.Portal>

--- a/docs/src/app/(docs)/react/components/select/page.mdx
+++ b/docs/src/app/(docs)/react/components/select/page.mdx
@@ -33,8 +33,8 @@ import { Select } from '@base-ui/react/select';
   <Select.Portal>
     <Select.Backdrop />
     <Select.Positioner>
-      <Select.ScrollUpArrow />
       <Select.Popup>
+        <Select.ScrollUpArrow />
         <Select.Arrow />
         <Select.List>
           <Select.Item>
@@ -46,8 +46,8 @@ import { Select } from '@base-ui/react/select';
             <Select.GroupLabel />
           </Select.Group>
         </Select.List>
+        <Select.ScrollDownArrow />
       </Select.Popup>
-      <Select.ScrollDownArrow />
     </Select.Positioner>
   </Select.Portal>
 </Select.Root>;

--- a/docs/src/app/(docs)/react/components/tooltip/page.mdx
+++ b/docs/src/app/(docs)/react/components/tooltip/page.mdx
@@ -31,6 +31,7 @@ import { Tooltip } from '@base-ui/react/tooltip';
       <Tooltip.Positioner>
         <Tooltip.Popup>
           <Tooltip.Arrow />
+          <Tooltip.Viewport />
         </Tooltip.Popup>
       </Tooltip.Positioner>
     </Tooltip.Portal>


### PR DESCRIPTION
Several anatomy snippets had drifted from the parts each docs page actually documents. This updates the affected `page.mdx` anatomy blocks so they better reflect the exported JSX parts and the popup composition patterns used elsewhere in the docs.

## Changes

- Keep `OTPField.Separator` in the OTP Field anatomy example without adding a second input.
- Move Select scroll arrows inside `Select.Popup` in the Select anatomy example.
- Add the missing popup viewport parts to the Tooltip and Preview Card anatomy examples.
- Nest checkbox and radio indicators in the Menu, Menubar, and Context Menu anatomy examples.
- Keep the Menu-based anatomy blocks aligned in ordering and spacing, with `SubmenuRoot` listed ahead of the other parent parts and `Viewport` kept as an optional standalone part.
