### PR TITLE
[docs-infra] Update docs to support turbopack mode

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -154,6 +154,7 @@ const nextConfig = {
   devIndicators: false,
   experimental: {
     globalNotFound: true,
+    turbopackFileSystemCacheForBuild: true,
   },
 };
 

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -3,35 +3,25 @@ import * as path from 'path';
 import * as url from 'url';
 import * as fs from 'fs';
 import { withDeploymentConfig } from '@mui/internal-docs-infra/withDocsInfra';
-import transformMarkdownMetadata from '@mui/internal-docs-infra/pipeline/transformMarkdownMetadata';
-import transformMarkdownRelativePaths from '@mui/internal-docs-infra/pipeline/transformMarkdownRelativePaths';
-import transformMarkdownCode from '@mui/internal-docs-infra/pipeline/transformMarkdownCode';
-import transformHtmlCodeBlock from '@mui/internal-docs-infra/pipeline/transformHtmlCodeBlock';
-import transformHtmlCodeInline from '@mui/internal-docs-infra/pipeline/transformHtmlCodeInline';
-import enhanceCodeInline from '@mui/internal-docs-infra/pipeline/enhanceCodeInline';
 import nextMdx from '@next/mdx';
-import rehypeExtractToc from '@stefanprobst/rehype-extract-toc';
-import remarkGfm from 'remark-gfm';
-import remarkTypography from 'remark-typography';
-import { remarkQuickNavExcludeHeading } from 'docs/src/components/QuickNav/remarkQuickNavExcludeHeading.mjs';
-import { rehypeQuickNav } from 'docs/src/components/QuickNav/rehypeQuickNav.mjs';
-import { rehypeConcatHeadings } from 'docs/src/components/QuickNav/rehypeConcatHeadings.mjs';
-import { rehypeKbd } from 'docs/src/components/Kbd/rehypeKbd.mjs';
-import { rehypeSlug } from 'docs/src/components/QuickNav/rehypeSlug.mjs';
-import { rehypeSubtitle } from 'docs/src/components/Subtitle/rehypeSubtitle.mjs';
-import { rehypeEagerCodeBlocks } from 'docs/src/components/CodeBlock/rehypeEagerCodeBlocks.mjs';
 import { ordering } from 'docs/src/utils/typeOrder.mjs';
 
 const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
 const workspaceRoot = path.resolve(currentDirectory, '../');
 const baseDir = path.dirname(url.fileURLToPath(import.meta.url));
 
+/**
+ * @param {string} relativePath
+ * @returns {string}
+ */
+const localPlugin = (relativePath) => path.join(baseDir, relativePath);
+
 const withMdx = nextMdx({
   options: {
     remarkPlugins: [
-      remarkGfm,
+      'remark-gfm',
       [
-        transformMarkdownMetadata,
+        '@mui/internal-docs-infra/pipeline/transformMarkdownMetadata',
         {
           titleSuffix: ' · Base UI',
           extractToIndex: {
@@ -48,22 +38,22 @@ const withMdx = nextMdx({
           },
         },
       ],
-      remarkTypography,
-      remarkQuickNavExcludeHeading,
-      transformMarkdownRelativePaths,
-      transformMarkdownCode,
+      'remark-typography',
+      localPlugin('src/components/QuickNav/remarkQuickNavExcludeHeading.mjs'),
+      '@mui/internal-docs-infra/pipeline/transformMarkdownRelativePaths',
+      '@mui/internal-docs-infra/pipeline/transformMarkdownCode',
     ],
     rehypePlugins: [
-      transformHtmlCodeBlock,
-      rehypeEagerCodeBlocks,
-      transformHtmlCodeInline,
-      enhanceCodeInline,
-      rehypeSlug,
-      rehypeConcatHeadings,
-      rehypeExtractToc,
-      rehypeQuickNav,
-      rehypeSubtitle,
-      rehypeKbd,
+      '@mui/internal-docs-infra/pipeline/transformHtmlCodeBlock',
+      localPlugin('src/components/CodeBlock/rehypeEagerCodeBlocks.mjs'),
+      '@mui/internal-docs-infra/pipeline/transformHtmlCodeInline',
+      '@mui/internal-docs-infra/pipeline/enhanceCodeInline',
+      localPlugin('src/components/QuickNav/rehypeSlug.mjs'),
+      localPlugin('src/components/QuickNav/rehypeConcatHeadings.mjs'),
+      '@stefanprobst/rehype-extract-toc',
+      localPlugin('src/components/QuickNav/rehypeQuickNav.mjs'),
+      localPlugin('src/components/Subtitle/rehypeSubtitle.mjs'),
+      localPlugin('src/components/Kbd/rehypeKbd.mjs'),
     ],
   },
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build --webpack && pnpm link-check",
+    "build": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build && pnpm link-check",
     "build:clean": "rimraf .next && pnpm build",
-    "dev": "next dev --webpack --port 3005",
+    "dev": "next dev --port 3005",
     "deploy": "git fetch upstream master && git push -f upstream FETCH_HEAD:docs-v1",
     "serve": "serve ./export -l 3010",
     "docs-infra": "docs-infra",

--- a/docs/src/components/CodeBlock/rehypeEagerCodeBlocks.mjs
+++ b/docs/src/components/CodeBlock/rehypeEagerCodeBlocks.mjs
@@ -2,7 +2,7 @@ import { visit, EXIT, CONTINUE } from 'unist-util-visit';
 
 const EAGER_COUNT = 2;
 
-export function rehypeEagerCodeBlocks() {
+export default function rehypeEagerCodeBlocks() {
   return (tree) => {
     let count = 0;
     visit(tree, 'element', (node) => {

--- a/docs/src/components/Kbd/rehypeKbd.mjs
+++ b/docs/src/components/Kbd/rehypeKbd.mjs
@@ -1,7 +1,7 @@
 import { visit } from 'unist-util-visit';
 
 /** Treat <kbd> as normal tags */
-export function rehypeKbd() {
+export default function rehypeKbd() {
   return (tree) => {
     visit(tree, (node) => {
       if (node.name === 'kbd') {

--- a/docs/src/components/QuickNav/rehypeConcatHeadings.mjs
+++ b/docs/src/components/QuickNav/rehypeConcatHeadings.mjs
@@ -4,7 +4,7 @@ import { toString } from 'hast-util-to-string';
 import { visit, CONTINUE, EXIT } from 'unist-util-visit';
 import { stringToUrl } from './rehypeSlug.mjs';
 
-export function rehypeConcatHeadings() {
+export default function rehypeConcatHeadings() {
   return (tree) => {
     /**
      * Forms page: prefix <h3>s under React Hook Form/TanStack Form with the library name

--- a/docs/src/components/QuickNav/rehypeQuickNav.mjs
+++ b/docs/src/components/QuickNav/rehypeQuickNav.mjs
@@ -21,7 +21,7 @@ const LINK = 'QuickNav.Link';
 /**
  * @returns {function(*, *): void}
  */
-export function rehypeQuickNav() {
+export default function rehypeQuickNav() {
   return (tree, file) => {
     /** @type {TocEntry[]} */
     const toc = file.data.toc ?? [];

--- a/docs/src/components/QuickNav/rehypeSlug.mjs
+++ b/docs/src/components/QuickNav/rehypeSlug.mjs
@@ -26,7 +26,7 @@ const emptyOptions = {};
  * @returns
  *   Transform.
  */
-export function rehypeSlug(options) {
+export default function rehypeSlug(options) {
   const settings = options || emptyOptions;
   const prefix = settings.prefix || '';
 

--- a/docs/src/components/QuickNav/remarkQuickNavExcludeHeading.mjs
+++ b/docs/src/components/QuickNav/remarkQuickNavExcludeHeading.mjs
@@ -8,7 +8,7 @@ import { visit } from 'unist-util-visit';
  *
  * @returns {function(*): void}
  */
-export function remarkQuickNavExcludeHeading() {
+export default function remarkQuickNavExcludeHeading() {
   return (tree) => {
     visit(tree, 'definition', (node, index, parent) => {
       if (

--- a/docs/src/components/Subtitle/rehypeSubtitle.mjs
+++ b/docs/src/components/Subtitle/rehypeSubtitle.mjs
@@ -3,7 +3,7 @@ import { visitParents } from 'unist-util-visit-parents';
 /**
  * Unwrap potential paragraphs inside `<Subtitle>`
  */
-export function rehypeSubtitle() {
+export default function rehypeSubtitle() {
   return (tree) => {
     visitParents(tree, (node, ancestors) => {
       const parent = ancestors.slice(-1)[0];

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -111,7 +111,6 @@
     "#test-utils": "./test/index.ts",
     "#formatErrorMessage": "@base-ui/utils/formatErrorMessage"
   },
-  "type": "commonjs",
   "scripts": {
     "prebuild": "rimraf --glob build build-tests \"*.tsbuildinfo\"",
     "build": "code-infra build --ignore \"**/*.template.js\" --copy .npmignore",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,6 @@
   "imports": {
     "#formatErrorMessage": "./src/formatErrorMessage.ts"
   },
-  "type": "commonjs",
   "scripts": {
     "prebuild": "rimraf --glob build build-tests \"*.tsbuildinfo\"",
     "build": "code-infra build --copy .npmignore",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,10 +347,10 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: latest
-        version: 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@base-ui/utils':
         specifier: latest
-        version: 0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 0.2.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-devtools':
         specifier: ^0.10.0
         version: 0.10.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)
@@ -423,7 +423,7 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: latest
-        version: 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1379,8 +1379,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.4.1':
-    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
+  '@base-ui/react@1.5.0':
+    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -1396,8 +1396,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.2.8':
-    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
+  '@base-ui/utils@0.2.9':
+    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -10764,10 +10764,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@base-ui/react@1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@base-ui/utils': 0.2.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@floating-ui/utils': 0.2.11
       react: 19.2.5
@@ -10778,7 +10778,7 @@ snapshots:
       '@types/react': 19.2.14
       date-fns: 4.1.0
 
-  '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@base-ui/utils@0.2.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.11


### PR DESCRIPTION
### TL;DR

- **Dev startup**: ~3× faster (1.0s → 0.35s)
- **Cold-route compile**: ~1.4× faster on average (5.87s → 4.26s across 4 routes); per-route range from 0.8× to 2.0×. Still dominated by `loadPrecomputedTypes` (1–2s per types.ts) in both modes. We need to improve this on the docs-infra package side.
- **HMR rebuilds**: ~2.8× faster (1.77s → 0.63s mean across 3 edit targets)
- **Production build**: 2.3× faster (61.5s → 27.0s), 2.7× less CPU

1. Dev server startup (cold, after `rm -rf .next`)

| | webpack | Turbopack |
|---|---|---|
| `Ready in` | 1.32–1.51s | **0.34–0.53s** |

~3× faster ready time.

2. First-request compile per route (no cache)

| route | webpack | Turbopack |
|---|---|---|
| `/` | 1.9s | **1.4s** |
| `/react/components/popover` | 6.1s* | **5.1s** |
| `/react/components/dialog` | 4.2s | **2.0s** |
| `/react/components/select` | 2.5s | 3.7s |
| `/react/components/combobox` | 3.5s | **2.7s** |

3. HMR / incremental recompile (3 edit cycles × 2 add+revert)

| file edited | webpack | Turbopack | speedup |
|---|---|---|---|
| `popover/page.mdx` | 1.86s | **0.48s** | 3.9× |
| `PopoverPopup.tsx` (workspace pkg) | 2.50s | **0.95s** | 2.6× |
| docs `CodeBlock.tsx` | 0.95s | **0.45s** | 2.1× |
| **mean** | **1.77s** | **0.63s** | **2.8×** |

4. Production build (cold, `rm -rf .next export`)

| | wall | user CPU |
|---|---|---|
| webpack | 61.5s | 128.3s |
| Turbopack | **27.0s** | **47.5s** |
| ratio | **2.3×** faster | 2.7× less CPU |

@dav-is When building the docs, I got a bunch of -

```
Unable to handle a type with flag "IncludesInstantiable". Using any instead.
```

Also, I need you to check if everything is working as far as docs-infra related transforms are concerned since you have larger context. I have already verified that a bunch of pages are working as expected.