### PR TITLE
[toast][docs] Change headings order

### DIFF
--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -1751,8 +1751,8 @@ Generates toast notifications.
     - Varying heights
   - API reference
     - Provider
-    - Viewport
     - Portal
+    - Viewport
     - Root
     - Content
     - Title

--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -279,13 +279,13 @@ import { TypesToast, TypesToastAdditional } from './types';
 
 <TypesToast.Provider />
 
-### Viewport
-
-<TypesToast.Viewport />
-
 ### Portal
 
 <TypesToast.Portal />
+
+### Viewport
+
+<TypesToast.Viewport />
 
 ### Root
 


### PR DESCRIPTION
Moves `Portal` before `Viewport` on the page so it matches the anatomy order.

Preview: https://deploy-preview-4976--base-ui.netlify.app/react/components/toast#api-reference