### PR TITLE
[toast] Fix timer and limit edge cases

### DIFF
--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -60,7 +60,7 @@ import { Toast } from '@base-ui/react/toast';
 A global toast manager can be created by passing the `toastManager` prop to the `<Toast.Provider>`.
 This enables you to queue a toast from anywhere in the app (such as in functions outside the React tree) while still using the same toast renderer.
 
-The created `toastManager` object has the same properties and methods as the `Toast.useToastManager()` hook.
+The created `toastManager` exposes the same `add`, `close`, `update`, and `promise` methods as the `Toast.useToastManager()` hook. Unlike the hook, it does not return the reactive `toasts` array, since it lives outside the React tree.
 
 ```tsx title="Creating a manager instance"
 const toastManager = Toast.createToastManager();
@@ -148,8 +148,8 @@ The `data-swipe-direction` attribute can be used to determine the swipe directio
 }
 ```
 
-The `data-limited` attribute indicates that the toast was removed from the list due to exceeding the `limit` option.
-This is useful for animating the toast differently when it is removed from the list.
+The `data-limited` attribute indicates that the toast exceeded the `limit` option.
+Limited toasts remain mounted but inert, so this is useful for hiding them or animating them differently.
 
 The `updateKey` property increments when a toast is updated or upserted.
 This can be used to replay attention-grabbing styles by switching animation names or, when remounting is acceptable, by including it in a React `key`.

--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -149,7 +149,7 @@ The `data-swipe-direction` attribute can be used to determine the swipe directio
 ```
 
 The `data-limited` attribute indicates that the toast exceeded the `limit` option.
-Limited toasts remain mounted but inert, so this is useful for hiding them or animating them differently.
+Limited toasts remain mounted with the HTML `inert` attribute, so this is useful for hiding them or animating them differently.
 
 The `updateKey` property increments when a toast is updated or upserted.
 This can be used to replay attention-grabbing styles by switching animation names or, when remounting is acceptable, by including it in a React `key`.

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -124,12 +124,12 @@ Provides a context for creating and managing toasts.
 
 **Provider Props:**
 
-| Prop         | Type              | Default | Description                                                                                                                                               |
-| :----------- | :---------------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| limit        | `number`          | `3`     | The maximum number of toasts that can be displayed at once.&#xA;When the limit is reached, the oldest toast will be removed to make room for the new one. |
-| toastManager | `ToastManager`    | -       | A global manager for toasts to use outside of a React component.                                                                                          |
-| timeout      | `number`          | `5000`  | The default amount of time (in ms) before a toast is auto dismissed.&#xA;A value of `0` will prevent the toast from being dismissed automatically.        |
-| children     | `React.ReactNode` | -       | -                                                                                                                                                         |
+| Prop         | Type              | Default | Description                                                                                                                                                                                                                              |
+| :----------- | :---------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| limit        | `number`          | `3`     | The maximum number of toasts that can be displayed at once.&#xA;When the limit is exceeded, the oldest toasts are marked as `limited` (via the `data-limited`&#xA;attribute) rather than removed, so they can be hidden or animated out. |
+| toastManager | `ToastManager`    | -       | A global manager for toasts to use outside of a React component.                                                                                                                                                                         |
+| timeout      | `number`          | `5000`  | The default amount of time (in ms) before a toast is auto dismissed.&#xA;A value of `0` will prevent the toast from being dismissed automatically.                                                                                       |
+| children     | `React.ReactNode` | -       | -                                                                                                                                                                                                                                        |
 
 ### Provider.Props
 

--- a/packages/react/src/toast/content/ToastContent.test.tsx
+++ b/packages/react/src/toast/content/ToastContent.test.tsx
@@ -1,0 +1,87 @@
+import { expect } from 'vitest';
+import * as React from 'react';
+import { Toast } from '@base-ui/react/toast';
+import { createRenderer, describeConformance } from '#test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
+
+const toast = {
+  id: 'test',
+  title: 'Toast title',
+};
+
+describe('<Toast.Content />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Toast.Content />, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render(node) {
+      return render(
+        <Toast.Provider>
+          <Toast.Viewport>
+            <Toast.Root toast={toast}>{node}</Toast.Root>
+          </Toast.Viewport>
+        </Toast.Provider>,
+      );
+    },
+  }));
+
+  function App() {
+    const { toasts, add } = Toast.useToastManager();
+    const [count, setCount] = React.useState(0);
+    return (
+      <React.Fragment>
+        <button
+          type="button"
+          onClick={() => {
+            const next = count + 1;
+            setCount(next);
+            add({ title: `toast-${next}` });
+          }}
+        >
+          add
+        </button>
+        <Toast.Viewport data-testid="viewport">
+          {toasts.map((toastItem) => (
+            <Toast.Root key={toastItem.id} toast={toastItem}>
+              <Toast.Content data-testid={`content-${toastItem.title}`}>
+                <Toast.Title />
+              </Toast.Content>
+            </Toast.Root>
+          ))}
+        </Toast.Viewport>
+      </React.Fragment>
+    );
+  }
+
+  it('marks content behind the frontmost toast with data-behind', async () => {
+    await render(
+      <Toast.Provider>
+        <App />
+      </Toast.Provider>,
+    );
+
+    const addButton = screen.getByRole('button', { name: 'add' });
+    fireEvent.click(addButton);
+    fireEvent.click(addButton);
+
+    // The newest toast is at the front; the older one sits behind it.
+    expect(screen.getByTestId('content-toast-2')).not.toHaveAttribute('data-behind');
+    expect(screen.getByTestId('content-toast-1')).toHaveAttribute('data-behind');
+  });
+
+  it('reflects the expanded state when the viewport is hovered', async () => {
+    await render(
+      <Toast.Provider>
+        <App />
+      </Toast.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'add' }));
+
+    const content = screen.getByTestId('content-toast-1');
+    expect(content).not.toHaveAttribute('data-expanded');
+
+    fireEvent.mouseEnter(screen.getByTestId('viewport'));
+    expect(content).toHaveAttribute('data-expanded');
+  });
+});

--- a/packages/react/src/toast/provider/ToastProvider.tsx
+++ b/packages/react/src/toast/provider/ToastProvider.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { useOnMount } from '@base-ui/utils/useOnMount';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { ToastContext } from './ToastProviderContext';
 import type { ToastManager } from '../createToastManager';
 import { ToastStore } from '../store';
@@ -55,7 +56,11 @@ export const ToastProvider: React.FC<ToastProvider.Props> = function ToastProvid
     [store, toastManager],
   );
 
-  store.useSyncedValues({ timeout, limit });
+  // `limit` needs custom syncing because changing it must also recompute each
+  // toast's `limited` flag; `useSyncedValues` would only update the raw value.
+  useIsoLayoutEffect(() => {
+    store.syncProviderProps({ timeout, limit });
+  }, [store, timeout, limit]);
 
   return <ToastContext.Provider value={store}>{children}</ToastContext.Provider>;
 };
@@ -72,7 +77,8 @@ export interface ToastProviderProps {
   timeout?: number | undefined;
   /**
    * The maximum number of toasts that can be displayed at once.
-   * When the limit is reached, the oldest toast will be removed to make room for the new one.
+   * When the limit is exceeded, the oldest toasts are marked as `limited` (via the `data-limited`
+   * attribute) rather than removed, so they can be hidden or animated out.
    * @default 3
    */
   limit?: number | undefined;

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -560,6 +560,42 @@ describe('<Toast.Root />', () => {
       expect(screen.queryByTestId('toast-root')).not.toBe(null);
     });
 
+    it('prevents native touchmove only during an active touch swipe', async () => {
+      await render(
+        <Toast.Provider>
+          <Toast.Viewport>
+            <Toast.Root toast={toast} data-testid="toast-root" swipeDirection="up">
+              <Toast.Title>{toast.title}</Toast.Title>
+            </Toast.Root>
+          </Toast.Viewport>
+        </Toast.Provider>,
+      );
+
+      const toastElement = screen.getByTestId('toast-root');
+      Object.defineProperty(toastElement, 'setPointerCapture', {
+        value: () => {},
+        configurable: true,
+      });
+
+      const beforeSwipeEvent = new Event('touchmove', { bubbles: true, cancelable: true });
+      toastElement.dispatchEvent(beforeSwipeEvent);
+      expect(beforeSwipeEvent.defaultPrevented).toBe(false);
+
+      fireEvent.pointerDown(toastElement, {
+        clientX: 100,
+        clientY: 100,
+        button: 0,
+        pointerId: 1,
+        pointerType: 'touch',
+      });
+
+      const duringSwipeEvent = new Event('touchmove', { bubbles: true, cancelable: true });
+      toastElement.dispatchEvent(duringSwipeEvent);
+      expect(duringSwipeEvent.defaultPrevented).toBe(true);
+
+      fireEvent.pointerCancel(toastElement, { pointerId: 1, pointerType: 'touch' });
+    });
+
     it('does not start swiping from elements with the data-base-ui-swipe-ignore attribute', async () => {
       await render(
         <Toast.Provider>

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -845,36 +845,4 @@ describe('<Toast.Root />', () => {
       });
     });
   });
-
-  describe('touch interactions', () => {
-    const { render: renderFakeTimers, clock } = createRenderer();
-
-    clock.withFakeTimers();
-
-    it('does not strand auto-dismiss timers when tapping an interactive element', async () => {
-      await renderFakeTimers(
-        <Toast.Provider>
-          <Toast.Viewport>
-            <List />
-          </Toast.Viewport>
-          <Button />
-        </Toast.Provider>,
-      );
-
-      fireEvent.click(screen.getByRole('button', { name: 'add' }));
-      expect(screen.queryByTestId('root')).not.toBe(null);
-
-      // A touch tap on the action button used to pause the timer before the
-      // interactive-element check, leaving it stranded with no resume path.
-      fireEvent.pointerDown(screen.getByTestId('action'), {
-        button: 0,
-        pointerId: 1,
-        pointerType: 'touch',
-      });
-
-      clock.tick(5001);
-
-      expect(screen.queryByTestId('root')).toBe(null);
-    });
-  });
 });

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -594,6 +594,10 @@ describe('<Toast.Root />', () => {
       expect(duringSwipeEvent.defaultPrevented).toBe(true);
 
       fireEvent.pointerCancel(toastElement, { pointerId: 1, pointerType: 'touch' });
+
+      const afterSwipeEvent = new Event('touchmove', { bubbles: true, cancelable: true });
+      toastElement.dispatchEvent(afterSwipeEvent);
+      expect(afterSwipeEvent.defaultPrevented).toBe(false);
     });
 
     it('does not start swiping from elements with the data-base-ui-swipe-ignore attribute', async () => {

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -845,4 +845,36 @@ describe('<Toast.Root />', () => {
       });
     });
   });
+
+  describe('touch interactions', () => {
+    const { render: renderFakeTimers, clock } = createRenderer();
+
+    clock.withFakeTimers();
+
+    it('does not strand auto-dismiss timers when tapping an interactive element', async () => {
+      await renderFakeTimers(
+        <Toast.Provider>
+          <Toast.Viewport>
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'add' }));
+      expect(screen.queryByTestId('root')).not.toBe(null);
+
+      // A touch tap on the action button used to pause the timer before the
+      // interactive-element check, leaving it stranded with no resume path.
+      fireEvent.pointerDown(screen.getByTestId('action'), {
+        button: 0,
+        pointerId: 1,
+        pointerType: 'touch',
+      });
+
+      clock.tick(5001);
+
+      expect(screen.queryByTestId('root')).toBe(null);
+    });
+  });
 });

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -266,10 +266,6 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
       return;
     }
 
-    if (event.pointerType === 'touch') {
-      store.pauseTimers();
-    }
-
     const target = getTarget(event.nativeEvent) as HTMLElement | null;
 
     const isInteractiveElement = target
@@ -278,6 +274,12 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
 
     if (isInteractiveElement) {
       return;
+    }
+
+    // Pause only once we know this is a swipe rather than a tap on an
+    // interactive element, which has no matching resume path.
+    if (event.pointerType === 'touch') {
+      store.pauseTimers();
     }
 
     cancelledSwipeRef.current = false;
@@ -461,9 +463,16 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     }
 
     function preventDefaultTouchStart(event: TouchEvent) {
-      if (contains(element, getTarget(event) as HTMLElement | null)) {
-        event.preventDefault();
+      if (
+        activePointerIdRef.current === null ||
+        !contains(element, getTarget(event) as HTMLElement | null)
+      ) {
+        return;
       }
+
+      // React's pointermove preventDefault is not enough on iOS; this
+      // non-passive touchmove listener blocks native scrolling while dragging.
+      event.preventDefault();
     }
 
     return addEventListener(element, 'touchmove', preventDefaultTouchStart, { passive: false });

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -266,6 +266,10 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
       return;
     }
 
+    if (event.pointerType === 'touch') {
+      store.pauseTimers();
+    }
+
     const target = getTarget(event.nativeEvent) as HTMLElement | null;
 
     const isInteractiveElement = target
@@ -274,12 +278,6 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
 
     if (isInteractiveElement) {
       return;
-    }
-
-    // Pause only once we know this is a swipe rather than a tap on an
-    // interactive element, which has no matching resume path.
-    if (event.pointerType === 'touch') {
-      store.pauseTimers();
     }
 
     cancelledSwipeRef.current = false;

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -106,5 +106,57 @@ describe('ToastStore', () => {
 
       expect(selectors.toast(store.state, newToastId)?.transitionStatus).not.toBe('ending');
     });
+
+    it('re-pauses timers after all toasts are closed and a new one is added', () => {
+      vi.useFakeTimers();
+      const store = createStore([]);
+
+      store.addToast({ id: 'a', title: 'a', timeout: 100 });
+      store.addToast({ id: 'b', title: 'b', timeout: 100 });
+      store.pauseTimers();
+
+      store.closeToast();
+
+      store.addToast({ id: 'c', title: 'c', timeout: 100 });
+      store.pauseTimers();
+      vi.advanceTimersByTime(200);
+
+      expect(selectors.toast(store.state, 'c')?.transitionStatus).not.toBe('ending');
+    });
+
+    it('re-pauses timers after the last active toast closes while ending toasts remain', () => {
+      vi.useFakeTimers();
+      const store = createStore([]);
+
+      store.addToast({ id: 'a', title: 'a', timeout: 100 });
+      store.addToast({ id: 'b', title: 'b', timeout: 100 });
+      store.pauseTimers();
+
+      store.closeToast('b');
+      store.closeToast('a');
+
+      store.addToast({ id: 'c', title: 'c', timeout: 100 });
+      store.pauseTimers();
+      vi.advanceTimersByTime(200);
+
+      expect(selectors.toast(store.state, 'c')?.transitionStatus).not.toBe('ending');
+    });
+
+    it('re-pauses timers after the last timed toast closes while untimed toasts remain', () => {
+      vi.useFakeTimers();
+      const store = createStore([]);
+
+      store.addToast({ id: 'loading', title: 'loading', type: 'loading' });
+      store.addToast({ id: 'timed', title: 'timed', timeout: 100 });
+      store.pauseTimers();
+
+      store.closeToast('timed');
+
+      store.addToast({ id: 'c', title: 'c', timeout: 100 });
+      store.pauseTimers();
+      vi.advanceTimersByTime(200);
+
+      expect(selectors.toast(store.state, 'c')?.transitionStatus).not.toBe('ending');
+    });
   });
 });

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ToastStore, selectors } from './store';
 import type { ToastObject } from './useToastManager';
 
@@ -61,5 +61,50 @@ describe('ToastStore', () => {
     store.addToast({ id: 'front', title: 'Front', timeout: 0 });
 
     expectToastMetadataToMatchToasts(store);
+  });
+
+  describe('limit', () => {
+    it('recomputes limited flags when the limit changes', () => {
+      // Ordered newest-first, matching how `addToast` prepends.
+      const store = createStore([{ id: 'c' }, { id: 'b' }, { id: 'a' }]);
+
+      store.setLimit(1);
+      expect(selectors.toast(store.state, 'c')?.limited).toBe(false);
+      expect(selectors.toast(store.state, 'b')?.limited).toBe(true);
+      expect(selectors.toast(store.state, 'a')?.limited).toBe(true);
+
+      store.setLimit(3);
+      expect(selectors.toast(store.state, 'c')?.limited).toBe(false);
+      expect(selectors.toast(store.state, 'b')?.limited).toBe(false);
+      expect(selectors.toast(store.state, 'a')?.limited).toBe(false);
+    });
+  });
+
+  describe('timer pausing', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('re-pauses timers after the last toast is closed and a new one is added', () => {
+      vi.useFakeTimers();
+      const store = createStore([]);
+
+      // Add a toast with a running timer, then pause it (as a hover would).
+      store.addToast({ title: 'a', timeout: 100 });
+      store.pauseTimers();
+
+      // Closing the last toast must clear the internal "paused" flag, otherwise
+      // the next toast's timer can never be paused again.
+      store.closeToast(store.state.toasts[0].id);
+
+      store.addToast({ title: 'b', timeout: 100 });
+      const newToastId = store.state.toasts[0].id;
+
+      // Hovering again should pause the new toast's timer.
+      store.pauseTimers();
+      vi.advanceTimersByTime(200);
+
+      expect(selectors.toast(store.state, newToastId)?.transitionStatus).not.toBe('ending');
+    });
   });
 });

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -68,12 +68,12 @@ describe('ToastStore', () => {
       // Ordered newest-first, matching how `addToast` prepends.
       const store = createStore([{ id: 'c' }, { id: 'b' }, { id: 'a' }]);
 
-      store.setLimit(1);
+      store.syncProviderProps({ timeout: 0, limit: 1 });
       expect(selectors.toast(store.state, 'c')?.limited).toBe(false);
       expect(selectors.toast(store.state, 'b')?.limited).toBe(true);
       expect(selectors.toast(store.state, 'a')?.limited).toBe(true);
 
-      store.setLimit(3);
+      store.syncProviderProps({ timeout: 0, limit: 3 });
       expect(selectors.toast(store.state, 'c')?.limited).toBe(false);
       expect(selectors.toast(store.state, 'b')?.limited).toBe(false);
       expect(selectors.toast(store.state, 'a')?.limited).toBe(false);

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -158,5 +158,21 @@ describe('ToastStore', () => {
 
       expect(selectors.toast(store.state, 'c')?.transitionStatus).not.toBe('ending');
     });
+
+    it('re-pauses timers after the last timed toast becomes untimed', () => {
+      vi.useFakeTimers();
+      const store = createStore([]);
+
+      store.addToast({ id: 'a', title: 'a', timeout: 100 });
+      store.pauseTimers();
+
+      store.updateToastInternal('a', { timeout: 0 });
+
+      store.addToast({ id: 'b', title: 'b', timeout: 100 });
+      store.pauseTimers();
+      vi.advanceTimersByTime(200);
+
+      expect(selectors.toast(store.state, 'b')?.transitionStatus).not.toBe('ending');
+    });
   });
 });

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -282,9 +282,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     const wasLoading = prevToast?.type === 'loading';
 
     if (!shouldHaveTimer && hasTimer) {
-      const timer = this.timers.get(id);
-      timer?.timeout?.clear();
-      this.timers.delete(id);
+      this.clearTimer(id);
       return;
     }
 
@@ -293,11 +291,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       shouldHaveTimer &&
       (!hasTimer || timeoutChanged || timeoutUpdated || wasLoading || behavior.resetTimer)
     ) {
-      const timer = this.timers.get(id);
-      if (timer) {
-        timer.timeout?.clear();
-        this.timers.delete(id);
-      }
+      this.clearTimer(id);
 
       this.scheduleTimer(id, nextTimeout, () => this.closeToast(id));
 
@@ -314,21 +308,14 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
 
     if (closeAll) {
       toastsToClose = toasts;
-      this.timers.forEach((timer) => {
-        timer.timeout?.clear();
-      });
-      this.timers.clear();
+      this.clearTimers();
     } else {
       const toast = selectors.toast(this.state, toastId);
       if (!toast) {
         return;
       }
       toastsToClose = [toast];
-      const timer = this.timers.get(toastId);
-      if (timer) {
-        timer.timeout?.clear();
-        this.timers.delete(toastId);
-      }
+      this.clearTimer(toastId);
     }
 
     const endingToasts = toasts.map((item) =>
@@ -346,11 +333,6 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     if (!hasActiveToasts) {
       updates.hovering = false;
       updates.focused = false;
-    }
-    if (this.timers.size === 0) {
-      // No timers remain to keep paused; clear the flag so a fresh toast's
-      // running timer can be paused again on hover/focus.
-      this.areTimersPaused = false;
     }
     this.update(updates);
 
@@ -471,6 +453,26 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       remaining: delay,
       callback,
     });
+  }
+
+  private clearTimers() {
+    this.timers.forEach((timer) => {
+      timer.timeout?.clear();
+    });
+    this.timers.clear();
+    this.areTimersPaused = false;
+  }
+
+  private clearTimer(id: string) {
+    const timer = this.timers.get(id);
+    timer?.timeout?.clear();
+    this.timers.delete(id);
+
+    if (this.timers.size === 0) {
+      // No timers remain to keep paused; clear the flag so a fresh toast's
+      // running timer can be paused again on hover/focus.
+      this.areTimersPaused = false;
+    }
   }
 
   private setToasts(newToasts: ToastObject<any>[]) {

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -66,6 +66,22 @@ function createToastMetadata(toasts: ToastObject<any>[]) {
   return metadata;
 }
 
+// Marks the active (non-ending) toasts beyond `limit` as limited. Toasts are
+// ordered newest-first, so the newest `limit` toasts stay visible and the rest
+// are flagged. Returns the same toast reference when its `limited` flag is
+// unchanged to avoid unnecessary re-renders.
+function applyLimited(toasts: ToastObject<any>[], limit: number): ToastObject<any>[] {
+  let activeIndex = 0;
+  return toasts.map((toast) => {
+    if (toast.transitionStatus === 'ending') {
+      return toast;
+    }
+    const limited = activeIndex >= limit;
+    activeIndex += 1;
+    return toast.limited === limited ? toast : { ...toast, limited };
+  });
+}
+
 const toastMetadataSelector = (state: State) => state.toastMetadata;
 
 export const selectors = {
@@ -132,6 +148,31 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     this.set('viewport', viewport);
   };
 
+  syncProviderProps(props: Pick<State, 'timeout' | 'limit'>) {
+    const limitChanged = this.state.limit !== props.limit;
+
+    if (this.state.timeout === props.timeout && !limitChanged) {
+      return;
+    }
+
+    const updates: Partial<State> = {
+      timeout: props.timeout,
+      limit: props.limit,
+    };
+
+    if (limitChanged) {
+      const newToasts = applyLimited(this.state.toasts, props.limit);
+      updates.toasts = newToasts;
+      updates.toastMetadata = createToastMetadata(newToasts);
+    }
+
+    this.update(updates);
+  }
+
+  setLimit(limit: number) {
+    this.syncProviderProps({ timeout: this.state.timeout, limit });
+  }
+
   disposeEffect = () => {
     return () => {
       this.timers.forEach((timer) => {
@@ -186,26 +227,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     };
 
     const updatedToasts = [toastToAdd, ...this.state.toasts];
-    const activeToasts = updatedToasts.filter((t) => t.transitionStatus !== 'ending');
-
-    // Mark oldest toasts for removal when over limit
-    if (activeToasts.length > limit) {
-      const excessCount = activeToasts.length - limit;
-      const oldestActiveToasts = activeToasts.slice(-excessCount);
-      const limitedIds = new Set(oldestActiveToasts.map((t) => t.id));
-
-      this.setToasts(
-        updatedToasts.map((t) => {
-          const limited = limitedIds.has(t.id);
-          if (t.limited !== limited) {
-            return { ...t, limited };
-          }
-          return t;
-        }),
-      );
-    } else {
-      this.setToasts(updatedToasts.map((t) => (t.limited ? { ...t, limited: false } : t)));
-    }
+    this.setToasts(applyLimited(updatedToasts, limit));
 
     const duration = toastToAdd.timeout ?? timeout;
     if (toastToAdd.type !== 'loading' && duration > 0) {
@@ -313,19 +335,12 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       }
     }
 
-    let activeIndex = 0;
-    const newToasts = toasts.map((item) => {
-      if (closeAll || item.id === toastId) {
-        return { ...item, transitionStatus: 'ending' as const, height: 0 };
-      }
-      if (item.transitionStatus === 'ending') {
-        return item;
-      }
-
-      const isLimited = activeIndex >= limit;
-      activeIndex += 1;
-      return item.limited !== isLimited ? { ...item, limited: isLimited } : item;
-    });
+    const endingToasts = toasts.map((item) =>
+      closeAll || item.id === toastId
+        ? { ...item, transitionStatus: 'ending' as const, height: 0 }
+        : item,
+    );
+    const newToasts = applyLimited(endingToasts, limit);
 
     const updates: Partial<State> = {
       toasts: newToasts,
@@ -334,6 +349,9 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     if (closeAll || toasts.length === 1) {
       updates.hovering = false;
       updates.focused = false;
+      // No timers remain to keep paused; clear the flag so a fresh toast's
+      // running timer can be paused again on hover/focus.
+      this.areTimersPaused = false;
     }
     this.update(updates);
 

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -66,10 +66,10 @@ function createToastMetadata(toasts: ToastObject<any>[]) {
   return metadata;
 }
 
-// Marks the active (non-ending) toasts beyond `limit` as limited. Toasts are
-// ordered newest-first, so the newest `limit` toasts stay visible and the rest
-// are flagged. Returns the same toast reference when its `limited` flag is
-// unchanged to avoid unnecessary re-renders.
+// Marks the active (non-ending) toasts beyond `limit` as limited. Callers pass
+// toasts in newest-first order, so the newest `limit` toasts stay visible and
+// the rest are flagged. Returns the same toast reference when its `limited`
+// flag is unchanged to avoid unnecessary re-renders.
 function applyLimited(toasts: ToastObject<any>[], limit: number): ToastObject<any>[] {
   let activeIndex = 0;
   return toasts.map((toast) => {
@@ -411,7 +411,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       timer.remaining = timer.remaining > 0 ? timer.remaining : timer.delay;
       timer.timeout ??= Timeout.create();
       timer.timeout.start(timer.remaining, () => {
-        this.timers.delete(id);
+        this.handleTimerFired(id);
         timer.callback();
       });
       timer.start = Date.now();
@@ -432,6 +432,8 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       return;
     }
 
+    // This is explicit touch activity outside the viewport, so the paused
+    // interaction state should end even if the window focus state is unchanged.
     this.resumeTimers();
     this.update({ hovering: false, focused: false });
   };
@@ -442,7 +444,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     const currentTimeout = shouldStartActive ? Timeout.create() : undefined;
 
     currentTimeout?.start(delay, () => {
-      this.timers.delete(id);
+      this.handleTimerFired(id);
       callback();
     });
 
@@ -468,6 +470,15 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     timer?.timeout?.clear();
     this.timers.delete(id);
 
+    this.resetPausedStateIfNoTimersRemain();
+  }
+
+  private handleTimerFired(id: string) {
+    this.timers.delete(id);
+    this.resetPausedStateIfNoTimersRemain();
+  }
+
+  private resetPausedStateIfNoTimersRemain() {
     if (this.timers.size === 0) {
       // No timers remain to keep paused; clear the flag so a fresh toast's
       // running timer can be paused again on hover/focus.

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -346,9 +346,12 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       toasts: newToasts,
       toastMetadata: createToastMetadata(newToasts),
     };
-    if (closeAll || toasts.length === 1) {
+    const hasActiveToasts = newToasts.some((toast) => toast.transitionStatus !== 'ending');
+    if (!hasActiveToasts) {
       updates.hovering = false;
       updates.focused = false;
+    }
+    if (this.timers.size === 0) {
       // No timers remain to keep paused; clear the flag so a fresh toast's
       // running timer can be paused again on hover/focus.
       this.areTimersPaused = false;

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -169,10 +169,6 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     this.update(updates);
   }
 
-  setLimit(limit: number) {
-    this.syncProviderProps({ timeout: this.state.timeout, limit });
-  }
-
   disposeEffect = () => {
     return () => {
       this.timers.forEach((timer) => {
@@ -329,8 +325,8 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       }
       toastsToClose = [toast];
       const timer = this.timers.get(toastId);
-      if (timer?.timeout) {
-        timer.timeout.clear();
+      if (timer) {
+        timer.timeout?.clear();
         this.timers.delete(toastId);
       }
     }

--- a/packages/react/src/toast/useToastManager.test.tsx
+++ b/packages/react/src/toast/useToastManager.test.tsx
@@ -1874,6 +1874,38 @@ describe.skipIf(!isJSDOM)('useToast', () => {
       expect(savedToast).toHaveAttribute('data-limited');
       expect(screen.getByTestId('Other toast')).not.toHaveAttribute('data-limited');
     });
+
+    it('recomputes limited toasts when the limit prop changes', async () => {
+      function App(props: { limit: number }) {
+        return (
+          <Toast.Provider limit={props.limit}>
+            <Toast.Viewport>
+              <TestList />
+            </Toast.Viewport>
+          </Toast.Provider>
+        );
+      }
+
+      const { setProps } = await render(<App limit={1} />);
+
+      const addButton = screen.getByRole('button', { name: 'add' });
+      fireEvent.click(addButton);
+      fireEvent.click(addButton);
+
+      const toast1 = screen.getByTestId('toast-1');
+      const toast2 = screen.getByTestId('toast-2');
+
+      expect(toast2).not.toHaveAttribute('data-limited');
+      expect(toast1).toHaveAttribute('data-limited');
+
+      // Raising the limit un-limits the older toast.
+      await setProps({ limit: 2 });
+      expect(toast1).not.toHaveAttribute('data-limited');
+
+      // Lowering it again re-limits it.
+      await setProps({ limit: 1 });
+      expect(toast1).toHaveAttribute('data-limited');
+    });
   });
 
   describe('in dialog', () => {

--- a/packages/react/src/toast/viewport/ToastViewport.test.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.test.tsx
@@ -469,5 +469,97 @@ describe('<Toast.Viewport />', () => {
 
       expect(screen.queryByTestId('root')).toBe(null);
     });
+
+    it.skipIf(!isJSDOM)(
+      'keeps timers paused on mouseleave while the window is blurred',
+      async () => {
+        const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+
+        await renderFakeTimers(
+          <Toast.Provider>
+            <Toast.Viewport>
+              <List />
+            </Toast.Viewport>
+            <Button />
+          </Toast.Provider>,
+        );
+
+        const button = screen.getByRole('button', { name: 'add' });
+        fireEvent.click(button);
+
+        const root = screen.getByTestId('root');
+
+        const blurListener = [...addEventListenerSpy.mock.calls]
+          .reverse()
+          .find((call) => call[0] === 'blur')?.[1] as EventListener | undefined;
+        addEventListenerSpy.mockRestore();
+
+        if (!blurListener) {
+          throw new Error('Expected window blur listener to be registered.');
+        }
+
+        const blurEvent = new FocusEvent('blur');
+        Object.defineProperty(blurEvent, 'composedPath', { value: () => [window] });
+
+        // Hovering pauses the timer.
+        fireEvent.mouseEnter(root);
+        clock.tick(1000);
+
+        // The window loses focus while still hovering.
+        await act(async () => {
+          blurListener(blurEvent);
+        });
+
+        // Leaving with the pointer must not resume the timer while the window is
+        // blurred, otherwise the toast could expire off-screen.
+        fireEvent.mouseLeave(root);
+        clock.tick(10000);
+
+        expect(screen.queryByTestId('root')).not.toBe(null);
+      },
+    );
+  });
+
+  describe('focus management', () => {
+    const { render: renderFakeTimers, clock } = createRenderer();
+
+    clock.withFakeTimers();
+
+    it.skipIf(!isJSDOM)('skips toasts animating out when tabbing into the viewport', async () => {
+      await renderFakeTimers(
+        <Toast.Provider>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+      fireEvent.click(button); // oldest toast
+      fireEvent.click(button); // newest toast (toasts[0])
+
+      const roots = screen.getAllByTestId('root');
+      const newest = roots[0];
+      const survivor = roots[1];
+
+      // Close the newest toast. It enters the `ending` state and stays mounted
+      // because the exit animation hasn't completed (no clock tick). The close
+      // button is `aria-hidden` until expanded, so query it by attribute.
+      const newestCloseButton = document.querySelectorAll(
+        '[aria-label="close-press"]',
+      )[0] as HTMLElement;
+      fireEvent.click(newestCloseButton);
+
+      // F6 focuses the viewport and renders the focus guards.
+      fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'F6' });
+
+      const viewport = screen.getByTestId('viewport');
+      const guard = document.querySelector('[data-base-ui-focus-guard]') as HTMLElement;
+      fireEvent.focus(guard, { relatedTarget: viewport });
+
+      expect(survivor).toHaveFocus();
+      expect(newest).not.toHaveFocus();
+    });
   });
 });

--- a/packages/react/src/toast/viewport/ToastViewport.test.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.test.tsx
@@ -419,14 +419,12 @@ describe('<Toast.Viewport />', () => {
       fireEvent.click(button);
 
       expect(screen.queryByTestId('root')).not.toBe(null);
-      const addEventListenerCalls = [...addEventListenerSpy.mock.calls].reverse();
-
-      const blurListener = addEventListenerCalls.find((call) => call[0] === 'blur')?.[1] as
-        | EventListener
-        | undefined;
-      const focusListener = addEventListenerCalls.find((call) => call[0] === 'focus')?.[1] as
-        | EventListener
-        | undefined;
+      const blurListener = addEventListenerSpy.mock.calls.find(
+        (call) => call[0] === 'blur' && call[2] === true,
+      )?.[1] as EventListener | undefined;
+      const focusListener = addEventListenerSpy.mock.calls.find(
+        (call) => call[0] === 'focus' && call[2] === true,
+      )?.[1] as EventListener | undefined;
 
       addEventListenerSpy.mockRestore();
 
@@ -489,9 +487,9 @@ describe('<Toast.Viewport />', () => {
 
         const root = screen.getByTestId('root');
 
-        const blurListener = [...addEventListenerSpy.mock.calls]
-          .reverse()
-          .find((call) => call[0] === 'blur')?.[1] as EventListener | undefined;
+        const blurListener = addEventListenerSpy.mock.calls.find(
+          (call) => call[0] === 'blur' && call[2] === true,
+        )?.[1] as EventListener | undefined;
         addEventListenerSpy.mockRestore();
 
         if (!blurListener) {
@@ -536,9 +534,9 @@ describe('<Toast.Viewport />', () => {
         const button = screen.getByRole('button', { name: 'add' });
         fireEvent.click(button);
 
-        const blurListener = [...addEventListenerSpy.mock.calls]
-          .reverse()
-          .find((call) => call[0] === 'blur')?.[1] as EventListener | undefined;
+        const blurListener = addEventListenerSpy.mock.calls.find(
+          (call) => call[0] === 'blur' && call[2] === true,
+        )?.[1] as EventListener | undefined;
         addEventListenerSpy.mockRestore();
 
         if (!blurListener) {

--- a/packages/react/src/toast/viewport/ToastViewport.test.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.test.tsx
@@ -518,6 +518,52 @@ describe('<Toast.Viewport />', () => {
         expect(screen.queryByTestId('root')).not.toBe(null);
       },
     );
+
+    it.skipIf(!isJSDOM)(
+      'keeps timers paused on viewport blur while the window is blurred',
+      async () => {
+        const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+
+        await renderFakeTimers(
+          <Toast.Provider>
+            <Toast.Viewport data-testid="viewport">
+              <List />
+            </Toast.Viewport>
+            <Button />
+          </Toast.Provider>,
+        );
+
+        const button = screen.getByRole('button', { name: 'add' });
+        fireEvent.click(button);
+
+        const blurListener = [...addEventListenerSpy.mock.calls]
+          .reverse()
+          .find((call) => call[0] === 'blur')?.[1] as EventListener | undefined;
+        addEventListenerSpy.mockRestore();
+
+        if (!blurListener) {
+          throw new Error('Expected window blur listener to be registered.');
+        }
+
+        fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'F6' });
+        expect(screen.getByTestId('viewport')).toHaveFocus();
+
+        clock.tick(1000);
+
+        const blurEvent = new FocusEvent('blur');
+        Object.defineProperty(blurEvent, 'composedPath', { value: () => [window] });
+
+        await act(async () => {
+          blurListener(blurEvent);
+        });
+
+        await act(async () => button.focus());
+
+        clock.tick(10000);
+
+        expect(screen.queryByTestId('root')).not.toBe(null);
+      },
+    );
   });
 
   describe('focus management', () => {
@@ -560,6 +606,31 @@ describe('<Toast.Viewport />', () => {
 
       expect(survivor).toHaveFocus();
       expect(newest).not.toHaveFocus();
+    });
+
+    it.skipIf(!isJSDOM)('returns focus when no toast can receive focus', async () => {
+      await renderFakeTimers(
+        <Toast.Provider limit={0}>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+      await act(async () => button.focus());
+      fireEvent.click(button);
+
+      fireEvent.keyDown(button, { key: 'F6' });
+
+      const viewport = screen.getByTestId('viewport');
+      expect(viewport).toHaveFocus();
+
+      const guard = document.querySelector('[data-base-ui-focus-guard]') as HTMLElement;
+      fireEvent.focus(guard, { relatedTarget: viewport });
+
+      expect(button).toHaveFocus();
     });
   });
 });

--- a/packages/react/src/toast/viewport/ToastViewport.test.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.test.tsx
@@ -562,6 +562,92 @@ describe('<Toast.Viewport />', () => {
         expect(screen.queryByTestId('root')).not.toBe(null);
       },
     );
+
+    it.skipIf(!isJSDOM)(
+      'collapses a deferred mouseleave after a closing toast is removed while blurred',
+      async () => {
+        const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+        const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        try {
+          function CloseNewestButton() {
+            const { close, toasts } = Toast.useToastManager();
+
+            return (
+              <button
+                onClick={() => {
+                  close(toasts[0]?.id);
+                }}
+              >
+                close newest
+              </button>
+            );
+          }
+
+          await renderFakeTimers(
+            <Toast.Provider>
+              <Toast.Viewport data-testid="viewport">
+                <List />
+              </Toast.Viewport>
+              <Button />
+              <CloseNewestButton />
+            </Toast.Provider>,
+          );
+
+          const button = screen.getByRole('button', { name: 'add' });
+          fireEvent.click(button);
+          fireEvent.click(button);
+
+          const viewport = screen.getByTestId('viewport');
+          const newestRoot = screen.getAllByTestId('root')[0];
+          let finishAnimation!: () => void;
+          const animationFinished = new Promise<void>((resolve) => {
+            finishAnimation = resolve;
+          });
+
+          Object.defineProperty(newestRoot, 'getAnimations', {
+            value: () => [{ finished: animationFinished }],
+            configurable: true,
+          });
+
+          fireEvent.mouseEnter(viewport);
+          expect(viewport).toHaveAttribute('data-expanded');
+
+          fireEvent.click(screen.getByRole('button', { name: 'close newest' }));
+          expect(newestRoot).toHaveAttribute('data-ending-style');
+
+          const blurListener = addEventListenerSpy.mock.calls.find(
+            (call) => call[0] === 'blur' && call[2] === true,
+          )?.[1] as EventListener | undefined;
+
+          if (!blurListener) {
+            throw new Error('Expected window blur listener to be registered.');
+          }
+
+          const blurEvent = new FocusEvent('blur');
+          Object.defineProperty(blurEvent, 'composedPath', { value: () => [window] });
+
+          fireEvent.mouseLeave(viewport);
+
+          await act(async () => {
+            blurListener(blurEvent);
+          });
+
+          await act(async () => {
+            clock.tick(20);
+            finishAnimation();
+            await Promise.resolve();
+          });
+
+          expect(screen.queryAllByTestId('root')).toHaveLength(1);
+          expect(viewport).not.toHaveAttribute('data-expanded');
+        } finally {
+          addEventListenerSpy.mockRestore();
+          globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
+        }
+      },
+    );
   });
 
   describe('focus management', () => {

--- a/packages/react/src/toast/viewport/ToastViewport.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.tsx
@@ -141,9 +141,13 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
 
     handlingFocusGuardRef.current = true;
 
-    // If we're coming off the container, move to the first toast
+    // If we're coming off the container, move to the first toast that can hold
+    // focus, skipping toasts that are animating out or inert because they're limited.
     if (event.relatedTarget === viewport) {
-      toasts[0]?.ref?.current?.focus();
+      const firstFocusableToast = toasts.find(
+        (toast) => toast.transitionStatus !== 'ending' && !toast.limited,
+      );
+      firstFocusableToast?.ref?.current?.focus();
     } else {
       store.restoreFocusToPrevElement();
     }
@@ -189,13 +193,19 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
     markedReadyForMouseLeaveRef.current = false;
   }
 
+  function resumeTimersIfWindowFocused() {
+    if (store.state.isWindowFocused) {
+      store.resumeTimers();
+    }
+  }
+
   function handleMouseLeave() {
     if (hasTransitioningToasts || touchActiveRef.current) {
       // When swiping to dismiss, wait until the transitions have settled
       // or the touch interaction ends to avoid collapsing mid-gesture.
       markedReadyForMouseLeaveRef.current = true;
     } else {
-      store.resumeTimers();
+      resumeTimersIfWindowFocused();
       store.setHovering(false);
     }
   }
@@ -240,7 +250,7 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
     }
 
     store.setFocused(false);
-    store.resumeTimers();
+    resumeTimersIfWindowFocused();
   }
 
   const defaultProps: HTMLProps = {

--- a/packages/react/src/toast/viewport/ToastViewport.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.tsx
@@ -173,19 +173,16 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
   function flushMouseLeave() {
     const hasEndingToasts = store.state.toasts.some((toast) => toast.transitionStatus === 'ending');
 
-    if (
-      !store.state.isWindowFocused ||
-      hasEndingToasts ||
-      touchActiveRef.current ||
-      !markedReadyForMouseLeaveRef.current
-    ) {
+    if (hasEndingToasts || touchActiveRef.current || !markedReadyForMouseLeaveRef.current) {
       return;
     }
 
     // Once transitions have finished, see if a mouseleave was already triggered
-    // but blocked from taking effect. If so, we can now safely resume timers and
-    // collapse the viewport.
-    store.resumeTimers();
+    // but blocked from taking effect. If so, we can now safely collapse the viewport
+    // without restarting timers while the window is blurred.
+    if (store.state.isWindowFocused) {
+      store.resumeTimers();
+    }
     store.setHovering(false);
     markedReadyForMouseLeaveRef.current = false;
   }
@@ -205,7 +202,9 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
   }
 
   function handleMouseLeave() {
-    if (hasTransitioningToasts || touchActiveRef.current) {
+    const hasEndingToasts = store.state.toasts.some((toast) => toast.transitionStatus === 'ending');
+
+    if (hasEndingToasts || touchActiveRef.current) {
       // When swiping to dismiss, wait until the transitions have settled
       // or the touch interaction ends to avoid collapsing mid-gesture.
       markedReadyForMouseLeaveRef.current = true;

--- a/packages/react/src/toast/viewport/ToastViewport.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.tsx
@@ -165,6 +165,7 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
     ) {
       event.preventDefault();
       store.restoreFocusToPrevElement();
+      // Shift+Tab is explicit keyboard navigation out of the viewport.
       store.resumeTimers();
     }
   }

--- a/packages/react/src/toast/viewport/ToastViewport.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.tsx
@@ -147,7 +147,11 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
       const firstFocusableToast = toasts.find(
         (toast) => toast.transitionStatus !== 'ending' && !toast.limited,
       );
-      firstFocusableToast?.ref?.current?.focus();
+      if (firstFocusableToast) {
+        firstFocusableToast.ref?.current?.focus();
+      } else {
+        store.restoreFocusToPrevElement();
+      }
     } else {
       store.restoreFocusToPrevElement();
     }


### PR DESCRIPTION
Toast now handles several limit, timer, and focus edge cases that could leave hidden or inactive toasts in the wrong state.

## Changes

- Recomputed limited toast state when the provider `limit` changes.
- Shared limited-state recomputation across add, close, and provider sync paths.
- Reset paused timer state when all active timers are cleared so future toasts can pause and resume normally.
- Only prevented touch scrolling while a toast swipe is active.
- Kept timers paused while the window is blurred, even if mouseleave or blur handlers run.
- Skipped ending and limited toasts when focus enters the viewport.
- Updated Toast docs and API output for the current limit and manager behavior.
- Added regression coverage for Toast root, viewport, content, manager, and store behavior.
