### PR TITLE
[radio group] Fix disabled selected form submission

### DIFF
--- a/docs/src/app/(docs)/react/components/radio/types.md
+++ b/docs/src/app/(docs)/react/components/radio/types.md
@@ -108,10 +108,26 @@ Re-export of [Indicator](#indicator) props.
 
 ```typescript
 type RadioIndicatorState = {
-  /** Whether the radio button is currently selected. */
-  checked: boolean;
   /** The transition status of the component. */
   transitionStatus: TransitionStatus;
+  /** Whether the radio button is currently selected. */
+  checked: boolean;
+  /** Whether the component should ignore user interaction. */
+  disabled: boolean;
+  /** Whether the user should be unable to select the radio button. */
+  readOnly: boolean;
+  /** Whether the user must choose a value before submitting a form. */
+  required: boolean;
+  /** Whether the field has been touched. */
+  touched: boolean;
+  /** Whether the field value has changed from its initial value. */
+  dirty: boolean;
+  /** Whether the field is valid. */
+  valid: boolean | null;
+  /** Whether the field has a value. */
+  filled: boolean;
+  /** Whether the field is focused. */
+  focused: boolean;
 };
 ```
 

--- a/docs/src/app/(docs)/react/components/radio/types.md
+++ b/docs/src/app/(docs)/react/components/radio/types.md
@@ -55,15 +55,15 @@ type RadioRootState = {
   readOnly: boolean;
   /** Whether the user must choose a value before submitting a form. */
   required: boolean;
-  /** Whether the field has been touched. */
+  /** Whether the radio button has been touched (when wrapped in Field.Root). */
   touched: boolean;
-  /** Whether the field value has changed from its initial value. */
+  /** Whether the radio button's value has changed from its initial value (when wrapped in Field.Root). */
   dirty: boolean;
-  /** Whether the field is valid. */
+  /** Whether the radio button is in a valid state (when wrapped in Field.Root). */
   valid: boolean | null;
-  /** Whether the field has a value. */
+  /** Whether the radio button has a value (when wrapped in Field.Root). */
   filled: boolean;
-  /** Whether the field is focused. */
+  /** Whether the radio button is focused (when wrapped in Field.Root). */
   focused: boolean;
 };
 ```
@@ -118,15 +118,15 @@ type RadioIndicatorState = {
   readOnly: boolean;
   /** Whether the user must choose a value before submitting a form. */
   required: boolean;
-  /** Whether the field has been touched. */
+  /** Whether the radio button has been touched (when wrapped in Field.Root). */
   touched: boolean;
-  /** Whether the field value has changed from its initial value. */
+  /** Whether the radio button's value has changed from its initial value (when wrapped in Field.Root). */
   dirty: boolean;
-  /** Whether the field is valid. */
+  /** Whether the radio button is in a valid state (when wrapped in Field.Root). */
   valid: boolean | null;
-  /** Whether the field has a value. */
+  /** Whether the radio button has a value (when wrapped in Field.Root). */
   filled: boolean;
-  /** Whether the field is focused. */
+  /** Whether the radio button is focused (when wrapped in Field.Root). */
   focused: boolean;
 };
 ```

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1056,6 +1056,70 @@ describe('<RadioGroup />', () => {
       expect(handleSubmit.mock.calls[0][0]).toEqual({ test: null });
     });
 
+    it.skipIf(isJSDOM)(
+      'excludes a disabled selected radio from onFormSubmit to match native form data',
+      async () => {
+        const handleSubmit = vi.fn();
+
+        function App() {
+          const [disabled, setDisabled] = React.useState(false);
+          return (
+            <Form onFormSubmit={handleSubmit} data-testid="form">
+              <Field.Root name="test">
+                <RadioGroup name="group" defaultValue="a">
+                  <Radio.Root value="a" disabled={disabled} data-testid="item-a" />
+                  <Radio.Root value="b" data-testid="item-b" />
+                </RadioGroup>
+              </Field.Root>
+              <button type="button" onClick={() => setDisabled(true)}>
+                Disable
+              </button>
+              <button type="submit">Submit</button>
+            </Form>
+          );
+        }
+
+        await renderFakeTimers(<App />);
+
+        fireEvent.click(screen.getByText('Disable'));
+
+        const form = screen.getByTestId('form') as HTMLFormElement;
+        // Native form submission excludes disabled inputs.
+        expect(new FormData(form).get('group')).toBe(null);
+
+        fireEvent.click(screen.getByText('Submit'));
+
+        expect(handleSubmit.mock.calls[0][0]).toEqual({ test: null });
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'excludes an initially disabled selected radio from onFormSubmit to match native form data',
+      async () => {
+        const handleSubmit = vi.fn();
+
+        await renderFakeTimers(
+          <Form onFormSubmit={handleSubmit} data-testid="form">
+            <Field.Root name="test">
+              <RadioGroup name="group" defaultValue="a">
+                <Radio.Root value="a" disabled data-testid="item-a" />
+                <Radio.Root value="b" data-testid="item-b" />
+              </RadioGroup>
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>,
+        );
+
+        const form = screen.getByTestId('form') as HTMLFormElement;
+        // Native form submission excludes disabled inputs.
+        expect(new FormData(form).get('group')).toBe(null);
+
+        fireEvent.click(screen.getByText('Submit'));
+
+        expect(handleSubmit.mock.calls[0][0]).toEqual({ test: null });
+      },
+    );
+
     it('clears required validation when a value is selected', async () => {
       const { user } = await renderFakeTimers(
         <Form>

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1056,69 +1056,97 @@ describe('<RadioGroup />', () => {
       expect(handleSubmit.mock.calls[0][0]).toEqual({ test: null });
     });
 
-    it.skipIf(isJSDOM)(
-      'excludes a disabled selected radio from onFormSubmit to match native form data',
-      async () => {
-        const handleSubmit = vi.fn();
+    it('excludes a disabled selected radio from onFormSubmit to match native form data', async () => {
+      const handleSubmit = vi.fn();
 
-        function App() {
-          const [disabled, setDisabled] = React.useState(false);
-          return (
-            <Form onFormSubmit={handleSubmit} data-testid="form">
-              <Field.Root name="test">
-                <RadioGroup name="group" defaultValue="a">
-                  <Radio.Root value="a" disabled={disabled} data-testid="item-a" />
-                  <Radio.Root value="b" data-testid="item-b" />
-                </RadioGroup>
-              </Field.Root>
-              <button type="button" onClick={() => setDisabled(true)}>
-                Disable
-              </button>
-              <button type="submit">Submit</button>
-            </Form>
-          );
-        }
-
-        await renderFakeTimers(<App />);
-
-        fireEvent.click(screen.getByText('Disable'));
-
-        const form = screen.getByTestId('form') as HTMLFormElement;
-        // Native form submission excludes disabled inputs.
-        expect(new FormData(form).get('group')).toBe(null);
-
-        fireEvent.click(screen.getByText('Submit'));
-
-        expect(handleSubmit.mock.calls[0][0]).toEqual({ test: null });
-      },
-    );
-
-    it.skipIf(isJSDOM)(
-      'excludes an initially disabled selected radio from onFormSubmit to match native form data',
-      async () => {
-        const handleSubmit = vi.fn();
-
-        await renderFakeTimers(
+      function App() {
+        const [disabled, setDisabled] = React.useState(false);
+        return (
           <Form onFormSubmit={handleSubmit} data-testid="form">
             <Field.Root name="test">
               <RadioGroup name="group" defaultValue="a">
-                <Radio.Root value="a" disabled data-testid="item-a" />
+                <Radio.Root value="a" disabled={disabled} data-testid="item-a" />
                 <Radio.Root value="b" data-testid="item-b" />
               </RadioGroup>
             </Field.Root>
+            <button type="button" onClick={() => setDisabled(true)}>
+              Disable
+            </button>
             <button type="submit">Submit</button>
-          </Form>,
+          </Form>
         );
+      }
 
-        const form = screen.getByTestId('form') as HTMLFormElement;
-        // Native form submission excludes disabled inputs.
-        expect(new FormData(form).get('group')).toBe(null);
+      await renderFakeTimers(<App />);
 
-        fireEvent.click(screen.getByText('Submit'));
+      fireEvent.click(screen.getByText('Disable'));
 
-        expect(handleSubmit.mock.calls[0][0]).toEqual({ test: null });
-      },
-    );
+      const form = screen.getByTestId('form') as HTMLFormElement;
+      expect(new FormData(form).get('test')).toBe(null);
+
+      fireEvent.click(screen.getByText('Submit'));
+
+      expect(handleSubmit.mock.calls[0][0]).toEqual({ test: null });
+    });
+
+    it('includes a selected radio again when it is re-enabled before form submission', async () => {
+      const handleSubmit = vi.fn();
+
+      function App() {
+        const [disabled, setDisabled] = React.useState(false);
+        return (
+          <Form onFormSubmit={handleSubmit} data-testid="form">
+            <Field.Root name="test">
+              <RadioGroup name="group" defaultValue="a">
+                <Radio.Root value="a" disabled={disabled} data-testid="item-a" />
+                <Radio.Root value="b" data-testid="item-b" />
+              </RadioGroup>
+            </Field.Root>
+            <button type="button" onClick={() => setDisabled((value) => !value)}>
+              Toggle disabled
+            </button>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      await renderFakeTimers(<App />);
+
+      const form = screen.getByTestId('form') as HTMLFormElement;
+
+      fireEvent.click(screen.getByText('Toggle disabled'));
+      expect(new FormData(form).get('test')).toBe(null);
+
+      fireEvent.click(screen.getByText('Toggle disabled'));
+      expect(new FormData(form).get('test')).toBe('a');
+
+      fireEvent.click(screen.getByText('Submit'));
+
+      expect(handleSubmit.mock.calls[0][0]).toEqual({ test: 'a' });
+    });
+
+    it('excludes an initially disabled selected radio from onFormSubmit to match native form data', async () => {
+      const handleSubmit = vi.fn();
+
+      await renderFakeTimers(
+        <Form onFormSubmit={handleSubmit} data-testid="form">
+          <Field.Root name="test">
+            <RadioGroup name="group" defaultValue="a">
+              <Radio.Root value="a" disabled data-testid="item-a" />
+              <Radio.Root value="b" data-testid="item-b" />
+            </RadioGroup>
+          </Field.Root>
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      const form = screen.getByTestId('form') as HTMLFormElement;
+      expect(new FormData(form).get('test')).toBe(null);
+
+      fireEvent.click(screen.getByText('Submit'));
+
+      expect(handleSubmit.mock.calls[0][0]).toEqual({ test: null });
+    });
 
     it('clears required validation when a value is selected', async () => {
       const { user } = await renderFakeTimers(

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -145,7 +145,14 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     return undefined;
   });
 
-  useRegisterFieldControl(controlRef, id, checkedValue ?? null, undefined, !disabled, nameProp);
+  const getFormValue = useStableCallback(() => {
+    // Disabled radios are excluded from native form submission, so a disabled
+    // selection shouldn't be reported as the field's value either.
+    const input = groupInputRef.current;
+    return input?.checked && !input.disabled ? (checkedValue ?? null) : null;
+  });
+
+  useRegisterFieldControl(controlRef, id, checkedValue ?? null, getFormValue, !disabled, nameProp);
 
   useValueChanged(checkedValue, () => {
     clearErrors(name);

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -149,7 +149,11 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     // Disabled radios are excluded from native form submission, so a disabled
     // selection shouldn't be reported as the field's value either.
     const input = groupInputRef.current;
-    return input?.checked && !input.disabled ? (checkedValue ?? null) : null;
+    if (!input || input.disabled || !input.checked) {
+      return null;
+    }
+
+    return checkedValue ?? null;
   });
 
   useRegisterFieldControl(controlRef, id, checkedValue ?? null, getFormValue, !disabled, nameProp);

--- a/packages/react/src/radio/indicator/RadioIndicator.tsx
+++ b/packages/react/src/radio/indicator/RadioIndicator.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
+import type { RadioRootState } from '../root/RadioRoot';
 import { useRadioRootContext } from '../root/RadioRootContext';
 import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../internals/useOpenChangeComplete';
@@ -66,11 +67,7 @@ export interface RadioIndicatorProps extends BaseUIComponentProps<'span', RadioI
   keepMounted?: boolean | undefined;
 }
 
-export interface RadioIndicatorState {
-  /**
-   * Whether the radio button is currently selected.
-   */
-  checked: boolean;
+export interface RadioIndicatorState extends RadioRootState {
   /**
    * The transition status of the component.
    */

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -303,6 +303,26 @@ export interface RadioRootState extends FieldRootState {
    * Whether the user must choose a value before submitting a form.
    */
   required: boolean;
+  /**
+   * Whether the radio button has been touched (when wrapped in Field.Root).
+   */
+  touched: boolean;
+  /**
+   * Whether the radio button's value has changed from its initial value (when wrapped in Field.Root).
+   */
+  dirty: boolean;
+  /**
+   * Whether the radio button is in a valid state (when wrapped in Field.Root).
+   */
+  valid: boolean | null;
+  /**
+   * Whether the radio button has a value (when wrapped in Field.Root).
+   */
+  filled: boolean;
+  /**
+   * Whether the radio button is focused (when wrapped in Field.Root).
+   */
+  focused: boolean;
 }
 
 export interface RadioRootProps<Value = any>

--- a/packages/react/src/radio/root/RadioRootContext.ts
+++ b/packages/react/src/radio/root/RadioRootContext.ts
@@ -1,12 +1,8 @@
 'use client';
 import * as React from 'react';
+import type { RadioRootState } from './RadioRoot';
 
-export interface RadioRootContext {
-  disabled: boolean;
-  readOnly: boolean;
-  checked: boolean;
-  required: boolean;
-}
+export type RadioRootContext = RadioRootState;
 
 export const RadioRootContext = React.createContext<RadioRootContext | undefined>(undefined);
 


### PR DESCRIPTION
Radio groups now match native form submission when the selected radio is disabled, and the indicator state type reflects the root state it already receives.

## Changes

- Return `null` from form values when the tracked selected radio is disabled.
- Add Chromium coverage for radios disabled after mount and initially disabled.
- Expose the full radio root state through `Radio.Indicator.State` docs and types.

## Original findings addressed

- [P1] Disabled selected radios were excluded from native `FormData` but still reported by `onFormSubmit`.
- [P2] `RadioIndicatorState` only declared `checked` even though it receives root field state at runtime.