### PR TITLE
[docs] Disable Open Type features in portals

### DIFF
--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -137,8 +137,12 @@
 /* Undo `tailwindcss/preflight` in non-Tailwind demos. */
 
 @layer base {
-  /* Undo Die Grotesk OpenType features in demos and regression tests */
+  /*
+   * Disable Die Grotesk OpenType features in demos and regression tests.
+   * We disable it also on all portal elements because popups from demos are rendered outside [data-demo].
+   */
   [data-demo],
+  [data-base-ui-portal],
   [data-testid='testcase'] {
     font-feature-settings: normal;
   }


### PR DESCRIPTION
Preview: https://deploy-preview-4763--base-ui.netlify.app/react/components/autocomplete#virtualized

Open Type features were already disabled on demos, but portals are appended to the body i.e. they're outside `[data-demo]`.

Note: this also removes Open Type features on portals outside demos, but I don't want to overcomplicate the thing.

|before|after|
|---|---|
|<img width="330" height="431" alt="Screenshot 2026-05-07 at 16 31 01" src="https://github.com/user-attachments/assets/db68865c-d437-4be3-a48b-3ffd8023c7ff" />|<img width="331" height="434" alt="Screenshot 2026-05-07 at 16 31 44" src="https://github.com/user-attachments/assets/0ea70e21-6238-4437-a24b-2d08dbdae5a4" />|