### PR TITLE
[menubar] Fix vertical menu focus behavior

### DIFF
--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -612,6 +612,32 @@ describe('Composite', () => {
   });
 
   describe('prop: disabledIndices', () => {
+    it('moves the initial tab stop to the first enabled item when the default item is disabled', async () => {
+      await render(
+        <CompositeRoot disabledIndices={[0]}>
+          <CompositeItem data-testid="1" />
+          <CompositeItem data-testid="2" />
+          <CompositeItem data-testid="3" />
+        </CompositeRoot>,
+      );
+
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('keeps the initial tab stop when all items are disabled', async () => {
+      await render(
+        <CompositeRoot disabledIndices={[0, 1]}>
+          <CompositeItem data-testid="1" />
+          <CompositeItem data-testid="2" />
+        </CompositeRoot>,
+      );
+
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '-1');
+    });
+
     it('disables navigating item when their index is included', async () => {
       function App() {
         const [highlightedIndex, setHighlightedIndex] = React.useState(0);

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -33,8 +33,8 @@ import {
   type ModifierKey,
 } from '../composite';
 import { ACTIVE_COMPOSITE_ITEM } from '../constants';
-import { CompositeMetadata } from '../list/CompositeList';
-import { HTMLProps } from '../../types';
+import type { CompositeMetadata } from '../list/CompositeList';
+import type { HTMLProps } from '../../types';
 import { getTarget } from '../../../floating-ui-react/utils';
 
 export interface UseCompositeRootParameters {
@@ -124,15 +124,26 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
       return;
     }
     hasSetDefaultIndexRef.current = true;
-    const sortedElements = Array.from(map.keys());
-    const activeItem = (sortedElements.find((compositeElement) =>
-      compositeElement?.hasAttribute(ACTIVE_COMPOSITE_ITEM),
-    ) ?? null) as HTMLElement | null;
+    const sortedElements = Array.from(map.keys()) as Array<HTMLElement | null>;
+    const activeItem =
+      sortedElements.find((compositeElement) =>
+        compositeElement?.hasAttribute(ACTIVE_COMPOSITE_ITEM),
+      ) ?? null;
     // Set the default highlighted index of an arbitrary composite item.
     const activeIndex = activeItem ? sortedElements.indexOf(activeItem) : -1;
 
     if (activeIndex !== -1) {
       onHighlightedIndexChange(activeIndex);
+    } else if (isListIndexDisabled(sortedElements, highlightedIndex, disabledIndices)) {
+      // The default highlighted item is disabled, so it should not hold the single
+      // roving tab stop: a natively disabled element is removed from the tab order,
+      // and an aria-disabled one should not be the entry point. Move the tab stop
+      // to the first enabled item. If every item is disabled, keep the current
+      // highlighted index.
+      const firstEnabledIndex = findNonDisabledListIndex(sortedElements, { disabledIndices });
+      if (!isIndexOutOfListBounds(sortedElements, firstEnabledIndex)) {
+        onHighlightedIndexChange(firstEnabledIndex);
+      }
     }
 
     scrollIntoViewIfNeeded(rootRef.current, activeItem, direction, orientation);

--- a/packages/react/src/menu/positioner/MenuPositioner.test.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 import { flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';
+import { Menubar } from '@base-ui/react/menubar';
 import { describeConformance, createRenderer, isJSDOM } from '#test-utils';
 
 const Trigger = React.forwardRef(function Trigger(
@@ -385,6 +386,56 @@ describe('<Menu.Positioner />', () => {
   const anchorHeight = 36;
   const triggerStyle = { width: anchorWidth, height: anchorHeight };
   const popupStyle = { width: popupWidth, height: popupHeight };
+
+  describe.skipIf(isJSDOM)('Menubar parent', () => {
+    it('uses bottom as the default side when the menubar is horizontal', async () => {
+      let side = 'none';
+
+      await render(
+        <Menubar>
+          <Menu.Root open>
+            <Trigger style={triggerStyle}>File</Trigger>
+            <Menu.Portal>
+              <Menu.Positioner
+                sideOffset={(data) => {
+                  side = data.side;
+                  return 0;
+                }}
+              >
+                <Menu.Popup style={popupStyle}>Open</Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
+          </Menu.Root>
+        </Menubar>,
+      );
+
+      expect(side).toBe('bottom');
+    });
+
+    it('uses inline-end as the default side when the menubar is vertical', async () => {
+      let side = 'none';
+
+      await render(
+        <Menubar orientation="vertical">
+          <Menu.Root open>
+            <Trigger style={triggerStyle}>File</Trigger>
+            <Menu.Portal>
+              <Menu.Positioner
+                sideOffset={(data) => {
+                  side = data.side;
+                  return 0;
+                }}
+              >
+                <Menu.Popup style={popupStyle}>Open</Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
+          </Menu.Root>
+        </Menubar>,
+      );
+
+      expect(side).toBe('inline-end');
+    });
+  });
 
   describe.skipIf(isJSDOM)('prop: sideOffset', () => {
     it('offsets the side when a number is specified', async () => {

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -102,7 +102,8 @@ export const MenuPositioner = React.forwardRef(function MenuPositioner(
     computedAlign = computedAlign ?? 'start';
     collisionAvoidance = componentProps.collisionAvoidance ?? POPUP_COLLISION_AVOIDANCE;
   } else if (parent.type === 'menubar') {
-    computedSide = computedSide ?? 'bottom';
+    computedSide =
+      computedSide ?? (parent.context.orientation === 'vertical' ? 'inline-end' : 'bottom');
     computedAlign = computedAlign ?? 'start';
   }
 

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -292,6 +292,27 @@ describe('<Menubar />', () => {
         });
       });
 
+      it('moves focus to the first and last triggers with Home and End', async () => {
+        const { user } = await render(<TestMenubar />);
+
+        const fileTrigger = screen.getByTestId('file-trigger');
+        const viewTrigger = screen.getByTestId('view-trigger');
+
+        await act(async () => {
+          fileTrigger.focus();
+        });
+
+        await user.keyboard('{End}');
+        await waitFor(() => {
+          expect(viewTrigger).toHaveFocus();
+        });
+
+        await user.keyboard('{Home}');
+        await waitFor(() => {
+          expect(fileTrigger).toHaveFocus();
+        });
+      });
+
       it('should open the menu with Space key', async () => {
         const { user } = await render(<TestMenubar />);
         const fileTrigger = screen.getByTestId('file-trigger');
@@ -955,6 +976,74 @@ describe('<Menubar />', () => {
         const menuItems = screen.getAllByRole('menuitem');
         expect(menuItems).toHaveLength(3);
       });
+    });
+  });
+
+  describe('disabled state', () => {
+    it('keeps the menubar reachable when the first trigger is disabled', async () => {
+      const { user } = await render(
+        <Menubar style={{ display: 'flex' }}>
+          <Menu.Root>
+            <Menu.Trigger disabled data-testid="file-trigger">
+              File
+            </Menu.Trigger>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item>Open</Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
+          </Menu.Root>
+          <Menu.Root>
+            <Menu.Trigger data-testid="edit-trigger">Edit</Menu.Trigger>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item>Copy</Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
+          </Menu.Root>
+        </Menubar>,
+      );
+
+      const fileTrigger = screen.getByTestId('file-trigger');
+      const editTrigger = screen.getByTestId('edit-trigger');
+
+      expect(fileTrigger).toHaveAttribute('disabled');
+      expect(fileTrigger).toHaveAttribute('tabindex', '-1');
+      expect(editTrigger).toHaveAttribute('tabindex', '0');
+
+      // The disabled first trigger must not swallow the only tab stop.
+      await user.tab();
+      expect(editTrigger).toHaveFocus();
+    });
+
+    it('disables menu items while the menubar is disabled', async () => {
+      const handleClick = vi.fn();
+      const { user } = await render(
+        <Menubar disabled>
+          <Menu.Root open>
+            <Menu.Trigger data-testid="file-trigger">File</Menu.Trigger>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.Item data-testid="file-item" onClick={handleClick}>
+                    Open
+                  </Menu.Item>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
+          </Menu.Root>
+        </Menubar>,
+      );
+
+      const item = screen.getByTestId('file-item');
+      expect(item).toHaveAttribute('aria-disabled', 'true');
+
+      await user.click(item);
+      expect(handleClick).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react/src/menubar/Menubar.tsx
+++ b/packages/react/src/menubar/Menubar.tsx
@@ -85,6 +85,7 @@ export const Menubar = React.forwardRef(function Menubar(
             props={[{ role: 'menubar', id }, elementProps]}
             orientation={orientation}
             loopFocus={loopFocus}
+            enableHomeAndEndKeys
             highlightItemOnHover={hasSubmenuOpen}
           />
         </MenubarContent>


### PR DESCRIPTION
This fixes Menubar behavior gaps around keyboard access, disabled state, and vertical orientation placement.

## Changes

- Move the initial composite highlight to the first enabled item when the default item is disabled.
- Enable Home and End navigation for Menubar triggers.
- Open vertical Menubar popups on the inline-end side by default while keeping horizontal Menubars opening downward.
- Keep open menu items disabled when the Menubar is disabled.
- Add CompositeRoot, Menubar, and positioner regression coverage.