### PR TITLE
[internal] Use clean Bluesky URL

### DIFF
--- a/docs/src/app/(website)/layout.tsx
+++ b/docs/src/app/(website)/layout.tsx
@@ -106,7 +106,7 @@ export default function Layout({ children }: React.PropsWithChildren) {
                 </Link>
                 <Link
                   className="Text sz-1"
-                  href="https://bsky.app/profile/did:plc:nwr6peuxqzdzlbi72qr5kldc"
+                  href="https://bsky.app/profile/base-ui.com"
                   rel="noopener noreferrer"
                 >
                   Bluesky

--- a/docs/src/app/(website)/page.tsx
+++ b/docs/src/app/(website)/page.tsx
@@ -44,7 +44,7 @@ export default function Homepage() {
               'https://x.com/base_ui',
               'https://www.npmjs.com/package/@base-ui/react',
               'https://discord.com/invite/g6C3hUtuxz',
-              'https://bsky.app/profile/did:plc:nwr6peuxqzdzlbi72qr5kldc',
+              'https://bsky.app/profile/base-ui.com',
             ],
           }),
         }}


### PR DESCRIPTION
We already have the clean one used https://github.com/search?q=repo%3Amui%2Fbase-ui%20https%3A%2F%2Fbsky.app%2Fprofile%2Fbase-ui.com&type=code, no reason to have something else here (the account ID).