### PR TITLE
[field] Remove input validation prop helper

### DIFF
--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -41,7 +41,7 @@ import { createCollatorItemFilter, createSingleSelectionCollatorFilter } from '.
 import { useCoreFilter } from './utils/useFilter';
 import { useTransitionStatus } from '../../internals/useTransitionStatus';
 import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
-import type { MaybeBaseUIEvent, HTMLProps } from '../../internals/types';
+import type { HTMLProps } from '../../internals/types';
 import { useValueChanged } from '../../internals/useValueChanged';
 import { NOOP } from '../../internals/noop';
 import { FOCUSABLE_POPUP_PROPS } from '../../utils/popups';
@@ -1244,7 +1244,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     <React.Fragment>
       {props.children}
       <input
-        {...validation.getInputValidationProps(disabled, {
+        {...validation.getValidationProps(disabled, {
           // Move focus when the hidden input is focused.
           onFocus() {
             if (inputInsidePopup) {
@@ -1255,15 +1255,12 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
             (inputRef.current || triggerElement)?.focus();
           },
           // Handle browser autofill.
-          onChange(event: MaybeBaseUIEvent<React.ChangeEvent<HTMLInputElement>>) {
+          onChange(event: React.ChangeEvent<HTMLInputElement>) {
             // Workaround for https://github.com/facebook/react/issues/9023
             if (event.nativeEvent.defaultPrevented || disabled || readOnly) {
-              // Outside Field.Root, the event is not wrapped by mergeProps.
-              event.preventBaseUIHandler?.();
               return;
             }
 
-            event.preventBaseUIHandler?.();
             clearErrors(name);
 
             const nextValue = event.currentTarget.value;

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -41,6 +41,21 @@ describe('<Field.Control />', () => {
     expect(afterFirstChange).toBeLessThanOrEqual(initialRenderCount + 1);
   });
 
+  it('validates once when changed by the user', async () => {
+    const validate = vi.fn();
+
+    await render(
+      <Field.Root validationMode="onChange" validate={validate}>
+        <Field.Control />
+      </Field.Root>,
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a' } });
+
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(validate.mock.lastCall?.[0]).toBe('a');
+  });
+
   it.skipIf(isJSDOM)('should sync focused state when autoFocus is used with SSR', async () => {
     vi.spyOn(console, 'error')
       .mockName('console.error')

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -56,6 +56,22 @@ describe('<Field.Control />', () => {
     expect(validate.mock.lastCall?.[0]).toBe('a');
   });
 
+  it('shows a required error when a prefilled value is cleared', async () => {
+    await render(
+      <Field.Root validationMode="onChange">
+        <Field.Control data-testid="control" defaultValue="value" required />
+        <Field.Error match="valueMissing">Required</Field.Error>
+      </Field.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+
+    fireEvent.change(control, { target: { value: '' } });
+
+    expect(control).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByText('Required')).not.toBe(null);
+  });
+
   it.skipIf(isJSDOM)('should sync focused state when autoFocus is used with SSR', async () => {
     vi.spyOn(console, 'error')
       .mockName('console.error')

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -69,7 +69,7 @@ describe('<Field.Control />', () => {
     fireEvent.change(control, { target: { value: '' } });
 
     expect(control).toHaveAttribute('aria-invalid', 'true');
-    expect(screen.getByText('Required')).not.toBe(null);
+    expect(screen.getByText('Required')).toBeInTheDocument();
   });
 
   it.skipIf(isJSDOM)('should sync focused state when autoFocus is used with SSR', async () => {

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -7,6 +7,7 @@ import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { type FieldRootState } from '../root/FieldRoot';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
 import { useRegisterFieldControl } from '../../internals/field-register-control/useRegisterFieldControl';
+import { useFormContext } from '../../internals/form-context/FormContext';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
 import { useLabelableId } from '../../internals/labelable-provider/useLabelableId';
 import { fieldValidityMapping } from '../../internals/field-constants/constants';
@@ -57,6 +58,7 @@ export const FieldControl = React.forwardRef(function FieldControl(
     validationMode,
     validation,
   } = useFieldRootContext();
+  const { clearErrors } = useFormContext();
 
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
@@ -117,6 +119,12 @@ export const FieldControl = React.forwardRef(function FieldControl(
           onValueChange?.(inputValue, createChangeEventDetails(REASONS.none, event.nativeEvent));
           setDirty(inputValue !== validityData.initialValue);
           setFilled(inputValue !== '');
+
+          // Workaround for https://github.com/facebook/react/issues/9023
+          if (!event.nativeEvent.defaultPrevented) {
+            clearErrors(name);
+            validation.change(inputValue);
+          }
         },
         onFocus() {
           setFocused(true);
@@ -136,7 +144,8 @@ export const FieldControl = React.forwardRef(function FieldControl(
           }
         },
       },
-      validation.getInputValidationProps(disabled, elementProps),
+      elementProps,
+      (props) => validation.getValidationProps(disabled, props),
     ],
     stateAttributesMapping: fieldValidityMapping,
   });

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -117,6 +117,7 @@ export const FieldControl = React.forwardRef(function FieldControl(
         onChange(event) {
           const inputValue = event.currentTarget.value;
           onValueChange?.(inputValue, createChangeEventDetails(REASONS.none, event.nativeEvent));
+          // `validation.change` reads `markedDirtyRef`, so update dirty before validating.
           setDirty(inputValue !== validityData.initialValue);
           setFilled(inputValue !== '');
 

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -130,7 +130,6 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
     invalid,
     markedDirtyRef,
     state,
-    name: effectiveName,
     shouldValidateOnChange,
     getRegisteredFieldId,
   });

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -39,7 +39,7 @@ function isOnlyValueMissing(state: Record<keyof ValidityState, boolean> | undefi
 export function useFieldValidation(
   params: UseFieldValidationParameters,
 ): UseFieldValidationReturnValue {
-  const { formRef, clearErrors } = useFormContext();
+  const { formRef } = useFormContext();
 
   const {
     setValidityData,
@@ -49,7 +49,6 @@ export function useFieldValidation(
     invalid,
     markedDirtyRef,
     state,
-    name,
     shouldValidateOnChange,
     getRegisteredFieldId,
   } = params;
@@ -276,35 +275,14 @@ export function useFieldValidation(
     [getDescriptionProps, state.disabled, state.valid],
   );
 
-  const getInputValidationProps = React.useCallback(
-    (disabled: boolean, externalProps: HTMLProps = {}) =>
-      mergeProps<'input'>(
-        {
-          onChange(event) {
-            // Workaround for https://github.com/facebook/react/issues/9023
-            if (event.nativeEvent.defaultPrevented) {
-              return;
-            }
-
-            clearErrors(name);
-
-            change(event.currentTarget.value);
-          },
-        },
-        getValidationProps(disabled, externalProps),
-      ),
-    [getValidationProps, clearErrors, name, change],
-  );
-
   return React.useMemo(
     () => ({
       getValidationProps,
-      getInputValidationProps,
       inputRef,
       commit,
       change,
     }),
-    [getValidationProps, getInputValidationProps, commit, change],
+    [getValidationProps, commit, change],
   );
 }
 
@@ -319,14 +297,12 @@ export interface UseFieldValidationParameters {
   invalid: boolean;
   markedDirtyRef: React.RefObject<boolean>;
   state: FieldRootState;
-  name: string | undefined;
   shouldValidateOnChange: () => boolean;
   getRegisteredFieldId: () => string | undefined;
 }
 
 export interface UseFieldValidationReturnValue {
   getValidationProps: (disabled: boolean, props?: HTMLProps) => HTMLProps;
-  getInputValidationProps: (disabled: boolean, props?: HTMLProps) => HTMLProps;
   inputRef: React.RefObject<HTMLInputElement | null>;
   commit: (value: unknown) => Promise<void>;
   change: (value: unknown) => void;

--- a/packages/react/src/internals/field-root-context/FieldRootContext.ts
+++ b/packages/react/src/internals/field-root-context/FieldRootContext.ts
@@ -72,7 +72,6 @@ export const DEFAULT_FIELD_ROOT_CONTEXT: FieldRootContext = {
   registerFieldControl: NOOP,
   validation: {
     getValidationProps: (_disabled: boolean, props: HTMLProps = EMPTY_OBJECT) => props,
-    getInputValidationProps: (_disabled: boolean, props: HTMLProps = EMPTY_OBJECT) => props,
     inputRef: { current: null },
     commit: async () => {},
     change: NOOP,

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -16,7 +16,7 @@ import { useFieldRootContext } from '../../internals/field-root-context/FieldRoo
 import { useFormContext } from '../../internals/form-context/FormContext';
 import type { FieldRootState } from '../../field/root/FieldRoot';
 import { useLabelableId } from '../../internals/labelable-provider/useLabelableId';
-import type { BaseUIComponentProps, MaybeBaseUIEvent } from '../../internals/types';
+import type { BaseUIComponentProps } from '../../internals/types';
 import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 import { useRenderElement } from '../../internals/useRenderElement';
 import {
@@ -462,15 +462,13 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
     <NumberFieldRootContext.Provider value={contextValue}>
       {element}
       <input
-        {...validation.getInputValidationProps(disabled, {
+        {...validation.getValidationProps(disabled, {
           onFocus() {
             inputRef.current?.focus();
           },
-          onChange(event: MaybeBaseUIEvent<React.ChangeEvent<HTMLInputElement>>) {
+          onChange(event: React.ChangeEvent<HTMLInputElement>) {
             // Workaround for https://github.com/facebook/react/issues/9023
             if (event.nativeEvent.defaultPrevented || disabled || readOnly) {
-              // Outside Field.Root, the event is not wrapped by mergeProps.
-              event.preventBaseUIHandler?.();
               return;
             }
 
@@ -483,7 +481,6 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
             setValue(parsedValue, details);
             clearErrors(name);
             validation.change(parsedValue);
-            event.preventBaseUIHandler?.();
           },
         })}
         ref={hiddenInputRef}

--- a/packages/react/src/otp-field/root/OTPFieldRoot.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.tsx
@@ -19,7 +19,7 @@ import { useAriaLabelledBy } from '../../internals/labelable-provider/useAriaLab
 import { useLabelableId } from '../../internals/labelable-provider/useLabelableId';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useValueChanged } from '../../internals/useValueChanged';
-import type { BaseUIComponentProps, MaybeBaseUIEvent } from '../../internals/types';
+import type { BaseUIComponentProps } from '../../internals/types';
 import {
   createChangeEventDetails,
   createGenericEventDetails,
@@ -395,14 +395,12 @@ export const OTPFieldRoot = React.forwardRef(function OTPFieldRoot(
         {element}
         {hasValidLength && (
           <input
-            {...validation.getInputValidationProps(disabled, {
+            {...validation.getValidationProps(disabled, {
               onFocus() {
                 focusInput(0);
               },
-              onChange(event: MaybeBaseUIEvent<React.ChangeEvent<HTMLInputElement>>) {
+              onChange(event: React.ChangeEvent<HTMLInputElement>) {
                 if (event.nativeEvent.defaultPrevented || disabled || readOnly) {
-                  // Outside Field.Root, the event is not wrapped by mergeProps.
-                  event.preventBaseUIHandler?.();
                   return;
                 }
 

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -34,7 +34,6 @@ import { useFormContext } from '../../internals/form-context/FormContext';
 import { type Group, stringifyAsLabel, stringifyAsValue } from '../../internals/resolveValueLabel';
 import { defaultItemEquality, findItemIndex } from '../../internals/itemEquality';
 import { useValueChanged } from '../../internals/useValueChanged';
-import type { MaybeBaseUIEvent } from '../../internals/types';
 import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
 import { getMaxScrollOffset, normalizeScrollOffset } from '../../utils/scrollEdges';
 import { FOCUSABLE_POPUP_PROPS } from '../../utils/popups';
@@ -552,7 +551,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
       <SelectFloatingContext.Provider value={floatingContext}>
         {children}
         <input
-          {...validation.getInputValidationProps(disabled, {
+          {...validation.getValidationProps(disabled, {
             onFocus() {
               // Move focus to the trigger element when the hidden input is focused.
               store.state.triggerElement?.focus({
@@ -561,15 +560,12 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
               });
             },
             // Handle browser autofill.
-            onChange(event: MaybeBaseUIEvent<React.ChangeEvent<HTMLInputElement>>) {
+            onChange(event: React.ChangeEvent<HTMLInputElement>) {
               // Workaround for https://github.com/facebook/react/issues/9023
               if (event.nativeEvent.defaultPrevented || disabled || readOnly) {
-                // Outside Field.Root, the event is not wrapped by mergeProps.
-                event.preventBaseUIHandler?.();
                 return;
               }
 
-              event.preventBaseUIHandler?.();
               clearErrors(name);
 
               const nextValue = event.currentTarget.value;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13769,10 +13769,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/type-utils': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/utils': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
@@ -20020,7 +20020,7 @@ snapshots:
 
   typescript-eslint@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
       '@typescript-eslint/utils': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13769,10 +13769,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/type-utils': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/utils': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
@@ -20020,7 +20020,7 @@ snapshots:
 
   typescript-eslint@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
       '@typescript-eslint/utils': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)


### PR DESCRIPTION
Cleanup pass following #4911, which fixed double validation for Checkbox, Switch, and Slider. This removes the shared input-specific validation prop helper so each field-aware control validates the semantic value it owns.

## Changes

- Removed `getInputValidationProps` from the field validation context.
- Moved plain string input validation into `Field.Control`.
- Updated Select, Combobox, NumberField, and OTP hidden inputs to use validation props without a default `onChange`.
- Added Field.Control regression tests for one on-change validation call and for clearing a prefilled required value.

## Behavior note

`Field.Control` now marks a prefilled required control invalid immediately when the user clears it in `validationMode="onChange"`, because clearing the value is treated as a dirty user edit.
