### PR TITLE
[navigation menu] Fix stale popup size on rapid trigger hover

### DIFF
--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
@@ -45,9 +45,7 @@ function TestNavigationMenuRapidHoverSizing() {
   );
 }
 
-function getPopupWidthCalls(
-  calls: Array<[property: string, value: string, priority?: string]>,
-) {
+function getPopupWidthCalls(calls: Array<[property: string, value: string, priority?: string]>) {
   return calls.filter((call) => call[0] === '--popup-width').map((call) => call[1]);
 }
 

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { expect, vi } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
@@ -15,6 +16,8 @@ const rapidHoverAnimationStyles = `
 `;
 
 function TestNavigationMenuRapidHoverSizing() {
+  const [isProductExpanded, setIsProductExpanded] = React.useState(false);
+
   return (
     <NavigationMenu.Root>
       {/* eslint-disable-next-line react/no-danger */}
@@ -23,7 +26,16 @@ function TestNavigationMenuRapidHoverSizing() {
         <NavigationMenu.Item value="product">
           <NavigationMenu.Trigger>Product</NavigationMenu.Trigger>
           <NavigationMenu.Content>
-            <div style={{ width: 700, height: 420 }}>Product panel</div>
+            <div>
+              <button type="button" onClick={() => setIsProductExpanded(true)}>
+                Expand Product
+              </button>
+              {isProductExpanded ? (
+                <div style={{ width: 760, height: 460 }}>Expanded product panel</div>
+              ) : (
+                <div style={{ width: 700, height: 420 }}>Product panel</div>
+              )}
+            </div>
           </NavigationMenu.Content>
         </NavigationMenu.Item>
 
@@ -47,6 +59,12 @@ function TestNavigationMenuRapidHoverSizing() {
 
 function getPopupWidthCalls(calls: Array<[property: string, value: string, priority?: string]>) {
   return calls.filter((call) => call[0] === '--popup-width').map((call) => call[1]);
+}
+
+function getPositionerWidthCalls(
+  calls: Array<[property: string, value: string, priority?: string]>,
+) {
+  return calls.filter((call) => call[0] === '--positioner-width').map((call) => call[1]);
 }
 
 describe('<NavigationMenu.Trigger />', () => {
@@ -312,6 +330,85 @@ describe('<NavigationMenu.Trigger />', () => {
       });
 
       setPropertySpy.mockRestore();
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    'does not let interrupted mutation resizing reapply popup sizes after a later switch',
+    async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+      await render(<TestNavigationMenuRapidHoverSizing />);
+
+      await user.hover(screen.getByRole('button', { name: 'Product' }));
+
+      const popupRoot = await screen.findByTestId('popup-root');
+      const positioner = popupRoot.parentElement as HTMLElement;
+      const setPositionerPropertySpy = vi.spyOn(positioner.style, 'setProperty');
+      const getPositionerWidthCallsSince = (startIndex = 0) =>
+        getPositionerWidthCalls(
+          setPositionerPropertySpy.mock.calls.slice(startIndex) as Array<
+            [property: string, value: string, priority?: string]
+          >,
+        );
+
+      await waitFor(() => {
+        expect(popupRoot.style.getPropertyValue('--popup-width')).toBe('700px');
+      });
+
+      let popupWidth = 700;
+      let popupHeight = 420;
+
+      Object.defineProperty(popupRoot, 'offsetWidth', {
+        configurable: true,
+        get: () => popupWidth,
+      });
+      Object.defineProperty(popupRoot, 'offsetHeight', {
+        configurable: true,
+        get: () => popupHeight,
+      });
+
+      popupRoot.style.setProperty('--popup-width', '700px');
+      popupRoot.style.setProperty('--popup-height', '420px');
+
+      popupWidth = 760;
+      popupHeight = 460;
+      await user.click(screen.getByRole('button', { name: 'Expand Product' }));
+
+      await waitFor(() => {
+        expect(
+          setPositionerPropertySpy.mock.calls.some(
+            (call) => call[0] === '--positioner-width' && call[1] === '760px',
+          ),
+        ).toBe(true);
+      });
+
+      popupWidth = 500;
+      popupHeight = 320;
+      const callsBeforeSolutionsHover = setPositionerPropertySpy.mock.calls.length;
+
+      await user.hover(screen.getByRole('button', { name: 'Solutions' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Solutions panel')).toBeVisible();
+      });
+
+      await waitFor(() => {
+        const positionerWidthCallsAfterSwitch =
+          getPositionerWidthCallsSince(callsBeforeSolutionsHover);
+        const solutionsWidthIndex = positionerWidthCallsAfterSwitch.indexOf('500px');
+
+        expect(solutionsWidthIndex).toBeGreaterThan(-1);
+        expect(positionerWidthCallsAfterSwitch.slice(solutionsWidthIndex + 1)).not.toContain(
+          '760px',
+        );
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.getPropertyValue('--positioner-width')).toBe('500px');
+      });
+
+      setPositionerPropertySpy.mockRestore();
     },
   );
 });

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
@@ -1,8 +1,49 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { screen, flushMicrotasks, waitFor, act } from '@mui/internal-test-utils';
 import userEvent from '@testing-library/user-event';
+
+const rapidHoverAnimationStyles = `
+  .test-navigation-menu-popup {
+    transition:
+      width 350ms cubic-bezier(0.22, 1, 0.36, 1),
+      height 350ms cubic-bezier(0.22, 1, 0.36, 1);
+    width: var(--popup-width);
+    height: var(--popup-height);
+  }
+`;
+
+function TestNavigationMenuRapidHoverSizing() {
+  return (
+    <NavigationMenu.Root>
+      {/* eslint-disable-next-line react/no-danger */}
+      <style dangerouslySetInnerHTML={{ __html: rapidHoverAnimationStyles }} />
+      <NavigationMenu.List style={{ display: 'flex' }}>
+        <NavigationMenu.Item value="product">
+          <NavigationMenu.Trigger>Product</NavigationMenu.Trigger>
+          <NavigationMenu.Content>
+            <div style={{ width: 700, height: 420 }}>Product panel</div>
+          </NavigationMenu.Content>
+        </NavigationMenu.Item>
+
+        <NavigationMenu.Item value="solutions">
+          <NavigationMenu.Trigger>Solutions</NavigationMenu.Trigger>
+          <NavigationMenu.Content>
+            <div style={{ width: 500, height: 320 }}>Solutions panel</div>
+          </NavigationMenu.Content>
+        </NavigationMenu.Item>
+      </NavigationMenu.List>
+      <NavigationMenu.Portal>
+        <NavigationMenu.Positioner>
+          <NavigationMenu.Popup data-testid="popup-root" className="test-navigation-menu-popup">
+            <NavigationMenu.Viewport />
+          </NavigationMenu.Popup>
+        </NavigationMenu.Positioner>
+      </NavigationMenu.Portal>
+    </NavigationMenu.Root>
+  );
+}
 
 describe('<NavigationMenu.Trigger />', () => {
   const { render } = createRenderer();
@@ -223,4 +264,45 @@ describe('<NavigationMenu.Trigger />', () => {
       expect(Math.abs(secondLeft - firstLeft)).toBeGreaterThan(20);
     });
   });
+
+  it.skipIf(isJSDOM)(
+    'does not let a previously hovered trigger reapply popup sizes after a later switch',
+    async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+      await render(<TestNavigationMenuRapidHoverSizing />);
+
+      await user.hover(screen.getByRole('button', { name: 'Product' }));
+
+      const popupRoot = await screen.findByTestId('popup-root');
+      const setPropertySpy = vi.spyOn(popupRoot.style, 'setProperty');
+
+      await act(async () => {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 80);
+        });
+      });
+
+      await user.hover(screen.getByRole('button', { name: 'Solutions' }));
+
+      await act(async () => {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 200);
+        });
+      });
+
+      const popupWidthCalls = (
+        setPropertySpy.mock.calls as Array<[property: string, value: string, priority?: string]>
+      )
+        .filter((call) => call[0] === '--popup-width')
+        .map((call) => call[1]);
+
+      const solutionsWidthIndex = popupWidthCalls.indexOf('500px');
+
+      expect(solutionsWidthIndex).toBeGreaterThan(-1);
+      expect(popupWidthCalls.slice(solutionsWidthIndex + 1)).not.toContain('700px');
+
+      setPropertySpy.mockRestore();
+    },
+  );
 });

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
@@ -45,6 +45,12 @@ function TestNavigationMenuRapidHoverSizing() {
   );
 }
 
+function getPopupWidthCalls(
+  calls: Array<[property: string, value: string, priority?: string]>,
+) {
+  return calls.filter((call) => call[0] === '--popup-width').map((call) => call[1]);
+}
+
 describe('<NavigationMenu.Trigger />', () => {
   const { render } = createRenderer();
 
@@ -276,31 +282,36 @@ describe('<NavigationMenu.Trigger />', () => {
 
       const popupRoot = await screen.findByTestId('popup-root');
       const setPropertySpy = vi.spyOn(popupRoot.style, 'setProperty');
+      const getWidthCallsSince = (startIndex = 0) =>
+        getPopupWidthCalls(
+          setPropertySpy.mock.calls.slice(startIndex) as Array<
+            [property: string, value: string, priority?: string]
+          >,
+        );
 
-      await act(async () => {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 80);
-        });
+      await waitFor(() => {
+        expect(popupRoot.style.getPropertyValue('--popup-width')).toBe('700px');
       });
+
+      const callsBeforeSolutionsHover = setPropertySpy.mock.calls.length;
 
       await user.hover(screen.getByRole('button', { name: 'Solutions' }));
 
-      await act(async () => {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 200);
-        });
+      await waitFor(() => {
+        expect(screen.getByText('Solutions panel')).toBeVisible();
       });
 
-      const popupWidthCalls = (
-        setPropertySpy.mock.calls as Array<[property: string, value: string, priority?: string]>
-      )
-        .filter((call) => call[0] === '--popup-width')
-        .map((call) => call[1]);
+      await waitFor(() => {
+        const popupWidthCallsAfterSwitch = getWidthCallsSince(callsBeforeSolutionsHover);
+        const solutionsWidthIndex = popupWidthCallsAfterSwitch.indexOf('500px');
 
-      const solutionsWidthIndex = popupWidthCalls.indexOf('500px');
+        expect(solutionsWidthIndex).toBeGreaterThan(-1);
+        expect(popupWidthCallsAfterSwitch.slice(solutionsWidthIndex + 1)).not.toContain('700px');
+      });
 
-      expect(solutionsWidthIndex).toBeGreaterThan(-1);
-      expect(popupWidthCalls.slice(solutionsWidthIndex + 1)).not.toContain('700px');
+      await waitFor(() => {
+        expect(popupRoot.style.getPropertyValue('--popup-width')).toBe('auto');
+      });
 
       setPropertySpy.mockRestore();
     },

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -145,7 +145,14 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     popupAutoSizeResetRef.current.owner = null;
   });
 
-  React.useEffect(cancelAutoSizeReset, [isActiveItem, cancelAutoSizeReset]);
+  useIsoLayoutEffect(() => {
+    if (isActiveItem) {
+      return;
+    }
+
+    sizeFrame.cancel();
+    cancelAutoSizeReset();
+  }, [isActiveItem, sizeFrame, cancelAutoSizeReset]);
 
   function setAutoSizes() {
     if (!popupElement) {
@@ -243,6 +250,10 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
       );
 
       sizeFrame.request(() => {
+        if (!isActiveItemRef.current) {
+          return;
+        }
+
         popupElement.style.setProperty(NavigationMenuPopupCssVars.popupWidth, `${measuredWidth}px`);
         popupElement.style.setProperty(
           NavigationMenuPopupCssVars.popupHeight,
@@ -488,6 +499,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
         skipAutoSizeSyncRef.current = false;
         return undefined;
       }
+
       const { width, height } = getCssDimensions(popupElement);
       handleValueChange(width, height);
     }

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -150,9 +150,10 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
       return;
     }
 
+    mutationFrame.cancel();
     sizeFrame.cancel();
     cancelAutoSizeReset();
-  }, [isActiveItem, sizeFrame, cancelAutoSizeReset]);
+  }, [isActiveItem, mutationFrame, sizeFrame, cancelAutoSizeReset]);
 
   function setAutoSizes() {
     if (!popupElement) {
@@ -303,6 +304,10 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
           setSharedFixedSizes(currentWidth, currentHeight);
 
           sizeFrame.request(() => {
+            if (!isActiveItemRef.current) {
+              return;
+            }
+
             setSharedFixedSizes(measuredWidth, measuredHeight);
             scheduleAutoSizeReset();
           });


### PR DESCRIPTION
Fixes #4619

Rapid trigger hovers could leave a queued popup size update behind from the previously active trigger. That extra size pass could reapply the old panel dimensions after the next trigger had already measured a smaller popup.

## Changes

- Cancel pending popup size work when a trigger stops being the active item.
- Ignore deferred popup size writes once the trigger that scheduled them is no longer active.
- Add a Chromium regression test that rapidly switches between differently sized popups and asserts the old width is not written again.