### PR TITLE
[otp field] Avoid password manager bubbles after first input

### DIFF
--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -101,8 +101,8 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
     autoCorrect: 'off',
     spellCheck: 'false',
     enterKeyHint: index === length - 1 ? 'done' : 'next',
-    // Allow the first slot to accept a full code so browser paste/autofill can target it directly.
-    maxLength: index === 0 ? length : 1,
+    // Only the first slot has a max length to avoid password manager bubbles appearing after later inputs.
+    maxLength: index === 0 ? length : undefined,
     tabIndex: activeIndex === index ? 0 : -1,
     disabled,
     form,

--- a/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
@@ -71,6 +71,9 @@ describe('<OTPFieldPreview />', () => {
 
       expect(inputs.map((input) => input.value)).toEqual(['1', '2', '3', '4', '5', '6']);
       expect(inputs[0]).toHaveAttribute('maxlength', '6');
+      inputs.slice(1).forEach((input) => {
+        expect(input).not.toHaveAttribute('maxlength');
+      });
       expect(hiddenInput).toHaveValue('123456');
     });
 
@@ -803,6 +806,16 @@ describe('<OTPFieldPreview />', () => {
         fireEvent.change(firstInput, { target: { value: '123456' } });
 
         expect(getValues()).toBe('123456');
+      });
+
+      it('replaces consecutive slots when typing multiple characters into a later input', async () => {
+        await render(<OTPField defaultValue="123456" />);
+
+        const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+
+        fireEvent.change(inputs[2], { target: { value: '99' } });
+
+        expect(getValues()).toBe('129956');
       });
     });
 


### PR DESCRIPTION
Only the first OTP field input needs the full-code max length. Later visible inputs now omit `maxlength`, so password managers do not treat every slot as a separate one-character target while typing still handles multi-character 
changes.

This notably affected iCloud password manager

## Root cause

Each visible slot had a `maxlength`, which could cause password manager UI to appear after later inputs.

## Changes

- Keep the full-code `maxlength` only on the first visible OTP input.
- Assert later visible inputs omit `maxlength` and cover multi-character replacement from a later slot.