### PR TITLE
[checkbox][radio][switch] Fix the type of forwarded refs

### DIFF
--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -45,7 +45,7 @@ export const PARENT_CHECKBOX = 'data-parent';
  */
 export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
   componentProps: CheckboxRoot.Props,
-  forwardedRef: React.ForwardedRef<HTMLElement>,
+  forwardedRef: React.ForwardedRef<HTMLSpanElement>,
 ) {
   const {
     checked: checkedProp,

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -34,7 +34,7 @@ import { RadioRootContext } from './RadioRootContext';
  */
 export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
   componentProps: RadioRoot.Props<Value>,
-  forwardedRef: React.ForwardedRef<HTMLElement>,
+  forwardedRef: React.ForwardedRef<HTMLSpanElement>,
 ) {
   const {
     render,

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -33,7 +33,7 @@ import { useValueChanged } from '../../internals/useValueChanged';
  */
 export const SwitchRoot = React.forwardRef(function SwitchRoot(
   componentProps: SwitchRoot.Props,
-  forwardedRef: React.ForwardedRef<HTMLElement>,
+  forwardedRef: React.ForwardedRef<HTMLSpanElement>,
 ) {
   const {
     checked: checkedProp,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Updates the forwarded ref types for Checkbox, Radio, and Switch roots from `HTMLElement` to `HTMLSpanElement`.

These components render a `<span>` by default, and their public props already extend `BaseUIComponentProps<'span', ...>`, so this aligns the implementation ref type with the rendered element.

Not sure about the breaking change policy in Base UI, but opened for now since the current type seems inaccurate.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
