### PR TITLE
[otp field] Prevent locked hidden autofill validation

### DIFF
--- a/packages/react/src/internals/types.ts
+++ b/packages/react/src/internals/types.ts
@@ -3,6 +3,9 @@ import type { BaseUIEvent, ComponentRenderFn, HTMLProps } from '../types';
 
 export type { HTMLProps, BaseUIEvent, ComponentRenderFn };
 
+export type MaybeBaseUIEvent<E extends React.SyntheticEvent<Element, Event>> = E &
+  Partial<Pick<BaseUIEvent<E>, 'preventBaseUIHandler' | 'baseUIHandlerPrevented'>>;
+
 export interface FloatingUIOpenChangeDetails {
   open: boolean;
   reason: string;

--- a/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
@@ -900,62 +900,60 @@ describe('<OTPFieldPreview />', () => {
       expect(onValueComplete.mock.calls[0]?.[1].reason).toBe(REASONS.inputChange);
     });
 
-    it('ignores hidden-input autofill when the field is readonly', async () => {
+    it.each([
+      { lockState: 'readOnly', label: 'inside Field', withField: true },
+      { lockState: 'disabled', label: 'inside Field', withField: true },
+      { lockState: 'readOnly', label: 'outside Field', withField: false },
+      { lockState: 'disabled', label: 'outside Field', withField: false },
+    ] as const)('ignores hidden-input autofill when $lockState $label', async ({
+      lockState,
+      withField,
+    }) => {
       const onValueChange = vi.fn();
       const onValueInvalid = vi.fn();
       const onValueComplete = vi.fn();
-
-      await render(
+      const otpField = (
         <OTPField
-          readOnly
-          name="otp"
+          readOnly={lockState === 'readOnly'}
+          disabled={lockState === 'disabled'}
+          name={withField ? undefined : 'otp'}
           onValueChange={onValueChange}
           onValueInvalid={onValueInvalid}
           onValueComplete={onValueComplete}
-        />,
+        />
+      );
+
+      await render(
+        withField ? (
+          <Form errors={{ otp: 'test' }}>
+            <Field.Root name="otp">
+              {otpField}
+              <Field.Error data-testid="error" />
+            </Field.Root>
+          </Form>
+        ) : (
+          otpField
+        ),
       );
 
       const hiddenInput = document.querySelector<HTMLInputElement>('input[name="otp"]');
 
       expect(hiddenInput).not.toBeNull();
 
-      fireEvent.change(hiddenInput!, { target: { value: '12a34b56' } });
-
-      const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
-
-      expect(inputs.map((input) => input.value)).toEqual(['', '', '', '', '', '']);
-      expect(onValueChange).not.toHaveBeenCalled();
-      expect(onValueInvalid).not.toHaveBeenCalled();
-      expect(onValueComplete).not.toHaveBeenCalled();
-    });
-
-    it('ignores hidden-input autofill when the field is disabled', async () => {
-      const onValueChange = vi.fn();
-      const onValueInvalid = vi.fn();
-      const onValueComplete = vi.fn();
-
-      await render(
-        <OTPField
-          disabled
-          name="otp"
-          onValueChange={onValueChange}
-          onValueInvalid={onValueInvalid}
-          onValueComplete={onValueComplete}
-        />,
-      );
-
-      const hiddenInput = document.querySelector<HTMLInputElement>('input[name="otp"]');
-
-      expect(hiddenInput).not.toBeNull();
+      if (withField) {
+        expect(screen.getByTestId('error')).toHaveTextContent('test');
+      }
 
       fireEvent.change(hiddenInput!, { target: { value: '12a34b56' } });
 
-      const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
-
-      expect(inputs.map((input) => input.value)).toEqual(['', '', '', '', '', '']);
+      expect(getValues()).toBe('');
       expect(onValueChange).not.toHaveBeenCalled();
       expect(onValueInvalid).not.toHaveBeenCalled();
       expect(onValueComplete).not.toHaveBeenCalled();
+
+      if (withField) {
+        expect(screen.getByTestId('error')).toHaveTextContent('test');
+      }
     });
 
     describe('prop: autoSubmit', () => {

--- a/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
@@ -905,56 +905,56 @@ describe('<OTPFieldPreview />', () => {
       { lockState: 'disabled', label: 'inside Field', withField: true },
       { lockState: 'readOnly', label: 'outside Field', withField: false },
       { lockState: 'disabled', label: 'outside Field', withField: false },
-    ] as const)('ignores hidden-input autofill when $lockState $label', async ({
-      lockState,
-      withField,
-    }) => {
-      const onValueChange = vi.fn();
-      const onValueInvalid = vi.fn();
-      const onValueComplete = vi.fn();
-      const otpField = (
-        <OTPField
-          readOnly={lockState === 'readOnly'}
-          disabled={lockState === 'disabled'}
-          name={withField ? undefined : 'otp'}
-          onValueChange={onValueChange}
-          onValueInvalid={onValueInvalid}
-          onValueComplete={onValueComplete}
-        />
-      );
+    ] as const)(
+      'ignores hidden-input autofill when $lockState $label',
+      async ({ lockState, withField }) => {
+        const onValueChange = vi.fn();
+        const onValueInvalid = vi.fn();
+        const onValueComplete = vi.fn();
+        const otpField = (
+          <OTPField
+            readOnly={lockState === 'readOnly'}
+            disabled={lockState === 'disabled'}
+            name={withField ? undefined : 'otp'}
+            onValueChange={onValueChange}
+            onValueInvalid={onValueInvalid}
+            onValueComplete={onValueComplete}
+          />
+        );
 
-      await render(
-        withField ? (
-          <Form errors={{ otp: 'test' }}>
-            <Field.Root name="otp">
-              {otpField}
-              <Field.Error data-testid="error" />
-            </Field.Root>
-          </Form>
-        ) : (
-          otpField
-        ),
-      );
+        await render(
+          withField ? (
+            <Form errors={{ otp: 'test' }}>
+              <Field.Root name="otp">
+                {otpField}
+                <Field.Error data-testid="error" />
+              </Field.Root>
+            </Form>
+          ) : (
+            otpField
+          ),
+        );
 
-      const hiddenInput = document.querySelector<HTMLInputElement>('input[name="otp"]');
+        const hiddenInput = document.querySelector<HTMLInputElement>('input[name="otp"]');
 
-      expect(hiddenInput).not.toBeNull();
+        expect(hiddenInput).not.toBeNull();
 
-      if (withField) {
-        expect(screen.getByTestId('error')).toHaveTextContent('test');
-      }
+        if (withField) {
+          expect(screen.getByTestId('error')).toHaveTextContent('test');
+        }
 
-      fireEvent.change(hiddenInput!, { target: { value: '12a34b56' } });
+        fireEvent.change(hiddenInput!, { target: { value: '12a34b56' } });
 
-      expect(getValues()).toBe('');
-      expect(onValueChange).not.toHaveBeenCalled();
-      expect(onValueInvalid).not.toHaveBeenCalled();
-      expect(onValueComplete).not.toHaveBeenCalled();
+        expect(getValues()).toBe('');
+        expect(onValueChange).not.toHaveBeenCalled();
+        expect(onValueInvalid).not.toHaveBeenCalled();
+        expect(onValueComplete).not.toHaveBeenCalled();
 
-      if (withField) {
-        expect(screen.getByTestId('error')).toHaveTextContent('test');
-      }
-    });
+        if (withField) {
+          expect(screen.getByTestId('error')).toHaveTextContent('test');
+        }
+      },
+    );
 
     describe('prop: autoSubmit', () => {
       const flushSyncLifecycleError = 'flushSync was called from inside a lifecycle method';

--- a/packages/react/src/otp-field/root/OTPFieldRoot.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.tsx
@@ -19,7 +19,7 @@ import { useAriaLabelledBy } from '../../internals/labelable-provider/useAriaLab
 import { useLabelableId } from '../../internals/labelable-provider/useLabelableId';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useValueChanged } from '../../internals/useValueChanged';
-import type { BaseUIComponentProps } from '../../internals/types';
+import type { BaseUIComponentProps, BaseUIEvent } from '../../internals/types';
 import {
   createChangeEventDetails,
   createGenericEventDetails,
@@ -406,8 +406,10 @@ export const OTPFieldRoot = React.forwardRef(function OTPFieldRoot(
               onFocus() {
                 focusInput(0);
               },
-              onChange(event) {
+              onChange(event: BaseUIEvent<React.ChangeEvent<HTMLInputElement>>) {
                 if (event.nativeEvent.defaultPrevented || disabled || readOnly) {
+                  // Outside Field.Root, the event is not wrapped by mergeProps.
+                  event.preventBaseUIHandler?.();
                   return;
                 }
 

--- a/packages/react/src/otp-field/root/OTPFieldRoot.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.tsx
@@ -19,7 +19,7 @@ import { useAriaLabelledBy } from '../../internals/labelable-provider/useAriaLab
 import { useLabelableId } from '../../internals/labelable-provider/useLabelableId';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useValueChanged } from '../../internals/useValueChanged';
-import type { BaseUIComponentProps, BaseUIEvent } from '../../internals/types';
+import type { BaseUIComponentProps, MaybeBaseUIEvent } from '../../internals/types';
 import {
   createChangeEventDetails,
   createGenericEventDetails,
@@ -406,7 +406,7 @@ export const OTPFieldRoot = React.forwardRef(function OTPFieldRoot(
               onFocus() {
                 focusInput(0);
               },
-              onChange(event: BaseUIEvent<React.ChangeEvent<HTMLInputElement>>) {
+              onChange(event: MaybeBaseUIEvent<React.ChangeEvent<HTMLInputElement>>) {
                 if (event.nativeEvent.defaultPrevented || disabled || readOnly) {
                   // Outside Field.Root, the event is not wrapped by mergeProps.
                   event.preventBaseUIHandler?.();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #4828.

Follow-up to #4806 and #4810.

#4806 added a locked-state guard to OTP Field's hidden autofill input, but when the component is wrapped in `Field.Root`, the merged Field validation `onChange` can still run after the OTP Field handler returns. This can clear existing Form errors or commit validation while the field is `readOnly` or `disabled`.

This PR calls `event.preventBaseUIHandler?.()` before returning from the locked hidden-input autofill path, matching the Select, Combobox, and NumberField handling from #4810.

The tests now cover the locked-state matrix for hidden-input autofill:

- `readOnly` / `disabled`
- inside `Field.Root` / outside `Field.Root`

The outside-Field cases keep asserting that OTP Field public callbacks are not called. The inside-Field cases additionally assert that existing `Field.Error` content is preserved.

Verified with:

- `pnpm test:jsdom OTPField --no-watch`
- `pnpm typescript`
