### PR TITLE
[utils] Fix UA-CH browser detection

### DIFF
--- a/packages/utils/src/detectBrowser.test.ts
+++ b/packages/utils/src/detectBrowser.test.ts
@@ -1,0 +1,96 @@
+import { expect, vi } from 'vitest';
+
+const originalNavigatorDescriptors = new Map<string, PropertyDescriptor | undefined>();
+
+function setNavigatorProperty(name: string, value: unknown) {
+  if (!originalNavigatorDescriptors.has(name)) {
+    originalNavigatorDescriptors.set(name, Object.getOwnPropertyDescriptor(navigator, name));
+  }
+
+  Object.defineProperty(navigator, name, {
+    configurable: true,
+    value,
+  });
+}
+
+async function importDetectBrowser() {
+  vi.resetModules();
+  return import('./detectBrowser');
+}
+
+afterEach(() => {
+  vi.resetModules();
+
+  originalNavigatorDescriptors.forEach((descriptor, name) => {
+    if (descriptor) {
+      Object.defineProperty(navigator, name, descriptor);
+    } else {
+      delete (navigator as unknown as Record<string, unknown>)[name];
+    }
+  });
+  originalNavigatorDescriptors.clear();
+});
+
+describe('detectBrowser', () => {
+  it('does not parse User-Agent Client Hints brands as the user agent string', async () => {
+    setNavigatorProperty(
+      'userAgent',
+      'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    );
+    setNavigatorProperty('userAgentData', {
+      brands: [
+        { brand: 'Chromium', version: '120' },
+        { brand: 'Definitely Firefox', version: '99' },
+      ],
+      mobile: false,
+      platform: 'macOS',
+    });
+
+    const { isFirefox } = await importDetectBrowser();
+
+    expect(isFirefox).toBe(false);
+  });
+
+  it('uses User-Agent Client Hints brands for Edge detection', async () => {
+    setNavigatorProperty(
+      'userAgent',
+      'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    );
+    setNavigatorProperty('userAgentData', {
+      brands: [
+        { brand: 'Chromium', version: '120' },
+        { brand: 'Microsoft Edge', version: '120' },
+      ],
+      mobile: false,
+      platform: 'Windows',
+    });
+
+    const { isEdge } = await importDetectBrowser();
+
+    expect(isEdge).toBe(true);
+  });
+
+  it('falls back to the legacy user agent string for Edge detection', async () => {
+    setNavigatorProperty(
+      'userAgent',
+      'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
+    );
+    setNavigatorProperty('userAgentData', undefined);
+
+    const { isEdge } = await importDetectBrowser();
+
+    expect(isEdge).toBe(true);
+  });
+
+  it('falls back to the legacy user agent string for legacy Edge detection', async () => {
+    setNavigatorProperty(
+      'userAgent',
+      'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.19582',
+    );
+    setNavigatorProperty('userAgentData', undefined);
+
+    const { isEdge } = await importDetectBrowser();
+
+    expect(isEdge).toBe(true);
+  });
+});

--- a/packages/utils/src/detectBrowser.test.ts
+++ b/packages/utils/src/detectBrowser.test.ts
@@ -1,4 +1,5 @@
 import { expect, vi } from 'vitest';
+import { isJSDOM } from './testUtils';
 
 const originalNavigatorDescriptors = new Map<string, PropertyDescriptor | undefined>();
 
@@ -32,7 +33,7 @@ afterEach(() => {
 });
 
 describe('detectBrowser', () => {
-  it('does not parse User-Agent Client Hints brands as the user agent string', async () => {
+  it('uses User-Agent Client Hints brands as structured data', async () => {
     setNavigatorProperty(
       'userAgent',
       'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
@@ -41,36 +42,19 @@ describe('detectBrowser', () => {
       brands: [
         { brand: 'Chromium', version: '120' },
         { brand: 'Definitely Firefox', version: '99' },
+        { brand: 'Microsoft Edge', version: '120' },
       ],
       mobile: false,
       platform: 'macOS',
     });
 
-    const { isFirefox } = await importDetectBrowser();
+    const { isEdge, isFirefox } = await importDetectBrowser();
 
+    expect(isEdge).toBe(true);
     expect(isFirefox).toBe(false);
   });
 
-  it('uses User-Agent Client Hints brands for Edge detection', async () => {
-    setNavigatorProperty(
-      'userAgent',
-      'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-    );
-    setNavigatorProperty('userAgentData', {
-      brands: [
-        { brand: 'Chromium', version: '120' },
-        { brand: 'Microsoft Edge', version: '120' },
-      ],
-      mobile: false,
-      platform: 'Windows',
-    });
-
-    const { isEdge } = await importDetectBrowser();
-
-    expect(isEdge).toBe(true);
-  });
-
-  it('falls back to the legacy user agent string for Edge detection', async () => {
+  it.skipIf(!isJSDOM)('falls back to the legacy user agent string for Edge detection', async () => {
     setNavigatorProperty(
       'userAgent',
       'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
@@ -82,15 +66,18 @@ describe('detectBrowser', () => {
     expect(isEdge).toBe(true);
   });
 
-  it('falls back to the legacy user agent string for legacy Edge detection', async () => {
-    setNavigatorProperty(
-      'userAgent',
-      'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.19582',
-    );
-    setNavigatorProperty('userAgentData', undefined);
+  it.skipIf(!isJSDOM)(
+    'falls back to the legacy user agent string for legacy Edge detection',
+    async () => {
+      setNavigatorProperty(
+        'userAgent',
+        'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.19582',
+      );
+      setNavigatorProperty('userAgentData', undefined);
 
-    const { isEdge } = await importDetectBrowser();
+      const { isEdge } = await importDetectBrowser();
 
-    expect(isEdge).toBe(true);
-  });
+      expect(isEdge).toBe(true);
+    },
+  );
 });

--- a/packages/utils/src/detectBrowser.ts
+++ b/packages/utils/src/detectBrowser.ts
@@ -6,9 +6,10 @@ interface NavigatorUAData {
 
 const hasNavigator = typeof navigator !== 'undefined';
 
+const userAgentData = getUserAgentData();
 const nav = getNavigatorData();
 const platform = getPlatform();
-const userAgent = getUserAgent();
+const userAgent = getUserAgentString();
 
 export const isWebKit =
   typeof CSS === 'undefined' || !CSS.supports
@@ -23,7 +24,9 @@ export const isIOS =
 
 export const isFirefox = hasNavigator && /firefox/i.test(userAgent);
 export const isSafari = hasNavigator && /apple/i.test(navigator.vendor);
-export const isEdge = hasNavigator && /Edg/i.test(userAgent);
+export const isEdge =
+  hasUserAgentDataBrand('Microsoft Edge') ||
+  (hasNavigator && /\bEdg(?:e|A|iOS|W)?\//.test(userAgent));
 export const isAndroid = (hasNavigator && /android/i.test(platform)) || /android/i.test(userAgent);
 export const isMac =
   hasNavigator && platform.toLowerCase().startsWith('mac') && !navigator.maxTouchPoints;
@@ -35,11 +38,9 @@ function getNavigatorData(): { platform: string; maxTouchPoints: number } {
     return { platform: '', maxTouchPoints: -1 };
   }
 
-  const uaData = (navigator as any).userAgentData as NavigatorUAData | undefined;
-
-  if (uaData?.platform) {
+  if (userAgentData?.platform) {
     return {
-      platform: uaData.platform,
+      platform: userAgentData.platform,
       maxTouchPoints: navigator.maxTouchPoints,
     };
   }
@@ -50,15 +51,9 @@ function getNavigatorData(): { platform: string; maxTouchPoints: number } {
   };
 }
 
-function getUserAgent(): string {
+function getUserAgentString(): string {
   if (!hasNavigator) {
     return '';
-  }
-
-  const uaData = (navigator as any).userAgentData as NavigatorUAData | undefined;
-
-  if (uaData && Array.isArray(uaData.brands)) {
-    return uaData.brands.map(({ brand, version }) => `${brand}/${version}`).join(' ');
   }
 
   return navigator.userAgent;
@@ -69,11 +64,21 @@ function getPlatform(): string {
     return '';
   }
 
-  const uaData = (navigator as any).userAgentData as NavigatorUAData | undefined;
-
-  if (uaData?.platform) {
-    return uaData.platform;
+  if (userAgentData?.platform) {
+    return userAgentData.platform;
   }
 
   return navigator.platform ?? '';
+}
+
+function getUserAgentData(): NavigatorUAData | undefined {
+  if (!hasNavigator) {
+    return undefined;
+  }
+
+  return (navigator as Navigator & { userAgentData?: NavigatorUAData | undefined }).userAgentData;
+}
+
+function hasUserAgentDataBrand(brandName: string): boolean {
+  return userAgentData?.brands.some(({ brand }) => brand === brandName) ?? false;
 }


### PR DESCRIPTION
This fixes `detectBrowser` so `navigator.userAgentData.brands` is no longer converted into a synthetic user-agent string before browser checks.

UA Client Hints expose structured brand data, so Edge detection now checks the `Microsoft Edge` brand directly and keeps the legacy `navigator.userAgent` fallback for browsers without UA-CH support.

References:
- https://developer.chrome.com/docs/privacy-security/user-agent-client-hints
- https://learn.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Browser_detection_using_the_user_agent

Verification:
- Added focused tests for UA-CH brands and legacy Edge UA fallback
- TypeScript and lint pass for the touched utils files