### PR TITLE
[docs] Fix table font-size

### DIFF
--- a/docs/src/components/ReferenceTable/ReferenceTable.css
+++ b/docs/src/components/ReferenceTable/ReferenceTable.css
@@ -77,8 +77,8 @@
     flex-direction: column;
     gap: 0.75rem;
     padding: 1rem;
-    font-size: var(--font-size-15);
-    line-height: 1.375rem;
+    font-size: var(--font-size-14);
+    line-height: 1.25rem;
     text-wrap: pretty;
   }
 


### PR DESCRIPTION
The cell text was 15px instead of 14px.

|before|after|
|---|---|
|<img width="463" height="208" alt="Screenshot 2026-06-05 at 12 07 09" src="https://github.com/user-attachments/assets/736fefaf-ca80-4d5e-858e-743510010613" />|<img width="460" height="205" alt="Screenshot 2026-06-05 at 12 06 21" src="https://github.com/user-attachments/assets/ed2b3d3b-9d40-403a-9e80-02e9622aefc4" />|