### PR TITLE
[docs-infra] Avoid redundant header in print

### DIFF
--- a/docs/src/components/Header.css
+++ b/docs/src/components/Header.css
@@ -31,6 +31,11 @@
       box-shadow: none;
       background-color: transparent;
     }
+
+    @media print {
+      /* Prevent the header to be visible on each printed page */
+      position: absolute;
+    }
   }
 
   .HeaderLink,


### PR DESCRIPTION
## The problem

This improves a bit the print UX. Currently, the header shows on each print page.

<img width="591" height="239" alt="SCR-20260512-kxql" src="https://github.com/user-attachments/assets/6643926f-1b7b-46e7-ac12-e9b715f67145" />

https://base-ui.com/react/components/checkbox

This is redundant information; to do it "right" we only need the header once on the first page. For example, websites optimized for print don't have this.

## Why

The print mode still has use cases in 2026:

- **The PDF export case**. It's common to export data grids, analytical dashboards, and project summaries into PDFs to share with stakeholders or attach to internal reports. This relies on the print mode.
- **Some apps have actual print needs** 🖨️. Order confirmations, invoices, receipts, flight tickets, and event tickets are often printed.

So we want our components to have some level of support for print.
So we need the docs-infra environment to allow us to test the print mode of the different components without getting too much in the way.

How much level of support we need is unclear, but here is a quick wins 😁