### PR TITLE
[otp field] Fix RTL arrow navigation

### DIFF
--- a/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import { OTPFieldPreview as OTPField } from '@base-ui/react/otp-field';
 import { Field } from '@base-ui/react/field';
+import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<OTPField.Input />', () => {
@@ -85,6 +86,26 @@ describe('<OTPField.Input />', () => {
     expect(document.activeElement).toBe(inputs[2]);
 
     fireEvent.keyDown(inputs[2], { key: 'ArrowLeft' });
+    expect(document.activeElement).toBe(inputs[1]);
+  });
+
+  it('moves focus with arrow keys in RTL', async () => {
+    await render(
+      <DirectionProvider direction="rtl">
+        <OTPFieldTest defaultValue="12" />
+      </DirectionProvider>,
+    );
+
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+
+    await act(async () => {
+      inputs[1].focus();
+    });
+
+    fireEvent.keyDown(inputs[1], { key: 'ArrowLeft' });
+    expect(document.activeElement).toBe(inputs[2]);
+
+    fireEvent.keyDown(inputs[2], { key: 'ArrowRight' });
     expect(document.activeElement).toBe(inputs[1]);
   });
 
@@ -240,6 +261,29 @@ describe('<OTPField.Input />', () => {
 
       fireEvent.keyDown(inputs[0], { key: 'ArrowRight', ...modifierKey });
       expect(document.activeElement).toBe(inputs[3]);
+    },
+  );
+
+  it.each(modifierKeys)(
+    'moves focus to the field boundaries with %s + arrow keys in RTL',
+    async (_, modifierKey) => {
+      await render(
+        <DirectionProvider direction="rtl">
+          <OTPFieldTest defaultValue="1234" />
+        </DirectionProvider>,
+      );
+
+      const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+
+      await act(async () => {
+        inputs[2].focus();
+      });
+
+      fireEvent.keyDown(inputs[2], { key: 'ArrowLeft', ...modifierKey });
+      expect(document.activeElement).toBe(inputs[3]);
+
+      fireEvent.keyDown(inputs[3], { key: 'ArrowRight', ...modifierKey });
+      expect(document.activeElement).toBe(inputs[0]);
     },
   );
 

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -8,6 +8,7 @@ import {
   useCompositeListItem,
 } from '../../internals/composite/list/useCompositeListItem';
 import type { BaseUIComponentProps } from '../../internals/types';
+import { useDirection } from '../../internals/direction-context/DirectionContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import {
   createChangeEventDetails,
@@ -68,6 +69,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
     indexGuessBehavior: IndexGuessBehavior.GuessFromOrder,
   });
   const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const direction = useDirection();
 
   const slotValue = value[index] ?? '';
   const inputState = getOTPFieldInputState(state, slotValue, index);
@@ -192,14 +194,17 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
       const firstIndex = 0;
       const lastFilledIndex = Math.max(value.length - 1, 0);
       const hasBoundaryModifier = (event.ctrlKey || event.metaKey) && !event.altKey;
+      const isRtl = direction === 'rtl';
+      const previousKey = isRtl ? 'ArrowRight' : 'ArrowLeft';
+      const nextKey = isRtl ? 'ArrowLeft' : 'ArrowRight';
 
-      if (event.key === 'ArrowLeft') {
+      if (event.key === previousKey) {
         stopEvent(event);
         focusInput(hasBoundaryModifier ? firstIndex : Math.max(firstIndex, index - 1));
         return;
       }
 
-      if (event.key === 'ArrowRight') {
+      if (event.key === nextKey) {
         stopEvent(event);
         focusInput(hasBoundaryModifier ? lastFilledIndex : Math.min(length - 1, index + 1));
         return;


### PR DESCRIPTION
Follow-up to #4840. OTP Field still handled slot arrow navigation as LTR, so RTL users moved to the visually wrong slot.

## Root cause

`OTPField.Input` handled left/right keys itself and did not read `DirectionProvider`.

## Changes

- Read Base UI direction in OTP Field inputs.
- Map previous/next arrow keys according to LTR or RTL.
- Add RTL coverage for normal and Ctrl/Cmd boundary arrow navigation.