### PR TITLE
[select] Allow mouse selection without highlight

### DIFF
--- a/packages/react/src/select/item/SelectItem.test.tsx
+++ b/packages/react/src/select/item/SelectItem.test.tsx
@@ -203,6 +203,64 @@ describe('<Select.Item />', () => {
     expect(handleClick).toHaveBeenCalledOnce();
   });
 
+  it('should select an unhighlighted item with the mouse', async () => {
+    await render(
+      <Select.Root defaultOpen highlightItemOnHover={false}>
+        <Select.Trigger data-testid="trigger">
+          <Select.Value data-testid="value" />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="one">one</Select.Item>
+              <Select.Item value="two">two</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const option = screen.getByRole('option', { name: 'two' });
+
+    expect(option).not.toHaveAttribute('data-highlighted');
+
+    fireEvent.pointerDown(option, { pointerType: 'mouse' });
+    fireEvent.mouseDown(option);
+    fireEvent.mouseUp(option);
+    fireEvent.click(option, { detail: 1 });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('value').textContent).toBe('two');
+    });
+  });
+
+  it('should ignore an unhighlighted item with a generic virtual click', async () => {
+    await render(
+      <Select.Root defaultOpen highlightItemOnHover={false}>
+        <Select.Trigger data-testid="trigger">
+          <Select.Value data-testid="value" />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="one">one</Select.Item>
+              <Select.Item value="two">two</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const option = screen.getByRole('option', { name: 'two' });
+
+    expect(option).not.toHaveAttribute('data-highlighted');
+
+    fireEvent.click(option, { detail: 0 });
+    await flushMicrotasks();
+
+    expect(screen.getByTestId('value').textContent).toBe('');
+  });
+
   it('should focus the selected item upon opening the popup', async () => {
     const { user } = await render(
       <Select.Root>
@@ -332,6 +390,40 @@ describe('<Select.Item />', () => {
       });
     });
 
+    it('should not select an unselected item within the selected delay when aligned with the trigger', async () => {
+      ignoreActWarnings();
+
+      await renderFakeTimers(
+        <Select.Root defaultValue="one">
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger>
+              <Select.Popup>
+                <Select.Item value="one">one</Select.Item>
+                <Select.Item value="two">two</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      const value = screen.getByTestId('value');
+
+      expect(value.textContent).toBe('one');
+
+      fireEvent.mouseDown(trigger);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+
+      const option = screen.getByRole('option', { name: 'two' });
+      await clock.tickAsync(250);
+      fireEvent.mouseUp(option);
+
+      expect(value.textContent).toBe('one');
+    });
+
     it('should call onClick when selecting via drag-to-select (mousedown on trigger, mouseup on item)', async () => {
       ignoreActWarnings();
       const handleClick = vi.fn();
@@ -360,16 +452,224 @@ describe('<Select.Item />', () => {
 
       const option = screen.getByRole('option', { name: 'one' });
       fireEvent.pointerEnter(option, { pointerType: 'mouse' });
-      fireEvent.pointerMove(option, { pointerType: 'mouse' });
+      for (let i = 0; i < 4; i += 1) {
+        fireEvent.pointerMove(option, {
+          pointerType: 'mouse',
+          buttons: 1,
+          movementY: 2,
+        });
+      }
 
-      // Wait past the delay gates and release the mouse over the option
+      // Real pointer movement over the item allows drag-to-select before the opening delay elapses.
       await act(async () => {
-        await clock.tickAsync(500);
+        await clock.tickAsync(100);
       });
       fireEvent.mouseUp(option);
 
       await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('one'));
       expect(handleClick).toHaveBeenCalledOnce();
+    });
+
+    it('should accumulate drag-to-select movement across items', async () => {
+      ignoreActWarnings();
+
+      await renderFakeTimers(
+        <Select.Root defaultValue="one">
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger>
+              <Select.Popup>
+                <Select.Item value="one">one</Select.Item>
+                <Select.Item value="two">two</Select.Item>
+                <Select.Item value="three">three</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.mouseDown(trigger);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+
+      const optionTwo = screen.getByRole('option', { name: 'two' });
+      fireEvent.pointerEnter(optionTwo, { pointerType: 'mouse' });
+      fireEvent.pointerMove(optionTwo, {
+        pointerType: 'mouse',
+        buttons: 1,
+        movementY: 4,
+      });
+
+      const optionThree = screen.getByRole('option', { name: 'three' });
+      fireEvent.pointerEnter(optionThree, { pointerType: 'mouse' });
+      fireEvent.pointerMove(optionThree, {
+        pointerType: 'mouse',
+        buttons: 1,
+        movementY: 4,
+      });
+
+      await act(async () => {
+        await clock.tickAsync(100);
+      });
+      fireEvent.mouseUp(optionThree);
+
+      await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('three'));
+    });
+
+    it('should select via drag-to-select when hover highlighting is disabled', async () => {
+      ignoreActWarnings();
+
+      await renderFakeTimers(
+        <Select.Root highlightItemOnHover={false}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" placeholder="Select font" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="one">one</Select.Item>
+                <Select.Item value="two">two</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.mouseDown(trigger);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+
+      const option = screen.getByRole('option', { name: 'two' });
+      fireEvent.pointerEnter(option, { pointerType: 'mouse' });
+      fireEvent.pointerMove(option, {
+        pointerType: 'mouse',
+        buttons: 1,
+        movementY: 8,
+      });
+
+      expect(option).not.toHaveAttribute('data-highlighted');
+
+      await act(async () => {
+        await clock.tickAsync(500);
+      });
+      fireEvent.mouseUp(option);
+
+      await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('two'));
+    });
+
+    it('should not treat small pointer movement as drag-to-select', async () => {
+      ignoreActWarnings();
+
+      await renderFakeTimers(
+        <Select.Root defaultValue="one">
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger>
+              <Select.Popup>
+                <Select.Item value="one">one</Select.Item>
+                <Select.Item value="two">two</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      const value = screen.getByTestId('value');
+
+      expect(value.textContent).toBe('one');
+
+      fireEvent.mouseDown(trigger);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+
+      const option = screen.getByRole('option', { name: 'two' });
+      fireEvent.pointerEnter(option, { pointerType: 'mouse' });
+      fireEvent.pointerMove(option, {
+        pointerType: 'mouse',
+        buttons: 1,
+        movementY: 2,
+      });
+
+      await act(async () => {
+        await clock.tickAsync(100);
+      });
+      fireEvent.mouseUp(option);
+
+      expect(value.textContent).toBe('one');
+    });
+
+    it('should allow small pointer movement to select after the opening delay', async () => {
+      ignoreActWarnings();
+
+      await renderFakeTimers(
+        <Select.Root defaultValue="one">
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger>
+              <Select.Popup>
+                <Select.Item value="one">one</Select.Item>
+                <Select.Item value="two">two</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.mouseDown(trigger);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+
+      const option = screen.getByRole('option', { name: 'two' });
+      fireEvent.pointerEnter(option, { pointerType: 'mouse' });
+      fireEvent.pointerMove(option, {
+        pointerType: 'mouse',
+        buttons: 1,
+        movementY: 2,
+      });
+
+      await act(async () => {
+        await clock.tickAsync(500);
+      });
+      fireEvent.mouseUp(option);
+
+      await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('two'));
+    });
+
+    it('should ignore an opening click that did not start on the item', async () => {
+      ignoreActWarnings();
+
+      await renderFakeTimers(
+        <Select.Root highlightItemOnHover={false}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" placeholder="Select font" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger>
+              <Select.Popup>
+                <Select.Item value="one">one</Select.Item>
+                <Select.Item value="two">two</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+      fireEvent.mouseDown(trigger);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+
+      const option = screen.getByRole('option', { name: 'one' });
+      fireEvent.mouseUp(option);
+      fireEvent.click(option, { detail: 1 });
+
+      expect(screen.getByTestId('value').textContent).toBe('Select font');
     });
 
     it('should not select item when onClick calls preventBaseUIHandler during drag-to-select', async () => {
@@ -400,7 +700,11 @@ describe('<Select.Item />', () => {
 
       const option = screen.getByRole('option', { name: 'one' });
       fireEvent.pointerEnter(option, { pointerType: 'mouse' });
-      fireEvent.pointerMove(option, { pointerType: 'mouse' });
+      fireEvent.pointerMove(option, {
+        pointerType: 'mouse',
+        buttons: 1,
+        movementY: 8,
+      });
 
       // Wait past the delay gates and release the mouse over the option
       await act(async () => {

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -20,6 +20,7 @@ import { useButton } from '../../internals/use-button';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 import { compareItemEquality, removeItem } from '../../internals/itemEquality';
+import { isVirtualClick } from '../../floating-ui-react/utils/event';
 
 /**
  * An individual option in the select popup.
@@ -112,7 +113,7 @@ export const SelectItem = React.memo(
 
     const lastKeyRef = React.useRef<string | null>(null);
     const pointerTypeRef = React.useRef<'mouse' | 'touch' | 'pen'>('mouse');
-    const didPointerDownRef = React.useRef(false);
+    const allowMouseSelectionRef = React.useRef(false);
 
     const { getButtonProps, buttonRef } = useButton({
       disabled,
@@ -130,7 +131,7 @@ export const SelectItem = React.memo(
       highlighted,
     };
 
-    function commitSelection(event: MouseEvent) {
+    function commitSelection(event: MouseEvent | KeyboardEvent | PointerEvent) {
       const selectedValue = store.state.value;
       if (multiple) {
         const currentValue = Array.isArray(selectedValue) ? selectedValue : [];
@@ -144,16 +145,14 @@ export const SelectItem = React.memo(
       }
     }
 
+    function resetDragMovement() {
+      selectionRef.current.dragY = 0;
+    }
+
     const defaultProps: HTMLProps = {
       role: 'option',
       'aria-selected': selected,
       tabIndex: highlighted ? 0 : -1,
-      onTouchStart() {
-        selectionRef.current = {
-          allowSelectedMouseUp: false,
-          allowUnselectedMouseUp: false,
-        };
-      },
       onKeyDown(event: BaseUIEvent<React.KeyboardEvent>) {
         lastKeyRef.current = event.key;
         store.set('activeIndex', index);
@@ -163,7 +162,22 @@ export const SelectItem = React.memo(
         }
       },
       onClick(event) {
-        didPointerDownRef.current = false;
+        const isMouseClick = event.type === 'click' && pointerTypeRef.current !== 'touch';
+        const clickPointerType = (event.nativeEvent as PointerEvent).pointerType;
+        const isVirtualMouseClick =
+          isMouseClick &&
+          isVirtualClick(event.nativeEvent) &&
+          // Generic no-pointer `detail === 0` clicks stay tied to highlight state. Virtual
+          // clicks that carry browser pointer data, including an empty string from assistive
+          // technology, can activate unhighlighted items.
+          (clickPointerType !== undefined || highlighted);
+        // With alignItemWithTrigger, opening can place an item under the cursor. Real mouse
+        // clicks must start on the item, while virtual clicks represent explicit keyboard or
+        // assistive technology activation.
+        const isInvalidMouseClick =
+          isMouseClick && !isVirtualMouseClick && !allowMouseSelectionRef.current;
+
+        allowMouseSelectionRef.current = false;
 
         // Prevent double commit on {Enter}
         if (event.type === 'keydown' && lastKeyRef.current === null) {
@@ -173,7 +187,7 @@ export const SelectItem = React.memo(
         if (
           disabled ||
           (event.type === 'keydown' && lastKeyRef.current === ' ' && typingRef.current) ||
-          (pointerTypeRef.current !== 'touch' && !highlighted)
+          isInvalidMouseClick
         ) {
           return;
         }
@@ -184,33 +198,43 @@ export const SelectItem = React.memo(
       onPointerEnter(event) {
         pointerTypeRef.current = event.pointerType;
       },
+      onPointerMove(event) {
+        if (event.pointerType === 'mouse' && event.buttons === 1) {
+          const selection = selectionRef.current;
+          selection.dragY += event.movementY;
+
+          if (selection.dragY ** 2 >= 64) {
+            selection.allowUnselectedMouseUp = true;
+          }
+        }
+      },
       onPointerDown(event) {
         pointerTypeRef.current = event.pointerType;
-        didPointerDownRef.current = true;
+        allowMouseSelectionRef.current = true;
+        resetDragMovement();
       },
       onMouseUp() {
-        if (disabled) {
+        resetDragMovement();
+
+        if (disabled || pointerTypeRef.current === 'touch') {
           return;
         }
 
-        // Regular click (pointerdown on this element) if didPointerDownRef is set, otherwise drag-to-select
-        if (didPointerDownRef.current) {
-          didPointerDownRef.current = false;
+        // Regular clicks are committed by the click event.
+        if (allowMouseSelectionRef.current) {
           return;
         }
 
         const disallowSelectedMouseUp = !selectionRef.current.allowSelectedMouseUp && selected;
         const disallowUnselectedMouseUp = !selectionRef.current.allowUnselectedMouseUp && !selected;
 
-        if (
-          disallowSelectedMouseUp ||
-          disallowUnselectedMouseUp ||
-          (pointerTypeRef.current !== 'touch' && !highlighted)
-        ) {
+        if (disallowSelectedMouseUp || disallowUnselectedMouseUp) {
           return;
         }
 
+        allowMouseSelectionRef.current = true;
         itemRef.current?.click();
+        allowMouseSelectionRef.current = false;
       },
     };
 

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -122,6 +122,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   const selectionRef = React.useRef({
     allowSelectedMouseUp: false,
     allowUnselectedMouseUp: false,
+    dragY: 0,
   });
   const alignItemWithTriggerActiveRef = React.useRef(false);
 

--- a/packages/react/src/select/root/SelectRootContext.ts
+++ b/packages/react/src/select/root/SelectRootContext.ts
@@ -32,6 +32,7 @@ export interface SelectRootContext {
   selectionRef: React.RefObject<{
     allowUnselectedMouseUp: boolean;
     allowSelectedMouseUp: boolean;
+    dragY: number;
   }>;
   firstItemTextRef: React.RefObject<HTMLElement | null>;
   selectedItemTextRef: React.RefObject<HTMLElement | null>;

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -28,7 +28,6 @@ import type { Side } from '../../utils/useAnchorPositioning';
 
 const BOUNDARY_OFFSET = 2;
 const SELECTED_DELAY = 400;
-const UNSELECTED_DELAY = 200;
 
 const stateAttributesMapping: StateAttributesMapping<SelectTriggerState> = {
   ...pressableTriggerOpenStateMapping,
@@ -89,8 +88,6 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const rootId = useStore(store, selectors.id);
   const selectLabelId = useStore(store, selectors.labelId);
   const hasSelectedValue = useStore(store, selectors.hasSelectedValue);
-  const shouldCheckNullItemLabel = !hasSelectedValue && open;
-  const hasNullItemLabel = useStore(store, selectors.hasNullItemLabel, shouldCheckNullItemLabel);
   const popupSide = mounted && positionerElement ? popupSideValue : null;
 
   const id = idProp ?? rootId;
@@ -121,56 +118,33 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const timeoutFocus = useTimeout();
   const timeoutMouseDown = useTimeout();
   const selectedDelayTimeout = useTimeout();
-  const unselectedDelayTimeout = useTimeout();
 
   React.useEffect(() => {
     if (open) {
-      const hasSelectedItemInList = hasSelectedValue || hasNullItemLabel;
-      const shouldDelayUnselectedMouseUpLonger = !hasSelectedItemInList;
-
-      // When there is no selected item in the list (placeholder-only selects), a mousedown
-      // on the trigger followed by a quick mouseup over the first option can accidentally select
-      // within 200ms. Delay unselected mouseup to match the safer 400ms window.
-      if (shouldDelayUnselectedMouseUpLonger) {
-        selectedDelayTimeout.start(SELECTED_DELAY, () => {
-          selectionRef.current.allowUnselectedMouseUp = true;
-          selectionRef.current.allowSelectedMouseUp = true;
-        });
-      } else {
-        // mousedown -> move to unselected item -> mouseup should not select within 200ms.
-        unselectedDelayTimeout.start(UNSELECTED_DELAY, () => {
-          selectionRef.current.allowUnselectedMouseUp = true;
-
-          // mousedown -> mouseup on selected item should not select within 400ms.
-          selectedDelayTimeout.start(UNSELECTED_DELAY, () => {
-            selectionRef.current.allowSelectedMouseUp = true;
-          });
-        });
-      }
+      // A mousedown on the trigger can open the popup under the cursor. Keep mouseup selection
+      // disabled briefly so releasing over either the selected item or a neighboring item doesn't
+      // commit an accidental selection. SelectItem can still opt into unselected mouseup sooner
+      // after a real drag over the item.
+      selectedDelayTimeout.start(SELECTED_DELAY, () => {
+        selectionRef.current.allowUnselectedMouseUp = true;
+        selectionRef.current.allowSelectedMouseUp = true;
+      });
 
       return () => {
         selectedDelayTimeout.clear();
-        unselectedDelayTimeout.clear();
       };
     }
 
     selectionRef.current = {
       allowSelectedMouseUp: false,
       allowUnselectedMouseUp: false,
+      dragY: 0,
     };
 
     timeoutMouseDown.clear();
 
     return undefined;
-  }, [
-    open,
-    hasSelectedValue,
-    hasNullItemLabel,
-    selectionRef,
-    timeoutMouseDown,
-    selectedDelayTimeout,
-    unselectedDelayTimeout,
-  ]);
+  }, [open, selectionRef, timeoutMouseDown, selectedDelayTimeout]);
 
   const props: HTMLProps = mergeProps<'button'>(
     triggerProps,


### PR DESCRIPTION
Partially addresses #4698
Closes #4663

Mouse selection could become a no-op when a Select item was not highlighted, even if the user clicked or drag-selected the item intentionally. This allows real mouse selection to commit when the press starts on the item, while keeping the guard for `alignItemWithTrigger` cases where an item appears under the cursor as the popup opens.

This does not claim to fix the underlying `[data-highlighted]` styling/registration issue; it only prevents mouse selection from bailing when highlight state is unavailable. For #4663, it only addresses pointer selection becoming a no-op; it does not make nested Accordion content a supported Select composition.

## Changes

- Allow real mouse clicks that start on a `Select.Item` to select even when the item is not highlighted.
- Allow drag-to-select to commit when `highlightItemOnHover` is disabled.
- Preserve the aligned-popup guard that ignores opening clicks that did not start on an item.
- Add regression tests for unhighlighted mouse clicks, drag-to-select, and the aligned opening-click case.