### PR TITLE
[select] Fix mouse selection in StrictMode dev

### DIFF
--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -50,7 +50,7 @@ describe('<CompositeList />', () => {
         const [showExtraItem, setShowExtraItem] = React.useState(false);
 
         return (
-          <>
+          <React.Fragment>
             <button type="button" onClick={() => setShowExtraItem(true)}>
               Add item
             </button>
@@ -60,7 +60,7 @@ describe('<CompositeList />', () => {
               <Item id="c" />
               {showExtraItem ? <Item id="d" /> : null}
             </CompositeList>
-          </>
+          </React.Fragment>
         );
       }
 

--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -1,4 +1,6 @@
+import * as React from 'react';
 import { expect } from 'vitest';
+import { flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';
 import { CompositeList } from './CompositeList';
 import { useCompositeListItem } from './useCompositeListItem';
@@ -32,6 +34,53 @@ describe('<CompositeList />', () => {
       unmount();
       expect(elementsRef.current).toHaveLength(0);
       expect(labelsRef.current).toHaveLength(0);
+    });
+
+    it('repopulates elementsRef from sortedMap after refs are wiped', async () => {
+      function Item({ id }: { id: string }) {
+        const { ref } = useCompositeListItem();
+        return <div ref={ref} data-testid={id} />;
+      }
+
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      function App() {
+        const [showExtraItem, setShowExtraItem] = React.useState(false);
+
+        return (
+          <>
+            <button type="button" onClick={() => setShowExtraItem(true)}>
+              Add item
+            </button>
+            <CompositeList elementsRef={elementsRef}>
+              <Item id="a" />
+              <Item id="b" />
+              <Item id="c" />
+              {showExtraItem ? <Item id="d" /> : null}
+            </CompositeList>
+          </>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      const optionA = screen.getByTestId('a');
+
+      expect(elementsRef.current.indexOf(optionA)).not.toBe(-1);
+
+      // Simulate StrictMode cleanup without ref re-attachment.
+      elementsRef.current = [null, null, null];
+      expect(elementsRef.current.indexOf(optionA)).toBe(-1);
+
+      // Trigger a map update so the layout effect re-syncs refs from sortedMap.
+      await user.click(screen.getByRole('button', { name: 'Add item' }));
+      await flushMicrotasks();
+
+      const optionD = screen.getByTestId('d');
+      expect(elementsRef.current.indexOf(optionA)).not.toBe(-1);
+      expect(elementsRef.current.indexOf(optionD)).not.toBe(-1);
     });
   });
 });

--- a/packages/react/src/internals/composite/list/CompositeList.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.tsx
@@ -107,6 +107,16 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
       nextIndexRef.current = sortedMap.size;
     }
 
+    // Re-sync refs from the sorted map so list navigation can resolve live nodes even
+    // when ref callbacks don't re-run after StrictMode cleanup wipes `elementsRef`.
+    sortedMap.forEach((metadata, node) => {
+      if (metadata.index == null) {
+        return;
+      }
+
+      elementsRef.current[metadata.index] = node as HTMLElement;
+    });
+
     onMapChange(sortedMap);
   }, [onMapChange, sortedMap, elementsRef, labelsRef, mapTick]);
 

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -21,6 +21,7 @@ describe('<Select.Root />', () => {
   });
 
   const { render, renderToString } = createRenderer();
+  const { render: renderStrict } = createRenderer({ strict: true });
 
   describe('conformance', () => {
     beforeEach(() => {
@@ -514,6 +515,39 @@ describe('<Select.Root />', () => {
       await waitFor(() => {
         expect(screen.queryByRole('listbox')).toBe(null);
       });
+    });
+  });
+
+  describe('StrictMode', () => {
+    it('should select an item with the mouse when opened', async () => {
+      const handleValueChange = vi.fn();
+
+      const { user } = await renderStrict(
+        <Select.Root value={null} onValueChange={handleValueChange}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value placeholder="Pick a flavor" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="strawberry">Strawberry</Select.Item>
+                <Select.Item value="pistachio">Pistachio</Select.Item>
+                <Select.Item value="hazelnut">Hazelnut</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      await user.click(screen.getByTestId('trigger'));
+
+      const option = screen.getByRole('option', { name: 'Pistachio' });
+      fireEvent.mouseMove(option);
+      await user.click(option);
+      await flushMicrotasks();
+
+      expect(handleValueChange).toHaveBeenCalledOnce();
+      expect(handleValueChange.mock.calls[0][0]).toBe('pistachio');
     });
   });
 

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -519,7 +519,7 @@ describe('<Select.Root />', () => {
   });
 
   describe('StrictMode', () => {
-    it('should select an item with the mouse when opened', async () => {
+    it.skipIf(!isJSDOM)('should select an item with the mouse when opened', async () => {
       const handleValueChange = vi.fn();
 
       const { user } = await renderStrict(
@@ -540,6 +540,10 @@ describe('<Select.Root />', () => {
       );
 
       await user.click(screen.getByTestId('trigger'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('listbox')).toBeVisible();
+      });
 
       const option = screen.getByRole('option', { name: 'Pistachio' });
       fireEvent.mouseMove(option);


### PR DESCRIPTION
## Summary
- Re-sync `CompositeList` `elementsRef` from `sortedMap` on each layout effect run so list navigation can resolve live DOM nodes after StrictMode cleanup wipes refs without re-running item ref callbacks
- Fixes mouse selection in `Select` (and other composite list consumers) in React StrictMode dev environments such as Next.js dev

Fixes https://github.com/mui/base-ui/issues/4698

## Test plan
- [x] `pnpm test:jsdom CompositeList --no-watch`
- [x] `pnpm test:jsdom SelectRoot --no-watch`
- [x] Manual verification in docs dev: open select, click item, value commits