### PR TITLE
[select][autocomplete] Fix iOS group scrollbar overflow

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/demos/grid/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/grid/css-modules/index.module.css
@@ -174,6 +174,7 @@
   scroll-padding-top: 2.5rem;
   scroll-padding-bottom: 0.35rem;
   overscroll-behavior: contain;
+  isolation: isolate; /* Prevent overlap with iOS overlay scrollbars. */
   max-height: min(
     calc(20.5rem - var(--input-container-height)),
     calc(var(--available-height) - var(--input-container-height))

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/grid/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/grid/tailwind/index.tsx
@@ -74,7 +74,7 @@ export default function ExampleEmojiPicker() {
                     No emojis found
                   </div>
                 </Autocomplete.Empty>
-                <Autocomplete.List className="max-h-[min(calc(20.5rem-var(--input-container-height)),calc(var(--available-height)-var(--input-container-height)))] overflow-auto scroll-pt-10 scroll-pb-[0.35rem] overscroll-contain">
+                <Autocomplete.List className="isolate max-h-[min(calc(20.5rem-var(--input-container-height)),calc(var(--available-height)-var(--input-container-height)))] overflow-auto scroll-pt-10 scroll-pb-[0.35rem] overscroll-contain">
                   {(group: EmojiGroup) => (
                     <Autocomplete.Group key={group.value} items={group.items} className="block">
                       <Autocomplete.GroupLabel className="sticky top-0 z-[1] m-0 w-full border-b border-gray-100 bg-[canvas] px-4 pb-1 pt-2 text-[0.75rem] font-bold uppercase tracking-wide text-gray-600">

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/grouped/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/grouped/css-modules/index.module.css
@@ -88,7 +88,7 @@
   position: sticky;
   z-index: 1;
   top: 0;
-  margin: 0 0.5rem 0 0;
+  margin: 0 0.5rem 0 0; /* Prevent overlap with iOS overlay scrollbars. */
   width: calc(100% - 0.5rem);
 }
 

--- a/docs/src/app/(docs)/react/components/combobox/demos/grouped/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/combobox/demos/grouped/css-modules/index.module.css
@@ -147,7 +147,7 @@
   position: sticky;
   z-index: 1;
   top: 0;
-  margin: 0 0.5rem 0 0;
+  margin: 0 0.5rem 0 0; /* Prevent overlap with iOS overlay scrollbars. */
   width: calc(100% - 0.5rem);
 }
 

--- a/docs/src/app/(docs)/react/components/select/demos/grouped/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/select/demos/grouped/css-modules/index.module.css
@@ -131,6 +131,8 @@
   position: sticky;
   z-index: 1;
   top: 0;
+  margin: 0 0.5rem 0 0; /* Prevent overlap with iOS overlay scrollbars. */
+  width: calc(100% - 0.5rem);
 }
 
 .Item {

--- a/docs/src/app/(docs)/react/components/select/demos/grouped/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/select/demos/grouped/tailwind/index.tsx
@@ -27,7 +27,7 @@ export default function ExampleSelectGrouped() {
                 {groupedProduce.map((group, index) => (
                   <React.Fragment key={group.value}>
                     <Select.Group className="block pb-0.5">
-                      <Select.GroupLabel className="sticky top-0 z-[1] bg-[canvas] pr-4 pb-1 pl-[1.875rem] pt-2 text-[0.6875rem] font-bold text-[var(--color-gray-700)] uppercase tracking-wider">
+                      <Select.GroupLabel className="sticky top-0 z-[1] mr-2 w-[calc(100%-0.5rem)] bg-[canvas] pr-4 pb-1 pl-[1.875rem] pt-2 text-[0.6875rem] font-bold text-[var(--color-gray-700)] uppercase tracking-wider">
                         {group.value}
                       </Select.GroupLabel>
                       {group.items.map((item) => (


### PR DESCRIPTION
## Problem

I'm not sure it makes sense to touch those demos since they are being reworked on https://x.com/colmtuite/status/2044408195737608217. But those issues are evergreen; they would apply to any kind of 
design. It's about fixing those cut scrollbars:

<img width="227" height="346" alt="SCR-20260502-reof" src="https://github.com/user-attachments/assets/ff6d3306-9c4d-474e-9ba7-3a35c25c322b" />

https://base-ui.com/react/components/select#grouped

<img width="291" height="428" alt="SCR-20260502-rcdq" src="https://github.com/user-attachments/assets/98dfbf1e-8f7c-43cc-81b1-00bc78a36aa2" />

https://base-ui.com/react/components/autocomplete#grid-layout

## Solution

For the components that are meant to be the starting point: use margin, like some of them already do
For the components that are meant to be more "finished", use isolation as conflict risks are lower and design fidelity is higher.

## Context

As for why I worked on this, I'm trying to use this to illustrate where I think we should place the **cursor** for how far to go when we are working on problems, in this case: https://github.com/mui/material-ui/pull/48375#issuecomment-4364386918.