### PR TITLE
[select] Fix no-value popup alignment after reopen

### DIFF
--- a/packages/react/src/select/item-text/SelectItemText.tsx
+++ b/packages/react/src/select/item-text/SelectItemText.tsx
@@ -16,23 +16,25 @@ export const SelectItemText = React.memo(
     componentProps: SelectItemText.Props,
     forwardedRef: React.ForwardedRef<HTMLDivElement>,
   ) {
-    const { indexRef, textRef, selectedByFocus, hasRegistered } = useSelectItemContext();
-    const { selectedItemTextRef } = useSelectRootContext();
+    const { index, textRef, selectedByFocus, hasRegistered } = useSelectItemContext();
+    const { firstItemTextRef, selectedItemTextRef } = useSelectRootContext();
 
     const { render, className, style, ...elementProps } = componentProps;
 
     const localRef = React.useCallback(
       (node: HTMLElement | null) => {
-        if (!node || !hasRegistered) {
+        if (!node) {
           return;
         }
-        const hasNoSelectedItemText =
-          selectedItemTextRef.current === null || !selectedItemTextRef.current.isConnected;
-        if (selectedByFocus || (hasNoSelectedItemText && indexRef.current === 0)) {
+
+        if (!firstItemTextRef.current?.isConnected || (hasRegistered && index === 0)) {
+          firstItemTextRef.current = node;
+        }
+        if (hasRegistered && selectedByFocus) {
           selectedItemTextRef.current = node;
         }
       },
-      [selectedItemTextRef, indexRef, selectedByFocus, hasRegistered],
+      [firstItemTextRef, selectedItemTextRef, index, selectedByFocus, hasRegistered],
     );
 
     const element = useRenderElement('div', componentProps, {

--- a/packages/react/src/select/item-text/SelectItemText.tsx
+++ b/packages/react/src/select/item-text/SelectItemText.tsx
@@ -27,7 +27,7 @@ export const SelectItemText = React.memo(
           return;
         }
 
-        if (!firstItemTextRef.current?.isConnected || (hasRegistered && index === 0)) {
+        if (hasRegistered && index === 0) {
           firstItemTextRef.current = node;
         }
         if (hasRegistered && selectedByFocus) {

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { useStore } from '@base-ui/utils/store';
 import { useSelectRootContext } from '../root/SelectRootContext';
 import {
@@ -72,7 +71,6 @@ export const SelectItem = React.memo(
     const hasRegistered = index !== -1;
 
     const itemRef = React.useRef<HTMLDivElement | null>(null);
-    const indexRef = useValueAsRef(index);
 
     useIsoLayoutEffect(() => {
       if (!hasRegistered) {
@@ -225,12 +223,12 @@ export const SelectItem = React.memo(
     const contextValue: SelectItemContext = React.useMemo(
       () => ({
         selected,
-        indexRef,
+        index,
         textRef,
         selectedByFocus,
         hasRegistered,
       }),
-      [selected, indexRef, textRef, selectedByFocus, hasRegistered],
+      [selected, index, textRef, selectedByFocus, hasRegistered],
     );
 
     return <SelectItemContext.Provider value={contextValue}>{element}</SelectItemContext.Provider>;

--- a/packages/react/src/select/item/SelectItemContext.ts
+++ b/packages/react/src/select/item/SelectItemContext.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 export interface SelectItemContext {
   selected: boolean;
-  indexRef: React.RefObject<number>;
+  index: number;
   textRef: React.RefObject<HTMLElement | null>;
   selectedByFocus: boolean;
   hasRegistered: boolean;

--- a/packages/react/src/select/popup/SelectPopup.test.tsx
+++ b/packages/react/src/select/popup/SelectPopup.test.tsx
@@ -409,6 +409,96 @@ describe('<Select.Popup />', () => {
     },
   );
 
+  it.skipIf(isJSDOM)('keeps item text aligned with the trigger after reopening', async () => {
+    function getCenterY(rect: DOMRect) {
+      return rect.top + rect.height / 2;
+    }
+
+    const itemStyle: React.CSSProperties = {
+      padding: '8px 16px 8px 10px',
+      fontSize: 14,
+      lineHeight: '16px',
+    };
+
+    const { user } = await render(
+      <div style={{ marginLeft: 100, minHeight: 600, paddingTop: 96 }}>
+        <Select.Root>
+          <Select.Trigger
+            data-testid="trigger"
+            style={{
+              boxSizing: 'border-box',
+              width: 176,
+              height: 40,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-start',
+              paddingInlineStart: 14,
+            }}
+          >
+            <Select.Value data-testid="value" placeholder="Select produce" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner data-testid="positioner">
+              <Select.Popup style={{ width: 220, maxHeight: 'none' }}>
+                <Select.List style={{ paddingBlock: 4, overflowY: 'auto' }}>
+                  <Select.Group>
+                    <Select.GroupLabel
+                      style={{
+                        padding: '8px 16px 4px 30px',
+                        fontSize: 11,
+                        lineHeight: '16px',
+                      }}
+                    >
+                      Fruits
+                    </Select.GroupLabel>
+                    <Select.Item value="apple" style={itemStyle}>
+                      <Select.ItemText data-testid="first-item-text">Apple</Select.ItemText>
+                    </Select.Item>
+                    <Select.Item value="banana" style={itemStyle}>
+                      <Select.ItemText data-testid="selected-item-text">Banana</Select.ItemText>
+                    </Select.Item>
+                  </Select.Group>
+                </Select.List>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>
+      </div>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+
+    async function expectItemAligned(testId: string) {
+      const value = screen.getByTestId('value');
+      const itemText = screen.getByTestId(testId);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('positioner')).toHaveAttribute('data-side', 'none');
+        expect(
+          Math.abs(
+            getCenterY(value.getBoundingClientRect()) -
+              getCenterY(itemText.getBoundingClientRect()),
+          ),
+        ).toBeLessThan(1);
+      });
+    }
+
+    await user.click(trigger);
+    await expectItemAligned('first-item-text');
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(trigger).toHaveAttribute('aria-expanded', 'false'));
+
+    await user.click(trigger);
+    await expectItemAligned('first-item-text');
+
+    await user.click(screen.getByTestId('selected-item-text'));
+    await waitFor(() => expect(trigger).toHaveAttribute('aria-expanded', 'false'));
+
+    await user.click(trigger);
+    await expectItemAligned('selected-item-text');
+  });
+
   describe.skipIf(isJSDOM)('rtl alignment', () => {
     const RTL_FIXTURE_OPTIONS = [
       { value: 'first', label: 'الخيار الأول' },

--- a/packages/react/src/select/popup/SelectPopup.tsx
+++ b/packages/react/src/select/popup/SelectPopup.tsx
@@ -57,6 +57,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     onOpenChangeComplete,
     setOpen,
     valueRef,
+    firstItemTextRef,
     selectedItemTextRef,
     keyboardActiveRef,
     multiple,
@@ -285,7 +286,16 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     popupElement.style.removeProperty('--transform-origin');
 
     try {
-      const textElement = selectedItemTextRef.current;
+      let textElement = selectedItemTextRef.current;
+
+      if (!textElement?.isConnected) {
+        const hasSelectedValue = selectors.hasSelectedValue(store.state);
+        textElement =
+          !hasSelectedValue && firstItemTextRef.current?.isConnected
+            ? firstItemTextRef.current
+            : null;
+      }
+
       const valueElement = valueRef.current;
 
       const positionerStyles = getComputedStyle(positionerElement);
@@ -425,6 +435,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     positionerElement,
     triggerElement,
     valueRef,
+    firstItemTextRef,
     selectedItemTextRef,
     popupRef,
     handleScrollArrowVisibility,

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -117,7 +117,8 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   const valuesRef = React.useRef<Array<any>>([]);
   const typingRef = React.useRef(false);
   const keyboardActiveRef = React.useRef(false);
-  const selectedItemTextRef = React.useRef<HTMLSpanElement | null>(null);
+  const firstItemTextRef = React.useRef<HTMLElement | null>(null);
+  const selectedItemTextRef = React.useRef<HTMLElement | null>(null);
   const selectionRef = React.useRef({
     allowSelectedMouseUp: false,
     allowUnselectedMouseUp: false,
@@ -471,6 +472,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
       labelsRef,
       typingRef,
       selectionRef,
+      firstItemTextRef,
       selectedItemTextRef,
       validation,
       onOpenChangeComplete,

--- a/packages/react/src/select/root/SelectRootContext.ts
+++ b/packages/react/src/select/root/SelectRootContext.ts
@@ -33,7 +33,8 @@ export interface SelectRootContext {
     allowUnselectedMouseUp: boolean;
     allowSelectedMouseUp: boolean;
   }>;
-  selectedItemTextRef: React.RefObject<HTMLSpanElement | null>;
+  firstItemTextRef: React.RefObject<HTMLElement | null>;
+  selectedItemTextRef: React.RefObject<HTMLElement | null>;
   validation: UseFieldValidationReturnValue;
   onOpenChangeComplete?: ((open: boolean) => void) | undefined;
   keyboardActiveRef: React.RefObject<boolean>;


### PR DESCRIPTION
This fixes a post-release regression from #4683 where a Select with no value could reopen aligned to the popup top instead of the first item. The stale selected-item text ref still clears when the value disappears, but no-value alignment now keeps a separate first-item text ref for measurement.

## Changes

- Track the first item text separately from the selected item text used for value alignment.
- Fall back to the first item text only when the select has no value.
- Add a Chromium regression test for open, close, and reopen alignment.
