### PR TITLE
[popover] Preserve active trigger on close press

### DIFF
--- a/packages/react/src/popover/close/PopoverClose.test.tsx
+++ b/packages/react/src/popover/close/PopoverClose.test.tsx
@@ -1,7 +1,9 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { Popover } from '@base-ui/react/popover';
+import { Tooltip } from '@base-ui/react/tooltip';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
+import { REASONS } from '../../internals/reasons';
 
 function isElementOrAncestorInert(element: HTMLElement) {
   let current: HTMLElement | null = element;
@@ -70,6 +72,45 @@ describe('<Popover.Close />', () => {
     fireEvent.click(screen.getByTestId('close'));
 
     expect(screen.queryByText('Content')).toBe(null);
+  });
+
+  it('keeps the trigger when closing with a tooltip trigger close button', async () => {
+    const handleOpenChange = vi.fn();
+
+    await render(
+      <Popover.Root defaultOpen onOpenChange={handleOpenChange}>
+        <Popover.Trigger id="trigger-1">Trigger</Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Positioner>
+            <Popover.Popup>
+              Content
+              <Popover.Close
+                data-testid="close"
+                render={(popoverCloseProps) => (
+                  <Tooltip.Root>
+                    <Tooltip.Trigger {...popoverCloseProps}>Close</Tooltip.Trigger>
+                    <Tooltip.Portal>
+                      <Tooltip.Positioner>
+                        <Tooltip.Popup>Tooltip</Tooltip.Popup>
+                      </Tooltip.Positioner>
+                    </Tooltip.Portal>
+                  </Tooltip.Root>
+                )}
+              />
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>,
+    );
+
+    expect(screen.queryByText('Content')).not.toBe(null);
+
+    fireEvent.click(screen.getByTestId('close'));
+
+    expect(screen.queryByText('Content')).toBe(null);
+    expect(handleOpenChange.mock.calls[0][0]).toBe(false);
+    expect(handleOpenChange.mock.calls[0][1].reason).toBe(REASONS.closePress);
+    expect(handleOpenChange.mock.calls[0][1].trigger?.id).toBe('trigger-1');
   });
 
   it('enables modal focus management when `modal=true` and close is rendered', async () => {

--- a/packages/react/src/popover/close/PopoverClose.tsx
+++ b/packages/react/src/popover/close/PopoverClose.tsx
@@ -41,10 +41,7 @@ export const PopoverClose = React.forwardRef(function PopoverClose(
     props: [
       {
         onClick(event) {
-          store.setOpen(
-            false,
-            createChangeEventDetails(REASONS.closePress, event.nativeEvent, event.currentTarget),
-          );
+          store.setOpen(false, createChangeEventDetails(REASONS.closePress, event.nativeEvent));
         },
       },
       elementProps,

--- a/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
@@ -1,8 +1,9 @@
 import { expect } from 'vitest';
 import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
-import { screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { Tooltip } from '@base-ui/react/tooltip';
+import { act, screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM, waitSingleFrame } from '#test-utils';
 
 const Trigger = React.forwardRef(function Trigger(
   props: Popover.Trigger.Props,
@@ -326,4 +327,75 @@ describe('<Popover.Positioner />', () => {
 
     expect(positioner.getBoundingClientRect()).toMatchObject(final);
   });
+
+  it.skipIf(isJSDOM)(
+    'remains anchored to the trigger when closing from a tooltip trigger close',
+    async () => {
+      const testPopover = Popover.createHandle();
+
+      function App() {
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <React.Fragment>
+            <Popover.Trigger
+              handle={testPopover}
+              id="trigger-1"
+              style={{ width: 100, height: 100 }}
+            >
+              Trigger
+            </Popover.Trigger>
+            <Popover.Root
+              handle={testPopover}
+              open={open}
+              triggerId="trigger-1"
+              onOpenChange={(nextOpen, eventDetails) => {
+                if (!nextOpen) {
+                  eventDetails.preventUnmountOnClose();
+                }
+                setOpen(nextOpen);
+              }}
+            >
+              <Popover.Portal>
+                <Popover.Positioner data-testid="positioner">
+                  <Popover.Popup data-testid="popup" style={{ width: 160, height: 120 }}>
+                    <Popover.Close
+                      render={(popoverCloseProps) => (
+                        <Tooltip.Root>
+                          <Tooltip.Trigger {...popoverCloseProps}>Close</Tooltip.Trigger>
+                          <Tooltip.Portal>
+                            <Tooltip.Positioner>
+                              <Tooltip.Popup>Tooltip</Tooltip.Popup>
+                            </Tooltip.Positioner>
+                          </Tooltip.Portal>
+                        </Tooltip.Root>
+                      )}
+                    />
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+      const positioner = screen.getByTestId('positioner');
+      const initialRect = positioner.getBoundingClientRect();
+
+      await user.click(screen.getByRole('button', { name: 'Close' }));
+      await act(async () => {
+        await waitSingleFrame();
+        await waitSingleFrame();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('popup')).toHaveAttribute('data-ending-style');
+      });
+
+      const closingRect = positioner.getBoundingClientRect();
+      expect(Math.abs(closingRect.x - initialRect.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(closingRect.y - initialRect.y)).toBeLessThanOrEqual(1);
+    },
+  );
 });

--- a/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
@@ -522,11 +522,15 @@ describe('<Popover.Root />', () => {
                   <Popover.Positioner data-testid="positioner" side="bottom" align="start">
                     <Popover.Popup>
                       <span data-testid="content">{payload}</span>
+                      <Popover.Close data-testid="close" id="close-button">
+                        Close
+                      </Popover.Close>
                     </Popover.Popup>
                   </Popover.Positioner>
                 </Popover.Portal>
               )}
             </Popover.Root>
+            <span data-testid="active-trigger">{activeTrigger}</span>
 
             <button
               onClick={() => {
@@ -568,6 +572,7 @@ describe('<Popover.Root />', () => {
 
       await user.click(screen.getByRole('button', { name: 'Open Trigger 2' }));
       expect(screen.getByTestId('content').textContent).toBe('2');
+      expect(screen.getByTestId('active-trigger').textContent).toBe('trigger-2');
       await waitFor(() => {
         expect(
           Math.abs(
@@ -576,9 +581,14 @@ describe('<Popover.Root />', () => {
           ),
         ).toBeLessThanOrEqual(1);
       });
+      expect(trigger2.previousElementSibling).toHaveAttribute('data-base-ui-focus-guard');
+      expect(trigger2.nextElementSibling).toHaveAttribute('data-base-ui-focus-guard');
 
-      await user.click(screen.getByRole('button', { name: 'Close' }));
+      await user.click(screen.getByTestId('close'));
       expect(screen.queryByTestId('content')).toBe(null);
+      expect(screen.getByTestId('active-trigger').textContent).toBe('trigger-2');
+      expect(trigger2.previousElementSibling).not.toHaveAttribute('data-base-ui-focus-guard');
+      expect(trigger2.nextElementSibling).not.toHaveAttribute('data-base-ui-focus-guard');
     });
 
     it('allows setting an initially open popover', async () => {

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -395,6 +395,40 @@ describe('<Popover.Root />', () => {
 
         expect(screen.queryByText('Content')).toBe(null);
       });
+
+      it('onOpenChange cancel() prevents closing from a close press without changing the trigger', async () => {
+        let closePressTriggerId: string | undefined;
+
+        await render(
+          <TestPopover
+            triggerProps={{ id: 'trigger-1' }}
+            rootProps={{
+              onOpenChange: (nextOpen, eventDetails) => {
+                if (!nextOpen && eventDetails.reason === REASONS.closePress) {
+                  closePressTriggerId = eventDetails.trigger?.id;
+                  eventDetails.cancel();
+                }
+              },
+            }}
+            popupProps={{
+              children: (
+                <Popover.Close data-testid="close" id="close-button">
+                  Close
+                </Popover.Close>
+              ),
+            }}
+          />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+        fireEvent.click(trigger);
+        await flushMicrotasks();
+
+        fireEvent.click(screen.getByTestId('close'));
+
+        expect(closePressTriggerId).toBe('trigger-1');
+        expect(screen.queryByTestId('close')).not.toBe(null);
+      });
     });
 
     describe('focus management', () => {
@@ -860,6 +894,7 @@ describe('<Popover.Root />', () => {
 
           expect(handleOpenChange.mock.calls.length).toBe(1);
           expect(handleOpenChange.mock.calls[0][1].reason).toBe(REASONS.outsidePress);
+          expect(handleOpenChange.mock.calls[0][1].trigger).toBe(undefined);
         } finally {
           await act(async () => {
             host.remove();
@@ -892,6 +927,7 @@ describe('<Popover.Root />', () => {
 
           expect(handleOpenChange.mock.calls.length).toBe(1);
           expect(handleOpenChange.mock.calls[0][1].reason).toBe(REASONS.outsidePress);
+          expect(handleOpenChange.mock.calls[0][1].trigger).toBe(undefined);
         } finally {
           await act(async () => {
             host.remove();

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -120,6 +120,20 @@ export class PopoverStore<Payload> extends ReactStore<
       this.set('preventUnmountingOnClose', true);
     };
 
+    const activeTriggerId = this.select('activeTriggerId');
+
+    if (
+      !nextOpen &&
+      eventDetails.reason === REASONS.closePress &&
+      eventDetails.trigger == null &&
+      activeTriggerId != null
+    ) {
+      eventDetails.trigger =
+        this.context.triggerElements.getById(activeTriggerId) ??
+        this.select('activeTriggerElement') ??
+        undefined;
+    }
+
     this.context.onOpenChange?.(nextOpen, eventDetails as PopoverRoot.ChangeEventDetails);
 
     if (eventDetails.isCanceled) {

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -144,7 +144,7 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
   // A fragment with key is required to ensure that the `element` is mounted to the same DOM node
   // regardless of whether the focus guards are rendered or not.
 
-  if (isTriggerActive && !focusManagerModal) {
+  if (isMountedByThisTrigger && !focusManagerModal) {
     return (
       <React.Fragment>
         <FocusGuard ref={preFocusGuardRef} onFocus={handlePreFocusGuardFocus} />


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/issues/4738

Preview: https://stackblitz.com/edit/8gvbf1wk-64lb8vbx?file=src%2Findex.module.css

Follows Dialog by preserving the active trigger when PopoverClose closes the popup

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
