### PR TITLE
[internal] Update the hook value when store/arguments change

### DIFF
--- a/packages/utils/src/store/ReactStore.test.tsx
+++ b/packages/utils/src/store/ReactStore.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { act, createRenderer, screen } from '@mui/internal-test-utils';
 import { ReactStore } from './ReactStore';
 import { useRefWithInit } from '../useRefWithInit';
+import { fastComponent } from '../fastHooks';
 import { createSelector } from './createSelector';
 
 type TestState = { value: number; label: string };
@@ -347,6 +348,36 @@ describe('ReactStore', () => {
     expect(childStore.select('count')).toBe(15);
     expect(output.textContent).toBe('15');
   });
+
+  it('updates useState result when selector arguments change in a fast component', () => {
+    type State = { values: Record<string, string> };
+    const selectors = {
+      valueByKey: (state: State, valueKey: string) => state.values[valueKey],
+    };
+    const store = new ReactStore<State, {}, typeof selectors>(
+      { values: { first: 'one', second: 'two', third: 'three' } },
+      undefined,
+      selectors,
+    );
+
+    function TestComponent({ valueKey }: { valueKey: string }) {
+      const value = store.useState('valueByKey', valueKey);
+      return <output data-testid="output">{value}</output>;
+    }
+
+    const Test = fastComponent(TestComponent);
+    const { setProps } = render(<Test valueKey="first" />, { strict: false });
+    const output = screen.getByTestId('output');
+
+    expect(output.textContent).toBe('one');
+
+    act(() => {
+      setProps({ valueKey: 'second' });
+    });
+
+    expect(output.textContent).toBe('two');
+  });
+
   describe('observeSelector', () => {
     type CounterState = { count: number; multiplier: number };
     const selectors = {

--- a/packages/utils/src/store/useStore.ts
+++ b/packages/utils/src/store/useStore.ts
@@ -69,7 +69,6 @@ export type StoreInstance = Instance & {
     a2: unknown;
     a3: unknown;
     value: unknown;
-    didChange: boolean;
   }[];
   didChangeStore: boolean;
   subscribe: (onStoreChange: any) => () => void;
@@ -89,10 +88,9 @@ register({
         for (let i = 0; i < instance.syncHooks.length; i += 1) {
           const hook = instance.syncHooks[i];
           const value = hook.selector(hook.store.state, hook.a1, hook.a2, hook.a3);
-          if (hook.didChange || !Object.is(hook.value, value)) {
+          if (!Object.is(hook.value, value)) {
             didChange = true;
             hook.value = value;
-            hook.didChange = false;
           }
         }
         if (didChange) {
@@ -153,7 +151,6 @@ function useStoreFast(
       a2,
       a3,
       value: selector(store.getSnapshot(), a1, a2, a3),
-      didChange: false,
     };
     instance.syncHooks.push(hook);
   } else {
@@ -173,7 +170,7 @@ function useStoreFast(
       hook.a1 = a1;
       hook.a2 = a2;
       hook.a3 = a3;
-      hook.didChange = true;
+      hook.value = selector(store.getSnapshot(), a1, a2, a3);
     }
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR fixes an issue where `useStoreFast` returns a stale value when selector arguments changes during render.
This was not an issue in all test cases and dev mode because of the `StrictMode`, but was causing issues in production build.

ex: MenuTrigger in the Menu hero demo does not update `aria-expanded`.
https://base-ui.com/react/components/menu

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
