### PR TITLE
[docs] Improve a11y color contrast

### DIFF
--- a/docs/src/css/syntax.css
+++ b/docs/src/css/syntax.css
@@ -42,7 +42,7 @@
     /* Docs-infra extensions for concepts not in prettylights */
     --color-docs-infra-syntax-number: var(--color-blue);
     --color-docs-infra-syntax-boolean: var(--color-blue);
-    --color-docs-infra-syntax-nullish: var(--color-gray-500);
+    --color-docs-infra-syntax-nullish: var(--color-gray-600);
     --color-docs-infra-syntax-attr-key: var(--color-violet);
     --color-docs-infra-syntax-attr-value: var(--color-navy);
     --color-docs-infra-syntax-attr-equals: var(--color-red);


### PR DESCRIPTION
The color used for `--color-docs-infra-syntax-nullish` works well in dark mode, but has a problem in light mode. For example, it breaks the 100% a11y score.

## Before

<img width="1224" height="700" alt="SCR-20260512-blbh" src="https://github.com/user-attachments/assets/9d15daa0-5a10-49bb-9893-1198de09d36a" />

https://base-ui.com/react/components/select

<img width="686" height="483" alt="SCR-20260512-blda" src="https://github.com/user-attachments/assets/d2f5530e-50c6-4708-ab81-045630460ae7" />

## After

One way to solve this is going from --color-gray-500 to --color-gray-600. This feels easier to read in light mode:

<img width="696" height="500" alt="SCR-20260512-blee" src="https://github.com/user-attachments/assets/10d04d42-0ff9-4fd1-bdc9-4b049bb875d8" />

And, personally, in dark mode too: https://deploy-preview-4812--base-ui.netlify.app/react/components/select#root.

Another option would be to change the color system (but then, it's no longer a quick win).