### PR TITLE
[code-infra] Deduplicate dependencies using Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "deduplicate": "pnpm dedupe",
+    "dedupe-harder": "tsx ./scripts/dedupeHarder.mts",
     "build": "lerna run --no-private build",
     "release:version": "lerna version --no-changelog --no-push --no-git-tag-version --no-private",
     "release:build": "lerna run --concurrency 8 --no-private build --skip-nx-cache",

--- a/scripts/dedupeHarder.mts
+++ b/scripts/dedupeHarder.mts
@@ -1,0 +1,70 @@
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Reproduce CircleCI's dependency resolver when `pnpm dedupe` disagrees between local
+// machines and CI. The container uses the same Node image as the CircleCI executor,
+// runs a fresh install, then runs pnpm dedupe against the mounted checkout.
+const repositoryRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+const image = process.env.DEDUPE_HARDER_IMAGE ?? 'cimg/node:22.21.1';
+const containerDirectory = '/tmp/base-ui';
+const pnpmStoreDirectory = '/tmp/pnpm-store';
+const dedupeArgs = process.argv.slice(2);
+
+function shellQuote(value: string) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+const hostUserId = typeof process.getuid === 'function' ? process.getuid() : null;
+const hostGroupId = typeof process.getgid === 'function' ? process.getgid() : null;
+const restoreOwnershipCommand =
+  hostUserId == null || hostGroupId == null
+    ? ''
+    : `chown ${hostUserId}:${hostGroupId} pnpm-lock.yaml package.json pnpm-workspace.yaml 2>/dev/null || true`;
+
+const shellCommands = [
+  'set -euo pipefail',
+  'corepack enable',
+  'node --version',
+  'pnpm --version',
+  `pnpm --store-dir ${shellQuote(pnpmStoreDirectory)} install`,
+  `pnpm --store-dir ${shellQuote(pnpmStoreDirectory)} dedupe${
+    dedupeArgs.length > 0 ? ` ${dedupeArgs.map(shellQuote).join(' ')}` : ''
+  }`,
+  restoreOwnershipCommand,
+].filter(Boolean);
+
+const dockerArgs = [
+  'run',
+  '--rm',
+  '--user',
+  'root',
+  '--volume',
+  `${repositoryRoot}:${containerDirectory}`,
+  // Keep the container install from purging or relinking the host's node_modules.
+  '--volume',
+  `${containerDirectory}/node_modules`,
+  '--workdir',
+  containerDirectory,
+  '--env',
+  'CI=true',
+  '--env',
+  'COREPACK_ENABLE_DOWNLOAD_PROMPT=0',
+  image,
+  'bash',
+  '-lc',
+  shellCommands.join('\n'),
+];
+
+const result = spawnSync('docker', dockerArgs, { stdio: 'inherit' });
+
+if (result.error) {
+  if ((result.error as NodeJS.ErrnoException).code === 'ENOENT') {
+    console.error('Docker is required to run `pnpm dedupe-harder`.');
+    process.exit(1);
+  }
+
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/dedupeHarder.mts
+++ b/scripts/dedupeHarder.mts
@@ -27,7 +27,7 @@ const shellCommands = [
   'corepack enable',
   'node --version',
   'pnpm --version',
-  `pnpm --store-dir ${shellQuote(pnpmStoreDirectory)} install`,
+  `pnpm --store-dir ${shellQuote(pnpmStoreDirectory)} install --no-frozen-lockfile`,
   `pnpm --store-dir ${shellQuote(pnpmStoreDirectory)} dedupe${
     dedupeArgs.length > 0 ? ` ${dedupeArgs.map(shellQuote).join(' ')}` : ''
   }`,


### PR DESCRIPTION
The stale lockfile errors are back (see https://app.circleci.com/pipelines/gh/mui/base-ui/25342/workflows/83dc889b-1767-4f31-8889-7cba4570af94/jobs/292838). This is an attempt to resolve them. It seems that the source of these issues is a different OS `dedupe` runs on. I created a script that runs `dedupe` in a Docker container with the same image that's used on CI.

The script runs pnpm install and pnpm dedupe inside the same `cimg/node:22.21.1` Docker image used by CircleCI’s shared mui-node executor, while isolating node_modules and pnpm’s store from the host checkout. It also supports passing args through to pnpm dedupe, e.g., `pnpm dedupe-harder -- --check`, and allows overriding the image with DEDUPE_HARDER_IMAGE.