### PR TITLE
[docs][experiments] Prefix user-select CSS property

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ This repository contains the source code and documentation for Base UI: a headl
 - Always use the shadow DOM-safe utilities for DOM traversal and event targeting: `contains`, `getTarget`, and `activeElement`. Always use the owner utilities `ownerDocument` and `ownerWindow` instead of global `document`/`window` lookups when the code is tied to a DOM node, including realm-sensitive checks such as `instanceof`.
 - Avoid duplicating logic where necessary. If two components can share logic (such as event handlers), define the logic/handlers in the parent and share it through a context to the child; use the existing context if it exists.
 
+## Styling
+
+When using `user-select: none;` in CSS, also add `-webkit-user-select: none;` to support Safari. Tailwind's `select-none` class already includes this.
+
 ## Linting, typechecking, and formatting
 
 - Do not randomly cast (for example `as any`) if there are no type errors without doing so. Run `pnpm typescript` to verify types.

--- a/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
+++ b/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
@@ -139,6 +139,7 @@ This example shows how to implement the component using CSS Modules.
   font-weight: 400;
   line-height: 1.25rem;
   text-align: left;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -426,6 +427,7 @@ This example shows how to implement the component using CSS Modules.
   font-weight: 400;
   line-height: 1.25rem;
   text-align: left;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -959,6 +961,7 @@ This example shows how to implement the component using CSS Modules.
   width: 14rem;
   padding-block: 0.75rem;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -966,6 +969,7 @@ This example shows how to implement the component using CSS Modules.
   width: 100%;
   height: 0.25rem;
   background-color: oklch(92.2% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -975,6 +979,7 @@ This example shows how to implement the component using CSS Modules.
 
 .Indicator {
   background-color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -988,6 +993,7 @@ This example shows how to implement the component using CSS Modules.
   height: 1rem;
   border: 1px solid oklch(14.5% 0 0deg);
   background-color: white;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/accordion/demos/_index.module.css
+++ b/docs/src/app/(docs)/react/components/accordion/demos/_index.module.css
@@ -45,6 +45,7 @@
   font-weight: 400;
   line-height: 1.25rem;
   text-align: left;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/_index.module.css
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/_index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/alert-dialog/demos/hero/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/async/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/async/css-modules/index.module.css
@@ -91,6 +91,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.5rem;

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/auto-highlight/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/auto-highlight/css-modules/index.module.css
@@ -96,6 +96,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.5rem;

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
@@ -16,6 +16,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
   cursor: default;
 
@@ -209,6 +210,7 @@
 
 .GroupLabel {
   outline: 0;
+  -webkit-user-select: none;
   user-select: none;
   display: flex;
   align-items: center;
@@ -229,6 +231,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   scroll-margin-block: 0.25rem;
   min-height: 2rem;

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/fuzzy-matching/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/fuzzy-matching/css-modules/index.module.css
@@ -97,6 +97,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding: 0.75rem 0.5rem;
   display: flex;

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/grid/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/grid/css-modules/index.module.css
@@ -128,6 +128,7 @@
   line-height: 1.5rem;
   color: oklch(14.5% 0 0deg);
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   min-width: 9rem;
   background-color: white;
@@ -272,6 +273,7 @@
   font-size: 0.875rem;
   line-height: 1rem;
   color: oklch(55.6% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -296,6 +298,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   display: flex;
   flex-direction: column;

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/grouped/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/grouped/css-modules/index.module.css
@@ -104,6 +104,7 @@
 
 .GroupLabel {
   box-sizing: border-box;
+  -webkit-user-select: none;
   user-select: none;
   padding: 0.5rem;
   font-size: 0.875rem;
@@ -119,6 +120,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding: 0.5rem;
   display: flex;

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/hero/css-modules/index.module.css
@@ -96,6 +96,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.5rem;

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/inline/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/inline/css-modules/index.module.css
@@ -106,6 +106,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.5rem;

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/limit/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/limit/css-modules/index.module.css
@@ -88,6 +88,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.5rem;

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/virtualized/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/virtualized/css-modules/index.module.css
@@ -92,6 +92,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.5rem;

--- a/docs/src/app/(docs)/react/components/avatar/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/avatar/demos/hero/css-modules/index.module.css
@@ -4,6 +4,7 @@
   align-items: center;
   vertical-align: middle;
   border-radius: 100%;
+  -webkit-user-select: none;
   user-select: none;
   font-weight: 400;
   color: oklch(14.5% 0 0deg);

--- a/docs/src/app/(docs)/react/components/button/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/button/demos/hero/css-modules/index.module.css
@@ -16,6 +16,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.module.css
@@ -16,6 +16,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/collapsible/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/collapsible/demos/hero/css-modules/index.module.css
@@ -33,6 +33,7 @@
   font-weight: 400;
   line-height: 1;
   white-space: nowrap;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/css-modules/index.module.css
@@ -269,6 +269,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-inline: 0.5rem;

--- a/docs/src/app/(docs)/react/components/combobox/demos/async-single/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/combobox/demos/async-single/css-modules/index.module.css
@@ -198,6 +198,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-inline: 0.5rem;

--- a/docs/src/app/(docs)/react/components/combobox/demos/creatable/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/combobox/demos/creatable/css-modules/index.module.css
@@ -221,6 +221,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.5rem;
@@ -457,6 +458,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/combobox/demos/grouped/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/combobox/demos/grouped/css-modules/index.module.css
@@ -169,6 +169,7 @@
 
 .GroupLabel {
   box-sizing: border-box;
+  -webkit-user-select: none;
   user-select: none;
   padding: 0.5rem 0.5rem 0.5rem 2rem;
   font-size: 0.875rem;
@@ -184,6 +185,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding: 0.5rem;
   display: grid;

--- a/docs/src/app/(docs)/react/components/combobox/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/combobox/demos/hero/css-modules/index.module.css
@@ -164,6 +164,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.5rem;

--- a/docs/src/app/(docs)/react/components/combobox/demos/input-inside-popup/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/combobox/demos/input-inside-popup/css-modules/index.module.css
@@ -25,6 +25,7 @@
   color: oklch(14.5% 0 0deg);
   cursor: default;
   background-color: white;
+  -webkit-user-select: none;
   user-select: none;
   min-width: 10rem;
 
@@ -204,6 +205,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   min-width: var(--anchor-width);
   padding-block: 0.5rem;

--- a/docs/src/app/(docs)/react/components/combobox/demos/multiple/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/combobox/demos/multiple/css-modules/index.module.css
@@ -234,6 +234,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.5rem;

--- a/docs/src/app/(docs)/react/components/combobox/demos/virtualized/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/combobox/demos/virtualized/css-modules/index.module.css
@@ -93,6 +93,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.5rem;

--- a/docs/src/app/(docs)/react/components/context-menu/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/hero/css-modules/index.module.css
@@ -56,6 +56,7 @@
 .Item {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(docs)/react/components/context-menu/demos/submenu/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/submenu/css-modules/index.module.css
@@ -106,6 +106,7 @@
 .SubmenuTrigger {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(docs)/react/components/dialog/demos/_index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/_index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/close-confirmation/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/dialog/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/hero/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/dialog/demos/inside-scroll/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/inside-scroll/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/dialog/demos/nested/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/nested/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -77,6 +78,7 @@
   font-weight: 400;
   line-height: 1.25rem;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/dialog/demos/outside-scroll/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/outside-scroll/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/dialog/demos/uncontained/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/dialog/demos/uncontained/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/drawer/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/hero/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -138,6 +139,7 @@
   }
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/indent-provider/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/indent-provider/css-modules/index.module.css
@@ -71,6 +71,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -181,6 +182,7 @@
   }
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -147,6 +148,7 @@
   transform: translateY(var(--drawer-swipe-movement-y));
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/nested/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/nested/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -161,6 +162,7 @@
   }
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/non-modal/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/non-modal/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -142,6 +143,7 @@
   }
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/position/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/position/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -126,6 +127,7 @@
   }
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -146,6 +147,7 @@
   }
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/css-modules/index.module.css
@@ -89,6 +89,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -207,6 +208,7 @@
   }
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/docs/src/app/(docs)/react/components/drawer/demos/uncontained/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/uncontained/css-modules/index.module.css
@@ -15,6 +15,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -118,6 +119,7 @@
   will-change: transform;
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 
@@ -174,6 +176,7 @@
   line-height: 1.25rem;
   text-align: center;
   color: inherit;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {
@@ -231,6 +234,7 @@
   line-height: 1.25rem;
   text-align: center;
   color: oklch(50% 55% 31deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(docs)/react/components/form/demos/form-action/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/form/demos/form-action/css-modules/index.module.css
@@ -97,6 +97,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/form/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/form/demos/hero/css-modules/index.module.css
@@ -97,6 +97,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/form/demos/zod/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/form/demos/zod/css-modules/index.module.css
@@ -97,6 +97,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/menu/demos/_index.module.css
+++ b/docs/src/app/(docs)/react/components/menu/demos/_index.module.css
@@ -12,6 +12,7 @@
   border-radius: 0;
   background-color: white;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -92,6 +93,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -182,6 +184,7 @@
 .Item {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;
@@ -224,6 +227,7 @@
 }
 
 .Label {
+  -webkit-user-select: none;
   user-select: none;
   padding: 0.5rem 1rem;
   font-size: 0.875rem;

--- a/docs/src/app/(docs)/react/components/menu/demos/arrow/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/menu/demos/arrow/css-modules/index.module.css
@@ -17,6 +17,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -154,6 +155,7 @@
 .Item {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(docs)/react/components/menu/demos/checkbox-items/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/menu/demos/checkbox-items/css-modules/index.module.css
@@ -17,6 +17,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -107,6 +108,7 @@
 .CheckboxItem {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.625rem;

--- a/docs/src/app/(docs)/react/components/menu/demos/group-labels/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/menu/demos/group-labels/css-modules/index.module.css
@@ -17,6 +17,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -108,6 +109,7 @@
 .RadioItem {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.625rem;
@@ -173,6 +175,7 @@
 }
 
 .GroupLabel {
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 2.125rem;

--- a/docs/src/app/(docs)/react/components/menu/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/menu/demos/hero/css-modules/index.module.css
@@ -17,6 +17,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -107,6 +108,7 @@
 .Item {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(docs)/react/components/menu/demos/open-on-hover/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/menu/demos/open-on-hover/css-modules/index.module.css
@@ -17,6 +17,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -107,6 +108,7 @@
 .Item {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(docs)/react/components/menu/demos/radio-items/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/menu/demos/radio-items/css-modules/index.module.css
@@ -17,6 +17,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -107,6 +108,7 @@
 .RadioItem {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.625rem;

--- a/docs/src/app/(docs)/react/components/menu/demos/submenu/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/menu/demos/submenu/css-modules/index.module.css
@@ -17,6 +17,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -108,6 +109,7 @@
 .SubmenuTrigger {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(docs)/react/components/menubar/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/menubar/demos/hero/css-modules/index.module.css
@@ -15,6 +15,7 @@
   font-size: 0.875rem;
   font-weight: 400;
   line-height: 1.25rem;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -107,6 +108,7 @@
 .SubmenuTrigger {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(docs)/react/components/navigation-menu/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/navigation-menu/demos/hero/css-modules/index.module.css
@@ -34,6 +34,7 @@
   font-weight: 400;
   line-height: 1.25rem;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
   text-decoration: none;
 

--- a/docs/src/app/(docs)/react/components/navigation-menu/demos/nested-inline/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/navigation-menu/demos/nested-inline/css-modules/index.module.css
@@ -34,6 +34,7 @@
   font-weight: 400;
   line-height: 1.25rem;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
   text-decoration: none;
 

--- a/docs/src/app/(docs)/react/components/navigation-menu/demos/nested/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/navigation-menu/demos/nested/css-modules/index.module.css
@@ -34,6 +34,7 @@
   font-weight: 400;
   line-height: 1.25rem;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
   text-decoration: none;
 

--- a/docs/src/app/(docs)/react/components/number-field/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/number-field/demos/hero/css-modules/index.module.css
@@ -8,6 +8,7 @@
 .ScrubArea {
   cursor: ew-resize;
   font-weight: 700;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -88,6 +89,7 @@
   background-color: white;
   background-clip: padding-box;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/popover/demos/_index.module.css
+++ b/docs/src/app/(docs)/react/components/popover/demos/_index.module.css
@@ -127,6 +127,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/popover/demos/detached-triggers-full/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/popover/demos/detached-triggers-full/css-modules/index.module.css
@@ -208,6 +208,7 @@
     justify-content: center;
     align-items: center;
     vertical-align: middle;
+    -webkit-user-select: none;
     user-select: none;
     font-weight: 700;
     color: oklch(14.5% 0 0deg);

--- a/docs/src/app/(docs)/react/components/preview-card/demos/index.module.css
+++ b/docs/src/app/(docs)/react/components/preview-card/demos/index.module.css
@@ -184,6 +184,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/select/demos/grouped/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/select/demos/grouped/css-modules/index.module.css
@@ -44,6 +44,7 @@
   white-space: nowrap;
   font-weight: 400;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
   min-width: 11rem;
 
@@ -102,6 +103,7 @@
 .Positioner {
   outline: none;
   z-index: 10;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -166,6 +168,7 @@
   padding-right: 1rem;
   font-size: 0.875rem;
   line-height: 1.25rem;
+  -webkit-user-select: none;
   user-select: none;
   color: oklch(55.6% 0 0deg);
 
@@ -187,6 +190,7 @@
   align-items: center;
   grid-template-columns: 1rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   &[data-highlighted] {

--- a/docs/src/app/(docs)/react/components/select/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/select/demos/hero/css-modules/index.module.css
@@ -44,6 +44,7 @@
   white-space: nowrap;
   font-weight: 400;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
   min-width: 10rem;
 
@@ -102,6 +103,7 @@
 .Positioner {
   outline: none;
   z-index: 10;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -162,6 +164,7 @@
   align-items: center;
   grid-template-columns: 1rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   &[data-highlighted] {

--- a/docs/src/app/(docs)/react/components/select/demos/multiple/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/select/demos/multiple/css-modules/index.module.css
@@ -44,6 +44,7 @@
   white-space: nowrap;
   font-weight: 400;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
   min-width: 14rem;
 
@@ -155,6 +156,7 @@
   align-items: center;
   grid-template-columns: 1rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   scroll-margin-block: 0.25rem;
 

--- a/docs/src/app/(docs)/react/components/select/demos/object-values/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/select/demos/object-values/css-modules/index.module.css
@@ -37,6 +37,7 @@
   white-space: nowrap;
   font-weight: 400;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
   min-width: 16rem;
 
@@ -117,6 +118,7 @@
 .Positioner {
   outline: none;
   z-index: 10;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -177,6 +179,7 @@
   align-items: flex-start;
   grid-template-columns: 1rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   &[data-highlighted] {

--- a/docs/src/app/(docs)/react/components/slider/demos/edge-alignment/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/slider/demos/edge-alignment/css-modules/index.module.css
@@ -5,6 +5,7 @@
   width: 14rem;
   padding-block: 0.75rem;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -12,6 +13,7 @@
   width: 100%;
   height: 0.25rem;
   background-color: oklch(92.2% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -21,6 +23,7 @@
 
 .Indicator {
   background-color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -34,6 +37,7 @@
   height: 1rem;
   border: 1px solid oklch(14.5% 0 0deg);
   background-color: white;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/slider/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/slider/demos/hero/css-modules/index.module.css
@@ -5,6 +5,7 @@
   width: 14rem;
   padding-block: 0.75rem;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -12,6 +13,7 @@
   width: 100%;
   height: 0.25rem;
   background-color: oklch(92.2% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -21,6 +23,7 @@
 
 .Indicator {
   background-color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -34,6 +37,7 @@
   height: 1rem;
   border: 1px solid oklch(14.5% 0 0deg);
   background-color: white;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/slider/demos/range-slider/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/slider/demos/range-slider/css-modules/index.module.css
@@ -5,6 +5,7 @@
   width: 14rem;
   padding-block: 0.75rem;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -12,6 +13,7 @@
   width: 100%;
   height: 0.25rem;
   background-color: oklch(92.2% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -21,6 +23,7 @@
 
 .Indicator {
   background-color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -34,6 +37,7 @@
   height: 1rem;
   border: 1px solid oklch(14.5% 0 0deg);
   background-color: white;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/slider/demos/vertical/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/slider/demos/vertical/css-modules/index.module.css
@@ -2,6 +2,7 @@
   box-sizing: border-box;
   display: flex;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 
   &[data-orientation='vertical'] {
@@ -12,6 +13,7 @@
 
 .Track {
   background-color: oklch(92.2% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -26,6 +28,7 @@
 
 .Indicator {
   background-color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -39,6 +42,7 @@
   height: 1rem;
   border: 1px solid oklch(14.5% 0 0deg);
   background-color: white;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/tabs/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/tabs/demos/hero/css-modules/index.module.css
@@ -26,6 +26,7 @@
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 400;
+  -webkit-user-select: none;
   user-select: none;
   white-space: nowrap;
   word-break: keep-all;

--- a/docs/src/app/(docs)/react/components/toast/demos/anchored/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toast/demos/anchored/css-modules/index.module.css
@@ -91,6 +91,7 @@
   bottom: 0;
   left: auto;
   margin-right: 0;
+  -webkit-user-select: none;
   user-select: none;
   transition:
     transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
@@ -367,6 +368,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -417,6 +419,7 @@
   background-color: white;
   font-family: inherit;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/toast/demos/custom/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toast/demos/custom/css-modules/index.module.css
@@ -38,6 +38,7 @@
   bottom: 0;
   left: auto;
   margin-right: 0;
+  -webkit-user-select: none;
   user-select: none;
   transition:
     transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
@@ -232,6 +233,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/toast/demos/deduplicate/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toast/demos/deduplicate/css-modules/index.module.css
@@ -38,6 +38,7 @@
   bottom: 0;
   left: auto;
   margin-right: 0;
+  -webkit-user-select: none;
   user-select: none;
   transition:
     transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
@@ -244,6 +245,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/toast/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toast/demos/hero/css-modules/index.module.css
@@ -38,6 +38,7 @@
   bottom: 0;
   left: auto;
   margin-right: 0;
+  -webkit-user-select: none;
   user-select: none;
   transition:
     transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
@@ -232,6 +233,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/toast/demos/position/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toast/demos/position/css-modules/index.module.css
@@ -33,6 +33,7 @@
   right: 0;
   margin-right: auto;
   margin-left: auto;
+  -webkit-user-select: none;
   user-select: none;
   transition:
     transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
@@ -227,6 +228,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/toast/demos/promise/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toast/demos/promise/css-modules/index.module.css
@@ -38,6 +38,7 @@
   bottom: 0;
   left: auto;
   margin-right: 0;
+  -webkit-user-select: none;
   user-select: none;
   transition:
     transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
@@ -248,6 +249,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/toast/demos/undo/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toast/demos/undo/css-modules/index.module.css
@@ -38,6 +38,7 @@
   bottom: 0;
   left: auto;
   margin-right: 0;
+  -webkit-user-select: none;
   user-select: none;
   transition:
     transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
@@ -238,6 +239,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/toast/demos/varying-heights/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toast/demos/varying-heights/css-modules/index.module.css
@@ -38,6 +38,7 @@
   bottom: 0;
   left: auto;
   margin-right: 0;
+  -webkit-user-select: none;
   user-select: none;
   transition:
     transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
@@ -232,6 +233,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/toggle-group/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toggle-group/demos/hero/css-modules/index.module.css
@@ -22,6 +22,7 @@
   border-radius: 0;
   background-color: transparent;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/toggle-group/demos/multiple/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toggle-group/demos/multiple/css-modules/index.module.css
@@ -22,6 +22,7 @@
   border-radius: 0;
   background-color: transparent;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/toggle/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toggle/demos/hero/css-modules/index.module.css
@@ -11,6 +11,7 @@
   border-radius: 0;
   background-color: transparent;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/toolbar/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/toolbar/demos/hero/css-modules/index.module.css
@@ -31,6 +31,7 @@
   border: 0;
   background-color: transparent;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
   font-family: inherit;
   font-size: 0.875rem;
@@ -158,6 +159,7 @@
 
 .Positioner {
   outline: none;
+  -webkit-user-select: none;
   user-select: none;
   z-index: 10;
 }
@@ -212,6 +214,7 @@
   align-items: center;
   grid-template-columns: 1rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (pointer: coarse) {

--- a/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-full/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-full/css-modules/index.module.css
@@ -18,6 +18,7 @@
   border: 1px solid oklch(14.5% 0 0deg);
   background-color: white;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/tooltip/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/tooltip/demos/hero/css-modules/index.module.css
@@ -21,6 +21,7 @@
   border: 0;
   background-color: transparent;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/components/tooltip/demos/index.module.css
+++ b/docs/src/app/(docs)/react/components/tooltip/demos/index.module.css
@@ -21,6 +21,7 @@
   border: 1px solid oklch(14.5% 0 0deg);
   background-color: white;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -183,6 +184,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/handbook/animation/demos/animated-popover-motion-keep-mounted-false/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/handbook/animation/demos/animated-popover-motion-keep-mounted-false/css-modules/index.module.css
@@ -14,6 +14,7 @@
   font-weight: 400;
   line-height: 1.25rem;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/handbook/animation/demos/animated-popover-motion-keep-mounted-true/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/handbook/animation/demos/animated-popover-motion-keep-mounted-true/css-modules/index.module.css
@@ -14,6 +14,7 @@
   font-weight: 400;
   line-height: 1.25rem;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/handbook/animation/demos/animated-select-motion/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/handbook/animation/demos/animated-select-motion/css-modules/index.module.css
@@ -16,6 +16,7 @@
   line-height: 1.25rem;
   font-weight: 400;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
   min-width: 9rem;
 
@@ -72,6 +73,7 @@
 .Positioner {
   outline: none;
   z-index: 10;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -168,6 +170,7 @@
   align-items: center;
   grid-template-columns: 1rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   &[data-highlighted] {

--- a/docs/src/app/(docs)/react/utils/direction-provider/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/utils/direction-provider/demos/hero/css-modules/index.module.css
@@ -5,6 +5,7 @@
   width: 14rem;
   padding-block: 0.75rem;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -12,6 +13,7 @@
   width: 100%;
   height: 0.25rem;
   background-color: oklch(92.2% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -21,6 +23,7 @@
 
 .Indicator {
   background-color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -34,6 +37,7 @@
   height: 1rem;
   border: 1px solid oklch(14.5% 0 0deg);
   background-color: white;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/utils/merge-props/demos/prevent-base-ui-handler/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/utils/merge-props/demos/prevent-base-ui-handler/css-modules/index.module.css
@@ -33,6 +33,7 @@
   border-radius: 0;
   background-color: transparent;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {
@@ -84,6 +85,7 @@
   line-height: 1;
   white-space: nowrap;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(docs)/react/utils/use-render/demos/render-callback/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/utils/use-render/demos/render-callback/css-modules/index.module.css
@@ -16,6 +16,7 @@
   font-weight: 400;
   line-height: 1.25rem;
   color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/app/(private)/experiments/_components/Select.module.css
+++ b/docs/src/app/(private)/experiments/_components/Select.module.css
@@ -16,6 +16,7 @@
   line-height: 1.5rem;
   color: var(--color-gray-900);
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   min-width: 5rem;
 
@@ -134,6 +135,7 @@
   align-items: center;
   grid-template-columns: 0.75rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   [data-side='none'] & {

--- a/docs/src/app/(private)/experiments/_components/SettingsPanel.module.css
+++ b/docs/src/app/(private)/experiments/_components/SettingsPanel.module.css
@@ -56,6 +56,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(private)/experiments/combobox-composition.module.css
+++ b/docs/src/app/(private)/experiments/combobox-composition.module.css
@@ -123,6 +123,7 @@
   font-size: 1rem;
   line-height: 1rem;
   outline: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/docs/src/app/(private)/experiments/combobox-perf.module.css
+++ b/docs/src/app/(private)/experiments/combobox-perf.module.css
@@ -114,6 +114,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(private)/experiments/combobox/creatable-tags.module.css
+++ b/docs/src/app/(private)/experiments/combobox/creatable-tags.module.css
@@ -122,6 +122,7 @@
   font-size: 1rem;
   line-height: 1rem;
   outline: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/docs/src/app/(private)/experiments/combobox/dialog-combobox.module.css
+++ b/docs/src/app/(private)/experiments/combobox/dialog-combobox.module.css
@@ -15,6 +15,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {
@@ -258,6 +259,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(private)/experiments/combobox/limited-chips.module.css
+++ b/docs/src/app/(private)/experiments/combobox/limited-chips.module.css
@@ -176,6 +176,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(private)/experiments/combobox/priority-combobox.module.css
+++ b/docs/src/app/(private)/experiments/combobox/priority-combobox.module.css
@@ -12,6 +12,7 @@
   font-size: 0.875rem;
   line-height: 1.25rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -143,6 +144,7 @@
   padding: 0.5rem 1rem;
   font-size: 0.875rem;
   line-height: 1rem;
+  -webkit-user-select: none;
   user-select: none;
   outline: none;
 }

--- a/docs/src/app/(private)/experiments/context-menu.module.css
+++ b/docs/src/app/(private)/experiments/context-menu.module.css
@@ -221,6 +221,7 @@
   background: var(--color-gray-50);
   padding: 1rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/docs/src/app/(private)/experiments/drawer-slider.module.css
+++ b/docs/src/app/(private)/experiments/drawer-slider.module.css
@@ -20,6 +20,7 @@
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: 500;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -152,6 +153,7 @@
   align-items: center;
   padding-block: 0.75rem;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -161,12 +163,14 @@
   border-radius: 99px;
   background-color: var(--color-gray-200);
   box-shadow: inset 0 0 0 1px var(--color-gray-200);
+  -webkit-user-select: none;
   user-select: none;
 }
 
 .SliderIndicator {
   border-radius: 99px;
   background-color: var(--color-gray-700);
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -176,6 +180,7 @@
   border-radius: 9999px;
   background-color: white;
   outline: 1px solid var(--color-gray-300);
+  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/docs/src/app/(private)/experiments/drawer/drawer-controlled-opening.module.css
+++ b/docs/src/app/(private)/experiments/drawer/drawer-controlled-opening.module.css
@@ -21,6 +21,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {
@@ -102,6 +103,7 @@
   transform: translateY(var(--drawer-swipe-movement-y));
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/docs/src/app/(private)/experiments/drawer/touch-ignore.module.css
+++ b/docs/src/app/(private)/experiments/drawer/touch-ignore.module.css
@@ -197,6 +197,7 @@
   outline: 1px solid var(--color-gray-200);
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/docs/src/app/(private)/experiments/forms/autofill.module.css
+++ b/docs/src/app/(private)/experiments/forms/autofill.module.css
@@ -107,6 +107,7 @@
   font-size: 1rem;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
   width: 100%;
   min-width: 10rem;
@@ -138,6 +139,7 @@
 .SelectPositioner {
   outline: none;
   z-index: 1;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -200,6 +202,7 @@
   align-items: center;
   grid-template-columns: 0.75rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (pointer: coarse) {
@@ -413,6 +416,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(private)/experiments/forms/form.module.css
+++ b/docs/src/app/(private)/experiments/forms/form.module.css
@@ -89,6 +89,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   &[data-color='red'] {
@@ -135,6 +136,7 @@
   line-height: 1.5rem;
   color: var(--color-gray-900);
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   min-width: 9rem;
 
@@ -255,6 +257,7 @@
   align-items: center;
   grid-template-columns: 0.75rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   scroll-margin-block: 1rem;
 
@@ -572,6 +575,7 @@
   width: 100%;
   padding-block: 0.75rem;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -581,12 +585,14 @@
   background-color: var(--color-gray-200);
   box-shadow: inset 0 0 0 1px var(--color-gray-200);
   border-radius: 0.25rem;
+  -webkit-user-select: none;
   user-select: none;
 }
 
 .SliderIndicator {
   border-radius: 0.25rem;
   background-color: var(--color-gray-700);
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -596,6 +602,7 @@
   border-radius: 100%;
   background-color: white;
   outline: 1px solid var(--color-gray-300);
+  -webkit-user-select: none;
   user-select: none;
 
   &:has(:focus),
@@ -651,6 +658,7 @@
   background-color: var(--color-gray-50);
   background-clip: padding-box;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(private)/experiments/menu/menu-horizontal.module.css
+++ b/docs/src/app/(private)/experiments/menu/menu-horizontal.module.css
@@ -104,6 +104,7 @@
   padding: 8px;
   border-radius: 8px;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   &:last-of-type {
@@ -142,6 +143,7 @@
   padding: 8px;
   border-radius: 8px;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   &:last-of-type {

--- a/docs/src/app/(private)/experiments/menu/menu-nested.module.css
+++ b/docs/src/app/(private)/experiments/menu/menu-nested.module.css
@@ -57,6 +57,7 @@
   padding: 8px;
   border-radius: 8px;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   &:last-of-type {
@@ -95,6 +96,7 @@
   padding: 8px;
   border-radius: 8px;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   &:last-of-type {

--- a/docs/src/app/(private)/experiments/menu/menu.module.css
+++ b/docs/src/app/(private)/experiments/menu/menu.module.css
@@ -16,6 +16,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {
@@ -136,6 +137,7 @@
 .SubmenuTrigger {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;
@@ -210,6 +212,7 @@
 .RadioItem {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 0.625rem;
@@ -265,6 +268,7 @@
 
 .GroupLabel {
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1.875rem;

--- a/docs/src/app/(private)/experiments/menu/nested-detached-triggers.module.css
+++ b/docs/src/app/(private)/experiments/menu/nested-detached-triggers.module.css
@@ -44,6 +44,7 @@
   border-radius: 0.25rem;
   background-color: transparent;
   color: var(--color-gray-600);
+  -webkit-user-select: none;
   user-select: none;
   font-family: inherit;
   font-size: 0.875rem;
@@ -90,6 +91,7 @@
   border: 0;
   color: var(--color-gray-600);
   border-radius: 0.25rem;
+  -webkit-user-select: none;
   user-select: none;
   height: 2rem;
   font-family: inherit;

--- a/docs/src/app/(private)/experiments/menu/pointer-events-scope.module.css
+++ b/docs/src/app/(private)/experiments/menu/pointer-events-scope.module.css
@@ -51,6 +51,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   padding: 0 0.875rem;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -202,6 +203,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -238,6 +240,7 @@
   justify-content: space-between;
   align-items: center;
   font-size: 0.875rem;
+  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/docs/src/app/(private)/experiments/menubar.module.css
+++ b/docs/src/app/(private)/experiments/menubar.module.css
@@ -28,6 +28,7 @@
   border: 0;
   color: var(--color-gray-600);
   border-radius: 0.25rem;
+  -webkit-user-select: none;
   user-select: none;
   height: 2rem;
   font-family: inherit;

--- a/docs/src/app/(private)/experiments/mobile-scroll-lock.module.css
+++ b/docs/src/app/(private)/experiments/mobile-scroll-lock.module.css
@@ -15,6 +15,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(private)/experiments/modality.module.css
+++ b/docs/src/app/(private)/experiments/modality.module.css
@@ -10,6 +10,7 @@
   border: none;
   font-size: 100%;
   line-height: 1.5;
+  -webkit-user-select: none;
   user-select: none;
   cursor: default;
 
@@ -63,6 +64,7 @@
   outline: 0;
   cursor: default;
   border-radius: 4px;
+  -webkit-user-select: none;
   user-select: none;
   display: flex;
   align-items: center;
@@ -142,6 +144,7 @@
   padding: 8px;
   border-radius: 8px;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   &:last-of-type {

--- a/docs/src/app/(private)/experiments/navigation-menu.module.css
+++ b/docs/src/app/(private)/experiments/navigation-menu.module.css
@@ -52,6 +52,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
   text-decoration: none;
 
@@ -509,6 +510,7 @@
   line-height: 1.5rem;
   font-weight: 500;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/docs/src/app/(private)/experiments/perf/perf.module.css
+++ b/docs/src/app/(private)/experiments/perf/perf.module.css
@@ -44,6 +44,7 @@
   font-weight: 400;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(private)/experiments/popover/calendar.module.css
+++ b/docs/src/app/(private)/experiments/popover/calendar.module.css
@@ -53,6 +53,7 @@
   padding: 4px;
   min-height: max(calc(100% / var(--hours-shown) * 0.5), 2em);
   font-size: 0.875rem;
+  -webkit-user-select: none;
   user-select: none;
   box-shadow:
     0.5px 1px 0.5px rgb(255 255 255 / 0.2) inset,

--- a/docs/src/app/(private)/experiments/popover/nested-open-on-hover.module.css
+++ b/docs/src/app/(private)/experiments/popover/nested-open-on-hover.module.css
@@ -12,6 +12,7 @@
   border-radius: 0.375rem;
   background-color: var(--color-gray-50);
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {
@@ -158,6 +159,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(private)/experiments/popover/popovers.module.css
+++ b/docs/src/app/(private)/experiments/popover/popovers.module.css
@@ -34,6 +34,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(private)/experiments/popover/vertical.module.css
+++ b/docs/src/app/(private)/experiments/popover/vertical.module.css
@@ -12,6 +12,7 @@
   border-radius: 0.375rem;
   background-color: var(--color-gray-50);
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
   font-size: 1rem;
   font-weight: bold;
@@ -295,6 +296,7 @@
   align-items: center;
   vertical-align: middle;
   border-radius: 100%;
+  -webkit-user-select: none;
   user-select: none;
   font-weight: 600;
   color: var(--color-gray-900);
@@ -350,6 +352,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(private)/experiments/popup-tabbing.module.css
+++ b/docs/src/app/(private)/experiments/popup-tabbing.module.css
@@ -220,6 +220,7 @@
   padding: 0.5rem 2rem 0.5rem 1rem;
   font-size: 0.875rem;
   line-height: 1rem;
+  -webkit-user-select: none;
   user-select: none;
   outline: none;
 }
@@ -350,6 +351,7 @@
   padding: 0.5rem 2rem 0.5rem 1rem;
   font-size: 1rem;
   line-height: 1rem;
+  -webkit-user-select: none;
   user-select: none;
   outline: none;
 }

--- a/docs/src/app/(private)/experiments/popups/popups-in-popups.module.css
+++ b/docs/src/app/(private)/experiments/popups/popups-in-popups.module.css
@@ -37,6 +37,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {
@@ -199,6 +200,7 @@
   transform: translateY(var(--drawer-swipe-movement-y));
 
   &[data-swiping] {
+    -webkit-user-select: none;
     user-select: none;
   }
 
@@ -291,6 +293,7 @@
   font-size: 1rem;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
   min-width: 10rem;
 
@@ -317,6 +320,7 @@
 .SelectPositioner {
   outline: none;
   z-index: 1;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -379,6 +383,7 @@
   align-items: center;
   grid-template-columns: 0.75rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   @media (pointer: coarse) {
@@ -512,6 +517,7 @@
 .MenuItem {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;
@@ -544,6 +550,7 @@
 .SubmenuTrigger {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;
@@ -718,6 +725,7 @@
   box-sizing: border-box;
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(private)/experiments/preview-card/triggers.module.css
+++ b/docs/src/app/(private)/experiments/preview-card/triggers.module.css
@@ -48,6 +48,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(private)/experiments/rtl.module.css
+++ b/docs/src/app/(private)/experiments/rtl.module.css
@@ -49,6 +49,7 @@
   padding: 8px;
   border-radius: 8px;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   color: black;
 
@@ -76,6 +77,7 @@
   padding: 8px;
   border-radius: 8px;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   color: #444;
 

--- a/docs/src/app/(private)/experiments/scroll-area/inside-menu.module.css
+++ b/docs/src/app/(private)/experiments/scroll-area/inside-menu.module.css
@@ -16,6 +16,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {
@@ -120,6 +121,7 @@
 .SubmenuTrigger {
   outline: 0;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   padding-block: 0.5rem;
   padding-left: 1rem;

--- a/docs/src/app/(private)/experiments/scroll-area/inside-select.module.css
+++ b/docs/src/app/(private)/experiments/scroll-area/inside-select.module.css
@@ -16,6 +16,7 @@
   line-height: 1.5rem;
   color: var(--color-gray-900);
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   min-width: 9rem;
 
@@ -125,6 +126,7 @@
   align-items: center;
   grid-template-columns: 0.75rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   scroll-margin-block: 1rem;
 

--- a/docs/src/app/(private)/experiments/select-perf.module.css
+++ b/docs/src/app/(private)/experiments/select-perf.module.css
@@ -16,6 +16,7 @@
   line-height: 1.5rem;
   color: var(--color-gray-900);
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   min-width: 9rem;
 
@@ -135,6 +136,7 @@
   align-items: center;
   grid-template-columns: 0.75rem 1fr;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 
   [data-side='none'] & {

--- a/docs/src/app/(private)/experiments/slider/inset.module.css
+++ b/docs/src/app/(private)/experiments/slider/inset.module.css
@@ -16,11 +16,13 @@
   box-sizing: border-box;
   border-radius: 9999px;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
 .InsetTrack {
   position: relative;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -36,6 +38,7 @@
 
 .InsetIndicator {
   background: var(--indicator-bg);
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -59,6 +62,7 @@
   height: calc(var(--thumb-radius) * 2);
   border-radius: 9999px;
   background: white;
+  -webkit-user-select: none;
   user-select: none;
   box-shadow: 0 0 3px 0 var(--color-gray-500);
 }
@@ -88,6 +92,7 @@
   box-sizing: border-box;
   width: var(--track-width);
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -96,11 +101,13 @@
   height: var(--track-height);
   border-radius: 9999px;
   background: var(--track-bg);
+  -webkit-user-select: none;
   user-select: none;
 }
 
 .DemoIndicator {
   background: var(--indicator-bg);
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -118,6 +125,7 @@
   height: calc(var(--thumb-radius) * 2);
   border-radius: 9999px;
   background: var(--indicator-bg);
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -135,6 +143,7 @@
   position: relative;
   display: flex;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/docs/src/app/(private)/experiments/slider/slider.module.css
+++ b/docs/src/app/(private)/experiments/slider/slider.module.css
@@ -31,6 +31,7 @@
   width: 100%;
   padding: 0.75rem 0.25rem;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -40,12 +41,14 @@
   background-color: var(--color-gray-200);
   box-shadow: inset 0 0 0 1px var(--color-gray-200);
   border-radius: 0.25rem;
+  -webkit-user-select: none;
   user-select: none;
 }
 
 .Indicator {
   border-radius: 0.25rem;
   background-color: var(--color-gray-700);
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -55,6 +58,7 @@
   border-radius: 100%;
   background-color: white;
   outline: 1px solid var(--color-gray-300);
+  -webkit-user-select: none;
   user-select: none;
 
   &:has(:focus-visible) {

--- a/docs/src/app/(private)/experiments/slider/small.module.css
+++ b/docs/src/app/(private)/experiments/slider/small.module.css
@@ -22,6 +22,7 @@
   width: 100%;
   padding: 0.75rem 0.25rem;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -32,6 +33,7 @@
   display: flex;
   flex-flow: row nowrap;
   justify-content: space-between;
+  -webkit-user-select: none;
   user-select: none;
 
   &::before {
@@ -47,6 +49,7 @@
 .Indicator {
   border-radius: 0.25rem;
   background-color: var(--color-gray-700);
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -56,6 +59,7 @@
   border-radius: 9999px;
   background-color: white;
   outline: 1px solid var(--color-gray-300);
+  -webkit-user-select: none;
   user-select: none;
 
   &:has(:focus-visible) {

--- a/docs/src/app/(private)/experiments/slider/vertical.module.css
+++ b/docs/src/app/(private)/experiments/slider/vertical.module.css
@@ -28,6 +28,7 @@
   height: 14rem;
   padding: 0.75rem;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -37,12 +38,14 @@
   background-color: var(--color-gray-200);
   box-shadow: inset 0 0 0 1px var(--color-gray-200);
   border-radius: 0.25rem;
+  -webkit-user-select: none;
   user-select: none;
 }
 
 .Indicator {
   border-radius: 0.25rem;
   background-color: var(--color-gray-700);
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -52,6 +55,7 @@
   border-radius: 100%;
   background-color: white;
   outline: 1px solid var(--color-gray-300);
+  -webkit-user-select: none;
   user-select: none;
 
   &:has(:focus-visible) {

--- a/docs/src/app/(private)/experiments/tabs/tabs-animations.module.css
+++ b/docs/src/app/(private)/experiments/tabs/tabs-animations.module.css
@@ -63,6 +63,7 @@
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 600;
+  -webkit-user-select: none;
   user-select: none;
   white-space: nowrap;
   word-break: keep-all;

--- a/docs/src/app/(private)/experiments/tabs/tabs-basic.module.css
+++ b/docs/src/app/(private)/experiments/tabs/tabs-basic.module.css
@@ -41,6 +41,7 @@
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
+  -webkit-user-select: none;
   user-select: none;
   white-space: nowrap;
   word-break: keep-all;

--- a/docs/src/app/(private)/experiments/toast.module.css
+++ b/docs/src/app/(private)/experiments/toast.module.css
@@ -24,6 +24,7 @@
   transform: translateY(calc(var(--toast-index) * 15px)) scale(calc(1 - (var(--toast-index) * 0.1)));
   opacity: 1;
   --gap: 10px;
+  -webkit-user-select: none;
   user-select: none;
 
   &::after {

--- a/docs/src/app/(private)/experiments/toolbar/toolbar.module.css
+++ b/docs/src/app/(private)/experiments/toolbar/toolbar.module.css
@@ -77,6 +77,7 @@
   line-height: 1.5rem;
   background-color: transparent;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   &:focus-visible {
@@ -118,6 +119,7 @@
   border-radius: 0.25rem;
   background-color: transparent;
   color: var(--color-gray-600);
+  -webkit-user-select: none;
   user-select: none;
 
   &:focus-visible {
@@ -171,6 +173,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(private)/experiments/tooltip/disabled.module.css
+++ b/docs/src/app/(private)/experiments/tooltip/disabled.module.css
@@ -22,6 +22,7 @@
   border: 1px solid var(--color-gray-200);
   background-color: var(--color-gray-50);
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   &[data-popup-open] {
@@ -163,6 +164,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(private)/experiments/tooltip/prevent-open.module.css
+++ b/docs/src/app/(private)/experiments/tooltip/prevent-open.module.css
@@ -14,6 +14,7 @@
   height: 2rem;
   border-radius: 0.25rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
   outline: none;
 }

--- a/docs/src/app/(private)/experiments/tooltip/tooltips.module.css
+++ b/docs/src/app/(private)/experiments/tooltip/tooltips.module.css
@@ -28,6 +28,7 @@
   border-radius: 0.25rem;
   background-color: transparent;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   &[data-popup-open] {
@@ -74,6 +75,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/app/(private)/experiments/transition-attrs.module.css
+++ b/docs/src/app/(private)/experiments/transition-attrs.module.css
@@ -49,6 +49,7 @@
   font-weight: 500;
   line-height: 1.5rem;
   color: var(--color-gray-900);
+  -webkit-user-select: none;
   user-select: none;
 
   @media (hover: hover) {

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -76,6 +76,7 @@
     height: 2.25rem;
     padding: 0;
     padding-inline-start: 0.75rem;
+    -webkit-user-select: none;
     user-select: none;
 
     /* Scroll */
@@ -282,6 +283,7 @@
     border-bottom: 1px solid transparent;
     background-clip: padding-box;
     margin-bottom: -1px;
+    -webkit-user-select: none;
     user-select: none;
 
     &[data-sticky] {

--- a/docs/src/components/GhostButton.css
+++ b/docs/src/components/GhostButton.css
@@ -11,6 +11,7 @@
     gap: 0.375rem;
     height: 1.75rem;
     outline: 0;
+    -webkit-user-select: none;
     user-select: none;
     border-radius: var(--radius-8);
     padding-inline: 0.5rem;

--- a/docs/src/components/Menu.css
+++ b/docs/src/components/Menu.css
@@ -13,6 +13,7 @@
     background-color: var(--color-popup);
     overflow: hidden;
     cursor: default;
+    -webkit-user-select: none;
     user-select: none;
     padding-block: 0.25rem;
 

--- a/docs/src/components/MobileNav.css
+++ b/docs/src/components/MobileNav.css
@@ -217,6 +217,7 @@
   .MobileNavBadge {
     color: var(--poppy-t1);
     line-height: inherit;
+    -webkit-user-select: none;
     user-select: none;
     text-transform: uppercase;
     font-size: 0.6875rem;

--- a/docs/src/components/ReleaseTimeline/ReleaseTimeline.css
+++ b/docs/src/components/ReleaseTimeline/ReleaseTimeline.css
@@ -193,6 +193,7 @@
     color: var(--green-t1);
     border: 1px solid currentColor;
     border-radius: 999px;
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/docs/src/components/Search/SearchBar.css
+++ b/docs/src/components/Search/SearchBar.css
@@ -44,6 +44,7 @@
     font-weight: var(--font-weight-400);
     line-height: 1.5;
     color: var(--gray-t2);
+    -webkit-user-select: none;
     user-select: none;
     outline: none;
 
@@ -240,6 +241,7 @@
     font-weight: var(--font-weight-400);
     line-height: 1;
     color: var(--gray-t1);
+    -webkit-user-select: none;
     user-select: none;
   }
 
@@ -256,6 +258,7 @@
     line-height: 1;
     color: var(--gray-t2);
     cursor: default;
+    -webkit-user-select: none;
     user-select: none;
     outline: none;
   }

--- a/docs/src/components/Select.css
+++ b/docs/src/components/Select.css
@@ -13,6 +13,7 @@
     background-color: var(--color-popup);
     overflow: hidden;
     cursor: default;
+    -webkit-user-select: none;
     user-select: none;
     padding-block: 0.25rem;
 

--- a/docs/src/components/SideNav.css
+++ b/docs/src/components/SideNav.css
@@ -114,6 +114,7 @@
     border-block: 1px solid transparent; /* Maintain a 1px gap between active an inactive item */
     background-clip: padding-box;
     border-radius: var(--radius-6);
+    -webkit-user-select: none;
     user-select: none;
 
     @media (hover: hover) {
@@ -143,6 +144,7 @@
   .SideNavBadge {
     color: var(--poppy-t1);
     line-height: inherit;
+    -webkit-user-select: none;
     user-select: none;
     text-transform: uppercase;
     font-size: 0.625rem;

--- a/packages/utils/src/store/StoreInspector.tsx
+++ b/packages/utils/src/store/StoreInspector.tsx
@@ -76,8 +76,8 @@ const STYLES = `
   display: flex;
   align-items: center;
   cursor: move;
-  user-select: none;
   -webkit-user-select: none;
+  user-select: none;
   touch-action: none;
   padding: 4px 8px 8px 8px;
   gap: 8px;


### PR DESCRIPTION
`-webkit-*` prefix is still needed for Safari, and we don't auto-prefix. The corresponding Tailwind class comes prefixed.