### PR TITLE
[all components] Fix display: contents tabbability

### DIFF
--- a/packages/react/src/dialog/popup/DialogPopup.test.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.test.tsx
@@ -309,6 +309,77 @@ describe('<Dialog.Popup />', () => {
     });
   });
 
+  describe.skipIf(isJSDOM)('display: contents ancestors', () => {
+    it('keeps initial focus working when the popup is wrapped by a display: contents ancestor', async () => {
+      const { user } = await render(
+        <div>
+          <button data-testid="outside-before">Outside before</button>
+          <Dialog.Root modal={false}>
+            <Dialog.Trigger>Open</Dialog.Trigger>
+            <Dialog.Portal>
+              <form style={{ display: 'contents' }}>
+                <Dialog.Popup data-testid="dialog-popup">
+                  <input data-testid="dialog-input" />
+                  <button type="button">Close</button>
+                </Dialog.Popup>
+              </form>
+            </Dialog.Portal>
+          </Dialog.Root>
+          <button data-testid="outside-after">Outside after</button>
+        </div>,
+      );
+
+      await user.click(screen.getByText('Open'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('dialog-input')).toHaveFocus();
+      });
+    });
+
+    it('keeps trap-focus tab cycling inside the popup when wrapped by a display: contents ancestor', async () => {
+      const { user } = await render(
+        <div>
+          <button data-testid="outside-before">Outside before</button>
+          <Dialog.Root defaultOpen modal="trap-focus">
+            <Dialog.Portal>
+              <form style={{ display: 'contents' }}>
+                <Dialog.Popup data-testid="dialog-popup">
+                  <input data-testid="first-input" />
+                  <button type="button" data-testid="second-button">
+                    Second
+                  </button>
+                </Dialog.Popup>
+              </form>
+            </Dialog.Portal>
+          </Dialog.Root>
+          <button data-testid="outside-after">Outside after</button>
+        </div>,
+      );
+
+      const popup = screen.getByTestId('dialog-popup');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('first-input')).toHaveFocus();
+      });
+
+      await user.keyboard('[Tab]');
+      expect(screen.getByTestId('second-button')).toHaveFocus();
+
+      await user.keyboard('[Tab]');
+      await waitFor(() => {
+        expect(screen.getByTestId('first-input')).toHaveFocus();
+      });
+      expect(screen.getByTestId('outside-before')).not.toHaveFocus();
+      expect(screen.getByTestId('outside-after')).not.toHaveFocus();
+
+      await user.keyboard('[ShiftLeft>][Tab][/ShiftLeft]');
+      await waitFor(() => {
+        expect(screen.getByTestId('second-button')).toHaveFocus();
+      });
+      expect(popup.contains(document.activeElement)).toBe(true);
+    });
+  });
+
   describe('prop: finalFocus', () => {
     it('should focus the trigger by default when closed', async () => {
       const { user } = await render(

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -182,279 +182,335 @@ function Dialog({ render, open: passedOpen = false, children }: DialogProps) {
   );
 }
 
-describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
-  describe('prop: initialFocus', () => {
-    test('default behavior focuses first tabbable element', async () => {
-      render(<App />);
+describe('FloatingFocusManager', () => {
+  describe.skipIf(!isJSDOM)('JSDOM-only coverage', () => {
+    describe('prop: initialFocus', () => {
+      test('default behavior focuses first tabbable element', async () => {
+        render(<App />);
 
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
 
-      expect(screen.getByTestId('one')).toHaveFocus();
-    });
+        expect(screen.getByTestId('one')).toHaveFocus();
+      });
 
-    test('default behavior focuses the checked radio in a named group', async () => {
-      render(<RadioApp />);
+      test('default behavior focuses the checked radio in a named group', async () => {
+        render(<RadioApp />);
 
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
 
-      expect(screen.getByTestId('radio-two')).toHaveFocus();
-    });
+        expect(screen.getByTestId('radio-two')).toHaveFocus();
+      });
 
-    test('ref', async () => {
-      render(<App initialFocus="two" />);
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
+      test('ref', async () => {
+        render(<App initialFocus="two" />);
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
 
-      expect(screen.getByTestId('two')).toHaveFocus();
-    });
+        expect(screen.getByTestId('two')).toHaveFocus();
+      });
 
-    test('respects autoFocus', async () => {
-      render(
-        <App>
-          <input autoFocus data-testid="input" />
-        </App>,
-      );
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-      expect(screen.getByTestId('input')).toHaveFocus();
-    });
-  });
-
-  describe('prop: returnFocus', () => {
-    test('when true', async () => {
-      const { rerender } = render(<App />);
-
-      screen.getByTestId('reference').focus();
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-
-      expect(screen.getByTestId('one')).toHaveFocus();
-
-      act(() => screen.getByTestId('two').focus());
-
-      rerender(<App returnFocus={false} />);
-
-      expect(screen.getByTestId('two')).toHaveFocus();
-
-      fireEvent.click(screen.getByTestId('three'));
-      expect(screen.getByTestId('reference')).not.toHaveFocus();
-    });
-
-    test('when false', async () => {
-      render(<App returnFocus={false} />);
-
-      screen.getByTestId('reference').focus();
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-
-      expect(screen.getByTestId('one')).toHaveFocus();
-
-      fireEvent.click(screen.getByTestId('three'));
-      expect(screen.getByTestId('reference')).not.toHaveFocus();
-    });
-
-    test('ref', async () => {
-      function Test() {
-        const ref = React.useRef<HTMLInputElement | null>(null);
-        return (
-          <div>
-            <input />
-            <input data-testid="focus-target" ref={ref} />
-            <input />
-            <App returnFocus={ref} />
-          </div>
+      test('respects autoFocus', async () => {
+        render(
+          <App>
+            <input autoFocus data-testid="input" />
+          </App>,
         );
-      }
-
-      render(<Test />);
-      screen.getByTestId('reference').focus();
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-
-      fireEvent.click(screen.getByTestId('three'));
-      await flushMicrotasks();
-      expect(screen.getByTestId('focus-target')).toHaveFocus();
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+        expect(screen.getByTestId('input')).toHaveFocus();
+      });
     });
 
-    test('always returns to the reference for nested elements', async () => {
-      const NestedDialog: React.FC<DialogProps> = (props) => {
-        const parentId = useFloatingParentNodeId();
+    describe('prop: returnFocus', () => {
+      test('when true', async () => {
+        const { rerender } = render(<App />);
 
-        if (parentId == null) {
+        screen.getByTestId('reference').focus();
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('one')).toHaveFocus();
+
+        act(() => screen.getByTestId('two').focus());
+
+        rerender(<App returnFocus={false} />);
+
+        expect(screen.getByTestId('two')).toHaveFocus();
+
+        fireEvent.click(screen.getByTestId('three'));
+        expect(screen.getByTestId('reference')).not.toHaveFocus();
+      });
+
+      test('when false', async () => {
+        render(<App returnFocus={false} />);
+
+        screen.getByTestId('reference').focus();
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('one')).toHaveFocus();
+
+        fireEvent.click(screen.getByTestId('three'));
+        expect(screen.getByTestId('reference')).not.toHaveFocus();
+      });
+
+      test('ref', async () => {
+        function Test() {
+          const ref = React.useRef<HTMLInputElement | null>(null);
           return (
-            <FloatingTree>
-              <Dialog {...props} />
-            </FloatingTree>
+            <div>
+              <input />
+              <input data-testid="focus-target" ref={ref} />
+              <input />
+              <App returnFocus={ref} />
+            </div>
           );
         }
 
-        return <Dialog {...props} />;
-      };
+        render(<Test />);
+        screen.getByTestId('reference').focus();
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
 
-      render(
-        <NestedDialog
-          render={({ close }) => (
-            <>
-              <NestedDialog
-                render={({ close }) => <button onClick={close} data-testid="close-nested-dialog" />}
-              >
-                <button data-testid="open-nested-dialog" />
-              </NestedDialog>
-              <button onClick={close} data-testid="close-dialog" />
-            </>
-          )}
-        >
-          <button data-testid="open-dialog" />
-        </NestedDialog>,
-      );
+        fireEvent.click(screen.getByTestId('three'));
+        await flushMicrotasks();
+        expect(screen.getByTestId('focus-target')).toHaveFocus();
+      });
 
-      await userEvent.click(screen.getByTestId('open-dialog'));
-      await userEvent.click(screen.getByTestId('open-nested-dialog'));
+      test('always returns to the reference for nested elements', async () => {
+        const NestedDialog: React.FC<DialogProps> = (props) => {
+          const parentId = useFloatingParentNodeId();
 
-      expect(screen.getByTestId('close-nested-dialog')).toBeInTheDocument();
+          if (parentId == null) {
+            return (
+              <FloatingTree>
+                <Dialog {...props} />
+              </FloatingTree>
+            );
+          }
 
-      fireEvent.pointerDown(document.body);
+          return <Dialog {...props} />;
+        };
 
-      expect(screen.queryByTestId('close-nested-dialog')).not.toBeInTheDocument();
-
-      fireEvent.pointerDown(document.body);
-
-      expect(screen.queryByTestId('close-dialog')).not.toBeInTheDocument();
-    });
-
-    test('return to the first focusable descendent of the reference, if the reference is not focusable', async () => {
-      render(
-        <Dialog render={({ close }) => <button onClick={close} data-testid="close-dialog" />}>
-          <div data-testid="non-focusable-reference">
+        render(
+          <NestedDialog
+            render={({ close }) => (
+              <>
+                <NestedDialog
+                  render={({ close }) => (
+                    <button onClick={close} data-testid="close-nested-dialog" />
+                  )}
+                >
+                  <button data-testid="open-nested-dialog" />
+                </NestedDialog>
+                <button onClick={close} data-testid="close-dialog" />
+              </>
+            )}
+          >
             <button data-testid="open-dialog" />
-          </div>
-        </Dialog>,
+          </NestedDialog>,
+        );
+
+        await userEvent.click(screen.getByTestId('open-dialog'));
+        await userEvent.click(screen.getByTestId('open-nested-dialog'));
+
+        expect(screen.getByTestId('close-nested-dialog')).toBeInTheDocument();
+
+        fireEvent.pointerDown(document.body);
+
+        expect(screen.queryByTestId('close-nested-dialog')).not.toBeInTheDocument();
+
+        fireEvent.pointerDown(document.body);
+
+        expect(screen.queryByTestId('close-dialog')).not.toBeInTheDocument();
+      });
+
+      test('return to the first focusable descendent of the reference, if the reference is not focusable', async () => {
+        render(
+          <Dialog render={({ close }) => <button onClick={close} data-testid="close-dialog" />}>
+            <div data-testid="non-focusable-reference">
+              <button data-testid="open-dialog" />
+            </div>
+          </Dialog>,
+        );
+        screen.getByTestId('open-dialog').focus();
+        await userEvent.keyboard('{Enter}');
+
+        expect(screen.getByTestId('close-dialog')).toBeInTheDocument();
+
+        await userEvent.keyboard('{Esc}');
+
+        expect(screen.queryByTestId('close-dialog')).not.toBeInTheDocument();
+
+        expect(screen.getByTestId('open-dialog')).toHaveFocus();
+      });
+
+      test('preserves tabbable context next to reference element if removed (modal)', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+          const [removed, setRemoved] = React.useState(false);
+
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          const click = useClick(context);
+
+          const { getReferenceProps, getFloatingProps } = useInteractions([click]);
+
+          return (
+            <>
+              {!removed && (
+                <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
+              )}
+              {isOpen && (
+                <FloatingPortal>
+                  <FloatingFocusManager context={context}>
+                    <div ref={refs.setFloating} {...getFloatingProps()}>
+                      <button
+                        data-testid="remove"
+                        onClick={() => {
+                          setRemoved(true);
+                          setIsOpen(false);
+                        }}
+                      >
+                        remove
+                      </button>
+                    </div>
+                  </FloatingFocusManager>
+                </FloatingPortal>
+              )}
+              <button data-testid="fallback" />
+            </>
+          );
+        }
+
+        render(<App />);
+
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        fireEvent.click(screen.getByTestId('remove'));
+        await flushMicrotasks();
+
+        await userEvent.tab();
+
+        expect(screen.getByTestId('fallback')).toHaveFocus();
+      });
+
+      test('preserves tabbable context next to reference element if removed (non-modal)', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+          const [removed, setRemoved] = React.useState(false);
+
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          const click = useClick(context);
+
+          const { getReferenceProps, getFloatingProps } = useInteractions([click]);
+
+          return (
+            <>
+              {!removed && (
+                <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
+              )}
+              {isOpen && (
+                <FloatingPortal>
+                  <FloatingFocusManager context={context} modal={false}>
+                    <div ref={refs.setFloating} {...getFloatingProps()}>
+                      <button
+                        data-testid="remove"
+                        onClick={() => {
+                          setRemoved(true);
+                          setIsOpen(false);
+                        }}
+                      >
+                        remove
+                      </button>
+                    </div>
+                  </FloatingFocusManager>
+                </FloatingPortal>
+              )}
+              <button data-testid="fallback" />
+            </>
+          );
+        }
+
+        render(<App />);
+
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        fireEvent.click(screen.getByTestId('remove'));
+        await flushMicrotasks();
+
+        await userEvent.tab();
+
+        expect(screen.getByTestId('fallback')).toHaveFocus();
+      });
+
+      test.skipIf(!isJSDOM)(
+        'does not return focus to reference on outside press when preventScroll is not supported',
+        async () => {
+          function App() {
+            const [isOpen, setIsOpen] = React.useState(false);
+
+            const { refs, context } = useFloating({
+              open: isOpen,
+              onOpenChange: setIsOpen,
+            });
+
+            const click = useClick(context);
+            const dismiss = useDismiss(context);
+
+            const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
+
+            return (
+              <>
+                <button ref={refs.setReference} {...getReferenceProps()}>
+                  reference
+                </button>
+                {isOpen && (
+                  <FloatingFocusManager context={context}>
+                    <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating" />
+                  </FloatingFocusManager>
+                )}
+              </>
+            );
+          }
+
+          render(<App />);
+
+          await userEvent.click(screen.getByText('reference'));
+          await flushMicrotasks();
+
+          expect(screen.getByTestId('floating')).toHaveFocus();
+
+          await userEvent.click(document.body);
+          await flushMicrotasks();
+
+          expect(screen.getByText('reference')).not.toHaveFocus();
+        },
       );
-      screen.getByTestId('open-dialog').focus();
-      await userEvent.keyboard('{Enter}');
 
-      expect(screen.getByTestId('close-dialog')).toBeInTheDocument();
-
-      await userEvent.keyboard('{Esc}');
-
-      expect(screen.queryByTestId('close-dialog')).not.toBeInTheDocument();
-
-      expect(screen.getByTestId('open-dialog')).toHaveFocus();
-    });
-
-    test('preserves tabbable context next to reference element if removed (modal)', async () => {
-      function App() {
-        const [isOpen, setIsOpen] = React.useState(false);
-        const [removed, setRemoved] = React.useState(false);
-
-        const { refs, context } = useFloating({
-          open: isOpen,
-          onOpenChange: setIsOpen,
+      test('returns focus to reference on outside press when preventScroll is supported', async () => {
+        const originalFocus = HTMLElement.prototype.focus;
+        Object.defineProperty(HTMLElement.prototype, 'focus', {
+          configurable: true,
+          writable: true,
+          value(options: any) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+            options && options.preventScroll;
+            return originalFocus.call(this, options);
+          },
         });
 
-        const click = useClick(context);
-
-        const { getReferenceProps, getFloatingProps } = useInteractions([click]);
-
-        return (
-          <>
-            {!removed && (
-              <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
-            )}
-            {isOpen && (
-              <FloatingPortal>
-                <FloatingFocusManager context={context}>
-                  <div ref={refs.setFloating} {...getFloatingProps()}>
-                    <button
-                      data-testid="remove"
-                      onClick={() => {
-                        setRemoved(true);
-                        setIsOpen(false);
-                      }}
-                    >
-                      remove
-                    </button>
-                  </div>
-                </FloatingFocusManager>
-              </FloatingPortal>
-            )}
-            <button data-testid="fallback" />
-          </>
-        );
-      }
-
-      render(<App />);
-
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-
-      fireEvent.click(screen.getByTestId('remove'));
-      await flushMicrotasks();
-
-      await userEvent.tab();
-
-      expect(screen.getByTestId('fallback')).toHaveFocus();
-    });
-
-    test('preserves tabbable context next to reference element if removed (non-modal)', async () => {
-      function App() {
-        const [isOpen, setIsOpen] = React.useState(false);
-        const [removed, setRemoved] = React.useState(false);
-
-        const { refs, context } = useFloating({
-          open: isOpen,
-          onOpenChange: setIsOpen,
-        });
-
-        const click = useClick(context);
-
-        const { getReferenceProps, getFloatingProps } = useInteractions([click]);
-
-        return (
-          <>
-            {!removed && (
-              <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
-            )}
-            {isOpen && (
-              <FloatingPortal>
-                <FloatingFocusManager context={context} modal={false}>
-                  <div ref={refs.setFloating} {...getFloatingProps()}>
-                    <button
-                      data-testid="remove"
-                      onClick={() => {
-                        setRemoved(true);
-                        setIsOpen(false);
-                      }}
-                    >
-                      remove
-                    </button>
-                  </div>
-                </FloatingFocusManager>
-              </FloatingPortal>
-            )}
-            <button data-testid="fallback" />
-          </>
-        );
-      }
-
-      render(<App />);
-
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-
-      fireEvent.click(screen.getByTestId('remove'));
-      await flushMicrotasks();
-
-      await userEvent.tab();
-
-      expect(screen.getByTestId('fallback')).toHaveFocus();
-    });
-
-    test.skipIf(!isJSDOM)(
-      'does not return focus to reference on outside press when preventScroll is not supported',
-      async () => {
         function App() {
           const [isOpen, setIsOpen] = React.useState(false);
 
@@ -492,28 +548,89 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
         await userEvent.click(document.body);
         await flushMicrotasks();
 
-        expect(screen.getByText('reference')).not.toHaveFocus();
-      },
-    );
+        expect(screen.getByText('reference')).toHaveFocus();
 
-    test('returns focus to reference on outside press when preventScroll is supported', async () => {
-      const originalFocus = HTMLElement.prototype.focus;
-      Object.defineProperty(HTMLElement.prototype, 'focus', {
-        configurable: true,
-        writable: true,
-        value(options: any) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          options && options.preventScroll;
-          return originalFocus.call(this, options);
-        },
+        HTMLElement.prototype.focus = originalFocus;
       });
 
-      function App() {
-        const [isOpen, setIsOpen] = React.useState(false);
+      test('does not insert fallback element when return element is falsy', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
 
-        const { refs, context } = useFloating({
-          open: isOpen,
-          onOpenChange: setIsOpen,
+          const { refs, context } = useFloating({ open: isOpen, onOpenChange: setIsOpen });
+
+          const click = useClick(context);
+          const { getReferenceProps, getFloatingProps } = useInteractions([click]);
+
+          return (
+            <>
+              <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
+              <FloatingPortal>
+                {isOpen && (
+                  <FloatingFocusManager context={context} returnFocus={() => undefined}>
+                    <div ref={refs.setFloating} {...getFloatingProps()}>
+                      <button data-testid="close" onClick={() => setIsOpen(false)} />
+                    </div>
+                  </FloatingFocusManager>
+                )}
+              </FloatingPortal>
+            </>
+          );
+        }
+
+        render(<App />);
+
+        const reference = screen.getByTestId('reference');
+        await userEvent.click(reference);
+        await flushMicrotasks();
+
+        expect(reference.nextElementSibling).toBeNull();
+
+        await userEvent.click(screen.getByTestId('close'));
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('close')).toBeNull();
+        });
+
+        expect(reference.nextElementSibling).toBeNull();
+      });
+    });
+
+    describe('iframe focus navigation', () => {
+      function App({ iframe }: { iframe: HTMLElement }) {
+        return (
+          <div>
+            <a href="#">prev iframe link</a>
+            <Popover
+              portalRef={iframe}
+              render={() => (
+                <div data-testid="popover">
+                  <a href="#">popover link 1</a>
+                  <a href="#">popover link 2</a>
+                </div>
+              )}
+            >
+              <button>Open</button>
+            </Popover>
+            <a href="#">next iframe link</a>
+          </div>
+        );
+      }
+
+      function Popover({
+        children,
+        render,
+        portalRef,
+      }: {
+        children: React.ReactElement;
+        render: () => React.ReactNode;
+        portalRef?: HTMLElement;
+      }) {
+        const [open, setOpen] = React.useState(false);
+
+        const { floatingStyles, refs, context } = useFloating({
+          open,
+          onOpenChange: setOpen,
         });
 
         const click = useClick(context);
@@ -523,199 +640,62 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
 
         return (
           <>
-            <button ref={refs.setReference} {...getReferenceProps()}>
-              reference
-            </button>
-            {isOpen && (
-              <FloatingFocusManager context={context}>
-                <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating" />
-              </FloatingFocusManager>
+            {React.cloneElement(children, getReferenceProps({ ref: refs.setReference }))}
+            {open && (
+              <FloatingPortal container={portalRef}>
+                <FloatingFocusManager context={context} modal={false}>
+                  <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
+                    {render()}
+                  </div>
+                </FloatingFocusManager>
+              </FloatingPortal>
             )}
           </>
         );
       }
 
-      render(<App />);
+      function IframeApp() {
+        React.useEffect(() => {
+          function createIframe() {
+            const innerRoot = document.querySelector('#innerRoot');
+            const iframe = document.createElement('iframe');
+            iframe.setAttribute('data-testid', 'iframe');
+            iframe.src = 'about:blank';
+            iframe.style.height = '300px';
 
-      await userEvent.click(screen.getByText('reference'));
-      await flushMicrotasks();
+            innerRoot?.appendChild(iframe);
 
-      expect(screen.getByTestId('floating')).toHaveFocus();
+            // Properly open, write, and close the iframe document.
+            const iframeDoc = iframe.contentWindow?.document;
+            if (iframeDoc) {
+              iframeDoc.open();
+              iframeDoc.write(`<div id="rootIframe"></div>`);
+              iframeDoc.close();
+            }
 
-      await userEvent.click(document.body);
-      await flushMicrotasks();
+            const rootIframe = iframe.contentWindow?.document.getElementById('rootIframe');
+            return rootIframe;
+          }
 
-      expect(screen.getByText('reference')).toHaveFocus();
-
-      HTMLElement.prototype.focus = originalFocus;
-    });
-
-    test('does not insert fallback element when return element is falsy', async () => {
-      function App() {
-        const [isOpen, setIsOpen] = React.useState(false);
-
-        const { refs, context } = useFloating({ open: isOpen, onOpenChange: setIsOpen });
-
-        const click = useClick(context);
-        const { getReferenceProps, getFloatingProps } = useInteractions([click]);
+          const root = createIframe();
+          if (root) {
+            ReactDOMClient.createRoot(root).render(<App iframe={root} />);
+          }
+        }, []);
 
         return (
           <>
-            <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
-            <FloatingPortal>
-              {isOpen && (
-                <FloatingFocusManager context={context} returnFocus={() => undefined}>
-                  <div ref={refs.setFloating} {...getFloatingProps()}>
-                    <button data-testid="close" onClick={() => setIsOpen(false)} />
-                  </div>
-                </FloatingFocusManager>
-              )}
-            </FloatingPortal>
+            <a href="#">Outside link 1</a>
+            <div id="innerRoot" />
+            <a href="#">Outside link 2</a>
           </>
         );
       }
 
-      render(<App />);
-
-      const reference = screen.getByTestId('reference');
-      await userEvent.click(reference);
-      await flushMicrotasks();
-
-      expect(reference.nextElementSibling).toBeNull();
-
-      await userEvent.click(screen.getByTestId('close'));
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('close')).toBeNull();
-      });
-
-      expect(reference.nextElementSibling).toBeNull();
-    });
-  });
-
-  describe('iframe focus navigation', () => {
-    function App({ iframe }: { iframe: HTMLElement }) {
-      return (
-        <div>
-          <a href="#">prev iframe link</a>
-          <Popover
-            portalRef={iframe}
-            render={() => (
-              <div data-testid="popover">
-                <a href="#">popover link 1</a>
-                <a href="#">popover link 2</a>
-              </div>
-            )}
-          >
-            <button>Open</button>
-          </Popover>
-          <a href="#">next iframe link</a>
-        </div>
-      );
-    }
-
-    function Popover({
-      children,
-      render,
-      portalRef,
-    }: {
-      children: React.ReactElement;
-      render: () => React.ReactNode;
-      portalRef?: HTMLElement;
-    }) {
-      const [open, setOpen] = React.useState(false);
-
-      const { floatingStyles, refs, context } = useFloating({
-        open,
-        onOpenChange: setOpen,
-      });
-
-      const click = useClick(context);
-      const dismiss = useDismiss(context);
-
-      const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
-
-      return (
-        <>
-          {React.cloneElement(children, getReferenceProps({ ref: refs.setReference }))}
-          {open && (
-            <FloatingPortal container={portalRef}>
-              <FloatingFocusManager context={context} modal={false}>
-                <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
-                  {render()}
-                </div>
-              </FloatingFocusManager>
-            </FloatingPortal>
-          )}
-        </>
-      );
-    }
-
-    function IframeApp() {
-      React.useEffect(() => {
-        function createIframe() {
-          const innerRoot = document.querySelector('#innerRoot');
-          const iframe = document.createElement('iframe');
-          iframe.setAttribute('data-testid', 'iframe');
-          iframe.src = 'about:blank';
-          iframe.style.height = '300px';
-
-          innerRoot?.appendChild(iframe);
-
-          // Properly open, write, and close the iframe document.
-          const iframeDoc = iframe.contentWindow?.document;
-          if (iframeDoc) {
-            iframeDoc.open();
-            iframeDoc.write(`<div id="rootIframe"></div>`);
-            iframeDoc.close();
-          }
-
-          const rootIframe = iframe.contentWindow?.document.getElementById('rootIframe');
-          return rootIframe;
-        }
-
-        const root = createIframe();
-        if (root) {
-          ReactDOMClient.createRoot(root).render(<App iframe={root} />);
-        }
-      }, []);
-
-      return (
-        <>
-          <a href="#">Outside link 1</a>
-          <div id="innerRoot" />
-          <a href="#">Outside link 2</a>
-        </>
-      );
-    }
-
-    /* eslint-disable testing-library/prefer-screen-queries */
-    // "Should not already be working"(?) when trying to click within the iframe
-    // https://github.com/facebook/react/pull/32441
-    test.skipIf(!isJSDOM)('tabs from the popover to the next element in the iframe', async () => {
-      render(<IframeApp />);
-
-      const iframe: HTMLIFrameElement = await screen.findByTestId('iframe');
-      const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-      const iframeWithin = iframeDoc ? within(iframeDoc.body) : screen;
-
-      const user = userEvent.setup({ document: iframeDoc });
-
-      await user.click(iframeWithin.getByRole('button', { name: 'Open' }));
-
-      expect(iframeWithin.getByTestId('popover')).toBeInTheDocument();
-
-      await user.tab();
-      await user.tab();
-
-      expect(isFocused(iframeWithin.getByText('next iframe link'))).toBe(true);
-    });
-
-    // "Should not already be working"(?) when trying to click within the iframe
-    // https://github.com/facebook/react/pull/32441
-    test.skipIf(!isJSDOM)(
-      'shift+tab from the popover to the previous element in the iframe',
-      async () => {
+      /* eslint-disable testing-library/prefer-screen-queries */
+      // "Should not already be working"(?) when trying to click within the iframe
+      // https://github.com/facebook/react/pull/32441
+      test.skipIf(!isJSDOM)('tabs from the popover to the next element in the iframe', async () => {
         render(<IframeApp />);
 
         const iframe: HTMLIFrameElement = await screen.findByTestId('iframe');
@@ -728,731 +708,768 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
 
         expect(iframeWithin.getByTestId('popover')).toBeInTheDocument();
 
-        await user.tab({ shift: true });
+        await user.tab();
+        await user.tab();
 
-        expect(isFocused(iframeWithin.getByRole('button', { name: 'Open' }))).toBe(true);
-      },
-    );
-  });
-  /* eslint-enable testing-library/prefer-screen-queries */
-
-  describe('prop: modal', () => {
-    test('when true', async () => {
-      render(<App modal />);
-
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-
-      await userEvent.tab();
-      expect(screen.getByTestId('two')).toHaveFocus();
-
-      await userEvent.tab();
-      expect(screen.getByTestId('three')).toHaveFocus();
-
-      await userEvent.tab();
-      expect(screen.getByTestId('one')).toHaveFocus();
-
-      await userEvent.tab({ shift: true });
-      expect(screen.getByTestId('three')).toHaveFocus();
-
-      await userEvent.tab({ shift: true });
-      expect(screen.getByTestId('two')).toHaveFocus();
-
-      await userEvent.tab({ shift: true });
-      expect(screen.getByTestId('one')).toHaveFocus();
-
-      await userEvent.tab({ shift: true });
-      expect(screen.getByTestId('three')).toHaveFocus();
-
-      await userEvent.tab();
-      expect(screen.getByTestId('one')).toHaveFocus();
-    });
-
-    test('when false', async () => {
-      render(<App modal={false} />);
-
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-
-      await userEvent.tab();
-      expect(screen.getByTestId('two')).toHaveFocus();
-
-      await userEvent.tab();
-      expect(screen.getByTestId('three')).toHaveFocus();
-
-      await userEvent.tab();
-
-      // Wait for the setTimeout that wraps onOpenChange(false).
-      await act(() => new Promise((resolve) => setTimeout(resolve)));
-
-      // Focus leaving the floating element closes it.
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-
-      expect(screen.getByTestId('last')).toHaveFocus();
-    });
-
-    test('false - comboboxes do not hide all other nodes', async () => {
-      function App() {
-        const [open, setOpen] = React.useState(false);
-        const { refs, context } = useFloating({
-          open,
-          onOpenChange: setOpen,
-        });
-
-        return (
-          <>
-            <input
-              role="combobox"
-              data-testid="reference"
-              ref={refs.setReference}
-              onFocus={() => setOpen(true)}
-            />
-            <button data-testid="btn-1" />
-            <button data-testid="btn-2" />
-            {open && (
-              <FloatingFocusManager context={context} modal={false}>
-                <div role="listbox" ref={refs.setFloating} data-testid="floating" />
-              </FloatingFocusManager>
-            )}
-          </>
-        );
-      }
-
-      render(<App />);
-
-      fireEvent.focus(screen.getByTestId('reference'));
-      await flushMicrotasks();
-
-      expect(screen.getByTestId('reference')).not.toHaveAttribute('inert');
-      expect(screen.getByTestId('floating')).not.toHaveAttribute('inert');
-      expect(screen.getByTestId('btn-1')).not.toHaveAttribute('inert');
-      expect(screen.getByTestId('btn-2')).not.toHaveAttribute('inert');
-    });
-
-    test('fallback to floating element when it has no tabbable content', async () => {
-      function App() {
-        const { refs, context } = useFloating({ open: true });
-        return (
-          <>
-            <button data-testid="reference" ref={refs.setReference} />
-            <FloatingFocusManager context={context} modal>
-              <div ref={refs.setFloating} data-testid="floating" tabIndex={-1} />
-            </FloatingFocusManager>
-          </>
-        );
-      }
-
-      render(<App />);
-      await flushMicrotasks();
-
-      await waitFor(() => {
-        expect(screen.getByTestId('floating')).toHaveFocus();
+        expect(isFocused(iframeWithin.getByText('next iframe link'))).toBe(true);
       });
-      await userEvent.tab();
-      expect(screen.getByTestId('floating')).toHaveFocus();
-      await userEvent.tab({ shift: true });
-      expect(screen.getByTestId('floating')).toHaveFocus();
+
+      // "Should not already be working"(?) when trying to click within the iframe
+      // https://github.com/facebook/react/pull/32441
+      test.skipIf(!isJSDOM)(
+        'shift+tab from the popover to the previous element in the iframe',
+        async () => {
+          render(<IframeApp />);
+
+          const iframe: HTMLIFrameElement = await screen.findByTestId('iframe');
+          const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+          const iframeWithin = iframeDoc ? within(iframeDoc.body) : screen;
+
+          const user = userEvent.setup({ document: iframeDoc });
+
+          await user.click(iframeWithin.getByRole('button', { name: 'Open' }));
+
+          expect(iframeWithin.getByTestId('popover')).toBeInTheDocument();
+
+          await user.tab({ shift: true });
+
+          expect(isFocused(iframeWithin.getByRole('button', { name: 'Open' }))).toBe(true);
+        },
+      );
     });
+    /* eslint-enable testing-library/prefer-screen-queries */
 
-    test('mixed modality and nesting', async () => {
-      interface Props {
-        open?: boolean;
-        modal?: boolean;
-        render: (props: { close: () => void }) => React.ReactNode;
-        children?: React.JSX.Element;
-        sideChildren?: React.JSX.Element;
-      }
+    describe('prop: modal', () => {
+      test('when true', async () => {
+        render(<App modal />);
 
-      const Dialog = ({
-        render,
-        open: controlledOpen,
-        modal = true,
-        children,
-        sideChildren,
-      }: Props) => {
-        const [internalOpen, setOpen] = React.useState(false);
-        const nodeId = useFloatingNodeId();
-        const open = controlledOpen !== undefined ? controlledOpen : internalOpen;
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
 
-        const { refs, context } = useFloating({
-          open,
-          onOpenChange: setOpen,
-          nodeId,
-        });
+        await userEvent.tab();
+        expect(screen.getByTestId('two')).toHaveFocus();
 
-        const { getReferenceProps, getFloatingProps } = useInteractions([
-          useClick(context),
-          useDismiss(context, { bubbles: false }),
-        ]);
+        await userEvent.tab();
+        expect(screen.getByTestId('three')).toHaveFocus();
 
-        return (
-          <FloatingNode id={nodeId}>
-            {children &&
-              React.cloneElement(
-                children,
-                getReferenceProps({ ref: refs.setReference, ...children.props }),
-              )}
-            <FloatingPortal>
+        await userEvent.tab();
+        expect(screen.getByTestId('one')).toHaveFocus();
+
+        await userEvent.tab({ shift: true });
+        expect(screen.getByTestId('three')).toHaveFocus();
+
+        await userEvent.tab({ shift: true });
+        expect(screen.getByTestId('two')).toHaveFocus();
+
+        await userEvent.tab({ shift: true });
+        expect(screen.getByTestId('one')).toHaveFocus();
+
+        await userEvent.tab({ shift: true });
+        expect(screen.getByTestId('three')).toHaveFocus();
+
+        await userEvent.tab();
+        expect(screen.getByTestId('one')).toHaveFocus();
+      });
+
+      test('when false', async () => {
+        render(<App modal={false} />);
+
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        await userEvent.tab();
+        expect(screen.getByTestId('two')).toHaveFocus();
+
+        await userEvent.tab();
+        expect(screen.getByTestId('three')).toHaveFocus();
+
+        await userEvent.tab();
+
+        // Wait for the setTimeout that wraps onOpenChange(false).
+        await act(() => new Promise((resolve) => setTimeout(resolve)));
+
+        // Focus leaving the floating element closes it.
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+        expect(screen.getByTestId('last')).toHaveFocus();
+      });
+
+      test('false - comboboxes do not hide all other nodes', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+          const { refs, context } = useFloating({
+            open,
+            onOpenChange: setOpen,
+          });
+
+          return (
+            <>
+              <input
+                role="combobox"
+                data-testid="reference"
+                ref={refs.setReference}
+                onFocus={() => setOpen(true)}
+              />
+              <button data-testid="btn-1" />
+              <button data-testid="btn-2" />
               {open && (
-                <FloatingFocusManager context={context} modal={modal}>
-                  <div {...getFloatingProps({ ref: refs.setFloating })}>
-                    {render({
-                      close: () => setOpen(false),
-                    })}
-                  </div>
+                <FloatingFocusManager context={context} modal={false}>
+                  <div role="listbox" ref={refs.setFloating} data-testid="floating" />
                 </FloatingFocusManager>
               )}
-            </FloatingPortal>
-            {sideChildren}
-          </FloatingNode>
-        );
-      };
-
-      const NestedDialog: React.FC<Props> = (props) => {
-        const parentId = useFloatingParentNodeId();
-
-        if (parentId == null) {
-          return (
-            <FloatingTree>
-              <Dialog {...props} />
-            </FloatingTree>
+            </>
           );
         }
 
-        return <Dialog {...props} />;
-      };
+        render(<App />);
 
-      const App = () => {
-        const [sideDialogOpen, setSideDialogOpen] = React.useState(false);
-        return (
-          <NestedDialog
-            modal={false}
-            render={({ close }) => (
-              <>
-                <button onClick={close} data-testid="close-dialog" />
-                <button onClick={() => setSideDialogOpen(true)} data-testid="open-nested-dialog" />
-              </>
-            )}
-            sideChildren={
-              <NestedDialog
-                modal
-                open={sideDialogOpen}
-                render={({ close }) => <button onClick={close} data-testid="close-nested-dialog" />}
-              />
-            }
-          >
-            <button data-testid="open-dialog" />
-          </NestedDialog>
-        );
-      };
+        fireEvent.focus(screen.getByTestId('reference'));
+        await flushMicrotasks();
 
-      render(<App />);
+        expect(screen.getByTestId('reference')).not.toHaveAttribute('inert');
+        expect(screen.getByTestId('floating')).not.toHaveAttribute('inert');
+        expect(screen.getByTestId('btn-1')).not.toHaveAttribute('inert');
+        expect(screen.getByTestId('btn-2')).not.toHaveAttribute('inert');
+      });
 
-      await userEvent.click(screen.getByTestId('open-dialog'));
-      await userEvent.click(screen.getByTestId('open-nested-dialog'));
-
-      expect(screen.getByTestId('close-dialog')).toBeInTheDocument();
-      expect(screen.getByTestId('close-nested-dialog')).toBeInTheDocument();
-    });
-
-    test('true - applies aria-hidden to outside nodes', async () => {
-      function App() {
-        const [isOpen, setIsOpen] = React.useState(false);
-        const { refs, context } = useFloating({
-          open: isOpen,
-          onOpenChange: setIsOpen,
-        });
-
-        return (
-          <>
-            <input
-              data-testid="reference"
-              ref={refs.setReference}
-              onClick={() => setIsOpen((v) => !v)}
-            />
-            <div data-testid="outside-wrapper">
-              <div data-testid="aria-live" aria-live="polite" />
-              <button data-testid="btn-1" />
-              <button data-testid="btn-2" />
-            </div>
-            {isOpen && (
-              <FloatingFocusManager context={context}>
-                <div ref={refs.setFloating} data-testid="floating" />
+      test('fallback to floating element when it has no tabbable content', async () => {
+        function App() {
+          const { refs, context } = useFloating({ open: true });
+          return (
+            <>
+              <button data-testid="reference" ref={refs.setReference} />
+              <FloatingFocusManager context={context} modal>
+                <div ref={refs.setFloating} data-testid="floating" tabIndex={-1} />
               </FloatingFocusManager>
-            )}
-          </>
-        );
-      }
+            </>
+          );
+        }
 
-      render(<App />);
+        render(<App />);
+        await flushMicrotasks();
 
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-
-      expect(screen.getByTestId('reference')).toHaveAttribute('aria-hidden', 'true');
-      expect(screen.getByTestId('floating')).not.toHaveAttribute('aria-hidden');
-      expect(screen.getByTestId('aria-live')).not.toHaveAttribute('aria-hidden');
-      expect(screen.getByTestId('btn-1')).toHaveAttribute('aria-hidden', 'true');
-      expect(screen.getByTestId('btn-2')).toHaveAttribute('aria-hidden', 'true');
-
-      fireEvent.click(screen.getByTestId('reference'));
-
-      expect(screen.getByTestId('reference')).not.toHaveAttribute('aria-hidden');
-      expect(screen.getByTestId('aria-live')).not.toHaveAttribute('aria-hidden');
-      expect(screen.getByTestId('btn-1')).not.toHaveAttribute('aria-hidden');
-      expect(screen.getByTestId('btn-2')).not.toHaveAttribute('aria-hidden');
-    });
-
-    test('true - keeps supplied inside elements outside the floating node exposed to assistive tech', async () => {
-      function App() {
-        const [isOpen, setIsOpen] = React.useState(false);
-        const dismissRef = React.useRef<HTMLButtonElement | null>(null);
-        const { refs, context } = useFloating({
-          open: isOpen,
-          onOpenChange: setIsOpen,
+        await waitFor(() => {
+          expect(screen.getByTestId('floating')).toHaveFocus();
         });
+        await userEvent.tab();
+        expect(screen.getByTestId('floating')).toHaveFocus();
+        await userEvent.tab({ shift: true });
+        expect(screen.getByTestId('floating')).toHaveFocus();
+      });
 
-        return (
-          <>
-            <input
-              data-testid="reference"
-              ref={refs.setReference}
-              onClick={() => setIsOpen((v) => !v)}
-            />
-            <div data-testid="outside-wrapper">
-              <button data-testid="outside-button" />
-            </div>
-            {isOpen && (
-              <FloatingFocusManager
-                context={context}
-                getInsideElements={() => [dismissRef.current]}
-              >
+      test('mixed modality and nesting', async () => {
+        interface Props {
+          open?: boolean;
+          modal?: boolean;
+          render: (props: { close: () => void }) => React.ReactNode;
+          children?: React.JSX.Element;
+          sideChildren?: React.JSX.Element;
+        }
+
+        const Dialog = ({
+          render,
+          open: controlledOpen,
+          modal = true,
+          children,
+          sideChildren,
+        }: Props) => {
+          const [internalOpen, setOpen] = React.useState(false);
+          const nodeId = useFloatingNodeId();
+          const open = controlledOpen !== undefined ? controlledOpen : internalOpen;
+
+          const { refs, context } = useFloating({
+            open,
+            onOpenChange: setOpen,
+            nodeId,
+          });
+
+          const { getReferenceProps, getFloatingProps } = useInteractions([
+            useClick(context),
+            useDismiss(context, { bubbles: false }),
+          ]);
+
+          return (
+            <FloatingNode id={nodeId}>
+              {children &&
+                React.cloneElement(
+                  children,
+                  getReferenceProps({ ref: refs.setReference, ...children.props }),
+                )}
+              <FloatingPortal>
+                {open && (
+                  <FloatingFocusManager context={context} modal={modal}>
+                    <div {...getFloatingProps({ ref: refs.setFloating })}>
+                      {render({
+                        close: () => setOpen(false),
+                      })}
+                    </div>
+                  </FloatingFocusManager>
+                )}
+              </FloatingPortal>
+              {sideChildren}
+            </FloatingNode>
+          );
+        };
+
+        const NestedDialog: React.FC<Props> = (props) => {
+          const parentId = useFloatingParentNodeId();
+
+          if (parentId == null) {
+            return (
+              <FloatingTree>
+                <Dialog {...props} />
+              </FloatingTree>
+            );
+          }
+
+          return <Dialog {...props} />;
+        };
+
+        const App = () => {
+          const [sideDialogOpen, setSideDialogOpen] = React.useState(false);
+          return (
+            <NestedDialog
+              modal={false}
+              render={({ close }) => (
                 <>
-                  <div ref={refs.setFloating} data-testid="floating" />
-                  <button ref={dismissRef} data-testid="dismiss" />
+                  <button onClick={close} data-testid="close-dialog" />
+                  <button
+                    onClick={() => setSideDialogOpen(true)}
+                    data-testid="open-nested-dialog"
+                  />
                 </>
-              </FloatingFocusManager>
-            )}
-          </>
-        );
-      }
+              )}
+              sideChildren={
+                <NestedDialog
+                  modal
+                  open={sideDialogOpen}
+                  render={({ close }) => (
+                    <button onClick={close} data-testid="close-nested-dialog" />
+                  )}
+                />
+              }
+            >
+              <button data-testid="open-dialog" />
+            </NestedDialog>
+          );
+        };
 
-      render(<App />);
+        render(<App />);
 
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
+        await userEvent.click(screen.getByTestId('open-dialog'));
+        await userEvent.click(screen.getByTestId('open-nested-dialog'));
 
-      expect(screen.getByTestId('floating')).not.toHaveAttribute('aria-hidden');
-      expect(screen.getByTestId('dismiss')).not.toHaveAttribute('aria-hidden');
-      expect(screen.getByTestId('outside-wrapper')).toHaveAttribute('aria-hidden', 'true');
-    });
+        expect(screen.getByTestId('close-dialog')).toBeInTheDocument();
+        expect(screen.getByTestId('close-nested-dialog')).toBeInTheDocument();
+      });
 
-    test('false - does not apply inert to outside nodes', async () => {
-      function App() {
-        const [isOpen, setIsOpen] = React.useState(false);
-        const { refs, context } = useFloating({
-          open: isOpen,
-          onOpenChange: setIsOpen,
-        });
+      test('true - applies aria-hidden to outside nodes', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
 
-        return (
-          <>
-            <input
-              data-testid="reference"
-              ref={refs.setReference}
-              onClick={() => setIsOpen((v) => !v)}
-            />
-            <div data-testid="outside-wrapper">
-              <div data-testid="aria-live" aria-live="polite" />
-              <button data-testid="btn-1" />
-              <button data-testid="btn-2" />
-            </div>
-            {isOpen && (
-              <FloatingFocusManager context={context} modal={false}>
-                <div role="listbox" ref={refs.setFloating} data-testid="floating" />
-              </FloatingFocusManager>
-            )}
-          </>
-        );
-      }
-
-      render(<App />);
-
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-
-      expect(screen.getByTestId('floating')).not.toHaveAttribute('inert');
-      expect(screen.getByTestId('aria-live')).not.toHaveAttribute('inert');
-      expect(screen.getByTestId('btn-1')).not.toHaveAttribute('inert');
-      expect(screen.getByTestId('btn-2')).not.toHaveAttribute('inert');
-      expect(screen.getByTestId('reference')).toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('outside-wrapper')).toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
-
-      fireEvent.click(screen.getByTestId('reference'));
-
-      expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('outside-wrapper')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
-    });
-
-    test('false - keeps marker on top-level outside ancestor when reference has siblings', async () => {
-      function App() {
-        const [isOpen, setIsOpen] = React.useState(false);
-        const { refs, context } = useFloating({
-          open: isOpen,
-          onOpenChange: setIsOpen,
-        });
-
-        return (
-          <>
-            <div data-testid="outside-wrapper">
+          return (
+            <>
               <input
                 data-testid="reference"
                 ref={refs.setReference}
                 onClick={() => setIsOpen((v) => !v)}
               />
-              <button data-testid="btn-1" />
-              <button data-testid="btn-2" />
-              <div data-testid="nested-wrapper">
-                <button data-testid="nested-btn" />
+              <div data-testid="outside-wrapper">
+                <div data-testid="aria-live" aria-live="polite" />
+                <button data-testid="btn-1" />
+                <button data-testid="btn-2" />
               </div>
-            </div>
-            <div data-testid="outside-sibling" />
-            {isOpen && (
-              <FloatingFocusManager context={context} modal={false}>
-                <div role="listbox" ref={refs.setFloating} data-testid="floating" />
-              </FloatingFocusManager>
-            )}
-          </>
-        );
-      }
-
-      render(<App />);
-
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-
-      expect(screen.getByTestId('floating')).not.toHaveAttribute('inert');
-      expect(screen.getByTestId('outside-wrapper')).toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('outside-sibling')).toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('nested-wrapper')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('nested-btn')).not.toHaveAttribute('data-base-ui-inert');
-
-      fireEvent.click(screen.getByTestId('reference'));
-
-      expect(screen.getByTestId('outside-wrapper')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('outside-sibling')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('nested-wrapper')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('nested-btn')).not.toHaveAttribute('data-base-ui-inert');
-    });
-  });
-
-  describe('prop: disabled', () => {
-    test('true -> false', async () => {
-      function App() {
-        const [isOpen, setIsOpen] = React.useState(false);
-        const [disabled, setDisabled] = React.useState(true);
-
-        const { refs, context } = useFloating({
-          open: isOpen,
-          onOpenChange: setIsOpen,
-        });
-
-        return (
-          <>
-            <button
-              data-testid="reference"
-              ref={refs.setReference}
-              onClick={() => setIsOpen((v) => !v)}
-            />
-            <button data-testid="toggle" onClick={() => setDisabled((v) => !v)} />
-            {isOpen && (
-              <FloatingFocusManager context={context} disabled={disabled}>
-                <div ref={refs.setFloating} data-testid="floating" role="dialog" />
-              </FloatingFocusManager>
-            )}
-          </>
-        );
-      }
-
-      render(<App />);
-
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-      expect(screen.getByTestId('floating')).not.toHaveFocus();
-      fireEvent.click(screen.getByTestId('toggle'));
-      await flushMicrotasks();
-      await waitFor(() => {
-        expect(screen.getByTestId('floating')).toHaveFocus();
-      });
-    });
-
-    test('when false', async () => {
-      function App() {
-        const [isOpen, setIsOpen] = React.useState(false);
-        const [disabled, setDisabled] = React.useState(false);
-
-        const { refs, context } = useFloating({
-          open: isOpen,
-          onOpenChange: setIsOpen,
-        });
-
-        const click = useClick(context);
-
-        const { getReferenceProps, getFloatingProps } = useInteractions([click]);
-
-        return (
-          <>
-            <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
-            <button data-testid="toggle" onClick={() => setDisabled((v) => !v)} />
-            {isOpen && (
-              <FloatingFocusManager context={context} disabled={disabled}>
-                <div ref={refs.setFloating} data-testid="floating" {...getFloatingProps()} />
-              </FloatingFocusManager>
-            )}
-          </>
-        );
-      }
-
-      render(<App />);
-
-      fireEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
-      expect(screen.getByTestId('floating')).toHaveFocus();
-    });
-
-    test('supports keepMounted behavior', async () => {
-      function App() {
-        const [isOpen, setIsOpen] = React.useState(false);
-
-        const { refs, context } = useFloating({
-          open: isOpen,
-          onOpenChange: setIsOpen,
-        });
-
-        const click = useClick(context);
-        const dismiss = useDismiss(context);
-
-        const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
-
-        return (
-          <>
-            <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
-            <FloatingFocusManager context={context} disabled={!isOpen} modal={false}>
-              <div ref={refs.setFloating} data-testid="floating" {...getFloatingProps()}>
-                <button data-testid="child" />
-              </div>
-            </FloatingFocusManager>
-            <button data-testid="after" />
-          </>
-        );
-      }
-
-      render(<App />);
-
-      await flushMicrotasks();
-
-      expect(screen.getByTestId('floating')).not.toHaveFocus();
-
-      fireEvent.click(screen.getByTestId('reference'));
-
-      await flushMicrotasks();
-
-      await waitFor(() => {
-        expect(screen.getByTestId('child')).toHaveFocus();
-      });
-
-      await userEvent.tab();
-
-      expect(screen.getByTestId('after')).toHaveFocus();
-
-      await userEvent.tab({ shift: true });
-
-      fireEvent.click(screen.getByTestId('reference'));
-
-      expect(screen.getByTestId('child')).toHaveFocus();
-
-      await userEvent.keyboard('{Escape}');
-
-      expect(screen.getByTestId('reference')).toHaveFocus();
-    });
-  });
-
-  describe('non-modal + FloatingPortal', () => {
-    test('focuses inside element, tabbing out focuses last document element', async () => {
-      function App() {
-        const [open, setOpen] = React.useState(false);
-        const { refs, context } = useFloating({
-          open,
-          onOpenChange: setOpen,
-        });
-
-        return (
-          <>
-            <span tabIndex={0} data-testid="first" />
-            <button data-testid="reference" ref={refs.setReference} onClick={() => setOpen(true)} />
-            <FloatingPortal>
-              {open && (
-                <FloatingFocusManager context={context} modal={false}>
-                  <div data-testid="floating" ref={refs.setFloating}>
-                    <span tabIndex={0} data-testid="inside" />
-                  </div>
+              {isOpen && (
+                <FloatingFocusManager context={context}>
+                  <div ref={refs.setFloating} data-testid="floating" />
                 </FloatingFocusManager>
               )}
-            </FloatingPortal>
-            <span tabIndex={0} data-testid="last" />
-          </>
-        );
-      }
+            </>
+          );
+        }
 
-      render(<App />);
+        render(<App />);
 
-      await userEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
 
-      expect(screen.getByTestId('inside')).toHaveFocus();
+        expect(screen.getByTestId('reference')).toHaveAttribute('aria-hidden', 'true');
+        expect(screen.getByTestId('floating')).not.toHaveAttribute('aria-hidden');
+        expect(screen.getByTestId('aria-live')).not.toHaveAttribute('aria-hidden');
+        expect(screen.getByTestId('btn-1')).toHaveAttribute('aria-hidden', 'true');
+        expect(screen.getByTestId('btn-2')).toHaveAttribute('aria-hidden', 'true');
 
-      await userEvent.tab();
+        fireEvent.click(screen.getByTestId('reference'));
 
-      expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
-      expect(screen.getByTestId('last')).toHaveFocus();
+        expect(screen.getByTestId('reference')).not.toHaveAttribute('aria-hidden');
+        expect(screen.getByTestId('aria-live')).not.toHaveAttribute('aria-hidden');
+        expect(screen.getByTestId('btn-1')).not.toHaveAttribute('aria-hidden');
+        expect(screen.getByTestId('btn-2')).not.toHaveAttribute('aria-hidden');
+      });
+
+      test('true - keeps supplied inside elements outside the floating node exposed to assistive tech', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+          const dismissRef = React.useRef<HTMLButtonElement | null>(null);
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          return (
+            <>
+              <input
+                data-testid="reference"
+                ref={refs.setReference}
+                onClick={() => setIsOpen((v) => !v)}
+              />
+              <div data-testid="outside-wrapper">
+                <button data-testid="outside-button" />
+              </div>
+              {isOpen && (
+                <FloatingFocusManager
+                  context={context}
+                  getInsideElements={() => [dismissRef.current]}
+                >
+                  <>
+                    <div ref={refs.setFloating} data-testid="floating" />
+                    <button ref={dismissRef} data-testid="dismiss" />
+                  </>
+                </FloatingFocusManager>
+              )}
+            </>
+          );
+        }
+
+        render(<App />);
+
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating')).not.toHaveAttribute('aria-hidden');
+        expect(screen.getByTestId('dismiss')).not.toHaveAttribute('aria-hidden');
+        expect(screen.getByTestId('outside-wrapper')).toHaveAttribute('aria-hidden', 'true');
+      });
+
+      test('false - does not apply inert to outside nodes', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          return (
+            <>
+              <input
+                data-testid="reference"
+                ref={refs.setReference}
+                onClick={() => setIsOpen((v) => !v)}
+              />
+              <div data-testid="outside-wrapper">
+                <div data-testid="aria-live" aria-live="polite" />
+                <button data-testid="btn-1" />
+                <button data-testid="btn-2" />
+              </div>
+              {isOpen && (
+                <FloatingFocusManager context={context} modal={false}>
+                  <div role="listbox" ref={refs.setFloating} data-testid="floating" />
+                </FloatingFocusManager>
+              )}
+            </>
+          );
+        }
+
+        render(<App />);
+
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating')).not.toHaveAttribute('inert');
+        expect(screen.getByTestId('aria-live')).not.toHaveAttribute('inert');
+        expect(screen.getByTestId('btn-1')).not.toHaveAttribute('inert');
+        expect(screen.getByTestId('btn-2')).not.toHaveAttribute('inert');
+        expect(screen.getByTestId('reference')).toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('outside-wrapper')).toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
+
+        fireEvent.click(screen.getByTestId('reference'));
+
+        expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('outside-wrapper')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
+      });
+
+      test('false - keeps marker on top-level outside ancestor when reference has siblings', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          return (
+            <>
+              <div data-testid="outside-wrapper">
+                <input
+                  data-testid="reference"
+                  ref={refs.setReference}
+                  onClick={() => setIsOpen((v) => !v)}
+                />
+                <button data-testid="btn-1" />
+                <button data-testid="btn-2" />
+                <div data-testid="nested-wrapper">
+                  <button data-testid="nested-btn" />
+                </div>
+              </div>
+              <div data-testid="outside-sibling" />
+              {isOpen && (
+                <FloatingFocusManager context={context} modal={false}>
+                  <div role="listbox" ref={refs.setFloating} data-testid="floating" />
+                </FloatingFocusManager>
+              )}
+            </>
+          );
+        }
+
+        render(<App />);
+
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating')).not.toHaveAttribute('inert');
+        expect(screen.getByTestId('outside-wrapper')).toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('outside-sibling')).toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('nested-wrapper')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('nested-btn')).not.toHaveAttribute('data-base-ui-inert');
+
+        fireEvent.click(screen.getByTestId('reference'));
+
+        expect(screen.getByTestId('outside-wrapper')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('outside-sibling')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('btn-1')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('btn-2')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('nested-wrapper')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('nested-btn')).not.toHaveAttribute('data-base-ui-inert');
+      });
     });
 
-    test('does not mark reference siblings due to outside focus guards', async () => {
-      function App() {
-        const [open, setOpen] = React.useState(false);
-        const { refs, context } = useFloating({
-          open,
-          onOpenChange: setOpen,
+    describe('prop: disabled', () => {
+      test('true -> false', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+          const [disabled, setDisabled] = React.useState(true);
+
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          return (
+            <>
+              <button
+                data-testid="reference"
+                ref={refs.setReference}
+                onClick={() => setIsOpen((v) => !v)}
+              />
+              <button data-testid="toggle" onClick={() => setDisabled((v) => !v)} />
+              {isOpen && (
+                <FloatingFocusManager context={context} disabled={disabled}>
+                  <div ref={refs.setFloating} data-testid="floating" role="dialog" />
+                </FloatingFocusManager>
+              )}
+            </>
+          );
+        }
+
+        render(<App />);
+
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+        expect(screen.getByTestId('floating')).not.toHaveFocus();
+        fireEvent.click(screen.getByTestId('toggle'));
+        await flushMicrotasks();
+        await waitFor(() => {
+          expect(screen.getByTestId('floating')).toHaveFocus();
+        });
+      });
+
+      test('when false', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+          const [disabled, setDisabled] = React.useState(false);
+
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          const click = useClick(context);
+
+          const { getReferenceProps, getFloatingProps } = useInteractions([click]);
+
+          return (
+            <>
+              <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
+              <button data-testid="toggle" onClick={() => setDisabled((v) => !v)} />
+              {isOpen && (
+                <FloatingFocusManager context={context} disabled={disabled}>
+                  <div ref={refs.setFloating} data-testid="floating" {...getFloatingProps()} />
+                </FloatingFocusManager>
+              )}
+            </>
+          );
+        }
+
+        render(<App />);
+
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+        expect(screen.getByTestId('floating')).toHaveFocus();
+      });
+
+      test('supports keepMounted behavior', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          const click = useClick(context);
+          const dismiss = useDismiss(context);
+
+          const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
+
+          return (
+            <>
+              <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
+              <FloatingFocusManager context={context} disabled={!isOpen} modal={false}>
+                <div ref={refs.setFloating} data-testid="floating" {...getFloatingProps()}>
+                  <button data-testid="child" />
+                </div>
+              </FloatingFocusManager>
+              <button data-testid="after" />
+            </>
+          );
+        }
+
+        render(<App />);
+
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating')).not.toHaveFocus();
+
+        fireEvent.click(screen.getByTestId('reference'));
+
+        await flushMicrotasks();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('child')).toHaveFocus();
         });
 
-        return (
-          <>
-            <div data-testid="reference-wrapper">
+        await userEvent.tab();
+
+        expect(screen.getByTestId('after')).toHaveFocus();
+
+        await userEvent.tab({ shift: true });
+
+        fireEvent.click(screen.getByTestId('reference'));
+
+        expect(screen.getByTestId('child')).toHaveFocus();
+
+        await userEvent.keyboard('{Escape}');
+
+        expect(screen.getByTestId('reference')).toHaveFocus();
+      });
+    });
+
+    describe('non-modal + FloatingPortal', () => {
+      test('focuses inside element, tabbing out focuses last document element', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+          const { refs, context } = useFloating({
+            open,
+            onOpenChange: setOpen,
+          });
+
+          return (
+            <>
+              <span tabIndex={0} data-testid="first" />
               <button
                 data-testid="reference"
                 ref={refs.setReference}
                 onClick={() => setOpen(true)}
               />
-              <span data-testid="reference-sibling-1" />
-              <span data-testid="reference-sibling-2" />
-            </div>
-            <FloatingPortal>
-              {open && (
-                <FloatingFocusManager context={context} modal={false}>
-                  <div data-testid="floating" ref={refs.setFloating}>
-                    <span tabIndex={0} data-testid="inside" />
-                  </div>
-                </FloatingFocusManager>
-              )}
-            </FloatingPortal>
-          </>
-        );
-      }
+              <FloatingPortal>
+                {open && (
+                  <FloatingFocusManager context={context} modal={false}>
+                    <div data-testid="floating" ref={refs.setFloating}>
+                      <span tabIndex={0} data-testid="inside" />
+                    </div>
+                  </FloatingFocusManager>
+                )}
+              </FloatingPortal>
+              <span tabIndex={0} data-testid="last" />
+            </>
+          );
+        }
 
-      render(<App />);
+        render(<App />);
 
-      await userEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
+        await userEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
 
-      expect(screen.getByTestId('floating')).toBeInTheDocument();
-      expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('reference-sibling-1')).not.toHaveAttribute('data-base-ui-inert');
-      expect(screen.getByTestId('reference-sibling-2')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('inside')).toHaveFocus();
+
+        await userEvent.tab();
+
+        expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
+        expect(screen.getByTestId('last')).toHaveFocus();
+      });
+
+      test('does not mark reference siblings due to outside focus guards', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+          const { refs, context } = useFloating({
+            open,
+            onOpenChange: setOpen,
+          });
+
+          return (
+            <>
+              <div data-testid="reference-wrapper">
+                <button
+                  data-testid="reference"
+                  ref={refs.setReference}
+                  onClick={() => setOpen(true)}
+                />
+                <span data-testid="reference-sibling-1" />
+                <span data-testid="reference-sibling-2" />
+              </div>
+              <FloatingPortal>
+                {open && (
+                  <FloatingFocusManager context={context} modal={false}>
+                    <div data-testid="floating" ref={refs.setFloating}>
+                      <span tabIndex={0} data-testid="inside" />
+                    </div>
+                  </FloatingFocusManager>
+                )}
+              </FloatingPortal>
+            </>
+          );
+        }
+
+        render(<App />);
+
+        await userEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating')).toBeInTheDocument();
+        expect(screen.getByTestId('reference')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('reference-sibling-1')).not.toHaveAttribute('data-base-ui-inert');
+        expect(screen.getByTestId('reference-sibling-2')).not.toHaveAttribute('data-base-ui-inert');
+      });
+
+      test('shift+tab', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+          const { refs, context } = useFloating({
+            open,
+            onOpenChange: setOpen,
+          });
+
+          return (
+            <>
+              <span tabIndex={0} data-testid="first" />
+              <button
+                data-testid="reference"
+                ref={refs.setReference}
+                onClick={() => setOpen(true)}
+              />
+              <FloatingPortal>
+                {open && (
+                  <FloatingFocusManager context={context} modal={false}>
+                    <div data-testid="floating" ref={refs.setFloating}>
+                      <span tabIndex={0} data-testid="inside" />
+                    </div>
+                  </FloatingFocusManager>
+                )}
+              </FloatingPortal>
+              <span tabIndex={0} data-testid="last" />
+            </>
+          );
+        }
+
+        render(<App />);
+
+        await userEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        await userEvent.tab({ shift: true });
+
+        expect(screen.getByTestId('floating')).toBeInTheDocument();
+
+        await userEvent.tab({ shift: true });
+
+        expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
+      });
     });
 
-    test('shift+tab', async () => {
-      function App() {
-        const [open, setOpen] = React.useState(false);
-        const { refs, context } = useFloating({
-          open,
-          onOpenChange: setOpen,
-        });
+    describe('Navigation', () => {
+      test('does not focus reference when hovering it', async () => {
+        render(<Navigation />);
+        await userEvent.hover(screen.getByText('Product'));
+        await userEvent.unhover(screen.getByText('Product'));
+        expect(screen.getByText('Product')).not.toHaveFocus();
+      });
 
-        return (
-          <>
-            <span tabIndex={0} data-testid="first" />
-            <button data-testid="reference" ref={refs.setReference} onClick={() => setOpen(true)} />
-            <FloatingPortal>
-              {open && (
-                <FloatingFocusManager context={context} modal={false}>
-                  <div data-testid="floating" ref={refs.setFloating}>
-                    <span tabIndex={0} data-testid="inside" />
-                  </div>
-                </FloatingFocusManager>
-              )}
-            </FloatingPortal>
-            <span tabIndex={0} data-testid="last" />
-          </>
-        );
-      }
+      test('returns focus to reference when floating element was opened by hover but is closed by esc key', async () => {
+        render(<Navigation />);
+        await userEvent.hover(screen.getByText('Product'));
+        await flushMicrotasks();
+        await userEvent.keyboard('{Escape}');
+        expect(screen.getByText('Product')).toHaveFocus();
+      });
 
-      render(<App />);
+      test('returns focus to reference when floating element was opened by hover but is closed by an explicit close button', async () => {
+        render(<Navigation />);
+        await userEvent.hover(screen.getByText('Product'));
+        await flushMicrotasks();
+        await userEvent.click(screen.getByText('Close').parentElement!);
+        await userEvent.keyboard('{Tab}');
+        expect(screen.getByText('Close')).toHaveFocus();
+        await userEvent.keyboard('{Enter}');
+        expect(screen.getByText('Product')).toHaveFocus();
+      });
 
-      await userEvent.click(screen.getByTestId('reference'));
-      await flushMicrotasks();
+      test('does not re-open after closing via escape key', async () => {
+        render(<Navigation />);
+        await userEvent.hover(screen.getByText('Product'));
+        await userEvent.keyboard('{Escape}');
+        expect(screen.queryByText('Link 1')).not.toBeInTheDocument();
+      });
 
-      await userEvent.tab({ shift: true });
-
-      expect(screen.getByTestId('floating')).toBeInTheDocument();
-
-      await userEvent.tab({ shift: true });
-
-      expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Navigation', () => {
-    test('does not focus reference when hovering it', async () => {
-      render(<Navigation />);
-      await userEvent.hover(screen.getByText('Product'));
-      await userEvent.unhover(screen.getByText('Product'));
-      expect(screen.getByText('Product')).not.toHaveFocus();
-    });
-
-    test('returns focus to reference when floating element was opened by hover but is closed by esc key', async () => {
-      render(<Navigation />);
-      await userEvent.hover(screen.getByText('Product'));
-      await flushMicrotasks();
-      await userEvent.keyboard('{Escape}');
-      expect(screen.getByText('Product')).toHaveFocus();
-    });
-
-    test('returns focus to reference when floating element was opened by hover but is closed by an explicit close button', async () => {
-      render(<Navigation />);
-      await userEvent.hover(screen.getByText('Product'));
-      await flushMicrotasks();
-      await userEvent.click(screen.getByText('Close').parentElement!);
-      await userEvent.keyboard('{Tab}');
-      expect(screen.getByText('Close')).toHaveFocus();
-      await userEvent.keyboard('{Enter}');
-      expect(screen.getByText('Product')).toHaveFocus();
-    });
-
-    test('does not re-open after closing via escape key', async () => {
-      render(<Navigation />);
-      await userEvent.hover(screen.getByText('Product'));
-      await userEvent.keyboard('{Escape}');
-      expect(screen.queryByText('Link 1')).not.toBeInTheDocument();
-    });
-
-    test('closes when unhovering floating element even when focus is inside it', async () => {
-      render(<Navigation />);
-      await userEvent.hover(screen.getByText('Product'));
-      await userEvent.click(screen.getByTestId('subnavigation'));
-      await userEvent.unhover(screen.getByTestId('subnavigation'));
-      await userEvent.hover(screen.getByText('Product'));
-      await userEvent.unhover(screen.getByText('Product'));
-      expect(screen.queryByTestId('subnavigation')).not.toBeInTheDocument();
+      test('closes when unhovering floating element even when focus is inside it', async () => {
+        render(<Navigation />);
+        await userEvent.hover(screen.getByText('Product'));
+        await userEvent.click(screen.getByTestId('subnavigation'));
+        await userEvent.unhover(screen.getByTestId('subnavigation'));
+        await userEvent.hover(screen.getByText('Product'));
+        await userEvent.unhover(screen.getByText('Product'));
+        expect(screen.queryByTestId('subnavigation')).not.toBeInTheDocument();
+      });
     });
   });
 
@@ -1534,537 +1551,571 @@ describe.skipIf(!isJSDOM)('FloatingFocusManager', () => {
         });
       },
     );
+
+    test('restores focus to the nearest tabbable element when the focused element becomes hidden', async () => {
+      render(<App />);
+
+      await userEvent.click(screen.getByTestId('reference'));
+      await flushMicrotasks();
+
+      const two = screen.getByRole('button', { name: 'two' });
+      const three = screen.getByRole('button', { name: 'three' });
+
+      expect(two).toHaveFocus();
+
+      document.body.tabIndex = -1;
+      two.style.visibility = 'hidden';
+      document.body.focus();
+
+      await waitFor(() => {
+        expect(three).toHaveFocus();
+      });
+    });
   });
 
-  test('trapped combobox prevents focus moving outside floating element', async () => {
-    function App() {
-      const [isOpen, setIsOpen] = React.useState(false);
+  describe.skipIf(!isJSDOM)('JSDOM-only coverage', () => {
+    test('trapped combobox prevents focus moving outside floating element', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
 
-      const { refs, floatingStyles, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
+        const { refs, floatingStyles, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
 
-      const role = useRole(context);
-      const dismiss = useDismiss(context);
-      const click = useClick(context);
+        const role = useRole(context);
+        const dismiss = useDismiss(context);
+        const click = useClick(context);
 
-      const { getReferenceProps, getFloatingProps } = useInteractions([role, dismiss, click]);
+        const { getReferenceProps, getFloatingProps } = useInteractions([role, dismiss, click]);
 
-      return (
-        <div className="App">
-          <input
-            ref={refs.setReference}
-            {...getReferenceProps()}
-            data-testid="input"
-            role="combobox"
-          />
-          {isOpen && (
-            <FloatingFocusManager context={context}>
-              <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
-                <button>one</button>
-                <button>two</button>
-              </div>
-            </FloatingFocusManager>
-          )}
-        </div>
-      );
-    }
-
-    render(<App />);
-    await userEvent.click(screen.getByTestId('input'));
-    await flushMicrotasks();
-    expect(screen.getByTestId('input')).not.toHaveFocus();
-    expect(screen.getByRole('button', { name: 'one' })).toHaveFocus();
-    await userEvent.tab();
-    expect(screen.getByRole('button', { name: 'two' })).toHaveFocus();
-    await userEvent.tab();
-    expect(screen.getByRole('button', { name: 'one' })).toHaveFocus();
-    await flushMicrotasks();
-  });
-
-  test('untrapped combobox creates non-modal focus management', async () => {
-    function App() {
-      const [isOpen, setIsOpen] = React.useState(false);
-
-      const { refs, floatingStyles, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
-
-      const role = useRole(context);
-      const dismiss = useDismiss(context);
-      const click = useClick(context);
-
-      const { getReferenceProps, getFloatingProps } = useInteractions([role, dismiss, click]);
-
-      return (
-        <>
-          <input
-            ref={refs.setReference}
-            {...getReferenceProps()}
-            data-testid="input"
-            role="combobox"
-          />
-          {isOpen && (
-            <FloatingPortal>
-              <FloatingFocusManager context={context} initialFocus={false} modal={false}>
+        return (
+          <div className="App">
+            <input
+              ref={refs.setReference}
+              {...getReferenceProps()}
+              data-testid="input"
+              role="combobox"
+            />
+            {isOpen && (
+              <FloatingFocusManager context={context}>
                 <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
                   <button>one</button>
                   <button>two</button>
                 </div>
               </FloatingFocusManager>
-            </FloatingPortal>
-          )}
-          <button>outside</button>
-        </>
-      );
-    }
-
-    render(<App />);
-    await userEvent.click(screen.getByTestId('input'));
-    await flushMicrotasks();
-    expect(screen.getByTestId('input')).toHaveFocus();
-    await userEvent.tab();
-    expect(screen.getByRole('button', { name: 'one' })).toHaveFocus();
-    await userEvent.tab({ shift: true });
-    expect(screen.getByTestId('input')).toHaveFocus();
-  });
-
-  test('returns focus to last connected element', async () => {
-    function Drawer({
-      open,
-      onOpenChange,
-    }: {
-      open: boolean;
-      onOpenChange: (open: boolean) => void;
-    }) {
-      const { refs, context } = useFloating({ open, onOpenChange });
-      const dismiss = useDismiss(context);
-      const { getFloatingProps } = useInteractions([dismiss]);
-
-      return (
-        <FloatingFocusManager context={context}>
-          <div ref={refs.setFloating} {...getFloatingProps()}>
-            <button data-testid="child-reference" />
+            )}
           </div>
-        </FloatingFocusManager>
-      );
-    }
-
-    function Parent() {
-      const [isOpen, setIsOpen] = React.useState(false);
-      const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
-
-      const { refs, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
-
-      const dismiss = useDismiss(context);
-      const click = useClick(context);
-
-      const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
-
-      return (
-        <>
-          <button ref={refs.setReference} data-testid="parent-reference" {...getReferenceProps()} />
-          {isOpen && (
-            <FloatingFocusManager context={context}>
-              <div ref={refs.setFloating} {...getFloatingProps()}>
-                Parent Floating
-                <button
-                  data-testid="parent-floating-reference"
-                  onClick={() => {
-                    setIsDrawerOpen(true);
-                    setIsOpen(false);
-                  }}
-                />
-              </div>
-            </FloatingFocusManager>
-          )}
-          {isDrawerOpen && <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen} />}
-        </>
-      );
-    }
-
-    render(<Parent />);
-    await userEvent.click(screen.getByTestId('parent-reference'));
-    await flushMicrotasks();
-    expect(screen.getByTestId('parent-floating-reference')).toHaveFocus();
-    await userEvent.click(screen.getByTestId('parent-floating-reference'));
-    await flushMicrotasks();
-    expect(screen.getByTestId('child-reference')).toHaveFocus();
-    await userEvent.keyboard('{Escape}');
-    expect(screen.getByTestId('parent-reference')).toHaveFocus();
-  });
-
-  test('focus is placed on element with floating props when floating element is a wrapper', async () => {
-    function App() {
-      const [isOpen, setIsOpen] = React.useState(false);
-
-      const { refs, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
-
-      const role = useRole(context);
-
-      const { getReferenceProps, getFloatingProps } = useInteractions([role]);
-
-      return (
-        <>
-          <button
-            ref={refs.setReference}
-            {...getReferenceProps({
-              onClick: () => setIsOpen((v) => !v),
-            })}
-          />
-          {isOpen && (
-            <FloatingFocusManager context={context}>
-              <div ref={refs.setFloating} data-testid="outer">
-                <div {...getFloatingProps()} data-testid="inner" />
-              </div>
-            </FloatingFocusManager>
-          )}
-        </>
-      );
-    }
-
-    render(<App />);
-
-    await userEvent.click(screen.getByRole('button'));
-    await flushMicrotasks();
-
-    expect(screen.getByTestId('inner')).toHaveFocus();
-  });
-
-  test('floating element closes upon tabbing out of modal combobox', async () => {
-    function App() {
-      const [isOpen, setIsOpen] = React.useState(false);
-
-      const { refs, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
-
-      const click = useClick(context);
-
-      const { getReferenceProps, getFloatingProps } = useInteractions([click]);
-
-      return (
-        <>
-          <input
-            ref={refs.setReference}
-            {...getReferenceProps()}
-            data-testid="input"
-            role="combobox"
-          />
-          {isOpen && (
-            <FloatingFocusManager context={context} initialFocus={false}>
-              <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating">
-                <button tabIndex={-1}>one</button>
-              </div>
-            </FloatingFocusManager>
-          )}
-          <button data-testid="after" />
-        </>
-      );
-    }
-
-    render(<App />);
-    await userEvent.click(screen.getByTestId('input'));
-    await flushMicrotasks();
-    expect(screen.getByTestId('input')).toHaveFocus();
-    await userEvent.tab();
-    await flushMicrotasks();
-    expect(screen.getByTestId('after')).toHaveFocus();
-  });
-
-  test('untrapped typeable combobox closes on second tab sequence (click -> tab -> click -> tab)', async () => {
-    function App() {
-      const [isOpen, setIsOpen] = React.useState(false);
-
-      const { refs, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
-
-      const click = useClick(context);
-      const { getReferenceProps, getFloatingProps } = useInteractions([click]);
-
-      return (
-        <>
-          <input
-            ref={refs.setReference}
-            {...getReferenceProps()}
-            data-testid="input"
-            role="combobox"
-          />
-          {isOpen && (
-            <FloatingFocusManager context={context} initialFocus={false} modal>
-              <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating">
-                <button tabIndex={-1}>one</button>
-              </div>
-            </FloatingFocusManager>
-          )}
-          <button data-testid="after" />
-        </>
-      );
-    }
-
-    render(<App />);
-
-    await userEvent.click(screen.getByTestId('input'));
-    await flushMicrotasks();
-
-    expect(screen.getByTestId('input')).toHaveFocus();
-
-    await userEvent.tab();
-    await flushMicrotasks();
-
-    expect(screen.getByTestId('after')).toHaveFocus();
-    expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
-
-    await userEvent.click(screen.getByTestId('input'));
-    await flushMicrotasks();
-
-    expect(screen.getByTestId('input')).toHaveFocus();
-
-    await userEvent.tab();
-    await flushMicrotasks();
-
-    expect(screen.getByTestId('after')).toHaveFocus();
-    expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
-  });
-
-  test('focus does not return to reference when floating element is triggered by hover', async () => {
-    function App() {
-      const [isOpen, setIsOpen] = React.useState(false);
-
-      const { refs, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
-
-      const hover = useHover(context);
-
-      const { getReferenceProps, getFloatingProps } = useInteractions([hover]);
-
-      return (
-        <>
-          <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
-          {isOpen && (
-            <FloatingFocusManager context={context}>
-              <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating" />
-            </FloatingFocusManager>
-          )}
-        </>
-      );
-    }
-
-    render(<App />);
-
-    const reference = screen.getByTestId('reference');
-
-    act(() => reference.focus());
-
-    await userEvent.hover(reference);
-    await flushMicrotasks();
-
-    expect(screen.getByTestId('floating')).toHaveFocus();
-
-    await userEvent.unhover(screen.getByTestId('floating'));
-
-    expect(screen.getByTestId('reference')).not.toHaveFocus();
-  });
-
-  test('uses aria-hidden instead of inert on outside nodes if opened with hover and modal=true', async () => {
-    function App() {
-      const [isOpen, setIsOpen] = React.useState(false);
-
-      const { refs, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
-
-      const hover = useHover(context);
-
-      const { getReferenceProps, getFloatingProps } = useInteractions([hover]);
-
-      return (
-        <>
-          <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
-          {isOpen && (
-            <FloatingFocusManager context={context}>
-              <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating" />
-            </FloatingFocusManager>
-          )}
-          <button>outside</button>
-        </>
-      );
-    }
-
-    render(<App />);
-
-    await userEvent.hover(screen.getByTestId('reference'));
-    await flushMicrotasks();
-
-    expect(screen.getByText('outside')).not.toHaveAttribute('inert');
-    expect(screen.getByText('outside')).toHaveAttribute('aria-hidden', 'true');
-  });
-
-  test('floating element with no focusable elements and no listbox role gets tabIndex=0 when initialFocus is -1', async () => {
-    function App() {
-      const [isOpen, setIsOpen] = React.useState(false);
-
-      const { refs, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
-
-      return (
-        <>
-          <button data-testid="reference" ref={refs.setReference} onClick={() => setIsOpen(true)} />
-          {isOpen && (
-            <FloatingFocusManager context={context} initialFocus={false} modal={false}>
-              <div ref={refs.setFloating} data-testid="floating" role="dialog" />
-            </FloatingFocusManager>
-          )}
-        </>
-      );
-    }
-
-    render(<App />);
-
-    const reference = screen.getByTestId('reference');
-    await userEvent.click(reference);
-    await flushMicrotasks();
-    fireEvent.focusOut(reference);
-    await flushMicrotasks();
-
-    expect(screen.getByTestId('floating')).toHaveAttribute('tabindex', '0');
-  });
-
-  test('floating element with listbox role ignores tabIndex setting', async () => {
-    function App() {
-      const [isOpen, setIsOpen] = React.useState(false);
-
-      const { refs, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
-
-      const click = useClick(context);
-      const { getReferenceProps, getFloatingProps } = useInteractions([click]);
-
-      return (
-        <>
-          <button
-            data-testid="reference"
-            ref={refs.setReference}
-            onClick={() => setIsOpen(true)}
-            {...getReferenceProps()}
-          >
-            ref
-          </button>
-          {isOpen && (
-            <FloatingFocusManager context={context} initialFocus={false} modal={false}>
-              <div
-                ref={refs.setFloating}
-                role="listbox"
-                data-testid="floating"
-                {...getFloatingProps()}
-              >
-                floating
-              </div>
-            </FloatingFocusManager>
-          )}
-        </>
-      );
-    }
-
-    render(<App />);
-    await userEvent.click(screen.getByTestId('reference'));
-    await flushMicrotasks();
-
-    expect(screen.getByTestId('floating')).toHaveAttribute('tabindex', '-1');
-  });
-
-  test('handles manual tabindex on dialog floating element', async () => {
-    function App() {
-      const [isOpen, setIsOpen] = React.useState(false);
-
-      const { refs, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
-
-      return (
-        <>
-          <button data-testid="reference" ref={refs.setReference} onClick={() => setIsOpen(true)} />
-          {isOpen && (
-            <FloatingFocusManager context={context} modal={false}>
-              <div ref={refs.setFloating} data-testid="floating" role="dialog" />
-            </FloatingFocusManager>
-          )}
-        </>
-      );
-    }
-
-    render(<App />);
-
-    await userEvent.click(screen.getByTestId('reference'));
-    await flushMicrotasks();
-
-    expect(screen.getByTestId('floating')).toHaveAttribute('tabindex', '0');
-    await userEvent.tab({ shift: true });
-    expect(screen.getByTestId('reference')).toHaveFocus();
-    await userEvent.tab();
-    expect(screen.getByTestId('floating')).toHaveFocus();
-  });
-
-  test('standard tabbing back and forth of a non-modal floating element', async () => {
-    function App() {
-      const [isOpen, setIsOpen] = React.useState(false);
-
-      const { refs, context } = useFloating({
-        open: isOpen,
-        onOpenChange: setIsOpen,
-      });
-
-      const click = useClick(context);
-      const { getReferenceProps, getFloatingProps } = useInteractions([click]);
-
-      return (
-        <>
-          <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
-          {isOpen && (
-            <FloatingPortal>
-              <FloatingFocusManager context={context} modal={false}>
-                <div
-                  ref={refs.setFloating}
-                  data-testid="floating"
-                  role="dialog"
-                  {...getFloatingProps()}
-                >
-                  <button data-testid="inner">inner</button>
+        );
+      }
+
+      render(<App />);
+      await userEvent.click(screen.getByTestId('input'));
+      await flushMicrotasks();
+      expect(screen.getByTestId('input')).not.toHaveFocus();
+      expect(screen.getByRole('button', { name: 'one' })).toHaveFocus();
+      await userEvent.tab();
+      expect(screen.getByRole('button', { name: 'two' })).toHaveFocus();
+      await userEvent.tab();
+      expect(screen.getByRole('button', { name: 'one' })).toHaveFocus();
+      await flushMicrotasks();
+    });
+
+    test('untrapped combobox creates non-modal focus management', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
+
+        const { refs, floatingStyles, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        const role = useRole(context);
+        const dismiss = useDismiss(context);
+        const click = useClick(context);
+
+        const { getReferenceProps, getFloatingProps } = useInteractions([role, dismiss, click]);
+
+        return (
+          <>
+            <input
+              ref={refs.setReference}
+              {...getReferenceProps()}
+              data-testid="input"
+              role="combobox"
+            />
+            {isOpen && (
+              <FloatingPortal>
+                <FloatingFocusManager context={context} initialFocus={false} modal={false}>
+                  <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
+                    <button>one</button>
+                    <button>two</button>
+                  </div>
+                </FloatingFocusManager>
+              </FloatingPortal>
+            )}
+            <button>outside</button>
+          </>
+        );
+      }
+
+      render(<App />);
+      await userEvent.click(screen.getByTestId('input'));
+      await flushMicrotasks();
+      expect(screen.getByTestId('input')).toHaveFocus();
+      await userEvent.tab();
+      expect(screen.getByRole('button', { name: 'one' })).toHaveFocus();
+      await userEvent.tab({ shift: true });
+      expect(screen.getByTestId('input')).toHaveFocus();
+    });
+
+    test('returns focus to last connected element', async () => {
+      function Drawer({
+        open,
+        onOpenChange,
+      }: {
+        open: boolean;
+        onOpenChange: (open: boolean) => void;
+      }) {
+        const { refs, context } = useFloating({ open, onOpenChange });
+        const dismiss = useDismiss(context);
+        const { getFloatingProps } = useInteractions([dismiss]);
+
+        return (
+          <FloatingFocusManager context={context}>
+            <div ref={refs.setFloating} {...getFloatingProps()}>
+              <button data-testid="child-reference" />
+            </div>
+          </FloatingFocusManager>
+        );
+      }
+
+      function Parent() {
+        const [isOpen, setIsOpen] = React.useState(false);
+        const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
+
+        const { refs, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        const dismiss = useDismiss(context);
+        const click = useClick(context);
+
+        const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
+
+        return (
+          <>
+            <button
+              ref={refs.setReference}
+              data-testid="parent-reference"
+              {...getReferenceProps()}
+            />
+            {isOpen && (
+              <FloatingFocusManager context={context}>
+                <div ref={refs.setFloating} {...getFloatingProps()}>
+                  Parent Floating
+                  <button
+                    data-testid="parent-floating-reference"
+                    onClick={() => {
+                      setIsDrawerOpen(true);
+                      setIsOpen(false);
+                    }}
+                  />
                 </div>
               </FloatingFocusManager>
-            </FloatingPortal>
-          )}
-        </>
-      );
-    }
-    render(<App />);
+            )}
+            {isDrawerOpen && <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen} />}
+          </>
+        );
+      }
 
-    await userEvent.click(screen.getByTestId('reference'));
-    await flushMicrotasks();
+      render(<Parent />);
+      await userEvent.click(screen.getByTestId('parent-reference'));
+      await flushMicrotasks();
+      expect(screen.getByTestId('parent-floating-reference')).toHaveFocus();
+      await userEvent.click(screen.getByTestId('parent-floating-reference'));
+      await flushMicrotasks();
+      expect(screen.getByTestId('child-reference')).toHaveFocus();
+      await userEvent.keyboard('{Escape}');
+      expect(screen.getByTestId('parent-reference')).toHaveFocus();
+    });
 
-    expect(screen.getByTestId('inner')).toHaveFocus();
-    await userEvent.tab({ shift: true });
-    expect(screen.getByTestId('reference')).toHaveFocus();
-    await userEvent.tab();
-    expect(screen.getByTestId('inner')).toHaveFocus();
+    test('focus is placed on element with floating props when floating element is a wrapper', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
+
+        const { refs, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        const role = useRole(context);
+
+        const { getReferenceProps, getFloatingProps } = useInteractions([role]);
+
+        return (
+          <>
+            <button
+              ref={refs.setReference}
+              {...getReferenceProps({
+                onClick: () => setIsOpen((v) => !v),
+              })}
+            />
+            {isOpen && (
+              <FloatingFocusManager context={context}>
+                <div ref={refs.setFloating} data-testid="outer">
+                  <div {...getFloatingProps()} data-testid="inner" />
+                </div>
+              </FloatingFocusManager>
+            )}
+          </>
+        );
+      }
+
+      render(<App />);
+
+      await userEvent.click(screen.getByRole('button'));
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('inner')).toHaveFocus();
+    });
+
+    test('floating element closes upon tabbing out of modal combobox', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
+
+        const { refs, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        const click = useClick(context);
+
+        const { getReferenceProps, getFloatingProps } = useInteractions([click]);
+
+        return (
+          <>
+            <input
+              ref={refs.setReference}
+              {...getReferenceProps()}
+              data-testid="input"
+              role="combobox"
+            />
+            {isOpen && (
+              <FloatingFocusManager context={context} initialFocus={false}>
+                <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating">
+                  <button tabIndex={-1}>one</button>
+                </div>
+              </FloatingFocusManager>
+            )}
+            <button data-testid="after" />
+          </>
+        );
+      }
+
+      render(<App />);
+      await userEvent.click(screen.getByTestId('input'));
+      await flushMicrotasks();
+      expect(screen.getByTestId('input')).toHaveFocus();
+      await userEvent.tab();
+      await flushMicrotasks();
+      expect(screen.getByTestId('after')).toHaveFocus();
+    });
+
+    test('untrapped typeable combobox closes on second tab sequence (click -> tab -> click -> tab)', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
+
+        const { refs, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        const click = useClick(context);
+        const { getReferenceProps, getFloatingProps } = useInteractions([click]);
+
+        return (
+          <>
+            <input
+              ref={refs.setReference}
+              {...getReferenceProps()}
+              data-testid="input"
+              role="combobox"
+            />
+            {isOpen && (
+              <FloatingFocusManager context={context} initialFocus={false} modal>
+                <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating">
+                  <button tabIndex={-1}>one</button>
+                </div>
+              </FloatingFocusManager>
+            )}
+            <button data-testid="after" />
+          </>
+        );
+      }
+
+      render(<App />);
+
+      await userEvent.click(screen.getByTestId('input'));
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('input')).toHaveFocus();
+
+      await userEvent.tab();
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('after')).toHaveFocus();
+      expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByTestId('input'));
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('input')).toHaveFocus();
+
+      await userEvent.tab();
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('after')).toHaveFocus();
+      expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
+    });
+
+    test('focus does not return to reference when floating element is triggered by hover', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
+
+        const { refs, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        const hover = useHover(context);
+
+        const { getReferenceProps, getFloatingProps } = useInteractions([hover]);
+
+        return (
+          <>
+            <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
+            {isOpen && (
+              <FloatingFocusManager context={context}>
+                <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating" />
+              </FloatingFocusManager>
+            )}
+          </>
+        );
+      }
+
+      render(<App />);
+
+      const reference = screen.getByTestId('reference');
+
+      act(() => reference.focus());
+
+      await userEvent.hover(reference);
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('floating')).toHaveFocus();
+
+      await userEvent.unhover(screen.getByTestId('floating'));
+
+      expect(screen.getByTestId('reference')).not.toHaveFocus();
+    });
+
+    test('uses aria-hidden instead of inert on outside nodes if opened with hover and modal=true', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
+
+        const { refs, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        const hover = useHover(context);
+
+        const { getReferenceProps, getFloatingProps } = useInteractions([hover]);
+
+        return (
+          <>
+            <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
+            {isOpen && (
+              <FloatingFocusManager context={context}>
+                <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating" />
+              </FloatingFocusManager>
+            )}
+            <button>outside</button>
+          </>
+        );
+      }
+
+      render(<App />);
+
+      await userEvent.hover(screen.getByTestId('reference'));
+      await flushMicrotasks();
+
+      expect(screen.getByText('outside')).not.toHaveAttribute('inert');
+      expect(screen.getByText('outside')).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    test('floating element with no focusable elements and no listbox role gets tabIndex=0 when initialFocus is -1', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
+
+        const { refs, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        return (
+          <>
+            <button
+              data-testid="reference"
+              ref={refs.setReference}
+              onClick={() => setIsOpen(true)}
+            />
+            {isOpen && (
+              <FloatingFocusManager context={context} initialFocus={false} modal={false}>
+                <div ref={refs.setFloating} data-testid="floating" role="dialog" />
+              </FloatingFocusManager>
+            )}
+          </>
+        );
+      }
+
+      render(<App />);
+
+      const reference = screen.getByTestId('reference');
+      await userEvent.click(reference);
+      await flushMicrotasks();
+      fireEvent.focusOut(reference);
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('floating')).toHaveAttribute('tabindex', '0');
+    });
+
+    test('floating element with listbox role ignores tabIndex setting', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
+
+        const { refs, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        const click = useClick(context);
+        const { getReferenceProps, getFloatingProps } = useInteractions([click]);
+
+        return (
+          <>
+            <button
+              data-testid="reference"
+              ref={refs.setReference}
+              onClick={() => setIsOpen(true)}
+              {...getReferenceProps()}
+            >
+              ref
+            </button>
+            {isOpen && (
+              <FloatingFocusManager context={context} initialFocus={false} modal={false}>
+                <div
+                  ref={refs.setFloating}
+                  role="listbox"
+                  data-testid="floating"
+                  {...getFloatingProps()}
+                >
+                  floating
+                </div>
+              </FloatingFocusManager>
+            )}
+          </>
+        );
+      }
+
+      render(<App />);
+      await userEvent.click(screen.getByTestId('reference'));
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('floating')).toHaveAttribute('tabindex', '-1');
+    });
+
+    test('handles manual tabindex on dialog floating element', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
+
+        const { refs, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        return (
+          <>
+            <button
+              data-testid="reference"
+              ref={refs.setReference}
+              onClick={() => setIsOpen(true)}
+            />
+            {isOpen && (
+              <FloatingFocusManager context={context} modal={false}>
+                <div ref={refs.setFloating} data-testid="floating" role="dialog" />
+              </FloatingFocusManager>
+            )}
+          </>
+        );
+      }
+
+      render(<App />);
+
+      await userEvent.click(screen.getByTestId('reference'));
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('floating')).toHaveAttribute('tabindex', '0');
+      await userEvent.tab({ shift: true });
+      expect(screen.getByTestId('reference')).toHaveFocus();
+      await userEvent.tab();
+      expect(screen.getByTestId('floating')).toHaveFocus();
+    });
+
+    test('standard tabbing back and forth of a non-modal floating element', async () => {
+      function App() {
+        const [isOpen, setIsOpen] = React.useState(false);
+
+        const { refs, context } = useFloating({
+          open: isOpen,
+          onOpenChange: setIsOpen,
+        });
+
+        const click = useClick(context);
+        const { getReferenceProps, getFloatingProps } = useInteractions([click]);
+
+        return (
+          <>
+            <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
+            {isOpen && (
+              <FloatingPortal>
+                <FloatingFocusManager context={context} modal={false}>
+                  <div
+                    ref={refs.setFloating}
+                    data-testid="floating"
+                    role="dialog"
+                    {...getFloatingProps()}
+                  >
+                    <button data-testid="inner">inner</button>
+                  </div>
+                </FloatingFocusManager>
+              </FloatingPortal>
+            )}
+          </>
+        );
+      }
+      render(<App />);
+
+      await userEvent.click(screen.getByTestId('reference'));
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('inner')).toHaveFocus();
+      await userEvent.tab({ shift: true });
+      expect(screen.getByTestId('reference')).toHaveFocus();
+      await userEvent.tab();
+      expect(screen.getByTestId('inner')).toHaveFocus();
+    });
   });
 });

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -105,18 +105,6 @@ function getFirstTabbableElement(container: Element | null) {
   return tabbable(container)[0] || container;
 }
 
-function isFocusable(element: Element | null) {
-  if (!element || !element.isConnected) {
-    return false;
-  }
-
-  if (typeof element.checkVisibility === 'function') {
-    return element.checkVisibility();
-  }
-
-  return isElementVisible(element);
-}
-
 function handleTabIndex(
   floatingFocusElement: HTMLElement,
   orderRef: React.RefObject<Array<'reference' | 'floating' | 'content'>>,
@@ -501,7 +489,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
         if (
           restoreFocus &&
           currentTarget !== domReference &&
-          !isFocusable(target) &&
+          !isElementVisible(target) &&
           activeElement(doc) === doc.body
         ) {
           // Let `FloatingPortal` effect knows that focus is still inside the

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
@@ -19,9 +19,10 @@ function App(
   inProps: Omit<Partial<UseListNavigationProps>, 'listRef'> & {
     disableFirstItem?: boolean;
     hideFirstItem?: boolean;
+    firstItemStyle?: React.CSSProperties;
   } = {},
 ) {
-  const { disableFirstItem, hideFirstItem, ...props } = inProps;
+  const { disableFirstItem, hideFirstItem, firstItemStyle, ...props } = inProps;
   const [open, setOpen] = React.useState(false);
   const listRef = React.useRef<Array<HTMLLIElement | null>>([]);
   const [activeIndex, setActiveIndex] = React.useState<null | number>(null);
@@ -48,29 +49,37 @@ function App(
       {open && (
         <div role="menu" {...getFloatingProps({ ref: refs.setFloating })}>
           <ul>
-            {['one', 'two', 'three'].map((string, index) => (
-              // eslint-disable-next-line
-              <li
-                data-testid={`item-${index}`}
-                aria-selected={activeIndex === index}
-                key={string}
-                style={hideFirstItem && index === 0 ? { display: 'none' } : undefined}
-                tabIndex={-1}
-                aria-disabled={
-                  (disableFirstItem && index === 0) ||
-                  (typeof props.disabledIndices === 'function'
-                    ? props.disabledIndices?.(index)
-                    : props.disabledIndices?.includes(index))
-                }
-                {...getItemProps({
-                  ref(node: HTMLLIElement) {
-                    listRef.current[index] = node;
-                  },
-                })}
-              >
-                {string}
-              </li>
-            ))}
+            {['one', 'two', 'three'].map((string, index) => {
+              let style: React.CSSProperties | undefined;
+
+              if (index === 0) {
+                style = hideFirstItem ? { display: 'none' } : firstItemStyle;
+              }
+
+              return (
+                // eslint-disable-next-line
+                <li
+                  data-testid={`item-${index}`}
+                  aria-selected={activeIndex === index}
+                  key={string}
+                  style={style}
+                  tabIndex={-1}
+                  aria-disabled={
+                    (disableFirstItem && index === 0) ||
+                    (typeof props.disabledIndices === 'function'
+                      ? props.disabledIndices?.(index)
+                      : props.disabledIndices?.includes(index))
+                  }
+                  {...getItemProps({
+                    ref(node: HTMLLIElement) {
+                      listRef.current[index] = node;
+                    },
+                  })}
+                >
+                  {string}
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}
@@ -266,6 +275,21 @@ describe('useListNavigation', () => {
 
   it('skips items hidden with CSS in navigation', async () => {
     render(<App hideFirstItem loopFocus disabledIndices={[]} />);
+
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('item-1')).toHaveFocus();
+    });
+
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowUp' });
+    await waitFor(() => {
+      expect(screen.getByTestId('item-2')).toHaveFocus();
+    });
+  });
+
+  it('skips visibility:hidden items in navigation', async () => {
+    render(<App firstItemStyle={{ visibility: 'hidden' }} loopFocus disabledIndices={[]} />);
 
     fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
     expect(screen.getByRole('menu')).toBeInTheDocument();

--- a/packages/react/src/floating-ui-react/hooks/useTypeahead.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useTypeahead.test.tsx
@@ -285,4 +285,18 @@ describe('useTypeahead', () => {
     await userEvent.keyboard('a');
     expect(spy).toHaveBeenCalledWith(1);
   });
+
+  it('skips visibility:hidden items when matching with elementsRef', async () => {
+    const spy = vi.fn();
+    render(<ComboboxWithElementsRef onMatch={spy} />);
+
+    const apple = screen.getByRole('option', { name: 'apple' });
+
+    apple.style.visibility = 'hidden';
+
+    await userEvent.click(screen.getByRole('combobox'));
+
+    await userEvent.keyboard('a');
+    expect(spy).toHaveBeenCalledWith(1);
+  });
 });

--- a/packages/react/src/floating-ui-react/hooks/useTypeahead.ts
+++ b/packages/react/src/floating-ui-react/hooks/useTypeahead.ts
@@ -27,8 +27,9 @@ export interface UseTypeaheadProps {
   onMatch?: ((index: number) => void) | undefined;
   /**
    * Optional list of item elements that correspond to `listRef` indices.
-   * When an element exists for an index, typeahead skips it if it is hidden
-   * via CSS (`display: none`).
+   * When an element exists for an index, typeahead skips it if it is hidden by
+   * `display: none`, `visibility: hidden|collapse`, or other
+   * browser-reported visibility checks.
    */
   elementsRef?: React.RefObject<Array<HTMLElement | null>> | undefined;
   /**

--- a/packages/react/src/floating-ui-react/utils/composite.test.ts
+++ b/packages/react/src/floating-ui-react/utils/composite.test.ts
@@ -1,0 +1,45 @@
+import { isElementVisible, isHiddenByStyles } from './composite';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+it('treats hidden visibility styles as hidden', () => {
+  const hidden = document.createElement('div');
+  const collapsed = document.createElement('div');
+  const visible = document.createElement('div');
+
+  hidden.style.visibility = 'hidden';
+  collapsed.style.visibility = 'collapse';
+
+  document.body.append(hidden, collapsed, visible);
+
+  expect(isHiddenByStyles(getComputedStyle(hidden))).toBe(true);
+  expect(isHiddenByStyles(getComputedStyle(collapsed))).toBe(true);
+  expect(isHiddenByStyles(getComputedStyle(visible))).toBe(false);
+});
+
+it('uses CSS visibility fallbacks when checkVisibility is unavailable', () => {
+  const visible = document.createElement('button');
+  const displayHidden = document.createElement('button');
+  const displayContents = document.createElement('button');
+  const contentHidden = document.createElement('button');
+
+  displayHidden.style.display = 'none';
+  displayContents.style.display = 'contents';
+  contentHidden.style.contentVisibility = 'hidden';
+  Object.defineProperty(displayContents, 'checkVisibility', {
+    configurable: true,
+    value: undefined,
+  });
+  Object.defineProperty(contentHidden, 'checkVisibility', {
+    configurable: true,
+    value: undefined,
+  });
+  document.body.append(visible, displayHidden, displayContents, contentHidden);
+
+  expect(isElementVisible(visible)).toBe(true);
+  expect(isElementVisible(displayHidden)).toBe(false);
+  expect(isElementVisible(displayContents)).toBe(false);
+  expect(isElementVisible(contentHidden)).toBe(true);
+});

--- a/packages/react/src/floating-ui-react/utils/composite.ts
+++ b/packages/react/src/floating-ui-react/utils/composite.ts
@@ -496,10 +496,21 @@ export function isListIndexDisabled(
   );
 }
 
-export function isElementVisible(element: Element) {
+export function isHiddenByStyles(styles: CSSStyleDeclaration) {
+  return styles.visibility === 'hidden' || styles.visibility === 'collapse';
+}
+
+export function isElementVisible(
+  element: Element | null,
+  styles: CSSStyleDeclaration | null = element ? getComputedStyle(element) : null,
+) {
+  if (!element || !element.isConnected || !styles || isHiddenByStyles(styles)) {
+    return false;
+  }
+
   if (typeof element.checkVisibility === 'function') {
     return element.checkVisibility();
   }
 
-  return getComputedStyle(element).display !== 'none';
+  return styles.display !== 'none' && styles.display !== 'contents';
 }

--- a/packages/react/src/floating-ui-react/utils/tabbable.test.ts
+++ b/packages/react/src/floating-ui-react/utils/tabbable.test.ts
@@ -1,3 +1,5 @@
+import { isJSDOM } from '@base-ui/utils/detectBrowser';
+import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import { isTabbable, tabbable } from './tabbable';
 
 afterEach(() => {
@@ -76,6 +78,36 @@ it('keeps the summary tabbable but excludes closed details content', () => {
   expect(tabbable(document.body)).not.toContain(button);
 });
 
+it('keeps only the first summary tabbable and includes details without a summary', () => {
+  const closedDetails = document.createElement('details');
+  const closedSummary = document.createElement('summary');
+  const hiddenButton = document.createElement('button');
+  const openDetails = document.createElement('details');
+  const openSummary = document.createElement('summary');
+  const ignoredSummary = document.createElement('summary');
+  const visibleButton = document.createElement('button');
+  const summarylessDetails = document.createElement('details');
+
+  openDetails.open = true;
+
+  closedSummary.textContent = 'closed';
+  openSummary.textContent = 'open';
+  ignoredSummary.textContent = 'ignored';
+
+  closedDetails.append(closedSummary, hiddenButton);
+  openDetails.append(openSummary, ignoredSummary, visibleButton);
+  summarylessDetails.textContent = 'summaryless';
+
+  document.body.append(closedDetails, openDetails, summarylessDetails);
+
+  expect(tabbable(document.body)).toEqual([
+    closedSummary,
+    openSummary,
+    visibleButton,
+    summarylessDetails,
+  ]);
+});
+
 it('keeps aria-disabled elements in the tab order', () => {
   const element = document.createElement('div');
 
@@ -87,10 +119,83 @@ it('keeps aria-disabled elements in the tab order', () => {
   expect(tabbable(document.body)).toContain(element);
 });
 
-it('uses checkVisibility to exclude hidden elements from the tab order', () => {
+it('excludes elements hidden with CSS visibility from the tab order', () => {
   const button = document.createElement('button');
 
   button.style.visibility = 'hidden';
+  document.body.append(button);
+
+  expect(isTabbable(button)).toBe(false);
+  expect(tabbable(document.body)).not.toContain(button);
+});
+
+it('keeps descendants of display: contents ancestors in the tab order', () => {
+  const wrapper = document.createElement('div');
+  const dialog = document.createElement('div');
+  const button = document.createElement('button');
+
+  wrapper.style.display = 'contents';
+  Object.defineProperty(wrapper, 'checkVisibility', {
+    configurable: true,
+    value: () => false,
+  });
+  dialog.setAttribute('role', 'dialog');
+  dialog.append(button);
+  wrapper.append(dialog);
+  document.body.append(wrapper);
+
+  expect(isTabbable(button)).toBe(true);
+  expect(tabbable(document.body)).toContain(button);
+});
+
+it.skipIf(isJSDOM)(
+  'keeps visible descendants of display: contents ancestors in the tab order in Chromium',
+  () => {
+    const wrapper = document.createElement('div');
+    const button = document.createElement('button');
+
+    wrapper.style.display = 'contents';
+    wrapper.tabIndex = 0;
+    wrapper.append(button);
+    document.body.append(wrapper);
+
+    expect(isTabbable(wrapper)).toBe(false);
+    expect(isTabbable(button)).toBe(true);
+    expect(tabbable(document.body)).toContain(button);
+    expect(tabbable(document.body)).not.toContain(wrapper);
+  },
+);
+
+it('excludes descendants of hidden display: contents ancestors from the tab order', () => {
+  const wrapper = document.createElement('div');
+  const button = document.createElement('button');
+
+  wrapper.style.display = 'contents';
+  wrapper.style.visibility = 'hidden';
+  wrapper.append(button);
+  document.body.append(wrapper);
+
+  expect(isTabbable(button)).toBe(false);
+  expect(tabbable(document.body)).not.toContain(button);
+});
+
+it('keeps descendants that override ancestor visibility in the tab order', () => {
+  const wrapper = document.createElement('div');
+  const button = document.createElement('button');
+
+  wrapper.style.visibility = 'hidden';
+  button.style.visibility = 'visible';
+  wrapper.append(button);
+  document.body.append(wrapper);
+
+  expect(isTabbable(button)).toBe(true);
+  expect(tabbable(document.body)).toContain(button);
+});
+
+it('excludes display: contents candidates when checkVisibility reports them hidden', () => {
+  const button = document.createElement('button');
+
+  button.style.display = 'contents';
   Object.defineProperty(button, 'checkVisibility', {
     configurable: true,
     value: () => false,
@@ -99,6 +204,124 @@ it('uses checkVisibility to exclude hidden elements from the tab order', () => {
 
   expect(isTabbable(button)).toBe(false);
   expect(tabbable(document.body)).not.toContain(button);
+});
+
+it('excludes display: contents candidates when checkVisibility is unavailable', () => {
+  const button = document.createElement('button');
+
+  button.style.display = 'contents';
+  Object.defineProperty(button, 'checkVisibility', {
+    configurable: true,
+    value: undefined,
+  });
+  document.body.append(button);
+
+  expect(isTabbable(button)).toBe(false);
+  expect(tabbable(document.body)).not.toContain(button);
+});
+
+it('excludes descendants of display: none ancestors from the tab order', () => {
+  const wrapper = document.createElement('div');
+  const button = document.createElement('button');
+
+  wrapper.style.display = 'none';
+  wrapper.append(button);
+  document.body.append(wrapper);
+
+  expect(isTabbable(button)).toBe(false);
+  expect(tabbable(document.body)).not.toContain(button);
+});
+
+it.skipIf(isJSDOM)(
+  'excludes descendants of block content-visibility:hidden ancestors from the tab order',
+  () => {
+    const wrapper = document.createElement('div');
+    const button = document.createElement('button');
+
+    wrapper.style.setProperty('content-visibility', 'hidden');
+    wrapper.append(button);
+    document.body.append(wrapper);
+
+    expect(isTabbable(button)).toBe(false);
+    expect(tabbable(document.body)).not.toContain(button);
+  },
+);
+
+it.skipIf(isJSDOM)(
+  'keeps descendants of display: contents content-visibility:hidden ancestors in the tab order',
+  () => {
+    const wrapper = document.createElement('div');
+    const button = document.createElement('button');
+
+    wrapper.style.display = 'contents';
+    wrapper.style.setProperty('content-visibility', 'hidden');
+    wrapper.append(button);
+    document.body.append(wrapper);
+
+    expect(isTabbable(button)).toBe(true);
+    expect(tabbable(document.body)).toContain(button);
+  },
+);
+
+it.skipIf(isJSDOM)(
+  'keeps descendants of inline content-visibility:hidden ancestors in the tab order',
+  () => {
+    const wrapper = document.createElement('div');
+    const button = document.createElement('button');
+
+    wrapper.style.display = 'inline';
+    wrapper.style.setProperty('content-visibility', 'hidden');
+    wrapper.append(button);
+    document.body.append(wrapper);
+
+    expect(isTabbable(button)).toBe(true);
+    expect(tabbable(document.body)).toContain(button);
+  },
+);
+
+it.skipIf(isJSDOM)('keeps content-visibility:hidden candidates in the tab order', () => {
+  const button = document.createElement('button');
+
+  button.style.setProperty('content-visibility', 'hidden');
+  document.body.append(button);
+
+  expect(isTabbable(button)).toBe(true);
+  expect(tabbable(document.body)).toContain(button);
+});
+
+it.skipIf(isJSDOM)('keeps zero-size elements in the tab order', () => {
+  const element = document.createElement('div');
+
+  element.tabIndex = 0;
+  element.style.width = '0';
+  element.style.height = '0';
+  element.style.padding = '0';
+  element.style.border = '0';
+  document.body.append(element);
+
+  expect(isTabbable(element)).toBe(true);
+  expect(tabbable(document.body)).toContain(element);
+});
+
+it('keeps visuallyHidden elements in the tab order', () => {
+  const button = document.createElement('button');
+
+  Object.assign(button.style, visuallyHidden);
+  document.body.append(button);
+
+  expect(isTabbable(button)).toBe(true);
+  expect(tabbable(document.body)).toContain(button);
+});
+
+it('keeps visuallyHiddenInput elements in the tab order', () => {
+  const input = document.createElement('input');
+
+  input.type = 'checkbox';
+  Object.assign(input.style, visuallyHiddenInput);
+  document.body.append(input);
+
+  expect(isTabbable(input)).toBe(true);
+  expect(tabbable(document.body)).toContain(input);
 });
 
 it('keeps only the checked radio in a named group', () => {

--- a/packages/react/src/floating-ui-react/utils/tabbable.ts
+++ b/packages/react/src/floating-ui-react/utils/tabbable.ts
@@ -1,4 +1,4 @@
-import { getNodeName, isHTMLElement, isShadowRoot } from '@floating-ui/utils/dom';
+import { getComputedStyle, getNodeName, isHTMLElement, isShadowRoot } from '@floating-ui/utils/dom';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { activeElement, contains } from './element';
 import { isElementVisible } from './composite';
@@ -62,6 +62,7 @@ function isFocusableElement(element: Element | null): element is FocusableElemen
   }
 
   for (let current: Element | null = element; current; current = getParentElement(current)) {
+    const isAncestor = current !== element;
     const isSlot = getNodeName(current) === 'slot';
 
     if (current.hasAttribute('inert')) {
@@ -69,18 +70,28 @@ function isFocusableElement(element: Element | null): element is FocusableElemen
     }
 
     if (
-      (current !== element &&
+      (isAncestor &&
         getNodeName(current) === 'details' &&
         !(current as HTMLDetailsElement).open &&
         !isWithinOpenDetailsSummary(element, current)) ||
       current.hasAttribute('hidden') ||
-      (!isSlot && !isElementVisible(current))
+      (!isSlot && !isVisibleInTabbableTree(current, isAncestor))
     ) {
       return false;
     }
   }
 
   return true;
+}
+
+function isVisibleInTabbableTree(element: Element, isAncestor: boolean) {
+  const styles = getComputedStyle(element);
+
+  if (!isAncestor) {
+    return isElementVisible(element, styles);
+  }
+
+  return styles.display !== 'none';
 }
 
 function getTabIndex(element: FocusableElement) {


### PR DESCRIPTION
Fixes #4622
Fixes #4629

Tabbability regressed when the internal visibility helper walked ancestors and treated `display: contents` wrappers as hidden. This narrows the `display: contents` exception to the ancestor walk, keeps the stricter element-level visibility checks for restore focus and typeahead, and adds regressions around the adjacent hidden-state cases.

## Changes

- Treat `display: contents` ancestors as transparent only in the tabbable tree walk.
- Keep element-level visibility checks strict for restore focus and list navigation paths.
- Add regressions for hidden `display: contents` ancestors, effective-visibility typeahead filtering, and restore-focus when a focused element becomes hidden.
