### PR TITLE
[useDismiss] Bug: MacOS Safari and Firefox minimize when closing popups via ESC key

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useDismiss.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useDismiss.test.tsx
@@ -77,6 +77,54 @@ describe.skipIf(!isJSDOM)('useDismiss', () => {
       await flushMicrotasks();
     });
 
+    test('calls preventDefault on escape key dismiss', async () => {
+      render(<App />);
+      const event = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      });
+      await act(async () => {
+        document.body.dispatchEvent(event);
+      });
+      expect(event.defaultPrevented).toBe(true);
+      await flushMicrotasks();
+    });
+
+    test('does not call preventDefault on escape key if close is canceled', async () => {
+      function CancelApp() {
+        const [open, setOpen] = React.useState(true);
+        const { refs, context } = useFloating({
+          open,
+          onOpenChange(openArg, data) {
+            data?.cancel();
+            setOpen(true);
+          },
+        });
+        const { getReferenceProps, getFloatingProps } = useInteractions([useDismiss(context)]);
+
+        return (
+          <React.Fragment>
+            <button {...getReferenceProps({ ref: refs.setReference })} />
+            {open && <div role="tooltip" {...getFloatingProps({ ref: refs.setFloating })} />}
+          </React.Fragment>
+        );
+      }
+
+      render(<CancelApp />);
+      const event = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      });
+      await act(async () => {
+        document.body.dispatchEvent(event);
+      });
+      expect(event.defaultPrevented).toBe(false);
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      await flushMicrotasks();
+    });
+
     test('does not dismiss with escape key if IME is active', async () => {
       const onClose = vi.fn();
 

--- a/packages/react/src/floating-ui-react/hooks/useDismiss.ts
+++ b/packages/react/src/floating-ui-react/hooks/useDismiss.ts
@@ -233,6 +233,10 @@ export function useDismiss(
 
       store.setOpen(false, eventDetails);
 
+      if (!eventDetails.isCanceled) {
+        event.preventDefault();
+      }
+
       if (!escapeKeyBubbles && !eventDetails.isPropagationAllowed) {
         event.stopPropagation();
       }


### PR DESCRIPTION
## Summary

In MacOS Safari and Firefox, when the browser window is in fullscreen (maximized) mode, pressing <kbd>Escape</kbd> while a popup is open (popover, dropdown menu, select, dialog, etc.) exits the maximized/fullscreen mode which leads to a really poor UX for a very common user behavior.

BEFORE:

https://github.com/user-attachments/assets/7b0af3ab-34a7-4dae-a3fb-f6400eb953b7

https://github.com/user-attachments/assets/9d60e33b-5e50-46e1-bc1b-b7801af74d4f

AFTER:

https://github.com/user-attachments/assets/a991f976-ea75-4d51-9ff3-7b19b1c735da

https://github.com/user-attachments/assets/b8a747c7-b3cd-45e6-a29f-da8771c2ba2d

### Root cause

The `closeOnEscapeKeyDown` handler in `useDismiss` was calling `event.stopPropagation()` but **not** `event.preventDefault()`. While `stopPropagation` prevents other JavaScript event listeners from seeing the event, only `preventDefault` prevents the browser's native behavior for that key. Safari's and Firefox native Escape behavior in fullscreen is to exit fullscreen, and without `preventDefault`, that fires before (or instead of) the popup closing.

### Fix

Added `event.preventDefault()` to the Escape keydown handler in `useDismiss`, gated on `!eventDetails.isCanceled` — so if a consumer calls `cancel()` in their `onOpenChange` callback, the browser's default Escape behavior is preserved.

### Prior art

Radix UI had the exact same bug and fix:
- Issue: https://github.com/radix-ui/primitives/issues/1751
- Fix: https://github.com/radix-ui/primitives/pull/1752

## Test plan

- Added test verifying `event.defaultPrevented` is `true` after Escape dismisses a floating element.
- Added test verifying `event.defaultPrevented` remains `false` when the consumer cancels the close via `cancel()`.
- All 47 existing `useDismiss` tests continue to pass.

### Manual verification

1. Open any Base UI popup component (Popover, Menu, Select, Dialog) in Safari
2. Enter fullscreen mode (Globe + F or green button)
3. Open the popup
4. Press <kbd>Escape</kbd>
5. **Before fix**: Safari and Firefox exits fullscreen and popup closes
6. **After fix**: Popup closes; Safari stays in fullscreen

@atomiks lmk if there's anything misssing 🫡

