### PR TITLE
[docs-infra] Force raw color values in CSS Modules demos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ This repository contains the source code and documentation for Base UI: a headl
 
 ## Styling
 
-When using `user-select: none;` in CSS, also add `-webkit-user-select: none;` to support Safari. Tailwind's `select-none` class already includes this.
+- In CSS Modules demos (`docs/src/app/(docs)/**/demos/**/*.module.css`), use raw color values from the Tailwind `@theme` block in `docs/src/css/index.css`. For example, use `oklch(14.5% 0 0deg)` instead of `var(--color-neutral-950)`.
+- When using `user-select: none;` in CSS, also add `-webkit-user-select: none;` to support Safari. Tailwind's `select-none` class already includes this.
 
 ## Linting, typechecking, and formatting
 
@@ -57,7 +58,7 @@ Every error message must:
 
 Format:
 
-- Prefix with `Base UI: `
+- Prefix with `Base UI:`
 - Use string concatenation for readability
 - Include a documentation link when applicable (`https://base-ui.com/...`)
 

--- a/docs/scripts/stylelint/no-unknown-demo-colors.test.mjs
+++ b/docs/scripts/stylelint/no-unknown-demo-colors.test.mjs
@@ -102,4 +102,15 @@ describe(ruleName, () => {
 
     expect(warnings).toEqual([]);
   });
+
+  it('does not treat strings or URLs as colors', async () => {
+    const warnings = await lint(`
+      .Test {
+        background-image: url("#red");
+        content: "blue";
+      }
+    `);
+
+    expect(warnings).toEqual([]);
+  });
 });

--- a/docs/scripts/stylelint/no-unknown-demo-colors.test.mjs
+++ b/docs/scripts/stylelint/no-unknown-demo-colors.test.mjs
@@ -35,12 +35,28 @@ describe(ruleName, () => {
     expect(warnings).toEqual([]);
   });
 
+  it('allows black and white as theme colors', async () => {
+    const warnings = await lint(`
+      .Test {
+        color: white;
+        background: black;
+        border: 1px solid white;
+        box-shadow: 0 0 0 1px black;
+        fill: black;
+        stroke: white;
+      }
+    `);
+
+    expect(warnings).toEqual([]);
+  });
+
   it('allows token-derived alpha colors', async () => {
     const warnings = await lint(`
       .Test {
         box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
         text-shadow: 0.25rem 0.25rem 0 rgb(255 255 255 / 12%);
         background: color-mix(in oklch, oklch(42.4% 0.199 265.638deg), transparent 90%);
+        outline: color-mix(in oklch, black, white 50%);
       }
     `);
 
@@ -54,14 +70,16 @@ describe(ruleName, () => {
         background-color: #000;
         border-color: oklch(45% 50% 264deg);
         outline-color: papaywhip;
+        box-shadow: 0 0 0 1px blue;
       }
     `);
 
-    expect(warnings).toHaveLength(4);
+    expect(warnings).toHaveLength(5);
     expect(warnings[0]).toContain('Unexpected demo color "red"');
     expect(warnings[1]).toContain('Unexpected demo color "#000"');
     expect(warnings[2]).toContain('Unexpected demo color "oklch(45% 50% 264deg)"');
     expect(warnings[3]).toContain('Unexpected demo color "papaywhip"');
+    expect(warnings[4]).toContain('Unexpected demo color "blue"');
   });
 
   it('requires rgb black and white derivations to include alpha', async () => {
@@ -82,14 +100,16 @@ describe(ruleName, () => {
     const warnings = await lint(`
       .Test {
         color: var(--accent);
+        border-color: var(--color-red-700);
         background: color-mix(in oklch, var(--accent), transparent 90%);
         margin: var(--space);
       }
     `);
 
-    expect(warnings).toHaveLength(2);
+    expect(warnings).toHaveLength(3);
     expect(warnings[0]).toContain('Unexpected demo color "var(--accent)"');
-    expect(warnings[1]).toContain('Unexpected demo color "var(--accent)"');
+    expect(warnings[1]).toContain('Unexpected demo color "var(--color-red-700)"');
+    expect(warnings[2]).toContain('Unexpected demo color "var(--accent)"');
   });
 
   it('does not treat named non-color property values as colors', async () => {

--- a/docs/scripts/stylelint/no-unknown-demo-colors.test.mjs
+++ b/docs/scripts/stylelint/no-unknown-demo-colors.test.mjs
@@ -1,0 +1,105 @@
+import path from 'node:path';
+import stylelint from 'stylelint';
+import { describe, expect, it } from 'vitest';
+import noUnknownDemoColors, {
+  ruleName,
+  // eslint-disable-next-line import/no-relative-packages
+} from '../../../scripts/stylelint/no-unknown-demo-colors.mjs';
+
+const themePath = path.resolve(import.meta.dirname, '../../src/css/index.css');
+
+async function lint(code) {
+  const result = await stylelint.lint({
+    code,
+    config: {
+      plugins: [noUnknownDemoColors],
+      rules: {
+        [ruleName]: [true, { themePath }],
+      },
+    },
+  });
+
+  return result.results[0].warnings.map((warning) => warning.text);
+}
+
+describe(ruleName, () => {
+  it('allows raw colors from the docs Tailwind theme', async () => {
+    const warnings = await lint(`
+      .Test {
+        color: oklch(14.5% 0 0deg);
+        background: white;
+        border-color: black;
+      }
+    `);
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('allows token-derived alpha colors', async () => {
+    const warnings = await lint(`
+      .Test {
+        box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+        text-shadow: 0.25rem 0.25rem 0 rgb(255 255 255 / 12%);
+        background: color-mix(in oklch, oklch(42.4% 0.199 265.638deg), transparent 90%);
+      }
+    `);
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('rejects unknown color syntaxes', async () => {
+    const warnings = await lint(`
+      .Test {
+        color: red;
+        background-color: #000;
+        border-color: oklch(45% 50% 264deg);
+        outline-color: papaywhip;
+      }
+    `);
+
+    expect(warnings).toHaveLength(4);
+    expect(warnings[0]).toContain('Unexpected demo color "red"');
+    expect(warnings[1]).toContain('Unexpected demo color "#000"');
+    expect(warnings[2]).toContain('Unexpected demo color "oklch(45% 50% 264deg)"');
+    expect(warnings[3]).toContain('Unexpected demo color "papaywhip"');
+  });
+
+  it('requires rgb black and white derivations to include alpha', async () => {
+    const warnings = await lint(`
+      .Test {
+        box-shadow: 0 0 0 rgb(0 0 0);
+        text-shadow: 0 0 0 rgb(255, 255, 255);
+        filter: drop-shadow(0 1px 1px rgb(0 0 0 / 53%));
+      }
+    `);
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('Unexpected demo color "rgb(0 0 0)"');
+    expect(warnings[1]).toContain('Unexpected demo color "rgb(255, 255, 255)"');
+  });
+
+  it('rejects CSS variables used as colors', async () => {
+    const warnings = await lint(`
+      .Test {
+        color: var(--accent);
+        background: color-mix(in oklch, var(--accent), transparent 90%);
+        margin: var(--space);
+      }
+    `);
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('Unexpected demo color "var(--accent)"');
+    expect(warnings[1]).toContain('Unexpected demo color "var(--accent)"');
+  });
+
+  it('does not treat named non-color property values as colors', async () => {
+    const warnings = await lint(`
+      .Test {
+        grid-area: red;
+        view-transition-name: blue;
+      }
+    `);
+
+    expect(warnings).toEqual([]);
+  });
+});

--- a/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.module.css
@@ -216,14 +216,6 @@
   }
 }
 
-.Meta {
-  margin: 0 0 1.5rem;
-  font-size: 0.9375rem;
-  line-height: 1.5rem;
-  color: oklch(50% 55% 31deg);
-  text-align: center;
-}
-
 .Cards {
   display: grid;
   gap: 0.75rem;

--- a/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/css-modules/index.module.css
@@ -54,8 +54,13 @@
   bottom: 0;
   width: 2.5rem;
   z-index: 1;
-  border-left: 2px dashed oklch(45% 50% 264deg);
-  background-color: color-mix(in oklch, oklch(45% 50% 264deg), transparent 90%);
+  border-left: 2px dashed oklch(42.4% 0.199 265.638deg);
+  background-color: color-mix(in oklch, oklch(42.4% 0.199 265.638deg), transparent 90%);
+
+  @media (prefers-color-scheme: dark) {
+    border-left-color: oklch(62.3% 0.214 259.815deg);
+    background-color: color-mix(in oklch, oklch(62.3% 0.214 259.815deg), transparent 90%);
+  }
 }
 
 .SwipeLabel {
@@ -70,9 +75,13 @@
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: oklch(45% 50% 264deg);
+  color: oklch(42.4% 0.199 265.638deg);
   white-space: nowrap;
   pointer-events: none;
+
+  @media (prefers-color-scheme: dark) {
+    color: oklch(62.3% 0.214 259.815deg);
+  }
 }
 
 .Button {

--- a/docs/src/app/(docs)/react/components/drawer/demos/uncontained/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/uncontained/css-modules/index.module.css
@@ -233,7 +233,7 @@
   font-size: 0.875rem;
   line-height: 1.25rem;
   text-align: center;
-  color: oklch(50% 55% 31deg);
+  color: oklch(50.5% 0.213 27.518deg);
   -webkit-user-select: none;
   user-select: none;
 

--- a/docs/src/app/(docs)/react/components/number-field/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/number-field/demos/hero/css-modules/index.module.css
@@ -13,7 +13,7 @@
 }
 
 .ScrubAreaCursor {
-  filter: drop-shadow(0 1px 1px #0008);
+  filter: drop-shadow(0 1px 1px rgb(0 0 0 / 50%));
 }
 
 .Label {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "jsdom": "27.4.0",
     "lerna": "9.0.7",
     "pkg-pr-new": "0.0.71",
+    "postcss-value-parser": "4.2.0",
     "prettier": "3.8.3",
     "pretty-quick": "4.2.2",
     "publint": "0.3.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,10 +350,10 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: latest
-        version: 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@base-ui/utils':
         specifier: latest
-        version: 0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 0.2.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-devtools':
         specifier: ^0.10.0
         version: 0.10.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)
@@ -426,7 +426,7 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: latest
-        version: 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1382,8 +1382,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.4.1':
-    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
+  '@base-ui/react@1.5.0':
+    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -1399,8 +1399,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.2.8':
-    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
+  '@base-ui/utils@0.2.9':
+    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -10767,10 +10767,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@base-ui/react@1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@base-ui/utils': 0.2.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@floating-ui/utils': 0.2.11
       react: 19.2.5
@@ -10781,7 +10781,7 @@ snapshots:
       '@types/react': 19.2.14
       date-fns: 4.1.0
 
-  '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@base-ui/utils@0.2.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       pkg-pr-new:
         specifier: 0.0.71
         version: 0.0.71
+      postcss-value-parser:
+        specifier: 4.2.0
+        version: 4.2.0
       prettier:
         specifier: 3.8.3
         version: 3.8.3

--- a/scripts/stylelint/no-unknown-demo-colors.mjs
+++ b/scripts/stylelint/no-unknown-demo-colors.mjs
@@ -294,13 +294,7 @@ function walkColorUsages(value, property, onUsage) {
   const scanBareWords = hasWord && isStrictColorProperty(property);
   const scanCssVariables = hasCssVariable && (scanNamedColors || scanBareWords);
 
-  if (
-    !hasFunction &&
-    !hasHex &&
-    !scanCssVariables &&
-    !scanNamedColors &&
-    !scanBareWords
-  ) {
+  if (!hasFunction && !hasHex && !scanCssVariables && !scanNamedColors && !scanBareWords) {
     return;
   }
 

--- a/scripts/stylelint/no-unknown-demo-colors.mjs
+++ b/scripts/stylelint/no-unknown-demo-colors.mjs
@@ -1,0 +1,501 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import stylelint from 'stylelint';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+
+const defaultThemePath = path.join(currentDirectory, '../../docs/src/css/index.css');
+
+const ruleName = 'base-ui/no-unknown-demo-colors';
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: (color) =>
+    `Unexpected demo color "${color}". Use raw color values defined in docs/src/css/index.css @theme in CSS Modules demos.`,
+});
+
+const allowedKeywords = new Set([
+  'auto',
+  'currentcolor',
+  'inherit',
+  'initial',
+  'none',
+  'revert',
+  'revert-layer',
+  'transparent',
+  'unset',
+]);
+
+const colorFunctionNames = new Set([
+  'color',
+  'hsl',
+  'hsla',
+  'hwb',
+  'lab',
+  'lch',
+  'oklab',
+  'oklch',
+  'rgb',
+  'rgba',
+]);
+
+const namedColors = new Set([
+  'aliceblue',
+  'antiquewhite',
+  'aqua',
+  'aquamarine',
+  'azure',
+  'beige',
+  'bisque',
+  'black',
+  'blanchedalmond',
+  'blue',
+  'blueviolet',
+  'brown',
+  'burlywood',
+  'cadetblue',
+  'chartreuse',
+  'chocolate',
+  'coral',
+  'cornflowerblue',
+  'cornsilk',
+  'crimson',
+  'cyan',
+  'darkblue',
+  'darkcyan',
+  'darkgoldenrod',
+  'darkgray',
+  'darkgreen',
+  'darkgrey',
+  'darkkhaki',
+  'darkmagenta',
+  'darkolivegreen',
+  'darkorange',
+  'darkorchid',
+  'darkred',
+  'darksalmon',
+  'darkseagreen',
+  'darkslateblue',
+  'darkslategray',
+  'darkslategrey',
+  'darkturquoise',
+  'darkviolet',
+  'deeppink',
+  'deepskyblue',
+  'dimgray',
+  'dimgrey',
+  'dodgerblue',
+  'firebrick',
+  'floralwhite',
+  'forestgreen',
+  'fuchsia',
+  'gainsboro',
+  'ghostwhite',
+  'gold',
+  'goldenrod',
+  'gray',
+  'green',
+  'greenyellow',
+  'grey',
+  'honeydew',
+  'hotpink',
+  'indianred',
+  'indigo',
+  'ivory',
+  'khaki',
+  'lavender',
+  'lavenderblush',
+  'lawngreen',
+  'lemonchiffon',
+  'lightblue',
+  'lightcoral',
+  'lightcyan',
+  'lightgoldenrodyellow',
+  'lightgray',
+  'lightgreen',
+  'lightgrey',
+  'lightpink',
+  'lightsalmon',
+  'lightseagreen',
+  'lightskyblue',
+  'lightslategray',
+  'lightslategrey',
+  'lightsteelblue',
+  'lightyellow',
+  'lime',
+  'limegreen',
+  'linen',
+  'magenta',
+  'maroon',
+  'mediumaquamarine',
+  'mediumblue',
+  'mediumorchid',
+  'mediumpurple',
+  'mediumseagreen',
+  'mediumslateblue',
+  'mediumspringgreen',
+  'mediumturquoise',
+  'mediumvioletred',
+  'midnightblue',
+  'mintcream',
+  'mistyrose',
+  'moccasin',
+  'navajowhite',
+  'navy',
+  'oldlace',
+  'olive',
+  'olivedrab',
+  'orange',
+  'orangered',
+  'orchid',
+  'palegoldenrod',
+  'palegreen',
+  'paleturquoise',
+  'palevioletred',
+  'papayawhip',
+  'peachpuff',
+  'peru',
+  'pink',
+  'plum',
+  'powderblue',
+  'purple',
+  'rebeccapurple',
+  'red',
+  'rosybrown',
+  'royalblue',
+  'saddlebrown',
+  'salmon',
+  'sandybrown',
+  'seagreen',
+  'seashell',
+  'sienna',
+  'silver',
+  'skyblue',
+  'slateblue',
+  'slategray',
+  'slategrey',
+  'snow',
+  'springgreen',
+  'steelblue',
+  'tan',
+  'teal',
+  'thistle',
+  'tomato',
+  'turquoise',
+  'violet',
+  'wheat',
+  'white',
+  'whitesmoke',
+  'yellow',
+  'yellowgreen',
+]);
+
+const hexColorRegex = /#[\da-f]{3,8}\b/gi;
+const colorVariableRegex = /var\(\s*(--color-[\w-]+)[^)]*\)/gi;
+const namedColorRegex = new RegExp(`(?<![-\\w])(?:${[...namedColors].join('|')})(?![-\\w])`, 'gi');
+const themeColorsCache = new Map();
+const namedColorPropertyCache = new Map();
+
+function normalizeColor(value) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s*,\s*/g, ', ')
+    .replace(/\s*\/\s*/g, ' / ')
+    .replace(/\s+/g, ' ');
+}
+
+function readThemeColors(themePath) {
+  const cachedThemeColors = themeColorsCache.get(themePath);
+
+  if (cachedThemeColors) {
+    return cachedThemeColors;
+  }
+
+  const themeCss = fs.readFileSync(themePath, 'utf8');
+  const themeBlock = /@theme\s*{([\s\S]*?)}/.exec(themeCss)?.[1] ?? '';
+  const values = new Set();
+  const colorDeclarationRegex = /--color-([\w-]+|\*)\s*:\s*([^;]+);/g;
+
+  for (const match of themeBlock.matchAll(colorDeclarationRegex)) {
+    const [, name, rawValue] = match;
+    const normalizedValue = normalizeColor(rawValue);
+
+    if (name !== '*' && normalizedValue !== 'initial') {
+      values.add(normalizedValue);
+    }
+  }
+
+  const themeColors = { values };
+
+  themeColorsCache.set(themePath, themeColors);
+
+  return themeColors;
+}
+
+function canContainNamedColor(property) {
+  const cachedResult = namedColorPropertyCache.get(property);
+
+  if (cachedResult !== undefined) {
+    return cachedResult;
+  }
+
+  const normalizedProperty = property.toLowerCase();
+
+  const result =
+    normalizedProperty !== 'print-color-adjust' &&
+    !normalizedProperty.includes('radius') &&
+    (normalizedProperty === 'color' ||
+      normalizedProperty.endsWith('-color') ||
+      normalizedProperty === 'column-rule' ||
+      normalizedProperty === 'fill' ||
+      normalizedProperty === 'filter' ||
+      normalizedProperty === 'stroke' ||
+      /^(?:background|border|outline|text-decoration)(?:-|$)/.test(normalizedProperty) ||
+      /(?:^|-)(?:shadow)$/.test(normalizedProperty));
+
+  namedColorPropertyCache.set(property, result);
+
+  return result;
+}
+
+function findClosingParenthesis(value, openParenthesisIndex) {
+  let depth = 0;
+
+  for (let index = openParenthesisIndex; index < value.length; index += 1) {
+    const character = value[index];
+
+    if (character === '(') {
+      depth += 1;
+    } else if (character === ')') {
+      depth -= 1;
+
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function stripStringsAndUrls(value) {
+  return value
+    .replace(/url\((?:\\.|[^\\)])*\)/gi, '')
+    .replace(/"[^"\\]*(?:\\.[^"\\]*)*"/g, '')
+    .replace(/'[^'\\]*(?:\\.[^'\\]*)*'/g, '');
+}
+
+function stripStringsAndUrlsIfNeeded(value) {
+  if (!/[("']|url\(/i.test(value)) {
+    return value;
+  }
+
+  return stripStringsAndUrls(value);
+}
+
+function pushColorMixArguments(value, usages) {
+  let depth = 0;
+  let start = 0;
+  let isFirstArgument = true;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+
+    if (character === '(') {
+      depth += 1;
+    } else if (character === ')') {
+      depth -= 1;
+    } else if (character === ',' && depth === 0) {
+      if (!isFirstArgument) {
+        const argumentValue = stripColorMixPercentage(value.slice(start, index));
+
+        if (argumentValue) {
+          usages.push({ type: 'color-mix-argument', value: argumentValue });
+        }
+      }
+
+      isFirstArgument = false;
+      start = index + 1;
+    }
+  }
+
+  const argumentValue = isFirstArgument ? '' : stripColorMixPercentage(value.slice(start));
+
+  if (argumentValue) {
+    usages.push({ type: 'color-mix-argument', value: argumentValue });
+  }
+}
+
+function pushFunctionUsages(value, usages) {
+  const functionRegex = /\b([a-z-]+)\(/gi;
+
+  let match = functionRegex.exec(value);
+
+  while (match) {
+    const functionName = match[1].toLowerCase();
+    const openParenthesisIndex = match.index + match[0].length - 1;
+    const closeParenthesisIndex = findClosingParenthesis(value, openParenthesisIndex);
+
+    if (closeParenthesisIndex === -1) {
+      match = functionRegex.exec(value);
+      continue;
+    }
+
+    if (colorFunctionNames.has(functionName)) {
+      usages.push({
+        type: 'function',
+        value: value.slice(match.index, closeParenthesisIndex + 1),
+      });
+    }
+
+    if (functionName === 'color-mix') {
+      pushColorMixArguments(value.slice(openParenthesisIndex + 1, closeParenthesisIndex), usages);
+    }
+
+    functionRegex.lastIndex = openParenthesisIndex + 1;
+    match = functionRegex.exec(value);
+  }
+}
+
+function stripColorMixPercentage(value) {
+  return value
+    .trim()
+    .replace(/\s+(?:\d*\.?\d+%|calc\([^)]*\))$/i, '')
+    .trim();
+}
+
+function getColorUsages(value, property) {
+  const shouldScanNamedColors = canContainNamedColor(property);
+
+  if (!value.includes('#') && !value.includes('(') && !shouldScanNamedColors) {
+    return [];
+  }
+
+  const valueWithoutStrings = stripStringsAndUrlsIfNeeded(value);
+  const usages = [];
+
+  if (valueWithoutStrings.includes('(')) {
+    pushFunctionUsages(valueWithoutStrings, usages);
+  }
+
+  if (valueWithoutStrings.includes('#')) {
+    for (const match of valueWithoutStrings.matchAll(hexColorRegex)) {
+      usages.push({ type: 'hex', value: match[0] });
+    }
+  }
+
+  if (valueWithoutStrings.includes('--color-')) {
+    for (const match of valueWithoutStrings.matchAll(colorVariableRegex)) {
+      usages.push({ type: 'custom-property', value: match[0] });
+    }
+  }
+
+  if (shouldScanNamedColors) {
+    for (const match of valueWithoutStrings.matchAll(namedColorRegex)) {
+      usages.push({ type: 'keyword', value: match[0].toLowerCase() });
+    }
+  }
+
+  return usages;
+}
+
+function isAllowedColorMixArgument(value, themeColors) {
+  const normalizedValue = normalizeColor(value);
+
+  if (themeColors.values.has(normalizedValue) || allowedKeywords.has(normalizedValue)) {
+    return true;
+  }
+
+  if (/^rgba?\(/i.test(normalizedValue)) {
+    return isTokenDerivedRgb(normalizedValue, themeColors.values);
+  }
+
+  return false;
+}
+
+function isTokenDerivedRgb(value, themeValues) {
+  const match = /rgba?\((.*)\)/i.exec(value);
+
+  if (!match) {
+    return false;
+  }
+
+  const [red, green, blue] = match[1]
+    .replace(/\s*\/.*$/, '')
+    .split(/[\s,]+/)
+    .filter(Boolean)
+    .map((component) => Number.parseFloat(component));
+
+  return (
+    (red === 0 && green === 0 && blue === 0 && themeValues.has('black')) ||
+    (red === 255 && green === 255 && blue === 255 && themeValues.has('white'))
+  );
+}
+
+function isAllowedUsage(usage, themeColors) {
+  const normalizedValue = normalizeColor(usage.value);
+
+  if (usage.type === 'custom-property') {
+    return false;
+  }
+
+  if (usage.type === 'color-mix-argument') {
+    return isAllowedColorMixArgument(usage.value, themeColors);
+  }
+
+  if (themeColors.values.has(normalizedValue) || allowedKeywords.has(normalizedValue)) {
+    return true;
+  }
+
+  if (/^rgba?\(/i.test(normalizedValue)) {
+    return isTokenDerivedRgb(normalizedValue, themeColors.values);
+  }
+
+  return false;
+}
+
+const plugin = stylelint.createPlugin(ruleName, (primary, secondaryOptions = {}) => {
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, {
+      actual: primary,
+      possible: [true, false],
+    });
+
+    if (!validOptions || primary === false) {
+      return;
+    }
+
+    const themePath = secondaryOptions.themePath ?? defaultThemePath;
+    const themeColors = readThemeColors(themePath);
+
+    root.walkDecls((declaration) => {
+      const usages = getColorUsages(declaration.value, declaration.prop);
+      const reportedValues = new Set();
+
+      for (const usage of usages) {
+        const normalizedValue = normalizeColor(usage.value);
+
+        if (reportedValues.has(normalizedValue) || isAllowedUsage(usage, themeColors)) {
+          continue;
+        }
+
+        reportedValues.add(normalizedValue);
+
+        stylelint.utils.report({
+          message: messages.rejected(usage.value),
+          node: declaration,
+          result,
+          ruleName,
+          word: usage.value,
+        });
+      }
+    });
+  };
+});
+
+plugin.ruleName = ruleName;
+plugin.messages = messages;
+
+export { messages, ruleName };
+export default plugin;

--- a/scripts/stylelint/no-unknown-demo-colors.mjs
+++ b/scripts/stylelint/no-unknown-demo-colors.mjs
@@ -481,6 +481,12 @@ function isTokenDerivedRgb(value, themeValues) {
     return false;
   }
 
+  const hasAlpha = /\//.test(match[1]) || /^rgba\(/i.test(value);
+
+  if (!hasAlpha) {
+    return false;
+  }
+
   const [red, green, blue] = match[1]
     .replace(/\s*\/.*$/, '')
     .split(/[\s,]+/)

--- a/scripts/stylelint/no-unknown-demo-colors.mjs
+++ b/scripts/stylelint/no-unknown-demo-colors.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import valueParser from 'postcss-value-parser';
 import stylelint from 'stylelint';
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
@@ -190,9 +191,7 @@ const namedColors = new Set([
   'yellowgreen',
 ]);
 
-const hexColorRegex = /#[\da-f]{3,8}\b/gi;
-const cssVariableRegex = /var\(\s*--[\w-]+[^)]*\)/gi;
-const wordRegex = /[a-z]+/gi;
+const hexColorRegex = /^#[\da-f]{3,8}$/i;
 const themeColorsCache = new Map();
 
 function normalizeColor(value) {
@@ -232,7 +231,7 @@ function readThemeColors(themePath) {
   return themeColors;
 }
 
-function canContainNamedColor(property) {
+function shouldScanNamedColors(property) {
   const normalizedProperty = property.toLowerCase();
 
   return (
@@ -249,7 +248,7 @@ function canContainNamedColor(property) {
   );
 }
 
-function shouldValidateBareColorValue(property) {
+function isStrictColorProperty(property) {
   const normalizedProperty = property.toLowerCase();
 
   return (
@@ -260,138 +259,6 @@ function shouldValidateBareColorValue(property) {
   );
 }
 
-function findClosingParenthesis(value, openParenthesisIndex) {
-  let depth = 0;
-
-  for (let index = openParenthesisIndex; index < value.length; index += 1) {
-    const character = value[index];
-
-    if (character === '(') {
-      depth += 1;
-    } else if (character === ')') {
-      depth -= 1;
-
-      if (depth === 0) {
-        return index;
-      }
-    }
-  }
-
-  return -1;
-}
-
-function stripStringsAndUrls(value) {
-  return value
-    .replace(/url\((?:\\.|[^\\)])*\)/gi, '')
-    .replace(/"[^"\\]*(?:\\.[^"\\]*)*"/g, '')
-    .replace(/'[^'\\]*(?:\\.[^'\\]*)*'/g, '');
-}
-
-function stripStringsAndUrlsIfNeeded(value) {
-  if (!/["']|url\(/i.test(value)) {
-    return value;
-  }
-
-  return stripStringsAndUrls(value);
-}
-
-function isStandaloneWord(value, startIndex, endIndex) {
-  const previousCharacter = value[startIndex - 1];
-  const nextCharacter = value[endIndex];
-
-  return !/[-\w]/.test(previousCharacter ?? '') && !/[-\w]/.test(nextCharacter ?? '');
-}
-
-function pushColorMixArguments(value, onUsage) {
-  let depth = 0;
-  let start = 0;
-  let isFirstArgument = true;
-
-  for (let index = 0; index < value.length; index += 1) {
-    const character = value[index];
-
-    if (character === '(') {
-      depth += 1;
-    } else if (character === ')') {
-      depth -= 1;
-    } else if (character === ',' && depth === 0) {
-      if (!isFirstArgument) {
-        const argumentValue = stripColorMixPercentage(value.slice(start, index));
-
-        if (argumentValue) {
-          onUsage({ type: 'color-mix-argument', value: argumentValue });
-        }
-      }
-
-      isFirstArgument = false;
-      start = index + 1;
-    }
-  }
-
-  const argumentValue = isFirstArgument ? '' : stripColorMixPercentage(value.slice(start));
-
-  if (argumentValue) {
-    onUsage({ type: 'color-mix-argument', value: argumentValue });
-  }
-}
-
-function pushFunctionUsages(value, shouldScanColorMix, onUsage) {
-  const functionRegex = /\b([a-z-]+)\(/gi;
-
-  let match = functionRegex.exec(value);
-
-  while (match) {
-    const functionName = match[1].toLowerCase();
-    const openParenthesisIndex = match.index + match[0].length - 1;
-    const closeParenthesisIndex = findClosingParenthesis(value, openParenthesisIndex);
-
-    if (closeParenthesisIndex === -1) {
-      match = functionRegex.exec(value);
-      continue;
-    }
-
-    if (colorFunctionNames.has(functionName)) {
-      onUsage({
-        type: 'function',
-        value: value.slice(match.index, closeParenthesisIndex + 1),
-      });
-    }
-
-    if (shouldScanColorMix && functionName === 'color-mix') {
-      pushColorMixArguments(value.slice(openParenthesisIndex + 1, closeParenthesisIndex), onUsage);
-    }
-
-    functionRegex.lastIndex = openParenthesisIndex + 1;
-    match = functionRegex.exec(value);
-  }
-}
-
-function replaceFunctionCallsWithSpaces(value) {
-  let sanitizedValue = '';
-  let index = 0;
-  const functionRegex = /\b([a-z-]+)\(/gi;
-
-  let match = functionRegex.exec(value);
-
-  while (match) {
-    const openParenthesisIndex = match.index + match[0].length - 1;
-    const closeParenthesisIndex = findClosingParenthesis(value, openParenthesisIndex);
-
-    if (closeParenthesisIndex === -1) {
-      match = functionRegex.exec(value);
-      continue;
-    }
-
-    sanitizedValue += value.slice(index, match.index);
-    sanitizedValue += ' '.repeat(closeParenthesisIndex + 1 - match.index);
-    index = closeParenthesisIndex + 1;
-    functionRegex.lastIndex = openParenthesisIndex + 1;
-    match = functionRegex.exec(value);
-  }
-
-  return sanitizedValue + value.slice(index);
-}
-
 function stripColorMixPercentage(value) {
   return value
     .trim()
@@ -399,79 +266,103 @@ function stripColorMixPercentage(value) {
     .trim();
 }
 
+function getColorMixArguments(nodes) {
+  const args = [];
+  let currentArg = [];
+
+  for (const node of nodes) {
+    if (node.type === 'div' && node.value === ',') {
+      args.push(currentArg);
+      currentArg = [];
+    } else {
+      currentArg.push(node);
+    }
+  }
+
+  args.push(currentArg);
+
+  // The first argument is the interpolation method: `in oklch`.
+  return args.slice(1).map((arg) => stripColorMixPercentage(valueParser.stringify(arg)));
+}
+
 function walkColorUsages(value, property, onUsage) {
   const hasFunction = value.includes('(');
   const hasHex = value.includes('#');
   const hasCssVariable = value.includes('var(');
   const hasWord = /[a-z]/i.test(value);
-  const shouldScanNamedColors = hasWord && canContainNamedColor(property);
-  const shouldValidateBareColors = hasWord && shouldValidateBareColorValue(property);
-  const shouldScanCssVariables = hasCssVariable && (shouldScanNamedColors || shouldValidateBareColors);
+  const scanNamedColors = hasWord && shouldScanNamedColors(property);
+  const scanBareWords = hasWord && isStrictColorProperty(property);
+  const scanCssVariables = hasCssVariable && (scanNamedColors || scanBareWords);
 
   if (
     !hasFunction &&
     !hasHex &&
-    !shouldScanCssVariables &&
-    !shouldScanNamedColors &&
-    !shouldValidateBareColors
+    !scanCssVariables &&
+    !scanNamedColors &&
+    !scanBareWords
   ) {
     return;
   }
 
-  const valueWithoutStrings = stripStringsAndUrlsIfNeeded(value);
-  const shouldScanColorMix = /color-mix\(/i.test(valueWithoutStrings);
+  const parsedValue = valueParser(value);
 
-  if (hasFunction && valueWithoutStrings.includes('(')) {
-    pushFunctionUsages(valueWithoutStrings, shouldScanColorMix, onUsage);
-  }
+  parsedValue.walk((node, _index, nodes) => {
+    if (node.type === 'function') {
+      const functionName = node.value.toLowerCase();
 
-  if (hasHex && valueWithoutStrings.includes('#')) {
-    for (const match of valueWithoutStrings.matchAll(hexColorRegex)) {
-      onUsage({ type: 'hex', value: match[0] });
-    }
-  }
-
-  if (shouldScanCssVariables && valueWithoutStrings.includes('var(')) {
-    for (const match of valueWithoutStrings.matchAll(cssVariableRegex)) {
-      onUsage({ type: 'custom-property', value: match[0] });
-    }
-  }
-
-  if (shouldScanNamedColors) {
-    const namedColorValue = hasFunction
-      ? replaceFunctionCallsWithSpaces(valueWithoutStrings)
-      : valueWithoutStrings;
-
-    for (const match of namedColorValue.matchAll(wordRegex)) {
-      const word = match[0].toLowerCase();
-      const endIndex = match.index + match[0].length;
-
-      if (
-        namedColorValue[endIndex] !== '(' &&
-        isStandaloneWord(namedColorValue, match.index, endIndex)
-      ) {
-        if (namedColors.has(word)) {
-          onUsage({ type: 'keyword', value: word });
-        } else if (shouldValidateBareColors) {
-          onUsage({ type: 'bare-word', value: word });
-        }
+      if (functionName === 'url') {
+        return false;
       }
+
+      if (functionName === 'var') {
+        if (scanCssVariables) {
+          onUsage(valueParser.stringify(node));
+        }
+
+        return false;
+      }
+
+      if (functionName === 'color-mix') {
+        for (const colorArgument of getColorMixArguments(node.nodes)) {
+          if (colorArgument) {
+            onUsage(colorArgument);
+          }
+        }
+
+        return false;
+      }
+
+      if (colorFunctionNames.has(functionName)) {
+        onUsage(valueParser.stringify(node));
+
+        return false;
+      }
+
+      return undefined;
     }
-  }
-}
 
-function isAllowedColorMixArgument(value, themeColors) {
-  const normalizedValue = normalizeColor(value);
+    if (node.type !== 'word') {
+      return undefined;
+    }
 
-  if (themeColors.values.has(normalizedValue) || allowedKeywords.has(normalizedValue)) {
-    return true;
-  }
+    const word = node.value.toLowerCase();
 
-  if (/^rgba?\(/i.test(normalizedValue)) {
-    return isTokenDerivedRgb(normalizedValue, themeColors.values);
-  }
+    if (hasHex && hexColorRegex.test(word)) {
+      onUsage(node.value);
 
-  return false;
+      return undefined;
+    }
+
+    if (!scanNamedColors || nodes !== parsedValue.nodes) {
+      return undefined;
+    }
+
+    if (namedColors.has(word) || (scanBareWords && /^[a-z-]+$/i.test(word))) {
+      onUsage(word);
+    }
+
+    return undefined;
+  });
 }
 
 function isTokenDerivedRgb(value, themeValues) {
@@ -499,19 +390,11 @@ function isTokenDerivedRgb(value, themeValues) {
   );
 }
 
-function isAllowedUsage(usage, themeColors) {
-  const normalizedValue = normalizeColor(usage.value);
+function isAllowedColor(value, themeColors) {
+  const normalizedValue = normalizeColor(value);
 
-  if (usage.type === 'custom-property') {
-    return false;
-  }
-
-  if (usage.type === 'bare-word') {
-    return allowedKeywords.has(normalizedValue);
-  }
-
-  if (usage.type === 'color-mix-argument') {
-    return isAllowedColorMixArgument(usage.value, themeColors);
+  if (allowedKeywords.has(normalizedValue)) {
+    return true;
   }
 
   if (themeColors.values.has(normalizedValue)) {
@@ -542,21 +425,21 @@ const plugin = stylelint.createPlugin(ruleName, (primary, secondaryOptions = {})
     root.walkDecls((declaration) => {
       const reportedValues = new Set();
 
-      walkColorUsages(declaration.value, declaration.prop, (usage) => {
-        const normalizedValue = normalizeColor(usage.value);
+      walkColorUsages(declaration.value, declaration.prop, (color) => {
+        const normalizedValue = normalizeColor(color);
 
-        if (reportedValues.has(normalizedValue) || isAllowedUsage(usage, themeColors)) {
+        if (reportedValues.has(normalizedValue) || isAllowedColor(color, themeColors)) {
           return;
         }
 
         reportedValues.add(normalizedValue);
 
         stylelint.utils.report({
-          message: messages.rejected(usage.value),
+          message: messages.rejected(color),
           node: declaration,
           result,
           ruleName,
-          word: usage.value,
+          word: color,
         });
       });
     });

--- a/scripts/stylelint/no-unknown-demo-colors.mjs
+++ b/scripts/stylelint/no-unknown-demo-colors.mjs
@@ -11,7 +11,7 @@ const ruleName = 'base-ui/no-unknown-demo-colors';
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
   rejected: (color) =>
-    `Unexpected demo color "${color}". Use raw color values defined in docs/src/css/index.css @theme in CSS Modules demos.`,
+    `Unexpected demo color "${color}". In CSS Modules demos, use raw color values defined in docs/src/css/index.css @theme.`,
 });
 
 const allowedKeywords = new Set([
@@ -191,10 +191,9 @@ const namedColors = new Set([
 ]);
 
 const hexColorRegex = /#[\da-f]{3,8}\b/gi;
-const colorVariableRegex = /var\(\s*(--color-[\w-]+)[^)]*\)/gi;
-const namedColorRegex = new RegExp(`(?<![-\\w])(?:${[...namedColors].join('|')})(?![-\\w])`, 'gi');
+const cssVariableRegex = /var\(\s*--[\w-]+[^)]*\)/gi;
+const wordRegex = /[a-z]+/gi;
 const themeColorsCache = new Map();
-const namedColorPropertyCache = new Map();
 
 function normalizeColor(value) {
   return value
@@ -234,15 +233,9 @@ function readThemeColors(themePath) {
 }
 
 function canContainNamedColor(property) {
-  const cachedResult = namedColorPropertyCache.get(property);
-
-  if (cachedResult !== undefined) {
-    return cachedResult;
-  }
-
   const normalizedProperty = property.toLowerCase();
 
-  const result =
+  return (
     normalizedProperty !== 'print-color-adjust' &&
     !normalizedProperty.includes('radius') &&
     (normalizedProperty === 'color' ||
@@ -252,11 +245,19 @@ function canContainNamedColor(property) {
       normalizedProperty === 'filter' ||
       normalizedProperty === 'stroke' ||
       /^(?:background|border|outline|text-decoration)(?:-|$)/.test(normalizedProperty) ||
-      /(?:^|-)(?:shadow)$/.test(normalizedProperty));
+      /(?:^|-)(?:shadow)$/.test(normalizedProperty))
+  );
+}
 
-  namedColorPropertyCache.set(property, result);
+function shouldValidateBareColorValue(property) {
+  const normalizedProperty = property.toLowerCase();
 
-  return result;
+  return (
+    normalizedProperty === 'color' ||
+    normalizedProperty.endsWith('-color') ||
+    normalizedProperty === 'fill' ||
+    normalizedProperty === 'stroke'
+  );
 }
 
 function findClosingParenthesis(value, openParenthesisIndex) {
@@ -287,14 +288,21 @@ function stripStringsAndUrls(value) {
 }
 
 function stripStringsAndUrlsIfNeeded(value) {
-  if (!/[("']|url\(/i.test(value)) {
+  if (!/["']|url\(/i.test(value)) {
     return value;
   }
 
   return stripStringsAndUrls(value);
 }
 
-function pushColorMixArguments(value, usages) {
+function isStandaloneWord(value, startIndex, endIndex) {
+  const previousCharacter = value[startIndex - 1];
+  const nextCharacter = value[endIndex];
+
+  return !/[-\w]/.test(previousCharacter ?? '') && !/[-\w]/.test(nextCharacter ?? '');
+}
+
+function pushColorMixArguments(value, onUsage) {
   let depth = 0;
   let start = 0;
   let isFirstArgument = true;
@@ -311,7 +319,7 @@ function pushColorMixArguments(value, usages) {
         const argumentValue = stripColorMixPercentage(value.slice(start, index));
 
         if (argumentValue) {
-          usages.push({ type: 'color-mix-argument', value: argumentValue });
+          onUsage({ type: 'color-mix-argument', value: argumentValue });
         }
       }
 
@@ -323,11 +331,11 @@ function pushColorMixArguments(value, usages) {
   const argumentValue = isFirstArgument ? '' : stripColorMixPercentage(value.slice(start));
 
   if (argumentValue) {
-    usages.push({ type: 'color-mix-argument', value: argumentValue });
+    onUsage({ type: 'color-mix-argument', value: argumentValue });
   }
 }
 
-function pushFunctionUsages(value, usages) {
+function pushFunctionUsages(value, shouldScanColorMix, onUsage) {
   const functionRegex = /\b([a-z-]+)\(/gi;
 
   let match = functionRegex.exec(value);
@@ -343,19 +351,45 @@ function pushFunctionUsages(value, usages) {
     }
 
     if (colorFunctionNames.has(functionName)) {
-      usages.push({
+      onUsage({
         type: 'function',
         value: value.slice(match.index, closeParenthesisIndex + 1),
       });
     }
 
-    if (functionName === 'color-mix') {
-      pushColorMixArguments(value.slice(openParenthesisIndex + 1, closeParenthesisIndex), usages);
+    if (shouldScanColorMix && functionName === 'color-mix') {
+      pushColorMixArguments(value.slice(openParenthesisIndex + 1, closeParenthesisIndex), onUsage);
     }
 
     functionRegex.lastIndex = openParenthesisIndex + 1;
     match = functionRegex.exec(value);
   }
+}
+
+function replaceFunctionCallsWithSpaces(value) {
+  let sanitizedValue = '';
+  let index = 0;
+  const functionRegex = /\b([a-z-]+)\(/gi;
+
+  let match = functionRegex.exec(value);
+
+  while (match) {
+    const openParenthesisIndex = match.index + match[0].length - 1;
+    const closeParenthesisIndex = findClosingParenthesis(value, openParenthesisIndex);
+
+    if (closeParenthesisIndex === -1) {
+      match = functionRegex.exec(value);
+      continue;
+    }
+
+    sanitizedValue += value.slice(index, match.index);
+    sanitizedValue += ' '.repeat(closeParenthesisIndex + 1 - match.index);
+    index = closeParenthesisIndex + 1;
+    functionRegex.lastIndex = openParenthesisIndex + 1;
+    match = functionRegex.exec(value);
+  }
+
+  return sanitizedValue + value.slice(index);
 }
 
 function stripColorMixPercentage(value) {
@@ -365,39 +399,65 @@ function stripColorMixPercentage(value) {
     .trim();
 }
 
-function getColorUsages(value, property) {
-  const shouldScanNamedColors = canContainNamedColor(property);
+function walkColorUsages(value, property, onUsage) {
+  const hasFunction = value.includes('(');
+  const hasHex = value.includes('#');
+  const hasCssVariable = value.includes('var(');
+  const hasWord = /[a-z]/i.test(value);
+  const shouldScanNamedColors = hasWord && canContainNamedColor(property);
+  const shouldValidateBareColors = hasWord && shouldValidateBareColorValue(property);
+  const shouldScanCssVariables = hasCssVariable && (shouldScanNamedColors || shouldValidateBareColors);
 
-  if (!value.includes('#') && !value.includes('(') && !shouldScanNamedColors) {
-    return [];
+  if (
+    !hasFunction &&
+    !hasHex &&
+    !shouldScanCssVariables &&
+    !shouldScanNamedColors &&
+    !shouldValidateBareColors
+  ) {
+    return;
   }
 
   const valueWithoutStrings = stripStringsAndUrlsIfNeeded(value);
-  const usages = [];
+  const shouldScanColorMix = /color-mix\(/i.test(valueWithoutStrings);
 
-  if (valueWithoutStrings.includes('(')) {
-    pushFunctionUsages(valueWithoutStrings, usages);
+  if (hasFunction && valueWithoutStrings.includes('(')) {
+    pushFunctionUsages(valueWithoutStrings, shouldScanColorMix, onUsage);
   }
 
-  if (valueWithoutStrings.includes('#')) {
+  if (hasHex && valueWithoutStrings.includes('#')) {
     for (const match of valueWithoutStrings.matchAll(hexColorRegex)) {
-      usages.push({ type: 'hex', value: match[0] });
+      onUsage({ type: 'hex', value: match[0] });
     }
   }
 
-  if (valueWithoutStrings.includes('--color-')) {
-    for (const match of valueWithoutStrings.matchAll(colorVariableRegex)) {
-      usages.push({ type: 'custom-property', value: match[0] });
+  if (shouldScanCssVariables && valueWithoutStrings.includes('var(')) {
+    for (const match of valueWithoutStrings.matchAll(cssVariableRegex)) {
+      onUsage({ type: 'custom-property', value: match[0] });
     }
   }
 
   if (shouldScanNamedColors) {
-    for (const match of valueWithoutStrings.matchAll(namedColorRegex)) {
-      usages.push({ type: 'keyword', value: match[0].toLowerCase() });
+    const namedColorValue = hasFunction
+      ? replaceFunctionCallsWithSpaces(valueWithoutStrings)
+      : valueWithoutStrings;
+
+    for (const match of namedColorValue.matchAll(wordRegex)) {
+      const word = match[0].toLowerCase();
+      const endIndex = match.index + match[0].length;
+
+      if (
+        namedColorValue[endIndex] !== '(' &&
+        isStandaloneWord(namedColorValue, match.index, endIndex)
+      ) {
+        if (namedColors.has(word)) {
+          onUsage({ type: 'keyword', value: word });
+        } else if (shouldValidateBareColors) {
+          onUsage({ type: 'bare-word', value: word });
+        }
+      }
     }
   }
-
-  return usages;
 }
 
 function isAllowedColorMixArgument(value, themeColors) {
@@ -440,11 +500,15 @@ function isAllowedUsage(usage, themeColors) {
     return false;
   }
 
+  if (usage.type === 'bare-word') {
+    return allowedKeywords.has(normalizedValue);
+  }
+
   if (usage.type === 'color-mix-argument') {
     return isAllowedColorMixArgument(usage.value, themeColors);
   }
 
-  if (themeColors.values.has(normalizedValue) || allowedKeywords.has(normalizedValue)) {
+  if (themeColors.values.has(normalizedValue)) {
     return true;
   }
 
@@ -470,14 +534,13 @@ const plugin = stylelint.createPlugin(ruleName, (primary, secondaryOptions = {})
     const themeColors = readThemeColors(themePath);
 
     root.walkDecls((declaration) => {
-      const usages = getColorUsages(declaration.value, declaration.prop);
       const reportedValues = new Set();
 
-      for (const usage of usages) {
+      walkColorUsages(declaration.value, declaration.prop, (usage) => {
         const normalizedValue = normalizeColor(usage.value);
 
         if (reportedValues.has(normalizedValue) || isAllowedUsage(usage, themeColors)) {
-          continue;
+          return;
         }
 
         reportedValues.add(normalizedValue);
@@ -489,7 +552,7 @@ const plugin = stylelint.createPlugin(ruleName, (primary, secondaryOptions = {})
           ruleName,
           word: usage.value,
         });
-      }
+      });
     });
   };
 });

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,9 +1,14 @@
+import noUnknownDemoColors, {
+  ruleName as noUnknownDemoColorsRuleName,
+} from './scripts/stylelint/no-unknown-demo-colors.mjs';
+
 // Note: To debug stylelint config resolution for a specific file, use
 //         pnpm exec stylelint --print-config <path-to-file>
 
 /** @type {import('stylelint').Config} */
 export default {
   extends: '@mui/internal-code-infra/stylelint',
+  plugins: [noUnknownDemoColors],
   rules: {
     // empty lines help with readability
     'declaration-empty-line-before': null,
@@ -24,6 +29,12 @@ export default {
         'declaration-property-value-no-unknown': null,
         // Remove when ready
         'keyframes-name-pattern': null,
+      },
+    },
+    {
+      files: ['docs/src/app/[(]docs[)]/**/demos/**/*.css'],
+      rules: {
+        [noUnknownDemoColorsRuleName]: true,
       },
     },
     {


### PR DESCRIPTION
This prevents incorrect usage of colors in CSS Modules demos. Helpful for LLMs and humans alike.

- Add a new custom Stylelint plugin to catch non-raw colors in CSS Modules demos.
- Update AGENTS.md mentioning the raw-colors requirement.
- Update three demos that were using wrong colors.