### PR TITLE
[docs] Restore previous changelog captialization behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _Apr 20, 2026_
 
-### General Changes
+### General changes
 
 - Clear highlight on pointer leave when item is clipped by scroll container (#4604) by @atomiks
 - Fix `display: contents` tabbability (#4642) by @atomiks
@@ -21,7 +21,7 @@ All contributors of this release in alphabetical order: @atomiks, @LukasTy
 
 _Apr 13, 2026_
 
-### General Changes
+### General changes
 
 - Improve `render` prop warning accuracy (#4324, #4363) by @atomiks
 - Fix `preventBaseUIHandler` runtime wrapping (#4330) by @atomiks
@@ -152,7 +152,7 @@ All contributors of this release in alphabetical order: @arturbien, @atomiks, @C
 
 _Mar 12, 2026_
 
-### General Changes
+### General changes
 
 - Warn when a component function is rendered directly (#4077) by @atomiks
 - Reset `openMethod` after close transition (#4128) by @atomiks

--- a/docs/src/app/(docs)/react/overview/releases/v1-3-0/page.mdx
+++ b/docs/src/app/(docs)/react/overview/releases/v1-3-0/page.mdx
@@ -3,7 +3,7 @@
 <Subtitle>Mar 12, 2026</Subtitle>
 <Meta name="description" content="v1.3.0 release notes. Mar 12, 2026." />
 
-## General Changes
+## General changes
 
 - Warn when a component function is rendered directly ([#4077](https://github.com/mui/base-ui/pull/4077))
 - Reset `openMethod` after close transition ([#4128](https://github.com/mui/base-ui/pull/4128))

--- a/docs/src/app/(docs)/react/overview/releases/v1-4-0/page.mdx
+++ b/docs/src/app/(docs)/react/overview/releases/v1-4-0/page.mdx
@@ -3,7 +3,7 @@
 <Subtitle>Apr 13, 2026</Subtitle>
 <Meta name="description" content="v1.4.0 release notes. Apr 13, 2026." />
 
-## General Changes
+## General changes
 
 - Improve `render` prop warning accuracy ([#4324](https://github.com/mui/base-ui/pull/4324), [#4363](https://github.com/mui/base-ui/pull/4363))
 - Fix `preventBaseUIHandler` runtime wrapping ([#4330](https://github.com/mui/base-ui/pull/4330))

--- a/docs/src/app/(docs)/react/overview/releases/v1-4-1/page.mdx
+++ b/docs/src/app/(docs)/react/overview/releases/v1-4-1/page.mdx
@@ -3,7 +3,7 @@
 <Subtitle>Apr 20, 2026</Subtitle>
 <Meta name="description" content="v1.4.1 release notes. Apr 20, 2026." />
 
-## General Changes
+## General changes
 
 - Clear highlight on pointer leave when item is clipped by scroll container ([#4604](https://github.com/mui/base-ui/pull/4604))
 - Fix `display: contents` tabbability ([#4642](https://github.com/mui/base-ui/pull/4642))

--- a/scripts/changelog.config.mjs
+++ b/scripts/changelog.config.mjs
@@ -39,7 +39,7 @@ export default {
       },
       // Category overrides - labels that force a specific section
       categoryOverrides: {
-        'scope: all components': 'general changes',
+        'scope: all components': 'General changes',
       },
       // Explicit flag labels
       flags: {
@@ -51,9 +51,9 @@ export default {
 
     sections: {
       order: {
-        'general changes': -1,
+        'General changes': -1,
       },
-      fallbackSection: 'general changes',
+      fallbackSection: 'General changes',
     },
   },
 };


### PR DESCRIPTION
The behavior changed in #3711. I see no thread about it. Considering it's different from the standard, I conclude it's a regression.

The other regression was https://github.com/mui/mui-public/pull/1350 but it's already fixed. The rest looks correct, e.g., Alert Dialog, we treat the components as nouns. 