### PR TITLE
[menu] Bump timeout for LinkItem keyboard navigation e2e test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ next-env.d.ts
 
 # Claude
 .claude/settings.local.json
+.claude/worktrees/
 
 # Testing
 test-results/

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -254,18 +254,22 @@ describe('e2e', () => {
         await expect(page.getByTestId('test-page')).toHaveText('Page two');
       });
 
-      it('navigates on Enter key press', { timeout: process.env.CIRCLECI === 'true' ? 8000 : 4000 }, async () => {
-        await renderFixture('menu/LinkItemNavigation');
+      it(
+        'navigates on Enter key press',
+        { timeout: process.env.CIRCLECI === 'true' ? 8000 : 4000 },
+        async () => {
+          await renderFixture('menu/LinkItemNavigation');
 
-        await page.keyboard.press('Tab');
-        await page.keyboard.press('Enter');
-        // first item (page one) is initially highlighted
-        await page.keyboard.press('ArrowDown');
-        await page.keyboard.press('Enter');
+          await page.keyboard.press('Tab');
+          await page.keyboard.press('Enter');
+          // first item (page one) is initially highlighted
+          await page.keyboard.press('ArrowDown');
+          await page.keyboard.press('Enter');
 
-        await expect(page).toHaveURL(/\/e2e-fixtures\/menu\/PageTwo/);
-        await expect(page.getByTestId('test-page')).toHaveText('Page two');
-      });
+          await expect(page).toHaveURL(/\/e2e-fixtures\/menu\/PageTwo/);
+          await expect(page.getByTestId('test-page')).toHaveText('Page two');
+        },
+      );
 
       it('navigates when rendering React Router Link component', async () => {
         await renderFixture('menu/ReactRouterLinkItemNavigation');

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -254,7 +254,7 @@ describe('e2e', () => {
         await expect(page.getByTestId('test-page')).toHaveText('Page two');
       });
 
-      it('navigates on Enter key press', async () => {
+      it('navigates on Enter key press', { timeout: process.env.CIRCLECI === 'true' ? 8000 : 4000 }, async () => {
         await renderFixture('menu/LinkItemNavigation');
 
         await page.keyboard.press('Tab');


### PR DESCRIPTION
The `<Menu.LinkItem /> > navigates on Enter key press` test is the slowest e2e test in CircleCI insights and intermittently times out at the 4 s CI cap.

Bumps the timeout for this single test to 8 s on CI / 4 s locally. The project-wide defaults are unchanged.