### PR TITLE
[react] Use floating document for virtual arrow

### DIFF
--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -343,10 +343,10 @@ export function useAnchorPositioning(
       },
     }),
     arrow(
-      () => ({
+      (state) => ({
         // `transform-origin` calculations rely on an element existing. If the arrow hasn't been set,
         // we'll create a fake element.
-        element: arrowRef.current || ownerDocument(arrowRef.current).createElement('div'),
+        element: arrowRef.current || ownerDocument(state.elements.floating).createElement('div'),
         padding: arrowPadding,
         offsetParent: 'floating',
       }),


### PR DESCRIPTION
## Summary

- create the virtual arrow element from the floating element's owner document

## Why

When no arrow element is mounted, the fallback element should use the same document as the positioned floating element instead of falling back through a null arrow ref.

## Checks

- pnpm typescript
- pnpm eslint packages/react/src/utils/useAnchorPositioning.ts
- pnpm prettier --check packages/react/src/utils/useAnchorPositioning.ts
