### PR TITLE
[useButton] Stop setting type on non-native buttons

### DIFF
--- a/packages/react/src/internals/use-button/useButton.test.tsx
+++ b/packages/react/src/internals/use-button/useButton.test.tsx
@@ -41,6 +41,19 @@ describe('useButton', () => {
         });
       });
 
+      it('does not set a type prop', async () => {
+        let buttonProps: Record<string, unknown> | undefined = undefined;
+
+        function Button() {
+          const { getButtonProps } = useButton({ native: false });
+          buttonProps = getButtonProps();
+          return <span {...buttonProps} />;
+        }
+
+        await render(<Button />);
+        expect(buttonProps).not.toHaveProperty('type');
+      });
+
       it.skipIf(isJSDOM)(
         'can be activated with Enter when the keyboard event originates inside a shadow root',
         async () => {

--- a/packages/react/src/internals/use-button/useButton.ts
+++ b/packages/react/src/internals/use-button/useButton.ts
@@ -98,11 +98,8 @@ export function useButton(parameters: UseButtonParameters = {}): UseButtonReturn
         ...otherExternalProps
       } = externalProps;
 
-      const type = isNativeButton ? 'button' : undefined;
-
       return mergeProps<'button'>(
         {
-          type,
           onClick(event: React.MouseEvent) {
             if (disabled) {
               event.preventDefault();
@@ -209,7 +206,7 @@ export function useButton(parameters: UseButtonParameters = {}): UseButtonReturn
             externalOnPointerDown?.(event);
           },
         },
-        !isNativeButton ? { role: 'button' } : undefined,
+        isNativeButton ? { type: 'button' } : { role: 'button' },
         focusableWhenDisabledProps,
         otherExternalProps,
       );


### PR DESCRIPTION
This is a minor PR to avoid passing `type={undefined}` from `useButton` when `nativeButton` is `false`.

Previously, custom non-native button renderers could receive an unnecessary `type` prop:

```tsx
import { Button } from "@base-ui/react/button";

function App() {
  return <Button render={<CustomButton />} nativeButton={false} />
}


function CustomButton(props) {
  // Previously props included type={undefined}
  return <span {...props} />
}
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
