### PR TITLE
[number field] Sync pasted input during step interactions

### DIFF
--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -10,6 +10,26 @@ import { REASONS } from '../../internals/reasons';
 describe('<NumberField />', () => {
   const { render } = createRenderer();
 
+  function pasteText(target: HTMLElement, value: string) {
+    if (isJSDOM) {
+      fireEvent.paste(target, {
+        clipboardData: {
+          getData: (type: string) => (type === 'text/plain' ? value : ''),
+        },
+      });
+      return;
+    }
+
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        getData: (type: string) => (type === 'text/plain' ? value : ''),
+      },
+    });
+
+    fireEvent(target, pasteEvent);
+  }
+
   describeConformance(<NumberFieldBase.Root />, () => ({
     refInstanceof: window.HTMLDivElement,
     render,
@@ -1084,6 +1104,25 @@ describe('<NumberField />', () => {
       fireEvent.blur(input);
       expect(onValueCommitted.mock.calls.length).toBe(1);
       expect(onValueCommitted.mock.calls[0][0]).toBe(5);
+    });
+
+    it('syncs the visible input value when using the mouse wheel after pasting', async () => {
+      const onValueChange = vi.fn();
+
+      await render(<NumberField defaultValue={10} allowWheelScrub onValueChange={onValueChange} />);
+
+      const input = screen.getByRole('textbox') as HTMLInputElement;
+      await act(async () => input.focus());
+
+      pasteText(input, '20');
+
+      expect(input).toHaveValue('20');
+      expect(onValueChange.mock.lastCall?.[0]).toBe(20);
+
+      fireEvent.wheel(input, { deltaY: -1 });
+
+      expect(onValueChange.mock.lastCall?.[0]).toBe(21);
+      expect(input).toHaveValue('21');
     });
   });
 

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -358,6 +358,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
 
         // Prevent the default behavior to avoid scrolling the page.
         event.preventDefault();
+        allowInputSyncRef.current = true;
 
         const amount = getStepAmount(event) ?? DEFAULT_STEP;
 

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.test.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.test.tsx
@@ -1,5 +1,5 @@
 import { expect, vi } from 'vitest';
-import { screen, act } from '@mui/internal-test-utils';
+import { screen, act, fireEvent } from '@mui/internal-test-utils';
 import { NumberField } from '@base-ui/react/number-field';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { isWebKit } from '@base-ui/utils/detectBrowser';
@@ -34,6 +34,28 @@ function createPointerMoveEvent({ movementX = 0, movementY = 0 }) {
 
 describe('<NumberField.ScrubArea />', () => {
   const { render } = createRenderer();
+
+  function createClipboardData(text: string) {
+    return {
+      getData: (type: string) => (type === 'text/plain' ? text : ''),
+    };
+  }
+
+  function pasteText(target: HTMLElement, value: string) {
+    if (isJSDOM) {
+      fireEvent.paste(target, {
+        clipboardData: createClipboardData(value),
+      });
+      return;
+    }
+
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: createClipboardData(value),
+    });
+
+    fireEvent(target, pasteEvent);
+  }
 
   describeConformance(<NumberField.ScrubArea />, () => ({
     refInstanceof: window.HTMLSpanElement,
@@ -86,6 +108,35 @@ describe('<NumberField.ScrubArea />', () => {
     });
 
     expect(input).toHaveValue('-7');
+  });
+
+  it('syncs the visible input value when scrubbing after pasting', async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      <NumberField.Root defaultValue={10} onValueChange={onValueChange}>
+        <NumberField.Input />
+        <NumberField.ScrubArea data-testid="scrub-area">
+          <NumberField.ScrubAreaCursor />
+        </NumberField.ScrubArea>
+      </NumberField.Root>,
+    );
+
+    const scrubArea = screen.getByTestId('scrub-area');
+    const input = screen.getByRole('textbox');
+
+    pasteText(input, '20');
+
+    expect(input).toHaveValue('20');
+    expect(onValueChange.mock.lastCall?.[0]).toBe(20);
+
+    await act(async () => {
+      scrubArea.dispatchEvent(createPointerDownEvent(scrubArea));
+      scrubArea.dispatchEvent(createPointerMoveEvent({ movementX: 2 }));
+    });
+
+    expect(onValueChange.mock.lastCall?.[0]).toBe(22);
+    expect(input).toHaveValue('22');
   });
 
   it('calls onValueChange while scrubbing and onValueCommitted on pointerup', async () => {

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
@@ -47,6 +47,7 @@ export const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubAr
     readOnly,
     inputRef,
     incrementValue,
+    allowInputSyncRef,
     getStepAmount,
     onValueCommitted,
     lastChangedValueRef,
@@ -213,6 +214,7 @@ export const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubAr
           const rawAmount = dValue * stepAmount;
 
           if (rawAmount !== 0) {
+            allowInputSyncRef.current = true;
             incrementValue(Math.abs(rawAmount), {
               direction: rawAmount >= 0 ? 1 : -1,
               event,
@@ -236,6 +238,7 @@ export const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubAr
     [
       disabled,
       readOnly,
+      allowInputSyncRef,
       incrementValue,
       isScrubbing,
       getStepAmount,


### PR DESCRIPTION
Fixes #4823.

## Problem

After pasting into an uncontrolled NumberField, wheel and scrub interactions could update the numeric value while leaving the visible input text unchanged.

## Cause

Pasting intentionally disables input syncing so raw user text is preserved until blur. Keyboard and increment/decrement button step interactions already restore input syncing before applying a stepped value, but wheel and scrub did not.

## Fix

Restore input syncing at the wheel and scrub interaction boundaries before applying the stepped value. This keeps direct text editing behavior intact while aligning wheel/scrub with the other step-based interactions.

## Verification

- pnpm test:jsdom NumberField --no-watch
- pnpm test:chromium NumberField --no-watch
- pnpm prettier
- pnpm typescript
- pnpm stylelint