### PR TITLE
[combobox] Fix clear browser test timing

### DIFF
--- a/packages/react/src/combobox/clear/ComboboxClear.test.tsx
+++ b/packages/react/src/combobox/clear/ComboboxClear.test.tsx
@@ -112,7 +112,7 @@ describe('<Combobox.Clear />', () => {
       <Combobox.Root defaultValue="a">
         <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
         <Combobox.Portal>
-          <Combobox.Positioner>
+          <Combobox.Positioner data-testid="positioner">
             <Combobox.Popup>
               <Combobox.Input />
               <Combobox.Clear
@@ -133,6 +133,9 @@ describe('<Combobox.Clear />', () => {
 
     const clear = await screen.findByTestId('clear');
 
+    await waitFor(() => {
+      expect(screen.getByTestId('positioner')).toHaveAttribute('data-open', '');
+    });
     expect(clear).toHaveClass('visible');
     expect(clear).toHaveAttribute('data-visible', '');
 


### PR DESCRIPTION
The React 18 browser suite can reach the clear button while the popup positioner is still closed, leaving pointer events disabled. This waits for the positioner to report open before clicking the clear button.

## Changes

- Add a positioner test id in the popup-rendered clear test.
- Wait for the positioner to be open before asserting visible state and clicking clear.