### PR TITLE
[popups] Fix controlled hover leave close

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
@@ -224,12 +224,14 @@ export function useHoverFloatingInteraction(
 
       // If the safePolygon handler is active, let it handle the close logic.
       if (instance.handler) {
-        instance.handler(event);
+        if (isHoverOpen()) {
+          instance.handler(event);
+        }
         return;
       }
 
       clearPointerEvents();
-      if (!isClickLikeOpenEvent()) {
+      if (isHoverOpen() && !isClickLikeOpenEvent()) {
         closeWithDelay(event);
       }
     }
@@ -262,6 +264,7 @@ export function useHoverFloatingInteraction(
     dataRef,
     closeDelayProp,
     nodeIdProp,
+    isHoverOpen,
     isClickLikeOpenEvent,
     clearPointerEvents,
     instance,

--- a/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
@@ -224,9 +224,7 @@ export function useHoverFloatingInteraction(
 
       // If the safePolygon handler is active, let it handle the close logic.
       if (instance.handler) {
-        if (isHoverOpen()) {
-          instance.handler(event);
-        }
+        instance.handler(event);
         return;
       }
 

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -1228,6 +1228,84 @@ describe('<Menu.Root />', () => {
       });
     });
 
+    describe('hover close', () => {
+      it('does not close after hovering out of a popup opened without trigger hover', async () => {
+        await render(<TestMenu rootProps={{ defaultOpen: true }} />);
+
+        await waitFor(() => {
+          expect(screen.queryByRole('menu')).not.toBe(null);
+        });
+
+        const positioner = screen.getByTestId('menu-positioner');
+
+        fireEvent.mouseEnter(positioner);
+        fireEvent.mouseLeave(positioner);
+
+        expect(screen.queryByRole('menu')).not.toBe(null);
+      });
+    });
+
+    describe('controlled open', () => {
+      it('does not close after hovering out of a popup opened externally', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+
+          return (
+            <React.Fragment>
+              <button type="button" onClick={() => setOpen(true)}>
+                Show
+              </button>
+              <TestMenu rootProps={{ open, onOpenChange: setOpen }} />
+            </React.Fragment>
+          );
+        }
+
+        const { user } = await render(<App />);
+
+        await user.click(screen.getByRole('button', { name: 'Show' }));
+
+        await waitFor(() => {
+          expect(screen.queryByRole('menu')).not.toBe(null);
+        });
+
+        const positioner = screen.getByTestId('menu-positioner');
+
+        fireEvent.mouseEnter(positioner);
+        fireEvent.mouseLeave(positioner);
+
+        expect(screen.queryByRole('menu')).not.toBe(null);
+      });
+
+      it('closes after hovering out of a popup opened by its trigger', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+
+          return (
+            <TestMenu
+              rootProps={{ open, onOpenChange: setOpen, modal: false }}
+              triggerProps={{ openOnHover: true, delay: 0 }}
+            />
+          );
+        }
+
+        await render(<App />);
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        expect(screen.queryByRole('menu')).not.toBe(null);
+
+        const positioner = screen.getByTestId('menu-positioner');
+
+        fireEvent.mouseEnter(positioner);
+        fireEvent.mouseLeave(positioner);
+
+        expect(screen.queryByRole('menu')).toBe(null);
+      });
+    });
+
     describe.skipIf(isJSDOM)('scroll locking', () => {
       describe('interaction type tracking (openMethod)', () => {
         it('should not apply scroll lock when opened via touch', async () => {

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -132,6 +132,68 @@ describe('<Popover.Root />', () => {
         expect(handleChange.mock.calls[0][0]).toBe(false);
         expect(handleChange.mock.calls[1][0]).toBe(true);
       });
+
+      it('does not close after hovering out of a popup opened externally', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+
+          return (
+            <React.Fragment>
+              <button type="button" onClick={() => setOpen(true)}>
+                Show
+              </button>
+              <TestPopover
+                rootProps={{ open, onOpenChange: setOpen }}
+                triggerProps={{ openOnHover: true, delay: 0 }}
+              />
+            </React.Fragment>
+          );
+        }
+
+        const { user } = await render(<App />);
+
+        await user.click(screen.getByRole('button', { name: 'Show' }));
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).not.toBe(null);
+        });
+
+        const positioner = screen.getByTestId('positioner');
+
+        fireEvent.mouseEnter(positioner);
+        fireEvent.mouseLeave(positioner);
+
+        expect(screen.queryByRole('dialog')).not.toBe(null);
+      });
+
+      it('closes after hovering out of a popup opened by its trigger', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+
+          return (
+            <TestPopover
+              rootProps={{ open, onOpenChange: setOpen }}
+              triggerProps={{ openOnHover: true, delay: 0 }}
+            />
+          );
+        }
+
+        await render(<App />);
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        expect(screen.queryByRole('dialog')).not.toBe(null);
+
+        const positioner = screen.getByTestId('positioner');
+
+        fireEvent.mouseEnter(positioner);
+        fireEvent.mouseLeave(positioner);
+
+        expect(screen.queryByRole('dialog')).toBe(null);
+      });
     });
 
     describe('nested menu interactions', () => {
@@ -290,6 +352,21 @@ describe('<Popover.Root />', () => {
         fireEvent.click(anchor);
 
         expect(screen.queryByText('Content')).toBe(null);
+      });
+
+      it('does not close after hovering out of a popup opened without trigger hover', async () => {
+        await render(
+          <TestPopover rootProps={{ defaultOpen: true }} triggerProps={{ openOnHover: true }} />,
+        );
+
+        expect(screen.getByText('Content')).not.toBe(null);
+
+        const positioner = screen.getByTestId('positioner');
+
+        fireEvent.mouseEnter(positioner);
+        fireEvent.mouseLeave(positioner);
+
+        expect(screen.getByText('Content')).not.toBe(null);
       });
     });
 

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -194,6 +194,57 @@ describe('<Popover.Root />', () => {
 
         expect(screen.queryByRole('dialog')).toBe(null);
       });
+
+      it('cleans up the safe polygon handler after a hover-opened popup becomes click-sticky', async () => {
+        const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+        const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
+
+        try {
+          await render(
+            <TestPopover
+              rootProps={{ modal: false }}
+              triggerProps={{ openOnHover: true, delay: 0, closeDelay: 0 }}
+            />,
+          );
+
+          const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+          fireEvent.mouseEnter(trigger);
+          fireEvent.mouseMove(trigger);
+
+          expect(screen.queryByRole('dialog')).not.toBe(null);
+
+          const positioner = screen.getByTestId('positioner');
+
+          fireEvent.mouseLeave(trigger, { relatedTarget: positioner });
+          fireEvent.mouseEnter(positioner);
+
+          let documentMouseMoveHandler: EventListenerOrEventListenerObject | undefined;
+          for (let i = addEventListenerSpy.mock.calls.length - 1; i >= 0; i -= 1) {
+            const [eventName, listener] = addEventListenerSpy.mock.calls[i];
+            if (eventName === 'mousemove') {
+              documentMouseMoveHandler = listener;
+              break;
+            }
+          }
+
+          expect(documentMouseMoveHandler).toEqual(expect.any(Function));
+
+          fireEvent.click(trigger);
+          await flushMicrotasks();
+
+          fireEvent.mouseLeave(positioner);
+
+          expect(screen.queryByRole('dialog')).not.toBe(null);
+          expect(removeEventListenerSpy).toHaveBeenCalledWith(
+            'mousemove',
+            documentMouseMoveHandler,
+          );
+        } finally {
+          addEventListenerSpy.mockRestore();
+          removeEventListenerSpy.mockRestore();
+        }
+      });
     });
 
     describe('nested menu interactions', () => {

--- a/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
@@ -156,6 +156,68 @@ describe('<PreviewCard.Root />', () => {
         expect(handleChange.mock.calls[1][0]).toBe(true);
       });
 
+      it('does not close after hovering out of a popup opened externally', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+
+          return (
+            <React.Fragment>
+              <button type="button" onClick={() => setOpen(true)}>
+                Show
+              </button>
+              <TestPreviewCard rootProps={{ open, onOpenChange: setOpen }} />
+            </React.Fragment>
+          );
+        }
+
+        await render(<App />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+
+        expect(screen.queryByText('Content')).not.toBe(null);
+
+        const positioner = screen.getByTestId('positioner');
+
+        fireEvent.mouseEnter(positioner);
+        fireEvent.mouseLeave(positioner);
+
+        clock.tick(CLOSE_DELAY);
+
+        await flushMicrotasks();
+
+        expect(screen.queryByText('Content')).not.toBe(null);
+      });
+
+      it('closes after hovering out of a popup opened by its trigger', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+
+          return <TestPreviewCard rootProps={{ open, onOpenChange: setOpen }} />;
+        }
+
+        await render(<App />);
+
+        const trigger = screen.getByRole('link', { name: 'Link' });
+
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        clock.tick(OPEN_DELAY);
+        await flushMicrotasks();
+
+        expect(screen.queryByText('Content')).not.toBe(null);
+
+        const positioner = screen.getByTestId('positioner');
+
+        fireEvent.mouseEnter(positioner);
+        fireEvent.mouseLeave(positioner);
+
+        clock.tick(CLOSE_DELAY);
+        await flushMicrotasks();
+
+        expect(screen.queryByText('Content')).toBe(null);
+      });
+
       it('should not call onChange when the open state does not change', async () => {
         const handleChange = vi.fn();
 
@@ -253,6 +315,28 @@ describe('<PreviewCard.Root />', () => {
         clock.tick(CLOSE_DELAY);
 
         expect(screen.queryByText('Content')).toBe(null);
+      });
+
+      it('does not close after hovering out of a popup opened without trigger hover', async () => {
+        await render(
+          <TestPreviewCard
+            rootProps={{
+              defaultOpen: true,
+            }}
+          />,
+        );
+
+        expect(screen.getByText('Content')).not.toBe(null);
+
+        const positioner = screen.getByTestId('positioner');
+
+        fireEvent.mouseEnter(positioner);
+        fireEvent.mouseLeave(positioner);
+
+        clock.tick(CLOSE_DELAY);
+        await flushMicrotasks();
+
+        expect(screen.getByText('Content')).not.toBe(null);
       });
     });
 
@@ -828,7 +912,7 @@ describe('<PreviewCard.Root />', () => {
                 <PreviewCard.Positioner>
                   <PreviewCard.Popup data-testid="parent-popup">
                     <div>Parent content</div>
-                    <PreviewCard.Root defaultOpen>
+                    <PreviewCard.Root>
                       <PreviewCard.Trigger href="#" data-testid="child-trigger">
                         Child
                       </PreviewCard.Trigger>
@@ -851,6 +935,14 @@ describe('<PreviewCard.Root />', () => {
 
         // Events must be triggered on positioner elements (parent of popup)
         const parentPopup = screen.getByTestId('parent-popup').parentElement!;
+        const childTrigger = screen.getByTestId('child-trigger');
+
+        fireEvent.mouseEnter(childTrigger);
+        fireEvent.mouseMove(childTrigger);
+
+        clock.tick(OPEN_DELAY);
+        await flushMicrotasks();
+
         let childPopup = screen.getByTestId('child-popup').parentElement!;
 
         // Step 3: Move mouse outside all previews
@@ -874,8 +966,6 @@ describe('<PreviewCard.Root />', () => {
         expect(screen.queryByTestId('child-popup')).toBe(null);
 
         // Step 5: Hover child trigger again to re-open child
-        const childTrigger = screen.getByTestId('child-trigger');
-
         fireEvent.mouseEnter(childTrigger);
         fireEvent.mouseMove(childTrigger);
 


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/pull/4815#pullrequestreview-4336715913

Hover-close now only runs when the current open state came from trigger hover. Eventless opens, including external controlled opens and default-open popups, no longer close just because the pointer leaves the floating element.

## Root cause

Floating `mouseleave` closed any non-click-like open, so an eventless open was treated like a trigger-hover open.

## Changes

- Gate floating `mouseleave` safe-polygon and close handling on the existing hover open event.
- Keep trigger-hover opens closing normally, including controlled popups opened by their own trigger.
- Cover Menu, Popover, and PreviewCard eventless opens plus trigger-hover controlled opens.