### PR TITLE
[core] Mark date-fns peer dependencies as optional

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@base-ui/react": "workspace:*",
     "@base-ui/utils": "workspace:*",
-    "@date-fns/tz": "^1.4.1",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@mui/internal-docs-infra": "0.7.1-canary.5",
@@ -30,7 +29,6 @@
     "@types/mdx": "^2.0.13",
     "clipboard-copy": "^4.0.1",
     "clsx": "^2.1.1",
-    "date-fns": "^4.1.0",
     "es-toolkit": "^1.45.1",
     "estree-util-value-to-estree": "^3.5.0",
     "globby": "^16.2.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -151,7 +151,13 @@
     "react-dom": "^17 || ^18 || ^19"
   },
   "peerDependenciesMeta": {
+    "@date-fns/tz": {
+      "optional": true
+    },
     "@types/react": {
+      "optional": true
+    },
+    "date-fns": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,9 +149,6 @@ importers:
       '@base-ui/utils':
         specifier: workspace:*
         version: link:../packages/utils/build
-      '@date-fns/tz':
-        specifier: ^1.4.1
-        version: 1.4.1
       '@mdx-js/loader':
         specifier: ^3.1.1
         version: 3.1.1(webpack@5.105.4(esbuild@0.27.7))
@@ -185,9 +182,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      date-fns:
-        specifier: ^4.1.0
-        version: 4.1.0
       es-toolkit:
         specifier: ^1.45.1
         version: 1.45.1


### PR DESCRIPTION
## Summary

- Mark `date-fns` and `@date-fns/tz` as optional peer dependencies in `@base-ui/react`. They're only used by the opt-in internal adapter at `./internals/temporal-adapter-date-fns`; no public component requires them, and the sibling `luxon` adapter isn't listed as a peer dep at all. Consumers who don't import the adapter now install Base UI without peer-dep warnings.
- Remove the now-unused `date-fns` and `@date-fns/tz` direct dependencies from `docs/package.json` (orphaned after the Calendar demos were removed in #4505).

Fixes #4632

## Test plan

- [x] Install `@base-ui/react` in a fresh project without `date-fns`/`@date-fns/tz` and confirm no peer-dependency warnings
- [x] Install with `date-fns`/`@date-fns/tz` present and confirm the version constraint is still validated
- [x] Docs build still passes