### PR TITLE
[number field] Respect Intl rounding options on blur

### DIFF
--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -706,6 +706,15 @@ describe('<NumberField.Input />', () => {
       0.0123,
     ],
     [
+      'percent with min-only precision',
+      {
+        style: 'percent',
+        minimumFractionDigits: 2,
+        roundingMode: 'floor',
+      },
+      0.0123,
+    ],
+    [
       'unit percent',
       {
         style: 'unit',

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -767,6 +767,39 @@ describe('<NumberField.Input />', () => {
     expect(input).toHaveValue(new Intl.NumberFormat('en-US', format).format(1.239));
   });
 
+  it('should not commit values that overflow while parsing on blur', async () => {
+    const format = {
+      style: 'percent',
+      maximumFractionDigits: 2,
+      roundingMode: 'floor',
+    } as const;
+    const onValueChange = vi.fn();
+    const onValueCommitted = vi.fn();
+
+    await render(
+      <NumberField.Root
+        format={format}
+        onValueChange={onValueChange}
+        onValueCommitted={onValueCommitted}
+      >
+        <NumberField.Input />
+      </NumberField.Root>,
+    );
+
+    const input = screen.getByRole('textbox');
+    const formattedOverflow = new Intl.NumberFormat('en-US', format).format(Number.MAX_VALUE);
+
+    await act(async () => {
+      input.focus();
+    });
+    fireEvent.change(input, { target: { value: formattedOverflow } });
+    fireEvent.blur(input);
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(onValueCommitted).not.toHaveBeenCalled();
+    expect(input).toHaveValue(formattedOverflow);
+  });
+
   it('should round to step precision on blur when step implies precision constraints', async () => {
     const onValueChange = vi.fn();
 

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -617,6 +617,7 @@ describe('<NumberField.Input />', () => {
   async function renderControlledNumberField(
     format: Intl.NumberFormatOptions,
     locale: Intl.LocalesArgument = 'en-US',
+    rootProps: { min?: number; max?: number; allowOutOfRange?: boolean } = {},
   ) {
     const onValueChange = vi.fn();
     const onValueCommitted = vi.fn();
@@ -633,6 +634,7 @@ describe('<NumberField.Input />', () => {
           onValueCommitted={onValueCommitted}
           format={format}
           locale={locale}
+          {...rootProps}
         >
           <NumberField.Input />
         </NumberField.Root>
@@ -830,6 +832,25 @@ describe('<NumberField.Input />', () => {
     expect(onValueChange.mock.lastCall?.[0]).toBe(0.0046);
     expect(onValueCommitted.mock.lastCall?.[0]).toBe(0.0046);
     expect(input).toHaveValue('0.46%');
+  });
+
+  it('should commit the clamped value when blur rounding crosses a boundary', async () => {
+    const format = {
+      style: 'percent',
+      maximumFractionDigits: 2,
+    } as const;
+
+    const { input, onValueChange, onValueCommitted, user } = await renderControlledNumberField(
+      format,
+      'en-US',
+      { max: 0.01235 },
+    );
+
+    await user.keyboard('1.236%');
+    fireEvent.blur(input);
+
+    expect(onValueChange.mock.lastCall?.[0]).toBe(0.01235);
+    expect(onValueCommitted.mock.lastCall?.[0]).toBe(0.01235);
   });
 
   it('should round currency values on blur without percent scaling', async () => {

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -833,6 +833,26 @@ describe('<NumberField.Input />', () => {
     expect(input).toHaveValue('1.23%');
   });
 
+  it('should parse locale prefix percent values on blur', async () => {
+    const format = {
+      style: 'percent',
+      maximumFractionDigits: 2,
+    } as const;
+    const formatted = new Intl.NumberFormat('tr-TR', format).format(0.0123);
+
+    const { input, onValueChange, onValueCommitted } = await renderControlledNumberField(
+      format,
+      'tr-TR',
+    );
+
+    fireEvent.change(input, { target: { value: formatted } });
+    fireEvent.blur(input);
+
+    expect(onValueChange.mock.lastCall?.[0]).toBe(0.0123);
+    expect(onValueCommitted.mock.lastCall?.[0]).toBe(0.0123);
+    expect(input).toHaveValue(formatted);
+  });
+
   it('should preserve exact percent precision boundaries with directional roundingMode on blur', async () => {
     const format = {
       style: 'percent',
@@ -938,7 +958,36 @@ describe('<NumberField.Input />', () => {
     expect(input).toHaveValue(formattedOverflow);
   });
 
-  it('should round to step precision on blur when step implies precision constraints', async () => {
+  it('should not commit a canceled blur change', async () => {
+    const onValueChange = vi.fn((_nextValue, details) => {
+      details.cancel();
+    });
+    const onValueCommitted = vi.fn();
+
+    await render(
+      <NumberField.Root
+        value={0}
+        format={{ maximumFractionDigits: 2 }}
+        onValueChange={onValueChange}
+        onValueCommitted={onValueCommitted}
+      >
+        <NumberField.Input />
+      </NumberField.Root>,
+    );
+
+    const input = screen.getByRole('textbox');
+
+    await act(async () => {
+      input.focus();
+    });
+    fireEvent.change(input, { target: { value: '1.239' } });
+    fireEvent.blur(input);
+
+    expect(onValueCommitted).not.toHaveBeenCalled();
+    expect(input).toHaveValue('1.239');
+  });
+
+  it('should normalize default floating point precision on blur', async () => {
     const onValueChange = vi.fn();
 
     function Controlled() {
@@ -950,7 +999,6 @@ describe('<NumberField.Input />', () => {
             onValueChange(val);
             setValue(val);
           }}
-          step={0.01}
         >
           <NumberField.Input />
         </NumberField.Root>
@@ -977,8 +1025,8 @@ describe('<NumberField.Input />', () => {
 
     fireEvent.blur(input);
 
-    // Without explicit precision formatting, the behavior depends on the step
-    // The current implementation preserves full precision until it differs from canonical
+    // Without explicit precision formatting, default floating point cleanup is applied.
+    // The current implementation preserves the cleaned value until it differs from canonical.
     expect(input).toHaveValue((1.235).toLocaleString(undefined, { minimumFractionDigits: 3 }));
     expect(onValueChange.mock.calls.length).toBe(callCountBeforeBlur + 1);
   });

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -851,6 +851,24 @@ describe('<NumberField.Input />', () => {
     expect(input).toHaveValue('0.46%');
   });
 
+  it('should preserve high-precision percent boundaries with directional roundingMode on blur', async () => {
+    const format = {
+      style: 'percent',
+      maximumFractionDigits: 16,
+      roundingMode: 'floor',
+    } as const;
+
+    const { input, onValueChange, onValueCommitted, user } =
+      await renderControlledNumberField(format);
+
+    await user.keyboard('0.46%');
+    fireEvent.blur(input);
+
+    expect(onValueChange.mock.lastCall?.[0]).toBe(0.0046);
+    expect(onValueCommitted.mock.lastCall?.[0]).toBe(0.0046);
+    expect(input).toHaveValue('0.46%');
+  });
+
   it('should commit the clamped value when blur rounding crosses a boundary', async () => {
     const format = {
       style: 'percent',

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -619,6 +619,7 @@ describe('<NumberField.Input />', () => {
     locale: Intl.LocalesArgument = 'en-US',
   ) {
     const onValueChange = vi.fn();
+    const onValueCommitted = vi.fn();
 
     function Controlled() {
       const [value, setValue] = React.useState<number | null>(null);
@@ -629,6 +630,7 @@ describe('<NumberField.Input />', () => {
             onValueChange(nextValue);
             setValue(nextValue);
           }}
+          onValueCommitted={onValueCommitted}
           format={format}
           locale={locale}
         >
@@ -644,7 +646,7 @@ describe('<NumberField.Input />', () => {
       input.focus();
     });
 
-    return { input, onValueChange, user };
+    return { input, onValueChange, onValueCommitted, user };
   }
 
   it.each([
@@ -702,13 +704,34 @@ describe('<NumberField.Input />', () => {
       roundingIncrement: 5,
     };
 
-    const { input, onValueChange, user } = await renderControlledNumberField(format);
+    const { input, onValueChange, onValueCommitted, user } =
+      await renderControlledNumberField(format);
 
     await user.keyboard('1.26');
+    expect(onValueCommitted).not.toHaveBeenCalled();
+
     fireEvent.blur(input);
 
     expect(onValueChange.mock.lastCall?.[0]).toBe(1.5);
+    expect(onValueCommitted.mock.lastCall?.[0]).toBe(1.5);
     expect(input).toHaveValue(new Intl.NumberFormat('en-US', format).format(1.26));
+  });
+
+  it('should commit significant digit rounded values on blur', async () => {
+    const format = {
+      maximumSignificantDigits: 3,
+      roundingMode: 'floor',
+    };
+
+    const { input, onValueChange, onValueCommitted, user } =
+      await renderControlledNumberField(format);
+
+    await user.keyboard('12345');
+    fireEvent.blur(input);
+
+    expect(onValueChange.mock.lastCall?.[0]).toBe(12300);
+    expect(onValueCommitted.mock.lastCall?.[0]).toBe(12300);
+    expect(input).toHaveValue(new Intl.NumberFormat('en-US', format).format(12345));
   });
 
   it.each([
@@ -748,6 +771,24 @@ describe('<NumberField.Input />', () => {
 
     expect(onValueChange.mock.lastCall?.[0]).toBe(expectedValue);
     expect(input).toHaveValue('1.23%');
+  });
+
+  it('should preserve exact percent precision boundaries with directional roundingMode on blur', async () => {
+    const format = {
+      style: 'percent',
+      maximumFractionDigits: 2,
+      roundingMode: 'floor',
+    } as const;
+
+    const { input, onValueChange, onValueCommitted, user } =
+      await renderControlledNumberField(format);
+
+    await user.keyboard('0.46%');
+    fireEvent.blur(input);
+
+    expect(onValueChange.mock.lastCall?.[0]).toBe(0.0046);
+    expect(onValueCommitted.mock.lastCall?.[0]).toBe(0.0046);
+    expect(input).toHaveValue('0.46%');
   });
 
   it('should round currency values on blur without percent scaling', async () => {

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -695,6 +695,22 @@ describe('<NumberField.Input />', () => {
     expect(input).toHaveValue(expectedValue);
   });
 
+  it('should commit roundingIncrement values on blur', async () => {
+    const format = {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+      roundingIncrement: 5,
+    };
+
+    const { input, onValueChange, user } = await renderControlledNumberField(format);
+
+    await user.keyboard('1.26');
+    fireEvent.blur(input);
+
+    expect(onValueChange.mock.lastCall?.[0]).toBe(1.5);
+    expect(input).toHaveValue(new Intl.NumberFormat('en-US', format).format(1.26));
+  });
+
   it.each([
     [
       'percent',
@@ -732,6 +748,23 @@ describe('<NumberField.Input />', () => {
 
     expect(onValueChange.mock.lastCall?.[0]).toBe(expectedValue);
     expect(input).toHaveValue('1.23%');
+  });
+
+  it('should round currency values on blur without percent scaling', async () => {
+    const format = {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 2,
+      roundingMode: 'floor',
+    } as const;
+
+    const { input, onValueChange, user } = await renderControlledNumberField(format);
+
+    await user.keyboard('1.239');
+    fireEvent.blur(input);
+
+    expect(onValueChange.mock.lastCall?.[0]).toBe(1.23);
+    expect(input).toHaveValue(new Intl.NumberFormat('en-US', format).format(1.239));
   });
 
   it('should round to step precision on blur when step implies precision constraints', async () => {

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -614,6 +614,61 @@ describe('<NumberField.Input />', () => {
     expect(onValueChange.mock.calls[0][0]).toBe(1.23);
   });
 
+  async function renderControlledNumberField(
+    format: Intl.NumberFormatOptions,
+    locale: Intl.LocalesArgument = 'en-US',
+  ) {
+    const onValueChange = vi.fn();
+
+    function Controlled() {
+      const [value, setValue] = React.useState<number | null>(null);
+      return (
+        <NumberField.Root
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue);
+          }}
+          format={format}
+          locale={locale}
+        >
+          <NumberField.Input />
+        </NumberField.Root>
+      );
+    }
+
+    const { user } = await render(<Controlled />);
+    const input = screen.getByRole('textbox');
+
+    await act(async () => {
+      input.focus();
+    });
+
+    return { input, onValueChange, user };
+  }
+
+  it.each([
+    ['en-US', '1.239'],
+    ['fr-FR', '1,239'],
+    ['ar-EG', '١٫٢٣٩'],
+  ] as const)(
+    'should respect roundingMode when rounding to explicit maximumFractionDigits on blur in %s',
+    async (locale, inputText) => {
+      const format = {
+        maximumFractionDigits: 2,
+        roundingMode: 'floor',
+      };
+
+      const { input, onValueChange, user } = await renderControlledNumberField(format, locale);
+
+      await user.keyboard(inputText);
+      fireEvent.blur(input);
+
+      expect(onValueChange.mock.lastCall?.[0]).toBe(1.23);
+      expect(input).toHaveValue(new Intl.NumberFormat(locale, format).format(1.239));
+    },
+  );
+
   it('should not throw on blur when format uses roundingIncrement with fixed fraction digits', async () => {
     const format = {
       minimumFractionDigits: 1,
@@ -638,6 +693,36 @@ describe('<NumberField.Input />', () => {
     });
 
     expect(input).toHaveValue(expectedValue);
+  });
+
+  it.each([
+    [
+      'percent',
+      {
+        style: 'percent',
+        maximumFractionDigits: 2,
+        roundingMode: 'floor',
+      },
+      0.0123,
+    ],
+    [
+      'unit percent',
+      {
+        style: 'unit',
+        unit: 'percent',
+        maximumFractionDigits: 2,
+        roundingMode: 'floor',
+      },
+      1.23,
+    ],
+  ] as const)('should round %s values on blur', async (_, format, expectedValue) => {
+    const { input, onValueChange, user } = await renderControlledNumberField(format);
+
+    await user.keyboard('1.239%');
+    fireEvent.blur(input);
+
+    expect(onValueChange.mock.lastCall?.[0]).toBe(expectedValue);
+    expect(input).toHaveValue('1.23%');
   });
 
   it('should round to step precision on blur when step implies precision constraints', async () => {

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -734,6 +734,23 @@ describe('<NumberField.Input />', () => {
     expect(input).toHaveValue(new Intl.NumberFormat('en-US', format).format(12345));
   });
 
+  it('should commit roundingMode values on blur without explicit precision', async () => {
+    const format = {
+      minimumIntegerDigits: 1,
+      roundingMode: 'floor',
+    };
+
+    const { input, onValueChange, onValueCommitted, user } =
+      await renderControlledNumberField(format);
+
+    await user.keyboard('1.2399');
+    fireEvent.blur(input);
+
+    expect(onValueChange.mock.lastCall?.[0]).toBe(1.239);
+    expect(onValueCommitted.mock.lastCall?.[0]).toBe(1.239);
+    expect(input).toHaveValue(new Intl.NumberFormat('en-US', format).format(1.2399));
+  });
+
   it.each([
     [
       'percent',

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -751,6 +751,30 @@ describe('<NumberField.Input />', () => {
     expect(input).toHaveValue(new Intl.NumberFormat('en-US', format).format(1.2399));
   });
 
+  it('should format controlled values with rounding options after external value changes', async () => {
+    const format = {
+      minimumIntegerDigits: 1,
+      roundingMode: 'floor',
+    };
+
+    function Controlled(props: { value: number | null }) {
+      return (
+        <NumberField.Root value={props.value} format={format}>
+          <NumberField.Input />
+        </NumberField.Root>
+      );
+    }
+
+    const { setProps } = await render(<Controlled value={null} />);
+    const input = screen.getByRole('textbox');
+
+    await act(async () => {
+      setProps({ value: 1.2399 });
+    });
+
+    expect(input).toHaveValue(new Intl.NumberFormat('en-US', format).format(1.2399));
+  });
+
   it.each([
     [
       'percent',

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -736,6 +736,23 @@ describe('<NumberField.Input />', () => {
     expect(input).toHaveValue(new Intl.NumberFormat('en-US', format).format(12345));
   });
 
+  it('should preserve tiny percent significant digit rounded values on blur', async () => {
+    const format = {
+      style: 'percent',
+      maximumSignificantDigits: 2,
+    } as const;
+
+    const { input, onValueChange, onValueCommitted, user } =
+      await renderControlledNumberField(format);
+
+    await user.keyboard('0.0001234%');
+    fireEvent.blur(input);
+
+    expect(onValueChange.mock.lastCall?.[0]).toBe(0.0000012);
+    expect(onValueCommitted.mock.lastCall?.[0]).toBe(0.0000012);
+    expect(input).toHaveValue(new Intl.NumberFormat('en-US', format).format(0.000001234));
+  });
+
   it('should commit roundingMode values on blur without explicit precision', async () => {
     const format = {
       minimumIntegerDigits: 1,

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -175,7 +175,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
         return;
       }
 
-      // If an explicit precision is requested, round the committed numeric value.
+      // Avoid applying Intl's default precision unless the format opts into it.
       const hasExplicitPrecision = hasExplicitNumberFormatPrecision(formatOptions);
 
       const committed = hasExplicitPrecision

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -33,7 +33,7 @@ import {
 import { formatNumber, formatNumberMaxPrecision } from '../../utils/formatNumber';
 import { useValueChanged } from '../../internals/useValueChanged';
 import { REASONS } from '../../internals/reasons';
-import { roundToFractionDigits } from '../utils/validate';
+import { removeFloatingPointErrors } from '../utils/validate';
 
 const stateAttributesMapping = {
   ...fieldValidityMapping,
@@ -181,7 +181,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
         formatOptions?.minimumFractionDigits != null;
 
       const committed = hasExplicitPrecision
-        ? roundToFractionDigits(parsedValue, formatOptions)
+        ? removeFloatingPointErrors(parsedValue, formatOptions)
         : parsedValue;
 
       const nextEventDetails = createGenericEventDetails(REASONS.inputBlur, event.nativeEvent);

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -33,6 +33,7 @@ import {
 import { formatNumber, formatNumberMaxPrecision } from '../../utils/formatNumber';
 import { useValueChanged } from '../../internals/useValueChanged';
 import { REASONS } from '../../internals/reasons';
+import { roundToFractionDigits } from '../utils/validate';
 
 const stateAttributesMapping = {
   ...fieldValidityMapping,
@@ -182,7 +183,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       const maxFrac = formatOptions?.maximumFractionDigits;
       const committed =
         hasExplicitPrecision && typeof maxFrac === 'number'
-          ? Number(parsedValue.toFixed(maxFrac))
+          ? roundToFractionDigits(parsedValue, maxFrac, formatOptions)
           : parsedValue;
 
       const nextEventDetails = createGenericEventDetails(REASONS.inputBlur, event.nativeEvent);

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -180,11 +180,9 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
         formatOptions?.maximumFractionDigits != null ||
         formatOptions?.minimumFractionDigits != null;
 
-      const maxFrac = formatOptions?.maximumFractionDigits;
-      const committed =
-        hasExplicitPrecision && typeof maxFrac === 'number'
-          ? roundToFractionDigits(parsedValue, maxFrac, formatOptions)
-          : parsedValue;
+      const committed = hasExplicitPrecision
+        ? roundToFractionDigits(parsedValue, formatOptions)
+        : parsedValue;
 
       const nextEventDetails = createGenericEventDetails(REASONS.inputBlur, event.nativeEvent);
       const shouldUpdateValue = value !== committed;

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -33,7 +33,7 @@ import {
 import { formatNumber, formatNumberMaxPrecision } from '../../utils/formatNumber';
 import { useValueChanged } from '../../internals/useValueChanged';
 import { REASONS } from '../../internals/reasons';
-import { removeFloatingPointErrors } from '../utils/validate';
+import { hasExplicitNumberFormatPrecision, removeFloatingPointErrors } from '../utils/validate';
 
 const stateAttributesMapping = {
   ...fieldValidityMapping,
@@ -176,9 +176,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       }
 
       // If an explicit precision is requested, round the committed numeric value.
-      const hasExplicitPrecision =
-        formatOptions?.maximumFractionDigits != null ||
-        formatOptions?.minimumFractionDigits != null;
+      const hasExplicitPrecision = hasExplicitNumberFormatPrecision(formatOptions);
 
       const committed = hasExplicitPrecision
         ? removeFloatingPointErrors(parsedValue, formatOptions)

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -33,7 +33,7 @@ import {
 import { formatNumber, formatNumberMaxPrecision } from '../../utils/formatNumber';
 import { useValueChanged } from '../../internals/useValueChanged';
 import { REASONS } from '../../internals/reasons';
-import { hasExplicitNumberFormatPrecision, removeFloatingPointErrors } from '../utils/validate';
+import { hasNumberFormatRoundingOptions, removeFloatingPointErrors } from '../utils/validate';
 
 const stateAttributesMapping = {
   ...fieldValidityMapping,
@@ -175,10 +175,10 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
         return;
       }
 
-      // Avoid applying Intl's default precision unless the format opts into it.
-      const hasExplicitPrecision = hasExplicitNumberFormatPrecision(formatOptions);
+      // Avoid applying Intl's default precision unless the format opts into rounding.
+      const hasRoundingOptions = hasNumberFormatRoundingOptions(formatOptions);
 
-      const committed = hasExplicitPrecision
+      const committed = hasRoundingOptions
         ? removeFloatingPointErrors(parsedValue, formatOptions)
         : parsedValue;
 
@@ -203,7 +203,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       // Normalize only the displayed text
       const canonicalText = formatNumber(committedValue, locale, formatOptions);
       const shouldPreserveFullPrecision =
-        !hasExplicitPrecision &&
+        !hasRoundingOptions &&
         parsedValue === value &&
         inputValue === formatNumberMaxPrecision(parsedValue, locale, formatOptions);
 

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -189,8 +189,13 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       // Use the stored value after `setValue` clamps it.
       let committedValue = committed;
       if (shouldUpdateValue) {
+        const changeDetails = createChangeEventDetails(REASONS.inputBlur, event.nativeEvent);
         blockRevalidationRef.current = true;
-        setValue(committed, createChangeEventDetails(REASONS.inputBlur, event.nativeEvent));
+        setValue(committed, changeDetails);
+        if (changeDetails.isCanceled) {
+          blockRevalidationRef.current = false;
+          return;
+        }
         committedValue = lastChangedValueRef.current ?? committed;
       }
       if (validationMode === 'onBlur') {

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -235,7 +235,6 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
         small: eventWithOptionalKeyState?.altKey ?? false,
         clamp: shouldClampValue,
       });
-      lastChangedValueRef.current = validatedValue;
 
       // Determine whether we should notify about a change even if the numeric value is unchanged.
       // This is needed when the user input is clamped/snapped to the same current value, or when
@@ -261,6 +260,8 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
         setDirty(validatedValue !== validityData.initialValue);
         hasPendingCommitRef.current = true;
       }
+
+      lastChangedValueRef.current = validatedValue;
 
       // Keep the visible input in sync immediately when programmatic changes occur
       // (increment/decrement, wheel, etc). During direct typing we don't want

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -235,6 +235,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
         small: eventWithOptionalKeyState?.altKey ?? false,
         clamp: shouldClampValue,
       });
+      lastChangedValueRef.current = validatedValue;
 
       // Determine whether we should notify about a change even if the numeric value is unchanged.
       // This is needed when the user input is clamped/snapped to the same current value, or when
@@ -250,7 +251,6 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
         (isInputReason && (unvalidatedValue !== value || allowInputSyncRef.current === false));
 
       if (shouldFireChange) {
-        lastChangedValueRef.current = validatedValue;
         onValueChangeProp?.(validatedValue, details);
 
         if (details.isCanceled) {

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -30,7 +30,7 @@ import {
 } from '../utils/parse';
 import { formatNumber, formatNumberMaxPrecision } from '../../utils/formatNumber';
 import { DEFAULT_STEP } from '../utils/constants';
-import { toValidatedNumber } from '../utils/validate';
+import { hasNumberFormatRoundingOptions, toValidatedNumber } from '../utils/validate';
 import { EventWithOptionalKeyState } from '../utils/types';
 import type { ChangeEventCustomProperties, IncrementValueParameters } from '../utils/types';
 import {
@@ -698,9 +698,7 @@ function getControlledInputValue(
   locale: Intl.LocalesArgument,
   format: Intl.NumberFormatOptions | undefined,
 ) {
-  const explicitPrecision =
-    format?.maximumFractionDigits != null || format?.minimumFractionDigits != null;
-  return explicitPrecision
+  return hasNumberFormatRoundingOptions(format)
     ? formatNumber(value, locale, format)
     : formatNumberMaxPrecision(value, locale, format);
 }

--- a/packages/react/src/number-field/utils/parse.test.ts
+++ b/packages/react/src/number-field/utils/parse.test.ts
@@ -49,6 +49,10 @@ describe('NumberField parse', () => {
       expect(parseNumber('12%', 'en-US', { style: 'percent' })).toBe(0.12);
     });
 
+    it('parses scientific notation percentages', () => {
+      expect(parseNumber('1e-7%', 'en-US', { style: 'percent' })).toBe(1e-9);
+    });
+
     it('handles percentages with style: "unit" and unit: "percent"', () => {
       expect(parseNumber('12%', 'en-US', { style: 'unit', unit: 'percent' })).toBe(12);
     });
@@ -122,6 +126,25 @@ describe('NumberField parse', () => {
         expect(parseNumber(formatted, locale, format)).toBe(0.00000123);
       },
     );
+
+    it.each(['ar-EG', 'fa-IR'] as const)(
+      'parses localized tiny percent scientific notation for %s',
+      (locale) => {
+        const format = {
+          style: 'percent',
+          notation: 'scientific',
+          maximumFractionDigits: 2,
+        } as const;
+        const value = 0.0000000000012345;
+        const formatted = new Intl.NumberFormat(locale, format).format(value);
+
+        expect(parseNumber(formatted, locale, format)).toBe(0.00000000000123);
+      },
+    );
+
+    it('parses scientific notation permille values', () => {
+      expect(parseNumber('1e-7‰', 'en-US')).toBe(1e-10);
+    });
 
     it('parses units when options specify unit style', () => {
       expect(parseNumber('12 kg', 'en-US', { style: 'unit', unit: 'kilogram' })).toBe(12);

--- a/packages/react/src/number-field/utils/parse.test.ts
+++ b/packages/react/src/number-field/utils/parse.test.ts
@@ -108,6 +108,15 @@ describe('NumberField parse', () => {
       expect(parseNumber('∞')).toBe(null);
     });
 
+    it('returns null when parsing overflows to Infinity', () => {
+      const formatted = new Intl.NumberFormat('en-US', {
+        style: 'percent',
+        maximumFractionDigits: 2,
+      }).format(Number.MAX_VALUE);
+
+      expect(parseNumber(formatted, 'en-US', { style: 'percent' })).toBe(null);
+    });
+
     it('collapses extra dots from mixed-locale inputs', () => {
       // Last '.' is decimal; previous '.' are removed
       expect(parseNumber('1.234.567.89')).toBe(1234567.89);

--- a/packages/react/src/number-field/utils/parse.test.ts
+++ b/packages/react/src/number-field/utils/parse.test.ts
@@ -49,6 +49,13 @@ describe('NumberField parse', () => {
       expect(parseNumber('12%', 'en-US', { style: 'percent' })).toBe(0.12);
     });
 
+    it('parses prefix percentages', () => {
+      const format = { style: 'percent', maximumFractionDigits: 2 } as const;
+      const formatted = new Intl.NumberFormat('tr-TR', format).format(0.0123);
+
+      expect(parseNumber(formatted, 'tr-TR', format)).toBe(0.0123);
+    });
+
     it('parses scientific notation percentages', () => {
       expect(parseNumber('1e-7%', 'en-US', { style: 'percent' })).toBe(1e-9);
     });
@@ -100,6 +107,19 @@ describe('NumberField parse', () => {
       expect(parseNumber('$1,234.56', 'en-US', { style: 'currency', currency: 'USD' })).toBe(
         1234.56,
       );
+    });
+
+    it('parses scientific notation with currency codes', () => {
+      const format = {
+        style: 'currency',
+        currency: 'EUR',
+        currencyDisplay: 'code',
+        notation: 'scientific',
+        maximumFractionDigits: 2,
+      } as const;
+      const formatted = new Intl.NumberFormat('en-US', format).format(12345);
+
+      expect(parseNumber(formatted, 'en-US', format)).toBe(12300);
     });
 
     it.each(['ar-EG', 'fa-IR'] as const)(

--- a/packages/react/src/number-field/utils/parse.test.ts
+++ b/packages/react/src/number-field/utils/parse.test.ts
@@ -98,6 +98,31 @@ describe('NumberField parse', () => {
       );
     });
 
+    it.each(['ar-EG', 'fa-IR'] as const)(
+      'parses localized scientific notation for %s',
+      (locale) => {
+        const format = { notation: 'scientific', maximumFractionDigits: 2 } as const;
+        const formatted = new Intl.NumberFormat(locale, format).format(12345);
+
+        expect(parseNumber(formatted, locale, format)).toBe(12300);
+      },
+    );
+
+    it.each(['ar-EG', 'fa-IR'] as const)(
+      'parses localized percent scientific notation with a negative exponent for %s',
+      (locale) => {
+        const format = {
+          style: 'percent',
+          notation: 'scientific',
+          maximumFractionDigits: 2,
+        } as const;
+        const value = 0.0000012345;
+        const formatted = new Intl.NumberFormat(locale, format).format(value);
+
+        expect(parseNumber(formatted, locale, format)).toBe(0.00000123);
+      },
+    );
+
     it('parses units when options specify unit style', () => {
       expect(parseNumber('12 kg', 'en-US', { style: 'unit', unit: 'kilogram' })).toBe(12);
     });

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -214,7 +214,7 @@ export function parseNumber(
     num /= 100;
   }
 
-  if (Number.isNaN(num)) {
+  if (!Number.isFinite(num)) {
     return null;
   }
 

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -136,7 +136,10 @@ export function parseNumber(
     }
   }
 
-  const { group, decimal, currency } = getNumberLocaleDetails(computedLocale, options);
+  const { group, decimal, currency, exponentSeparator } = getNumberLocaleDetails(
+    computedLocale,
+    options,
+  );
 
   // Build robust unit regex from all unit parts (such as "km/h")
   const unitParts = getFormatter(computedLocale, options)
@@ -174,6 +177,10 @@ export function parseNumber(
     // Arabic punctuation
     { regex: /٫/g, replacement: '.' }, // ARABIC DECIMAL SEPARATOR (U+066B)
     { regex: /٬/g, replacement: '' }, // ARABIC THOUSANDS SEPARATOR (U+066C)
+    {
+      regex: exponentSeparator ? new RegExp(escapeRegExp(exponentSeparator), 'g') : null,
+      replacement: 'e',
+    },
     // Currency & unit labels
     { regex: currency ? new RegExp(escapeRegExp(currency), 'g') : null, replacement: '' },
     { regex: unitRegex, replacement: '' },
@@ -209,9 +216,9 @@ export function parseNumber(
   const hasPermilleSymbol = PERMILLE_RE.test(formattedNumber);
 
   if (hasPermilleSymbol) {
-    num /= 1000;
+    num = Number(`${num}e-3`);
   } else if (!isUnitPercent && hasPercentSymbol) {
-    num /= 100;
+    num = Number(`${num}e-2`);
   }
 
   if (!Number.isFinite(num)) {

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -35,6 +35,8 @@ export const FULLWIDTH_RE = new RegExp(`[${FULLWIDTH_NUMERALS.join('')}]`, 'g');
 export const HAN_RE = new RegExp(`[${HAN_NUMERALS.join('')}]`, 'g');
 export const PERCENT_RE = new RegExp(`[${PERCENTAGES.join('')}]`);
 export const PERMILLE_RE = new RegExp(`[${PERMILLE.join('')}]`);
+const PERCENT_GLOBAL_RE = new RegExp(PERCENT_RE.source, 'g');
+const PERMILLE_GLOBAL_RE = new RegExp(PERMILLE_RE.source, 'g');
 
 // Detection regexes (non-global to avoid lastIndex side effects)
 export const ARABIC_DETECT_RE = /[٠١٢٣٤٥٦٧٨٩]/;
@@ -182,13 +184,15 @@ export function parseNumber(
     // Arabic punctuation
     { regex: /٫/g, replacement: '.' }, // ARABIC DECIMAL SEPARATOR (U+066B)
     { regex: /٬/g, replacement: '' }, // ARABIC THOUSANDS SEPARATOR (U+066C)
+    // Currency & unit labels
+    { regex: currency ? new RegExp(escapeRegExp(currency), 'g') : null, replacement: '' },
+    { regex: unitRegex, replacement: '' },
+    { regex: PERCENT_GLOBAL_RE, replacement: '' },
+    { regex: PERMILLE_GLOBAL_RE, replacement: '' },
     {
       regex: exponentSeparator ? new RegExp(escapeRegExp(exponentSeparator), 'g') : null,
       replacement: 'e',
     },
-    // Currency & unit labels
-    { regex: currency ? new RegExp(escapeRegExp(currency), 'g') : null, replacement: '' },
-    { regex: unitRegex, replacement: '' },
     // Numeral systems to ASCII digits
     { regex: ARABIC_RE, replacement: (ch) => String(ARABIC_NUMERALS.indexOf(ch)) },
     { regex: PERSIAN_RE, replacement: (ch) => String(PERSIAN_NUMERALS.indexOf(ch)) },

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -57,6 +57,11 @@ export const MINUS_SIGNS_WITH_ASCII = ['-', ...UNICODE_MINUS_SIGNS];
 const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const escapeClassChar = (s: string) => s.replace(/[-\\\]^]/g, (m) => `\\${m}`); // escape for use inside [...]
 
+function shiftDecimal(value: number, exponentDelta: number) {
+  const [coefficient, exponent = '0'] = String(value).split('e');
+  return Number(`${coefficient}e${Number(exponent) + exponentDelta}`);
+}
+
 const charClassFrom = (chars: string[]) => `[${chars.map(escapeClassChar).join('')}]`;
 
 const ANY_MINUS_CLASS = charClassFrom(['-'].concat(UNICODE_MINUS_SIGNS));
@@ -216,9 +221,9 @@ export function parseNumber(
   const hasPermilleSymbol = PERMILLE_RE.test(formattedNumber);
 
   if (hasPermilleSymbol) {
-    num = Number(`${num}e-3`);
+    num = shiftDecimal(num, -3);
   } else if (!isUnitPercent && hasPercentSymbol) {
-    num = Number(`${num}e-2`);
+    num = shiftDecimal(num, -2);
   }
 
   if (!Number.isFinite(num)) {

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -122,14 +122,14 @@ describe('NumberField validate', () => {
       ).toBe(1.5);
     });
 
-    it('does not return NaN when percent scaling overflows before Intl rounding', () => {
+    it('keeps the original finite value when percent scaling overflows before Intl rounding', () => {
       expect(
         removeFloatingPointErrors(Number.MAX_VALUE, {
           style: 'percent',
           maximumFractionDigits: 2,
           roundingMode: 'floor',
         }),
-      ).toBe(Infinity);
+      ).toBe(Number.MAX_VALUE);
     });
 
     it('returns 1000 for 1000, ignoring grouping', () => {
@@ -279,6 +279,20 @@ describe('NumberField validate', () => {
         ).toBe(12.3);
       });
     });
+  });
+
+  it('applies roundingMode after step validation', () => {
+    expect(
+      toValidatedNumber(1.239, {
+        ...defaultOptions,
+        step: 0.001,
+        snapOnStep: true,
+        format: {
+          maximumFractionDigits: 2,
+          roundingMode: 'floor',
+        },
+      }),
+    ).toBe(1.23);
   });
 
   it('removes floating point errors by default', () => {

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -240,6 +240,18 @@ describe('NumberField validate', () => {
       ).toBe(1.23);
     });
 
+    it('rounds scientific currency code values', () => {
+      const format = {
+        style: 'currency',
+        currency: 'EUR',
+        currencyDisplay: 'code',
+        notation: 'scientific',
+        maximumFractionDigits: 2,
+      } as const;
+
+      expect(removeFloatingPointErrors(12345, format)).toBe(12300);
+    });
+
     it('preserves negative values when signDisplay hides the sign', () => {
       const format = {
         maximumFractionDigits: 2,
@@ -324,6 +336,17 @@ describe('NumberField validate', () => {
       expect(new Intl.NumberFormat('en-US', format).format(rounded)).toBe(
         new Intl.NumberFormat('en-US', format).format(value),
       );
+    });
+
+    it('rounds invertible scientific zero buckets', () => {
+      expect(
+        removeFloatingPointErrors(1, {
+          notation: 'scientific',
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 0,
+          roundingIncrement: 5,
+        }),
+      ).toBe(0);
     });
 
     it('returns 1000 for 1000, ignoring grouping', () => {

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -34,6 +34,36 @@ describe('NumberField validate', () => {
       ).toBe(1.23);
     });
 
+    it('respects half-even rounding at ties', () => {
+      expect(
+        removeFloatingPointErrors(1.235, {
+          maximumFractionDigits: 2,
+          roundingMode: 'halfEven',
+        }),
+      ).toBe(1.24);
+      expect(
+        removeFloatingPointErrors(1.245, {
+          maximumFractionDigits: 2,
+          roundingMode: 'halfEven',
+        }),
+      ).toBe(1.24);
+    });
+
+    it('respects rounding mode differences for negative values', () => {
+      expect(
+        removeFloatingPointErrors(-1.239, {
+          maximumFractionDigits: 2,
+          roundingMode: 'floor',
+        }),
+      ).toBe(-1.24);
+      expect(
+        removeFloatingPointErrors(-1.239, {
+          maximumFractionDigits: 2,
+          roundingMode: 'trunc',
+        }),
+      ).toBe(-1.23);
+    });
+
     it('rounds percent values at display scale when maximumFractionDigits is provided', () => {
       expect(
         removeFloatingPointErrors(0.01236, {
@@ -71,6 +101,17 @@ describe('NumberField validate', () => {
       ).toBe(1.23);
     });
 
+    it('rounds currency values without percent scaling', () => {
+      expect(
+        removeFloatingPointErrors(1.239, {
+          style: 'currency',
+          currency: 'USD',
+          maximumFractionDigits: 2,
+          roundingMode: 'floor',
+        }),
+      ).toBe(1.23);
+    });
+
     it('respects roundingIncrement when maximumFractionDigits is provided', () => {
       expect(
         removeFloatingPointErrors(1.26, {
@@ -79,6 +120,16 @@ describe('NumberField validate', () => {
           roundingIncrement: 5,
         }),
       ).toBe(1.5);
+    });
+
+    it('does not return NaN when percent scaling overflows before Intl rounding', () => {
+      expect(
+        removeFloatingPointErrors(Number.MAX_VALUE, {
+          style: 'percent',
+          maximumFractionDigits: 2,
+          roundingMode: 'floor',
+        }),
+      ).toBe(Infinity);
     });
 
     it('returns 1000 for 1000, ignoring grouping', () => {

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -80,6 +80,19 @@ describe('NumberField validate', () => {
       ).toBe(0.0123);
     });
 
+    it.each(['floor', 'ceil', 'trunc', 'expand'] as const)(
+      'preserves exact percent precision boundaries with roundingMode: %s',
+      (roundingMode) => {
+        expect(
+          removeFloatingPointErrors(0.0046, {
+            style: 'percent',
+            maximumFractionDigits: 2,
+            roundingMode,
+          }),
+        ).toBe(0.0046);
+      },
+    );
+
     it('rounds percent values at display scale when only minimumFractionDigits is provided', () => {
       expect(
         removeFloatingPointErrors(0.01239, {
@@ -88,6 +101,36 @@ describe('NumberField validate', () => {
           roundingMode: 'floor',
         }),
       ).toBe(0.0123);
+    });
+
+    it('rounds values with significant digit precision', () => {
+      expect(
+        removeFloatingPointErrors(12345, {
+          maximumSignificantDigits: 3,
+          roundingMode: 'floor',
+        }),
+      ).toBe(12300);
+    });
+
+    it('rounds percent values at display scale when significant digits are provided', () => {
+      expect(
+        removeFloatingPointErrors(0.01239, {
+          style: 'percent',
+          maximumSignificantDigits: 3,
+          roundingMode: 'floor',
+        }),
+      ).toBe(0.0123);
+    });
+
+    it('respects roundingPriority when fraction and significant digits are provided', () => {
+      expect(
+        removeFloatingPointErrors(1.2345, {
+          minimumFractionDigits: 2,
+          maximumSignificantDigits: 3,
+          roundingMode: 'floor',
+          roundingPriority: 'morePrecision',
+        }),
+      ).toBe(1.234);
     });
 
     it('does not scale unit percent values when maximumFractionDigits is provided', () => {

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -174,6 +174,25 @@ describe('NumberField validate', () => {
       expect(removeFloatingPointErrors(value, format)).toBe(value);
     });
 
+    it('preserves high-precision percent boundaries with directional rounding', () => {
+      const format = {
+        style: 'percent',
+        maximumFractionDigits: 16,
+        roundingMode: 'floor',
+      } as const;
+      const value = 0.0046;
+      const rounded = removeFloatingPointErrors(value, format);
+
+      expect(rounded).toBe(value);
+      expect(new Intl.NumberFormat('en-US', format).format(rounded)).toBe(
+        new Intl.NumberFormat('en-US', format).format(value),
+      );
+    });
+
+    it('preserves tiny values when Intl supports more than 20 fraction digits', () => {
+      expect(removeFloatingPointErrors(1e-21, { maximumFractionDigits: 21 })).toBe(1e-21);
+    });
+
     it('uses percent fraction defaults when significant digits use roundingPriority', () => {
       const format = {
         style: 'percent',
@@ -260,6 +279,22 @@ describe('NumberField validate', () => {
       expect(rounded).toBe(0.000123);
       expect(new Intl.NumberFormat('en-US', format).format(rounded)).toBe(
         new Intl.NumberFormat('en-US', format).format(0.000123456),
+      );
+    });
+
+    it('preserves non-invertible scientific rounded zero buckets', () => {
+      const format = {
+        notation: 'scientific',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+        roundingIncrement: 5,
+      } as const;
+      const value = 12345;
+      const rounded = removeFloatingPointErrors(value, format);
+
+      expect(rounded).toBe(value);
+      expect(new Intl.NumberFormat('en-US', format).format(rounded)).toBe(
+        new Intl.NumberFormat('en-US', format).format(value),
       );
     });
 

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -122,6 +122,20 @@ describe('NumberField validate', () => {
       ).toBe(0.0123);
     });
 
+    it('uses percent fraction defaults when significant digits use roundingPriority', () => {
+      const format = {
+        style: 'percent',
+        maximumSignificantDigits: 3,
+        roundingPriority: 'morePrecision',
+      } as const;
+      const rounded = removeFloatingPointErrors(0.0123456, format);
+
+      expect(rounded).toBe(0.0123);
+      expect(new Intl.NumberFormat('en-US', format).format(rounded)).toBe(
+        new Intl.NumberFormat('en-US', format).format(0.0123456),
+      );
+    });
+
     it('respects roundingPriority when fraction and significant digits are provided', () => {
       expect(
         removeFloatingPointErrors(1.2345, {
@@ -153,6 +167,15 @@ describe('NumberField validate', () => {
           roundingMode: 'floor',
         }),
       ).toBe(1.23);
+    });
+
+    it('respects roundingMode when no precision is provided', () => {
+      expect(
+        removeFloatingPointErrors(1.2399, {
+          minimumIntegerDigits: 1,
+          roundingMode: 'floor',
+        }),
+      ).toBe(1.239);
     });
 
     it('respects roundingIncrement when maximumFractionDigits is provided', () => {

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -122,6 +122,34 @@ describe('NumberField validate', () => {
       ).toBe(0.0123);
     });
 
+    it('rounds percent significant digit values without reintroducing binary noise', () => {
+      const format = {
+        style: 'percent',
+        maximumSignificantDigits: 2,
+        roundingMode: 'floor',
+      } as const;
+      const rounded = removeFloatingPointErrors(0.009995, format);
+
+      expect(rounded).toBe(0.0099);
+      expect(new Intl.NumberFormat('en-US', format).format(rounded)).toBe(
+        new Intl.NumberFormat('en-US', format).format(0.009995),
+      );
+    });
+
+    it('preserves meaningful percent precision above directional rounding boundaries', () => {
+      const format = {
+        style: 'percent',
+        maximumFractionDigits: 2,
+        roundingMode: 'ceil',
+      } as const;
+      const rounded = removeFloatingPointErrors(0.01230000001, format);
+
+      expect(rounded).toBe(0.0124);
+      expect(new Intl.NumberFormat('en-US', format).format(rounded)).toBe(
+        new Intl.NumberFormat('en-US', format).format(0.01230000001),
+      );
+    });
+
     it('uses percent fraction defaults when significant digits use roundingPriority', () => {
       const format = {
         style: 'percent',
@@ -196,6 +224,19 @@ describe('NumberField validate', () => {
           roundingMode: 'floor',
         }),
       ).toBe(Number.MAX_VALUE);
+    });
+
+    it('rounds scientific notation values at their formatted scale', () => {
+      const format = {
+        notation: 'scientific',
+        maximumFractionDigits: 2,
+      } as const;
+      const rounded = removeFloatingPointErrors(0.000123456, format);
+
+      expect(rounded).toBe(0.000123);
+      expect(new Intl.NumberFormat('en-US', format).format(rounded)).toBe(
+        new Intl.NumberFormat('en-US', format).format(0.000123456),
+      );
     });
 
     it('returns 1000 for 1000, ignoring grouping', () => {
@@ -359,6 +400,38 @@ describe('NumberField validate', () => {
         },
       }),
     ).toBe(1.23);
+  });
+
+  it('clamps the final value after percent rounding crosses max', () => {
+    expect(
+      toValidatedNumber(0.01236, {
+        ...defaultOptions,
+        step: undefined,
+        snapOnStep: false,
+        maxWithDefault: 0.01235,
+        format: {
+          style: 'percent',
+          maximumFractionDigits: 2,
+        },
+      }),
+    ).toBe(0.01235);
+  });
+
+  it('clamps the final value after directional percent rounding crosses min', () => {
+    expect(
+      toValidatedNumber(0.01234, {
+        ...defaultOptions,
+        step: undefined,
+        snapOnStep: false,
+        minWithDefault: 0.01235,
+        minWithZeroDefault: 0.01235,
+        format: {
+          style: 'percent',
+          maximumFractionDigits: 2,
+          roundingMode: 'floor',
+        },
+      }),
+    ).toBe(0.01235);
   });
 
   it('removes floating point errors by default', () => {

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -50,6 +50,16 @@ describe('NumberField validate', () => {
       ).toBe(0.0123);
     });
 
+    it('rounds percent values at display scale when only minimumFractionDigits is provided', () => {
+      expect(
+        removeFloatingPointErrors(0.01239, {
+          style: 'percent',
+          minimumFractionDigits: 2,
+          roundingMode: 'floor',
+        }),
+      ).toBe(0.0123);
+    });
+
     it('does not scale unit percent values when maximumFractionDigits is provided', () => {
       expect(
         removeFloatingPointErrors(1.239, {

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -240,6 +240,34 @@ describe('NumberField validate', () => {
       ).toBe(1.23);
     });
 
+    it('preserves negative values when signDisplay hides the sign', () => {
+      const format = {
+        maximumFractionDigits: 2,
+        signDisplay: 'never',
+      } as const;
+      const rounded = removeFloatingPointErrors(-1.239, format);
+
+      expect(rounded).toBe(-1.24);
+      expect(new Intl.NumberFormat('en-US', format).format(rounded)).toBe(
+        new Intl.NumberFormat('en-US', format).format(-1.239),
+      );
+    });
+
+    it('rounds negative accounting currency values', () => {
+      const format = {
+        style: 'currency',
+        currency: 'USD',
+        currencySign: 'accounting',
+        maximumFractionDigits: 2,
+      } as const;
+      const rounded = removeFloatingPointErrors(-1.239, format);
+
+      expect(rounded).toBe(-1.24);
+      expect(new Intl.NumberFormat('en-US', format).format(rounded)).toBe(
+        new Intl.NumberFormat('en-US', format).format(-1.239),
+      );
+    });
+
     it('respects roundingMode when no precision is provided', () => {
       expect(
         removeFloatingPointErrors(1.2399, {

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -136,6 +136,20 @@ describe('NumberField validate', () => {
       );
     });
 
+    it('preserves tiny percent significant digit values after scaling back', () => {
+      const format = {
+        style: 'percent',
+        maximumSignificantDigits: 2,
+      } as const;
+      const value = 0.000001234;
+      const rounded = removeFloatingPointErrors(value, format);
+
+      expect(rounded).toBe(0.0000012);
+      expect(new Intl.NumberFormat('en-US', format).format(rounded)).toBe(
+        new Intl.NumberFormat('en-US', format).format(value),
+      );
+    });
+
     it('preserves meaningful percent precision above directional rounding boundaries', () => {
       const format = {
         style: 'percent',

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -150,6 +150,16 @@ describe('NumberField validate', () => {
       );
     });
 
+    it('preserves high-precision percent fraction digits', () => {
+      const format = {
+        style: 'percent',
+        maximumFractionDigits: 16,
+      } as const;
+      const value = 0.001234567890123456;
+
+      expect(removeFloatingPointErrors(value, format)).toBe(value);
+    });
+
     it('uses percent fraction defaults when significant digits use roundingPriority', () => {
       const format = {
         style: 'percent',

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -25,6 +25,52 @@ describe('NumberField validate', () => {
       expect(removeFloatingPointErrors(0.2 + 0.1, { maximumFractionDigits: 1 })).toBe(0.3);
     });
 
+    it('respects roundingMode when maximumFractionDigits is provided', () => {
+      expect(
+        removeFloatingPointErrors(1.239, {
+          maximumFractionDigits: 2,
+          roundingMode: 'floor',
+        }),
+      ).toBe(1.23);
+    });
+
+    it('rounds percent values at display scale when maximumFractionDigits is provided', () => {
+      expect(
+        removeFloatingPointErrors(0.01236, {
+          style: 'percent',
+          maximumFractionDigits: 2,
+        }),
+      ).toBe(0.0124);
+      expect(
+        removeFloatingPointErrors(0.01239, {
+          style: 'percent',
+          maximumFractionDigits: 2,
+          roundingMode: 'floor',
+        }),
+      ).toBe(0.0123);
+    });
+
+    it('does not scale unit percent values when maximumFractionDigits is provided', () => {
+      expect(
+        removeFloatingPointErrors(1.239, {
+          style: 'unit',
+          unit: 'percent',
+          maximumFractionDigits: 2,
+          roundingMode: 'floor',
+        }),
+      ).toBe(1.23);
+    });
+
+    it('respects roundingIncrement when maximumFractionDigits is provided', () => {
+      expect(
+        removeFloatingPointErrors(1.26, {
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1,
+          roundingIncrement: 5,
+        }),
+      ).toBe(1.5);
+    });
+
     it('returns 1000 for 1000, ignoring grouping', () => {
       expect(removeFloatingPointErrors(1000)).toBe(1000);
     });

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -209,13 +209,13 @@ describe('NumberField validate', () => {
 
     it('respects roundingPriority when fraction and significant digits are provided', () => {
       expect(
-        removeFloatingPointErrors(1.2345, {
+        removeFloatingPointErrors(1.2399, {
           minimumFractionDigits: 2,
           maximumSignificantDigits: 3,
           roundingMode: 'floor',
           roundingPriority: 'morePrecision',
         }),
-      ).toBe(1.234);
+      ).toBe(1.239);
     });
 
     it('does not scale unit percent values when maximumFractionDigits is provided', () => {

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -11,18 +11,14 @@ type NumberFormatOptionsWithRounding = Intl.NumberFormatOptions & {
   roundingPriority?: string | undefined;
 };
 
-export function hasExplicitNumberFormatPrecision(format?: NumberFormatOptionsWithRounding) {
+export function hasNumberFormatRoundingOptions(
+  format?: NumberFormatOptionsWithRounding,
+): format is NumberFormatOptionsWithRounding {
   return (
     format?.maximumFractionDigits != null ||
     format?.minimumFractionDigits != null ||
     format?.maximumSignificantDigits != null ||
-    format?.minimumSignificantDigits != null
-  );
-}
-
-export function hasNumberFormatRoundingOptions(format?: NumberFormatOptionsWithRounding) {
-  return (
-    hasExplicitNumberFormatPrecision(format) ||
+    format?.minimumSignificantDigits != null ||
     format?.roundingIncrement != null ||
     format?.roundingMode != null ||
     format?.roundingPriority != null
@@ -35,25 +31,18 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   }
 
   const hasRoundingOptions = hasNumberFormatRoundingOptions(format);
-  const resolvedOptions =
-    format && (hasRoundingOptions || format.minimumFractionDigits != null)
-      ? getFormatter('en-US', format).resolvedOptions()
-      : undefined;
-  const minimumFractionDigits =
-    format?.minimumFractionDigits ?? resolvedOptions?.minimumFractionDigits ?? 0;
+  if (!hasRoundingOptions) {
+    return +value.toFixed(3);
+  }
+
+  const resolvedOptions = getFormatter('en-US', format).resolvedOptions();
   const digits = Math.min(
-    Math.max(
-      format?.maximumFractionDigits ??
-        (hasRoundingOptions || format?.minimumFractionDigits != null
-          ? (resolvedOptions?.maximumFractionDigits ?? 3)
-          : 3),
-      minimumFractionDigits,
-      0,
-    ),
+    format.maximumFractionDigits ?? resolvedOptions.maximumFractionDigits ?? 3,
     20,
   );
+
   // Percent values are stored as fractions, so rounding must happen at the displayed scale.
-  const scale = format?.style === 'percent' && hasRoundingOptions ? 100 : 1;
+  const scale = format.style === 'percent' ? 100 : 1;
   let valueToRound = value * scale;
 
   if (!Number.isFinite(valueToRound)) {
@@ -61,31 +50,25 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     return value;
   }
 
-  if (scale !== 1) {
+  if (scale > 1) {
     // Directional Intl rounding has no tolerance for the binary noise introduced by `value * 100`.
     // Clean a few extra decimal places first so exact typed boundaries like 0.46% stay exact.
-    valueToRound = Number(valueToRound.toFixed(Math.min(digits + 6, 20)));
+    valueToRound = +valueToRound.toFixed(Math.min(digits + 6, 20));
   }
 
-  if (hasRoundingOptions) {
-    return (
-      Number(
-        getFormatter('en-US', {
-          // Keep style/unit/notation out so the formatted string parses back as a plain number.
-          useGrouping: false,
-          minimumFractionDigits: digits,
-          maximumFractionDigits: digits,
-          minimumSignificantDigits: format?.minimumSignificantDigits,
-          maximumSignificantDigits: format?.maximumSignificantDigits,
-          roundingIncrement: format?.roundingIncrement,
-          roundingMode: format?.roundingMode,
-          roundingPriority: format?.roundingPriority,
-        } as NumberFormatOptionsWithRounding).format(valueToRound),
-      ) / scale
-    );
-  }
-
-  return Number(valueToRound.toFixed(digits)) / scale;
+  return (
+    +getFormatter('en-US', {
+      // Keep style/unit/notation out so the formatted string parses back as a plain number.
+      useGrouping: false,
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+      minimumSignificantDigits: format.minimumSignificantDigits,
+      maximumSignificantDigits: format.maximumSignificantDigits,
+      roundingIncrement: format.roundingIncrement,
+      roundingMode: format.roundingMode,
+      roundingPriority: format.roundingPriority,
+    } as NumberFormatOptionsWithRounding).format(valueToRound) / scale
+  );
 }
 
 function snapToStep(

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -2,6 +2,12 @@ import { clamp } from '../../internals/clamp';
 import { getFormatter } from '../../utils/formatNumber';
 
 const STEP_EPSILON_FACTOR = 1e-10;
+// Matches Intl.NumberFormat's decimal maximumFractionDigits default.
+const DEFAULT_DIGITS = 3;
+// Keep committed-value normalization aligned with Number Field's max-precision display path.
+const MAX_DIGITS = 20;
+// Extra places used to scrub percent-scale float noise without affecting normal input precision.
+const PERCENT_GUARD_DIGITS = 6;
 
 // The repo compiles against es2022 Intl types, so model NumberFormat v3 options locally.
 // Delete this once tsconfig.base.json includes es2023.
@@ -32,13 +38,13 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
 
   const hasRoundingOptions = hasNumberFormatRoundingOptions(format);
   if (!hasRoundingOptions) {
-    return +value.toFixed(3);
+    return +value.toFixed(DEFAULT_DIGITS);
   }
 
   const resolvedOptions = getFormatter('en-US', format).resolvedOptions();
   const digits = Math.min(
-    format.maximumFractionDigits ?? resolvedOptions.maximumFractionDigits ?? 3,
-    20,
+    format.maximumFractionDigits ?? resolvedOptions.maximumFractionDigits ?? DEFAULT_DIGITS,
+    MAX_DIGITS,
   );
 
   // Percent values are stored as fractions, so rounding must happen at the displayed scale.
@@ -53,7 +59,7 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   if (scale > 1) {
     // Directional Intl rounding has no tolerance for the binary noise introduced by `value * 100`.
     // Clean a few extra decimal places first so exact typed boundaries like 0.46% stay exact.
-    valueToRound = +valueToRound.toFixed(Math.min(digits + 6, 20));
+    valueToRound = +valueToRound.toFixed(Math.min(digits + PERCENT_GUARD_DIGITS, MAX_DIGITS));
   }
 
   return (

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -20,28 +20,13 @@ export function hasExplicitNumberFormatPrecision(format?: NumberFormatOptionsWit
   );
 }
 
-function getMaximumFractionDigits(format?: NumberFormatOptionsWithRounding) {
-  // Preserve the old decimal defaults unless min-only precision needs style-specific defaults.
-  const minimumFractionDigits = format?.minimumFractionDigits ?? 0;
-
-  if (format?.maximumFractionDigits != null) {
-    return Math.max(format.maximumFractionDigits, minimumFractionDigits);
-  }
-
-  if (format?.minimumFractionDigits == null) {
-    return 3;
-  }
-
-  // Some invalid Intl option combinations throw when constructing the formatter. Rendering usually
-  // fails first for those configs, but keep blur-time rounding on the safe decimal fallback.
-  try {
-    return Math.max(
-      getFormatter('en-US', format).resolvedOptions().maximumFractionDigits ?? 20,
-      minimumFractionDigits,
-    );
-  } catch {
-    return Math.max(3, minimumFractionDigits);
-  }
+export function hasNumberFormatRoundingOptions(format?: NumberFormatOptionsWithRounding) {
+  return (
+    hasExplicitNumberFormatPrecision(format) ||
+    format?.roundingIncrement != null ||
+    format?.roundingMode != null ||
+    format?.roundingPriority != null
+  );
 }
 
 export function removeFloatingPointErrors(value: number, format?: NumberFormatOptionsWithRounding) {
@@ -49,13 +34,26 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     return value;
   }
 
-  const digits = Math.min(Math.max(getMaximumFractionDigits(format), 0), 20);
-  const hasSignificantPrecision =
-    format?.maximumSignificantDigits != null || format?.minimumSignificantDigits != null;
+  const hasRoundingOptions = hasNumberFormatRoundingOptions(format);
+  const resolvedOptions =
+    format && (hasRoundingOptions || format.minimumFractionDigits != null)
+      ? getFormatter('en-US', format).resolvedOptions()
+      : undefined;
+  const minimumFractionDigits =
+    format?.minimumFractionDigits ?? resolvedOptions?.minimumFractionDigits ?? 0;
+  const digits = Math.min(
+    Math.max(
+      format?.maximumFractionDigits ??
+        (hasRoundingOptions || format?.minimumFractionDigits != null
+          ? (resolvedOptions?.maximumFractionDigits ?? 3)
+          : 3),
+      minimumFractionDigits,
+      0,
+    ),
+    20,
+  );
   // Percent values are stored as fractions, so rounding must happen at the displayed scale.
-  const isPercentWithExplicitPrecision =
-    format?.style === 'percent' && hasExplicitNumberFormatPrecision(format);
-  const scale = isPercentWithExplicitPrecision ? 100 : 1;
+  const scale = format?.style === 'percent' && hasRoundingOptions ? 100 : 1;
   let valueToRound = value * scale;
 
   if (!Number.isFinite(valueToRound)) {
@@ -69,36 +67,25 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     valueToRound = Number(valueToRound.toFixed(Math.min(digits + 6, 20)));
   }
 
-  const roundedFallback = Number(valueToRound.toFixed(digits)) / scale;
-
-  if (
-    !hasSignificantPrecision &&
-    format?.roundingIncrement == null &&
-    format?.roundingMode == null &&
-    format?.roundingPriority == null
-  ) {
-    return roundedFallback;
+  if (hasRoundingOptions) {
+    return (
+      Number(
+        getFormatter('en-US', {
+          // Keep style/unit/notation out so the formatted string parses back as a plain number.
+          useGrouping: false,
+          minimumFractionDigits: digits,
+          maximumFractionDigits: digits,
+          minimumSignificantDigits: format?.minimumSignificantDigits,
+          maximumSignificantDigits: format?.maximumSignificantDigits,
+          roundingIncrement: format?.roundingIncrement,
+          roundingMode: format?.roundingMode,
+          roundingPriority: format?.roundingPriority,
+        } as NumberFormatOptionsWithRounding).format(valueToRound),
+      ) / scale
+    );
   }
 
-  try {
-    // Keep style/unit/notation out so the formatted string parses back as a plain number.
-    const roundingFormatOptions = {
-      useGrouping: false,
-      minimumFractionDigits: digits,
-      maximumFractionDigits: digits,
-      minimumSignificantDigits: format?.minimumSignificantDigits,
-      maximumSignificantDigits: format?.maximumSignificantDigits,
-      roundingIncrement: format?.roundingIncrement,
-      roundingMode: format?.roundingMode,
-      roundingPriority: format?.roundingPriority,
-    } satisfies NumberFormatOptionsWithRounding;
-
-    const roundedValue = Number(getFormatter('en-US', roundingFormatOptions).format(valueToRound));
-
-    return Number.isFinite(roundedValue) ? roundedValue / scale : roundedFallback;
-  } catch {
-    return roundedFallback;
-  }
+  return Number(valueToRound.toFixed(digits)) / scale;
 }
 
 function snapToStep(

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -28,10 +28,6 @@ export function hasNumberFormatRoundingOptions(
   );
 }
 
-function isScientificOrEngineering(format: NumberFormatOptionsWithRounding) {
-  return format.notation === 'scientific' || format.notation === 'engineering';
-}
-
 export function removeFloatingPointErrors(value: number, format?: NumberFormatOptionsWithRounding) {
   if (!Number.isFinite(value)) {
     return value;
@@ -56,16 +52,7 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     return value;
   }
 
-  if (
-    roundedValue === 0 &&
-    value !== 0 &&
-    isScientificOrEngineering(format) &&
-    formatter.formatToParts(value).some((part) => part.type === 'exponentSeparator')
-  ) {
-    return value;
-  }
-
-  return roundedValue;
+  return formatter.format(roundedValue) === roundedText ? roundedValue : value;
 }
 
 function snapToStep(

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -3,6 +3,8 @@ import { getFormatter } from '../../utils/formatNumber';
 
 const STEP_EPSILON_FACTOR = 1e-10;
 
+// The repo compiles against es2022 Intl types, so model NumberFormat v3 options locally.
+// Delete this once tsconfig.base.json includes es2023.
 type NumberFormatOptionsWithRounding = Intl.NumberFormatOptions & {
   roundingIncrement?: number | undefined;
   roundingMode?: string | undefined;

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -38,7 +38,7 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
 
   const hasRoundingOptions = hasNumberFormatRoundingOptions(format);
   if (!hasRoundingOptions) {
-    return +value.toFixed(DEFAULT_DIGITS);
+    return Number(value.toFixed(DEFAULT_DIGITS));
   }
 
   const resolvedOptions = getFormatter('en-US', format).resolvedOptions();
@@ -59,21 +59,25 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   if (scale > 1) {
     // Directional Intl rounding has no tolerance for the binary noise introduced by `value * 100`.
     // Clean a few extra decimal places first so exact typed boundaries like 0.46% stay exact.
-    valueToRound = +valueToRound.toFixed(Math.min(digits + PERCENT_GUARD_DIGITS, MAX_DIGITS));
+    valueToRound = Number(
+      valueToRound.toFixed(Math.min(digits + PERCENT_GUARD_DIGITS, MAX_DIGITS)),
+    );
   }
 
   return (
-    +getFormatter('en-US', {
-      // Keep style/unit/notation out so the formatted string parses back as a plain number.
-      useGrouping: false,
-      minimumFractionDigits: digits,
-      maximumFractionDigits: digits,
-      minimumSignificantDigits: format.minimumSignificantDigits,
-      maximumSignificantDigits: format.maximumSignificantDigits,
-      roundingIncrement: format.roundingIncrement,
-      roundingMode: format.roundingMode,
-      roundingPriority: format.roundingPriority,
-    } as NumberFormatOptionsWithRounding).format(valueToRound) / scale
+    Number(
+      getFormatter('en-US', {
+        // Keep style/unit/notation out so the formatted string parses back as a plain number.
+        useGrouping: false,
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+        minimumSignificantDigits: format.minimumSignificantDigits,
+        maximumSignificantDigits: format.maximumSignificantDigits,
+        roundingIncrement: format.roundingIncrement,
+        roundingMode: format.roundingMode,
+        roundingPriority: format.roundingPriority,
+      } as NumberFormatOptionsWithRounding).format(valueToRound),
+    ) / scale
   );
 }
 

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -9,28 +9,24 @@ type NumberFormatOptionsWithRounding = Intl.NumberFormatOptions & {
   roundingMode?: string | undefined;
 };
 
-function getFractionDigits(format?: NumberFormatOptionsWithRounding) {
-  const hasExplicitPrecision =
-    format?.maximumFractionDigits != null || format?.minimumFractionDigits != null;
-  const resolvedOptions = getFormatter(
-    'en-US',
-    hasExplicitPrecision ? format : undefined,
-  ).resolvedOptions();
-  const minimumFractionDigits =
-    format?.minimumFractionDigits ?? resolvedOptions.minimumFractionDigits ?? 0;
-  const maximumFractionDigits = Math.max(
-    format?.maximumFractionDigits ?? resolvedOptions.maximumFractionDigits ?? 20,
-    minimumFractionDigits,
+function getMaximumFractionDigits(format?: NumberFormatOptionsWithRounding) {
+  return Math.max(
+    format?.maximumFractionDigits ??
+      getFormatter(
+        'en-US',
+        format?.minimumFractionDigits == null ? undefined : format,
+      ).resolvedOptions().maximumFractionDigits ??
+      20,
+    format?.minimumFractionDigits ?? 0,
   );
-  return { maximumFractionDigits, minimumFractionDigits };
 }
 
-export function roundToFractionDigits(value: number, format?: NumberFormatOptionsWithRounding) {
+export function removeFloatingPointErrors(value: number, format?: NumberFormatOptionsWithRounding) {
   if (!Number.isFinite(value)) {
     return value;
   }
-  const { maximumFractionDigits } = getFractionDigits(format);
-  const digits = Math.min(Math.max(maximumFractionDigits, 0), 20);
+
+  const digits = Math.min(Math.max(getMaximumFractionDigits(format), 0), 20);
   const isPercentWithExplicitPrecision =
     format?.style === 'percent' &&
     (format.maximumFractionDigits != null || format.minimumFractionDigits != null);
@@ -45,15 +41,11 @@ export function roundToFractionDigits(value: number, format?: NumberFormatOption
     useGrouping: false,
     minimumFractionDigits: digits,
     maximumFractionDigits: digits,
-    roundingIncrement: format?.roundingIncrement,
-    roundingMode: format?.roundingMode,
+    roundingIncrement: format.roundingIncrement,
+    roundingMode: format.roundingMode,
   };
 
   return Number(getFormatter('en-US', roundingFormatOptions).format(valueToRound)) / scale;
-}
-
-export function removeFloatingPointErrors(value: number, format?: NumberFormatOptionsWithRounding) {
-  return roundToFractionDigits(value, format);
 }
 
 function snapToStep(

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -5,10 +5,6 @@ import { parseNumber } from './parse';
 const STEP_EPSILON_FACTOR = 1e-10;
 // Matches Intl.NumberFormat's decimal maximumFractionDigits default.
 const DEFAULT_DIGITS = 3;
-const PERCENT_SCALE = 100;
-const PERCENT_SCALE_DIGITS = 2;
-// Extra decimal places used to scrub percent-scale float noise without dropping user precision.
-const PERCENT_GUARD_DIGITS = 10;
 
 // The repo compiles against es2022 Intl types, so model NumberFormat v3 options locally.
 // Delete this once tsconfig.base.json includes es2023.
@@ -36,57 +32,6 @@ function isScientificOrEngineering(format: NumberFormatOptionsWithRounding) {
   return format.notation === 'scientific' || format.notation === 'engineering';
 }
 
-function roundWithPlainNumberFormat(value: number, format: NumberFormatOptionsWithRounding) {
-  const resolvedOptions = getFormatter('en-US', format).resolvedOptions();
-  const digits = Math.min(
-    format.maximumFractionDigits ?? resolvedOptions.maximumFractionDigits ?? DEFAULT_DIGITS,
-    20,
-  );
-  const precision = Math.max(
-    digits,
-    format.maximumSignificantDigits ?? resolvedOptions.maximumSignificantDigits ?? 0,
-  );
-
-  // Percent values are stored as fractions, so rounding must happen at the displayed scale.
-  const scale = format.style === 'percent' ? PERCENT_SCALE : 1;
-  let valueToRound = value * scale;
-
-  if (!Number.isFinite(valueToRound)) {
-    // Percent scaling can overflow for extreme finite values; fall back to the unscaled value.
-    return value;
-  }
-
-  if (scale > 1) {
-    // Directional Intl rounding has no tolerance for the binary noise introduced by `value * 100`.
-    valueToRound = Number(valueToRound.toFixed(Math.min(precision + PERCENT_GUARD_DIGITS, 20)));
-  }
-
-  const roundedText = getFormatter('en-US', {
-    // Keep style/unit/compact notation out so the formatted string parses back as a plain number.
-    useGrouping: false,
-    minimumFractionDigits: digits,
-    maximumFractionDigits: digits,
-    minimumSignificantDigits: format.minimumSignificantDigits,
-    maximumSignificantDigits: format.maximumSignificantDigits,
-    roundingIncrement: format.roundingIncrement,
-    roundingMode: format.roundingMode,
-    roundingPriority: format.roundingPriority,
-  } as NumberFormatOptionsWithRounding).format(valueToRound);
-
-  const roundedValue = Number(roundedText);
-
-  if (!Number.isFinite(roundedValue)) {
-    return value;
-  }
-
-  if (scale > 1) {
-    const scaledValue = Number(`${roundedText}e-${PERCENT_SCALE_DIGITS}`);
-    return Number.isFinite(scaledValue) ? scaledValue : roundedValue / scale;
-  }
-
-  return roundedValue;
-}
-
 export function removeFloatingPointErrors(value: number, format?: NumberFormatOptionsWithRounding) {
   if (!Number.isFinite(value)) {
     return value;
@@ -96,12 +41,12 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     return Number(value.toFixed(DEFAULT_DIGITS));
   }
 
-  if (format.notation === 'compact') {
-    return roundWithPlainNumberFormat(value, format);
-  }
-
   const formatter = getFormatter('en-US', {
     ...format,
+    // These options alter only display decoration, not numeric rounding.
+    signDisplay: 'auto',
+    currencySign: 'standard',
+    notation: format.notation === 'compact' ? 'standard' : format.notation,
     useGrouping: false,
   } as NumberFormatOptionsWithRounding);
   const roundedText = formatter.format(value);

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -59,7 +59,7 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   let valueToRound = value * scale;
 
   if (!Number.isFinite(valueToRound)) {
-    // Percent scaling can overflow for extreme finite values; preserve the old finite value.
+    // Percent scaling can overflow for extreme finite values; fall back to the unscaled value.
     return value;
   }
 

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -1,5 +1,6 @@
 import { clamp } from '../../internals/clamp';
 import { getFormatter } from '../../utils/formatNumber';
+import { parseNumber } from './parse';
 
 const STEP_EPSILON_FACTOR = 1e-10;
 // Matches Intl.NumberFormat's decimal maximumFractionDigits default.
@@ -31,15 +32,11 @@ export function hasNumberFormatRoundingOptions(
   );
 }
 
-export function removeFloatingPointErrors(value: number, format?: NumberFormatOptionsWithRounding) {
-  if (!Number.isFinite(value)) {
-    return value;
-  }
+function isScientificOrEngineering(format: NumberFormatOptionsWithRounding) {
+  return format.notation === 'scientific' || format.notation === 'engineering';
+}
 
-  if (!hasNumberFormatRoundingOptions(format)) {
-    return Number(value.toFixed(DEFAULT_DIGITS));
-  }
-
+function roundWithPlainNumberFormat(value: number, format: NumberFormatOptionsWithRounding) {
   const resolvedOptions = getFormatter('en-US', format).resolvedOptions();
   const digits = Math.min(
     format.maximumFractionDigits ?? resolvedOptions.maximumFractionDigits ?? DEFAULT_DIGITS,
@@ -71,10 +68,6 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     maximumFractionDigits: digits,
     minimumSignificantDigits: format.minimumSignificantDigits,
     maximumSignificantDigits: format.maximumSignificantDigits,
-    notation:
-      format.notation === 'scientific' || format.notation === 'engineering'
-        ? format.notation
-        : undefined,
     roundingIncrement: format.roundingIncrement,
     roundingMode: format.roundingMode,
     roundingPriority: format.roundingPriority,
@@ -89,6 +82,42 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   if (scale > 1) {
     const scaledValue = Number(`${roundedText}e-${PERCENT_SCALE_DIGITS}`);
     return Number.isFinite(scaledValue) ? scaledValue : roundedValue / scale;
+  }
+
+  return roundedValue;
+}
+
+export function removeFloatingPointErrors(value: number, format?: NumberFormatOptionsWithRounding) {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+
+  if (!hasNumberFormatRoundingOptions(format)) {
+    return Number(value.toFixed(DEFAULT_DIGITS));
+  }
+
+  if (format.notation === 'compact') {
+    return roundWithPlainNumberFormat(value, format);
+  }
+
+  const formatter = getFormatter('en-US', {
+    ...format,
+    useGrouping: false,
+  } as NumberFormatOptionsWithRounding);
+  const roundedText = formatter.format(value);
+  const roundedValue = parseNumber(roundedText, 'en-US', format);
+
+  if (roundedValue === null) {
+    return value;
+  }
+
+  if (
+    roundedValue === 0 &&
+    value !== 0 &&
+    isScientificOrEngineering(format) &&
+    formatter.formatToParts(value).some((part) => part.type === 'exponentSeparator')
+  ) {
+    return value;
   }
 
   return roundedValue;

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -4,8 +4,8 @@ import { getFormatter } from '../../utils/formatNumber';
 const STEP_EPSILON_FACTOR = 1e-10;
 // Matches Intl.NumberFormat's decimal maximumFractionDigits default.
 const DEFAULT_DIGITS = 3;
-// Keeps binary scale/unscale noise out of committed percent values while preserving meaningful input.
-const FLOATING_POINT_SIGNIFICANT_DIGITS = 15;
+// Extra decimal places used to scrub percent-scale float noise without dropping user precision.
+const PERCENT_GUARD_DIGITS = 10;
 
 // The repo compiles against es2022 Intl types, so model NumberFormat v3 options locally.
 // Delete this once tsconfig.base.json includes es2023.
@@ -38,11 +38,14 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     return Number(value.toFixed(DEFAULT_DIGITS));
   }
 
+  const resolvedOptions = getFormatter('en-US', format).resolvedOptions();
   const digits = Math.min(
-    format.maximumFractionDigits ??
-      getFormatter('en-US', format).resolvedOptions().maximumFractionDigits ??
-      DEFAULT_DIGITS,
+    format.maximumFractionDigits ?? resolvedOptions.maximumFractionDigits ?? DEFAULT_DIGITS,
     20,
+  );
+  const precision = Math.max(
+    digits,
+    format.maximumSignificantDigits ?? resolvedOptions.maximumSignificantDigits ?? 0,
   );
 
   // Percent values are stored as fractions, so rounding must happen at the displayed scale.
@@ -56,8 +59,7 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
 
   if (scale > 1) {
     // Directional Intl rounding has no tolerance for the binary noise introduced by `value * 100`.
-    // Keep real precision while removing artifacts like 0.45999999999999996 for typed 0.46%.
-    valueToRound = removeFloatingPointNoise(valueToRound);
+    valueToRound = Number(valueToRound.toFixed(Math.min(precision + PERCENT_GUARD_DIGITS, 20)));
   }
 
   const roundedValue = Number(
@@ -83,11 +85,7 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   }
 
   const nextValue = roundedValue / scale;
-  return scale > 1 ? removeFloatingPointNoise(nextValue) : nextValue;
-}
-
-function removeFloatingPointNoise(value: number) {
-  return Number(value.toPrecision(FLOATING_POINT_SIGNIFICANT_DIGITS));
+  return scale > 1 ? Number(nextValue.toFixed(Math.min(precision + 2, 20))) : nextValue;
 }
 
 function snapToStep(

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -3,7 +3,13 @@ import { getFormatter } from '../../utils/formatNumber';
 
 const STEP_EPSILON_FACTOR = 1e-10;
 
-function getFractionDigits(format?: Intl.NumberFormatOptions) {
+// The repo's configured Intl types do not include the newer NumberFormat v3 rounding options yet.
+type NumberFormatOptionsWithRounding = Intl.NumberFormatOptions & {
+  roundingIncrement?: number | undefined;
+  roundingMode?: string | undefined;
+};
+
+function getFractionDigits(format?: NumberFormatOptionsWithRounding) {
   const defaultOptions = getFormatter('en-US').resolvedOptions();
   const minimumFractionDigits =
     format?.minimumFractionDigits ?? defaultOptions.minimumFractionDigits ?? 0;
@@ -14,18 +20,40 @@ function getFractionDigits(format?: Intl.NumberFormatOptions) {
   return { maximumFractionDigits, minimumFractionDigits };
 }
 
-function roundToFractionDigits(value: number, maximumFractionDigits: number) {
+export function roundToFractionDigits(
+  value: number,
+  maximumFractionDigits: number,
+  format?: NumberFormatOptionsWithRounding,
+) {
   if (!Number.isFinite(value)) {
     return value;
   }
 
   const digits = Math.min(Math.max(maximumFractionDigits, 0), 20);
-  return Number(value.toFixed(digits));
+  const isPercentWithExplicitPrecision =
+    format?.style === 'percent' &&
+    (format.maximumFractionDigits != null || format.minimumFractionDigits != null);
+  const scale = isPercentWithExplicitPrecision ? 100 : 1;
+  const valueToRound = value * scale;
+
+  if (format?.roundingIncrement == null && format?.roundingMode == null) {
+    return Number(valueToRound.toFixed(digits)) / scale;
+  }
+
+  const roundingFormatOptions: NumberFormatOptionsWithRounding = {
+    useGrouping: false,
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+    roundingIncrement: format?.roundingIncrement,
+    roundingMode: format?.roundingMode,
+  };
+
+  return Number(getFormatter('en-US', roundingFormatOptions).format(valueToRound)) / scale;
 }
 
-export function removeFloatingPointErrors(value: number, format?: Intl.NumberFormatOptions) {
+export function removeFloatingPointErrors(value: number, format?: NumberFormatOptionsWithRounding) {
   const { maximumFractionDigits } = getFractionDigits(format);
-  return roundToFractionDigits(value, maximumFractionDigits);
+  return roundToFractionDigits(value, maximumFractionDigits, format);
 }
 
 function snapToStep(
@@ -74,7 +102,7 @@ export function toValidatedNumber(
     minWithDefault: number;
     maxWithDefault: number;
     minWithZeroDefault: number;
-    format: Intl.NumberFormatOptions | undefined;
+    format: NumberFormatOptionsWithRounding | undefined;
     snapOnStep: boolean;
     small: boolean;
     clamp: boolean;

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -4,12 +4,14 @@ import { getFormatter } from '../../utils/formatNumber';
 const STEP_EPSILON_FACTOR = 1e-10;
 
 // The repo compiles against es2022 Intl types, so model NumberFormat v3 options locally.
+// Delete this once tsconfig.base.json includes es2023.
 type NumberFormatOptionsWithRounding = Intl.NumberFormatOptions & {
   roundingIncrement?: number | undefined;
   roundingMode?: string | undefined;
 };
 
 function getMaximumFractionDigits(format?: NumberFormatOptionsWithRounding) {
+  // Preserve the old decimal defaults unless min-only precision needs style-specific defaults.
   return Math.max(
     format?.maximumFractionDigits ??
       getFormatter(
@@ -27,6 +29,7 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   }
 
   const digits = Math.min(Math.max(getMaximumFractionDigits(format), 0), 20);
+  // Percent values are stored as fractions, so rounding must happen at the displayed scale.
   const isPercentWithExplicitPrecision =
     format?.style === 'percent' &&
     (format.maximumFractionDigits != null || format.minimumFractionDigits != null);
@@ -34,7 +37,7 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   const valueToRound = value * scale;
 
   if (!Number.isFinite(valueToRound)) {
-    return valueToRound / scale;
+    return value;
   }
 
   if (format?.roundingIncrement == null && format?.roundingMode == null) {

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -6,8 +6,8 @@ const STEP_EPSILON_FACTOR = 1e-10;
 const DEFAULT_DIGITS = 3;
 // Keep committed-value normalization aligned with Number Field's max-precision display path.
 const MAX_DIGITS = 20;
-// Extra places used to scrub percent-scale float noise without affecting normal input precision.
-const PERCENT_GUARD_DIGITS = 6;
+// Keeps binary scale/unscale noise out of committed percent values while preserving meaningful input.
+const FLOATING_POINT_SIGNIFICANT_DIGITS = 15;
 
 // The repo compiles against es2022 Intl types, so model NumberFormat v3 options locally.
 // Delete this once tsconfig.base.json includes es2023.
@@ -58,27 +58,37 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
 
   if (scale > 1) {
     // Directional Intl rounding has no tolerance for the binary noise introduced by `value * 100`.
-    // Clean a few extra decimal places first so exact typed boundaries like 0.46% stay exact.
-    valueToRound = Number(
-      valueToRound.toFixed(Math.min(digits + PERCENT_GUARD_DIGITS, MAX_DIGITS)),
-    );
+    // Keep real precision while removing artifacts like 0.45999999999999996 for typed 0.46%.
+    valueToRound = removeFloatingPointNoise(valueToRound);
   }
 
-  return (
-    Number(
-      getFormatter('en-US', {
-        // Keep style/unit/notation out so the formatted string parses back as a plain number.
-        useGrouping: false,
-        minimumFractionDigits: digits,
-        maximumFractionDigits: digits,
-        minimumSignificantDigits: format.minimumSignificantDigits,
-        maximumSignificantDigits: format.maximumSignificantDigits,
-        roundingIncrement: format.roundingIncrement,
-        roundingMode: format.roundingMode,
-        roundingPriority: format.roundingPriority,
-      } as NumberFormatOptionsWithRounding).format(valueToRound),
-    ) / scale
+  const notation = format.notation;
+  const supportsNumericNotation = notation === 'scientific' || notation === 'engineering';
+  const roundedValue = Number(
+    getFormatter('en-US', {
+      // Keep style/unit/compact notation out so the formatted string parses back as a plain number.
+      useGrouping: false,
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+      minimumSignificantDigits: format.minimumSignificantDigits,
+      maximumSignificantDigits: format.maximumSignificantDigits,
+      notation: supportsNumericNotation ? notation : undefined,
+      roundingIncrement: format.roundingIncrement,
+      roundingMode: format.roundingMode,
+      roundingPriority: format.roundingPriority,
+    } as NumberFormatOptionsWithRounding).format(valueToRound),
   );
+
+  if (!Number.isFinite(roundedValue)) {
+    return value;
+  }
+
+  const nextValue = roundedValue / scale;
+  return scale > 1 ? removeFloatingPointNoise(nextValue) : nextValue;
+}
+
+function removeFloatingPointNoise(value: number) {
+  return Number(value.toPrecision(FLOATING_POINT_SIGNIFICANT_DIGITS));
 }
 
 function snapToStep(
@@ -151,5 +161,6 @@ export function toValidatedNumber(
     result = clamp(result, minWithDefault, maxWithDefault);
   }
 
-  return removeFloatingPointErrors(result, format);
+  const roundedValue = removeFloatingPointErrors(result, format);
+  return shouldClamp ? clamp(roundedValue, minWithDefault, maxWithDefault) : roundedValue;
 }

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -4,6 +4,8 @@ import { getFormatter } from '../../utils/formatNumber';
 const STEP_EPSILON_FACTOR = 1e-10;
 // Matches Intl.NumberFormat's decimal maximumFractionDigits default.
 const DEFAULT_DIGITS = 3;
+const PERCENT_SCALE = 100;
+const PERCENT_SCALE_DIGITS = 2;
 // Extra decimal places used to scrub percent-scale float noise without dropping user precision.
 const PERCENT_GUARD_DIGITS = 10;
 
@@ -49,7 +51,7 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   );
 
   // Percent values are stored as fractions, so rounding must happen at the displayed scale.
-  const scale = format.style === 'percent' ? 100 : 1;
+  const scale = format.style === 'percent' ? PERCENT_SCALE : 1;
   let valueToRound = value * scale;
 
   if (!Number.isFinite(valueToRound)) {
@@ -62,30 +64,34 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     valueToRound = Number(valueToRound.toFixed(Math.min(precision + PERCENT_GUARD_DIGITS, 20)));
   }
 
-  const roundedValue = Number(
-    getFormatter('en-US', {
-      // Keep style/unit/compact notation out so the formatted string parses back as a plain number.
-      useGrouping: false,
-      minimumFractionDigits: digits,
-      maximumFractionDigits: digits,
-      minimumSignificantDigits: format.minimumSignificantDigits,
-      maximumSignificantDigits: format.maximumSignificantDigits,
-      notation:
-        format.notation === 'scientific' || format.notation === 'engineering'
-          ? format.notation
-          : undefined,
-      roundingIncrement: format.roundingIncrement,
-      roundingMode: format.roundingMode,
-      roundingPriority: format.roundingPriority,
-    } as NumberFormatOptionsWithRounding).format(valueToRound),
-  );
+  const roundedText = getFormatter('en-US', {
+    // Keep style/unit/compact notation out so the formatted string parses back as a plain number.
+    useGrouping: false,
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+    minimumSignificantDigits: format.minimumSignificantDigits,
+    maximumSignificantDigits: format.maximumSignificantDigits,
+    notation:
+      format.notation === 'scientific' || format.notation === 'engineering'
+        ? format.notation
+        : undefined,
+    roundingIncrement: format.roundingIncrement,
+    roundingMode: format.roundingMode,
+    roundingPriority: format.roundingPriority,
+  } as NumberFormatOptionsWithRounding).format(valueToRound);
+
+  const roundedValue = Number(roundedText);
 
   if (!Number.isFinite(roundedValue)) {
     return value;
   }
 
-  const nextValue = roundedValue / scale;
-  return scale > 1 ? Number(nextValue.toFixed(Math.min(precision + 2, 20))) : nextValue;
+  if (scale > 1) {
+    const scaledValue = Number(`${roundedText}e-${PERCENT_SCALE_DIGITS}`);
+    return Number.isFinite(scaledValue) ? scaledValue : roundedValue / scale;
+  }
+
+  return roundedValue;
 }
 
 function snapToStep(

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -3,7 +3,7 @@ import { getFormatter } from '../../utils/formatNumber';
 
 const STEP_EPSILON_FACTOR = 1e-10;
 
-// The repo's configured Intl types do not include the newer NumberFormat v3 rounding options yet.
+// The repo compiles against es2022 Intl types, so model NumberFormat v3 options locally.
 type NumberFormatOptionsWithRounding = Intl.NumberFormatOptions & {
   roundingIncrement?: number | undefined;
   roundingMode?: string | undefined;
@@ -32,6 +32,10 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     (format.maximumFractionDigits != null || format.minimumFractionDigits != null);
   const scale = isPercentWithExplicitPrecision ? 100 : 1;
   const valueToRound = value * scale;
+
+  if (!Number.isFinite(valueToRound)) {
+    return valueToRound / scale;
+  }
 
   if (format?.roundingIncrement == null && format?.roundingMode == null) {
     return Number(valueToRound.toFixed(digits)) / scale;

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -3,24 +3,89 @@ import { getFormatter } from '../../utils/formatNumber';
 
 const STEP_EPSILON_FACTOR = 1e-10;
 
-// The repo compiles against es2022 Intl types, so model NumberFormat v3 options locally.
-// Delete this once tsconfig.base.json includes es2023.
 type NumberFormatOptionsWithRounding = Intl.NumberFormatOptions & {
   roundingIncrement?: number | undefined;
   roundingMode?: string | undefined;
+  roundingPriority?: string | undefined;
 };
+
+export function hasExplicitNumberFormatPrecision(format?: NumberFormatOptionsWithRounding) {
+  return (
+    format?.maximumFractionDigits != null ||
+    format?.minimumFractionDigits != null ||
+    format?.maximumSignificantDigits != null ||
+    format?.minimumSignificantDigits != null
+  );
+}
+
+function hasSignificantDigits(format?: NumberFormatOptionsWithRounding) {
+  return format?.maximumSignificantDigits != null || format?.minimumSignificantDigits != null;
+}
+
+function roundToFractionDigits(value: number, maximumFractionDigits: number) {
+  const digits = Math.min(Math.max(maximumFractionDigits, 0), 20);
+  return Number(value.toFixed(digits));
+}
+
+function cleanScaledPercentValue(value: number, maximumFractionDigits: number) {
+  // Directional Intl rounding has no tolerance for the binary noise introduced by `value * 100`.
+  // Clean a few extra decimal places first so exact typed boundaries like 0.46% stay exact.
+  const digits = Math.min(Math.max(maximumFractionDigits + 6, 0), 20);
+  return Number(value.toFixed(digits));
+}
+
+function roundWithIntl(
+  value: number,
+  digits: number,
+  format?: NumberFormatOptionsWithRounding,
+): number {
+  // Keep style/unit/notation out so the formatted string parses back as a plain number. Percent
+  // scaling is applied explicitly before and after this formatter.
+  const roundingFormatOptions: NumberFormatOptionsWithRounding = {
+    useGrouping: false,
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+    minimumSignificantDigits: format?.minimumSignificantDigits,
+    maximumSignificantDigits: format?.maximumSignificantDigits,
+    roundingIncrement: format?.roundingIncrement,
+    roundingMode: format?.roundingMode,
+    roundingPriority: format?.roundingPriority,
+  };
+
+  try {
+    const roundedValue = Number(getFormatter('en-US', roundingFormatOptions).format(value));
+    return Number.isFinite(roundedValue) ? roundedValue : roundToFractionDigits(value, digits);
+  } catch {
+    return roundToFractionDigits(value, digits);
+  }
+}
+
+function getDefaultMaximumFractionDigits() {
+  return getFormatter('en-US').resolvedOptions().maximumFractionDigits ?? 20;
+}
 
 function getMaximumFractionDigits(format?: NumberFormatOptionsWithRounding) {
   // Preserve the old decimal defaults unless min-only precision needs style-specific defaults.
-  return Math.max(
-    format?.maximumFractionDigits ??
-      getFormatter(
-        'en-US',
-        format?.minimumFractionDigits == null ? undefined : format,
-      ).resolvedOptions().maximumFractionDigits ??
-      20,
-    format?.minimumFractionDigits ?? 0,
-  );
+  const minimumFractionDigits = format?.minimumFractionDigits ?? 0;
+
+  if (format?.maximumFractionDigits != null) {
+    return Math.max(format.maximumFractionDigits, minimumFractionDigits);
+  }
+
+  if (format?.minimumFractionDigits == null) {
+    return Math.max(getDefaultMaximumFractionDigits(), 0);
+  }
+
+  // Some invalid Intl option combinations throw when constructing the formatter. Rendering usually
+  // fails first for those configs, but keep blur-time rounding on the safe decimal fallback.
+  try {
+    return Math.max(
+      getFormatter('en-US', format).resolvedOptions().maximumFractionDigits ?? 20,
+      minimumFractionDigits,
+    );
+  } catch {
+    return Math.max(getDefaultMaximumFractionDigits(), minimumFractionDigits);
+  }
 }
 
 export function removeFloatingPointErrors(value: number, format?: NumberFormatOptionsWithRounding) {
@@ -29,30 +94,32 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   }
 
   const digits = Math.min(Math.max(getMaximumFractionDigits(format), 0), 20);
+  const hasSignificantPrecision = hasSignificantDigits(format);
   // Percent values are stored as fractions, so rounding must happen at the displayed scale.
   const isPercentWithExplicitPrecision =
-    format?.style === 'percent' &&
-    (format.maximumFractionDigits != null || format.minimumFractionDigits != null);
+    format?.style === 'percent' && hasExplicitNumberFormatPrecision(format);
   const scale = isPercentWithExplicitPrecision ? 100 : 1;
-  const valueToRound = value * scale;
+  let valueToRound = value * scale;
 
   if (!Number.isFinite(valueToRound)) {
+    // Percent scaling can overflow for extreme finite values; preserve the old finite value.
     return value;
   }
 
-  if (format?.roundingIncrement == null && format?.roundingMode == null) {
-    return Number(valueToRound.toFixed(digits)) / scale;
+  if (scale !== 1) {
+    valueToRound = cleanScaledPercentValue(valueToRound, digits);
   }
 
-  const roundingFormatOptions: NumberFormatOptionsWithRounding = {
-    useGrouping: false,
-    minimumFractionDigits: digits,
-    maximumFractionDigits: digits,
-    roundingIncrement: format.roundingIncrement,
-    roundingMode: format.roundingMode,
-  };
+  if (
+    !hasSignificantPrecision &&
+    format?.roundingIncrement == null &&
+    format?.roundingMode == null &&
+    format?.roundingPriority == null
+  ) {
+    return roundToFractionDigits(valueToRound, digits) / scale;
+  }
 
-  return Number(getFormatter('en-US', roundingFormatOptions).format(valueToRound)) / scale;
+  return roundWithIntl(valueToRound, digits, format) / scale;
 }
 
 function snapToStep(

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -18,52 +18,6 @@ export function hasExplicitNumberFormatPrecision(format?: NumberFormatOptionsWit
   );
 }
 
-function hasSignificantDigits(format?: NumberFormatOptionsWithRounding) {
-  return format?.maximumSignificantDigits != null || format?.minimumSignificantDigits != null;
-}
-
-function roundToFractionDigits(value: number, maximumFractionDigits: number) {
-  const digits = Math.min(Math.max(maximumFractionDigits, 0), 20);
-  return Number(value.toFixed(digits));
-}
-
-function cleanScaledPercentValue(value: number, maximumFractionDigits: number) {
-  // Directional Intl rounding has no tolerance for the binary noise introduced by `value * 100`.
-  // Clean a few extra decimal places first so exact typed boundaries like 0.46% stay exact.
-  const digits = Math.min(Math.max(maximumFractionDigits + 6, 0), 20);
-  return Number(value.toFixed(digits));
-}
-
-function roundWithIntl(
-  value: number,
-  digits: number,
-  format?: NumberFormatOptionsWithRounding,
-): number {
-  // Keep style/unit/notation out so the formatted string parses back as a plain number. Percent
-  // scaling is applied explicitly before and after this formatter.
-  const roundingFormatOptions: NumberFormatOptionsWithRounding = {
-    useGrouping: false,
-    minimumFractionDigits: digits,
-    maximumFractionDigits: digits,
-    minimumSignificantDigits: format?.minimumSignificantDigits,
-    maximumSignificantDigits: format?.maximumSignificantDigits,
-    roundingIncrement: format?.roundingIncrement,
-    roundingMode: format?.roundingMode,
-    roundingPriority: format?.roundingPriority,
-  };
-
-  try {
-    const roundedValue = Number(getFormatter('en-US', roundingFormatOptions).format(value));
-    return Number.isFinite(roundedValue) ? roundedValue : roundToFractionDigits(value, digits);
-  } catch {
-    return roundToFractionDigits(value, digits);
-  }
-}
-
-function getDefaultMaximumFractionDigits() {
-  return getFormatter('en-US').resolvedOptions().maximumFractionDigits ?? 20;
-}
-
 function getMaximumFractionDigits(format?: NumberFormatOptionsWithRounding) {
   // Preserve the old decimal defaults unless min-only precision needs style-specific defaults.
   const minimumFractionDigits = format?.minimumFractionDigits ?? 0;
@@ -73,7 +27,7 @@ function getMaximumFractionDigits(format?: NumberFormatOptionsWithRounding) {
   }
 
   if (format?.minimumFractionDigits == null) {
-    return Math.max(getDefaultMaximumFractionDigits(), 0);
+    return 3;
   }
 
   // Some invalid Intl option combinations throw when constructing the formatter. Rendering usually
@@ -84,7 +38,7 @@ function getMaximumFractionDigits(format?: NumberFormatOptionsWithRounding) {
       minimumFractionDigits,
     );
   } catch {
-    return Math.max(getDefaultMaximumFractionDigits(), minimumFractionDigits);
+    return Math.max(3, minimumFractionDigits);
   }
 }
 
@@ -94,7 +48,8 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   }
 
   const digits = Math.min(Math.max(getMaximumFractionDigits(format), 0), 20);
-  const hasSignificantPrecision = hasSignificantDigits(format);
+  const hasSignificantPrecision =
+    format?.maximumSignificantDigits != null || format?.minimumSignificantDigits != null;
   // Percent values are stored as fractions, so rounding must happen at the displayed scale.
   const isPercentWithExplicitPrecision =
     format?.style === 'percent' && hasExplicitNumberFormatPrecision(format);
@@ -107,8 +62,12 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
   }
 
   if (scale !== 1) {
-    valueToRound = cleanScaledPercentValue(valueToRound, digits);
+    // Directional Intl rounding has no tolerance for the binary noise introduced by `value * 100`.
+    // Clean a few extra decimal places first so exact typed boundaries like 0.46% stay exact.
+    valueToRound = Number(valueToRound.toFixed(Math.min(digits + 6, 20)));
   }
+
+  const roundedFallback = Number(valueToRound.toFixed(digits)) / scale;
 
   if (
     !hasSignificantPrecision &&
@@ -116,10 +75,28 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     format?.roundingMode == null &&
     format?.roundingPriority == null
   ) {
-    return roundToFractionDigits(valueToRound, digits) / scale;
+    return roundedFallback;
   }
 
-  return roundWithIntl(valueToRound, digits, format) / scale;
+  try {
+    // Keep style/unit/notation out so the formatted string parses back as a plain number.
+    const roundingFormatOptions = {
+      useGrouping: false,
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+      minimumSignificantDigits: format?.minimumSignificantDigits,
+      maximumSignificantDigits: format?.maximumSignificantDigits,
+      roundingIncrement: format?.roundingIncrement,
+      roundingMode: format?.roundingMode,
+      roundingPriority: format?.roundingPriority,
+    } satisfies NumberFormatOptionsWithRounding;
+
+    const roundedValue = Number(getFormatter('en-US', roundingFormatOptions).format(valueToRound));
+
+    return Number.isFinite(roundedValue) ? roundedValue / scale : roundedFallback;
+  } catch {
+    return roundedFallback;
+  }
 }
 
 function snapToStep(

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -4,8 +4,6 @@ import { getFormatter } from '../../utils/formatNumber';
 const STEP_EPSILON_FACTOR = 1e-10;
 // Matches Intl.NumberFormat's decimal maximumFractionDigits default.
 const DEFAULT_DIGITS = 3;
-// Keep committed-value normalization aligned with Number Field's max-precision display path.
-const MAX_DIGITS = 20;
 // Keeps binary scale/unscale noise out of committed percent values while preserving meaningful input.
 const FLOATING_POINT_SIGNIFICANT_DIGITS = 15;
 
@@ -36,15 +34,15 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     return value;
   }
 
-  const hasRoundingOptions = hasNumberFormatRoundingOptions(format);
-  if (!hasRoundingOptions) {
+  if (!hasNumberFormatRoundingOptions(format)) {
     return Number(value.toFixed(DEFAULT_DIGITS));
   }
 
-  const resolvedOptions = getFormatter('en-US', format).resolvedOptions();
   const digits = Math.min(
-    format.maximumFractionDigits ?? resolvedOptions.maximumFractionDigits ?? DEFAULT_DIGITS,
-    MAX_DIGITS,
+    format.maximumFractionDigits ??
+      getFormatter('en-US', format).resolvedOptions().maximumFractionDigits ??
+      DEFAULT_DIGITS,
+    20,
   );
 
   // Percent values are stored as fractions, so rounding must happen at the displayed scale.
@@ -62,8 +60,6 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
     valueToRound = removeFloatingPointNoise(valueToRound);
   }
 
-  const notation = format.notation;
-  const supportsNumericNotation = notation === 'scientific' || notation === 'engineering';
   const roundedValue = Number(
     getFormatter('en-US', {
       // Keep style/unit/compact notation out so the formatted string parses back as a plain number.
@@ -72,7 +68,10 @@ export function removeFloatingPointErrors(value: number, format?: NumberFormatOp
       maximumFractionDigits: digits,
       minimumSignificantDigits: format.minimumSignificantDigits,
       maximumSignificantDigits: format.maximumSignificantDigits,
-      notation: supportsNumericNotation ? notation : undefined,
+      notation:
+        format.notation === 'scientific' || format.notation === 'engineering'
+          ? format.notation
+          : undefined,
       roundingIncrement: format.roundingIncrement,
       roundingMode: format.roundingMode,
       roundingPriority: format.roundingPriority,
@@ -97,28 +96,18 @@ function snapToStep(
   step: number,
   mode: 'directional' | 'nearest' = 'directional',
 ) {
-  if (step === 0) {
-    return value;
-  }
-
   const stepSize = Math.abs(step);
   const direction = Math.sign(step);
   const tolerance = stepSize * STEP_EPSILON_FACTOR * direction;
-  const divisor = mode === 'nearest' ? step : stepSize;
-  const rawSteps = (value - base + tolerance) / divisor;
+  const rawSteps = value - base + tolerance;
 
-  let snappedSteps: number;
   if (mode === 'nearest') {
-    snappedSteps = Math.round(rawSteps);
-  } else if (direction > 0) {
-    snappedSteps = Math.floor(rawSteps);
-  } else {
-    snappedSteps = Math.ceil(rawSteps);
+    return base + Math.round(rawSteps / step) * step;
   }
 
-  const stepForResult = mode === 'nearest' ? step : stepSize;
-
-  return base + snappedSteps * stepForResult;
+  const snappedSteps =
+    direction > 0 ? Math.floor(rawSteps / stepSize) : Math.ceil(rawSteps / stepSize);
+  return base + snappedSteps * stepSize;
 }
 
 export function toValidatedNumber(

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -147,20 +147,20 @@ export function toValidatedNumber(
     return value;
   }
 
-  let result = value;
+  let nextValue = value;
 
   if (step != null && snapOnStep && step !== 0) {
     const base =
       small || minWithDefault === Number.MIN_SAFE_INTEGER ? minWithZeroDefault : minWithDefault;
 
     // Snap before clamping so non-step-aligned boundaries stay reachable.
-    result = snapToStep(result, base, step, small ? 'nearest' : 'directional');
+    nextValue = snapToStep(nextValue, base, step, small ? 'nearest' : 'directional');
   }
 
   if (shouldClamp) {
-    result = clamp(result, minWithDefault, maxWithDefault);
+    nextValue = clamp(nextValue, minWithDefault, maxWithDefault);
   }
 
-  const roundedValue = removeFloatingPointErrors(result, format);
+  const roundedValue = removeFloatingPointErrors(nextValue, format);
   return shouldClamp ? clamp(roundedValue, minWithDefault, maxWithDefault) : roundedValue;
 }

--- a/packages/react/src/number-field/utils/validate.ts
+++ b/packages/react/src/number-field/utils/validate.ts
@@ -10,25 +10,26 @@ type NumberFormatOptionsWithRounding = Intl.NumberFormatOptions & {
 };
 
 function getFractionDigits(format?: NumberFormatOptionsWithRounding) {
-  const defaultOptions = getFormatter('en-US').resolvedOptions();
+  const hasExplicitPrecision =
+    format?.maximumFractionDigits != null || format?.minimumFractionDigits != null;
+  const resolvedOptions = getFormatter(
+    'en-US',
+    hasExplicitPrecision ? format : undefined,
+  ).resolvedOptions();
   const minimumFractionDigits =
-    format?.minimumFractionDigits ?? defaultOptions.minimumFractionDigits ?? 0;
+    format?.minimumFractionDigits ?? resolvedOptions.minimumFractionDigits ?? 0;
   const maximumFractionDigits = Math.max(
-    format?.maximumFractionDigits ?? defaultOptions.maximumFractionDigits ?? 20,
+    format?.maximumFractionDigits ?? resolvedOptions.maximumFractionDigits ?? 20,
     minimumFractionDigits,
   );
   return { maximumFractionDigits, minimumFractionDigits };
 }
 
-export function roundToFractionDigits(
-  value: number,
-  maximumFractionDigits: number,
-  format?: NumberFormatOptionsWithRounding,
-) {
+export function roundToFractionDigits(value: number, format?: NumberFormatOptionsWithRounding) {
   if (!Number.isFinite(value)) {
     return value;
   }
-
+  const { maximumFractionDigits } = getFractionDigits(format);
   const digits = Math.min(Math.max(maximumFractionDigits, 0), 20);
   const isPercentWithExplicitPrecision =
     format?.style === 'percent' &&
@@ -52,8 +53,7 @@ export function roundToFractionDigits(
 }
 
 export function removeFloatingPointErrors(value: number, format?: NumberFormatOptionsWithRounding) {
-  const { maximumFractionDigits } = getFractionDigits(format);
-  return roundToFractionDigits(value, maximumFractionDigits, format);
+  return roundToFractionDigits(value, format);
 }
 
 function snapToStep(


### PR DESCRIPTION
Fixes #4803

Keeps the committed NumberField value in sync with `Intl.NumberFormat` rounding behavior when the field normalizes on blur.

## Root cause

The blur commit path previously rounded with `toFixed`, so it could diverge from display formatting when `Intl.NumberFormat` options such as `roundingMode`, `roundingIncrement`, significant digits, or percent formatting changed the displayed value. Percent values also need to round at display scale before converting back to the stored fraction.

## Changes

- Detect number format options that affect rounding, including fraction digits, significant digits, `roundingMode`, `roundingIncrement`, and `roundingPriority`.
- Round committed blur values through `Intl.NumberFormat` and parse the formatted result back to the stored numeric value.
- Handle percent, permille, localized, scientific, currency, and significant-digit parsing edge cases.
- Preserve existing full-precision blur behavior when the format does not opt into rounding.
- Add regression coverage for blur commits, controlled values, canceled changes, clamping, percent display-scale rounding, localized input, scientific notation, and validation helpers.