### PR TITLE
[radio] Fix Radio to trigger on space key press

### DIFF
--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -60,6 +60,30 @@ describe('<RadioGroup />', () => {
       expect(handleChange.mock.calls.length).toBe(1);
       expect(handleChange.mock.results[0]?.value.event.shiftKey).toBe(true);
     });
+
+    it('should select an item with Space on keyup', async () => {
+      const handleChange = vi.fn();
+      const { user } = await render(
+        <RadioGroup onValueChange={handleChange}>
+          <Radio.Root value="a" data-testid="item" />
+        </RadioGroup>,
+      );
+
+      const item = screen.getByTestId('item');
+
+      act(() => {
+        item.focus();
+      });
+
+      await user.keyboard('[Space>]');
+
+      expect(handleChange).not.toHaveBeenCalled();
+
+      await user.keyboard('[/Space]');
+
+      expect(handleChange).toHaveBeenCalledOnce();
+      expect(handleChange).toHaveBeenLastCalledWith('a', expect.anything());
+    });
   });
 
   describe('prop: disabled', () => {

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -186,6 +186,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
   const { getButtonProps, buttonRef } = useButton({
     disabled,
     native: nativeButton,
+    composite: false,
   });
 
   const inputProps: React.ComponentPropsWithRef<'input'> = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Radio should trigger on Space as per the WAI-ARIA radio pattern:
https://www.w3.org/WAI/ARIA/apg/patterns/radio/

Previously, `useButton` ran `onClick` from `onKeyDown`, but Radio's click handler ignored it because the event was `defaultPrevented`.

Unlike other "composite items", it is more natural for Radio to activate on `keyUp`, so this fixes Space key activation by setting `composite: false` on `useButton`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
