### PR TITLE
[docs][tooltip] Fix box-sizing

### DIFF
--- a/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-full/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/tooltip/demos/detached-triggers-full/css-modules/index.module.css
@@ -95,6 +95,7 @@
 }
 
 .Popup {
+  box-sizing: border-box;
   position: relative;
   height: var(--popup-height, auto);
   width: var(--popup-width, auto);


### PR DESCRIPTION
When opening the demo on Stackblitz, a missing `box-sizing: border-box` on the popup part caused the tooltip to glitch when opening it and when transitioning from one tooltip to another.