### PR TITLE
[menu] Fix submenu safePolygon scope for keepMounted portals

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
@@ -116,10 +116,18 @@ export function useHoverFloatingInteraction(
         parentFloating.style.pointerEvents = '';
       }
 
+      // A keep-mounted submenu can appear in the tree before it opens, so a
+      // cached scope or parent lookup may resolve to the submenu itself. That
+      // would not shield sibling items in the parent menu.
+      const cachedScopeElement =
+        instance.pointerEventsScopeElement !== floatingEl
+          ? instance.pointerEventsScopeElement
+          : null;
+      const parentScopeElement = parentFloating !== floatingEl ? parentFloating : null;
       const scopeElement =
         instance.handleCloseOptions?.getScope?.() ??
-        instance.pointerEventsScopeElement ??
-        parentFloating ??
+        cachedScopeElement ??
+        parentScopeElement ??
         (ref.closest('[data-rootownerid]') as HTMLElement | SVGSVGElement | null) ??
         doc.body;
 

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -1641,6 +1641,48 @@ describe('<Menu.Root />', () => {
         }
       });
 
+      it('scopes submenu safePolygon pointer events to the parent menu with keepMounted portal', async () => {
+        await render(
+          <TestMenu
+            rootProps={{ defaultOpen: true }}
+            popupProps={{
+              children: (
+                <React.Fragment>
+                  <Menu.Item data-testid="item-1">Item 1</Menu.Item>
+                  <Menu.SubmenuRoot>
+                    <Menu.SubmenuTrigger data-testid="submenu-trigger" delay={0}>
+                      Item 2
+                    </Menu.SubmenuTrigger>
+                    <Menu.Portal keepMounted>
+                      <Menu.Positioner data-testid="submenu-positioner">
+                        <Menu.Popup data-testid="submenu">
+                          <Menu.Item>Item 2.1</Menu.Item>
+                        </Menu.Popup>
+                      </Menu.Positioner>
+                    </Menu.Portal>
+                  </Menu.SubmenuRoot>
+                  <Menu.Item data-testid="item-3">Item 3</Menu.Item>
+                </React.Fragment>
+              ),
+            }}
+          />,
+        );
+
+        const submenuTrigger = screen.getByTestId('submenu-trigger');
+        await userEvent.hover(submenuTrigger);
+
+        await waitFor(() => {
+          expect(screen.getByTestId('submenu')).not.toBe(null);
+        });
+
+        const menu = screen.getByTestId('menu');
+        const submenuPositioner = screen.getByTestId('submenu-positioner');
+
+        expect(menu.style.pointerEvents).toBe('none');
+        expect(submenuPositioner.style.pointerEvents).toBe('auto');
+        expect(screen.getByTestId('item-3').style.pointerEvents).toBe('');
+      });
+
       it('should not close when submenu is hovered after root menu is hovered', async () => {
         await render(
           <TestMenu


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #4722

This fixes submenu hover traversal when a submenu uses `<Menu.Portal keepMounted>`. In that case, the kept-mounted submenu can already be present in the floating tree before it opens, so safePolygon pointer-events scoping can resolve to the submenu itself. That scope does not shield sibling items in the parent menu, allowing sibling hover handling to close the submenu during diagonal pointer movement.

The change keeps the existing scope fallback order, but ignores cached or parent scope candidates when they are the current floating element. This lets the parent menu remain the pointer-events scope while the submenu positioner stays interactive.

Validation:
- Confirmed the new regression test fails without the implementation change.
- `PLAYWRIGHT_BROWSERS_PATH=.playwright VITEST_ENV=chromium pnpm vitest run --project @base-ui/react packages/react/src/menu/root/MenuRoot.test.tsx -t "scopes submenu safePolygon"`