### PR TITLE
[experiments] Remove Tailwind classes

### DIFF
--- a/docs/src/app/(private)/experiments/drawer/drawer-controlled-opening.module.css
+++ b/docs/src/app/(private)/experiments/drawer/drawer-controlled-opening.module.css
@@ -1,0 +1,172 @@
+.Row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.5rem;
+  padding: 0 0.875rem;
+  margin: 0;
+  outline: 0;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 0.375rem;
+  background-color: var(--color-gray-50);
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5rem;
+  color: var(--color-gray-900);
+  user-select: none;
+
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--color-gray-100);
+    }
+  }
+
+  &:active {
+    background-color: var(--color-gray-100);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: -1px;
+  }
+}
+
+.Backdrop {
+  --backdrop-opacity: 0.2;
+  --bleed: 3rem;
+  position: fixed;
+  min-height: 100dvh;
+  inset: 0;
+  background-color: black;
+  opacity: calc(var(--backdrop-opacity) * (1 - var(--drawer-swipe-progress)));
+  transition-property: opacity;
+  transition-duration: 450ms;
+  transition-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+
+  @media (prefers-color-scheme: dark) {
+    --backdrop-opacity: 0.7;
+  }
+
+  @supports (-webkit-touch-callout: none) {
+    position: absolute;
+  }
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+  }
+
+  &[data-swiping] {
+    transition-duration: 0ms;
+  }
+
+  &[data-ending-style] {
+    transition-duration: calc(var(--drawer-swipe-strength) * 400ms);
+  }
+}
+
+.Viewport {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.Popup {
+  --bleed: 3rem;
+  box-sizing: border-box;
+  width: 100%;
+  max-height: calc(80vh + var(--bleed));
+  margin-bottom: calc(-1 * var(--bleed));
+  padding: 1rem 1.5rem 1.5rem;
+  padding-bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px) + var(--bleed));
+  border-radius: 1rem 1rem 0 0;
+  outline: 1px solid var(--color-gray-200);
+  background-color: var(--color-gray-50);
+  color: var(--color-gray-900);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  touch-action: auto;
+  transition-property: transform;
+  transition-duration: 450ms;
+  transition-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+  transform: translateY(var(--drawer-swipe-movement-y));
+
+  &[data-swiping] {
+    user-select: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    outline: 1px solid var(--color-gray-300);
+  }
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    transform: translateY(calc(100% - 3rem));
+  }
+
+  &[data-ending-style] {
+    transition-duration: calc(var(--drawer-swipe-strength) * 400ms);
+  }
+}
+
+.Handle {
+  width: 3rem;
+  height: 0.25rem;
+  margin: 0 auto 1rem;
+  border-radius: 9999px;
+  background-color: var(--color-gray-300);
+}
+
+.Content {
+  width: 100%;
+  max-width: 32rem;
+  margin: 0 auto;
+}
+
+.CheckboxLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.CheckboxLabelCentered {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+}
+
+.Title {
+  margin: 0 0 0.25rem;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  font-weight: 500;
+  text-align: center;
+}
+
+.Description {
+  margin: 0 0 1.5rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: var(--color-gray-600);
+  text-align: center;
+}
+
+.Actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}

--- a/docs/src/app/(private)/experiments/drawer/drawer-controlled-opening.tsx
+++ b/docs/src/app/(private)/experiments/drawer/drawer-controlled-opening.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import { Drawer } from '@base-ui/react/drawer';
+import styles from './drawer-controlled-opening.module.css';
 
 export default function ControlledOpening() {
   const [open, setOpen] = React.useState(false);
@@ -15,11 +16,9 @@ export default function ControlledOpening() {
         setOpen(nextOpen);
       }}
     >
-      <div className="flex items-center gap-4">
-        <Drawer.Trigger className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-          Open bottom drawer
-        </Drawer.Trigger>
-        <label className="flex items-center gap-2 text-sm">
+      <div className={styles.Row}>
+        <Drawer.Trigger className={styles.Button}>Open bottom drawer</Drawer.Trigger>
+        <label className={styles.CheckboxLabel}>
           <input
             type="checkbox"
             checked={locked}
@@ -29,23 +28,19 @@ export default function ControlledOpening() {
         </label>
       </div>
       <Drawer.Portal>
-        <Drawer.Backdrop className="[--backdrop-opacity:0.2] [--bleed:3rem] dark:[--backdrop-opacity:0.7] fixed inset-0 min-h-dvh bg-black opacity-[calc(var(--backdrop-opacity)*(1-var(--drawer-swipe-progress)))] transition-opacity duration-450 ease-[cubic-bezier(0.32,0.72,0,1)] data-swiping:duration-0 data-ending-style:opacity-0 data-starting-style:opacity-0 data-ending-style:duration-[calc(var(--drawer-swipe-strength)*400ms)] supports-[-webkit-touch-callout:none]:absolute" />
-        <Drawer.Viewport className="fixed inset-0 flex items-end justify-center">
-          <Drawer.Popup className="-mb-12 w-full max-h-[calc(80vh+3rem)] rounded-t-2xl bg-gray-50 px-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px)+3rem)] pt-4 text-gray-900 outline outline-gray-200 overflow-y-auto overscroll-contain touch-auto transform-[translateY(var(--drawer-swipe-movement-y))] transition-transform duration-450 ease-[cubic-bezier(0.32,0.72,0,1)] data-swiping:select-none data-ending-style:transform-[translateY(calc(100%-3rem))] data-starting-style:transform-[translateY(calc(100%-3rem))] data-ending-style:duration-[calc(var(--drawer-swipe-strength)*400ms)] dark:outline-gray-300">
-            <div className="w-12 h-1 mx-auto mb-4 rounded-full bg-gray-300" />
-            <Drawer.Content className="mx-auto w-full max-w-lg">
-              <Drawer.Title className="mb-1 text-lg font-medium text-center">
-                Notifications
-              </Drawer.Title>
-              <Drawer.Description className="mb-6 text-base text-gray-600 text-center">
+        <Drawer.Backdrop className={styles.Backdrop} />
+        <Drawer.Viewport className={styles.Viewport}>
+          <Drawer.Popup className={styles.Popup}>
+            <div className={styles.Handle} />
+            <Drawer.Content className={styles.Content}>
+              <Drawer.Title className={styles.Title}>Notifications</Drawer.Title>
+              <Drawer.Description className={styles.Description}>
                 You are all caught up. Good job!
               </Drawer.Description>
-              <div className="flex justify-center gap-4">
-                <Drawer.Close className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-medium text-gray-900 select-none hover:bg-gray-100 focus-visible:outline focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100">
-                  Close
-                </Drawer.Close>
+              <div className={styles.Actions}>
+                <Drawer.Close className={styles.Button}>Close</Drawer.Close>
               </div>
-              <label className="flex items-center justify-center gap-2 mt-4 text-sm">
+              <label className={styles.CheckboxLabelCentered}>
                 <input
                   type="checkbox"
                   checked={locked}

--- a/docs/src/app/(private)/experiments/drawer/touch-ignore.module.css
+++ b/docs/src/app/(private)/experiments/drawer/touch-ignore.module.css
@@ -1,0 +1,337 @@
+.Root {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem;
+  color: var(--color-gray-900);
+}
+
+.Header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.Title {
+  margin: 0;
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+  letter-spacing: -0.025em;
+  font-weight: 600;
+}
+
+.Lead {
+  max-width: 42rem;
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: var(--color-gray-600);
+}
+
+.PanelGrid {
+  display: grid;
+  gap: 1rem;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 1rem;
+  background: white;
+  padding: 1.25rem;
+  box-shadow: 0 1px 2px rgb(15 23 42 / 0.06);
+}
+
+@media (min-width: 48rem) {
+  .PanelGrid {
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
+  }
+}
+
+.InstructionsPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+  color: var(--color-gray-700);
+}
+
+.PanelTitle {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 600;
+  color: var(--color-gray-900);
+}
+
+.InstructionsList {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.InstructionsList li + li {
+  margin-top: 0.5rem;
+}
+
+.EventsPanel {
+  border-radius: 0.75rem;
+  background: rgb(2 6 23);
+  padding: 1rem;
+  font-size: 0.875rem;
+  color: rgb(241 245 249);
+}
+
+.EventsTitle {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 600;
+}
+
+.CounterList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.EventLogSection {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgb(255 255 255 / 0.1);
+}
+
+.EventLogHeading {
+  margin-bottom: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgb(148 163 184);
+}
+
+.EventList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: rgb(203 213 225);
+}
+
+.TriggerButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  height: 2.75rem;
+  padding: 0 1rem;
+  border: 0;
+  border-radius: 0.75rem;
+  background: rgb(15 23 42);
+  color: white;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition-property:
+    color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow,
+    transform, translate, scale, rotate, filter, backdrop-filter;
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@media (hover: hover) {
+  .TriggerButton:hover {
+    background: rgb(51 65 85);
+  }
+
+  .CloseButton:hover {
+    background: var(--color-gray-50);
+  }
+}
+
+.TriggerButton:focus-visible,
+.CloseButton:focus-visible {
+  outline: 2px solid var(--color-blue);
+  outline-offset: 2px;
+}
+
+.Backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgb(2 6 23 / 0.3);
+  transition-property: opacity;
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+  }
+}
+
+.Viewport {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.Popup {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 42rem;
+  max-height: 85vh;
+  padding-right: 1.5rem;
+  padding-left: 1.5rem;
+  padding-top: 1rem;
+  padding-bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));
+  border-radius: 1.5rem 1.5rem 0 0;
+  background: white;
+  color: var(--color-gray-900);
+  box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+  transition-property: transform;
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  outline: 1px solid var(--color-gray-200);
+
+  &[data-swiping] {
+    user-select: none;
+  }
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    transform: translateY(100%);
+  }
+}
+
+.Handle {
+  width: 3rem;
+  height: 0.375rem;
+  margin: 0 auto 1rem;
+  border-radius: 9999px;
+  background: var(--color-gray-300);
+}
+
+.DrawerContent {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-bottom: 0.5rem;
+}
+
+.DrawerTitle {
+  margin: 0;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  font-weight: 600;
+}
+
+.DrawerDescription {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: var(--color-gray-600);
+}
+
+.TileGrid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.Tile {
+  padding: 1rem;
+  border-radius: 1rem;
+  text-align: left;
+}
+
+.TileAmber {
+  border: 1px solid rgb(252 211 77);
+  background: rgb(255 251 235);
+}
+
+.TileEmerald {
+  border: 1px solid rgb(110 231 183);
+  background: rgb(236 253 245);
+}
+
+.TileSky {
+  border: 1px solid rgb(125 211 252);
+  background: rgb(240 249 255);
+}
+
+.TileTitle {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.TileTitleAmber {
+  color: rgb(120 53 15);
+}
+
+.TileTitleEmerald {
+  color: rgb(6 78 59);
+}
+
+.TileTitleSky {
+  color: rgb(12 74 110);
+}
+
+.TileDescription {
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.TileDescriptionAmber {
+  color: rgb(146 64 14);
+}
+
+.TileDescriptionEmerald {
+  color: rgb(6 95 70);
+}
+
+.TileDescriptionSky {
+  color: rgb(7 89 133);
+}
+
+.Actions {
+  display: flex;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+}
+
+.CloseButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.5rem;
+  padding: 0 0.875rem;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 0.5rem;
+  background: transparent;
+  color: var(--color-gray-900);
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition-property:
+    color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow,
+    transform, translate, scale, rotate, filter, backdrop-filter;
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.CounterRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-radius: 0.5rem;
+  background: rgb(255 255 255 / 0.05);
+  padding: 0.5rem 0.75rem;
+}
+
+.CounterValue {
+  font-family: monospace;
+  font-size: 1rem;
+  color: white;
+}

--- a/docs/src/app/(private)/experiments/drawer/touch-ignore.tsx
+++ b/docs/src/app/(private)/experiments/drawer/touch-ignore.tsx
@@ -1,6 +1,8 @@
 'use client';
 import * as React from 'react';
+import clsx from 'clsx';
 import { Drawer } from '@base-ui/react/drawer';
+import styles from './touch-ignore.module.css';
 
 type EventName = 'plain div click' | 'ignored div click' | 'native button click' | 'drawer closed';
 
@@ -15,20 +17,20 @@ export default function DrawerTouchIgnoreExperiment() {
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-10 text-slate-900">
-      <div className="space-y-3">
-        <h1 className="text-3xl font-semibold tracking-tight">Drawer touch ignore experiment</h1>
-        <p className="max-w-2xl text-sm leading-6 text-slate-600">
+    <div className={styles.Root}>
+      <div className={styles.Header}>
+        <h1 className={styles.Title}>Drawer touch ignore experiment</h1>
+        <p className={styles.Lead}>
           Use this to compare touch behavior inside <code>Drawer.Content</code>. The plain div
           should still participate in swipe-to-dismiss, while the explicit{' '}
           <code>data-base-ui-swipe-ignore</code> div should preserve taps.
         </p>
       </div>
 
-      <div className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm md:grid-cols-[1.2fr_0.8fr]">
-        <div className="space-y-3 text-sm text-slate-700">
-          <h2 className="text-base font-semibold text-slate-900">What to test</h2>
-          <ol className="list-inside list-decimal space-y-2">
+      <div className={styles.PanelGrid}>
+        <div className={styles.InstructionsPanel}>
+          <h2 className={styles.PanelTitle}>What to test</h2>
+          <ol className={styles.InstructionsList}>
             <li>Tap the plain div on a touch device. It should still be part of swipe handling.</li>
             <li>
               Tap the <code>data-base-ui-swipe-ignore</code> div. Its click counter should
@@ -39,18 +41,16 @@ export default function DrawerTouchIgnoreExperiment() {
           </ol>
         </div>
 
-        <div className="rounded-xl bg-slate-950 p-4 text-sm text-slate-100">
-          <h2 className="mb-3 text-base font-semibold">Latest events</h2>
-          <div className="space-y-2">
+        <div className={styles.EventsPanel}>
+          <h2 className={styles.EventsTitle}>Latest events</h2>
+          <div className={styles.CounterList}>
             <CounterRow label="Plain div clicks" value={plainDivClicks} />
             <CounterRow label="Ignored div clicks" value={ignoredDivClicks} />
             <CounterRow label="Native button clicks" value={buttonClicks} />
           </div>
-          <div className="mt-4 border-t border-white/10 pt-4">
-            <div className="mb-2 text-xs font-medium uppercase tracking-[0.2em] text-slate-400">
-              Event log
-            </div>
-            <ul className="space-y-1 text-sm text-slate-300">
+          <div className={styles.EventLogSection}>
+            <div className={styles.EventLogHeading}>Event log</div>
+            <ul className={styles.EventList}>
               {events.length === 0 ? <li>No events yet.</li> : null}
               {events.map((eventName, index) => (
                 <li key={`${eventName}-${index}`}>{eventName}</li>
@@ -67,35 +67,33 @@ export default function DrawerTouchIgnoreExperiment() {
           }
         }}
       >
-        <Drawer.Trigger className="inline-flex h-11 w-fit items-center justify-center rounded-xl bg-slate-900 px-4 text-sm font-medium text-white transition hover:bg-slate-700">
-          Open touch test drawer
-        </Drawer.Trigger>
+        <Drawer.Trigger className={styles.TriggerButton}>Open touch test drawer</Drawer.Trigger>
         <Drawer.Portal>
-          <Drawer.Backdrop className="fixed inset-0 bg-slate-950/30 transition-opacity data-starting-style:opacity-0 data-ending-style:opacity-0" />
-          <Drawer.Viewport className="fixed inset-0 flex items-end justify-center">
-            <Drawer.Popup className="flex w-full max-w-2xl max-h-[85vh] flex-col rounded-t-3xl bg-white px-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] pt-4 text-slate-900 shadow-2xl outline outline-1 outline-slate-200 transition-transform data-swiping:select-none data-starting-style:translate-y-full data-ending-style:translate-y-full">
-              <div className="mx-auto mb-4 h-1.5 w-12 rounded-full bg-slate-300" />
-              <Drawer.Content className="space-y-4 overflow-y-auto overscroll-contain pb-2">
-                <Drawer.Title className="text-lg font-semibold">Touch behavior test</Drawer.Title>
-                <Drawer.Description className="text-sm leading-6 text-slate-600">
+          <Drawer.Backdrop className={styles.Backdrop} />
+          <Drawer.Viewport className={styles.Viewport}>
+            <Drawer.Popup className={styles.Popup}>
+              <div className={styles.Handle} />
+              <Drawer.Content className={styles.DrawerContent}>
+                <Drawer.Title className={styles.DrawerTitle}>Touch behavior test</Drawer.Title>
+                <Drawer.Description className={styles.DrawerDescription}>
                   The tiles below intentionally use different interaction models so you can verify
                   the drawer bugfix on a real touch device or emulator.
                 </Drawer.Description>
 
-                <div className="grid gap-3">
+                <div className={styles.TileGrid}>
                   {/* Intentional non-interactive div to reproduce the touch click behavior. */}
                   {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
                   <div
-                    className="rounded-2xl border border-amber-300 bg-amber-50 p-4 text-left"
+                    className={clsx(styles.Tile, styles.TileAmber)}
                     onClick={() => {
                       setPlainDivClicks((value) => value + 1);
                       recordEvent('plain div click');
                     }}
                   >
-                    <div className="text-sm font-semibold text-amber-950">
+                    <div className={clsx(styles.TileTitle, styles.TileTitleAmber)}>
                       Plain div inside Drawer.Content
                     </div>
-                    <div className="mt-1 text-sm text-amber-800">
+                    <div className={clsx(styles.TileDescription, styles.TileDescriptionAmber)}>
                       On touch, this area should still participate in swipe-to-dismiss.
                     </div>
                   </div>
@@ -104,39 +102,37 @@ export default function DrawerTouchIgnoreExperiment() {
                   {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
                   <div
                     data-base-ui-swipe-ignore
-                    className="rounded-2xl border border-emerald-300 bg-emerald-50 p-4 text-left"
+                    className={clsx(styles.Tile, styles.TileEmerald)}
                     onClick={() => {
                       setIgnoredDivClicks((value) => value + 1);
                       recordEvent('ignored div click');
                     }}
                   >
-                    <div className="text-sm font-semibold text-emerald-950">
+                    <div className={clsx(styles.TileTitle, styles.TileTitleEmerald)}>
                       Div with data-base-ui-swipe-ignore
                     </div>
-                    <div className="mt-1 text-sm text-emerald-800">
+                    <div className={clsx(styles.TileDescription, styles.TileDescriptionEmerald)}>
                       Tapping here should preserve the click even on touch.
                     </div>
                   </div>
 
                   <button
                     type="button"
-                    className="rounded-2xl border border-sky-300 bg-sky-50 p-4 text-left"
+                    className={clsx(styles.Tile, styles.TileSky)}
                     onClick={() => {
                       setButtonClicks((value) => value + 1);
                       recordEvent('native button click');
                     }}
                   >
-                    <div className="text-sm font-semibold text-sky-950">Native button</div>
-                    <div className="mt-1 text-sm text-sky-800">
+                    <div className={clsx(styles.TileTitle, styles.TileTitleSky)}>Native button</div>
+                    <div className={clsx(styles.TileDescription, styles.TileDescriptionSky)}>
                       Control case to compare against the custom div targets.
                     </div>
                   </button>
                 </div>
 
-                <div className="flex gap-3 pt-2">
-                  <Drawer.Close className="inline-flex h-10 items-center justify-center rounded-lg border border-slate-200 px-3.5 text-sm font-medium text-slate-900 transition hover:bg-slate-50">
-                    Close
-                  </Drawer.Close>
+                <div className={styles.Actions}>
+                  <Drawer.Close className={styles.CloseButton}>Close</Drawer.Close>
                 </div>
               </Drawer.Content>
             </Drawer.Popup>
@@ -151,9 +147,9 @@ function CounterRow(props: { label: string; value: number }) {
   const { label, value } = props;
 
   return (
-    <div className="flex items-center justify-between gap-4 rounded-lg bg-white/5 px-3 py-2">
+    <div className={styles.CounterRow}>
       <span>{label}</span>
-      <span className="font-mono text-base text-white">{value}</span>
+      <span className={styles.CounterValue}>{value}</span>
     </div>
   );
 }


### PR DESCRIPTION
We don't use Tailwind classes in experiments anymore. The two modified experiments in this PR were broken in master because `(private)/experiments` is not a source taken into account by our Tailwind setup.

Preview:
- https://deploy-preview-4617--base-ui.netlify.app/experiments/drawer/drawer-controlled-opening
- https://deploy-preview-4617--base-ui.netlify.app/experiments/drawer/touch-ignore