### PR TITLE
[direction provider] Fix RTL component behavior

### DIFF
--- a/packages/react/src/combobox/chip/ComboboxChip.test.tsx
+++ b/packages/react/src/combobox/chip/ComboboxChip.test.tsx
@@ -1,6 +1,7 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
+import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { createRenderer, describeConformance } from '#test-utils';
 import { act, screen, waitFor } from '@mui/internal-test-utils';
 
@@ -310,6 +311,48 @@ describe('<Combobox.Chip />', () => {
       await act(async () => {
         chipApple.focus();
       });
+      await user.keyboard('{ArrowLeft}');
+      expect(input).toHaveFocus();
+    });
+
+    it('mirrors chip keyboard navigation in RTL mode', async () => {
+      const { user } = await render(
+        <DirectionProvider direction="rtl">
+          <Combobox.Root multiple defaultValue={['apple', 'banana']}>
+            <Combobox.Chips>
+              <Combobox.Chip data-testid="chip-apple">apple</Combobox.Chip>
+              <Combobox.Chip data-testid="chip-banana">banana</Combobox.Chip>
+              <Combobox.Input data-testid="input" />
+            </Combobox.Chips>
+          </Combobox.Root>
+        </DirectionProvider>,
+      );
+
+      const chipApple = screen.getByTestId('chip-apple');
+      const chipBanana = screen.getByTestId('chip-banana');
+      const input = screen.getByTestId<HTMLInputElement>('input');
+
+      await act(async () => {
+        input.focus();
+        input.setSelectionRange(0, 0);
+      });
+
+      await user.keyboard('{ArrowRight}');
+      expect(chipBanana).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(chipApple).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(input).toHaveFocus();
+
+      await act(async () => {
+        chipApple.focus();
+      });
+
+      await user.keyboard('{ArrowLeft}');
+      expect(chipBanana).toHaveFocus();
+
       await user.keyboard('{ArrowLeft}');
       expect(input).toHaveFocus();
     });

--- a/packages/react/src/combobox/chip/ComboboxChip.tsx
+++ b/packages/react/src/combobox/chip/ComboboxChip.tsx
@@ -12,6 +12,7 @@ import { stopEvent } from '../../floating-ui-react/utils';
 import { selectors } from '../store';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
+import { useDirection } from '../../internals/direction-context/DirectionContext';
 
 /**
  * An individual chip that represents a value in a multiselectable input.
@@ -27,6 +28,7 @@ export const ComboboxChip = React.forwardRef(function ComboboxChip(
 
   const store = useComboboxRootContext();
   const { setHighlightedChipIndex, chipsRef } = useComboboxChipsContext()!;
+  const direction = useDirection();
 
   const disabled = useStore(store, selectors.disabled);
   const readOnly = useStore(store, selectors.readOnly);
@@ -36,15 +38,18 @@ export const ComboboxChip = React.forwardRef(function ComboboxChip(
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
     let nextIndex: number | undefined = index;
+    const isRtl = direction === 'rtl';
+    const previousChipKey = isRtl ? 'ArrowRight' : 'ArrowLeft';
+    const nextChipKey = isRtl ? 'ArrowLeft' : 'ArrowRight';
 
-    if (event.key === 'ArrowLeft') {
+    if (event.key === previousChipKey) {
       event.preventDefault();
       if (index > 0) {
         nextIndex = index - 1;
       } else {
         nextIndex = undefined;
       }
-    } else if (event.key === 'ArrowRight') {
+    } else if (event.key === nextChipKey) {
       event.preventDefault();
       if (index < chipsRef.current.length - 1) {
         nextIndex = index + 1;

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -140,16 +140,19 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
 
     const { highlightedChipIndex } = comboboxChipsContext;
     const renderedChipsCount = comboboxChipsContext.chipsRef.current.length;
+    const isRtl = direction === 'rtl';
+    const previousChipKey = isRtl ? 'ArrowRight' : 'ArrowLeft';
+    const nextChipKey = isRtl ? 'ArrowLeft' : 'ArrowRight';
 
     if (highlightedChipIndex !== undefined) {
-      if (event.key === 'ArrowLeft') {
+      if (event.key === previousChipKey) {
         event.preventDefault();
         if (highlightedChipIndex > 0) {
           nextIndex = highlightedChipIndex - 1;
         } else {
           nextIndex = undefined;
         }
-      } else if (event.key === 'ArrowRight') {
+      } else if (event.key === nextChipKey) {
         event.preventDefault();
         if (highlightedChipIndex < renderedChipsCount - 1) {
           nextIndex = highlightedChipIndex + 1;
@@ -172,7 +175,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
 
     // Handle navigation when no chip is highlighted
     if (
-      event.key === 'ArrowLeft' &&
+      event.key === previousChipKey &&
       (event.currentTarget.selectionStart ?? 0) === 0 &&
       selectedValue.length > 0
     ) {

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -60,6 +60,7 @@ import {
   selectedValueIncludes,
 } from '../../internals/itemEquality';
 import { INITIAL_LAST_HIGHLIGHT, NO_ACTIVE_VALUE } from './utils/constants';
+import { useDirection } from '../../internals/direction-context/DirectionContext';
 
 /**
  * @internal
@@ -132,6 +133,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     validation,
   } = useFieldRootContext();
 
+  const direction = useDirection();
   const id = useLabelableId({ id: idProp });
   const collatorFilter = useCoreFilter({ locale });
 
@@ -1072,6 +1074,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     // Floating UI tests don't require `role="row"` wrappers, so retains the number API.
     cols: grid ? 2 : 1,
     orientation: grid ? 'horizontal' : undefined,
+    rtl: direction === 'rtl',
     disabledIndices: EMPTY_ARRAY as number[],
     onNavigate(nextActiveIndex, event) {
       // Retain the highlight only while actually transitioning out or closed.

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/internal-test-utils';
 import { createRenderer, isJSDOM, popupConformanceTests } from '#test-utils';
 import { Combobox } from '@base-ui/react/combobox';
+import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Dialog } from '@base-ui/react/dialog';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
@@ -2556,6 +2557,51 @@ describe('<Combobox.Root />', () => {
       await waitFor(() => expect(onItemHighlighted.mock.lastCall?.[0]).toBe('5'));
 
       await user.keyboard('{ArrowUp}');
+      await waitFor(() => expect(onItemHighlighted.mock.lastCall?.[0]).toBe('2'));
+    });
+
+    it('mirrors horizontal grid navigation in RTL mode', async () => {
+      const onItemHighlighted = vi.fn();
+      const { user } = await render(
+        <DirectionProvider direction="rtl">
+          <Combobox.Root grid onItemHighlighted={onItemHighlighted} defaultOpen>
+            <Combobox.Input data-testid="input" />
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <Combobox.List>
+                    <Combobox.Row>
+                      <Combobox.Item value="1">1</Combobox.Item>
+                      <Combobox.Item value="2">2</Combobox.Item>
+                      <Combobox.Item value="3">3</Combobox.Item>
+                    </Combobox.Row>
+                    <Combobox.Row>
+                      <Combobox.Item value="4">4</Combobox.Item>
+                      <Combobox.Item value="5">5</Combobox.Item>
+                      <Combobox.Item value="6">6</Combobox.Item>
+                    </Combobox.Row>
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>
+        </DirectionProvider>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+      await waitFor(() => expect(screen.getByRole('grid')).not.toBe(null));
+
+      await user.keyboard('{ArrowDown}');
+      await waitFor(() => expect(onItemHighlighted.mock.lastCall?.[0]).toBe('1'));
+
+      await user.keyboard('{ArrowLeft}');
+      await waitFor(() => expect(onItemHighlighted.mock.lastCall?.[0]).toBe('2'));
+
+      await user.keyboard('{ArrowLeft}');
+      await waitFor(() => expect(onItemHighlighted.mock.lastCall?.[0]).toBe('3'));
+
+      await user.keyboard('{ArrowRight}');
       await waitFor(() => expect(onItemHighlighted.mock.lastCall?.[0]).toBe('2'));
     });
 

--- a/packages/react/src/direction-provider/DirectionProvider.spec.tsx
+++ b/packages/react/src/direction-provider/DirectionProvider.spec.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { expectType } from '#test-utils';
+import {
+  DirectionProvider,
+  useDirection,
+  type DirectionProviderProps,
+  type TextDirection,
+} from '@base-ui/react/direction-provider';
+
+const direction = null as unknown as ReturnType<typeof useDirection>;
+
+expectType<TextDirection, typeof direction>(direction);
+
+const props: DirectionProviderProps = {
+  direction: 'rtl',
+  children: <div />,
+};
+
+expectType<TextDirection | undefined, typeof props.direction>(props.direction);
+
+<DirectionProvider />;
+<DirectionProvider direction="ltr" />;
+<DirectionProvider direction="rtl" />;
+
+const invalidDirection = (
+  // @ts-expect-error
+  <DirectionProvider direction="vertical" />
+);

--- a/packages/react/src/direction-provider/DirectionProvider.test.tsx
+++ b/packages/react/src/direction-provider/DirectionProvider.test.tsx
@@ -1,0 +1,42 @@
+import { expect } from 'vitest';
+import * as React from 'react';
+import {
+  DirectionProvider,
+  useDirection,
+  type TextDirection,
+} from '@base-ui/react/direction-provider';
+import { screen } from '@mui/internal-test-utils';
+import { createRenderer } from '#test-utils';
+
+function DirectionProbe() {
+  const direction = useDirection();
+  return <span data-testid="direction">{direction}</span>;
+}
+
+function DirectionProviderTest(props: { direction?: TextDirection }) {
+  return (
+    <DirectionProvider direction={props.direction}>
+      <DirectionProbe />
+    </DirectionProvider>
+  );
+}
+
+describe('<DirectionProvider />', () => {
+  const { render } = createRenderer();
+
+  it('defaults useDirection to ltr outside a provider', async () => {
+    await render(<DirectionProbe />);
+
+    expect(screen.getByTestId('direction')).toHaveTextContent('ltr');
+  });
+
+  it('provides the configured direction to descendants', async () => {
+    const { setProps } = await render(<DirectionProviderTest direction="rtl" />);
+
+    expect(screen.getByTestId('direction')).toHaveTextContent('rtl');
+
+    await setProps({ direction: 'ltr' });
+
+    expect(screen.getByTestId('direction')).toHaveTextContent('ltr');
+  });
+});

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect, vi } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
+import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { screen, flushMicrotasks, waitFor, act } from '@mui/internal-test-utils';
 import userEvent from '@testing-library/user-event';
@@ -84,6 +85,39 @@ describe('<NavigationMenu.Trigger />', () => {
       );
     },
   }));
+
+  it('opens a vertical menu with the mirrored arrow key in RTL mode', async () => {
+    await render(
+      <DirectionProvider direction="rtl">
+        <NavigationMenu.Root orientation="vertical">
+          <NavigationMenu.List>
+            <NavigationMenu.Item>
+              <NavigationMenu.Trigger>Overview</NavigationMenu.Trigger>
+              <NavigationMenu.Content>
+                <NavigationMenu.Link href="#">Quick Start</NavigationMenu.Link>
+              </NavigationMenu.Content>
+            </NavigationMenu.Item>
+          </NavigationMenu.List>
+          <NavigationMenu.Portal>
+            <NavigationMenu.Positioner>
+              <NavigationMenu.Popup>
+                <NavigationMenu.Viewport />
+              </NavigationMenu.Popup>
+            </NavigationMenu.Positioner>
+          </NavigationMenu.Portal>
+        </NavigationMenu.Root>
+      </DirectionProvider>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Overview' });
+    trigger.focus();
+
+    await userEvent.keyboard('{ArrowLeft}');
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Quick Start' })).toBeVisible();
+    });
+  });
 
   it.skipIf(isJSDOM)('handles focus and positioner height', async () => {
     await render(

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -54,6 +54,7 @@ import { useNavigationMenuDismissContext } from '../list/NavigationMenuDismissCo
 import { NavigationMenuPopupCssVars } from '../popup/NavigationMenuPopupCssVars';
 import { NavigationMenuPositionerCssVars } from '../positioner/NavigationMenuPositionerCssVars';
 import { mergeProps } from '../../merge-props';
+import { useDirection } from '../../internals/direction-context/DirectionContext';
 
 const DEFAULT_SIZE = { width: 0, height: 0 };
 
@@ -106,6 +107,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   const nodeId = useNavigationMenuTreeContext();
   const tree = useFloatingTree();
   const dismissProps = useNavigationMenuDismissContext();
+  const direction = useDirection();
 
   const stickIfOpenTimeout = useTimeout();
   const focusFrame = useAnimationFrame();
@@ -768,8 +770,9 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
         return;
       }
 
+      const verticalOpenKey = direction === 'rtl' ? 'ArrowLeft' : 'ArrowRight';
       const openHorizontal = orientation === 'horizontal' && event.key === 'ArrowDown';
-      const openVertical = orientation === 'vertical' && event.key === 'ArrowRight';
+      const openVertical = orientation === 'vertical' && event.key === verticalOpenKey;
 
       if (openHorizontal || openVertical) {
         setValue(itemValue, createChangeEventDetails(REASONS.listNavigation, event.nativeEvent));

--- a/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
@@ -1,5 +1,6 @@
 import { expect } from 'vitest';
 import * as React from 'react';
+import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Popover } from '@base-ui/react/popover';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { act, screen, waitFor } from '@mui/internal-test-utils';
@@ -148,6 +149,31 @@ describe('<Popover.Positioner />', () => {
 
       // correctly flips the side in the browser
       expect(side).toBe('inline-end');
+    });
+
+    it('reads logical side inside sideOffset in RTL mode', async () => {
+      let side = 'none';
+      await render(
+        <DirectionProvider direction="rtl">
+          <Popover.Root open>
+            <Trigger style={triggerStyle}>Trigger</Trigger>
+            <Popover.Portal>
+              <Popover.Positioner
+                side="inline-start"
+                data-testid="positioner"
+                sideOffset={(data) => {
+                  side = data.side;
+                  return 0;
+                }}
+              >
+                <Popover.Popup style={popupStyle}>Popup</Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          </Popover.Root>
+        </DirectionProvider>,
+      );
+
+      expect(side).toBe('inline-start');
     });
   });
 

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -1,4 +1,5 @@
 import { expect } from 'vitest';
+import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { screen, fireEvent, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, isJSDOM, describeConformance } from '#test-utils';
@@ -187,6 +188,68 @@ describe('<ScrollArea.Scrollbar />', () => {
       fireEvent(verticalScrollbar, event);
 
       expect(viewport.scrollTop).toBe(0);
+    });
+  });
+
+  describe('wheel', () => {
+    it('allows horizontal scrolling away from the RTL start edge', async () => {
+      await render(
+        <DirectionProvider direction="rtl">
+          <ScrollArea.Root style={{ width: 200, height: 200, direction: 'rtl' }}>
+            <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
+              <div style={{ width: 1000, height: 200 }} />
+            </ScrollArea.Viewport>
+            <ScrollArea.Scrollbar orientation="horizontal" data-testid="horizontal" keepMounted />
+          </ScrollArea.Root>
+        </DirectionProvider>,
+      );
+
+      const viewport = screen.getByTestId('viewport') as HTMLDivElement;
+      const horizontalScrollbar = screen.getByTestId('horizontal');
+
+      Object.defineProperties(viewport, {
+        clientWidth: {
+          configurable: true,
+          value: 200,
+        },
+        scrollWidth: {
+          configurable: true,
+          value: 1000,
+        },
+        scrollLeft: {
+          configurable: true,
+          writable: true,
+          value: 0,
+        },
+      });
+
+      fireEvent.wheel(horizontalScrollbar, { deltaX: -50 });
+
+      expect(viewport.scrollLeft).toBe(-50);
+    });
+
+    it.skipIf(isJSDOM)('registers after the horizontal scrollbar becomes visible', async () => {
+      await render(
+        <DirectionProvider direction="rtl">
+          <ScrollArea.Root style={{ width: 200, height: 200, direction: 'rtl' }}>
+            <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
+              <div style={{ width: 1000, height: 200 }} />
+            </ScrollArea.Viewport>
+            <ScrollArea.Scrollbar orientation="horizontal" data-testid="horizontal">
+              <ScrollArea.Thumb />
+            </ScrollArea.Scrollbar>
+          </ScrollArea.Root>
+        </DirectionProvider>,
+      );
+
+      const viewport = screen.getByTestId('viewport') as HTMLDivElement;
+      const horizontalScrollbar = await screen.findByTestId('horizontal');
+
+      await waitFor(() => expect(horizontalScrollbar).toHaveAttribute('data-has-overflow-x'));
+
+      fireEvent.wheel(horizontalScrollbar, { deltaX: -50 });
+
+      expect(viewport.scrollLeft).toBe(-50);
     });
   });
 

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
-import { DirectionProvider } from '@base-ui/react/direction-provider';
+import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { screen, fireEvent, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, isJSDOM, describeConformance } from '#test-utils';
@@ -193,7 +193,7 @@ describe('<ScrollArea.Scrollbar />', () => {
 
   describe('wheel', () => {
     async function renderWheelTest(props: {
-      direction?: 'ltr' | 'rtl';
+      direction?: TextDirection;
       orientation?: 'horizontal' | 'vertical';
       scrollLeft?: number;
       scrollTop?: number;
@@ -252,37 +252,9 @@ describe('<ScrollArea.Scrollbar />', () => {
     }
 
     it('allows horizontal scrolling away from the RTL start edge', async () => {
-      await render(
-        <DirectionProvider direction="rtl">
-          <ScrollArea.Root style={{ width: 200, height: 200, direction: 'rtl' }}>
-            <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
-              <div style={{ width: 1000, height: 200 }} />
-            </ScrollArea.Viewport>
-            <ScrollArea.Scrollbar orientation="horizontal" data-testid="horizontal" keepMounted />
-          </ScrollArea.Root>
-        </DirectionProvider>,
-      );
+      const { viewport, scrollbar } = await renderWheelTest({ direction: 'rtl' });
 
-      const viewport = screen.getByTestId('viewport') as HTMLDivElement;
-      const horizontalScrollbar = screen.getByTestId('horizontal');
-
-      Object.defineProperties(viewport, {
-        clientWidth: {
-          configurable: true,
-          value: 200,
-        },
-        scrollWidth: {
-          configurable: true,
-          value: 1000,
-        },
-        scrollLeft: {
-          configurable: true,
-          writable: true,
-          value: 0,
-        },
-      });
-
-      fireEvent.wheel(horizontalScrollbar, { deltaX: -50 });
+      fireEvent.wheel(scrollbar, { deltaX: -50 });
 
       expect(viewport.scrollLeft).toBe(-50);
     });
@@ -306,6 +278,10 @@ describe('<ScrollArea.Scrollbar />', () => {
 
       fireEvent.wheel(scrollbar, { deltaX: 50 });
       expect(viewport.scrollLeft).toBe(0);
+
+      viewport.scrollLeft = -100;
+      fireEvent.wheel(scrollbar, { deltaX: 50 });
+      expect(viewport.scrollLeft).toBe(-50);
 
       viewport.scrollLeft = -790;
       fireEvent.wheel(scrollbar, { deltaX: -50 });

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -192,6 +192,65 @@ describe('<ScrollArea.Scrollbar />', () => {
   });
 
   describe('wheel', () => {
+    async function renderWheelTest(props: {
+      direction?: 'ltr' | 'rtl';
+      orientation?: 'horizontal' | 'vertical';
+      scrollLeft?: number;
+      scrollTop?: number;
+    }) {
+      const {
+        direction = 'ltr',
+        orientation = 'horizontal',
+        scrollLeft = 0,
+        scrollTop = 0,
+      } = props;
+
+      await render(
+        <DirectionProvider direction={direction}>
+          <ScrollArea.Root style={{ width: 200, height: 200, direction }}>
+            <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
+              <div style={{ width: 1000, height: 1000 }} />
+            </ScrollArea.Viewport>
+            <ScrollArea.Scrollbar orientation={orientation} data-testid="scrollbar" keepMounted />
+          </ScrollArea.Root>
+        </DirectionProvider>,
+      );
+
+      const viewport = screen.getByTestId('viewport') as HTMLDivElement;
+      const scrollbar = screen.getByTestId('scrollbar');
+
+      Object.defineProperties(viewport, {
+        clientHeight: {
+          configurable: true,
+          value: 200,
+        },
+        clientWidth: {
+          configurable: true,
+          value: 200,
+        },
+        scrollHeight: {
+          configurable: true,
+          value: 1000,
+        },
+        scrollWidth: {
+          configurable: true,
+          value: 1000,
+        },
+        scrollLeft: {
+          configurable: true,
+          writable: true,
+          value: scrollLeft,
+        },
+        scrollTop: {
+          configurable: true,
+          writable: true,
+          value: scrollTop,
+        },
+      });
+
+      return { viewport, scrollbar };
+    }
+
     it('allows horizontal scrolling away from the RTL start edge', async () => {
       await render(
         <DirectionProvider direction="rtl">
@@ -226,6 +285,52 @@ describe('<ScrollArea.Scrollbar />', () => {
       fireEvent.wheel(horizontalScrollbar, { deltaX: -50 });
 
       expect(viewport.scrollLeft).toBe(-50);
+    });
+
+    it('clamps horizontal LTR wheel scrolling at both edges', async () => {
+      const { viewport, scrollbar } = await renderWheelTest({ direction: 'ltr' });
+
+      fireEvent.wheel(scrollbar, { deltaX: -50 });
+      expect(viewport.scrollLeft).toBe(0);
+
+      viewport.scrollLeft = 790;
+      fireEvent.wheel(scrollbar, { deltaX: 50 });
+      expect(viewport.scrollLeft).toBe(800);
+
+      fireEvent.wheel(scrollbar, { deltaX: 50 });
+      expect(viewport.scrollLeft).toBe(800);
+    });
+
+    it('clamps horizontal RTL wheel scrolling at both edges', async () => {
+      const { viewport, scrollbar } = await renderWheelTest({ direction: 'rtl' });
+
+      fireEvent.wheel(scrollbar, { deltaX: 50 });
+      expect(viewport.scrollLeft).toBe(0);
+
+      viewport.scrollLeft = -790;
+      fireEvent.wheel(scrollbar, { deltaX: -50 });
+      expect(viewport.scrollLeft).toBe(-800);
+
+      fireEvent.wheel(scrollbar, { deltaX: -50 });
+      expect(viewport.scrollLeft).toBe(-800);
+
+      viewport.scrollLeft = -10;
+      fireEvent.wheel(scrollbar, { deltaX: 50 });
+      expect(viewport.scrollLeft).toBe(0);
+    });
+
+    it('clamps vertical wheel scrolling at both edges', async () => {
+      const { viewport, scrollbar } = await renderWheelTest({ orientation: 'vertical' });
+
+      fireEvent.wheel(scrollbar, { deltaY: -50 });
+      expect(viewport.scrollTop).toBe(0);
+
+      viewport.scrollTop = 790;
+      fireEvent.wheel(scrollbar, { deltaY: 50 });
+      expect(viewport.scrollTop).toBe(800);
+
+      fireEvent.wheel(scrollbar, { deltaY: 50 });
+      expect(viewport.scrollTop).toBe(800);
     });
 
     it.skipIf(isJSDOM)('registers after the horizontal scrollbar becomes visible', async () => {

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
@@ -96,6 +96,7 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
       const maxScroll = horizontal
         ? viewportEl.scrollWidth - viewportEl.clientWidth
         : viewportEl.scrollHeight - viewportEl.clientHeight;
+      // RTL horizontal scrolling uses a negative `scrollLeft` range, from 0 to `-maxScroll`.
       const minScroll = horizontal && direction === 'rtl' ? -maxScroll : 0;
       const maxScrollValue = horizontal && direction === 'rtl' ? 0 : maxScroll;
       const scrollValue = viewportEl[scrollProperty];

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
@@ -68,8 +68,14 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
 
   const direction = useDirection();
   const hideTrackUntilMeasured = !hasMeasuredScrollbar && !keepMounted;
+  const isHidden = orientation === 'vertical' ? hiddenState.y : hiddenState.x;
+  const shouldRender = keepMounted || !isHidden;
 
   React.useEffect(() => {
+    if (!shouldRender) {
+      return undefined;
+    }
+
     const viewportEl = viewportRef.current;
     const scrollbarEl = orientation === 'vertical' ? scrollbarYRef.current : scrollbarXRef.current;
 
@@ -84,37 +90,28 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
 
       event.preventDefault();
 
-      if (orientation === 'vertical') {
-        if (viewportEl.scrollTop === 0 && event.deltaY < 0) {
-          return;
-        }
-      } else if (viewportEl.scrollLeft === 0 && event.deltaX < 0) {
+      const horizontal = orientation === 'horizontal';
+      const scrollProperty = horizontal ? 'scrollLeft' : 'scrollTop';
+      const delta = horizontal ? event.deltaX : event.deltaY;
+      const maxScroll = horizontal
+        ? viewportEl.scrollWidth - viewportEl.clientWidth
+        : viewportEl.scrollHeight - viewportEl.clientHeight;
+      const minScroll = horizontal && direction === 'rtl' ? -maxScroll : 0;
+      const maxScrollValue = horizontal && direction === 'rtl' ? 0 : maxScroll;
+      const scrollValue = viewportEl[scrollProperty];
+
+      if ((scrollValue <= minScroll && delta < 0) || (scrollValue >= maxScrollValue && delta > 0)) {
         return;
       }
 
-      if (orientation === 'vertical') {
-        if (
-          viewportEl.scrollTop === viewportEl.scrollHeight - viewportEl.clientHeight &&
-          event.deltaY > 0
-        ) {
-          return;
-        }
-      } else if (
-        viewportEl.scrollLeft === viewportEl.scrollWidth - viewportEl.clientWidth &&
-        event.deltaX > 0
-      ) {
-        return;
-      }
-
-      if (orientation === 'vertical') {
-        viewportEl.scrollTop += event.deltaY;
-      } else {
-        viewportEl.scrollLeft += event.deltaX;
-      }
+      viewportEl[scrollProperty] = Math.min(
+        maxScrollValue,
+        Math.max(minScroll, scrollValue + delta),
+      );
     }
 
     return addEventListener(scrollbarEl, 'wheel', handleWheel, { passive: false });
-  }, [orientation, scrollbarXRef, scrollbarYRef, viewportRef]);
+  }, [direction, orientation, scrollbarXRef, scrollbarYRef, shouldRender, viewportRef]);
 
   const props: HTMLProps = {
     ...(rootId && { 'data-id': `${rootId}-scrollbar` }),
@@ -220,9 +217,6 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
 
   const contextValue = React.useMemo(() => ({ orientation }), [orientation]);
 
-  const isHidden = orientation === 'vertical' ? hiddenState.y : hiddenState.x;
-
-  const shouldRender = keepMounted || !isHidden;
   if (!shouldRender) {
     return null;
   }


### PR DESCRIPTION
Several direction-sensitive paths still treated left/right or wheel movement as LTR, so RTL keyboard and scroll interactions could stall or move the wrong way.

This also uncovered a bug with Scroll Area where the `wheel` listener was not registered depending on the render timing.

## Root cause

Combobox, Scroll Area, Navigation Menu, and logical positioning coverage did not consistently pass or assert `DirectionProvider` state.

## Changes

- Pass RTL direction into Combobox grid navigation.
- Mirror Combobox chip left/right keyboard behavior in RTL.
- Clamp horizontal Scroll Area wheel movement to the RTL negative `scrollLeft` range.
- Mirror vertical Navigation Menu trigger opening in RTL.
- Add RTL coverage for Popover logical-side positioning and Direction Provider runtime/types.