### PR TITLE
[combobox][docs] Fix TalkBack option wrappers in docs demos

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/demos/async/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/async/css-modules/index.tsx
@@ -89,10 +89,10 @@ export default function ExampleAsyncAutocomplete() {
             <Autocomplete.List>
               {(movie: Movie) => (
                 <Autocomplete.Item key={movie.id} className={styles.Item} value={movie}>
-                  <div className={styles.MovieItem}>
-                    <div className={styles.MovieName}>{movie.title}</div>
-                    <div className={styles.MovieYear}>{movie.year}</div>
-                  </div>
+                  <span className={styles.MovieItem}>
+                    <span className={styles.MovieName}>{movie.title}</span>
+                    <span className={styles.MovieYear}>{movie.year}</span>
+                  </span>
                 </Autocomplete.Item>
               )}
             </Autocomplete.List>

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/async/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/async/tailwind/index.tsx
@@ -105,10 +105,10 @@ export default function ExampleAsyncAutocomplete() {
                   className="flex cursor-default py-2 pr-8 pl-4 text-base leading-4 outline-hidden select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-gray-50 data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-2 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-gray-900"
                   value={movie}
                 >
-                  <div className="flex w-full flex-col gap-1">
-                    <div className="font-bold leading-5">{movie.title}</div>
-                    <div className="text-sm leading-4 opacity-80">{movie.year}</div>
-                  </div>
+                  <span className="flex w-full flex-col gap-1">
+                    <span className="font-bold leading-5">{movie.title}</span>
+                    <span className="text-sm leading-4 opacity-80">{movie.year}</span>
+                  </span>
                 </Autocomplete.Item>
               )}
             </Autocomplete.List>

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/fuzzy-matching/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/fuzzy-matching/css-modules/index.tsx
@@ -28,14 +28,16 @@ export default function ExampleFuzzyMatchingAutocomplete() {
                 <Autocomplete.Item key={item.title} value={item} className={styles.Item}>
                   <Autocomplete.Value>
                     {(value) => (
-                      <div className={styles.ItemContent}>
-                        <div className={styles.ItemHeader}>
-                          <div className={styles.ItemTitle}>{highlightText(item.title, value)}</div>
-                        </div>
-                        <div className={styles.ItemDescription}>
+                      <span className={styles.ItemContent}>
+                        <span className={styles.ItemHeader}>
+                          <span className={styles.ItemTitle}>
+                            {highlightText(item.title, value)}
+                          </span>
+                        </span>
+                        <span className={styles.ItemDescription}>
                           {highlightText(item.description, value)}
-                        </div>
-                      </div>
+                        </span>
+                      </span>
                     )}
                   </Autocomplete.Value>
                 </Autocomplete.Item>

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/fuzzy-matching/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/fuzzy-matching/tailwind/index.tsx
@@ -36,16 +36,16 @@ export default function ExampleFuzzyMatchingAutocomplete() {
                 >
                   <Autocomplete.Value>
                     {(value) => (
-                      <div className="flex w-full flex-col gap-1">
-                        <div className="flex items-center justify-between gap-3">
-                          <div className="flex-1 font-bold leading-5">
+                      <span className="flex w-full flex-col gap-1">
+                        <span className="flex items-center justify-between gap-3">
+                          <span className="flex-1 font-bold leading-5">
                             {highlightText(item.title, value)}
-                          </div>
-                        </div>
-                        <div className="text-sm leading-5 text-gray-600">
+                          </span>
+                        </span>
+                        <span className="text-sm leading-5 text-gray-600">
                           {highlightText(item.description, value)}
-                        </div>
-                      </div>
+                        </span>
+                      </span>
                     )}
                   </Autocomplete.Value>
                 </Autocomplete.Item>

--- a/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/css-modules/index.tsx
@@ -179,14 +179,14 @@ export default function ExampleAsyncMultipleCombobox() {
                   <Combobox.ItemIndicator className={styles.ItemIndicator}>
                     <CheckIcon className={styles.ItemIndicatorIcon} />
                   </Combobox.ItemIndicator>
-                  <div className={styles.ItemText}>
-                    <div className={styles.ItemTitle}>{user.name}</div>
-                    <div className={styles.ItemSubtitle}>
+                  <span className={styles.ItemText}>
+                    <span className={styles.ItemTitle}>{user.name}</span>
+                    <span className={styles.ItemSubtitle}>
                       <span className={styles.ItemUsername}>@{user.username}</span>
                       <span>{user.title}</span>
-                    </div>
-                    <div className={styles.ItemEmail}>{user.email}</div>
-                  </div>
+                    </span>
+                    <span className={styles.ItemEmail}>{user.email}</span>
+                  </span>
                 </Combobox.Item>
               )}
             </Combobox.List>

--- a/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/tailwind/index.tsx
@@ -200,14 +200,14 @@ export default function ExampleAsyncMultipleCombobox() {
                   <Combobox.ItemIndicator className="col-start-1 mt-1">
                     <CheckIcon className="size-3" />
                   </Combobox.ItemIndicator>
-                  <div className="col-start-2 flex flex-col gap-1">
-                    <div className="text-[0.95rem] font-bold">{user.name}</div>
-                    <div className="flex flex-wrap gap-2 text-[0.8125rem] text-gray-600">
+                  <span className="col-start-2 flex flex-col gap-1">
+                    <span className="text-[0.95rem] font-bold">{user.name}</span>
+                    <span className="flex flex-wrap gap-2 text-[0.8125rem] text-gray-600">
                       <span className="opacity-80">@{user.username}</span>
                       <span>{user.title}</span>
-                    </div>
-                    <div className="text-xs text-gray-500">{user.email}</div>
-                  </div>
+                    </span>
+                    <span className="text-xs text-gray-500">{user.email}</span>
+                  </span>
                 </Combobox.Item>
               )}
             </Combobox.List>

--- a/docs/src/app/(docs)/react/components/combobox/demos/async-single/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/async-single/css-modules/index.tsx
@@ -140,14 +140,14 @@ export default function ExampleAsyncSingleCombobox() {
                   <Combobox.ItemIndicator className={styles.ItemIndicator}>
                     <CheckIcon className={styles.ItemIndicatorIcon} />
                   </Combobox.ItemIndicator>
-                  <div className={styles.ItemText}>
-                    <div className={styles.ItemTitle}>{user.name}</div>
-                    <div className={styles.ItemSubtitle}>
+                  <span className={styles.ItemText}>
+                    <span className={styles.ItemTitle}>{user.name}</span>
+                    <span className={styles.ItemSubtitle}>
                       <span className={styles.ItemUsername}>@{user.username}</span>
                       <span>{user.title}</span>
-                    </div>
-                    <div className={styles.ItemEmail}>{user.email}</div>
-                  </div>
+                    </span>
+                    <span className={styles.ItemEmail}>{user.email}</span>
+                  </span>
                 </Combobox.Item>
               )}
             </Combobox.List>

--- a/docs/src/app/(docs)/react/components/combobox/demos/async-single/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/async-single/tailwind/index.tsx
@@ -166,14 +166,14 @@ export default function ExampleAsyncSingleCombobox() {
                   <Combobox.ItemIndicator className="col-start-1 mt-1">
                     <CheckIcon className="size-3" />
                   </Combobox.ItemIndicator>
-                  <div className="col-start-2 flex flex-col gap-1">
-                    <div className="text-[0.95rem] font-bold">{user.name}</div>
-                    <div className="flex flex-wrap gap-3 text-[0.8125rem] text-gray-600">
+                  <span className="col-start-2 flex flex-col gap-1">
+                    <span className="text-[0.95rem] font-bold">{user.name}</span>
+                    <span className="flex flex-wrap gap-3 text-[0.8125rem] text-gray-600">
                       <span className="opacity-80">@{user.username}</span>
                       <span>{user.title}</span>
-                    </div>
-                    <div className="text-xs opacity-80">{user.email}</div>
-                  </div>
+                    </span>
+                    <span className="text-xs opacity-80">{user.email}</span>
+                  </span>
                 </Combobox.Item>
               )}
             </Combobox.List>

--- a/docs/src/app/(docs)/react/components/combobox/demos/creatable/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/creatable/css-modules/index.tsx
@@ -173,14 +173,14 @@ export default function ExampleCreatableCombobox() {
                       <span className={styles.ItemIndicator}>
                         <PlusIcon className={styles.CreateIcon} />
                       </span>
-                      <div className={styles.ItemText}>Create "{item.creatable}"</div>
+                      <span className={styles.ItemText}>Create "{item.creatable}"</span>
                     </Combobox.Item>
                   ) : (
                     <Combobox.Item key={item.id} className={styles.Item} value={item}>
                       <Combobox.ItemIndicator className={styles.ItemIndicator}>
                         <CheckIcon className={styles.ItemIndicatorIcon} />
                       </Combobox.ItemIndicator>
-                      <div className={styles.ItemText}>{item.value}</div>
+                      <span className={styles.ItemText}>{item.value}</span>
                     </Combobox.Item>
                   )
                 }

--- a/docs/src/app/(docs)/react/components/combobox/demos/creatable/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/creatable/tailwind/index.tsx
@@ -178,7 +178,7 @@ export default function ExampleCreatableCombobox() {
                       <span className="col-start-1">
                         <PlusIcon className="size-3" />
                       </span>
-                      <div className="col-start-2">Create "{item.creatable}"</div>
+                      <span className="col-start-2">Create "{item.creatable}"</span>
                     </Combobox.Item>
                   ) : (
                     <Combobox.Item
@@ -189,7 +189,7 @@ export default function ExampleCreatableCombobox() {
                       <Combobox.ItemIndicator className="col-start-1">
                         <CheckIcon className="size-3" />
                       </Combobox.ItemIndicator>
-                      <div className="col-start-2">{item.value}</div>
+                      <span className="col-start-2">{item.value}</span>
                     </Combobox.Item>
                   )
                 }

--- a/docs/src/app/(docs)/react/components/combobox/demos/grouped/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/grouped/css-modules/index.tsx
@@ -40,7 +40,7 @@ export default function ExampleGroupedCombobox() {
                         <Combobox.ItemIndicator className={styles.ItemIndicator}>
                           <CheckIcon className={styles.ItemIndicatorIcon} />
                         </Combobox.ItemIndicator>
-                        <div className={styles.ItemText}>{item.label}</div>
+                        <span className={styles.ItemText}>{item.label}</span>
                       </Combobox.Item>
                     )}
                   </Combobox.Collection>

--- a/docs/src/app/(docs)/react/components/combobox/demos/grouped/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/grouped/tailwind/index.tsx
@@ -53,7 +53,7 @@ export default function ExampleGroupedCombobox() {
                         <Combobox.ItemIndicator className="col-start-1 flex items-center justify-center">
                           <CheckIcon className="size-3" />
                         </Combobox.ItemIndicator>
-                        <div className="col-start-2">{item.label}</div>
+                        <span className="col-start-2">{item.label}</span>
                       </Combobox.Item>
                     )}
                   </Combobox.Collection>

--- a/docs/src/app/(docs)/react/components/combobox/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/hero/css-modules/index.tsx
@@ -34,7 +34,7 @@ export default function ExampleCombobox() {
                   <Combobox.ItemIndicator className={styles.ItemIndicator}>
                     <CheckIcon className={styles.ItemIndicatorIcon} />
                   </Combobox.ItemIndicator>
-                  <div className={styles.ItemText}>{item.label}</div>
+                  <span className={styles.ItemText}>{item.label}</span>
                 </Combobox.Item>
               )}
             </Combobox.List>

--- a/docs/src/app/(docs)/react/components/combobox/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/hero/tailwind/index.tsx
@@ -47,7 +47,7 @@ export default function ExampleCombobox() {
                   <Combobox.ItemIndicator className="col-start-1">
                     <CheckIcon className="size-3" />
                   </Combobox.ItemIndicator>
-                  <div className="col-start-2">{item.label}</div>
+                  <span className="col-start-2">{item.label}</span>
                 </Combobox.Item>
               )}
             </Combobox.List>

--- a/docs/src/app/(docs)/react/components/combobox/demos/input-inside-popup/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/input-inside-popup/css-modules/index.tsx
@@ -31,7 +31,7 @@ export default function ExamplePopoverCombobox() {
                     <Combobox.ItemIndicator className={styles.ItemIndicator}>
                       <CheckIcon className={styles.ItemIndicatorIcon} />
                     </Combobox.ItemIndicator>
-                    <div className={styles.ItemText}>{country.label}</div>
+                    <span className={styles.ItemText}>{country.label}</span>
                   </Combobox.Item>
                 )}
               </Combobox.List>

--- a/docs/src/app/(docs)/react/components/combobox/demos/input-inside-popup/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/input-inside-popup/tailwind/index.tsx
@@ -42,7 +42,7 @@ export default function ExamplePopoverCombobox() {
                     <Combobox.ItemIndicator className="col-start-1">
                       <CheckIcon className="size-3" />
                     </Combobox.ItemIndicator>
-                    <div className="col-start-2">{country.label}</div>
+                    <span className="col-start-2">{country.label}</span>
                   </Combobox.Item>
                 )}
               </Combobox.List>

--- a/docs/src/app/(docs)/react/components/combobox/demos/multiple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/multiple/css-modules/index.tsx
@@ -56,7 +56,7 @@ export default function ExampleMultipleCombobox() {
                   <Combobox.ItemIndicator className={styles.ItemIndicator}>
                     <CheckIcon className={styles.ItemIndicatorIcon} />
                   </Combobox.ItemIndicator>
-                  <div className={styles.ItemText}>{language.value}</div>
+                  <span className={styles.ItemText}>{language.value}</span>
                 </Combobox.Item>
               )}
             </Combobox.List>

--- a/docs/src/app/(docs)/react/components/combobox/demos/multiple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/multiple/tailwind/index.tsx
@@ -61,7 +61,7 @@ export default function ExampleMultipleCombobox() {
                   <Combobox.ItemIndicator className="col-start-1">
                     <CheckIcon className="size-3" />
                   </Combobox.ItemIndicator>
-                  <div className="col-start-2">{language.value}</div>
+                  <span className="col-start-2">{language.value}</span>
                 </Combobox.Item>
               )}
             </Combobox.List>

--- a/docs/src/app/(docs)/react/components/combobox/demos/virtualized/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/virtualized/css-modules/index.tsx
@@ -129,7 +129,7 @@ function VirtualizedList({
               <Combobox.ItemIndicator className={styles.ItemIndicator}>
                 <CheckIcon className={styles.ItemIndicatorIcon} />
               </Combobox.ItemIndicator>
-              <div className={styles.ItemText}>{item.name}</div>
+              <span className={styles.ItemText}>{item.name}</span>
             </Combobox.Item>
           );
         })}

--- a/docs/src/app/(docs)/react/components/combobox/demos/virtualized/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/virtualized/tailwind/index.tsx
@@ -132,7 +132,7 @@ function VirtualizedList({
               <Combobox.ItemIndicator className="col-start-1">
                 <CheckIcon className="size-3" />
               </Combobox.ItemIndicator>
-              <div className="col-start-2">{item.name}</div>
+              <span className="col-start-2">{item.name}</span>
             </Combobox.Item>
           );
         })}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/hero/tailwind/index.tsx
@@ -66,7 +66,7 @@ function ExampleForm() {
                         <Combobox.ItemIndicator>
                           <Check className="size-4" />
                         </Combobox.ItemIndicator>
-                        <div className="col-start-2">{region}</div>
+                        <span className="col-start-2">{region}</span>
                       </Combobox.Item>
                     );
                   }}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/react-hook-form/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/react-hook-form/tailwind/index.tsx
@@ -116,7 +116,7 @@ function ReactHookForm() {
                             <Combobox.ItemIndicator>
                               <Check className="size-4" />
                             </Combobox.ItemIndicator>
-                            <div className="col-start-2">{region}</div>
+                            <span className="col-start-2">{region}</span>
                           </Combobox.Item>
                         );
                       }}

--- a/docs/src/app/(docs)/react/handbook/forms/demos/tanstack-form/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/tanstack-form/tailwind/index.tsx
@@ -151,7 +151,7 @@ function TanstackForm() {
                               <Combobox.ItemIndicator>
                                 <Check className="size-3" />
                               </Combobox.ItemIndicator>
-                              <div className="col-start-2">{region}</div>
+                              <span className="col-start-2">{region}</span>
                             </Combobox.Item>
                           );
                         }}


### PR DESCRIPTION
Fixes #4435

TalkBack breaks in the docs demos when an option renders block-level `div` wrappers inside `Combobox.Item` or `Autocomplete.Item`. This change replaces those wrappers with `span`s across the affected demos and handbook form examples while keeping the existing layouts intact.

## Changes

- Replace option-internal `div` wrappers with `span` wrappers in the affected combobox demos.
- Apply the same wrapper change to the affected autocomplete demos and handbook form demos.
- Preserve the existing grid and flex layout styling so the docs presentation stays the same.