### PR TITLE
[docs] Improve a11y labels

### DIFF
--- a/docs/src/components/Header.tsx
+++ b/docs/src/components/Header.tsx
@@ -21,8 +21,8 @@ export function Header() {
     <header className="Header">
       <div className="HeaderInner">
         <SkipNav>Skip to contents</SkipNav>
-        <NextLink href="/" className="HeaderLogoLink">
-          <Logo aria-label="Base UI" />
+        <NextLink href="/" className="HeaderLogoLink" aria-label="Base UI - Go to homepage">
+          <Logo aria-label="Base UI" />
         </NextLink>
         <div className="HeaderDesktopActions">
           <Search containedScroll enableKeyboardShortcut />
@@ -30,6 +30,7 @@ export function Header() {
             className="HeaderLink"
             href="https://www.npmjs.com/package/@base-ui/react"
             rel="noopener"
+            aria-label={`npm version ${process.env.LIB_VERSION}`}
           >
             <NpmIcon />
             {process.env.LIB_VERSION}

--- a/docs/src/components/Header.tsx
+++ b/docs/src/components/Header.tsx
@@ -21,7 +21,7 @@ export function Header() {
     <header className="Header">
       <div className="HeaderInner">
         <SkipNav>Skip to contents</SkipNav>
-        <NextLink href="/" className="HeaderLogoLink" aria-label="Go to homepage">
+        <NextLink href="/" className="HeaderLogoLink" aria-label="Go to the homepage">
           <Logo aria-label="Base UI" />
         </NextLink>
         <div className="HeaderDesktopActions">

--- a/docs/src/components/Header.tsx
+++ b/docs/src/components/Header.tsx
@@ -21,7 +21,7 @@ export function Header() {
     <header className="Header">
       <div className="HeaderInner">
         <SkipNav>Skip to contents</SkipNav>
-        <NextLink href="/" className="HeaderLogoLink" aria-label="Base UI - Go to homepage">
+        <NextLink href="/" className="HeaderLogoLink" aria-label="Go to homepage">
           <Logo aria-label="Base UI" />
         </NextLink>
         <div className="HeaderDesktopActions">


### PR DESCRIPTION
A quick one, this is clearer, and arguably fixes WCAG level A support. It's a small regression compared to mui.com. 

Before: https://base-ui.com/react/overview/quick-start
<img width="710" height="239" alt="SCR-20260418-thec" src="https://github.com/user-attachments/assets/9c2e49ec-f00a-40ae-8769-0aaf77d9f036" />

After: https://deploy-preview-4648--base-ui.netlify.app/react/overview/quick-start
<img width="671" height="215" alt="SCR-20260418-thal" src="https://github.com/user-attachments/assets/3b18ef35-95cf-453b-a0b3-125f061b4fdc" />

Why: https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA8. IMHO, there isn't enough context, so it's required to pass level A (if the context is enough, then it's about going from A to AAA)

See other folks doing this:

- https://nextjs.org/showcase
- https://www.google.com/search?q=bar
- https://linear.app/about