### PR TITLE
[docs] Fix nullish syntax gray

### DIFF
--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -167,7 +167,7 @@
     --color-line-highlight-strong-mark: oklch(80% 28% 264deg / 50%);
 
     /* Syntax highlighting */
-    --color-gray: var(--color-gray-600);
+    --color-gray: var(--gray-t1);
     --color-navy: oklch(31% 25% 264deg);
     --color-green: oklch(46% 30% 150deg);
     --color-violet: oklch(40% 60% 300deg);
@@ -289,7 +289,6 @@
       --color-line-highlight-strong-mark: oklch(50% 50% 264deg / 50%);
 
       /* Syntax highlighting */
-      --color-gray: var(--color-gray-600);
       --color-green: oklch(75% 25% 150deg);
       --color-navy: oklch(85% 25% 264deg);
       --color-violet: oklch(80% 60% 280deg);

--- a/docs/src/css/syntax.css
+++ b/docs/src/css/syntax.css
@@ -42,7 +42,7 @@
     /* Docs-infra extensions for concepts not in prettylights */
     --color-docs-infra-syntax-number: var(--color-blue);
     --color-docs-infra-syntax-boolean: var(--color-blue);
-    --color-docs-infra-syntax-nullish: var(--color-gray-600);
+    --color-docs-infra-syntax-nullish: var(--color-gray);
     --color-docs-infra-syntax-attr-key: var(--color-violet);
     --color-docs-infra-syntax-attr-value: var(--color-navy);
     --color-docs-infra-syntax-attr-equals: var(--color-red);


### PR DESCRIPTION
`--color-gray-600` was removed in a previous [PR](https://github.com/mui/base-ui/pull/4676).

|before|after|
|---|---|
|<img width="188" height="63" alt="image" src="https://github.com/user-attachments/assets/cddd1b83-cfd8-4ae5-ae53-0cf1a0c4f386" />|<img width="181" height="67" alt="Screenshot 2026-05-19 at 16 09 32" src="https://github.com/user-attachments/assets/cd8296a5-a22b-4151-9a6c-cf60c6c4d1a3" />|
