### PR TITLE
[preview-card] Fix inline trigger repositioning

### DIFF
--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
@@ -81,6 +81,16 @@ export const PreviewCardPositioner = React.forwardRef(function PreviewCardPositi
   const updatePosition = positioning.update;
 
   useIsoLayoutEffect(() => {
+    store.context.inlineRectPositionerUpdateRef.current = updatePosition;
+
+    return () => {
+      if (store.context.inlineRectPositionerUpdateRef.current === updatePosition) {
+        store.context.inlineRectPositionerUpdateRef.current = undefined;
+      }
+    };
+  }, [store, updatePosition]);
+
+  useIsoLayoutEffect(() => {
     if (open && mounted) {
       updatePosition();
     }

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -25,6 +25,7 @@ export type State<Payload> = PopupStoreState<Payload> & {
 export type Context = PopupStoreContext<PreviewCardRoot.ChangeEventDetails> & {
   closeDelayRef: React.RefObject<number>;
   inlineRectCoordsRef: React.MutableRefObject<InlineRectCoords | undefined>;
+  inlineRectPositionerUpdateRef: React.MutableRefObject<(() => void) | undefined>;
 };
 
 const selectors = {
@@ -57,6 +58,7 @@ export class PreviewCardStore<Payload> extends ReactStore<
         triggerElements,
         closeDelayRef: { current: CLOSE_DELAY },
         inlineRectCoordsRef: { current: undefined },
+        inlineRectPositionerUpdateRef: { current: undefined },
       },
       selectors,
     );

--- a/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
+++ b/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { fastComponentRef } from '@base-ui/utils/fastHooks';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { usePreviewCardRootContext } from '../root/PreviewCardContext';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
@@ -83,9 +84,13 @@ export const PreviewCardTrigger = fastComponentRef(function PreviewCardTrigger(
   const state: PreviewCardTriggerState = { open: isOpenedByThisTrigger };
 
   const rootTriggerProps = store.useState('triggerProps', isMountedByThisTrigger);
+  const updateInlineRectPositioner = useStableCallback(() => {
+    store.context.inlineRectPositionerUpdateRef.current?.();
+  });
   const inlineRectTriggerProps = getInlineRectTriggerProps(
     inlineRectCoordsRef,
     isOpenedByThisTrigger,
+    updateInlineRectPositioner,
   );
 
   const element = useRenderElement('a', componentProps, {

--- a/packages/react/src/utils/popups/inlineRect.test.ts
+++ b/packages/react/src/utils/popups/inlineRect.test.ts
@@ -148,6 +148,40 @@ describe('inlineRect', () => {
     expect(coordsRef.current).toEqual({ x: 5, y: 25, lineIndex: 1, element: trigger });
   });
 
+  it('notifies when stored coords update while open', () => {
+    const trigger = createTrigger([
+      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
+      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
+    ]);
+    const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
+      current: { x: 1, y: 1, lineIndex: 0, element: trigger },
+    };
+    const onCoordsChange = vi.fn();
+
+    getInlineRectTriggerProps(coordsRef, true, onCoordsChange).onMouseEnter?.(
+      createMouseEvent(trigger, 5, 25),
+    );
+
+    expect(onCoordsChange).toHaveBeenCalledOnce();
+  });
+
+  it('does not notify when stored coords update while closed', () => {
+    const trigger = createTrigger([
+      { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },
+      { left: 0, top: 20, right: 10, bottom: 30, width: 10, height: 10 },
+    ]);
+    const coordsRef: React.MutableRefObject<InlineRectCoords | undefined> = {
+      current: { x: 1, y: 1, lineIndex: 0, element: trigger },
+    };
+    const onCoordsChange = vi.fn();
+
+    getInlineRectTriggerProps(coordsRef, false, onCoordsChange).onMouseEnter?.(
+      createMouseEvent(trigger, 5, 25),
+    );
+
+    expect(onCoordsChange).not.toHaveBeenCalled();
+  });
+
   it('updates stored coords from a native mouse event while open', () => {
     const trigger = createTrigger([
       { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 },

--- a/packages/react/src/utils/popups/inlineRect.ts
+++ b/packages/react/src/utils/popups/inlineRect.ts
@@ -203,9 +203,13 @@ function getContextElement(reference: Element | VirtualElement): Element | undef
 export function getInlineRectTriggerProps(
   coordsRef: React.RefObject<InlineRectCoords | undefined>,
   isOpen: boolean,
+  onCoordsChange?: (() => void) | undefined,
 ): Pick<React.HTMLAttributes<Element>, 'onFocus' | 'onMouseEnter' | 'onMouseMove'> {
   function updateCoords(event: React.MouseEvent<Element>) {
     updateInlineRectCoords(coordsRef, event.currentTarget, event.clientX, event.clientY);
+    if (isOpen) {
+      onCoordsChange?.();
+    }
   }
 
   function updateCoordsOnMove(event: React.MouseEvent<Element>) {


### PR DESCRIPTION
Try to fix https://app.circleci.com/jobs/github/mui/base-ui/299088

- Requests a Preview Card position update when inline trigger coordinates change while open.
- Keeps inline rect coordinates in a ref while letting the positioner own the Floating UI update.