### PR TITLE
[menu] Always highlight the first item on open

### DIFF
--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -692,7 +692,6 @@ describe('<Menu.Root />', () => {
         await user.keyboard('[ArrowDown]');
         await user.keyboard('[ArrowDown]');
         await user.keyboard('[ArrowDown]');
-        await user.keyboard('[ArrowDown]');
 
         const submenuTrigger1 = await screen.findByTestId('submenu-trigger');
         await waitFor(() => {
@@ -995,6 +994,31 @@ describe('<Menu.Root />', () => {
 
         expect(items[4].tabIndex).toBe(0);
         [items[0], items[1], items[2], items[3]].forEach((item) => {
+          expect(item.tabIndex).toBe(-1);
+        });
+      });
+
+      it('focuses the first item when the menu is opened programmatically', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+          return (
+            <div>
+              <button type="button" onClick={() => setOpen(true)}>
+                external
+              </button>
+              <TestMenu rootProps={{ open, onOpenChange: setOpen }} />
+            </div>
+          );
+        }
+
+        const { user } = await render(<App />);
+
+        await user.click(screen.getByRole('button', { name: 'external' }));
+
+        const [firstItem, ...otherItems] = await screen.findAllByRole('menuitem');
+        await waitFor(() => expect(firstItem).toHaveFocus());
+        expect(firstItem.tabIndex).toBe(0);
+        otherItems.forEach((item) => {
           expect(item.tabIndex).toBe(-1);
         });
       });

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -423,6 +423,8 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     openOnArrowKeyDown: parent.type !== 'context-menu',
     externalTree: nested ? floatingTreeRoot : undefined,
     focusItemOnHover: highlightItemOnHover,
+    // Ensure an item is highlighted on open even when opened programmatically (no trigger keydown).
+    focusItemOnOpen: true,
   });
 
   const onTyping = React.useCallback(

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -587,13 +587,11 @@ describe('<Menubar />', () => {
         const fileTrigger = screen.getByTestId('file-trigger');
         await user.click(fileTrigger);
 
-        // Menu should be open
+        // Menu should be open with the first item focused
         await waitFor(() => {
           expect(screen.queryByTestId('file-menu')).not.toBe(null);
         });
 
-        // Navigate with keyboard
-        await user.keyboard('{ArrowDown}');
         const firstItem = screen.getByTestId('file-item-1');
         await waitFor(() => {
           expect(firstItem).toHaveFocus();


### PR DESCRIPTION
When a menu is opened programmatically (via controlled `open` or by calling `onOpenChange(true)` from a custom interaction that isn't one of `Menu.Trigger`'s built-in open keys), `useListNavigation` leaves `activeIndex` as `null`. Its default `focusItemOnOpen: 'auto'` only highlights an item when Floating UI's own trigger handlers set the internal `keyRef`/`focusItemOnOpenRef` — which doesn't happen for external opens. Every item then renders with `tabindex="-1"`, `FloatingFocusManager` parks focus on the popup container, and the user needs an extra `↓` press before arrow navigation works.

This PR passes `focusItemOnOpen: true` to `useListNavigation` in `MenuRoot`, so the first item is highlighted on open regardless of how the menu was opened. `ArrowUp`-on-trigger continues to highlight the last item because `keyRef` still takes precedence inside `useListNavigation`'s initial-sync effect.

### Behavior change

This also means **pointer-driven opens (mouse/touch click on the trigger) now highlight the first item** instead of leaving the popup container focused. Two existing tests have been updated to reflect that:

- `MenuRoot.test.tsx` — removed one `ArrowDown` from the nested-menu outside-click test (item 1 is now focused after click).
- `Menubar.test.tsx` — the "keyboard navigation after mouse click" test now asserts item 1 is focused immediately, without a leading `ArrowDown`.

Related: #4815 adds an imperative `actionsRef.setActiveIndex` escape hatch as a non-breaking alternative; this PR is the broader behavior fix and can land independently or instead of it.
