### PR TITLE
[dialog] Fix sibling Escape dismissal

### DIFF
--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -754,49 +754,6 @@ describe('<Dialog.Root />', () => {
       });
     });
 
-    it('dismisses sibling modal dialogs one by one on Escape from the topmost focus guard', async () => {
-      const { user } = await render(
-        <React.Fragment>
-          <TestDialog
-            rootProps={{ defaultOpen: true }}
-            popupProps={
-              { 'data-testid': 'level-1', children: 'First dialog' } as Dialog.Popup.Props
-            }
-            omitTrigger
-          />
-          <TestDialog
-            rootProps={{ defaultOpen: true }}
-            popupProps={
-              { 'data-testid': 'level-2', children: 'Second dialog' } as Dialog.Popup.Props
-            }
-            omitTrigger
-          />
-          <TestDialog
-            rootProps={{ defaultOpen: true }}
-            popupProps={
-              { 'data-testid': 'level-3', children: 'Third dialog' } as Dialog.Popup.Props
-            }
-            omitTrigger
-          />
-        </React.Fragment>,
-      );
-
-      const level3 = screen.getByTestId('level-3');
-      const beforeGuard = level3.previousElementSibling as HTMLElement;
-
-      act(() => {
-        beforeGuard.focus();
-      });
-
-      await user.keyboard('[Escape]');
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('level-3')).toBe(null);
-      });
-      expect(screen.queryByTestId('level-2')).not.toBe(null);
-      expect(screen.queryByTestId('level-1')).not.toBe(null);
-    });
-
     describe.skipIf(isJSDOM)('nested popups', () => {
       it('should not dismiss the dialog when dismissing outside a nested modal menu', async () => {
         const { user } = await render(

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -689,6 +689,114 @@ describe('<Dialog.Root />', () => {
       });
     });
 
+    it('dismisses sibling modal dialogs one by one on Escape', async () => {
+      await render(
+        <React.Fragment>
+          <TestDialog
+            rootProps={{ defaultOpen: true }}
+            popupProps={
+              { 'data-testid': 'level-1', children: 'First dialog' } as Dialog.Popup.Props
+            }
+            omitTrigger
+          />
+          <TestDialog
+            rootProps={{ defaultOpen: true }}
+            popupProps={
+              { 'data-testid': 'level-2', children: 'Second dialog' } as Dialog.Popup.Props
+            }
+            omitTrigger
+          />
+          <TestDialog
+            rootProps={{ defaultOpen: true }}
+            popupProps={
+              { 'data-testid': 'level-3', children: 'Third dialog' } as Dialog.Popup.Props
+            }
+            omitTrigger
+          />
+        </React.Fragment>,
+      );
+
+      expect(screen.queryByTestId('level-1')).not.toBe(null);
+      expect(screen.queryByTestId('level-2')).not.toBe(null);
+      expect(screen.queryByTestId('level-3')).not.toBe(null);
+
+      const level3 = screen.getByTestId('level-3');
+      act(() => {
+        level3.focus();
+      });
+      fireEvent.keyDown(level3, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('level-3')).toBe(null);
+      });
+      expect(screen.queryByTestId('level-2')).not.toBe(null);
+      expect(screen.queryByTestId('level-1')).not.toBe(null);
+
+      const level2 = screen.getByTestId('level-2');
+      act(() => {
+        level2.focus();
+      });
+      fireEvent.keyDown(level2, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('level-2')).toBe(null);
+      });
+      expect(screen.queryByTestId('level-1')).not.toBe(null);
+
+      const level1 = screen.getByTestId('level-1');
+      act(() => {
+        level1.focus();
+      });
+      fireEvent.keyDown(level1, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('level-1')).toBe(null);
+      });
+    });
+
+    it('dismisses sibling modal dialogs one by one on Escape from the topmost focus guard', async () => {
+      const { user } = await render(
+        <React.Fragment>
+          <TestDialog
+            rootProps={{ defaultOpen: true }}
+            popupProps={
+              { 'data-testid': 'level-1', children: 'First dialog' } as Dialog.Popup.Props
+            }
+            omitTrigger
+          />
+          <TestDialog
+            rootProps={{ defaultOpen: true }}
+            popupProps={
+              { 'data-testid': 'level-2', children: 'Second dialog' } as Dialog.Popup.Props
+            }
+            omitTrigger
+          />
+          <TestDialog
+            rootProps={{ defaultOpen: true }}
+            popupProps={
+              { 'data-testid': 'level-3', children: 'Third dialog' } as Dialog.Popup.Props
+            }
+            omitTrigger
+          />
+        </React.Fragment>,
+      );
+
+      const level3 = screen.getByTestId('level-3');
+      const beforeGuard = level3.previousElementSibling as HTMLElement;
+
+      act(() => {
+        beforeGuard.focus();
+      });
+
+      await user.keyboard('[Escape]');
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('level-3')).toBe(null);
+      });
+      expect(screen.queryByTestId('level-2')).not.toBe(null);
+      expect(screen.queryByTestId('level-1')).not.toBe(null);
+    });
+
     describe.skipIf(isJSDOM)('nested popups', () => {
       it('should not dismiss the dialog when dismissing outside a nested modal menu', async () => {
         const { user } = await render(

--- a/packages/react/src/floating-ui-react/hooks/useDismiss.ts
+++ b/packages/react/src/floating-ui-react/hooks/useDismiss.ts
@@ -28,6 +28,7 @@ import { REASONS } from '../../internals/reasons';
 import { createAttribute } from '../utils/createAttribute';
 
 type PressType = 'intentional' | 'sloppy';
+
 const bubbleHandlerKeys = {
   intentional: 'onClick',
   sloppy: 'onPointerDown',
@@ -441,8 +442,7 @@ export function useDismiss(
         }
       }
 
-      const eventDetails = createChangeEventDetails(REASONS.outsidePress, event);
-      store.setOpen(false, eventDetails);
+      store.setOpen(false, createChangeEventDetails(REASONS.outsidePress, event));
       clearInsideReactTree();
     }
 

--- a/packages/react/src/floating-ui-react/hooks/useDismiss.ts
+++ b/packages/react/src/floating-ui-react/hooks/useDismiss.ts
@@ -28,7 +28,6 @@ import { REASONS } from '../../internals/reasons';
 import { createAttribute } from '../utils/createAttribute';
 
 type PressType = 'intentional' | 'sloppy';
-
 const bubbleHandlerKeys = {
   intentional: 'onClick',
   sloppy: 'onPointerDown',
@@ -197,6 +196,7 @@ export function useDismiss(
         return;
       }
 
+      const native = isReactEvent(event) ? event.nativeEvent : event;
       const nodeId = dataRef.current.floatingContext?.nodeId;
 
       const children = tree ? getNodeChildren(tree.nodesRef.current, nodeId) : [];
@@ -217,12 +217,12 @@ export function useDismiss(
         }
       }
 
-      const native = isReactEvent(event) ? event.nativeEvent : event;
       const eventDetails = createChangeEventDetails(REASONS.escapeKey, native);
 
       store.setOpen(false, eventDetails);
 
       if (!escapeKeyBubbles && !eventDetails.isPropagationAllowed) {
+        native.stopImmediatePropagation();
         event.stopPropagation();
       }
     },
@@ -441,7 +441,8 @@ export function useDismiss(
         }
       }
 
-      store.setOpen(false, createChangeEventDetails(REASONS.outsidePress, event));
+      const eventDetails = createChangeEventDetails(REASONS.outsidePress, event);
+      store.setOpen(false, eventDetails);
       clearInsideReactTree();
     }
 

--- a/packages/react/src/floating-ui-react/hooks/useDismiss.ts
+++ b/packages/react/src/floating-ui-react/hooks/useDismiss.ts
@@ -197,7 +197,6 @@ export function useDismiss(
         return;
       }
 
-      const native = isReactEvent(event) ? event.nativeEvent : event;
       const nodeId = dataRef.current.floatingContext?.nodeId;
 
       const children = tree ? getNodeChildren(tree.nodesRef.current, nodeId) : [];
@@ -218,6 +217,7 @@ export function useDismiss(
         }
       }
 
+      const native = isReactEvent(event) ? event.nativeEvent : event;
       const eventDetails = createChangeEventDetails(REASONS.escapeKey, native);
 
       store.setOpen(false, eventDetails);


### PR DESCRIPTION
Fixes #4583

Escape could close more than one sibling modal dialog because later dismiss listeners could reuse the same non-bubbling key event after the topmost dialog closed. This change stops propagation once the topmost dialog handles that Escape, which keeps the fix local and avoids adding a dialog stack.

This is the simplest fix for the reported bug, but it is intentionally scoped to the normal modal path where focus is inside the active dialog when Escape is pressed. The existing outside-focus document-listener path is unchanged.

## Changes

- Prevent later sibling dismiss listeners from handling the same non-bubbling Escape after the topmost dialog closes.
- Add regression coverage for Escape from the topmost popup so sibling modal dialogs close one by one.
