### PR TITLE
[docs] Fix format of OTP Field in changelog

### DIFF
--- a/scripts/changelog.config.mjs
+++ b/scripts/changelog.config.mjs
@@ -40,6 +40,7 @@ export default {
       // Category overrides - labels that force a specific section
       categoryOverrides: {
         'scope: all components': 'General changes',
+        'component: otp field': 'OTP Field',
       },
       // Explicit flag labels
       flags: {


### PR DESCRIPTION
Fix `pnpm release:changelog` generation as expected in #4850.

Before: `## Otp Field`
After: `## OTP Field` 

---

Context: I noticed this as I was curious to see how the changelog would explain how to handle the breaking changes from #4717: Would it explain what changed, closer to https://github.com/mui/mui-x/releases/tag/v9.0.0, or would it be left for developers to figure out how to upgrade?

It looks like it's not making it super easy for developers; the same goes for the description of #4717.
So, the first step would be to have a clear breaking change section on our PR descriptions.
The second step could be to automate the extraction of it for the changelog, but that might be overkill.

Anyway, opened a PR as it was quick & easy (we had 2 releases with this issue), the time-consuming part was to see what the breaking change experience was for developers.