### PR TITLE
[otp field] Fix vertical arrow slot navigation

### DIFF
--- a/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
@@ -196,6 +196,57 @@ describe('<OTPField.Input />', () => {
     expect(document.activeElement).toBe(inputs[2]);
   });
 
+  it.each([
+    ['ArrowUp', 0],
+    ['ArrowDown', 3],
+  ] as const)('moves focus to the field boundary with %s', async (key, targetIndex) => {
+    await render(<OTPFieldTest defaultValue="1234" />);
+
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+
+    await act(async () => {
+      inputs[1].focus();
+    });
+
+    expect(fireEvent.keyDown(inputs[1], { key })).toBe(false);
+    expect(inputs[targetIndex]).toHaveFocus();
+  });
+
+  it('keeps focus on an empty slot with ArrowDown', async () => {
+    await render(<OTPFieldTest defaultValue="12" />);
+
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+
+    await act(async () => {
+      inputs[2].focus();
+    });
+
+    expect(fireEvent.keyDown(inputs[2], { key: 'ArrowDown' })).toBe(false);
+    expect(inputs[2]).toHaveFocus();
+  });
+
+  it('does not reselect the final slot when typing the same character', async () => {
+    const { user } = await render(<OTPFieldTest defaultValue="123456" />);
+
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+    const lastInput = inputs[5];
+
+    await act(async () => {
+      lastInput.focus();
+    });
+
+    const select = vi.spyOn(lastInput, 'select');
+
+    try {
+      await user.keyboard('6');
+
+      expect(select).not.toHaveBeenCalled();
+      expect(lastInput).toHaveFocus();
+    } finally {
+      select.mockRestore();
+    }
+  });
+
   it('moves focus to the first slot with Home', async () => {
     await render(<OTPFieldTest defaultValue="1234" />);
 
@@ -255,10 +306,10 @@ describe('<OTPField.Input />', () => {
     fireEvent.keyDown(inputs[1], { key: 'ArrowRight' });
     expect(document.activeElement).toBe(inputs[2]);
 
-    fireEvent.keyDown(inputs[2], { key: 'Home' });
+    fireEvent.keyDown(inputs[2], { key: 'ArrowUp' });
     expect(document.activeElement).toBe(inputs[0]);
 
-    fireEvent.keyDown(inputs[0], { key: 'End' });
+    fireEvent.keyDown(inputs[0], { key: 'ArrowDown' });
     expect(document.activeElement).toBe(inputs[3]);
   });
 

--- a/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
@@ -364,9 +364,9 @@ describe('<OTPField.Input />', () => {
       });
 
       fireEvent.keyDown(inputs[2], { key: 'ArrowLeft', ...modifierKey });
-      expect(document.activeElement).toBe(inputs[3]);
+      expect(document.activeElement).toBe(inputs[4]);
 
-      fireEvent.keyDown(inputs[3], { key: 'ArrowRight', ...modifierKey });
+      fireEvent.keyDown(inputs[4], { key: 'ArrowRight', ...modifierKey });
       expect(document.activeElement).toBe(inputs[0]);
     },
   );

--- a/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
@@ -198,7 +198,7 @@ describe('<OTPField.Input />', () => {
 
   it.each([
     ['ArrowUp', 0],
-    ['ArrowDown', 3],
+    ['ArrowDown', 4],
   ] as const)('moves focus to the field boundary with %s', async (key, targetIndex) => {
     await render(<OTPFieldTest defaultValue="1234" />);
 
@@ -212,7 +212,27 @@ describe('<OTPField.Input />', () => {
     expect(inputs[targetIndex]).toHaveFocus();
   });
 
-  it('keeps focus on an empty slot with ArrowDown', async () => {
+  it('stops propagation when ArrowDown moves focus to the empty end slot', async () => {
+    const onKeyDown = vi.fn();
+
+    await render(
+      <div onKeyDown={onKeyDown}>
+        <OTPFieldTest defaultValue="1234" />
+      </div>,
+    );
+
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+
+    await act(async () => {
+      inputs[1].focus();
+    });
+
+    expect(fireEvent.keyDown(inputs[1], { key: 'ArrowDown' })).toBe(false);
+    expect(onKeyDown).not.toHaveBeenCalled();
+    expect(inputs[4]).toHaveFocus();
+  });
+
+  it('keeps focus on the empty end slot with ArrowDown', async () => {
     await render(<OTPFieldTest defaultValue="12" />);
 
     const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
@@ -223,6 +243,19 @@ describe('<OTPField.Input />', () => {
 
     expect(fireEvent.keyDown(inputs[2], { key: 'ArrowDown' })).toBe(false);
     expect(inputs[2]).toHaveFocus();
+  });
+
+  it('keeps focus on the final slot with ArrowDown when the value is complete', async () => {
+    await render(<OTPFieldTest defaultValue="123456" />);
+
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+
+    await act(async () => {
+      inputs[5].focus();
+    });
+
+    expect(fireEvent.keyDown(inputs[5], { key: 'ArrowDown' })).toBe(false);
+    expect(inputs[5]).toHaveFocus();
   });
 
   it('does not reselect the final slot when typing the same character', async () => {
@@ -261,7 +294,7 @@ describe('<OTPField.Input />', () => {
     expect(document.activeElement).toBe(inputs[0]);
   });
 
-  it('moves focus to the last filled slot with End', async () => {
+  it('moves focus to the empty end slot with End', async () => {
     await render(<OTPFieldTest defaultValue="1234" />);
 
     const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
@@ -272,7 +305,7 @@ describe('<OTPField.Input />', () => {
 
     fireEvent.keyDown(inputs[0], { key: 'End' });
 
-    expect(document.activeElement).toBe(inputs[3]);
+    expect(document.activeElement).toBe(inputs[4]);
   });
 
   it.each(modifierKeys)(
@@ -290,7 +323,7 @@ describe('<OTPField.Input />', () => {
       expect(document.activeElement).toBe(inputs[0]);
 
       fireEvent.keyDown(inputs[0], { key: 'ArrowRight', ...modifierKey });
-      expect(document.activeElement).toBe(inputs[3]);
+      expect(document.activeElement).toBe(inputs[4]);
     },
   );
 
@@ -306,11 +339,44 @@ describe('<OTPField.Input />', () => {
     fireEvent.keyDown(inputs[1], { key: 'ArrowRight' });
     expect(document.activeElement).toBe(inputs[2]);
 
-    fireEvent.keyDown(inputs[2], { key: 'ArrowUp' });
+    fireEvent.keyDown(inputs[2], { key: 'Home' });
+    expect(document.activeElement).toBe(inputs[0]);
+
+    fireEvent.keyDown(inputs[0], { key: 'End' });
+    expect(document.activeElement).toBe(inputs[4]);
+
+    fireEvent.keyDown(inputs[4], { key: 'ArrowUp' });
     expect(document.activeElement).toBe(inputs[0]);
 
     fireEvent.keyDown(inputs[0], { key: 'ArrowDown' });
-    expect(document.activeElement).toBe(inputs[3]);
+    expect(document.activeElement).toBe(inputs[4]);
+  });
+
+  it('leaves vertical arrow navigation unhandled in disabled mode', async () => {
+    const onKeyDown = vi.fn();
+
+    await render(
+      <div onKeyDown={onKeyDown}>
+        <OTPFieldTest defaultValue="12" disabled />
+      </div>,
+    );
+
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+
+    const arrowUpEvent = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'ArrowUp',
+    });
+    const arrowDownEvent = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'ArrowDown',
+    });
+
+    expect(inputs[1].dispatchEvent(arrowUpEvent)).toBe(true);
+    expect(inputs[1].dispatchEvent(arrowDownEvent)).toBe(true);
+    expect(onKeyDown).toHaveBeenCalledTimes(2);
   });
 
   it('blocks Delete and Backspace from changing the value in readonly mode', async () => {

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -205,15 +205,19 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
         return;
       }
 
-      if (event.key === 'Home') {
+      if (event.key === 'Home' || event.key === 'ArrowUp') {
         stopEvent(event);
         focusInput(firstIndex);
         return;
       }
 
-      if (event.key === 'End') {
+      const isEnd = event.key === 'End';
+
+      if (isEnd || event.key === 'ArrowDown') {
         stopEvent(event);
-        focusInput(lastFilledIndex);
+        if (isEnd || slotValue !== '') {
+          focusInput(lastFilledIndex);
+        }
         return;
       }
 
@@ -251,7 +255,9 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
 
       if (event.key.length === 1 && fullSelection && slotValue === event.key) {
         stopEvent(event);
-        focusInput(Math.min(length - 1, index + 1));
+        if (index < length - 1) {
+          focusInput(index + 1);
+        }
         return;
       }
 

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -190,7 +190,8 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
       }
 
       const firstIndex = 0;
-      const lastFilledIndex = Math.max(value.length - 1, 0);
+      const lastIndex = Math.max(length - 1, firstIndex);
+      const endTargetIndex = Math.min(value.length, lastIndex);
       const hasBoundaryModifier = (event.ctrlKey || event.metaKey) && !event.altKey;
 
       if (event.key === 'ArrowLeft') {
@@ -201,7 +202,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
 
       if (event.key === 'ArrowRight') {
         stopEvent(event);
-        focusInput(hasBoundaryModifier ? lastFilledIndex : Math.min(length - 1, index + 1));
+        focusInput(hasBoundaryModifier ? endTargetIndex : Math.min(lastIndex, index + 1));
         return;
       }
 
@@ -211,13 +212,9 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
         return;
       }
 
-      const isEnd = event.key === 'End';
-
-      if (isEnd || event.key === 'ArrowDown') {
+      if (event.key === 'End' || event.key === 'ArrowDown') {
         stopEvent(event);
-        if (isEnd || slotValue !== '') {
-          focusInput(lastFilledIndex);
-        }
+        focusInput(endTargetIndex);
         return;
       }
 


### PR DESCRIPTION
Pressing <kbd>ArrowUp</kbd> or <kbd>ArrowDown</kbd> in an OTP slot could collapse the slot selection, so a later typed character could be blocked by the one-character input length.

## Root cause

Vertical arrows fell through to native text-input caret handling instead of being handled as OTP field navigation.

## Changes

- Map <kbd>ArrowUp</kbd> to the first slot, matching <kbd>Home</kbd>.
- Map <kbd>ArrowDown</kbd> to the last filled slot when the current slot has a character, matching <kbd>End</kbd>.
- Keep focus in place when pressing <kbd>ArrowDown</kbd> on an empty slot.
- Only advance same-character typing when another slot exists.
- Add regression coverage for vertical arrow navigation and final-slot same-character handling.