### PR TITLE
[popups] Restore focus after Escape closes animated menus

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -740,7 +740,9 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
     // Dismissing via outside press should always ignore `returnFocus` to
     // prevent unwanted scrolling.
     function onOpenChangeLocal(details: FloatingUIOpenChangeDetails) {
-      if (!details.open) {
+      if (details.open) {
+        ignoreFocusOutReturnPreventRef.current = false;
+      } else {
         closeTypeRef.current = getEventType(details.nativeEvent, lastInteractionTypeRef.current);
         ignoreFocusOutReturnPreventRef.current =
           details.reason !== REASONS.focusOut && details.reason !== REASONS.outsidePress;

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -295,6 +295,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
   const portalContext = usePortalContext();
 
   const preventReturnFocusRef = React.useRef(false);
+  const ignoreFocusOutReturnPreventRef = React.useRef(false);
   const isPointerDownRef = React.useRef(false);
   const pointerDownOutsideRef = React.useRef(false);
   const lastFocusedTabbableRef = React.useRef<FocusableElement | null>(null);
@@ -536,8 +537,10 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
           // Allow closing when `isUntrappedTypeableCombobox` regardless of the previously focused element.
           (isUntrappedTypeableCombobox || relatedTarget !== getPreviouslyFocusedElement())
         ) {
-          preventReturnFocusRef.current = true;
-          store.setOpen(false, createChangeEventDetails(REASONS.focusOut, event));
+          if (store.select('open') && !ignoreFocusOutReturnPreventRef.current) {
+            preventReturnFocusRef.current = true;
+            store.setOpen(false, createChangeEventDetails(REASONS.focusOut, event));
+          }
         }
       });
     }
@@ -739,10 +742,17 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
     function onOpenChangeLocal(details: FloatingUIOpenChangeDetails) {
       if (!details.open) {
         closeTypeRef.current = getEventType(details.nativeEvent, lastInteractionTypeRef.current);
+        ignoreFocusOutReturnPreventRef.current =
+          details.reason !== REASONS.focusOut && details.reason !== REASONS.outsidePress;
       }
 
-      if (details.reason === REASONS.triggerHover && details.nativeEvent.type === 'mouseleave') {
+      if (
+        details.reason === REASONS.triggerHover &&
+        details.nativeEvent.type === 'mouseleave' &&
+        store.select('open')
+      ) {
         preventReturnFocusRef.current = true;
+        ignoreFocusOutReturnPreventRef.current = false;
       }
 
       if (details.reason !== REASONS.outsidePress) {
@@ -843,6 +853,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
         }
 
         preventReturnFocusRef.current = false;
+        ignoreFocusOutReturnPreventRef.current = false;
       });
     };
   }, [
@@ -851,6 +862,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
     floatingFocusElement,
     returnFocusRef,
     events,
+    store,
     tree,
     domReference,
     getNodeId,
@@ -940,7 +952,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
             if (modal) {
               enqueueFocus(getTabbableContent()[0]);
             } else if (portalContext?.portalNode) {
-              if (closeOnFocusOut) {
+              if (closeOnFocusOut && open && !ignoreFocusOutReturnPreventRef.current) {
                 preventReturnFocusRef.current = true;
               }
 

--- a/test/e2e/fixtures/menu/FocusAfterEscape.module.css
+++ b/test/e2e/fixtures/menu/FocusAfterEscape.module.css
@@ -1,0 +1,37 @@
+.Button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2rem;
+  padding: 0 0.75rem;
+  border: 1px solid black;
+  background: white;
+}
+
+.Button:focus-visible {
+  outline: 2px solid black;
+  outline-offset: 2px;
+}
+
+.Popup {
+  padding-block: 0.25rem;
+  border: 1px solid black;
+  background: white;
+  transition: opacity 100ms ease-out;
+}
+
+.Popup[data-ending-style] {
+  opacity: 0;
+}
+
+.Item {
+  padding: 0.5rem 2rem 0.5rem 1rem;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Item[data-highlighted] {
+  background: black;
+  color: white;
+}

--- a/test/e2e/fixtures/menu/FocusAfterEscape.tsx
+++ b/test/e2e/fixtures/menu/FocusAfterEscape.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { Menu } from '@base-ui/react/menu';
+import styles from './FocusAfterEscape.module.css';
+
+export default function FocusAfterEscape() {
+  return (
+    <Menu.Root>
+      <Menu.Trigger className={styles.Button} data-testid="menu-trigger">
+        Song
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner sideOffset={8}>
+          <Menu.Popup className={styles.Popup}>
+            <Menu.Item className={styles.Item}>Add to Library</Menu.Item>
+            <Menu.Item className={styles.Item}>Add to Playlist</Menu.Item>
+            <Menu.Item className={styles.Item}>Play Next</Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -230,6 +230,25 @@ describe('e2e', () => {
   });
 
   describe('<Menu />', () => {
+    it('restores focus to the trigger after closing an animated popup with Escape', async () => {
+      await renderFixture('menu/FocusAfterEscape');
+
+      const trigger = page.getByTestId('menu-trigger');
+      await trigger.click();
+
+      const item = page.getByRole('menuitem', { name: 'Add to Playlist' });
+      await item.hover();
+      await expect(item).toBeFocused();
+
+      await page.keyboard.press('Escape');
+      await page.waitForSelector('[role="menu"]', { state: 'detached' });
+
+      const triggerHasFocus = await trigger.evaluate(
+        (element) => element === document.activeElement,
+      );
+      expect(triggerHasFocus).toBe(true);
+    }, 5000);
+
     describe('<Menu.LinkItem />', () => {
       it('navigates on click', async () => {
         await renderFixture('menu/LinkItemNavigation');


### PR DESCRIPTION
## Summary

Fixes a focus restoration issue when closing an animated Menu with Escape while the pointer is over a menu item.

When a menu item is focused by hover and the popup has an exit animation, closing with Escape can leave focus on `body` instead of returning it to the trigger.

## Fix

`FloatingFocusManager` now preserves the return-focus decision made by the primary close reason. Follow-up focusout or hover-close events that happen during the close animation no longer override Escape-driven focus restoration.

This keeps the existing behavior for true focus-out and outside-press closes, where focus should not be forced back to the trigger.

## Test

Adds an e2e regression fixture covering:

- click trigger to open an animated menu
- hover a menu item so it receives focus
- press Escape
- wait for the popup to unmount
- verify focus returns to the trigger

Fixes https://github.com/mui/base-ui/issues/4898