### PR TITLE
[docs-infra] Add suffix to component page titles

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -33,7 +33,6 @@ const withMdx = nextMdx({
       [
         transformMarkdownMetadata,
         {
-          titleSuffix: ' · Base UI',
           extractToIndex: {
             include: ['src/app/react'],
             exclude: [

--- a/docs/src/app/(docs)/layout.tsx
+++ b/docs/src/app/(docs)/layout.tsx
@@ -112,7 +112,10 @@ export default function Layout({ children }: React.PropsWithChildren) {
 
 export const metadata: Metadata = {
   // Title and description are pulled from <h1> and <Subtitle> in the MDX.
-  title: null,
+  title: {
+    template: '%s · Base UI',
+    default: 'Base UI',
+  },
   description: null,
   twitter: {
     site: '@base_ui',

--- a/docs/src/app/(docs)/react/components/layout.tsx
+++ b/docs/src/app/(docs)/react/components/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next/types';
+import type * as React from 'react';
+
+export default function ComponentsLayout({ children }: React.PropsWithChildren) {
+  return children;
+}
+
+export const metadata: Metadata = {
+  title: {
+    template: '%s React Component · Base UI',
+    default: 'Components',
+  },
+};

--- a/test/regressions/fixtures.ts
+++ b/test/regressions/fixtures.ts
@@ -76,7 +76,7 @@ function excludeDemoFixture(suite: string, name: string, path: string) {
 // Also use all public demos to avoid code duplication.
 const globbedDemos = import.meta.glob<{ default: React.ComponentType<unknown> }>(
   // technically it should be 'docs/src/app/\\(public\\)/\\(content\\)/react/**/*.tsx' but tinyglobby doesn't resolve this on Windows
-  'docs/src/app/?docs?/react/**/*.tsx',
+  ['docs/src/app/?docs?/react/**/*.tsx', '!docs/src/app/?docs?/react/**/layout.tsx'],
   { eager: true },
 );
 


### PR DESCRIPTION
Adds "React Component" suffix to all component page titles to improve SEO e.g. "Accordion" -> "Accordion React Component"