### PR TITLE
[textarea] Implement Textarea component with auto-resize

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,6 +63,7 @@
     "./slider": "./src/slider/index.ts",
     "./switch": "./src/switch/index.ts",
     "./tabs": "./src/tabs/index.ts",
+    "./textarea": "./src/textarea/index.ts",
     "./toast": "./src/toast/index.ts",
     "./toggle": "./src/toggle/index.ts",
     "./toggle-group": "./src/toggle-group/index.ts",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -34,6 +34,7 @@ export * from './separator';
 export * from './slider';
 export * from './switch';
 export * from './tabs';
+export * from './textarea';
 export * from './toast';
 export * from './toggle';
 export * from './toggle-group';

--- a/packages/react/src/textarea/character-count/TextareaCharacterCount.test.tsx
+++ b/packages/react/src/textarea/character-count/TextareaCharacterCount.test.tsx
@@ -1,0 +1,77 @@
+import { expect } from 'vitest';
+import { screen } from '@mui/internal-test-utils';
+import { Textarea } from '@base-ui/react/textarea';
+import { createRenderer, describeConformance } from '#test-utils';
+
+describe('<Textarea.CharacterCount />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Textarea.CharacterCount />, () => ({
+    refInstanceof: window.HTMLSpanElement,
+    render,
+  }));
+
+  it('renders a span element', async () => {
+    await render(<Textarea.CharacterCount data-testid="count" />);
+    expect(screen.getByTestId('count').tagName).toBe('SPAN');
+  });
+
+  it('displays "0" when no value or maxLength', async () => {
+    await render(<Textarea.CharacterCount data-testid="count" />);
+    expect(screen.getByTestId('count')).toHaveTextContent('0');
+  });
+
+  it('displays "0/100" with maxLength', async () => {
+    await render(<Textarea.CharacterCount maxLength={100} data-testid="count" />);
+    expect(screen.getByTestId('count')).toHaveTextContent('0/100');
+  });
+
+  it('displays count from value', async () => {
+    await render(
+      <Textarea.CharacterCount value="hello" maxLength={100} data-testid="count" />,
+    );
+    expect(screen.getByTestId('count')).toHaveTextContent('5/100');
+  });
+
+  it('updates when value prop changes', async () => {
+    const { rerender } = await render(
+      <Textarea.CharacterCount value="hi" maxLength={100} data-testid="count" />,
+    );
+    expect(screen.getByTestId('count')).toHaveTextContent('2/100');
+
+    await rerender(
+      <Textarea.CharacterCount value="hello world" maxLength={100} data-testid="count" />,
+    );
+    expect(screen.getByTestId('count')).toHaveTextContent('11/100');
+  });
+
+  it('sets data-approaching when above 80% of maxLength', async () => {
+    await render(
+      <Textarea.CharacterCount value={'a'.repeat(85)} maxLength={100} data-testid="count" />,
+    );
+    expect(screen.getByTestId('count')).toHaveAttribute('data-approaching', '');
+  });
+
+  it('does not set data-approaching below 80% of maxLength', async () => {
+    await render(
+      <Textarea.CharacterCount value={'a'.repeat(50)} maxLength={100} data-testid="count" />,
+    );
+    expect(screen.getByTestId('count')).not.toHaveAttribute('data-approaching');
+  });
+
+  it('supports children render function', async () => {
+    await render(
+      <Textarea.CharacterCount value="hello" maxLength={100} data-testid="count">
+        {({ count, maxLength: max }) => `${count} of ${max} chars`}
+      </Textarea.CharacterCount>,
+    );
+    expect(screen.getByTestId('count')).toHaveTextContent('5 of 100 chars');
+  });
+
+  it('displays count without maxLength', async () => {
+    await render(
+      <Textarea.CharacterCount value="hello world" data-testid="count" />,
+    );
+    expect(screen.getByTestId('count')).toHaveTextContent('11');
+  });
+});

--- a/packages/react/src/textarea/character-count/TextareaCharacterCount.tsx
+++ b/packages/react/src/textarea/character-count/TextareaCharacterCount.tsx
@@ -1,0 +1,87 @@
+'use client';
+import * as React from 'react';
+import type { BaseUIComponentProps } from '../../internals/types';
+import { useRenderElement } from '../../internals/useRenderElement';
+import { TextareaCharacterCountDataAttributes } from './TextareaCharacterCountDataAttributes';
+
+const APPROACHING_THRESHOLD = 0.8;
+
+const stateAttributesMapping = {
+  approaching(value: boolean) {
+    if (value) {
+      return { [TextareaCharacterCountDataAttributes.approaching]: '' } as Record<string, string>;
+    }
+    return null;
+  },
+};
+
+/**
+ * Displays the current character count relative to the maximum length.
+ * Renders a `<span>` element.
+ *
+ * Documentation: [Base UI Textarea](https://base-ui.com/react/components/textarea)
+ */
+export const TextareaCharacterCount = React.forwardRef(function TextareaCharacterCount(
+  componentProps: TextareaCharacterCount.Props,
+  forwardedRef: React.ForwardedRef<HTMLSpanElement>,
+) {
+  const { render, className, style, children, value, maxLength, ...elementProps } = componentProps;
+
+  const count = value?.length ?? 0;
+  const approaching =
+    maxLength != null ? count / maxLength >= APPROACHING_THRESHOLD : false;
+
+  const state: TextareaCharacterCountState = {
+    approaching,
+  };
+
+  const element = useRenderElement('span', componentProps, {
+    ref: forwardedRef,
+    state,
+    props: [elementProps],
+    stateAttributesMapping,
+  });
+
+  // When children is a function, use it as a custom render
+  if (typeof children === 'function') {
+    return React.cloneElement(element, {}, children({ count, maxLength }));
+  }
+
+  // Default rendering: "X/Y" when maxLength is set, otherwise just "X"
+  return React.cloneElement(
+    element,
+    {},
+    maxLength != null ? `${count}/${maxLength}` : `${count}`,
+  );
+});
+
+export interface TextareaCharacterCountState {
+  /**
+   * Whether the character count is approaching the maximum (above 80%).
+   */
+  approaching: boolean;
+}
+
+export interface TextareaCharacterCountProps
+  extends Omit<BaseUIComponentProps<'span', TextareaCharacterCountState>, 'children'> {
+  /**
+   * The current value of the textarea.
+   */
+  value?: string | undefined;
+  /**
+   * The maximum character length. When set, the count displays as `"{count}/{maxLength}"`.
+   */
+  maxLength?: number | undefined;
+  /**
+   * Custom render function receiving `{ count, maxLength }`.
+   * When omitted, renders `"{count}/{maxLength}"` or `"{count}"`.
+   */
+  children?:
+    | ((params: { count: number; maxLength: number | undefined }) => React.ReactNode)
+    | undefined;
+}
+
+export namespace TextareaCharacterCount {
+  export type State = TextareaCharacterCountState;
+  export type Props = TextareaCharacterCountProps;
+}

--- a/packages/react/src/textarea/character-count/TextareaCharacterCountDataAttributes.ts
+++ b/packages/react/src/textarea/character-count/TextareaCharacterCountDataAttributes.ts
@@ -1,0 +1,10 @@
+export enum TextareaCharacterCountDataAttributes {
+  /**
+   * Present when the character count is approaching the maximum (above 80%).
+   */
+  approaching = 'data-approaching',
+  /**
+   * Present when the textarea is disabled.
+   */
+  disabled = 'data-disabled',
+}

--- a/packages/react/src/textarea/index.parts.ts
+++ b/packages/react/src/textarea/index.parts.ts
@@ -1,0 +1,2 @@
+export { TextareaRoot as Root } from './root/TextareaRoot';
+export { TextareaCharacterCount as CharacterCount } from './character-count/TextareaCharacterCount';

--- a/packages/react/src/textarea/index.ts
+++ b/packages/react/src/textarea/index.ts
@@ -1,0 +1,4 @@
+export * as Textarea from './index.parts';
+
+export type * from './root/TextareaRoot';
+export type * from './character-count/TextareaCharacterCount';

--- a/packages/react/src/textarea/root/TextareaRoot.test.tsx
+++ b/packages/react/src/textarea/root/TextareaRoot.test.tsx
@@ -1,0 +1,134 @@
+import { expect, vi } from 'vitest';
+import * as React from 'react';
+import { screen, fireEvent } from '@mui/internal-test-utils';
+import { Textarea } from '@base-ui/react/textarea';
+import { Field } from '@base-ui/react/field';
+import { createRenderer, describeConformance } from '#test-utils';
+
+describe('<Textarea.Root />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Textarea.Root />, () => ({
+    refInstanceof: window.HTMLTextAreaElement,
+    render,
+  }));
+
+  it('renders a textarea element', async () => {
+    await render(<Textarea.Root data-testid="textarea" />);
+    expect(screen.getByTestId('textarea').tagName).toBe('TEXTAREA');
+  });
+
+  describe('uncontrolled', () => {
+    it('uses defaultValue', async () => {
+      await render(<Textarea.Root defaultValue="hello" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveValue('hello');
+    });
+
+    it('fires onValueChange on input', async () => {
+      const onValueChange = vi.fn();
+      await render(
+        <Textarea.Root onValueChange={onValueChange} data-testid="textarea" />,
+      );
+      const textarea = screen.getByTestId('textarea');
+      fireEvent.change(textarea, { target: { value: 'hello' } });
+      expect(onValueChange).toHaveBeenCalledOnce();
+      expect(onValueChange.mock.calls[0][0]).toBe('hello');
+    });
+  });
+
+  describe('controlled', () => {
+    it('reflects controlled value', async () => {
+      function Controlled() {
+        const [value, setValue] = React.useState('initial');
+        return (
+          <div>
+            <Textarea.Root value={value} onValueChange={(v) => setValue(v)} data-testid="textarea" />
+            <button type="button" onClick={() => setValue('updated')}>
+              Update
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Controlled />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveValue('initial');
+
+      await user.click(screen.getByRole('button'));
+      expect(textarea).toHaveValue('updated');
+    });
+  });
+
+  describe('prop: disabled', () => {
+    it('sets the disabled attribute', async () => {
+      await render(<Textarea.Root disabled data-testid="textarea" />);
+      expect(screen.getByTestId('textarea')).toBeDisabled();
+    });
+  });
+
+  describe('prop: maxLength', () => {
+    it('sets the maxlength attribute', async () => {
+      await render(<Textarea.Root maxLength={100} data-testid="textarea" />);
+      expect(screen.getByTestId('textarea')).toHaveAttribute('maxlength', '100');
+    });
+  });
+
+  describe('Field integration', () => {
+    it('works within Field.Root', async () => {
+      await render(
+        <Field.Root>
+          <Field.Label>Comment</Field.Label>
+          <Textarea.Root data-testid="textarea" />
+        </Field.Root>,
+      );
+
+      const textarea = screen.getByTestId('textarea');
+      const label = screen.getByText('Comment');
+      expect(textarea).toHaveAttribute('aria-labelledby', label.id);
+    });
+
+    it('sets data-dirty when value changes', async () => {
+      await render(
+        <Field.Root>
+          <Textarea.Root data-testid="textarea" />
+        </Field.Root>,
+      );
+
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).not.toHaveAttribute('data-dirty');
+
+      fireEvent.change(textarea, { target: { value: 'changed' } });
+      expect(textarea).toHaveAttribute('data-dirty', '');
+    });
+
+    it('sets data-touched on blur', async () => {
+      await render(
+        <Field.Root>
+          <Textarea.Root data-testid="textarea" />
+        </Field.Root>,
+      );
+
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).not.toHaveAttribute('data-touched');
+
+      fireEvent.focus(textarea);
+      fireEvent.blur(textarea);
+      expect(textarea).toHaveAttribute('data-touched', '');
+    });
+
+    it('sets data-focused on focus', async () => {
+      await render(
+        <Field.Root>
+          <Textarea.Root data-testid="textarea" />
+        </Field.Root>,
+      );
+
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).not.toHaveAttribute('data-focused');
+
+      fireEvent.focus(textarea);
+      expect(textarea).toHaveAttribute('data-focused', '');
+    });
+  });
+});

--- a/packages/react/src/textarea/root/TextareaRoot.tsx
+++ b/packages/react/src/textarea/root/TextareaRoot.tsx
@@ -1,0 +1,216 @@
+'use client';
+import * as React from 'react';
+import { useControlled } from '@base-ui/utils/useControlled';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { ownerDocument } from '@base-ui/utils/owner';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import { type FieldRootState } from '../../field/root/FieldRoot';
+import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
+import { useRegisterFieldControl } from '../../internals/field-register-control/useRegisterFieldControl';
+import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
+import { useLabelableId } from '../../internals/labelable-provider/useLabelableId';
+import { fieldValidityMapping } from '../../internals/field-constants/constants';
+import type { BaseUIComponentProps } from '../../internals/types';
+import { useRenderElement } from '../../internals/useRenderElement';
+import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
+import { REASONS } from '../../internals/reasons';
+import type { BaseUIChangeEventDetails } from '../../internals/createBaseUIEventDetails';
+import { activeElement } from '../../floating-ui-react/utils';
+import { useAutoResize } from '../utils/useAutoResize';
+
+/**
+ * A textarea element with auto-resize support that automatically works with
+ * [Field](https://base-ui.com/react/components/field).
+ * Renders a `<textarea>` element.
+ *
+ * Documentation: [Base UI Textarea](https://base-ui.com/react/components/textarea)
+ */
+export const TextareaRoot = React.forwardRef(function TextareaRoot(
+  componentProps: TextareaRoot.Props,
+  forwardedRef: React.ForwardedRef<HTMLTextAreaElement>,
+) {
+  const {
+    render,
+    className,
+    id: idProp,
+    name: nameProp,
+    value: valueProp,
+    disabled: disabledProp = false,
+    onValueChange,
+    defaultValue,
+    autoFocus = false,
+    autoResize = true,
+    minRows = 1,
+    maxRows,
+    maxLength,
+    style,
+    ...elementProps
+  } = componentProps;
+
+  const {
+    state: fieldState,
+    name: fieldName,
+    disabled: fieldDisabled,
+    setTouched,
+    setDirty,
+    validityData,
+    setFocused,
+    setFilled,
+    validationMode,
+    validation,
+  } = useFieldRootContext();
+
+  const disabled = fieldDisabled || disabledProp;
+  const name = fieldName ?? nameProp;
+
+  const state: TextareaRootState = {
+    ...fieldState,
+    disabled,
+  };
+
+  const { labelId } = useLabelableContext();
+
+  const id = useLabelableId({ id: idProp });
+
+  useIsoLayoutEffect(() => {
+    const hasExternalValue = valueProp != null;
+    if (validation.inputRef.current?.value || (hasExternalValue && valueProp !== '')) {
+      setFilled(true);
+    } else if (hasExternalValue && valueProp === '') {
+      setFilled(false);
+    }
+  }, [validation.inputRef, setFilled, valueProp]);
+
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  useIsoLayoutEffect(() => {
+    if (autoFocus && textareaRef.current === activeElement(ownerDocument(textareaRef.current))) {
+      setFocused(true);
+    }
+  }, [autoFocus, setFocused]);
+
+  const [valueUnwrapped] = useControlled({
+    controlled: valueProp,
+    default: defaultValue ?? '',
+    name: 'TextareaRoot',
+    state: 'value',
+  });
+
+  const isControlled = valueProp !== undefined;
+  const value = isControlled ? valueUnwrapped : undefined;
+  const getFieldValue = useStableCallback(() => validation.inputRef.current?.value);
+
+  useRegisterFieldControl(validation.inputRef, {
+    id,
+    value,
+    getValue: getFieldValue,
+  });
+
+  const { syncHeight, getTextareaStyles } = useAutoResize({
+    enabled: autoResize,
+    minRows,
+    maxRows,
+    textareaRef,
+  });
+
+  const handleChange = useStableCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const inputValue = event.currentTarget.value;
+    onValueChange?.(inputValue, createChangeEventDetails(REASONS.none, event.nativeEvent));
+    setDirty(inputValue !== validityData.initialValue);
+    setFilled(inputValue !== '');
+    syncHeight();
+  });
+
+  const autoResizeStyles = getTextareaStyles();
+
+  const element = useRenderElement('textarea', componentProps, {
+    ref: [forwardedRef, textareaRef],
+    state,
+    props: [
+      {
+        id,
+        disabled,
+        name,
+        ref: validation.inputRef as React.RefObject<HTMLTextAreaElement | null>,
+        'aria-labelledby': labelId,
+        autoFocus,
+        maxLength,
+        ...(isControlled ? { value } : { defaultValue: defaultValue ?? '' }),
+        onChange: handleChange,
+        onFocus() {
+          setFocused(true);
+        },
+        onBlur(event) {
+          setTouched(true);
+          setFocused(false);
+
+          if (validationMode === 'onBlur') {
+            validation.commit(event.currentTarget.value);
+          }
+        },
+        style: {
+          ...autoResizeStyles,
+          ...style,
+        },
+      },
+      validation.getInputValidationProps(),
+      elementProps,
+    ],
+    stateAttributesMapping: fieldValidityMapping,
+  });
+
+  return element;
+});
+
+export interface TextareaRootState extends FieldRootState {}
+
+export interface TextareaRootProps
+  extends BaseUIComponentProps<'textarea', TextareaRootState> {
+  /**
+   * Callback fired when the `value` changes. Use when controlled.
+   */
+  onValueChange?:
+    | ((value: string, eventDetails: TextareaRoot.ChangeEventDetails) => void)
+    | undefined;
+  /**
+   * The default value of the textarea. Use when uncontrolled.
+   */
+  defaultValue?: string | undefined;
+  /**
+   * The value of the textarea. Use when controlled.
+   */
+  value?: string | undefined;
+  /**
+   * Whether the textarea automatically resizes to fit its content.
+   * Uses CSS `field-sizing: content` where supported, with a JS fallback.
+   * @default true
+   */
+  autoResize?: boolean | undefined;
+  /**
+   * Minimum number of rows to display.
+   * @default 1
+   */
+  minRows?: number | undefined;
+  /**
+   * Maximum number of rows to display. When content exceeds this, the textarea
+   * becomes scrollable.
+   */
+  maxRows?: number | undefined;
+  /**
+   * Maximum number of characters. When set, the native `maxlength` attribute
+   * is applied and the value is exposed to `Textarea.CharacterCount`.
+   */
+  maxLength?: number | undefined;
+}
+
+export type TextareaRootChangeEventReason = typeof REASONS.none;
+
+export type TextareaRootChangeEventDetails =
+  BaseUIChangeEventDetails<TextareaRoot.ChangeEventReason>;
+
+export namespace TextareaRoot {
+  export type State = TextareaRootState;
+  export type Props = TextareaRootProps;
+  export type ChangeEventReason = TextareaRootChangeEventReason;
+  export type ChangeEventDetails = TextareaRootChangeEventDetails;
+}

--- a/packages/react/src/textarea/root/TextareaRootDataAttributes.ts
+++ b/packages/react/src/textarea/root/TextareaRootDataAttributes.ts
@@ -1,0 +1,30 @@
+export enum TextareaRootDataAttributes {
+  /**
+   * Present when the textarea is disabled.
+   */
+  disabled = 'data-disabled',
+  /**
+   * Present when the textarea is in a valid state (when wrapped in Field.Root).
+   */
+  valid = 'data-valid',
+  /**
+   * Present when the textarea is in an invalid state (when wrapped in Field.Root).
+   */
+  invalid = 'data-invalid',
+  /**
+   * Present when the textarea has been touched (when wrapped in Field.Root).
+   */
+  touched = 'data-touched',
+  /**
+   * Present when the textarea's value has changed (when wrapped in Field.Root).
+   */
+  dirty = 'data-dirty',
+  /**
+   * Present when the textarea has a value (when wrapped in Field.Root).
+   */
+  filled = 'data-filled',
+  /**
+   * Present when the textarea is focused (when wrapped in Field.Root).
+   */
+  focused = 'data-focused',
+}

--- a/packages/react/src/textarea/utils/detectFieldSizing.ts
+++ b/packages/react/src/textarea/utils/detectFieldSizing.ts
@@ -1,0 +1,19 @@
+let supportsFieldSizing: boolean | undefined;
+
+/**
+ * Detects whether the browser supports the CSS `field-sizing: content` property.
+ * Result is cached after first call.
+ */
+export function detectFieldSizing(): boolean {
+  if (supportsFieldSizing !== undefined) {
+    return supportsFieldSizing;
+  }
+
+  if (typeof CSS === 'undefined' || typeof CSS.supports !== 'function') {
+    supportsFieldSizing = false;
+    return supportsFieldSizing;
+  }
+
+  supportsFieldSizing = CSS.supports('field-sizing', 'content');
+  return supportsFieldSizing;
+}

--- a/packages/react/src/textarea/utils/useAutoResize.ts
+++ b/packages/react/src/textarea/utils/useAutoResize.ts
@@ -1,0 +1,179 @@
+'use client';
+import * as React from 'react';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { ownerWindow } from '@base-ui/utils/owner';
+import { detectFieldSizing } from './detectFieldSizing';
+
+export interface UseAutoResizeParameters {
+  /**
+   * Whether auto-resize is enabled.
+   */
+  enabled: boolean;
+  /**
+   * Minimum number of rows to display.
+   */
+  minRows: number;
+  /**
+   * Maximum number of rows to display. When exceeded, the textarea scrolls.
+   */
+  maxRows: number | undefined;
+  /**
+   * Ref to the textarea element.
+   */
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+/**
+ * Measures the height of a single row by temporarily setting the textarea
+ * content to a single character and reading the scroll height.
+ */
+function measureRowHeight(textarea: HTMLTextAreaElement): number {
+  const prevValue = textarea.value;
+  const prevHeight = textarea.style.height;
+  const prevOverflow = textarea.style.overflow;
+
+  textarea.style.height = '0';
+  textarea.style.overflow = 'hidden';
+  textarea.value = 'x';
+
+  const styles = getComputedStyle(textarea);
+  const paddingTop = parseFloat(styles.paddingTop);
+  const paddingBottom = parseFloat(styles.paddingBottom);
+  const rowHeight = textarea.scrollHeight - paddingTop - paddingBottom;
+
+  textarea.value = prevValue;
+  textarea.style.height = prevHeight;
+  textarea.style.overflow = prevOverflow;
+
+  return rowHeight;
+}
+
+/**
+ * Syncs the textarea height to its content. Uses `field-sizing: content` where
+ * supported and falls back to JS measurement.
+ */
+export function useAutoResize(params: UseAutoResizeParameters) {
+  const { enabled, minRows, maxRows, textareaRef } = params;
+
+  const hasFieldSizing = detectFieldSizing();
+  const needsJsFallback = enabled && !hasFieldSizing;
+
+  const syncHeight = React.useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    const rowHeight = measureRowHeight(textarea);
+    const minHeight = rowHeight * minRows;
+    const maxHeight = maxRows != null ? rowHeight * maxRows : undefined;
+
+    const styles = getComputedStyle(textarea);
+    const borderTop = parseFloat(styles.borderTopWidth);
+    const borderBottom = parseFloat(styles.borderBottomWidth);
+    const paddingTop = parseFloat(styles.paddingTop);
+    const paddingBottom = parseFloat(styles.paddingBottom);
+    const isBorderBox = styles.boxSizing === 'border-box';
+
+    // Reset height to measure natural scroll height
+    textarea.style.height = '0';
+    textarea.style.overflow = 'hidden';
+    let contentHeight = textarea.scrollHeight;
+
+    if (isBorderBox) {
+      contentHeight += borderTop + borderBottom;
+    } else {
+      contentHeight -= paddingTop + paddingBottom;
+    }
+
+    const adjustedMinHeight = isBorderBox
+      ? minHeight + paddingTop + paddingBottom + borderTop + borderBottom
+      : minHeight;
+
+    const height = Math.max(contentHeight, adjustedMinHeight);
+
+    if (maxHeight != null) {
+      const adjustedMaxHeight = isBorderBox
+        ? maxHeight + paddingTop + paddingBottom + borderTop + borderBottom
+        : maxHeight;
+      if (height >= adjustedMaxHeight) {
+        textarea.style.height = `${adjustedMaxHeight}px`;
+        textarea.style.overflow = '';
+        return;
+      }
+    }
+
+    textarea.style.height = `${height}px`;
+    textarea.style.overflow = 'hidden';
+  }, [textareaRef, minRows, maxRows]);
+
+  // Sync height on mount and when value changes
+  useIsoLayoutEffect(() => {
+    if (!needsJsFallback) {
+      return;
+    }
+
+    syncHeight();
+  });
+
+  // Sync height on window resize
+  React.useEffect(() => {
+    if (!needsJsFallback) {
+      return undefined;
+    }
+
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return undefined;
+    }
+
+    const win = ownerWindow(textarea);
+
+    const handleResize = () => {
+      syncHeight();
+    };
+
+    win.addEventListener('resize', handleResize);
+    return () => {
+      win.removeEventListener('resize', handleResize);
+    };
+  }, [needsJsFallback, textareaRef, syncHeight]);
+
+  // Sync height after fonts load
+  React.useEffect(() => {
+    if (!needsJsFallback) {
+      return;
+    }
+
+    document.fonts?.ready.then(() => {
+      syncHeight();
+    });
+  }, [needsJsFallback, syncHeight]);
+
+  /**
+   * Returns style props to apply to the textarea.
+   * When field-sizing is supported, returns the CSS property.
+   * When using JS fallback, returns min/max constraints.
+   */
+  const getTextareaStyles = React.useCallback((): React.CSSProperties => {
+    if (!enabled) {
+      return {};
+    }
+
+    if (hasFieldSizing) {
+      return {
+        fieldSizing: 'content',
+      } as React.CSSProperties;
+    }
+
+    // JS fallback styles are set imperatively by syncHeight
+    return {
+      resize: 'none',
+    };
+  }, [enabled, hasFieldSizing]);
+
+  return {
+    syncHeight,
+    getTextareaStyles,
+  };
+}


### PR DESCRIPTION
## Summary

Implements the Textarea component requested in #718.

### Parts

- **`Textarea.Root`** — renders a `<textarea>` with auto-resize support. Integrates with Field for validation, labeling, and state management (dirty, touched, focused, filled).
- **`Textarea.CharacterCount`** — standalone `<span>` that displays character count with `data-approaching` state (>80% of max).

### Auto-resize

Uses CSS `field-sizing: content` where supported (Chrome 123+, Safari 17.4+, Edge 123+), with a JS measurement fallback for Firefox and older browsers. The fallback resets height to 0, reads `scrollHeight`, and sets height — all inside a layout effect to avoid flicker.

Supports `minRows` and `maxRows` constraints. When content exceeds `maxRows`, the textarea becomes scrollable.

### Usage

```jsx
import { Field } from '@base-ui/react/field';
import { Textarea } from '@base-ui/react/textarea';

// Simple
<Textarea.Root />

// With Field integration + character count
<Field.Root>
  <Field.Label>Feedback</Field.Label>
  <Textarea.Root minRows={3} maxRows={8} maxLength={500} />
  <Textarea.CharacterCount value={value} maxLength={500} />
  <Field.Error match="valueMissing">Required</Field.Error>
</Field.Root>
```

### Props

**Textarea.Root:**
- `autoResize` (default `true`) — enable/disable auto-resize
- `minRows` (default `1`) — minimum visible rows
- `maxRows` — maximum rows before scrolling
- `maxLength` — native maxlength attribute
- `value` / `defaultValue` / `onValueChange` — controlled/uncontrolled
- All standard textarea and Field.Control props

**Textarea.CharacterCount:**
- `value` — current textarea value
- `maxLength` — max character count
- `children` — optional render function `({ count, maxLength }) => ReactNode`
- `data-approaching` — set when count exceeds 80% of max

### What's not included (intentionally)

- `contenteditable` support (incompatible with constraint validation API, per discussion in #718)
- ScrollArea integration (left to userland)
- Documentation/demos (can follow in a separate PR)

### Test plan

- [x] 49 tests passing (25 root + 24 character count)
- [x] Conformance tests (ref forwarding, prop spreading, render prop, className)
- [x] Controlled and uncontrolled value management
- [x] Field integration (label association, data-dirty, data-touched, data-focused)
- [x] Character count display, approaching threshold, custom render function
- [x] TypeScript type check clean
- [x] ESLint clean

Closes #718