### PR TITLE
[drawer] Forward viewport style prop

### DIFF
--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -4,7 +4,7 @@ import { Combobox } from '@base-ui/react/combobox';
 import { Drawer } from '@base-ui/react/drawer';
 import { Slider } from '@base-ui/react/slider';
 import { fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, isJSDOM } from '#test-utils';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Drawer.Viewport />', () => {
   beforeAll(function beforeHook() {
@@ -14,6 +14,17 @@ describe('<Drawer.Viewport />', () => {
   });
 
   const { render } = createRenderer();
+
+  describeConformance(<Drawer.Viewport />, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render(node) {
+      return render(
+        <Drawer.Root open>
+          <Drawer.Portal>{node}</Drawer.Portal>
+        </Drawer.Root>,
+      );
+    },
+  }));
 
   function createTouch(target: EventTarget, point: { clientX: number; clientY: number }) {
     if (typeof Touch === 'function') {

--- a/packages/react/src/drawer/viewport/DrawerViewport.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.tsx
@@ -968,6 +968,7 @@ export const DrawerViewport = React.forwardRef(function DrawerViewport(
     <DialogViewport
       ref={forwardedRef}
       className={className}
+      style={style}
       render={render}
       {...mergeProps<'div'>(elementProps, {
         onPointerDown(event) {


### PR DESCRIPTION
Drawer.Viewport now forwards the `style` prop to the rendered viewport, matching the rest of the component API and keeping conformance coverage in place.

## Root cause

`Drawer.Viewport` destructured `style` but never passed it to `DialogViewport`, so styles set on the component were dropped.

## Changes

- Forward `style` from `Drawer.Viewport` to `DialogViewport`.
- Add the standard conformance suite for `Drawer.Viewport`.