### PR TITLE
[test] Clean up component tests

### DIFF
--- a/packages/react/src/accordion/root/AccordionRoot.test.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.test.tsx
@@ -242,6 +242,200 @@ describe('<Accordion.Root />', () => {
     });
   });
 
+  describe('prop: orientation', () => {
+    it('sets the orientation data attribute', async () => {
+      const { container, setProps } = await render(<Accordion.Root orientation="vertical" />);
+      const root = container.firstElementChild as HTMLElement;
+
+      expect(root).toHaveAttribute('data-orientation', 'vertical');
+
+      await setProps({ orientation: 'horizontal' });
+
+      expect(root).toHaveAttribute('data-orientation', 'horizontal');
+    });
+  });
+
+  describe.skipIf(isJSDOM)('prop: multiple', () => {
+    it('multiple items can be open when `multiple = true`', async () => {
+      const { user } = await render(
+        <Accordion.Root multiple>
+          <Accordion.Item>
+            <Accordion.Header>
+              <Accordion.Trigger>Trigger 1</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>{PANEL_CONTENT_1}</Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item>
+            <Accordion.Header>
+              <Accordion.Trigger>Trigger 2</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>{PANEL_CONTENT_2}</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion.Root>,
+      );
+
+      const [trigger1, trigger2] = screen.getAllByRole('button');
+
+      expect(trigger1).not.toHaveAttribute('data-panel-open');
+      expect(trigger2).not.toHaveAttribute('data-panel-open');
+      expect(screen.queryByText(PANEL_CONTENT_1)).toBe(null);
+      expect(screen.queryByText(PANEL_CONTENT_2)).toBe(null);
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger1 });
+      await user.pointer({ keys: '[MouseLeft]', target: trigger2 });
+
+      expect(screen.queryByText(PANEL_CONTENT_1)).toHaveAttribute('data-open');
+      expect(screen.queryByText(PANEL_CONTENT_2)).toHaveAttribute('data-open');
+      expect(trigger1).toHaveAttribute('data-panel-open');
+      expect(trigger2).toHaveAttribute('data-panel-open');
+    });
+
+    it('when false only one item can be open', async () => {
+      const { user } = await render(
+        <Accordion.Root multiple={false}>
+          <Accordion.Item>
+            <Accordion.Header>
+              <Accordion.Trigger>Trigger 1</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>{PANEL_CONTENT_1}</Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item>
+            <Accordion.Header>
+              <Accordion.Trigger>Trigger 2</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>{PANEL_CONTENT_2}</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion.Root>,
+      );
+
+      const [trigger1, trigger2] = screen.getAllByRole('button');
+
+      expect(screen.queryByText(PANEL_CONTENT_1)).toBe(null);
+      expect(screen.queryByText(PANEL_CONTENT_2)).toBe(null);
+      expect(trigger1).not.toHaveAttribute('data-panel-open');
+      expect(trigger2).not.toHaveAttribute('data-panel-open');
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger1 });
+
+      expect(screen.queryByText(PANEL_CONTENT_1)).toHaveAttribute('data-open');
+      expect(trigger1).toHaveAttribute('data-panel-open');
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger2 });
+
+      expect(screen.queryByText(PANEL_CONTENT_2)).toHaveAttribute('data-open');
+      expect(trigger2).toHaveAttribute('data-panel-open');
+      expect(screen.queryByText(PANEL_CONTENT_1)).toBe(null);
+      expect(trigger1).not.toHaveAttribute('data-panel-open');
+    });
+  });
+
+  describe.skipIf(isJSDOM)('prop: onValueChange', () => {
+    it('default item value', async () => {
+      const onValueChange = vi.fn();
+
+      const { user } = await render(
+        <Accordion.Root onValueChange={onValueChange} multiple>
+          <Accordion.Item value={0}>
+            <Accordion.Header>
+              <Accordion.Trigger>Trigger 1</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>1</Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item value={1}>
+            <Accordion.Header>
+              <Accordion.Trigger>Trigger 2</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>2</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion.Root>,
+      );
+
+      const [trigger1, trigger2] = screen.getAllByRole('button');
+
+      expect(onValueChange.mock.calls.length).toBe(0);
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger1 });
+
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.lastCall?.[0]).toEqual([0]);
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger2 });
+
+      expect(onValueChange.mock.calls.length).toBe(2);
+      expect(onValueChange.mock.lastCall?.[0]).toEqual([0, 1]);
+    });
+
+    it('custom item value', async () => {
+      const onValueChange = vi.fn();
+
+      const { user } = await render(
+        <Accordion.Root onValueChange={onValueChange} multiple>
+          <Accordion.Item value="one">
+            <Accordion.Header>
+              <Accordion.Trigger>Trigger 1</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>1</Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item value="two">
+            <Accordion.Header>
+              <Accordion.Trigger>Trigger 2</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>2</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion.Root>,
+      );
+
+      const [trigger1, trigger2] = screen.getAllByRole('button');
+
+      expect(onValueChange.mock.calls.length).toBe(0);
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger2 });
+
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.calls[0][0]).toEqual(['two']);
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger1 });
+
+      expect(onValueChange.mock.calls.length).toBe(2);
+      expect(onValueChange.mock.calls[1][0]).toEqual(['two', 'one']);
+    });
+
+    it('`multiple` is false', async () => {
+      const onValueChange = vi.fn();
+
+      const { user } = await render(
+        <Accordion.Root onValueChange={onValueChange} multiple={false}>
+          <Accordion.Item value="one">
+            <Accordion.Header>
+              <Accordion.Trigger>Trigger 1</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>1</Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item value="two">
+            <Accordion.Header>
+              <Accordion.Trigger>Trigger 2</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>2</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion.Root>,
+      );
+
+      const [trigger1, trigger2] = screen.getAllByRole('button');
+
+      expect(onValueChange.mock.calls.length).toBe(0);
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger1 });
+
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.calls[0][0]).toEqual(['one']);
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger2 });
+
+      expect(onValueChange.mock.calls.length).toBe(2);
+      expect(onValueChange.mock.calls[1][0]).toEqual(['two']);
+    });
+  });
+
   it('allows onMouseUp to call preventBaseUIHandler on the trigger', async () => {
     await render(
       <Accordion.Root>
@@ -598,80 +792,6 @@ describe('<Accordion.Root />', () => {
     });
   });
 
-  describe.skipIf(isJSDOM)('prop: multiple', () => {
-    it('multiple items can be open when `multiple = true`', async () => {
-      const { user } = await render(
-        <Accordion.Root multiple>
-          <Accordion.Item>
-            <Accordion.Header>
-              <Accordion.Trigger>Trigger 1</Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Panel>{PANEL_CONTENT_1}</Accordion.Panel>
-          </Accordion.Item>
-          <Accordion.Item>
-            <Accordion.Header>
-              <Accordion.Trigger>Trigger 2</Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Panel>{PANEL_CONTENT_2}</Accordion.Panel>
-          </Accordion.Item>
-        </Accordion.Root>,
-      );
-
-      const [trigger1, trigger2] = screen.getAllByRole('button');
-
-      expect(trigger1).not.toHaveAttribute('data-panel-open');
-      expect(trigger2).not.toHaveAttribute('data-panel-open');
-      expect(screen.queryByText(PANEL_CONTENT_1)).toBe(null);
-      expect(screen.queryByText(PANEL_CONTENT_2)).toBe(null);
-
-      await user.pointer({ keys: '[MouseLeft]', target: trigger1 });
-      await user.pointer({ keys: '[MouseLeft]', target: trigger2 });
-
-      expect(screen.queryByText(PANEL_CONTENT_1)).toHaveAttribute('data-open');
-      expect(screen.queryByText(PANEL_CONTENT_2)).toHaveAttribute('data-open');
-      expect(trigger1).toHaveAttribute('data-panel-open');
-      expect(trigger2).toHaveAttribute('data-panel-open');
-    });
-
-    it('when false only one item can be open', async () => {
-      const { user } = await render(
-        <Accordion.Root multiple={false}>
-          <Accordion.Item>
-            <Accordion.Header>
-              <Accordion.Trigger>Trigger 1</Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Panel>{PANEL_CONTENT_1}</Accordion.Panel>
-          </Accordion.Item>
-          <Accordion.Item>
-            <Accordion.Header>
-              <Accordion.Trigger>Trigger 2</Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Panel>{PANEL_CONTENT_2}</Accordion.Panel>
-          </Accordion.Item>
-        </Accordion.Root>,
-      );
-
-      const [trigger1, trigger2] = screen.getAllByRole('button');
-
-      expect(screen.queryByText(PANEL_CONTENT_1)).toBe(null);
-      expect(screen.queryByText(PANEL_CONTENT_2)).toBe(null);
-      expect(trigger1).not.toHaveAttribute('data-panel-open');
-      expect(trigger2).not.toHaveAttribute('data-panel-open');
-
-      await user.pointer({ keys: '[MouseLeft]', target: trigger1 });
-
-      expect(screen.queryByText(PANEL_CONTENT_1)).toHaveAttribute('data-open');
-      expect(trigger1).toHaveAttribute('data-panel-open');
-
-      await user.pointer({ keys: '[MouseLeft]', target: trigger2 });
-
-      expect(screen.queryByText(PANEL_CONTENT_2)).toHaveAttribute('data-open');
-      expect(trigger2).toHaveAttribute('data-panel-open');
-      expect(screen.queryByText(PANEL_CONTENT_1)).toBe(null);
-      expect(trigger1).not.toHaveAttribute('data-panel-open');
-    });
-  });
-
   describe.skipIf(isJSDOM)('horizontal orientation', () => {
     it('ArrowLeft/Right moves focus in horizontal orientation', async () => {
       const { user } = await render(
@@ -747,113 +867,6 @@ describe('<Accordion.Root />', () => {
         await user.keyboard('[ArrowLeft]');
         expect(trigger1).toHaveFocus();
       });
-    });
-  });
-
-  describe.skipIf(isJSDOM)('prop: onValueChange', () => {
-    it('default item value', async () => {
-      const onValueChange = vi.fn();
-
-      const { user } = await render(
-        <Accordion.Root onValueChange={onValueChange} multiple>
-          <Accordion.Item value={0}>
-            <Accordion.Header>
-              <Accordion.Trigger>Trigger 1</Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Panel>1</Accordion.Panel>
-          </Accordion.Item>
-          <Accordion.Item value={1}>
-            <Accordion.Header>
-              <Accordion.Trigger>Trigger 2</Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Panel>2</Accordion.Panel>
-          </Accordion.Item>
-        </Accordion.Root>,
-      );
-
-      const [trigger1, trigger2] = screen.getAllByRole('button');
-
-      expect(onValueChange.mock.calls.length).toBe(0);
-
-      await user.pointer({ keys: '[MouseLeft]', target: trigger1 });
-
-      expect(onValueChange.mock.calls.length).toBe(1);
-      expect(onValueChange.mock.lastCall?.[0]).toEqual([0]);
-
-      await user.pointer({ keys: '[MouseLeft]', target: trigger2 });
-
-      expect(onValueChange.mock.calls.length).toBe(2);
-      expect(onValueChange.mock.lastCall?.[0]).toEqual([0, 1]);
-    });
-
-    it('custom item value', async () => {
-      const onValueChange = vi.fn();
-
-      const { user } = await render(
-        <Accordion.Root onValueChange={onValueChange} multiple>
-          <Accordion.Item value="one">
-            <Accordion.Header>
-              <Accordion.Trigger>Trigger 1</Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Panel>1</Accordion.Panel>
-          </Accordion.Item>
-          <Accordion.Item value="two">
-            <Accordion.Header>
-              <Accordion.Trigger>Trigger 2</Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Panel>2</Accordion.Panel>
-          </Accordion.Item>
-        </Accordion.Root>,
-      );
-
-      const [trigger1, trigger2] = screen.getAllByRole('button');
-
-      expect(onValueChange.mock.calls.length).toBe(0);
-
-      await user.pointer({ keys: '[MouseLeft]', target: trigger2 });
-
-      expect(onValueChange.mock.calls.length).toBe(1);
-      expect(onValueChange.mock.calls[0][0]).toEqual(['two']);
-
-      await user.pointer({ keys: '[MouseLeft]', target: trigger1 });
-
-      expect(onValueChange.mock.calls.length).toBe(2);
-      expect(onValueChange.mock.calls[1][0]).toEqual(['two', 'one']);
-    });
-
-    it('`multiple` is false', async () => {
-      const onValueChange = vi.fn();
-
-      const { user } = await render(
-        <Accordion.Root onValueChange={onValueChange} multiple={false}>
-          <Accordion.Item value="one">
-            <Accordion.Header>
-              <Accordion.Trigger>Trigger 1</Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Panel>1</Accordion.Panel>
-          </Accordion.Item>
-          <Accordion.Item value="two">
-            <Accordion.Header>
-              <Accordion.Trigger>Trigger 2</Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Panel>2</Accordion.Panel>
-          </Accordion.Item>
-        </Accordion.Root>,
-      );
-
-      const [trigger1, trigger2] = screen.getAllByRole('button');
-
-      expect(onValueChange.mock.calls.length).toBe(0);
-
-      await user.pointer({ keys: '[MouseLeft]', target: trigger1 });
-
-      expect(onValueChange.mock.calls.length).toBe(1);
-      expect(onValueChange.mock.calls[0][0]).toEqual(['one']);
-
-      await user.pointer({ keys: '[MouseLeft]', target: trigger2 });
-
-      expect(onValueChange.mock.calls.length).toBe(2);
-      expect(onValueChange.mock.calls[1][0]).toEqual(['two']);
     });
   });
 });

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
@@ -241,21 +241,181 @@ describe('<AlertDialog.Root />', () => {
       const trigger = screen.getByText('Open');
       await user.click(trigger);
 
-      await waitFor(() => {
-        expect(screen.queryByRole('alertdialog')).not.toBe(null);
-      });
+      await screen.findByRole('alertdialog');
 
       await user.click(trigger);
 
-      await waitFor(() => {
-        expect(screen.queryByRole('alertdialog')).not.toBe(null);
-      });
+      await screen.findByRole('alertdialog');
 
       await act(async () => actionsRef.current.unmount());
 
       await waitFor(() => {
         expect(screen.queryByRole('alertdialog')).toBe(null);
       });
+    });
+  });
+
+  describe.skipIf(isJSDOM)('prop: onOpenChangeComplete', () => {
+    it('is called on close when there is no exit animation defined', async () => {
+      const onOpenChangeComplete = vi.fn();
+
+      function Test() {
+        const [open, setOpen] = React.useState(true);
+        return (
+          <div>
+            <button onClick={() => setOpen(false)}>Close</button>
+            <AlertDialog.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
+              <AlertDialog.Portal>
+                <AlertDialog.Popup data-testid="popup" />
+              </AlertDialog.Portal>
+            </AlertDialog.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const closeButton = screen.getByText('Close');
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('popup')).toBe(null);
+      });
+
+      expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+      expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
+    });
+
+    it('is called on close when the exit animation finishes', async () => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+      const onOpenChangeComplete = vi.fn();
+
+      function Test() {
+        const style = `
+          @keyframes test-anim {
+            to {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-indicator[data-ending-style] {
+            animation: test-anim 1ms;
+          }
+        `;
+
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <div>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            <button onClick={() => setOpen(false)}>Close</button>
+            <AlertDialog.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
+              <AlertDialog.Portal>
+                <AlertDialog.Popup className="animation-test-indicator" data-testid="popup" />
+              </AlertDialog.Portal>
+            </AlertDialog.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      expect(screen.getByTestId('popup')).not.toBe(null);
+
+      // Wait for open animation to finish
+      await waitFor(() => {
+        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+      });
+
+      const closeButton = screen.getByText('Close');
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('popup')).toBe(null);
+      });
+
+      expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
+    });
+
+    it('is called on open when there is no enter animation defined', async () => {
+      const onOpenChangeComplete = vi.fn();
+
+      function Test() {
+        const [open, setOpen] = React.useState(false);
+        return (
+          <div>
+            <button onClick={() => setOpen(true)}>Open</button>
+            <AlertDialog.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
+              <AlertDialog.Portal>
+                <AlertDialog.Popup data-testid="popup" />
+              </AlertDialog.Portal>
+            </AlertDialog.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const openButton = screen.getByText('Open');
+      await user.click(openButton);
+
+      await screen.findByTestId('popup');
+
+      expect(onOpenChangeComplete.mock.calls.length).toBe(2);
+      expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+    });
+
+    it('is called on open when the enter animation finishes', async () => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+      const onOpenChangeComplete = vi.fn();
+
+      function Test() {
+        const style = `
+          @keyframes test-anim {
+            from {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-indicator[data-starting-style] {
+            animation: test-anim 1ms;
+          }
+        `;
+
+        const [open, setOpen] = React.useState(false);
+
+        return (
+          <div>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            <button onClick={() => setOpen(true)}>Open</button>
+            <AlertDialog.Root
+              open={open}
+              onOpenChange={setOpen}
+              onOpenChangeComplete={onOpenChangeComplete}
+            >
+              <AlertDialog.Portal>
+                <AlertDialog.Popup className="animation-test-indicator" data-testid="popup" />
+              </AlertDialog.Portal>
+            </AlertDialog.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const openButton = screen.getByText('Open');
+      await user.click(openButton);
+
+      // Wait for open animation to finish
+      await waitFor(() => {
+        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+      });
+
+      expect(screen.queryByTestId('popup')).not.toBe(null);
     });
   });
 
@@ -285,27 +445,21 @@ describe('<AlertDialog.Root />', () => {
       expect(screen.queryByText('Alert dialog content')).toBe(null);
 
       await user.click(trigger1);
-      await waitFor(() => {
-        expect(screen.queryByText('Alert dialog content')).not.toBe(null);
-      });
+      await screen.findByText('Alert dialog content');
       await user.click(screen.getByText('Close'));
       await waitFor(() => {
         expect(screen.queryByText('Alert dialog content')).toBe(null);
       });
 
       await user.click(trigger2);
-      await waitFor(() => {
-        expect(screen.queryByText('Alert dialog content')).not.toBe(null);
-      });
+      await screen.findByText('Alert dialog content');
       await user.click(screen.getByText('Close'));
       await waitFor(() => {
         expect(screen.queryByText('Alert dialog content')).toBe(null);
       });
 
       await user.click(trigger3);
-      await waitFor(() => {
-        expect(screen.queryByText('Alert dialog content')).not.toBe(null);
-      });
+      await screen.findByText('Alert dialog content');
     });
 
     it('sets the payload and renders content based on its value', async () => {
@@ -498,27 +652,21 @@ describe('<AlertDialog.Root />', () => {
       expect(screen.queryByText('Alert dialog content')).toBe(null);
 
       await user.click(trigger1);
-      await waitFor(() => {
-        expect(screen.queryByText('Alert dialog content')).not.toBe(null);
-      });
+      await screen.findByText('Alert dialog content');
       await user.click(screen.getByText('Close'));
       await waitFor(() => {
         expect(screen.queryByText('Alert dialog content')).toBe(null);
       });
 
       await user.click(trigger2);
-      await waitFor(() => {
-        expect(screen.queryByText('Alert dialog content')).not.toBe(null);
-      });
+      await screen.findByText('Alert dialog content');
       await user.click(screen.getByText('Close'));
       await waitFor(() => {
         expect(screen.queryByText('Alert dialog content')).toBe(null);
       });
 
       await user.click(trigger3);
-      await waitFor(() => {
-        expect(screen.queryByText('Alert dialog content')).not.toBe(null);
-      });
+      await screen.findByText('Alert dialog content');
     });
 
     it('keeps detached triggers clickable when reparented (remove wrappers)', async () => {
@@ -705,9 +853,7 @@ describe('<AlertDialog.Root />', () => {
       const backdrop = await screen.findByRole('presentation', { hidden: true });
       await user.click(backdrop);
 
-      await waitFor(() => {
-        expect(screen.queryByRole('alertdialog')).not.toBe(null);
-      });
+      await screen.findByRole('alertdialog');
     });
 
     it('opens and closes the dialog', async () => {
@@ -729,9 +875,7 @@ describe('<AlertDialog.Root />', () => {
       expect(screen.queryByRole('alertdialog')).toBe(null);
 
       await act(() => dialog.open('trigger'));
-      await waitFor(() => {
-        expect(screen.queryByRole('alertdialog')).not.toBe(null);
-      });
+      await screen.findByRole('alertdialog');
 
       expect(screen.getByTestId('content').textContent).toBe('Content');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
@@ -769,9 +913,7 @@ describe('<AlertDialog.Root />', () => {
       expect(screen.queryByRole('alertdialog')).toBe(null);
 
       await act(() => dialog.open('trigger2'));
-      await waitFor(() => {
-        expect(screen.queryByRole('alertdialog')).not.toBe(null);
-      });
+      await screen.findByRole('alertdialog');
 
       expect(screen.getByTestId('content').textContent).toBe('2');
       expect(trigger2).toHaveAttribute('aria-expanded', 'true');
@@ -810,9 +952,7 @@ describe('<AlertDialog.Root />', () => {
       expect(screen.queryByRole('alertdialog')).toBe(null);
 
       await act(() => dialog.openWithPayload(8));
-      await waitFor(() => {
-        expect(screen.queryByRole('alertdialog')).not.toBe(null);
-      });
+      await screen.findByRole('alertdialog');
 
       expect(screen.getByTestId('content').textContent).toBe('8');
       expect(trigger1).not.toHaveAttribute('aria-expanded', 'true');
@@ -839,172 +979,6 @@ describe('<AlertDialog.Root />', () => {
       );
 
       expect(screen.getByRole('presentation', { hidden: true })).not.toBe(null);
-    });
-  });
-
-  describe.skipIf(isJSDOM)('prop: onOpenChangeComplete', () => {
-    it('is called on close when there is no exit animation defined', async () => {
-      const onOpenChangeComplete = vi.fn();
-
-      function Test() {
-        const [open, setOpen] = React.useState(true);
-        return (
-          <div>
-            <button onClick={() => setOpen(false)}>Close</button>
-            <AlertDialog.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
-              <AlertDialog.Portal>
-                <AlertDialog.Popup data-testid="popup" />
-              </AlertDialog.Portal>
-            </AlertDialog.Root>
-          </div>
-        );
-      }
-
-      const { user } = await render(<Test />);
-
-      const closeButton = screen.getByText('Close');
-      await user.click(closeButton);
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup')).toBe(null);
-      });
-
-      expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-      expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
-    });
-
-    it('is called on close when the exit animation finishes', async () => {
-      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-      const onOpenChangeComplete = vi.fn();
-
-      function Test() {
-        const style = `
-          @keyframes test-anim {
-            to {
-              opacity: 0;
-            }
-          }
-
-          .animation-test-indicator[data-ending-style] {
-            animation: test-anim 1ms;
-          }
-        `;
-
-        const [open, setOpen] = React.useState(true);
-
-        return (
-          <div>
-            {/* eslint-disable-next-line react/no-danger */}
-            <style dangerouslySetInnerHTML={{ __html: style }} />
-            <button onClick={() => setOpen(false)}>Close</button>
-            <AlertDialog.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
-              <AlertDialog.Portal>
-                <AlertDialog.Popup className="animation-test-indicator" data-testid="popup" />
-              </AlertDialog.Portal>
-            </AlertDialog.Root>
-          </div>
-        );
-      }
-
-      const { user } = await render(<Test />);
-
-      expect(screen.getByTestId('popup')).not.toBe(null);
-
-      // Wait for open animation to finish
-      await waitFor(() => {
-        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-      });
-
-      const closeButton = screen.getByText('Close');
-      await user.click(closeButton);
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup')).toBe(null);
-      });
-
-      expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
-    });
-
-    it('is called on open when there is no enter animation defined', async () => {
-      const onOpenChangeComplete = vi.fn();
-
-      function Test() {
-        const [open, setOpen] = React.useState(false);
-        return (
-          <div>
-            <button onClick={() => setOpen(true)}>Open</button>
-            <AlertDialog.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
-              <AlertDialog.Portal>
-                <AlertDialog.Popup data-testid="popup" />
-              </AlertDialog.Portal>
-            </AlertDialog.Root>
-          </div>
-        );
-      }
-
-      const { user } = await render(<Test />);
-
-      const openButton = screen.getByText('Open');
-      await user.click(openButton);
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup')).not.toBe(null);
-      });
-
-      expect(onOpenChangeComplete.mock.calls.length).toBe(2);
-      expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-    });
-
-    it('is called on open when the enter animation finishes', async () => {
-      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-      const onOpenChangeComplete = vi.fn();
-
-      function Test() {
-        const style = `
-          @keyframes test-anim {
-            from {
-              opacity: 0;
-            }
-          }
-
-          .animation-test-indicator[data-starting-style] {
-            animation: test-anim 1ms;
-          }
-        `;
-
-        const [open, setOpen] = React.useState(false);
-
-        return (
-          <div>
-            {/* eslint-disable-next-line react/no-danger */}
-            <style dangerouslySetInnerHTML={{ __html: style }} />
-            <button onClick={() => setOpen(true)}>Open</button>
-            <AlertDialog.Root
-              open={open}
-              onOpenChange={setOpen}
-              onOpenChangeComplete={onOpenChangeComplete}
-            >
-              <AlertDialog.Portal>
-                <AlertDialog.Popup className="animation-test-indicator" data-testid="popup" />
-              </AlertDialog.Portal>
-            </AlertDialog.Root>
-          </div>
-        );
-      }
-
-      const { user } = await render(<Test />);
-
-      const openButton = screen.getByText('Open');
-      await user.click(openButton);
-
-      // Wait for open animation to finish
-      await waitFor(() => {
-        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-      });
-
-      expect(screen.queryByTestId('popup')).not.toBe(null);
     });
   });
 });

--- a/packages/react/src/autocomplete/item/AutocompleteItem.test.tsx
+++ b/packages/react/src/autocomplete/item/AutocompleteItem.test.tsx
@@ -60,7 +60,7 @@ describe('<Autocomplete.Item />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       // Move highlight to an option then press Enter to select it
       await user.keyboard('{ArrowDown}');

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -54,9 +54,7 @@ describe('<Autocomplete.Root />', () => {
       await user.clear(input);
       await user.type(input, 'a');
 
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       await user.tab();
 
@@ -155,7 +153,7 @@ describe('<Autocomplete.Root />', () => {
     expect(input.value).toBe('');
   });
 
-  it('should pass autoComplete to the visible input', async () => {
+  it('passes autoComplete to the visible input', async () => {
     await render(
       <Autocomplete.Root name="search">
         <Autocomplete.Input autoComplete="on" />
@@ -468,7 +466,7 @@ describe('<Autocomplete.Root />', () => {
       await user.click(input);
       await user.type(input, 'ban');
 
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       expect(input).toHaveAttribute('aria-activedescendant');
 
       const highlightedBefore = input.getAttribute('aria-activedescendant');
@@ -476,7 +474,7 @@ describe('<Autocomplete.Root />', () => {
 
       await user.clear(input);
 
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       expect(input.getAttribute('aria-activedescendant')).toBe(highlightedBefore);
     });
 
@@ -1094,7 +1092,7 @@ describe('<Autocomplete.Root />', () => {
     });
   });
 
-  describe('Form', () => {
+  describe('Form integration', () => {
     const { render: renderFakeTimers, clock } = createRenderer({
       clockOptions: {
         shouldAdvanceTime: true,
@@ -1758,7 +1756,7 @@ describe('<Autocomplete.Root />', () => {
     });
   });
 
-  describe('Field', () => {
+  describe('Field integration', () => {
     const { render: renderFakeTimers, clock } = createRenderer({
       clockOptions: {
         shouldAdvanceTime: true,
@@ -1782,7 +1780,7 @@ describe('<Autocomplete.Root />', () => {
       expect(screen.getByTestId('input')).toHaveAttribute('required');
     });
 
-    it('[data-touched]', async () => {
+    it('adds data-touched after blur', async () => {
       await render(
         <Field.Root>
           <Autocomplete.Root>
@@ -1813,7 +1811,7 @@ describe('<Autocomplete.Root />', () => {
       expect(input).toHaveAttribute('data-touched', '');
     });
 
-    it('[data-dirty]', async () => {
+    it('adds data-dirty after the value changes', async () => {
       const { user } = await renderFakeTimers(
         <Field.Root>
           <Autocomplete.Root>
@@ -1842,8 +1840,8 @@ describe('<Autocomplete.Root />', () => {
       expect(input).toHaveAttribute('data-dirty', '');
     });
 
-    describe('[data-filled]', () => {
-      it('adds [data-filled] attribute when input has content', async () => {
+    describe('field state attribute: data-filled', () => {
+      it('adds data-filled when input has content', async () => {
         const { user } = await renderFakeTimers(
           <Field.Root>
             <Autocomplete.Root>
@@ -1872,7 +1870,7 @@ describe('<Autocomplete.Root />', () => {
         expect(input).toHaveAttribute('data-filled', '');
       });
 
-      it('adds [data-filled] attribute when already filled with defaultValue', async () => {
+      it('adds data-filled when already filled with defaultValue', async () => {
         await render(
           <Field.Root>
             <Autocomplete.Root defaultValue="initial value">
@@ -1896,7 +1894,7 @@ describe('<Autocomplete.Root />', () => {
       });
     });
 
-    it('[data-focused]', async () => {
+    it('adds data-focused while focused', async () => {
       await render(
         <Field.Root>
           <Autocomplete.Root>
@@ -1928,7 +1926,7 @@ describe('<Autocomplete.Root />', () => {
       expect(input).not.toHaveAttribute('data-focused');
     });
 
-    it('[data-invalid]', async () => {
+    it('adds data-invalid when the field is invalid', async () => {
       await render(
         <Field.Root invalid>
           <Autocomplete.Root>
@@ -1951,7 +1949,7 @@ describe('<Autocomplete.Root />', () => {
       expect(input).toHaveAttribute('data-invalid', '');
     });
 
-    it('[data-valid]', async () => {
+    it('adds data-valid after validation succeeds', async () => {
       const { user } = await render(
         <Field.Root validationMode="onBlur">
           <Autocomplete.Root required>
@@ -1981,143 +1979,147 @@ describe('<Autocomplete.Root />', () => {
       expect(input).not.toHaveAttribute('data-invalid');
     });
 
-    it('prop: validate', async () => {
-      await render(
-        <Field.Root validationMode="onBlur" validate={() => 'error'}>
-          <Autocomplete.Root>
-            <Autocomplete.Input data-testid="input" />
-            <Autocomplete.Portal>
-              <Autocomplete.Positioner />
-            </Autocomplete.Portal>
-          </Autocomplete.Root>
-        </Field.Root>,
-      );
+    describe('prop: validate', () => {
+      it('applies aria-invalid after blur', async () => {
+        await render(
+          <Field.Root validationMode="onBlur" validate={() => 'error'}>
+            <Autocomplete.Root>
+              <Autocomplete.Input data-testid="input" />
+              <Autocomplete.Portal>
+                <Autocomplete.Positioner />
+              </Autocomplete.Portal>
+            </Autocomplete.Root>
+          </Field.Root>,
+        );
 
-      const input = screen.getByTestId('input');
-      expect(input).not.toHaveAttribute('aria-invalid');
+        const input = screen.getByTestId('input');
+        expect(input).not.toHaveAttribute('aria-invalid');
 
-      fireEvent.focus(input);
-      fireEvent.blur(input);
-      await flushMicrotasks();
-      expect(input).toHaveAttribute('aria-invalid', 'true');
+        fireEvent.focus(input);
+        fireEvent.blur(input);
+        await flushMicrotasks();
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+      });
     });
 
-    it('prop: validationMode=onSubmit', async () => {
-      const { user } = await render(
-        <Form>
+    describe('prop: validationMode', () => {
+      it('validates when validationMode is onSubmit', async () => {
+        const { user } = await render(
+          <Form>
+            <Field.Root
+              validate={(value) => {
+                return value === 'one' ? 'error' : null;
+              }}
+            >
+              <Autocomplete.Root required>
+                <Autocomplete.Input data-testid="input" />
+                <Autocomplete.Portal>
+                  <Autocomplete.Positioner>
+                    <Autocomplete.Popup>
+                      <Autocomplete.List>
+                        <Autocomplete.Item value="one">Option 1</Autocomplete.Item>
+                        <Autocomplete.Item value="two">Option 2</Autocomplete.Item>
+                      </Autocomplete.List>
+                    </Autocomplete.Popup>
+                  </Autocomplete.Positioner>
+                </Autocomplete.Portal>
+              </Autocomplete.Root>
+            </Field.Root>
+            <button type="submit">submit</button>
+          </Form>,
+        );
+
+        const input = screen.getByTestId('input');
+        expect(input).not.toHaveAttribute('aria-invalid');
+
+        await user.click(screen.getByText('submit'));
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+
+        await user.type(input, 'two');
+        expect(input).not.toHaveAttribute('aria-invalid');
+
+        await user.clear(input);
+        await user.type(input, 'one');
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+
+        await user.clear(input);
+        await user.type(input, 'three');
+        expect(input).not.toHaveAttribute('aria-invalid');
+      });
+
+      // flaky in real browser
+      it.skipIf(!isJSDOM)('validates when validationMode is onChange', async () => {
+        const { user } = await render(
           <Field.Root
+            validationMode="onChange"
             validate={(value) => {
-              return value === 'one' ? 'error' : null;
+              return value === 'invalid' ? 'error' : null;
             }}
           >
-            <Autocomplete.Root required>
+            <Autocomplete.Root>
               <Autocomplete.Input data-testid="input" />
               <Autocomplete.Portal>
                 <Autocomplete.Positioner>
                   <Autocomplete.Popup>
                     <Autocomplete.List>
-                      <Autocomplete.Item value="one">Option 1</Autocomplete.Item>
-                      <Autocomplete.Item value="two">Option 2</Autocomplete.Item>
+                      <Autocomplete.Item value="valid">Valid Option</Autocomplete.Item>
                     </Autocomplete.List>
                   </Autocomplete.Popup>
                 </Autocomplete.Positioner>
               </Autocomplete.Portal>
             </Autocomplete.Root>
-          </Field.Root>
-          <button type="submit">submit</button>
-        </Form>,
-      );
+          </Field.Root>,
+        );
 
-      const input = screen.getByTestId('input');
-      expect(input).not.toHaveAttribute('aria-invalid');
+        const input = screen.getByTestId('input');
 
-      await user.click(screen.getByText('submit'));
-      expect(input).toHaveAttribute('aria-invalid', 'true');
+        expect(input).not.toHaveAttribute('aria-invalid');
 
-      await user.type(input, 'two');
-      expect(input).not.toHaveAttribute('aria-invalid');
+        await user.type(input, 'invalid');
 
-      await user.clear(input);
-      await user.type(input, 'one');
-      expect(input).toHaveAttribute('aria-invalid', 'true');
-
-      await user.clear(input);
-      await user.type(input, 'three');
-      expect(input).not.toHaveAttribute('aria-invalid');
-    });
-
-    // flaky in real browser
-    it.skipIf(!isJSDOM)('prop: validationMode=onChange', async () => {
-      const { user } = await render(
-        <Field.Root
-          validationMode="onChange"
-          validate={(value) => {
-            return value === 'invalid' ? 'error' : null;
-          }}
-        >
-          <Autocomplete.Root>
-            <Autocomplete.Input data-testid="input" />
-            <Autocomplete.Portal>
-              <Autocomplete.Positioner>
-                <Autocomplete.Popup>
-                  <Autocomplete.List>
-                    <Autocomplete.Item value="valid">Valid Option</Autocomplete.Item>
-                  </Autocomplete.List>
-                </Autocomplete.Popup>
-              </Autocomplete.Positioner>
-            </Autocomplete.Portal>
-          </Autocomplete.Root>
-        </Field.Root>,
-      );
-
-      const input = screen.getByTestId('input');
-
-      expect(input).not.toHaveAttribute('aria-invalid');
-
-      await user.type(input, 'invalid');
-
-      expect(input).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    // flaky in real browser
-    it.skipIf(!isJSDOM)('prop: validationMode=onBlur', async () => {
-      const { user } = await render(
-        <Field.Root
-          validationMode="onBlur"
-          validate={(value) => {
-            return value === 'invalid' ? 'error' : null;
-          }}
-        >
-          <Autocomplete.Root>
-            <Autocomplete.Input data-testid="input" />
-            <Autocomplete.Portal>
-              <Autocomplete.Positioner>
-                <Autocomplete.Popup>
-                  <Autocomplete.List>
-                    <Autocomplete.Item value="valid">Valid Option</Autocomplete.Item>
-                  </Autocomplete.List>
-                </Autocomplete.Popup>
-              </Autocomplete.Positioner>
-            </Autocomplete.Portal>
-          </Autocomplete.Root>
-          <Field.Error data-testid="error" />
-        </Field.Root>,
-      );
-
-      const input = screen.getByTestId('input');
-
-      expect(input).not.toHaveAttribute('aria-invalid');
-
-      await user.type(input, 'invalid');
-
-      fireEvent.blur(input);
-
-      await waitFor(() => {
         expect(input).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      // flaky in real browser
+      it.skipIf(!isJSDOM)('validates when validationMode is onBlur', async () => {
+        const { user } = await render(
+          <Field.Root
+            validationMode="onBlur"
+            validate={(value) => {
+              return value === 'invalid' ? 'error' : null;
+            }}
+          >
+            <Autocomplete.Root>
+              <Autocomplete.Input data-testid="input" />
+              <Autocomplete.Portal>
+                <Autocomplete.Positioner>
+                  <Autocomplete.Popup>
+                    <Autocomplete.List>
+                      <Autocomplete.Item value="valid">Valid Option</Autocomplete.Item>
+                    </Autocomplete.List>
+                  </Autocomplete.Popup>
+                </Autocomplete.Positioner>
+              </Autocomplete.Portal>
+            </Autocomplete.Root>
+            <Field.Error data-testid="error" />
+          </Field.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+
+        expect(input).not.toHaveAttribute('aria-invalid');
+
+        await user.type(input, 'invalid');
+
+        fireEvent.blur(input);
+
+        await waitFor(() => {
+          expect(input).toHaveAttribute('aria-invalid', 'true');
+        });
       });
     });
 
-    it('Field.Label', async () => {
+    it('links Field.Label to the input', async () => {
       await render(
         <Field.Root>
           <Autocomplete.Root>
@@ -2136,7 +2138,7 @@ describe('<Autocomplete.Root />', () => {
       );
     });
 
-    it('Field.Description', async () => {
+    it('links Field.Description to the input', async () => {
       await render(
         <Field.Root>
           <Autocomplete.Root>

--- a/packages/react/src/avatar/fallback/AvatarFallback.test.tsx
+++ b/packages/react/src/avatar/fallback/AvatarFallback.test.tsx
@@ -46,9 +46,7 @@ describe('<Avatar.Fallback />', () => {
       </Avatar.Root>,
     );
 
-    await waitFor(() => {
-      expect(screen.queryByText('AC')).not.toBe(null);
-    });
+    await screen.findByText('AC');
   });
 
   describe.skipIf(!isJSDOM)('prop: delay', () => {

--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -228,25 +228,68 @@ describe('<CheckboxGroup />', () => {
     });
   });
 
-  describe('Field', () => {
-    it('prop: validationMode=onSubmit', async () => {
-      const validateSpy = vi.fn((value) => {
-        const v = value as string[];
-        if (v.length === 0) {
-          return 'custom error 1';
-        }
-        if (v.length < 2) {
-          return 'custom error 2';
-        }
-        if (v.includes('two')) {
-          return 'custom error 3';
-        }
-        return null;
+  describe('Field integration', () => {
+    describe('prop: validationMode', () => {
+      it('validates when validationMode is onSubmit', async () => {
+        const validateSpy = vi.fn((value) => {
+          const v = value as string[];
+          if (v.length === 0) {
+            return 'custom error 1';
+          }
+          if (v.length < 2) {
+            return 'custom error 2';
+          }
+          if (v.includes('two')) {
+            return 'custom error 3';
+          }
+          return null;
+        });
+        const { user } = render(
+          <Form>
+            <Field.Root validate={validateSpy} name="test">
+              <CheckboxGroup defaultValue={[]}>
+                <Field.Item>
+                  <Checkbox.Root value="one" data-testid="checkbox" />
+                </Field.Item>
+                <Field.Item>
+                  <Checkbox.Root value="two" data-testid="checkbox" />
+                </Field.Item>
+                <Field.Item>
+                  <Checkbox.Root value="three" data-testid="checkbox" />
+                </Field.Item>
+              </CheckboxGroup>
+            </Field.Root>
+            <button type="submit">submit</button>
+          </Form>,
+        );
+
+        const checkboxes = screen.getAllByTestId('checkbox');
+        const [checkbox1, checkbox2, checkbox3] = checkboxes;
+        checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
+
+        await user.click(checkbox2);
+        checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
+
+        await user.click(screen.getByText('submit'));
+        checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid'));
+
+        await user.click(checkbox1);
+        expect(validateSpy.mock.lastCall?.[0]).toEqual(['two', 'one']);
+        checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid'));
+        await user.click(checkbox2);
+        await user.click(checkbox3);
+        expect(validateSpy.mock.lastCall?.[0]).toEqual(['one', 'three']);
+        checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
       });
-      const { user } = render(
-        <Form>
-          <Field.Root validate={validateSpy} name="test">
-            <CheckboxGroup defaultValue={[]}>
+
+      it('validates when validationMode is onChange', async () => {
+        const validateSpy = vi.fn((value) => {
+          const v = value as string[];
+          return v.includes('one') ? 'error' : null;
+        });
+        render(
+          <Field.Root validationMode="onChange" validate={validateSpy} name="apple">
+            <CheckboxGroup defaultValue={['one']}>
               <Field.Item>
                 <Checkbox.Root value="one" data-testid="checkbox" />
               </Field.Item>
@@ -257,172 +300,131 @@ describe('<CheckboxGroup />', () => {
                 <Checkbox.Root value="three" data-testid="checkbox" />
               </Field.Item>
             </CheckboxGroup>
-          </Field.Root>
-          <button type="submit">submit</button>
-        </Form>,
-      );
-
-      const checkboxes = screen.getAllByTestId('checkbox');
-      const [checkbox1, checkbox2, checkbox3] = checkboxes;
-      checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
-
-      await user.click(checkbox2);
-      checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
-
-      await user.click(screen.getByText('submit'));
-      checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid'));
-
-      await user.click(checkbox1);
-      expect(validateSpy.mock.lastCall?.[0]).toEqual(['two', 'one']);
-      checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid'));
-      await user.click(checkbox2);
-      await user.click(checkbox3);
-      expect(validateSpy.mock.lastCall?.[0]).toEqual(['one', 'three']);
-      checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
-    });
-
-    it('prop: validationMode=onChange', async () => {
-      const validateSpy = vi.fn((value) => {
-        const v = value as string[];
-        return v.includes('one') ? 'error' : null;
-      });
-      render(
-        <Field.Root validationMode="onChange" validate={validateSpy} name="apple">
-          <CheckboxGroup defaultValue={['one']}>
-            <Field.Item>
-              <Checkbox.Root value="one" data-testid="checkbox" />
-            </Field.Item>
-            <Field.Item>
-              <Checkbox.Root value="two" data-testid="checkbox" />
-            </Field.Item>
-            <Field.Item>
-              <Checkbox.Root value="three" data-testid="checkbox" />
-            </Field.Item>
-          </CheckboxGroup>
-        </Field.Root>,
-      );
-
-      const checkboxes = screen.getAllByTestId('checkbox');
-      const [checkbox1, checkbox2, checkbox3] = checkboxes;
-
-      checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
-
-      fireEvent.click(checkbox1);
-      checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
-      expect(validateSpy.mock.calls.length).toBe(1);
-      expect(validateSpy.mock.lastCall?.[0]).toEqual([]);
-
-      fireEvent.click(checkbox2);
-      checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
-      expect(validateSpy.mock.calls.length).toBe(2);
-      expect(validateSpy.mock.lastCall?.[0]).toEqual(['two']);
-
-      fireEvent.click(checkbox1);
-      checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid', 'true'));
-      expect(validateSpy.mock.calls.length).toBe(3);
-      expect(validateSpy.mock.lastCall?.[0]).toEqual(['two', 'one']);
-
-      fireEvent.click(checkbox3);
-      checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid', 'true'));
-    });
-
-    it('revalidates when the controlled value changes externally', async () => {
-      const validateSpy = vi.fn((value: unknown) => {
-        const values = value as string[];
-        return values.includes('one') ? 'error' : null;
-      });
-
-      function App() {
-        const [selected, setSelected] = React.useState<string[]>([]);
-
-        return (
-          <React.Fragment>
-            <Field.Root validationMode="onChange" validate={validateSpy} name="apple">
-              <CheckboxGroup value={selected}>
-                <Field.Item>
-                  <Checkbox.Root value="one" data-testid="checkbox" />
-                </Field.Item>
-                <Field.Item>
-                  <Checkbox.Root value="two" data-testid="checkbox" />
-                </Field.Item>
-              </CheckboxGroup>
-            </Field.Root>
-            <button type="button" onClick={() => setSelected(['one'])}>
-              Select externally
-            </button>
-          </React.Fragment>
+          </Field.Root>,
         );
-      }
 
-      render(<App />);
+        const checkboxes = screen.getAllByTestId('checkbox');
+        const [checkbox1, checkbox2, checkbox3] = checkboxes;
 
-      const checkboxes = screen.getAllByTestId('checkbox');
-      const toggle = screen.getByText('Select externally');
+        checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
 
-      checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
-      const initialCallCount = validateSpy.mock.calls.length;
+        fireEvent.click(checkbox1);
+        checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
+        expect(validateSpy.mock.calls.length).toBe(1);
+        expect(validateSpy.mock.lastCall?.[0]).toEqual([]);
 
-      fireEvent.click(toggle);
+        fireEvent.click(checkbox2);
+        checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
+        expect(validateSpy.mock.calls.length).toBe(2);
+        expect(validateSpy.mock.lastCall?.[0]).toEqual(['two']);
 
-      expect(validateSpy.mock.calls.length).toBe(initialCallCount + 1);
-      expect(validateSpy.mock.lastCall?.[0]).toEqual(['one']);
-      checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid', 'true'));
-    });
+        fireEvent.click(checkbox1);
+        checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid', 'true'));
+        expect(validateSpy.mock.calls.length).toBe(3);
+        expect(validateSpy.mock.lastCall?.[0]).toEqual(['two', 'one']);
 
-    it('prop: validationMode=onBlur', async () => {
-      const validateSpy = vi.fn((value) => {
-        const v = value as string[];
-        return v.includes('one') ? 'error' : null;
+        fireEvent.click(checkbox3);
+        checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid', 'true'));
       });
-      render(
-        <Field.Root validationMode="onBlur" validate={validateSpy} name="apple">
-          <CheckboxGroup defaultValue={['one']}>
-            <Field.Item>
-              <Checkbox.Root value="one" data-testid="checkbox" />
-            </Field.Item>
-            <Field.Item>
-              <Checkbox.Root value="two" data-testid="checkbox" />
-            </Field.Item>
-            <Field.Item>
-              <Checkbox.Root value="three" data-testid="checkbox" />
-            </Field.Item>
-          </CheckboxGroup>
-          <Field.Error data-testid="error" />
-        </Field.Root>,
-      );
 
-      const checkboxes = screen.getAllByTestId('checkbox');
-      const [checkbox1, , checkbox3] = checkboxes;
+      it('revalidates when the controlled value changes externally', async () => {
+        const validateSpy = vi.fn((value: unknown) => {
+          const values = value as string[];
+          return values.includes('one') ? 'error' : null;
+        });
 
-      checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
+        function App() {
+          const [selected, setSelected] = React.useState<string[]>([]);
 
-      fireEvent.click(checkbox1);
-      expect(validateSpy.mock.calls.length).toBe(0);
-      fireEvent.blur(checkbox1);
-      expect(validateSpy.mock.calls.length).toBe(1);
-      expect(validateSpy.mock.lastCall?.[0]).toEqual([]);
+          return (
+            <React.Fragment>
+              <Field.Root validationMode="onChange" validate={validateSpy} name="apple">
+                <CheckboxGroup value={selected}>
+                  <Field.Item>
+                    <Checkbox.Root value="one" data-testid="checkbox" />
+                  </Field.Item>
+                  <Field.Item>
+                    <Checkbox.Root value="two" data-testid="checkbox" />
+                  </Field.Item>
+                </CheckboxGroup>
+              </Field.Root>
+              <button type="button" onClick={() => setSelected(['one'])}>
+                Select externally
+              </button>
+            </React.Fragment>
+          );
+        }
 
-      checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
+        render(<App />);
 
-      fireEvent.click(checkbox3);
-      expect(validateSpy.mock.calls.length).toBe(1);
-      fireEvent.blur(checkbox3);
-      expect(validateSpy.mock.calls.length).toBe(2);
-      expect(validateSpy.mock.lastCall?.[0]).toEqual(['three']);
+        const checkboxes = screen.getAllByTestId('checkbox');
+        const toggle = screen.getByText('Select externally');
 
-      checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
+        checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
+        const initialCallCount = validateSpy.mock.calls.length;
 
-      fireEvent.click(checkbox1);
-      expect(validateSpy.mock.calls.length).toBe(2);
-      fireEvent.blur(checkbox1);
-      expect(validateSpy.mock.calls.length).toBe(3);
-      expect(validateSpy.mock.lastCall?.[0]).toEqual(['three', 'one']);
+        fireEvent.click(toggle);
 
-      checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid', 'true'));
+        expect(validateSpy.mock.calls.length).toBe(initialCallCount + 1);
+        expect(validateSpy.mock.lastCall?.[0]).toEqual(['one']);
+        checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid', 'true'));
+      });
+
+      it('validates when validationMode is onBlur', async () => {
+        const validateSpy = vi.fn((value) => {
+          const v = value as string[];
+          return v.includes('one') ? 'error' : null;
+        });
+        render(
+          <Field.Root validationMode="onBlur" validate={validateSpy} name="apple">
+            <CheckboxGroup defaultValue={['one']}>
+              <Field.Item>
+                <Checkbox.Root value="one" data-testid="checkbox" />
+              </Field.Item>
+              <Field.Item>
+                <Checkbox.Root value="two" data-testid="checkbox" />
+              </Field.Item>
+              <Field.Item>
+                <Checkbox.Root value="three" data-testid="checkbox" />
+              </Field.Item>
+            </CheckboxGroup>
+            <Field.Error data-testid="error" />
+          </Field.Root>,
+        );
+
+        const checkboxes = screen.getAllByTestId('checkbox');
+        const [checkbox1, , checkbox3] = checkboxes;
+
+        checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
+
+        fireEvent.click(checkbox1);
+        expect(validateSpy.mock.calls.length).toBe(0);
+        fireEvent.blur(checkbox1);
+        expect(validateSpy.mock.calls.length).toBe(1);
+        expect(validateSpy.mock.lastCall?.[0]).toEqual([]);
+
+        checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
+
+        fireEvent.click(checkbox3);
+        expect(validateSpy.mock.calls.length).toBe(1);
+        fireEvent.blur(checkbox3);
+        expect(validateSpy.mock.calls.length).toBe(2);
+        expect(validateSpy.mock.lastCall?.[0]).toEqual(['three']);
+
+        checkboxes.forEach((checkbox) => expect(checkbox).not.toHaveAttribute('aria-invalid'));
+
+        fireEvent.click(checkbox1);
+        expect(validateSpy.mock.calls.length).toBe(2);
+        fireEvent.blur(checkbox1);
+        expect(validateSpy.mock.calls.length).toBe(3);
+        expect(validateSpy.mock.lastCall?.[0]).toEqual(['three', 'one']);
+
+        checkboxes.forEach((checkbox) => expect(checkbox).toHaveAttribute('aria-invalid', 'true'));
+      });
     });
   });
 
-  describe('Field.Label', () => {
+  describe('Field.Label integration', () => {
     it('implicit association', async () => {
       const changeSpy = vi.fn();
       render(
@@ -452,7 +454,7 @@ describe('<CheckboxGroup />', () => {
 
       const checkboxes = screen.getAllByRole('checkbox');
       const labels = screen.getAllByTestId('label');
-      const inputs = document.querySelectorAll('input[type="checkbox"]');
+      const inputs = document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
 
       checkboxes.forEach((checkbox, index) => {
         const label = labels[index];
@@ -495,7 +497,7 @@ describe('<CheckboxGroup />', () => {
       const checkboxes = screen.getAllByRole('checkbox');
       const labels = screen.getAllByTestId('label');
       const descriptions = screen.getAllByTestId('description');
-      const inputs = document.querySelectorAll('input[type="checkbox"]');
+      const inputs = document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
 
       checkboxes.forEach((checkbox, index) => {
         const label = labels[index];
@@ -515,7 +517,7 @@ describe('<CheckboxGroup />', () => {
     });
   });
 
-  describe('Field.Description', () => {
+  describe('Field.Description integration', () => {
     it('links the group and individual checkboxes', async () => {
       await render(
         <Field.Root name="apple">

--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.test.tsx
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.test.tsx
@@ -128,7 +128,7 @@ describe('useCheckboxGroupParent', () => {
     expect(checkboxC).toHaveAttribute('aria-checked', 'false');
   });
 
-  it('should correctly initialize the values array', () => {
+  it('initializes the values array', () => {
     function App() {
       const [value, setValue] = React.useState<string[]>(['a']);
       return (
@@ -181,7 +181,7 @@ describe('useCheckboxGroupParent', () => {
     expect(screen.getByTestId('parent')).toHaveAttribute('aria-checked', 'true');
   });
 
-  it('should apply space-separated aria-controls attribute with child names', () => {
+  it('applies space-separated aria-controls attribute with child names', () => {
     function App() {
       const [value, setValue] = React.useState<string[]>([]);
       return (

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -121,10 +121,12 @@ describe('<Checkbox.Root />', () => {
     it('should update its state if the underlying input is toggled', async () => {
       await render(<Checkbox.Root />);
       const checkbox = screen.getByRole('checkbox');
-      const internalInput = document.querySelector<HTMLInputElement>('input[type="checkbox"]');
+      const [, internalInput] = screen.getAllByRole<HTMLInputElement>('checkbox', {
+        hidden: true,
+      });
 
       await act(async () => {
-        internalInput?.click();
+        internalInput.click();
       });
 
       expect(checkbox).toHaveAttribute('aria-checked', 'true');
@@ -184,7 +186,7 @@ describe('<Checkbox.Root />', () => {
       expect(screen.getAllByRole('checkbox')[0]).toHaveAttribute('aria-readonly', 'true');
     });
 
-    it('should not have the aria attribute when `readOnly` is not set', async () => {
+    it('does not set aria-readonly when readOnly is not set', async () => {
       await render(<Checkbox.Root />);
       expect(screen.getAllByRole('checkbox')[0]).not.toHaveAttribute('aria-readonly');
     });
@@ -241,7 +243,7 @@ describe('<Checkbox.Root />', () => {
       expect(checkbox).toHaveAttribute('aria-checked', 'mixed');
     });
 
-    it('should not have the aria attribute when `indeterminate` is not set', async () => {
+    it('does not set aria-checked to mixed when indeterminate is not set', async () => {
       await render(<Checkbox.Root />);
       expect(screen.getAllByRole('checkbox')[0]).not.toHaveAttribute('aria-checked', 'mixed');
     });
@@ -266,7 +268,7 @@ describe('<Checkbox.Root />', () => {
     expect(checkbox).toHaveAttribute('aria-checked', 'true');
   });
 
-  it('should place the style hooks on the root and the indicator', async () => {
+  it('adds state attributes to the root and indicator', async () => {
     const { setProps } = await render(
       <Checkbox.Root defaultChecked disabled readOnly required>
         <Checkbox.Indicator />
@@ -367,7 +369,7 @@ describe('<Checkbox.Root />', () => {
     });
   });
 
-  describe('Form', () => {
+  describe('Form integration', () => {
     it('triggers native HTML validation on submit', async () => {
       const { user } = await render(
         <Form>
@@ -950,8 +952,8 @@ describe('<Checkbox.Root />', () => {
     );
   });
 
-  describe('Field', () => {
-    it('should receive disabled prop from Field.Root', async () => {
+  describe('Field integration', () => {
+    it('receives the disabled prop from Field.Root', async () => {
       await render(
         <Field.Root disabled>
           <Checkbox.Root />
@@ -962,7 +964,7 @@ describe('<Checkbox.Root />', () => {
       expect(checkbox).toHaveAttribute('aria-disabled', 'true');
     });
 
-    it('should receive name prop from Field.Root', async () => {
+    it('receives the name prop from Field.Root', async () => {
       await render(
         <Field.Root name="field-checkbox">
           <Checkbox.Root />
@@ -975,7 +977,7 @@ describe('<Checkbox.Root />', () => {
       expect(input).toHaveAttribute('name', 'field-checkbox');
     });
 
-    it('[data-touched]', async () => {
+    it('adds data-touched after blur', async () => {
       await render(
         <Field.Root>
           <Checkbox.Root data-testid="button" />
@@ -990,7 +992,7 @@ describe('<Checkbox.Root />', () => {
       expect(button).toHaveAttribute('data-touched', '');
     });
 
-    it('[data-dirty]', async () => {
+    it('adds data-dirty after the value changes', async () => {
       await render(
         <Field.Root>
           <Checkbox.Root data-testid="button" />
@@ -1006,8 +1008,8 @@ describe('<Checkbox.Root />', () => {
       expect(button).toHaveAttribute('data-dirty', '');
     });
 
-    describe('[data-filled]', () => {
-      it('adds [data-filled] attribute when checked after being initially unchecked', async () => {
+    describe('field state attribute: data-filled', () => {
+      it('adds data-filled when checked after being initially unchecked', async () => {
         await render(
           <Field.Root>
             <Checkbox.Root data-testid="button" />
@@ -1027,7 +1029,7 @@ describe('<Checkbox.Root />', () => {
         expect(button).not.toHaveAttribute('data-filled');
       });
 
-      it('removes [data-filled] attribute when unchecked after being initially checked', async () => {
+      it('removes data-filled when unchecked after being initially checked', async () => {
         await render(
           <Field.Root>
             <Checkbox.Root data-testid="button" defaultChecked />
@@ -1043,7 +1045,7 @@ describe('<Checkbox.Root />', () => {
         expect(button).not.toHaveAttribute('data-filled', '');
       });
 
-      it('adds [data-filled] attribute when any checkbox is filled when inside a group', async () => {
+      it('adds data-filled when any checkbox is filled when inside a group', async () => {
         await render(
           <Field.Root>
             <CheckboxGroup defaultValue={['1', '2']}>
@@ -1071,7 +1073,7 @@ describe('<Checkbox.Root />', () => {
       });
     });
 
-    it('[data-focused]', async () => {
+    it('adds data-focused while focused', async () => {
       await render(
         <Field.Root>
           <Checkbox.Root data-testid="button" />
@@ -1091,7 +1093,7 @@ describe('<Checkbox.Root />', () => {
       expect(button).not.toHaveAttribute('data-focused');
     });
 
-    it('[data-invalid]', async () => {
+    it('adds data-invalid when the field is invalid', async () => {
       await render(
         <Field.Root invalid>
           <Checkbox.Root data-testid="button" />
@@ -1103,7 +1105,7 @@ describe('<Checkbox.Root />', () => {
       expect(button).toHaveAttribute('data-invalid', '');
     });
 
-    it('[data-valid]', async () => {
+    it('adds data-valid after validation succeeds', async () => {
       await render(
         <Field.Root validationMode="onBlur">
           <Checkbox.Root data-testid="button" required />
@@ -1124,122 +1126,128 @@ describe('<Checkbox.Root />', () => {
       expect(button).not.toHaveAttribute('data-invalid');
     });
 
-    it('prop: validationMode=onSubmit', async () => {
-      await render(
-        <Form>
-          <Field.Root>
-            <Checkbox.Root required />
-            <Field.Error data-testid="error" />
-          </Field.Root>
-          <button type="submit">submit</button>
-        </Form>,
-      );
-
-      const checkbox = screen.getByRole('checkbox');
-      expect(checkbox).not.toHaveAttribute('aria-invalid');
-
-      fireEvent.click(checkbox);
-      expect(checkbox).toHaveAttribute('data-checked', '');
-      fireEvent.click(checkbox);
-      expect(checkbox).toHaveAttribute('data-unchecked', '');
-      expect(checkbox).not.toHaveAttribute('aria-invalid');
-
-      fireEvent.click(screen.getByText('submit'));
-      expect(checkbox).toHaveAttribute('aria-invalid', 'true');
-
-      fireEvent.click(checkbox);
-      expect(checkbox).toHaveAttribute('data-checked', '');
-      expect(checkbox).not.toHaveAttribute('aria-invalid');
-
-      fireEvent.click(checkbox);
-      expect(checkbox).toHaveAttribute('data-unchecked', '');
-      expect(checkbox).toHaveAttribute('aria-invalid');
-
-      fireEvent.click(checkbox);
-      expect(checkbox).toHaveAttribute('data-checked', '');
-      expect(checkbox).not.toHaveAttribute('aria-invalid');
-    });
-
-    it('props: validationMode=onChange', async () => {
-      await render(
-        <Field.Root
-          validationMode="onChange"
-          validate={(value) => {
-            const checked = value as boolean;
-            return checked ? 'error' : null;
-          }}
-        >
-          <Checkbox.Root data-testid="button" />
-        </Field.Root>,
-      );
-
-      const button = screen.getByTestId('button');
-
-      expect(button).not.toHaveAttribute('aria-invalid');
-
-      fireEvent.click(button);
-
-      expect(button).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    it('revalidates when a controlled value changes externally', async () => {
-      const validateSpy = vi.fn((value: unknown) => ((value as boolean) ? 'error' : null));
-
-      function App() {
-        const [checked, setChecked] = React.useState(false);
-
-        return (
-          <React.Fragment>
-            <Field.Root validationMode="onChange" validate={validateSpy} name="terms">
-              <Checkbox.Root data-testid="button" checked={checked} onCheckedChange={setChecked} />
+    describe('prop: validationMode', () => {
+      it('validates when validationMode is onSubmit', async () => {
+        await render(
+          <Form>
+            <Field.Root>
+              <Checkbox.Root required />
+              <Field.Error data-testid="error" />
             </Field.Root>
-            <button type="button" onClick={() => setChecked((prev) => !prev)}>
-              Toggle externally
-            </button>
-          </React.Fragment>
+            <button type="submit">submit</button>
+          </Form>,
         );
-      }
 
-      await render(<App />);
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).not.toHaveAttribute('aria-invalid');
 
-      const button = screen.getByTestId('button');
-      const toggle = screen.getByText('Toggle externally');
+        fireEvent.click(checkbox);
+        expect(checkbox).toHaveAttribute('data-checked', '');
+        fireEvent.click(checkbox);
+        expect(checkbox).toHaveAttribute('data-unchecked', '');
+        expect(checkbox).not.toHaveAttribute('aria-invalid');
 
-      expect(button).not.toHaveAttribute('aria-invalid');
-      const initialCallCount = validateSpy.mock.calls.length;
+        fireEvent.click(screen.getByText('submit'));
+        expect(checkbox).toHaveAttribute('aria-invalid', 'true');
 
-      fireEvent.click(toggle);
+        fireEvent.click(checkbox);
+        expect(checkbox).toHaveAttribute('data-checked', '');
+        expect(checkbox).not.toHaveAttribute('aria-invalid');
 
-      expect(validateSpy.mock.calls.length).toBe(initialCallCount + 1);
-      expect(validateSpy.mock.lastCall?.[0]).toBe(true);
-      expect(button).toHaveAttribute('aria-invalid', 'true');
+        fireEvent.click(checkbox);
+        expect(checkbox).toHaveAttribute('data-unchecked', '');
+        expect(checkbox).toHaveAttribute('aria-invalid');
+
+        fireEvent.click(checkbox);
+        expect(checkbox).toHaveAttribute('data-checked', '');
+        expect(checkbox).not.toHaveAttribute('aria-invalid');
+      });
+
+      it('validates when validationMode is onChange', async () => {
+        await render(
+          <Field.Root
+            validationMode="onChange"
+            validate={(value) => {
+              const checked = value as boolean;
+              return checked ? 'error' : null;
+            }}
+          >
+            <Checkbox.Root data-testid="button" />
+          </Field.Root>,
+        );
+
+        const button = screen.getByTestId('button');
+
+        expect(button).not.toHaveAttribute('aria-invalid');
+
+        fireEvent.click(button);
+
+        expect(button).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      it('revalidates when a controlled value changes externally', async () => {
+        const validateSpy = vi.fn((value: unknown) => ((value as boolean) ? 'error' : null));
+
+        function App() {
+          const [checked, setChecked] = React.useState(false);
+
+          return (
+            <React.Fragment>
+              <Field.Root validationMode="onChange" validate={validateSpy} name="terms">
+                <Checkbox.Root
+                  data-testid="button"
+                  checked={checked}
+                  onCheckedChange={setChecked}
+                />
+              </Field.Root>
+              <button type="button" onClick={() => setChecked((prev) => !prev)}>
+                Toggle externally
+              </button>
+            </React.Fragment>
+          );
+        }
+
+        await render(<App />);
+
+        const button = screen.getByTestId('button');
+        const toggle = screen.getByText('Toggle externally');
+
+        expect(button).not.toHaveAttribute('aria-invalid');
+        const initialCallCount = validateSpy.mock.calls.length;
+
+        fireEvent.click(toggle);
+
+        expect(validateSpy.mock.calls.length).toBe(initialCallCount + 1);
+        expect(validateSpy.mock.lastCall?.[0]).toBe(true);
+        expect(button).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      it('validates when validationMode is onBlur', async () => {
+        await render(
+          <Field.Root
+            validationMode="onBlur"
+            validate={(value) => {
+              const checked = value as boolean;
+              return checked ? 'error' : null;
+            }}
+          >
+            <Checkbox.Root data-testid="button" />
+            <Field.Error data-testid="error" />
+          </Field.Root>,
+        );
+
+        const button = screen.getByTestId('button');
+
+        expect(button).not.toHaveAttribute('aria-invalid');
+
+        fireEvent.click(button);
+        fireEvent.blur(button);
+
+        expect(button).toHaveAttribute('aria-invalid', 'true');
+      });
     });
 
-    it('prop: validationMode=onBlur', async () => {
-      await render(
-        <Field.Root
-          validationMode="onBlur"
-          validate={(value) => {
-            const checked = value as boolean;
-            return checked ? 'error' : null;
-          }}
-        >
-          <Checkbox.Root data-testid="button" />
-          <Field.Error data-testid="error" />
-        </Field.Root>,
-      );
-
-      const button = screen.getByTestId('button');
-
-      expect(button).not.toHaveAttribute('aria-invalid');
-
-      fireEvent.click(button);
-      fireEvent.blur(button);
-
-      expect(button).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    describe('Field.Label', () => {
+    describe('Field.Label integration', () => {
       describe('explicit association', () => {
         it('when label and checkbox are siblings', async () => {
           await render(
@@ -1252,7 +1260,7 @@ describe('<Checkbox.Root />', () => {
           const label = screen.getByText('Label');
           expect(label.getAttribute('id')).not.toBe(null);
 
-          const input = document.querySelector('input[type="checkbox"]');
+          const [, input] = screen.getAllByRole<HTMLInputElement>('checkbox', { hidden: true });
           expect(label.getAttribute('for')).toBe(input?.getAttribute('id'));
 
           const checkbox = screen.getByRole('checkbox');
@@ -1276,7 +1284,7 @@ describe('<Checkbox.Root />', () => {
           );
 
           const label = screen.getByTestId('label');
-          const input = document.querySelector('input[type="checkbox"]');
+          const [, input] = screen.getAllByRole<HTMLInputElement>('checkbox', { hidden: true });
           expect(label.getAttribute('for')).not.toBe(null);
           expect(label.getAttribute('for')).toBe(input?.getAttribute('id'));
 

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -138,6 +138,29 @@ describe('<Collapsible.Panel />', () => {
     );
   });
 
+  // we test firefox in browserstack which does not support this yet
+  describe.skipIf(!('onbeforematch' in window) || isJSDOM)('prop: hiddenUntilFound', () => {
+    it('uses `hidden="until-found" to hide panel when true', async () => {
+      const handleOpenChange = vi.fn();
+
+      await render(
+        <Collapsible.Root defaultOpen={false} onOpenChange={handleOpenChange}>
+          <Collapsible.Trigger />
+          <Collapsible.Panel hiddenUntilFound keepMounted>
+            {PANEL_CONTENT}
+          </Collapsible.Panel>
+        </Collapsible.Root>,
+      );
+
+      const panel = screen.getByText(PANEL_CONTENT);
+
+      fireBeforeMatch(panel);
+
+      expect(handleOpenChange.mock.calls.length).toBe(1);
+      expect(panel).toHaveAttribute('data-open');
+    });
+  });
+
   describe.skipIf(isJSDOM)('CSS transitions', () => {
     it('restores a measured height before applying closing transition styles', async () => {
       const { user } = await render(
@@ -1021,27 +1044,4 @@ describe('<Collapsible.Panel />', () => {
       });
     },
   );
-
-  // we test firefox in browserstack which does not support this yet
-  describe.skipIf(!('onbeforematch' in window) || isJSDOM)('prop: hiddenUntilFound', () => {
-    it('uses `hidden="until-found" to hide panel when true', async () => {
-      const handleOpenChange = vi.fn();
-
-      await render(
-        <Collapsible.Root defaultOpen={false} onOpenChange={handleOpenChange}>
-          <Collapsible.Trigger />
-          <Collapsible.Panel hiddenUntilFound keepMounted>
-            {PANEL_CONTENT}
-          </Collapsible.Panel>
-        </Collapsible.Root>,
-      );
-
-      const panel = screen.getByText(PANEL_CONTENT);
-
-      fireBeforeMatch(panel);
-
-      expect(handleOpenChange.mock.calls.length).toBe(1);
-      expect(panel).toHaveAttribute('data-open');
-    });
-  });
 });

--- a/packages/react/src/combobox/clear/ComboboxClear.test.tsx
+++ b/packages/react/src/combobox/clear/ComboboxClear.test.tsx
@@ -195,7 +195,7 @@ describe('<Combobox.Clear />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       await user.click(screen.getByRole('option', { name: 'a' }));
 
       await waitFor(() => {

--- a/packages/react/src/combobox/input-group/ComboboxInputGroup.test.tsx
+++ b/packages/react/src/combobox/input-group/ComboboxInputGroup.test.tsx
@@ -1,5 +1,4 @@
 import { expect, vi } from 'vitest';
-import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { Field } from '@base-ui/react/field';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/combobox/input/ComboboxInput.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.test.tsx
@@ -164,7 +164,7 @@ describe('<Combobox.Input />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       await waitFor(() => {
         screen.getByRole('option', { name: 'a' });
@@ -249,7 +249,7 @@ describe('<Combobox.Input />', () => {
       expect(input.value).toBe('');
 
       await user.type(input, 'a');
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const options = screen.getAllByRole('option');
       options.forEach((opt) => {
@@ -377,15 +377,11 @@ describe('<Combobox.Input />', () => {
 
       await user.type(input, 'a');
 
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
       await user.click(screen.getByRole('option', { name: 'apple' }));
 
       await user.type(input, 'a');
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       await user.keyboard('{Escape}');
 
@@ -596,9 +592,7 @@ describe('<Combobox.Input />', () => {
 
       await user.click(input);
 
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       await user.tab();
 
@@ -609,9 +603,7 @@ describe('<Combobox.Input />', () => {
 
       await user.click(input);
 
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       await user.tab();
 
@@ -648,7 +640,7 @@ describe('<Combobox.Input />', () => {
 
       await user.click(input);
 
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       expect(input).toHaveAttribute('data-popup-side', 'right');
 
       await user.click(document.body);
@@ -675,7 +667,7 @@ describe('<Combobox.Input />', () => {
 
       await user.click(input);
 
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       expect(input).toHaveAttribute('data-list-empty');
     });
   });

--- a/packages/react/src/combobox/item/ComboboxItem.test.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.test.tsx
@@ -92,7 +92,7 @@ describe('<Combobox.Item />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       await user.keyboard('{ArrowDown}');
       await user.keyboard('{Enter}');
@@ -176,7 +176,7 @@ describe('<Combobox.Item />', () => {
 
     const input = screen.getByTestId('input');
     await user.click(input);
-    await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+    expect(await screen.findByRole('listbox')).not.toBe(null);
     await user.keyboard('{ArrowDown}');
     await user.keyboard('{Enter}');
 
@@ -264,9 +264,7 @@ describe('<Combobox.Item />', () => {
 
     const input = screen.getByTestId('input');
     await user.click(input);
-    await waitFor(() => {
-      expect(screen.getByRole('listbox')).not.toBe(null);
-    });
+    await screen.findByRole('listbox');
 
     const a = screen.getByRole('option', { name: 'a' });
     await user.click(a);
@@ -296,7 +294,7 @@ describe('<Combobox.Item />', () => {
 
     const input = screen.getByTestId('input');
     await user.click(input);
-    await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+    expect(await screen.findByRole('listbox')).not.toBe(null);
     await waitFor(() =>
       expect(screen.getByRole('option', { name: 'two' })).toHaveAttribute('aria-selected', 'true'),
     );

--- a/packages/react/src/combobox/portal/ComboboxPortal.test.tsx
+++ b/packages/react/src/combobox/portal/ComboboxPortal.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/combobox/positioner/ComboboxPositioner.test.tsx
+++ b/packages/react/src/combobox/positioner/ComboboxPositioner.test.tsx
@@ -8,6 +8,17 @@ import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 describe('<Combobox.Positioner />', () => {
   const { render } = createRenderer();
 
+  describeConformance(<Combobox.Positioner />, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render(node) {
+      return render(
+        <Combobox.Root open>
+          <Combobox.Portal>{node}</Combobox.Portal>
+        </Combobox.Root>,
+      );
+    },
+  }));
+
   it('should not lock body scroll when controlled value={[]} triggers a re-render', async () => {
     // Render outside of act() to match real browser behavior where
     // the initial render and the useEffect re-render are separate commits.
@@ -62,17 +73,6 @@ describe('<Combobox.Positioner />', () => {
     expect(htmlOverflowX).not.toBe('hidden');
     expect(htmlOverflowY).not.toBe('hidden');
   });
-
-  describeConformance(<Combobox.Positioner />, () => ({
-    refInstanceof: window.HTMLDivElement,
-    render(node) {
-      return render(
-        <Combobox.Root open>
-          <Combobox.Portal>{node}</Combobox.Portal>
-        </Combobox.Root>,
-      );
-    },
-  }));
 
   describe.skipIf(isJSDOM)('default anchor', () => {
     it('uses the input when input group is absent', async () => {

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -315,9 +315,7 @@ describe('<Combobox.Root />', () => {
 
     await user.click(screen.getByTestId('input'));
 
-    await waitFor(() => {
-      expect(screen.queryByRole('listbox')).not.toBe(null);
-    });
+    await screen.findByRole('listbox');
 
     const outside = screen.getByTestId('outside');
     const trigger = screen.getByTestId('trigger');
@@ -506,7 +504,7 @@ describe('<Combobox.Root />', () => {
 
         const input = screen.getByRole('combobox');
         await user.click(input);
-        await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+        expect(await screen.findByRole('listbox')).not.toBe(null);
 
         await user.keyboard('{ArrowDown}');
         onOpenChange.mockClear();
@@ -566,13 +564,13 @@ describe('<Combobox.Root />', () => {
 
         const input = screen.getByTestId('input');
         await user.click(input);
-        await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+        expect(await screen.findByRole('listbox')).not.toBe(null);
 
         await user.click(screen.getByRole('option', { name: 'Cherry' }));
         await waitFor(() => expect(screen.queryByRole('listbox')).toBe(null));
 
         await user.click(input);
-        await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+        expect(await screen.findByRole('listbox')).not.toBe(null);
 
         const cherryOption = screen.getByRole('option', { name: 'Cherry' });
         expect(cherryOption).toHaveAttribute('data-selected', '');
@@ -1043,7 +1041,7 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByTestId('input');
 
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       // Highlight first item and select it
       await user.keyboard('{ArrowDown}');
@@ -1078,9 +1076,7 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByTestId('input');
 
       await user.click(input);
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       await user.type(input, 'c'); // filter to "cherry"
       await user.keyboard('{ArrowDown}');
@@ -1116,9 +1112,7 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByRole('combobox');
 
       await user.click(input);
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       const listbox = screen.getByRole('listbox');
       await user.click(listbox);
@@ -1182,9 +1176,7 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByTestId('input');
       await user.click(input);
 
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       await user.keyboard('{Escape}');
 
@@ -1556,9 +1548,7 @@ describe('<Combobox.Root />', () => {
 
     await user.click(input);
 
-    await waitFor(() => {
-      expect(screen.getByRole('listbox')).not.toBe(null);
-    });
+    await screen.findByRole('listbox');
     expect(screen.getByRole('option', { name: 'a' })).not.toBe(null);
     expect(screen.getByRole('option', { name: 'b' })).not.toBe(null);
     expect(screen.getByRole('option', { name: 'c' })).not.toBe(null);
@@ -1595,9 +1585,7 @@ describe('<Combobox.Root />', () => {
 
     await user.click(input);
 
-    await waitFor(() => {
-      expect(screen.getByRole('listbox')).not.toBe(null);
-    });
+    await screen.findByRole('listbox');
     expect(screen.getByRole('option', { name: 'a' })).not.toBe(null);
     expect(screen.getByRole('option', { name: 'b' })).not.toBe(null);
     expect(screen.getByRole('option', { name: 'c' })).not.toBe(null);
@@ -1714,7 +1702,7 @@ describe('<Combobox.Root />', () => {
     });
   });
 
-  it('should pass autoComplete to the hidden input', async () => {
+  it('passes autoComplete to the hidden input', async () => {
     await render(
       <Combobox.Root name="country" autoComplete="country">
         <Combobox.Input />
@@ -1864,9 +1852,7 @@ describe('<Combobox.Root />', () => {
       inputType: 'insertFromPaste',
     });
 
-    await waitFor(() => {
-      expect(screen.getByRole('listbox')).not.toBe(null);
-    });
+    await screen.findByRole('listbox');
   });
 
   describe('prop: id', () => {
@@ -2315,169 +2301,6 @@ describe('<Combobox.Root />', () => {
     });
   });
 
-  describe('initial input value derivation', () => {
-    it('derives input from defaultValue on first mount when unspecified', async () => {
-      await render(
-        <Combobox.Root defaultValue="apple">
-          <Combobox.Input />
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByRole('combobox')).toHaveValue('apple');
-    });
-
-    it('derives input from defaultValue on first mount with items prop', async () => {
-      const items = [{ value: 'apple', label: 'Apple' }];
-      await render(
-        <Combobox.Root items={items} defaultValue={items[0]}>
-          <Combobox.Input />
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByRole('combobox')).toHaveValue('Apple');
-    });
-
-    it('derives input from controlled value on first mount when unspecified', async () => {
-      await render(
-        <Combobox.Root value="banana">
-          <Combobox.Input />
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByRole('combobox')).toHaveValue('banana');
-    });
-
-    it('defaultInputValue overrides derivation when provided', async () => {
-      await render(
-        <Combobox.Root defaultValue="apple" defaultInputValue="x">
-          <Combobox.Input />
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByRole('combobox')).toHaveValue('x');
-    });
-
-    it('inputValue overrides derivation when provided', async () => {
-      await render(
-        <Combobox.Root value="apple" inputValue="x">
-          <Combobox.Input />
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByRole('combobox')).toHaveValue('x');
-    });
-
-    it('multiple mode initial input remains empty', async () => {
-      const items = [
-        { value: 'a', label: 'A' },
-        { value: 'b', label: 'B' },
-      ];
-      await render(
-        <Combobox.Root multiple items={items}>
-          <Combobox.Input />
-        </Combobox.Root>,
-      );
-
-      const input = screen.getAllByRole('combobox').find((element) => element.tagName === 'INPUT');
-
-      expect(input).toHaveValue('');
-    });
-
-    it('does not set input value for input-inside-popup pattern', async () => {
-      await render(
-        <Combobox.Root defaultOpen defaultValue="apple">
-          <Combobox.Trigger>Trigger</Combobox.Trigger>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.Input />
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      const input = screen.getAllByRole('combobox').find((element) => element.tagName === 'INPUT');
-
-      expect(input).toHaveValue('');
-    });
-  });
-
-  describe('input value synchronization', () => {
-    it('updates derived input when controlled value changes externally', async () => {
-      const items = [
-        { value: 'apple', label: 'Apple' },
-        { value: 'banana', label: 'Banana' },
-      ];
-
-      const { setProps } = await render(
-        <Combobox.Root items={items} value={items[0]}>
-          <Combobox.Input />
-        </Combobox.Root>,
-      );
-
-      const input = screen.getByRole<HTMLInputElement>('combobox');
-      expect(input).toHaveValue('Apple');
-
-      await setProps({ value: items[1] });
-
-      expect(input).toHaveValue('Banana');
-    });
-
-    it('re-derives input when items array changes', async () => {
-      const initialItems = [
-        { value: 'a', label: 'Apple' },
-        { value: 'b', label: 'Banana' },
-      ];
-
-      const { setProps } = await render(
-        <Combobox.Root items={initialItems} value={initialItems[0]}>
-          <Combobox.Input />
-        </Combobox.Root>,
-      );
-
-      const input = screen.getByRole<HTMLInputElement>('combobox');
-      expect(input).toHaveValue('Apple');
-
-      const nextItems = [
-        { value: 'a', label: 'Apricot' },
-        { value: 'b', label: 'Banana' },
-        { value: 'c', label: 'Cherry' },
-      ];
-
-      await setProps({ items: nextItems, value: nextItems[0] });
-      expect(input).toHaveValue('Apricot');
-
-      const sameLengthDifferentItems = [
-        { value: 'a', label: 'Ambrosia' },
-        { value: 'b', label: 'Blue Java' },
-        { value: 'c', label: 'Clementine' },
-      ];
-
-      await setProps({ items: sameLengthDifferentItems, value: sameLengthDifferentItems[0] });
-      expect(input).toHaveValue('Ambrosia');
-    });
-
-    it('restores derived input after items load asynchronously', async () => {
-      const { setProps } = await render(
-        <Combobox.Root items={[]} value="banana">
-          <Combobox.Input />
-        </Combobox.Root>,
-      );
-
-      const input = screen.getByRole<HTMLInputElement>('combobox');
-      expect(input).toHaveValue('banana');
-
-      await setProps({ items: ['apple', 'banana', 'bread'] });
-
-      expect(input).toHaveValue('banana');
-
-      await setProps({ items: ['banana'] });
-
-      expect(input).toHaveValue('banana');
-    });
-  });
-
   describe('prop: grid', () => {
     it('sets grid roles when grid is enabled and rows are used', async () => {
       await render(
@@ -2538,7 +2361,7 @@ describe('<Combobox.Root />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('grid')).not.toBe(null));
+      await screen.findByRole('grid');
 
       await user.keyboard('{ArrowDown}');
       await waitFor(() => expect(onItemHighlighted.mock.lastCall?.[0]).toBe('1'));
@@ -2593,7 +2416,7 @@ describe('<Combobox.Root />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('grid')).not.toBe(null));
+      await screen.findByRole('grid');
 
       await user.keyboard('{ArrowDown}');
       await waitFor(() => expect(onItemHighlighted.mock.lastCall?.[0]).toBe('1'));
@@ -2667,7 +2490,7 @@ describe('<Combobox.Root />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('grid')).not.toBe(null));
+      await screen.findByRole('grid');
 
       await user.keyboard('{ArrowDown}');
       await waitFor(() => expect(onItemHighlighted.mock.lastCall?.[0]).toBe('1'));
@@ -2717,7 +2540,7 @@ describe('<Combobox.Root />', () => {
       expect(input).toHaveValue('b');
 
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       expect(screen.getByRole('option', { name: 'b' })).toHaveAttribute('aria-selected', 'true');
     });
 
@@ -2779,9 +2602,7 @@ describe('<Combobox.Root />', () => {
       await user.type(input, 'app');
       await user.click(screen.getByRole('option', { name: 'apple' }));
 
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
       expect(input).toHaveValue('');
     });
 
@@ -3123,9 +2944,7 @@ describe('<Combobox.Root />', () => {
       await user.click(input);
       await screen.findByRole('listbox');
 
-      await waitFor(() => {
-        expect(screen.queryByRole('option', { name: 'Spirited Away' })).not.toBe(null);
-      });
+      await screen.findByRole('option', { name: 'Spirited Away' });
     });
   });
 
@@ -3229,9 +3048,7 @@ describe('<Combobox.Root />', () => {
 
       await user.click(input);
 
-      await waitFor(() => {
-        expect(screen.queryByRole('option', { name: 'orange' })).not.toBe(null);
-      });
+      await screen.findByRole('option', { name: 'orange' });
     });
 
     it('uses filteredItems when items prop is omitted', async () => {
@@ -3274,9 +3091,7 @@ describe('<Combobox.Root />', () => {
       await user.click(input);
       await screen.findByRole('listbox');
 
-      await waitFor(() => {
-        expect(screen.queryByRole('option', { name: 'Banana' })).not.toBe(null);
-      });
+      await screen.findByRole('option', { name: 'Banana' });
     });
 
     it('highlights the externally filtered item order when filtering reorders items', async () => {
@@ -3322,7 +3137,7 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByTestId('input');
 
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       onItemHighlighted.mockClear();
 
@@ -3356,11 +3171,11 @@ describe('<Combobox.Root />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       // Click input again should not toggle closed automatically
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
     });
 
     it('does not open on input click when false, but opens on typing', async () => {
@@ -3499,7 +3314,7 @@ describe('<Combobox.Root />', () => {
       fireEvent.change(input, { target: { value: 'ch' } });
       fireEvent.compositionEnd(input, { data: 'ch' });
 
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       const cherry = await screen.findByRole('option', { name: 'cherry' });
       await waitFor(() => expect(input).toHaveAttribute('aria-activedescendant', cherry.id));
     });
@@ -3595,13 +3410,11 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByRole<HTMLInputElement>('combobox');
 
       await user.type(input, 'a');
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
       await waitFor(() => expect(input).toHaveAttribute('aria-activedescendant'));
 
       await user.clear(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       await waitFor(() => expect(input).toHaveAttribute('aria-activedescendant'));
     });
 
@@ -3627,7 +3440,7 @@ describe('<Combobox.Root />', () => {
 
       const input = screen.getByRole<HTMLInputElement>('combobox');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       await user.type(input, 'ban');
       await screen.findByRole('option', { name: 'banana' });
@@ -3636,7 +3449,7 @@ describe('<Combobox.Root />', () => {
       expect(highlightedBefore).not.toBe(null);
 
       await user.clear(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       await waitFor(() => expect(input).toHaveAttribute('aria-activedescendant'));
     });
 
@@ -3663,9 +3476,7 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByRole<HTMLInputElement>('combobox');
 
       await user.type(input, 'ba');
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       const activeId = input.getAttribute('aria-activedescendant');
       expect(activeId).not.toBe(null);
@@ -3715,9 +3526,7 @@ describe('<Combobox.Root />', () => {
 
       const input = screen.getByTestId('input');
 
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       await user.type(input, 'a');
       await waitFor(() => expect(input).toHaveAttribute('aria-activedescendant'));
@@ -3757,7 +3566,7 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByTestId('input');
 
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       await user.click(screen.getByRole('option', { name: 'JavaScript' }));
       await user.click(screen.getByRole('option', { name: 'TypeScript' }));
@@ -3769,7 +3578,7 @@ describe('<Combobox.Root />', () => {
 
       input.focus();
       await user.keyboard('{ArrowDown}');
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       await user.hover(screen.getByRole('option', { name: 'JavaScript' }));
       await user.click(screen.getByRole('option', { name: 'JavaScript' }));
@@ -3820,7 +3629,7 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByTestId('input');
 
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const typeScriptOption = screen.getByRole('option', { name: 'TypeScript' });
       await user.hover(typeScriptOption);
@@ -3878,7 +3687,7 @@ describe('<Combobox.Root />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const typeScriptOption = screen.getByRole('option', { name: 'TypeScript' });
       await user.hover(typeScriptOption);
@@ -3941,7 +3750,7 @@ describe('<Combobox.Root />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       await user.keyboard('{ArrowUp}');
 
@@ -3987,7 +3796,7 @@ describe('<Combobox.Root />', () => {
 
       const input = screen.getByRole<HTMLInputElement>('combobox');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       // Select index 4
       await user.click(screen.getByRole('option', { name: 'epsilon' }));
@@ -3995,7 +3804,7 @@ describe('<Combobox.Root />', () => {
 
       // Reopen and press Backspace to narrow to a single match
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       // Backspace once: from 'epsilon' -> 'epsilo', which should still only match 'epsilon'
       await user.keyboard('{Backspace}');
@@ -4028,14 +3837,14 @@ describe('<Combobox.Root />', () => {
 
       // Open and select Apple
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       await user.click(screen.getByRole('option', { name: 'Apple' }));
 
       // Edit input to "Ape" (matches Grape and Grapefruit)
       await user.click(input);
       await user.clear(input);
       await user.type(input, 'Ape');
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const grape = screen.getByRole('option', { name: 'Grape' });
       const grapefruit = screen.getByRole('option', { name: 'Grapefruit' });
@@ -4078,7 +3887,7 @@ describe('<Combobox.Root />', () => {
 
       const input = screen.getByRole('combobox');
 
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       await user.click(input);
       await user.keyboard('{ArrowDown}');
 
@@ -4130,7 +3939,7 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByRole('combobox');
 
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       await user.type(input, 'app');
 
       // Reset history to focus on close events only.
@@ -4173,7 +3982,7 @@ describe('<Combobox.Root />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       await user.keyboard('{ArrowDown}');
 
       await waitFor(() => {
@@ -4212,14 +4021,10 @@ describe('<Combobox.Root />', () => {
       });
 
       await setProps({ open: true });
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       await user.click(document.body);
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
     });
 
     it('keeps filtering responsive after selection when inline and open is controlled', async () => {
@@ -4251,9 +4056,7 @@ describe('<Combobox.Root />', () => {
       await user.clear(input);
       await user.type(input, 'ba');
 
-      await waitFor(() => {
-        expect(screen.getByRole('option', { name: 'Banana' })).not.toBe(null);
-      });
+      await screen.findByRole('option', { name: 'Banana' });
     });
   });
 
@@ -4664,6 +4467,757 @@ describe('<Combobox.Root />', () => {
     });
   });
 
+  describe('prop: isItemEqualToValue', () => {
+    it('matches object values using the provided comparator', async () => {
+      const users = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ];
+
+      await render(
+        <Combobox.Root
+          items={users}
+          value={{ id: 2, name: 'Bob' }}
+          itemToStringLabel={(item) => item.name}
+          itemToStringValue={(item) => String(item.id)}
+          isItemEqualToValue={(item, value) => item.id === value.id}
+          defaultOpen
+        >
+          <Combobox.Input data-testid="input" />
+          <span data-testid="value">
+            <Combobox.Value />
+          </span>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item) => (
+                    <Combobox.Item key={item.id} value={item}>
+                      {item.name}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('value')).toHaveTextContent('Bob');
+      expect(screen.getByRole('option', { name: 'Bob' })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('properly deselects object values using the provided comparator', async () => {
+      const users = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ];
+
+      await render(
+        <Combobox.Root
+          items={users}
+          defaultValue={[{ id: 2, name: 'Bob' }]}
+          itemToStringLabel={(item) => item.name}
+          itemToStringValue={(item) => String(item.id)}
+          isItemEqualToValue={(item, value) => item.id === value.id}
+          defaultOpen
+          multiple
+        >
+          <Combobox.Input data-testid="input" />
+          <span data-testid="value">
+            <Combobox.Value />
+          </span>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item) => (
+                    <Combobox.Item key={item.id} value={item}>
+                      {item.name}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const option = screen.getByRole('option', { name: 'Bob' });
+
+      fireEvent.click(option);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Bob' })).toHaveAttribute(
+          'aria-selected',
+          'false',
+        );
+      });
+    });
+
+    it('passes item as the first comparator argument in multiple mode', async () => {
+      const users = [
+        { id: 1, name: 'Alice', source: 'item' },
+        { id: 2, name: 'Bob', source: 'item' },
+      ];
+
+      await render(
+        <Combobox.Root
+          items={users}
+          defaultValue={[{ id: 2, name: 'Bob', source: 'selected' }]}
+          itemToStringLabel={(item) => item.name}
+          itemToStringValue={(item) => String(item.id)}
+          isItemEqualToValue={(item, value) =>
+            item.id === value.id && item.source === 'item' && value.source === 'selected'
+          }
+          defaultOpen
+          multiple
+        >
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item) => (
+                    <Combobox.Item key={item.id} value={item}>
+                      {item.name}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const option = screen.getByRole('option', { name: 'Bob' });
+      expect(option).toHaveAttribute('aria-selected', 'true');
+
+      fireEvent.click(option);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Bob' })).toHaveAttribute(
+          'aria-selected',
+          'false',
+        );
+      });
+    });
+
+    it('does not call comparator with null when clearing the value', async () => {
+      const users = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ];
+
+      const compare = vi.fn((item: any, value: any) => {
+        if (value == null) {
+          throw new Error('Compared against null');
+        }
+        return item.id === value.id;
+      });
+
+      const hiddenInputRef = React.createRef<HTMLInputElement>();
+
+      const { user } = await render(
+        <Combobox.Root
+          items={users}
+          defaultValue={users[0]}
+          itemToStringLabel={(item) => item.name}
+          itemToStringValue={(item) => String(item.id)}
+          isItemEqualToValue={compare}
+          inputRef={hiddenInputRef}
+        >
+          <Combobox.Trigger>
+            <Combobox.Value data-testid="value" />
+          </Combobox.Trigger>
+          <Combobox.Clear data-testid="clear" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item) => (
+                    <Combobox.Item key={item.id} value={item}>
+                      {item.name}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const clear = await screen.findByTestId('clear');
+      await user.click(clear);
+
+      await waitFor(() => {
+        expect(hiddenInputRef.current?.value ?? '').toBe('');
+      });
+
+      expect(compare.mock.calls.length).toBeGreaterThan(0);
+      compare.mock.calls.forEach((call) => {
+        expect(call[1]).not.toBe(null);
+      });
+    });
+
+    it('does not call comparator with undefined when items load asynchronously after opening', async () => {
+      interface Country {
+        code: string;
+        label: string;
+      }
+
+      const loadedItems: Country[] = [
+        { code: 'ca', label: 'Canada' },
+        { code: 'us', label: 'United States' },
+      ];
+
+      const compare = vi.fn((item: Country, value: Country) => {
+        if (item == null || value == null) {
+          throw new Error('Compared against undefined');
+        }
+        return item.code === value.code;
+      });
+
+      const handleInputValueChange = vi.fn();
+      const handleValueChange = vi.fn();
+
+      const { user, setProps } = await render(
+        <Combobox.Root
+          items={undefined}
+          value={loadedItems[0]}
+          inputValue=""
+          onInputValueChange={handleInputValueChange}
+          onValueChange={handleValueChange}
+          itemToStringLabel={(item: Country) => item.label}
+          isItemEqualToValue={compare}
+          filter={null}
+        >
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: Country) => (
+                    <Combobox.Item key={item.code} value={item}>
+                      {item.label}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+
+      await setProps({ items: loadedItems });
+
+      const canada = await screen.findByRole('option', { name: 'Canada' });
+      fireEvent.mouseMove(canada, { pointerType: 'mouse' });
+      await waitFor(() => expect(canada).toHaveAttribute('data-highlighted'));
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'United States' })).toHaveAttribute(
+          'data-highlighted',
+        );
+      });
+
+      expect(compare.mock.calls.length).toBeGreaterThan(0);
+      compare.mock.calls.forEach((call) => {
+        expect(call[0]).not.toBe(null);
+        expect(call[0]).not.toBe(undefined);
+        expect(call[1]).not.toBe(null);
+        expect(call[1]).not.toBe(undefined);
+      });
+    });
+
+    it('keeps showing items after selecting in controlled input-inside-popup async load flow', async () => {
+      interface Country {
+        code: string;
+        label: string;
+      }
+
+      const loadedItems: Country[] = [
+        { code: 'ca', label: 'Canada' },
+        { code: 'us', label: 'United States' },
+      ];
+
+      function AsyncControlledCombobox(props: { countries: Country[] | undefined }) {
+        const { countries } = props;
+        const [country, setCountry] = React.useState<Country | null>(null);
+        const [inputValue, setInputValue] = React.useState('');
+
+        return (
+          <Combobox.Root
+            items={countries}
+            filter={null}
+            value={country}
+            inputValue={inputValue}
+            onInputValueChange={setInputValue}
+            isItemEqualToValue={(item, selected) => item?.code === selected?.code}
+            onValueChange={(value) => {
+              if (country?.code === value?.code) {
+                setCountry(null);
+              } else {
+                setCountry(value);
+              }
+            }}
+          >
+            <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <Combobox.Input />
+                  <Combobox.Empty data-testid="empty">No countries found.</Combobox.Empty>
+                  <Combobox.List>
+                    {(item: Country) => (
+                      <Combobox.Item key={item.code} value={item}>
+                        {item.label}
+                      </Combobox.Item>
+                    )}
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>
+        );
+      }
+
+      const { user, setProps } = await render(<AsyncControlledCombobox countries={undefined} />);
+
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(trigger);
+      await setProps({ countries: loadedItems });
+
+      const canada = await screen.findByRole('option', { name: 'Canada' });
+      fireEvent.mouseMove(canada, { pointerType: 'mouse' });
+      await waitFor(() => expect(canada).toHaveAttribute('data-highlighted'));
+
+      await user.click(canada);
+      await waitFor(() => expect(screen.queryByRole('listbox')).toBe(null));
+
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Canada' })).not.toBe(null);
+        expect(screen.getByRole('option', { name: 'United States' })).not.toBe(null);
+      });
+    });
+  });
+
+  describe('prop: highlightItemOnHover', () => {
+    it('highlights an item on mouse move by default', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['apple', 'banana', 'cherry']}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      await user.click(input);
+
+      const banana = screen.getByRole('option', { name: 'banana' });
+      fireEvent.mouseMove(banana, { pointerType: 'mouse' });
+
+      await waitFor(() => expect(banana).toHaveAttribute('data-highlighted'));
+      expect(input.getAttribute('aria-activedescendant')).toBe(banana.id);
+    });
+
+    it('does not highlight items from mouse movement when disabled', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['apple', 'banana', 'cherry']} highlightItemOnHover={false}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      await user.click(input);
+
+      const banana = screen.getByRole('option', { name: 'banana' });
+      fireEvent.mouseMove(banana, { pointerType: 'mouse' });
+
+      await waitFor(() => expect(input).not.toHaveAttribute('aria-activedescendant'));
+      expect(banana).not.toHaveAttribute('data-highlighted');
+    });
+  });
+
+  describe('prop: loopFocus', () => {
+    it('loops focus from last to first item with ArrowDown by default', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['apple', 'banana', 'cherry']}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      await act(async () => input.focus());
+
+      // ArrowUp opens and focuses last item
+      await user.keyboard('{ArrowUp}');
+
+      expect(await screen.findByRole('listbox')).not.toBe(null);
+
+      const options = screen.getAllByRole('option');
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-activedescendant', options[2].id);
+      });
+
+      // Loop cycles through input
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(input).not.toHaveAttribute('aria-activedescendant');
+      });
+
+      // Then to first item
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+      });
+    });
+
+    it('loops focus from first to last item with ArrowUp by default', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['apple', 'banana', 'cherry']}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      await act(async () => input.focus());
+
+      // ArrowDown opens and focuses first item
+      await user.keyboard('{ArrowDown}');
+
+      expect(await screen.findByRole('listbox')).not.toBe(null);
+
+      const options = screen.getAllByRole('option');
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+      });
+
+      // Loop cycles through input
+      await user.keyboard('{ArrowUp}');
+
+      await waitFor(() => {
+        expect(input).not.toHaveAttribute('aria-activedescendant');
+      });
+
+      // Then to last item
+      await user.keyboard('{ArrowUp}');
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-activedescendant', options[2].id);
+      });
+    });
+
+    it('does not loop focus from last to first with ArrowDown when loopFocus={false}', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['apple', 'banana', 'cherry']} loopFocus={false}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      await act(async () => input.focus());
+
+      // ArrowUp opens and focuses last item
+      await user.keyboard('{ArrowUp}');
+
+      expect(await screen.findByRole('listbox')).not.toBe(null);
+
+      const options = screen.getAllByRole('option');
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-activedescendant', options[2].id);
+      });
+
+      // Should stay at last item (no loop)
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-activedescendant', options[2].id);
+      });
+    });
+
+    it('does not loop focus from first to last with ArrowUp when loopFocus={false}', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['apple', 'banana', 'cherry']} loopFocus={false}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      await act(async () => input.focus());
+
+      // ArrowDown opens and focuses first item
+      await user.keyboard('{ArrowDown}');
+
+      expect(await screen.findByRole('listbox')).not.toBe(null);
+
+      const options = screen.getAllByRole('option');
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+      });
+
+      // Should stay at first item (no loop)
+      await user.keyboard('{ArrowUp}');
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+      });
+    });
+  });
+
+  describe('initial input value derivation', () => {
+    it('derives input from defaultValue on first mount when unspecified', async () => {
+      await render(
+        <Combobox.Root defaultValue="apple">
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByRole('combobox')).toHaveValue('apple');
+    });
+
+    it('derives input from defaultValue on first mount with items prop', async () => {
+      const items = [{ value: 'apple', label: 'Apple' }];
+      await render(
+        <Combobox.Root items={items} defaultValue={items[0]}>
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByRole('combobox')).toHaveValue('Apple');
+    });
+
+    it('derives input from controlled value on first mount when unspecified', async () => {
+      await render(
+        <Combobox.Root value="banana">
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByRole('combobox')).toHaveValue('banana');
+    });
+
+    it('defaultInputValue overrides derivation when provided', async () => {
+      await render(
+        <Combobox.Root defaultValue="apple" defaultInputValue="x">
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByRole('combobox')).toHaveValue('x');
+    });
+
+    it('inputValue overrides derivation when provided', async () => {
+      await render(
+        <Combobox.Root value="apple" inputValue="x">
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByRole('combobox')).toHaveValue('x');
+    });
+
+    it('multiple mode initial input remains empty', async () => {
+      const items = [
+        { value: 'a', label: 'A' },
+        { value: 'b', label: 'B' },
+      ];
+      await render(
+        <Combobox.Root multiple items={items}>
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      const input = screen.getAllByRole('combobox').find((element) => element.tagName === 'INPUT');
+
+      expect(input).toHaveValue('');
+    });
+
+    it('does not set input value for input-inside-popup pattern', async () => {
+      await render(
+        <Combobox.Root defaultOpen defaultValue="apple">
+          <Combobox.Trigger>Trigger</Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.Input />
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getAllByRole('combobox').find((element) => element.tagName === 'INPUT');
+
+      expect(input).toHaveValue('');
+    });
+  });
+
+  describe('input value synchronization', () => {
+    it('updates derived input when controlled value changes externally', async () => {
+      const items = [
+        { value: 'apple', label: 'Apple' },
+        { value: 'banana', label: 'Banana' },
+      ];
+
+      const { setProps } = await render(
+        <Combobox.Root items={items} value={items[0]}>
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      expect(input).toHaveValue('Apple');
+
+      await setProps({ value: items[1] });
+
+      expect(input).toHaveValue('Banana');
+    });
+
+    it('re-derives input when items array changes', async () => {
+      const initialItems = [
+        { value: 'a', label: 'Apple' },
+        { value: 'b', label: 'Banana' },
+      ];
+
+      const { setProps } = await render(
+        <Combobox.Root items={initialItems} value={initialItems[0]}>
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      expect(input).toHaveValue('Apple');
+
+      const nextItems = [
+        { value: 'a', label: 'Apricot' },
+        { value: 'b', label: 'Banana' },
+        { value: 'c', label: 'Cherry' },
+      ];
+
+      await setProps({ items: nextItems, value: nextItems[0] });
+      expect(input).toHaveValue('Apricot');
+
+      const sameLengthDifferentItems = [
+        { value: 'a', label: 'Ambrosia' },
+        { value: 'b', label: 'Blue Java' },
+        { value: 'c', label: 'Clementine' },
+      ];
+
+      await setProps({ items: sameLengthDifferentItems, value: sameLengthDifferentItems[0] });
+      expect(input).toHaveValue('Ambrosia');
+    });
+
+    it('restores derived input after items load asynchronously', async () => {
+      const { setProps } = await render(
+        <Combobox.Root items={[]} value="banana">
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      expect(input).toHaveValue('banana');
+
+      await setProps({ items: ['apple', 'banana', 'bread'] });
+
+      expect(input).toHaveValue('banana');
+
+      await setProps({ items: ['banana'] });
+
+      expect(input).toHaveValue('banana');
+    });
+  });
+
   describe('dialog pattern', () => {
     const fruits = ['Apple', 'Apricot', 'Banana', 'Grape', 'Orange'];
     const asyncFruits = ['apple', 'banana', 'cherry'];
@@ -4840,9 +5394,7 @@ describe('<Combobox.Root />', () => {
         await user.click(screen.getByRole('option', { name: 'Apple' }));
 
         expect(input).toHaveValue('');
-        await waitFor(() => {
-          expect(screen.queryByRole('option', { name: 'Banana' })).not.toBe(null);
-        });
+        await screen.findByRole('option', { name: 'Banana' });
         expect(input).toHaveAttribute('aria-activedescendant');
       });
 
@@ -4862,9 +5414,7 @@ describe('<Combobox.Root />', () => {
         await user.click(screen.getByRole('option', { name: 'Apple' }));
 
         expect(input).toHaveValue('');
-        await waitFor(() => {
-          expect(screen.queryByRole('option', { name: 'Banana' })).not.toBe(null);
-        });
+        await screen.findByRole('option', { name: 'Banana' });
         expect(input).toHaveAttribute('aria-activedescendant');
 
         await user.type(input, 'ap');
@@ -4991,7 +5541,7 @@ describe('<Combobox.Root />', () => {
     });
   });
 
-  describe('Form', () => {
+  describe('Form integration', () => {
     const { render: renderFakeTimers, clock } = createRenderer({
       clockOptions: {
         shouldAdvanceTime: true,
@@ -5547,7 +6097,7 @@ describe('<Combobox.Root />', () => {
     });
   });
 
-  describe('Field', () => {
+  describe('Field integration', () => {
     const { render: renderFakeTimers, clock } = createRenderer({
       clockOptions: {
         shouldAdvanceTime: true,
@@ -5556,7 +6106,7 @@ describe('<Combobox.Root />', () => {
 
     clock.withFakeTimers();
 
-    it('should receive disabled prop from Field.Root', async () => {
+    it('receives the disabled prop from Field.Root', async () => {
       await render(
         <Field.Root disabled>
           <Combobox.Root>
@@ -5583,7 +6133,7 @@ describe('<Combobox.Root />', () => {
       expect(trigger).toHaveAttribute('disabled');
     });
 
-    it('should receive name prop from Field.Root', async () => {
+    it('receives the name prop from Field.Root', async () => {
       await render(
         <Field.Root name="field-combobox">
           <Combobox.Root>
@@ -5742,7 +6292,7 @@ describe('<Combobox.Root />', () => {
       expect(screen.queryByRole('dialog')).toBe(null);
     });
 
-    it('[data-touched]', async () => {
+    it('adds data-touched after blur', async () => {
       await render(
         <Field.Root>
           <Combobox.Root>
@@ -5777,7 +6327,7 @@ describe('<Combobox.Root />', () => {
       expect(trigger).toHaveAttribute('data-touched', '');
     });
 
-    it('[data-dirty]', async () => {
+    it('adds data-dirty after the value changes', async () => {
       const { user } = await renderFakeTimers(
         <Field.Root>
           <Combobox.Root>
@@ -5818,8 +6368,8 @@ describe('<Combobox.Root />', () => {
       expect(trigger).toHaveAttribute('data-dirty', '');
     });
 
-    describe('[data-filled]', () => {
-      it('adds [data-filled] attribute when filled', async () => {
+    describe('field state attribute: data-filled', () => {
+      it('adds data-filled when filled', async () => {
         const { user } = await renderFakeTimers(
           <Field.Root>
             <Combobox.Root>
@@ -5868,7 +6418,7 @@ describe('<Combobox.Root />', () => {
         expect(listbox).not.toHaveAttribute('data-filled');
       });
 
-      it('adds [data-filled] attribute when already filled', async () => {
+      it('adds data-filled when already filled', async () => {
         await render(
           <Field.Root>
             <Combobox.Root defaultValue="1">
@@ -5895,7 +6445,7 @@ describe('<Combobox.Root />', () => {
       });
     });
 
-    it('[data-focused]', async () => {
+    it('adds data-focused while focused', async () => {
       await render(
         <Field.Root>
           <Combobox.Root>
@@ -6023,7 +6573,7 @@ describe('<Combobox.Root />', () => {
       expect(trigger).toHaveAttribute('aria-invalid', 'true');
     });
 
-    it('[data-invalid]', async () => {
+    it('adds data-invalid when the field is invalid', async () => {
       await render(
         <Field.Root invalid>
           <Combobox.Root>
@@ -6049,7 +6599,7 @@ describe('<Combobox.Root />', () => {
       expect(trigger).toHaveAttribute('data-invalid', '');
     });
 
-    it('[data-valid]', async () => {
+    it('adds data-valid after validation succeeds', async () => {
       const { user } = await render(
         <Field.Root validationMode="onBlur">
           <Combobox.Root>
@@ -6090,199 +6640,200 @@ describe('<Combobox.Root />', () => {
       expect(trigger).not.toHaveAttribute('data-invalid');
     });
 
-    it('prop: validate', async () => {
-      await render(
-        <Field.Root validationMode="onBlur" validate={() => 'error'}>
-          <Combobox.Root>
-            <Combobox.Input data-testid="input" />
-            <Combobox.Portal>
-              <Combobox.Positioner />
-            </Combobox.Portal>
-          </Combobox.Root>
-        </Field.Root>,
-      );
-
-      const input = screen.getByTestId('input');
-
-      expect(input).not.toHaveAttribute('aria-invalid');
-
-      fireEvent.focus(input);
-      fireEvent.blur(input);
-
-      await flushMicrotasks();
-
-      expect(input).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    it('passes raw value to validate when itemToStringValue is provided', async () => {
-      const items = [
-        { code: 'US', label: 'United States' },
-        { code: 'CA', label: 'Canada' },
-      ];
-      const validateSpy = vi.fn((value: unknown) => {
-        expect(value).toBe(items[0]);
-        return 'error';
-      });
-
-      await render(
-        <Field.Root validationMode="onBlur" validate={validateSpy}>
-          <Combobox.Root
-            items={items}
-            defaultValue={items[0]}
-            itemToStringLabel={(item) => item.label}
-            itemToStringValue={(item) => item.code}
-          >
-            <Combobox.Input data-testid="input" />
-            <Combobox.Portal>
-              <Combobox.Positioner />
-            </Combobox.Portal>
-          </Combobox.Root>
-        </Field.Root>,
-      );
-
-      const input = screen.getByTestId('input');
-
-      fireEvent.focus(input);
-      fireEvent.blur(input);
-
-      await waitFor(() => {
-        expect(validateSpy.mock.calls.length).toBe(1);
-      });
-      expect(input).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    it('prop: validationMode=onSubmit', async () => {
-      const { user } = await render(
-        <Form>
-          <Field.Root validate={(val) => (val === 'a' ? 'error' : null)}>
-            <Combobox.Root required>
+    describe('prop: validate', () => {
+      it('applies aria-invalid after blur', async () => {
+        await render(
+          <Field.Root validationMode="onBlur" validate={() => 'error'}>
+            <Combobox.Root>
               <Combobox.Input data-testid="input" />
-              <Combobox.Clear data-testid="clear" />
+              <Combobox.Portal>
+                <Combobox.Positioner />
+              </Combobox.Portal>
+            </Combobox.Root>
+          </Field.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+
+        expect(input).not.toHaveAttribute('aria-invalid');
+
+        fireEvent.focus(input);
+        fireEvent.blur(input);
+
+        await flushMicrotasks();
+
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      it('passes raw value when itemToStringValue is provided', async () => {
+        const items = [
+          { code: 'US', label: 'United States' },
+          { code: 'CA', label: 'Canada' },
+        ];
+        const validateSpy = vi.fn((value: unknown) => {
+          expect(value).toBe(items[0]);
+          return 'error';
+        });
+
+        await render(
+          <Field.Root validationMode="onBlur" validate={validateSpy}>
+            <Combobox.Root
+              items={items}
+              defaultValue={items[0]}
+              itemToStringLabel={(item) => item.label}
+              itemToStringValue={(item) => item.code}
+            >
+              <Combobox.Input data-testid="input" />
+              <Combobox.Portal>
+                <Combobox.Positioner />
+              </Combobox.Portal>
+            </Combobox.Root>
+          </Field.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+
+        fireEvent.focus(input);
+        fireEvent.blur(input);
+
+        await waitFor(() => {
+          expect(validateSpy.mock.calls.length).toBe(1);
+        });
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+      });
+    });
+
+    describe('prop: validationMode', () => {
+      it('validates when validationMode is onSubmit', async () => {
+        const { user } = await render(
+          <Form>
+            <Field.Root validate={(val) => (val === 'a' ? 'error' : null)}>
+              <Combobox.Root required>
+                <Combobox.Input data-testid="input" />
+                <Combobox.Clear data-testid="clear" />
+                <Combobox.Portal>
+                  <Combobox.Positioner>
+                    <Combobox.Popup>
+                      <Combobox.List>
+                        <Combobox.Item value="a">a</Combobox.Item>
+                        <Combobox.Item value="b">b</Combobox.Item>
+                      </Combobox.List>
+                    </Combobox.Popup>
+                  </Combobox.Positioner>
+                </Combobox.Portal>
+              </Combobox.Root>
+            </Field.Root>
+            <button type="submit">submit</button>
+          </Form>,
+        );
+
+        const input = screen.getByTestId('input');
+        expect(input).not.toHaveAttribute('aria-invalid');
+
+        await user.click(screen.getByText('submit'));
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+
+        await user.click(input);
+
+        await user.keyboard('{ArrowDown}');
+        await user.keyboard('{ArrowDown}');
+        await user.keyboard('{Enter}');
+
+        expect(input).not.toHaveAttribute('aria-invalid');
+
+        const clear = screen.getByTestId('clear');
+        await user.click(clear);
+
+        expect(document.activeElement).toBe(input);
+        await user.keyboard('{Tab}');
+
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      // flaky in real browser
+      it.skipIf(!isJSDOM)('validates when validationMode is onChange', async () => {
+        const { user } = await render(
+          <Field.Root
+            validationMode="onChange"
+            validate={(value) => {
+              return value === '1' ? 'error' : null;
+            }}
+          >
+            <Combobox.Root>
+              <Combobox.Input data-testid="input" />
               <Combobox.Portal>
                 <Combobox.Positioner>
                   <Combobox.Popup>
                     <Combobox.List>
-                      <Combobox.Item value="a">a</Combobox.Item>
-                      <Combobox.Item value="b">b</Combobox.Item>
+                      <Combobox.Item value="1">Option 1</Combobox.Item>
                     </Combobox.List>
                   </Combobox.Popup>
                 </Combobox.Positioner>
               </Combobox.Portal>
             </Combobox.Root>
-          </Field.Root>
-          <button type="submit">submit</button>
-        </Form>,
-      );
+          </Field.Root>,
+        );
 
-      const input = screen.getByTestId('input');
-      expect(input).not.toHaveAttribute('aria-invalid');
+        const input = screen.getByTestId('input');
 
-      await user.click(screen.getByText('submit'));
-      expect(input).toHaveAttribute('aria-invalid', 'true');
+        expect(input).not.toHaveAttribute('aria-invalid');
 
-      await user.click(input);
+        await user.click(input);
 
-      await user.keyboard('{ArrowDown}');
-      await user.keyboard('{ArrowDown}');
-      await user.keyboard('{Enter}');
+        await flushMicrotasks();
 
-      expect(input).not.toHaveAttribute('aria-invalid');
+        // Arrow Down to focus the Option 1
+        await user.keyboard('{ArrowDown}');
+        await user.keyboard('{Enter}');
 
-      const clear = screen.getByTestId('clear');
-      await user.click(clear);
-
-      expect(document.activeElement).toBe(input);
-      await user.keyboard('{Tab}');
-
-      expect(input).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    // flaky in real browser
-    it.skipIf(!isJSDOM)('prop: validationMode=onChange', async () => {
-      const { user } = await render(
-        <Field.Root
-          validationMode="onChange"
-          validate={(value) => {
-            return value === '1' ? 'error' : null;
-          }}
-        >
-          <Combobox.Root>
-            <Combobox.Input data-testid="input" />
-            <Combobox.Portal>
-              <Combobox.Positioner>
-                <Combobox.Popup>
-                  <Combobox.List>
-                    <Combobox.Item value="1">Option 1</Combobox.Item>
-                  </Combobox.List>
-                </Combobox.Popup>
-              </Combobox.Positioner>
-            </Combobox.Portal>
-          </Combobox.Root>
-        </Field.Root>,
-      );
-
-      const input = screen.getByTestId('input');
-
-      expect(input).not.toHaveAttribute('aria-invalid');
-
-      await user.click(input);
-
-      await flushMicrotasks();
-
-      // Arrow Down to focus the Option 1
-      await user.keyboard('{ArrowDown}');
-      await user.keyboard('{Enter}');
-
-      expect(input).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    // flaky in real browser
-    it.skipIf(!isJSDOM)('prop: validationMode=onBlur', async () => {
-      const { user } = await render(
-        <Field.Root
-          validationMode="onBlur"
-          validate={(value) => {
-            return value === '1' ? 'error' : null;
-          }}
-        >
-          <Combobox.Root>
-            <Combobox.Input data-testid="input" />
-            <Combobox.Portal>
-              <Combobox.Positioner>
-                <Combobox.Popup>
-                  <Combobox.List>
-                    <Combobox.Item value="1">Option 1</Combobox.Item>
-                  </Combobox.List>
-                </Combobox.Popup>
-              </Combobox.Positioner>
-            </Combobox.Portal>
-          </Combobox.Root>
-          <Field.Error data-testid="error" />
-        </Field.Root>,
-      );
-
-      const input = screen.getByTestId('input');
-
-      expect(input).not.toHaveAttribute('aria-invalid');
-
-      await user.click(input);
-
-      await flushMicrotasks();
-
-      // Arrow Down to focus the Option 1
-      await user.keyboard('{ArrowDown}');
-      await user.keyboard('{Enter}');
-
-      fireEvent.blur(input);
-
-      await flushMicrotasks();
-
-      await waitFor(() => {
         expect(input).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      // flaky in real browser
+      it.skipIf(!isJSDOM)('validates when validationMode is onBlur', async () => {
+        const { user } = await render(
+          <Field.Root
+            validationMode="onBlur"
+            validate={(value) => {
+              return value === '1' ? 'error' : null;
+            }}
+          >
+            <Combobox.Root>
+              <Combobox.Input data-testid="input" />
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.List>
+                      <Combobox.Item value="1">Option 1</Combobox.Item>
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+            <Field.Error data-testid="error" />
+          </Field.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+
+        expect(input).not.toHaveAttribute('aria-invalid');
+
+        await user.click(input);
+
+        await flushMicrotasks();
+
+        // Arrow Down to focus the Option 1
+        await user.keyboard('{ArrowDown}');
+        await user.keyboard('{Enter}');
+
+        fireEvent.blur(input);
+        await waitFor(() => {
+          expect(input).toHaveAttribute('aria-invalid', 'true');
+        });
       });
     });
 
-    it('Field.Label', async () => {
+    it('links Field.Label to the input', async () => {
       await render(
         <Field.Root>
           <Combobox.Root>
@@ -6385,594 +6936,6 @@ describe('<Combobox.Root />', () => {
         'aria-describedby',
         screen.getByTestId('description').id,
       );
-    });
-  });
-
-  describe('prop: isItemEqualToValue', () => {
-    it('matches object values using the provided comparator', async () => {
-      const users = [
-        { id: 1, name: 'Alice' },
-        { id: 2, name: 'Bob' },
-      ];
-
-      await render(
-        <Combobox.Root
-          items={users}
-          value={{ id: 2, name: 'Bob' }}
-          itemToStringLabel={(item) => item.name}
-          itemToStringValue={(item) => String(item.id)}
-          isItemEqualToValue={(item, value) => item.id === value.id}
-          defaultOpen
-        >
-          <Combobox.Input data-testid="input" />
-          <span data-testid="value">
-            <Combobox.Value />
-          </span>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  {(item) => (
-                    <Combobox.Item key={item.id} value={item}>
-                      {item.name}
-                    </Combobox.Item>
-                  )}
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByTestId('value')).toHaveTextContent('Bob');
-      expect(screen.getByRole('option', { name: 'Bob' })).toHaveAttribute('aria-selected', 'true');
-    });
-
-    it('properly deselects object values using the provided comparator', async () => {
-      const users = [
-        { id: 1, name: 'Alice' },
-        { id: 2, name: 'Bob' },
-      ];
-
-      await render(
-        <Combobox.Root
-          items={users}
-          defaultValue={[{ id: 2, name: 'Bob' }]}
-          itemToStringLabel={(item) => item.name}
-          itemToStringValue={(item) => String(item.id)}
-          isItemEqualToValue={(item, value) => item.id === value.id}
-          defaultOpen
-          multiple
-        >
-          <Combobox.Input data-testid="input" />
-          <span data-testid="value">
-            <Combobox.Value />
-          </span>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  {(item) => (
-                    <Combobox.Item key={item.id} value={item}>
-                      {item.name}
-                    </Combobox.Item>
-                  )}
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      const option = screen.getByRole('option', { name: 'Bob' });
-
-      fireEvent.click(option);
-
-      await waitFor(() => {
-        expect(screen.getByRole('option', { name: 'Bob' })).toHaveAttribute(
-          'aria-selected',
-          'false',
-        );
-      });
-    });
-
-    it('passes item as the first comparator argument in multiple mode', async () => {
-      const users = [
-        { id: 1, name: 'Alice', source: 'item' },
-        { id: 2, name: 'Bob', source: 'item' },
-      ];
-
-      await render(
-        <Combobox.Root
-          items={users}
-          defaultValue={[{ id: 2, name: 'Bob', source: 'selected' }]}
-          itemToStringLabel={(item) => item.name}
-          itemToStringValue={(item) => String(item.id)}
-          isItemEqualToValue={(item, value) =>
-            item.id === value.id && item.source === 'item' && value.source === 'selected'
-          }
-          defaultOpen
-          multiple
-        >
-          <Combobox.Input data-testid="input" />
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  {(item) => (
-                    <Combobox.Item key={item.id} value={item}>
-                      {item.name}
-                    </Combobox.Item>
-                  )}
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      const option = screen.getByRole('option', { name: 'Bob' });
-      expect(option).toHaveAttribute('aria-selected', 'true');
-
-      fireEvent.click(option);
-
-      await waitFor(() => {
-        expect(screen.getByRole('option', { name: 'Bob' })).toHaveAttribute(
-          'aria-selected',
-          'false',
-        );
-      });
-    });
-
-    it('does not call comparator with null when clearing the value', async () => {
-      const users = [
-        { id: 1, name: 'Alice' },
-        { id: 2, name: 'Bob' },
-      ];
-
-      const compare = vi.fn((item: any, value: any) => {
-        if (value == null) {
-          throw new Error('Compared against null');
-        }
-        return item.id === value.id;
-      });
-
-      const hiddenInputRef = React.createRef<HTMLInputElement>();
-
-      const { user } = await render(
-        <Combobox.Root
-          items={users}
-          defaultValue={users[0]}
-          itemToStringLabel={(item) => item.name}
-          itemToStringValue={(item) => String(item.id)}
-          isItemEqualToValue={compare}
-          inputRef={hiddenInputRef}
-        >
-          <Combobox.Trigger>
-            <Combobox.Value data-testid="value" />
-          </Combobox.Trigger>
-          <Combobox.Clear data-testid="clear" />
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  {(item) => (
-                    <Combobox.Item key={item.id} value={item}>
-                      {item.name}
-                    </Combobox.Item>
-                  )}
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      const clear = await screen.findByTestId('clear');
-      await user.click(clear);
-
-      await waitFor(() => {
-        expect(hiddenInputRef.current?.value ?? '').toBe('');
-      });
-
-      expect(compare.mock.calls.length).toBeGreaterThan(0);
-      compare.mock.calls.forEach((call) => {
-        expect(call[1]).not.toBe(null);
-      });
-    });
-
-    it('does not call comparator with undefined when items load asynchronously after opening', async () => {
-      interface Country {
-        code: string;
-        label: string;
-      }
-
-      const loadedItems: Country[] = [
-        { code: 'ca', label: 'Canada' },
-        { code: 'us', label: 'United States' },
-      ];
-
-      const compare = vi.fn((item: Country, value: Country) => {
-        if (item == null || value == null) {
-          throw new Error('Compared against undefined');
-        }
-        return item.code === value.code;
-      });
-
-      const handleInputValueChange = vi.fn();
-      const handleValueChange = vi.fn();
-
-      const { user, setProps } = await render(
-        <Combobox.Root
-          items={undefined}
-          value={loadedItems[0]}
-          inputValue=""
-          onInputValueChange={handleInputValueChange}
-          onValueChange={handleValueChange}
-          itemToStringLabel={(item: Country) => item.label}
-          isItemEqualToValue={compare}
-          filter={null}
-        >
-          <Combobox.Input />
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  {(item: Country) => (
-                    <Combobox.Item key={item.code} value={item}>
-                      {item.label}
-                    </Combobox.Item>
-                  )}
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      const input = screen.getByRole('combobox');
-      await user.click(input);
-
-      await setProps({ items: loadedItems });
-
-      const canada = await screen.findByRole('option', { name: 'Canada' });
-      fireEvent.mouseMove(canada, { pointerType: 'mouse' });
-      await waitFor(() => expect(canada).toHaveAttribute('data-highlighted'));
-      await user.keyboard('{ArrowDown}');
-
-      await waitFor(() => {
-        expect(screen.getByRole('option', { name: 'United States' })).toHaveAttribute(
-          'data-highlighted',
-        );
-      });
-
-      expect(compare.mock.calls.length).toBeGreaterThan(0);
-      compare.mock.calls.forEach((call) => {
-        expect(call[0]).not.toBe(null);
-        expect(call[0]).not.toBe(undefined);
-        expect(call[1]).not.toBe(null);
-        expect(call[1]).not.toBe(undefined);
-      });
-    });
-
-    it('keeps showing items after selecting in controlled input-inside-popup async load flow', async () => {
-      interface Country {
-        code: string;
-        label: string;
-      }
-
-      const loadedItems: Country[] = [
-        { code: 'ca', label: 'Canada' },
-        { code: 'us', label: 'United States' },
-      ];
-
-      function AsyncControlledCombobox(props: { countries: Country[] | undefined }) {
-        const { countries } = props;
-        const [country, setCountry] = React.useState<Country | null>(null);
-        const [inputValue, setInputValue] = React.useState('');
-
-        return (
-          <Combobox.Root
-            items={countries}
-            filter={null}
-            value={country}
-            inputValue={inputValue}
-            onInputValueChange={setInputValue}
-            isItemEqualToValue={(item, selected) => item?.code === selected?.code}
-            onValueChange={(value) => {
-              if (country?.code === value?.code) {
-                setCountry(null);
-              } else {
-                setCountry(value);
-              }
-            }}
-          >
-            <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
-            <Combobox.Portal>
-              <Combobox.Positioner>
-                <Combobox.Popup>
-                  <Combobox.Input />
-                  <Combobox.Empty data-testid="empty">No countries found.</Combobox.Empty>
-                  <Combobox.List>
-                    {(item: Country) => (
-                      <Combobox.Item key={item.code} value={item}>
-                        {item.label}
-                      </Combobox.Item>
-                    )}
-                  </Combobox.List>
-                </Combobox.Popup>
-              </Combobox.Positioner>
-            </Combobox.Portal>
-          </Combobox.Root>
-        );
-      }
-
-      const { user, setProps } = await render(<AsyncControlledCombobox countries={undefined} />);
-
-      const trigger = screen.getByTestId('trigger');
-
-      await user.click(trigger);
-      await setProps({ countries: loadedItems });
-
-      const canada = await screen.findByRole('option', { name: 'Canada' });
-      fireEvent.mouseMove(canada, { pointerType: 'mouse' });
-      await waitFor(() => expect(canada).toHaveAttribute('data-highlighted'));
-
-      await user.click(canada);
-      await waitFor(() => expect(screen.queryByRole('listbox')).toBe(null));
-
-      await user.click(trigger);
-
-      await waitFor(() => {
-        expect(screen.getByRole('option', { name: 'Canada' })).not.toBe(null);
-        expect(screen.getByRole('option', { name: 'United States' })).not.toBe(null);
-      });
-    });
-  });
-
-  describe('prop: highlightItemOnHover', () => {
-    it('highlights an item on mouse move by default', async () => {
-      const { user } = await render(
-        <Combobox.Root items={['apple', 'banana', 'cherry']}>
-          <Combobox.Input data-testid="input" />
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  {(item: string) => (
-                    <Combobox.Item key={item} value={item}>
-                      {item}
-                    </Combobox.Item>
-                  )}
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      const input = screen.getByRole<HTMLInputElement>('combobox');
-      await user.click(input);
-
-      const banana = screen.getByRole('option', { name: 'banana' });
-      fireEvent.mouseMove(banana, { pointerType: 'mouse' });
-
-      await waitFor(() => expect(banana).toHaveAttribute('data-highlighted'));
-      expect(input.getAttribute('aria-activedescendant')).toBe(banana.id);
-    });
-
-    it('does not highlight items from mouse movement when disabled', async () => {
-      const { user } = await render(
-        <Combobox.Root items={['apple', 'banana', 'cherry']} highlightItemOnHover={false}>
-          <Combobox.Input data-testid="input" />
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  {(item: string) => (
-                    <Combobox.Item key={item} value={item}>
-                      {item}
-                    </Combobox.Item>
-                  )}
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      const input = screen.getByRole<HTMLInputElement>('combobox');
-      await user.click(input);
-
-      const banana = screen.getByRole('option', { name: 'banana' });
-      fireEvent.mouseMove(banana, { pointerType: 'mouse' });
-
-      await waitFor(() => expect(input).not.toHaveAttribute('aria-activedescendant'));
-      expect(banana).not.toHaveAttribute('data-highlighted');
-    });
-  });
-
-  describe('prop: loopFocus', () => {
-    it('loops focus from last to first item with ArrowDown by default', async () => {
-      const { user } = await render(
-        <Combobox.Root items={['apple', 'banana', 'cherry']}>
-          <Combobox.Input data-testid="input" />
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  {(item: string) => (
-                    <Combobox.Item key={item} value={item}>
-                      {item}
-                    </Combobox.Item>
-                  )}
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      const input = screen.getByRole<HTMLInputElement>('combobox');
-      await act(async () => input.focus());
-
-      // ArrowUp opens and focuses last item
-      await user.keyboard('{ArrowUp}');
-
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
-
-      const options = screen.getAllByRole('option');
-
-      await waitFor(() => {
-        expect(input).toHaveAttribute('aria-activedescendant', options[2].id);
-      });
-
-      // Loop cycles through input
-      await user.keyboard('{ArrowDown}');
-
-      await waitFor(() => {
-        expect(input).not.toHaveAttribute('aria-activedescendant');
-      });
-
-      // Then to first item
-      await user.keyboard('{ArrowDown}');
-
-      await waitFor(() => {
-        expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
-      });
-    });
-
-    it('loops focus from first to last item with ArrowUp by default', async () => {
-      const { user } = await render(
-        <Combobox.Root items={['apple', 'banana', 'cherry']}>
-          <Combobox.Input data-testid="input" />
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  {(item: string) => (
-                    <Combobox.Item key={item} value={item}>
-                      {item}
-                    </Combobox.Item>
-                  )}
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      const input = screen.getByRole<HTMLInputElement>('combobox');
-      await act(async () => input.focus());
-
-      // ArrowDown opens and focuses first item
-      await user.keyboard('{ArrowDown}');
-
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
-
-      const options = screen.getAllByRole('option');
-
-      await waitFor(() => {
-        expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
-      });
-
-      // Loop cycles through input
-      await user.keyboard('{ArrowUp}');
-
-      await waitFor(() => {
-        expect(input).not.toHaveAttribute('aria-activedescendant');
-      });
-
-      // Then to last item
-      await user.keyboard('{ArrowUp}');
-
-      await waitFor(() => {
-        expect(input).toHaveAttribute('aria-activedescendant', options[2].id);
-      });
-    });
-
-    it('does not loop focus from last to first with ArrowDown when loopFocus={false}', async () => {
-      const { user } = await render(
-        <Combobox.Root items={['apple', 'banana', 'cherry']} loopFocus={false}>
-          <Combobox.Input data-testid="input" />
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  {(item: string) => (
-                    <Combobox.Item key={item} value={item}>
-                      {item}
-                    </Combobox.Item>
-                  )}
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      const input = screen.getByRole<HTMLInputElement>('combobox');
-      await act(async () => input.focus());
-
-      // ArrowUp opens and focuses last item
-      await user.keyboard('{ArrowUp}');
-
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
-
-      const options = screen.getAllByRole('option');
-
-      await waitFor(() => {
-        expect(input).toHaveAttribute('aria-activedescendant', options[2].id);
-      });
-
-      // Should stay at last item (no loop)
-      await user.keyboard('{ArrowDown}');
-
-      await waitFor(() => {
-        expect(input).toHaveAttribute('aria-activedescendant', options[2].id);
-      });
-    });
-
-    it('does not loop focus from first to last with ArrowUp when loopFocus={false}', async () => {
-      const { user } = await render(
-        <Combobox.Root items={['apple', 'banana', 'cherry']} loopFocus={false}>
-          <Combobox.Input data-testid="input" />
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  {(item: string) => (
-                    <Combobox.Item key={item} value={item}>
-                      {item}
-                    </Combobox.Item>
-                  )}
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      const input = screen.getByRole<HTMLInputElement>('combobox');
-      await act(async () => input.focus());
-
-      // ArrowDown opens and focuses first item
-      await user.keyboard('{ArrowDown}');
-
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
-
-      const options = screen.getAllByRole('option');
-
-      await waitFor(() => {
-        expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
-      });
-
-      // Should stay at first item (no loop)
-      await user.keyboard('{ArrowUp}');
-
-      await waitFor(() => {
-        expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
-      });
     });
   });
 

--- a/packages/react/src/combobox/row/ComboboxRow.test.tsx
+++ b/packages/react/src/combobox/row/ComboboxRow.test.tsx
@@ -1,0 +1,25 @@
+import { expect } from 'vitest';
+import { Combobox } from '@base-ui/react/combobox';
+import { screen } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance } from '#test-utils';
+
+describe('<Combobox.Row />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Combobox.Row />, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render(node) {
+      return render(<Combobox.Root grid>{node}</Combobox.Root>);
+    },
+  }));
+
+  it('has role="row"', async () => {
+    await render(
+      <Combobox.Root grid>
+        <Combobox.Row />
+      </Combobox.Root>,
+    );
+
+    expect(screen.getByRole('row')).not.toBe(null);
+  });
+});

--- a/packages/react/src/combobox/status/ComboboxStatus.test.tsx
+++ b/packages/react/src/combobox/status/ComboboxStatus.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { screen } from '@mui/internal-test-utils';
 import { INITIAL_LIVE_REGION_TEXT_MUTATION_RESET_DELAY } from '../utils/useInitialLiveRegionTextMutation';
 
 describe('<Combobox.Status />', () => {
@@ -34,7 +34,7 @@ describe('<Combobox.Status />', () => {
 
     expect(screen.queryByTestId('status')).toBe(null);
     await user.click(screen.getByTestId('input'));
-    await waitFor(() => expect(screen.getByTestId('status')).not.toBe(null));
+    await screen.findByTestId('status');
   });
 
   describe('a11y', () => {

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
@@ -137,7 +137,7 @@ describe('<Combobox.Trigger />', () => {
       expect(screen.queryByRole('listbox')).toBe(null);
     });
 
-    it('should not toggle when readOnly=false (control)', async () => {
+    it('toggles popup when readOnly is false', async () => {
       const { user } = await render(
         <Combobox.Root readOnly={false}>
           <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
@@ -617,7 +617,7 @@ describe('<Combobox.Trigger />', () => {
 
       await user.click(trigger);
 
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       expect(trigger).toHaveAttribute('data-popup-side', 'right');
 
       await user.click(document.body);
@@ -644,7 +644,7 @@ describe('<Combobox.Trigger />', () => {
 
       await user.click(trigger);
 
-      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       expect(trigger).toHaveAttribute('data-list-empty');
     });
 

--- a/packages/react/src/combobox/value/ComboboxValue.test.tsx
+++ b/packages/react/src/combobox/value/ComboboxValue.test.tsx
@@ -117,6 +117,222 @@ describe('<Combobox.Value />', () => {
     });
   });
 
+  describe('prop: itemToStringLabel', () => {
+    it('uses custom itemToStringLabel function', async () => {
+      const customitemToStringLabel = (item: any) => {
+        if (item && typeof item === 'object' && 'name' in item) {
+          return `Custom: ${item.name}`;
+        }
+        return String(item);
+      };
+
+      const complexItem = { id: 1, name: 'Test Item' };
+
+      await render(
+        <Combobox.Root defaultValue={complexItem} itemToStringLabel={customitemToStringLabel}>
+          <Combobox.Trigger data-testid="value">
+            <Combobox.Value />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value={complexItem}>Test Item</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('value')).toHaveTextContent('Custom: Test Item');
+    });
+  });
+
+  describe('prop: placeholder', () => {
+    it('displays placeholder when no value is selected', async () => {
+      await render(
+        <Combobox.Root>
+          <Combobox.Trigger data-testid="value">
+            <Combobox.Value placeholder="Select an option" />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="option1">Option 1</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('value')).toHaveTextContent('Select an option');
+    });
+
+    it('does not display placeholder when value is selected', async () => {
+      await render(
+        <Combobox.Root defaultValue="option1">
+          <Combobox.Trigger data-testid="value">
+            <Combobox.Value placeholder="Select an option" />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="option1">Option 1</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('value')).toHaveTextContent('option1');
+    });
+
+    it('children prop takes precedence over placeholder', async () => {
+      await render(
+        <Combobox.Root>
+          <Combobox.Trigger data-testid="value">
+            <Combobox.Value placeholder="Select an option">Custom Text</Combobox.Value>
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="option1">Option 1</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('value')).toHaveTextContent('Custom Text');
+    });
+
+    it('children function takes precedence over placeholder', async () => {
+      await render(
+        <Combobox.Root>
+          <Combobox.Trigger data-testid="value">
+            <Combobox.Value placeholder="Select an option">
+              {(value) => value || 'Function fallback'}
+            </Combobox.Value>
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="option1">Option 1</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('value')).toHaveTextContent('Function fallback');
+    });
+
+    it('null item label in items takes precedence over placeholder', async () => {
+      const items = [
+        { value: null, label: 'None' },
+        { value: 'option1', label: 'Option 1' },
+      ];
+
+      await render(
+        <Combobox.Root items={items}>
+          <Combobox.Trigger data-testid="value">
+            <Combobox.Value placeholder="Select an option" />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value={null}>None</Combobox.Item>
+                  <Combobox.Item value="option1">Option 1</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('value')).toHaveTextContent('None');
+    });
+
+    it('uses placeholder when items have null value without label', async () => {
+      const items = [
+        { value: null, label: null },
+        { value: 'option1', label: 'Option 1' },
+      ];
+
+      await render(
+        <Combobox.Root items={items}>
+          <Combobox.Trigger data-testid="value">
+            <Combobox.Value placeholder="Select an option" />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value={null}>None</Combobox.Item>
+                  <Combobox.Item value="option1">Option 1</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('value')).toHaveTextContent('Select an option');
+    });
+
+    it('supports ReactNode as placeholder', async () => {
+      await render(
+        <Combobox.Root>
+          <Combobox.Trigger>
+            <Combobox.Value placeholder={<span data-testid="placeholder">Select an option</span>} />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="option1">Option 1</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('placeholder')).toHaveTextContent('Select an option');
+    });
+
+    it('displays placeholder when multiple mode has empty array', async () => {
+      await render(
+        <Combobox.Root multiple defaultValue={[]}>
+          <Combobox.Trigger data-testid="value">
+            <Combobox.Value placeholder="Select options" />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="option1">Option 1</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('value')).toHaveTextContent('Select options');
+    });
+  });
+
   describe('selected value with label property', () => {
     it('renders label from selected value object', async () => {
       const valueWithLabel = { value: 'test', label: 'Test Label' };
@@ -679,222 +895,6 @@ describe('<Combobox.Value />', () => {
       );
 
       expect(screen.getByTestId('value')).toHaveTextContent('true');
-    });
-  });
-
-  describe('prop: itemToStringLabel', () => {
-    it('uses custom itemToStringLabel function', async () => {
-      const customitemToStringLabel = (item: any) => {
-        if (item && typeof item === 'object' && 'name' in item) {
-          return `Custom: ${item.name}`;
-        }
-        return String(item);
-      };
-
-      const complexItem = { id: 1, name: 'Test Item' };
-
-      await render(
-        <Combobox.Root defaultValue={complexItem} itemToStringLabel={customitemToStringLabel}>
-          <Combobox.Trigger data-testid="value">
-            <Combobox.Value />
-          </Combobox.Trigger>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  <Combobox.Item value={complexItem}>Test Item</Combobox.Item>
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByTestId('value')).toHaveTextContent('Custom: Test Item');
-    });
-  });
-
-  describe('prop: placeholder', () => {
-    it('displays placeholder when no value is selected', async () => {
-      await render(
-        <Combobox.Root>
-          <Combobox.Trigger data-testid="value">
-            <Combobox.Value placeholder="Select an option" />
-          </Combobox.Trigger>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  <Combobox.Item value="option1">Option 1</Combobox.Item>
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByTestId('value')).toHaveTextContent('Select an option');
-    });
-
-    it('does not display placeholder when value is selected', async () => {
-      await render(
-        <Combobox.Root defaultValue="option1">
-          <Combobox.Trigger data-testid="value">
-            <Combobox.Value placeholder="Select an option" />
-          </Combobox.Trigger>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  <Combobox.Item value="option1">Option 1</Combobox.Item>
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByTestId('value')).toHaveTextContent('option1');
-    });
-
-    it('children prop takes precedence over placeholder', async () => {
-      await render(
-        <Combobox.Root>
-          <Combobox.Trigger data-testid="value">
-            <Combobox.Value placeholder="Select an option">Custom Text</Combobox.Value>
-          </Combobox.Trigger>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  <Combobox.Item value="option1">Option 1</Combobox.Item>
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByTestId('value')).toHaveTextContent('Custom Text');
-    });
-
-    it('children function takes precedence over placeholder', async () => {
-      await render(
-        <Combobox.Root>
-          <Combobox.Trigger data-testid="value">
-            <Combobox.Value placeholder="Select an option">
-              {(value) => value || 'Function fallback'}
-            </Combobox.Value>
-          </Combobox.Trigger>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  <Combobox.Item value="option1">Option 1</Combobox.Item>
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByTestId('value')).toHaveTextContent('Function fallback');
-    });
-
-    it('null item label in items takes precedence over placeholder', async () => {
-      const items = [
-        { value: null, label: 'None' },
-        { value: 'option1', label: 'Option 1' },
-      ];
-
-      await render(
-        <Combobox.Root items={items}>
-          <Combobox.Trigger data-testid="value">
-            <Combobox.Value placeholder="Select an option" />
-          </Combobox.Trigger>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  <Combobox.Item value={null}>None</Combobox.Item>
-                  <Combobox.Item value="option1">Option 1</Combobox.Item>
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByTestId('value')).toHaveTextContent('None');
-    });
-
-    it('uses placeholder when items have null value without label', async () => {
-      const items = [
-        { value: null, label: null },
-        { value: 'option1', label: 'Option 1' },
-      ];
-
-      await render(
-        <Combobox.Root items={items}>
-          <Combobox.Trigger data-testid="value">
-            <Combobox.Value placeholder="Select an option" />
-          </Combobox.Trigger>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  <Combobox.Item value={null}>None</Combobox.Item>
-                  <Combobox.Item value="option1">Option 1</Combobox.Item>
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByTestId('value')).toHaveTextContent('Select an option');
-    });
-
-    it('supports ReactNode as placeholder', async () => {
-      await render(
-        <Combobox.Root>
-          <Combobox.Trigger>
-            <Combobox.Value placeholder={<span data-testid="placeholder">Select an option</span>} />
-          </Combobox.Trigger>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  <Combobox.Item value="option1">Option 1</Combobox.Item>
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByTestId('placeholder')).toHaveTextContent('Select an option');
-    });
-
-    it('displays placeholder when multiple mode has empty array', async () => {
-      await render(
-        <Combobox.Root multiple defaultValue={[]}>
-          <Combobox.Trigger data-testid="value">
-            <Combobox.Value placeholder="Select options" />
-          </Combobox.Trigger>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  <Combobox.Item value="option1">Option 1</Combobox.Item>
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
-        </Combobox.Root>,
-      );
-
-      expect(screen.getByTestId('value')).toHaveTextContent('Select options');
     });
   });
 });

--- a/packages/react/src/context-menu/root/ContextMenuRoot.non-mac.test.tsx
+++ b/packages/react/src/context-menu/root/ContextMenuRoot.non-mac.test.tsx
@@ -1,11 +1,5 @@
 import { vi, expect } from 'vitest';
-import {
-  fireEvent,
-  ignoreActWarnings,
-  reactMajor,
-  screen,
-  waitFor,
-} from '@mui/internal-test-utils';
+import { fireEvent, ignoreActWarnings, reactMajor, screen } from '@mui/internal-test-utils';
 import { ContextMenu } from '@base-ui/react/context-menu';
 import { createRenderer } from '#test-utils';
 
@@ -64,9 +58,7 @@ describe('<ContextMenu.Root /> (non-Mac)', () => {
       fireEvent.pointerMove(document.body, { clientX: 24, clientY: 24 });
       fireEvent.mouseUp(item, { button: 2, clientX: 24, clientY: 24 });
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('context-popup')).not.toBe(null);
-      });
+      await screen.findByTestId('context-popup');
 
       expect(onOpenChange.mock.calls.length).toBe(1);
     });

--- a/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
+++ b/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
@@ -125,9 +125,7 @@ describe('<ContextMenu.Root />', () => {
 
       fireEvent.mouseUp(item, { button: 2, clientX: 12, clientY: 12 });
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('context-popup')).not.toBe(null);
-      });
+      await screen.findByTestId('context-popup');
 
       expect(onOpenChange.mock.calls.length).toBe(1);
     });
@@ -161,9 +159,7 @@ describe('<ContextMenu.Root />', () => {
 
       fireEvent.mouseUp(item, { button: 2, clientX: 18, clientY: 18 });
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('context-popup')).not.toBe(null);
-      });
+      await screen.findByTestId('context-popup');
 
       expect(onOpenChange.mock.calls.length).toBe(1);
     });

--- a/packages/react/src/dialog/popup/DialogPopup.test.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.test.tsx
@@ -342,77 +342,6 @@ describe('<Dialog.Popup />', () => {
     });
   });
 
-  describe.skipIf(isJSDOM)('display: contents ancestors', () => {
-    it('keeps initial focus working when the popup is wrapped by a display: contents ancestor', async () => {
-      const { user } = await render(
-        <div>
-          <button data-testid="outside-before">Outside before</button>
-          <Dialog.Root modal={false}>
-            <Dialog.Trigger>Open</Dialog.Trigger>
-            <Dialog.Portal>
-              <form style={{ display: 'contents' }}>
-                <Dialog.Popup data-testid="dialog-popup">
-                  <input data-testid="dialog-input" />
-                  <button type="button">Close</button>
-                </Dialog.Popup>
-              </form>
-            </Dialog.Portal>
-          </Dialog.Root>
-          <button data-testid="outside-after">Outside after</button>
-        </div>,
-      );
-
-      await user.click(screen.getByText('Open'));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('dialog-input')).toHaveFocus();
-      });
-    });
-
-    it('keeps trap-focus tab cycling inside the popup when wrapped by a display: contents ancestor', async () => {
-      const { user } = await render(
-        <div>
-          <button data-testid="outside-before">Outside before</button>
-          <Dialog.Root defaultOpen modal="trap-focus">
-            <Dialog.Portal>
-              <form style={{ display: 'contents' }}>
-                <Dialog.Popup data-testid="dialog-popup">
-                  <input data-testid="first-input" />
-                  <button type="button" data-testid="second-button">
-                    Second
-                  </button>
-                </Dialog.Popup>
-              </form>
-            </Dialog.Portal>
-          </Dialog.Root>
-          <button data-testid="outside-after">Outside after</button>
-        </div>,
-      );
-
-      const popup = screen.getByTestId('dialog-popup');
-
-      await waitFor(() => {
-        expect(screen.getByTestId('first-input')).toHaveFocus();
-      });
-
-      await user.keyboard('[Tab]');
-      expect(screen.getByTestId('second-button')).toHaveFocus();
-
-      await user.keyboard('[Tab]');
-      await waitFor(() => {
-        expect(screen.getByTestId('first-input')).toHaveFocus();
-      });
-      expect(screen.getByTestId('outside-before')).not.toHaveFocus();
-      expect(screen.getByTestId('outside-after')).not.toHaveFocus();
-
-      await user.keyboard('[ShiftLeft>][Tab][/ShiftLeft]');
-      await waitFor(() => {
-        expect(screen.getByTestId('second-button')).toHaveFocus();
-      });
-      expect(popup.contains(document.activeElement)).toBe(true);
-    });
-  });
-
   describe('prop: finalFocus', () => {
     it('should focus the trigger by default when closed', async () => {
       const { user } = await render(
@@ -704,6 +633,77 @@ describe('<Dialog.Popup />', () => {
     });
   });
 
+  describe.skipIf(isJSDOM)('display: contents ancestors', () => {
+    it('keeps initial focus working when the popup is wrapped by a display: contents ancestor', async () => {
+      const { user } = await render(
+        <div>
+          <button data-testid="outside-before">Outside before</button>
+          <Dialog.Root modal={false}>
+            <Dialog.Trigger>Open</Dialog.Trigger>
+            <Dialog.Portal>
+              <form style={{ display: 'contents' }}>
+                <Dialog.Popup data-testid="dialog-popup">
+                  <input data-testid="dialog-input" />
+                  <button type="button">Close</button>
+                </Dialog.Popup>
+              </form>
+            </Dialog.Portal>
+          </Dialog.Root>
+          <button data-testid="outside-after">Outside after</button>
+        </div>,
+      );
+
+      await user.click(screen.getByText('Open'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('dialog-input')).toHaveFocus();
+      });
+    });
+
+    it('keeps trap-focus tab cycling inside the popup when wrapped by a display: contents ancestor', async () => {
+      const { user } = await render(
+        <div>
+          <button data-testid="outside-before">Outside before</button>
+          <Dialog.Root defaultOpen modal="trap-focus">
+            <Dialog.Portal>
+              <form style={{ display: 'contents' }}>
+                <Dialog.Popup data-testid="dialog-popup">
+                  <input data-testid="first-input" />
+                  <button type="button" data-testid="second-button">
+                    Second
+                  </button>
+                </Dialog.Popup>
+              </form>
+            </Dialog.Portal>
+          </Dialog.Root>
+          <button data-testid="outside-after">Outside after</button>
+        </div>,
+      );
+
+      const popup = screen.getByTestId('dialog-popup');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('first-input')).toHaveFocus();
+      });
+
+      await user.keyboard('[Tab]');
+      expect(screen.getByTestId('second-button')).toHaveFocus();
+
+      await user.keyboard('[Tab]');
+      await waitFor(() => {
+        expect(screen.getByTestId('first-input')).toHaveFocus();
+      });
+      expect(screen.getByTestId('outside-before')).not.toHaveFocus();
+      expect(screen.getByTestId('outside-after')).not.toHaveFocus();
+
+      await user.keyboard('[ShiftLeft>][Tab][/ShiftLeft]');
+      await waitFor(() => {
+        expect(screen.getByTestId('second-button')).toHaveFocus();
+      });
+      expect(popup.contains(document.activeElement)).toBe(true);
+    });
+  });
+
   describe.skipIf(isJSDOM)('nested dialog count', () => {
     it('provides the number of open nested dialogs as a CSS variable', async () => {
       const { user } = await render(
@@ -734,9 +734,7 @@ describe('<Dialog.Popup />', () => {
 
       await user.click(screen.getByRole('button', { name: 'Trigger 0' }));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('popup0')).not.toBe(null);
-      });
+      await screen.findByTestId('popup0');
 
       const computedStyles = getComputedStyle(screen.getByTestId('popup0'));
 
@@ -744,17 +742,13 @@ describe('<Dialog.Popup />', () => {
 
       await user.click(screen.getByRole('button', { name: 'Trigger 1' }));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('popup1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup1');
 
       expect(computedStyles.getPropertyValue('--nested-dialogs')).toBe('1');
 
       await user.click(screen.getByRole('button', { name: 'Trigger 2' }));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('popup2')).not.toBe(null);
-      });
+      await screen.findByTestId('popup2');
 
       expect(computedStyles.getPropertyValue('--nested-dialogs')).toBe('2');
 
@@ -799,9 +793,7 @@ describe('<Dialog.Popup />', () => {
 
       await user.click(screen.getByRole('button', { name: 'Trigger 0' }));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('popup0')).not.toBe(null);
-      });
+      await screen.findByTestId('popup0');
 
       const computedStyles = getComputedStyle(screen.getByTestId('popup0'));
 
@@ -809,9 +801,7 @@ describe('<Dialog.Popup />', () => {
 
       await user.click(screen.getByRole('button', { name: 'Trigger 1' }));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('popup1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup1');
 
       expect(computedStyles.getPropertyValue('--nested-dialogs')).toBe('1');
 
@@ -848,9 +838,7 @@ describe('<Dialog.Popup />', () => {
 
       await user.click(screen.getByRole('button', { name: 'Trigger 0' }));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('popup0')).not.toBe(null);
-      });
+      await screen.findByTestId('popup0');
 
       const computedStyles = getComputedStyle(screen.getByTestId('popup0'));
 
@@ -882,13 +870,13 @@ describe('<Dialog.Popup />', () => {
       );
 
       await user.click(screen.getByRole('button', { name: 'Open Dialog' }));
-      await waitFor(() => expect(screen.getByTestId('parent-dialog')).not.toBe(null));
+      await screen.findByTestId('parent-dialog');
 
       const parent = screen.getByTestId('parent-dialog');
       expect(getComputedStyle(parent).getPropertyValue('--nested-dialogs')).toBe('0');
 
       await user.click(screen.getByRole('button', { name: 'Open Alert' }));
-      await waitFor(() => expect(screen.getByTestId('nested-alert')).not.toBe(null));
+      await screen.findByTestId('nested-alert');
       await waitFor(() => {
         expect(getComputedStyle(parent).getPropertyValue('--nested-dialogs')).toBe('1');
       });
@@ -900,8 +888,8 @@ describe('<Dialog.Popup />', () => {
     });
   });
 
-  describe('style hooks', () => {
-    it('adds the `nested` and `nested-dialog-open` style hooks if a dialog has a parent dialog', async () => {
+  describe('state attributes', () => {
+    it('adds data-nested and data-nested-dialog-open when a dialog has a parent dialog', async () => {
       await render(
         <Dialog.Root open>
           <Dialog.Portal>
@@ -931,7 +919,7 @@ describe('<Dialog.Popup />', () => {
       expect(nestedDialog).not.toHaveAttribute('data-nested-dialog-open');
     });
 
-    it('adds the `nested` and `nested-dialog-open` style hooks if a dialog has a parent alert dialog', async () => {
+    it('adds data-nested and data-nested-dialog-open when a dialog has a parent alert dialog', async () => {
       await render(
         <AlertDialog.Root open>
           <AlertDialog.Portal>

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -38,9 +38,7 @@ describe('<Dialog.Root />', () => {
       expect(screen.queryByText('Dialog Content')).toBe(null);
 
       await user.click(trigger1);
-      await waitFor(() => {
-        expect(screen.queryByText('Dialog Content')).not.toBe(null);
-      });
+      await screen.findByText('Dialog Content');
 
       await user.click(screen.getByText('Close'));
       await waitFor(() => {
@@ -48,9 +46,7 @@ describe('<Dialog.Root />', () => {
       });
 
       await user.click(trigger2);
-      await waitFor(() => {
-        expect(screen.queryByText('Dialog Content')).not.toBe(null);
-      });
+      await screen.findByText('Dialog Content');
 
       await user.click(screen.getByText('Close'));
       await waitFor(() => {
@@ -58,9 +54,7 @@ describe('<Dialog.Root />', () => {
       });
 
       await user.click(trigger3);
-      await waitFor(() => {
-        expect(screen.queryByText('Dialog Content')).not.toBe(null);
-      });
+      await screen.findByText('Dialog Content');
     });
 
     it('sets the payload and renders content based on its value', async () => {
@@ -368,27 +362,21 @@ describe('<Dialog.Root />', () => {
       expect(screen.queryByText('Dialog Content')).toBe(null);
 
       await user.click(trigger1);
-      await waitFor(() => {
-        expect(screen.queryByText('Dialog Content')).not.toBe(null);
-      });
+      await screen.findByText('Dialog Content');
       await user.click(screen.getByText('Close'));
       await waitFor(() => {
         expect(screen.queryByText('Dialog Content')).toBe(null);
       });
 
       await user.click(trigger2);
-      await waitFor(() => {
-        expect(screen.queryByText('Dialog Content')).not.toBe(null);
-      });
+      await screen.findByText('Dialog Content');
       await user.click(screen.getByText('Close'));
       await waitFor(() => {
         expect(screen.queryByText('Dialog Content')).toBe(null);
       });
 
       await user.click(trigger3);
-      await waitFor(() => {
-        expect(screen.queryByText('Dialog Content')).not.toBe(null);
-      });
+      await screen.findByText('Dialog Content');
     });
 
     it('keeps detached triggers clickable when reparented (remove wrappers)', async () => {
@@ -685,9 +673,7 @@ describe('<Dialog.Root />', () => {
       expect(screen.queryByRole('dialog')).toBe(null);
 
       await act(() => dialog.open('trigger'));
-      await waitFor(() => {
-        expect(screen.queryByRole('dialog')).not.toBe(null);
-      });
+      await screen.findByRole('dialog');
 
       expect(screen.getByTestId('content').textContent).toBe('Content');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
@@ -725,9 +711,7 @@ describe('<Dialog.Root />', () => {
       expect(screen.queryByRole('dialog')).toBe(null);
 
       await act(() => dialog.open('trigger2'));
-      await waitFor(() => {
-        expect(screen.queryByRole('dialog')).not.toBe(null);
-      });
+      await screen.findByRole('dialog');
 
       expect(screen.getByTestId('content').textContent).toBe('2');
       expect(trigger2).toHaveAttribute('aria-expanded', 'true');
@@ -766,9 +750,7 @@ describe('<Dialog.Root />', () => {
       expect(screen.queryByRole('dialog')).toBe(null);
 
       await act(() => dialog.openWithPayload(8));
-      await waitFor(() => {
-        expect(screen.queryByRole('dialog')).not.toBe(null);
-      });
+      await screen.findByRole('dialog');
 
       expect(screen.getByTestId('content').textContent).toBe('8');
       expect(trigger1).not.toHaveAttribute('aria-expanded', 'true');

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -79,9 +79,7 @@ describe('<Dialog.Root />', () => {
       const trigger = screen.getByTestId('trigger');
 
       await user.click(trigger);
-      await waitFor(() => {
-        expect(screen.queryByRole('dialog')).not.toBe(null);
-      });
+      await screen.findByRole('dialog');
 
       await user.keyboard('[Escape]');
       await waitFor(() => {
@@ -89,9 +87,7 @@ describe('<Dialog.Root />', () => {
       });
 
       await user.click(trigger);
-      await waitFor(() => {
-        expect(screen.queryByRole('dialog')).not.toBe(null);
-      });
+      await screen.findByRole('dialog');
 
       fireEvent.click(document.body);
       await waitFor(() => {
@@ -377,6 +373,387 @@ describe('<Dialog.Root />', () => {
       });
     });
 
+    describe('prop: modal', () => {
+      it('should render an internal backdrop when `true`', async () => {
+        const { user } = await render(
+          <div>
+            <TestDialog rootProps={{ modal: true }} />
+            <button>Outside</button>
+          </div>,
+        );
+
+        const trigger = screen.getByTestId('trigger');
+
+        await user.click(trigger);
+
+        await screen.findByRole('dialog');
+
+        const popup = screen.getByRole('dialog');
+
+        // focus guard -> internal backdrop
+        expect(popup.previousElementSibling?.previousElementSibling).toHaveAttribute(
+          'role',
+          'presentation',
+        );
+      });
+
+      it('should not render an internal backdrop when `false`', async () => {
+        const { user } = await render(
+          <div>
+            <TestDialog rootProps={{ modal: false }} />
+            <button>Outside</button>
+          </div>,
+        );
+
+        const trigger = screen.getByTestId('trigger');
+
+        await user.click(trigger);
+
+        await screen.findByRole('dialog');
+
+        const popup = screen.getByRole('dialog');
+
+        // focus guard -> internal backdrop
+        expect(popup.previousElementSibling?.previousElementSibling).toBe(null);
+      });
+    });
+
+    describe('prop: actionsRef', () => {
+      it('unmounts the dialog when the `unmount` method is called', async () => {
+        const actionsRef = {
+          current: {
+            unmount: vi.fn(),
+            close: vi.fn(),
+          },
+        };
+
+        const { user } = await render(
+          <TestDialog
+            rootProps={{
+              actionsRef,
+              onOpenChange: (open, details) => {
+                details.preventUnmountOnClose();
+              },
+            }}
+          />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Open' });
+        await user.click(trigger);
+
+        await screen.findByRole('dialog');
+
+        await user.click(trigger);
+
+        await screen.findByRole('dialog');
+
+        await act(async () => actionsRef.current.unmount());
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).toBe(null);
+        });
+      });
+    });
+
+    describe.skipIf(isJSDOM)('prop: onOpenChangeComplete', () => {
+      it('is called on close when there is no exit animation defined', async () => {
+        const onOpenChangeComplete = vi.fn();
+
+        function Test() {
+          const [open, setOpen] = React.useState(true);
+          return (
+            <div>
+              <button onClick={() => setOpen(false)}>Close externally</button>
+              <TestDialog rootProps={{ open, onOpenChangeComplete }} />
+            </div>
+          );
+        }
+
+        const { user } = await render(<Test />);
+
+        const closeButton = screen.getByText('Close externally');
+        await user.click(closeButton);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('dialog-popup')).toBe(null);
+        });
+
+        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+        expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
+      });
+
+      it('is called on close when the exit animation finishes', async () => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        const onOpenChangeComplete = vi.fn();
+
+        function Test() {
+          const style = `
+        @keyframes test-anim {
+          to {
+            opacity: 0;
+          }
+        }
+
+        .animation-test-indicator[data-ending-style] {
+          animation: test-anim 1ms;
+        }
+      `;
+
+          const [open, setOpen] = React.useState(true);
+
+          return (
+            <div>
+              {/* eslint-disable-next-line react/no-danger */}
+              <style dangerouslySetInnerHTML={{ __html: style }} />
+              <button onClick={() => setOpen(false)}>Close externally</button>
+              <TestDialog
+                rootProps={{ open, onOpenChangeComplete }}
+                popupProps={{
+                  className: 'animation-test-indicator',
+                }}
+              />
+            </div>
+          );
+        }
+
+        const { user } = await render(<Test />);
+
+        expect(screen.getByTestId('dialog-popup')).not.toBe(null);
+
+        // Wait for open animation to finish
+        await waitFor(() => {
+          expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+        });
+
+        const closeButton = screen.getByText('Close externally');
+        await user.click(closeButton);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('dialog-popup')).toBe(null);
+        });
+
+        expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
+      });
+
+      it('is called on open when there is no enter animation defined', async () => {
+        const onOpenChangeComplete = vi.fn();
+
+        function Test() {
+          const [open, setOpen] = React.useState(false);
+          return (
+            <div>
+              <button onClick={() => setOpen(true)}>Open externally</button>
+              <TestDialog rootProps={{ open, onOpenChangeComplete }} />
+            </div>
+          );
+        }
+
+        const { user } = await render(<Test />);
+
+        const openButton = screen.getByText('Open externally');
+        await user.click(openButton);
+
+        await screen.findByTestId('dialog-popup');
+
+        expect(onOpenChangeComplete.mock.calls.length).toBe(2);
+        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+      });
+
+      it('is called on open when the enter animation finishes', async () => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        const onOpenChangeComplete = vi.fn();
+
+        function Test() {
+          const style = `
+          @keyframes test-anim {
+            from {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-indicator[data-starting-style] {
+            animation: test-anim 1ms;
+          }
+        `;
+
+          const [open, setOpen] = React.useState(false);
+
+          return (
+            <div>
+              {/* eslint-disable-next-line react/no-danger */}
+              <style dangerouslySetInnerHTML={{ __html: style }} />
+              <button onClick={() => setOpen(true)}>Open externally</button>
+              <TestDialog
+                rootProps={{ open, onOpenChange: setOpen, onOpenChangeComplete }}
+                popupProps={{
+                  className: 'animation-test-indicator',
+                }}
+              />
+            </div>
+          );
+        }
+
+        const { user } = await render(<Test />);
+
+        const openButton = screen.getByText('Open externally');
+        await user.click(openButton);
+
+        // Wait for open animation to finish
+        await waitFor(() => {
+          expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+        });
+
+        expect(screen.queryByTestId('dialog-popup')).not.toBe(null);
+      });
+
+      it('waits for a restarted enter animation to finish', async () => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        const onOpenChangeComplete = vi.fn();
+
+        function Test() {
+          const style = `
+            @keyframes test-enter-a {
+              from {
+                opacity: 0;
+              }
+            }
+
+            @keyframes test-enter-b {
+              from {
+                opacity: 0;
+              }
+            }
+
+            .animation-test-indicator.animation-a[data-open] {
+              animation: test-enter-a 50ms linear;
+            }
+
+            .animation-test-indicator.animation-b[data-open] {
+              animation: test-enter-b 50ms linear;
+            }
+          `;
+
+          const [open, setOpen] = React.useState(false);
+          const [variant, setVariant] = React.useState<'a' | 'b'>('a');
+
+          return (
+            <div>
+              {/* eslint-disable-next-line react/no-danger */}
+              <style dangerouslySetInnerHTML={{ __html: style }} />
+              <button onClick={() => setOpen(true)}>Open externally</button>
+              <button onClick={() => setVariant((v) => (v === 'a' ? 'b' : 'a'))}>
+                Swap animation
+              </button>
+              <TestDialog
+                rootProps={{ open, onOpenChange: setOpen, onOpenChangeComplete }}
+                popupProps={{
+                  className: `animation-test-indicator animation-${variant}`,
+                }}
+              />
+            </div>
+          );
+        }
+
+        const { user } = await render(<Test />);
+
+        const openButton = screen.getByText('Open externally');
+        await user.click(openButton);
+
+        const popup = screen.getByTestId('dialog-popup');
+        await waitFor(() => {
+          expect(popup.getAnimations().length).not.toBe(0);
+        });
+
+        const swapButton = screen.getByText('Swap animation');
+        await user.click(swapButton);
+
+        await flushMicrotasks();
+        expect(onOpenChangeComplete.mock.calls.length).toBe(0);
+
+        await waitFor(() => {
+          expect(onOpenChangeComplete.mock.calls.length).toBe(1);
+          expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+        });
+      });
+
+      it('does not get called on open when dismissed during the enter animation', async () => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        const onOpenChangeComplete = vi.fn();
+
+        function Test() {
+          const style = `
+            .animation-test-indicator {
+              opacity: 0;
+              transition: opacity 200ms linear;
+            }
+
+            .animation-test-indicator[data-open] {
+              opacity: 1;
+            }
+
+            .animation-test-indicator[data-open][data-starting-style] {
+              opacity: 0;
+            }
+
+            .animation-test-indicator[data-ending-style] {
+              opacity: 0;
+            }
+          `;
+
+          const [open, setOpen] = React.useState(false);
+
+          return (
+            <div>
+              {/* eslint-disable-next-line react/no-danger */}
+              <style dangerouslySetInnerHTML={{ __html: style }} />
+              <button onClick={() => setOpen(true)}>Open externally</button>
+              <TestDialog
+                rootProps={{ open, onOpenChange: setOpen, onOpenChangeComplete }}
+                popupProps={{
+                  className: 'animation-test-indicator',
+                }}
+              />
+            </div>
+          );
+        }
+
+        const { user } = await render(<Test />);
+
+        const openButton = screen.getByText('Open externally');
+        await user.click(openButton);
+
+        await screen.findByTestId('dialog-popup');
+
+        const popup = screen.getByTestId('dialog-popup');
+        await waitFor(() => {
+          const animations = popup.getAnimations();
+          expect(animations.length).not.toBe(0);
+          expect(animations.some((anim) => anim.playState !== 'finished')).toBe(true);
+        });
+
+        await user.click(document.body);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('dialog-popup')).toBe(null);
+        });
+
+        expect(onOpenChangeComplete.mock.calls.length).toBe(1);
+        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(false);
+      });
+
+      it('does not get called on mount when not open', async () => {
+        const onOpenChangeComplete = vi.fn();
+
+        await render(<TestDialog rootProps={{ onOpenChangeComplete }} />);
+
+        expect(onOpenChangeComplete.mock.calls.length).toBe(0);
+      });
+    });
+
     describe('outside press event with backdrops', () => {
       it('uses intentional outside press with user backdrop (mouse): closes on click, not on mousedown', async () => {
         const handleOpenChange = vi.fn();
@@ -593,55 +970,6 @@ describe('<Dialog.Root />', () => {
       expect(notifyTransitionEnd.mock.calls.length).toBe(1);
     });
 
-    describe('prop: modal', () => {
-      it('should render an internal backdrop when `true`', async () => {
-        const { user } = await render(
-          <div>
-            <TestDialog rootProps={{ modal: true }} />
-            <button>Outside</button>
-          </div>,
-        );
-
-        const trigger = screen.getByTestId('trigger');
-
-        await user.click(trigger);
-
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
-
-        const popup = screen.getByRole('dialog');
-
-        // focus guard -> internal backdrop
-        expect(popup.previousElementSibling?.previousElementSibling).toHaveAttribute(
-          'role',
-          'presentation',
-        );
-      });
-
-      it('should not render an internal backdrop when `false`', async () => {
-        const { user } = await render(
-          <div>
-            <TestDialog rootProps={{ modal: false }} />
-            <button>Outside</button>
-          </div>,
-        );
-
-        const trigger = screen.getByTestId('trigger');
-
-        await user.click(trigger);
-
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
-
-        const popup = screen.getByRole('dialog');
-
-        // focus guard -> internal backdrop
-        expect(popup.previousElementSibling?.previousElementSibling).toBe(null);
-      });
-    });
-
     it('does not dismiss previous modal dialog when clicking new modal dialog', async () => {
       function App() {
         const [openNested, setOpenNested] = React.useState(false);
@@ -775,17 +1103,13 @@ describe('<Dialog.Root />', () => {
         const dialogTrigger = screen.getByRole('button', { name: 'Open' });
         await user.click(dialogTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
+        await screen.findByRole('dialog');
 
         const menuTrigger = screen.getByRole('button', { name: 'Open menu' });
 
         await user.click(menuTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByRole('menu')).not.toBe(null);
-        });
+        await screen.findByRole('menu');
 
         const menuPositioner = screen.getByTestId('menu-positioner');
         const menuInternalBackdrop = menuPositioner.previousElementSibling as HTMLElement;
@@ -795,9 +1119,7 @@ describe('<Dialog.Root />', () => {
         await waitFor(() => {
           expect(screen.queryByRole('menu')).toBe(null);
         });
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
+        await screen.findByRole('dialog');
 
         const dialogPopup = screen.getByTestId('dialog-popup');
         const dialogInternalBackdrop = dialogPopup.previousElementSibling
@@ -833,17 +1155,13 @@ describe('<Dialog.Root />', () => {
         const dialogTrigger = screen.getByRole('button', { name: 'Open' });
         await user.click(dialogTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
+        await screen.findByRole('dialog');
 
         const selectTrigger = screen.getByTestId('select-trigger');
 
         await user.click(selectTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByRole('listbox')).not.toBe(null);
-        });
+        await screen.findByRole('listbox');
 
         const selectPositioner = screen.getByTestId('select-positioner');
         const selectInternalBackdrop = selectPositioner.previousElementSibling as HTMLElement;
@@ -853,9 +1171,7 @@ describe('<Dialog.Root />', () => {
         await waitFor(() => {
           expect(screen.queryByRole('listbox')).toBe(null);
         });
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
+        await screen.findByRole('dialog');
 
         const dialogPopup = screen.getByTestId('dialog-popup');
         const dialogInternalBackdrop = dialogPopup.previousElementSibling
@@ -890,66 +1206,19 @@ describe('<Dialog.Root />', () => {
         const menuTrigger = screen.getByRole('button', { name: 'Open menu' });
         await user.click(menuTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByRole('menu')).not.toBe(null);
-        });
+        await screen.findByRole('menu');
 
         const dialogTrigger = screen.getByRole('menuitem', { name: 'Open dialog' });
         await user.click(dialogTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
+        await screen.findByRole('dialog');
 
         await user.keyboard('[Escape]');
 
         await waitFor(() => {
           expect(screen.queryByRole('dialog')).toBe(null);
         });
-        await waitFor(() => {
-          expect(screen.queryByRole('menu')).not.toBe(null);
-        });
-      });
-    });
-
-    describe('prop: actionsRef', () => {
-      it('unmounts the dialog when the `unmount` method is called', async () => {
-        const actionsRef = {
-          current: {
-            unmount: vi.fn(),
-            close: vi.fn(),
-          },
-        };
-
-        const { user } = await render(
-          <TestDialog
-            rootProps={{
-              actionsRef,
-              onOpenChange: (open, details) => {
-                details.preventUnmountOnClose();
-              },
-            }}
-          />,
-        );
-
-        const trigger = screen.getByRole('button', { name: 'Open' });
-        await user.click(trigger);
-
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
-
-        await user.click(trigger);
-
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
-
-        await act(async () => actionsRef.current.unmount());
-
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).toBe(null);
-        });
+        await screen.findByRole('menu');
       });
     });
 
@@ -1032,309 +1301,6 @@ describe('<Dialog.Root />', () => {
         } finally {
           Element.prototype.requestPointerLock = originalRequestPointerLock;
         }
-      });
-    });
-
-    describe.skipIf(isJSDOM)('prop: onOpenChangeComplete', () => {
-      it('is called on close when there is no exit animation defined', async () => {
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const [open, setOpen] = React.useState(true);
-          return (
-            <div>
-              <button onClick={() => setOpen(false)}>Close externally</button>
-              <TestDialog rootProps={{ open, onOpenChangeComplete }} />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        const closeButton = screen.getByText('Close externally');
-        await user.click(closeButton);
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('dialog-popup')).toBe(null);
-        });
-
-        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-        expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
-      });
-
-      it('is called on close when the exit animation finishes', async () => {
-        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const style = `
-        @keyframes test-anim {
-          to {
-            opacity: 0;
-          }
-        }
-
-        .animation-test-indicator[data-ending-style] {
-          animation: test-anim 1ms;
-        }
-      `;
-
-          const [open, setOpen] = React.useState(true);
-
-          return (
-            <div>
-              {/* eslint-disable-next-line react/no-danger */}
-              <style dangerouslySetInnerHTML={{ __html: style }} />
-              <button onClick={() => setOpen(false)}>Close externally</button>
-              <TestDialog
-                rootProps={{ open, onOpenChangeComplete }}
-                popupProps={{
-                  className: 'animation-test-indicator',
-                }}
-              />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        expect(screen.getByTestId('dialog-popup')).not.toBe(null);
-
-        // Wait for open animation to finish
-        await waitFor(() => {
-          expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-        });
-
-        const closeButton = screen.getByText('Close externally');
-        await user.click(closeButton);
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('dialog-popup')).toBe(null);
-        });
-
-        expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
-      });
-
-      it('is called on open when there is no enter animation defined', async () => {
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const [open, setOpen] = React.useState(false);
-          return (
-            <div>
-              <button onClick={() => setOpen(true)}>Open externally</button>
-              <TestDialog rootProps={{ open, onOpenChangeComplete }} />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        const openButton = screen.getByText('Open externally');
-        await user.click(openButton);
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('dialog-popup')).not.toBe(null);
-        });
-
-        expect(onOpenChangeComplete.mock.calls.length).toBe(2);
-        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-      });
-
-      it('is called on open when the enter animation finishes', async () => {
-        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const style = `
-          @keyframes test-anim {
-            from {
-              opacity: 0;
-            }
-          }
-
-          .animation-test-indicator[data-starting-style] {
-            animation: test-anim 1ms;
-          }
-        `;
-
-          const [open, setOpen] = React.useState(false);
-
-          return (
-            <div>
-              {/* eslint-disable-next-line react/no-danger */}
-              <style dangerouslySetInnerHTML={{ __html: style }} />
-              <button onClick={() => setOpen(true)}>Open externally</button>
-              <TestDialog
-                rootProps={{ open, onOpenChange: setOpen, onOpenChangeComplete }}
-                popupProps={{
-                  className: 'animation-test-indicator',
-                }}
-              />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        const openButton = screen.getByText('Open externally');
-        await user.click(openButton);
-
-        // Wait for open animation to finish
-        await waitFor(() => {
-          expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-        });
-
-        expect(screen.queryByTestId('dialog-popup')).not.toBe(null);
-      });
-
-      it('waits for a restarted enter animation to finish', async () => {
-        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const style = `
-            @keyframes test-enter-a {
-              from {
-                opacity: 0;
-              }
-            }
-
-            @keyframes test-enter-b {
-              from {
-                opacity: 0;
-              }
-            }
-
-            .animation-test-indicator.animation-a[data-open] {
-              animation: test-enter-a 50ms linear;
-            }
-
-            .animation-test-indicator.animation-b[data-open] {
-              animation: test-enter-b 50ms linear;
-            }
-          `;
-
-          const [open, setOpen] = React.useState(false);
-          const [variant, setVariant] = React.useState<'a' | 'b'>('a');
-
-          return (
-            <div>
-              {/* eslint-disable-next-line react/no-danger */}
-              <style dangerouslySetInnerHTML={{ __html: style }} />
-              <button onClick={() => setOpen(true)}>Open externally</button>
-              <button onClick={() => setVariant((v) => (v === 'a' ? 'b' : 'a'))}>
-                Swap animation
-              </button>
-              <TestDialog
-                rootProps={{ open, onOpenChange: setOpen, onOpenChangeComplete }}
-                popupProps={{
-                  className: `animation-test-indicator animation-${variant}`,
-                }}
-              />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        const openButton = screen.getByText('Open externally');
-        await user.click(openButton);
-
-        const popup = screen.getByTestId('dialog-popup');
-        await waitFor(() => {
-          expect(popup.getAnimations().length).not.toBe(0);
-        });
-
-        const swapButton = screen.getByText('Swap animation');
-        await user.click(swapButton);
-
-        await flushMicrotasks();
-        expect(onOpenChangeComplete.mock.calls.length).toBe(0);
-
-        await waitFor(() => {
-          expect(onOpenChangeComplete.mock.calls.length).toBe(1);
-          expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-        });
-      });
-
-      it('does not get called on open when dismissed during the enter animation', async () => {
-        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const style = `
-            .animation-test-indicator {
-              opacity: 0;
-              transition: opacity 200ms linear;
-            }
-
-            .animation-test-indicator[data-open] {
-              opacity: 1;
-            }
-
-            .animation-test-indicator[data-open][data-starting-style] {
-              opacity: 0;
-            }
-
-            .animation-test-indicator[data-ending-style] {
-              opacity: 0;
-            }
-          `;
-
-          const [open, setOpen] = React.useState(false);
-
-          return (
-            <div>
-              {/* eslint-disable-next-line react/no-danger */}
-              <style dangerouslySetInnerHTML={{ __html: style }} />
-              <button onClick={() => setOpen(true)}>Open externally</button>
-              <TestDialog
-                rootProps={{ open, onOpenChange: setOpen, onOpenChangeComplete }}
-                popupProps={{
-                  className: 'animation-test-indicator',
-                }}
-              />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        const openButton = screen.getByText('Open externally');
-        await user.click(openButton);
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('dialog-popup')).not.toBe(null);
-        });
-
-        const popup = screen.getByTestId('dialog-popup');
-        await waitFor(() => {
-          const animations = popup.getAnimations();
-          expect(animations.length).not.toBe(0);
-          expect(animations.some((anim) => anim.playState !== 'finished')).toBe(true);
-        });
-
-        await user.click(document.body);
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('dialog-popup')).toBe(null);
-        });
-
-        expect(onOpenChangeComplete.mock.calls.length).toBe(1);
-        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(false);
-      });
-
-      it('does not get called on mount when not open', async () => {
-        const onOpenChangeComplete = vi.fn();
-
-        await render(<TestDialog rootProps={{ onOpenChangeComplete }} />);
-
-        expect(onOpenChangeComplete.mock.calls.length).toBe(0);
       });
     });
   });

--- a/packages/react/src/drawer/backdrop/DrawerBackdrop.test.tsx
+++ b/packages/react/src/drawer/backdrop/DrawerBackdrop.test.tsx
@@ -1,0 +1,46 @@
+import { expect } from 'vitest';
+import { Drawer } from '@base-ui/react/drawer';
+import { screen } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance } from '#test-utils';
+
+describe('<Drawer.Backdrop />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Drawer.Backdrop />, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render(node) {
+      return render(
+        <Drawer.Root open modal={false}>
+          {node}
+        </Drawer.Root>,
+      );
+    },
+  }));
+
+  it('has role="presentation"', async () => {
+    await render(
+      <Drawer.Root open>
+        <Drawer.Backdrop data-testid="backdrop" />
+      </Drawer.Root>,
+    );
+
+    expect(screen.getByTestId('backdrop')).toHaveAttribute('role', 'presentation');
+  });
+
+  it('has open and closed state attributes', async () => {
+    const { setProps } = await render(
+      <Drawer.Root open>
+        <Drawer.Backdrop data-testid="backdrop" />
+      </Drawer.Root>,
+    );
+
+    const backdrop = screen.getByTestId('backdrop');
+    expect(backdrop).toHaveAttribute('data-open', '');
+    expect(backdrop).not.toHaveAttribute('data-closed');
+
+    await setProps({ open: false });
+
+    expect(backdrop).toHaveAttribute('data-closed', '');
+    expect(backdrop).not.toHaveAttribute('data-open');
+  });
+});

--- a/packages/react/src/drawer/indent-background/DrawerIndentBackground.test.tsx
+++ b/packages/react/src/drawer/indent-background/DrawerIndentBackground.test.tsx
@@ -1,7 +1,7 @@
 import { expect } from 'vitest';
 import { Drawer } from '@base-ui/react/drawer';
 import { screen } from '@mui/internal-test-utils';
-import { createRenderer } from '#test-utils';
+import { createRenderer, describeConformance } from '#test-utils';
 
 interface TestCaseProps {
   open: boolean;
@@ -22,6 +22,13 @@ function TestCase(props: TestCaseProps) {
 
 describe('<Drawer.IndentBackground />', () => {
   const { render } = createRenderer();
+
+  describeConformance(<Drawer.IndentBackground />, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render(node) {
+      return render(<Drawer.Provider>{node}</Drawer.Provider>);
+    },
+  }));
 
   it('sets data-active when any drawer is open', async () => {
     const { setProps } = await render(<TestCase open={false} />);

--- a/packages/react/src/drawer/indent/DrawerIndent.test.tsx
+++ b/packages/react/src/drawer/indent/DrawerIndent.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Drawer } from '@base-ui/react/drawer';
 import { screen } from '@mui/internal-test-utils';
-import { createRenderer } from '#test-utils';
+import { createRenderer, describeConformance } from '#test-utils';
 
 interface TestCaseProps {
   open: boolean;
@@ -24,6 +24,13 @@ function TestCase(props: TestCaseProps) {
 
 describe('<Drawer.Indent />', () => {
   const { render } = createRenderer();
+
+  describeConformance(<Drawer.Indent />, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render(node) {
+      return render(<Drawer.Provider>{node}</Drawer.Provider>);
+    },
+  }));
 
   it('sets data-active when any drawer is open', async () => {
     const { setProps } = await render(<TestCase open={false} />);

--- a/packages/react/src/drawer/popup/DrawerPopup.test.tsx
+++ b/packages/react/src/drawer/popup/DrawerPopup.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest';
-import * as React from 'react';
 import { AlertDialog } from '@base-ui/react/alert-dialog';
 import { Dialog } from '@base-ui/react/dialog';
 import { Drawer } from '@base-ui/react/drawer';

--- a/packages/react/src/drawer/root/DrawerRoot.test.tsx
+++ b/packages/react/src/drawer/root/DrawerRoot.test.tsx
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import * as React from 'react';
 import { Drawer } from '@base-ui/react/drawer';
-import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { createRenderer, isJSDOM, waitSingleFrame } from '#test-utils';
 import { REASONS } from '../../internals/reasons';
 import { useDrawerRootContext } from './DrawerRootContext';
@@ -697,8 +697,6 @@ describe('<Drawer.Root />', () => {
     const handleOpenChange = vi.fn();
     await render(<TestCase onOpenChange={handleOpenChange} />);
 
-    await flushMicrotasks();
-
     const viewport = screen.getByTestId('viewport');
     const popup = screen.getByTestId('popup');
 
@@ -764,7 +762,6 @@ describe('<Drawer.Root />', () => {
       </div>,
     );
 
-    await flushMicrotasks();
     expect(screen.queryByTestId('payload')).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Trigger 1' }));
@@ -795,9 +792,7 @@ describe('<Drawer.Root />', () => {
     const trigger = screen.getByRole('button', { name: 'Open' });
     await user.click(trigger);
 
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).not.toBe(null);
-    });
+    await screen.findByRole('dialog');
 
     const popup = screen.getByTestId('popup');
     expect(trigger.getAttribute('aria-controls')).toBe(popup.getAttribute('id'));
@@ -805,7 +800,6 @@ describe('<Drawer.Root />', () => {
 
   it('resets the active snap point when closing', async () => {
     await render(<SnapPointResetCase />);
-    await flushMicrotasks();
 
     const closeButton = screen.getByTestId('close');
     fireEvent.click(closeButton);
@@ -817,7 +811,6 @@ describe('<Drawer.Root />', () => {
 
   it('resets to the default snap point when provided', async () => {
     await render(<DefaultSnapPointResetCase />);
-    await flushMicrotasks();
 
     expect(screen.getByTestId('active-snap').textContent).toBe('300px');
 
@@ -832,7 +825,6 @@ describe('<Drawer.Root />', () => {
   it('provides event details when snap point changes', async () => {
     const handleSnapPointChange = vi.fn();
     await render(<SnapPointChangeDetailsCase onSnapPointChange={handleSnapPointChange} />);
-    await flushMicrotasks();
 
     const closeButton = screen.getByTestId('close');
     fireEvent.click(closeButton);
@@ -846,7 +838,6 @@ describe('<Drawer.Root />', () => {
 
   it('does not reset snap point when a close is canceled', async () => {
     await render(<CanceledCloseSnapPointResetCase />);
-    await flushMicrotasks();
 
     expect(screen.getByTestId('active-snap').textContent).toBe('1');
 
@@ -861,7 +852,6 @@ describe('<Drawer.Root />', () => {
 
     try {
       await render(<CanceledSwipeCloseCase />);
-      await flushMicrotasks();
 
       const viewport = screen.getByTestId('viewport');
       const popup = screen.getByTestId('popup');
@@ -892,7 +882,6 @@ describe('<Drawer.Root />', () => {
 
       try {
         await render(<ControlledAlwaysOpenCase onOpenChange={handleOpenChange} />);
-        await flushMicrotasks();
 
         const viewport = screen.getByTestId('viewport');
         const popup = screen.getByTestId('popup');
@@ -931,7 +920,6 @@ describe('<Drawer.Root />', () => {
 
       try {
         await render(<ControlledSwipeCloseSnapPointCase />);
-        await flushMicrotasks();
 
         const viewport = screen.getByTestId('viewport');
         const popup = screen.getByTestId('popup');
@@ -953,7 +941,6 @@ describe('<Drawer.Root />', () => {
 
       try {
         await render(<CanceledSwipeCloseSnapPointCase />);
-        await flushMicrotasks();
 
         const viewport = screen.getByTestId('viewport');
         const popup = screen.getByTestId('popup');
@@ -985,7 +972,6 @@ describe('<Drawer.Root />', () => {
 
       try {
         await render(<SnapPointSequentialSkipCase />);
-        await flushMicrotasks();
 
         const viewport = screen.getByTestId('viewport');
         const popup = screen.getByTestId('popup');
@@ -1020,7 +1006,6 @@ describe('<Drawer.Root />', () => {
 
       try {
         await render(<SnapPointSequentialSkipCase />);
-        await flushMicrotasks();
 
         const viewport = screen.getByTestId('viewport');
         const popup = screen.getByTestId('popup');
@@ -1054,7 +1039,6 @@ describe('<Drawer.Root />', () => {
 
     try {
       await render(<SnapPointSwipeCase onOpenChange={handleOpenChange} />);
-      await flushMicrotasks();
 
       const viewport = screen.getByTestId('viewport');
       const popup = screen.getByTestId('popup');
@@ -1091,7 +1075,6 @@ describe('<Drawer.Root />', () => {
 
       try {
         await render(<SnapPointSwipeCase onOpenChange={handleOpenChange} />);
-        await flushMicrotasks();
 
         const viewport = screen.getByTestId('viewport');
         const popup = screen.getByTestId('popup');
@@ -1153,8 +1136,6 @@ describe('<Drawer.Root />', () => {
           </Drawer.Portal>
         </Drawer.Root>,
       );
-
-      await flushMicrotasks();
 
       const instance = CloseWatcherStub.instances[CloseWatcherStub.instances.length - 1];
       expect(instance).not.toBeUndefined();

--- a/packages/react/src/field/item/FieldItem.test.tsx
+++ b/packages/react/src/field/item/FieldItem.test.tsx
@@ -1,5 +1,4 @@
 import { expect, vi } from 'vitest';
-import * as React from 'react';
 import { Field } from '@base-ui/react/field';
 import { Checkbox } from '@base-ui/react/checkbox';
 import { CheckboxGroup } from '@base-ui/react/checkbox-group';

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -10,14 +10,7 @@ import { CheckboxGroup } from '@base-ui/react/checkbox-group';
 import { Switch } from '@base-ui/react/switch';
 import { Slider } from '@base-ui/react/slider';
 import { Field } from '@base-ui/react/field';
-import {
-  act,
-  fireEvent,
-  flushMicrotasks,
-  reactMajor,
-  screen,
-  waitFor,
-} from '@mui/internal-test-utils';
+import { act, fireEvent, reactMajor, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { LabelableProvider } from '../../internals/labelable-provider';
 
@@ -323,7 +316,7 @@ describe('<Field.Root />', () => {
   );
 
   describe('prop: disabled', () => {
-    it('should add data-disabled style hook to all components', async () => {
+    it('adds data-disabled to field parts', async () => {
       await render(
         <Field.Root data-testid="field" disabled>
           <Field.Control data-testid="control" />
@@ -402,7 +395,7 @@ describe('<Field.Root />', () => {
       // expect(screen.queryByText('custom error')).toBe(null);
     });
 
-    it('should apply aria-invalid prop to control once validation finishes', async () => {
+    it('applies aria-invalid to the control after validation finishes', async () => {
       await render(
         <Form>
           <Field.Root validate={() => 'error'}>
@@ -634,8 +627,8 @@ describe('<Field.Root />', () => {
   });
 
   describe('prop: validationMode', () => {
-    describe('onSubmit', () => {
-      it('should validate the field on submit', async () => {
+    describe('validationMode: onSubmit', () => {
+      it('validates the field on submit', async () => {
         await render(
           <Form>
             <Field.Root validate={() => 'error'}>
@@ -678,7 +671,7 @@ describe('<Field.Root />', () => {
       });
     });
 
-    describe('onChange', () => {
+    describe('validationMode: onChange', () => {
       it('validates the field on change', async () => {
         await render(
           <Field.Root
@@ -705,7 +698,7 @@ describe('<Field.Root />', () => {
       });
     });
 
-    describe('onBlur', () => {
+    describe('validationMode: onBlur', () => {
       it('validates the field on blur', async () => {
         await render(
           <Field.Root
@@ -735,7 +728,7 @@ describe('<Field.Root />', () => {
         expect(control).toHaveAttribute('aria-invalid', 'true');
       });
 
-      it('should not mark invalid if `valueMissing` is the only error and not yet dirtied', async () => {
+      it('does not mark invalid if `valueMissing` is the only error and not yet dirtied', async () => {
         await render(
           <Field.Root validationMode="onBlur">
             <Field.Control data-testid="control" required />
@@ -751,7 +744,7 @@ describe('<Field.Root />', () => {
         expect(control).not.toHaveAttribute('aria-invalid');
       });
 
-      it('should mark invalid if `valueMissing` is the only error and dirtied', async () => {
+      it('marks invalid if `valueMissing` is the only error and dirtied', async () => {
         await render(
           <Field.Root validationMode="onBlur">
             <Field.Control data-testid="control" required />
@@ -784,15 +777,10 @@ describe('<Field.Root />', () => {
 
         fireEvent.focus(control);
         fireEvent.blur(control);
-
-        await flushMicrotasks();
-
-        await waitFor(() => {
-          expect(screen.queryByText('error')).not.toBe(null);
-        });
+        await screen.findByText('error');
       });
 
-      it('should apply [data-field] style hooks to field components', async () => {
+      it('adds validity state attributes to field parts', async () => {
         await render(
           <Field.Root validationMode="onBlur">
             <Field.Label data-testid="label">Label</Field.Label>
@@ -838,7 +826,7 @@ describe('<Field.Root />', () => {
         expect(error).toBe(null);
       });
 
-      describe('revalidation', () => {
+      describe('revalidation after initial validation', () => {
         it('revalidates on change for `valueMissing`', async () => {
           await render(
             <Field.Root validationMode="onBlur">
@@ -952,8 +940,8 @@ describe('<Field.Root />', () => {
         });
       });
 
-      describe('computed validity state', () => {
-        it('should not mark field as invalid for valueMissing if not dirty', async () => {
+      describe('computed validity state attributes', () => {
+        it('does not mark the field invalid for untouched valueMissing', async () => {
           await render(
             <Field.Root validationMode="onBlur">
               <Field.Control data-testid="control" required />
@@ -969,7 +957,7 @@ describe('<Field.Root />', () => {
           expect(control).not.toHaveAttribute('aria-invalid');
         });
 
-        it('should mark field as invalid for valueMissing if dirty', async () => {
+        it('marks the field invalid for dirty valueMissing', async () => {
           await render(
             <Field.Root validationMode="onBlur">
               <Field.Control data-testid="control" required />
@@ -978,18 +966,16 @@ describe('<Field.Root />', () => {
 
           const control = screen.getByTestId('control');
 
-          // Mark as touched and dirtied
           fireEvent.focus(control);
           fireEvent.change(control, { target: { value: 'a' } });
           fireEvent.change(control, { target: { value: '' } });
           fireEvent.blur(control);
 
-          // valueMissing is true, and markedDirtyRef is true, so valid should be false
           expect(control).toHaveAttribute('data-invalid', '');
           expect(control).toHaveAttribute('aria-invalid', 'true');
         });
 
-        it('should mark field as invalid for other errors (e.g., typeMismatch) even if not dirty', async () => {
+        it('marks the field invalid for typeMismatch even when not dirty', async () => {
           await render(
             <Field.Root validationMode="onBlur">
               <Field.Control data-testid="control" type="email" defaultValue="not_an_email@" />
@@ -998,11 +984,9 @@ describe('<Field.Root />', () => {
 
           const control = screen.getByTestId('control');
 
-          // Mark as touched but not dirty
           fireEvent.focus(control);
           fireEvent.blur(control);
 
-          // typeMismatch is true, so valid should be false regardless of dirty state
           expect(control).toHaveAttribute('data-invalid', '');
           expect(control).toHaveAttribute('aria-invalid', 'true');
         });
@@ -1054,9 +1038,70 @@ describe('<Field.Root />', () => {
     });
   });
 
-  describe('style hooks', () => {
-    describe('touched', () => {
-      it('should apply [data-touched] style hook to all components when touched', async () => {
+  describe('prop: dirty', () => {
+    it('controls the dirty state', async () => {
+      await render(
+        <Field.Root data-testid="root" dirty>
+          <Field.Control data-testid="control" />
+          <Field.Label data-testid="label" />
+          <Field.Description data-testid="description" />
+          <Field.Error data-testid="error" />
+        </Field.Root>,
+      );
+
+      ['root', 'control', 'label', 'description'].forEach((part) => {
+        expect(screen.getByTestId(part)).toHaveAttribute('data-dirty');
+      });
+    });
+  });
+
+  describe('prop: touched', () => {
+    it('controls the touched state', async () => {
+      await render(
+        <Field.Root data-testid="root" touched>
+          <Field.Control data-testid="control" />
+          <Field.Label data-testid="label" />
+          <Field.Description data-testid="description" />
+          <Field.Error data-testid="error" />
+        </Field.Root>,
+      );
+
+      ['root', 'control', 'label', 'description'].forEach((part) => {
+        expect(screen.getByTestId(part)).toHaveAttribute('data-touched');
+      });
+    });
+  });
+
+  describe('prop: actionsRef', () => {
+    it('validates the field when the `validate` method is called', async () => {
+      function App() {
+        const actionsRef = React.useRef<Field.Root.Actions>(null);
+        return (
+          <div>
+            <Field.Root name="username" actionsRef={actionsRef}>
+              <Field.Control defaultValue="" required />
+              <Field.Error data-testid="error" />
+            </Field.Root>
+            <button type="button" onClick={() => actionsRef.current?.validate()}>
+              validate
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      expect(screen.queryByTestId('error')).toBe(null);
+
+      await user.click(screen.getByText('validate'));
+
+      expect(screen.queryByTestId('error')).not.toBe(null);
+    });
+  });
+
+  describe('field state attributes', () => {
+    describe('data-touched', () => {
+      it('adds data-touched to field parts when touched', async () => {
         await render(
           <Field.Root data-testid="root">
             <Field.Control data-testid="control" />
@@ -1089,8 +1134,8 @@ describe('<Field.Root />', () => {
       });
     });
 
-    describe('dirty', () => {
-      it('should apply [data-dirty] style hook to all components when dirty', async () => {
+    describe('data-dirty', () => {
+      it('adds data-dirty to field parts when dirty', async () => {
         await render(
           <Field.Root data-testid="root">
             <Field.Control data-testid="control" />
@@ -1126,8 +1171,8 @@ describe('<Field.Root />', () => {
       });
     });
 
-    describe('filled', () => {
-      it('should apply [data-filled] style hook to all components when filled', async () => {
+    describe('data-filled', () => {
+      it('adds data-filled to field parts when filled', async () => {
         await render(
           <Field.Root data-testid="root">
             <Field.Control data-testid="control" />
@@ -1162,7 +1207,7 @@ describe('<Field.Root />', () => {
         expect(description).not.toHaveAttribute('data-filled');
       });
 
-      it('changes [data-filled] when the value is changed externally', async () => {
+      it('updates data-filled when the value is changed externally', async () => {
         function App() {
           const [value, setValue] = React.useState('');
           return (
@@ -1188,8 +1233,8 @@ describe('<Field.Root />', () => {
       });
     });
 
-    describe('focused', () => {
-      it('should apply [data-focused] style hook to all components when focused', async () => {
+    describe('data-focused', () => {
+      it('adds data-focused to field parts when focused', async () => {
         await render(
           <Field.Root data-testid="root">
             <Field.Control data-testid="control" />
@@ -1273,67 +1318,6 @@ describe('<Field.Root />', () => {
       fireEvent.focus(input);
 
       expect(input.value).toBe('abc');
-    });
-  });
-
-  describe('prop: dirty', () => {
-    it('controls the dirty state', async () => {
-      await render(
-        <Field.Root data-testid="root" dirty>
-          <Field.Control data-testid="control" />
-          <Field.Label data-testid="label" />
-          <Field.Description data-testid="description" />
-          <Field.Error data-testid="error" />
-        </Field.Root>,
-      );
-
-      ['root', 'control', 'label', 'description'].forEach((part) => {
-        expect(screen.getByTestId(part)).toHaveAttribute('data-dirty');
-      });
-    });
-  });
-
-  describe('prop: touched', () => {
-    it('controls the touched state', async () => {
-      await render(
-        <Field.Root data-testid="root" touched>
-          <Field.Control data-testid="control" />
-          <Field.Label data-testid="label" />
-          <Field.Description data-testid="description" />
-          <Field.Error data-testid="error" />
-        </Field.Root>,
-      );
-
-      ['root', 'control', 'label', 'description'].forEach((part) => {
-        expect(screen.getByTestId(part)).toHaveAttribute('data-touched');
-      });
-    });
-  });
-
-  describe('prop: actionsRef', () => {
-    it('validates the field when the `validate` method is called', async () => {
-      function App() {
-        const actionsRef = React.useRef<Field.Root.Actions>(null);
-        return (
-          <div>
-            <Field.Root name="username" actionsRef={actionsRef}>
-              <Field.Control defaultValue="" required />
-              <Field.Error data-testid="error" />
-            </Field.Root>
-            <button type="button" onClick={() => actionsRef.current?.validate()}>
-              validate
-            </button>
-          </div>
-        );
-      }
-
-      const { user } = await render(<App />);
-
-      expect(screen.queryByTestId('error')).toBe(null);
-
-      await user.click(screen.getByText('validate'));
-
-      expect(screen.queryByTestId('error')).not.toBe(null);
     });
   });
 });

--- a/packages/react/src/field/validity/FieldValidity.test.tsx
+++ b/packages/react/src/field/validity/FieldValidity.test.tsx
@@ -6,8 +6,8 @@ import { Form } from '@base-ui/react/form';
 describe('<Field.Validity />', () => {
   const { render } = createRenderer();
 
-  describe('validationMode=onSubmit', () => {
-    it('should pass validity data', () => {
+  describe('validationMode: onSubmit', () => {
+    it('passes validity data', () => {
       const handleValidity = vi.fn();
 
       render(
@@ -39,8 +39,8 @@ describe('<Field.Validity />', () => {
     });
   });
 
-  describe('validationMode=onBlur', () => {
-    it('should pass validity data', () => {
+  describe('validationMode: onBlur', () => {
+    it('passes validity data', () => {
       const handleValidity = vi.fn();
 
       render(
@@ -63,7 +63,7 @@ describe('<Field.Validity />', () => {
       expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(false);
     });
 
-    it('should correctly pass errors when validate function returns a string', () => {
+    it('passes errors when validate returns a string', () => {
       const handleValidity = vi.fn();
 
       render(
@@ -82,7 +82,7 @@ describe('<Field.Validity />', () => {
       expect(handleValidity.mock.lastCall?.[0].errors).toEqual(['error']);
     });
 
-    it('should correctly pass errors when validate function returns an array of strings', () => {
+    it('passes errors when validate returns an array of strings', () => {
       const handleValidity = vi.fn();
 
       render(

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -326,7 +326,7 @@ describe('FloatingFocusManager', () => {
         expect(screen.queryByTestId('close-dialog')).not.toBeInTheDocument();
       });
 
-      test('return to the first focusable descendent of the reference, if the reference is not focusable', async () => {
+      test('return to the first focusable descendant of the reference, if the reference is not focusable', async () => {
         render(
           <Dialog render={({ close }) => <button onClick={close} data-testid="close-dialog" />}>
             <div data-testid="non-focusable-reference">
@@ -595,149 +595,6 @@ describe('FloatingFocusManager', () => {
       });
     });
 
-    describe('iframe focus navigation', () => {
-      function App({ iframe }: { iframe: HTMLElement }) {
-        return (
-          <div>
-            <a href="#">prev iframe link</a>
-            <Popover
-              portalRef={iframe}
-              render={() => (
-                <div data-testid="popover">
-                  <a href="#">popover link 1</a>
-                  <a href="#">popover link 2</a>
-                </div>
-              )}
-            >
-              <button>Open</button>
-            </Popover>
-            <a href="#">next iframe link</a>
-          </div>
-        );
-      }
-
-      function Popover({
-        children,
-        render,
-        portalRef,
-      }: {
-        children: React.ReactElement;
-        render: () => React.ReactNode;
-        portalRef?: HTMLElement;
-      }) {
-        const [open, setOpen] = React.useState(false);
-
-        const { floatingStyles, refs, context } = useFloating({
-          open,
-          onOpenChange: setOpen,
-        });
-
-        const click = useClick(context);
-        const dismiss = useDismiss(context);
-
-        const { getReferenceProps, getFloatingProps } = useTestInteractions([click, dismiss]);
-
-        return (
-          <>
-            {React.cloneElement(children, getReferenceProps({ ref: refs.setReference }))}
-            {open && (
-              <FloatingPortal container={portalRef}>
-                <FloatingFocusManager context={context} modal={false}>
-                  <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
-                    {render()}
-                  </div>
-                </FloatingFocusManager>
-              </FloatingPortal>
-            )}
-          </>
-        );
-      }
-
-      function IframeApp() {
-        React.useEffect(() => {
-          function createIframe() {
-            const innerRoot = document.querySelector('#innerRoot');
-            const iframe = document.createElement('iframe');
-            iframe.setAttribute('data-testid', 'iframe');
-            iframe.src = 'about:blank';
-            iframe.style.height = '300px';
-
-            innerRoot?.appendChild(iframe);
-
-            // Properly open, write, and close the iframe document.
-            const iframeDoc = iframe.contentWindow?.document;
-            if (iframeDoc) {
-              iframeDoc.open();
-              iframeDoc.write(`<div id="rootIframe"></div>`);
-              iframeDoc.close();
-            }
-
-            const rootIframe = iframe.contentWindow?.document.getElementById('rootIframe');
-            return rootIframe;
-          }
-
-          const root = createIframe();
-          if (root) {
-            ReactDOMClient.createRoot(root).render(<App iframe={root} />);
-          }
-        }, []);
-
-        return (
-          <>
-            <a href="#">Outside link 1</a>
-            <div id="innerRoot" />
-            <a href="#">Outside link 2</a>
-          </>
-        );
-      }
-
-      /* eslint-disable testing-library/prefer-screen-queries */
-      // "Should not already be working"(?) when trying to click within the iframe
-      // https://github.com/facebook/react/pull/32441
-      test.skipIf(!isJSDOM)('tabs from the popover to the next element in the iframe', async () => {
-        render(<IframeApp />);
-
-        const iframe: HTMLIFrameElement = await screen.findByTestId('iframe');
-        const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-        const iframeWithin = iframeDoc ? within(iframeDoc.body) : screen;
-
-        const user = userEvent.setup({ document: iframeDoc });
-
-        await user.click(iframeWithin.getByRole('button', { name: 'Open' }));
-
-        expect(iframeWithin.getByTestId('popover')).toBeInTheDocument();
-
-        await user.tab();
-        await user.tab();
-
-        expect(isFocused(iframeWithin.getByText('next iframe link'))).toBe(true);
-      });
-
-      // "Should not already be working"(?) when trying to click within the iframe
-      // https://github.com/facebook/react/pull/32441
-      test.skipIf(!isJSDOM)(
-        'shift+tab from the popover to the previous element in the iframe',
-        async () => {
-          render(<IframeApp />);
-
-          const iframe: HTMLIFrameElement = await screen.findByTestId('iframe');
-          const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-          const iframeWithin = iframeDoc ? within(iframeDoc.body) : screen;
-
-          const user = userEvent.setup({ document: iframeDoc });
-
-          await user.click(iframeWithin.getByRole('button', { name: 'Open' }));
-
-          expect(iframeWithin.getByTestId('popover')).toBeInTheDocument();
-
-          await user.tab({ shift: true });
-
-          expect(isFocused(iframeWithin.getByRole('button', { name: 'Open' }))).toBe(true);
-        },
-      );
-    });
-    /* eslint-enable testing-library/prefer-screen-queries */
-
     describe('prop: modal', () => {
       test('when true', async () => {
         render(<App modal />);
@@ -845,8 +702,6 @@ describe('FloatingFocusManager', () => {
         }
 
         render(<App />);
-        await flushMicrotasks();
-
         await waitFor(() => {
           expect(screen.getByTestId('floating')).toHaveFocus();
         });
@@ -1197,7 +1052,6 @@ describe('FloatingFocusManager', () => {
         await flushMicrotasks();
         expect(screen.getByTestId('floating')).not.toHaveFocus();
         fireEvent.click(screen.getByTestId('toggle'));
-        await flushMicrotasks();
         await waitFor(() => {
           expect(screen.getByTestId('floating')).toHaveFocus();
         });
@@ -1271,9 +1125,6 @@ describe('FloatingFocusManager', () => {
         expect(screen.getByTestId('floating')).not.toHaveFocus();
 
         fireEvent.click(screen.getByTestId('reference'));
-
-        await flushMicrotasks();
-
         await waitFor(() => {
           expect(screen.getByTestId('child')).toHaveFocus();
         });
@@ -1292,6 +1143,148 @@ describe('FloatingFocusManager', () => {
 
         expect(screen.getByTestId('reference')).toHaveFocus();
       });
+    });
+
+    describe('iframe focus navigation', () => {
+      function App({ iframe }: { iframe: HTMLElement }) {
+        return (
+          <div>
+            <a href="#">prev iframe link</a>
+            <Popover
+              portalRef={iframe}
+              render={() => (
+                <div data-testid="popover">
+                  <a href="#">popover link 1</a>
+                  <a href="#">popover link 2</a>
+                </div>
+              )}
+            >
+              <button>Open</button>
+            </Popover>
+            <a href="#">next iframe link</a>
+          </div>
+        );
+      }
+
+      function Popover({
+        children,
+        render,
+        portalRef,
+      }: {
+        children: React.ReactElement;
+        render: () => React.ReactNode;
+        portalRef?: HTMLElement;
+      }) {
+        const [open, setOpen] = React.useState(false);
+
+        const { floatingStyles, refs, context } = useFloating({
+          open,
+          onOpenChange: setOpen,
+        });
+
+        const click = useClick(context);
+        const dismiss = useDismiss(context);
+
+        const { getReferenceProps, getFloatingProps } = useTestInteractions([click, dismiss]);
+
+        return (
+          <>
+            {React.cloneElement(children, getReferenceProps({ ref: refs.setReference }))}
+            {open && (
+              <FloatingPortal container={portalRef}>
+                <FloatingFocusManager context={context} modal={false}>
+                  <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
+                    {render()}
+                  </div>
+                </FloatingFocusManager>
+              </FloatingPortal>
+            )}
+          </>
+        );
+      }
+
+      function IframeApp() {
+        React.useEffect(() => {
+          function createIframe() {
+            const innerRoot = document.querySelector('#innerRoot');
+            const iframe = document.createElement('iframe');
+            iframe.setAttribute('data-testid', 'iframe');
+            iframe.src = 'about:blank';
+            iframe.style.height = '300px';
+
+            innerRoot?.appendChild(iframe);
+
+            // Properly open, write, and close the iframe document.
+            const iframeDoc = iframe.contentWindow?.document;
+            if (iframeDoc) {
+              iframeDoc.open();
+              iframeDoc.write(`<div id="rootIframe"></div>`);
+              iframeDoc.close();
+            }
+
+            const rootIframe = iframe.contentWindow?.document.getElementById('rootIframe');
+            return rootIframe;
+          }
+
+          const root = createIframe();
+          if (root) {
+            ReactDOMClient.createRoot(root).render(<App iframe={root} />);
+          }
+        }, []);
+
+        return (
+          <>
+            <a href="#">Outside link 1</a>
+            <div id="innerRoot" />
+            <a href="#">Outside link 2</a>
+          </>
+        );
+      }
+
+      /* eslint-disable testing-library/prefer-screen-queries */
+      // "Should not already be working"(?) when trying to click within the iframe
+      // https://github.com/facebook/react/pull/32441
+      test.skipIf(!isJSDOM)('tabs from the popover to the next element in the iframe', async () => {
+        render(<IframeApp />);
+
+        const iframe: HTMLIFrameElement = await screen.findByTestId('iframe');
+        const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+        const iframeWithin = iframeDoc ? within(iframeDoc.body) : screen;
+
+        const user = userEvent.setup({ document: iframeDoc });
+
+        await user.click(iframeWithin.getByRole('button', { name: 'Open' }));
+
+        expect(iframeWithin.getByTestId('popover')).toBeInTheDocument();
+
+        await user.tab();
+        await user.tab();
+
+        expect(isFocused(iframeWithin.getByText('next iframe link'))).toBe(true);
+      });
+
+      // "Should not already be working"(?) when trying to click within the iframe
+      // https://github.com/facebook/react/pull/32441
+      test.skipIf(!isJSDOM)(
+        'shift+tab from the popover to the previous element in the iframe',
+        async () => {
+          render(<IframeApp />);
+
+          const iframe: HTMLIFrameElement = await screen.findByTestId('iframe');
+          const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+          const iframeWithin = iframeDoc ? within(iframeDoc.body) : screen;
+
+          const user = userEvent.setup({ document: iframeDoc });
+
+          await user.click(iframeWithin.getByRole('button', { name: 'Open' }));
+
+          expect(iframeWithin.getByTestId('popover')).toBeInTheDocument();
+
+          await user.tab({ shift: true });
+
+          expect(isFocused(iframeWithin.getByRole('button', { name: 'Open' }))).toBe(true);
+        },
+      );
     });
 
     describe('non-modal + FloatingPortal', () => {
@@ -1543,8 +1536,6 @@ describe('FloatingFocusManager', () => {
         expect(two).toHaveFocus();
 
         fireEvent.click(remove);
-        await flushMicrotasks();
-
         await waitFor(() => {
           expect(document.body).toHaveFocus();
         });

--- a/packages/react/src/floating-ui-react/hooks/useFloating.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useFloating.test.tsx
@@ -1,5 +1,4 @@
 import { expect, test, vi } from 'vitest';
-import * as React from 'react';
 import { flushMicrotasks, render } from '@mui/internal-test-utils';
 import { PopupTriggerMap } from '../../utils/popups';
 import { FloatingRootStore } from '../components/FloatingRootStore';

--- a/packages/react/src/floating-ui-react/hooks/useHover.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useHover.test.tsx
@@ -176,9 +176,6 @@ describe.skipIf(!isJSDOM)('useHover', () => {
 
     fireEvent.pointerDown(screen.getByRole('button'), { pointerType: 'touch' });
     fireEvent.mouseMove(screen.getByRole('button'));
-
-    await flushMicrotasks();
-
     await waitFor(() => {
       expect(screen.getByRole('tooltip')).toBeInTheDocument();
     });

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
@@ -630,44 +630,6 @@ describe('useListNavigation', () => {
     });
   });
 
-  describe('allowEscape + virtual', () => {
-    it('when true', async () => {
-      render(<App allowEscape virtual loopFocus />);
-      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
-      expect(screen.getByTestId('item-0').getAttribute('aria-selected')).toBe('true');
-      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowUp' });
-      expect(screen.getByTestId('item-0').getAttribute('aria-selected')).toBe('false');
-      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
-      expect(screen.getByTestId('item-0').getAttribute('aria-selected')).toBe('true');
-      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
-      expect(screen.getByTestId('item-1').getAttribute('aria-selected')).toBe('true');
-      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
-      expect(screen.getByTestId('item-2').getAttribute('aria-selected')).toBe('true');
-      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
-      expect(screen.getByTestId('item-2').getAttribute('aria-selected')).toBe('false');
-      await flushMicrotasks();
-    });
-
-    it('when false', async () => {
-      render(<App allowEscape={false} virtual loopFocus />);
-      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
-      expect(screen.getByTestId('item-0').getAttribute('aria-selected')).toBe('true');
-      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
-      expect(screen.getByTestId('item-1').getAttribute('aria-selected')).toBe('true');
-      await flushMicrotasks();
-    });
-
-    it('true - onNavigate is called with `null` when escaped', async () => {
-      const spy = vi.fn();
-      render(<App allowEscape virtual loopFocus onNavigate={spy} />);
-      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
-      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowUp' });
-      expect(spy).toHaveBeenCalledTimes(2);
-      expect(spy.mock.calls.some((args) => args[0] === null)).toBe(true);
-      await flushMicrotasks();
-    });
-  });
-
   describe('prop: openOnArrowKeyDown', () => {
     it('opens on ArrowDown when true', async () => {
       render(<App openOnArrowKeyDown />);
@@ -859,6 +821,44 @@ describe('useListNavigation', () => {
         expect(item).toHaveAttribute('aria-selected', 'false');
       });
       expect(spy.mock.calls.at(-1)?.[0]).toBe(null);
+    });
+  });
+
+  describe('allowEscape + virtual', () => {
+    it('when true', async () => {
+      render(<App allowEscape virtual loopFocus />);
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+      expect(screen.getByTestId('item-0').getAttribute('aria-selected')).toBe('true');
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowUp' });
+      expect(screen.getByTestId('item-0').getAttribute('aria-selected')).toBe('false');
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+      expect(screen.getByTestId('item-0').getAttribute('aria-selected')).toBe('true');
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+      expect(screen.getByTestId('item-1').getAttribute('aria-selected')).toBe('true');
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+      expect(screen.getByTestId('item-2').getAttribute('aria-selected')).toBe('true');
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+      expect(screen.getByTestId('item-2').getAttribute('aria-selected')).toBe('false');
+      await flushMicrotasks();
+    });
+
+    it('when false', async () => {
+      render(<App allowEscape={false} virtual loopFocus />);
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+      expect(screen.getByTestId('item-0').getAttribute('aria-selected')).toBe('true');
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+      expect(screen.getByTestId('item-1').getAttribute('aria-selected')).toBe('true');
+      await flushMicrotasks();
+    });
+
+    it('true - onNavigate is called with `null` when escaped', async () => {
+      const spy = vi.fn();
+      render(<App allowEscape virtual loopFocus onNavigate={spy} />);
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowUp' });
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy.mock.calls.some((args) => args[0] === null)).toBe(true);
+      await flushMicrotasks();
     });
   });
 

--- a/packages/react/src/form/Form.test.tsx
+++ b/packages/react/src/form/Form.test.tsx
@@ -469,32 +469,6 @@ describe('<Form />', () => {
     });
   });
 
-  it('does not submit when invalid prop remains true even if validate returns null', async () => {
-    const submitSpy = vi.fn();
-    const validateSpy = vi.fn(() => null);
-
-    const { user } = render(
-      <Form onSubmit={submitSpy}>
-        <Field.Root name="name" invalid validate={validateSpy} validationMode="onChange">
-          <Field.Control data-testid="name" />
-          <Field.Error data-testid="name-error" />
-        </Field.Root>
-        <button type="submit">submit</button>
-      </Form>,
-    );
-
-    const input = screen.getByTestId('name');
-    await user.click(input);
-    await user.keyboard('o');
-
-    expect(validateSpy.mock.calls.length).toBe(1);
-
-    await user.click(screen.getByText('submit'));
-
-    expect(submitSpy.mock.calls.length).toBe(0);
-    expect(input).toHaveAttribute('aria-invalid', 'true');
-  });
-
   describe('prop: noValidate', () => {
     it('should disable native validation if set to true (default)', () => {
       render(<Form data-testid="form" />);
@@ -575,5 +549,31 @@ describe('<Form />', () => {
 
       await expect(screen.queryByTestId('error')).toHaveTextContent('number field error');
     });
+  });
+
+  it('does not submit when invalid prop remains true even if validate returns null', async () => {
+    const submitSpy = vi.fn();
+    const validateSpy = vi.fn(() => null);
+
+    const { user } = render(
+      <Form onSubmit={submitSpy}>
+        <Field.Root name="name" invalid validate={validateSpy} validationMode="onChange">
+          <Field.Control data-testid="name" />
+          <Field.Error data-testid="name-error" />
+        </Field.Root>
+        <button type="submit">submit</button>
+      </Form>,
+    );
+
+    const input = screen.getByTestId('name');
+    await user.click(input);
+    await user.keyboard('o');
+
+    expect(validateSpy.mock.calls.length).toBe(1);
+
+    await user.click(screen.getByText('submit'));
+
+    expect(submitSpy.mock.calls.length).toBe(0);
+    expect(input).toHaveAttribute('aria-invalid', 'true');
   });
 });

--- a/packages/react/src/menu/link-item/MenuLinkItem.test.tsx
+++ b/packages/react/src/menu/link-item/MenuLinkItem.test.tsx
@@ -1,5 +1,4 @@
 import { expect } from 'vitest';
-import * as React from 'react';
 import { MemoryRouter, Route, Routes, Link, useLocation } from 'react-router';
 import { act, screen, waitFor } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';

--- a/packages/react/src/menu/portal/MenuPortal.test.tsx
+++ b/packages/react/src/menu/portal/MenuPortal.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/menu/positioner/MenuPositioner.test.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.test.tsx
@@ -26,6 +26,15 @@ describe('<Menu.Positioner />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
+  const baselineX = 10;
+  const baselineY = 36;
+  const popupWidth = 52;
+  const popupHeight = 24;
+  const anchorWidth = 72;
+  const anchorHeight = 36;
+  const triggerStyle = { width: anchorWidth, height: anchorHeight };
+  const popupStyle = { width: popupWidth, height: popupHeight };
+
   describe.skipIf(isJSDOM)('prop: anchor', () => {
     it('should be placed near the specified element when a ref is passed', async () => {
       function TestComponent() {
@@ -327,15 +336,11 @@ describe('<Menu.Positioner />', () => {
       expect(screen.queryByRole('menu', { hidden: true })).toBeInaccessible();
 
       await user.click(trigger, { delay: 20 });
-      await waitFor(() => {
-        expect(screen.queryByRole('menu', { hidden: false })).not.toBe(null);
-      });
+      await screen.findByRole('menu', { hidden: false });
       expect(screen.queryByRole('menu', { hidden: false })).not.toBeInaccessible();
 
       await user.click(trigger, { delay: 20 });
-      await waitFor(() => {
-        expect(screen.queryByRole('menu', { hidden: true })).not.toBe(null);
-      });
+      await screen.findByRole('menu', { hidden: true });
       await waitFor(() => {
         expect(screen.queryByRole('menu', { hidden: true })).toBeInaccessible();
       });
@@ -364,10 +369,7 @@ describe('<Menu.Positioner />', () => {
       expect(screen.queryByRole('menu', { hidden: true })).toBe(null);
 
       await user.click(trigger, { delay: 20 });
-      await flushMicrotasks();
-      await waitFor(() => {
-        expect(screen.queryByRole('menu', { hidden: false })).not.toBe(null);
-      });
+      await screen.findByRole('menu', { hidden: false });
       expect(screen.queryByRole('menu', { hidden: false })).not.toBeInaccessible();
 
       await user.click(trigger, { delay: 20 });
@@ -376,15 +378,6 @@ describe('<Menu.Positioner />', () => {
       });
     });
   });
-
-  const baselineX = 10;
-  const baselineY = 36;
-  const popupWidth = 52;
-  const popupHeight = 24;
-  const anchorWidth = 72;
-  const anchorHeight = 36;
-  const triggerStyle = { width: anchorWidth, height: anchorHeight };
-  const popupStyle = { width: popupWidth, height: popupHeight };
 
   describe.skipIf(isJSDOM)('prop: sideOffset', () => {
     it('offsets the side when a number is specified', async () => {

--- a/packages/react/src/menu/root/MenuRoot.detached-triggers.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.detached-triggers.test.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, ignoreActWarnings, screen, waitFor } from '@mui/interna
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, isJSDOM, wait } from '#test-utils';
 
-describe('<MenuRoot />', () => {
+describe('<Menu.Root />', () => {
   beforeEach(() => {
     globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
   });
@@ -1057,9 +1057,7 @@ describe('<MenuRoot />', () => {
       await act(async () => {
         menuHandle.open('trigger');
       });
-      await waitFor(() => {
-        expect(screen.queryByRole('menu')).not.toBe(null);
-      });
+      await screen.findByRole('menu');
 
       expect(screen.getByTestId('content').textContent).toBe('Content');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
@@ -1105,9 +1103,7 @@ describe('<MenuRoot />', () => {
       await act(async () => {
         menuHandle.open('trigger2');
       });
-      await waitFor(() => {
-        expect(screen.queryByRole('menu')).not.toBe(null);
-      });
+      await screen.findByRole('menu');
 
       expect(screen.getByTestId('content').textContent).toBe('2');
       expect(trigger2).toHaveAttribute('aria-expanded', 'true');

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -653,9 +653,7 @@ describe('<Menu.Root />', () => {
         const submenuTrigger = await screen.findByTestId('submenu-trigger');
         await user.hover(submenuTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('submenu')).not.toBe(null);
-        });
+        await screen.findByTestId('submenu');
 
         const submenuItem = await screen.findByTestId('item-4_1');
         await act(async () => {
@@ -764,16 +762,12 @@ describe('<Menu.Root />', () => {
         const menuTrigger = screen.getByTestId('menu-trigger');
         await user.click(menuTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('menu-popup')).not.toBe(null);
-        });
+        await screen.findByTestId('menu-popup');
 
         const dialogTrigger = screen.getByTestId('dialog-trigger');
         await user.click(dialogTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('dialog-popup')).not.toBe(null);
-        });
+        await screen.findByTestId('dialog-popup');
 
         const dialogButton = screen.getByTestId('dialog-button');
         await act(async () => {
@@ -1197,9 +1191,7 @@ describe('<Menu.Root />', () => {
 
         await user.click(trigger);
 
-        await waitFor(() => {
-          expect(screen.queryByRole('menu')).not.toBe(null);
-        });
+        await screen.findByRole('menu');
 
         const positioner = screen.getByTestId('menu-positioner');
 
@@ -1218,124 +1210,11 @@ describe('<Menu.Root />', () => {
 
         await user.click(trigger);
 
-        await waitFor(() => {
-          expect(screen.queryByRole('menu')).not.toBe(null);
-        });
+        await screen.findByRole('menu');
 
         const positioner = screen.getByTestId('menu-positioner');
 
         expect(positioner.previousElementSibling).toBe(null);
-      });
-    });
-
-    describe.skipIf(isJSDOM)('scroll locking', () => {
-      describe('interaction type tracking (openMethod)', () => {
-        it('should not apply scroll lock when opened via touch', async () => {
-          await render(<TestMenu rootProps={{ modal: true }} />);
-
-          const trigger = screen.getByRole('button', { name: 'Toggle' });
-
-          fireEvent.pointerDown(trigger, { pointerType: 'touch' });
-          fireEvent.mouseDown(trigger);
-
-          const menu = await screen.findByRole('menu');
-
-          const doc = menu.ownerDocument;
-
-          const isScrollLocked =
-            doc.documentElement.style.overflow === 'hidden' ||
-            doc.documentElement.hasAttribute('data-base-ui-scroll-locked') ||
-            doc.body.style.overflow === 'hidden';
-
-          expect(isScrollLocked).toBe(false);
-        });
-
-        it('should apply scroll lock when opened via mouse', async () => {
-          const { user } = await render(<TestMenu rootProps={{ modal: true }} />);
-
-          const trigger = screen.getByRole('button', { name: 'Toggle' });
-          const doc = trigger.ownerDocument;
-
-          await user.click(trigger);
-          await screen.findByRole('menu');
-
-          const isScrollLocked =
-            doc.documentElement.style.overflow === 'hidden' ||
-            doc.documentElement.hasAttribute('data-base-ui-scroll-locked') ||
-            doc.body.style.overflow === 'hidden';
-
-          expect(isScrollLocked).toBe(true);
-        });
-      });
-
-      describe('touch scroll lock', () => {
-        it('should apply scroll lock when a touch-opened popup covers the viewport width', async () => {
-          await render(
-            <Menu.Root modal>
-              <Menu.Trigger>Open</Menu.Trigger>
-              <Menu.Portal>
-                <Menu.Positioner data-testid="positioner" style={{ width: 'calc(100vw - 10px)' }}>
-                  <Menu.Popup>
-                    <Menu.Item>1</Menu.Item>
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Portal>
-            </Menu.Root>,
-          );
-
-          const trigger = screen.getByRole('button', { name: 'Open' });
-
-          fireEvent.pointerDown(trigger, { pointerType: 'touch' });
-          fireEvent.mouseDown(trigger);
-
-          const menu = await screen.findByRole('menu');
-          const doc = menu.ownerDocument;
-
-          await waitFor(() => {
-            const isScrollLocked =
-              doc.documentElement.style.overflow === 'hidden' ||
-              doc.documentElement.hasAttribute('data-base-ui-scroll-locked') ||
-              doc.body.style.overflow === 'hidden';
-
-            expect(isScrollLocked).toBe(true);
-          });
-        });
-
-        it('should not apply scroll lock when a touch-opened popup is narrower than the viewport', async () => {
-          await render(
-            <Menu.Root modal>
-              <Menu.Trigger>Open</Menu.Trigger>
-              <Menu.Portal>
-                <Menu.Positioner data-testid="positioner" style={{ width: '240px' }}>
-                  <Menu.Popup>
-                    <Menu.Item>1</Menu.Item>
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Portal>
-            </Menu.Root>,
-          );
-
-          const trigger = screen.getByRole('button', { name: 'Open' });
-
-          fireEvent.pointerDown(trigger, { pointerType: 'touch' });
-          fireEvent.mouseDown(trigger);
-
-          const menu = await screen.findByRole('menu');
-          const doc = menu.ownerDocument;
-
-          await act(async () => {
-            await new Promise<void>((resolve) => {
-              requestAnimationFrame(() => resolve());
-            });
-          });
-
-          const isScrollLocked =
-            doc.documentElement.style.overflow === 'hidden' ||
-            doc.documentElement.hasAttribute('data-base-ui-scroll-locked') ||
-            doc.body.style.overflow === 'hidden';
-
-          expect(isScrollLocked).toBe(false);
-        });
       });
     });
 
@@ -1366,15 +1245,11 @@ describe('<Menu.Root />', () => {
 
         await user.keyboard('{Enter}');
 
-        await waitFor(() => {
-          expect(screen.queryByRole('menu')).not.toBe(null);
-        });
+        await screen.findByRole('menu');
 
         await user.click(trigger);
 
-        await waitFor(() => {
-          expect(screen.queryByRole('menu')).not.toBe(null);
-        });
+        await screen.findByRole('menu');
 
         await act(async () => {
           await new Promise((resolve) => {
@@ -1487,9 +1362,7 @@ describe('<Menu.Root />', () => {
         const openButton = screen.getByText('Open');
         await user.click(openButton);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('menu')).not.toBe(null);
-        });
+        await screen.findByTestId('menu');
 
         expect(onOpenChangeComplete.mock.calls.length).toBe(2);
         expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
@@ -1562,9 +1435,7 @@ describe('<Menu.Root />', () => {
 
         await userEvent.hover(trigger);
 
-        await waitFor(() => {
-          expect(screen.queryByRole('menu')).not.toBe(null);
-        });
+        await screen.findByRole('menu');
       });
 
       it('should close the menu when the trigger is no longer hovered', async () => {
@@ -1580,9 +1451,7 @@ describe('<Menu.Root />', () => {
 
         await userEvent.hover(trigger);
 
-        await waitFor(() => {
-          expect(screen.queryByRole('menu')).not.toBe(null);
-        });
+        await screen.findByRole('menu');
 
         await userEvent.unhover(trigger);
 
@@ -1603,9 +1472,7 @@ describe('<Menu.Root />', () => {
 
         await userEvent.hover(submenuTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('submenu')).not.toBe(null);
-        });
+        await screen.findByTestId('submenu');
       });
 
       it('does not clear body pointer-events styles when closing a scoped submenu', async () => {
@@ -1619,9 +1486,7 @@ describe('<Menu.Root />', () => {
         const submenuTrigger = screen.getByTestId('submenu-trigger');
         await userEvent.hover(submenuTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('submenu')).not.toBe(null);
-        });
+        await screen.findByTestId('submenu');
 
         const previousBodyPointerEvents = document.body.style.pointerEvents;
         try {
@@ -1671,9 +1536,7 @@ describe('<Menu.Root />', () => {
         const submenuTrigger = screen.getByTestId('submenu-trigger');
         await userEvent.hover(submenuTrigger);
 
-        await waitFor(() => {
-          expect(screen.getByTestId('submenu')).not.toBe(null);
-        });
+        await screen.findByTestId('submenu');
 
         const menu = screen.getByTestId('menu');
         const submenuPositioner = screen.getByTestId('submenu-positioner');
@@ -1699,9 +1562,7 @@ describe('<Menu.Root />', () => {
 
         await userEvent.hover(trigger);
 
-        await waitFor(() => {
-          expect(screen.getByTestId('menu')).not.toBe(null);
-        });
+        await screen.findByTestId('menu');
 
         const menu = screen.getByTestId('menu');
 
@@ -1711,12 +1572,8 @@ describe('<Menu.Root />', () => {
 
         await userEvent.hover(submenuTrigger);
 
-        await waitFor(() => {
-          expect(screen.getByTestId('menu')).not.toBe(null);
-        });
-        await waitFor(() => {
-          expect(screen.getByTestId('submenu')).not.toBe(null);
-        });
+        await screen.findByTestId('menu');
+        await screen.findByTestId('submenu');
 
         const submenu = screen.getByTestId('submenu');
 
@@ -1725,12 +1582,8 @@ describe('<Menu.Root />', () => {
         fireEvent.mouseLeave(menu);
         await userEvent.hover(submenu);
 
-        await waitFor(() => {
-          expect(screen.getByTestId('menu')).not.toBe(null);
-        });
-        await waitFor(() => {
-          expect(screen.getByTestId('submenu')).not.toBe(null);
-        });
+        await screen.findByTestId('menu');
+        await screen.findByTestId('submenu');
       });
 
       it('keeps the parent submenu open after a third-level submenu closes due to sibling hover', async () => {
@@ -1749,25 +1602,19 @@ describe('<Menu.Root />', () => {
 
         await userEvent.hover(trigger);
 
-        await waitFor(() => {
-          expect(screen.getByTestId('menu')).not.toBe(null);
-        });
+        await screen.findByTestId('menu');
 
         // Open first-level submenu
         const level1Trigger = screen.getByRole('menuitem', { name: 'Item 4' });
         await userEvent.hover(level1Trigger);
 
-        await waitFor(() => {
-          expect(screen.getByTestId('submenu')).not.toBe(null);
-        });
+        await screen.findByTestId('submenu');
 
         // Open second-level submenu
         const level2Trigger = screen.getByRole('menuitem', { name: 'Item 4.3' });
         await userEvent.hover(level2Trigger);
 
-        await waitFor(() => {
-          expect(screen.getByTestId('nested-submenu')).not.toBe(null);
-        });
+        await screen.findByTestId('nested-submenu');
 
         // Hover a sibling item in the parent submenu to close the second-level submenu
         const parentSibling = screen.getByRole('menuitem', { name: 'Item 4.2' });
@@ -1783,9 +1630,7 @@ describe('<Menu.Root />', () => {
         fireEvent.mouseLeave(submenu1);
 
         // Parent submenu should still be open
-        await waitFor(() => {
-          expect(screen.getByTestId('submenu')).not.toBe(null);
-        });
+        await screen.findByTestId('submenu');
       });
 
       describe('modal behavior', () => {
@@ -1973,6 +1818,117 @@ describe('<Menu.Root />', () => {
       });
     });
 
+    describe.skipIf(isJSDOM)('scroll locking', () => {
+      describe('interaction type tracking (openMethod)', () => {
+        it('should not apply scroll lock when opened via touch', async () => {
+          await render(<TestMenu rootProps={{ modal: true }} />);
+
+          const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+          fireEvent.pointerDown(trigger, { pointerType: 'touch' });
+          fireEvent.mouseDown(trigger);
+
+          const menu = await screen.findByRole('menu');
+
+          const doc = menu.ownerDocument;
+
+          const isScrollLocked =
+            doc.documentElement.style.overflow === 'hidden' ||
+            doc.documentElement.hasAttribute('data-base-ui-scroll-locked') ||
+            doc.body.style.overflow === 'hidden';
+
+          expect(isScrollLocked).toBe(false);
+        });
+
+        it('should apply scroll lock when opened via mouse', async () => {
+          const { user } = await render(<TestMenu rootProps={{ modal: true }} />);
+
+          const trigger = screen.getByRole('button', { name: 'Toggle' });
+          const doc = trigger.ownerDocument;
+
+          await user.click(trigger);
+          await screen.findByRole('menu');
+
+          const isScrollLocked =
+            doc.documentElement.style.overflow === 'hidden' ||
+            doc.documentElement.hasAttribute('data-base-ui-scroll-locked') ||
+            doc.body.style.overflow === 'hidden';
+
+          expect(isScrollLocked).toBe(true);
+        });
+      });
+
+      describe('touch scroll lock', () => {
+        it('should apply scroll lock when a touch-opened popup covers the viewport width', async () => {
+          await render(
+            <Menu.Root modal>
+              <Menu.Trigger>Open</Menu.Trigger>
+              <Menu.Portal>
+                <Menu.Positioner data-testid="positioner" style={{ width: 'calc(100vw - 10px)' }}>
+                  <Menu.Popup>
+                    <Menu.Item>1</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>,
+          );
+
+          const trigger = screen.getByRole('button', { name: 'Open' });
+
+          fireEvent.pointerDown(trigger, { pointerType: 'touch' });
+          fireEvent.mouseDown(trigger);
+
+          const menu = await screen.findByRole('menu');
+          const doc = menu.ownerDocument;
+
+          await waitFor(() => {
+            const isScrollLocked =
+              doc.documentElement.style.overflow === 'hidden' ||
+              doc.documentElement.hasAttribute('data-base-ui-scroll-locked') ||
+              doc.body.style.overflow === 'hidden';
+
+            expect(isScrollLocked).toBe(true);
+          });
+        });
+
+        it('should not apply scroll lock when a touch-opened popup is narrower than the viewport', async () => {
+          await render(
+            <Menu.Root modal>
+              <Menu.Trigger>Open</Menu.Trigger>
+              <Menu.Portal>
+                <Menu.Positioner data-testid="positioner" style={{ width: '240px' }}>
+                  <Menu.Popup>
+                    <Menu.Item>1</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>,
+          );
+
+          const trigger = screen.getByRole('button', { name: 'Open' });
+
+          fireEvent.pointerDown(trigger, { pointerType: 'touch' });
+          fireEvent.mouseDown(trigger);
+
+          const menu = await screen.findByRole('menu');
+          const doc = menu.ownerDocument;
+
+          await act(async () => {
+            await new Promise<void>((resolve) => {
+              requestAnimationFrame(() => resolve());
+            });
+          });
+
+          const isScrollLocked =
+            doc.documentElement.style.overflow === 'hidden' ||
+            doc.documentElement.hasAttribute('data-base-ui-scroll-locked') ||
+            doc.body.style.overflow === 'hidden';
+
+          expect(isScrollLocked).toBe(false);
+        });
+      });
+    });
+
     describe.skipIf(isJSDOM)('mouse interaction', () => {
       afterEach(async () => {
         const { cleanup } = await import('vitest-browser-react');
@@ -2009,9 +1965,7 @@ describe('<Menu.Root />', () => {
 
         fireEvent.mouseDown(trigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('menu')).not.toBe(null);
-        });
+        await screen.findByTestId('menu');
 
         await wait(200);
 
@@ -2205,9 +2159,7 @@ describe('<Menu.Root />', () => {
 
       await user.keyboard('{ArrowDown}');
 
-      await waitFor(() => {
-        expect(screen.queryByRole('menu')).not.toBe(null);
-      });
+      await screen.findByRole('menu');
 
       await user.keyboard('{ArrowDown}');
       await user.keyboard('{ArrowDown}'); // Share

--- a/packages/react/src/menu/trigger/MenuTrigger.test.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.test.tsx
@@ -147,8 +147,8 @@ describe('<Menu.Trigger />', () => {
     });
   });
 
-  describe('style hooks', () => {
-    it('should have the data-popup-open and data-pressed attributes when open', async () => {
+  describe('state attributes', () => {
+    it('adds data-popup-open and data-pressed when open', async () => {
       await render(
         <Menu.Root>
           <Menu.Trigger />

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -93,9 +93,7 @@ describe('<Menubar />', () => {
 
         await user.hover(editTrigger!);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('edit-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('edit-menu');
 
         // The file menu should now be closed
         expect(screen.queryByTestId('file-menu')).toBe(null);
@@ -104,9 +102,7 @@ describe('<Menubar />', () => {
         const viewTrigger = screen.getByTestId('view-trigger');
         await user.hover(viewTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('view-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('view-menu');
 
         // The edit menu should now be closed
         expect(screen.queryByTestId('edit-menu')).toBe(null);
@@ -122,9 +118,7 @@ describe('<Menubar />', () => {
         const fileTrigger = screen.getByTestId('file-trigger');
         await user.click(fileTrigger);
 
-        await waitFor(() => {
-          expect(screen.getByTestId('file-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('file-menu');
         await waitFor(() => {
           expect(screen.getByRole('menubar')).toHaveAttribute('data-has-submenu-open');
         });
@@ -136,9 +130,7 @@ describe('<Menubar />', () => {
         await user.hover(shareTrigger);
 
         // The share submenu should open
-        await waitFor(() => {
-          expect(screen.queryByTestId('share-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('share-menu');
       });
 
       it('should open another menu on hover when a nested submenu is open', async () => {
@@ -151,9 +143,7 @@ describe('<Menubar />', () => {
         const fileTrigger = screen.getByTestId('file-trigger');
         await user.click(fileTrigger);
 
-        await waitFor(() => {
-          expect(screen.getByTestId('file-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('file-menu');
         await waitFor(() => {
           expect(screen.getByRole('menubar')).toHaveAttribute('data-has-submenu-open');
         });
@@ -163,9 +153,7 @@ describe('<Menubar />', () => {
         await user.hover(shareTrigger);
 
         // The share submenu should open
-        await waitFor(() => {
-          expect(screen.queryByTestId('share-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('share-menu');
 
         // Hover over the first item in the share submenu
         await user.hover(screen.getByTestId('share-item-1'));
@@ -174,9 +162,7 @@ describe('<Menubar />', () => {
         const editTrigger = screen.getByTestId('edit-trigger');
         await user.hover(editTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('edit-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('edit-menu');
 
         expect(screen.queryByTestId('file-menu')).toBe(null);
         expect(screen.queryByTestId('share-menu')).toBe(null);
@@ -198,9 +184,7 @@ describe('<Menubar />', () => {
         await wait(50);
 
         await user.keyboard('{Enter}');
-        await waitFor(() => {
-          expect(screen.queryByTestId('file-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('file-menu');
       });
     });
 
@@ -230,9 +214,7 @@ describe('<Menubar />', () => {
         await user.click(layoutItem2, { delay: 30 });
 
         // The layout menu should not close after clicking an item
-        await waitFor(() => {
-          expect(screen.queryByTestId('layout-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('layout-menu');
       });
 
       // https://github.com/mui/base-ui/issues/2092
@@ -260,9 +242,7 @@ describe('<Menubar />', () => {
         await user.click(layoutItem2, { delay: 30 });
 
         // The layout menu should not close after clicking an item
-        await waitFor(() => {
-          expect(screen.queryByTestId('layout-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('layout-menu');
       });
     });
 
@@ -305,9 +285,7 @@ describe('<Menubar />', () => {
         await user.keyboard(' ');
 
         // Menu should be open
-        await waitFor(() => {
-          expect(screen.queryByTestId('file-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('file-menu');
       });
 
       it('should navigate within the menu using arrow keys', async () => {
@@ -321,9 +299,7 @@ describe('<Menubar />', () => {
         await user.keyboard('{Enter}');
 
         // File menu should be open
-        await waitFor(() => {
-          expect(screen.queryByTestId('file-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('file-menu');
 
         // First item should be focused automatically
         const firstItem = screen.getByTestId('file-item-1');
@@ -355,9 +331,7 @@ describe('<Menubar />', () => {
           fileTrigger.focus();
         });
         await user.keyboard('{Enter}');
-        await waitFor(() => {
-          expect(screen.queryByTestId('file-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('file-menu');
 
         await waitFor(() => {
           expect(screen.getByTestId('file-item-1')).toHaveFocus();
@@ -377,9 +351,7 @@ describe('<Menubar />', () => {
         await user.keyboard('{ArrowRight}');
 
         // Share submenu should be open
-        await waitFor(() => {
-          expect(screen.queryByTestId('share-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('share-menu');
 
         // First submenu item should be focused
         const submenuItem = screen.getByTestId('share-item-1');
@@ -400,9 +372,7 @@ describe('<Menubar />', () => {
         await user.keyboard('{Enter}');
 
         // Menu should be open
-        await waitFor(() => {
-          expect(screen.queryByTestId('file-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('file-menu');
 
         // Press Escape to close
         await user.keyboard('{Escape}');
@@ -441,9 +411,7 @@ describe('<Menubar />', () => {
 
         // Open submenu
         await user.keyboard('{ArrowRight}');
-        await waitFor(() => {
-          expect(screen.queryByTestId('share-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('share-menu');
 
         // Close submenu with left arrow
         await user.keyboard('{ArrowLeft}');
@@ -561,9 +529,7 @@ describe('<Menubar />', () => {
           await user.keyboard('{Enter}');
 
           // File menu should be open
-          await waitFor(() => {
-            expect(screen.queryByTestId('file-menu')).not.toBe(null);
-          });
+          await screen.findByTestId('file-menu');
 
           // Navigate right to edit menu
           await user.keyboard('{ArrowRight}');
@@ -572,9 +538,7 @@ describe('<Menubar />', () => {
           await waitFor(() => {
             expect(screen.queryByTestId('file-menu')).toBe(null);
           });
-          await waitFor(() => {
-            expect(screen.queryByTestId('edit-menu')).not.toBe(null);
-          });
+          await screen.findByTestId('edit-menu');
         },
       );
     });
@@ -588,9 +552,7 @@ describe('<Menubar />', () => {
         await user.click(fileTrigger);
 
         // Menu should be open
-        await waitFor(() => {
-          expect(screen.queryByTestId('file-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('file-menu');
 
         // Navigate with keyboard
         await user.keyboard('{ArrowDown}');
@@ -614,9 +576,7 @@ describe('<Menubar />', () => {
         const fileTrigger = screen.getByTestId('file-trigger');
         await user.click(fileTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('file-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('file-menu');
 
         // Navigate to edit menu with keyboard
         await user.keyboard('{ArrowRight}');
@@ -625,9 +585,7 @@ describe('<Menubar />', () => {
         await waitFor(() => {
           expect(screen.queryByTestId('file-menu')).toBe(null);
         });
-        await waitFor(() => {
-          expect(screen.queryByTestId('edit-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('edit-menu');
       });
     });
 
@@ -845,9 +803,7 @@ describe('<Menubar />', () => {
           });
 
           await user.keyboard('{ArrowRight}');
-          await waitFor(() => {
-            expect(screen.queryByTestId('edit-trigger')).not.toBe(null);
-          });
+          await screen.findByTestId('edit-trigger');
 
           await user.keyboard('{ArrowRight}');
 
@@ -905,18 +861,14 @@ describe('<Menubar />', () => {
         const editTrigger = screen.getByTestId('edit-trigger');
         await user.click(fileTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('file-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('file-menu');
         await waitFor(() => {
           expect(screen.getByRole('menubar')).toHaveAttribute('data-has-submenu-open');
         });
 
         await user.hover(editTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('edit-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('edit-menu');
 
         await user.click(editTrigger);
 
@@ -929,18 +881,14 @@ describe('<Menubar />', () => {
 
         await user.click(fileTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('file-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('file-menu');
         await waitFor(() => {
           expect(screen.getByRole('menubar')).toHaveAttribute('data-has-submenu-open');
         });
 
         await user.hover(editTrigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('edit-menu')).not.toBe(null);
-        });
+        await screen.findByTestId('edit-menu');
       },
     );
 

--- a/packages/react/src/meter/root/MeterRoot.test.tsx
+++ b/packages/react/src/meter/root/MeterRoot.test.tsx
@@ -33,7 +33,7 @@ describe('<Meter.Root />', () => {
       );
     });
 
-    it('should update aria-valuenow when value changes', async () => {
+    it('updates aria-valuenow when value changes', async () => {
       const { setProps } = await render(
         <Meter.Root value={50}>
           <Meter.Track>

--- a/packages/react/src/navigation-menu/content/NavigationMenuContent.test.tsx
+++ b/packages/react/src/navigation-menu/content/NavigationMenuContent.test.tsx
@@ -6,12 +6,12 @@ import { createRenderer, describeConformance } from '#test-utils';
 describe('<NavigationMenu.Content />', () => {
   const { render } = createRenderer();
 
-  describeConformance.skip(<NavigationMenu.Content />, () => ({
+  describeConformance(<NavigationMenu.Content />, () => ({
     refInstanceof: window.HTMLDivElement,
     render(node) {
       return render(
         <NavigationMenu.Root value="test">
-          <NavigationMenu.Item>{node}</NavigationMenu.Item>
+          <NavigationMenu.Item value="test">{node}</NavigationMenu.Item>
           <NavigationMenu.Portal>
             <NavigationMenu.Positioner>
               <NavigationMenu.Popup>
@@ -167,11 +167,7 @@ describe('<NavigationMenu.Content />', () => {
     expect(list.contains(content1)).toBe(false);
 
     fireEvent.click(screen.getByRole('button', { name: 'Item 2' }));
-    await flushMicrotasks();
-
-    await waitFor(() => {
-      expect(screen.queryByTestId('content-2')).not.toBe(null);
-    });
+    await screen.findByTestId('content-2');
 
     const content1After = screen.queryByTestId('content-1');
     const content2 = screen.queryByTestId('content-2');
@@ -210,8 +206,6 @@ describe('<NavigationMenu.Content />', () => {
     expect(viewport.contains(screen.getByTestId('content-1'))).toBe(true);
 
     await user.keyboard('{Escape}');
-    await flushMicrotasks();
-
     await waitFor(() => {
       expect(screen.getByTestId('content-1')).toHaveAttribute('hidden');
     });

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
@@ -46,9 +46,7 @@ describe('<NavigationMenu.Link />', () => {
 
       await user.click(trigger);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-1');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
       const link = screen.getByRole('link', { name: 'Link 1' });
@@ -86,15 +84,13 @@ describe('<NavigationMenu.Link />', () => {
 
       await user.click(trigger);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-1');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
       const link = screen.getByRole('link', { name: 'Link 1' });
       await user.click(link);
 
-      await waitFor(() => expect(screen.queryByTestId('popup-1')).not.toBe(null));
+      await screen.findByTestId('popup-1');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
   });

--- a/packages/react/src/navigation-menu/portal/NavigationMenuPortal.test.tsx
+++ b/packages/react/src/navigation-menu/portal/NavigationMenuPortal.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -1198,9 +1198,7 @@ describe('<NavigationMenu.Root />', () => {
 
       await user.hover(trigger2);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-2')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-2');
     });
 
     it.skipIf(isJSDOM)(
@@ -1236,9 +1234,7 @@ describe('<NavigationMenu.Root />', () => {
 
         await user.hover(trigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('popup-1')).not.toBe(null);
-        });
+        await screen.findByTestId('popup-1');
       },
     );
 
@@ -1249,18 +1245,14 @@ describe('<NavigationMenu.Root />', () => {
 
       await user.hover(trigger1);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-1');
 
       await user.click(trigger1);
       await flushMicrotasks();
 
       await user.hover(trigger2);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-2')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-2');
 
       await user.unhover(trigger2);
 
@@ -1270,9 +1262,7 @@ describe('<NavigationMenu.Root />', () => {
 
       await user.hover(trigger1);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-1');
     });
 
     it('closes after pointerdown on a link in a hover-open popup when pointer leaves', async () => {
@@ -1281,9 +1271,7 @@ describe('<NavigationMenu.Root />', () => {
 
       await user.hover(trigger1);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-1');
 
       const popup1 = screen.getByTestId('popup-1');
       const link1 = within(popup1).getByText('Link 1');
@@ -1718,9 +1706,7 @@ describe('<NavigationMenu.Root />', () => {
 
       await user.click(trigger);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-1');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
       const dialogTrigger = screen.getByTestId('dialog-trigger');
@@ -1730,9 +1716,7 @@ describe('<NavigationMenu.Root />', () => {
 
       await user.click(screen.getByTestId('dialog-button'));
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-1');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
 
@@ -1742,9 +1726,7 @@ describe('<NavigationMenu.Root />', () => {
 
       await user.click(trigger);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-1');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
       const popoverTrigger = screen.getByTestId('popover-trigger');
@@ -1754,9 +1736,7 @@ describe('<NavigationMenu.Root />', () => {
 
       await user.click(screen.getByTestId('popover-button'));
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-1');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
   });
@@ -1917,9 +1897,7 @@ describe('<NavigationMenu.Root />', () => {
 
       await user.click(trigger1);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-1');
 
       const popup1 = screen.getByTestId('popup-1');
       const nestedTrigger1 = within(popup1).getByTestId('nested-trigger-1');
@@ -1950,9 +1928,7 @@ describe('<NavigationMenu.Root />', () => {
 
       await user.click(trigger1);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('popup-1')).not.toBe(null);
-      });
+      await screen.findByTestId('popup-1');
 
       const popup1 = screen.getByTestId('popup-1');
       const nestedTrigger1 = within(popup1).getByTestId('nested-trigger-1');
@@ -1976,9 +1952,7 @@ describe('<NavigationMenu.Root />', () => {
 
       await user.click(trigger1);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('content-1')).not.toBe(null);
-      });
+      await screen.findByTestId('content-1');
 
       expect(screen.queryByTestId('level2-content-1')).not.toBe(null);
       expect(screen.queryByTestId('level3-content-1')).not.toBe(null);
@@ -2740,8 +2714,6 @@ describe('<NavigationMenu.Root />', () => {
           popupHeight = 180;
 
           fireEvent(window, new Event('resize'));
-          await flushMicrotasks();
-
           await waitFor(() => {
             expect(popupRoot.style.getPropertyValue('--popup-width')).toBe('auto');
             expect(popupRoot.style.getPropertyValue('--popup-height')).toBe('auto');
@@ -2957,8 +2929,6 @@ describe('<NavigationMenu.Root />', () => {
           fireEvent.mouseEnter(topLevelLink);
           fireEvent.mouseMove(topLevelLink);
           clock.tick(OPEN_DELAY);
-          await flushMicrotasks();
-
           await waitFor(() => {
             expect(triggerProduct).toHaveAttribute('aria-expanded', 'false');
           });
@@ -3031,8 +3001,6 @@ describe('<NavigationMenu.Root />', () => {
 
           const closeStart = performance.now();
           fireEvent.keyDown(screen.getByTestId('trigger-learn'), { key: 'Escape' });
-          await flushMicrotasks();
-
           await waitFor(() => {
             expect(onOpenChangeComplete.mock.calls.length).toBe(1);
             expect(onOpenChangeComplete.mock.calls[0][0]).toBe(false);

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.webkit.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.webkit.test.tsx
@@ -1,5 +1,4 @@
 import { vi, expect } from 'vitest';
-import * as React from 'react';
 import { fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
@@ -150,8 +150,6 @@ describe('<NavigationMenu.Trigger />', () => {
     });
 
     await userEvent.keyboard('{ArrowDown}');
-    await flushMicrotasks();
-
     await waitFor(() => {
       expect(
         Math.abs(
@@ -176,7 +174,6 @@ describe('<NavigationMenu.Trigger />', () => {
     });
 
     await userEvent.keyboard('{ArrowDown}');
-    await flushMicrotasks();
     await waitFor(() => {
       expect(
         Math.abs(

--- a/packages/react/src/number-field/decrement/NumberFieldDecrement.test.tsx
+++ b/packages/react/src/number-field/decrement/NumberFieldDecrement.test.tsx
@@ -17,7 +17,7 @@ describe('<NumberField.Decrement />', () => {
     },
   }));
 
-  it('has decrease label', async () => {
+  it('has the default "Decrease" label', async () => {
     await render(
       <NumberField.Root>
         <NumberField.Decrement />
@@ -26,7 +26,7 @@ describe('<NumberField.Decrement />', () => {
     expect(screen.queryByLabelText('Decrease')).not.toBe(null);
   });
 
-  it('decrements starting from 0 click', async () => {
+  it('keeps an empty value at 0 when clicked', async () => {
     await render(
       <NumberField.Root>
         <NumberField.Decrement />
@@ -39,7 +39,7 @@ describe('<NumberField.Decrement />', () => {
     expect(screen.getByRole('textbox')).toHaveValue('0');
   });
 
-  it('decrements to -1 starting from defaultValue=0 click', async () => {
+  it('decrements from defaultValue=0 to -1 when clicked', async () => {
     await render(
       <NumberField.Root defaultValue={0}>
         <NumberField.Decrement />
@@ -52,7 +52,7 @@ describe('<NumberField.Decrement />', () => {
     expect(screen.getByRole('textbox')).toHaveValue('-1');
   });
 
-  it('first decrement after external controlled update', async () => {
+  it('decrements from an external controlled update', async () => {
     function Controlled() {
       const [value, setValue] = React.useState<number | null>(null);
       return (
@@ -66,12 +66,12 @@ describe('<NumberField.Decrement />', () => {
 
     const { user } = await render(<Controlled />);
     const input = screen.getByRole('textbox');
-    const increase = screen.getByLabelText('Decrease');
+    const decrement = screen.getByLabelText('Decrease');
 
     await user.click(screen.getByText('external'));
     expect(input).toHaveValue((1.23456).toLocaleString(undefined, { minimumFractionDigits: 5 }));
 
-    await user.click(increase);
+    await user.click(decrement);
     expect(input).toHaveValue((0.235).toLocaleString(undefined, { minimumFractionDigits: 3 }));
   });
 
@@ -445,7 +445,7 @@ describe('<NumberField.Decrement />', () => {
     });
   });
 
-  describe('disabled state', () => {
+  describe('prop: disabled', () => {
     it('should not decrement when root is disabled', async () => {
       const handleValueChange = vi.fn();
       await render(
@@ -478,31 +478,31 @@ describe('<NumberField.Decrement />', () => {
       expect(handleValueChange.mock.calls.length).toBe(0);
       expect(input).toHaveValue('0');
     });
+  });
 
-    describe('prop: className', () => {
-      it('when root is disabled', async () => {
-        const classNameSpy = vi.fn();
-        await render(
-          <NumberField.Root disabled>
-            <NumberField.Decrement className={classNameSpy} />
-            <NumberField.Input />
-          </NumberField.Root>,
-        );
+  describe('prop: className', () => {
+    it('receives disabled state when the root is disabled', async () => {
+      const classNameSpy = vi.fn();
+      await render(
+        <NumberField.Root disabled>
+          <NumberField.Decrement className={classNameSpy} />
+          <NumberField.Input />
+        </NumberField.Root>,
+      );
 
-        expect(classNameSpy.mock.lastCall?.[0]).toHaveProperty('disabled', true);
-      });
+      expect(classNameSpy.mock.lastCall?.[0]).toHaveProperty('disabled', true);
+    });
 
-      it('when button is disabled', async () => {
-        const classNameSpy = vi.fn();
-        await render(
-          <NumberField.Root>
-            <NumberField.Decrement disabled className={classNameSpy} />
-            <NumberField.Input />
-          </NumberField.Root>,
-        );
+    it('receives disabled state when the button is disabled', async () => {
+      const classNameSpy = vi.fn();
+      await render(
+        <NumberField.Root>
+          <NumberField.Decrement disabled className={classNameSpy} />
+          <NumberField.Input />
+        </NumberField.Root>,
+      );
 
-        expect(classNameSpy.mock.lastCall?.[0]).toHaveProperty('disabled', true);
-      });
+      expect(classNameSpy.mock.lastCall?.[0]).toHaveProperty('disabled', true);
     });
   });
 });

--- a/packages/react/src/number-field/increment/NumberFieldIncrement.test.tsx
+++ b/packages/react/src/number-field/increment/NumberFieldIncrement.test.tsx
@@ -17,7 +17,7 @@ describe('<NumberField.Increment />', () => {
     },
   }));
 
-  it('has increase label', async () => {
+  it('has the default "Increase" label', async () => {
     await render(
       <NumberField.Root>
         <NumberField.Increment />
@@ -26,7 +26,7 @@ describe('<NumberField.Increment />', () => {
     expect(screen.queryByLabelText('Increase')).not.toBe(null);
   });
 
-  it('increments starting from 0 click', async () => {
+  it('keeps an empty value at 0 when clicked', async () => {
     await render(
       <NumberField.Root>
         <NumberField.Increment />
@@ -39,7 +39,7 @@ describe('<NumberField.Increment />', () => {
     expect(screen.getByRole('textbox')).toHaveValue('0');
   });
 
-  it('increments to 1 starting from defaultValue=0 click', async () => {
+  it('increments from defaultValue=0 to 1 when clicked', async () => {
     await render(
       <NumberField.Root defaultValue={0}>
         <NumberField.Increment />
@@ -52,7 +52,7 @@ describe('<NumberField.Increment />', () => {
     expect(screen.getByRole('textbox')).toHaveValue('1');
   });
 
-  it('first increment after external controlled update', async () => {
+  it('increments from an external controlled update', async () => {
     function Controlled() {
       const [value, setValue] = React.useState<number | null>(null);
       return (
@@ -464,7 +464,7 @@ describe('<NumberField.Increment />', () => {
     });
   });
 
-  describe('disabled state', () => {
+  describe('prop: disabled', () => {
     it('should not increment when root is disabled', async () => {
       const handleValueChange = vi.fn();
       await render(
@@ -497,31 +497,31 @@ describe('<NumberField.Increment />', () => {
       expect(handleValueChange.mock.calls.length).toBe(0);
       expect(input).toHaveValue('0');
     });
+  });
 
-    describe('prop: className', () => {
-      it('when root is disabled', async () => {
-        const classNameSpy = vi.fn();
-        await render(
-          <NumberField.Root disabled>
-            <NumberField.Increment className={classNameSpy} />
-            <NumberField.Input />
-          </NumberField.Root>,
-        );
+  describe('prop: className', () => {
+    it('receives disabled state when the root is disabled', async () => {
+      const classNameSpy = vi.fn();
+      await render(
+        <NumberField.Root disabled>
+          <NumberField.Increment className={classNameSpy} />
+          <NumberField.Input />
+        </NumberField.Root>,
+      );
 
-        expect(classNameSpy.mock.lastCall?.[0]).toHaveProperty('disabled', true);
-      });
+      expect(classNameSpy.mock.lastCall?.[0]).toHaveProperty('disabled', true);
+    });
 
-      it('when button is disabled', async () => {
-        const classNameSpy = vi.fn();
-        await render(
-          <NumberField.Root>
-            <NumberField.Increment disabled className={classNameSpy} />
-            <NumberField.Input />
-          </NumberField.Root>,
-        );
+    it('receives disabled state when the button is disabled', async () => {
+      const classNameSpy = vi.fn();
+      await render(
+        <NumberField.Root>
+          <NumberField.Increment disabled className={classNameSpy} />
+          <NumberField.Input />
+        </NumberField.Root>,
+      );
 
-        expect(classNameSpy.mock.lastCall?.[0]).toHaveProperty('disabled', true);
-      });
+      expect(classNameSpy.mock.lastCall?.[0]).toHaveProperty('disabled', true);
     });
   });
 });

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -7,7 +7,7 @@ import { Form } from '@base-ui/react/form';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { REASONS } from '../../internals/reasons';
 
-describe('<NumberField />', () => {
+describe('<NumberField.Root />', () => {
   const { render } = createRenderer();
 
   function pasteText(target: HTMLElement, value: string) {
@@ -90,81 +90,6 @@ describe('<NumberField />', () => {
       fireEvent.change(input, { target: { value: '  ' } });
       expect(onValueChange.mock.calls[0][0]).toBe(null);
     });
-  });
-
-  it('blocks submission when step mismatch occurs', async () => {
-    await render(
-      <form data-testid="form">
-        <NumberFieldBase.Root name="quantity" min={0} step={0.1}>
-          <NumberFieldBase.Group>
-            <NumberFieldBase.Input />
-          </NumberFieldBase.Group>
-        </NumberFieldBase.Root>
-        <button type="submit">Submit</button>
-      </form>,
-    );
-
-    const input = screen.getByRole('textbox');
-    fireEvent.change(input, { target: { value: '0.11' } });
-
-    const hiddenInput = document.querySelector(
-      'input[type="number"][name="quantity"]',
-    ) as HTMLInputElement;
-    expect(hiddenInput).not.toBe(null);
-    expect(hiddenInput.validity.stepMismatch).toBe(true);
-
-    const form = screen.getByTestId<HTMLFormElement>('form');
-    expect(form.checkValidity()).toBe(false);
-  });
-
-  it.skipIf(isJSDOM)('blocks submission when step mismatch occurs with default step', async () => {
-    await render(
-      <form data-testid="form">
-        <NumberFieldBase.Root name="quantity" min={0}>
-          <NumberFieldBase.Group>
-            <NumberFieldBase.Input />
-          </NumberFieldBase.Group>
-        </NumberFieldBase.Root>
-        <button type="submit">Submit</button>
-      </form>,
-    );
-
-    const input = screen.getByRole('textbox');
-    fireEvent.change(input, { target: { value: '0.11' } });
-
-    const hiddenInput = document.querySelector(
-      'input[type="number"][name="quantity"]',
-    ) as HTMLInputElement;
-    expect(hiddenInput).not.toBe(null);
-    expect(hiddenInput.validity.stepMismatch).toBe(true);
-
-    const form = screen.getByTestId<HTMLFormElement>('form');
-    expect(form.checkValidity()).toBe(false);
-  });
-
-  it('does not block submission when step="any"', async () => {
-    await render(
-      <form data-testid="form">
-        <NumberFieldBase.Root name="quantity" min={0} step="any">
-          <NumberFieldBase.Group>
-            <NumberFieldBase.Input />
-          </NumberFieldBase.Group>
-        </NumberFieldBase.Root>
-        <button type="submit">Submit</button>
-      </form>,
-    );
-
-    const input = screen.getByRole('textbox');
-    fireEvent.change(input, { target: { value: '0.11' } });
-
-    const hiddenInput = document.querySelector(
-      'input[type="number"][name="quantity"]',
-    ) as HTMLInputElement;
-    expect(hiddenInput).not.toBe(null);
-    expect(hiddenInput.validity.stepMismatch).toBe(false);
-
-    const form = screen.getByTestId<HTMLFormElement>('form');
-    expect(form.checkValidity()).toBe(true);
   });
 
   describe('prop: onValueChange', () => {
@@ -325,283 +250,6 @@ describe('<NumberField />', () => {
         NumberFieldBase.Root.ChangeEventDetails,
       ];
       expect(details.reason).toBe('wheel');
-    });
-  });
-
-  describe('typing behavior (parseable changes)', () => {
-    it('fires onValueChange for each parseable change while typing', async () => {
-      const onValueChange = vi.fn();
-      const onValueCommitted = vi.fn();
-      await render(
-        <NumberField onValueChange={onValueChange} onValueCommitted={onValueCommitted} />,
-      );
-      const input = screen.getByRole('textbox');
-
-      // Type '1' -> parseable
-      fireEvent.change(input, { target: { value: '1' } });
-      // Type '12' -> parseable
-      fireEvent.change(input, { target: { value: '12' } });
-      // Type '12.' -> parseable (treated as 12)
-      fireEvent.change(input, { target: { value: '12.' } });
-      // Type '12.a' -> not parseable, should not fire
-      fireEvent.change(input, { target: { value: '12.a' } });
-
-      expect(onValueChange.mock.calls.length).toBe(3);
-      expect(onValueChange.mock.calls[0][0]).toBe(1);
-      expect(onValueChange.mock.calls[1][0]).toBe(12);
-      expect(onValueChange.mock.calls[2][0]).toBe(12);
-
-      expect(onValueCommitted.mock.calls.length).toBe(0);
-    });
-
-    it('does not fire onValueChange for non-numeric composition/partial input', async () => {
-      const onValueChange = vi.fn();
-      const onValueCommitted = vi.fn();
-      await render(
-        <NumberField onValueChange={onValueChange} onValueCommitted={onValueCommitted} />,
-      );
-      const input = screen.getByRole('textbox');
-
-      // Simulate IME composition of non-numeric text; intermediate values like 'ni'
-      fireEvent.compositionStart(input);
-      fireEvent.change(input, { target: { value: 'n' } });
-      fireEvent.change(input, { target: { value: 'ni' } });
-      fireEvent.compositionEnd(input);
-
-      expect(onValueChange.mock.calls.length).toBe(0);
-
-      // Now enter a Han numeral which is parseable
-      fireEvent.change(input, { target: { value: '一' } });
-      expect(onValueChange.mock.calls.length).toBe(1);
-      expect(onValueChange.mock.calls[0][0]).toBe(1);
-
-      expect(onValueCommitted.mock.calls.length).toBe(0);
-      fireEvent.blur(input);
-      expect(onValueCommitted.mock.calls.length).toBe(1);
-      expect(onValueCommitted.mock.calls[0][0]).toBe(1);
-    });
-
-    it('handles sign and decimal partials vs. parseable numbers', async () => {
-      const onValueChange = vi.fn();
-      const onValueCommitted = vi.fn();
-      await render(
-        <NumberField onValueChange={onValueChange} onValueCommitted={onValueCommitted} min={-10} />,
-      );
-      const input = screen.getByRole('textbox');
-
-      // '-' or '.' alone aren't parseable
-      fireEvent.change(input, { target: { value: '-' } });
-      fireEvent.change(input, { target: { value: '.' } });
-      // '0.' is parseable (-> 0)
-      fireEvent.change(input, { target: { value: '0.' } });
-      fireEvent.change(input, { target: { value: '-1' } });
-      fireEvent.change(input, { target: { value: '-1.5' } });
-
-      expect(onValueChange.mock.calls.length).toBe(3);
-      expect(onValueChange.mock.calls[0][0]).toBe(0);
-      expect(onValueChange.mock.calls[1][0]).toBe(-1);
-      expect(onValueChange.mock.calls[2][0]).toBe(-1.5);
-
-      // No commit until blur
-      expect(onValueCommitted.mock.calls.length).toBe(0);
-
-      fireEvent.blur(input);
-      expect(onValueCommitted.mock.calls.length).toBe(1);
-      expect(onValueCommitted.mock.calls[0][0]).toBe(-1.5);
-    });
-
-    it('allows typing a decimal while replacing a selection', async () => {
-      await render(<NumberField defaultValue={12.3} locale="en-US" />);
-      const input = screen.getByRole<HTMLInputElement>('textbox');
-
-      await act(async () => {
-        input.focus();
-      });
-
-      const decimalIndex = input.value.indexOf('.');
-      expect(decimalIndex).toBeGreaterThan(-1);
-      await act(async () => {
-        input.setSelectionRange(1, decimalIndex + 2);
-      });
-
-      const keydownResult = fireEvent.keyDown(input, { key: '.' });
-      expect(keydownResult).toBe(true);
-    });
-
-    it('accepts grouping while typing and parses progressively', async () => {
-      const onValueChange = vi.fn();
-      const onValueCommitted = vi.fn();
-      await render(
-        <NumberField onValueChange={onValueChange} onValueCommitted={onValueCommitted} />,
-      );
-      const input = screen.getByRole('textbox');
-
-      fireEvent.change(input, { target: { value: '1' } }); // 1
-      fireEvent.change(input, { target: { value: '1,' } }); // 1 (group symbol)
-      fireEvent.change(input, { target: { value: '1,2' } }); // 12
-      fireEvent.change(input, { target: { value: '1,23' } }); // 123
-      fireEvent.change(input, { target: { value: '1,234' } }); // 1234
-
-      expect(onValueChange.mock.calls.length).toBe(5);
-      expect(onValueChange.mock.calls[0][0]).toBe(1);
-      expect(onValueChange.mock.calls[1][0]).toBe(1);
-      expect(onValueChange.mock.calls[2][0]).toBe(12);
-      expect(onValueChange.mock.calls[3][0]).toBe(123);
-      expect(onValueChange.mock.calls[4][0]).toBe(1234);
-
-      expect(onValueCommitted.mock.calls.length).toBe(0);
-      fireEvent.blur(input);
-      expect(onValueCommitted.mock.calls.length).toBe(1);
-      expect(onValueCommitted.mock.calls[0][0]).toBe(1234);
-    });
-
-    it('respects locale decimal separator while typing (de-DE)', async () => {
-      const onValueChange = vi.fn();
-      const onValueCommitted = vi.fn();
-      await render(
-        <NumberField
-          onValueChange={onValueChange}
-          onValueCommitted={onValueCommitted}
-          locale="de-DE"
-        />,
-      );
-      const input = screen.getByRole('textbox');
-
-      fireEvent.change(input, { target: { value: '1' } }); // 1
-      fireEvent.change(input, { target: { value: '1,' } }); // 1 (decimal separator typed)
-      fireEvent.change(input, { target: { value: '1,5' } }); // 1.5
-
-      expect(onValueChange.mock.calls.length).toBe(3);
-      expect(onValueChange.mock.calls[0][0]).toBe(1);
-      expect(onValueChange.mock.calls[1][0]).toBe(1);
-      expect(onValueChange.mock.calls[2][0]).toBe(1.5);
-
-      fireEvent.blur(input);
-      expect(onValueCommitted.mock.calls.length).toBe(1);
-      expect(onValueCommitted.mock.calls[0][0]).toBe(1.5);
-    });
-
-    it('parses percent while typing and commits canonical percent value', async () => {
-      const onValueChange = vi.fn();
-      const onValueCommitted = vi.fn();
-      await render(
-        <NumberField
-          onValueChange={onValueChange}
-          onValueCommitted={onValueCommitted}
-          format={{ style: 'percent' }}
-        />,
-      );
-      const input = screen.getByRole('textbox');
-
-      // Typing digits in percent style represents a fraction (12 -> 0.12)
-      fireEvent.change(input, { target: { value: '12' } });
-      // Typing with explicit percent sign also remains 0.12
-      fireEvent.change(input, { target: { value: '12%' } });
-
-      expect(onValueChange.mock.calls.length).toBe(2);
-      expect(onValueChange.mock.calls[0][0]).toBe(0.12);
-      expect(onValueChange.mock.calls[1][0]).toBe(0.12);
-      expect(onValueCommitted.mock.calls.length).toBe(0);
-
-      fireEvent.blur(input);
-      expect(onValueCommitted.mock.calls.length).toBe(1);
-      expect(onValueCommitted.mock.calls[0][0]).toBe(0.12);
-    });
-
-    it('accepts currency symbol while typing and parses numeric value', async () => {
-      const onValueChange = vi.fn();
-      await render(
-        <NumberField
-          onValueChange={onValueChange}
-          format={{ style: 'currency', currency: 'USD' }}
-        />,
-      );
-      const input = screen.getByRole('textbox');
-
-      fireEvent.change(input, { target: { value: '$1' } });
-      fireEvent.change(input, { target: { value: '$1,2' } });
-
-      expect(onValueChange.mock.calls.length).toBe(2);
-      expect(onValueChange.mock.calls[0][0]).toBe(1);
-      expect(onValueChange.mock.calls[1][0]).toBe(12);
-    });
-
-    it('allows deleting trailing currency symbols with locale literals', async () => {
-      const onValueChange = vi.fn();
-      const format: Intl.NumberFormatOptions = {
-        style: 'currency',
-        currency: 'EUR',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      };
-      const formatter = new Intl.NumberFormat('de-DE', format);
-
-      await render(
-        <NumberField
-          defaultValue={12.34}
-          locale="de-DE"
-          format={format}
-          onValueChange={onValueChange}
-        />,
-      );
-      const input = screen.getByRole('textbox');
-      const formatted = formatter.format(12.34);
-      const withoutCurrency = formatted.replace('€', '');
-
-      fireEvent.change(input, { target: { value: withoutCurrency } });
-
-      expect(input).toHaveValue(withoutCurrency);
-      expect(onValueChange.mock.calls.length).toBe(1);
-      expect(onValueChange.mock.calls[0][0]).toBe(12.34);
-    });
-
-    it('allows backspace to remove trailing currency symbol that follows a locale literal', async () => {
-      const onValueChange = vi.fn();
-      const format: Intl.NumberFormatOptions = {
-        style: 'currency',
-        currency: 'EUR',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      };
-      const formatter = new Intl.NumberFormat('de-DE', format);
-
-      await render(
-        <NumberField
-          defaultValue={12.34}
-          locale="de-DE"
-          format={format}
-          onValueChange={onValueChange}
-        />,
-      );
-
-      const input = screen.getByRole('textbox');
-      const formatted = formatter.format(12.34);
-      const afterBackspace = formatted.slice(0, -1);
-
-      await act(async () => {
-        input.focus();
-      });
-
-      const keydownResult = fireEvent.keyDown(input, { key: 'Backspace' });
-      expect(keydownResult).toBe(true);
-
-      fireEvent.change(input, { target: { value: afterBackspace } });
-
-      expect(input).toHaveValue(afterBackspace);
-      expect(onValueChange.mock.calls.length).toBe(1);
-      expect(onValueChange.mock.calls[0][0]).toBe(12.34);
-    });
-
-    it('does not commit on blur for invalid input', async () => {
-      const onValueCommitted = vi.fn();
-      await render(<NumberField onValueCommitted={onValueCommitted} />);
-      const input = screen.getByRole('textbox');
-
-      fireEvent.change(input, { target: { value: '.' } });
-      expect(input).toHaveValue('.');
-      fireEvent.blur(input);
-
-      expect(onValueCommitted.mock.calls.length).toBe(0);
     });
   });
 
@@ -1126,7 +774,399 @@ describe('<NumberField />', () => {
     });
   });
 
-  describe('Form', () => {
+  describe('prop: inputMode', () => {
+    it('should set the inputMode to numeric', async () => {
+      await render(<NumberField />);
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveAttribute('inputmode', 'numeric');
+    });
+  });
+
+  describe('prop: locale', () => {
+    it('should set the locale of the input', async () => {
+      await render(<NumberField defaultValue={1000.5} locale="de-DE" />);
+      const input = screen.getByRole('textbox');
+
+      // In German locale, numbers use dot as thousands separator and comma as decimal separator
+      const expectedValue = new Intl.NumberFormat('de-DE').format(1000.5);
+      expect(input).toHaveValue(expectedValue);
+    });
+
+    it('should use the default locale if no locale is provided', async () => {
+      await render(<NumberField defaultValue={1000.5} />);
+      const input = screen.getByRole('textbox');
+      const expectedValue = new Intl.NumberFormat().format(1000.5);
+      expect(input).toHaveValue(expectedValue);
+    });
+
+    it('should handle locales using space as the thousands separator', async () => {
+      await render(<NumberField defaultValue={12345.5} locale="pl" />);
+
+      const input = screen.getByRole('textbox');
+      const expectedValue = new Intl.NumberFormat('pl').format(12345.5);
+      expect(input).toHaveValue(expectedValue);
+
+      const incrementButton = screen.getByLabelText('Increase');
+      fireEvent.click(incrementButton);
+
+      const newExpectedValue = new Intl.NumberFormat('pl').format(12346.5);
+      expect(input).toHaveValue(newExpectedValue);
+    });
+  });
+
+  it('blocks submission when step mismatch occurs', async () => {
+    await render(
+      <form data-testid="form">
+        <NumberFieldBase.Root name="quantity" min={0} step={0.1}>
+          <NumberFieldBase.Group>
+            <NumberFieldBase.Input />
+          </NumberFieldBase.Group>
+        </NumberFieldBase.Root>
+        <button type="submit">Submit</button>
+      </form>,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '0.11' } });
+
+    const hiddenInput = document.querySelector(
+      'input[type="number"][name="quantity"]',
+    ) as HTMLInputElement;
+    expect(hiddenInput).not.toBe(null);
+    expect(hiddenInput.validity.stepMismatch).toBe(true);
+
+    const form = screen.getByTestId<HTMLFormElement>('form');
+    expect(form.checkValidity()).toBe(false);
+  });
+
+  it.skipIf(isJSDOM)('blocks submission when step mismatch occurs with default step', async () => {
+    await render(
+      <form data-testid="form">
+        <NumberFieldBase.Root name="quantity" min={0}>
+          <NumberFieldBase.Group>
+            <NumberFieldBase.Input />
+          </NumberFieldBase.Group>
+        </NumberFieldBase.Root>
+        <button type="submit">Submit</button>
+      </form>,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '0.11' } });
+
+    const hiddenInput = document.querySelector(
+      'input[type="number"][name="quantity"]',
+    ) as HTMLInputElement;
+    expect(hiddenInput).not.toBe(null);
+    expect(hiddenInput.validity.stepMismatch).toBe(true);
+
+    const form = screen.getByTestId<HTMLFormElement>('form');
+    expect(form.checkValidity()).toBe(false);
+  });
+
+  it('does not block submission when step="any"', async () => {
+    await render(
+      <form data-testid="form">
+        <NumberFieldBase.Root name="quantity" min={0} step="any">
+          <NumberFieldBase.Group>
+            <NumberFieldBase.Input />
+          </NumberFieldBase.Group>
+        </NumberFieldBase.Root>
+        <button type="submit">Submit</button>
+      </form>,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '0.11' } });
+
+    const hiddenInput = document.querySelector(
+      'input[type="number"][name="quantity"]',
+    ) as HTMLInputElement;
+    expect(hiddenInput).not.toBe(null);
+    expect(hiddenInput.validity.stepMismatch).toBe(false);
+
+    const form = screen.getByTestId<HTMLFormElement>('form');
+    expect(form.checkValidity()).toBe(true);
+  });
+
+  describe('typing behavior (parseable changes)', () => {
+    it('fires onValueChange for each parseable change while typing', async () => {
+      const onValueChange = vi.fn();
+      const onValueCommitted = vi.fn();
+      await render(
+        <NumberField onValueChange={onValueChange} onValueCommitted={onValueCommitted} />,
+      );
+      const input = screen.getByRole('textbox');
+
+      // Type '1' -> parseable
+      fireEvent.change(input, { target: { value: '1' } });
+      // Type '12' -> parseable
+      fireEvent.change(input, { target: { value: '12' } });
+      // Type '12.' -> parseable (treated as 12)
+      fireEvent.change(input, { target: { value: '12.' } });
+      // Type '12.a' -> not parseable, should not fire
+      fireEvent.change(input, { target: { value: '12.a' } });
+
+      expect(onValueChange.mock.calls.length).toBe(3);
+      expect(onValueChange.mock.calls[0][0]).toBe(1);
+      expect(onValueChange.mock.calls[1][0]).toBe(12);
+      expect(onValueChange.mock.calls[2][0]).toBe(12);
+
+      expect(onValueCommitted.mock.calls.length).toBe(0);
+    });
+
+    it('does not fire onValueChange for non-numeric composition/partial input', async () => {
+      const onValueChange = vi.fn();
+      const onValueCommitted = vi.fn();
+      await render(
+        <NumberField onValueChange={onValueChange} onValueCommitted={onValueCommitted} />,
+      );
+      const input = screen.getByRole('textbox');
+
+      // Simulate IME composition of non-numeric text; intermediate values like 'ni'
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: 'n' } });
+      fireEvent.change(input, { target: { value: 'ni' } });
+      fireEvent.compositionEnd(input);
+
+      expect(onValueChange.mock.calls.length).toBe(0);
+
+      // Now enter a Han numeral which is parseable
+      fireEvent.change(input, { target: { value: '一' } });
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.calls[0][0]).toBe(1);
+
+      expect(onValueCommitted.mock.calls.length).toBe(0);
+      fireEvent.blur(input);
+      expect(onValueCommitted.mock.calls.length).toBe(1);
+      expect(onValueCommitted.mock.calls[0][0]).toBe(1);
+    });
+
+    it('handles sign and decimal partials vs. parseable numbers', async () => {
+      const onValueChange = vi.fn();
+      const onValueCommitted = vi.fn();
+      await render(
+        <NumberField onValueChange={onValueChange} onValueCommitted={onValueCommitted} min={-10} />,
+      );
+      const input = screen.getByRole('textbox');
+
+      // '-' or '.' alone aren't parseable
+      fireEvent.change(input, { target: { value: '-' } });
+      fireEvent.change(input, { target: { value: '.' } });
+      // '0.' is parseable (-> 0)
+      fireEvent.change(input, { target: { value: '0.' } });
+      fireEvent.change(input, { target: { value: '-1' } });
+      fireEvent.change(input, { target: { value: '-1.5' } });
+
+      expect(onValueChange.mock.calls.length).toBe(3);
+      expect(onValueChange.mock.calls[0][0]).toBe(0);
+      expect(onValueChange.mock.calls[1][0]).toBe(-1);
+      expect(onValueChange.mock.calls[2][0]).toBe(-1.5);
+
+      // No commit until blur
+      expect(onValueCommitted.mock.calls.length).toBe(0);
+
+      fireEvent.blur(input);
+      expect(onValueCommitted.mock.calls.length).toBe(1);
+      expect(onValueCommitted.mock.calls[0][0]).toBe(-1.5);
+    });
+
+    it('allows typing a decimal while replacing a selection', async () => {
+      await render(<NumberField defaultValue={12.3} locale="en-US" />);
+      const input = screen.getByRole<HTMLInputElement>('textbox');
+
+      await act(async () => {
+        input.focus();
+      });
+
+      const decimalIndex = input.value.indexOf('.');
+      expect(decimalIndex).toBeGreaterThan(-1);
+      await act(async () => {
+        input.setSelectionRange(1, decimalIndex + 2);
+      });
+
+      const keydownResult = fireEvent.keyDown(input, { key: '.' });
+      expect(keydownResult).toBe(true);
+    });
+
+    it('accepts grouping while typing and parses progressively', async () => {
+      const onValueChange = vi.fn();
+      const onValueCommitted = vi.fn();
+      await render(
+        <NumberField onValueChange={onValueChange} onValueCommitted={onValueCommitted} />,
+      );
+      const input = screen.getByRole('textbox');
+
+      fireEvent.change(input, { target: { value: '1' } }); // 1
+      fireEvent.change(input, { target: { value: '1,' } }); // 1 (group symbol)
+      fireEvent.change(input, { target: { value: '1,2' } }); // 12
+      fireEvent.change(input, { target: { value: '1,23' } }); // 123
+      fireEvent.change(input, { target: { value: '1,234' } }); // 1234
+
+      expect(onValueChange.mock.calls.length).toBe(5);
+      expect(onValueChange.mock.calls[0][0]).toBe(1);
+      expect(onValueChange.mock.calls[1][0]).toBe(1);
+      expect(onValueChange.mock.calls[2][0]).toBe(12);
+      expect(onValueChange.mock.calls[3][0]).toBe(123);
+      expect(onValueChange.mock.calls[4][0]).toBe(1234);
+
+      expect(onValueCommitted.mock.calls.length).toBe(0);
+      fireEvent.blur(input);
+      expect(onValueCommitted.mock.calls.length).toBe(1);
+      expect(onValueCommitted.mock.calls[0][0]).toBe(1234);
+    });
+
+    it('respects locale decimal separator while typing (de-DE)', async () => {
+      const onValueChange = vi.fn();
+      const onValueCommitted = vi.fn();
+      await render(
+        <NumberField
+          onValueChange={onValueChange}
+          onValueCommitted={onValueCommitted}
+          locale="de-DE"
+        />,
+      );
+      const input = screen.getByRole('textbox');
+
+      fireEvent.change(input, { target: { value: '1' } }); // 1
+      fireEvent.change(input, { target: { value: '1,' } }); // 1 (decimal separator typed)
+      fireEvent.change(input, { target: { value: '1,5' } }); // 1.5
+
+      expect(onValueChange.mock.calls.length).toBe(3);
+      expect(onValueChange.mock.calls[0][0]).toBe(1);
+      expect(onValueChange.mock.calls[1][0]).toBe(1);
+      expect(onValueChange.mock.calls[2][0]).toBe(1.5);
+
+      fireEvent.blur(input);
+      expect(onValueCommitted.mock.calls.length).toBe(1);
+      expect(onValueCommitted.mock.calls[0][0]).toBe(1.5);
+    });
+
+    it('parses percent while typing and commits canonical percent value', async () => {
+      const onValueChange = vi.fn();
+      const onValueCommitted = vi.fn();
+      await render(
+        <NumberField
+          onValueChange={onValueChange}
+          onValueCommitted={onValueCommitted}
+          format={{ style: 'percent' }}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+
+      // Typing digits in percent style represents a fraction (12 -> 0.12)
+      fireEvent.change(input, { target: { value: '12' } });
+      // Typing with explicit percent sign also remains 0.12
+      fireEvent.change(input, { target: { value: '12%' } });
+
+      expect(onValueChange.mock.calls.length).toBe(2);
+      expect(onValueChange.mock.calls[0][0]).toBe(0.12);
+      expect(onValueChange.mock.calls[1][0]).toBe(0.12);
+      expect(onValueCommitted.mock.calls.length).toBe(0);
+
+      fireEvent.blur(input);
+      expect(onValueCommitted.mock.calls.length).toBe(1);
+      expect(onValueCommitted.mock.calls[0][0]).toBe(0.12);
+    });
+
+    it('accepts currency symbol while typing and parses numeric value', async () => {
+      const onValueChange = vi.fn();
+      await render(
+        <NumberField
+          onValueChange={onValueChange}
+          format={{ style: 'currency', currency: 'USD' }}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+
+      fireEvent.change(input, { target: { value: '$1' } });
+      fireEvent.change(input, { target: { value: '$1,2' } });
+
+      expect(onValueChange.mock.calls.length).toBe(2);
+      expect(onValueChange.mock.calls[0][0]).toBe(1);
+      expect(onValueChange.mock.calls[1][0]).toBe(12);
+    });
+
+    it('allows deleting trailing currency symbols with locale literals', async () => {
+      const onValueChange = vi.fn();
+      const format: Intl.NumberFormatOptions = {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      };
+      const formatter = new Intl.NumberFormat('de-DE', format);
+
+      await render(
+        <NumberField
+          defaultValue={12.34}
+          locale="de-DE"
+          format={format}
+          onValueChange={onValueChange}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+      const formatted = formatter.format(12.34);
+      const withoutCurrency = formatted.replace('€', '');
+
+      fireEvent.change(input, { target: { value: withoutCurrency } });
+
+      expect(input).toHaveValue(withoutCurrency);
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.calls[0][0]).toBe(12.34);
+    });
+
+    it('allows backspace to remove trailing currency symbol that follows a locale literal', async () => {
+      const onValueChange = vi.fn();
+      const format: Intl.NumberFormatOptions = {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      };
+      const formatter = new Intl.NumberFormat('de-DE', format);
+
+      await render(
+        <NumberField
+          defaultValue={12.34}
+          locale="de-DE"
+          format={format}
+          onValueChange={onValueChange}
+        />,
+      );
+
+      const input = screen.getByRole('textbox');
+      const formatted = formatter.format(12.34);
+      const afterBackspace = formatted.slice(0, -1);
+
+      await act(async () => {
+        input.focus();
+      });
+
+      const keydownResult = fireEvent.keyDown(input, { key: 'Backspace' });
+      expect(keydownResult).toBe(true);
+
+      fireEvent.change(input, { target: { value: afterBackspace } });
+
+      expect(input).toHaveValue(afterBackspace);
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.calls[0][0]).toBe(12.34);
+    });
+
+    it('does not commit on blur for invalid input', async () => {
+      const onValueCommitted = vi.fn();
+      await render(<NumberField onValueCommitted={onValueCommitted} />);
+      const input = screen.getByRole('textbox');
+
+      fireEvent.change(input, { target: { value: '.' } });
+      expect(input).toHaveValue('.');
+      fireEvent.blur(input);
+
+      expect(onValueCommitted.mock.calls.length).toBe(0);
+    });
+  });
+
+  describe('Form integration', () => {
     it('should include the input value in the form submission', async ({ skip }) => {
       if (isJSDOM) {
         // FormData is not available in JSDOM
@@ -1350,10 +1390,9 @@ describe('<NumberField />', () => {
       );
 
       const input = screen.getByRole('textbox');
-      const hiddenInput = document.querySelector('input[type="number"][name="quantity"]');
+      const hiddenInput = screen.getByRole('spinbutton', { hidden: true });
 
-      expect(hiddenInput).not.toBe(null);
-      fireEvent.change(hiddenInput!, { target: { value: '42' } });
+      fireEvent.change(hiddenInput, { target: { value: '42' } });
 
       expect(onValueChange.mock.calls.length).toBe(1);
       expect(onValueChange.mock.calls[0][0]).toBe(42);
@@ -1417,8 +1456,8 @@ describe('<NumberField />', () => {
     );
   });
 
-  describe('Field', () => {
-    it('[data-touched]', async () => {
+  describe('Field integration', () => {
+    it('adds data-touched after blur', async () => {
       await render(
         <Field.Root>
           <NumberFieldBase.Root>
@@ -1435,7 +1474,7 @@ describe('<NumberField />', () => {
       expect(input).toHaveAttribute('data-touched', '');
     });
 
-    it('[data-dirty]', async () => {
+    it('adds data-dirty after the value changes', async () => {
       await render(
         <Field.Root>
           <NumberFieldBase.Root>
@@ -1453,8 +1492,8 @@ describe('<NumberField />', () => {
       expect(input).toHaveAttribute('data-dirty', '');
     });
 
-    describe('[data-filled]', () => {
-      it('adds [data-filled] attribute when filled', async () => {
+    describe('field state attribute: data-filled', () => {
+      it('adds data-filled when filled', async () => {
         await render(
           <Field.Root>
             <NumberFieldBase.Root>
@@ -1476,7 +1515,7 @@ describe('<NumberField />', () => {
         expect(input).not.toHaveAttribute('data-filled');
       });
 
-      it('has [data-filled] attribute when already filled', async () => {
+      it('has data-filled when already filled', async () => {
         await render(
           <Field.Root>
             <NumberFieldBase.Root defaultValue={1}>
@@ -1495,7 +1534,7 @@ describe('<NumberField />', () => {
       });
     });
 
-    it('[data-filled]', async () => {
+    it('adds data-focused while focused', async () => {
       await render(
         <Field.Root>
           <NumberFieldBase.Root>
@@ -1517,7 +1556,7 @@ describe('<NumberField />', () => {
       expect(input).not.toHaveAttribute('data-focused');
     });
 
-    it('adds [data-focused] attribute on every focus', async () => {
+    it('adds data-focused on every focus', async () => {
       await render(
         <Field.Root>
           <NumberFieldBase.Root>
@@ -1538,28 +1577,30 @@ describe('<NumberField />', () => {
       expect(input).toHaveAttribute('data-focused', '');
     });
 
-    it('prop: validate', async () => {
-      await render(
-        <Field.Root validationMode="onBlur" validate={() => 'error'}>
-          <NumberFieldBase.Root>
-            <NumberFieldBase.Input />
-          </NumberFieldBase.Root>
-          <Field.Error data-testid="error" />
-        </Field.Root>,
-      );
+    describe('prop: validate', () => {
+      it('applies aria-invalid after blur', async () => {
+        await render(
+          <Field.Root validationMode="onBlur" validate={() => 'error'}>
+            <NumberFieldBase.Root>
+              <NumberFieldBase.Input />
+            </NumberFieldBase.Root>
+            <Field.Error data-testid="error" />
+          </Field.Root>,
+        );
 
-      const input = screen.getByRole('textbox');
+        const input = screen.getByRole('textbox');
 
-      expect(input).not.toHaveAttribute('aria-invalid');
+        expect(input).not.toHaveAttribute('aria-invalid');
 
-      fireEvent.focus(input);
-      fireEvent.blur(input);
+        fireEvent.focus(input);
+        fireEvent.blur(input);
 
-      expect(input).toHaveAttribute('aria-invalid', 'true');
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+      });
     });
 
     describe('prop: validationMode', () => {
-      it('onSubmit', async () => {
+      it('validates when validationMode is onSubmit', async () => {
         await render(
           <Form>
             <Field.Root validate={(value) => (value === 1 ? 'custom error' : null)}>
@@ -1615,7 +1656,7 @@ describe('<NumberField />', () => {
         expect(screen.queryByTestId('error')).toHaveTextContent('valueMissing error');
       });
 
-      it('onChange', async () => {
+      it('validates when validationMode is onChange', async () => {
         await render(
           <Field.Root
             validationMode="onChange"
@@ -1675,7 +1716,7 @@ describe('<NumberField />', () => {
         expect(input).toHaveAttribute('aria-invalid', 'true');
       });
 
-      it('onBlur', async () => {
+      it('validates when validationMode is onBlur', async () => {
         await render(
           <Field.Root
             validationMode="onBlur"
@@ -1802,7 +1843,7 @@ describe('<NumberField />', () => {
       expect(input).not.toHaveAttribute('disabled');
     });
 
-    it('is validated with latest value when validationMode=onBlur', async () => {
+    it('validates with the latest value when validationMode is onBlur', async () => {
       const validate = vi.fn(() => 'error');
 
       await render(
@@ -1852,14 +1893,6 @@ describe('<NumberField />', () => {
         'aria-describedby',
         screen.getByTestId('description').id,
       );
-    });
-  });
-
-  describe('prop: inputMode', () => {
-    it('should set the inputMode to numeric', async () => {
-      await render(<NumberField />);
-      const input = screen.getByRole('textbox');
-      expect(input).toHaveAttribute('inputmode', 'numeric');
     });
   });
 
@@ -2131,38 +2164,6 @@ describe('<NumberField />', () => {
       const preventDefaultSpy = vi.fn();
       fireEvent.keyDown(input, { key, preventDefault: preventDefaultSpy });
       expect(preventDefaultSpy).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  describe('prop: locale', () => {
-    it('should set the locale of the input', async () => {
-      await render(<NumberField defaultValue={1000.5} locale="de-DE" />);
-      const input = screen.getByRole('textbox');
-
-      // In German locale, numbers use dot as thousands separator and comma as decimal separator
-      const expectedValue = new Intl.NumberFormat('de-DE').format(1000.5);
-      expect(input).toHaveValue(expectedValue);
-    });
-
-    it('should use the default locale if no locale is provided', async () => {
-      await render(<NumberField defaultValue={1000.5} />);
-      const input = screen.getByRole('textbox');
-      const expectedValue = new Intl.NumberFormat().format(1000.5);
-      expect(input).toHaveValue(expectedValue);
-    });
-
-    it('should handle locales using space as the thousands separator', async () => {
-      await render(<NumberField defaultValue={12345.5} locale="pl" />);
-
-      const input = screen.getByRole('textbox');
-      const expectedValue = new Intl.NumberFormat('pl').format(12345.5);
-      expect(input).toHaveValue(expectedValue);
-
-      const incrementButton = screen.getByLabelText('Increase');
-      fireEvent.click(incrementButton);
-
-      const newExpectedValue = new Intl.NumberFormat('pl').format(12346.5);
-      expect(input).toHaveValue(newExpectedValue);
     });
   });
 });

--- a/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
@@ -7,7 +7,7 @@ import { Form } from '@base-ui/react/form';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { REASONS } from '../../internals/reasons';
 
-describe('<OTPFieldPreview />', () => {
+describe('<OTPField.Root />', () => {
   const { render, renderToString } = createRenderer();
   const OTP_LENGTH = 6;
 
@@ -521,7 +521,7 @@ describe('<OTPFieldPreview />', () => {
     });
   });
 
-  describe('Field', () => {
+  describe('Field integration', () => {
     it('associates Field.Label with the first slot', async () => {
       await render(
         <Field.Root>
@@ -836,7 +836,7 @@ describe('<OTPFieldPreview />', () => {
     });
   });
 
-  describe('Form', () => {
+  describe('Form integration', () => {
     it('blocks form submission while the code is incomplete', async () => {
       await render(
         <form data-testid="form">

--- a/packages/react/src/popover/popup/PopoverPopup.test.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.test.tsx
@@ -299,85 +299,6 @@ describe('<Popover.Popup />', () => {
     });
   });
 
-  it.skipIf(isJSDOM)('focuses the popup when the active element becomes display:none', async () => {
-    function TestComponent() {
-      const [hidden, setHidden] = React.useState(false);
-
-      return (
-        <Popover.Root open>
-          <Popover.Trigger>Open</Popover.Trigger>
-          <Popover.Portal>
-            <Popover.Positioner>
-              <Popover.Popup data-testid="popup">
-                <button
-                  data-testid="hide-button"
-                  style={{ display: hidden ? 'none' : undefined }}
-                  onClick={() => setHidden(true)}
-                >
-                  Hide
-                </button>
-                <input />
-              </Popover.Popup>
-            </Popover.Positioner>
-          </Popover.Portal>
-        </Popover.Root>
-      );
-    }
-
-    const { user } = await render(<TestComponent />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('hide-button')).toHaveFocus();
-    });
-
-    await user.click(screen.getByTestId('hide-button'));
-
-    await waitFor(() => {
-      expect(screen.getByTestId('popup')).toHaveFocus();
-    });
-  });
-
-  describe('openOnHover: delay + click', () => {
-    clock.withFakeTimers();
-
-    it('returns focus to the trigger if opened by click before the hover delay completes', async () => {
-      await render(
-        <Popover.Root>
-          <Popover.Trigger openOnHover delay={300}>
-            Open
-          </Popover.Trigger>
-          <Popover.Portal>
-            <Popover.Positioner>
-              <Popover.Popup>
-                <Popover.Close>Close</Popover.Close>
-              </Popover.Popup>
-            </Popover.Positioner>
-          </Popover.Portal>
-        </Popover.Root>,
-      );
-
-      const trigger = screen.getByText('Open');
-
-      fireEvent.mouseEnter(trigger);
-      fireEvent.mouseMove(trigger);
-
-      clock.tick(100);
-
-      fireEvent.click(trigger);
-      await flushMicrotasks();
-
-      expect(screen.getByText('Close')).not.toBe(null);
-
-      clock.tick(1000);
-      await flushMicrotasks();
-
-      fireEvent.click(screen.getByText('Close'));
-      await flushMicrotasks();
-
-      expect(trigger).toHaveFocus();
-    });
-  });
-
   describe('prop: finalFocus', () => {
     it('should focus the trigger by default when closed', async () => {
       await render(
@@ -618,6 +539,85 @@ describe('<Popover.Popup />', () => {
       await waitFor(() => {
         expect(trigger).toHaveFocus();
       });
+    });
+  });
+
+  it.skipIf(isJSDOM)('focuses the popup when the active element becomes display:none', async () => {
+    function TestComponent() {
+      const [hidden, setHidden] = React.useState(false);
+
+      return (
+        <Popover.Root open>
+          <Popover.Trigger>Open</Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup data-testid="popup">
+                <button
+                  data-testid="hide-button"
+                  style={{ display: hidden ? 'none' : undefined }}
+                  onClick={() => setHidden(true)}
+                >
+                  Hide
+                </button>
+                <input />
+              </Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>
+      );
+    }
+
+    const { user } = await render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('hide-button')).toHaveFocus();
+    });
+
+    await user.click(screen.getByTestId('hide-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('popup')).toHaveFocus();
+    });
+  });
+
+  describe('openOnHover: delay + click', () => {
+    clock.withFakeTimers();
+
+    it('returns focus to the trigger if opened by click before the hover delay completes', async () => {
+      await render(
+        <Popover.Root>
+          <Popover.Trigger openOnHover delay={300}>
+            Open
+          </Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup>
+                <Popover.Close>Close</Popover.Close>
+              </Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>,
+      );
+
+      const trigger = screen.getByText('Open');
+
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
+
+      clock.tick(100);
+
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      expect(screen.getByText('Close')).not.toBe(null);
+
+      clock.tick(1000);
+      await flushMicrotasks();
+
+      fireEvent.click(screen.getByText('Close'));
+      await flushMicrotasks();
+
+      expect(trigger).toHaveFocus();
     });
   });
 });

--- a/packages/react/src/popover/portal/PopoverPortal.test.tsx
+++ b/packages/react/src/popover/portal/PopoverPortal.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
@@ -773,9 +773,7 @@ describe('<Popover.Root />', () => {
       expect(screen.queryByRole('dialog')).toBe(null);
 
       await act(() => popover.open('trigger'));
-      await waitFor(() => {
-        expect(screen.queryByRole('dialog')).not.toBe(null);
-      });
+      await screen.findByRole('dialog');
 
       expect(screen.getByTestId('content').textContent).toBe('Content');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
@@ -815,9 +813,7 @@ describe('<Popover.Root />', () => {
       expect(screen.queryByRole('dialog')).toBe(null);
 
       await act(() => popover.open('trigger2'));
-      await waitFor(() => {
-        expect(screen.queryByRole('dialog')).not.toBe(null);
-      });
+      await screen.findByRole('dialog');
 
       expect(screen.getByTestId('content').textContent).toBe('2');
       expect(trigger2).toHaveAttribute('aria-expanded', 'true');

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -72,9 +72,7 @@ describe('<Popover.Root />', () => {
         const trigger = screen.getByTestId('trigger');
 
         await user.click(trigger);
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
+        await screen.findByRole('dialog');
 
         await user.keyboard('{Escape}');
         await waitFor(() => {
@@ -82,9 +80,7 @@ describe('<Popover.Root />', () => {
         });
 
         await user.click(trigger);
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
+        await screen.findByRole('dialog');
 
         fireEvent.click(document.body);
         await waitFor(() => {
@@ -255,9 +251,7 @@ describe('<Popover.Root />', () => {
         const item = await screen.findByText('Item');
         await user.click(item);
 
-        await waitFor(() => {
-          expect(screen.getByTestId('popover-popup')).not.toBe(null);
-        });
+        await screen.findByTestId('popover-popup');
       });
     });
 
@@ -342,6 +336,391 @@ describe('<Popover.Root />', () => {
         clock.tick(50);
 
         expect(screen.queryByText('Content')).toBe(null);
+      });
+    });
+
+    describe('prop: actionsRef', () => {
+      it('unmounts the popover when the `unmount` method is called', async () => {
+        const actionsRef = {
+          current: {
+            unmount: vi.fn(),
+            close: vi.fn(),
+          },
+        };
+
+        const { user } = await render(
+          <TestPopover
+            rootProps={{
+              actionsRef,
+              onOpenChange: (open, details) => {
+                details.preventUnmountOnClose();
+              },
+            }}
+          />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+        await user.click(trigger);
+
+        await screen.findByRole('dialog');
+
+        await user.click(trigger);
+
+        await screen.findByRole('dialog');
+
+        await act(async () => actionsRef.current.unmount());
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).toBe(null);
+        });
+      });
+
+      it('closes the popover when the `close` method is called', async () => {
+        const actionsRef = React.createRef<Popover.Root.Actions>();
+        await render(<TestPopover rootProps={{ defaultOpen: true, actionsRef }} />);
+
+        await act(async () => {
+          actionsRef.current!.close();
+        });
+
+        await waitFor(() => {
+          expect(screen.queryByText('Content')).toBe(null);
+        });
+      });
+    });
+
+    describe('prop: modal', () => {
+      it('should render an internal backdrop when `true`', async () => {
+        const { user } = await render(
+          <div>
+            <TestPopover rootProps={{ modal: true }} />
+            <button>Outside</button>
+          </div>,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        await user.click(trigger);
+
+        await screen.findByRole('dialog');
+
+        const positioner = screen.getByTestId('positioner');
+
+        expect(positioner.previousElementSibling).toHaveAttribute('role', 'presentation');
+      });
+
+      it('should only render focus guards inside the popup when `true`', async () => {
+        const { user } = await render(
+          <div>
+            <TestPopover
+              rootProps={{ modal: true }}
+              popupProps={{ children: <Popover.Close>Close</Popover.Close> }}
+            />
+          </div>,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        await user.click(trigger);
+
+        await screen.findByRole('dialog');
+
+        expect(
+          trigger.previousElementSibling?.hasAttribute('data-base-ui-focus-guard') ?? false,
+        ).toBe(false);
+        expect(trigger.nextElementSibling?.hasAttribute('data-base-ui-focus-guard') ?? false).toBe(
+          false,
+        );
+        expect(
+          document.querySelectorAll('[data-base-ui-focus-guard][data-type="inside"]'),
+        ).toHaveLength(2);
+      });
+
+      it('should keep trigger focus guards when `true` without a close part', async () => {
+        const { user } = await render(
+          <div>
+            <TestPopover
+              rootProps={{ defaultOpen: true, modal: true }}
+              popupProps={{ children: <input data-testid="input-inside" /> }}
+              afterTrigger={<input data-testid="focus-target" />}
+            />
+          </div>,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+        expect(trigger.previousElementSibling).toHaveAttribute('data-base-ui-focus-guard');
+        expect(trigger.nextElementSibling).toHaveAttribute('data-base-ui-focus-guard');
+
+        await act(async () => {
+          screen.getByTestId('input-inside').focus();
+        });
+
+        await user.tab();
+
+        expect(screen.getByTestId('focus-target')).toHaveFocus();
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('popover-popup')).toBe(null);
+        });
+      });
+
+      it('should not render an internal backdrop when `false`', async () => {
+        const { user } = await render(
+          <div>
+            <TestPopover rootProps={{ modal: false }} />
+            <button>Outside</button>
+          </div>,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        await user.click(trigger);
+
+        await screen.findByRole('dialog');
+
+        const positioner = screen.getByTestId('positioner');
+
+        expect(positioner.previousElementSibling).toBe(null);
+      });
+
+      describe('with openOnHover', () => {
+        clock.withFakeTimers();
+
+        it('enables modal behavior after a hover-open is clicked', async () => {
+          await render(
+            <TestPopover
+              rootProps={{ modal: true }}
+              triggerProps={{ openOnHover: true, delay: 0 }}
+            />,
+          );
+
+          const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+          fireEvent.mouseEnter(trigger);
+          fireEvent.mouseMove(trigger);
+
+          await flushMicrotasks();
+          expect(screen.queryByRole('dialog')).not.toBe(null);
+
+          const positioner = screen.getByTestId('positioner');
+          expect(positioner.previousElementSibling).toBe(null);
+
+          clock.tick(PATIENT_CLICK_THRESHOLD - 1);
+          fireEvent.click(trigger);
+
+          await flushMicrotasks();
+
+          expect(positioner.previousElementSibling).toHaveAttribute('role', 'presentation');
+        });
+
+        it('reopens on hover after an impatient click is followed by a close button press', async () => {
+          await render(
+            <TestPopover
+              triggerProps={{ openOnHover: true, delay: 100 }}
+              popupProps={{ children: <Popover.Close>Close</Popover.Close> }}
+            />,
+          );
+
+          const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+          fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+          fireEvent.mouseEnter(trigger);
+          fireEvent.mouseMove(trigger, { movementX: 10, movementY: 0 });
+
+          clock.tick(100);
+          await flushMicrotasks();
+
+          expect(screen.queryByRole('dialog')).not.toBe(null);
+
+          clock.tick(PATIENT_CLICK_THRESHOLD - 1);
+          fireEvent.click(trigger);
+          await flushMicrotasks();
+
+          fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+          await flushMicrotasks();
+
+          expect(screen.queryByRole('dialog')).toBe(null);
+
+          // Re-enter with mouse events only. A fresh pointerenter can be
+          // missed after the click-driven close, but hover should still work.
+          fireEvent.mouseEnter(trigger);
+          fireEvent.mouseMove(trigger, { movementX: 10, movementY: 0 });
+
+          clock.tick(100);
+          await flushMicrotasks();
+
+          expect(screen.queryByRole('dialog')).not.toBe(null);
+        });
+      });
+    });
+
+    describe.skipIf(isJSDOM)('prop: onOpenChangeComplete', () => {
+      it('is called on close when there is no exit animation defined', async () => {
+        const onOpenChangeComplete = vi.fn();
+
+        function Test() {
+          const [open, setOpen] = React.useState(true);
+          return (
+            <div>
+              <button onClick={() => setOpen(false)}>Close</button>
+              <TestPopover
+                rootProps={{ open, onOpenChangeComplete }}
+                popupProps={{ children: null }}
+              />
+            </div>
+          );
+        }
+
+        const { user } = await render(<Test />);
+
+        const closeButton = screen.getByText('Close');
+        await user.click(closeButton);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('popover-popup')).toBe(null);
+        });
+
+        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+        expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
+      });
+
+      it('is called on close when the exit animation finishes', async () => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        const onOpenChangeComplete = vi.fn();
+
+        function Test() {
+          const style = `
+          @keyframes test-anim {
+            to {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-indicator[data-ending-style] {
+            animation: test-anim 1ms;
+          }
+        `;
+
+          const [open, setOpen] = React.useState(true);
+
+          return (
+            <div>
+              {/* eslint-disable-next-line react/no-danger */}
+              <style dangerouslySetInnerHTML={{ __html: style }} />
+              <button onClick={() => setOpen(false)}>Close</button>
+              <TestPopover
+                rootProps={{ open, onOpenChangeComplete }}
+                popupProps={{ className: 'animation-test-indicator', children: null }}
+              />
+            </div>
+          );
+        }
+
+        const { user } = await render(<Test />);
+
+        expect(screen.getByTestId('popover-popup')).not.toBe(null);
+
+        // Wait for open animation to finish
+        await waitFor(() => {
+          expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+        });
+
+        const closeButton = screen.getByText('Close');
+        await user.click(closeButton);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('popover-popup')).toBe(null);
+        });
+
+        expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
+      });
+
+      it('is called on open when there is no enter animation defined', async () => {
+        const onOpenChangeComplete = vi.fn();
+
+        function Test() {
+          const [open, setOpen] = React.useState(false);
+          return (
+            <div>
+              <button onClick={() => setOpen(true)}>Open</button>
+              <TestPopover
+                rootProps={{ open, onOpenChangeComplete }}
+                popupProps={{ children: null }}
+              />
+            </div>
+          );
+        }
+
+        const { user } = await render(<Test />);
+
+        const openButton = screen.getByText('Open');
+        await user.click(openButton);
+
+        await screen.findByTestId('popover-popup');
+
+        expect(onOpenChangeComplete.mock.calls.length).toBe(2);
+        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+      });
+
+      it('is called on open when the enter animation finishes', async () => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        const onOpenChangeComplete = vi.fn();
+
+        function Test() {
+          const style = `
+          @keyframes test-anim {
+            from {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-indicator[data-starting-style] {
+            animation: test-anim 1ms;
+          }
+        `;
+
+          const [open, setOpen] = React.useState(false);
+
+          return (
+            <div>
+              {/* eslint-disable-next-line react/no-danger */}
+              <style dangerouslySetInnerHTML={{ __html: style }} />
+              <button onClick={() => setOpen(true)}>Open</button>
+              <TestPopover
+                rootProps={{
+                  open,
+                  onOpenChange: (nextOpen) => setOpen(nextOpen),
+                  onOpenChangeComplete,
+                }}
+                popupProps={{ className: 'animation-test-indicator', children: null }}
+              />
+            </div>
+          );
+        }
+
+        const { user } = await render(<Test />);
+
+        const openButton = screen.getByText('Open');
+        await user.click(openButton);
+
+        // Wait for open animation to finish
+        await waitFor(() => {
+          expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+        });
+
+        expect(screen.queryByTestId('popover-popup')).not.toBe(null);
+      });
+
+      it('does not get called on mount when not open', async () => {
+        const onOpenChangeComplete = vi.fn();
+
+        await render(
+          <TestPopover rootProps={{ onOpenChangeComplete }} popupProps={{ children: null }} />,
+        );
+
+        expect(onOpenChangeComplete.mock.calls.length).toBe(0);
       });
     });
 
@@ -551,8 +930,6 @@ describe('<Popover.Root />', () => {
         await flushMicrotasks();
 
         await user.hover(firstInput);
-        await flushMicrotasks();
-
         await waitFor(() => {
           expect(screen.queryByRole('dialog')).toBe(null);
         });
@@ -1090,231 +1467,6 @@ describe('<Popover.Root />', () => {
       });
     });
 
-    describe('prop: actionsRef', () => {
-      it('unmounts the popover when the `unmount` method is called', async () => {
-        const actionsRef = {
-          current: {
-            unmount: vi.fn(),
-            close: vi.fn(),
-          },
-        };
-
-        const { user } = await render(
-          <TestPopover
-            rootProps={{
-              actionsRef,
-              onOpenChange: (open, details) => {
-                details.preventUnmountOnClose();
-              },
-            }}
-          />,
-        );
-
-        const trigger = screen.getByRole('button', { name: 'Toggle' });
-        await user.click(trigger);
-
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
-
-        await user.click(trigger);
-
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
-
-        await act(async () => actionsRef.current.unmount());
-
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).toBe(null);
-        });
-      });
-
-      it('closes the popover when the `close` method is called', async () => {
-        const actionsRef = React.createRef<Popover.Root.Actions>();
-        await render(<TestPopover rootProps={{ defaultOpen: true, actionsRef }} />);
-
-        await act(async () => {
-          actionsRef.current!.close();
-        });
-
-        await waitFor(() => {
-          expect(screen.queryByText('Content')).toBe(null);
-        });
-      });
-    });
-
-    describe('prop: modal', () => {
-      it('should render an internal backdrop when `true`', async () => {
-        const { user } = await render(
-          <div>
-            <TestPopover rootProps={{ modal: true }} />
-            <button>Outside</button>
-          </div>,
-        );
-
-        const trigger = screen.getByRole('button', { name: 'Toggle' });
-
-        await user.click(trigger);
-
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
-
-        const positioner = screen.getByTestId('positioner');
-
-        expect(positioner.previousElementSibling).toHaveAttribute('role', 'presentation');
-      });
-
-      it('should only render focus guards inside the popup when `true`', async () => {
-        const { user } = await render(
-          <div>
-            <TestPopover
-              rootProps={{ modal: true }}
-              popupProps={{ children: <Popover.Close>Close</Popover.Close> }}
-            />
-          </div>,
-        );
-
-        const trigger = screen.getByRole('button', { name: 'Toggle' });
-
-        await user.click(trigger);
-
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
-
-        expect(
-          trigger.previousElementSibling?.hasAttribute('data-base-ui-focus-guard') ?? false,
-        ).toBe(false);
-        expect(trigger.nextElementSibling?.hasAttribute('data-base-ui-focus-guard') ?? false).toBe(
-          false,
-        );
-        expect(
-          document.querySelectorAll('[data-base-ui-focus-guard][data-type="inside"]'),
-        ).toHaveLength(2);
-      });
-
-      it('should keep trigger focus guards when `true` without a close part', async () => {
-        const { user } = await render(
-          <div>
-            <TestPopover
-              rootProps={{ defaultOpen: true, modal: true }}
-              popupProps={{ children: <input data-testid="input-inside" /> }}
-              afterTrigger={<input data-testid="focus-target" />}
-            />
-          </div>,
-        );
-
-        const trigger = screen.getByRole('button', { name: 'Toggle' });
-        expect(trigger.previousElementSibling).toHaveAttribute('data-base-ui-focus-guard');
-        expect(trigger.nextElementSibling).toHaveAttribute('data-base-ui-focus-guard');
-
-        await act(async () => {
-          screen.getByTestId('input-inside').focus();
-        });
-
-        await user.tab();
-
-        expect(screen.getByTestId('focus-target')).toHaveFocus();
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('popover-popup')).toBe(null);
-        });
-      });
-
-      it('should not render an internal backdrop when `false`', async () => {
-        const { user } = await render(
-          <div>
-            <TestPopover rootProps={{ modal: false }} />
-            <button>Outside</button>
-          </div>,
-        );
-
-        const trigger = screen.getByRole('button', { name: 'Toggle' });
-
-        await user.click(trigger);
-
-        await waitFor(() => {
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
-
-        const positioner = screen.getByTestId('positioner');
-
-        expect(positioner.previousElementSibling).toBe(null);
-      });
-
-      describe('with openOnHover', () => {
-        clock.withFakeTimers();
-
-        it('enables modal behavior after a hover-open is clicked', async () => {
-          await render(
-            <TestPopover
-              rootProps={{ modal: true }}
-              triggerProps={{ openOnHover: true, delay: 0 }}
-            />,
-          );
-
-          const trigger = screen.getByRole('button', { name: 'Toggle' });
-
-          fireEvent.mouseEnter(trigger);
-          fireEvent.mouseMove(trigger);
-
-          await flushMicrotasks();
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-
-          const positioner = screen.getByTestId('positioner');
-          expect(positioner.previousElementSibling).toBe(null);
-
-          clock.tick(PATIENT_CLICK_THRESHOLD - 1);
-          fireEvent.click(trigger);
-
-          await flushMicrotasks();
-
-          expect(positioner.previousElementSibling).toHaveAttribute('role', 'presentation');
-        });
-
-        it('reopens on hover after an impatient click is followed by a close button press', async () => {
-          await render(
-            <TestPopover
-              triggerProps={{ openOnHover: true, delay: 100 }}
-              popupProps={{ children: <Popover.Close>Close</Popover.Close> }}
-            />,
-          );
-
-          const trigger = screen.getByRole('button', { name: 'Toggle' });
-
-          fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
-          fireEvent.mouseEnter(trigger);
-          fireEvent.mouseMove(trigger, { movementX: 10, movementY: 0 });
-
-          clock.tick(100);
-          await flushMicrotasks();
-
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-
-          clock.tick(PATIENT_CLICK_THRESHOLD - 1);
-          fireEvent.click(trigger);
-          await flushMicrotasks();
-
-          fireEvent.click(screen.getByRole('button', { name: 'Close' }));
-          await flushMicrotasks();
-
-          expect(screen.queryByRole('dialog')).toBe(null);
-
-          // Re-enter with mouse events only. A fresh pointerenter can be
-          // missed after the click-driven close, but hover should still work.
-          fireEvent.mouseEnter(trigger);
-          fireEvent.mouseMove(trigger, { movementX: 10, movementY: 0 });
-
-          clock.tick(100);
-          await flushMicrotasks();
-
-          expect(screen.queryByRole('dialog')).not.toBe(null);
-        });
-      });
-    });
-
     describe.skipIf(isJSDOM)('scroll locking', () => {
       describe('touch scroll lock', () => {
         it('applies scroll lock when a touch-opened popup covers the viewport width', async () => {
@@ -1388,178 +1540,6 @@ describe('<Popover.Root />', () => {
       });
     });
 
-    describe.skipIf(isJSDOM)('prop: onOpenChangeComplete', () => {
-      it('is called on close when there is no exit animation defined', async () => {
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const [open, setOpen] = React.useState(true);
-          return (
-            <div>
-              <button onClick={() => setOpen(false)}>Close</button>
-              <TestPopover
-                rootProps={{ open, onOpenChangeComplete }}
-                popupProps={{ children: null }}
-              />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        const closeButton = screen.getByText('Close');
-        await user.click(closeButton);
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('popover-popup')).toBe(null);
-        });
-
-        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-        expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
-      });
-
-      it('is called on close when the exit animation finishes', async () => {
-        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const style = `
-          @keyframes test-anim {
-            to {
-              opacity: 0;
-            }
-          }
-
-          .animation-test-indicator[data-ending-style] {
-            animation: test-anim 1ms;
-          }
-        `;
-
-          const [open, setOpen] = React.useState(true);
-
-          return (
-            <div>
-              {/* eslint-disable-next-line react/no-danger */}
-              <style dangerouslySetInnerHTML={{ __html: style }} />
-              <button onClick={() => setOpen(false)}>Close</button>
-              <TestPopover
-                rootProps={{ open, onOpenChangeComplete }}
-                popupProps={{ className: 'animation-test-indicator', children: null }}
-              />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        expect(screen.getByTestId('popover-popup')).not.toBe(null);
-
-        // Wait for open animation to finish
-        await waitFor(() => {
-          expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-        });
-
-        const closeButton = screen.getByText('Close');
-        await user.click(closeButton);
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('popover-popup')).toBe(null);
-        });
-
-        expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
-      });
-
-      it('is called on open when there is no enter animation defined', async () => {
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const [open, setOpen] = React.useState(false);
-          return (
-            <div>
-              <button onClick={() => setOpen(true)}>Open</button>
-              <TestPopover
-                rootProps={{ open, onOpenChangeComplete }}
-                popupProps={{ children: null }}
-              />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        const openButton = screen.getByText('Open');
-        await user.click(openButton);
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('popover-popup')).not.toBe(null);
-        });
-
-        expect(onOpenChangeComplete.mock.calls.length).toBe(2);
-        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-      });
-
-      it('is called on open when the enter animation finishes', async () => {
-        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const style = `
-          @keyframes test-anim {
-            from {
-              opacity: 0;
-            }
-          }
-
-          .animation-test-indicator[data-starting-style] {
-            animation: test-anim 1ms;
-          }
-        `;
-
-          const [open, setOpen] = React.useState(false);
-
-          return (
-            <div>
-              {/* eslint-disable-next-line react/no-danger */}
-              <style dangerouslySetInnerHTML={{ __html: style }} />
-              <button onClick={() => setOpen(true)}>Open</button>
-              <TestPopover
-                rootProps={{
-                  open,
-                  onOpenChange: (nextOpen) => setOpen(nextOpen),
-                  onOpenChangeComplete,
-                }}
-                popupProps={{ className: 'animation-test-indicator', children: null }}
-              />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        const openButton = screen.getByText('Open');
-        await user.click(openButton);
-
-        // Wait for open animation to finish
-        await waitFor(() => {
-          expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-        });
-
-        expect(screen.queryByTestId('popover-popup')).not.toBe(null);
-      });
-
-      it('does not get called on mount when not open', async () => {
-        const onOpenChangeComplete = vi.fn();
-
-        await render(
-          <TestPopover rootProps={{ onOpenChangeComplete }} popupProps={{ children: null }} />,
-        );
-
-        expect(onOpenChangeComplete.mock.calls.length).toBe(0);
-      });
-    });
-
     describe('nested popup interactions', () => {
       it('keeps the parent popover open when press starts in nested popover and ends outside', async () => {
         function Test() {
@@ -1604,9 +1584,7 @@ describe('<Popover.Root />', () => {
         fireEvent.pointerDown(childPopup, { pointerType: 'mouse', button: 0 });
         fireEvent.click(outside);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('parent-popup')).not.toBe(null);
-        });
+        await screen.findByTestId('parent-popup');
         expect(screen.queryByTestId('child-popup')).not.toBe(null);
       });
 

--- a/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
@@ -72,8 +72,8 @@ describe('<Popover.Trigger />', () => {
     });
   });
 
-  describe('style hooks', () => {
-    it('should have the data-popup-open and data-pressed attributes when open by clicking', async () => {
+  describe('state attributes', () => {
+    it('adds data-popup-open and data-pressed when opened by click', async () => {
       await render(
         <Popover.Root>
           <Popover.Trigger />
@@ -90,7 +90,7 @@ describe('<Popover.Trigger />', () => {
       expect(trigger).toHaveAttribute('data-pressed');
     });
 
-    it('should have the data-popup-open but not the data-pressed attribute when open by hover', async () => {
+    it('adds data-popup-open but not data-pressed when opened by hover', async () => {
       const { user } = await render(
         <Popover.Root>
           <Popover.Trigger openOnHover delay={0} />

--- a/packages/react/src/preview-card/popup/PreviewCardPopup.test.tsx
+++ b/packages/react/src/preview-card/popup/PreviewCardPopup.test.tsx
@@ -3,7 +3,7 @@ import { PreviewCard } from '@base-ui/react/preview-card';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
-describe('<Popover.Popup />', () => {
+describe('<PreviewCard.Popup />', () => {
   const { render } = createRenderer();
 
   describeConformance(<PreviewCard.Popup />, () => ({

--- a/packages/react/src/preview-card/portal/PreviewCardPortal.test.tsx
+++ b/packages/react/src/preview-card/portal/PreviewCardPortal.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/preview-card/root/PreviewCardRoot.detached-triggers.test.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.detached-triggers.test.tsx
@@ -224,7 +224,6 @@ describe('<PreviewCard.Root />', () => {
       const trigger2 = screen.getByRole('link', { name: 'Trigger 2' });
 
       await act(async () => trigger1.focus());
-      await flushMicrotasks();
       await waitFor(() => {
         expect(screen.getByTestId('content').textContent).toBe('1');
       });
@@ -1144,9 +1143,7 @@ describe('<PreviewCard.Root />', () => {
       expect(screen.queryByTestId('content')).toBe(null);
 
       await act(() => handle.open('trigger'));
-      await waitFor(() => {
-        expect(screen.queryByTestId('content')).not.toBe(null);
-      });
+      await screen.findByTestId('content');
 
       expect(screen.getByTestId('content').textContent).toBe('Content');
       expect(trigger).toHaveAttribute('data-popup-open');
@@ -1187,9 +1184,7 @@ describe('<PreviewCard.Root />', () => {
       expect(screen.queryByTestId('content')).toBe(null);
 
       await act(() => handle.open('trigger2'));
-      await waitFor(() => {
-        expect(screen.queryByTestId('content')).not.toBe(null);
-      });
+      await screen.findByTestId('content');
 
       expect(screen.getByTestId('content').textContent).toBe('2');
       expect(trigger2).toHaveAttribute('data-popup-open');

--- a/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
@@ -306,64 +306,6 @@ describe('<PreviewCard.Root />', () => {
       });
     });
 
-    describe('BaseUIChangeEventDetails', () => {
-      it('onOpenChange cancel() prevents opening while uncontrolled', async () => {
-        await render(
-          <TestPreviewCard
-            rootProps={{
-              onOpenChange: (nextOpen, eventDetails) => {
-                if (nextOpen) {
-                  eventDetails.cancel();
-                }
-              },
-            }}
-          />,
-        );
-
-        const trigger = screen.getByRole('link', { name: 'Link' });
-        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
-        fireEvent.mouseEnter(trigger);
-        fireEvent.mouseMove(trigger);
-        await flushMicrotasks();
-
-        expect(screen.queryByText('Content')).toBe(null);
-      });
-    });
-
-    describe('dismissal', () => {
-      clock.withFakeTimers();
-
-      it('reopens on hover after Escape closes it', async () => {
-        await render(<TestPreviewCard triggerProps={{ delay: 100 }} />);
-
-        const trigger = screen.getByRole('link', { name: 'Link' });
-
-        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
-        fireEvent.mouseEnter(trigger);
-        fireEvent.mouseMove(trigger);
-
-        clock.tick(100);
-        await flushMicrotasks();
-
-        expect(screen.getByText('Content')).not.toBe(null);
-
-        fireEvent.keyDown(document.body, { key: 'Escape' });
-        await flushMicrotasks();
-
-        expect(screen.queryByText('Content')).toBe(null);
-
-        // Re-enter with mouse events only. A fresh pointerenter can be missed
-        // after the click-driven close, but hover should still work.
-        fireEvent.mouseEnter(trigger);
-        fireEvent.mouseMove(trigger);
-
-        clock.tick(100);
-        await flushMicrotasks();
-
-        expect(screen.getByText('Content')).not.toBe(null);
-      });
-    });
-
     describe.skipIf(!isJSDOM)('prop: actionsRef', () => {
       it('unmounts the preview card when the `unmount` method is called', async () => {
         const actionsRef = {
@@ -391,15 +333,11 @@ describe('<PreviewCard.Root />', () => {
         const trigger = screen.getByRole('link', { name: 'Link' });
         await user.hover(trigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('positioner')).not.toBe(null);
-        });
+        await screen.findByTestId('positioner');
 
         await user.unhover(trigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('positioner')).not.toBe(null);
-        });
+        await screen.findByTestId('positioner');
 
         await act(async () => actionsRef.current.unmount());
 
@@ -606,9 +544,7 @@ describe('<PreviewCard.Root />', () => {
         const openButton = screen.getByText('Open');
         await user.click(openButton);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('popup')).not.toBe(null);
-        });
+        await screen.findByTestId('popup');
 
         expect(onOpenChangeComplete.mock.calls.length).toBe(2);
         expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
@@ -677,6 +613,64 @@ describe('<PreviewCard.Root />', () => {
         );
 
         expect(onOpenChangeComplete.mock.calls.length).toBe(0);
+      });
+    });
+
+    describe('BaseUIChangeEventDetails', () => {
+      it('onOpenChange cancel() prevents opening while uncontrolled', async () => {
+        await render(
+          <TestPreviewCard
+            rootProps={{
+              onOpenChange: (nextOpen, eventDetails) => {
+                if (nextOpen) {
+                  eventDetails.cancel();
+                }
+              },
+            }}
+          />,
+        );
+
+        const trigger = screen.getByRole('link', { name: 'Link' });
+        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+        await flushMicrotasks();
+
+        expect(screen.queryByText('Content')).toBe(null);
+      });
+    });
+
+    describe('dismissal', () => {
+      clock.withFakeTimers();
+
+      it('reopens on hover after Escape closes it', async () => {
+        await render(<TestPreviewCard triggerProps={{ delay: 100 }} />);
+
+        const trigger = screen.getByRole('link', { name: 'Link' });
+
+        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        clock.tick(100);
+        await flushMicrotasks();
+
+        expect(screen.getByText('Content')).not.toBe(null);
+
+        fireEvent.keyDown(document.body, { key: 'Escape' });
+        await flushMicrotasks();
+
+        expect(screen.queryByText('Content')).toBe(null);
+
+        // Re-enter with mouse events only. A fresh pointerenter can be missed
+        // after the click-driven close, but hover should still work.
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        clock.tick(100);
+        await flushMicrotasks();
+
+        expect(screen.getByText('Content')).not.toBe(null);
       });
     });
   });
@@ -763,9 +757,7 @@ describe('<PreviewCard.Root />', () => {
       fireEvent.pointerDown(childPopup, { pointerType: 'mouse', button: 0 });
       fireEvent.click(outside);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('parent-popup')).not.toBe(null);
-      });
+      await screen.findByTestId('parent-popup');
       expect(screen.queryByTestId('child-popup')).not.toBe(null);
     });
 

--- a/packages/react/src/progress/indicator/ProgressIndicator.test.tsx
+++ b/packages/react/src/progress/indicator/ProgressIndicator.test.tsx
@@ -13,6 +13,23 @@ describe('<Progress.Indicator />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
+  it('has progress state attributes', async () => {
+    const { setProps } = await render(
+      <Progress.Root value={40}>
+        <Progress.Indicator data-testid="indicator" />
+      </Progress.Root>,
+    );
+
+    const indicator = screen.getByTestId('indicator');
+    expect(indicator).toHaveAttribute('data-progressing', '');
+
+    await setProps({ value: 100 });
+    expect(indicator).toHaveAttribute('data-complete', '');
+
+    await setProps({ value: null });
+    expect(indicator).toHaveAttribute('data-indeterminate', '');
+  });
+
   describe.skipIf(isJSDOM)('internal styles', () => {
     it('determinate', async () => {
       await render(

--- a/packages/react/src/progress/label/ProgressLabel.test.tsx
+++ b/packages/react/src/progress/label/ProgressLabel.test.tsx
@@ -1,4 +1,6 @@
+import { expect } from 'vitest';
 import { Progress } from '@base-ui/react/progress';
+import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Progress.Label />', () => {
@@ -10,4 +12,21 @@ describe('<Progress.Label />', () => {
     },
     refInstanceof: window.HTMLSpanElement,
   }));
+
+  it('has progress state attributes', async () => {
+    const { setProps } = await render(
+      <Progress.Root value={40}>
+        <Progress.Label data-testid="label" />
+      </Progress.Root>,
+    );
+
+    const label = screen.getByTestId('label');
+    expect(label).toHaveAttribute('data-progressing', '');
+
+    await setProps({ value: 100 });
+    expect(label).toHaveAttribute('data-complete', '');
+
+    await setProps({ value: null });
+    expect(label).toHaveAttribute('data-indeterminate', '');
+  });
 });

--- a/packages/react/src/progress/root/ProgressRoot.test.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.test.tsx
@@ -47,11 +47,34 @@ describe('<Progress.Root />', () => {
       expect(progressbar.getAttribute('aria-labelledby')).toBe(label.getAttribute('id'));
     });
 
-    it('should update aria-valuenow when value changes', async () => {
+    it('updates aria-valuenow when value changes', async () => {
       const { setProps } = await render(<TestProgress value={50} />);
       const progressbar = screen.getByRole('progressbar');
       await setProps({ value: 77 });
       expect(progressbar).toHaveAttribute('aria-valuenow', '77');
+    });
+  });
+
+  describe('state attributes', () => {
+    it('indicates progressing, complete, and indeterminate states', async () => {
+      const { setProps } = await render(<TestProgress value={50} />);
+      const progressbar = screen.getByRole('progressbar');
+
+      expect(progressbar).toHaveAttribute('data-progressing', '');
+      expect(progressbar).not.toHaveAttribute('data-complete');
+      expect(progressbar).not.toHaveAttribute('data-indeterminate');
+
+      await setProps({ value: 100 });
+
+      expect(progressbar).toHaveAttribute('data-complete', '');
+      expect(progressbar).not.toHaveAttribute('data-progressing');
+      expect(progressbar).not.toHaveAttribute('data-indeterminate');
+
+      await setProps({ value: null });
+
+      expect(progressbar).toHaveAttribute('data-indeterminate', '');
+      expect(progressbar).not.toHaveAttribute('data-complete');
+      expect(progressbar).not.toHaveAttribute('data-progressing');
     });
   });
 

--- a/packages/react/src/progress/track/ProgressTrack.test.tsx
+++ b/packages/react/src/progress/track/ProgressTrack.test.tsx
@@ -1,4 +1,6 @@
+import { expect } from 'vitest';
 import { Progress } from '@base-ui/react/progress';
+import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Progress.Track />', () => {
@@ -10,4 +12,21 @@ describe('<Progress.Track />', () => {
     },
     refInstanceof: window.HTMLDivElement,
   }));
+
+  it('has progress state attributes', async () => {
+    const { setProps } = await render(
+      <Progress.Root value={40}>
+        <Progress.Track data-testid="track" />
+      </Progress.Root>,
+    );
+
+    const track = screen.getByTestId('track');
+    expect(track).toHaveAttribute('data-progressing', '');
+
+    await setProps({ value: 100 });
+    expect(track).toHaveAttribute('data-complete', '');
+
+    await setProps({ value: null });
+    expect(track).toHaveAttribute('data-indeterminate', '');
+  });
 });

--- a/packages/react/src/progress/value/ProgressValue.test.tsx
+++ b/packages/react/src/progress/value/ProgressValue.test.tsx
@@ -13,6 +13,23 @@ describe('<Progress.Value />', () => {
     refInstanceof: window.HTMLSpanElement,
   }));
 
+  it('has progress state attributes', async () => {
+    const { setProps } = await render(
+      <Progress.Root value={40}>
+        <Progress.Value data-testid="value" />
+      </Progress.Root>,
+    );
+
+    const value = screen.getByTestId('value');
+    expect(value).toHaveAttribute('data-progressing', '');
+
+    await setProps({ value: 100 });
+    expect(value).toHaveAttribute('data-complete', '');
+
+    await setProps({ value: null });
+    expect(value).toHaveAttribute('data-indeterminate', '');
+  });
+
   describe('prop: children', () => {
     it('renders the value when children is not provided', async () => {
       await render(

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -72,11 +72,11 @@ describe('<RadioGroup />', () => {
       expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-disabled', 'true');
       expect(screen.getByRole('radio')).toHaveAttribute('aria-disabled', 'true');
       expect(screen.getByRole('radio')).toHaveAttribute('data-disabled');
-      const input = document.querySelector('input[type="radio"]');
+      const [, input] = screen.getAllByRole<HTMLInputElement>('radio', { hidden: true });
       expect(input).toHaveAttribute('disabled');
     });
 
-    it('should not have the aria attribute when `disabled` is not set', async () => {
+    it('does not set aria-disabled when disabled is not set', async () => {
       await render(<RadioGroup />);
       expect(screen.getByRole('radiogroup')).not.toHaveAttribute('aria-disabled');
     });
@@ -105,7 +105,7 @@ describe('<RadioGroup />', () => {
       expect(group).toHaveAttribute('aria-readonly', 'true');
     });
 
-    it('should not have the aria attribute when `readOnly` is not set', async () => {
+    it('does not set aria-readonly when readOnly is not set', async () => {
       await render(<RadioGroup />);
       const group = screen.getByRole('radiogroup');
       expect(group).not.toHaveAttribute('aria-readonly');
@@ -135,17 +135,15 @@ describe('<RadioGroup />', () => {
       </RadioGroup>,
     );
 
-    const group = screen.getByTestId('root');
     const item = screen.getByTestId('item');
-
-    const input = group.querySelector<HTMLInputElement>('input')!;
+    const [, input] = screen.getAllByRole<HTMLInputElement>('radio', { hidden: true });
 
     fireEvent.click(input);
 
     expect(item).toHaveAttribute('aria-checked', 'true');
   });
 
-  it('should place the style hooks on the root and subcomponents', async () => {
+  it('adds state attributes to the root and subcomponents', async () => {
     await render(
       <RadioGroup defaultValue="1" disabled readOnly required>
         <Radio.Root value="1" data-testid="item">
@@ -532,8 +530,8 @@ describe('<RadioGroup />', () => {
     });
   });
 
-  describe('style hooks', () => {
-    it('should apply data-checked and data-unchecked to radio root and indicator', async () => {
+  describe('state attributes', () => {
+    it('adds data-checked and data-unchecked to radio root and indicator', async () => {
       await render(
         <RadioGroup>
           <Radio.Root value="a" data-testid="a">
@@ -667,7 +665,7 @@ describe('<RadioGroup />', () => {
     });
   });
 
-  describe('Field', () => {
+  describe('Field integration', () => {
     it('passes the `name` prop to the radio input', async () => {
       await render(
         <Field.Root name="test" data-testid="field">
@@ -685,8 +683,8 @@ describe('<RadioGroup />', () => {
       expect(input).toHaveAttribute('name', 'test');
     });
 
-    describe('Field.Root', () => {
-      it('should receive disabled prop from Field.Root', async () => {
+    describe('Field.Root integration', () => {
+      it('receives the disabled prop from Field.Root', async () => {
         await render(
           <Field.Root disabled>
             <RadioGroup>
@@ -706,7 +704,7 @@ describe('<RadioGroup />', () => {
         expect(radio).toHaveAttribute('data-disabled');
       });
 
-      it('should receive name prop from Field.Root', async () => {
+      it('receives the name prop from Field.Root', async () => {
         await render(
           <Field.Root name="field-radio">
             <RadioGroup value="a">
@@ -767,7 +765,7 @@ describe('<RadioGroup />', () => {
       });
     });
 
-    describe('Field.Label', () => {
+    describe('Field.Label integration', () => {
       it('associates implicitly', async () => {
         const changeSpy = vi.fn((newValue) => newValue);
         await render(
@@ -826,7 +824,7 @@ describe('<RadioGroup />', () => {
         const radios = screen.getAllByRole('radio');
         const labels = screen.getAllByTestId('label');
         const descriptions = screen.getAllByTestId('description');
-        const inputs = document.querySelectorAll('input[type="radio"]');
+        const inputs = document.querySelectorAll<HTMLInputElement>('input[type="radio"]');
 
         radios.forEach((radio, index) => {
           const label = labels[index];
@@ -844,7 +842,7 @@ describe('<RadioGroup />', () => {
       });
     });
 
-    describe('Field.Description', () => {
+    describe('Field.Description integration', () => {
       it('links the group and individual radios', async () => {
         await render(
           <Field.Root name="apple">
@@ -875,7 +873,7 @@ describe('<RadioGroup />', () => {
     });
 
     describe('prop: validationMode', () => {
-      it('onSubmit', async () => {
+      it('validates when validationMode is onSubmit', async () => {
         const { user } = await render(
           <Form>
             <Field.Root
@@ -922,7 +920,7 @@ describe('<RadioGroup />', () => {
     });
   });
 
-  describe('Fieldset', () => {
+  describe('Fieldset integration', () => {
     it('labels the radio group from the fieldset legend', async () => {
       await render(
         <Field.Root name="test">
@@ -942,7 +940,7 @@ describe('<RadioGroup />', () => {
     });
   });
 
-  describe('Form', () => {
+  describe('Form integration', () => {
     const { render: renderFakeTimers, clock } = createRenderer({
       clockOptions: {
         shouldAdvanceTime: true,

--- a/packages/react/src/select/item/SelectItem.test.tsx
+++ b/packages/react/src/select/item/SelectItem.test.tsx
@@ -72,11 +72,7 @@ describe('<Select.Item />', () => {
     );
 
     fireEvent.click(screen.getByTestId('trigger'));
-    await flushMicrotasks();
-
-    await waitFor(() => {
-      expect(screen.getByRole('listbox')).not.toBe(null);
-    });
+    await screen.findByRole('listbox');
     await waitFor(() => {
       expect(screen.getByText('one')).toHaveFocus();
     });
@@ -374,9 +370,7 @@ describe('<Select.Item />', () => {
       // Open on mousedown and keep the mouse button "held" (no mouseup yet).
       fireEvent.mouseDown(trigger);
 
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       const option = screen.getByRole('option', { name: 'Sans-serif' });
       fireEvent.mouseMove(option);
@@ -415,7 +409,7 @@ describe('<Select.Item />', () => {
       expect(value.textContent).toBe('one');
 
       fireEvent.mouseDown(trigger);
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const option = screen.getByRole('option', { name: 'two' });
       await clock.tickAsync(250);
@@ -448,7 +442,7 @@ describe('<Select.Item />', () => {
 
       const trigger = screen.getByTestId('trigger');
       fireEvent.mouseDown(trigger);
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const option = screen.getByRole('option', { name: 'one' });
       fireEvent.pointerEnter(option, { pointerType: 'mouse' });
@@ -492,7 +486,7 @@ describe('<Select.Item />', () => {
 
       const trigger = screen.getByTestId('trigger');
       fireEvent.mouseDown(trigger);
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const optionTwo = screen.getByRole('option', { name: 'two' });
       fireEvent.pointerEnter(optionTwo, { pointerType: 'mouse' });
@@ -539,7 +533,7 @@ describe('<Select.Item />', () => {
 
       const trigger = screen.getByTestId('trigger');
       fireEvent.mouseDown(trigger);
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const option = screen.getByRole('option', { name: 'two' });
       fireEvent.pointerEnter(option, { pointerType: 'mouse' });
@@ -584,7 +578,7 @@ describe('<Select.Item />', () => {
       expect(value.textContent).toBe('one');
 
       fireEvent.mouseDown(trigger);
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const option = screen.getByRole('option', { name: 'two' });
       fireEvent.pointerEnter(option, { pointerType: 'mouse' });
@@ -623,7 +617,7 @@ describe('<Select.Item />', () => {
 
       const trigger = screen.getByTestId('trigger');
       fireEvent.mouseDown(trigger);
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const option = screen.getByRole('option', { name: 'two' });
       fireEvent.pointerEnter(option, { pointerType: 'mouse' });
@@ -663,7 +657,7 @@ describe('<Select.Item />', () => {
       const trigger = screen.getByTestId('trigger');
       fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
       fireEvent.mouseDown(trigger);
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const option = screen.getByRole('option', { name: 'one' });
       fireEvent.mouseUp(option);
@@ -696,7 +690,7 @@ describe('<Select.Item />', () => {
 
       const trigger = screen.getByTestId('trigger');
       fireEvent.mouseDown(trigger);
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
 
       const option = screen.getByRole('option', { name: 'one' });
       fireEvent.pointerEnter(option, { pointerType: 'mouse' });
@@ -718,8 +712,8 @@ describe('<Select.Item />', () => {
     });
   });
 
-  describe.skipIf(!isJSDOM)('style hooks', () => {
-    it('should apply data-highlighted attribute when item is highlighted', async () => {
+  describe.skipIf(!isJSDOM)('state attributes', () => {
+    it('adds data-highlighted when item is highlighted', async () => {
       const { user } = await render(
         <Select.Root defaultValue="a">
           <Select.Trigger data-testid="trigger" />
@@ -747,7 +741,7 @@ describe('<Select.Item />', () => {
       expect(screen.getByRole('option', { name: 'b' })).toHaveAttribute('data-highlighted', '');
     });
 
-    it('should apply data-selected attribute when item is selected', async () => {
+    it('adds data-selected when item is selected', async () => {
       await render(
         <Select.Root>
           <Select.Trigger data-testid="trigger" />

--- a/packages/react/src/select/portal/SelectPortal.test.tsx
+++ b/packages/react/src/select/portal/SelectPortal.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -547,6 +547,1136 @@ describe('<Select.Root />', () => {
     });
   });
 
+  describe('prop: modal', () => {
+    it('should render an internal backdrop when `true`', async () => {
+      const { user } = await render(
+        <div>
+          <Select.Root modal>
+            <Select.Trigger data-testid="trigger">Open</Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner data-testid="positioner">
+                <Select.Popup>
+                  <Select.Item>1</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+          <button>Outside</button>
+        </div>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(trigger);
+
+      await screen.findByRole('listbox');
+
+      const positioner = screen.getByTestId('positioner');
+
+      expect(positioner.previousElementSibling).toHaveAttribute('role', 'presentation');
+    });
+
+    it('should not render an internal backdrop when `false`', async () => {
+      const { user } = await render(
+        <div>
+          <Select.Root modal={false}>
+            <Select.Trigger data-testid="trigger">Open</Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner data-testid="positioner">
+                <Select.Popup>
+                  <Select.Item>1</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+          <button>Outside</button>
+        </div>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(trigger);
+
+      await screen.findByRole('listbox');
+
+      const positioner = screen.getByTestId('positioner');
+
+      expect(positioner.previousElementSibling).toBe(null);
+    });
+  });
+
+  describe('prop: actionsRef', () => {
+    it('unmounts the select when the `unmount` method is called', async () => {
+      const actionsRef = {
+        current: {
+          unmount: vi.fn(),
+        },
+      };
+
+      const { user } = await render(
+        <Select.Root actionsRef={actionsRef}>
+          <Select.Trigger data-testid="trigger">Open</Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item>1</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      await user.click(trigger);
+
+      await screen.findByRole('listbox');
+
+      await user.click(trigger);
+
+      await screen.findByRole('listbox');
+
+      await act(async () => {
+        await new Promise((resolve) => {
+          requestAnimationFrame(resolve);
+        });
+        actionsRef.current.unmount();
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).toBe(null);
+      });
+    });
+  });
+
+  describe.skipIf(isJSDOM)('prop: onOpenChangeComplete', () => {
+    it('is called on close when there is no exit animation defined', async () => {
+      const onOpenChangeComplete = vi.fn();
+
+      function Test() {
+        const [open, setOpen] = React.useState(true);
+        return (
+          <div>
+            <button onClick={() => setOpen(false)}>Close</button>
+            <Select.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup data-testid="popup" />
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const closeButton = screen.getByText('Close');
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).toBe(null);
+      });
+
+      expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+      expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
+    });
+
+    it('is called on close when the exit animation finishes', async () => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+      const onOpenChangeComplete = vi.fn();
+
+      function Test() {
+        const style = `
+          @keyframes test-anim {
+            to {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-indicator[data-ending-style] {
+            animation: test-anim 1ms;
+          }
+        `;
+
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <div>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            <button onClick={() => setOpen(false)}>Close</button>
+            <Select.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup className="animation-test-indicator" data-testid="popup" />
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      expect(screen.queryByRole('listbox')).not.toBe(null);
+
+      // Wait for open animation to finish
+      await waitFor(() => {
+        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+      });
+
+      const closeButton = screen.getByText('Close');
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).toBe(null);
+      });
+
+      expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
+    });
+
+    it('is called on open when there is no enter animation defined', async () => {
+      const onOpenChangeComplete = vi.fn();
+
+      function Test() {
+        const [open, setOpen] = React.useState(false);
+        return (
+          <div>
+            <button onClick={() => setOpen(true)}>Open</button>
+            <Select.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup data-testid="popup" />
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const openButton = screen.getByText('Open');
+      await user.click(openButton);
+
+      await screen.findByRole('listbox');
+
+      expect(onOpenChangeComplete.mock.calls.length).toBe(2); // 1 in browser
+      expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+    });
+
+    it('is called on open when the enter animation finishes', async () => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+      const onOpenChangeComplete = vi.fn();
+
+      function Test() {
+        const style = `
+          @keyframes test-anim {
+            from {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-indicator[data-starting-style] {
+            animation: test-anim 1ms;
+          }
+        `;
+
+        const [open, setOpen] = React.useState(false);
+
+        return (
+          <div>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            <button onClick={() => setOpen(true)}>Open</button>
+            <Select.Root
+              open={open}
+              onOpenChange={setOpen}
+              onOpenChangeComplete={onOpenChangeComplete}
+            >
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup className="animation-test-indicator" data-testid="popup" />
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const openButton = screen.getByText('Open');
+      await user.click(openButton);
+
+      // Wait for open animation to finish
+      await waitFor(() => {
+        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
+      });
+
+      expect(screen.queryByRole('listbox')).not.toBe(null);
+    });
+
+    it('does not get called on mount when not open', async () => {
+      const onOpenChangeComplete = vi.fn();
+
+      await render(
+        <Select.Root onOpenChangeComplete={onOpenChangeComplete}>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup data-testid="popup" />
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      expect(onOpenChangeComplete.mock.calls.length).toBe(0);
+    });
+  });
+
+  describe('prop: disabled', () => {
+    it('sets the disabled state', async () => {
+      const handleOpenChange = vi.fn();
+      const { user } = await render(
+        <Select.Root defaultValue="b" onOpenChange={handleOpenChange} disabled>
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toHaveAttribute('disabled');
+      expect(trigger).toHaveAttribute('data-disabled');
+
+      await user.keyboard('[Tab]');
+
+      expect(expect(document.activeElement)).not.toBe(trigger);
+
+      await user.click(trigger);
+      expect(handleOpenChange.mock.calls.length).toBe(0);
+    });
+
+    it('updates the disabled state when the disabled prop changes', async () => {
+      const handleOpenChange = vi.fn();
+      function App() {
+        const [disabled, setDisabled] = React.useState(true);
+        return (
+          <React.Fragment>
+            <button onClick={() => setDisabled(!disabled)}>toggle</button>
+            <Select.Root defaultValue="b" onOpenChange={handleOpenChange} disabled={disabled}>
+              <Select.Trigger>
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    <Select.Item value="a">a</Select.Item>
+                    <Select.Item value="b">b</Select.Item>
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </React.Fragment>
+        );
+      }
+      const { user } = await render(<App />);
+
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toHaveAttribute('disabled');
+      expect(trigger).toHaveAttribute('data-disabled');
+
+      await user.keyboard('[Tab]');
+
+      expect(expect(document.activeElement)).not.toBe(trigger);
+
+      await user.click(trigger);
+      expect(handleOpenChange.mock.calls.length).toBe(0);
+
+      await user.click(screen.getByRole('button', { name: 'toggle' }));
+
+      expect(trigger).not.toHaveAttribute('disabled');
+      expect(trigger).not.toHaveAttribute('data-disabled');
+
+      await user.keyboard('[Tab]');
+      expect(trigger).toHaveFocus();
+
+      await user.click(trigger);
+      await waitFor(() => {
+        expect(handleOpenChange.mock.calls.length).toBe(1);
+      });
+    });
+  });
+
+  describe('prop: readOnly', () => {
+    it('sets the readOnly state', async () => {
+      const handleOpenChange = vi.fn();
+      const { user } = await render(
+        <Select.Root defaultValue="b" onOpenChange={handleOpenChange} readOnly>
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toHaveAttribute('aria-readonly', 'true');
+      expect(trigger).toHaveAttribute('data-readonly');
+
+      await user.keyboard('[Tab]');
+      expect(trigger).toHaveFocus();
+
+      await user.click(trigger);
+      expect(handleOpenChange.mock.calls.length).toBe(0);
+    });
+
+    it('should not open the select when clicked', async () => {
+      const handleOpenChange = vi.fn();
+      const { user } = await render(
+        <Select.Root onOpenChange={handleOpenChange} readOnly>
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+
+      await user.click(trigger);
+      expect(screen.queryByRole('listbox')).toBe(null);
+      expect(handleOpenChange.mock.calls.length).toBe(0);
+    });
+
+    it('should not open the select when using keyboard', async () => {
+      const handleOpenChange = vi.fn();
+      const { user } = await render(
+        <Select.Root onOpenChange={handleOpenChange} readOnly>
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+
+      await act(async () => {
+        trigger.focus();
+      });
+
+      expect(screen.queryByRole('listbox')).toBe(null);
+      expect(document.activeElement).toBe(trigger);
+
+      await user.keyboard('[ArrowDown]');
+      expect(screen.queryByRole('listbox')).toBe(null);
+      expect(handleOpenChange.mock.calls.length).toBe(0);
+
+      await user.keyboard('[Enter]');
+      expect(screen.queryByRole('listbox')).toBe(null);
+      expect(handleOpenChange.mock.calls.length).toBe(0);
+
+      await user.keyboard('[Space]');
+      expect(screen.queryByRole('listbox')).toBe(null);
+      expect(handleOpenChange.mock.calls.length).toBe(0);
+    });
+  });
+
+  describe('prop: id', () => {
+    it('sets the id on the trigger', async () => {
+      await render(
+        <Select.Root id="test-id">
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toHaveAttribute('id', 'test-id');
+    });
+
+    it('sets a hidden input id when name is not provided', async () => {
+      await render(
+        <Select.Root id="test-id">
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+        </Select.Root>,
+      );
+
+      const hiddenInput = screen.getByRole('textbox', { hidden: true });
+      expect(hiddenInput).toHaveAttribute('id', 'test-id-hidden-input');
+      expect(hiddenInput).not.toHaveAttribute('name');
+    });
+
+    it('does not set a hidden input id when name is provided', async () => {
+      await render(
+        <Select.Root id="test-id" name="country">
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+        </Select.Root>,
+      );
+
+      const hiddenInput = screen.getByRole('textbox', { hidden: true });
+      expect(hiddenInput).toHaveAttribute('name', 'country');
+      expect(hiddenInput).not.toHaveAttribute('id');
+    });
+  });
+
+  describe('prop: multiple', () => {
+    it('removes selections that no longer exist', async () => {
+      function Test() {
+        const [items, setItems] = React.useState(['a', 'b', 'c']);
+        return (
+          <div>
+            <Select.Root multiple defaultValue={['a', 'c']}>
+              <Select.Trigger data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    {items.map((it) => (
+                      <Select.Item key={it} value={it}>
+                        {it}
+                      </Select.Item>
+                    ))}
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+            <button
+              data-testid="remove-a"
+              onClick={() => setItems((prev) => prev.filter((i) => i !== 'a'))}
+            >
+              Remove A
+            </button>
+            <button
+              data-testid="remove-c"
+              onClick={() => setItems((prev) => prev.filter((i) => i !== 'c'))}
+            >
+              Remove C
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const trigger = screen.getByTestId('trigger');
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
+      });
+      expect(screen.getByRole('option', { name: 'c' })).toHaveAttribute('data-selected', '');
+
+      // Remove one of the selected items; remaining selection should persist
+      await user.click(screen.getByTestId('remove-c'));
+
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
+      });
+      expect(screen.queryByRole('option', { name: 'c' })).toBe(null);
+
+      // Remove the last selected item; selection should become empty
+      await user.click(screen.getByTestId('remove-a'));
+
+      await user.click(trigger);
+
+      const options = await screen.findAllByRole('option');
+      options.forEach((opt) => {
+        expect(opt).not.toHaveAttribute('data-selected');
+      });
+    });
+
+    it('should allow multiple selections when multiple is true', async () => {
+      const handleValueChange = vi.fn();
+
+      function App() {
+        const [value, setValue] = React.useState<any[]>([]);
+
+        return (
+          <Select.Root
+            multiple
+            value={value}
+            onValueChange={(newValue) => {
+              setValue(newValue);
+              handleValueChange(newValue);
+            }}
+          >
+            <Select.Trigger data-testid="trigger">
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup>
+                  <Select.Item value="a">a</Select.Item>
+                  <Select.Item value="b">b</Select.Item>
+                  <Select.Item value="c">c</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(trigger);
+      await flushMicrotasks();
+
+      const optionA = await screen.findByRole('option', { name: 'a' });
+      await user.click(optionA);
+      await flushMicrotasks();
+
+      expect(handleValueChange.mock.calls[0][0]).toEqual(['a']);
+      expect(optionA).toHaveAttribute('data-selected', '');
+
+      const optionB = screen.getByRole('option', { name: 'b' });
+      await user.click(optionB);
+      await flushMicrotasks();
+
+      expect(handleValueChange.mock.calls[1][0]).toEqual(['a', 'b']);
+      expect(optionA).toHaveAttribute('data-selected', '');
+      expect(optionB).toHaveAttribute('data-selected', '');
+
+      expect(screen.getByRole('listbox')).not.toBe(null);
+    });
+
+    it('should deselect items when clicked again in multiple mode', async () => {
+      const handleValueChange = vi.fn();
+
+      function App() {
+        const [value, setValue] = React.useState(['a', 'b']);
+
+        return (
+          <Select.Root
+            multiple
+            value={value}
+            onValueChange={(newValue) => {
+              setValue(newValue);
+              handleValueChange(newValue);
+            }}
+          >
+            <Select.Trigger data-testid="trigger">
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup>
+                  <Select.Item value="a">a</Select.Item>
+                  <Select.Item value="b">b</Select.Item>
+                  <Select.Item value="c">c</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(trigger);
+      await flushMicrotasks();
+
+      const optionA = await screen.findByRole('option', { name: 'a' });
+      const optionB = screen.getByRole('option', { name: 'b' });
+
+      expect(optionA).toHaveAttribute('data-selected', '');
+      expect(optionB).toHaveAttribute('data-selected', '');
+
+      await user.click(optionA);
+      await flushMicrotasks();
+
+      expect(handleValueChange.mock.calls[0][0]).toEqual(['b']);
+      expect(optionA).not.toHaveAttribute('data-selected');
+      expect(optionB).toHaveAttribute('data-selected', '');
+    });
+
+    it('keeps the active index on a deselected item in multiple mode', async () => {
+      const { user } = await render(
+        <Select.Root multiple value={['a']}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(trigger);
+
+      const optionB = await screen.findByRole('option', { name: 'b' });
+
+      await user.click(optionB);
+
+      await waitFor(() => {
+        expect(optionB).toHaveAttribute('data-highlighted');
+      });
+
+      await user.click(optionB);
+
+      await waitFor(() => {
+        expect(optionB).toHaveAttribute('data-highlighted');
+      });
+    });
+
+    it('should handle defaultValue as array in multiple mode', async () => {
+      await render(
+        <Select.Root multiple defaultValue={['a', 'c']}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
+      expect(screen.getByRole('option', { name: 'b' })).not.toHaveAttribute('data-selected');
+      expect(screen.getByRole('option', { name: 'c' })).toHaveAttribute('data-selected', '');
+    });
+
+    it('should serialize multiple values correctly for form submission', async () => {
+      const { container } = await render(
+        <Select.Root multiple name="select" value={['a', 'c']}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      // eslint-disable-next-line testing-library/no-container -- No appropriate method on screen since it's a hidden input without any type
+      const hiddenInputs = container.querySelectorAll(
+        '[name="select"]',
+      ) as NodeListOf<HTMLInputElement>;
+      expect(hiddenInputs).toHaveLength(2);
+      const values = Array.from(hiddenInputs).map((input) => input.value);
+      expect(values).toEqual(['a', 'c']);
+    });
+
+    it('should serialize empty array as empty string in multiple mode', async () => {
+      const { container } = await render(
+        <Select.Root multiple name="select">
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      // In multiple mode with empty array, no hidden inputs with name should exist
+      // eslint-disable-next-line testing-library/no-container -- No appropriate method on screen since it's a hidden input without any type
+      const namedHiddenInputs = container.querySelectorAll('[name="select"]');
+      expect(namedHiddenInputs).toHaveLength(0);
+
+      // But the main input should have the serialized empty value for Field validation purposes
+      // eslint-disable-next-line testing-library/no-container -- No appropriate method on screen since it's a hidden input without any type
+      const mainInput = container.querySelector<HTMLInputElement>('input[aria-hidden="true"]');
+      expect(mainInput).not.toBe(null);
+      expect(mainInput?.value).toBe('');
+    });
+
+    it('does not mark the hidden input as required when selection exists', async () => {
+      await render(
+        <Select.Root multiple required name="select" value={['a']}>
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+        </Select.Root>,
+      );
+
+      const hiddenInput = screen.getByRole('textbox', { hidden: true });
+      expect(hiddenInput).not.toBe(null);
+      expect(hiddenInput).not.toHaveAttribute('required');
+    });
+
+    it('keeps the hidden input required when no selection exists', async () => {
+      await render(
+        <Select.Root multiple required name="select" value={[]}>
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+        </Select.Root>,
+      );
+
+      const hiddenInput = screen.getByRole('textbox', { hidden: true });
+      expect(hiddenInput).not.toBe(null);
+      expect(hiddenInput).toHaveAttribute('required');
+    });
+
+    it('should not close popup when selecting items in multiple mode', async () => {
+      const { user } = await render(
+        <Select.Root multiple>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(trigger);
+      await screen.findByRole('listbox');
+
+      const optionA = await screen.findByRole('option', { name: 'a' });
+      await user.click(optionA);
+      await flushMicrotasks();
+
+      expect(screen.getByRole('listbox')).not.toBe(null);
+
+      const optionB = screen.getByRole('option', { name: 'b' });
+      await user.click(optionB);
+      await flushMicrotasks();
+
+      expect(screen.getByRole('listbox')).not.toBe(null);
+    });
+
+    it('should close popup in single select mode', async () => {
+      const { user } = await render(
+        <Select.Root>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(trigger);
+      await screen.findByRole('listbox');
+
+      const optionA = await screen.findByRole('option', { name: 'a' });
+      await user.click(optionA);
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).toBe(null);
+      });
+    });
+
+    it('should update selected items when value prop changes', async () => {
+      const { setProps } = await render(
+        <Select.Root multiple value={['a']}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      expect(await screen.findByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
+      expect(screen.getByRole('option', { name: 'b' })).not.toHaveAttribute('data-selected');
+
+      await setProps({ value: ['a', 'b', 'c'] });
+
+      expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
+      expect(screen.getByRole('option', { name: 'b' })).toHaveAttribute('data-selected', '');
+      expect(screen.getByRole('option', { name: 'c' })).toHaveAttribute('data-selected', '');
+    });
+  });
+
+  describe('prop: isItemEqualToValue', () => {
+    it('matches object values using the provided comparator', async () => {
+      const users = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ];
+
+      await render(
+        <Select.Root
+          value={{ id: 2, name: 'Bob' }}
+          itemToStringLabel={(item) => item.name}
+          itemToStringValue={(item) => String(item.id)}
+          isItemEqualToValue={(item, value) => item.id === value.id}
+        >
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                {users.map((user) => (
+                  <Select.Item key={user.id} value={user}>
+                    {user.name}
+                  </Select.Item>
+                ))}
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      expect(trigger).toHaveTextContent('Bob');
+
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Bob' })).toHaveAttribute('data-selected', '');
+      });
+    });
+
+    it('passes item as the first comparator argument in multiple mode', async () => {
+      const users = [
+        { id: 1, name: 'Alice', source: 'item' },
+        { id: 2, name: 'Bob', source: 'item' },
+      ];
+
+      await render(
+        <Select.Root
+          multiple
+          defaultOpen
+          defaultValue={[{ id: 2, name: 'Bob', source: 'selected' }]}
+          itemToStringLabel={(item) => item.name}
+          itemToStringValue={(item) => String(item.id)}
+          isItemEqualToValue={(item, value) =>
+            item.id === value.id && item.source === 'item' && value.source === 'selected'
+          }
+        >
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                {users.map((user) => (
+                  <Select.Item key={user.id} value={user}>
+                    {user.name}
+                  </Select.Item>
+                ))}
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const option = screen.getByRole('option', { name: 'Bob' });
+      expect(option).toHaveAttribute('data-selected', '');
+
+      fireEvent.click(option);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Bob' })).not.toHaveAttribute('data-selected');
+      });
+    });
+  });
+
+  describe('prop: highlightItemOnHover', () => {
+    it('highlights an item on mouse move by default', async () => {
+      const { user } = await render(
+        <Select.Root defaultOpen>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const optionB = screen.getByRole('option', { name: 'b' });
+      await user.hover(optionB);
+
+      await waitFor(() => {
+        expect(optionB).toHaveAttribute('data-highlighted');
+      });
+    });
+
+    it.skipIf(isJSDOM)(
+      'highlights the first item after opening when alignItemWithTrigger is active and no value is selected',
+      async () => {
+        await render(
+          <div style={{ paddingTop: 120, paddingLeft: 24 }}>
+            <Select.Root>
+              <Select.Trigger data-testid="trigger" style={{ width: 120, height: 36 }}>
+                <Select.Value placeholder="Pick one" />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup style={{ maxHeight: 'none' }}>
+                    <Select.Item value="a">a</Select.Item>
+                    <Select.Item value="b">b</Select.Item>
+                    <Select.Item value="c">c</Select.Item>
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </div>,
+        );
+
+        const trigger = screen.getByTestId('trigger');
+        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseDown(trigger);
+
+        const optionA = await screen.findByRole('option', { name: 'a' });
+
+        await waitFor(() => {
+          expect(optionA).toHaveAttribute('data-highlighted');
+        });
+      },
+    );
+
+    it('does not highlight items from mouse movement when disabled', async () => {
+      const { user } = await render(
+        <Select.Root defaultOpen highlightItemOnHover={false}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const optionB = screen.getByRole('option', { name: 'b' });
+      await user.hover(optionB);
+
+      await flushMicrotasks();
+
+      expect(optionB).not.toHaveAttribute('data-highlighted');
+    });
+
+    it('does not remove highlight when mousing out of popup when disabled', async () => {
+      const { user } = await render(
+        <Select.Root defaultOpen highlightItemOnHover={false}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const optionA = screen.getByRole('option', { name: 'a' });
+      await user.hover(optionA);
+
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(optionA).toHaveAttribute('data-highlighted');
+      });
+
+      const popup = screen.getByRole('listbox');
+      await user.unhover(popup);
+
+      await waitFor(() => {
+        expect(optionA).toHaveAttribute('data-highlighted');
+      });
+    });
+  });
+
   describe('BaseUIChangeEventDetails', () => {
     it('onOpenChange cancel() prevents opening while uncontrolled', async () => {
       await render(
@@ -611,7 +1741,7 @@ describe('<Select.Root />', () => {
     });
   });
 
-  it('should pass autoComplete to the hidden input', async () => {
+  it('passes autoComplete to the hidden input', async () => {
     await render(
       <Select.Root name="country" autoComplete="country">
         <Select.Trigger data-testid="trigger">
@@ -795,68 +1925,6 @@ describe('<Select.Root />', () => {
     },
   );
 
-  describe('prop: modal', () => {
-    it('should render an internal backdrop when `true`', async () => {
-      const { user } = await render(
-        <div>
-          <Select.Root modal>
-            <Select.Trigger data-testid="trigger">Open</Select.Trigger>
-            <Select.Portal>
-              <Select.Positioner data-testid="positioner">
-                <Select.Popup>
-                  <Select.Item>1</Select.Item>
-                </Select.Popup>
-              </Select.Positioner>
-            </Select.Portal>
-          </Select.Root>
-          <button>Outside</button>
-        </div>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-
-      await user.click(trigger);
-
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).not.toBe(null);
-      });
-
-      const positioner = screen.getByTestId('positioner');
-
-      expect(positioner.previousElementSibling).toHaveAttribute('role', 'presentation');
-    });
-
-    it('should not render an internal backdrop when `false`', async () => {
-      const { user } = await render(
-        <div>
-          <Select.Root modal={false}>
-            <Select.Trigger data-testid="trigger">Open</Select.Trigger>
-            <Select.Portal>
-              <Select.Positioner data-testid="positioner">
-                <Select.Popup>
-                  <Select.Item>1</Select.Item>
-                </Select.Popup>
-              </Select.Positioner>
-            </Select.Portal>
-          </Select.Root>
-          <button>Outside</button>
-        </div>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-
-      await user.click(trigger);
-
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).not.toBe(null);
-      });
-
-      const positioner = screen.getByTestId('positioner');
-
-      expect(positioner.previousElementSibling).toBe(null);
-    });
-  });
-
   describe.skipIf(isJSDOM)('scroll locking', () => {
     describe('interaction type tracking (openMethod)', () => {
       it('keeps touch interaction type when reopening quickly after close', async ({
@@ -947,9 +2015,7 @@ describe('<Select.Root />', () => {
           flushAnimationFrames();
         });
 
-        await waitFor(() => {
-          expect(screen.queryByRole('listbox')).not.toBe(null);
-        });
+        await screen.findByRole('listbox');
 
         fireTouchPress();
 
@@ -968,9 +2034,7 @@ describe('<Select.Root />', () => {
           flushAnimationFrames();
         });
 
-        await waitFor(() => {
-          expect(screen.queryByRole('listbox')).not.toBe(null);
-        });
+        await screen.findByRole('listbox');
 
         await wait(30);
 
@@ -1191,9 +2255,7 @@ describe('<Select.Root />', () => {
 
         fireTouchPress();
 
-        await waitFor(() => {
-          expect(screen.queryByRole('listbox')).not.toBe(null);
-        });
+        await screen.findByRole('listbox');
 
         const initialPositioner = screen.getByTestId('positioner');
 
@@ -1288,53 +2350,6 @@ describe('<Select.Root />', () => {
           trigger.ownerDocument.body.style.overflow === 'hidden';
 
         expect(isScrollLocked).toBe(false);
-      });
-    });
-  });
-
-  describe('prop: actionsRef', () => {
-    it('unmounts the select when the `unmount` method is called', async () => {
-      const actionsRef = {
-        current: {
-          unmount: vi.fn(),
-        },
-      };
-
-      const { user } = await render(
-        <Select.Root actionsRef={actionsRef}>
-          <Select.Trigger data-testid="trigger">Open</Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item>1</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-      await user.click(trigger);
-
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).not.toBe(null);
-      });
-
-      await user.click(trigger);
-
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).not.toBe(null);
-      });
-
-      await act(async () => {
-        await new Promise((resolve) => {
-          requestAnimationFrame(resolve);
-        });
-        actionsRef.current.unmount();
-      });
-
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).toBe(null);
       });
     });
   });
@@ -1737,403 +2752,8 @@ describe('<Select.Root />', () => {
     });
   });
 
-  describe.skipIf(isJSDOM)('prop: onOpenChangeComplete', () => {
-    it('is called on close when there is no exit animation defined', async () => {
-      const onOpenChangeComplete = vi.fn();
-
-      function Test() {
-        const [open, setOpen] = React.useState(true);
-        return (
-          <div>
-            <button onClick={() => setOpen(false)}>Close</button>
-            <Select.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
-              <Select.Portal>
-                <Select.Positioner>
-                  <Select.Popup data-testid="popup" />
-                </Select.Positioner>
-              </Select.Portal>
-            </Select.Root>
-          </div>
-        );
-      }
-
-      const { user } = await render(<Test />);
-
-      const closeButton = screen.getByText('Close');
-      await user.click(closeButton);
-
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).toBe(null);
-      });
-
-      expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-      expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
-    });
-
-    it('is called on close when the exit animation finishes', async () => {
-      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-      const onOpenChangeComplete = vi.fn();
-
-      function Test() {
-        const style = `
-          @keyframes test-anim {
-            to {
-              opacity: 0;
-            }
-          }
-
-          .animation-test-indicator[data-ending-style] {
-            animation: test-anim 1ms;
-          }
-        `;
-
-        const [open, setOpen] = React.useState(true);
-
-        return (
-          <div>
-            {/* eslint-disable-next-line react/no-danger */}
-            <style dangerouslySetInnerHTML={{ __html: style }} />
-            <button onClick={() => setOpen(false)}>Close</button>
-            <Select.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
-              <Select.Portal>
-                <Select.Positioner>
-                  <Select.Popup className="animation-test-indicator" data-testid="popup" />
-                </Select.Positioner>
-              </Select.Portal>
-            </Select.Root>
-          </div>
-        );
-      }
-
-      const { user } = await render(<Test />);
-
-      expect(screen.queryByRole('listbox')).not.toBe(null);
-
-      // Wait for open animation to finish
-      await waitFor(() => {
-        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-      });
-
-      const closeButton = screen.getByText('Close');
-      await user.click(closeButton);
-
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).toBe(null);
-      });
-
-      expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
-    });
-
-    it('is called on open when there is no enter animation defined', async () => {
-      const onOpenChangeComplete = vi.fn();
-
-      function Test() {
-        const [open, setOpen] = React.useState(false);
-        return (
-          <div>
-            <button onClick={() => setOpen(true)}>Open</button>
-            <Select.Root open={open} onOpenChangeComplete={onOpenChangeComplete}>
-              <Select.Portal>
-                <Select.Positioner>
-                  <Select.Popup data-testid="popup" />
-                </Select.Positioner>
-              </Select.Portal>
-            </Select.Root>
-          </div>
-        );
-      }
-
-      const { user } = await render(<Test />);
-
-      const openButton = screen.getByText('Open');
-      await user.click(openButton);
-
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).not.toBe(null);
-      });
-
-      expect(onOpenChangeComplete.mock.calls.length).toBe(2); // 1 in browser
-      expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-    });
-
-    it('is called on open when the enter animation finishes', async () => {
-      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-      const onOpenChangeComplete = vi.fn();
-
-      function Test() {
-        const style = `
-          @keyframes test-anim {
-            from {
-              opacity: 0;
-            }
-          }
-
-          .animation-test-indicator[data-starting-style] {
-            animation: test-anim 1ms;
-          }
-        `;
-
-        const [open, setOpen] = React.useState(false);
-
-        return (
-          <div>
-            {/* eslint-disable-next-line react/no-danger */}
-            <style dangerouslySetInnerHTML={{ __html: style }} />
-            <button onClick={() => setOpen(true)}>Open</button>
-            <Select.Root
-              open={open}
-              onOpenChange={setOpen}
-              onOpenChangeComplete={onOpenChangeComplete}
-            >
-              <Select.Portal>
-                <Select.Positioner>
-                  <Select.Popup className="animation-test-indicator" data-testid="popup" />
-                </Select.Positioner>
-              </Select.Portal>
-            </Select.Root>
-          </div>
-        );
-      }
-
-      const { user } = await render(<Test />);
-
-      const openButton = screen.getByText('Open');
-      await user.click(openButton);
-
-      // Wait for open animation to finish
-      await waitFor(() => {
-        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-      });
-
-      expect(screen.queryByRole('listbox')).not.toBe(null);
-    });
-
-    it('does not get called on mount when not open', async () => {
-      const onOpenChangeComplete = vi.fn();
-
-      await render(
-        <Select.Root onOpenChangeComplete={onOpenChangeComplete}>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup data-testid="popup" />
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      expect(onOpenChangeComplete.mock.calls.length).toBe(0);
-    });
-  });
-
-  describe('prop: disabled', () => {
-    it('sets the disabled state', async () => {
-      const handleOpenChange = vi.fn();
-      const { user } = await render(
-        <Select.Root defaultValue="b" onOpenChange={handleOpenChange} disabled>
-          <Select.Trigger>
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByRole('combobox');
-      expect(trigger).toHaveAttribute('disabled');
-      expect(trigger).toHaveAttribute('data-disabled');
-
-      await user.keyboard('[Tab]');
-
-      expect(expect(document.activeElement)).not.toBe(trigger);
-
-      await user.click(trigger);
-      expect(handleOpenChange.mock.calls.length).toBe(0);
-    });
-
-    it('updates the disabled state when the disabled prop changes', async () => {
-      const handleOpenChange = vi.fn();
-      function App() {
-        const [disabled, setDisabled] = React.useState(true);
-        return (
-          <React.Fragment>
-            <button onClick={() => setDisabled(!disabled)}>toggle</button>
-            <Select.Root defaultValue="b" onOpenChange={handleOpenChange} disabled={disabled}>
-              <Select.Trigger>
-                <Select.Value />
-              </Select.Trigger>
-              <Select.Portal>
-                <Select.Positioner>
-                  <Select.Popup>
-                    <Select.Item value="a">a</Select.Item>
-                    <Select.Item value="b">b</Select.Item>
-                  </Select.Popup>
-                </Select.Positioner>
-              </Select.Portal>
-            </Select.Root>
-          </React.Fragment>
-        );
-      }
-      const { user } = await render(<App />);
-
-      const trigger = screen.getByRole('combobox');
-      expect(trigger).toHaveAttribute('disabled');
-      expect(trigger).toHaveAttribute('data-disabled');
-
-      await user.keyboard('[Tab]');
-
-      expect(expect(document.activeElement)).not.toBe(trigger);
-
-      await user.click(trigger);
-      expect(handleOpenChange.mock.calls.length).toBe(0);
-
-      await user.click(screen.getByRole('button', { name: 'toggle' }));
-
-      expect(trigger).not.toHaveAttribute('disabled');
-      expect(trigger).not.toHaveAttribute('data-disabled');
-
-      await user.keyboard('[Tab]');
-      expect(trigger).toHaveFocus();
-
-      await user.click(trigger);
-      await waitFor(() => {
-        expect(handleOpenChange.mock.calls.length).toBe(1);
-      });
-    });
-  });
-
-  describe('prop: readOnly', () => {
-    it('sets the readOnly state', async () => {
-      const handleOpenChange = vi.fn();
-      const { user } = await render(
-        <Select.Root defaultValue="b" onOpenChange={handleOpenChange} readOnly>
-          <Select.Trigger>
-            <Select.Value />
-          </Select.Trigger>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByRole('combobox');
-      expect(trigger).toHaveAttribute('aria-readonly', 'true');
-      expect(trigger).toHaveAttribute('data-readonly');
-
-      await user.keyboard('[Tab]');
-      expect(trigger).toHaveFocus();
-
-      await user.click(trigger);
-      expect(handleOpenChange.mock.calls.length).toBe(0);
-    });
-
-    it('should not open the select when clicked', async () => {
-      const handleOpenChange = vi.fn();
-      const { user } = await render(
-        <Select.Root onOpenChange={handleOpenChange} readOnly>
-          <Select.Trigger>
-            <Select.Value />
-          </Select.Trigger>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByRole('combobox');
-
-      await user.click(trigger);
-      expect(screen.queryByRole('listbox')).toBe(null);
-      expect(handleOpenChange.mock.calls.length).toBe(0);
-    });
-
-    it('should not open the select when using keyboard', async () => {
-      const handleOpenChange = vi.fn();
-      const { user } = await render(
-        <Select.Root onOpenChange={handleOpenChange} readOnly>
-          <Select.Trigger>
-            <Select.Value />
-          </Select.Trigger>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByRole('combobox');
-
-      await act(async () => {
-        trigger.focus();
-      });
-
-      expect(screen.queryByRole('listbox')).toBe(null);
-      expect(document.activeElement).toBe(trigger);
-
-      await user.keyboard('[ArrowDown]');
-      expect(screen.queryByRole('listbox')).toBe(null);
-      expect(handleOpenChange.mock.calls.length).toBe(0);
-
-      await user.keyboard('[Enter]');
-      expect(screen.queryByRole('listbox')).toBe(null);
-      expect(handleOpenChange.mock.calls.length).toBe(0);
-
-      await user.keyboard('[Space]');
-      expect(screen.queryByRole('listbox')).toBe(null);
-      expect(handleOpenChange.mock.calls.length).toBe(0);
-    });
-  });
-
-  describe('prop: id', () => {
-    it('sets the id on the trigger', async () => {
-      await render(
-        <Select.Root id="test-id">
-          <Select.Trigger>
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByRole('combobox');
-      expect(trigger).toHaveAttribute('id', 'test-id');
-    });
-
-    it('sets a hidden input id when name is not provided', async () => {
-      await render(
-        <Select.Root id="test-id">
-          <Select.Trigger>
-            <Select.Value />
-          </Select.Trigger>
-        </Select.Root>,
-      );
-
-      const hiddenInput = screen.getByRole('textbox', { hidden: true });
-      expect(hiddenInput).toHaveAttribute('id', 'test-id-hidden-input');
-      expect(hiddenInput).not.toHaveAttribute('name');
-    });
-
-    it('does not set a hidden input id when name is provided', async () => {
-      await render(
-        <Select.Root id="test-id" name="country">
-          <Select.Trigger>
-            <Select.Value />
-          </Select.Trigger>
-        </Select.Root>,
-      );
-
-      const hiddenInput = screen.getByRole('textbox', { hidden: true });
-      expect(hiddenInput).toHaveAttribute('name', 'country');
-      expect(hiddenInput).not.toHaveAttribute('id');
-    });
-  });
-
   describe('with Field.Root parent', () => {
-    it('should receive disabled prop from Field.Root', async () => {
+    it('receives the disabled prop from Field.Root', async () => {
       await render(
         <Field.Root disabled>
           <Select.Root>
@@ -2156,7 +2776,7 @@ describe('<Select.Root />', () => {
       expect(trigger).toHaveAttribute('disabled');
     });
 
-    it('should receive name prop from Field.Root', async () => {
+    it('receives the name prop from Field.Root', async () => {
       await render(
         <Field.Root name="field-select">
           <Select.Root>
@@ -2224,7 +2844,7 @@ describe('<Select.Root />', () => {
     });
   });
 
-  describe('Form', () => {
+  describe('Form integration', () => {
     const { render: renderFakeTimers, clock } = createRenderer({
       clockOptions: {
         shouldAdvanceTime: true,
@@ -2463,7 +3083,7 @@ describe('<Select.Root />', () => {
     });
   });
 
-  describe('Field', () => {
+  describe('Field integration', () => {
     const { render: renderFakeTimers, clock } = createRenderer({
       clockOptions: {
         shouldAdvanceTime: true,
@@ -2472,7 +3092,7 @@ describe('<Select.Root />', () => {
 
     clock.withFakeTimers();
 
-    it('[data-touched]', async () => {
+    it('adds data-touched after blur', async () => {
       await render(
         <Field.Root>
           <Select.Root>
@@ -2501,7 +3121,7 @@ describe('<Select.Root />', () => {
       expect(trigger).toHaveAttribute('data-touched', '');
     });
 
-    it('[data-dirty]', async () => {
+    it('adds data-dirty after the value changes', async () => {
       ignoreActWarnings();
 
       const { user } = await renderFakeTimers(
@@ -2538,8 +3158,8 @@ describe('<Select.Root />', () => {
       expect(trigger).toHaveAttribute('data-dirty', '');
     });
 
-    describe('[data-filled]', () => {
-      it('adds [data-filled] attribute when filled', async () => {
+    describe('field state attribute: data-filled', () => {
+      it('adds data-filled when filled', async () => {
         ignoreActWarnings();
 
         const { user } = await renderFakeTimers(
@@ -2584,7 +3204,7 @@ describe('<Select.Root />', () => {
         expect(select).not.toHaveAttribute('data-filled');
       });
 
-      it('adds [data-filled] attribute when already filled', async () => {
+      it('adds data-filled when already filled', async () => {
         await render(
           <Field.Root>
             <Select.Root defaultValue="1">
@@ -2605,7 +3225,7 @@ describe('<Select.Root />', () => {
         expect(trigger).toHaveAttribute('data-filled');
       });
 
-      it('does not add [data-filled] attribute when multiple value is empty', async () => {
+      it('does not add data-filled when multiple value is empty', async () => {
         ignoreActWarnings();
         const { user } = await renderFakeTimers(
           <Field.Root>
@@ -2644,7 +3264,7 @@ describe('<Select.Root />', () => {
         expect(trigger).not.toHaveAttribute('data-filled');
       });
 
-      it('does not add [data-filled] attribute when multiple defaultValue is empty array', async () => {
+      it('does not add data-filled when multiple defaultValue is empty array', async () => {
         ignoreActWarnings();
 
         const { user } = await renderFakeTimers(
@@ -2685,7 +3305,7 @@ describe('<Select.Root />', () => {
       });
     });
 
-    it('[data-focused]', async () => {
+    it('adds data-focused while focused', async () => {
       await render(
         <Field.Root>
           <Select.Root>
@@ -2805,249 +3425,250 @@ describe('<Select.Root />', () => {
       expect(trigger).toHaveAttribute('aria-invalid', 'true');
     });
 
-    it('prop: validate', async () => {
-      await render(
-        <Field.Root validationMode="onBlur" validate={() => 'error'}>
-          <Select.Root>
-            <Select.Trigger data-testid="trigger" />
-            <Select.Portal>
-              <Select.Positioner />
-            </Select.Portal>
-          </Select.Root>
-        </Field.Root>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-
-      expect(trigger).not.toHaveAttribute('aria-invalid');
-
-      fireEvent.focus(trigger);
-      fireEvent.blur(trigger);
-
-      await flushMicrotasks();
-
-      expect(trigger).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    it('passes raw value to validate when itemToStringValue is provided', async () => {
-      const items = [
-        { code: 'US', label: 'United States' },
-        { code: 'CA', label: 'Canada' },
-      ];
-      const validateSpy = vi.fn((value: unknown) => {
-        expect(value).toBe(items[0]);
-        return 'error';
-      });
-
-      await render(
-        <Field.Root validationMode="onBlur" validate={validateSpy}>
-          <Select.Root
-            defaultValue={items[0]}
-            itemToStringLabel={(item) => item.label}
-            itemToStringValue={(item) => item.code}
-          >
-            <Select.Trigger data-testid="trigger">
-              <Select.Value />
-            </Select.Trigger>
-            <Select.Portal>
-              <Select.Positioner />
-            </Select.Portal>
-          </Select.Root>
-        </Field.Root>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-
-      fireEvent.focus(trigger);
-      fireEvent.blur(trigger);
-
-      await waitFor(() => {
-        expect(validateSpy.mock.calls.length).toBe(1);
-      });
-      expect(trigger).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    it('prop: validateMode=onSubmit', async () => {
-      ignoreActWarnings();
-
-      const { user } = await render(
-        <Form>
-          <Field.Root validate={(val) => (val === '2' ? 'error' : null)}>
-            <Select.Root required>
-              <Select.Trigger />
+    describe('prop: validate', () => {
+      it('applies aria-invalid after blur', async () => {
+        await render(
+          <Field.Root validationMode="onBlur" validate={() => 'error'}>
+            <Select.Root>
+              <Select.Trigger data-testid="trigger" />
               <Select.Portal>
-                <Select.Positioner>
-                  <Select.Popup>
-                    <Select.Item value="1">Option 1</Select.Item>
-                    <Select.Item value="2">Option 2</Select.Item>
-                  </Select.Popup>
-                </Select.Positioner>
+                <Select.Positioner />
               </Select.Portal>
             </Select.Root>
-          </Field.Root>
-          <button type="submit">submit</button>
-        </Form>,
-      );
+          </Field.Root>,
+        );
 
-      const trigger = screen.getByRole('combobox');
-      expect(trigger).not.toHaveAttribute('aria-invalid');
+        const trigger = screen.getByTestId('trigger');
 
-      await user.click(screen.getByText('submit'));
-      expect(trigger).toHaveAttribute('aria-invalid', 'true');
+        expect(trigger).not.toHaveAttribute('aria-invalid');
 
-      // Arrow Down to focus Option 1 (valid)
-      await user.keyboard('{ArrowDown}');
-      await user.keyboard('{Enter}');
-      expect(trigger).not.toHaveAttribute('aria-invalid');
+        fireEvent.focus(trigger);
+        fireEvent.blur(trigger);
 
-      await user.click(trigger);
-      // Arrow Down to focus Option 2 (invalid)
-      await user.keyboard('{ArrowDown}');
-      await user.keyboard('{Enter}');
-      expect(trigger).toHaveAttribute('aria-invalid', 'true');
+        await flushMicrotasks();
 
-      await user.click(trigger);
-      // Arrow Down to focus Option 1 (valid)
-      await user.keyboard('{ArrowUp}');
-      await user.keyboard('{Enter}');
-      await flushMicrotasks();
-      expect(trigger).not.toHaveAttribute('aria-invalid');
+        expect(trigger).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      it('passes raw value when itemToStringValue is provided', async () => {
+        const items = [
+          { code: 'US', label: 'United States' },
+          { code: 'CA', label: 'Canada' },
+        ];
+        const validateSpy = vi.fn((value: unknown) => {
+          expect(value).toBe(items[0]);
+          return 'error';
+        });
+
+        await render(
+          <Field.Root validationMode="onBlur" validate={validateSpy}>
+            <Select.Root
+              defaultValue={items[0]}
+              itemToStringLabel={(item) => item.label}
+              itemToStringValue={(item) => item.code}
+            >
+              <Select.Trigger data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner />
+              </Select.Portal>
+            </Select.Root>
+          </Field.Root>,
+        );
+
+        const trigger = screen.getByTestId('trigger');
+
+        fireEvent.focus(trigger);
+        fireEvent.blur(trigger);
+
+        await waitFor(() => {
+          expect(validateSpy.mock.calls.length).toBe(1);
+        });
+        expect(trigger).toHaveAttribute('aria-invalid', 'true');
+      });
     });
 
-    // flaky in real browser
-    it.skipIf(!isJSDOM)('prop: validationMode=onChange', async () => {
-      ignoreActWarnings();
-      const { user } = await render(
-        <Field.Root
-          validationMode="onChange"
-          validate={(value) => {
-            return value === '1' ? 'error' : null;
-          }}
-        >
-          <Select.Root>
-            <Select.Trigger data-testid="trigger">
-              <Select.Value />
-            </Select.Trigger>
-            <Select.Portal>
-              <Select.Positioner>
-                <Select.Popup>
-                  <Select.Item value="1">Option 1</Select.Item>
-                </Select.Popup>
-              </Select.Positioner>
-            </Select.Portal>
-          </Select.Root>
-        </Field.Root>,
-      );
+    describe('prop: validationMode', () => {
+      it('validates when validationMode is onSubmit', async () => {
+        ignoreActWarnings();
 
-      const trigger = screen.getByTestId('trigger');
-
-      expect(trigger).not.toHaveAttribute('aria-invalid');
-
-      await user.click(trigger);
-
-      await flushMicrotasks();
-
-      // Arrow Down to focus the Option 1
-      await user.keyboard('{ArrowDown}');
-      await user.keyboard('{Enter}');
-
-      expect(trigger).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    it('revalidates when the controlled value changes externally', async () => {
-      const validateSpy = vi.fn((value: unknown) => ((value as string) === 'b' ? 'error' : null));
-
-      function App() {
-        const [value, setValue] = React.useState('a');
-
-        return (
-          <React.Fragment>
-            <Field.Root validationMode="onChange" validate={validateSpy} name="flavor">
-              <Select.Root value={value} onValueChange={(next) => setValue(next as string)}>
-                <Select.Trigger data-testid="trigger">
-                  <Select.Value />
-                </Select.Trigger>
+        const { user } = await render(
+          <Form>
+            <Field.Root validate={(val) => (val === '2' ? 'error' : null)}>
+              <Select.Root required>
+                <Select.Trigger />
                 <Select.Portal>
                   <Select.Positioner>
                     <Select.Popup>
-                      <Select.Item value="a">Option A</Select.Item>
-                      <Select.Item value="b">Option B</Select.Item>
+                      <Select.Item value="1">Option 1</Select.Item>
+                      <Select.Item value="2">Option 2</Select.Item>
                     </Select.Popup>
                   </Select.Positioner>
                 </Select.Portal>
               </Select.Root>
             </Field.Root>
-            <button type="button" onClick={() => setValue('b')}>
-              Select externally
-            </button>
-          </React.Fragment>
+            <button type="submit">submit</button>
+          </Form>,
         );
-      }
 
-      await render(<App />);
+        const trigger = screen.getByRole('combobox');
+        expect(trigger).not.toHaveAttribute('aria-invalid');
 
-      const trigger = screen.getByTestId('trigger');
-      const toggle = screen.getByText('Select externally');
-
-      expect(trigger).not.toHaveAttribute('aria-invalid');
-      const initialCallCount = validateSpy.mock.calls.length;
-
-      fireEvent.click(toggle);
-      await flushMicrotasks();
-
-      expect(validateSpy.mock.calls.length).toBe(initialCallCount + 1);
-      expect(validateSpy.mock.lastCall?.[0]).toBe('b');
-      expect(trigger).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    // flaky in real browser
-    it.skipIf(!isJSDOM)('prop: validationMode=onBlur', async () => {
-      ignoreActWarnings();
-      const { user } = await render(
-        <Field.Root
-          validationMode="onBlur"
-          validate={(value) => {
-            return value === '1' ? 'error' : null;
-          }}
-        >
-          <Select.Root>
-            <Select.Trigger data-testid="trigger">
-              <Select.Value />
-            </Select.Trigger>
-            <Select.Portal>
-              <Select.Positioner>
-                <Select.Popup>
-                  <Select.Item value="1">Option 1</Select.Item>
-                </Select.Popup>
-              </Select.Positioner>
-            </Select.Portal>
-          </Select.Root>
-          <Field.Error data-testid="error" />
-        </Field.Root>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-
-      expect(trigger).not.toHaveAttribute('aria-invalid');
-
-      await user.click(trigger);
-
-      await flushMicrotasks();
-
-      // Arrow Down to focus the Option 1
-      await user.keyboard('{ArrowDown}');
-      await user.keyboard('{Enter}');
-
-      fireEvent.blur(trigger);
-
-      await flushMicrotasks();
-
-      await waitFor(() => {
+        await user.click(screen.getByText('submit'));
         expect(trigger).toHaveAttribute('aria-invalid', 'true');
+
+        // Arrow Down to focus Option 1 (valid)
+        await user.keyboard('{ArrowDown}');
+        await user.keyboard('{Enter}');
+        expect(trigger).not.toHaveAttribute('aria-invalid');
+
+        await user.click(trigger);
+        // Arrow Down to focus Option 2 (invalid)
+        await user.keyboard('{ArrowDown}');
+        await user.keyboard('{Enter}');
+        expect(trigger).toHaveAttribute('aria-invalid', 'true');
+
+        await user.click(trigger);
+        // Arrow Down to focus Option 1 (valid)
+        await user.keyboard('{ArrowUp}');
+        await user.keyboard('{Enter}');
+        await flushMicrotasks();
+        expect(trigger).not.toHaveAttribute('aria-invalid');
+      });
+
+      // flaky in real browser
+      it.skipIf(!isJSDOM)('validates when validationMode is onChange', async () => {
+        ignoreActWarnings();
+        const { user } = await render(
+          <Field.Root
+            validationMode="onChange"
+            validate={(value) => {
+              return value === '1' ? 'error' : null;
+            }}
+          >
+            <Select.Root>
+              <Select.Trigger data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    <Select.Item value="1">Option 1</Select.Item>
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </Field.Root>,
+        );
+
+        const trigger = screen.getByTestId('trigger');
+
+        expect(trigger).not.toHaveAttribute('aria-invalid');
+
+        await user.click(trigger);
+
+        await flushMicrotasks();
+
+        // Arrow Down to focus the Option 1
+        await user.keyboard('{ArrowDown}');
+        await user.keyboard('{Enter}');
+
+        expect(trigger).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      it('revalidates when the controlled value changes externally', async () => {
+        const validateSpy = vi.fn((value: unknown) => ((value as string) === 'b' ? 'error' : null));
+
+        function App() {
+          const [value, setValue] = React.useState('a');
+
+          return (
+            <React.Fragment>
+              <Field.Root validationMode="onChange" validate={validateSpy} name="flavor">
+                <Select.Root value={value} onValueChange={(next) => setValue(next as string)}>
+                  <Select.Trigger data-testid="trigger">
+                    <Select.Value />
+                  </Select.Trigger>
+                  <Select.Portal>
+                    <Select.Positioner>
+                      <Select.Popup>
+                        <Select.Item value="a">Option A</Select.Item>
+                        <Select.Item value="b">Option B</Select.Item>
+                      </Select.Popup>
+                    </Select.Positioner>
+                  </Select.Portal>
+                </Select.Root>
+              </Field.Root>
+              <button type="button" onClick={() => setValue('b')}>
+                Select externally
+              </button>
+            </React.Fragment>
+          );
+        }
+
+        await render(<App />);
+
+        const trigger = screen.getByTestId('trigger');
+        const toggle = screen.getByText('Select externally');
+
+        expect(trigger).not.toHaveAttribute('aria-invalid');
+        const initialCallCount = validateSpy.mock.calls.length;
+
+        fireEvent.click(toggle);
+        await flushMicrotasks();
+
+        expect(validateSpy.mock.calls.length).toBe(initialCallCount + 1);
+        expect(validateSpy.mock.lastCall?.[0]).toBe('b');
+        expect(trigger).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      // flaky in real browser
+      it.skipIf(!isJSDOM)('validates when validationMode is onBlur', async () => {
+        ignoreActWarnings();
+        const { user } = await render(
+          <Field.Root
+            validationMode="onBlur"
+            validate={(value) => {
+              return value === '1' ? 'error' : null;
+            }}
+          >
+            <Select.Root>
+              <Select.Trigger data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    <Select.Item value="1">Option 1</Select.Item>
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+            <Field.Error data-testid="error" />
+          </Field.Root>,
+        );
+
+        const trigger = screen.getByTestId('trigger');
+
+        expect(trigger).not.toHaveAttribute('aria-invalid');
+
+        await user.click(trigger);
+
+        await flushMicrotasks();
+
+        // Arrow Down to focus the Option 1
+        await user.keyboard('{ArrowDown}');
+        await user.keyboard('{Enter}');
+
+        fireEvent.blur(trigger);
+        await waitFor(() => {
+          expect(trigger).toHaveAttribute('aria-invalid', 'true');
+        });
       });
     });
 
-    it('Field.Label', async () => {
+    it('links Field.Label to the trigger', async () => {
       await render(
         <Field.Root>
           <Select.Root>
@@ -3066,7 +3687,7 @@ describe('<Select.Root />', () => {
       );
     });
 
-    it('Select.Label', async () => {
+    it('links Select.Label to the trigger', async () => {
       await render(
         <Select.Root>
           <Select.Label data-testid="label" />
@@ -3288,9 +3909,7 @@ describe('<Select.Root />', () => {
 
       await user.keyboard('{ArrowDown}');
 
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).not.toBe(null);
-      });
+      await screen.findByRole('listbox');
 
       await user.keyboard('{ArrowDown}');
       await user.keyboard('{ArrowDown}'); // Share
@@ -3919,652 +4538,6 @@ describe('<Select.Root />', () => {
 
       await user.keyboard('a');
       expect(valueEl.textContent).toBe('cat');
-    });
-  });
-
-  describe('prop: multiple', () => {
-    it('removes selections that no longer exist', async () => {
-      function Test() {
-        const [items, setItems] = React.useState(['a', 'b', 'c']);
-        return (
-          <div>
-            <Select.Root multiple defaultValue={['a', 'c']}>
-              <Select.Trigger data-testid="trigger">
-                <Select.Value />
-              </Select.Trigger>
-              <Select.Portal>
-                <Select.Positioner>
-                  <Select.Popup>
-                    {items.map((it) => (
-                      <Select.Item key={it} value={it}>
-                        {it}
-                      </Select.Item>
-                    ))}
-                  </Select.Popup>
-                </Select.Positioner>
-              </Select.Portal>
-            </Select.Root>
-            <button
-              data-testid="remove-a"
-              onClick={() => setItems((prev) => prev.filter((i) => i !== 'a'))}
-            >
-              Remove A
-            </button>
-            <button
-              data-testid="remove-c"
-              onClick={() => setItems((prev) => prev.filter((i) => i !== 'c'))}
-            >
-              Remove C
-            </button>
-          </div>
-        );
-      }
-
-      const { user } = await render(<Test />);
-
-      const trigger = screen.getByTestId('trigger');
-      await user.click(trigger);
-
-      await waitFor(() => {
-        expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
-      });
-      expect(screen.getByRole('option', { name: 'c' })).toHaveAttribute('data-selected', '');
-
-      // Remove one of the selected items; remaining selection should persist
-      await user.click(screen.getByTestId('remove-c'));
-
-      await user.click(trigger);
-
-      await waitFor(() => {
-        expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
-      });
-      expect(screen.queryByRole('option', { name: 'c' })).toBe(null);
-
-      // Remove the last selected item; selection should become empty
-      await user.click(screen.getByTestId('remove-a'));
-
-      await user.click(trigger);
-
-      const options = await screen.findAllByRole('option');
-      options.forEach((opt) => {
-        expect(opt).not.toHaveAttribute('data-selected');
-      });
-    });
-
-    it('should allow multiple selections when multiple is true', async () => {
-      const handleValueChange = vi.fn();
-
-      function App() {
-        const [value, setValue] = React.useState<any[]>([]);
-
-        return (
-          <Select.Root
-            multiple
-            value={value}
-            onValueChange={(newValue) => {
-              setValue(newValue);
-              handleValueChange(newValue);
-            }}
-          >
-            <Select.Trigger data-testid="trigger">
-              <Select.Value />
-            </Select.Trigger>
-            <Select.Portal>
-              <Select.Positioner>
-                <Select.Popup>
-                  <Select.Item value="a">a</Select.Item>
-                  <Select.Item value="b">b</Select.Item>
-                  <Select.Item value="c">c</Select.Item>
-                </Select.Popup>
-              </Select.Positioner>
-            </Select.Portal>
-          </Select.Root>
-        );
-      }
-
-      const { user } = await render(<App />);
-
-      const trigger = screen.getByTestId('trigger');
-
-      await user.click(trigger);
-      await flushMicrotasks();
-
-      const optionA = await screen.findByRole('option', { name: 'a' });
-      await user.click(optionA);
-      await flushMicrotasks();
-
-      expect(handleValueChange.mock.calls[0][0]).toEqual(['a']);
-      expect(optionA).toHaveAttribute('data-selected', '');
-
-      const optionB = screen.getByRole('option', { name: 'b' });
-      await user.click(optionB);
-      await flushMicrotasks();
-
-      expect(handleValueChange.mock.calls[1][0]).toEqual(['a', 'b']);
-      expect(optionA).toHaveAttribute('data-selected', '');
-      expect(optionB).toHaveAttribute('data-selected', '');
-
-      expect(screen.getByRole('listbox')).not.toBe(null);
-    });
-
-    it('should deselect items when clicked again in multiple mode', async () => {
-      const handleValueChange = vi.fn();
-
-      function App() {
-        const [value, setValue] = React.useState(['a', 'b']);
-
-        return (
-          <Select.Root
-            multiple
-            value={value}
-            onValueChange={(newValue) => {
-              setValue(newValue);
-              handleValueChange(newValue);
-            }}
-          >
-            <Select.Trigger data-testid="trigger">
-              <Select.Value />
-            </Select.Trigger>
-            <Select.Portal>
-              <Select.Positioner>
-                <Select.Popup>
-                  <Select.Item value="a">a</Select.Item>
-                  <Select.Item value="b">b</Select.Item>
-                  <Select.Item value="c">c</Select.Item>
-                </Select.Popup>
-              </Select.Positioner>
-            </Select.Portal>
-          </Select.Root>
-        );
-      }
-
-      const { user } = await render(<App />);
-
-      const trigger = screen.getByTestId('trigger');
-
-      await user.click(trigger);
-      await flushMicrotasks();
-
-      const optionA = await screen.findByRole('option', { name: 'a' });
-      const optionB = screen.getByRole('option', { name: 'b' });
-
-      expect(optionA).toHaveAttribute('data-selected', '');
-      expect(optionB).toHaveAttribute('data-selected', '');
-
-      await user.click(optionA);
-      await flushMicrotasks();
-
-      expect(handleValueChange.mock.calls[0][0]).toEqual(['b']);
-      expect(optionA).not.toHaveAttribute('data-selected');
-      expect(optionB).toHaveAttribute('data-selected', '');
-    });
-
-    it('keeps the active index on a deselected item in multiple mode', async () => {
-      const { user } = await render(
-        <Select.Root multiple value={['a']}>
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-                <Select.Item value="c">c</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-
-      await user.click(trigger);
-
-      const optionB = await screen.findByRole('option', { name: 'b' });
-
-      await user.click(optionB);
-
-      await waitFor(() => {
-        expect(optionB).toHaveAttribute('data-highlighted');
-      });
-
-      await user.click(optionB);
-
-      await waitFor(() => {
-        expect(optionB).toHaveAttribute('data-highlighted');
-      });
-    });
-
-    it('should handle defaultValue as array in multiple mode', async () => {
-      await render(
-        <Select.Root multiple defaultValue={['a', 'c']}>
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-                <Select.Item value="c">c</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-
-      fireEvent.click(trigger);
-      await flushMicrotasks();
-
-      expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
-      expect(screen.getByRole('option', { name: 'b' })).not.toHaveAttribute('data-selected');
-      expect(screen.getByRole('option', { name: 'c' })).toHaveAttribute('data-selected', '');
-    });
-
-    it('should serialize multiple values correctly for form submission', async () => {
-      const { container } = await render(
-        <Select.Root multiple name="select" value={['a', 'c']}>
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-                <Select.Item value="c">c</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      // eslint-disable-next-line testing-library/no-container -- No appropriate method on screen since it's a hidden input without any type
-      const hiddenInputs = container.querySelectorAll(
-        '[name="select"]',
-      ) as NodeListOf<HTMLInputElement>;
-      expect(hiddenInputs).toHaveLength(2);
-      const values = Array.from(hiddenInputs).map((input) => input.value);
-      expect(values).toEqual(['a', 'c']);
-    });
-
-    it('should serialize empty array as empty string in multiple mode', async () => {
-      const { container } = await render(
-        <Select.Root multiple name="select">
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-                <Select.Item value="c">c</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      // In multiple mode with empty array, no hidden inputs with name should exist
-      // eslint-disable-next-line testing-library/no-container -- No appropriate method on screen since it's a hidden input without any type
-      const namedHiddenInputs = container.querySelectorAll('[name="select"]');
-      expect(namedHiddenInputs).toHaveLength(0);
-
-      // But the main input should have the serialized empty value for Field validation purposes
-      // eslint-disable-next-line testing-library/no-container -- No appropriate method on screen since it's a hidden input without any type
-      const mainInput = container.querySelector<HTMLInputElement>('input[aria-hidden="true"]');
-      expect(mainInput).not.toBe(null);
-      expect(mainInput?.value).toBe('');
-    });
-
-    it('does not mark the hidden input as required when selection exists', async () => {
-      await render(
-        <Select.Root multiple required name="select" value={['a']}>
-          <Select.Trigger>
-            <Select.Value />
-          </Select.Trigger>
-        </Select.Root>,
-      );
-
-      const hiddenInput = screen.getByRole('textbox', { hidden: true });
-      expect(hiddenInput).not.toBe(null);
-      expect(hiddenInput).not.toHaveAttribute('required');
-    });
-
-    it('keeps the hidden input required when no selection exists', async () => {
-      await render(
-        <Select.Root multiple required name="select" value={[]}>
-          <Select.Trigger>
-            <Select.Value />
-          </Select.Trigger>
-        </Select.Root>,
-      );
-
-      const hiddenInput = screen.getByRole('textbox', { hidden: true });
-      expect(hiddenInput).not.toBe(null);
-      expect(hiddenInput).toHaveAttribute('required');
-    });
-
-    it('should not close popup when selecting items in multiple mode', async () => {
-      const { user } = await render(
-        <Select.Root multiple>
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-                <Select.Item value="c">c</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-
-      await user.click(trigger);
-      await flushMicrotasks();
-
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
-
-      const optionA = await screen.findByRole('option', { name: 'a' });
-      await user.click(optionA);
-      await flushMicrotasks();
-
-      expect(screen.getByRole('listbox')).not.toBe(null);
-
-      const optionB = screen.getByRole('option', { name: 'b' });
-      await user.click(optionB);
-      await flushMicrotasks();
-
-      expect(screen.getByRole('listbox')).not.toBe(null);
-    });
-
-    it('should close popup in single select mode', async () => {
-      const { user } = await render(
-        <Select.Root>
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-                <Select.Item value="c">c</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-
-      await user.click(trigger);
-      await flushMicrotasks();
-
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).not.toBe(null);
-      });
-
-      const optionA = await screen.findByRole('option', { name: 'a' });
-      await user.click(optionA);
-      await flushMicrotasks();
-
-      await waitFor(() => {
-        expect(screen.queryByRole('listbox')).toBe(null);
-      });
-    });
-
-    it('should update selected items when value prop changes', async () => {
-      const { setProps } = await render(
-        <Select.Root multiple value={['a']}>
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-                <Select.Item value="c">c</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-
-      fireEvent.click(trigger);
-      await flushMicrotasks();
-
-      expect(await screen.findByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
-      expect(screen.getByRole('option', { name: 'b' })).not.toHaveAttribute('data-selected');
-
-      await setProps({ value: ['a', 'b', 'c'] });
-
-      expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
-      expect(screen.getByRole('option', { name: 'b' })).toHaveAttribute('data-selected', '');
-      expect(screen.getByRole('option', { name: 'c' })).toHaveAttribute('data-selected', '');
-    });
-  });
-
-  describe('prop: isItemEqualToValue', () => {
-    it('matches object values using the provided comparator', async () => {
-      const users = [
-        { id: 1, name: 'Alice' },
-        { id: 2, name: 'Bob' },
-      ];
-
-      await render(
-        <Select.Root
-          value={{ id: 2, name: 'Bob' }}
-          itemToStringLabel={(item) => item.name}
-          itemToStringValue={(item) => String(item.id)}
-          isItemEqualToValue={(item, value) => item.id === value.id}
-        >
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                {users.map((user) => (
-                  <Select.Item key={user.id} value={user}>
-                    {user.name}
-                  </Select.Item>
-                ))}
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const trigger = screen.getByTestId('trigger');
-      expect(trigger).toHaveTextContent('Bob');
-
-      fireEvent.click(trigger);
-
-      await waitFor(() => {
-        expect(screen.getByRole('option', { name: 'Bob' })).toHaveAttribute('data-selected', '');
-      });
-    });
-
-    it('passes item as the first comparator argument in multiple mode', async () => {
-      const users = [
-        { id: 1, name: 'Alice', source: 'item' },
-        { id: 2, name: 'Bob', source: 'item' },
-      ];
-
-      await render(
-        <Select.Root
-          multiple
-          defaultOpen
-          defaultValue={[{ id: 2, name: 'Bob', source: 'selected' }]}
-          itemToStringLabel={(item) => item.name}
-          itemToStringValue={(item) => String(item.id)}
-          isItemEqualToValue={(item, value) =>
-            item.id === value.id && item.source === 'item' && value.source === 'selected'
-          }
-        >
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                {users.map((user) => (
-                  <Select.Item key={user.id} value={user}>
-                    {user.name}
-                  </Select.Item>
-                ))}
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const option = screen.getByRole('option', { name: 'Bob' });
-      expect(option).toHaveAttribute('data-selected', '');
-
-      fireEvent.click(option);
-
-      await waitFor(() => {
-        expect(screen.getByRole('option', { name: 'Bob' })).not.toHaveAttribute('data-selected');
-      });
-    });
-  });
-
-  describe('prop: highlightItemOnHover', () => {
-    it('highlights an item on mouse move by default', async () => {
-      const { user } = await render(
-        <Select.Root defaultOpen>
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-                <Select.Item value="c">c</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const optionB = screen.getByRole('option', { name: 'b' });
-      await user.hover(optionB);
-
-      await waitFor(() => {
-        expect(optionB).toHaveAttribute('data-highlighted');
-      });
-    });
-
-    it.skipIf(isJSDOM)(
-      'highlights the first item after opening when alignItemWithTrigger is active and no value is selected',
-      async () => {
-        await render(
-          <div style={{ paddingTop: 120, paddingLeft: 24 }}>
-            <Select.Root>
-              <Select.Trigger data-testid="trigger" style={{ width: 120, height: 36 }}>
-                <Select.Value placeholder="Pick one" />
-              </Select.Trigger>
-              <Select.Portal>
-                <Select.Positioner>
-                  <Select.Popup style={{ maxHeight: 'none' }}>
-                    <Select.Item value="a">a</Select.Item>
-                    <Select.Item value="b">b</Select.Item>
-                    <Select.Item value="c">c</Select.Item>
-                  </Select.Popup>
-                </Select.Positioner>
-              </Select.Portal>
-            </Select.Root>
-          </div>,
-        );
-
-        const trigger = screen.getByTestId('trigger');
-        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
-        fireEvent.mouseDown(trigger);
-
-        const optionA = await screen.findByRole('option', { name: 'a' });
-
-        await waitFor(() => {
-          expect(optionA).toHaveAttribute('data-highlighted');
-        });
-      },
-    );
-
-    it('does not highlight items from mouse movement when disabled', async () => {
-      const { user } = await render(
-        <Select.Root defaultOpen highlightItemOnHover={false}>
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-                <Select.Item value="c">c</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const optionB = screen.getByRole('option', { name: 'b' });
-      await user.hover(optionB);
-
-      await flushMicrotasks();
-
-      expect(optionB).not.toHaveAttribute('data-highlighted');
-    });
-
-    it('does not remove highlight when mousing out of popup when disabled', async () => {
-      const { user } = await render(
-        <Select.Root defaultOpen highlightItemOnHover={false}>
-          <Select.Trigger data-testid="trigger">
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Positioner>
-              <Select.Popup>
-                <Select.Item value="a">a</Select.Item>
-                <Select.Item value="b">b</Select.Item>
-                <Select.Item value="c">c</Select.Item>
-              </Select.Popup>
-            </Select.Positioner>
-          </Select.Portal>
-        </Select.Root>,
-      );
-
-      const optionA = screen.getByRole('option', { name: 'a' });
-      await user.hover(optionA);
-
-      await user.keyboard('{ArrowDown}');
-
-      await waitFor(() => {
-        expect(optionA).toHaveAttribute('data-highlighted');
-      });
-
-      const popup = screen.getByRole('listbox');
-      await user.unhover(popup);
-
-      await waitFor(() => {
-        expect(optionA).toHaveAttribute('data-highlighted');
-      });
     });
   });
 });

--- a/packages/react/src/select/scroll-down-arrow/SelectScrollDownArrow.test.tsx
+++ b/packages/react/src/select/scroll-down-arrow/SelectScrollDownArrow.test.tsx
@@ -17,6 +17,18 @@ describe('<Select.ScrollDownArrow />', () => {
     },
   }));
 
+  it('has the down direction data attribute', async () => {
+    await render(
+      <Select.Root open>
+        <Select.Positioner>
+          <Select.ScrollDownArrow keepMounted data-testid="arrow" />
+        </Select.Positioner>
+      </Select.Root>,
+    );
+
+    expect(screen.getByTestId('arrow')).toHaveAttribute('data-direction', 'down');
+  });
+
   it('snaps hover scrolling to the true bottom when the remaining space is fractional', async () => {
     let scrollTop = 19.5;
 

--- a/packages/react/src/select/scroll-up-arrow/SelectScrollUpArrow.test.tsx
+++ b/packages/react/src/select/scroll-up-arrow/SelectScrollUpArrow.test.tsx
@@ -17,6 +17,18 @@ describe('<Select.ScrollUpArrow />', () => {
     },
   }));
 
+  it('has the up direction data attribute', async () => {
+    await render(
+      <Select.Root open>
+        <Select.Positioner>
+          <Select.ScrollUpArrow keepMounted data-testid="arrow" />
+        </Select.Positioner>
+      </Select.Root>,
+    );
+
+    expect(screen.getByTestId('arrow')).toHaveAttribute('data-direction', 'up');
+  });
+
   it('keeps advancing when the previous item top is fractionally within the visible top', async () => {
     let scrollTop = 72.18181610107422;
 

--- a/packages/react/src/select/trigger/SelectTrigger.test.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.test.tsx
@@ -141,7 +141,7 @@ describe('<Select.Trigger />', () => {
       expect(value.textContent).toBe('Select font');
     });
 
-    it('should not have the data-placeholder attribute when provided a value', async () => {
+    it('does not add data-placeholder when provided a value', async () => {
       await render(
         <Select.Root defaultValue="a">
           <Select.Trigger data-testid="trigger">
@@ -157,7 +157,7 @@ describe('<Select.Trigger />', () => {
       expect(value).not.toHaveAttribute('data-placeholder');
     });
 
-    it('should not have the data-placeholder attribute when multiple mode has a default value', async () => {
+    it('does not add data-placeholder when multiple mode has a default value', async () => {
       await render(
         <Select.Root multiple defaultValue={['a']}>
           <Select.Trigger data-testid="trigger">
@@ -174,7 +174,7 @@ describe('<Select.Trigger />', () => {
     });
   });
 
-  describe('style hooks', () => {
+  describe('state attributes', () => {
     it.skipIf(isJSDOM)('sets data-popup-side to the current popup side', async () => {
       const { user } = await render(
         <Select.Root>
@@ -194,7 +194,7 @@ describe('<Select.Trigger />', () => {
 
       await user.click(trigger);
 
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
       expect(trigger).toHaveAttribute('data-popup-side', 'right');
 
       await user.click(document.body);

--- a/packages/react/src/select/value/SelectValue.test.tsx
+++ b/packages/react/src/select/value/SelectValue.test.tsx
@@ -55,6 +55,24 @@ describe('<Select.Value />', () => {
     });
   });
 
+  describe('prop: placeholder', () => {
+    it('has the placeholder data attribute when no value is selected', async () => {
+      const { setProps } = await render(
+        <Select.Root value={null}>
+          <Select.Value data-testid="value" placeholder="Select a value" />
+        </Select.Root>,
+      );
+
+      const value = screen.getByTestId('value');
+      expect(value).toHaveTextContent('Select a value');
+      expect(value).toHaveAttribute('data-placeholder', '');
+
+      await setProps({ value: 'one' });
+
+      expect(value).not.toHaveAttribute('data-placeholder');
+    });
+  });
+
   describe('prop: items (object format)', () => {
     it('displays the label from items object when no children are provided', async () => {
       const items = {
@@ -424,46 +442,6 @@ describe('<Select.Value />', () => {
     });
   });
 
-  it('changes text when the value changes', async () => {
-    function App() {
-      const [value, setValue] = React.useState<string | null>(null);
-      return (
-        <div>
-          <button onClick={() => setValue('1')}>1</button>
-          <button onClick={() => setValue('2')}>2</button>
-          <button onClick={() => setValue(null)}>null</button>
-          <Select.Root value={value} onValueChange={setValue}>
-            <Select.Trigger>
-              <Select.Value data-testid="value">{(val) => val ?? 'initial'}</Select.Value>
-            </Select.Trigger>
-            <Select.Portal>
-              <Select.Positioner>
-                <Select.Popup>
-                  <Select.Item value="1">1</Select.Item>
-                  <Select.Item value="2">2</Select.Item>
-                </Select.Popup>
-              </Select.Positioner>
-            </Select.Portal>
-          </Select.Root>
-        </div>
-      );
-    }
-
-    const { user } = await render(<App />);
-
-    await user.click(screen.getByText('initial'));
-    await flushMicrotasks();
-
-    await user.click(screen.getByRole('button', { name: '1' }));
-    expect(screen.getByTestId('value')).toHaveTextContent('1');
-
-    await user.click(screen.getByRole('button', { name: '2' }));
-    expect(screen.getByTestId('value')).toHaveTextContent('2');
-
-    await user.click(screen.getByRole('button', { name: 'null' }));
-    expect(screen.getByTestId('value')).toHaveTextContent('initial');
-  });
-
   describe('prop: multiple', () => {
     it('displays comma-separated labels for multiple values with items object', async () => {
       const items = {
@@ -760,5 +738,45 @@ describe('<Select.Value />', () => {
 
       expect(screen.getByTestId('placeholder')).toHaveTextContent('Select an option');
     });
+  });
+
+  it('changes text when the value changes', async () => {
+    function App() {
+      const [value, setValue] = React.useState<string | null>(null);
+      return (
+        <div>
+          <button onClick={() => setValue('1')}>1</button>
+          <button onClick={() => setValue('2')}>2</button>
+          <button onClick={() => setValue(null)}>null</button>
+          <Select.Root value={value} onValueChange={setValue}>
+            <Select.Trigger>
+              <Select.Value data-testid="value">{(val) => val ?? 'initial'}</Select.Value>
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup>
+                  <Select.Item value="1">1</Select.Item>
+                  <Select.Item value="2">2</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        </div>
+      );
+    }
+
+    const { user } = await render(<App />);
+
+    await user.click(screen.getByText('initial'));
+    await flushMicrotasks();
+
+    await user.click(screen.getByRole('button', { name: '1' }));
+    expect(screen.getByTestId('value')).toHaveTextContent('1');
+
+    await user.click(screen.getByRole('button', { name: '2' }));
+    expect(screen.getByTestId('value')).toHaveTextContent('2');
+
+    await user.click(screen.getByRole('button', { name: 'null' }));
+    expect(screen.getByTestId('value')).toHaveTextContent('initial');
   });
 });

--- a/packages/react/src/separator/Separator.test.tsx
+++ b/packages/react/src/separator/Separator.test.tsx
@@ -22,6 +22,7 @@ describe('<Separator />', () => {
         await render(<Separator orientation={orientation as Separator.Props['orientation']} />);
 
         expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', orientation);
+        expect(screen.getByRole('separator')).toHaveAttribute('data-orientation', orientation);
       });
     });
   });

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -717,6 +717,495 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     });
   });
 
+  describe('prop: onValueChange', () => {
+    it.skipIf(isJSDOM)('is called when clicking on the control', async () => {
+      const handleValueChange = vi.fn();
+      await render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
+
+      const sliderControl = screen.getByTestId('control');
+
+      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+
+      fireEvent.pointerDown(sliderControl, {
+        buttons: 1,
+        clientX: 41,
+      });
+
+      expect(handleValueChange.mock.calls.length).toBe(1);
+    });
+
+    it('is not called when clicking on the thumb', async () => {
+      const handleValueChange = vi.fn();
+      await render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
+
+      const sliderControl = screen.getByTestId('control');
+      const sliderThumb = screen.getByTestId('thumb');
+
+      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+
+      fireEvent.pointerDown(sliderThumb, {
+        buttons: 1,
+        clientX: 51,
+      });
+
+      expect(handleValueChange.mock.calls.length).toBe(0);
+    });
+
+    it('should not react to right clicks', async () => {
+      const handleValueChange = vi.fn();
+      await render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
+
+      const sliderControl = screen.getByTestId('control');
+
+      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+
+      fireEvent.pointerDown(sliderControl, {
+        button: 2,
+        clientX: 41,
+      });
+
+      expect(handleValueChange.mock.calls.length).toBe(0);
+    });
+
+    it('provides the change reason for input events', async () => {
+      const handleValueChange = vi.fn();
+      await render(<TestSlider defaultValue={30} onValueChange={handleValueChange} />);
+
+      const slider = screen.getByRole('slider');
+      fireEvent.change(slider, { target: { value: '35' } });
+
+      expect(handleValueChange).toHaveBeenCalledTimes(1);
+      const [, details] = handleValueChange.mock.calls[0] as [
+        number,
+        SliderRoot.ChangeEventDetails,
+      ];
+      expect(details.reason).toBe(REASONS.inputChange);
+      expect(details.activeThumbIndex).toBe(0);
+    });
+
+    it('provides the change reason for keyboard interactions', async () => {
+      const handleValueChange = vi.fn();
+      await render(<TestSlider defaultValue={40} onValueChange={handleValueChange} />);
+
+      const slider = screen.getByRole('slider');
+      await act(async () => {
+        slider.focus();
+      });
+      fireEvent.keyDown(slider, { key: ARROW_RIGHT });
+
+      expect(handleValueChange).toHaveBeenCalledTimes(1);
+      const [, details] = handleValueChange.mock.calls[0] as [
+        number,
+        SliderRoot.ChangeEventDetails,
+      ];
+      expect(details.reason).toBe('keyboard');
+    });
+
+    it.skipIf(isJSDOM || isWebKit)(
+      'shows :focus-visible after keyboard interaction following a pointer press',
+      async () => {
+        await render(<TestSlider defaultValue={40} />);
+
+        const sliderControl = screen.getByTestId('control');
+        vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(
+          getHorizontalSliderRect,
+        );
+
+        const slider = screen.getByRole('slider');
+
+        fireEvent.pointerDown(sliderControl, {
+          pointerId: 1,
+          pointerType: 'mouse',
+          button: 0,
+          buttons: 1,
+          clientX: 40,
+          clientY: 0,
+        });
+
+        await waitFor(() => {
+          expect(slider).toHaveFocus();
+        });
+
+        expect(slider.matches(':focus-visible')).toBe(false);
+
+        fireEvent.keyDown(slider, { key: ARROW_RIGHT });
+
+        await waitFor(() => {
+          expect(slider.matches(':focus-visible')).toBe(true);
+        });
+      },
+    );
+
+    it('provides the change reason for track presses', async () => {
+      const handleValueChange = vi.fn();
+      await render(<TestSlider defaultValue={0} onValueChange={handleValueChange} />);
+
+      const sliderControl = screen.getByTestId('control');
+      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+
+      fireEvent.pointerDown(sliderControl, {
+        pointerId: 1,
+        pointerType: 'mouse',
+        button: 0,
+        buttons: 1,
+        clientX: 80,
+        clientY: 0,
+      });
+
+      await waitFor(() => {
+        expect(handleValueChange.mock.calls.length).toBe(1);
+      });
+      const [, details] = handleValueChange.mock.calls[0] as [
+        number | number[],
+        SliderRoot.ChangeEventDetails,
+      ];
+      expect(details.reason).toBe(REASONS.trackPress);
+    });
+
+    it.skipIf(isJSDOM)('drags the intended thumb when 3 thumbs are present', async () => {
+      const handleValueChange = vi.fn();
+
+      await render(
+        <TestMultiThumbSlider
+          defaultValue={[10, 40, 60]}
+          min={0}
+          max={100}
+          onValueChange={handleValueChange}
+        />,
+      );
+
+      const sliderControl = screen.getByTestId('control');
+      const thirdThumb = screen.getAllByTestId('thumb')[2];
+
+      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+      vi.spyOn(thirdThumb, 'getBoundingClientRect').mockImplementation(() => ({
+        width: 0,
+        height: 0,
+        bottom: 0,
+        left: 60,
+        right: 60,
+        top: 0,
+        x: 60,
+        y: 0,
+        toJSON() {},
+      }));
+
+      fireEvent.pointerDown(thirdThumb, {
+        pointerId: 1,
+        buttons: 1,
+        clientX: 60,
+      });
+
+      fireEvent.pointerMove(document, {
+        pointerId: 1,
+        buttons: 1,
+        clientX: 80,
+      });
+
+      expect(handleValueChange.mock.calls.length).toBeGreaterThan(0);
+
+      const [newValue] = handleValueChange.mock.lastCall ?? [];
+      expect(handleValueChange.mock.lastCall?.[1].activeThumbIndex).toBe(2);
+      expect(newValue[0]).toBe(10);
+      expect(newValue[1]).toBe(40);
+      expect(newValue[2]).not.toBe(60);
+    });
+
+    it.skipIf(isJSDOM)('should fire only when the value changes', async () => {
+      const handleValueChange = vi.fn();
+      await render(<TestSlider defaultValue={20} onValueChange={handleValueChange} />);
+
+      const sliderControl = screen.getByTestId('control');
+
+      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+
+      fireEvent.pointerDown(sliderControl, {
+        buttons: 1,
+        clientX: 21,
+      });
+
+      fireEvent.pointerMove(document.body, {
+        buttons: 1,
+        clientX: 22,
+      });
+      // Sometimes another event with the same position is fired by the browser.
+      fireEvent.pointerMove(document.body, {
+        buttons: 1,
+        clientX: 22,
+      });
+
+      expect(handleValueChange.mock.calls.length).toBe(2);
+      expect(handleValueChange.mock.calls[0][0]).toEqual(21);
+      expect(handleValueChange.mock.calls[1][0]).toEqual(22);
+    });
+
+    type Values = Array<[string, number[]]>;
+
+    const values = [
+      ['readonly range', Object.freeze([2, 1])],
+      ['range', [2, 1]],
+    ] as Values;
+    values.forEach(([valueLabel, value]) => {
+      it.skipIf(isJSDOM)(`is called even if the ${valueLabel} did not change`, async () => {
+        const handleValueChange = vi.fn();
+
+        await render(
+          <TestRangeSlider
+            min={0}
+            max={5}
+            onValueChange={handleValueChange}
+            value={value}
+            style={{ width: '100px' }}
+          />,
+        );
+
+        const sliderControl = screen.getByTestId('control');
+
+        vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(
+          getHorizontalSliderRect,
+        );
+
+        // pixel:  0   20  40  60  80  100
+        // slider: |---|---|---|---|---|
+        // values: 0   1   2   3   4   5
+        // value:      ��   ��
+        // mouse:           ��
+
+        fireEvent.pointerDown(sliderControl, {
+          buttons: 1,
+          clientX: 41,
+        });
+
+        expect(handleValueChange.mock.calls.length).toBe(1);
+        expect(handleValueChange.mock.calls[0][0]).not.toBe(value);
+        expect(handleValueChange.mock.calls[0][0]).toEqual(value.slice().sort((a, b) => a - b));
+      });
+    });
+
+    it('passes name and value on the onValueChange event target', async () => {
+      const handleValueChange = vi
+        .fn()
+        .mockImplementation((newValue, data) => (data as any).event.target);
+
+      await render(
+        <TestSlider onValueChange={handleValueChange} name="change-testing" value={3} />,
+      );
+
+      const slider = screen.getByRole('slider');
+
+      await act(async () => {
+        slider.focus();
+      });
+      fireEvent.change(slider, {
+        target: {
+          value: 4,
+        },
+      });
+
+      expect(handleValueChange.mock.calls.length).toBe(1);
+      const target = handleValueChange.mock.results[0]?.value;
+      expect(target).toEqual({
+        name: 'change-testing',
+        value: 4,
+      });
+    });
+
+    it.skipIf(!isJSDOM)(
+      'should not rely on the global event when cloning change events',
+      async () => {
+        const hadGlobalEvent = Object.prototype.hasOwnProperty.call(globalThis, 'event');
+        const previousDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'event');
+        const globalEventConstructor = class {
+          constructor() {
+            throw new Error('Should not construct global event');
+          }
+        };
+        const fakeGlobalEvent = {
+          type: 'click',
+          constructor: globalEventConstructor,
+        };
+
+        Object.defineProperty(globalThis, 'event', {
+          configurable: true,
+          get() {
+            return fakeGlobalEvent;
+          },
+          set() {
+            // Ignore assignments from the event system to ensure we never use it.
+          },
+        });
+
+        try {
+          const handleValueChange = vi.fn();
+
+          await render(
+            <TestSlider onValueChange={handleValueChange} name="change-testing" value={3} />,
+          );
+
+          const slider = screen.getByRole('slider');
+
+          await act(async () => {
+            slider.focus();
+          });
+
+          expectVitest(() => {
+            fireEvent.change(slider, {
+              target: {
+                value: 4,
+              },
+            });
+          }).not.toThrow();
+
+          expectVitest(handleValueChange).toHaveBeenCalledTimes(1);
+        } finally {
+          if (hadGlobalEvent && previousDescriptor) {
+            Object.defineProperty(globalThis, 'event', previousDescriptor);
+          } else {
+            delete (globalThis as any).event;
+          }
+        }
+      },
+    );
+
+    it.skipIf(isJSDOM)('should handle keyboard changes inside a shadow root', async () => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+      const container = document.createElement('div');
+      shadowRoot.appendChild(container);
+
+      try {
+        const handleValueChange = vi.fn();
+
+        await render(<TestSlider onValueChange={handleValueChange} name="shadow" value={3} />, {
+          container,
+        });
+
+        const slider = shadowRoot.querySelector('input[type="range"]');
+        expectVitest(slider).toBeTruthy();
+
+        if (!slider) {
+          return;
+        }
+
+        await act(async () => {
+          (slider as HTMLInputElement).focus();
+        });
+
+        await act(async () => {
+          slider.dispatchEvent(new KeyboardEvent('keydown', { key: ARROW_RIGHT, bubbles: true }));
+        });
+
+        expectVitest(handleValueChange).toHaveBeenCalledTimes(1);
+      } finally {
+        await act(async () => {
+          host.remove();
+        });
+      }
+    });
+
+    it.skipIf(isJSDOM)(
+      'onValueCommitted is called with the same value as the latest onValueChange when pointerUp occurs at a different location than onValueChange',
+      async () => {
+        const handleValueChange = vi.fn();
+        const handleValueCommitted = vi.fn();
+
+        await render(
+          <TestSlider
+            onValueChange={handleValueChange}
+            onValueCommitted={handleValueCommitted}
+            defaultValue={0}
+          />,
+        );
+
+        const sliderControl = screen.getByTestId('control');
+
+        vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(
+          getHorizontalSliderRect,
+        );
+
+        fireEvent.pointerDown(sliderControl, {
+          buttons: 1,
+          clientX: 10,
+        });
+        fireEvent.pointerMove(sliderControl, {
+          buttons: 1,
+          clientX: 15,
+        });
+        fireEvent.pointerUp(sliderControl, {
+          buttons: 1,
+          clientX: 20,
+        });
+
+        expect(handleValueChange.mock.calls.length).toBe(2);
+        expect(handleValueChange.mock.calls[0][0]).toBe(10);
+        expect(handleValueChange.mock.calls[1][0]).toBe(15);
+        expect(handleValueCommitted.mock.calls.length).toBe(1);
+        expect(handleValueCommitted.mock.calls[0][0]).toBe(15);
+        expect(handleValueCommitted.mock.calls[0][1].reason).toBe('drag');
+      },
+    );
+  });
+
+  describe('prop: format', () => {
+    it('formats the value', async () => {
+      function formatValue(v: number) {
+        return new Intl.NumberFormat(undefined, USD_NUMBER_FORMAT).format(v);
+      }
+
+      await render(<TestSlider defaultValue={50} format={USD_NUMBER_FORMAT} />);
+
+      const value = screen.getByTestId('value');
+      const slider = screen.getByRole('slider');
+      expect(value).toHaveTextContent(formatValue(50));
+      expect(slider).toHaveAttribute('aria-valuetext', formatValue(50));
+    });
+
+    it('formats range values', async () => {
+      function formatValue(v: number) {
+        return new Intl.NumberFormat(undefined, USD_NUMBER_FORMAT).format(v);
+      }
+
+      await render(<TestRangeSlider defaultValue={[50, 75]} format={USD_NUMBER_FORMAT} />);
+
+      const value = screen.getByTestId('value');
+      expect(value).toHaveTextContent(`${formatValue(50)} – ${formatValue(75)}`);
+      const [slider1, slider2] = screen.getAllByRole('slider');
+      expect(slider1).toHaveAttribute('aria-valuetext', `${formatValue(50)} start range`);
+      expect(slider2).toHaveAttribute('aria-valuetext', `${formatValue(75)} end range`);
+    });
+  });
+
+  describe('prop: locale', () => {
+    it('sets the locale when formatting a single value', async () => {
+      const format: Intl.NumberFormatOptions = {
+        style: 'decimal',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      };
+      const expectedValue = new Intl.NumberFormat('de-DE', format).format(70.51);
+
+      await render(<TestSlider value={70.51} format={format} step={0.01} locale="de-DE" />);
+
+      expect(screen.getByTestId('value')).toHaveTextContent(expectedValue);
+    });
+
+    it('sets the locale when formatting a range value', async () => {
+      const format: Intl.NumberFormatOptions = {
+        style: 'decimal',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      };
+      const expectedValue = `${new Intl.NumberFormat('de-DE', format).format(24.8)} – ${new Intl.NumberFormat('de-DE', format).format(70.51)}`;
+
+      await render(
+        <TestRangeSlider value={[24.8, 70.51]} format={format} step={0.01} locale="de-DE" />,
+      );
+
+      expect(screen.getByTestId('value')).toHaveTextContent(expectedValue);
+    });
+  });
+
   describe('events', () => {
     it.skipIf(isJSDOM)('should call handlers', async () => {
       const handleValueChange = vi.fn();
@@ -1037,7 +1526,7 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
       fireEvent.touchEnd(document.body, createTouches([{ identifier: 1, clientX: 0, clientY: 0 }]));
     });
 
-    it('should apply data-dragging for dragging modality', async () => {
+    it('adds data-dragging for dragging modality', async () => {
       await render(<TestSlider defaultValue={90} />);
 
       const sliderControl = screen.getByTestId('control');
@@ -1068,436 +1557,6 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
       fireEvent.touchEnd(document.body, createTouches([{ identifier: 1, clientX: 0, clientY: 0 }]));
       expect(sliderControl).not.toHaveAttribute('data-dragging');
     });
-  });
-
-  describe('prop: onValueChange', () => {
-    it.skipIf(isJSDOM)('is called when clicking on the control', async () => {
-      const handleValueChange = vi.fn();
-      await render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
-
-      const sliderControl = screen.getByTestId('control');
-
-      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
-
-      fireEvent.pointerDown(sliderControl, {
-        buttons: 1,
-        clientX: 41,
-      });
-
-      expect(handleValueChange.mock.calls.length).toBe(1);
-    });
-
-    it('is not called when clicking on the thumb', async () => {
-      const handleValueChange = vi.fn();
-      await render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
-
-      const sliderControl = screen.getByTestId('control');
-      const sliderThumb = screen.getByTestId('thumb');
-
-      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
-
-      fireEvent.pointerDown(sliderThumb, {
-        buttons: 1,
-        clientX: 51,
-      });
-
-      expect(handleValueChange.mock.calls.length).toBe(0);
-    });
-
-    it('should not react to right clicks', async () => {
-      const handleValueChange = vi.fn();
-      await render(<TestSlider defaultValue={50} onValueChange={handleValueChange} />);
-
-      const sliderControl = screen.getByTestId('control');
-
-      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
-
-      fireEvent.pointerDown(sliderControl, {
-        button: 2,
-        clientX: 41,
-      });
-
-      expect(handleValueChange.mock.calls.length).toBe(0);
-    });
-
-    it('provides the change reason for input events', async () => {
-      const handleValueChange = vi.fn();
-      await render(<TestSlider defaultValue={30} onValueChange={handleValueChange} />);
-
-      const slider = screen.getByRole('slider');
-      fireEvent.change(slider, { target: { value: '35' } });
-
-      expect(handleValueChange).toHaveBeenCalledTimes(1);
-      const [, details] = handleValueChange.mock.calls[0] as [
-        number,
-        SliderRoot.ChangeEventDetails,
-      ];
-      expect(details.reason).toBe(REASONS.inputChange);
-      expect(details.activeThumbIndex).toBe(0);
-    });
-
-    it('provides the change reason for keyboard interactions', async () => {
-      const handleValueChange = vi.fn();
-      await render(<TestSlider defaultValue={40} onValueChange={handleValueChange} />);
-
-      const slider = screen.getByRole('slider');
-      await act(async () => {
-        slider.focus();
-      });
-      fireEvent.keyDown(slider, { key: ARROW_RIGHT });
-
-      expect(handleValueChange).toHaveBeenCalledTimes(1);
-      const [, details] = handleValueChange.mock.calls[0] as [
-        number,
-        SliderRoot.ChangeEventDetails,
-      ];
-      expect(details.reason).toBe('keyboard');
-    });
-
-    it.skipIf(isJSDOM || isWebKit)(
-      'shows :focus-visible after keyboard interaction following a pointer press',
-      async () => {
-        await render(<TestSlider defaultValue={40} />);
-
-        const sliderControl = screen.getByTestId('control');
-        vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(
-          getHorizontalSliderRect,
-        );
-
-        const slider = screen.getByRole('slider');
-
-        fireEvent.pointerDown(sliderControl, {
-          pointerId: 1,
-          pointerType: 'mouse',
-          button: 0,
-          buttons: 1,
-          clientX: 40,
-          clientY: 0,
-        });
-
-        await waitFor(() => {
-          expect(slider).toHaveFocus();
-        });
-
-        expect(slider.matches(':focus-visible')).toBe(false);
-
-        fireEvent.keyDown(slider, { key: ARROW_RIGHT });
-
-        await waitFor(() => {
-          expect(slider.matches(':focus-visible')).toBe(true);
-        });
-      },
-    );
-
-    it('provides the change reason for track presses', async () => {
-      const handleValueChange = vi.fn();
-      await render(<TestSlider defaultValue={0} onValueChange={handleValueChange} />);
-
-      const sliderControl = screen.getByTestId('control');
-      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
-
-      fireEvent.pointerDown(sliderControl, {
-        pointerId: 1,
-        pointerType: 'mouse',
-        button: 0,
-        buttons: 1,
-        clientX: 80,
-        clientY: 0,
-      });
-
-      await waitFor(() => {
-        expect(handleValueChange.mock.calls.length).toBe(1);
-      });
-      const [, details] = handleValueChange.mock.calls[0] as [
-        number | number[],
-        SliderRoot.ChangeEventDetails,
-      ];
-      expect(details.reason).toBe(REASONS.trackPress);
-    });
-
-    it.skipIf(isJSDOM)('drags the intended thumb when 3 thumbs are present', async () => {
-      const handleValueChange = vi.fn();
-
-      await render(
-        <TestMultiThumbSlider
-          defaultValue={[10, 40, 60]}
-          min={0}
-          max={100}
-          onValueChange={handleValueChange}
-        />,
-      );
-
-      const sliderControl = screen.getByTestId('control');
-      const thirdThumb = screen.getAllByTestId('thumb')[2];
-
-      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
-      vi.spyOn(thirdThumb, 'getBoundingClientRect').mockImplementation(() => ({
-        width: 0,
-        height: 0,
-        bottom: 0,
-        left: 60,
-        right: 60,
-        top: 0,
-        x: 60,
-        y: 0,
-        toJSON() {},
-      }));
-
-      fireEvent.pointerDown(thirdThumb, {
-        pointerId: 1,
-        buttons: 1,
-        clientX: 60,
-      });
-
-      fireEvent.pointerMove(document, {
-        pointerId: 1,
-        buttons: 1,
-        clientX: 80,
-      });
-
-      expect(handleValueChange.mock.calls.length).toBeGreaterThan(0);
-
-      const [newValue] = handleValueChange.mock.lastCall ?? [];
-      expect(handleValueChange.mock.lastCall?.[1].activeThumbIndex).toBe(2);
-      expect(newValue[0]).toBe(10);
-      expect(newValue[1]).toBe(40);
-      expect(newValue[2]).not.toBe(60);
-    });
-
-    it.skipIf(isJSDOM)('should fire only when the value changes', async () => {
-      const handleValueChange = vi.fn();
-      await render(<TestSlider defaultValue={20} onValueChange={handleValueChange} />);
-
-      const sliderControl = screen.getByTestId('control');
-
-      vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
-
-      fireEvent.pointerDown(sliderControl, {
-        buttons: 1,
-        clientX: 21,
-      });
-
-      fireEvent.pointerMove(document.body, {
-        buttons: 1,
-        clientX: 22,
-      });
-      // Sometimes another event with the same position is fired by the browser.
-      fireEvent.pointerMove(document.body, {
-        buttons: 1,
-        clientX: 22,
-      });
-
-      expect(handleValueChange.mock.calls.length).toBe(2);
-      expect(handleValueChange.mock.calls[0][0]).toEqual(21);
-      expect(handleValueChange.mock.calls[1][0]).toEqual(22);
-    });
-
-    type Values = Array<[string, number[]]>;
-
-    const values = [
-      ['readonly range', Object.freeze([2, 1])],
-      ['range', [2, 1]],
-    ] as Values;
-    values.forEach(([valueLabel, value]) => {
-      it.skipIf(isJSDOM)(`is called even if the ${valueLabel} did not change`, async () => {
-        const handleValueChange = vi.fn();
-
-        await render(
-          <TestRangeSlider
-            min={0}
-            max={5}
-            onValueChange={handleValueChange}
-            value={value}
-            style={{ width: '100px' }}
-          />,
-        );
-
-        const sliderControl = screen.getByTestId('control');
-
-        vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(
-          getHorizontalSliderRect,
-        );
-
-        // pixel:  0   20  40  60  80  100
-        // slider: |---|---|---|---|---|
-        // values: 0   1   2   3   4   5
-        // value:      ��   ��
-        // mouse:           ��
-
-        fireEvent.pointerDown(sliderControl, {
-          buttons: 1,
-          clientX: 41,
-        });
-
-        expect(handleValueChange.mock.calls.length).toBe(1);
-        expect(handleValueChange.mock.calls[0][0]).not.toBe(value);
-        expect(handleValueChange.mock.calls[0][0]).toEqual(value.slice().sort((a, b) => a - b));
-      });
-    });
-
-    it('should pass "name" and "value" as part of the event.target for onValueChange', async () => {
-      const handleValueChange = vi
-        .fn()
-        .mockImplementation((newValue, data) => (data as any).event.target);
-
-      await render(
-        <TestSlider onValueChange={handleValueChange} name="change-testing" value={3} />,
-      );
-
-      const slider = screen.getByRole('slider');
-
-      await act(async () => {
-        slider.focus();
-      });
-      fireEvent.change(slider, {
-        target: {
-          value: 4,
-        },
-      });
-
-      expect(handleValueChange.mock.calls.length).toBe(1);
-      const target = handleValueChange.mock.results[0]?.value;
-      expect(target).toEqual({
-        name: 'change-testing',
-        value: 4,
-      });
-    });
-
-    it.skipIf(!isJSDOM)(
-      'should not rely on the global event when cloning change events',
-      async () => {
-        const hadGlobalEvent = Object.prototype.hasOwnProperty.call(globalThis, 'event');
-        const previousDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'event');
-        const globalEventConstructor = class {
-          constructor() {
-            throw new Error('Should not construct global event');
-          }
-        };
-        const fakeGlobalEvent = {
-          type: 'click',
-          constructor: globalEventConstructor,
-        };
-
-        Object.defineProperty(globalThis, 'event', {
-          configurable: true,
-          get() {
-            return fakeGlobalEvent;
-          },
-          set() {
-            // Ignore assignments from the event system to ensure we never use it.
-          },
-        });
-
-        try {
-          const handleValueChange = vi.fn();
-
-          await render(
-            <TestSlider onValueChange={handleValueChange} name="change-testing" value={3} />,
-          );
-
-          const slider = screen.getByRole('slider');
-
-          await act(async () => {
-            slider.focus();
-          });
-
-          expectVitest(() => {
-            fireEvent.change(slider, {
-              target: {
-                value: 4,
-              },
-            });
-          }).not.toThrow();
-
-          expectVitest(handleValueChange).toHaveBeenCalledTimes(1);
-        } finally {
-          if (hadGlobalEvent && previousDescriptor) {
-            Object.defineProperty(globalThis, 'event', previousDescriptor);
-          } else {
-            delete (globalThis as any).event;
-          }
-        }
-      },
-    );
-
-    it.skipIf(isJSDOM)('should handle keyboard changes inside a shadow root', async () => {
-      const host = document.createElement('div');
-      document.body.appendChild(host);
-      const shadowRoot = host.attachShadow({ mode: 'open' });
-      const container = document.createElement('div');
-      shadowRoot.appendChild(container);
-
-      try {
-        const handleValueChange = vi.fn();
-
-        await render(<TestSlider onValueChange={handleValueChange} name="shadow" value={3} />, {
-          container,
-        });
-
-        const slider = shadowRoot.querySelector('input[type="range"]');
-        expectVitest(slider).toBeTruthy();
-
-        if (!slider) {
-          return;
-        }
-
-        await act(async () => {
-          (slider as HTMLInputElement).focus();
-        });
-
-        await act(async () => {
-          slider.dispatchEvent(new KeyboardEvent('keydown', { key: ARROW_RIGHT, bubbles: true }));
-        });
-
-        expectVitest(handleValueChange).toHaveBeenCalledTimes(1);
-      } finally {
-        await act(async () => {
-          host.remove();
-        });
-      }
-    });
-
-    it.skipIf(isJSDOM)(
-      'onValueCommitted is called with the same value as the latest onValueChange when pointerUp occurs at a different location than onValueChange',
-      async () => {
-        const handleValueChange = vi.fn();
-        const handleValueCommitted = vi.fn();
-
-        await render(
-          <TestSlider
-            onValueChange={handleValueChange}
-            onValueCommitted={handleValueCommitted}
-            defaultValue={0}
-          />,
-        );
-
-        const sliderControl = screen.getByTestId('control');
-
-        vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(
-          getHorizontalSliderRect,
-        );
-
-        fireEvent.pointerDown(sliderControl, {
-          buttons: 1,
-          clientX: 10,
-        });
-        fireEvent.pointerMove(sliderControl, {
-          buttons: 1,
-          clientX: 15,
-        });
-        fireEvent.pointerUp(sliderControl, {
-          buttons: 1,
-          clientX: 20,
-        });
-
-        expect(handleValueChange.mock.calls.length).toBe(2);
-        expect(handleValueChange.mock.calls[0][0]).toBe(10);
-        expect(handleValueChange.mock.calls[1][0]).toBe(15);
-        expect(handleValueCommitted.mock.calls.length).toBe(1);
-        expect(handleValueCommitted.mock.calls[0][0]).toBe(15);
-        expect(handleValueCommitted.mock.calls[0][1].reason).toBe('drag');
-      },
-    );
   });
 
   describe('keyboard interactions', () => {
@@ -2099,66 +2158,7 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     });
   });
 
-  describe('prop: format', () => {
-    it('formats the value', async () => {
-      function formatValue(v: number) {
-        return new Intl.NumberFormat(undefined, USD_NUMBER_FORMAT).format(v);
-      }
-
-      await render(<TestSlider defaultValue={50} format={USD_NUMBER_FORMAT} />);
-
-      const value = screen.getByTestId('value');
-      const slider = screen.getByRole('slider');
-      expect(value).toHaveTextContent(formatValue(50));
-      expect(slider).toHaveAttribute('aria-valuetext', formatValue(50));
-    });
-
-    it('formats range values', async () => {
-      function formatValue(v: number) {
-        return new Intl.NumberFormat(undefined, USD_NUMBER_FORMAT).format(v);
-      }
-
-      await render(<TestRangeSlider defaultValue={[50, 75]} format={USD_NUMBER_FORMAT} />);
-
-      const value = screen.getByTestId('value');
-      expect(value).toHaveTextContent(`${formatValue(50)} – ${formatValue(75)}`);
-      const [slider1, slider2] = screen.getAllByRole('slider');
-      expect(slider1).toHaveAttribute('aria-valuetext', `${formatValue(50)} start range`);
-      expect(slider2).toHaveAttribute('aria-valuetext', `${formatValue(75)} end range`);
-    });
-  });
-
-  describe('prop: locale', () => {
-    it('sets the locale when formatting a single value', async () => {
-      const format: Intl.NumberFormatOptions = {
-        style: 'decimal',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      };
-      const expectedValue = new Intl.NumberFormat('de-DE', format).format(70.51);
-
-      await render(<TestSlider value={70.51} format={format} step={0.01} locale="de-DE" />);
-
-      expect(screen.getByTestId('value')).toHaveTextContent(expectedValue);
-    });
-
-    it('sets the locale when formatting a range value', async () => {
-      const format: Intl.NumberFormatOptions = {
-        style: 'decimal',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      };
-      const expectedValue = `${new Intl.NumberFormat('de-DE', format).format(24.8)} – ${new Intl.NumberFormat('de-DE', format).format(70.51)}`;
-
-      await render(
-        <TestRangeSlider value={[24.8, 70.51]} format={format} step={0.01} locale="de-DE" />,
-      );
-
-      expect(screen.getByTestId('value')).toHaveTextContent(expectedValue);
-    });
-  });
-
-  describe('Form', () => {
+  describe('Form integration', () => {
     it('clears external errors on change', async () => {
       const { user } = await render(
         <Form
@@ -2267,8 +2267,8 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     });
   });
 
-  describe('Field', () => {
-    it('should receive disabled prop from Field.Root', async () => {
+  describe('Field integration', () => {
+    it('receives the disabled prop from Field.Root', async () => {
       await render(
         <Field.Root disabled>
           <Slider.Root data-testid="root">
@@ -2283,7 +2283,7 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
       expect(root).toHaveAttribute('data-disabled', '');
     });
 
-    it('should receive name prop from Field.Root', async () => {
+    it('receives the name prop from Field.Root', async () => {
       await render(
         <Field.Root name="field-slider">
           <Slider.Root>
@@ -2297,7 +2297,7 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
       expect(screen.getByRole('slider')).toHaveAttribute('name', 'field-slider');
     });
 
-    it('[data-touched]', async () => {
+    it('adds data-touched after blur', async () => {
       await render(
         <Field.Root>
           <Slider.Root data-testid="root">
@@ -2317,7 +2317,7 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
       expect(root).toHaveAttribute('data-touched', '');
     });
 
-    it('[data-dirty]', async () => {
+    it('adds data-dirty after the value changes', async () => {
       await render(
         <Field.Root>
           <Slider.Root data-testid="root">
@@ -2338,7 +2338,7 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
       expect(root).toHaveAttribute('data-dirty', '');
     });
 
-    it('[data-focused]', async () => {
+    it('adds data-focused while focused', async () => {
       await render(
         <Field.Root>
           <Slider.Root data-testid="root">
@@ -2364,7 +2364,7 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
     });
 
     describe('prop: validate', () => {
-      it('validationMode=onSubmit', async () => {
+      it('validates when validationMode is onSubmit', async () => {
         await render(
           <Form>
             <Field.Root validate={(val) => ((val as number) > 90 ? 'error' : null)}>
@@ -2412,7 +2412,7 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
         expect(screen.queryByTestId('error')).toBe(null);
       });
 
-      it('validationMode=onBlur', async () => {
+      it('validates when validationMode is onBlur', async () => {
         await render(
           <Field.Root
             validationMode="onBlur"
@@ -2437,7 +2437,7 @@ describe.skipIf(typeof Touch === 'undefined')('<Slider.Root />', () => {
         expect(input).toHaveAttribute('aria-invalid', 'true');
       });
 
-      it('validationMode=onChange', async () => {
+      it('validates when validationMode is onChange', async () => {
         await render(
           <Field.Root
             validationMode="onChange"

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -337,48 +337,6 @@ describe('<Slider.Thumb />', () => {
     });
   });
 
-  describe('stacking order', () => {
-    it('relies on DOM order before any thumb is used', async () => {
-      await render(
-        <Slider.Root defaultValue={[20, 20]}>
-          <Slider.Control>
-            <Slider.Thumb data-testid="thumb-0" />
-            <Slider.Thumb data-testid="thumb-1" />
-          </Slider.Control>
-        </Slider.Root>,
-      );
-
-      expect(screen.getByTestId('thumb-0').style.zIndex).toBe('');
-      expect(screen.getByTestId('thumb-1').style.zIndex).toBe('');
-    });
-
-    it('keeps the most recently active thumb on top after focus moves away', async () => {
-      const { user } = await render(
-        <Slider.Root defaultValue={[20, 20]}>
-          <Slider.Control>
-            <Slider.Thumb data-testid="thumb-0" />
-            <Slider.Thumb data-testid="thumb-1" />
-          </Slider.Control>
-        </Slider.Root>,
-      );
-
-      const [thumb0, thumb1] = [screen.getByTestId('thumb-0'), screen.getByTestId('thumb-1')];
-
-      await user.keyboard('[Tab]');
-      expect(screen.getAllByRole('slider')[0]).toHaveFocus();
-      expect(thumb0.style.zIndex).toBe('2');
-
-      await user.keyboard('[Tab]');
-      expect(screen.getAllByRole('slider')[1]).toHaveFocus();
-      expect(thumb1.style.zIndex).toBe('2');
-
-      await user.keyboard('[Tab]');
-      expect(document.body).toHaveFocus();
-      expect(thumb1.style.zIndex).toBe('1');
-      expect(thumb0.style.zIndex).toBe('');
-    });
-  });
-
   describe('prop: thumbAlignment', () => {
     it.skipIf(isJSDOM)('recomputes inset positions when the slider becomes visible', async () => {
       function App() {
@@ -496,6 +454,48 @@ describe('<Slider.Thumb />', () => {
         });
       },
     );
+  });
+
+  describe('stacking order', () => {
+    it('relies on DOM order before any thumb is used', async () => {
+      await render(
+        <Slider.Root defaultValue={[20, 20]}>
+          <Slider.Control>
+            <Slider.Thumb data-testid="thumb-0" />
+            <Slider.Thumb data-testid="thumb-1" />
+          </Slider.Control>
+        </Slider.Root>,
+      );
+
+      expect(screen.getByTestId('thumb-0').style.zIndex).toBe('');
+      expect(screen.getByTestId('thumb-1').style.zIndex).toBe('');
+    });
+
+    it('keeps the most recently active thumb on top after focus moves away', async () => {
+      const { user } = await render(
+        <Slider.Root defaultValue={[20, 20]}>
+          <Slider.Control>
+            <Slider.Thumb data-testid="thumb-0" />
+            <Slider.Thumb data-testid="thumb-1" />
+          </Slider.Control>
+        </Slider.Root>,
+      );
+
+      const [thumb0, thumb1] = [screen.getByTestId('thumb-0'), screen.getByTestId('thumb-1')];
+
+      await user.keyboard('[Tab]');
+      expect(screen.getAllByRole('slider')[0]).toHaveFocus();
+      expect(thumb0.style.zIndex).toBe('2');
+
+      await user.keyboard('[Tab]');
+      expect(screen.getAllByRole('slider')[1]).toHaveFocus();
+      expect(thumb1.style.zIndex).toBe('2');
+
+      await user.keyboard('[Tab]');
+      expect(document.body).toHaveFocus();
+      expect(thumb1.style.zIndex).toBe('1');
+      expect(thumb0.style.zIndex).toBe('');
+    });
   });
 
   /**

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -191,7 +191,7 @@ describe('<Switch.Root />', () => {
       expect(screen.getByRole('switch')).toHaveAttribute('aria-disabled', 'true');
     });
 
-    it('should not have the `disabled` attribute when `disabled` is not set', async () => {
+    it('does not set disabled when disabled is not set', async () => {
       await render(<Switch.Root />);
       expect(screen.getByRole('switch')).not.toHaveAttribute('disabled');
     });
@@ -216,7 +216,7 @@ describe('<Switch.Root />', () => {
       expect(screen.getByRole('switch')).toHaveAttribute('aria-readonly', 'true');
     });
 
-    it('should not have the aria attribute when `readOnly` is not set', async () => {
+    it('does not set aria-readonly when readOnly is not set', async () => {
       await render(<Switch.Root />);
       expect(screen.getByRole('switch')).not.toHaveAttribute('aria-readonly');
     });
@@ -260,7 +260,7 @@ describe('<Switch.Root />', () => {
       expect(screen.getByRole('switch')).toHaveAttribute('aria-required', 'true');
     });
 
-    it('should not have the aria attribute when `required` is not set', async () => {
+    it('does not set aria-required when required is not set', async () => {
       await render(<Switch.Root />);
       expect(screen.getByRole('switch')).not.toHaveAttribute('aria-required');
     });
@@ -276,7 +276,7 @@ describe('<Switch.Root />', () => {
     });
   });
 
-  it('should place the style hooks on the root and the thumb', async () => {
+  it('adds state attributes to the root and thumb', async () => {
     const { setProps } = await render(
       <Switch.Root defaultChecked disabled readOnly required>
         <Switch.Thumb data-testid="thumb" />
@@ -391,7 +391,7 @@ describe('<Switch.Root />', () => {
     });
   });
 
-  describe('Form', () => {
+  describe('Form integration', () => {
     // FormData is not available in JSDOM
     it.skipIf(isJSDOM)(
       'should include the switch value in form submission, matching native checkbox behavior',
@@ -650,8 +650,8 @@ describe('<Switch.Root />', () => {
     });
   });
 
-  describe('Field', () => {
-    it('should receive disabled prop from Field.Root', async () => {
+  describe('Field integration', () => {
+    it('receives the disabled prop from Field.Root', async () => {
       await render(
         <Field.Root disabled>
           <Switch.Root />
@@ -662,7 +662,7 @@ describe('<Switch.Root />', () => {
       expect(switchElement).toHaveAttribute('data-disabled');
     });
 
-    it('should receive name prop from Field.Root', async () => {
+    it('receives the name prop from Field.Root', async () => {
       await render(
         <Field.Root name="field-switch">
           <Switch.Root />
@@ -673,7 +673,7 @@ describe('<Switch.Root />', () => {
       expect(input).toHaveAttribute('name', 'field-switch');
     });
 
-    it('[data-touched]', async () => {
+    it('adds data-touched after blur', async () => {
       await render(
         <Field.Root>
           <Switch.Root data-testid="button" />
@@ -688,7 +688,7 @@ describe('<Switch.Root />', () => {
       expect(button).toHaveAttribute('data-touched', '');
     });
 
-    it('[data-dirty]', async () => {
+    it('adds data-dirty after the value changes', async () => {
       await render(
         <Field.Root>
           <Switch.Root data-testid="button" />
@@ -704,8 +704,8 @@ describe('<Switch.Root />', () => {
       expect(button).toHaveAttribute('data-dirty', '');
     });
 
-    describe('[data-filled]', () => {
-      it('adds [data-filled] attribute when checked after being initially unchecked', async () => {
+    describe('field state attribute: data-filled', () => {
+      it('adds data-filled when checked after being initially unchecked', async () => {
         await render(
           <Field.Root>
             <Switch.Root data-testid="button" />
@@ -725,7 +725,7 @@ describe('<Switch.Root />', () => {
         expect(button).not.toHaveAttribute('data-filled');
       });
 
-      it('removes [data-filled] attribute when unchecked after being initially checked', async () => {
+      it('removes data-filled when unchecked after being initially checked', async () => {
         await render(
           <Field.Root>
             <Switch.Root data-testid="button" defaultChecked />
@@ -742,7 +742,7 @@ describe('<Switch.Root />', () => {
       });
     });
 
-    it('[data-focused]', async () => {
+    it('adds data-focused while focused', async () => {
       await render(
         <Field.Root>
           <Switch.Root data-testid="button" />
@@ -762,113 +762,115 @@ describe('<Switch.Root />', () => {
       expect(button).not.toHaveAttribute('data-focused');
     });
 
-    it('prop: validationMode=onSubmit', async () => {
-      await render(
-        <Form>
-          <Field.Root>
-            <Switch.Root required />
-            <Field.Error data-testid="error" />
-          </Field.Root>
-          <button type="submit">submit</button>
-        </Form>,
-      );
-
-      const button = screen.getByRole('switch');
-      expect(button).not.toHaveAttribute('aria-invalid');
-
-      fireEvent.click(screen.getByText('submit'));
-      expect(button).toHaveAttribute('aria-invalid', 'true');
-      expect(screen.queryByTestId('error')).not.toBe(null);
-
-      fireEvent.click(button);
-      expect(button).not.toHaveAttribute('aria-invalid');
-      expect(screen.queryByTestId('error')).toBe(null);
-
-      fireEvent.click(button);
-      expect(button).toHaveAttribute('aria-invalid', 'true');
-      expect(screen.queryByTestId('error')).not.toBe(null);
-    });
-
-    it('prop: validationMode=onChange', async () => {
-      await render(
-        <Field.Root
-          validationMode="onChange"
-          validate={(value) => {
-            const checked = value as boolean;
-            return checked ? 'error' : null;
-          }}
-        >
-          <Switch.Root data-testid="button" />
-        </Field.Root>,
-      );
-
-      const button = screen.getByTestId('button');
-
-      expect(button).not.toHaveAttribute('aria-invalid');
-
-      fireEvent.click(button);
-
-      expect(button).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    it('revalidates when a controlled value changes externally', async () => {
-      const validateSpy = vi.fn((value: unknown) => ((value as boolean) ? 'error' : null));
-
-      function App() {
-        const [checked, setChecked] = React.useState(false);
-
-        return (
-          <React.Fragment>
-            <Field.Root validationMode="onChange" validate={validateSpy} name="newsletters">
-              <Switch.Root data-testid="button" checked={checked} onCheckedChange={setChecked} />
+    describe('prop: validationMode', () => {
+      it('validates when validationMode is onSubmit', async () => {
+        await render(
+          <Form>
+            <Field.Root>
+              <Switch.Root required />
+              <Field.Error data-testid="error" />
             </Field.Root>
-            <button type="button" onClick={() => setChecked((prev) => !prev)}>
-              Toggle externally
-            </button>
-          </React.Fragment>
+            <button type="submit">submit</button>
+          </Form>,
         );
-      }
 
-      await render(<App />);
+        const button = screen.getByRole('switch');
+        expect(button).not.toHaveAttribute('aria-invalid');
 
-      const button = screen.getByTestId('button');
-      const toggle = screen.getByText('Toggle externally');
+        fireEvent.click(screen.getByText('submit'));
+        expect(button).toHaveAttribute('aria-invalid', 'true');
+        expect(screen.queryByTestId('error')).not.toBe(null);
 
-      expect(button).not.toHaveAttribute('aria-invalid');
-      const initialCallCount = validateSpy.mock.calls.length;
+        fireEvent.click(button);
+        expect(button).not.toHaveAttribute('aria-invalid');
+        expect(screen.queryByTestId('error')).toBe(null);
 
-      fireEvent.click(toggle);
+        fireEvent.click(button);
+        expect(button).toHaveAttribute('aria-invalid', 'true');
+        expect(screen.queryByTestId('error')).not.toBe(null);
+      });
 
-      expect(validateSpy.mock.calls.length).toBe(initialCallCount + 1);
-      expect(validateSpy.mock.lastCall?.[0]).toBe(true);
-      expect(button).toHaveAttribute('aria-invalid', 'true');
+      it('validates when validationMode is onChange', async () => {
+        await render(
+          <Field.Root
+            validationMode="onChange"
+            validate={(value) => {
+              const checked = value as boolean;
+              return checked ? 'error' : null;
+            }}
+          >
+            <Switch.Root data-testid="button" />
+          </Field.Root>,
+        );
+
+        const button = screen.getByTestId('button');
+
+        expect(button).not.toHaveAttribute('aria-invalid');
+
+        fireEvent.click(button);
+
+        expect(button).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      it('revalidates when a controlled value changes externally', async () => {
+        const validateSpy = vi.fn((value: unknown) => ((value as boolean) ? 'error' : null));
+
+        function App() {
+          const [checked, setChecked] = React.useState(false);
+
+          return (
+            <React.Fragment>
+              <Field.Root validationMode="onChange" validate={validateSpy} name="newsletters">
+                <Switch.Root data-testid="button" checked={checked} onCheckedChange={setChecked} />
+              </Field.Root>
+              <button type="button" onClick={() => setChecked((prev) => !prev)}>
+                Toggle externally
+              </button>
+            </React.Fragment>
+          );
+        }
+
+        await render(<App />);
+
+        const button = screen.getByTestId('button');
+        const toggle = screen.getByText('Toggle externally');
+
+        expect(button).not.toHaveAttribute('aria-invalid');
+        const initialCallCount = validateSpy.mock.calls.length;
+
+        fireEvent.click(toggle);
+
+        expect(validateSpy.mock.calls.length).toBe(initialCallCount + 1);
+        expect(validateSpy.mock.lastCall?.[0]).toBe(true);
+        expect(button).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      it('validates when validationMode is onBlur', async () => {
+        await render(
+          <Field.Root
+            validationMode="onBlur"
+            validate={(value) => {
+              const checked = value as boolean;
+              return checked ? 'error' : null;
+            }}
+          >
+            <Switch.Root data-testid="button" />
+            <Field.Error data-testid="error" />
+          </Field.Root>,
+        );
+
+        const button = screen.getByTestId('button');
+
+        expect(button).not.toHaveAttribute('aria-invalid');
+
+        fireEvent.click(button);
+        fireEvent.blur(button);
+
+        expect(button).toHaveAttribute('aria-invalid', 'true');
+      });
     });
 
-    it('prop: validationMode=onBlur', async () => {
-      await render(
-        <Field.Root
-          validationMode="onBlur"
-          validate={(value) => {
-            const checked = value as boolean;
-            return checked ? 'error' : null;
-          }}
-        >
-          <Switch.Root data-testid="button" />
-          <Field.Error data-testid="error" />
-        </Field.Root>,
-      );
-
-      const button = screen.getByTestId('button');
-
-      expect(button).not.toHaveAttribute('aria-invalid');
-
-      fireEvent.click(button);
-      fireEvent.blur(button);
-
-      expect(button).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    describe('Field.Label', () => {
+    describe('Field.Label integration', () => {
       describe('implicit', () => {
         it('sets `for` on the label', async () => {
           await render(
@@ -883,7 +885,7 @@ describe('<Switch.Root />', () => {
           const label = screen.getByTestId('label');
           expect(label.getAttribute('for')).not.toBe(null);
 
-          const input = document.querySelector('input[type="checkbox"]');
+          const input = screen.getByRole('checkbox', { hidden: true });
           expect(label.getAttribute('for')).toBe(input?.getAttribute('id'));
 
           const switchEl = screen.getByRole('switch');
@@ -906,7 +908,7 @@ describe('<Switch.Root />', () => {
 
           const label = screen.getByTestId('label');
           const switchEl = screen.getByRole('switch');
-          const input = document.querySelector('input[type="checkbox"]');
+          const input = screen.getByRole('checkbox', { hidden: true });
 
           expect(label.getAttribute('for')).not.toBe(null);
 
@@ -929,7 +931,7 @@ describe('<Switch.Root />', () => {
 
           const label = screen.getByTestId('label');
           expect(label.getAttribute('for')).not.toBe(null);
-          const input = document.querySelector('input[type="checkbox"]');
+          const input = screen.getByRole('checkbox', { hidden: true });
           expect(input?.getAttribute('id')).toBe(label.getAttribute('for'));
           const switchEl = screen.getByRole('switch');
           expect(switchEl.getAttribute('aria-labelledby')).toBe(label.getAttribute('id'));

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -213,200 +213,6 @@ describe('<Tabs.Root />', () => {
     });
   });
 
-  describe('disabled tabs', () => {
-    it('should select the second tab when the first one is disabled', async () => {
-      await render(
-        <Tabs.Root>
-          <Tabs.List>
-            <Tabs.Tab value={0} disabled>
-              Disabled tab
-            </Tabs.Tab>
-            <Tabs.Tab value={1}>Enabled tab</Tabs.Tab>
-          </Tabs.List>
-          <Tabs.Panel value={0} keepMounted>
-            Disabled panel
-          </Tabs.Panel>
-          <Tabs.Panel value={1} keepMounted>
-            Enabled panel
-          </Tabs.Panel>
-        </Tabs.Root>,
-      );
-
-      const [disabledTab, enabledTab] = screen.getAllByRole('tab');
-      const [disabledPanel, enabledPanel] = screen.getAllByRole('tabpanel', { hidden: true });
-
-      expect(disabledTab).toHaveAttribute('aria-selected', 'false');
-      expect(enabledTab).toHaveAttribute('aria-selected', 'true');
-      expect(disabledPanel).toHaveAttribute('hidden');
-      expect(enabledPanel).not.toHaveAttribute('hidden');
-      expect(enabledPanel).toHaveTextContent('Enabled panel');
-    });
-
-    it('should select the third tab when first two tabs are disabled', async () => {
-      await render(
-        <Tabs.Root>
-          <Tabs.List>
-            <Tabs.Tab value={0} disabled data-testid="tab-0">
-              Tab 0
-            </Tabs.Tab>
-            <Tabs.Tab value={1} disabled data-testid="tab-1">
-              Tab 1
-            </Tabs.Tab>
-            <Tabs.Tab value={2} data-testid="tab-2">
-              Tab 2
-            </Tabs.Tab>
-            <Tabs.Tab value={3} data-testid="tab-3">
-              Tab 3
-            </Tabs.Tab>
-          </Tabs.List>
-          <Tabs.Panel value={0}>Panel 0</Tabs.Panel>
-          <Tabs.Panel value={1}>Panel 1</Tabs.Panel>
-          <Tabs.Panel value={2}>Panel 2</Tabs.Panel>
-          <Tabs.Panel value={3}>Panel 3</Tabs.Panel>
-        </Tabs.Root>,
-      );
-
-      const tabs = screen.getAllByRole('tab');
-
-      // The first non-disabled tab (tab 2) should be selected
-      expect(tabs[2]).toHaveAttribute('aria-selected', 'true');
-      expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
-      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
-      expect(tabs[3]).toHaveAttribute('aria-selected', 'false');
-    });
-
-    it('should still honor explicit defaultValue even if it points to a disabled tab', async () => {
-      await render(
-        <Tabs.Root defaultValue={0}>
-          <Tabs.List>
-            <Tabs.Tab value={0} disabled data-testid="tab-0">
-              Tab 0
-            </Tabs.Tab>
-            <Tabs.Tab value={1} data-testid="tab-1">
-              Tab 1
-            </Tabs.Tab>
-            <Tabs.Tab value={2} data-testid="tab-2">
-              Tab 2
-            </Tabs.Tab>
-          </Tabs.List>
-          <Tabs.Panel value={0}>Panel 0</Tabs.Panel>
-          <Tabs.Panel value={1}>Panel 1</Tabs.Panel>
-          <Tabs.Panel value={2}>Panel 2</Tabs.Panel>
-        </Tabs.Root>,
-      );
-
-      const tabs = screen.getAllByRole('tab');
-
-      // The explicitly set disabled tab should be selected
-      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
-      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
-      expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
-    });
-
-    it('should still honor explicit value prop even if it points to a disabled tab', async () => {
-      await render(
-        <Tabs.Root value={0}>
-          <Tabs.List>
-            <Tabs.Tab value={0} disabled data-testid="tab-0">
-              Tab 0
-            </Tabs.Tab>
-            <Tabs.Tab value={1} data-testid="tab-1">
-              Tab 1
-            </Tabs.Tab>
-            <Tabs.Tab value={2} data-testid="tab-2">
-              Tab 2
-            </Tabs.Tab>
-          </Tabs.List>
-          <Tabs.Panel value={0}>Panel 0</Tabs.Panel>
-          <Tabs.Panel value={1}>Panel 1</Tabs.Panel>
-          <Tabs.Panel value={2}>Panel 2</Tabs.Panel>
-        </Tabs.Root>,
-      );
-
-      const tabs = screen.getAllByRole('tab');
-
-      // The explicitly set disabled tab should be selected
-      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
-      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
-      expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
-    });
-
-    it('does not set tabIndex=0 on disabled tabs when they are programmatically selected', async () => {
-      const { setProps } = await render(
-        <Tabs.Root value={1}>
-          <Tabs.List>
-            <Tabs.Tab value={0} disabled>
-              Tab 0
-            </Tabs.Tab>
-            <Tabs.Tab value={1}>Tab 1</Tabs.Tab>
-            <Tabs.Tab value={2}>Tab 2</Tabs.Tab>
-          </Tabs.List>
-          <Tabs.Panel value={0}>Panel 0</Tabs.Panel>
-          <Tabs.Panel value={1}>Panel 1</Tabs.Panel>
-          <Tabs.Panel value={2}>Panel 2</Tabs.Panel>
-        </Tabs.Root>,
-      );
-
-      const tabs = screen.getAllByRole('tab');
-
-      // Initially, tab 1 is selected and should be highlighted (tabIndex=0)
-      expect(tabs[1]).toHaveAttribute('tabindex', '0');
-      expect(tabs[0]).toHaveAttribute('tabindex', '-1');
-      expect(tabs[2]).toHaveAttribute('tabindex', '-1');
-
-      // Programmatically select the disabled tab 0
-      await setProps({ value: 0 });
-      await flushMicrotasks();
-
-      // The disabled tab should be selected but NOT highlighted (tabIndex should remain -1)
-      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
-      expect(tabs[0]).toHaveAttribute('tabindex', '-1');
-
-      // The previously highlighted tab should retain the highlight
-      expect(tabs[1]).toHaveAttribute('tabindex', '0');
-    });
-
-    it('does not select any tab when all tabs are disabled', async () => {
-      await render(
-        <Tabs.Root>
-          <Tabs.List>
-            <Tabs.Tab value={0} disabled>
-              Tab 0
-            </Tabs.Tab>
-            <Tabs.Tab value={1} disabled>
-              Tab 1
-            </Tabs.Tab>
-            <Tabs.Tab value={2} disabled>
-              Tab 2
-            </Tabs.Tab>
-          </Tabs.List>
-          <Tabs.Panel value={0} keepMounted>
-            Panel 0
-          </Tabs.Panel>
-          <Tabs.Panel value={1} keepMounted>
-            Panel 1
-          </Tabs.Panel>
-          <Tabs.Panel value={2} keepMounted>
-            Panel 2
-          </Tabs.Panel>
-        </Tabs.Root>,
-      );
-
-      const tabs = screen.getAllByRole('tab');
-      const panels = screen.getAllByRole('tabpanel', { hidden: true });
-
-      // No tab should be selected
-      expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
-      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
-      expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
-
-      // All panels should be hidden
-      expect(panels[0]).toHaveAttribute('hidden');
-      expect(panels[1]).toHaveAttribute('hidden');
-      expect(panels[2]).toHaveAttribute('hidden');
-    });
-  });
-
   describe('prop: onValueChange', () => {
     it('when `activateOnFocus = true` should call onValueChange on pointerdown', async () => {
       const handleChange = vi.fn();
@@ -982,26 +788,224 @@ describe('<Tabs.Root />', () => {
   describe('prop: orientation', () => {
     it('does not add aria-orientation by default', async () => {
       await render(
-        <Tabs.Root value={0}>
+        <Tabs.Root value={0} data-testid="root">
           <Tabs.List>
-            <Tabs.Root />
+            <Tabs.Tab value={0} />
           </Tabs.List>
         </Tabs.Root>,
       );
 
       expect(screen.getByRole('tablist')).not.toHaveAttribute('aria-orientation');
+      expect(screen.getByTestId('root')).toHaveAttribute('data-orientation', 'horizontal');
+      expect(screen.getByRole('tablist')).toHaveAttribute('data-orientation', 'horizontal');
     });
 
     it('adds the proper aria-orientation when vertical', async () => {
       await render(
-        <Tabs.Root value={0} orientation="vertical">
+        <Tabs.Root value={0} orientation="vertical" data-testid="root">
           <Tabs.List>
-            <Tabs.Root />
+            <Tabs.Tab value={0} />
           </Tabs.List>
         </Tabs.Root>,
       );
 
       expect(screen.getByRole('tablist')).toHaveAttribute('aria-orientation', 'vertical');
+      expect(screen.getByTestId('root')).toHaveAttribute('data-orientation', 'vertical');
+      expect(screen.getByRole('tablist')).toHaveAttribute('data-orientation', 'vertical');
+    });
+  });
+
+  describe('disabled tabs', () => {
+    it('should select the second tab when the first one is disabled', async () => {
+      await render(
+        <Tabs.Root>
+          <Tabs.List>
+            <Tabs.Tab value={0} disabled>
+              Disabled tab
+            </Tabs.Tab>
+            <Tabs.Tab value={1}>Enabled tab</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value={0} keepMounted>
+            Disabled panel
+          </Tabs.Panel>
+          <Tabs.Panel value={1} keepMounted>
+            Enabled panel
+          </Tabs.Panel>
+        </Tabs.Root>,
+      );
+
+      const [disabledTab, enabledTab] = screen.getAllByRole('tab');
+      const [disabledPanel, enabledPanel] = screen.getAllByRole('tabpanel', { hidden: true });
+
+      expect(disabledTab).toHaveAttribute('aria-selected', 'false');
+      expect(enabledTab).toHaveAttribute('aria-selected', 'true');
+      expect(disabledPanel).toHaveAttribute('hidden');
+      expect(enabledPanel).not.toHaveAttribute('hidden');
+      expect(enabledPanel).toHaveTextContent('Enabled panel');
+    });
+
+    it('should select the third tab when first two tabs are disabled', async () => {
+      await render(
+        <Tabs.Root>
+          <Tabs.List>
+            <Tabs.Tab value={0} disabled data-testid="tab-0">
+              Tab 0
+            </Tabs.Tab>
+            <Tabs.Tab value={1} disabled data-testid="tab-1">
+              Tab 1
+            </Tabs.Tab>
+            <Tabs.Tab value={2} data-testid="tab-2">
+              Tab 2
+            </Tabs.Tab>
+            <Tabs.Tab value={3} data-testid="tab-3">
+              Tab 3
+            </Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value={0}>Panel 0</Tabs.Panel>
+          <Tabs.Panel value={1}>Panel 1</Tabs.Panel>
+          <Tabs.Panel value={2}>Panel 2</Tabs.Panel>
+          <Tabs.Panel value={3}>Panel 3</Tabs.Panel>
+        </Tabs.Root>,
+      );
+
+      const tabs = screen.getAllByRole('tab');
+
+      // The first non-disabled tab (tab 2) should be selected
+      expect(tabs[2]).toHaveAttribute('aria-selected', 'true');
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+      expect(tabs[3]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('should still honor explicit defaultValue even if it points to a disabled tab', async () => {
+      await render(
+        <Tabs.Root defaultValue={0}>
+          <Tabs.List>
+            <Tabs.Tab value={0} disabled data-testid="tab-0">
+              Tab 0
+            </Tabs.Tab>
+            <Tabs.Tab value={1} data-testid="tab-1">
+              Tab 1
+            </Tabs.Tab>
+            <Tabs.Tab value={2} data-testid="tab-2">
+              Tab 2
+            </Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value={0}>Panel 0</Tabs.Panel>
+          <Tabs.Panel value={1}>Panel 1</Tabs.Panel>
+          <Tabs.Panel value={2}>Panel 2</Tabs.Panel>
+        </Tabs.Root>,
+      );
+
+      const tabs = screen.getAllByRole('tab');
+
+      // The explicitly set disabled tab should be selected
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+      expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('should still honor explicit value prop even if it points to a disabled tab', async () => {
+      await render(
+        <Tabs.Root value={0}>
+          <Tabs.List>
+            <Tabs.Tab value={0} disabled data-testid="tab-0">
+              Tab 0
+            </Tabs.Tab>
+            <Tabs.Tab value={1} data-testid="tab-1">
+              Tab 1
+            </Tabs.Tab>
+            <Tabs.Tab value={2} data-testid="tab-2">
+              Tab 2
+            </Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value={0}>Panel 0</Tabs.Panel>
+          <Tabs.Panel value={1}>Panel 1</Tabs.Panel>
+          <Tabs.Panel value={2}>Panel 2</Tabs.Panel>
+        </Tabs.Root>,
+      );
+
+      const tabs = screen.getAllByRole('tab');
+
+      // The explicitly set disabled tab should be selected
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+      expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('does not set tabIndex=0 on disabled tabs when they are programmatically selected', async () => {
+      const { setProps } = await render(
+        <Tabs.Root value={1}>
+          <Tabs.List>
+            <Tabs.Tab value={0} disabled>
+              Tab 0
+            </Tabs.Tab>
+            <Tabs.Tab value={1}>Tab 1</Tabs.Tab>
+            <Tabs.Tab value={2}>Tab 2</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value={0}>Panel 0</Tabs.Panel>
+          <Tabs.Panel value={1}>Panel 1</Tabs.Panel>
+          <Tabs.Panel value={2}>Panel 2</Tabs.Panel>
+        </Tabs.Root>,
+      );
+
+      const tabs = screen.getAllByRole('tab');
+
+      // Initially, tab 1 is selected and should be highlighted (tabIndex=0)
+      expect(tabs[1]).toHaveAttribute('tabindex', '0');
+      expect(tabs[0]).toHaveAttribute('tabindex', '-1');
+      expect(tabs[2]).toHaveAttribute('tabindex', '-1');
+
+      // Programmatically select the disabled tab 0
+      await setProps({ value: 0 });
+      await flushMicrotasks();
+
+      // The disabled tab should be selected but NOT highlighted (tabIndex should remain -1)
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+      expect(tabs[0]).toHaveAttribute('tabindex', '-1');
+
+      // The previously highlighted tab should retain the highlight
+      expect(tabs[1]).toHaveAttribute('tabindex', '0');
+    });
+
+    it('does not select any tab when all tabs are disabled', async () => {
+      await render(
+        <Tabs.Root>
+          <Tabs.List>
+            <Tabs.Tab value={0} disabled>
+              Tab 0
+            </Tabs.Tab>
+            <Tabs.Tab value={1} disabled>
+              Tab 1
+            </Tabs.Tab>
+            <Tabs.Tab value={2} disabled>
+              Tab 2
+            </Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value={0} keepMounted>
+            Panel 0
+          </Tabs.Panel>
+          <Tabs.Panel value={1} keepMounted>
+            Panel 1
+          </Tabs.Panel>
+          <Tabs.Panel value={2} keepMounted>
+            Panel 2
+          </Tabs.Panel>
+        </Tabs.Root>,
+      );
+
+      const tabs = screen.getAllByRole('tab');
+      const panels = screen.getAllByRole('tabpanel', { hidden: true });
+
+      // No tab should be selected
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+      expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
+
+      // All panels should be hidden
+      expect(panels[0]).toHaveAttribute('hidden');
+      expect(panels[1]).toHaveAttribute('hidden');
+      expect(panels[2]).toHaveAttribute('hidden');
     });
   });
 

--- a/packages/react/src/toast/action/ToastAction.test.tsx
+++ b/packages/react/src/toast/action/ToastAction.test.tsx
@@ -44,6 +44,20 @@ describe('<Toast.Action />', () => {
     expect(screen.getByTestId('action').id).toBe('action');
   });
 
+  it('has the toast type data attribute', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <Toast.Root toast={{ ...toast, type: 'success' }}>
+            <Toast.Action data-testid="action">Action</Toast.Action>
+          </Toast.Root>
+        </Toast.Viewport>
+      </Toast.Provider>,
+    );
+
+    expect(screen.getByTestId('action')).toHaveAttribute('data-type', 'success');
+  });
+
   it('does not render if it has no children', async () => {
     function AddButton() {
       const { add } = Toast.useToastManager();

--- a/packages/react/src/toast/close/ToastClose.test.tsx
+++ b/packages/react/src/toast/close/ToastClose.test.tsx
@@ -27,6 +27,20 @@ describe('<Toast.Close />', () => {
     },
   }));
 
+  it('has the toast type data attribute', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <Toast.Root toast={{ ...toast, type: 'success' }}>
+            <Toast.Close data-testid="close" />
+          </Toast.Root>
+        </Toast.Viewport>
+      </Toast.Provider>,
+    );
+
+    expect(screen.getByTestId('close')).toHaveAttribute('data-type', 'success');
+  });
+
   it('closes the toast when clicked', async () => {
     const { user } = await render(
       <Toast.Provider>

--- a/packages/react/src/toast/content/ToastContent.test.tsx
+++ b/packages/react/src/toast/content/ToastContent.test.tsx
@@ -1,0 +1,77 @@
+import { expect } from 'vitest';
+import { Toast } from '@base-ui/react/toast';
+import { fireEvent, screen } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance } from '#test-utils';
+
+const toast: Toast.Root.ToastObject = {
+  id: 'test',
+  title: 'Toast title',
+};
+
+function AddToastButton() {
+  const { add } = Toast.useToastManager();
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        add({
+          title: 'Toast title',
+        });
+      }}
+    >
+      Add
+    </button>
+  );
+}
+
+function ToastList() {
+  const { toasts } = Toast.useToastManager();
+
+  return toasts.map((toastItem) => (
+    <Toast.Root key={toastItem.id} toast={toastItem}>
+      <Toast.Content data-testid="content">Content</Toast.Content>
+    </Toast.Root>
+  ));
+}
+
+describe('<Toast.Content />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Toast.Content>content</Toast.Content>, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render(node) {
+      return render(
+        <Toast.Provider>
+          <Toast.Viewport>
+            <Toast.Root toast={toast}>{node}</Toast.Root>
+          </Toast.Viewport>
+        </Toast.Provider>,
+      );
+    },
+  }));
+
+  it('has expanded and behind state attributes', async () => {
+    const { user } = await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <ToastList />
+        </Toast.Viewport>
+        <AddToastButton />
+      </Toast.Provider>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Add' });
+    await user.click(button);
+    await user.click(button);
+
+    const contents = await screen.findAllByTestId('content');
+    expect(contents.some((content) => content.hasAttribute('data-behind'))).toBe(true);
+
+    fireEvent.mouseEnter(contents[0].closest('[role="dialog"]') as HTMLElement);
+
+    for (const content of contents) {
+      expect(content).toHaveAttribute('data-expanded', '');
+    }
+  });
+});

--- a/packages/react/src/toast/description/ToastDescription.test.tsx
+++ b/packages/react/src/toast/description/ToastDescription.test.tsx
@@ -46,6 +46,20 @@ describe('<Toast.Description />', () => {
     expect(rootElement.getAttribute('aria-describedby')).toBe(descriptionId);
   });
 
+  it('has the toast type data attribute', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <Toast.Root toast={{ ...toast, type: 'success' }}>
+            <Toast.Description data-testid="description">Description</Toast.Description>
+          </Toast.Root>
+        </Toast.Viewport>
+      </Toast.Provider>,
+    );
+
+    expect(screen.getByTestId('description')).toHaveAttribute('data-type', 'success');
+  });
+
   it('does not render if it has no children', async () => {
     function AddButton() {
       const { add } = Toast.useToastManager();

--- a/packages/react/src/toast/portal/ToastPortal.test.tsx
+++ b/packages/react/src/toast/portal/ToastPortal.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Toast } from '@base-ui/react/toast';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/toast/title/ToastTitle.test.tsx
+++ b/packages/react/src/toast/title/ToastTitle.test.tsx
@@ -46,6 +46,20 @@ describe('<Toast.Title />', () => {
     expect(rootElement.getAttribute('aria-labelledby')).toBe(titleId);
   });
 
+  it('has the toast type data attribute', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <Toast.Root toast={{ ...toast, type: 'success' }}>
+            <Toast.Title data-testid="title">Title</Toast.Title>
+          </Toast.Root>
+        </Toast.Viewport>
+      </Toast.Provider>,
+    );
+
+    expect(screen.getByTestId('title')).toHaveAttribute('data-type', 'success');
+  });
+
   it('does not render if it has no children', async () => {
     function AddButton() {
       const { add } = Toast.useToastManager();

--- a/packages/react/src/toggle-group/ToggleGroup.test.tsx
+++ b/packages/react/src/toggle-group/ToggleGroup.test.tsx
@@ -21,7 +21,7 @@ describe('<ToggleGroup />', () => {
   });
 
   describe('uncontrolled', () => {
-    it('pressed state', async ({ skip }) => {
+    it('updates pressed state from user input', async ({ skip }) => {
       if (isJSDOM) {
         skip();
       }
@@ -51,25 +51,27 @@ describe('<ToggleGroup />', () => {
       expect(button1).toHaveAttribute('aria-pressed', 'false');
     });
 
-    it('prop: defaultValue', async () => {
-      const { user } = await render(
-        <ToggleGroup defaultValue={['two']}>
-          <Toggle value="one" />
-          <Toggle value="two" />
-        </ToggleGroup>,
-      );
+    describe('prop: defaultValue', () => {
+      it('sets the initial pressed item', async () => {
+        const { user } = await render(
+          <ToggleGroup defaultValue={['two']}>
+            <Toggle value="one" />
+            <Toggle value="two" />
+          </ToggleGroup>,
+        );
 
-      const [button1, button2] = screen.getAllByRole('button');
+        const [button1, button2] = screen.getAllByRole('button');
 
-      expect(button2).toHaveAttribute('aria-pressed', 'true');
-      expect(button2).toHaveAttribute('data-pressed');
-      expect(button1).toHaveAttribute('aria-pressed', 'false');
+        expect(button2).toHaveAttribute('aria-pressed', 'true');
+        expect(button2).toHaveAttribute('data-pressed');
+        expect(button1).toHaveAttribute('aria-pressed', 'false');
 
-      await user.pointer({ keys: '[MouseLeft]', target: button1 });
+        await user.pointer({ keys: '[MouseLeft]', target: button1 });
 
-      expect(button1).toHaveAttribute('aria-pressed', 'true');
-      expect(button1).toHaveAttribute('data-pressed');
-      expect(button2).toHaveAttribute('aria-pressed', 'false');
+        expect(button1).toHaveAttribute('aria-pressed', 'true');
+        expect(button1).toHaveAttribute('data-pressed');
+        expect(button2).toHaveAttribute('aria-pressed', 'false');
+      });
     });
 
     it('when Toggles omit value', async () => {
@@ -94,7 +96,7 @@ describe('<ToggleGroup />', () => {
       expect(button2).toHaveAttribute('aria-pressed', 'true');
     });
 
-    it('should warn if Toggle value is not set and ToggleGroup value is defined', async () => {
+    it('warns when Toggle value is missing and ToggleGroup value is defined', async () => {
       vi.spyOn(console, 'error')
         .mockName('console.error')
         .mockImplementation(() => {});
@@ -113,7 +115,7 @@ describe('<ToggleGroup />', () => {
   });
 
   describe('controlled', () => {
-    it('pressed state', async () => {
+    it('updates pressed state from prop changes', async () => {
       const { setProps } = await render(
         <ToggleGroup value={['two']}>
           <Toggle value="one" />
@@ -140,25 +142,27 @@ describe('<ToggleGroup />', () => {
       expect(button1).toHaveAttribute('aria-pressed', 'false');
     });
 
-    it('prop: value', async () => {
-      const { setProps } = await render(
-        <ToggleGroup value={['two']}>
-          <Toggle value="one" />
-          <Toggle value="two" />
-        </ToggleGroup>,
-      );
+    describe('prop: value', () => {
+      it('sets the pressed item', async () => {
+        const { setProps } = await render(
+          <ToggleGroup value={['two']}>
+            <Toggle value="one" />
+            <Toggle value="two" />
+          </ToggleGroup>,
+        );
 
-      const [button1, button2] = screen.getAllByRole('button');
+        const [button1, button2] = screen.getAllByRole('button');
 
-      expect(button2).toHaveAttribute('aria-pressed', 'true');
-      expect(button2).toHaveAttribute('data-pressed');
-      expect(button1).toHaveAttribute('aria-pressed', 'false');
+        expect(button2).toHaveAttribute('aria-pressed', 'true');
+        expect(button2).toHaveAttribute('data-pressed');
+        expect(button1).toHaveAttribute('aria-pressed', 'false');
 
-      await setProps({ value: ['one'] });
+        await setProps({ value: ['one'] });
 
-      expect(button1).toHaveAttribute('aria-pressed', 'true');
-      expect(button1).toHaveAttribute('data-pressed');
-      expect(button2).toHaveAttribute('aria-pressed', 'false');
+        expect(button1).toHaveAttribute('aria-pressed', 'true');
+        expect(button1).toHaveAttribute('data-pressed');
+        expect(button2).toHaveAttribute('aria-pressed', 'false');
+      });
     });
   });
 
@@ -219,8 +223,10 @@ describe('<ToggleGroup />', () => {
         </ToggleGroup>,
       );
 
+      const group = screen.getByRole('group');
       const [button1, button2] = screen.getAllByRole('button');
 
+      expect(group).toHaveAttribute('data-multiple', '');
       expect(button1).toHaveAttribute('aria-pressed', 'true');
       expect(button2).toHaveAttribute('aria-pressed', 'false');
 
@@ -238,8 +244,10 @@ describe('<ToggleGroup />', () => {
         </ToggleGroup>,
       );
 
+      const group = screen.getByRole('group');
       const [button1, button2] = screen.getAllByRole('button');
 
+      expect(group).not.toHaveAttribute('data-multiple');
       expect(button1).toHaveAttribute('aria-pressed', 'true');
       expect(button2).toHaveAttribute('aria-pressed', 'false');
 
@@ -276,7 +284,73 @@ describe('<ToggleGroup />', () => {
     });
   });
 
-  describe.skipIf(isJSDOM)('keyboard interactions', () => {
+  describe('prop: onValueChange', () => {
+    it('fires when an Item is clicked', async () => {
+      const onValueChange = vi.fn();
+
+      const { user } = await render(
+        <ToggleGroup onValueChange={onValueChange}>
+          <Toggle value="one" />
+          <Toggle value="two" />
+        </ToggleGroup>,
+      );
+
+      const [button1, button2] = screen.getAllByRole('button');
+
+      expect(onValueChange.mock.calls.length).toBe(0);
+
+      await user.pointer({ keys: '[MouseLeft]', target: button1 });
+
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.calls[0][0]).toEqual(['one']);
+
+      await user.pointer({ keys: '[MouseLeft]', target: button2 });
+
+      expect(onValueChange.mock.calls.length).toBe(2);
+      expect(onValueChange.mock.calls[1][0]).toEqual(['two']);
+    });
+
+    ['Enter', 'Space'].forEach((key) => {
+      it(`fires when the ${key} is pressed`, async ({ skip }) => {
+        if (isJSDOM) {
+          skip();
+        }
+
+        const onValueChange = vi.fn();
+
+        const { user } = await render(
+          <ToggleGroup onValueChange={onValueChange}>
+            <Toggle value="one" />
+            <Toggle value="two" />
+          </ToggleGroup>,
+        );
+
+        const [button1, button2] = screen.getAllByRole('button');
+
+        expect(onValueChange.mock.calls.length).toBe(0);
+
+        await act(async () => {
+          button1.focus();
+        });
+
+        await user.keyboard(`[${key}]`);
+
+        expect(onValueChange.mock.calls.length).toBe(1);
+        expect(onValueChange.mock.calls[0][0]).toEqual(['one']);
+
+        await act(async () => {
+          button2.focus();
+        });
+
+        await user.keyboard(`[${key}]`);
+
+        expect(onValueChange.mock.calls.length).toBe(2);
+        expect(onValueChange.mock.calls[1][0]).toEqual(['two']);
+      });
+    });
+  });
+
+  describe('keyboard interactions', () => {
     [
       ['ltr', 'horizontal', 'ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'],
       ['ltr', 'vertical', 'ArrowDown', 'ArrowUp', 'ArrowRight', 'ArrowLeft'],
@@ -423,72 +497,6 @@ describe('<ToggleGroup />', () => {
         await user.keyboard(`[${key}]`);
 
         expect(button1).toHaveAttribute('aria-pressed', 'false');
-      });
-    });
-  });
-
-  describe('prop: onValueChange', () => {
-    it('fires when an Item is clicked', async () => {
-      const onValueChange = vi.fn();
-
-      const { user } = await render(
-        <ToggleGroup onValueChange={onValueChange}>
-          <Toggle value="one" />
-          <Toggle value="two" />
-        </ToggleGroup>,
-      );
-
-      const [button1, button2] = screen.getAllByRole('button');
-
-      expect(onValueChange.mock.calls.length).toBe(0);
-
-      await user.pointer({ keys: '[MouseLeft]', target: button1 });
-
-      expect(onValueChange.mock.calls.length).toBe(1);
-      expect(onValueChange.mock.calls[0][0]).toEqual(['one']);
-
-      await user.pointer({ keys: '[MouseLeft]', target: button2 });
-
-      expect(onValueChange.mock.calls.length).toBe(2);
-      expect(onValueChange.mock.calls[1][0]).toEqual(['two']);
-    });
-
-    ['Enter', 'Space'].forEach((key) => {
-      it(`fires when the ${key} is pressed`, async ({ skip }) => {
-        if (isJSDOM) {
-          skip();
-        }
-
-        const onValueChange = vi.fn();
-
-        const { user } = await render(
-          <ToggleGroup onValueChange={onValueChange}>
-            <Toggle value="one" />
-            <Toggle value="two" />
-          </ToggleGroup>,
-        );
-
-        const [button1, button2] = screen.getAllByRole('button');
-
-        expect(onValueChange.mock.calls.length).toBe(0);
-
-        await act(async () => {
-          button1.focus();
-        });
-
-        await user.keyboard(`[${key}]`);
-
-        expect(onValueChange.mock.calls.length).toBe(1);
-        expect(onValueChange.mock.calls[0][0]).toEqual(['one']);
-
-        await act(async () => {
-          button2.focus();
-        });
-
-        await user.keyboard(`[${key}]`);
-
-        expect(onValueChange.mock.calls.length).toBe(2);
-        expect(onValueChange.mock.calls[1][0]).toEqual(['two']);
       });
     });
   });

--- a/packages/react/src/toggle/Toggle.test.tsx
+++ b/packages/react/src/toggle/Toggle.test.tsx
@@ -15,7 +15,7 @@ describe('<Toggle />', () => {
     render,
   }));
 
-  describe('pressed state', () => {
+  describe('prop: pressed', () => {
     it('controlled', async () => {
       function App() {
         const [pressed, setPressed] = React.useState(false);
@@ -32,17 +32,20 @@ describe('<Toggle />', () => {
       const button = screen.getByRole('button');
 
       expect(button).toHaveAttribute('aria-pressed', 'false');
+      expect(button).not.toHaveAttribute('data-pressed');
       await act(async () => {
         checkbox.click();
       });
 
       expect(button).toHaveAttribute('aria-pressed', 'true');
+      expect(button).toHaveAttribute('data-pressed', '');
 
       await act(async () => {
         checkbox.click();
       });
 
       expect(button).toHaveAttribute('aria-pressed', 'false');
+      expect(button).not.toHaveAttribute('data-pressed');
     });
 
     it('uncontrolled', async () => {
@@ -51,17 +54,20 @@ describe('<Toggle />', () => {
       const button = screen.getByRole('button');
 
       expect(button).toHaveAttribute('aria-pressed', 'false');
+      expect(button).not.toHaveAttribute('data-pressed');
       await act(async () => {
         button.click();
       });
 
       expect(button).toHaveAttribute('aria-pressed', 'true');
+      expect(button).toHaveAttribute('data-pressed', '');
 
       await act(async () => {
         button.click();
       });
 
       expect(button).toHaveAttribute('aria-pressed', 'false');
+      expect(button).not.toHaveAttribute('data-pressed');
     });
   });
 

--- a/packages/react/src/toolbar/button/ToolbarButton.test.tsx
+++ b/packages/react/src/toolbar/button/ToolbarButton.test.tsx
@@ -47,13 +47,19 @@ describe('<Toolbar.Button />', () => {
 
   describe('ARIA attributes', () => {
     it('renders a button', async () => {
-      await render(
-        <Toolbar.Root>
+      const { setProps } = await render(
+        <Toolbar.Root orientation="horizontal">
           <Toolbar.Button data-testid="button" />
         </Toolbar.Root>,
       );
 
-      expect(screen.getByTestId('button')).toBe(screen.getByRole('button'));
+      const button = screen.getByTestId('button');
+      expect(button).toBe(screen.getByRole('button'));
+      expect(button).toHaveAttribute('data-orientation', 'horizontal');
+
+      await setProps({ orientation: 'vertical' });
+
+      expect(button).toHaveAttribute('data-orientation', 'vertical');
     });
   });
 
@@ -80,6 +86,7 @@ describe('<Toolbar.Button />', () => {
 
       expect(button).not.toHaveAttribute('disabled');
       expect(button).toHaveAttribute('data-disabled');
+      expect(button).toHaveAttribute('data-focusable');
       expect(button).toHaveAttribute('aria-disabled', 'true');
 
       await user.click(button);
@@ -118,7 +125,7 @@ describe('<Toolbar.Button />', () => {
         expect(screen.getByTestId('button')).toBe(screen.getByRole('switch'));
       });
 
-      it('handles interactions', async () => {
+      it('toggles the switch with pointer and keyboard activation', async () => {
         vi.spyOn(console, 'error')
           .mockName('console.error')
           .mockImplementation(() => {});
@@ -238,7 +245,7 @@ describe('<Toolbar.Button />', () => {
         expect(screen.getByTestId('button')).toHaveAttribute('aria-haspopup', 'menu');
       });
 
-      it('handles interactions', async () => {
+      it('opens the menu and calls trigger handlers', async () => {
         const handleOpenChange = vi.fn();
         const handleClick = vi.fn();
         const { user } = await render(
@@ -374,57 +381,60 @@ describe('<Toolbar.Button />', () => {
         expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
       });
 
-      it.skipIf(!isJSDOM)('handles interactions', async () => {
-        const handleValueChange = vi.fn();
-        const { user } = await render(
-          <Toolbar.Root>
-            <Select.Root defaultValue="a" onValueChange={handleValueChange}>
-              <Toolbar.Button data-testid="button" render={<Select.Trigger />} />
-              <Select.Portal>
-                <Select.Positioner>
-                  <Select.Popup data-testid="popup">
-                    <Select.Item value="a" data-testid="item-a">
-                      a
-                    </Select.Item>
-                    <Select.Item value="b" data-testid="item-b">
-                      b
-                    </Select.Item>
-                  </Select.Popup>
-                </Select.Positioner>
-              </Select.Portal>
-            </Select.Root>
-          </Toolbar.Root>,
-        );
+      it.skipIf(!isJSDOM)(
+        'opens the select and changes value with keyboard activation',
+        async () => {
+          const handleValueChange = vi.fn();
+          const { user } = await render(
+            <Toolbar.Root>
+              <Select.Root defaultValue="a" onValueChange={handleValueChange}>
+                <Toolbar.Button data-testid="button" render={<Select.Trigger />} />
+                <Select.Portal>
+                  <Select.Positioner>
+                    <Select.Popup data-testid="popup">
+                      <Select.Item value="a" data-testid="item-a">
+                        a
+                      </Select.Item>
+                      <Select.Item value="b" data-testid="item-b">
+                        b
+                      </Select.Item>
+                    </Select.Popup>
+                  </Select.Positioner>
+                </Select.Portal>
+              </Select.Root>
+            </Toolbar.Root>,
+          );
 
-        expect(screen.queryByRole('listbox')).toBe(null);
-
-        const trigger = screen.getByTestId('button');
-        await user.keyboard('[Tab]');
-        expect(trigger).toHaveFocus();
-
-        await user.keyboard('[ArrowDown]');
-        expect(screen.queryByRole('listbox')).toBe(screen.getByTestId('popup'));
-        await waitFor(() => {
-          expect(screen.getByRole('option', { name: 'a' })).toHaveFocus();
-        });
-
-        await user.keyboard('[ArrowDown]');
-        await waitFor(() => {
-          expect(screen.getByRole('option', { name: 'b' })).toHaveFocus();
-        });
-
-        await user.keyboard('[Enter]');
-        await waitFor(() => {
           expect(screen.queryByRole('listbox')).toBe(null);
-        });
 
-        await waitFor(() => {
+          const trigger = screen.getByTestId('button');
+          await user.keyboard('[Tab]');
           expect(trigger).toHaveFocus();
-        });
 
-        expect(handleValueChange).toHaveBeenCalledTimes(1);
-        expect(handleValueChange).toHaveBeenCalledWith('b', expect.anything());
-      });
+          await user.keyboard('[ArrowDown]');
+          expect(screen.queryByRole('listbox')).toBe(screen.getByTestId('popup'));
+          await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'a' })).toHaveFocus();
+          });
+
+          await user.keyboard('[ArrowDown]');
+          await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'b' })).toHaveFocus();
+          });
+
+          await user.keyboard('[Enter]');
+          await waitFor(() => {
+            expect(screen.queryByRole('listbox')).toBe(null);
+          });
+
+          await waitFor(() => {
+            expect(trigger).toHaveFocus();
+          });
+
+          expect(handleValueChange).toHaveBeenCalledTimes(1);
+          expect(handleValueChange).toHaveBeenCalledWith('b', expect.anything());
+        },
+      );
 
       it('disabled state', async () => {
         await expect(async () => {
@@ -499,7 +509,7 @@ describe('<Toolbar.Button />', () => {
         expect(screen.getByTestId('trigger')).toBe(screen.getByRole('button'));
       });
 
-      it('handles interactions', async () => {
+      it('opens the dialog from the toolbar trigger', async () => {
         const onOpenChange = vi.fn();
         const { user } = await render(
           <Toolbar.Root>
@@ -620,7 +630,7 @@ describe('<Toolbar.Button />', () => {
         expect(screen.getByTestId('trigger')).toBe(screen.getByRole('button'));
       });
 
-      it('handles interactions', async () => {
+      it('opens the alert dialog from the toolbar trigger', async () => {
         const onOpenChange = vi.fn();
         const { user } = await render(
           <Toolbar.Root>
@@ -741,7 +751,7 @@ describe('<Toolbar.Button />', () => {
         expect(screen.getByRole('button')).toHaveAttribute('aria-haspopup', 'dialog');
       });
 
-      it('handles interactions', async () => {
+      it('opens and closes the popover with keyboard activation', async () => {
         const onOpenChange = vi.fn();
         const { user } = await render(
           <Toolbar.Root>
@@ -828,7 +838,7 @@ describe('<Toolbar.Button />', () => {
         });
       });
 
-      it('handles interactions', async () => {
+      it('toggles standalone and grouped buttons', async () => {
         const onPressedChange = vi.fn();
         const { user } = await render(
           <Toolbar.Root>

--- a/packages/react/src/toolbar/group/ToolbarGroup.test.tsx
+++ b/packages/react/src/toolbar/group/ToolbarGroup.test.tsx
@@ -37,13 +37,19 @@ describe('<Toolbar.Group />', () => {
 
   describe('ARIA attributes', () => {
     it('renders a group', async () => {
-      await render(
-        <Toolbar.Root>
+      const { setProps } = await render(
+        <Toolbar.Root orientation="horizontal">
           <Toolbar.Group data-testid="group" />
         </Toolbar.Root>,
       );
 
-      expect(screen.getByTestId('group')).toBe(screen.getByRole('group'));
+      const group = screen.getByTestId('group');
+      expect(group).toBe(screen.getByRole('group'));
+      expect(group).toHaveAttribute('data-orientation', 'horizontal');
+
+      await setProps({ orientation: 'vertical' });
+
+      expect(group).toHaveAttribute('data-orientation', 'vertical');
     });
   });
 

--- a/packages/react/src/toolbar/input/ToolbarInput.test.tsx
+++ b/packages/react/src/toolbar/input/ToolbarInput.test.tsx
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import { Toolbar } from '@base-ui/react/toolbar';
 import { NumberField } from '@base-ui/react/number-field';
 import { screen } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { createRenderer, describeConformance } from '#test-utils';
 import { NOOP } from '../../internals/noop';
 import { ToolbarRootContext } from '../root/ToolbarRootContext';
 import { type Orientation } from '../../internals/types';
@@ -41,17 +41,23 @@ describe('<Toolbar.Input />', () => {
 
   describe('ARIA attributes', () => {
     it('renders a textbox', async () => {
-      await render(
-        <Toolbar.Root>
+      const { setProps } = await render(
+        <Toolbar.Root orientation="horizontal">
           <Toolbar.Input data-testid="input" />
         </Toolbar.Root>,
       );
 
-      expect(screen.getByTestId('input')).toBe(screen.getByRole('textbox'));
+      const input = screen.getByTestId('input');
+      expect(input).toBe(screen.getByRole('textbox'));
+      expect(input).toHaveAttribute('data-orientation', 'horizontal');
+
+      await setProps({ orientation: 'vertical' });
+
+      expect(input).toHaveAttribute('data-orientation', 'vertical');
     });
   });
 
-  describe.skipIf(isJSDOM)('keyboard navigation', () => {
+  describe('keyboard navigation', () => {
     // when navigating through RTL text in real browsers the arrow keys for
     // moving the text insertion cursor is also reversed from LTR but this doesn't
     // work with testing library
@@ -113,7 +119,7 @@ describe('<Toolbar.Input />', () => {
       expect(screen.getByRole('textbox')).toHaveAttribute('aria-roledescription', 'Number field');
     });
 
-    it('handles interactions', async () => {
+    it('increments and decrements a rendered NumberField.Input', async () => {
       const onValueChange = vi.fn();
       const { user } = await render(
         <Toolbar.Root>
@@ -160,6 +166,7 @@ describe('<Toolbar.Input />', () => {
 
       expect(input).not.toHaveAttribute('disabled');
       expect(input).toHaveAttribute('data-disabled');
+      expect(input).toHaveAttribute('data-focusable');
       expect(input).toHaveAttribute('aria-disabled', 'true');
 
       await user.keyboard('[Tab]');

--- a/packages/react/src/toolbar/link/ToolbarLink.test.tsx
+++ b/packages/react/src/toolbar/link/ToolbarLink.test.tsx
@@ -38,13 +38,19 @@ describe('<Toolbar.Link />', () => {
 
   describe('ARIA attributes', () => {
     it('renders an anchor', async () => {
-      await render(
-        <Toolbar.Root>
+      const { setProps } = await render(
+        <Toolbar.Root orientation="horizontal">
           <Toolbar.Link data-testid="link" href="https://base-ui.com" />
         </Toolbar.Root>,
       );
 
-      expect(screen.getByTestId('link')).toBe(screen.getByRole('link'));
+      const link = screen.getByTestId('link');
+      expect(link).toBe(screen.getByRole('link'));
+      expect(link).toHaveAttribute('data-orientation', 'horizontal');
+
+      await setProps({ orientation: 'vertical' });
+
+      expect(link).toHaveAttribute('data-orientation', 'vertical');
     });
   });
 });

--- a/packages/react/src/toolbar/root/ToolbarRoot.test.tsx
+++ b/packages/react/src/toolbar/root/ToolbarRoot.test.tsx
@@ -2,7 +2,7 @@ import { expect } from 'vitest';
 import { Toolbar } from '@base-ui/react/toolbar';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
 import { screen } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { createRenderer, describeConformance } from '#test-utils';
 import { type Orientation } from '../../internals/types';
 
 describe('<Toolbar.Root />', () => {
@@ -19,9 +19,20 @@ describe('<Toolbar.Root />', () => {
 
       expect(container.firstElementChild as HTMLElement).toHaveAttribute('role', 'toolbar');
     });
+
+    it('has orientation data attributes', async () => {
+      const { setProps } = await render(<Toolbar.Root orientation="horizontal" />);
+      const toolbar = screen.getByRole('toolbar');
+
+      expect(toolbar).toHaveAttribute('data-orientation', 'horizontal');
+
+      await setProps({ orientation: 'vertical' });
+
+      expect(toolbar).toHaveAttribute('data-orientation', 'vertical');
+    });
   });
 
-  describe.skipIf(isJSDOM)('keyboard navigation', () => {
+  describe('keyboard navigation', () => {
     [
       ['ltr', 'horizontal', 'ArrowRight', 'ArrowLeft'],
       ['ltr', 'vertical', 'ArrowDown', 'ArrowUp'],
@@ -109,7 +120,7 @@ describe('<Toolbar.Root />', () => {
     });
   });
 
-  describe.skipIf(isJSDOM)('prop: focusableWhenDisabled', () => {
+  describe('prop: focusableWhenDisabled', () => {
     function expectFocusedWhenDisabled(element: Element) {
       expect(element).toHaveAttribute('data-disabled');
       expect(element).toHaveAttribute('aria-disabled', 'true');

--- a/packages/react/src/toolbar/separator/ToolbarSeparator.test.tsx
+++ b/packages/react/src/toolbar/separator/ToolbarSeparator.test.tsx
@@ -1,0 +1,32 @@
+import { expect } from 'vitest';
+import { Toolbar } from '@base-ui/react/toolbar';
+import { screen } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance } from '#test-utils';
+
+describe('<Toolbar.Separator />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Toolbar.Separator />, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render(node) {
+      return render(<Toolbar.Root>{node}</Toolbar.Root>);
+    },
+  }));
+
+  it('has the opposite orientation from the toolbar', async () => {
+    const { setProps } = await render(
+      <Toolbar.Root orientation="horizontal">
+        <Toolbar.Separator />
+      </Toolbar.Root>,
+    );
+
+    const separator = screen.getByRole('separator');
+    expect(separator).toHaveAttribute('aria-orientation', 'vertical');
+    expect(separator).toHaveAttribute('data-orientation', 'vertical');
+
+    await setProps({ orientation: 'vertical' });
+
+    expect(separator).toHaveAttribute('aria-orientation', 'horizontal');
+    expect(separator).toHaveAttribute('data-orientation', 'horizontal');
+  });
+});

--- a/packages/react/src/tooltip/portal/TooltipPortal.test.tsx
+++ b/packages/react/src/tooltip/portal/TooltipPortal.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/tooltip/root/TooltipRoot.detached-triggers.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.detached-triggers.test.tsx
@@ -430,7 +430,6 @@ describe('<Tooltip.Root />', () => {
       expect(screen.getByTestId('content').textContent).toBe('1');
 
       await act(async () => trigger2.focus());
-      await flushMicrotasks();
       await waitFor(() => {
         expect(screen.queryByTestId('content')).toBe(null);
       });
@@ -796,9 +795,7 @@ describe('<Tooltip.Root />', () => {
       expect(screen.queryByTestId('content')).toBe(null);
 
       await act(() => tooltip.open('trigger'));
-      await waitFor(() => {
-        expect(screen.queryByTestId('content')).not.toBe(null);
-      });
+      await screen.findByTestId('content');
 
       expect(screen.getByTestId('content').textContent).toBe('Content');
       expect(trigger).toHaveAttribute('data-popup-open');
@@ -838,9 +835,7 @@ describe('<Tooltip.Root />', () => {
       expect(screen.queryByTestId('content')).toBe(null);
 
       await act(() => tooltip.open('trigger2'));
-      await waitFor(() => {
-        expect(screen.queryByTestId('content')).not.toBe(null);
-      });
+      await screen.findByTestId('content');
 
       expect(screen.getByTestId('content').textContent).toBe('2');
       expect(trigger2).toHaveAttribute('data-popup-open');

--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -202,15 +202,11 @@ describe('<Tooltip.Root />', () => {
       it('should open when the component is rendered', async () => {
         await render(<TestTooltip rootProps={{ defaultOpen: true }} />);
 
-        await flushMicrotasks();
-
         expect(screen.getByText('Content')).not.toBe(null);
       });
 
       it('should not open when the component is rendered and open is controlled', async () => {
         await render(<TestTooltip rootProps={{ defaultOpen: true, open: false }} />);
-
-        await flushMicrotasks();
 
         expect(screen.queryByText('Content')).toBe(null);
       });
@@ -218,15 +214,11 @@ describe('<Tooltip.Root />', () => {
       it('should not close when the component is rendered and open is controlled', async () => {
         await render(<TestTooltip rootProps={{ defaultOpen: true, open: true }} />);
 
-        await flushMicrotasks();
-
         expect(screen.getByText('Content')).not.toBe(null);
       });
 
       it('should remain uncontrolled', async () => {
         await render(<TestTooltip rootProps={{ defaultOpen: true }} />);
-
-        await flushMicrotasks();
 
         expect(screen.getByText('Content')).not.toBe(null);
 
@@ -313,15 +305,11 @@ describe('<Tooltip.Root />', () => {
         const trigger = screen.getByRole('button', { name: 'Toggle' });
         await user.hover(trigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('positioner')).not.toBe(null);
-        });
+        await screen.findByTestId('positioner');
 
         await user.unhover(trigger);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('positioner')).not.toBe(null);
-        });
+        await screen.findByTestId('positioner');
 
         await act(async () => actionsRef.current.unmount());
 
@@ -443,9 +431,7 @@ describe('<Tooltip.Root />', () => {
         const openButton = screen.getByText('Open');
         await user.click(openButton);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('popup')).not.toBe(null);
-        });
+        await screen.findByTestId('popup');
 
         expect(onOpenChangeComplete.mock.calls.length).toBe(2);
         expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
@@ -518,6 +504,106 @@ describe('<Tooltip.Root />', () => {
         );
 
         expect(onOpenChangeComplete.mock.calls.length).toBe(0);
+      });
+    });
+
+    describe('prop: disabled', () => {
+      it('should not open when disabled', async () => {
+        await render(<TestTooltip rootProps={{ disabled: true }} triggerProps={{ delay: 0 }} />);
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        await flushMicrotasks();
+
+        expect(screen.queryByText('Content')).toBe(null);
+
+        await act(async () => trigger.focus());
+
+        expect(screen.queryByText('Content')).toBe(null);
+      });
+
+      it('should not open on focus when the trigger is disabled', async () => {
+        await render(<TestTooltip triggerProps={{ disabled: true, delay: 0 }} />);
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        await act(async () => trigger.focus());
+        await flushMicrotasks();
+
+        expect(screen.queryByText('Content')).toBe(null);
+      });
+
+      it('should close if open when becoming disabled', async () => {
+        function App() {
+          const [disabled, setDisabled] = React.useState(false);
+          return (
+            <div>
+              <TestTooltip
+                rootProps={{ defaultOpen: true, disabled }}
+                triggerProps={{ delay: 0 }}
+              />
+              <button
+                data-testid="disabled"
+                onClick={() => {
+                  setDisabled(true);
+                }}
+              />
+            </div>
+          );
+        }
+
+        await render(<App />);
+
+        expect(screen.queryByText('Content')).not.toBe(null);
+
+        const disabledButton = screen.getByTestId('disabled');
+        fireEvent.click(disabledButton);
+
+        expect(screen.queryByText('Content')).toBe(null);
+      });
+
+      it('does not throw error when combined with defaultOpen', async () => {
+        await render(<TestTooltip rootProps={{ defaultOpen: true, disabled: true }} />);
+
+        expect(screen.queryByText('Content')).toBe(null);
+      });
+    });
+
+    describe('prop: disableHoverablePopup', () => {
+      it('applies pointer-events: none to the positioner when `disableHoverablePopup = true`', async () => {
+        await render(
+          <TestTooltip rootProps={{ disableHoverablePopup: true }} triggerProps={{ delay: 0 }} />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('positioner').style.pointerEvents).toBe('none');
+      });
+
+      it('does not apply pointer-events: none to the positioner when `disableHoverablePopup = false`', async () => {
+        await render(
+          <TestTooltip rootProps={{ disableHoverablePopup: false }} triggerProps={{ delay: 0 }} />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('positioner').style.pointerEvents).toBe('');
       });
     });
 
@@ -640,106 +726,6 @@ describe('<Tooltip.Root />', () => {
             .filter((a) => (a as CSSTransition).transitionProperty === 'opacity');
           expect(opacityAnimations.length).toBe(0);
         });
-      });
-    });
-
-    describe('prop: disabled', () => {
-      it('should not open when disabled', async () => {
-        await render(<TestTooltip rootProps={{ disabled: true }} triggerProps={{ delay: 0 }} />);
-
-        const trigger = screen.getByRole('button', { name: 'Toggle' });
-
-        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
-        fireEvent.mouseEnter(trigger);
-        fireEvent.mouseMove(trigger);
-
-        await flushMicrotasks();
-
-        expect(screen.queryByText('Content')).toBe(null);
-
-        await act(async () => trigger.focus());
-
-        expect(screen.queryByText('Content')).toBe(null);
-      });
-
-      it('should not open on focus when the trigger is disabled', async () => {
-        await render(<TestTooltip triggerProps={{ disabled: true, delay: 0 }} />);
-
-        const trigger = screen.getByRole('button', { name: 'Toggle' });
-
-        await act(async () => trigger.focus());
-        await flushMicrotasks();
-
-        expect(screen.queryByText('Content')).toBe(null);
-      });
-
-      it('should close if open when becoming disabled', async () => {
-        function App() {
-          const [disabled, setDisabled] = React.useState(false);
-          return (
-            <div>
-              <TestTooltip
-                rootProps={{ defaultOpen: true, disabled }}
-                triggerProps={{ delay: 0 }}
-              />
-              <button
-                data-testid="disabled"
-                onClick={() => {
-                  setDisabled(true);
-                }}
-              />
-            </div>
-          );
-        }
-
-        await render(<App />);
-
-        expect(screen.queryByText('Content')).not.toBe(null);
-
-        const disabledButton = screen.getByTestId('disabled');
-        fireEvent.click(disabledButton);
-
-        expect(screen.queryByText('Content')).toBe(null);
-      });
-
-      it('does not throw error when combined with defaultOpen', async () => {
-        await render(<TestTooltip rootProps={{ defaultOpen: true, disabled: true }} />);
-
-        expect(screen.queryByText('Content')).toBe(null);
-      });
-    });
-
-    describe('prop: disableHoverablePopup', () => {
-      it('applies pointer-events: none to the positioner when `disableHoverablePopup = true`', async () => {
-        await render(
-          <TestTooltip rootProps={{ disableHoverablePopup: true }} triggerProps={{ delay: 0 }} />,
-        );
-
-        const trigger = screen.getByRole('button', { name: 'Toggle' });
-
-        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
-        fireEvent.mouseEnter(trigger);
-        fireEvent.mouseMove(trigger);
-
-        await flushMicrotasks();
-
-        expect(screen.getByTestId('positioner').style.pointerEvents).toBe('none');
-      });
-
-      it('does not apply pointer-events: none to the positioner when `disableHoverablePopup = false`', async () => {
-        await render(
-          <TestTooltip rootProps={{ disableHoverablePopup: false }} triggerProps={{ delay: 0 }} />,
-        );
-
-        const trigger = screen.getByRole('button', { name: 'Toggle' });
-
-        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
-        fireEvent.mouseEnter(trigger);
-        fireEvent.mouseMove(trigger);
-
-        await flushMicrotasks();
-
-        expect(screen.getByTestId('positioner').style.pointerEvents).toBe('');
       });
     });
 

--- a/packages/react/src/utils/useIsHydrating.test.tsx
+++ b/packages/react/src/utils/useIsHydrating.test.tsx
@@ -1,5 +1,4 @@
 import { expect } from 'vitest';
-import * as React from 'react';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';
 import { useIsHydrating } from './useIsHydrating';


### PR DESCRIPTION
This PR does a mechanical cleanup pass over component tests

## Changes

- Add missing test files for component parts that need their own suites.
- Normalize describe grouping and prop, Field, and Form sections.
- Rename unclear tests and remove stale waits, skips, and imports where safe.