### PR TITLE
[menu] Reduce closed root work

### DIFF
--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -5,7 +5,7 @@ import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useId } from '@base-ui/utils/useId';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useOnFirstRender } from '@base-ui/utils/useOnFirstRender';
-import { EMPTY_ARRAY } from '@base-ui/utils/empty';
+import { EMPTY_ARRAY, EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { fastComponent } from '@base-ui/utils/fastHooks';
 import {
   FloatingTree,
@@ -22,7 +22,6 @@ import { MenuRootContext, useMenuRootContext } from './MenuRootContext';
 import { MenubarContext, useMenubarContext } from '../../menubar/MenubarContext';
 import { TYPEAHEAD_RESET_MS } from '../../internals/constants';
 import { useDirection } from '../../internals/direction-context/DirectionContext';
-import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
 import {
   createChangeEventDetails,
   type BaseUIChangeEventDetails,
@@ -40,6 +39,7 @@ import {
   useImplicitActiveTrigger,
   useOpenStateTransitions,
   usePopupInteractionProps,
+  usePopupRootSync,
 } from '../../utils/popups';
 import { useMenuSubmenuRootContext } from '../submenu-root/MenuSubmenuRootContext';
 
@@ -133,6 +133,7 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
   const floatingParentNodeIdFromContext = useFloatingParentNodeId();
 
   const open = store.useState('open');
+  const mounted = store.useState('mounted');
   const activeTriggerElement = store.useState('activeTriggerElement');
   const positionerElement = store.useState('positionerElement');
   const hoverEnabled = store.useState('hoverEnabled');
@@ -160,15 +161,13 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     }
   }
 
-  const { openMethod, triggerProps: interactionTypeProps } = useOpenInteractionType(open);
-
   store.useSyncedValues({
     disabled: disabledProp,
     modal: parent.type === undefined ? modalProp : undefined,
-    openMethod,
     rootId,
   });
 
+  usePopupRootSync(store, open);
   useImplicitActiveTrigger(store);
   const { forceUnmount } = useOpenStateTransitions(open, store, () => {
     store.update({ allowMouseEnter: false, stickIfOpen: true });
@@ -385,6 +384,8 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
 
   React.useImperativeHandle(ctx?.actionsRef, () => ({ setOpen }), [setOpen]);
 
+  const shouldSyncPopupProps = open || mounted;
+
   const dismiss = useDismiss(floatingRootContext, {
     enabled: !disabled,
     bubbles: { escapeKey: closeParentOnEsc && parent.type === 'menu' },
@@ -458,19 +459,15 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
   ]);
 
   const activeTriggerProps = React.useMemo(() => {
-    const mergedProps = mergeProps(
-      getReferenceProps(),
-      {
-        onMouseMove() {
-          store.set('allowMouseEnter', true);
-        },
+    const mergedProps = mergeProps(getReferenceProps(), {
+      onMouseMove() {
+        store.set('allowMouseEnter', true);
       },
-      interactionTypeProps,
-    );
+    });
 
     delete mergedProps.role;
     return mergedProps;
-  }, [getReferenceProps, store, interactionTypeProps]);
+  }, [getReferenceProps, store]);
 
   const inactiveTriggerProps = React.useMemo(() => {
     const triggerProps = getTriggerProps();
@@ -478,40 +475,45 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
       return triggerProps;
     }
 
-    const mergedProps = mergeProps(triggerProps, interactionTypeProps);
+    const mergedProps = { ...triggerProps };
     delete mergedProps.role;
     delete mergedProps['aria-controls'];
     return mergedProps;
-  }, [getTriggerProps, interactionTypeProps]);
+  }, [getTriggerProps]);
 
   const popupProps = React.useMemo(
     () =>
-      getFloatingProps({
-        onMouseMove() {
-          store.set('allowMouseEnter', true);
-          if (parent.type === 'menu') {
-            store.set('hoverEnabled', false);
-          }
-        },
-        onClick() {
-          if (store.select('hoverEnabled')) {
-            store.set('hoverEnabled', false);
-          }
-        },
-        onKeyDown(event) {
-          // The Menubar's CompositeRoot captures keyboard events via
-          // event delegation. This works well when Menu.Root is nested inside Menubar,
-          // but with detached triggers we need to manually forward the event to the CompositeRoot.
-          const relay = store.select('keyboardEventRelay');
-          if (relay && !event.isPropagationStopped()) {
-            relay(event);
-          }
-        },
-      }),
-    [getFloatingProps, parent.type, store],
+      shouldSyncPopupProps
+        ? getFloatingProps({
+            onMouseMove() {
+              store.set('allowMouseEnter', true);
+              if (parent.type === 'menu') {
+                store.set('hoverEnabled', false);
+              }
+            },
+            onClick() {
+              if (store.select('hoverEnabled')) {
+                store.set('hoverEnabled', false);
+              }
+            },
+            onKeyDown(event) {
+              // The Menubar's CompositeRoot captures keyboard events via
+              // event delegation. This works well when Menu.Root is nested inside Menubar,
+              // but with detached triggers we need to manually forward the event to the CompositeRoot.
+              const relay = store.select('keyboardEventRelay');
+              if (relay && !event.isPropagationStopped()) {
+                relay(event);
+              }
+            },
+          })
+        : EMPTY_OBJECT,
+    [getFloatingProps, parent.type, shouldSyncPopupProps, store],
   );
 
-  const itemProps = React.useMemo(() => getItemProps(), [getItemProps]);
+  const itemProps = React.useMemo(
+    () => (shouldSyncPopupProps ? getItemProps() : EMPTY_OBJECT),
+    [getItemProps, shouldSyncPopupProps],
+  );
 
   usePopupInteractionProps(store, {
     floatingRootContext,

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -20,6 +20,7 @@ import { useRenderElement } from '../../internals/useRenderElement';
 import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 import { useTriggerRegistration } from '../../utils/popups';
 import { useMenuSubmenuRootContext } from '../submenu-root/MenuSubmenuRootContext';
+import { useOpenMethodTriggerProps } from '../../utils/useOpenInteractionType';
 
 /**
  * A menu item that opens a submenu.
@@ -159,6 +160,12 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
 
   const rootTriggerProps = store.useState('triggerProps', true);
   delete rootTriggerProps.id;
+  const interactionTypeProps = useOpenMethodTriggerProps(
+    () => store.select('open'),
+    (interactionType) => {
+      store.set('openMethod', interactionType);
+    },
+  );
 
   const state: MenuSubmenuTriggerState = { disabled, highlighted, open };
 
@@ -169,6 +176,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
       localInteractionProps.getReferenceProps(),
       hoverProps,
       rootTriggerProps,
+      interactionTypeProps,
       itemProps,
       {
         tabIndex: open || highlighted ? 0 : -1,

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -38,6 +38,7 @@ import { useMenubarContext } from '../../menubar/MenubarContext';
 import { MenuParent } from '../root/MenuRoot';
 import { PATIENT_CLICK_THRESHOLD } from '../../internals/constants';
 import { FocusGuard } from '../../utils/FocusGuard';
+import { useOpenMethodTriggerProps } from '../../utils/useOpenInteractionType';
 
 const BOUNDARY_OFFSET = 2;
 
@@ -214,6 +215,12 @@ export const MenuTrigger = fastComponentRef(function MenuTrigger(
   const localInteractionProps = useInteractions([click, focus]);
 
   const rootTriggerProps = store.useState('triggerProps', isMountedByThisTrigger);
+  const interactionTypeProps = useOpenMethodTriggerProps(
+    () => store.select('open'),
+    (interactionType) => {
+      store.set('openMethod', interactionType);
+    },
+  );
 
   const { preFocusGuardRef, handlePreFocusGuardFocus, handleFocusTargetFocus } =
     useTriggerFocusGuards(store, triggerElementRef);
@@ -228,6 +235,7 @@ export const MenuTrigger = fastComponentRef(function MenuTrigger(
     localInteractionProps.getReferenceProps(),
     hoverProps ?? EMPTY_OBJECT,
     rootTriggerProps,
+    interactionTypeProps,
     {
       'aria-haspopup': 'menu' as const,
       id: thisTriggerId,


### PR DESCRIPTION
Menu roots were still doing some trigger interaction setup and popup prop syncing work while closed. This keeps that work on the trigger or delays it until the menu is open or mounted.

## Changes

- Move open-method tracking from `Menu.Root` to menu triggers and submenu triggers.
- Reset the stored open method through the shared popup root sync helper.
- Skip menu popup and item prop syncing while the popup is closed and unmounted.
