### PR TITLE
[meter] Sync value text with indicator

### DIFF
--- a/packages/react/src/meter/indicator/MeterIndicator.test.tsx
+++ b/packages/react/src/meter/indicator/MeterIndicator.test.tsx
@@ -13,6 +13,44 @@ describe('<Meter.Indicator />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
+  describe('value bounds', () => {
+    it('clamps the width to 100% when the value exceeds max', async () => {
+      await render(
+        <Meter.Root value={150}>
+          <Meter.Track>
+            <Meter.Indicator data-testid="indicator" />
+          </Meter.Track>
+        </Meter.Root>,
+      );
+
+      expect(screen.getByTestId('indicator').style.width).toBe('100%');
+    });
+
+    it('clamps the width to 0% when the value is below min', async () => {
+      await render(
+        <Meter.Root value={-10}>
+          <Meter.Track>
+            <Meter.Indicator data-testid="indicator" />
+          </Meter.Track>
+        </Meter.Root>,
+      );
+
+      expect(screen.getByTestId('indicator').style.width).toBe('0%');
+    });
+
+    it('produces a finite width when min equals max', async () => {
+      await render(
+        <Meter.Root value={5} min={5} max={5}>
+          <Meter.Track>
+            <Meter.Indicator data-testid="indicator" />
+          </Meter.Track>
+        </Meter.Root>,
+      );
+
+      expect(screen.getByTestId('indicator').style.width).toBe('0%');
+    });
+  });
+
   describe.skipIf(isJSDOM)('internal styles', () => {
     it('sets positioning styles', async () => {
       await render(

--- a/packages/react/src/meter/indicator/MeterIndicator.tsx
+++ b/packages/react/src/meter/indicator/MeterIndicator.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import { BaseUIComponentProps } from '../../internals/types';
-import { valueToPercent } from '../../utils/valueToPercent';
 import type { MeterRootState } from '../root/MeterRoot';
 import { useMeterRootContext } from '../root/MeterRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
@@ -18,9 +17,7 @@ export const MeterIndicator = React.forwardRef(function MeterIndicator(
 ) {
   const { render, className, style, ...elementProps } = componentProps;
 
-  const context = useMeterRootContext();
-
-  const percentageWidth = valueToPercent(context.value, context.min, context.max);
+  const { percentageValue } = useMeterRootContext();
 
   return useRenderElement('div', componentProps, {
     ref: forwardedRef,
@@ -29,7 +26,7 @@ export const MeterIndicator = React.forwardRef(function MeterIndicator(
         style: {
           insetInlineStart: 0,
           height: 'inherit',
-          width: `${percentageWidth}%`,
+          width: `${percentageValue}%`,
         },
       },
       elementProps,

--- a/packages/react/src/meter/root/MeterRoot.test.tsx
+++ b/packages/react/src/meter/root/MeterRoot.test.tsx
@@ -1,10 +1,14 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { Meter } from '@base-ui/react/meter';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Meter.Root />', () => {
   const { render } = createRenderer();
+
+  function formatPercent(value: number) {
+    return value.toLocaleString(undefined, { style: 'percent' });
+  }
 
   describeConformance(<Meter.Root value={50} />, () => ({
     render,
@@ -27,24 +31,161 @@ describe('<Meter.Root />', () => {
       expect(meter).toHaveAttribute('aria-valuenow', '30');
       expect(meter).toHaveAttribute('aria-valuemin', '0');
       expect(meter).toHaveAttribute('aria-valuemax', '100');
-      expect(meter).toHaveAttribute('aria-valuetext', '30%');
+      expect(meter).toHaveAttribute('aria-valuetext', formatPercent(0.3));
       expect(meter.getAttribute('aria-labelledby')).toBe(
         screen.getByText('Battery Level').getAttribute('id'),
       );
     });
 
-    it('should update aria-valuenow when value changes', async () => {
+    it('defaults aria-valuetext to the localized formatted value, matching Meter.Value', async () => {
+      // German percent formatting inserts a narrow no-break space before `%`, so the localized
+      // output differs from the raw `30%` string.
+      const expected = new Intl.NumberFormat('de-DE', { style: 'percent' }).format(0.3);
+
+      await render(
+        <Meter.Root value={30} locale="de-DE">
+          <Meter.Value data-testid="value" />
+        </Meter.Root>,
+      );
+
+      const meter = screen.getByRole('meter');
+      expect(meter).toHaveAttribute('aria-valuetext', expected);
+      expect(meter.getAttribute('aria-valuetext')).toBe(screen.getByTestId('value').textContent);
+    });
+
+    it('rounds the default aria-valuetext like the displayed value', async () => {
+      const expected = formatPercent(0.33333);
+
+      await render(
+        <Meter.Root value={33.333}>
+          <Meter.Value data-testid="value" />
+        </Meter.Root>,
+      );
+
+      const meter = screen.getByRole('meter');
+      expect(meter).toHaveAttribute('aria-valuetext', expected);
+      expect(meter.getAttribute('aria-valuetext')).toBe(screen.getByTestId('value').textContent);
+    });
+
+    it('refreshes aria-valuenow, aria-valuetext, the value text, and the indicator when value changes', async () => {
+      const fiftyPercent = formatPercent(0.5);
+      const seventySevenPercent = formatPercent(0.77);
+
       const { setProps } = await render(
         <Meter.Root value={50}>
+          <Meter.Value data-testid="value" />
           <Meter.Track>
-            <Meter.Indicator />
+            <Meter.Indicator data-testid="indicator" />
           </Meter.Track>
         </Meter.Root>,
       );
       const meter = screen.getByRole('meter');
+      const value = screen.getByTestId('value');
+      const indicator = screen.getByTestId('indicator');
+
+      expect(meter).toHaveAttribute('aria-valuenow', '50');
+      expect(meter).toHaveAttribute('aria-valuetext', fiftyPercent);
+      expect(value.textContent).toBe(fiftyPercent);
+      expect(indicator.style.width).toBe('50%');
+
       await setProps({ value: 77 });
+
       expect(meter).toHaveAttribute('aria-valuenow', '77');
+      expect(meter).toHaveAttribute('aria-valuetext', seventySevenPercent);
+      expect(value.textContent).toBe(seventySevenPercent);
+      expect(indicator.style.width).toBe('77%');
     });
+  });
+
+  describe('prop: getAriaValueText', () => {
+    it('uses the returned text and receives the formatted and raw value', async () => {
+      const formatted = formatPercent(0.3);
+      const getAriaValueText = vi.fn(
+        (formattedValue: string, value: number) => `${value} of 100 (${formattedValue})`,
+      );
+
+      await render(
+        <Meter.Root value={30} getAriaValueText={getAriaValueText}>
+          <Meter.Value data-testid="value" />
+        </Meter.Root>,
+      );
+
+      const meter = screen.getByRole('meter');
+      expect(getAriaValueText).toHaveBeenCalledWith(formatted, 30);
+      expect(meter).toHaveAttribute('aria-valuetext', `30 of 100 (${formatted})`);
+      // getAriaValueText only affects the spoken text, not the visible value.
+      expect(screen.getByTestId('value').textContent).toBe(formatted);
+    });
+  });
+
+  describe('range', () => {
+    it('formats the value as its position within a custom range and keeps the indicator in sync', async () => {
+      const expected = formatPercent(0.5);
+
+      await render(
+        <Meter.Root value={0.5} min={0} max={1}>
+          <Meter.Value data-testid="value" />
+          <Meter.Track>
+            <Meter.Indicator data-testid="indicator" />
+          </Meter.Track>
+        </Meter.Root>,
+      );
+
+      const meter = screen.getByRole('meter');
+      expect(meter).toHaveAttribute('aria-valuenow', '0.5');
+      expect(meter).toHaveAttribute('aria-valuetext', expected);
+      expect(screen.getByTestId('value').textContent).toBe(expected);
+      expect(screen.getByTestId('indicator').style.width).toBe('50%');
+    });
+
+    it('formats the value relative to a non-zero min', async () => {
+      const expected = formatPercent(0.5);
+
+      await render(
+        <Meter.Root value={30} min={20} max={40}>
+          <Meter.Value data-testid="value" />
+        </Meter.Root>,
+      );
+
+      expect(screen.getByRole('meter')).toHaveAttribute('aria-valuetext', expected);
+      expect(screen.getByTestId('value').textContent).toBe(expected);
+    });
+
+    it.each([
+      {
+        label: 'value exceeds max',
+        props: { value: 150 },
+        ariaValueNow: '100',
+        ariaValueText: formatPercent(1),
+      },
+      {
+        label: 'value is below min',
+        props: { value: -10 },
+        ariaValueNow: '0',
+        ariaValueText: formatPercent(0),
+      },
+      {
+        label: 'min equals max',
+        props: { value: 5, min: 5, max: 5 },
+        ariaValueNow: '5',
+        ariaValueText: formatPercent(0),
+      },
+      {
+        label: 'value is NaN',
+        props: { value: Number.NaN },
+        ariaValueNow: '0',
+        ariaValueText: formatPercent(0),
+      },
+    ] as const)(
+      'normalizes aria attributes when $label',
+      async ({ props, ariaValueNow, ariaValueText }) => {
+        await render(<Meter.Root {...props} />);
+
+        const meter = screen.getByRole('meter');
+        expect(meter).toHaveAttribute('aria-valuenow', ariaValueNow);
+        expect(meter).toHaveAttribute('aria-valuetext', ariaValueText);
+      },
+    );
   });
 
   describe('prop: format', () => {
@@ -68,8 +209,31 @@ describe('<Meter.Root />', () => {
 
       const value = screen.getByTestId('value');
       const meter = screen.getByRole('meter');
-      expect(value).toHaveTextContent(formatValue(30));
+      expect(value.textContent).toBe(formatValue(30));
       expect(meter).toHaveAttribute('aria-valuetext', formatValue(30));
+    });
+
+    it('formats the raw value while clamping range attributes and indicator width', async () => {
+      const format: Intl.NumberFormatOptions = {
+        style: 'currency',
+        currency: 'USD',
+      };
+      const expectedValue = new Intl.NumberFormat(undefined, format).format(150);
+
+      await render(
+        <Meter.Root value={150} format={format}>
+          <Meter.Value data-testid="value" />
+          <Meter.Track>
+            <Meter.Indicator data-testid="indicator" />
+          </Meter.Track>
+        </Meter.Root>,
+      );
+
+      const meter = screen.getByRole('meter');
+      expect(screen.getByTestId('value').textContent).toBe(expectedValue);
+      expect(meter).toHaveAttribute('aria-valuenow', '100');
+      expect(meter).toHaveAttribute('aria-valuetext', expectedValue);
+      expect(screen.getByTestId('indicator').style.width).toBe('100%');
     });
   });
 
@@ -92,7 +256,7 @@ describe('<Meter.Root />', () => {
         </Meter.Root>,
       );
 
-      expect(screen.getByTestId('value')).toHaveTextContent(expectedValue);
+      expect(screen.getByTestId('value').textContent).toBe(expectedValue);
     });
   });
 });

--- a/packages/react/src/meter/root/MeterRoot.tsx
+++ b/packages/react/src/meter/root/MeterRoot.tsx
@@ -3,7 +3,9 @@ import * as React from 'react';
 import { visuallyHidden } from '@base-ui/utils/visuallyHidden';
 import { MeterRootContext } from './MeterRootContext';
 import { BaseUIComponentProps, HTMLProps } from '../../internals/types';
-import { formatNumberValue } from '../../utils/formatNumber';
+import { formatNumber } from '../../utils/formatNumber';
+import { valueToPercent } from '../../utils/valueToPercent';
+import { clamp } from '../../internals/clamp';
 import { useRenderElement } from '../../internals/useRenderElement';
 
 /**
@@ -31,20 +33,28 @@ export const MeterRoot = React.forwardRef(function MeterRoot(
   } = componentProps;
 
   const [labelId, setLabelId] = React.useState<string | undefined>();
-  const formattedValue = formatNumberValue(valueProp, locale, format);
 
-  let ariaValuetext = `${valueProp}%`;
+  // `clamp` handles infinity, but NaN needs an explicit fallback before normalizing range outputs.
+  const rawPercentage = valueToPercent(valueProp, min, max);
+  const percentageValue = clamp(Number.isNaN(rawPercentage) ? 0 : rawPercentage, 0, 100);
+  const clampedValue = clamp(Number.isNaN(valueProp) ? min : valueProp, min, max);
+
+  // Without an explicit `format`, the value is displayed as its position within the range so the
+  // text stays in sync with the indicator fill for any `min`/`max` (not just the default 0–100).
+  const formattedValue = format
+    ? formatNumber(valueProp, locale, format)
+    : formatNumber(percentageValue / 100, locale, { style: 'percent' });
+
+  let ariaValuetext = formattedValue;
   if (getAriaValueText) {
     ariaValuetext = getAriaValueText(formattedValue, valueProp);
-  } else if (format) {
-    ariaValuetext = formattedValue;
   }
 
   const defaultProps: HTMLProps = {
     'aria-labelledby': labelId,
     'aria-valuemax': max,
     'aria-valuemin': min,
-    'aria-valuenow': valueProp,
+    'aria-valuenow': clampedValue,
     'aria-valuetext': ariaValuetext,
     role: 'meter',
     children: (
@@ -62,10 +72,11 @@ export const MeterRoot = React.forwardRef(function MeterRoot(
       formattedValue,
       max,
       min,
+      percentageValue,
       setLabelId,
       value: valueProp,
     }),
-    [formattedValue, max, min, setLabelId, valueProp],
+    [formattedValue, max, min, percentageValue, setLabelId, valueProp],
   );
 
   const element = useRenderElement('div', componentProps, {

--- a/packages/react/src/meter/root/MeterRootContext.ts
+++ b/packages/react/src/meter/root/MeterRootContext.ts
@@ -5,6 +5,10 @@ export type MeterRootContext = {
   formattedValue: string;
   max: number;
   min: number;
+  /**
+   * The value normalized to a `0`–`100` percentage of the range, clamped to those bounds.
+   */
+  percentageValue: number;
   setLabelId: React.Dispatch<React.SetStateAction<string | undefined>>;
   value: number;
 };

--- a/packages/react/src/meter/value/MeterValue.test.tsx
+++ b/packages/react/src/meter/value/MeterValue.test.tsx
@@ -22,7 +22,7 @@ describe('<Meter.Value />', () => {
       );
 
       const value = screen.getByTestId('value');
-      expect(value).toHaveTextContent((0.3).toLocaleString(undefined, { style: 'percent' }));
+      expect(value.textContent).toBe((0.3).toLocaleString(undefined, { style: 'percent' }));
     });
 
     it('renders a formatted value when a format is provided', async () => {
@@ -41,7 +41,7 @@ describe('<Meter.Value />', () => {
       );
 
       const value = screen.getByTestId('value');
-      expect(value).toHaveTextContent(formatValue(30));
+      expect(value.textContent).toBe(formatValue(30));
     });
 
     it('accepts a render function', async () => {
@@ -60,6 +60,28 @@ describe('<Meter.Value />', () => {
       );
       expect(renderSpy.mock.lastCall?.[0]).toEqual(formatValue(30));
       expect(renderSpy.mock.lastCall?.[1]).toEqual(30);
+    });
+
+    it('passes updated arguments to the render function when value changes', async () => {
+      const renderSpy = vi.fn();
+
+      const { setProps } = await render(
+        <Meter.Root value={30}>
+          <Meter.Value>{renderSpy}</Meter.Value>
+        </Meter.Root>,
+      );
+
+      expect(renderSpy.mock.lastCall?.[0]).toEqual(
+        (0.3).toLocaleString(undefined, { style: 'percent' }),
+      );
+      expect(renderSpy.mock.lastCall?.[1]).toEqual(30);
+
+      await setProps({ value: 60 });
+
+      expect(renderSpy.mock.lastCall?.[0]).toEqual(
+        (0.6).toLocaleString(undefined, { style: 'percent' }),
+      );
+      expect(renderSpy.mock.lastCall?.[1]).toEqual(60);
     });
   });
 });

--- a/packages/react/src/meter/value/MeterValue.tsx
+++ b/packages/react/src/meter/value/MeterValue.tsx
@@ -24,10 +24,7 @@ export const MeterValue = React.forwardRef(function MeterValue(
     props: [
       {
         'aria-hidden': true,
-        children:
-          typeof children === 'function'
-            ? children(formattedValue, value)
-            : ((formattedValue || value) ?? ''),
+        children: typeof children === 'function' ? children(formattedValue, value) : formattedValue,
       },
       elementProps,
     ],


### PR DESCRIPTION
## Changes

- Keep Meter's default value text, aria-valuetext, and indicator width aligned for custom ranges.
- Clamp Meter indicator width and aria-valuenow when values fall outside the range.
- Add Meter coverage for localized text, custom ranges, bounded ARIA values, and value updates.