### PR TITLE
[tabs] Fix state edge cases

### DIFF
--- a/docs/src/app/(docs)/react/components/tabs/types.md
+++ b/docs/src/app/(docs)/react/components/tabs/types.md
@@ -258,6 +258,8 @@ type TabsTabState = {
   active: boolean;
   /** The component orientation. */
   orientation: Tabs.Root.Orientation;
+  /** The direction used for tab activation. */
+  tabActivationDirection: Tabs.Tab.ActivationDirection;
 };
 ```
 

--- a/packages/react/src/tabs/indicator/TabsIndicator.test.tsx
+++ b/packages/react/src/tabs/indicator/TabsIndicator.test.tsx
@@ -23,6 +23,37 @@ describe('<Tabs.Indicator />', () => {
     testRenderPropWith: 'div',
   }));
 
+  it('exposes null active tab state when the selected value has no matching tab', async () => {
+    const indicatorStates: Tabs.Indicator.State[] = [];
+
+    function renderIndicator(
+      props: React.HTMLAttributes<HTMLSpanElement>,
+      state: Tabs.Indicator.State,
+    ) {
+      indicatorStates.push(state);
+      return <span data-testid="bubble" {...props} />;
+    }
+
+    await render(
+      <Tabs.Root value="missing">
+        <Tabs.List>
+          <Tabs.Tab value="one">One</Tabs.Tab>
+          <Tabs.Indicator render={renderIndicator} />
+        </Tabs.List>
+      </Tabs.Root>,
+    );
+
+    // Wait for Tabs.List to register its element; before that no tab can be measured.
+    await waitFor(() => {
+      expect(indicatorStates.length).toBeGreaterThan(1);
+    });
+
+    const state = indicatorStates.at(-1)!;
+    expect(state.activeTabPosition).toBe(null);
+    expect(state.activeTabSize).toBe(null);
+    expect(screen.getByTestId('bubble')).toHaveAttribute('hidden');
+  });
+
   describe.skipIf(isJSDOM)('rendering', () => {
     it('should not render when no tab is active', async () => {
       await render(

--- a/packages/react/src/tabs/indicator/TabsIndicator.tsx
+++ b/packages/react/src/tabs/indicator/TabsIndicator.tsx
@@ -64,9 +64,10 @@ export const TabsIndicator = React.forwardRef(function TabsIndicator(
 
   if (value != null && tabsListElement != null) {
     const activeTab = getTabElementBySelectedValue(value);
-    isTabSelected = true;
 
     if (activeTab != null) {
+      isTabSelected = true;
+
       const { width: computedWidth, height: computedHeight } = getCssDimensions(activeTab);
       const { width: tabListWidth, height: tabListHeight } = getCssDimensions(tabsListElement);
       const tabRect = activeTab.getBoundingClientRect();

--- a/packages/react/src/tabs/list/TabsList.test.tsx
+++ b/packages/react/src/tabs/list/TabsList.test.tsx
@@ -1,6 +1,6 @@
 import { expect } from 'vitest';
 import * as React from 'react';
-import { act, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { Tabs } from '@base-ui/react/tabs';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -55,6 +55,54 @@ describe('<Tabs.List />', () => {
       expect(tab1).toHaveAttribute('aria-selected', 'true');
       expect(tab2).toHaveAttribute('aria-selected', 'false');
       expect(tab3).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  describe('prop: loopFocus', () => {
+    it('does not wrap focus past the first tab when `loopFocus` is false', async () => {
+      await render(
+        <Tabs.Root value={0}>
+          <Tabs.List loopFocus={false}>
+            <Tabs.Tab value={0} />
+            <Tabs.Tab value={1} />
+            <Tabs.Tab value={2} />
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      const [firstTab, , lastTab] = screen.getAllByRole('tab');
+      await act(async () => {
+        firstTab.focus();
+      });
+
+      fireEvent.keyDown(firstTab, { key: 'ArrowLeft' });
+      await flushMicrotasks();
+
+      expect(firstTab).toHaveFocus();
+      expect(lastTab).not.toHaveFocus();
+    });
+
+    it('does not wrap focus past the last tab when `loopFocus` is false', async () => {
+      await render(
+        <Tabs.Root value={2}>
+          <Tabs.List loopFocus={false}>
+            <Tabs.Tab value={0} />
+            <Tabs.Tab value={1} />
+            <Tabs.Tab value={2} />
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      const [firstTab, , lastTab] = screen.getAllByRole('tab');
+      await act(async () => {
+        lastTab.focus();
+      });
+
+      fireEvent.keyDown(lastTab, { key: 'ArrowRight' });
+      await flushMicrotasks();
+
+      expect(lastTab).toHaveFocus();
+      expect(firstTab).not.toHaveFocus();
     });
   });
 

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -303,6 +303,33 @@ describe('<Tabs.Root />', () => {
       expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
     });
 
+    it('continues honoring an initially disabled explicit defaultValue after defaultValue changes', async () => {
+      const { setProps } = await render(
+        <Tabs.Root defaultValue={0}>
+          <Tabs.List>
+            <Tabs.Tab value={0} disabled>
+              Tab 0
+            </Tabs.Tab>
+            <Tabs.Tab value={1}>Tab 1</Tabs.Tab>
+            <Tabs.Tab value={2}>Tab 2</Tabs.Tab>
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      const tabs = screen.getAllByRole('tab');
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+
+      await expect(async () => {
+        await setProps({ defaultValue: 1 });
+      }).toErrorDev(
+        'Base UI: A component is changing the default value state of an uncontrolled Tabs after being initialized.',
+      );
+
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+      expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
+    });
+
     it('should still honor explicit value prop even if it points to a disabled tab', async () => {
       await render(
         <Tabs.Root value={0}>
@@ -618,6 +645,36 @@ describe('<Tabs.Root />', () => {
       const tabs = screen.getAllByRole('tab');
       expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
       expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('does not move an uncontrolled selection when a user-initiated change is canceled', async () => {
+      const handleChange = vi.fn(
+        (_value: Tabs.Tab.Value, eventDetails: Tabs.Root.ChangeEventDetails) => {
+          if (eventDetails.reason === 'none') {
+            eventDetails.cancel();
+          }
+        },
+      );
+
+      const { user } = await render(
+        <Tabs.Root defaultValue={0} onValueChange={handleChange}>
+          <Tabs.List>
+            <Tabs.Tab value={0}>Tab 0</Tabs.Tab>
+            <Tabs.Tab value={1}>Tab 1</Tabs.Tab>
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      const tabs = screen.getAllByRole('tab');
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+
+      await user.click(tabs[1]);
+
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      expect(handleChange.mock.calls[0][1].reason).toBe('none');
+      // The canceled click must not commit the new value in an uncontrolled root.
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
     });
 
     it('calls onValueChange with null when all tabs are initially disabled', async () => {
@@ -1862,7 +1919,9 @@ describe('<Tabs.Root />', () => {
       panelRenderMock.mockClear();
 
       const root = screen.getByTestId('root');
+      const tabs = screen.getAllByRole('tab');
       expect(root).toHaveAttribute('data-activation-direction', 'none');
+      expect(tabs[0]).toHaveAttribute('data-activation-direction', 'none');
 
       await setProps({ value: 1 });
 
@@ -1870,6 +1929,7 @@ describe('<Tabs.Root />', () => {
         expect.objectContaining({ value: 1, tabActivationDirection: 'right' }),
       );
       expect(root).toHaveAttribute('data-activation-direction', 'right');
+      expect(tabs[1]).toHaveAttribute('data-activation-direction', 'right');
 
       panelRenderMock.mockClear();
 
@@ -1879,6 +1939,7 @@ describe('<Tabs.Root />', () => {
         expect.objectContaining({ value: 0, tabActivationDirection: 'left' }),
       );
       expect(root).toHaveAttribute('data-activation-direction', 'left');
+      expect(tabs[0]).toHaveAttribute('data-activation-direction', 'left');
     });
 
     it('should update `data-activation-direction` on programmatic value changes with orientation=vertical', async () => {
@@ -1898,7 +1959,9 @@ describe('<Tabs.Root />', () => {
       panelRenderMock.mockClear();
 
       const root = screen.getByTestId('root');
+      const tabs = screen.getAllByRole('tab');
       expect(root).toHaveAttribute('data-activation-direction', 'none');
+      expect(tabs[0]).toHaveAttribute('data-activation-direction', 'none');
 
       await setProps({ value: 1 });
 
@@ -1906,6 +1969,7 @@ describe('<Tabs.Root />', () => {
         expect.objectContaining({ value: 1, tabActivationDirection: 'down' }),
       );
       expect(root).toHaveAttribute('data-activation-direction', 'down');
+      expect(tabs[1]).toHaveAttribute('data-activation-direction', 'down');
 
       panelRenderMock.mockClear();
 
@@ -1915,6 +1979,7 @@ describe('<Tabs.Root />', () => {
         expect.objectContaining({ value: 0, tabActivationDirection: 'up' }),
       );
       expect(root).toHaveAttribute('data-activation-direction', 'up');
+      expect(tabs[0]).toHaveAttribute('data-activation-direction', 'up');
     });
 
     it('keeps activation direction none after automatic disabled fallback', async () => {

--- a/packages/react/src/tabs/root/TabsRoot.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.tsx
@@ -245,6 +245,9 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
   // Implicit uncontrolled selections are still automatic changes, so notify
   // once when the tabs first register. Explicit defaults are treated as user-owned.
   const shouldNotifyInitialValueChangeRef = React.useRef(!hasExplicitDefaultValueProp);
+  // useControlled warns if defaultValue changes after mount, but the
+  // disabled-default honor policy below still needs a stable initial value.
+  const initialDefaultValueRef = React.useRef(defaultValueProp);
   // An explicit defaultValue can intentionally point at a disabled tab on mount.
   // Once that selection becomes valid, later disabled states should fall back.
   const shouldHonorDisabledDefaultValueRef = React.useRef(hasExplicitDefaultValueProp);
@@ -295,14 +298,14 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
     const selectionIsDisabled = selectedTabMetadata?.disabled;
     const selectionIsMissing = selectedTabMetadata == null && value !== null;
 
-    if (!selectionIsDisabled && value === defaultValueProp) {
+    if (!selectionIsDisabled && value === initialDefaultValueRef.current) {
       shouldHonorDisabledDefaultValueRef.current = false;
     }
 
     if (
       shouldHonorDisabledDefaultValueRef.current &&
       selectionIsDisabled &&
-      value === defaultValueProp
+      value === initialDefaultValueRef.current
     ) {
       return;
     }
@@ -336,7 +339,6 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
       shouldNotifyInitialValueChangeRef.current = false;
     }
   }, [
-    defaultValueProp,
     firstEnabledTabValue,
     isControlled,
     notifyAutomaticValueChange,

--- a/packages/react/src/tabs/tab/TabsTab.test.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.test.tsx
@@ -1,5 +1,8 @@
+import { expect, vi } from 'vitest';
+import * as React from 'react';
+import { screen } from '@mui/internal-test-utils';
 import { Tabs } from '@base-ui/react/tabs';
-import { createRenderer, describeConformance } from '#test-utils';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Tabs.Tab />', () => {
   const { render } = createRenderer();
@@ -15,4 +18,73 @@ describe('<Tabs.Tab />', () => {
         </Tabs.Root>,
       ),
   }));
+
+  describe('prop: nativeButton', () => {
+    it('renders as an anchor and toggles selection when `nativeButton` is false', async () => {
+      const { user } = await render(
+        <Tabs.Root defaultValue="overview">
+          <Tabs.List>
+            <Tabs.Tab nativeButton={false} render={<a href="#overview" />} value="overview">
+              Overview
+            </Tabs.Tab>
+            <Tabs.Tab nativeButton={false} render={<a href="#details" />} value="details">
+              Details
+            </Tabs.Tab>
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      const tabs = screen.getAllByRole('tab');
+      expect(tabs[0].tagName).toBe('A');
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+
+      await user.click(tabs[1]);
+
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+      expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('state', () => {
+    it.skipIf(isJSDOM)('exposes tab activation direction through the render prop', async () => {
+      const tabRenderMock = vi.fn();
+
+      const { setProps } = await render(
+        <Tabs.Root value={0}>
+          <Tabs.List>
+            <Tabs.Tab
+              value={0}
+              render={(props, state) => {
+                tabRenderMock({ value: 0, ...state });
+                return <button {...props} />;
+              }}
+            >
+              Tab 0
+            </Tabs.Tab>
+            <Tabs.Tab
+              value={1}
+              render={(props, state) => {
+                tabRenderMock({ value: 1, ...state });
+                return <button {...props} />;
+              }}
+            >
+              Tab 1
+            </Tabs.Tab>
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      tabRenderMock.mockClear();
+
+      await setProps({ value: 1 });
+
+      expect(
+        tabRenderMock.mock.calls.some(
+          ([state]) =>
+            state.value === 1 && state.active === true && state.tabActivationDirection === 'right',
+        ),
+      ).toBe(true);
+    });
+  });
 });

--- a/packages/react/src/tabs/tab/TabsTab.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.tsx
@@ -10,6 +10,7 @@ import { ACTIVE_COMPOSITE_ITEM } from '../../internals/composite/constants';
 import { useCompositeItem } from '../../internals/composite/item/useCompositeItem';
 import type { TabsRoot } from '../root/TabsRoot';
 import { useTabsRootContext } from '../root/TabsRootContext';
+import { tabsStateAttributesMapping } from '../root/stateAttributesMapping';
 import { useTabsListContext } from '../list/TabsListContext';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
@@ -36,7 +37,12 @@ export const TabsTab = React.forwardRef(function TabsTab(
     ...elementProps
   } = componentProps;
 
-  const { value: activeTabValue, getTabPanelIdByValue, orientation } = useTabsRootContext();
+  const {
+    value: activeTabValue,
+    getTabPanelIdByValue,
+    orientation,
+    tabActivationDirection,
+  } = useTabsRootContext();
 
   const {
     activateOnFocus,
@@ -181,6 +187,7 @@ export const TabsTab = React.forwardRef(function TabsTab(
     disabled,
     active,
     orientation,
+    tabActivationDirection,
   };
 
   const element = useRenderElement('button', componentProps, {
@@ -204,6 +211,7 @@ export const TabsTab = React.forwardRef(function TabsTab(
       elementProps,
       getButtonProps,
     ],
+    stateAttributesMapping: tabsStateAttributesMapping,
   });
 
   return element;
@@ -244,6 +252,10 @@ export interface TabsTabState {
    * The component orientation.
    */
   orientation: TabsRoot.Orientation;
+  /**
+   * The direction used for tab activation.
+   */
+  tabActivationDirection: TabsTab.ActivationDirection;
 }
 
 export interface TabsTabProps


### PR DESCRIPTION
Fixes a few Tabs state edge cases where fallback state could drift from the selected tab or omit state data from customized parts.

## Changes

- Preserve the initial uncontrolled `defaultValue` when deciding whether an explicitly selected disabled tab should stay selected.
- Expose `data-activation-direction` and `tabActivationDirection` on `Tabs.Tab`.
- Report `null` indicator position and size when the selected value has no matching tab.
- Add regression coverage for these cases plus nearby keyboard and rendered-element behavior.