### PR TITLE
[tooltip] Preserve focus-opened tooltip on hover leave

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingRootStore.ts
+++ b/packages/react/src/floating-ui-react/components/FloatingRootStore.ts
@@ -5,7 +5,7 @@ import { type BaseUIChangeEventDetails } from '../../internals/createBaseUIEvent
 import { createEventEmitter } from '../utils/createEventEmitter';
 import { type FloatingUIOpenChangeDetails } from '../../internals/types';
 import { type PopupTriggerMap } from '../../utils/popups';
-import { isClickLikeEvent } from '../utils';
+import { isClickLikeEvent, isFocusLikeEvent } from '../utils';
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
 
 export interface FloatingRootState {
@@ -97,8 +97,8 @@ export class FloatingRootStore extends ReactStore<
       !newOpen ||
       !this.state.open ||
       // Prevent a pending hover-open from overwriting a click-open event, while allowing
-      // click events to upgrade a hover-open.
-      (event != null && isClickLikeEvent(event))
+      // click or focus events to upgrade a hover-open.
+      (event != null && (isClickLikeEvent(event) || isFocusLikeEvent(event)))
     ) {
       this.context.dataRef.current.openEvent = newOpen ? event : undefined;
     }

--- a/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
@@ -21,9 +21,9 @@ import {
 } from './useHoverInteractionSharedState';
 import {
   getDelay,
-  isClickLikeOpenEvent as isClickLikeOpenEventShared,
   isHoverOpenEvent,
   isInsideEnabledTrigger,
+  isNonHoverOpenEvent as isNonHoverOpenEventShared,
 } from './useHoverShared';
 
 export type UseHoverFloatingInteractionProps = {
@@ -68,8 +68,8 @@ export function useHoverFloatingInteraction(
 
   const childClosedTimeout = useTimeout();
 
-  const isClickLikeOpenEvent = useStableCallback(() => {
-    return isClickLikeOpenEventShared(dataRef.current.openEvent?.type, instance.interactedInside);
+  const isNonHoverOpenEvent = useStableCallback(() => {
+    return isNonHoverOpenEventShared(dataRef.current.openEvent?.type, instance.interactedInside);
   });
 
   const isHoverOpen = useStableCallback(() => {
@@ -229,7 +229,7 @@ export function useHoverFloatingInteraction(
       }
 
       clearPointerEvents();
-      if (!isClickLikeOpenEvent()) {
+      if (!isNonHoverOpenEvent()) {
         closeWithDelay(event);
       }
     }
@@ -262,7 +262,7 @@ export function useHoverFloatingInteraction(
     dataRef,
     closeDelayProp,
     nodeIdProp,
-    isClickLikeOpenEvent,
+    isNonHoverOpenEvent,
     clearPointerEvents,
     instance,
     tree,

--- a/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
@@ -11,7 +11,7 @@ import { createChangeEventDetails } from '../../internals/createBaseUIEventDetai
 import { REASONS } from '../../internals/reasons';
 import { useFloatingParentNodeId, useFloatingTree } from '../components/FloatingTree';
 import type { FloatingContext, FloatingRootContext } from '../types';
-import { contains, getTarget } from '../utils/element';
+import { activeElement, contains, getTarget } from '../utils/element';
 import { getNodeChildren } from '../utils/nodes';
 import {
   applySafePolygonPointerEventsMutation,
@@ -68,8 +68,18 @@ export function useHoverFloatingInteraction(
 
   const childClosedTimeout = useTimeout();
 
+  const isFocusOwnedOpenEvent = useStableCallback(() => {
+    const activeEl = activeElement(ownerDocument(domReferenceElement ?? floatingElement));
+
+    return contains(domReferenceElement, activeEl) || contains(floatingElement, activeEl);
+  });
+
   const isNonHoverOpenEvent = useStableCallback(() => {
-    return isNonHoverOpenEventShared(dataRef.current.openEvent?.type, instance.interactedInside);
+    return isNonHoverOpenEventShared(
+      dataRef.current.openEvent?.type,
+      instance.interactedInside,
+      isFocusOwnedOpenEvent(),
+    );
   });
 
   const isHoverOpen = useStableCallback(() => {

--- a/packages/react/src/floating-ui-react/hooks/useHoverReferenceInteraction.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverReferenceInteraction.ts
@@ -13,7 +13,7 @@ import { FloatingUIOpenChangeDetails, HTMLProps } from '../../internals/types';
 import { useFloatingTree } from '../components/FloatingTree';
 import type { FloatingTreeStore } from '../components/FloatingTreeStore';
 import type { Delay, FloatingContext, FloatingRootContext } from '../types';
-import { contains, getTarget } from '../utils/element';
+import { activeElement, contains, getTarget } from '../utils/element';
 import { isMouseLikePointerType } from '../utils/event';
 import {
   applySafePolygonPointerEventsMutation,
@@ -94,8 +94,20 @@ export function useHoverReferenceInteraction(
   const shouldOpenRef = useValueAsRef(shouldOpenProp);
   const isClosingRef = useValueAsRef(isClosing);
 
+  const isFocusOwnedOpenEvent = useStableCallback(() => {
+    const domReferenceElement = store.select('domReferenceElement');
+    const floatingElement = store.select('floatingElement');
+    const activeEl = activeElement(ownerDocument(domReferenceElement ?? floatingElement));
+
+    return contains(domReferenceElement, activeEl) || contains(floatingElement, activeEl);
+  });
+
   const isNonHoverOpenEvent = useStableCallback(() => {
-    return isNonHoverOpenEventShared(dataRef.current.openEvent?.type, instance.interactedInside);
+    return isNonHoverOpenEventShared(
+      dataRef.current.openEvent?.type,
+      instance.interactedInside,
+      isFocusOwnedOpenEvent(),
+    );
   });
 
   const checkShouldOpen = useStableCallback(() => {

--- a/packages/react/src/floating-ui-react/hooks/useHoverReferenceInteraction.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverReferenceInteraction.ts
@@ -24,8 +24,8 @@ import type { HandleClose, HandleCloseContextBase } from './useHoverShared';
 import {
   getDelay,
   getRestMs,
-  isClickLikeOpenEvent as isClickLikeOpenEventShared,
   isInsideEnabledTrigger,
+  isNonHoverOpenEvent as isNonHoverOpenEventShared,
 } from './useHoverShared';
 
 export interface UseHoverReferenceInteractionProps {
@@ -94,8 +94,8 @@ export function useHoverReferenceInteraction(
   const shouldOpenRef = useValueAsRef(shouldOpenProp);
   const isClosingRef = useValueAsRef(isClosing);
 
-  const isClickLikeOpenEvent = useStableCallback(() => {
-    return isClickLikeOpenEventShared(dataRef.current.openEvent?.type, instance.interactedInside);
+  const isNonHoverOpenEvent = useStableCallback(() => {
+    return isNonHoverOpenEventShared(dataRef.current.openEvent?.type, instance.interactedInside);
   });
 
   const checkShouldOpen = useStableCallback(() => {
@@ -289,7 +289,7 @@ export function useHoverReferenceInteraction(
     }
 
     function onMouseLeave(event: MouseEvent) {
-      if (isClickLikeOpenEvent()) {
+      if (isNonHoverOpenEvent()) {
         clearPointerEvents();
         return;
       }
@@ -324,7 +324,7 @@ export function useHoverReferenceInteraction(
             cleanupMouseMoveHandler();
             if (
               enabledRef.current &&
-              !isClickLikeOpenEvent() &&
+              !isNonHoverOpenEvent() &&
               currentTrigger === store.select('domReferenceElement')
             ) {
               closeWithDelay(event, true);
@@ -371,7 +371,7 @@ export function useHoverReferenceInteraction(
     instance,
     isActiveTrigger,
     isOverInactiveTrigger,
-    isClickLikeOpenEvent,
+    isNonHoverOpenEvent,
     mouseOnly,
     move,
     restMsRef,
@@ -440,9 +440,9 @@ export function useHoverReferenceInteraction(
         function handleMouseMove() {
           instance.restTimeoutPending = false;
 
-          // A delayed hover open should not override a click-like open that happened
+          // A delayed hover open should not override a non-hover open that happened
           // while the hover delay was pending.
-          if (isClickLikeOpenEvent()) {
+          if (isNonHoverOpenEvent()) {
             return;
           }
 
@@ -471,7 +471,7 @@ export function useHoverReferenceInteraction(
   }, [
     enabled,
     instance,
-    isClickLikeOpenEvent,
+    isNonHoverOpenEvent,
     isOverInactiveTrigger,
     mouseOnly,
     store,

--- a/packages/react/src/floating-ui-react/hooks/useHoverShared.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverShared.ts
@@ -70,14 +70,21 @@ export function isClickLikeOpenEvent(openEventType: string | undefined, interact
   return interactedInside || openEventType === 'click' || openEventType === 'mousedown';
 }
 
+export function isFocusOpenEvent(openEventType: string | undefined) {
+  return openEventType === 'focus' || openEventType === 'focusin';
+}
+
 /**
- * Returns true if the open event is a click-like event (click or mousedown), a focus event, or if the user interacted inside the floating element.
+ * Returns true if the open event is a click-like event (click or mousedown), a focus-owned event, or if the user interacted inside the floating element.
  */
-export function isNonHoverOpenEvent(openEventType: string | undefined, interactedInside: boolean) {
+export function isNonHoverOpenEvent(
+  openEventType: string | undefined,
+  interactedInside: boolean,
+  focusOwned = true,
+) {
   return (
     isClickLikeOpenEvent(openEventType, interactedInside) ||
-    openEventType === 'focus' ||
-    openEventType === 'focusin'
+    (focusOwned && isFocusOpenEvent(openEventType))
   );
 }
 

--- a/packages/react/src/floating-ui-react/hooks/useHoverShared.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverShared.ts
@@ -63,8 +63,22 @@ export function getRestMs(value: number | (() => number)) {
   return value;
 }
 
+/**
+ * Returns true if the open event is a click-like event (click or mousedown) or if the user interacted inside the floating element.
+ */
 export function isClickLikeOpenEvent(openEventType: string | undefined, interactedInside: boolean) {
   return interactedInside || openEventType === 'click' || openEventType === 'mousedown';
+}
+
+/**
+ * Returns true if the open event is a click-like event (click or mousedown), a focus event, or if the user interacted inside the floating element.
+ */
+export function isNonHoverOpenEvent(openEventType: string | undefined, interactedInside: boolean) {
+  return (
+    isClickLikeOpenEvent(openEventType, interactedInside) ||
+    openEventType === 'focus' ||
+    openEventType === 'focusin'
+  );
 }
 
 export function isHoverOpenEvent(openEventType: string | undefined) {

--- a/packages/react/src/floating-ui-react/utils/event.ts
+++ b/packages/react/src/floating-ui-react/utils/event.ts
@@ -57,3 +57,8 @@ export function isClickLikeEvent(event: Event | React.SyntheticEvent) {
   const type = event.type;
   return type === 'click' || type === 'mousedown' || type === 'keydown' || type === 'keyup';
 }
+
+export function isFocusLikeEvent(event: Event | React.SyntheticEvent) {
+  const type = event.type;
+  return type === 'focus' || type === 'focusin';
+}

--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -108,6 +108,11 @@ describe('<Tooltip.Root />', () => {
 
           expect(screen.getByText('Content')).not.toBe(null);
 
+          fireEvent.mouseLeave(screen.getByTestId('positioner'), { relatedTarget: document.body });
+          await flushMicrotasks();
+
+          expect(screen.getByText('Content')).not.toBe(null);
+
           fireEvent.mouseLeave(trigger, { relatedTarget: document.body });
           await flushMicrotasks();
 
@@ -136,6 +141,79 @@ describe('<Tooltip.Root />', () => {
           await flushMicrotasks();
 
           expect(screen.queryByText('Content')).toBe(null);
+        },
+      );
+
+      it.skipIf(isJSDOM)(
+        'should keep a hover-opened tooltip open after the trigger receives focus',
+        async () => {
+          await render(<TestTooltip triggerProps={{ delay: 0, closeDelay: 0 }} />);
+
+          const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+          fireEvent.mouseEnter(trigger);
+          await flushMicrotasks();
+
+          expect(screen.getByText('Content')).not.toBe(null);
+
+          await act(async () => {
+            trigger.focus();
+          });
+          await flushMicrotasks();
+
+          fireEvent.mouseLeave(trigger, { relatedTarget: document.body });
+          await flushMicrotasks();
+
+          expect(screen.getByText('Content')).not.toBe(null);
+
+          await act(async () => {
+            trigger.blur();
+          });
+          clock.tick(OPEN_DELAY);
+
+          expect(screen.queryByText('Content')).toBe(null);
+        },
+      );
+
+      it.skipIf(isJSDOM)(
+        'should not let a pending hover open override a focus-opened tooltip',
+        async () => {
+          const handleOpenChange = vi.fn();
+
+          await render(
+            <TestTooltip
+              rootProps={{
+                onOpenChange: handleOpenChange,
+              }}
+            />,
+          );
+
+          const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+          fireEvent.mouseEnter(trigger);
+          fireEvent.mouseMove(trigger);
+          await flushMicrotasks();
+
+          expect(screen.queryByText('Content')).toBe(null);
+
+          await act(async () => {
+            trigger.focus();
+          });
+          await flushMicrotasks();
+
+          expect(screen.getByText('Content')).not.toBe(null);
+          expect(handleOpenChange).toHaveBeenCalledTimes(1);
+          expect(handleOpenChange.mock.lastCall?.[1].reason).toBe(REASONS.triggerFocus);
+
+          clock.tick(OPEN_DELAY);
+          await flushMicrotasks();
+
+          expect(handleOpenChange).toHaveBeenCalledTimes(1);
+
+          fireEvent.mouseLeave(trigger, { relatedTarget: document.body });
+          await flushMicrotasks();
+
+          expect(screen.getByText('Content')).not.toBe(null);
         },
       );
 

--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -94,6 +94,51 @@ describe('<Tooltip.Root />', () => {
         expect(screen.getByText('Content')).not.toBe(null);
       });
 
+      it.skipIf(isJSDOM)(
+        'should keep a focus-opened tooltip open on mouse leave until blur or Escape',
+        async () => {
+          await render(<TestTooltip triggerProps={{ delay: 0, closeDelay: 0 }} />);
+
+          const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+          await act(async () => {
+            trigger.focus();
+          });
+          await flushMicrotasks();
+
+          expect(screen.getByText('Content')).not.toBe(null);
+
+          fireEvent.mouseLeave(trigger, { relatedTarget: document.body });
+          await flushMicrotasks();
+
+          expect(screen.getByText('Content')).not.toBe(null);
+
+          await act(async () => {
+            trigger.blur();
+          });
+          clock.tick(OPEN_DELAY);
+
+          expect(screen.queryByText('Content')).toBe(null);
+
+          await act(async () => {
+            trigger.focus();
+          });
+          await flushMicrotasks();
+
+          expect(screen.getByText('Content')).not.toBe(null);
+
+          fireEvent.mouseLeave(trigger, { relatedTarget: document.body });
+          await flushMicrotasks();
+
+          expect(screen.getByText('Content')).not.toBe(null);
+
+          fireEvent.keyDown(trigger, { key: 'Escape' });
+          await flushMicrotasks();
+
+          expect(screen.queryByText('Content')).toBe(null);
+        },
+      );
+
       it('should close when the trigger is blurred', async () => {
         await render(<TestTooltip />);
 


### PR DESCRIPTION
## Summary

- Keep a tooltip opened by focus open when the pointer leaves the focused trigger.
- Continue closing it on blur or Escape.
- Add regression coverage for focus -> mouseLeave -> blur/Escape.

## Bug

A tooltip can be opened by focus and then closed by hover leave while the trigger still has focus. That leaves keyboard users with a tooltip that disappears even though the focus-open condition is still true.

## Reproduction

- Before: https://codesandbox.io/s/yt6z9g?file=/src/App.tsx
- After: https://codesandbox.io/s/lr75l2?file=/src/App.tsx

## Test plan

- `pnpm test:jsdom TooltipRoot --no-watch`
- `pnpm test:chromium TooltipRoot --no-watch`