### PR TITLE
[select] Fix flaky Select trigger side test

### DIFF
--- a/packages/react/src/select/trigger/SelectTrigger.test.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.test.tsx
@@ -207,19 +207,21 @@ describe('<Select.Trigger />', () => {
       'sets data-popup-side to the resolved side when alignItemWithTrigger is active',
       async () => {
         const { user } = await render(
-          <Select.Root defaultValue="apple">
-            <Select.Trigger data-testid="trigger" style={{ width: 120, height: 36 }}>
-              <Select.Value />
-            </Select.Trigger>
-            <Select.Portal>
-              <Select.Positioner data-testid="positioner">
-                <Select.Popup style={{ maxHeight: 'none' }}>
-                  <Select.Item value="apple">apple</Select.Item>
-                  <Select.Item value="orange">orange</Select.Item>
-                </Select.Popup>
-              </Select.Positioner>
-            </Select.Portal>
-          </Select.Root>,
+          <div style={{ paddingTop: 100, paddingLeft: 10 }}>
+            <Select.Root defaultValue="apple">
+              <Select.Trigger data-testid="trigger" style={{ width: 120, height: 36 }}>
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner data-testid="positioner">
+                  <Select.Popup style={{ maxHeight: 'none' }}>
+                    <Select.Item value="apple">apple</Select.Item>
+                    <Select.Item value="orange">orange</Select.Item>
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </div>,
         );
 
         const trigger = screen.getByTestId('trigger');
@@ -228,8 +230,8 @@ describe('<Select.Trigger />', () => {
 
         await waitFor(() => {
           expect(screen.getByTestId('positioner')).toHaveAttribute('data-side', 'none');
+          expect(trigger).toHaveAttribute('data-popup-side', 'bottom');
         });
-        expect(trigger).toHaveAttribute('data-popup-side', 'bottom');
       },
     );
 


### PR DESCRIPTION
## Summary

This is an attempt to fix a flaky Select test (https://app.circleci.com/pipelines/github/mui/base-ui/25114/workflows/ba771923-5b6d-412a-9efa-9b2aacdfc8c7/jobs/286549)
This makes the Select trigger style-hook test less layout-sensitive by rendering the trigger away from the viewport edge before opening the popup.

## Root cause

`Select.Popup` intentionally falls back out of `alignItemWithTrigger` when the trigger is too close to a viewport edge or the aligned popup cannot satisfy its minimum height. The test rendered at the default document position, so CI could occasionally hit that fallback and observe `data-side="bottom"` instead of the aligned `data-side="none"` state.

## Changes

- Adds stable top/left spacing around the test Select fixture.
- Waits for both the positioner side and trigger `data-popup-side` hook in the same async assertion.
