### PR TITLE
[docs] Document test animations

### DIFF
--- a/docs/src/app/(docs)/react/handbook/animation/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/animation/page.mdx
@@ -80,6 +80,21 @@ JavaScript animation libraries such as [Motion](https://motion.dev) require cont
 
 Base UI relies on [`element.getAnimations()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAnimations) to detect if animations have finished on an element. When using Motion, `opacity` animations are reflected in `element.getAnimations()`, so Base UI automatically waits for the animation finish before unmounting the component. If `opacity` isn't part of your animation (such as in a translating drawer component), you should still animate it using a value close to `1` (such as `opacity: 0.9999`), so that Base UI can detect the animation.
 
+### Disabling animations in tests
+
+When testing animated components in a browser environment, you can make Base UI skip waiting for animations to finish by setting `globalThis.BASE_UI_ANIMATIONS_DISABLED` to `true` in your test setup file.
+This can help avoid timing-related failures in tools such as Playwright when a test only needs to verify the final state.
+
+```ts title="setup-tests.ts"
+(
+  globalThis as typeof globalThis & {
+    BASE_UI_ANIMATIONS_DISABLED: boolean;
+  }
+).BASE_UI_ANIMATIONS_DISABLED = true;
+```
+
+This flag affects Base UI's animation-related JavaScript logic. It does not remove CSS transitions or animations from your styles.
+
 ### Animating components unmounted from DOM when closed with Motion
 
 Most popup components like Popover, Dialog, Tooltip, and Menu are unmounted from the DOM when they are closed by default. To animate them with Motion:

--- a/docs/src/app/(docs)/react/handbook/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/page.mdx
@@ -48,6 +48,7 @@ A guide to animating Base UI components.
   - CSS transitions
   - CSS animations
   - JavaScript animations
+    - Disabling animations in tests
     - Animating components unmounted from DOM when closed with Motion
     - Animating components kept in DOM when closed with Motion
     - Animating Select component with Motion


### PR DESCRIPTION
## What changed

- Added guidance for setting `globalThis.BASE_UI_ANIMATIONS_DISABLED = true` in test setup files.
- Clarified that the flag skips Base UI animation waiting logic but does not remove CSS transitions or animations.

## Why

Closes #4313.

## Validation

- `pnpm exec markdownlint-cli2 'docs/src/app/\(docs\)/react/handbook/animation/page.mdx'`
- `pnpm exec prettier --check "docs/src/app/(docs)/react/handbook/animation/page.mdx"`
