### PR TITLE
[popups] Fix positioning and viewport edge cases

### DIFF
--- a/docs/src/app/(docs)/react/components/menu/types.md
+++ b/docs/src/app/(docs)/react/components/menu/types.md
@@ -481,6 +481,7 @@ Re-export of [Viewport](#viewport) props.
 
 ```typescript
 type MenuViewportState = {
+  /** The activation direction of the transitioned content. */
   activationDirection: string | undefined;
   /** Whether the viewport is currently transitioning between contents. */
   transitioning: boolean;
@@ -1148,7 +1149,7 @@ type PayloadChildRenderFunction = (arg: { payload: unknown | undefined }) => Rea
 - `Menu.SubmenuTrigger`: `Menu.SubmenuTrigger`, `Menu.SubmenuTrigger.Props`, `Menu.SubmenuTrigger.State`
 - `Menu.Handle`
 - `Menu.createHandle`
-- `Default`: `MenuRootState`, `MenuRootProps`, `MenuRootActions`, `MenuRootChangeEventReason`, `MenuRootChangeEventDetails`, `MenuRootOrientation`, `MenuParent`, `MenuArrowState`, `MenuArrowProps`, `MenuBackdropState`, `MenuBackdropProps`, `MenuCheckboxItemState`, `MenuCheckboxItemProps`, `MenuCheckboxItemChangeEventReason`, `MenuCheckboxItemChangeEventDetails`, `MenuCheckboxItemIndicatorProps`, `MenuCheckboxItemIndicatorState`, `MenuGroupLabelProps`, `MenuGroupLabelState`, `MenuGroupProps`, `MenuGroupState`, `MenuItemState`, `MenuItemProps`, `MenuLinkItemState`, `MenuLinkItemProps`, `MenuPopupProps`, `MenuPopupState`, `MenuPortalState`, `MenuPortalProps`, `MenuPositionerState`, `MenuPositionerProps`, `MenuRadioGroupProps`, `MenuRadioGroupState`, `MenuRadioGroupChangeEventReason`, `MenuRadioGroupChangeEventDetails`, `MenuRadioItemState`, `MenuRadioItemProps`, `MenuRadioItemIndicatorProps`, `MenuRadioItemIndicatorState`, `MenuSubmenuRootProps`, `MenuSubmenuRootState`, `MenuSubmenuRootChangeEventReason`, `MenuSubmenuRootChangeEventDetails`, `MenuTriggerProps`, `MenuTriggerState`, `MenuSubmenuTriggerState`, `MenuSubmenuTriggerProps`
+- `Default`: `MenuRootState`, `MenuRootProps`, `MenuRootActions`, `MenuRootChangeEventReason`, `MenuRootChangeEventDetails`, `MenuRootOrientation`, `MenuParent`, `MenuArrowState`, `MenuArrowProps`, `MenuBackdropState`, `MenuBackdropProps`, `MenuCheckboxItemState`, `MenuCheckboxItemProps`, `MenuCheckboxItemChangeEventReason`, `MenuCheckboxItemChangeEventDetails`, `MenuCheckboxItemIndicatorProps`, `MenuCheckboxItemIndicatorState`, `MenuGroupLabelProps`, `MenuGroupLabelState`, `MenuGroupProps`, `MenuGroupState`, `MenuItemState`, `MenuItemProps`, `MenuLinkItemState`, `MenuLinkItemProps`, `MenuPopupProps`, `MenuPopupState`, `MenuPortalState`, `MenuPortalProps`, `MenuPositionerState`, `MenuPositionerProps`, `MenuRadioGroupProps`, `MenuRadioGroupState`, `MenuRadioGroupChangeEventReason`, `MenuRadioGroupChangeEventDetails`, `MenuRadioItemState`, `MenuRadioItemProps`, `MenuRadioItemIndicatorProps`, `MenuRadioItemIndicatorState`, `MenuSubmenuRootProps`, `MenuSubmenuRootState`, `MenuSubmenuRootChangeEventReason`, `MenuSubmenuRootChangeEventDetails`, `MenuTriggerProps`, `MenuTriggerState`, `MenuSubmenuTriggerState`, `MenuSubmenuTriggerProps`, `MenuViewportState`, `MenuViewportProps`
 
 ## Canonical Types
 
@@ -1198,5 +1199,7 @@ Maps `Canonical`: `Alias` — Use Canonical when its namespace is already import
 - `Menu.SubmenuRoot.ChangeEventDetails`: `MenuSubmenuRootChangeEventDetails`
 - `Menu.Trigger.Props`: `MenuTriggerProps`
 - `Menu.Trigger.State`: `MenuTriggerState`
+- `Menu.Viewport.Props`: `MenuViewportProps`
+- `Menu.Viewport.State`: `MenuViewportState`
 - `Menu.SubmenuTrigger.Props`: `MenuSubmenuTriggerProps`
 - `Menu.SubmenuTrigger.State`: `MenuSubmenuTriggerState`

--- a/docs/src/app/(docs)/react/components/popover/types.md
+++ b/docs/src/app/(docs)/react/components/popover/types.md
@@ -473,13 +473,13 @@ Renders a `<div>` element.
 
 **Viewport Data Attributes:**
 
-| Attribute                 | Type                                                  | Description                                                                                                                                                                                                                        |
-| :------------------------ | :---------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data-activation-direction | `` `${'left' \| 'right'} {'top' \| 'bottom'}` ``      | Indicates the direction from which the popup was activated.&#xA;This can be used to create directional animations based on how the popup was triggered.&#xA;Contains space-separated values for both horizontal and vertical axes. |
-| data-current              | -                                                     | Applied to the direct child of the viewport when no transitions are present or the new content when it's entering.                                                                                                                 |
-| data-instant              | `'click' \| 'dismiss' \| 'focus' \| 'trigger-change'` | Present if animations should be instant.                                                                                                                                                                                           |
-| data-previous             | -                                                     | Applied to the direct child of the viewport that contains the exiting content when transitions are present.                                                                                                                        |
-| data-transitioning        | -                                                     | Indicates that the viewport is currently transitioning between old and new content.                                                                                                                                                |
+| Attribute                 | Type                                                       | Description                                                                                                                                                                                                                        |
+| :------------------------ | :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data-activation-direction | `` `${'left' \| 'right' \| ''} ${'down' \| 'up' \| ''}` `` | Indicates the direction from which the popup was activated.&#xA;This can be used to create directional animations based on how the popup was triggered.&#xA;Contains space-separated values for both horizontal and vertical axes. |
+| data-current              | -                                                          | Applied to the direct child of the viewport when no transitions are present or the new content when it's entering.                                                                                                                 |
+| data-instant              | `'click' \| 'dismiss' \| 'focus' \| 'trigger-change'`      | Present if animations should be instant.                                                                                                                                                                                           |
+| data-previous             | -                                                          | Applied to the direct child of the viewport that contains the exiting content when transitions are present.                                                                                                                        |
+| data-transitioning        | -                                                          | Indicates that the viewport is currently transitioning between old and new content.                                                                                                                                                |
 
 **Viewport CSS Variables:**
 
@@ -596,7 +596,7 @@ type InteractionType = 'mouse' | 'touch' | 'pen' | 'keyboard' | '';
 - `Popover.Viewport`: `Popover.Viewport`, `Popover.Viewport.Props`, `Popover.Viewport.State`
 - `Popover.createHandle`
 - `Popover.Handle`
-- `Default`: `PopoverRootState`, `PopoverRootProps`, `PopoverRootActions`, `PopoverRootChangeEventReason`, `PopoverRootChangeEventDetails`, `PopoverTriggerState`, `PopoverTriggerProps`, `PopoverPortalState`, `PopoverPortalProps`, `PopoverPositionerState`, `PopoverPositionerProps`, `PopoverPopupState`, `PopoverPopupProps`, `PopoverArrowState`, `PopoverArrowProps`, `PopoverBackdropState`, `PopoverBackdropProps`, `PopoverTitleState`, `PopoverTitleProps`, `PopoverDescriptionState`, `PopoverDescriptionProps`, `PopoverCloseState`, `PopoverCloseProps`, `PopoverViewportState`
+- `Default`: `PopoverRootState`, `PopoverRootProps`, `PopoverRootActions`, `PopoverRootChangeEventReason`, `PopoverRootChangeEventDetails`, `PopoverTriggerState`, `PopoverTriggerProps`, `PopoverPortalState`, `PopoverPortalProps`, `PopoverPositionerState`, `PopoverPositionerProps`, `PopoverPopupState`, `PopoverPopupProps`, `PopoverArrowState`, `PopoverArrowProps`, `PopoverBackdropState`, `PopoverBackdropProps`, `PopoverTitleState`, `PopoverTitleProps`, `PopoverDescriptionState`, `PopoverDescriptionProps`, `PopoverCloseState`, `PopoverCloseProps`, `PopoverViewportState`, `PopoverViewportProps`
 
 ## Canonical Types
 
@@ -625,4 +625,5 @@ Maps `Canonical`: `Alias` — Use Canonical when its namespace is already import
 - `Popover.Description.Props`: `PopoverDescriptionProps`
 - `Popover.Close.State`: `PopoverCloseState`
 - `Popover.Close.Props`: `PopoverCloseProps`
+- `Popover.Viewport.Props`: `PopoverViewportProps`
 - `Popover.Viewport.State`: `PopoverViewportState`

--- a/docs/src/app/(docs)/react/components/preview-card/types.md
+++ b/docs/src/app/(docs)/react/components/preview-card/types.md
@@ -380,13 +380,13 @@ Renders a `<div>` element.
 
 **Viewport Data Attributes:**
 
-| Attribute                 | Type                                              | Description                                                                                                                                                                                                                        |
-| :------------------------ | :------------------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data-activation-direction | `` `${'left' \| 'right'} ${'top' \| 'bottom'}` `` | Indicates the direction from which the popup was activated.&#xA;This can be used to create directional animations based on how the popup was triggered.&#xA;Contains space-separated values for both horizontal and vertical axes. |
-| data-current              | -                                                 | Applied to the direct child of the viewport when no transitions are present or the new content when it's entering.                                                                                                                 |
-| data-instant              | `'dismiss' \| 'focus'`                            | Present if animations should be instant.                                                                                                                                                                                           |
-| data-previous             | -                                                 | Applied to the direct child of the viewport that contains the exiting content when transitions are present.                                                                                                                        |
-| data-transitioning        | -                                                 | Indicates that the viewport is currently transitioning between old and new content.                                                                                                                                                |
+| Attribute                 | Type                                                       | Description                                                                                                                                                                                                                        |
+| :------------------------ | :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data-activation-direction | `` `${'left' \| 'right' \| ''} ${'down' \| 'up' \| ''}` `` | Indicates the direction from which the popup was activated.&#xA;This can be used to create directional animations based on how the popup was triggered.&#xA;Contains space-separated values for both horizontal and vertical axes. |
+| data-current              | -                                                          | Applied to the direct child of the viewport when no transitions are present or the new content when it's entering.                                                                                                                 |
+| data-instant              | `'dismiss' \| 'focus'`                                     | Present if animations should be instant.                                                                                                                                                                                           |
+| data-previous             | -                                                          | Applied to the direct child of the viewport that contains the exiting content when transitions are present.                                                                                                                        |
+| data-transitioning        | -                                                          | Indicates that the viewport is currently transitioning between old and new content.                                                                                                                                                |
 
 **Viewport CSS Variables:**
 
@@ -498,7 +498,7 @@ type OffsetFunction = (data: {
 - `PreviewCard.Viewport`: `PreviewCard.Viewport`, `PreviewCard.Viewport.Props`, `PreviewCard.Viewport.State`
 - `PreviewCard.createHandle`
 - `PreviewCard.Handle`
-- `Default`: `PreviewCardRootState`, `PreviewCardRootProps`, `PreviewCardRootActions`, `PreviewCardRootChangeEventReason`, `PreviewCardRootChangeEventDetails`, `PreviewCardTriggerState`, `PreviewCardTriggerProps`, `PreviewCardPortalState`, `PreviewCardPortalProps`, `PreviewCardPositionerState`, `PreviewCardPositionerProps`, `PreviewCardPopupState`, `PreviewCardPopupProps`, `PreviewCardArrowState`, `PreviewCardArrowProps`, `PreviewCardViewportState`, `PreviewCardBackdropState`, `PreviewCardBackdropProps`
+- `Default`: `PreviewCardRootState`, `PreviewCardRootProps`, `PreviewCardRootActions`, `PreviewCardRootChangeEventReason`, `PreviewCardRootChangeEventDetails`, `PreviewCardTriggerState`, `PreviewCardTriggerProps`, `PreviewCardPortalState`, `PreviewCardPortalProps`, `PreviewCardPositionerState`, `PreviewCardPositionerProps`, `PreviewCardPopupState`, `PreviewCardPopupProps`, `PreviewCardArrowState`, `PreviewCardArrowProps`, `PreviewCardViewportState`, `PreviewCardViewportProps`, `PreviewCardBackdropState`, `PreviewCardBackdropProps`
 
 ## Canonical Types
 
@@ -521,4 +521,5 @@ Maps `Canonical`: `Alias` — Use Canonical when its namespace is already import
 - `PreviewCard.Arrow.Props`: `PreviewCardArrowProps`
 - `PreviewCard.Backdrop.State`: `PreviewCardBackdropState`
 - `PreviewCard.Backdrop.Props`: `PreviewCardBackdropProps`
+- `PreviewCard.Viewport.Props`: `PreviewCardViewportProps`
 - `PreviewCard.Viewport.State`: `PreviewCardViewportState`

--- a/docs/src/app/(docs)/react/components/tooltip/types.md
+++ b/docs/src/app/(docs)/react/components/tooltip/types.md
@@ -379,13 +379,13 @@ Renders a `<div>` element.
 
 **Viewport Data Attributes:**
 
-| Attribute                 | Type                                              | Description                                                                                                                                                                                                                        |
-| :------------------------ | :------------------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data-activation-direction | `` `${'left' \| 'right'} ${'top' \| 'bottom'}` `` | Indicates the direction from which the popup was activated.&#xA;This can be used to create directional animations based on how the popup was triggered.&#xA;Contains space-separated values for both horizontal and vertical axes. |
-| data-current              | -                                                 | Applied to the direct child of the viewport when no transitions are present or the new content when it's entering.                                                                                                                 |
-| data-instant              | `'delay' \| 'dismiss' \| 'focus'`                 | Present if animations should be instant.                                                                                                                                                                                           |
-| data-previous             | -                                                 | Applied to the direct child of the viewport that contains the exiting content when transitions are present.                                                                                                                        |
-| data-transitioning        | -                                                 | Indicates that the viewport is currently transitioning between old and new content.                                                                                                                                                |
+| Attribute                 | Type                                                       | Description                                                                                                                                                                                                                        |
+| :------------------------ | :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data-activation-direction | `` `${'left' \| 'right' \| ''} ${'down' \| 'up' \| ''}` `` | Indicates the direction from which the popup was activated.&#xA;This can be used to create directional animations based on how the popup was triggered.&#xA;Contains space-separated values for both horizontal and vertical axes. |
+| data-current              | -                                                          | Applied to the direct child of the viewport when no transitions are present or the new content when it's entering.                                                                                                                 |
+| data-instant              | `'delay' \| 'dismiss' \| 'focus'`                          | Present if animations should be instant.                                                                                                                                                                                           |
+| data-previous             | -                                                          | Applied to the direct child of the viewport that contains the exiting content when transitions are present.                                                                                                                        |
+| data-transitioning        | -                                                          | Indicates that the viewport is currently transitioning between old and new content.                                                                                                                                                |
 
 **Viewport CSS Variables:**
 
@@ -497,7 +497,7 @@ type OffsetFunction = (data: {
 - `Tooltip.Viewport`: `Tooltip.Viewport`, `Tooltip.Viewport.Props`, `Tooltip.Viewport.State`
 - `Tooltip.createHandle`
 - `Tooltip.Handle`
-- `Default`: `TooltipProviderState`, `TooltipProviderProps`, `TooltipRootState`, `TooltipRootProps`, `TooltipRootActions`, `TooltipRootChangeEventReason`, `TooltipRootChangeEventDetails`, `TooltipTriggerState`, `TooltipTriggerProps`, `TooltipPortalState`, `TooltipPortalProps`, `TooltipPositionerState`, `TooltipPositionerProps`, `TooltipPopupState`, `TooltipPopupProps`, `TooltipViewportState`, `TooltipArrowState`, `TooltipArrowProps`
+- `Default`: `TooltipProviderState`, `TooltipProviderProps`, `TooltipRootState`, `TooltipRootProps`, `TooltipRootActions`, `TooltipRootChangeEventReason`, `TooltipRootChangeEventDetails`, `TooltipTriggerState`, `TooltipTriggerProps`, `TooltipPortalState`, `TooltipPortalProps`, `TooltipPositionerState`, `TooltipPositionerProps`, `TooltipPopupState`, `TooltipPopupProps`, `TooltipViewportState`, `TooltipViewportProps`, `TooltipArrowState`, `TooltipArrowProps`
 
 ## Canonical Types
 
@@ -520,4 +520,5 @@ Maps `Canonical`: `Alias` — Use Canonical when its namespace is already import
 - `Tooltip.Arrow.Props`: `TooltipArrowProps`
 - `Tooltip.Provider.State`: `TooltipProviderState`
 - `Tooltip.Provider.Props`: `TooltipProviderProps`
+- `Tooltip.Viewport.Props`: `TooltipViewportProps`
 - `Tooltip.Viewport.State`: `TooltipViewportState`

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -9,7 +9,7 @@ import {
   popupStoreSelectors,
   PopupStoreState,
   PopupTriggerMap,
-  setOpenTriggerState,
+  setPopupOpenState,
   usePopupStore,
 } from '../../utils/popups';
 
@@ -105,7 +105,7 @@ export class DialogStore<Payload> extends ReactStore<
       open: nextOpen,
     };
 
-    setOpenTriggerState(updatedState, nextOpen, eventDetails.trigger);
+    setPopupOpenState(updatedState, nextOpen, eventDetails.trigger);
 
     this.update(updatedState);
   };

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -2314,6 +2314,45 @@ describe('<Menu.Root />', () => {
           expect(screen.queryByRole('menu')).toBe(null);
         });
       });
+
+      it('unmounts on a later normal close after a preventUnmountOnClose cycle and reopen', async () => {
+        let preventNextUnmount = true;
+        const { user } = await render(
+          <TestMenu
+            rootProps={{
+              onOpenChange: (open, details) => {
+                if (!open && preventNextUnmount) {
+                  preventNextUnmount = false;
+                  details.preventUnmountOnClose();
+                }
+              },
+            }}
+          />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        await user.click(trigger);
+        await waitFor(() => {
+          expect(screen.queryByRole('menu')).not.toBe(null);
+        });
+
+        await user.click(trigger);
+        await waitFor(() => {
+          expect(trigger).not.toHaveAttribute('data-popup-open');
+        });
+        expect(screen.queryByRole('menu')).not.toBe(null);
+
+        await user.click(trigger);
+        await waitFor(() => {
+          expect(trigger).toHaveAttribute('data-popup-open');
+        });
+
+        await user.click(trigger);
+        await waitFor(() => {
+          expect(screen.queryByRole('menu')).toBe(null);
+        });
+      });
     });
   });
 

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -36,6 +36,7 @@ import { MenuHandle } from '../store/MenuHandle';
 import {
   FOCUSABLE_POPUP_PROPS,
   PayloadChildRenderFunction,
+  setPopupOpenState,
   useImplicitActiveTrigger,
   useOpenStateTransitions,
   usePopupInteractionProps,
@@ -310,13 +311,7 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
       };
       openEventRef.current = eventDetails.event ?? null;
 
-      // If a popup is closing, the `trigger` may be null.
-      // We want to keep the previous value so that exit animations are played and focus is returned correctly.
-      const newTriggerId = eventDetails.trigger?.id ?? null;
-      if (newTriggerId || nextOpen) {
-        updatedState.activeTriggerId = newTriggerId;
-        updatedState.activeTriggerElement = eventDetails.trigger ?? null;
-      }
+      setPopupOpenState(updatedState, nextOpen, eventDetails.trigger);
 
       store.update(updatedState);
 

--- a/packages/react/src/menu/viewport/MenuViewport.tsx
+++ b/packages/react/src/menu/viewport/MenuViewport.tsx
@@ -8,7 +8,7 @@ import { StateAttributesMapping } from '../../internals/getStateAttributesProps'
 import { usePopupViewport } from '../../utils/usePopupViewport';
 import { MenuViewportCssVars } from './MenuViewportCssVars';
 
-const stateAttributesMapping: StateAttributesMapping<MenuViewport.State> = {
+const stateAttributesMapping: StateAttributesMapping<MenuViewportState> = {
   activationDirection: (value) =>
     value
       ? {
@@ -43,7 +43,7 @@ export const MenuViewport = React.forwardRef(function MenuViewport(
     children,
   });
 
-  const state: MenuViewport.State = {
+  const state: MenuViewportState = {
     activationDirection: viewportState.activationDirection,
     transitioning: viewportState.transitioning,
     instant: instantType,
@@ -57,23 +57,29 @@ export const MenuViewport = React.forwardRef(function MenuViewport(
   });
 });
 
-export namespace MenuViewport {
-  export interface Props extends BaseUIComponentProps<'div', State> {
-    /**
-     * The content to render inside the transition container.
-     */
-    children?: React.ReactNode;
-  }
+export interface MenuViewportState {
+  /**
+   * The activation direction of the transitioned content.
+   */
+  activationDirection: string | undefined;
+  /**
+   * Whether the viewport is currently transitioning between contents.
+   */
+  transitioning: boolean;
+  /**
+   * Present if animations should be instant.
+   */
+  instant: 'dismiss' | 'click' | 'group' | 'trigger-change' | undefined;
+}
 
-  export interface State {
-    activationDirection: string | undefined;
-    /**
-     * Whether the viewport is currently transitioning between contents.
-     */
-    transitioning: boolean;
-    /**
-     * Present if animations should be instant.
-     */
-    instant: 'dismiss' | 'click' | 'group' | 'trigger-change' | undefined;
-  }
+export interface MenuViewportProps extends BaseUIComponentProps<'div', MenuViewportState> {
+  /**
+   * The content to render inside the transition container.
+   */
+  children?: React.ReactNode;
+}
+
+export namespace MenuViewport {
+  export type Props = MenuViewportProps;
+  export type State = MenuViewportState;
 }

--- a/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
@@ -354,6 +354,57 @@ describe('<Popover.Positioner />', () => {
     expect(positioner.getBoundingClientRect()).toMatchObject(final);
   });
 
+  it.skipIf(isJSDOM)('observes a custom anchor for keepMounted auto-updates', async () => {
+    const originalResizeObserver = window.ResizeObserver;
+    const observedElements: Element[] = [];
+
+    class TestResizeObserver {
+      observe(element: Element) {
+        observedElements.push(element);
+      }
+
+      unobserve() {}
+
+      disconnect() {}
+    }
+
+    window.ResizeObserver = TestResizeObserver as typeof ResizeObserver;
+
+    function App() {
+      const [anchor, setAnchor] = React.useState<HTMLElement | null>(null);
+      return (
+        <Popover.Root open>
+          <Trigger data-testid="trigger" style={{ width: 100, height: 100 }}>
+            Trigger
+          </Trigger>
+          <div
+            ref={setAnchor}
+            data-testid="custom-anchor"
+            style={{ width: 50, height: 50, position: 'relative' }}
+          >
+            Anchor
+          </div>
+          <Popover.Portal keepMounted>
+            <Popover.Positioner data-testid="positioner" anchor={anchor}>
+              <Popover.Popup style={{ width: 100, height: 100 }}>Popup</Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>
+      );
+    }
+
+    try {
+      await render(<App />);
+      const anchor = screen.getByTestId('custom-anchor');
+
+      await waitFor(() => {
+        expect(observedElements).toContain(anchor);
+      });
+    } finally {
+      window.ResizeObserver = originalResizeObserver;
+    }
+  });
+
   it.skipIf(isJSDOM)(
     'remains anchored to the trigger when closing from a tooltip trigger close',
     async () => {

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -133,6 +133,58 @@ describe('<Popover.Root />', () => {
         expect(handleChange.mock.calls[1][0]).toBe(true);
       });
 
+      it('unmounts on a normal close after preventUnmountOnClose and external reopen', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+          const preventNextUnmountRef = React.useRef(true);
+
+          return (
+            <React.Fragment>
+              <button type="button" onClick={() => setOpen(true)}>
+                Open externally
+              </button>
+              <TestPopover
+                rootProps={{
+                  open,
+                  onOpenChange(nextOpen, details) {
+                    if (!nextOpen && preventNextUnmountRef.current) {
+                      preventNextUnmountRef.current = false;
+                      details.preventUnmountOnClose();
+                    }
+
+                    setOpen(nextOpen);
+                  },
+                }}
+              />
+            </React.Fragment>
+          );
+        }
+
+        const { user } = await render(<App />);
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        await user.click(trigger);
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).not.toBe(null);
+        });
+
+        await user.click(trigger);
+        await waitFor(() => {
+          expect(trigger).not.toHaveAttribute('data-popup-open');
+        });
+        expect(screen.queryByRole('dialog')).not.toBe(null);
+
+        await user.click(screen.getByRole('button', { name: 'Open externally' }));
+        await waitFor(() => {
+          expect(trigger).toHaveAttribute('data-popup-open');
+        });
+
+        await user.click(trigger);
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).toBe(null);
+        });
+      });
+
       it('does not close after hovering out of a popup opened externally', async () => {
         function App() {
           const [open, setOpen] = React.useState(false);
@@ -587,6 +639,45 @@ describe('<Popover.Root />', () => {
 
         expect(closePressTriggerId).toBe('trigger-1');
         expect(screen.queryByTestId('close')).not.toBe(null);
+      });
+
+      it('unmounts on a later normal close after a preventUnmountOnClose cycle and reopen', async () => {
+        let preventNextUnmount = true;
+        const { user } = await render(
+          <TestPopover
+            rootProps={{
+              onOpenChange: (open, details) => {
+                if (!open && preventNextUnmount) {
+                  preventNextUnmount = false;
+                  details.preventUnmountOnClose();
+                }
+              },
+            }}
+          />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        await user.click(trigger);
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).not.toBe(null);
+        });
+
+        await user.click(trigger);
+        await waitFor(() => {
+          expect(trigger).not.toHaveAttribute('data-popup-open');
+        });
+        expect(screen.queryByRole('dialog')).not.toBe(null);
+
+        await user.click(trigger);
+        await waitFor(() => {
+          expect(trigger).toHaveAttribute('data-popup-open');
+        });
+
+        await user.click(trigger);
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).toBe(null);
+        });
       });
     });
 

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -14,7 +14,7 @@ import {
   popupStoreSelectors,
   PopupStoreState,
   PopupTriggerMap,
-  setOpenTriggerState,
+  setPopupOpenState,
   usePopupStore,
 } from '../../utils/popups';
 import { PATIENT_CLICK_THRESHOLD } from '../../internals/constants';
@@ -162,7 +162,7 @@ export class PopoverStore<Payload> extends ReactStore<
         openChangeReason: eventDetails.reason,
       };
 
-      setOpenTriggerState(updatedState, nextOpen, eventDetails.trigger);
+      setPopupOpenState(updatedState, nextOpen, eventDetails.trigger);
 
       this.update(updatedState);
     };

--- a/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
@@ -70,6 +70,28 @@ describe('<Popover.Trigger />', () => {
       await user.keyboard('[Tab]');
       expect(document.activeElement).not.toBe(trigger);
     });
+
+    it('does not open on hover when disabled', async () => {
+      const { user } = await render(
+        <Popover.Root>
+          <Popover.Trigger disabled openOnHover delay={0} render={<span />} nativeButton={false} />
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup>Content</Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>,
+      );
+
+      const trigger = screen.getByRole('button');
+      expect(trigger).toHaveAttribute('data-disabled');
+
+      await user.hover(trigger);
+      await flushMicrotasks();
+
+      expect(screen.queryByText('Content')).toBe(null);
+      expect(trigger).not.toHaveAttribute('data-popup-open');
+    });
   });
 
   describe('style hooks', () => {

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -80,6 +80,7 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
 
   const hoverProps = useHoverReferenceInteraction(floatingContext, {
     enabled:
+      !disabled &&
       floatingContext != null &&
       openOnHover &&
       (openMethod !== 'touch' || openReason !== REASONS.triggerPress),

--- a/packages/react/src/popover/viewport/PopoverViewport.tsx
+++ b/packages/react/src/popover/viewport/PopoverViewport.tsx
@@ -72,13 +72,14 @@ export interface PopoverViewportState {
   instant: 'dismiss' | 'click' | 'focus' | 'trigger-change' | undefined;
 }
 
-export namespace PopoverViewport {
-  export interface Props extends BaseUIComponentProps<'div', PopoverViewportState> {
-    /**
-     * The content to render inside the transition container.
-     */
-    children?: React.ReactNode;
-  }
+export interface PopoverViewportProps extends BaseUIComponentProps<'div', PopoverViewportState> {
+  /**
+   * The content to render inside the transition container.
+   */
+  children?: React.ReactNode;
+}
 
+export namespace PopoverViewport {
+  export type Props = PopoverViewportProps;
   export type State = PopoverViewportState;
 }

--- a/packages/react/src/popover/viewport/PopoverViewportDataAttributes.ts
+++ b/packages/react/src/popover/viewport/PopoverViewportDataAttributes.ts
@@ -11,7 +11,7 @@ export enum PopoverViewportDataAttributes {
    * Indicates the direction from which the popup was activated.
    * This can be used to create directional animations based on how the popup was triggered.
    * Contains space-separated values for both horizontal and vertical axes.
-   * @type {`${'left' | 'right'} {'top' | 'bottom'}`}
+   * @type {`${'left' | 'right' | ''} ${'down' | 'up' | ''}`}
    */
   activationDirection = 'data-activation-direction',
   /**

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -9,7 +9,7 @@ import {
   popupStoreSelectors,
   PopupStoreState,
   PopupTriggerMap,
-  setOpenTriggerState,
+  setPopupOpenState,
   updateInlineRectCoords,
   usePopupStore,
 } from '../../utils/popups';
@@ -113,7 +113,7 @@ export class PreviewCardStore<Payload> extends ReactStore<
         updatedState.instantType = undefined;
       }
 
-      setOpenTriggerState(updatedState, nextOpen, eventDetails.trigger);
+      setPopupOpenState(updatedState, nextOpen, eventDetails.trigger);
 
       this.update(updatedState);
     };

--- a/packages/react/src/preview-card/viewport/PreviewCardViewport.tsx
+++ b/packages/react/src/preview-card/viewport/PreviewCardViewport.tsx
@@ -72,13 +72,17 @@ export interface PreviewCardViewportState {
   instant: 'dismiss' | 'focus' | undefined;
 }
 
-export namespace PreviewCardViewport {
-  export interface Props extends BaseUIComponentProps<'div', PreviewCardViewportState> {
-    /**
-     * The content to render inside the transition container.
-     */
-    children?: React.ReactNode;
-  }
+export interface PreviewCardViewportProps extends BaseUIComponentProps<
+  'div',
+  PreviewCardViewportState
+> {
+  /**
+   * The content to render inside the transition container.
+   */
+  children?: React.ReactNode;
+}
 
+export namespace PreviewCardViewport {
+  export type Props = PreviewCardViewportProps;
   export type State = PreviewCardViewportState;
 }

--- a/packages/react/src/preview-card/viewport/PreviewCardViewportDataAttributes.ts
+++ b/packages/react/src/preview-card/viewport/PreviewCardViewportDataAttributes.ts
@@ -11,7 +11,7 @@ export enum PreviewCardViewportDataAttributes {
    * Indicates the direction from which the popup was activated.
    * This can be used to create directional animations based on how the popup was triggered.
    * Contains space-separated values for both horizontal and vertical axes.
-   * @type {`${'left' | 'right'} ${'top' | 'bottom'}`}
+   * @type {`${'left' | 'right' | ''} ${'down' | 'up' | ''}`}
    */
   activationDirection = 'data-activation-direction',
   /**

--- a/packages/react/src/tooltip/store/TooltipStore.ts
+++ b/packages/react/src/tooltip/store/TooltipStore.ts
@@ -11,7 +11,7 @@ import {
   popupStoreSelectors,
   PopupStoreState,
   PopupTriggerMap,
-  setOpenTriggerState,
+  setPopupOpenState,
   usePopupStore,
 } from '../../utils/popups';
 
@@ -105,7 +105,7 @@ export class TooltipStore<Payload> extends ReactStore<
         updatedState.instantType = undefined;
       }
 
-      setOpenTriggerState(updatedState, nextOpen, eventDetails.trigger);
+      setPopupOpenState(updatedState, nextOpen, eventDetails.trigger);
 
       this.update(updatedState);
     };

--- a/packages/react/src/tooltip/viewport/TooltipViewport.tsx
+++ b/packages/react/src/tooltip/viewport/TooltipViewport.tsx
@@ -72,13 +72,14 @@ export interface TooltipViewportState {
   instant: 'delay' | 'dismiss' | 'focus' | undefined;
 }
 
-export namespace TooltipViewport {
-  export interface Props extends BaseUIComponentProps<'div', TooltipViewportState> {
-    /**
-     * The content to render inside the transition container.
-     */
-    children?: React.ReactNode;
-  }
+export interface TooltipViewportProps extends BaseUIComponentProps<'div', TooltipViewportState> {
+  /**
+   * The content to render inside the transition container.
+   */
+  children?: React.ReactNode;
+}
 
+export namespace TooltipViewport {
+  export type Props = TooltipViewportProps;
   export type State = TooltipViewportState;
 }

--- a/packages/react/src/tooltip/viewport/TooltipViewportDataAttributes.ts
+++ b/packages/react/src/tooltip/viewport/TooltipViewportDataAttributes.ts
@@ -11,7 +11,7 @@ export enum TooltipViewportDataAttributes {
    * Indicates the direction from which the popup was activated.
    * This can be used to create directional animations based on how the popup was triggered.
    * Contains space-separated values for both horizontal and vertical axes.
-   * @type {`${'left' | 'right'} ${'top' | 'bottom'}`}
+   * @type {`${'left' | 'right' | ''} ${'down' | 'up' | ''}`}
    */
   activationDirection = 'data-activation-direction',
   /**

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -116,11 +116,16 @@ export function useTriggerRegistration<State extends PopupStoreState<unknown>>(
   );
 }
 
-export function setOpenTriggerState(
+export function setPopupOpenState(
   state: Partial<PopupStoreState<unknown>>,
   open: boolean,
   trigger: Element | undefined,
 ) {
+  if (open) {
+    // Opening starts a new close cycle, so clear any previous request to keep the popup mounted.
+    state.preventUnmountingOnClose = false;
+  }
+
   const triggerId = trigger?.id ?? null;
 
   // If a popup is closing, the `trigger` may be undefined.
@@ -258,8 +263,13 @@ export function useOpenStateTransitions<State extends PopupStoreState<unknown>>(
   onUnmount?: () => void,
 ) {
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
+  const preventUnmountingOnClose = store.useState('preventUnmountingOnClose');
 
-  store.useSyncedValues({ mounted, transitionStatus } as Partial<State>);
+  store.useSyncedValues({
+    mounted,
+    transitionStatus,
+    preventUnmountingOnClose: open ? false : preventUnmountingOnClose,
+  } as Partial<State>);
 
   const forceUnmount = useStableCallback(() => {
     setMounted(false);
@@ -272,8 +282,6 @@ export function useOpenStateTransitions<State extends PopupStoreState<unknown>>(
     onUnmount?.();
     store.context.onOpenChangeComplete?.(false);
   });
-
-  const preventUnmountingOnClose = store.useState('preventUnmountingOnClose');
 
   useOpenChangeComplete({
     enabled: mounted && !open && !preventUnmountingOnClose,

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -504,8 +504,8 @@ export function useAnchorPositioning(
   }, [mounted, refs, anchorDep, anchorValueRef]);
 
   React.useEffect(() => {
-    if (keepMounted && mounted && elements.domReference && elements.floating) {
-      return autoUpdate(elements.domReference, elements.floating, update, autoUpdateOptions);
+    if (keepMounted && mounted && elements.reference && elements.floating) {
+      return autoUpdate(elements.reference, elements.floating, update, autoUpdateOptions);
     }
     return undefined;
   }, [keepMounted, mounted, elements, update, autoUpdateOptions]);


### PR DESCRIPTION
Updates shared popup behavior so keep-mounted/custom-anchor positioning, preventUnmountOnClose reopen cycles, and viewport API docs are handled consistently across popup components.

## Changes

- Observes the actual positioning reference for keep-mounted popups so custom anchors trigger updates.
- Clears preventUnmountOnClose when popups reopen, including controlled external reopens.
- Shares active-trigger open-state updates across popup stores and menu root.
- Prevents disabled hover popover triggers from opening.
- Exports consistent viewport props/state types and regenerates popup viewport API docs.
