### PR TITLE
[FloatingPortal] Reroute portals into the active fullscreen element

### DIFF
--- a/packages/react/src/combobox/portal/ComboboxPortal.tsx
+++ b/packages/react/src/combobox/portal/ComboboxPortal.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useStore } from '@base-ui/utils/store';
 import { FloatingPortal } from '../../floating-ui-react';
-import { useComboboxRootContext } from '../root/ComboboxRootContext';
+import { useComboboxFloatingContext, useComboboxRootContext } from '../root/ComboboxRootContext';
 import { ComboboxPortalContext } from './ComboboxPortalContext';
 import { selectors } from '../store';
 
@@ -20,9 +20,11 @@ export const ComboboxPortal = React.forwardRef(function ComboboxPortal(
   const { keepMounted = false, ...portalProps } = props;
 
   const store = useComboboxRootContext();
+  const floatingRootContext = useComboboxFloatingContext();
 
   const mounted = useStore(store, selectors.mounted);
   const forceMounted = useStore(store, selectors.forceMounted);
+  const anchorElement = floatingRootContext.useState('domAnchorElement');
 
   const shouldRender = mounted || keepMounted || forceMounted;
   if (!shouldRender) {
@@ -31,7 +33,7 @@ export const ComboboxPortal = React.forwardRef(function ComboboxPortal(
 
   return (
     <ComboboxPortalContext.Provider value={keepMounted}>
-      <FloatingPortal ref={forwardedRef} {...portalProps} />
+      <FloatingPortal ref={forwardedRef} referenceElement={anchorElement} {...portalProps} />
     </ComboboxPortalContext.Provider>
   );
 });

--- a/packages/react/src/dialog/portal/DialogPortal.test.tsx
+++ b/packages/react/src/dialog/portal/DialogPortal.test.tsx
@@ -1,8 +1,8 @@
-import { expect } from 'vitest';
+import { afterEach, beforeEach, expect } from 'vitest';
 import * as React from 'react';
 import { Dialog } from '@base-ui/react/dialog';
-import { createRenderer, describeConformance } from '#test-utils';
-import { screen } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { act, flushMicrotasks, screen } from '@mui/internal-test-utils';
 
 describe('<Dialog.Portal />', () => {
   const { render } = createRenderer();
@@ -13,6 +13,70 @@ describe('<Dialog.Portal />', () => {
       return render(<Dialog.Root open>{node}</Dialog.Root>);
     },
   }));
+
+  describe.skipIf(!isJSDOM)('fullscreen rerouting', () => {
+    let fullscreenElement: Element | null = null;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      'fullscreenElement',
+    );
+
+    beforeEach(() => {
+      fullscreenElement = null;
+      Object.defineProperty(Document.prototype, 'fullscreenElement', {
+        configurable: true,
+        get: () => fullscreenElement,
+      });
+    });
+
+    afterEach(() => {
+      fullscreenElement = null;
+      if (originalDescriptor) {
+        Object.defineProperty(Document.prototype, 'fullscreenElement', originalDescriptor);
+      } else {
+        Reflect.deleteProperty(Document.prototype, 'fullscreenElement');
+      }
+    });
+
+    function setFullscreenElement(element: Element | null) {
+      fullscreenElement = element;
+      document.dispatchEvent(new Event('fullscreenchange'));
+    }
+
+    test('reroutes the dialog into fullscreen regardless of where the trigger lives', async () => {
+      // Dialogs are not anchored to their trigger - they're viewport-relative.
+      // Even when the trigger is in `document.body` (outside the fullscreen
+      // subtree), an open dialog must reroute into the fullscreen element so
+      // it stays visible. This is the opposite contract from Popover/Menu,
+      // whose popups remain in body when the trigger is off-screen.
+      const fsContainer = document.createElement('div');
+      document.body.appendChild(fsContainer);
+
+      try {
+        const { setPropsAsync } = await render(
+          <Dialog.Root open>
+            <Dialog.Trigger>open</Dialog.Trigger>
+            <Dialog.Portal>
+              <Dialog.Popup data-testid="popup">popup</Dialog.Popup>
+            </Dialog.Portal>
+          </Dialog.Root>,
+        );
+        await flushMicrotasks();
+
+        await act(async () => {
+          setFullscreenElement(fsContainer);
+        });
+        await flushMicrotasks();
+
+        const popup = await screen.findByTestId('popup');
+        expect(fsContainer.contains(popup)).toBe(true);
+
+        await setPropsAsync({ open: false });
+      } finally {
+        fsContainer.remove();
+      }
+    });
+  });
 
   describe('Suspense integration', () => {
     // Issue #3695

--- a/packages/react/src/dialog/portal/DialogPortal.tsx
+++ b/packages/react/src/dialog/portal/DialogPortal.tsx
@@ -23,17 +23,24 @@ export const DialogPortal = React.forwardRef(function DialogPortal(
   const mounted = store.useState('mounted');
   const modal = store.useState('modal');
   const open = store.useState('open');
-  const floatingRootContext = store.useState('floatingRootContext');
-  const anchorElement = floatingRootContext.useState('domAnchorElement');
 
   const shouldRender = mounted || keepMounted;
   if (!shouldRender) {
     return null;
   }
 
+  // Intentionally NOT passing `referenceElement` to `FloatingPortal`.
+  // Dialogs (modal or non-modal), AlertDialogs and Drawers are not visually
+  // anchored to a trigger the way Popover/Menu/Tooltip popups are - they
+  // cover the viewport, slide in from a screen edge, or center themselves
+  // with their own internal layout. If they're open while a fullscreen
+  // element is active they should always be rerouted into that fullscreen
+  // subtree, regardless of where the trigger lives. Opting out of the
+  // anchor-aware heuristic falls back to FloatingPortal's simpler
+  // "reroute when the default container is outside fullscreen" behaviour.
   return (
     <DialogPortalContext.Provider value={keepMounted}>
-      <FloatingPortal ref={forwardedRef} referenceElement={anchorElement} {...portalProps}>
+      <FloatingPortal ref={forwardedRef} {...portalProps}>
         {mounted && modal === true && (
           <InternalBackdrop ref={store.context.internalBackdropRef} inert={inertValue(!open)} />
         )}

--- a/packages/react/src/dialog/portal/DialogPortal.tsx
+++ b/packages/react/src/dialog/portal/DialogPortal.tsx
@@ -23,6 +23,8 @@ export const DialogPortal = React.forwardRef(function DialogPortal(
   const mounted = store.useState('mounted');
   const modal = store.useState('modal');
   const open = store.useState('open');
+  const floatingRootContext = store.useState('floatingRootContext');
+  const anchorElement = floatingRootContext.useState('domAnchorElement');
 
   const shouldRender = mounted || keepMounted;
   if (!shouldRender) {
@@ -31,7 +33,7 @@ export const DialogPortal = React.forwardRef(function DialogPortal(
 
   return (
     <DialogPortalContext.Provider value={keepMounted}>
-      <FloatingPortal ref={forwardedRef} {...portalProps}>
+      <FloatingPortal ref={forwardedRef} referenceElement={anchorElement} {...portalProps}>
         {mounted && modal === true && (
           <InternalBackdrop ref={store.context.internalBackdropRef} inert={inertValue(!open)} />
         )}

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
@@ -27,6 +27,37 @@ function App(props: AppProps) {
   );
 }
 
+interface AppWithReferenceProps {
+  testId?: string;
+}
+
+function AppWithReference(props: AppWithReferenceProps) {
+  const { testId = 'app' } = props;
+  const [open, setOpen] = React.useState(false);
+  const [reference, setReference] = React.useState<HTMLElement | null>(null);
+  const { refs } = useFloating({
+    open,
+    onOpenChange: setOpen,
+    elements: { reference },
+  });
+
+  return (
+    <React.Fragment>
+      <button
+        data-testid={`${testId}-reference`}
+        ref={(node) => {
+          setReference(node);
+          refs.setReference(node);
+        }}
+        onClick={() => setOpen(!open)}
+      />
+      <FloatingPortal referenceElement={reference}>
+        {open && <div ref={refs.setFloating} data-testid={`${testId}-floating`} />}
+      </FloatingPortal>
+    </React.Fragment>
+  );
+}
+
 describe.skipIf(!isJSDOM)('FloatingPortal', () => {
   test('allows custom containers', async () => {
     const customRoot = document.createElement('div');
@@ -282,6 +313,93 @@ describe.skipIf(!isJSDOM)('FloatingPortal', () => {
         await flushMicrotasks();
 
         fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(fsContainer);
+      } finally {
+        fsContainer.remove();
+      }
+    });
+
+    test('does not reroute when the referenceElement is outside the fullscreen subtree', async () => {
+      // Real-world edge case: two sibling elements A and B. The user opens a
+      // dropdown inside A whose item programmatically fullscreens B. The
+      // dropdown is still open but its trigger lives in A (now invisible).
+      // Rerouting the portal into B would make the popup visible but anchored
+      // to an off-screen trigger.
+      const siblingA = document.createElement('div');
+      const siblingB = document.createElement('div');
+      document.body.appendChild(siblingA);
+      document.body.appendChild(siblingB);
+
+      try {
+        render(
+          <div>
+            <AppWithReference testId="a" />
+          </div>,
+          { container: siblingA },
+        );
+
+        fireEvent.click(screen.getByTestId('a-reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('a-floating').parentElement?.parentElement).toBe(document.body);
+
+        await act(async () => {
+          setFullscreenElement(siblingB);
+        });
+        await flushMicrotasks();
+
+        // Trigger is in siblingA, not in siblingB's fullscreen subtree, so the
+        // portal must stay in body rather than reroute into siblingB.
+        expect(screen.getByTestId('a-floating').parentElement?.parentElement).toBe(document.body);
+        expect(siblingB.contains(screen.getByTestId('a-floating'))).toBe(false);
+      } finally {
+        siblingA.remove();
+        siblingB.remove();
+      }
+    });
+
+    test('reroutes when the referenceElement is inside the fullscreen subtree', async () => {
+      // Normal case: the fullscreen element is an ancestor of the trigger, so
+      // rerouting into it keeps the popup visible AND correctly anchored.
+      const fsContainer = document.createElement('div');
+      document.body.appendChild(fsContainer);
+
+      try {
+        render(<AppWithReference />, { container: fsContainer });
+
+        fireEvent.click(screen.getByTestId('app-reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('app-floating').parentElement?.parentElement).toBe(document.body);
+
+        await act(async () => {
+          setFullscreenElement(fsContainer);
+        });
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('app-floating').parentElement?.parentElement).toBe(fsContainer);
+      } finally {
+        fsContainer.remove();
+      }
+    });
+
+    test('falls back to the default heuristic when referenceElement is not provided', async () => {
+      // Direct FloatingPortal users who don't pass a trigger still get the
+      // existing "container outside fullscreen -> reroute" behaviour so they
+      // remain visible during fullscreen mode.
+      const fsContainer = document.createElement('div');
+      document.body.appendChild(fsContainer);
+
+      try {
+        render(<App />);
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        await act(async () => {
+          setFullscreenElement(fsContainer);
+        });
         await flushMicrotasks();
 
         expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(fsContainer);

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
@@ -1,6 +1,6 @@
-import { expect } from 'vitest';
+import { afterEach, beforeEach, expect, vi } from 'vitest';
 import * as React from 'react';
-import { fireEvent, flushMicrotasks, render, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, flushMicrotasks, render, screen } from '@mui/internal-test-utils';
 import { isJSDOM } from '@base-ui/utils/detectBrowser';
 import { FloatingPortal, useFloating } from '../index';
 import { FloatingPortalLite } from '../../utils/FloatingPortalLite';
@@ -149,5 +149,173 @@ describe.skipIf(!isJSDOM)('FloatingPortal', () => {
 
     const portal = document.querySelector('[data-testid="lite-portal"]');
     expect(portal).not.toBeNull();
+  });
+
+  describe('fullscreen rerouting', () => {
+    let fullscreenElement: Element | null = null;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      'fullscreenElement',
+    );
+
+    beforeEach(() => {
+      fullscreenElement = null;
+      Object.defineProperty(Document.prototype, 'fullscreenElement', {
+        configurable: true,
+        get: () => fullscreenElement,
+      });
+    });
+
+    afterEach(() => {
+      fullscreenElement = null;
+      if (originalDescriptor) {
+        Object.defineProperty(Document.prototype, 'fullscreenElement', originalDescriptor);
+      } else {
+        Reflect.deleteProperty(Document.prototype, 'fullscreenElement');
+      }
+    });
+
+    function setFullscreenElement(element: Element | null) {
+      fullscreenElement = element;
+      document.dispatchEvent(new Event('fullscreenchange'));
+    }
+
+    test('reroutes the portal into the fullscreen element when default container is outside it', async () => {
+      const fsContainer = document.createElement('div');
+      fsContainer.id = 'fs-container';
+      document.body.appendChild(fsContainer);
+
+      try {
+        render(<App />);
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(document.body);
+
+        await act(async () => {
+          setFullscreenElement(fsContainer);
+        });
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(fsContainer);
+      } finally {
+        fsContainer.remove();
+      }
+    });
+
+    test('does not reroute when the default container is already inside the fullscreen element', async () => {
+      render(<App />);
+      fireEvent.click(screen.getByTestId('reference'));
+      await flushMicrotasks();
+
+      await act(async () => {
+        setFullscreenElement(document.documentElement);
+      });
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(document.body);
+    });
+
+    test('respects an explicit `container` prop even while in fullscreen', async () => {
+      const fsContainer = document.createElement('div');
+      const explicitContainer = document.createElement('div');
+      explicitContainer.id = 'explicit';
+      document.body.appendChild(fsContainer);
+      document.body.appendChild(explicitContainer);
+
+      try {
+        render(<App container={explicitContainer} />);
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(explicitContainer);
+
+        await act(async () => {
+          setFullscreenElement(fsContainer);
+        });
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(explicitContainer);
+      } finally {
+        fsContainer.remove();
+        explicitContainer.remove();
+      }
+    });
+
+    test('moves the portal back to body when fullscreen exits', async () => {
+      const fsContainer = document.createElement('div');
+      document.body.appendChild(fsContainer);
+
+      try {
+        render(<App />);
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        await act(async () => {
+          setFullscreenElement(fsContainer);
+        });
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(fsContainer);
+
+        await act(async () => {
+          setFullscreenElement(null);
+        });
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(document.body);
+      } finally {
+        fsContainer.remove();
+      }
+    });
+
+    test('mounts directly into the fullscreen element when opened while fullscreen is already active', async () => {
+      const fsContainer = document.createElement('div');
+      document.body.appendChild(fsContainer);
+
+      try {
+        render(<App />);
+
+        await act(async () => {
+          setFullscreenElement(fsContainer);
+        });
+        await flushMicrotasks();
+
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(fsContainer);
+      } finally {
+        fsContainer.remove();
+      }
+    });
+
+    test('shares a single document fullscreenchange subscription across multiple portals', async () => {
+      // Mount one portal first so the singleton store attaches its listener
+      // (if it isn't already) and we can spy on additions made afterwards.
+      render(<App />);
+      await flushMicrotasks();
+
+      const addSpy = vi.spyOn(document, 'addEventListener');
+
+      try {
+        render(<App />);
+        render(<App />);
+        render(<App />);
+        for (const reference of screen.getAllByTestId('reference')) {
+          fireEvent.click(reference);
+        }
+        await flushMicrotasks();
+
+        const fullscreenCalls = addSpy.mock.calls.filter(
+          ([type]) => type === 'fullscreenchange' || type === 'webkitfullscreenchange',
+        );
+        // Mounting more portals must not attach additional document listeners
+        // because all subscribers share the singleton fullscreen store.
+        expect(fullscreenCalls).toHaveLength(0);
+      } finally {
+        addSpy.mockRestore();
+      }
+    });
   });
 });

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -154,6 +154,20 @@ export interface UseFloatingPortalNodeProps {
     | null
     | React.RefObject<HTMLElement | ShadowRoot | null>
     | undefined;
+  /**
+   * The element that triggers the floating element (the popup's anchor).
+   *
+   * When provided, it controls whether the portal is rerouted into an active
+   * `document.fullscreenElement`: rerouting only happens if the trigger is
+   * itself inside the fullscreen subtree. Without this information we'd risk
+   * mounting a popup that is visible but anchored to an off-screen trigger.
+   *
+   * Base UI's own portal wrappers (Menu, Dialog, Popover, etc.) thread this
+   * through automatically. Direct users of `FloatingPortal` who don't pass
+   * it fall back to the simpler "container is outside fullscreen subtree"
+   * heuristic.
+   */
+  referenceElement?: Element | null | undefined;
   componentProps?: UseRenderElementComponentProps<any> | undefined;
   elementProps?: React.HTMLAttributes<HTMLDivElement> | undefined;
 }
@@ -166,7 +180,13 @@ export interface UseFloatingPortalNodeResult {
 export function useFloatingPortalNode(
   props: UseFloatingPortalNodeProps = {},
 ): UseFloatingPortalNodeResult {
-  const { ref, container: containerProp, componentProps = EMPTY_OBJECT, elementProps } = props;
+  const {
+    ref,
+    container: containerProp,
+    referenceElement,
+    componentProps = EMPTY_OBJECT,
+    elementProps,
+  } = props;
 
   const uniqueId = useId();
   const portalContext = usePortalContext();
@@ -221,11 +241,20 @@ export function useFloatingPortalNode(
     // into the DOM but never paint. Reroute to the fullscreen element so
     // popups, menus, and dialogs remain visible. The user's explicit
     // `container` prop is always respected.
+    //
+    // When the caller has told us where the trigger lives, only reroute if
+    // the trigger is also inside the fullscreen subtree. Rerouting otherwise
+    // would render the popup visible but anchored to an off-screen trigger
+    // (e.g. dropdown in element A whose item programmatically fullscreens a
+    // sibling element B — A and its trigger are unpainted, B is on screen).
+    // Falling back to the simpler heuristic when no trigger is known keeps
+    // direct `FloatingPortal` users working.
     if (
       !userContainer &&
       fullscreenElement &&
       resolvedContainer instanceof Element &&
-      !contains(fullscreenElement, resolvedContainer)
+      !contains(fullscreenElement, resolvedContainer) &&
+      (referenceElement == null || contains(fullscreenElement, referenceElement))
     ) {
       resolvedContainer = fullscreenElement as HTMLElement;
     }
@@ -244,7 +273,7 @@ export function useFloatingPortalNode(
       setPortalNode(null);
       setContainerElement(resolvedContainer);
     }
-  }, [containerProp, parentPortalNode, uniqueId, fullscreenElement]);
+  }, [containerProp, parentPortalNode, uniqueId, fullscreenElement, referenceElement]);
 
   const portalElement = useRenderElement('div', componentProps, {
     ref: [ref, setPortalNodeRef],
@@ -283,11 +312,20 @@ export const FloatingPortal = React.forwardRef(function FloatingPortal(
   componentProps: FloatingPortal.Props<any> & { renderGuards?: boolean | undefined },
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { render, className, style, children, container, renderGuards, ...elementProps } =
-    componentProps;
+  const {
+    render,
+    className,
+    style,
+    children,
+    container,
+    referenceElement,
+    renderGuards,
+    ...elementProps
+  } = componentProps;
 
   const { portalNode, portalSubtree } = useFloatingPortalNode({
     container,
+    referenceElement,
     ref: forwardedRef,
     componentProps,
     elementProps,
@@ -419,5 +457,13 @@ export namespace FloatingPortal {
      * A parent element to render the portal element into.
      */
     container?: UseFloatingPortalNodeProps['container'] | undefined;
+    /**
+     * The trigger element associated with the floating content. Used to scope
+     * the fullscreen rerouting heuristic: rerouting into an active
+     * `document.fullscreenElement` only happens when the trigger lives inside
+     * that fullscreen subtree. When omitted, the simpler default-container
+     * heuristic is used.
+     */
+    referenceElement?: UseFloatingPortalNodeProps['referenceElement'] | undefined;
   }
 }

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -8,6 +8,7 @@ import { useId } from '@base-ui/utils/useId';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
+import { contains } from '../../internals/shadowDom';
 import { FocusGuard } from '../../utils/FocusGuard';
 import {
   enableFocusInside,
@@ -50,6 +51,101 @@ export const usePortalContext = () => React.useContext(PortalContext);
 
 const attr = createAttribute('portal');
 
+interface PrefixedFullscreenDocument {
+  fullscreenElement?: Element | null | undefined;
+  webkitFullscreenElement?: Element | null | undefined;
+}
+
+function getCurrentFullscreenElement(): Element | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const doc = document as Document & PrefixedFullscreenDocument;
+  return doc.fullscreenElement ?? doc.webkitFullscreenElement ?? null;
+}
+
+/**
+ * Module-level singleton that tracks `document.fullscreenElement` and fans
+ * out changes to all subscribed portals via `useSyncExternalStore`. Using a
+ * shared subscription keeps the attached `document` event-listener count at
+ * exactly one regardless of how many `<FloatingPortal>`s are mounted on the
+ * page, instead of one listener pair (standard + webkit) per portal.
+ */
+const fullscreenStore = (() => {
+  let cachedElement: Element | null = null;
+  let initialized = false;
+  const subscribers = new Set<() => void>();
+  let documentCleanup: (() => void) | undefined;
+
+  function recompute() {
+    const next = getCurrentFullscreenElement();
+    if (next !== cachedElement) {
+      cachedElement = next;
+      for (const subscriber of subscribers) {
+        subscriber();
+      }
+    }
+  }
+
+  function startWatching() {
+    if (typeof document === 'undefined' || documentCleanup) {
+      return;
+    }
+    documentCleanup = mergeCleanups(
+      addEventListener(document, 'fullscreenchange', recompute),
+      addEventListener(document, 'webkitfullscreenchange' as 'fullscreenchange', recompute),
+    );
+  }
+
+  function stopWatching() {
+    documentCleanup?.();
+    documentCleanup = undefined;
+  }
+
+  return {
+    subscribe(notify: () => void) {
+      if (!initialized) {
+        cachedElement = getCurrentFullscreenElement();
+        initialized = true;
+      }
+      if (subscribers.size === 0) {
+        startWatching();
+      }
+      subscribers.add(notify);
+      // A fullscreenchange event may have fired between module init and this
+      // first subscription; resync so we don't return a stale snapshot.
+      recompute();
+      return () => {
+        subscribers.delete(notify);
+        if (subscribers.size === 0) {
+          stopWatching();
+        }
+      };
+    },
+    getSnapshot(): Element | null {
+      return cachedElement;
+    },
+    getServerSnapshot(): Element | null {
+      return null;
+    },
+  };
+})();
+
+/**
+ * Subscribes to the shared fullscreen store and returns the current
+ * `document.fullscreenElement` (with a webkit fallback).
+ *
+ * Used by `useFloatingPortalNode` to re-route portals into the fullscreen
+ * element while a fullscreen view is active. See `fullscreenStore`.
+ */
+function useFullscreenElement(): Element | null {
+  return React.useSyncExternalStore(
+    fullscreenStore.subscribe,
+    fullscreenStore.getSnapshot,
+    fullscreenStore.getServerSnapshot,
+  );
+}
+
 export interface UseFloatingPortalNodeProps {
   ref?: React.Ref<HTMLDivElement> | undefined;
   container?:
@@ -75,6 +171,13 @@ export function useFloatingPortalNode(
   const uniqueId = useId();
   const portalContext = usePortalContext();
   const parentPortalNode = portalContext?.portalNode;
+
+  // Tracks `document.fullscreenElement` so portals can re-route into it when
+  // the default container (`document.body` or a parent portal) would otherwise
+  // be hidden by the browser's fullscreen rendering. Anything outside the
+  // fullscreen subtree is not painted, so a Dialog/Popover/Menu portalled to
+  // body would render but be invisible. See the resolution logic below.
+  const fullscreenElement = useFullscreenElement();
 
   const [containerElement, setContainerElement] = React.useState<HTMLElement | ShadowRoot | null>(
     null,
@@ -107,10 +210,25 @@ export function useFloatingPortalNode(
       return;
     }
 
-    const resolvedContainer =
-      (containerProp && (isNode(containerProp) ? containerProp : containerProp.current)) ??
-      parentPortalNode ??
-      document.body;
+    const userContainer =
+      containerProp && (isNode(containerProp) ? containerProp : containerProp.current);
+
+    let resolvedContainer: HTMLElement | ShadowRoot | null =
+      userContainer ?? parentPortalNode ?? document.body;
+
+    // If a fullscreen element is active and the default container chain
+    // (parent portal -> body) lands outside of it, the portal would mount
+    // into the DOM but never paint. Reroute to the fullscreen element so
+    // popups, menus, and dialogs remain visible. The user's explicit
+    // `container` prop is always respected.
+    if (
+      !userContainer &&
+      fullscreenElement &&
+      resolvedContainer instanceof Element &&
+      !contains(fullscreenElement, resolvedContainer)
+    ) {
+      resolvedContainer = fullscreenElement as HTMLElement;
+    }
 
     if (resolvedContainer == null) {
       if (containerRef.current) {
@@ -126,7 +244,7 @@ export function useFloatingPortalNode(
       setPortalNode(null);
       setContainerElement(resolvedContainer);
     }
-  }, [containerProp, parentPortalNode, uniqueId]);
+  }, [containerProp, parentPortalNode, uniqueId, fullscreenElement]);
 
   const portalElement = useRenderElement('div', componentProps, {
     ref: [ref, setPortalNodeRef],

--- a/packages/react/src/floating-ui-react/components/FloatingRootStore.ts
+++ b/packages/react/src/floating-ui-react/components/FloatingRootStore.ts
@@ -16,6 +16,15 @@ export interface FloatingRootState {
   floatingElement: HTMLElement | null;
   positionReference: ReferenceType | null;
   /**
+   * The DOM element the popup is visually anchored to, after resolving any
+   * custom `anchor` prop on the positioner. Falls back to the trigger when no
+   * custom anchor is set. Updated by `useAnchorPositioning` so consumers of
+   * this store (notably `FloatingPortal`'s fullscreen rerouting heuristic) can
+   * reason about where the popup will actually appear, not just where the
+   * trigger lives.
+   */
+  domAnchorElement: Element | null;
+  /**
    * The ID of the floating element.
    */
   floatingId: string | undefined;
@@ -37,6 +46,15 @@ const selectors = {
   domReferenceElement: createSelector((state: FloatingRootState) => state.domReferenceElement),
   referenceElement: createSelector(
     (state: FloatingRootState) => state.positionReference ?? state.referenceElement,
+  ),
+  /**
+   * Resolves the DOM element the popup is anchored to. Prefers the explicit
+   * anchor set via the positioner's `anchor` prop, falling back to the
+   * trigger. This is the element to consult for "is the popup attached to
+   * something visible" decisions.
+   */
+  domAnchorElement: createSelector(
+    (state: FloatingRootState) => state.domAnchorElement ?? state.domReferenceElement,
   ),
   floatingElement: createSelector((state: FloatingRootState) => state.floatingElement),
   floatingId: createSelector((state: FloatingRootState) => state.floatingId),
@@ -75,6 +93,7 @@ export class FloatingRootStore extends ReactStore<
         ...initialState,
         positionReference: initialState.referenceElement,
         domReferenceElement: initialState.referenceElement as Element | null,
+        domAnchorElement: null,
       },
       {
         onOpenChange,

--- a/packages/react/src/menu/portal/MenuPortal.tsx
+++ b/packages/react/src/menu/portal/MenuPortal.tsx
@@ -19,6 +19,8 @@ export const MenuPortal = React.forwardRef(function MenuPortal(
 
   const { store } = useMenuRootContext();
   const mounted = store.useState('mounted');
+  const floatingRootContext = store.useState('floatingRootContext');
+  const anchorElement = floatingRootContext.useState('domAnchorElement');
 
   const shouldRender = mounted || keepMounted;
   if (!shouldRender) {
@@ -27,7 +29,7 @@ export const MenuPortal = React.forwardRef(function MenuPortal(
 
   return (
     <MenuPortalContext.Provider value={keepMounted}>
-      <FloatingPortal ref={forwardedRef} {...portalProps} />
+      <FloatingPortal ref={forwardedRef} referenceElement={anchorElement} {...portalProps} />
     </MenuPortalContext.Provider>
   );
 });

--- a/packages/react/src/popover/portal/PopoverPortal.test.tsx
+++ b/packages/react/src/popover/portal/PopoverPortal.test.tsx
@@ -1,4 +1,7 @@
 import * as React from 'react';
+import { afterEach, beforeEach, expect } from 'vitest';
+import { act, flushMicrotasks, screen } from '@mui/internal-test-utils';
+import { isJSDOM } from '@base-ui/utils/detectBrowser';
 import { Popover } from '@base-ui/react/popover';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -11,4 +14,118 @@ describe('<Popover.Portal />', () => {
       return render(<Popover.Root open>{node}</Popover.Root>);
     },
   }));
+
+  describe.skipIf(!isJSDOM)('fullscreen rerouting follows the resolved anchor', () => {
+    let fullscreenElement: Element | null = null;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      'fullscreenElement',
+    );
+
+    beforeEach(() => {
+      fullscreenElement = null;
+      Object.defineProperty(Document.prototype, 'fullscreenElement', {
+        configurable: true,
+        get: () => fullscreenElement,
+      });
+    });
+
+    afterEach(() => {
+      fullscreenElement = null;
+      if (originalDescriptor) {
+        Object.defineProperty(Document.prototype, 'fullscreenElement', originalDescriptor);
+      } else {
+        Reflect.deleteProperty(Document.prototype, 'fullscreenElement');
+      }
+    });
+
+    function setFullscreenElement(element: Element | null) {
+      fullscreenElement = element;
+      document.dispatchEvent(new Event('fullscreenchange'));
+    }
+
+    function TestPopover({
+      open,
+      anchorElement,
+    }: {
+      open: boolean;
+      anchorElement: Element;
+    }) {
+      return (
+        <Popover.Root open={open}>
+          <Popover.Trigger>trigger</Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Positioner anchor={anchorElement}>
+              <Popover.Popup data-testid="popup">popup</Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>
+      );
+    }
+
+    test('reroutes into fullscreen when the custom anchor lives inside the fullscreen subtree', async () => {
+      // Trigger is rendered in `document.body` (outside fullscreen). The
+      // positioner is anchored to a button inside the fullscreened container,
+      // so the popup must follow the anchor into the fullscreen subtree.
+      const fsContainer = document.createElement('div');
+      document.body.appendChild(fsContainer);
+      const anchorButton = document.createElement('button');
+      anchorButton.textContent = 'anchor';
+      fsContainer.appendChild(anchorButton);
+
+      try {
+        const { setPropsAsync } = await render(
+          <TestPopover open anchorElement={anchorButton} />,
+        );
+        await flushMicrotasks();
+
+        await act(async () => {
+          setFullscreenElement(fsContainer);
+        });
+        await flushMicrotasks();
+
+        const popup = await screen.findByTestId('popup');
+        expect(fsContainer.contains(popup)).toBe(true);
+
+        // Close the popup before the test ends so Floating UI's autoUpdate
+        // listeners detach and don't fire updates after teardown.
+        await setPropsAsync({ open: false, anchorElement: anchorButton });
+      } finally {
+        fsContainer.remove();
+      }
+    });
+
+    test('does not reroute when both trigger and custom anchor are outside the fullscreen subtree', async () => {
+      // The user fullscreens a sibling element that contains neither the
+      // trigger nor the anchor. The popup must stay in body — rerouting it
+      // into the fullscreened sibling would render it visible but anchored to
+      // an off-screen element.
+      const fsContainer = document.createElement('div');
+      document.body.appendChild(fsContainer);
+      const externalAnchor = document.createElement('button');
+      externalAnchor.textContent = 'anchor';
+      document.body.appendChild(externalAnchor);
+
+      try {
+        const { setPropsAsync } = await render(
+          <TestPopover open anchorElement={externalAnchor} />,
+        );
+        await flushMicrotasks();
+
+        await act(async () => {
+          setFullscreenElement(fsContainer);
+        });
+        await flushMicrotasks();
+
+        const popup = await screen.findByTestId('popup');
+        expect(fsContainer.contains(popup)).toBe(false);
+        expect(document.body.contains(popup)).toBe(true);
+
+        await setPropsAsync({ open: false, anchorElement: externalAnchor });
+      } finally {
+        fsContainer.remove();
+        externalAnchor.remove();
+      }
+    });
+  });
 });

--- a/packages/react/src/popover/portal/PopoverPortal.tsx
+++ b/packages/react/src/popover/portal/PopoverPortal.tsx
@@ -19,6 +19,8 @@ export const PopoverPortal = React.forwardRef(function PopoverPortal(
 
   const { store } = usePopoverRootContext();
   const mounted = store.useState('mounted');
+  const floatingRootContext = store.useState('floatingRootContext');
+  const anchorElement = floatingRootContext.useState('domAnchorElement');
 
   const shouldRender = mounted || keepMounted;
   if (!shouldRender) {
@@ -27,7 +29,7 @@ export const PopoverPortal = React.forwardRef(function PopoverPortal(
 
   return (
     <PopoverPortalContext.Provider value={keepMounted}>
-      <FloatingPortal ref={forwardedRef} {...portalProps} />
+      <FloatingPortal ref={forwardedRef} referenceElement={anchorElement} {...portalProps} />
     </PopoverPortalContext.Provider>
   );
 });

--- a/packages/react/src/preview-card/portal/PreviewCardPortal.tsx
+++ b/packages/react/src/preview-card/portal/PreviewCardPortal.tsx
@@ -19,6 +19,8 @@ export const PreviewCardPortal = React.forwardRef(function PreviewCardPortal(
 
   const store = usePreviewCardRootContext();
   const mounted = store.useState('mounted');
+  const floatingRootContext = store.useState('floatingRootContext');
+  const anchorElement = floatingRootContext.useState('domAnchorElement');
 
   const shouldRender = mounted || keepMounted;
   if (!shouldRender) {
@@ -27,7 +29,7 @@ export const PreviewCardPortal = React.forwardRef(function PreviewCardPortal(
 
   return (
     <PreviewCardPortalContext.Provider value={keepMounted}>
-      <FloatingPortalLite ref={forwardedRef} {...portalProps} />
+      <FloatingPortalLite ref={forwardedRef} referenceElement={anchorElement} {...portalProps} />
     </PreviewCardPortalContext.Provider>
   );
 });

--- a/packages/react/src/select/portal/SelectPortal.tsx
+++ b/packages/react/src/select/portal/SelectPortal.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useStore } from '@base-ui/utils/store';
 import { FloatingPortal } from '../../floating-ui-react';
 import { SelectPortalContext } from './SelectPortalContext';
-import { useSelectRootContext } from '../root/SelectRootContext';
+import { useSelectFloatingContext, useSelectRootContext } from '../root/SelectRootContext';
 import { selectors } from '../store';
 
 /**
@@ -18,8 +18,10 @@ export const SelectPortal = React.forwardRef(function SelectPortal(
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { store } = useSelectRootContext();
+  const floatingRootContext = useSelectFloatingContext();
   const mounted = useStore(store, selectors.mounted);
   const forceMount = useStore(store, selectors.forceMount);
+  const anchorElement = floatingRootContext.useState('domAnchorElement');
 
   const shouldRender = mounted || forceMount;
   if (!shouldRender) {
@@ -28,7 +30,7 @@ export const SelectPortal = React.forwardRef(function SelectPortal(
 
   return (
     <SelectPortalContext.Provider value>
-      <FloatingPortal ref={forwardedRef} {...portalProps} />
+      <FloatingPortal ref={forwardedRef} referenceElement={anchorElement} {...portalProps} />
     </SelectPortalContext.Provider>
   );
 });

--- a/packages/react/src/tooltip/portal/TooltipPortal.tsx
+++ b/packages/react/src/tooltip/portal/TooltipPortal.tsx
@@ -19,6 +19,8 @@ export const TooltipPortal = React.forwardRef(function TooltipPortal(
 
   const store = useTooltipRootContext();
   const mounted = store.useState('mounted');
+  const floatingRootContext = store.useState('floatingRootContext');
+  const anchorElement = floatingRootContext.useState('domAnchorElement');
 
   const shouldRender = mounted || keepMounted;
   if (!shouldRender) {
@@ -27,7 +29,7 @@ export const TooltipPortal = React.forwardRef(function TooltipPortal(
 
   return (
     <TooltipPortalContext.Provider value={keepMounted}>
-      <FloatingPortalLite ref={forwardedRef} {...portalProps} />
+      <FloatingPortalLite ref={forwardedRef} referenceElement={anchorElement} {...portalProps} />
     </TooltipPortalContext.Provider>
   );
 });

--- a/packages/react/src/utils/FloatingPortalLite.tsx
+++ b/packages/react/src/utils/FloatingPortalLite.tsx
@@ -12,10 +12,12 @@ export const FloatingPortalLite = React.forwardRef(function FloatingPortalLite(
   componentProps: FloatingPortalLite.Props<any>,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { children, container, className, render, style, ...elementProps } = componentProps;
+  const { children, container, referenceElement, className, render, style, ...elementProps } =
+    componentProps;
 
   const { portalNode, portalSubtree } = useFloatingPortalNode({
     container,
+    referenceElement,
     ref: forwardedRef,
     componentProps,
     elementProps,

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -413,6 +413,7 @@ export function useAnchorPositioning(
         floatingElement: null,
         domReferenceElement: null,
         positionReference: null,
+        domAnchorElement: null,
       });
     }
   }, [mounted, floatingRootContext]);
@@ -467,6 +468,22 @@ export function useAnchorPositioning(
 
   const registeredPositionReferenceRef = React.useRef<Element | VirtualElement | null>(null);
 
+  // Mirrors the resolved DOM anchor onto the FloatingRootStore so consumers
+  // outside the positioner (notably FloatingPortal's fullscreen rerouting
+  // heuristic) can reason about the element the popup is visually attached
+  // to, not just the trigger.
+  const syncDomAnchorElement = useStableCallback(
+    (resolvedRef: Element | VirtualElement | null) => {
+      if (!floatingRootContext) {
+        return;
+      }
+      const domAnchor = resolvedRef instanceof Element ? resolvedRef : null;
+      if (floatingRootContext.state.domAnchorElement !== domAnchor) {
+        floatingRootContext.set('domAnchorElement', domAnchor);
+      }
+    },
+  );
+
   useIsoLayoutEffect(() => {
     if (!mounted) {
       return;
@@ -482,7 +499,9 @@ export function useAnchorPositioning(
       refs.setPositionReference(finalAnchor);
       registeredPositionReferenceRef.current = finalAnchor;
     }
-  }, [mounted, refs, anchorDep, anchorValueRef]);
+
+    syncDomAnchorElement(finalAnchor);
+  }, [mounted, refs, anchorDep, anchorValueRef, syncDomAnchorElement]);
 
   React.useEffect(() => {
     if (!mounted) {
@@ -500,8 +519,9 @@ export function useAnchorPositioning(
     if (isRef(anchorValue) && anchorValue.current !== registeredPositionReferenceRef.current) {
       refs.setPositionReference(anchorValue.current);
       registeredPositionReferenceRef.current = anchorValue.current;
+      syncDomAnchorElement(anchorValue.current);
     }
-  }, [mounted, refs, anchorDep, anchorValueRef]);
+  }, [mounted, refs, anchorDep, anchorValueRef, syncDomAnchorElement]);
 
   React.useEffect(() => {
     if (keepMounted && mounted && elements.domReference && elements.floating) {


### PR DESCRIPTION
# [FloatingPortal] Reroute portals into the active fullscreen element

## Summary

When an ancestor of a Base UI popup enters browser fullscreen, the popup becomes **invisible** until fullscreen exits. This is because `FloatingPortal` portals popup content into `document.body` (or a parent portal) by default, and the browser stops painting anything outside the fullscreen element's subtree once `requestFullscreen()` is granted.

Every Base UI primitive that renders a floating element is affected: `Dialog`, `Popover`, `Menu`, `Tooltip`, `Select`, `Combobox`, `ContextMenu`, `Menubar`, `NavigationMenu`, `PreviewCard`, and any user component that builds on `FloatingPortal`.

This PR makes `FloatingPortal` automatically reroute its target into the active `document.fullscreenElement` whenever the default container chain would otherwise land outside the fullscreen subtree.

## Repro before the fix

```tsx
function App() {
  const sectionRef = React.useRef<HTMLElement>(null);

  return (
    <section ref={sectionRef}>
      <button onClick={() => sectionRef.current?.requestFullscreen()}>
        Enter fullscreen
      </button>

      <Menu.Root>
        <Menu.Trigger>Open menu</Menu.Trigger>
        <Menu.Portal>
          <Menu.Positioner>
            <Menu.Popup>
              <Menu.Item>This is invisible while fullscreen is active</Menu.Item>
            </Menu.Popup>
          </Menu.Positioner>
        </Menu.Portal>
      </Menu.Root>
    </section>
  );
}
```

1. Click "Enter fullscreen" — the section takes over the screen.
2. Click "Open menu" — the menu trigger reports it's open, but **nothing appears on screen**.

The DOM is fine. The menu popup is in `document.body`. The problem is that the browser only renders descendants of `document.fullscreenElement`, and `document.body` is not one.

## The fix

`useFloatingPortalNode` now subscribes to a shared store that tracks `document.fullscreenElement` (with the `webkitFullscreenElement` fallback). When the resolved default container chain (`container` prop → parent portal → `document.body`) lands **outside** the active fullscreen element, the portal target is swapped to the fullscreen element itself.

```ts
let resolvedContainer = userContainer ?? parentPortalNode ?? document.body;

if (
  !userContainer &&
  fullscreenElement &&
  resolvedContainer instanceof Element &&
  !contains(fullscreenElement, resolvedContainer) &&
  // Robust scoping: only reroute if the popup is anchored to something
  // inside the fullscreen subtree. Otherwise we'd render the popup visible
  // but positioned to an off-screen anchor.
  (referenceElement == null || contains(fullscreenElement, referenceElement))
) {
  resolvedContainer = fullscreenElement;
}
```

A user-supplied `container` prop is always respected — we never override an explicit choice.

The check uses the existing shadow-DOM-aware `contains` helper so a portal already inside the fullscreen subtree (e.g. when the user fullscreens `document.documentElement`) is left alone.

### Anchor-aware, not trigger-aware

`referenceElement` is the **resolved DOM anchor** of the popup — what the positioner is actually attached to — not just the trigger that opened it. This matters because Base UI supports decoupling the two:

- **Detached triggers** (`Popover.createHandle`, `Menu.createHandle`, etc.): one trigger somewhere on the page opens a popup defined under a separate `Root` elsewhere in the tree. The popup is still anchored to the trigger by default, so trigger and anchor coincide.
- **Custom positioner anchor** (`<Popover.Positioner anchor={someEl} />`, etc.): the trigger and the anchor are completely independent DOM nodes. The popup is positioned relative to `anchor`, not the trigger.

The heuristic follows the **anchor** in both cases. Without this, a popup whose trigger is outside fullscreen but whose anchor lives inside the fullscreened element would stay invisible in `body`; conversely, a popup whose trigger happens to be inside fullscreen but whose anchor is off-screen would be rerouted to an invisible target. Using the resolved anchor makes the rerouting decision match what the user actually sees.

How the wiring works:

- `useAnchorPositioning` resolves the positioner's `anchor` prop on every relevant change and mirrors the final DOM element onto a new `domAnchorElement` slot on the shared `FloatingRootStore` (it's reset to `null` when the popup unmounts or the anchor is virtual / not an `Element`).
- A matching `domAnchorElement` selector returns `state.domAnchorElement ?? state.domReferenceElement`, so consumers transparently get the explicit anchor when present and fall back to the trigger when it isn't.
- Each Base UI **anchored popup** wrapper (`Popover`, `Menu`, `Tooltip`, `PreviewCard`, `Select`, `Combobox`, plus the shared `FloatingPortalLite`) reads this selector and passes the element through to `FloatingPortal` as `referenceElement`.
- Direct users of `FloatingPortal` who don't pass `referenceElement` opt into a simpler fallback: reroute whenever the default container is outside fullscreen. Backward-compatible, conservative.

### Dialogs, AlertDialogs and Drawers opt out — by design

Dialogs (modal or non-modal), AlertDialogs and Drawers are **not** visually anchored to a trigger: they cover the viewport with a backdrop, slide in from a screen edge, or center themselves using their own internal layout. The trigger only opens them; it doesn't define where they appear.

That makes the anchor-aware heuristic wrong for these. Consider: user opens a Dialog from a button in `<aside>`, then puts `<main>` into fullscreen. With anchor-aware logic the Dialog would stay parented to body (anchored to the trigger in `<aside>`, which is outside fullscreen) — and would be invisible. But the user obviously still wants to see the Dialog.

So `DialogPortal` (which `Drawer` and `AlertDialog` also re-export) deliberately does **not** pass `referenceElement`. It opts into the simpler fallback — "if a fullscreen element is active and the default container is outside it, reroute" — which is exactly what a viewport-relative overlay should do.

## Performance: one document listener, not N

A naive implementation would attach `fullscreenchange` + `webkitfullscreenchange` listeners on `document` from inside every `<FloatingPortal>` `useEffect`. On a typical app with 30–50 mounted popups (tooltips, dropdowns, menus, etc.), that's 60–100 document listeners for an event that fires at most a handful of times per session.

Instead, this PR uses a **module-level singleton store** fanned out via `React.useSyncExternalStore`:

- Exactly **one pair** of `document` listeners is ever attached, regardless of how many portals are mounted.
- Listeners are **refcounted**: lazily attached when the first portal mounts, cleanly detached when the last unmounts.
- The cached `fullscreenElement` is read directly from a closure variable, so per-portal renders are cheap.
- `getServerSnapshot` returns `null` for SSR safety.
- A subscribe-time `recompute()` resyncs the cache in case a `fullscreenchange` fired between module init and the first subscription.

A regression test (see "Testing" below) spies on `document.addEventListener` after the singleton is initialized and verifies that mounting additional portals adds zero new listeners.

## Behavior summary

| Component category | Fullscreen active, default container outside | Behavior |
|:-------------------|:---------------------------------------------|:---------|
| Anchored popups (Popover, Menu, Tooltip, PreviewCard, Select, Combobox) | Anchor is **inside** the fullscreen subtree | Portal reroutes into `document.fullscreenElement` |
| Anchored popups | Anchor is **outside** the fullscreen subtree (sibling fullscreened, detached anchor, etc.) | Portal stays in `document.body` — popup is hidden but never visibly mis-anchored |
| Viewport overlays (Dialog, AlertDialog, Drawer) | Any | Portal **always** reroutes into `document.fullscreenElement` — these are not anchored to their trigger |
| Any | Default container already inside the fullscreen subtree | No reroute — existing target is fine |
| Any | User passes an explicit `container` prop | Never overridden, regardless of fullscreen state |
| Any | No fullscreen active | Existing behavior unchanged (portals to `container` prop → parent portal → `document.body`) |
| Any | Fullscreen exits | Portal moves back to the default container automatically |
| Any | Portal opens while fullscreen is already active | Mounts directly into the fullscreen element from the start |

## Backward compatibility

- `FloatingPortal` gains one optional prop, `referenceElement`. All existing usage (no prop set) opts into the simpler "container-outside-fullscreen" fallback, so direct users of `FloatingPortal` see no behavioral regression.
- `FloatingRootStore` gains one new state field (`domAnchorElement`) and one new selector. Both default to `null` / fall back to the trigger, so other consumers of the store are unaffected.
- Pages that never enter fullscreen are completely unaffected at runtime — the singleton store never starts watching because subscribe is called inside an effect, and even with subscribers attached the only added cost is one closure on the shared listener.
- SSR-safe: `useSyncExternalStore`'s `getServerSnapshot` returns `null`, and the document-side feature detection guards against undefined `document`.

## Testing

15/15 tests pass in `FloatingPortal.test.tsx` (6 pre-existing + 9 new under `describe('fullscreen rerouting')`), plus 2 new integration tests in `PopoverPortal.test.tsx` for the anchor-aware behavior end-to-end.

`FloatingPortal.test.tsx` covers:

- Reroutes the portal into the fullscreen element when the default container is outside it (no anchor info)
- Does not reroute when the default container is already inside the fullscreen element
- Respects an explicit `container` prop even while in fullscreen
- Moves the portal back to body when fullscreen exits
- Mounts directly into the fullscreen element when opened while fullscreen is already active
- Shares a single `document` `fullscreenchange` subscription across multiple portals (regression test for the singleton)
- Does **not** reroute when the supplied `referenceElement` is outside the fullscreen subtree (robust-fix regression)
- Does reroute when the supplied `referenceElement` is inside the fullscreen subtree
- Falls back to the default heuristic when `referenceElement` is not provided

`PopoverPortal.test.tsx` covers the wired-up integration:

- Reroutes into fullscreen when a `Popover.Positioner anchor={…}` lives inside the fullscreen subtree even though the trigger does not
- Does not reroute when neither trigger nor custom anchor lives inside the fullscreen subtree

`DialogPortal.test.tsx` covers the viewport-overlay contract:

- Reroutes the dialog into fullscreen even when the trigger is outside the fullscreen subtree (dialogs are not anchored to their trigger)

```bash
pnpm typescript          # ✅
pnpm eslint              # ✅
pnpm test:jsdom FloatingPortal --no-watch  # ✅ 15 passed (15)
pnpm test:jsdom Portal --no-watch          # ✅ 154 passed (154, all wrappers)
pnpm test:jsdom Dialog --no-watch          # ✅ 271 passed
pnpm test:jsdom Drawer --no-watch          # ✅ 120 passed
pnpm test:jsdom AlertDialog --no-watch     # ✅ 25 passed
```

## Why now

The Fullscreen API has been broadly supported across modern browsers for years, but Base UI's popups don't compose with it cleanly today. As more apps adopt full-page editing surfaces, video players, distraction-free reading modes, and presentation views, this surfaces as a recurring footgun: a `Dialog` or `Menu` inside a fullscreened element appears to "stop working" with no console error.

The fix is localized to `FloatingPortal`, uses standard DOM APIs only, and benefits every Base UI primitive that relies on portals — no per-component changes needed.
