### PR TITLE
[tooltip] Cancel pending open on pointerdown

### DIFF
--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -821,6 +821,26 @@ describe('<Tooltip.Root />', () => {
         expect(screen.queryByText('Content')).toBe(null);
       });
 
+      it('should not open when the trigger receives pointerdown before delay duration', async () => {
+        await render(<TestTooltip />);
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        clock.tick(OPEN_DELAY / 2);
+
+        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+
+        clock.tick(OPEN_DELAY / 2);
+
+        await flushMicrotasks();
+
+        expect(screen.queryByText('Content')).toBe(null);
+      });
+
       it('should open when the trigger was clicked before delay duration and closeOnClick is false', async () => {
         await render(<TestTooltip triggerProps={{ closeOnClick: false }} />);
 

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -289,6 +289,9 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
         onPointerDown(event: React.PointerEvent) {
           pointerTypeRef.current = event.pointerType;
           store.set('closeOnClick', closeOnClick);
+          if (closeOnClick && !store.select('open')) {
+            store.cancelPendingOpen(event.nativeEvent);
+          }
         },
         onClick(event) {
           if (closeOnClick && !store.select('open')) {


### PR DESCRIPTION
A post-1.4.1 regression let a tooltip open if its trigger received pointerdown while the hover delay was pending and pointerup/click had not fired yet. This is marked internal and should not be mentioned in release notes.

## Root cause

After interaction splitting, closed tooltips no longer had dismiss interactions mounted, so pointerdown did not emit the internal close event that clears pending hover timers.

## Changes

- Cancel pending tooltip opens on pointerdown when the trigger is configured to close on click.
- Cover pointerdown without pointerup while the hover delay is pending.
