### PR TITLE
fix(FloatingPortal): guard addEventListener against null portalNode under concurrent React

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -216,9 +216,11 @@ export const FloatingPortal = React.forwardRef(function FloatingPortal(
 
     // Listen to the event on the capture phase so they run before the focus
     // trap elements onFocus prop is called.
+    // Guard with `portalNode &&` to defend against concurrent React renders
+    // where the effect fires before the ref is attached (issue #4739).
     return mergeCleanups(
-      addEventListener(portalNode, 'focusin', onFocus, true),
-      addEventListener(portalNode, 'focusout', onFocus, true),
+      portalNode && addEventListener(portalNode, 'focusin', onFocus, true),
+      portalNode && addEventListener(portalNode, 'focusout', onFocus, true),
     );
   }, [portalNode, modal]);
 


### PR DESCRIPTION
## Bug

Under React 18+ concurrent rendering (Next.js App Router with `useTransition`/client-side navigation), `FloatingPortal` throws:

```
Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
    at Provider (<anonymous>)
```

## Environment

- `@base-ui/react`: 1.4.1
- React: 19
- Next.js: 16 (App Router)
- Reproduction: client-side navigation to a page that contains `Dialog` (used as Sheet) and `Select` components inside a `Suspense` boundary

## Root cause

In `packages/react/src/floating-ui-react/components/FloatingPortal.tsx`, the `useEffect` that attaches `focusin`/`focusout` listeners has an early-return guard at the top:

```ts
React.useEffect(() => {
  if (!portalNode || modal) {
    return undefined;
  }
  // ...
  return mergeCleanups(
    addEventListener(portalNode, 'focusin', onFocus, true),
    addEventListener(portalNode, 'focusout', onFocus, true),
  );
}, [portalNode, modal]);
```

Under concurrent React, the effect can fire with a `portalNode` that passes the `!portalNode` guard at the start but has since become `null` — or `portalNode` was briefly truthy during the transition phase and the effect was scheduled before it reset to `null`.

The `@base-ui/utils/addEventListener` utility has **no null guard**:

```ts
function addEventListener(target, type, listener, options) {
  target.addEventListener(type, listener, options);  // throws if target is null
  return () => { target.removeEventListener(type, listener, options); };
}
```

Compare this with the guarded pattern used elsewhere in `FloatingFocusManager.tsx`:

```ts
// safe — short-circuit prevents null call
floating && addEventListener(floating, 'focusin', handleFocusIn)
```

But the `FloatingPortal` call site does NOT use this pattern:

```ts
// unguarded — portalNode can be null under concurrent rendering
return mergeCleanups(
  addEventListener(portalNode, 'focusin', onFocus, true),
  addEventListener(portalNode, 'focusout', onFocus, true),
);
```

## Suggested fix

Align the call site with the guarded pattern already used in `FloatingFocusManager`:

```ts
return mergeCleanups(
  portalNode && addEventListener(portalNode, 'focusin', onFocus, true),
  portalNode && addEventListener(portalNode, 'focusout', onFocus, true),
);
```

Or add a null guard to `@base-ui/utils/addEventListener`:

```ts
function addEventListener(target, type, listener, options) {
  if (!target) return () => {};
  target.addEventListener(type, listener, options);
  return () => { target.removeEventListener(type, listener, options); };
}
```

## Impact

Non-fatal console error on every client-side navigation to a page with `Dialog`/`Select` components. Does not break functionality but pollutes the console and will surface as an error in monitoring tools (Sentry, etc.).
