### PR TITLE
[docs] Improve controlled detached triggers demo in popover docs

### DIFF
--- a/docs/src/app/(docs)/react/components/popover/demos/detached-triggers-controlled/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/popover/demos/detached-triggers-controlled/css-modules/index.tsx
@@ -9,7 +9,18 @@ export default function PopoverDetachedTriggersControlledDemo() {
   const [open, setOpen] = React.useState(false);
   const [triggerId, setTriggerId] = React.useState<string | null>(null);
 
+  const buttonRef = React.useRef<HTMLButtonElement | null>(null);
   const handleOpenChange = (isOpen: boolean, eventDetails: Popover.Root.ChangeEventDetails) => {
+    // Clicks on the programmatic button are treated as an outside press.
+    // Call eventDetails.cancel() so onClick can close the popover without conflicting updates.
+    if (
+      !isOpen &&
+      eventDetails.reason === 'outside-press' &&
+      buttonRef.current?.contains(eventDetails.event.target as Node)
+    ) {
+      eventDetails.cancel();
+      return;
+    }
     setOpen(isOpen);
     setTriggerId(eventDetails.trigger?.id ?? null);
   };
@@ -32,9 +43,15 @@ export default function PopoverDetachedTriggersControlledDemo() {
         <button
           className={styles.Button}
           type="button"
+          ref={buttonRef}
           onClick={() => {
-            setTriggerId('trigger-2');
-            setOpen(true);
+            if (open) {
+              // Close regardless of which trigger opened it
+              setOpen(false);
+            } else {
+              setTriggerId('trigger-2');
+              setOpen(true);
+            }
           }}
         >
           Open programmatically

--- a/docs/src/app/(docs)/react/components/popover/demos/detached-triggers-controlled/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/popover/demos/detached-triggers-controlled/tailwind/index.tsx
@@ -9,7 +9,18 @@ export default function PopoverDetachedTriggersSimpleDemo() {
   const [open, setOpen] = React.useState(false);
   const [triggerId, setTriggerId] = React.useState<string | null>(null);
 
+  const buttonRef = React.useRef<HTMLButtonElement | null>(null);
   const handleOpenChange = (isOpen: boolean, eventDetails: Popover.Root.ChangeEventDetails) => {
+    // Clicks on the programmatic button are treated as an outside press.
+    // Call eventDetails.cancel() so onClick can close the popover without conflicting updates.
+    if (
+      !isOpen &&
+      eventDetails.reason === 'outside-press' &&
+      buttonRef.current?.contains(eventDetails.event.target as Node)
+    ) {
+      eventDetails.cancel();
+      return;
+    }
     setOpen(isOpen);
     setTriggerId(eventDetails.trigger?.id ?? null);
   };
@@ -44,9 +55,15 @@ export default function PopoverDetachedTriggersSimpleDemo() {
         <button
           type="button"
           className="flex h-10 items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-3.5 text-base font-normal text-gray-900 select-none hover:bg-gray-100 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-blue-800 active:bg-gray-100"
+          ref={buttonRef}
           onClick={() => {
-            setTriggerId('trigger-2');
-            setOpen(true);
+            if (open) {
+              // Close regardless of which trigger opened it
+              setOpen(false);
+            } else {
+              setTriggerId('trigger-2');
+              setOpen(true);
+            }
           }}
         >
           Open programmatically


### PR DESCRIPTION
## Summary

Updates the **Controlled mode with multiple triggers** popover demo so the detached programmatic `<button>` can close the popover on a second click — the behavior called out in #4466.

Clicks on that button while the popover is open are handled as an `outside-press` in `onOpenChange`, which can fight with the Base UI event. The demo now cancels that close when the press targets the programmatic button, then closes via `onClick` instead. Icon triggers via `Popover.Trigger` keep working as before.

Docs-only; no library changes.

## Changes

- **Tailwind & CSS Modules** (`detached-triggers-controlled`): toggle `open` on the programmatic button (`setOpen(false)` when already open).
- **`onOpenChange`**: if the close reason is `outside-press` and the event target is inside the programmatic button, call `eventDetails.cancel()` so `onClick` can close without conflicting state updates.
- Short inline comments explaining the `outside-press` / `cancel()` pattern for copy-paste from the docs.