### PR TITLE
[number field] Allow Persian digits in keyboard input

### DIFF
--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -335,6 +335,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       const isAsciiDigit = event.key >= '0' && event.key <= '9';
       const isArabicNumeral = ARABIC_DETECT_RE.test(event.key);
       const isHanNumeral = HAN_DETECT_RE.test(event.key);
+      const isPersianNumeral = PERSIAN_DETECT_RE.test(event.key);
       const isFullwidthNumeral = FULLWIDTH_DETECT_RE.test(event.key);
       const isNavigateKey = NAVIGATE_KEYS.has(event.key);
 
@@ -351,6 +352,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
         isArabicNumeral ||
         isFullwidthNumeral ||
         isHanNumeral ||
+        isPersianNumeral ||
         isNavigateKey
       ) {
         return;

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -1769,6 +1769,28 @@ describe('<NumberField />', () => {
   });
 
   describe('integration: exotic inputs and IME', () => {
+    it('accepts Persian digit keyboard input', async () => {
+      const onValueChange = vi.fn();
+      function App() {
+        const [value, setValue] = React.useState<number | null>(null);
+        return (
+          <NumberField
+            value={value}
+            onValueChange={(v) => {
+              onValueChange(v);
+              setValue(v);
+            }}
+          />
+        );
+      }
+      const { user } = await render(<App />);
+      const input = screen.getByRole('textbox');
+
+      await user.type(input, '۱۲۳');
+
+      expect(onValueChange.mock.calls.at(-1)?.[0]).toBe(123);
+    });
+
     it('parses Persian digits and separators via change events', async () => {
       const onValueChange = vi.fn();
       function App() {


### PR DESCRIPTION
Fixes #4718

## Problem

Persian digits could not be typed into Number Field inputs because they were blocked during keyboard handling, even though the parser already supports them.

## Solution

Allow Persian numerals through the same keyboard input path as Arabic, Han, and fullwidth numerals.

## Test

Added a regression test that types Persian digits with `user.type()`.

Ran:

```bash
pnpm test:jsdom NumberField --no-watch
```