### PR TITLE
[form] Fix validation bugs

### DIFF
--- a/docs/src/app/(docs)/react/components/form/page.mdx
+++ b/docs/src/app/(docs)/react/components/form/page.mdx
@@ -52,7 +52,8 @@ You can use `onFormSubmit` instead of the native `onSubmit` to access form value
 
     const response = await fetch('https://api.example.com', {
       method: 'POST',
-      body: payload,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
     });
   }}
 />

--- a/docs/src/app/(docs)/react/components/form/types.md
+++ b/docs/src/app/(docs)/react/components/form/types.md
@@ -25,10 +25,10 @@ Renders a `<form>` element.
 
 ```tsx
 // validate all fields
-actionsRef.current.validate();
+actionsRef.current?.validate();
 
 // validate one field
-actionsRef.current.validate('email');
+actionsRef.current?.validate('email');
 ```
 
 ### Form.Props

--- a/packages/react/src/form/Form.test.tsx
+++ b/packages/react/src/form/Form.test.tsx
@@ -37,6 +37,27 @@ describe('<Form />', () => {
     expect(onSubmit.mock.calls.length > 0).toBe(false);
   });
 
+  it('submits when a valid async validator is pending', async () => {
+    const onSubmit = vi.fn((event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+    });
+    const validate = vi.fn(() => new Promise<null>(() => {}));
+
+    render(
+      <Form onSubmit={onSubmit}>
+        <Field.Root validate={validate}>
+          <Field.Control />
+        </Field.Root>
+        <button type="submit">Submit</button>
+      </Form>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
   it('does not submit if an unnamed registered field control is invalid', async () => {
     const onSubmit = vi.fn((event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();

--- a/packages/react/src/form/Form.tsx
+++ b/packages/react/src/form/Form.tsx
@@ -107,11 +107,11 @@ export const Form = React.forwardRef(function Form<
 
           values = Array.from(formRef.current.fields.values());
 
-          const invalidFields = values.filter((field) => !field.validityData.state.valid);
+          const invalidField = values.find((field) => field.validityData.state.valid === false);
 
-          if (invalidFields.length) {
+          if (invalidField) {
             event.preventDefault();
-            focusControl(invalidFields[0].controlRef.current);
+            focusControl(invalidField.controlRef.current);
           } else {
             submittedRef.current = true;
             onSubmit?.(event as any);
@@ -207,10 +207,10 @@ export interface FormProps<
    * @example
    * ```tsx
    * // validate all fields
-   * actionsRef.current.validate();
+   * actionsRef.current?.validate();
    *
    * // validate one field
-   * actionsRef.current.validate('email');
+   * actionsRef.current?.validate('email');
    * ```
    */
   actionsRef?: React.RefObject<Form.Actions | null> | undefined;


### PR DESCRIPTION
This fixes a small batch of Form bugs found during review.

## Changes

- Allow submit to continue when async field validation is still pending unless a field is already explicitly invalid.
- Make Form docs snippets safer by JSON-stringifying fetch bodies and null-checking `actionsRef` examples.

## Original findings addressed

- [P2] Async validators could block the first valid submit.
- [P3] Public docs examples had copy-paste issues.
