### PR TITLE
[select] Fix flaky tab-out test from stale focus-on-open

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -283,6 +283,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
   const initialFocusRef = useValueAsRef(initialFocus);
   const returnFocusRef = useValueAsRef(returnFocus);
   const openInteractionTypeRef = useValueAsRef(openInteractionType);
+  const openRef = useValueAsRef(open);
 
   const tree = useFloatingTree(externalTree);
   const portalContext = usePortalContext();
@@ -693,6 +694,13 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
       enqueueFocus(elToFocus, {
         preventScroll: elToFocus === floatingFocusElement,
         shouldFocus() {
+          // This focus is queued on the next animation frame. If the floating element has closed
+          // before it runs — e.g. tabbing out of a kept-mounted popup — don't pull focus back
+          // onto the initial element after it has legitimately moved elsewhere.
+          if (!openRef.current) {
+            return false;
+          }
+
           if (hadFocusInside) {
             return true;
           }
@@ -713,6 +721,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
     getTabbableContent,
     initialFocusRef,
     openInteractionTypeRef,
+    openRef,
   ]);
 
   // Track return focus targets and restore focus on unmount/close.


### PR DESCRIPTION
A Select test flaked on React 18 (`does not leave a tabbable option while closed and kept mounted after tabbing out`). The initial focus queued by `FloatingFocusManager` could run after the popup had already closed and pull focus back onto the item.

## Root cause

`FloatingFocusManager` queues the initial focus on the next animation frame. When the popup closes before that frame runs (tabbing out of a kept-mounted popup), the queued focus still ran and stole focus back onto the item.

## Changes

- Skip the queued initial focus when the floating element is no longer open.
