### PR TITLE
[code-infra] Add flat build setup

### DIFF
--- a/babel.config.mjs
+++ b/babel.config.mjs
@@ -17,6 +17,7 @@ export default function getBabelConfig(api) {
         runtimeModule: '#formatErrorMessage',
         detection: 'opt-out',
         errorCodesPath,
+        outExtension: process.env.MUI_OUT_FILE_EXTENSION ?? undefined,
       },
     ],
   ];

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -113,8 +113,8 @@
   },
   "scripts": {
     "prebuild": "rimraf --glob build build-tests published-docs \"*.tsbuildinfo\" && node ./scripts/stagePublishedDocs.mjs",
-    "build": "code-infra build --ignore \"**/*.template.js\" --copy .npmignore --copy \"published-docs/**:docs\" --tsgo",
-    "test:package": "publint --pack pnpm && attw --pack ./build --exclude-entrypoints package.json --exclude-entrypoints esm --exclude-entrypoints cjs",
+    "build": "code-infra build --flat --ignore \"**/*.template.js\" --copy .npmignore --copy \"published-docs/**:docs\" --tsgo",
+    "test:package": "publint --pack pnpm && attw --pack ./build --exclude-entrypoints package.json",
     "release": "pnpm build && pnpm publish",
     "test": "cross-env VITEST_ENV=jsdom vitest",
     "typescript": "tsgo -b tsconfig.json"

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -10,7 +10,7 @@
     "moduleResolution": "bundler",
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "build/esm",
+    "outDir": "build",
     "types": ["@mui/internal-code-infra/build-env"],
     // Drop the `@base-ui/react` self-alias so tsgo emits relative `import()` types instead of
     // leaking internal, non-exported subpaths into `.d.ts`. Keep `@base-ui/utils/*` for resolution.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,15 +12,17 @@
   "exports": {
     "./store": "./src/store/index.ts",
     "./platform": "./src/platform/index.ts",
-    "./*": "./src/*.ts"
+    "./*": "./src/*.ts",
+    "./*.test": null,
+    "./*.spec": null
   },
   "imports": {
     "#formatErrorMessage": "./src/formatErrorMessage.ts"
   },
   "scripts": {
     "prebuild": "rimraf --glob build build-tests \"*.tsbuildinfo\"",
-    "build": "code-infra build --copy .npmignore --tsgo",
-    "test:package": "publint --pack pnpm run ./build && attw --pack ./build --exclude-entrypoints package.json --exclude-entrypoints esm --exclude-entrypoints cjs",
+    "build": "code-infra build --flat --copy .npmignore --tsgo",
+    "test:package": "publint --pack pnpm run ./build && attw --pack ./build --exclude-entrypoints package.json",
     "release": "pnpm build && pnpm publish",
     "test": "cross-env VITEST_ENV=jsdom vitest",
     "typescript": "tsgo -b tsconfig.json"

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -10,7 +10,7 @@
     "moduleResolution": "bundler",
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "build/esm",
+    "outDir": "build",
     "lib": ["ES2022", "DOM"],
     "types": ["@mui/internal-code-infra/build-env"]
   },

--- a/test/bundle-size/bundle-size-checker.config.mjs
+++ b/test/bundle-size/bundle-size-checker.config.mjs
@@ -47,7 +47,7 @@ async function getUtilsExports() {
         return false;
       }
       // Exclude test files
-      if (file.includes('.test.')) {
+      if (file.includes('.test.') || file.includes('.spec.')) {
         return false;
       }
       return true;


### PR DESCRIPTION
Adds the flat build setup (`code-infra build --flat`): build output is flat with extension-based module type (`.js` CJS, `.mjs` ESM, `.d.ts`/`.d.mts` types) instead of separate `esm`/`cjs` subdirectories.

Verified `publint` and `attw` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)