### PR TITLE
[focus] Fix enqueueFocus cleanup not cancelling RAF when a newer call has overwritten rafId

### DIFF
--- a/packages/react/src/floating-ui-react/utils/enqueueFocus.ts
+++ b/packages/react/src/floating-ui-react/utils/enqueueFocus.ts
@@ -22,8 +22,8 @@ export function enqueueFocus(el: FocusableElement | null, options: Options = {})
   const currentRafId = requestAnimationFrame(exec);
   rafId = currentRafId;
   return () => {
+    cancelAnimationFrame(currentRafId);
     if (rafId === currentRafId) {
-      cancelAnimationFrame(currentRafId);
       rafId = 0;
     }
   };


### PR DESCRIPTION
The cleanup function returned by `enqueueFocus` only cancels the queued RAF if `rafId` still equals `currentRafId`:

```ts
return () => {
  if (rafId === currentRafId) {  // misses if a newer call has overwritten rafId
    cancelAnimationFrame(currentRafId);
    rafId = 0;
  }
};
```

When a second call to `enqueueFocus` happens after the first (e.g. a nested or concurrent popup interaction), `rafId` gets overwritten. The first call's cleanup no longer matches, so its RAF is never cancelled on unmount and fires as a ghost after the component is gone.

Moving the `cancelAnimationFrame` outside the guard fixes this — it's always safe to cancel a specific RAF id, even if it has already fired or been cancelled by another call.

Fixes a scenario where a `Combobox` inside a `Dialog` leaves a pending RAF after unmount that fires during a subsequent render and steals focus, preventing the popup from opening.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).