### PR TITLE
Fix outdated accesibility information in color contrast section

### DIFF
--- a/docs/src/app/(docs)/react/overview/accessibility/page.mdx
+++ b/docs/src/app/(docs)/react/overview/accessibility/page.mdx
@@ -31,7 +31,7 @@ WCAG provides [guidelines on focus appearance](https://www.w3.org/WAI/WCAG22/Und
 ## Color contrast
 
 When styling elements, it's important to meet the minimum requirements for color contrast between each foreground element and its corresponding background element.
-Unless your application has strict requirements around compliance with current standards, consider adhering to [APCA](https://apcacontrast.com/), which is slated to become the new standard in WCAG 3.
+Unless your application has strict requirements around compliance with current standards, consider adhering to [APCA](https://apcacontrast.com/).
 
 ## Accessible labels
 


### PR DESCRIPTION
Removed reference to APCA becoming the new standard in WCAG 3. APCA was removed from the WCAG 3 draft in July 2023. It may come back, as the APCA algorithm has had updates since then. The contrast algorithm used in WCAG 3 has not been determined.

Source:
https://adrianroselli.com/2026/04/wcag3-contrast-as-of-april-2026.html

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
