### PR TITLE
[navigation menu] Fix interaction, value, and styling-hook bugs

### DIFF
--- a/docs/src/app/(docs)/react/components/navigation-menu/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/navigation-menu/demos/hero/css-modules/index.tsx
@@ -27,7 +27,7 @@ export default function ExampleNavigationMenu() {
           </NavigationMenu.Content>
         </NavigationMenu.Item>
 
-        <NavigationMenu.Item value="b">
+        <NavigationMenu.Item>
           <NavigationMenu.Trigger className={styles.Trigger}>
             Handbook
             <NavigationMenu.Icon className={styles.Icon}>

--- a/docs/src/app/(docs)/react/components/navigation-menu/types.md
+++ b/docs/src/app/(docs)/react/components/navigation-menu/types.md
@@ -139,6 +139,12 @@ An icon that indicates that the trigger button opens a menu.
 | style     | `React.CSSProperties \| ((state: NavigationMenu.Icon.State) => React.CSSProperties \| undefined)` | -       | Style applied to the element, or a function that&#xA;returns a style object based on the component's state.                                                                                   |
 | render    | `ReactElement \| ((props: HTMLProps, state: NavigationMenu.Icon.State) => ReactElement)`          | -       | Allows you to replace the component's HTML element&#xA;with a different tag, or compose it with another component. Accepts a `ReactElement` or a function that returns the element to render. |
 
+**Icon Data Attributes:**
+
+| Attribute       | Type | Description                                                      |
+| :-------------- | :--- | :--------------------------------------------------------------- |
+| data-popup-open | -    | Present when the navigation menu is open and the item is active. |
+
 ### Icon.Props
 
 Re-export of [Icon](#icon) props.
@@ -361,6 +367,7 @@ Renders a `<nav>` element.
 | :------------------ | :------------------------------------------------------------------------- | :-------------------------------------------------------------------- |
 | data-open           | -                                                                          | Present when the popup is open.                                       |
 | data-closed         | -                                                                          | Present when the popup is closed.                                     |
+| data-anchor-hidden  | -                                                                          | Present when the anchor is hidden.                                    |
 | data-align          | `'start' \| 'center' \| 'end'`                                             | Indicates how the popup is aligned relative to the specified side.    |
 | data-side           | `'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
 | data-starting-style | -                                                                          | Present when the popup is animating in.                               |
@@ -477,13 +484,13 @@ Renders a `<div>` element.
 
 **Content Data Attributes:**
 
-| Attribute                 | Type | Description                                         |
-| :------------------------ | :--- | :-------------------------------------------------- |
-| data-open                 | -    | Present when the popup is open.                     |
-| data-closed               | -    | Present when the popup is closed.                   |
-| data-activation-direction | -    | Which direction another trigger was activated from. |
-| data-starting-style       | -    | Present when the content is animating in.           |
-| data-ending-style         | -    | Present when the content is animating out.          |
+| Attribute                 | Type                                  | Description                                         |
+| :------------------------ | :------------------------------------ | :-------------------------------------------------- |
+| data-open                 | -                                     | Present when the popup is open.                     |
+| data-closed               | -                                     | Present when the popup is closed.                   |
+| data-activation-direction | `'left' \| 'right' \| 'up' \| 'down'` | Which direction another trigger was activated from. |
+| data-starting-style       | -                                     | Present when the content is animating in.           |
+| data-ending-style         | -                                     | Present when the content is animating out.          |
 
 ### Content.Props
 

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -1101,6 +1101,7 @@ A collection of links and menus for website navigation.
     - Data Attributes: data-popup-open, data-pressed
   - Navigation Menu - Icon
     - Props: className, render, style
+    - Data Attributes: data-popup-open
   - Navigation Menu - List
     - Props: className, render, style
   - Navigation Menu - Portal
@@ -1114,7 +1115,7 @@ A collection of links and menus for website navigation.
     - CSS Variables: --anchor-height, --anchor-width, --available-height, --available-width, --positioner-height, --positioner-width, --transform-origin
   - Navigation Menu - Popup
     - Props: className, render, style
-    - Data Attributes: data-align, data-closed, data-ending-style, data-open, data-side, data-starting-style
+    - Data Attributes: data-align, data-anchor-hidden, data-closed, data-ending-style, data-open, data-side, data-starting-style
     - CSS Variables: --popup-height, --popup-width
   - Navigation Menu - Arrow
     - Props: className, render, style

--- a/packages/react/src/navigation-menu/arrow/NavigationMenuArrow.tsx
+++ b/packages/react/src/navigation-menu/arrow/NavigationMenuArrow.tsx
@@ -6,6 +6,7 @@ import type { Align, Side } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { popupStateMapping } from '../../utils/popupStateMapping';
 import { useRenderElement } from '../../internals/useRenderElement';
+import { getDisabledMountTransitionStyles } from '../../utils/getDisabledMountTransitionStyles';
 
 /**
  * Displays an element pointing toward the navigation menu's current anchor.
@@ -19,7 +20,7 @@ export const NavigationMenuArrow = React.forwardRef(function NavigationMenuArrow
 ) {
   const { render, className, style, ...elementProps } = componentProps;
 
-  const { open } = useNavigationMenuRootContext();
+  const { open, transitionStatus } = useNavigationMenuRootContext();
   const { arrowRef, side, align, arrowUncentered, arrowStyles } =
     useNavigationMenuPositionerContext();
 
@@ -33,7 +34,11 @@ export const NavigationMenuArrow = React.forwardRef(function NavigationMenuArrow
   const element = useRenderElement('div', componentProps, {
     state,
     ref: [forwardedRef, arrowRef],
-    props: [{ style: arrowStyles, 'aria-hidden': true }, elementProps],
+    props: [
+      { style: arrowStyles, 'aria-hidden': true },
+      getDisabledMountTransitionStyles(transitionStatus),
+      elementProps,
+    ],
     stateAttributesMapping: popupStateMapping,
   });
 

--- a/packages/react/src/navigation-menu/content/NavigationMenuContentDataAttributes.ts
+++ b/packages/react/src/navigation-menu/content/NavigationMenuContentDataAttributes.ts
@@ -19,6 +19,7 @@ export enum NavigationMenuContentDataAttributes {
   endingStyle = CommonPopupDataAttributes.endingStyle,
   /**
    * Which direction another trigger was activated from.
+   * @type {'left' | 'right' | 'up' | 'down'}
    */
   activationDirection = 'data-activation-direction',
 }

--- a/packages/react/src/navigation-menu/icon/NavigationMenuIconDataAttributes.ts
+++ b/packages/react/src/navigation-menu/icon/NavigationMenuIconDataAttributes.ts
@@ -1,0 +1,8 @@
+import { CommonTriggerDataAttributes } from '../../utils/popupStateMapping';
+
+export enum NavigationMenuIconDataAttributes {
+  /**
+   * Present when the navigation menu is open and the item is active.
+   */
+  popupOpen = CommonTriggerDataAttributes.popupOpen,
+}

--- a/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
+++ b/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
@@ -41,8 +41,8 @@ export const NavigationMenuList = React.forwardRef(function NavigationMenuList(
 
   const fallbackContext = React.useMemo(() => getEmptyRootContext(), []);
   const context = floatingRootContext || fallbackContext;
-  const interactionsEnabled = positionerElement ? true : !value;
-  const hoverInteractionsEnabled = positionerElement || viewportElement ? true : !value;
+  const interactionsEnabled = positionerElement ? true : value == null;
+  const hoverInteractionsEnabled = positionerElement || viewportElement ? true : value == null;
 
   useHoverFloatingInteraction(context, {
     enabled: Boolean(floatingRootContext) && hoverInteractionsEnabled,

--- a/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
+++ b/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
@@ -41,8 +41,9 @@ export const NavigationMenuList = React.forwardRef(function NavigationMenuList(
 
   const fallbackContext = React.useMemo(() => getEmptyRootContext(), []);
   const context = floatingRootContext || fallbackContext;
-  const interactionsEnabled = positionerElement ? true : value == null;
-  const hoverInteractionsEnabled = positionerElement || viewportElement ? true : value == null;
+  const interactionsEnabled = positionerElement != null || value == null;
+  const hoverInteractionsEnabled =
+    positionerElement != null || viewportElement != null || value == null;
 
   useHoverFloatingInteraction(context, {
     enabled: Boolean(floatingRootContext) && hoverInteractionsEnabled,

--- a/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
+++ b/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
@@ -95,8 +95,8 @@ export const NavigationMenuList = React.forwardRef(function NavigationMenuList(
   ];
 
   // When nested, skip the CompositeRoot wrapper so that triggers can participate
-  // in the parent Content's composite navigation context. Also skip the onKeyDown
-  // handler that blocks propagation so arrow keys can reach the parent CompositeRoot.
+  // in the parent Content's composite navigation context. The key propagation
+  // guard is already omitted through `defaultProps` above.
   const element = useRenderElement('ul', componentProps, {
     state,
     ref: forwardedRef,

--- a/packages/react/src/navigation-menu/popup/NavigationMenuPopup.tsx
+++ b/packages/react/src/navigation-menu/popup/NavigationMenuPopup.tsx
@@ -44,15 +44,13 @@ export const NavigationMenuPopup = React.forwardRef(function NavigationMenuPopup
   };
 
   // Ensure popup size transitions correctly when anchored to `bottom` (side=top) or `right` (side=left).
-  let isOriginSide = positioning.side === 'top';
   let isPhysicalLeft = positioning.side === 'left';
   if (direction === 'rtl') {
-    isOriginSide = isOriginSide || positioning.side === 'inline-end';
     isPhysicalLeft = isPhysicalLeft || positioning.side === 'inline-end';
   } else {
-    isOriginSide = isOriginSide || positioning.side === 'inline-start';
     isPhysicalLeft = isPhysicalLeft || positioning.side === 'inline-start';
   }
+  const isOriginSide = positioning.side === 'top' || isPhysicalLeft;
 
   const element = useRenderElement('nav', componentProps, {
     state,

--- a/packages/react/src/navigation-menu/popup/NavigationMenuPopup.tsx
+++ b/packages/react/src/navigation-menu/popup/NavigationMenuPopup.tsx
@@ -11,6 +11,7 @@ import { useDirection } from '../../internals/direction-context/DirectionContext
 import { StateAttributesMapping } from '../../internals/getStateAttributesProps';
 import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
 import { Align, Side } from '../../utils/useAnchorPositioning';
+import { getDisabledMountTransitionStyles } from '../../utils/getDisabledMountTransitionStyles';
 
 const stateAttributesMapping: StateAttributesMapping<NavigationMenuPopupState> = {
   ...baseMapping,
@@ -67,6 +68,7 @@ export const NavigationMenuPopup = React.forwardRef(function NavigationMenuPopup
             }
           : {},
       },
+      getDisabledMountTransitionStyles(transitionStatus),
       elementProps,
     ],
     stateAttributesMapping,

--- a/packages/react/src/navigation-menu/popup/NavigationMenuPopupDataAttributes.ts
+++ b/packages/react/src/navigation-menu/popup/NavigationMenuPopupDataAttributes.ts
@@ -18,6 +18,10 @@ export enum NavigationMenuPopupDataAttributes {
    */
   endingStyle = CommonPopupDataAttributes.endingStyle,
   /**
+   * Present when the anchor is hidden.
+   */
+  anchorHidden = CommonPopupDataAttributes.anchorHidden,
+  /**
    * Indicates which side the popup is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}
    */

--- a/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
+++ b/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
@@ -137,14 +137,20 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
   };
 
   React.useEffect(() => {
-    if (!open) {
+    if (!open || !instant) {
       return undefined;
     }
 
-    if (instant) {
-      instantTimeout.start(0, () => {
-        setInstant(false);
-      });
+    instantTimeout.start(0, () => {
+      setInstant(false);
+    });
+
+    return undefined;
+  }, [open, instant, instantTimeout]);
+
+  React.useEffect(() => {
+    if (!open) {
+      return undefined;
     }
 
     function handleResize() {
@@ -159,7 +165,7 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
 
     const win = ownerWindow(positionerElement);
     return addEventListener(win, 'resize', handleResize);
-  }, [open, instant, instantTimeout, positionerElement]);
+  }, [open, instantTimeout, positionerElement]);
 
   const element = usePositioner(componentProps, state, {
     styles: positioning.positionerStyles,

--- a/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
+++ b/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
@@ -133,7 +133,7 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
     side: positioning.side,
     align: positioning.align,
     anchorHidden: positioning.anchorHidden,
-    instant: instant || transitionStatus === 'starting',
+    instant,
   };
 
   React.useEffect(() => {

--- a/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
+++ b/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
@@ -146,9 +146,12 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
     }
 
     if (needsInitialInstantResetRef.current) {
-      needsInitialInstantResetRef.current = false;
       initialInstantTimeout.start(0, () => {
-        setInstant(false);
+        needsInitialInstantResetRef.current = false;
+
+        if (!resizeTimeout.isStarted()) {
+          setInstant(false);
+        }
       });
     }
 

--- a/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
+++ b/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
@@ -72,9 +72,13 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
   const keepMounted = useNavigationMenuPortalContext();
   const nodeId = useNavigationMenuTreeContext();
 
-  const instantTimeout = useTimeout();
+  const initialInstantTimeout = useTimeout();
+  const resizeTimeout = useTimeout();
 
+  // When the menu is initially open, disable the positioner's transition for one frame
+  // so a default value does not animate in from the unpositioned portal state.
   const [instant, setInstant] = React.useState(open);
+  const needsInitialInstantResetRef = React.useRef(open);
 
   const positionerRef = React.useRef<HTMLDivElement | null>(null);
   const prevTriggerElementRef = React.useRef<Element | null>(null);
@@ -141,8 +145,9 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
       return undefined;
     }
 
-    if (instant) {
-      instantTimeout.start(0, () => {
+    if (needsInitialInstantResetRef.current) {
+      needsInitialInstantResetRef.current = false;
+      initialInstantTimeout.start(0, () => {
         setInstant(false);
       });
     }
@@ -152,14 +157,14 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
         setInstant(true);
       });
 
-      instantTimeout.start(100, () => {
+      resizeTimeout.start(100, () => {
         setInstant(false);
       });
     }
 
     const win = ownerWindow(positionerElement);
     return addEventListener(win, 'resize', handleResize);
-  }, [open, instant, instantTimeout, positionerElement]);
+  }, [open, initialInstantTimeout, resizeTimeout, positionerElement]);
 
   const element = usePositioner(componentProps, state, {
     styles: positioning.positionerStyles,

--- a/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
+++ b/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
@@ -137,20 +137,14 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
   };
 
   React.useEffect(() => {
-    if (!open || !instant) {
+    if (!open) {
       return undefined;
     }
 
-    instantTimeout.start(0, () => {
-      setInstant(false);
-    });
-
-    return undefined;
-  }, [open, instant, instantTimeout]);
-
-  React.useEffect(() => {
-    if (!open) {
-      return undefined;
+    if (instant) {
+      instantTimeout.start(0, () => {
+        setInstant(false);
+      });
     }
 
     function handleResize() {
@@ -165,7 +159,7 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
 
     const win = ownerWindow(positionerElement);
     return addEventListener(win, 'resize', handleResize);
-  }, [open, instantTimeout, positionerElement]);
+  }, [open, instant, instantTimeout, positionerElement]);
 
   const element = usePositioner(componentProps, state, {
     styles: positioning.positionerStyles,

--- a/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
+++ b/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
@@ -72,9 +72,9 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
   const keepMounted = useNavigationMenuPortalContext();
   const nodeId = useNavigationMenuTreeContext();
 
-  const resizeTimeout = useTimeout();
+  const instantTimeout = useTimeout();
 
-  const [instant, setInstant] = React.useState(false);
+  const [instant, setInstant] = React.useState(open);
 
   const positionerRef = React.useRef<HTMLDivElement | null>(null);
   const prevTriggerElementRef = React.useRef<Element | null>(null);
@@ -133,7 +133,7 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
     side: positioning.side,
     align: positioning.align,
     anchorHidden: positioning.anchorHidden,
-    instant,
+    instant: instant || transitionStatus === 'starting',
   };
 
   React.useEffect(() => {
@@ -141,19 +141,25 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
       return undefined;
     }
 
+    if (instant) {
+      instantTimeout.start(0, () => {
+        setInstant(false);
+      });
+    }
+
     function handleResize() {
       ReactDOM.flushSync(() => {
         setInstant(true);
       });
 
-      resizeTimeout.start(100, () => {
+      instantTimeout.start(100, () => {
         setInstant(false);
       });
     }
 
     const win = ownerWindow(positionerElement);
     return addEventListener(win, 'resize', handleResize);
-  }, [open, resizeTimeout, positionerElement]);
+  }, [open, instant, instantTimeout, positionerElement]);
 
   const element = usePositioner(componentProps, state, {
     styles: positioning.positionerStyles,

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -79,6 +79,31 @@ function TestNavigationMenuWithTopLevelLink(props: NavigationMenu.Root.Props = {
   );
 }
 
+function TestNavigationMenuWithDisabledTrigger(props: NavigationMenu.Root.Props = {}) {
+  return (
+    <NavigationMenu.Root {...props}>
+      <NavigationMenu.List>
+        <NavigationMenu.Item value="item-1">
+          <NavigationMenu.Trigger data-testid="trigger-1" disabled>
+            Item 1
+          </NavigationMenu.Trigger>
+          <NavigationMenu.Content data-testid="popup-1">
+            <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
+          </NavigationMenu.Content>
+        </NavigationMenu.Item>
+      </NavigationMenu.List>
+
+      <NavigationMenu.Portal>
+        <NavigationMenu.Positioner>
+          <NavigationMenu.Popup>
+            <NavigationMenu.Viewport />
+          </NavigationMenu.Popup>
+        </NavigationMenu.Positioner>
+      </NavigationMenu.Portal>
+    </NavigationMenu.Root>
+  );
+}
+
 const scopedPopupAnimationStyles = `
   .test-navigation-menu-popup {
     transition-property: opacity, transform, width, height;
@@ -1496,6 +1521,65 @@ describe('<NavigationMenu.Root />', () => {
       expect(onValueChange.mock.lastCall?.[0]).toBe('item-2');
     });
 
+    it('does not emit a duplicate onValueChange when switching items via keyboard', async () => {
+      const onValueChange = vi.fn();
+      const { user } = await render(<TestNavigationMenu onValueChange={onValueChange} />);
+      const trigger1 = screen.getByTestId('trigger-1');
+      const trigger2 = screen.getByTestId('trigger-2');
+
+      await act(async () => {
+        trigger1.focus();
+      });
+      await user.keyboard('{ArrowDown}');
+      await flushMicrotasks();
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.lastCall?.[0]).toBe('item-1');
+
+      // Switching to another open item via the arrow key previously also ran the activation
+      // path's `triggerPress` setValue, emitting a second onValueChange for the same item.
+      await act(async () => {
+        trigger2.focus();
+      });
+      await user.keyboard('{ArrowDown}');
+      await flushMicrotasks();
+
+      expect(onValueChange.mock.calls.filter((call) => call[0] === 'item-2')).toHaveLength(1);
+      expect(trigger2).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('treats a falsy item value as a valid open value', async () => {
+      const onValueChange = vi.fn();
+      await render(
+        <NavigationMenu.Root onValueChange={onValueChange}>
+          <NavigationMenu.List>
+            <NavigationMenu.Item value={0}>
+              <NavigationMenu.Trigger data-testid="trigger-0">Zero</NavigationMenu.Trigger>
+              <NavigationMenu.Content data-testid="popup-0">
+                <NavigationMenu.Link href="#link-0">Zero link</NavigationMenu.Link>
+              </NavigationMenu.Content>
+            </NavigationMenu.Item>
+          </NavigationMenu.List>
+          <NavigationMenu.Portal>
+            <NavigationMenu.Positioner>
+              <NavigationMenu.Popup>
+                <NavigationMenu.Viewport />
+              </NavigationMenu.Popup>
+            </NavigationMenu.Positioner>
+          </NavigationMenu.Portal>
+        </NavigationMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger-0');
+
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.lastCall?.[0]).toBe(0);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.queryByTestId('popup-0')).not.toBe(null);
+    });
+
     it('should be controlled by value prop', async () => {
       const { setProps } = await render(<TestNavigationMenu value="item-1" />);
 
@@ -1693,6 +1777,114 @@ describe('<NavigationMenu.Root />', () => {
 
       expect(screen.queryByTestId('popup-1')).toBe(null);
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  describe('prop: disabled', () => {
+    it('does not open on hover when the trigger is disabled', async () => {
+      const onValueChange = vi.fn();
+      await render(<TestNavigationMenuWithDisabledTrigger onValueChange={onValueChange} />);
+      const trigger = screen.getByTestId('trigger-1');
+
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
+      clock.tick(OPEN_DELAY);
+      await flushMicrotasks();
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByTestId('popup-1')).toBe(null);
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('does not open on click when the trigger is disabled', async () => {
+      const onValueChange = vi.fn();
+      await render(<TestNavigationMenuWithDisabledTrigger onValueChange={onValueChange} />);
+      const trigger = screen.getByTestId('trigger-1');
+
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByTestId('popup-1')).toBe(null);
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('does not open via keyboard when the trigger is disabled', async () => {
+      const onValueChange = vi.fn();
+      const { user } = await render(
+        <TestNavigationMenuWithDisabledTrigger onValueChange={onValueChange} />,
+      );
+      const trigger = screen.getByTestId('trigger-1');
+
+      await act(async () => {
+        trigger.focus();
+      });
+      await user.keyboard('{ArrowDown}');
+      await flushMicrotasks();
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByTestId('popup-1')).toBe(null);
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('prop: actionsRef', () => {
+    it('exposes an unmount action and defers unmounting until it is called', async () => {
+      const actionsRef = React.createRef<NavigationMenu.Root.Actions>();
+
+      function ControlledNavigationMenu(props: { value: string | null }) {
+        return <TestNavigationMenu value={props.value} actionsRef={actionsRef} />;
+      }
+
+      const { rerender } = await render(<ControlledNavigationMenu value="item-1" />);
+
+      expect(actionsRef.current).not.toBe(null);
+      expect(actionsRef.current?.unmount).toBeTypeOf('function');
+      expect(screen.queryByTestId('popup-root')).not.toBe(null);
+
+      // Closing keeps the popup mounted because `actionsRef` disables the automatic unmount.
+      await rerender(<ControlledNavigationMenu value={null} />);
+      await flushMicrotasks();
+      expect(screen.queryByTestId('popup-root')).not.toBe(null);
+
+      await act(async () => {
+        actionsRef.current?.unmount();
+      });
+      await flushMicrotasks();
+
+      expect(screen.queryByTestId('popup-root')).toBe(null);
+    });
+  });
+
+  describe('prop: side', () => {
+    it('pins the popup to the right edge when side="left" so it grows leftward', async () => {
+      await render(
+        <NavigationMenu.Root>
+          <NavigationMenu.List>
+            <NavigationMenu.Item value="item-1">
+              <NavigationMenu.Trigger data-testid="trigger-1">Item 1</NavigationMenu.Trigger>
+              <NavigationMenu.Content>
+                <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
+              </NavigationMenu.Content>
+            </NavigationMenu.Item>
+          </NavigationMenu.List>
+          <NavigationMenu.Portal>
+            <NavigationMenu.Positioner side="left">
+              <NavigationMenu.Popup data-testid="popup-root">
+                <NavigationMenu.Viewport />
+              </NavigationMenu.Popup>
+            </NavigationMenu.Positioner>
+          </NavigationMenu.Portal>
+        </NavigationMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger-1');
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      const popup = screen.getByTestId('popup-root');
+      expect(popup).toHaveAttribute('data-side', 'left');
+      expect(popup).toHaveStyle({ position: 'absolute', top: '0px', right: '0px' });
     });
   });
 

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -1507,14 +1507,6 @@ describe('<NavigationMenu.Root />', () => {
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
 
-    it('marks the positioner instant while opening a kept portal', async () => {
-      await render(<TestNavigationMenu keepMountedPortal />);
-
-      fireEvent.click(screen.getByTestId('trigger-1'));
-
-      expect(screen.getByTestId('top-level-positioner')).toHaveAttribute('data-instant');
-    });
-
     it('disables popup and arrow transitions while a kept portal opens', async () => {
       await render(
         <NavigationMenu.Root>

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -3242,7 +3242,15 @@ describe('<NavigationMenu.Root />', () => {
           popupHeight = 180;
 
           fireEvent(window, new Event('resize'));
+          expect(positioner).toHaveAttribute('data-instant');
+
+          clock.tick(0);
           await flushMicrotasks();
+          expect(positioner).toHaveAttribute('data-instant');
+
+          clock.tick(100);
+          await flushMicrotasks();
+          expect(positioner).not.toHaveAttribute('data-instant');
 
           await waitFor(() => {
             expect(popupRoot.style.getPropertyValue('--popup-width')).toBe('auto');

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -1506,6 +1506,46 @@ describe('<NavigationMenu.Root />', () => {
       await flushMicrotasks();
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
+
+    it('marks the positioner instant while opening a kept portal', async () => {
+      await render(<TestNavigationMenu keepMountedPortal />);
+
+      fireEvent.click(screen.getByTestId('trigger-1'));
+
+      expect(screen.getByTestId('top-level-positioner')).toHaveAttribute('data-instant');
+    });
+
+    it('disables popup and arrow transitions while a kept portal opens', async () => {
+      await render(
+        <NavigationMenu.Root>
+          <NavigationMenu.List>
+            <NavigationMenu.Item value="item-1">
+              <NavigationMenu.Trigger data-testid="trigger-1">Item 1</NavigationMenu.Trigger>
+              <NavigationMenu.Content>
+                <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
+              </NavigationMenu.Content>
+            </NavigationMenu.Item>
+          </NavigationMenu.List>
+          <NavigationMenu.Portal keepMounted>
+            <NavigationMenu.Positioner>
+              <NavigationMenu.Popup data-testid="popup-root">
+                <NavigationMenu.Arrow data-testid="arrow" />
+                <NavigationMenu.Viewport />
+              </NavigationMenu.Popup>
+            </NavigationMenu.Positioner>
+          </NavigationMenu.Portal>
+        </NavigationMenu.Root>,
+      );
+
+      fireEvent.click(screen.getByTestId('trigger-1'));
+
+      expect(screen.getByTestId('popup-root')).toHaveStyle({
+        transition: 'none',
+      });
+      expect(screen.getByTestId('arrow')).toHaveStyle({
+        transition: 'none',
+      });
+    });
   });
 
   describe('prop: onValueChange', () => {

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -3744,3 +3744,26 @@ describe('<NavigationMenu.Root />', () => {
     });
   });
 });
+
+describe('initial open', () => {
+  // A dedicated renderer without `shouldAdvanceTime` so the one-frame instant reset
+  // (scheduled via a zero-delay timeout) can be observed deterministically rather
+  // than racing the assertion.
+  const { render, clock } = createRenderer();
+
+  clock.withFakeTimers();
+
+  it('suppresses the positioner transition for the first frame while initially open', async () => {
+    await render(<TestNavigationMenu defaultValue="item-1" />);
+
+    // While initially open, the positioner starts with its transition suppressed so a
+    // default value does not animate in from the unpositioned portal state.
+    const positioner = screen.getByTestId('top-level-positioner');
+    expect(positioner).toHaveAttribute('data-instant');
+
+    // The suppression is released on the next tick.
+    clock.tick(0);
+    await flushMicrotasks();
+    expect(positioner).not.toHaveAttribute('data-instant');
+  });
+});

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -285,11 +285,16 @@ function TestNavigationMenuOrientationAttributes() {
 
 function TestInlineNestedNavigationMenu(
   props: {
-    nestedDefaultValue?: string | null;
+    nestedDefaultValue?: string | number | null;
+    nestedItem1Value?: string | number;
     keepMountedContent?: boolean;
   } = {},
 ) {
-  const { nestedDefaultValue = 'nested-item-1', keepMountedContent = false } = props;
+  const {
+    nestedDefaultValue = 'nested-item-1',
+    nestedItem1Value = 'nested-item-1',
+    keepMountedContent = false,
+  } = props;
   const nestedRootProps =
     nestedDefaultValue == null ? undefined : { defaultValue: nestedDefaultValue };
 
@@ -303,7 +308,7 @@ function TestInlineNestedNavigationMenu(
             <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
             <NavigationMenu.Root {...nestedRootProps}>
               <NavigationMenu.List data-testid="inline-nested-list">
-                <NavigationMenu.Item value="nested-item-1">
+                <NavigationMenu.Item value={nestedItem1Value}>
                   <NavigationMenu.Trigger data-testid="nested-trigger-1">
                     Nested Item 1
                   </NavigationMenu.Trigger>
@@ -2595,6 +2600,27 @@ describe('<NavigationMenu.Root />', () => {
         expect(nestedTrigger1).toHaveAttribute('aria-expanded', 'false');
         expect(screen.queryByTestId('nested-popup-2')).not.toBe(null);
         expect(screen.queryByTestId('nested-popup-1')).toBe(null);
+      });
+
+      it('treats a falsy value as open for inline nested trigger interactions', async () => {
+        await render(
+          <TestInlineNestedNavigationMenu nestedDefaultValue={0} nestedItem1Value={0} />,
+        );
+        const trigger1 = screen.getByTestId('trigger-1');
+
+        fireEvent.click(trigger1);
+        await flushMicrotasks();
+
+        const popup1 = screen.getByTestId('popup-1');
+        const nestedTrigger1 = within(popup1).getByTestId('nested-trigger-1');
+        expect(nestedTrigger1).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.queryByTestId('nested-popup-1')).not.toBe(null);
+
+        fireEvent.click(nestedTrigger1);
+        await flushMicrotasks();
+
+        expect(nestedTrigger1).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.queryByTestId('nested-popup-1')).not.toBe(null);
       });
 
       it('allows arrow key navigation to submenu triggers', async () => {

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -1523,17 +1523,6 @@ describe('<NavigationMenu.Root />', () => {
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
 
-    it.skipIf(isJSDOM)('disables positioner transitions while initially open', async () => {
-      await render(<TestNavigationMenu defaultValue="item-1" />);
-
-      const positioner = screen.getByTestId('top-level-positioner');
-      expect(positioner).toHaveAttribute('data-instant');
-
-      await waitFor(() => {
-        expect(positioner).not.toHaveAttribute('data-instant');
-      });
-    });
-
     it('disables popup and arrow transitions while a kept portal opens', async () => {
       await render(
         <NavigationMenu.Root>

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -3,10 +3,19 @@ import * as React from 'react';
 import { fireEvent, screen, flushMicrotasks, act, within, waitFor } from '@mui/internal-test-utils';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { Dialog } from '@base-ui/react/dialog';
+import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
 import { Popover } from '@base-ui/react/popover';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { PATIENT_CLICK_THRESHOLD } from '../../internals/constants';
 import { OPEN_DELAY } from '../utils/constants';
+
+type FalsyNavigationMenuValue = 0 | '' | false;
+
+const falsyNavigationMenuValueCases = [
+  ['0', 0],
+  ['empty string', ''],
+  ['false', false],
+] as const satisfies ReadonlyArray<[string, FalsyNavigationMenuValue]>;
 
 function TestNavigationMenu(
   props: NavigationMenu.Root.Props & {
@@ -285,15 +294,17 @@ function TestNavigationMenuOrientationAttributes() {
 
 function TestInlineNestedNavigationMenu(
   props: {
-    nestedDefaultValue?: string | number | null;
-    nestedItem1Value?: string | number;
+    nestedDefaultValue?: string | number | boolean | null;
+    nestedItem1Value?: string | number | boolean;
     keepMountedContent?: boolean;
+    nestedLinkCloseOnClick?: boolean;
   } = {},
 ) {
   const {
     nestedDefaultValue = 'nested-item-1',
     nestedItem1Value = 'nested-item-1',
     keepMountedContent = false,
+    nestedLinkCloseOnClick = false,
   } = props;
   const nestedRootProps =
     nestedDefaultValue == null ? undefined : { defaultValue: nestedDefaultValue };
@@ -316,7 +327,12 @@ function TestInlineNestedNavigationMenu(
                     data-testid="nested-popup-1"
                     keepMounted={keepMountedContent}
                   >
-                    <NavigationMenu.Link href="#nested-link-1">Nested Link 1</NavigationMenu.Link>
+                    <NavigationMenu.Link
+                      href="#nested-link-1"
+                      closeOnClick={nestedLinkCloseOnClick}
+                    >
+                      Nested Link 1
+                    </NavigationMenu.Link>
                   </NavigationMenu.Content>
                 </NavigationMenu.Item>
                 <NavigationMenu.Item value="nested-item-2">
@@ -1537,6 +1553,15 @@ describe('<NavigationMenu.Root />', () => {
       expect(screen.getByTestId('arrow')).toHaveStyle({
         transition: 'none',
       });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-root')).not.toHaveStyle({
+          transition: 'none',
+        });
+      });
+      expect(screen.getByTestId('arrow')).not.toHaveStyle({
+        transition: 'none',
+      });
     });
   });
 
@@ -1564,19 +1589,19 @@ describe('<NavigationMenu.Root />', () => {
       const trigger1 = screen.getByTestId('trigger-1');
       const trigger2 = screen.getByTestId('trigger-2');
 
-      await act(async () => {
-        trigger1.focus();
-      });
-      await user.keyboard('{ArrowDown}');
+      await user.click(trigger1);
       await flushMicrotasks();
       expect(onValueChange.mock.calls.length).toBe(1);
       expect(onValueChange.mock.lastCall?.[0]).toBe('item-1');
 
-      // Switching to another open item via the arrow key previously also ran the activation
-      // path's `triggerPress` setValue, emitting a second onValueChange for the same item.
       await act(async () => {
-        trigger2.focus();
+        trigger1.focus();
       });
+      await user.keyboard('{ArrowRight}');
+      await flushMicrotasks();
+      expect(trigger2).toHaveFocus();
+      expect(onValueChange.mock.calls.filter((call) => call[0] === 'item-2')).toHaveLength(0);
+
       await user.keyboard('{ArrowDown}');
       await flushMicrotasks();
 
@@ -1584,38 +1609,41 @@ describe('<NavigationMenu.Root />', () => {
       expect(trigger2).toHaveAttribute('aria-expanded', 'true');
     });
 
-    it('treats a falsy item value as a valid open value', async () => {
-      const onValueChange = vi.fn();
-      await render(
-        <NavigationMenu.Root onValueChange={onValueChange}>
-          <NavigationMenu.List>
-            <NavigationMenu.Item value={0}>
-              <NavigationMenu.Trigger data-testid="trigger-0">Zero</NavigationMenu.Trigger>
-              <NavigationMenu.Content data-testid="popup-0">
-                <NavigationMenu.Link href="#link-0">Zero link</NavigationMenu.Link>
-              </NavigationMenu.Content>
-            </NavigationMenu.Item>
-          </NavigationMenu.List>
-          <NavigationMenu.Portal>
-            <NavigationMenu.Positioner>
-              <NavigationMenu.Popup>
-                <NavigationMenu.Viewport />
-              </NavigationMenu.Popup>
-            </NavigationMenu.Positioner>
-          </NavigationMenu.Portal>
-        </NavigationMenu.Root>,
-      );
+    it.each(falsyNavigationMenuValueCases)(
+      'treats a falsy item value (%s) as a valid open value',
+      async (_label, itemValue) => {
+        const onValueChange = vi.fn();
+        await render(
+          <NavigationMenu.Root<FalsyNavigationMenuValue> onValueChange={onValueChange}>
+            <NavigationMenu.List>
+              <NavigationMenu.Item value={itemValue}>
+                <NavigationMenu.Trigger data-testid="trigger-0">Zero</NavigationMenu.Trigger>
+                <NavigationMenu.Content data-testid="popup-0">
+                  <NavigationMenu.Link href="#link-0">Zero link</NavigationMenu.Link>
+                </NavigationMenu.Content>
+              </NavigationMenu.Item>
+            </NavigationMenu.List>
+            <NavigationMenu.Portal>
+              <NavigationMenu.Positioner>
+                <NavigationMenu.Popup>
+                  <NavigationMenu.Viewport />
+                </NavigationMenu.Popup>
+              </NavigationMenu.Positioner>
+            </NavigationMenu.Portal>
+          </NavigationMenu.Root>,
+        );
 
-      const trigger = screen.getByTestId('trigger-0');
+        const trigger = screen.getByTestId('trigger-0');
 
-      fireEvent.click(trigger);
-      await flushMicrotasks();
+        fireEvent.click(trigger);
+        await flushMicrotasks();
 
-      expect(onValueChange.mock.calls.length).toBe(1);
-      expect(onValueChange.mock.lastCall?.[0]).toBe(0);
-      expect(trigger).toHaveAttribute('aria-expanded', 'true');
-      expect(screen.queryByTestId('popup-0')).not.toBe(null);
-    });
+        expect(onValueChange.mock.calls.length).toBe(1);
+        expect(onValueChange.mock.lastCall?.[0]).toBe(itemValue);
+        expect(trigger).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.queryByTestId('popup-0')).not.toBe(null);
+      },
+    );
 
     it('should be controlled by value prop', async () => {
       const { setProps } = await render(<TestNavigationMenu value="item-1" />);
@@ -1823,8 +1851,7 @@ describe('<NavigationMenu.Root />', () => {
       await render(<TestNavigationMenuWithDisabledTrigger onValueChange={onValueChange} />);
       const trigger = screen.getByTestId('trigger-1');
 
-      fireEvent.mouseEnter(trigger);
-      fireEvent.mouseMove(trigger);
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
       clock.tick(OPEN_DELAY);
       await flushMicrotasks();
 
@@ -1838,6 +1865,21 @@ describe('<NavigationMenu.Root />', () => {
       await render(<TestNavigationMenuWithDisabledTrigger onValueChange={onValueChange} />);
       const trigger = screen.getByTestId('trigger-1');
 
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByTestId('popup-1')).toBe(null);
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('does not open on touch when the trigger is disabled', async () => {
+      const onValueChange = vi.fn();
+      await render(<TestNavigationMenuWithDisabledTrigger onValueChange={onValueChange} />);
+      const trigger = screen.getByTestId('trigger-1');
+
+      fireEvent.pointerDown(trigger, { pointerType: 'touch' });
+      fireEvent.pointerUp(trigger, { pointerType: 'touch' });
       fireEvent.click(trigger);
       await flushMicrotasks();
 
@@ -1891,38 +1933,85 @@ describe('<NavigationMenu.Root />', () => {
 
       expect(screen.queryByTestId('popup-root')).toBe(null);
     });
+
+    it('unmounts immediately when called while the popup is closing', async () => {
+      const previousAnimationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+      try {
+        const actionsRef = React.createRef<NavigationMenu.Root.Actions>();
+
+        function ControlledNavigationMenu(props: { value: string | null }) {
+          return <TestNavigationMenu value={props.value} actionsRef={actionsRef} />;
+        }
+
+        const { rerender } = await render(<ControlledNavigationMenu value="item-1" />);
+
+        const popupRoot = screen.getByTestId('popup-root');
+        const animations = mockAnimations(popupRoot);
+        const closingAnimation = animations.start();
+
+        await rerender(<ControlledNavigationMenu value={null} />);
+        await flushMicrotasks();
+
+        expect(popupRoot).toHaveAttribute('data-ending-style');
+
+        await act(async () => {
+          actionsRef.current?.unmount();
+        });
+        await flushMicrotasks();
+
+        expect(screen.queryByTestId('popup-root')).toBe(null);
+
+        await act(async () => {
+          animations.finish(closingAnimation);
+          await flushMicrotasks();
+        });
+      } finally {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = previousAnimationsDisabled;
+      }
+    });
   });
 
   describe('prop: side', () => {
-    it('pins the popup to the right edge when side="left" so it grows leftward', async () => {
-      await render(
-        <NavigationMenu.Root>
-          <NavigationMenu.List>
-            <NavigationMenu.Item value="item-1">
-              <NavigationMenu.Trigger data-testid="trigger-1">Item 1</NavigationMenu.Trigger>
-              <NavigationMenu.Content>
-                <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
-              </NavigationMenu.Content>
-            </NavigationMenu.Item>
-          </NavigationMenu.List>
-          <NavigationMenu.Portal>
-            <NavigationMenu.Positioner side="left">
-              <NavigationMenu.Popup data-testid="popup-root">
-                <NavigationMenu.Viewport />
-              </NavigationMenu.Popup>
-            </NavigationMenu.Positioner>
-          </NavigationMenu.Portal>
-        </NavigationMenu.Root>,
-      );
+    it.each([
+      ['left in LTR', 'ltr', 'left'],
+      ['inline-start in LTR', 'ltr', 'inline-start'],
+      ['inline-end in RTL', 'rtl', 'inline-end'],
+    ] as const)(
+      'pins the popup to the right edge when side is %s so it grows leftward',
+      async (_label, direction, side) => {
+        await render(
+          <DirectionProvider direction={direction as TextDirection}>
+            <NavigationMenu.Root>
+              <NavigationMenu.List>
+                <NavigationMenu.Item value="item-1">
+                  <NavigationMenu.Trigger data-testid="trigger-1">Item 1</NavigationMenu.Trigger>
+                  <NavigationMenu.Content>
+                    <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
+                  </NavigationMenu.Content>
+                </NavigationMenu.Item>
+              </NavigationMenu.List>
+              <NavigationMenu.Portal>
+                <NavigationMenu.Positioner side={side}>
+                  <NavigationMenu.Popup data-testid="popup-root">
+                    <NavigationMenu.Viewport />
+                  </NavigationMenu.Popup>
+                </NavigationMenu.Positioner>
+              </NavigationMenu.Portal>
+            </NavigationMenu.Root>
+          </DirectionProvider>,
+        );
 
-      const trigger = screen.getByTestId('trigger-1');
-      fireEvent.click(trigger);
-      await flushMicrotasks();
+        const trigger = screen.getByTestId('trigger-1');
+        fireEvent.click(trigger);
+        await flushMicrotasks();
 
-      const popup = screen.getByTestId('popup-root');
-      expect(popup).toHaveAttribute('data-side', 'left');
-      expect(popup).toHaveStyle({ position: 'absolute', top: '0px', right: '0px' });
-    });
+        const popup = screen.getByTestId('popup-root');
+        expect(popup).toHaveAttribute('data-side', side);
+        expect(popup).toHaveStyle({ position: 'absolute', top: '0px', right: '0px' });
+      },
+    );
   });
 
   describe('tabbing', () => {
@@ -2634,9 +2723,40 @@ describe('<NavigationMenu.Root />', () => {
         expect(screen.queryByTestId('nested-popup-1')).toBe(null);
       });
 
-      it('treats a falsy value as open for inline nested trigger interactions', async () => {
+      it.each(falsyNavigationMenuValueCases)(
+        'treats a falsy value (%s) as open for inline nested trigger interactions',
+        async (_label, itemValue) => {
+          await render(
+            <TestInlineNestedNavigationMenu
+              nestedDefaultValue={itemValue}
+              nestedItem1Value={itemValue}
+            />,
+          );
+          const trigger1 = screen.getByTestId('trigger-1');
+
+          fireEvent.click(trigger1);
+          await flushMicrotasks();
+
+          const popup1 = screen.getByTestId('popup-1');
+          const nestedTrigger1 = within(popup1).getByTestId('nested-trigger-1');
+          expect(nestedTrigger1).toHaveAttribute('aria-expanded', 'true');
+          expect(screen.queryByTestId('nested-popup-1')).not.toBe(null);
+
+          fireEvent.click(nestedTrigger1);
+          await flushMicrotasks();
+
+          expect(nestedTrigger1).toHaveAttribute('aria-expanded', 'true');
+          expect(screen.queryByTestId('nested-popup-1')).not.toBe(null);
+        },
+      );
+
+      it('propagates a nested close with a falsy open value to the parent root', async () => {
         await render(
-          <TestInlineNestedNavigationMenu nestedDefaultValue={0} nestedItem1Value={0} />,
+          <TestInlineNestedNavigationMenu
+            nestedDefaultValue={false}
+            nestedItem1Value={false}
+            nestedLinkCloseOnClick
+          />,
         );
         const trigger1 = screen.getByTestId('trigger-1');
 
@@ -2646,13 +2766,12 @@ describe('<NavigationMenu.Root />', () => {
         const popup1 = screen.getByTestId('popup-1');
         const nestedTrigger1 = within(popup1).getByTestId('nested-trigger-1');
         expect(nestedTrigger1).toHaveAttribute('aria-expanded', 'true');
-        expect(screen.queryByTestId('nested-popup-1')).not.toBe(null);
 
-        fireEvent.click(nestedTrigger1);
+        fireEvent.click(screen.getByText('Nested Link 1'));
         await flushMicrotasks();
 
-        expect(nestedTrigger1).toHaveAttribute('aria-expanded', 'true');
-        expect(screen.queryByTestId('nested-popup-1')).not.toBe(null);
+        expect(trigger1).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.queryByTestId('popup-1')).toBe(null);
       });
 
       it('allows arrow key navigation to submenu triggers', async () => {

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -1523,6 +1523,17 @@ describe('<NavigationMenu.Root />', () => {
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
 
+    it.skipIf(isJSDOM)('disables positioner transitions while initially open', async () => {
+      await render(<TestNavigationMenu defaultValue="item-1" />);
+
+      const positioner = screen.getByTestId('top-level-positioner');
+      expect(positioner).toHaveAttribute('data-instant');
+
+      await waitFor(() => {
+        expect(positioner).not.toHaveAttribute('data-instant');
+      });
+    });
+
     it('disables popup and arrow transitions while a kept portal opens', async () => {
       await render(
         <NavigationMenu.Root>
@@ -1851,7 +1862,8 @@ describe('<NavigationMenu.Root />', () => {
       await render(<TestNavigationMenuWithDisabledTrigger onValueChange={onValueChange} />);
       const trigger = screen.getByTestId('trigger-1');
 
-      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
       clock.tick(OPEN_DELAY);
       await flushMicrotasks();
 
@@ -2721,6 +2733,44 @@ describe('<NavigationMenu.Root />', () => {
         expect(nestedTrigger1).toHaveAttribute('aria-expanded', 'false');
         expect(screen.queryByTestId('nested-popup-2')).not.toBe(null);
         expect(screen.queryByTestId('nested-popup-1')).toBe(null);
+      });
+
+      it('adds popup-open data attributes to the active icon', async () => {
+        await render(
+          <NavigationMenu.Root defaultValue="item-1">
+            <NavigationMenu.List>
+              <NavigationMenu.Item value="item-1">
+                <NavigationMenu.Trigger>
+                  Item 1
+                  <NavigationMenu.Icon data-testid="icon-1" />
+                </NavigationMenu.Trigger>
+                <NavigationMenu.Content>
+                  <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
+                </NavigationMenu.Content>
+              </NavigationMenu.Item>
+              <NavigationMenu.Item value="item-2">
+                <NavigationMenu.Trigger>
+                  Item 2
+                  <NavigationMenu.Icon data-testid="icon-2" />
+                </NavigationMenu.Trigger>
+                <NavigationMenu.Content>
+                  <NavigationMenu.Link href="#link-2">Link 2</NavigationMenu.Link>
+                </NavigationMenu.Content>
+              </NavigationMenu.Item>
+            </NavigationMenu.List>
+
+            <NavigationMenu.Portal>
+              <NavigationMenu.Positioner>
+                <NavigationMenu.Popup>
+                  <NavigationMenu.Viewport />
+                </NavigationMenu.Popup>
+              </NavigationMenu.Positioner>
+            </NavigationMenu.Portal>
+          </NavigationMenu.Root>,
+        );
+
+        expect(screen.getByTestId('icon-1')).toHaveAttribute('data-popup-open');
+        expect(screen.getByTestId('icon-2')).not.toHaveAttribute('data-popup-open');
       });
 
       it.each(falsyNavigationMenuValueCases)(

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.tsx
@@ -154,7 +154,7 @@ export const NavigationMenuRoot = React.forwardRef(function NavigationMenuRoot<V
       nextValue: NavigationMenuRoot.Value<Value>,
       eventDetails: NavigationMenuRoot.ChangeEventDetails,
     ) => {
-      if (!nextValue) {
+      if (nextValue == null) {
         closeReasonRef.current = eventDetails.reason;
       }
 
@@ -166,14 +166,19 @@ export const NavigationMenuRoot = React.forwardRef(function NavigationMenuRoot<V
         return;
       }
 
-      if (!nextValue) {
+      if (nextValue == null) {
         setActivationDirection(null);
         setFloatingRootContext(undefined);
       }
 
       setValueUnwrapped(nextValue);
 
-      if (nested && !nextValue && eventDetails.reason === REASONS.linkPress && parentRootContext) {
+      if (
+        nested &&
+        nextValue == null &&
+        eventDetails.reason === REASONS.linkPress &&
+        parentRootContext
+      ) {
         parentRootContext.setValue(null, eventDetails);
       }
     },
@@ -205,6 +210,8 @@ export const NavigationMenuRoot = React.forwardRef(function NavigationMenuRoot<V
     currentContentRef.current = null;
     closeReasonRef.current = undefined;
   });
+
+  React.useImperativeHandle(actionsRef, () => ({ unmount: handleUnmount }), [handleUnmount]);
 
   useOpenChangeComplete({
     enabled: !actionsRef,

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.tsx
@@ -211,6 +211,7 @@ export const NavigationMenuRoot = React.forwardRef(function NavigationMenuRoot<V
     closeReasonRef.current = undefined;
   });
 
+  // Providing `actionsRef` opts into manual unmounting, so close completion hooks leave it mounted.
   React.useImperativeHandle(actionsRef, () => ({ unmount: handleUnmount }), [handleUnmount]);
 
   useOpenChangeComplete({

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -127,9 +127,9 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
 
   const isActiveItem = open && value === itemValue;
   const isActiveItemRef = useValueAsRef(isActiveItem);
-  const interactionsEnabled = positionerElement ? true : !value;
+  const interactionsEnabled = (positionerElement ? true : !value) && !disabled;
   const hoverFloatingElement = positionerElement || viewportElement;
-  const hoverInteractionsEnabled = hoverFloatingElement ? true : !value;
+  const hoverInteractionsEnabled = (hoverFloatingElement ? true : !value) && !disabled;
 
   const runOnceAnimationsFinish = useAnimationsFinished(popupElement, false, false);
 
@@ -658,7 +658,9 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
         return;
       }
 
-      if (value != null) {
+      // Keyboard opening already sets the value with the `listNavigation` reason in the
+      // trigger's `onKeyDown`, so re-setting it here would emit a duplicate `onValueChange`.
+      if (value != null && event.type !== 'keydown') {
         setValue(
           itemValue,
           createChangeEventDetails(
@@ -695,6 +697,10 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   }
 
   const handleOpenEvent = useStableCallback((event: React.MouseEvent | React.KeyboardEvent) => {
+    if (disabled) {
+      return;
+    }
+
     if (!popupElement || !positionerElement) {
       handleActivation(event);
       return;

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -127,9 +127,9 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
 
   const isActiveItem = open && value === itemValue;
   const isActiveItemRef = useValueAsRef(isActiveItem);
-  const interactionsEnabled = (positionerElement ? true : !value) && !disabled;
+  const interactionsEnabled = (positionerElement ? true : value == null) && !disabled;
   const hoverFloatingElement = positionerElement || viewportElement;
-  const hoverInteractionsEnabled = (hoverFloatingElement ? true : !value) && !disabled;
+  const hoverInteractionsEnabled = (hoverFloatingElement ? true : value == null) && !disabled;
 
   const runOnceAnimationsFinish = useAnimationsFinished(popupElement, false, false);
 

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -127,9 +127,9 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
 
   const isActiveItem = open && value === itemValue;
   const isActiveItemRef = useValueAsRef(isActiveItem);
-  const interactionsEnabled = (positionerElement ? true : value == null) && !disabled;
+  const interactionsEnabled = (positionerElement != null || value == null) && !disabled;
   const hoverFloatingElement = positionerElement || viewportElement;
-  const hoverInteractionsEnabled = (hoverFloatingElement ? true : value == null) && !disabled;
+  const hoverInteractionsEnabled = (hoverFloatingElement != null || value == null) && !disabled;
 
   const runOnceAnimationsFinish = useAnimationsFinished(popupElement, false, false);
 

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -658,8 +658,8 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
         return;
       }
 
-      // Keyboard opening already sets the value with the `listNavigation` reason in the
-      // trigger's `onKeyDown`, so re-setting it here would emit a duplicate `onValueChange`.
+      // Keyboard open events reach this activation path after `onKeyDown` has already set
+      // the value with the `listNavigation` reason.
       if (value != null && event.type !== 'keydown') {
         setValue(
           itemValue,


### PR DESCRIPTION
This is part of the Codex sweep for Navigation Menu. It restores the local fixes from the recovered branch while preserving newer upstream changes.

## Changes

- Prevented disabled triggers from opening through hover, click, or keyboard paths.
- Avoided duplicate `onValueChange` calls when switching items via keyboard.
- Treated non-nullish falsy item values as valid open values.
- Exposed the documented `actionsRef.unmount()` action.
- Pinned left-side popup transitions to the correct edge.
- Documented the missing Navigation Menu styling hooks.

## Original findings addressed

- Disabled triggers could still activate their content.
- Keyboard activation could emit duplicate value changes.
- Falsy item values were handled like closed values in root cleanup.
- The documented imperative unmount action was not wired up.
- Popup and data-attribute styling hooks were incomplete.