### PR TITLE
[number-field] Handle unreadable clipboard paste

### DIFF
--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -18,6 +18,8 @@ describe('<NumberField.Input />', () => {
     });
 
     fireEvent(target, pasteEvent);
+
+    return pasteEvent;
   }
 
   describeConformance(<NumberField.Input />, () => ({
@@ -705,9 +707,10 @@ describe('<NumberField.Input />', () => {
       const input = screen.getByRole('textbox');
       await act(async () => input.focus());
 
-      pasteWithError(input, new DOMException('Blocked', 'SecurityError'));
+      const pasteEvent = pasteWithError(input, new DOMException('Blocked', 'SecurityError'));
 
       expect(input).toHaveValue('12');
+      expect(pasteEvent.defaultPrevented).toBe(false);
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy.mock.calls[0]?.[0]).toContain(
         'Base UI: <NumberField.Input> could not read clipboard text during paste handling.',

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -7,6 +7,19 @@ import { createRenderer, describeConformance } from '#test-utils';
 describe('<NumberField.Input />', () => {
   const { render } = createRenderer();
 
+  function pasteWithError(target: HTMLElement, error: Error) {
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        getData() {
+          throw error;
+        },
+      },
+    });
+
+    fireEvent(target, pasteEvent);
+  }
+
   describeConformance(<NumberField.Input />, () => ({
     refInstanceof: window.HTMLInputElement,
     render(node) {
@@ -677,5 +690,30 @@ describe('<NumberField.Input />', () => {
     expect(onValueChange.mock.calls[0][0]).toBe(1234.5);
 
     expect(input.value).toBe((1234.5).toLocaleString('fr-FR'));
+  });
+
+  it('warns in development when clipboard text cannot be read during paste handling', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await render(
+        <NumberField.Root defaultValue={12}>
+          <NumberField.Input />
+        </NumberField.Root>,
+      );
+
+      const input = screen.getByRole('textbox');
+      await act(async () => input.focus());
+
+      pasteWithError(input, new DOMException('Blocked', 'SecurityError'));
+
+      expect(input).toHaveValue('12');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(
+        'Base UI: <NumberField.Input> could not read clipboard text during paste handling.',
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -1,5 +1,7 @@
 'use client';
 import * as React from 'react';
+import { SafeReact } from '@base-ui/utils/safeReact';
+import { warn } from '@base-ui/utils/warn';
 import { stopEvent } from '../../floating-ui-react/utils';
 import { useNumberFieldRootContext } from '../root/NumberFieldRootContext';
 import type { BaseUIComponentProps } from '../../internals/types';
@@ -397,11 +399,25 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
         return;
       }
 
+      let pastedData = '';
+
+      try {
+        pastedData = event.clipboardData?.getData('text/plain') ?? '';
+      } catch {
+        if (process.env.NODE_ENV !== 'production') {
+          const ownerStackMessage = SafeReact.captureOwnerStack?.() || '';
+          warn(
+            '<NumberField.Input> could not read clipboard text during paste handling.',
+            ownerStackMessage,
+          );
+        }
+
+        return;
+      }
+
       // Prevent `onChange` from being called.
       event.preventDefault();
 
-      const clipboardData = event.clipboardData || window.Clipboard;
-      const pastedData = clipboardData.getData('text/plain');
       const parsedValue = parseNumber(pastedData, locale, formatOptionsRef.current);
 
       if (parsedValue !== null) {


### PR DESCRIPTION
Handle clipboard read failures during NumberField paste events without throwing, matching the existing OTPField paste behavior.