### PR TITLE
[dialog] Fix menu focus flake

### DIFF
--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -1373,7 +1373,11 @@ describe('<Dialog.Root />', () => {
 
       const menuTrigger = screen.getByRole('button', { name: 'Open menu' });
       await user.click(menuTrigger);
-      expect(menuTrigger).toHaveFocus();
+
+      const menu = await screen.findByRole('menu');
+      await waitFor(() => {
+        expect(menu).toHaveFocus();
+      });
 
       const dialogTrigger = await screen.findByRole('menuitem', { name: 'Open dialog' });
       await user.click(dialogTrigger);


### PR DESCRIPTION
Pointer-opening the menu in this Dialog regression test settles focus on the menu popup. The test was checking the trigger before that deferred focus finished, so it could pass or fail depending on frame timing.

## Root cause

The test asserted the pre-rAF focus state instead of the settled pointer-open focus target.

## Changes

- Wait for the menu popup to receive focus before activating the dialog trigger.