### PR TITLE
[autocomplete]  Prevent data-highlighted on disabled items (#4666)

### DIFF
--- a/packages/react/src/autocomplete/item/AutocompleteItem.test.tsx
+++ b/packages/react/src/autocomplete/item/AutocompleteItem.test.tsx
@@ -98,4 +98,70 @@ describe('<Autocomplete.Item />', () => {
       expect(screen.getByRole('option', { name: 'banana' })).not.toHaveAttribute('data-selected'),
     );
   });
+
+  describe('prop: disabled', () => {
+    it('does not highlight disabled items with keyboard navigation', async () => {
+      const { user } = await render(
+        <Autocomplete.Root items={['one', 'two', 'three']} openOnInputClick>
+          <Autocomplete.Input data-testid="input" />
+          <Autocomplete.Portal>
+            <Autocomplete.Positioner>
+              <Autocomplete.Popup>
+                <Autocomplete.List>
+                  {(item: string) => (
+                    <Autocomplete.Item key={item} value={item} disabled={item === 'two'}>
+                      {item}
+                    </Autocomplete.Item>
+                  )}
+                </Autocomplete.List>
+              </Autocomplete.Popup>
+            </Autocomplete.Positioner>
+          </Autocomplete.Portal>
+        </Autocomplete.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{ArrowDown}');
+
+      const twoOption = screen.getByRole('option', { name: 'two' });
+      const threeOption = screen.getByRole('option', { name: 'three' });
+
+      expect(twoOption).not.toHaveAttribute('data-highlighted');
+      expect(threeOption).toHaveAttribute('data-highlighted');
+    });
+
+    it('does not highlight disabled items on pointer hover', async () => {
+      const { user } = await render(
+        <Autocomplete.Root items={['one', 'two', 'three']} openOnInputClick>
+          <Autocomplete.Input data-testid="input" />
+          <Autocomplete.Portal>
+            <Autocomplete.Positioner>
+              <Autocomplete.Popup>
+                <Autocomplete.List>
+                  {(item: string) => (
+                    <Autocomplete.Item key={item} value={item} disabled={item === 'two'}>
+                      {item}
+                    </Autocomplete.Item>
+                  )}
+                </Autocomplete.List>
+              </Autocomplete.Popup>
+            </Autocomplete.Positioner>
+          </Autocomplete.Portal>
+        </Autocomplete.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+
+      const twoOption = screen.getByRole('option', { name: 'two' });
+      await user.hover(twoOption);
+
+      expect(twoOption).not.toHaveAttribute('data-highlighted');
+    });
+  });
 });

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -18,7 +18,7 @@ import {
   useListNavigation,
   useClick,
 } from '../../floating-ui-react';
-import { contains, getTarget } from '../../floating-ui-react/utils';
+import { contains, getTarget, isListIndexDisabled } from '../../floating-ui-react/utils';
 import {
   createChangeEventDetails,
   createGenericEventDetails,
@@ -1048,11 +1048,17 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     // Floating UI tests don't require `role="row"` wrappers, so retains the number API.
     cols: grid ? 2 : 1,
     orientation: grid ? 'horizontal' : undefined,
-    disabledIndices: EMPTY_ARRAY as number[],
     onNavigate(nextActiveIndex, event) {
       // Retain the highlight only while actually transitioning out or closed.
       if ((!event && !open) || transitionStatus === 'ending') {
         return;
+      }
+
+      if (nextActiveIndex != null) {
+        const nextItem = listRef.current[nextActiveIndex];
+        if (nextItem?.hasAttribute('data-disabled') || isListIndexDisabled(listRef, nextActiveIndex)) {
+          return;
+        }
       }
 
       if (!event) {

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -1056,7 +1056,10 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
       if (nextActiveIndex != null) {
         const nextItem = listRef.current[nextActiveIndex];
-        if (nextItem?.hasAttribute('data-disabled') || isListIndexDisabled(listRef, nextActiveIndex)) {
+        if (
+          nextItem?.hasAttribute('data-disabled') ||
+          isListIndexDisabled(listRef?.current, nextActiveIndex)
+        ) {
           return;
         }
       }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This fixes #4666 

Changes
- Remove the disabledIndices override in AriaCombobox so default disabled/aria-disabled detection is respected.
- Ignore pointer/keyboard navigation updates that target disabled indices in combobox onNavigate.



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
