### PR TITLE
[dialog][popover][tooltip][menu][preview]  Remove  dead create*EventDetails wrapper functions

### DIFF
--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useScrollLock } from '@base-ui/utils/useScrollLock';
 import {
   useDismiss,
@@ -29,21 +28,9 @@ export function useDialogRoot(params: UseDialogRootParameters): UseDialogRootRet
   useImplicitActiveTrigger(store);
   const { forceUnmount } = useOpenStateTransitions(open, store);
 
-  const createDialogEventDetails = useStableCallback((reason: DialogRoot.ChangeEventReason) => {
-    const details: DialogRoot.ChangeEventDetails =
-      createChangeEventDetails<DialogRoot.ChangeEventReason>(
-        reason,
-      ) as DialogRoot.ChangeEventDetails;
-    details.preventUnmountOnClose = () => {
-      store.set('preventUnmountingOnClose', true);
-    };
-
-    return details;
-  });
-
   const handleImperativeClose = React.useCallback(() => {
-    store.setOpen(false, createDialogEventDetails(REASONS.imperativeAction));
-  }, [store, createDialogEventDetails]);
+    store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction));
+  }, [store]);
 
   React.useImperativeHandle(
     actionsRef,

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -336,22 +336,9 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     },
   );
 
-  const createMenuEventDetails = React.useCallback(
-    (reason: MenuRoot.ChangeEventReason) => {
-      const details: MenuRoot.ChangeEventDetails =
-        createChangeEventDetails<MenuRoot.ChangeEventReason>(reason) as MenuRoot.ChangeEventDetails;
-      details.preventUnmountOnClose = () => {
-        store.set('preventUnmountingOnClose', true);
-      };
-
-      return details;
-    },
-    [store],
-  );
-
   const handleImperativeClose = React.useCallback(() => {
-    store.setOpen(false, createMenuEventDetails(REASONS.imperativeAction));
-  }, [store, createMenuEventDetails]);
+    store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction));
+  }, [store]);
 
   React.useImperativeHandle(
     actionsRef,

--- a/packages/react/src/popover/root/PopoverRoot.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.tsx
@@ -77,24 +77,9 @@ function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Pay
     }
   }, [store, open]);
 
-  const createPopoverEventDetails = React.useCallback(
-    (reason: PopoverRoot.ChangeEventReason) => {
-      const details: PopoverRoot.ChangeEventDetails =
-        createChangeEventDetails<PopoverRoot.ChangeEventReason>(
-          reason,
-        ) as PopoverRoot.ChangeEventDetails;
-      details.preventUnmountOnClose = () => {
-        store.set('preventUnmountingOnClose', true);
-      };
-
-      return details;
-    },
-    [store],
-  );
-
   const handleImperativeClose = React.useCallback(() => {
-    store.setOpen(false, createPopoverEventDetails(REASONS.imperativeAction));
-  }, [store, createPopoverEventDetails]);
+    store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction));
+  }, [store]);
 
   React.useImperativeHandle(
     props.actionsRef,

--- a/packages/react/src/preview-card/root/PreviewCardRoot.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.tsx
@@ -71,7 +71,7 @@ function PreviewCardRootComponent<Payload>(props: PreviewCardRoot.Props<Payload>
   }, [store, activeTriggerId, open]);
 
   const handleImperativeClose = React.useCallback(() => {
-    store.setOpen(false, createPreviewCardEventDetails(store, REASONS.imperativeAction));
+    store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction));
   }, [store]);
 
   React.useImperativeHandle(
@@ -117,20 +117,6 @@ export function PreviewCardRoot<Payload>(props: PreviewCardRoot.Props<Payload>) 
       <PreviewCardRootComponent {...props} />
     </FloatingTree>
   );
-}
-
-function createPreviewCardEventDetails<Payload>(
-  store: PreviewCardStore<Payload>,
-  reason: PreviewCardRoot.ChangeEventReason,
-) {
-  const details: PreviewCardRoot.ChangeEventDetails =
-    createChangeEventDetails<PreviewCardRoot.ChangeEventReason>(
-      reason,
-    ) as PreviewCardRoot.ChangeEventDetails;
-  details.preventUnmountOnClose = () => {
-    store.set('preventUnmountingOnClose', true);
-  };
-  return details;
 }
 
 export interface PreviewCardRootState {}

--- a/packages/react/src/tooltip/root/TooltipRoot.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.tsx
@@ -124,7 +124,7 @@ export const TooltipRoot = fastComponent(function TooltipRoot<Payload>(
   }, [store, activeTriggerId, open]);
 
   const handleImperativeClose = React.useCallback(() => {
-    store.setOpen(false, createTooltipEventDetails(store, REASONS.imperativeAction));
+    store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction));
   }, [store]);
 
   React.useImperativeHandle(
@@ -163,20 +163,6 @@ export const TooltipRoot = fastComponent(function TooltipRoot<Payload>(
     </TooltipRootContext.Provider>
   );
 });
-
-function createTooltipEventDetails<Payload>(
-  store: TooltipStore<Payload>,
-  reason: TooltipRoot.ChangeEventReason,
-) {
-  const details: TooltipRoot.ChangeEventDetails =
-    createChangeEventDetails<TooltipRoot.ChangeEventReason>(
-      reason,
-    ) as TooltipRoot.ChangeEventDetails;
-  details.preventUnmountOnClose = () => {
-    store.set('preventUnmountingOnClose', true);
-  };
-  return details;
-}
 
 export interface TooltipRootState {}
 


### PR DESCRIPTION
  - Remove 5 dead create*EventDetails wrapper functions across tooltip, popover, dialog, menu, and preview-card
  - Each wrapper pre-attached preventUnmountOnClose to the event details object, but every store.setOpen() unconditionally overwrites it
  before the details reach any consumer


  Each store's setOpen method accepts Omit<ChangeEventDetails, 'preventUnmountOnClose'> and always attaches its own preventUnmountOnClose
  closure before firing onOpenChange:

  // e.g. TooltipStore.ts:74–76, PopoverStore.ts:120–122, DialogStore.ts:75–77, etc.
  (eventDetails as ChangeEventDetails).preventUnmountOnClose = () => {
    this.set('preventUnmountingOnClose', true);
  };

  The wrappers were doing the same attachment beforehand, which was immediately overwritten — making them dead code. TooltipHandle.ts
  already called store.setOpen with plain createChangeEventDetails(...), confirming the wrappers were unnecessary.

  For popover, dialog, and menu, the wrappers were also wrapped in React.useCallback/useStableCallback, occupying extra memo slots and
  appearing in the dependency arrays of handleImperativeClose. Removing them simplifies the callback chains.