### PR TITLE
[drawer] Fix Safari backdrop positioning demo

### DIFF
--- a/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.module.css
@@ -74,6 +74,11 @@
   transition-property: opacity;
   transition-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
 
+  /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
+  @supports (-webkit-touch-callout: none) {
+    position: absolute;
+  }
+
   @media (prefers-color-scheme: dark) {
     --backdrop-opacity: 0.7;
   }


### PR DESCRIPTION
Align the snap points Drawer CSS Modules backdrop demo with the existing iOS Safari positioning pattern.