### PR TITLE
[docs] Demo chrome tweaks

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -103,7 +103,12 @@ const nextConfig = {
       },
       './src/app/**/demos/*/index.ts': {
         as: '*.ts',
-        loaders: ['@mui/internal-docs-infra/pipeline/loadPrecomputedCodeHighlighter'],
+        loaders: [
+          {
+            loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedCodeHighlighter',
+            options: { emphasisOptions: { focusFramesMaxSize: 4 } },
+          },
+        ],
       },
       './src/demo-data/*/index.ts': {
         as: '*.ts',

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -136,7 +136,10 @@ const nextConfig = {
       test: /[/\\\\]demos[/\\\\][^/\\\\]+[/\\\\]index\.ts$/,
       use: [
         defaultLoaders.babel,
-        '@mui/internal-docs-infra/pipeline/loadPrecomputedCodeHighlighter',
+        {
+          loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedCodeHighlighter',
+          options: { emphasisOptions: { focusFramesMaxSize: 4 } },
+        },
       ],
     });
     config.module.rules.push({

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -106,7 +106,7 @@ const nextConfig = {
         loaders: [
           {
             loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedCodeHighlighter',
-            options: { emphasisOptions: { focusFramesMaxSize: 4 } },
+            options: { emphasisOptions: { focusFramesMaxSize: 6 } },
           },
         ],
       },
@@ -138,7 +138,7 @@ const nextConfig = {
         defaultLoaders.babel,
         {
           loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedCodeHighlighter',
-          options: { emphasisOptions: { focusFramesMaxSize: 4 } },
+          options: { emphasisOptions: { focusFramesMaxSize: 6 } },
         },
       ],
     });

--- a/docs/src/app/(docs)/react/components/accordion/page.mdx
+++ b/docs/src/app/(docs)/react/components/accordion/page.mdx
@@ -35,7 +35,7 @@ You can set up the accordion to allow multiple panels to be open at the same tim
 
 import { DemoAccordionMultiple } from './demos/multiple';
 
-<DemoAccordionMultiple compact />
+<DemoAccordionMultiple />
 
 ## API reference
 

--- a/docs/src/app/(docs)/react/components/alert-dialog/page.mdx
+++ b/docs/src/app/(docs)/react/components/alert-dialog/page.mdx
@@ -89,7 +89,7 @@ Use the `[data-nested-dialog-open]` selector and the `var(--nested-dialogs)` CSS
 
 import { DemoDialogCloseConfirmation } from '../dialog/demos/close-confirmation';
 
-<DemoDialogCloseConfirmation compact />
+<DemoDialogCloseConfirmation />
 
 ### Detached triggers
 

--- a/docs/src/app/(docs)/react/components/autocomplete/page.mdx
+++ b/docs/src/app/(docs)/react/components/autocomplete/page.mdx
@@ -73,7 +73,7 @@ Load items asynchronously while typing and render custom status content.
 
 import { DemoAutocompleteAsync } from './demos/async';
 
-<DemoAutocompleteAsync compact />
+<DemoAutocompleteAsync />
 
 ### Inline autocomplete
 
@@ -81,7 +81,7 @@ Autofill the input with the highlighted item while navigating with arrow keys us
 
 import { DemoAutocompleteInline } from './demos/inline';
 
-<DemoAutocompleteInline compact />
+<DemoAutocompleteInline />
 
 ### Grouped
 
@@ -112,7 +112,7 @@ const groups: ProduceGroupItem[] = [
 
 import { DemoAutocompleteGrouped } from './demos/grouped';
 
-<DemoAutocompleteGrouped compact />
+<DemoAutocompleteGrouped />
 
 ### Fuzzy matching
 
@@ -120,7 +120,7 @@ Use fuzzy matching to find relevant results even when the query doesn't exactly 
 
 import { DemoAutocompleteFuzzyMatching } from './demos/fuzzy-matching';
 
-<DemoAutocompleteFuzzyMatching compact />
+<DemoAutocompleteFuzzyMatching />
 
 ### Limit results
 
@@ -128,7 +128,7 @@ Limit the number of visible items using the `limit` prop and guide users to refi
 
 import { DemoAutocompleteLimit } from './demos/limit';
 
-<DemoAutocompleteLimit compact />
+<DemoAutocompleteLimit />
 
 ### Auto highlight
 
@@ -138,7 +138,7 @@ The prop can be combined with the `keepHighlight` and `highlightItemOnHover` pro
 
 import { DemoAutocompleteAutoHighlight } from './demos/auto-highlight';
 
-<DemoAutocompleteAutoHighlight compact />
+<DemoAutocompleteAutoHighlight />
 
 ### Command palette
 
@@ -146,7 +146,7 @@ Use the autocomplete input to filter a list of command items that perform an act
 
 import { DemoAutocompleteCommandPalette } from './demos/command-palette';
 
-<DemoAutocompleteCommandPalette compact />
+<DemoAutocompleteCommandPalette />
 
 ### Grid layout
 
@@ -154,7 +154,7 @@ Display items in a grid layout, wrapping each row in `<Autocomplete.Row>` compon
 
 import { DemoAutocompleteGrid } from './demos/grid';
 
-<DemoAutocompleteGrid compact />
+<DemoAutocompleteGrid />
 
 ### Virtualized
 
@@ -162,7 +162,7 @@ Efficiently handle large datasets using a virtualization library like `@tanstack
 
 import { DemoAutocompleteVirtualized } from './demos/virtualized';
 
-<DemoAutocompleteVirtualized compact />
+<DemoAutocompleteVirtualized />
 
 ## API reference
 

--- a/docs/src/app/(docs)/react/components/button/page.mdx
+++ b/docs/src/app/(docs)/react/components/button/page.mdx
@@ -54,7 +54,7 @@ For buttons that enter a loading state after being clicked, specify the `focusab
 
 import { DemoButtonLoading } from './demos/loading';
 
-<DemoButtonLoading compact />
+<DemoButtonLoading />
 
 ## API reference
 

--- a/docs/src/app/(docs)/react/components/checkbox-group/page.mdx
+++ b/docs/src/app/(docs)/react/components/checkbox-group/page.mdx
@@ -137,7 +137,7 @@ import { DemoCheckboxGroupParent } from './demos/parent';
 
 import { DemoCheckboxGroupNested } from './demos/nested';
 
-<DemoCheckboxGroupNested compact />
+<DemoCheckboxGroupNested />
 
 ## API reference
 

--- a/docs/src/app/(docs)/react/components/combobox/page.mdx
+++ b/docs/src/app/(docs)/react/components/combobox/page.mdx
@@ -100,7 +100,7 @@ Selection chips are rendered with `<Combobox.Chip>` inside the input that can be
 
 import { DemoComboboxMultiple } from './demos/multiple';
 
-<DemoComboboxMultiple compact />
+<DemoComboboxMultiple />
 
 Visible chips can be limited by slicing the selected values rendered in `<Combobox.Value>`:
 
@@ -137,7 +137,7 @@ const CHIP_LIMIT = 3;
 
 import { DemoComboboxInputInsidePopup } from './demos/input-inside-popup';
 
-<DemoComboboxInputInsidePopup compact />
+<DemoComboboxInputInsidePopup />
 
 Use `<Combobox.Label>` to provide a visible label for the combobox trigger in this pattern:
 
@@ -180,7 +180,7 @@ const groups: ProduceGroupItem[] = [
 
 import { DemoComboboxGrouped } from './demos/grouped';
 
-<DemoComboboxGrouped compact />
+<DemoComboboxGrouped />
 
 ### Async search (single)
 
@@ -188,7 +188,7 @@ Load items from a remote source by fetching on input changes. Keep the selected 
 
 import { DemoComboboxAsyncSingle } from './demos/async-single';
 
-<DemoComboboxAsyncSingle compact />
+<DemoComboboxAsyncSingle />
 
 ### Async search (multiple)
 
@@ -196,7 +196,7 @@ Load items from a remote source by fetching on input changes while supporting mu
 
 import { DemoComboboxAsyncMultiple } from './demos/async-multiple';
 
-<DemoComboboxAsyncMultiple compact />
+<DemoComboboxAsyncMultiple />
 
 ### Creatable
 
@@ -204,7 +204,7 @@ Create a new item when the filter matches no items, opening a creation `<Dialog>
 
 import { DemoComboboxCreatable } from './demos/creatable';
 
-<DemoComboboxCreatable compact />
+<DemoComboboxCreatable />
 
 ### Virtualized
 
@@ -212,7 +212,7 @@ Efficiently handle large datasets using a virtualization library like `@tanstack
 
 import { DemoComboboxVirtualized } from './demos/virtualized';
 
-<DemoComboboxVirtualized compact />
+<DemoComboboxVirtualized />
 
 ## API reference
 

--- a/docs/src/app/(docs)/react/components/dialog/page.mdx
+++ b/docs/src/app/(docs)/react/components/dialog/page.mdx
@@ -148,7 +148,7 @@ Use the `[data-nested-dialog-open]` selector and the `var(--nested-dialogs)` CSS
 
 import { DemoDialogNested } from './demos/nested';
 
-<DemoDialogNested compact />
+<DemoDialogNested />
 
 ### Close confirmation
 
@@ -158,7 +158,7 @@ To implement this, both dialogs should be controlled. The confirmation dialog ma
 
 import { DemoDialogCloseConfirmation } from './demos/close-confirmation';
 
-<DemoDialogCloseConfirmation compact />
+<DemoDialogCloseConfirmation />
 
 ### Outside scroll dialog
 
@@ -166,7 +166,7 @@ The dialog can be made scrollable by using `<Dialog.Viewport>` as an outer scrol
 
 import { DemoDialogOutsideScroll } from './demos/outside-scroll';
 
-<DemoDialogOutsideScroll compact />
+<DemoDialogOutsideScroll />
 
 ### Inside scroll dialog
 
@@ -174,7 +174,7 @@ The dialog can be made scrollable by making an inner container scrollable while 
 
 import { DemoDialogInsideScroll } from './demos/inside-scroll';
 
-<DemoDialogInsideScroll compact />
+<DemoDialogInsideScroll />
 
 ### Placing elements outside the popup
 
@@ -184,7 +184,7 @@ When adding elements that should appear "outside" the colored popup area, contin
 
 import { DemoDialogUncontained } from './demos/uncontained';
 
-<DemoDialogUncontained compact />
+<DemoDialogUncontained />
 
 ### Detached triggers
 

--- a/docs/src/app/(docs)/react/components/drawer/page.mdx
+++ b/docs/src/app/(docs)/react/components/drawer/page.mdx
@@ -109,7 +109,7 @@ This demo stacks nested drawers using a constant peek so the frontmost drawer st
 
 import { DemoDrawerNested } from './demos/nested';
 
-<DemoDrawerNested compact />
+<DemoDrawerNested />
 
 ### Snap points
 
@@ -188,7 +188,7 @@ This demo builds an action sheet with a grouped list of actions plus a separate 
 
 import { DemoDrawerUncontained } from './demos/uncontained';
 
-<DemoDrawerUncontained compact />
+<DemoDrawerUncontained />
 
 ### Detached triggers
 

--- a/docs/src/app/(docs)/react/components/menu/page.mdx
+++ b/docs/src/app/(docs)/react/components/menu/page.mdx
@@ -62,7 +62,7 @@ To create a menu that opens on hover, add the `openOnHover` prop to `<Menu.Trigg
 
 import { DemoMenuOpenOnHover } from './demos/open-on-hover';
 
-<DemoMenuOpenOnHover compact />
+<DemoMenuOpenOnHover />
 
 ### Checkbox items
 
@@ -70,7 +70,7 @@ Use the `<Menu.CheckboxItem>` part to create a menu item that can toggle a setti
 
 import { DemoMenuCheckboxItems } from './demos/checkbox-items';
 
-<DemoMenuCheckboxItems compact />
+<DemoMenuCheckboxItems />
 
 ### Radio items
 
@@ -78,7 +78,7 @@ Use the `<Menu.RadioGroup>` and `<Menu.RadioItem>` parts to create menu items th
 
 import { DemoMenuRadioItems } from './demos/radio-items';
 
-<DemoMenuRadioItems compact />
+<DemoMenuRadioItems />
 
 ### Close on click
 
@@ -98,7 +98,7 @@ Use the `<Menu.GroupLabel>` part to add a label to a `<Menu.Group>` or `<Menu.Ra
 
 import { DemoMenuGroupLabels } from './demos/group-labels';
 
-<DemoMenuGroupLabels compact />
+<DemoMenuGroupLabels />
 
 ### Nested menu
 
@@ -135,7 +135,7 @@ To create a submenu, nest another menu inside the parent menu with `<Menu.Submen
 
 import { DemoMenuSubmenu } from './demos/submenu';
 
-<DemoMenuSubmenu compact />
+<DemoMenuSubmenu />
 
 ### Navigate to another page
 
@@ -300,7 +300,7 @@ The `onOpenChange` callback receives `eventDetails`, which includes the DOM elem
 
 import { DemoMenuDetachedTriggersControlled } from './demos/detached-triggers-controlled';
 
-<DemoMenuDetachedTriggersControlled compact />
+<DemoMenuDetachedTriggersControlled />
 
 ### Arrow
 
@@ -308,7 +308,7 @@ Use the `<Menu.Arrow>` part inside the popup to visually connect the menu to its
 
 import { DemoMenuArrow } from './demos/arrow';
 
-<DemoMenuArrow compact />
+<DemoMenuArrow />
 
 ### Animating the Menu
 

--- a/docs/src/app/(docs)/react/components/navigation-menu/page.mdx
+++ b/docs/src/app/(docs)/react/components/navigation-menu/page.mdx
@@ -49,7 +49,7 @@ import { NavigationMenu } from '@base-ui/react/navigation-menu';
 
 import { DemoNavigationMenuNested } from './demos/nested';
 
-<DemoNavigationMenuNested compact />
+<DemoNavigationMenuNested />
 
 ### Nested inline submenus
 
@@ -57,7 +57,7 @@ For second-level navigation that should stay in the same panel, omit the nested 
 
 import { DemoNavigationMenuNestedInline } from './demos/nested-inline';
 
-<DemoNavigationMenuNestedInline compact />
+<DemoNavigationMenuNestedInline />
 
 ### Custom links
 

--- a/docs/src/app/(docs)/react/components/otp-field/page.mdx
+++ b/docs/src/app/(docs)/react/components/otp-field/page.mdx
@@ -86,7 +86,7 @@ numbers.
 
 import { DemoOTPFieldAlphanumeric } from './demos/alphanumeric';
 
-<DemoOTPFieldAlphanumeric compact />
+<DemoOTPFieldAlphanumeric />
 
 ### Grouped layouts
 
@@ -95,7 +95,7 @@ want the code presented in smaller visual chunks such as `123-456`.
 
 import { DemoOTPFieldGrouped } from './demos/grouped';
 
-<DemoOTPFieldGrouped compact />
+<DemoOTPFieldGrouped />
 
 ### Placeholder hints
 
@@ -104,7 +104,7 @@ example keeps placeholder hints visible until the active slot receives focus.
 
 import { DemoOTPFieldFocusedPlaceholder } from './demos/focused-placeholder';
 
-<DemoOTPFieldFocusedPlaceholder compact />
+<DemoOTPFieldFocusedPlaceholder />
 
 ### Custom normalization
 
@@ -117,7 +117,7 @@ Pair custom rules with `inputMode` for keyboard hints and `onValueInvalid` for r
 
 import { DemoOTPFieldCustomNormalize } from './demos/custom-sanitize';
 
-<DemoOTPFieldCustomNormalize compact />
+<DemoOTPFieldCustomNormalize />
 
 ### Masked entry
 
@@ -125,7 +125,7 @@ Use `mask` when the code should be obscured while it is being typed.
 
 import { DemoOTPFieldPassword } from './demos/password';
 
-<DemoOTPFieldPassword compact />
+<DemoOTPFieldPassword />
 
 ## API reference
 

--- a/docs/src/app/(docs)/react/components/popover/page.mdx
+++ b/docs/src/app/(docs)/react/components/popover/page.mdx
@@ -45,7 +45,7 @@ You can use the `delay` prop to specify how long to wait (in milliseconds) befor
 
 import { DemoPopoverOpenOnHover } from './demos/open-on-hover';
 
-<DemoPopoverOpenOnHover compact />
+<DemoPopoverOpenOnHover />
 
 ### Detached triggers
 

--- a/docs/src/app/(docs)/react/components/scroll-area/page.mdx
+++ b/docs/src/app/(docs)/react/components/scroll-area/page.mdx
@@ -37,7 +37,7 @@ Use `<ScrollArea.Corner>` to prevent the scrollbars from intersecting.
 
 import { DemoScrollAreaBoth } from './demos/both';
 
-<DemoScrollAreaBoth compact />
+<DemoScrollAreaBoth />
 
 ### Gradient scroll fade
 
@@ -74,7 +74,7 @@ When the fade is applied to `<ScrollArea.Viewport>` itself, the variables can be
 }
 ```
 
-<DemoScrollAreaScrollFade compact />
+<DemoScrollAreaScrollFade />
 
 ### Combining with Tabs
 

--- a/docs/src/app/(docs)/react/components/select/page.mdx
+++ b/docs/src/app/(docs)/react/components/select/page.mdx
@@ -182,7 +182,7 @@ Add the `multiple` prop to the `<Select.Root>` component to allow multiple selec
 
 import { DemoSelectMultiple } from './demos/multiple';
 
-<DemoSelectMultiple compact />
+<DemoSelectMultiple />
 
 ### Object values
 
@@ -191,7 +191,7 @@ This lets you access the full object in custom render functions, and can avoid n
 
 import { DemoSelectObjectValues } from './demos/object-values';
 
-<DemoSelectObjectValues compact />
+<DemoSelectObjectValues />
 
 ### Grouped
 
@@ -222,7 +222,7 @@ const groups: ProduceGroupItem[] = [
 
 import { DemoSelectGrouped } from './demos/grouped';
 
-<DemoSelectGrouped compact />
+<DemoSelectGrouped />
 
 ## API reference
 

--- a/docs/src/app/(docs)/react/components/slider/page.mdx
+++ b/docs/src/app/(docs)/react/components/slider/page.mdx
@@ -46,7 +46,7 @@ Thumbs can be configured to behave differently when they collide during pointer 
 
 import { DemoSliderRangeSlider } from './demos/range-slider';
 
-<DemoSliderRangeSlider compact />
+<DemoSliderRangeSlider />
 
 ### Thumb alignment
 
@@ -56,7 +56,7 @@ A client-only alternative `thumbAlignment="edge-client-only"` can be used to red
 
 import { DemoSliderEdgeAlignment } from './demos/edge-alignment';
 
-<DemoSliderEdgeAlignment compact />
+<DemoSliderEdgeAlignment />
 
 ### Labeling a slider
 
@@ -112,7 +112,7 @@ Set `orientation="vertical"` on `<Slider.Root>` to build a vertical slider.
 
 import { DemoSliderVertical } from './demos/vertical';
 
-<DemoSliderVertical compact />
+<DemoSliderVertical />
 
 ### Form integration
 

--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -214,7 +214,7 @@ function StackedToasts() {
 
 import { DemoToastAnchored } from './demos/anchored';
 
-<DemoToastAnchored compact />
+<DemoToastAnchored />
 
 ### Custom position
 
@@ -225,7 +225,7 @@ The following shows a top-center position:
 
 import { DemoToastPosition } from './demos/position';
 
-<DemoToastPosition compact />
+<DemoToastPosition />
 
 ### Undo action
 
@@ -233,7 +233,7 @@ When adding a toast, the `actionProps` option can be used to define props for an
 
 import { DemoToastUndo } from './demos/undo';
 
-<DemoToastUndo compact />
+<DemoToastUndo />
 
 ### Promise
 
@@ -243,7 +243,7 @@ Each of the states also accepts the [method options](#toastmanagerupdateoptions)
 
 import { DemoToastPromise } from './demos/promise';
 
-<DemoToastPromise compact />
+<DemoToastPromise />
 
 ### Custom
 
@@ -252,7 +252,7 @@ This enables you to pass any data (including functions) you need to the toast an
 
 import { DemoToastCustom } from './demos/custom';
 
-<DemoToastCustom compact />
+<DemoToastCustom />
 
 ### Deduplicated toast
 
@@ -260,7 +260,7 @@ When you upsert the same toast by `id`, the `updateKey` property increments so a
 
 import { DemoToastDeduplicate } from './demos/deduplicate';
 
-<DemoToastDeduplicate compact />
+<DemoToastDeduplicate />
 
 ### Varying heights
 
@@ -269,7 +269,7 @@ This prevents taller toasts from overflowing the stack when collapsed.
 
 import { DemoToastVaryingHeights } from './demos/varying-heights';
 
-<DemoToastVaryingHeights compact />
+<DemoToastVaryingHeights />
 
 ## API reference
 

--- a/docs/src/app/(docs)/react/handbook/animation/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/animation/page.mdx
@@ -90,7 +90,7 @@ Most popup components like Popover, Dialog, Tooltip, and Menu are unmounted from
 
 import { DemoAnimatedPopoverMotionKeepMountedFalse } from './demos/animated-popover-motion-keep-mounted-false';
 
-<DemoAnimatedPopoverMotionKeepMountedFalse compact showExtraPlaygroundLink />
+<DemoAnimatedPopoverMotionKeepMountedFalse showExtraPlaygroundLink />
 
 ```jsx title="animated-popover.tsx"
 function App() {
@@ -134,7 +134,7 @@ Components that specify `keepMounted` remain rendered in the DOM when they are c
 
 import { DemoAnimatedPopoverMotionKeepMountedTrue } from './demos/animated-popover-motion-keep-mounted-true';
 
-<DemoAnimatedPopoverMotionKeepMountedTrue compact showExtraPlaygroundLink />
+<DemoAnimatedPopoverMotionKeepMountedTrue showExtraPlaygroundLink />
 
 ```jsx title="animated-popover.tsx"
 function App() {
@@ -172,7 +172,7 @@ The Select component is initially unmounted but remains mounted after interactio
 
 import { DemoAnimatedSelectMotion } from './demos/animated-select-motion';
 
-<DemoAnimatedSelectMotion compact showExtraPlaygroundLink />
+<DemoAnimatedSelectMotion showExtraPlaygroundLink />
 
 ### Manual unmounting
 

--- a/docs/src/components/Accordion.css
+++ b/docs/src/components/Accordion.css
@@ -14,15 +14,16 @@
     justify-content: center;
     color: var(--gray-t1);
 
-    border: 1px solid var(--gray-c2);
+    border: 1px solid var(--color-border);
     border-collapse: separate;
     border-radius: var(--radius-12);
   }
 
   .AccordionHeaderRow {
     border-radius: calc(var(--radius-12) - 1px) calc(var(--radius-12) - 1px) 0 0;
-    border-bottom: 1px solid var(--gray-c2);
+    border-bottom: 1px solid var(--color-border);
     background-color: var(--gray-s2);
+    background-clip: padding-box;
   }
 
   .AccordionHeaderCell {
@@ -33,7 +34,7 @@
   }
 
   .AccordionItem:not(:last-child) {
-    border-bottom: 1px solid var(--gray-c2);
+    border-bottom: 1px solid var(--color-border);
   }
 
   .AccordionTrigger {

--- a/docs/src/components/Accordion.css
+++ b/docs/src/components/Accordion.css
@@ -16,11 +16,11 @@
 
     border: 1px solid var(--gray-c2);
     border-collapse: separate;
-    border-radius: var(--radius-6);
+    border-radius: var(--radius-12);
   }
 
   .AccordionHeaderRow {
-    border-radius: var(--radius-6) var(--radius-6) 0 0;
+    border-radius: calc(var(--radius-12) - 1px) calc(var(--radius-12) - 1px) 0 0;
     border-bottom: 1px solid var(--gray-c2);
     background-color: var(--gray-s2);
   }
@@ -76,8 +76,8 @@
     }
 
     .AccordionItem:not([open]):last-child & {
-      border-bottom-left-radius: var(--radius-6);
-      border-bottom-right-radius: var(--radius-6);
+      border-bottom-left-radius: calc(var(--radius-12) - 1px);
+      border-bottom-right-radius: calc(var(--radius-12) - 1px);
     }
   }
 
@@ -110,8 +110,8 @@
     }
 
     .AccordionItem:last-child & {
-      border-bottom-left-radius: var(--radius-6);
-      border-bottom-right-radius: var(--radius-6);
+      border-bottom-left-radius: calc(var(--radius-12) - 1px);
+      border-bottom-right-radius: calc(var(--radius-12) - 1px);
     }
   }
 

--- a/docs/src/components/CodeBlock/CodeBlock.css
+++ b/docs/src/components/CodeBlock/CodeBlock.css
@@ -2,7 +2,7 @@
   .CodeBlockRoot {
     align-self: stretch;
     background-color: var(--color-content);
-    border: 1px solid var(--gray-c2);
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-12);
 
     & code .frame {
@@ -37,7 +37,7 @@
     gap: 1rem;
     border-top-left-radius: calc(var(--radius-12) - 1px);
     border-top-right-radius: calc(var(--radius-12) - 1px);
-    border-bottom: 1px solid var(--gray-c2);
+    border-bottom: 1px solid var(--color-border);
 
     /* Scroll */
     overflow: auto hidden;

--- a/docs/src/components/CodeBlock/CodeBlock.css
+++ b/docs/src/components/CodeBlock/CodeBlock.css
@@ -65,8 +65,8 @@
 
   .CodeBlockCopyIcon {
     display: flex;
-    width: 14px;
-    height: 14px;
+    width: 1rem;
+    height: 1rem;
     align-items: center;
     justify-content: center;
   }

--- a/docs/src/components/CodeBlock/CodeBlock.css
+++ b/docs/src/components/CodeBlock/CodeBlock.css
@@ -3,7 +3,7 @@
     align-self: stretch;
     background-color: var(--color-content);
     border: 1px solid var(--gray-c2);
-    border-radius: var(--radius-6);
+    border-radius: var(--radius-12);
 
     & code .frame {
       padding-left: 0.75rem;
@@ -35,8 +35,8 @@
     padding-inline-end: 0.25rem;
     height: 2.25rem;
     gap: 1rem;
-    border-top-left-radius: inherit;
-    border-top-right-radius: inherit;
+    border-top-left-radius: calc(var(--radius-12) - 1px);
+    border-top-right-radius: calc(var(--radius-12) - 1px);
     border-bottom: 1px solid var(--gray-c2);
 
     /* Scroll */
@@ -73,8 +73,8 @@
 
   .CodeBlockViewport {
     outline: 0;
-    border-bottom-right-radius: var(--radius-6);
-    border-bottom-left-radius: var(--radius-6);
+    border-bottom-right-radius: calc(var(--radius-12) - 1px);
+    border-bottom-left-radius: calc(var(--radius-12) - 1px);
 
     &[data-has-overflow-x] {
       /* Prevent Chrome/Safari page navigation gestures when scrolling horizontally */
@@ -129,7 +129,7 @@
   .CodeBlockPre,
   .CodeBlockRoot .CodeBlockPreInline {
     padding: 0.5rem 0;
-    border-radius: var(--radius-6);
+    border-radius: calc(var(--radius-12) - 1px);
   }
 
   .CodeBlockPreContainer {

--- a/docs/src/components/CodeBlock/CodeBlock.tsx
+++ b/docs/src/components/CodeBlock/CodeBlock.tsx
@@ -55,6 +55,7 @@ export function Panel({ className, title, children, ...other }: CodeBlockPanelPr
       )}
       <GhostButton
         aria-label="Copy code"
+        layout="icon"
         onClick={async () => {
           const codeRoot = document.getElementById(codeId);
           const code = codeRoot?.querySelector('pre code')?.textContent ?? codeRoot?.textContent;
@@ -80,7 +81,6 @@ export function Panel({ className, title, children, ...other }: CodeBlockPanelPr
           }
         }}
       >
-        Copy
         <span className="CodeBlockCopyIcon">{copyTimeout ? <CheckIcon /> : <CopyIcon />}</span>
       </GhostButton>
     </div>

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -203,7 +203,8 @@
         content: '';
         position: absolute;
         pointer-events: none;
-        height: 7.5rem;
+        height: 100%;
+        max-height: 6rem;
         bottom: 0;
         left: 0;
         right: 0;
@@ -230,6 +231,12 @@
     &[data-closed] {
       overflow: hidden;
       max-height: calc(8.75lh + 0.5rem); /* Show almost 9 code lines plus top padding */
+    }
+
+    &[data-closed] code .frame:not([data-frame-type]),
+    &[data-closed] code .frame[data-frame-type='highlighted-unfocused'],
+    &[data-closed] code .frame[data-frame-type='focus-unfocused'] {
+      display: none;
     }
   }
 

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -157,7 +157,8 @@
           content: '';
           position: absolute;
           inset: 0 0 1px;
-          border-radius: inherit;
+          border-top-left-radius: calc(var(--radius-8) - 1px);
+          border-top-right-radius: calc(var(--radius-8) - 1px);
           background-color: var(--gray-c1);
           pointer-events: none;
         }

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -230,6 +230,9 @@
   }
 
   .DemoCodeBlockViewport {
+    --demo-code-block-line-height: 1.25rem; /* 20px */
+    line-height: var(--demo-code-block-line-height);
+
     &[data-has-overflow-x] {
       /* Prevent Chrome/Safari page navigation gestures when scrolling horizontally */
       overscroll-behavior-x: contain;
@@ -240,7 +243,7 @@
 
     &[data-closed] {
       overflow: hidden;
-      max-height: calc(8.75lh + 0.5rem); /* Show almost 9 code lines plus top padding */
+      max-height: calc(5.7lh + 0.5rem); /* Display almost 6 code lines plus top padding */
     }
     &[data-closed] code .frame:not([data-frame-type]),
     &[data-closed] code .frame[data-frame-type='highlighted-unfocused'],
@@ -252,7 +255,7 @@
   .DemoSourceBrowser {
     position: relative;
     font-size: 0.8125rem; /* 13px */
-    line-height: 1.25rem; /* 20px */
+    line-height: var(--demo-code-block-line-height); /* 20px */
     cursor: text;
     display: flex;
 

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -312,7 +312,12 @@
     position: absolute;
     top: 0.5rem;
     right: 0.5rem;
-    z-index: 3;
+    background-color: color-mix(in srgb, var(--gray-s1), transparent 10%);
+
+    @media (--md) {
+      background-color: transparent;
+      box-shadow: none;
+    }
   }
 
   .DemoCollapseButton {

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -215,7 +215,6 @@
         z-index: 1;
         pointer-events: none;
         height: 100%;
-        max-height: 6rem;
         bottom: 0;
         left: 0;
         right: 0;
@@ -223,8 +222,8 @@
         border-bottom-right-radius: calc(var(--demo-radius) - 1px);
         background: linear-gradient(
           to bottom,
-          transparent 20%,
-          color-mix(in srgb, var(--gray-s1), transparent 20%) 100%
+          transparent 0%,
+          color-mix(in srgb, var(--gray-s1), transparent 5%) 100%
         );
       }
     }

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -195,26 +195,6 @@
     position: relative;
     display: flex;
     flex-direction: column;
-
-    &:not([data-open]) {
-      .DemoCollapseButton {
-        position: absolute;
-        inset: 0;
-        align-items: flex-end;
-        padding-bottom: 0.75rem;
-      }
-    }
-
-    &[data-open] {
-      .DemoCollapseButton {
-        position: sticky;
-        bottom: 0;
-        align-self: stretch;
-        align-items: flex-start;
-        padding-top: 0.75rem;
-        padding-bottom: 0.75rem;
-      }
-    }
   }
 
   .DemoCodeBlockRoot {
@@ -324,13 +304,14 @@
 
   .DemoCollapseButton {
     box-sizing: border-box;
-    position: relative;
+    position: absolute;
+    inset: 0;
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     justify-content: center;
     flex-shrink: 0;
     border: none;
-    padding: 0;
+    padding: 0 0 0.75rem;
     color: var(--color-foreground);
     background: transparent;
     font-family: inherit;
@@ -344,10 +325,6 @@
     user-select: none;
     -webkit-tap-highlight-color: transparent;
     appearance: none;
-
-    &[data-sticky] {
-      z-index: 1;
-    }
 
     &:focus-visible {
       outline: 0;

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -3,7 +3,7 @@
 @layer components {
   .DemoRoot {
     --demo-radius: var(--radius-12);
-    border: 1px solid var(--gray-c2);
+    border: 1px solid var(--color-border);
     border-radius: var(--demo-radius);
     margin-bottom: var(--space-24);
   }
@@ -166,7 +166,7 @@
     }
 
     &[data-active] {
-      border-color: var(--gray-c2);
+      border-color: var(--color-border);
       background-color: var(--gray-s1);
 
       &::after {
@@ -202,7 +202,7 @@
     flex-direction: column;
     position: relative;
     outline: 0;
-    border-top: 1px solid var(--gray-c2);
+    border-top: 1px solid var(--color-border);
     border-bottom-left-radius: var(--demo-radius);
     border-bottom-right-radius: var(--demo-radius);
     margin-top: -1px;

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -131,10 +131,10 @@
     position: relative;
     z-index: 0;
     outline: 0;
-    height: 2rem;
+    height: 2.25rem;
     padding-inline: 0.5rem;
     padding-top: 0.25rem;
-    padding-bottom: 0.25rem;
+    padding-bottom: calc(0.25rem + 1px);
     border-top: 1px solid transparent;
     border-right: 1px solid transparent;
     border-left: 1px solid transparent;

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -2,24 +2,10 @@
 
 @layer components {
   .DemoRoot {
-    background-color: var(--color-content);
+    --demo-radius: var(--radius-12);
     border: 1px solid var(--gray-c2);
-    border-radius: var(--radius-6);
+    border-radius: var(--demo-radius);
     margin-bottom: var(--space-24);
-
-    --shadow-1:
-      0 1px 1px 0 var(--blackA-1), 0 2px 1px -1px var(--blackA-1), 0 1px 3px 0 var(--blackA-1);
-    --shadow-2:
-      0 1px 1px 0 var(--blackA-1), 0 1px 3px -1px var(--blackA-1), 0 4px 8px -2px var(--blackA-1);
-    --shadow-3:
-      0 1px 1px 0 var(--blackA-1), 0 2px 6px -1px var(--blackA-1), 0 6px 12px -3px var(--blackA-1),
-      0 8px 16px -4px var(--blackA-1);
-    --shadow-4:
-      0 1px 1px 0 var(--blackA-1), 0 2px 4px -1px var(--blackA-1), 0 4px 8px -2px var(--blackA-1),
-      0 12px 32px -6px var(--blackA-3), 0 20px 48px -10px var(--blackA-1);
-    --shadow-5:
-      0 10px 32px var(--blackA-5), 0 1px 1px var(--blackA-1), 0 4px 6px var(--blackA-2),
-      0 1px 1px var(--blackA-2), 0 24px 68px var(--blackA-4);
   }
 
   .DemoPlaygroundExternalLink {
@@ -32,8 +18,8 @@
     position: relative;
 
     background-color: var(--color-content);
-    border-top-left-radius: var(--radius-6);
-    border-top-right-radius: var(--radius-6);
+    border-top-left-radius: calc(var(--demo-radius) - 1px);
+    border-top-right-radius: calc(var(--demo-radius) - 1px);
 
     /* Scroll */
     overflow: auto hidden;
@@ -63,19 +49,19 @@
   }
 
   .DemoToolbar {
+    box-sizing: border-box;
+    position: relative;
+    z-index: 1;
     font-size: var(--font-size-13);
     line-height: 1.25rem;
     white-space: nowrap;
     color: var(--gray-t2);
-    background-color: var(--gray-s2);
     background-clip: padding-box;
-    border-block: 1px solid var(--gray-c2);
     display: flex;
-    align-items: center;
-    gap: 2rem;
+    align-items: end;
+    gap: 1.5rem;
     height: 2.25rem;
-    padding: 0;
-    padding-inline-start: 0.75rem;
+    padding: 0 0 0 0.5rem;
     -webkit-user-select: none;
     user-select: none;
 
@@ -99,52 +85,45 @@
 
   .DemoToolbarActions {
     position: relative;
-    /* Apply sticky only on wider viewports to avoid actions taking up most of it */
-    @media (min-width: 48rem) {
-      position: sticky;
-      padding-left: 1rem;
-    }
     right: 0;
     display: flex;
     align-items: center;
     margin-left: auto;
     padding-right: 0.5rem;
-    background-color: var(--gray-s2);
     height: 100%;
-    gap: 0.25rem;
+    gap: var(--space-4);
 
-    &::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: -24px;
-      width: 24px;
-      height: 100%;
-      background: linear-gradient(to right, transparent, var(--gray-s2));
-      pointer-events: none;
-    }
-  }
+    /* Apply sticky only on wider viewports to avoid actions taking up most of it */
+    @media (min-width: 48rem) {
+      position: sticky;
+      padding-left: 0.75rem;
 
-  .DemoFilename {
-    font-family: var(--font-mono);
-    color: var(--color-foreground);
-    font-weight: bold;
-    user-select: text;
-    border-radius: var(--radius-4);
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0 0 1px;
+        border-radius: inherit;
+        background-color: var(--color-content);
+        pointer-events: none;
+      }
 
-    &:hover {
-      text-decoration: underline;
-    }
-
-    &:focus-visible {
-      outline: 2px solid var(--gray-t2);
+      &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 1px;
+        left: -24px;
+        width: 24px;
+        background: linear-gradient(to right, transparent, var(--color-content));
+        pointer-events: none;
+      }
     }
   }
 
   .DemoTabsList {
     display: flex;
-    gap: 2px;
-    margin-inline-start: -0.5rem;
+    align-self: flex-end;
+    gap: 0.125rem;
   }
 
   .DemoTab {
@@ -152,43 +131,91 @@
     position: relative;
     z-index: 0;
     outline: 0;
-    height: 1.75rem;
+    height: 2rem;
     padding-inline: 0.5rem;
-    border-radius: var(--radius-8);
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    border-top: 1px solid transparent;
+    border-right: 1px solid transparent;
+    border-left: 1px solid transparent;
+    border-top-left-radius: var(--radius-8);
+    border-top-right-radius: var(--radius-8);
     display: inline-flex;
     align-items: center;
     justify-content: center;
     line-height: 1;
 
+    > span {
+      position: relative;
+    }
+
     @media (hover: hover) {
-      &:hover {
-        background-color: var(--gray-c2);
+      &:hover:not([data-active]) {
+        border-color: var(--gray-c1);
+
+        &::before {
+          content: '';
+          position: absolute;
+          inset: 0 0 1px;
+          border-radius: inherit;
+          background-color: var(--gray-c1);
+          pointer-events: none;
+        }
       }
     }
 
     &[data-active] {
-      color: var(--color-foreground);
-      font-weight: var(--font-weight-700);
-      background-color: white;
+      border-color: var(--gray-c2);
+      background-color: var(--gray-s1);
 
-      @media (prefers-color-scheme: light) {
-        box-shadow:
-          0 0 1px var(--blackA-4),
-          0 0.5px 1px var(--blackA-3),
-          0 1px 3px var(--blackA-1),
-          0 2px 4px -1px var(--blackA-1),
-          0 4px 12px -2px var(--blackA-1),
-          0 4px 16px -4px var(--blackA-1);
-      }
-
-      @media (prefers-color-scheme: dark) {
-        background-color: var(--gray-c2);
+      &::after {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 1px;
+        background-color: var(--gray-s1);
+        pointer-events: none;
       }
     }
 
     &:focus-visible {
       outline: 2px solid var(--gray-t2);
-      outline-offset: -1px;
+      outline-offset: -2px;
+
+      &::after {
+        content: none;
+      }
+    }
+  }
+
+  .DemoCodeBlockCollapsible {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--gray-c2);
+    border-bottom-left-radius: var(--demo-radius);
+    border-bottom-right-radius: var(--demo-radius);
+    margin-top: -1px;
+    background-color: var(--gray-s1);
+
+    &:not([data-open]) {
+      .DemoCollapseButton {
+        position: absolute;
+        left: 50%;
+        bottom: 0.5rem;
+        transform: translateX(-50%);
+      }
+    }
+
+    &[data-open] {
+      .DemoCollapseButton {
+        position: sticky;
+        bottom: 0.5rem;
+        align-self: center;
+        margin-bottom: 0.5rem;
+      }
     }
   }
 
@@ -202,19 +229,20 @@
       &::before {
         content: '';
         position: absolute;
+        z-index: 1;
         pointer-events: none;
         height: 100%;
         max-height: 6rem;
         bottom: 0;
         left: 0;
         right: 0;
-        background: linear-gradient(to bottom, rgb(255 255 255 / 0), rgb(255 255 255 / 60%));
-      }
-
-      @media (prefers-color-scheme: dark) {
-        &::before {
-          background: linear-gradient(to bottom, rgb(0 0 0 / 0), rgb(0 0 0 / 60%));
-        }
+        border-bottom-left-radius: calc(var(--demo-radius) - 1px);
+        border-bottom-right-radius: calc(var(--demo-radius) - 1px);
+        background: linear-gradient(
+          to bottom,
+          transparent 25%,
+          color-mix(in srgb, var(--gray-s1), transparent 30%) 100%
+        );
       }
     }
   }
@@ -232,7 +260,6 @@
       overflow: hidden;
       max-height: calc(8.75lh + 0.5rem); /* Show almost 9 code lines plus top padding */
     }
-
     &[data-closed] code .frame:not([data-frame-type]),
     &[data-closed] code .frame[data-frame-type='highlighted-unfocused'],
     &[data-closed] code .frame[data-frame-type='focus-unfocused'] {
@@ -241,10 +268,17 @@
   }
 
   .DemoSourceBrowser {
+    position: relative;
     font-size: 0.8125rem; /* 13px */
     line-height: 1.25rem; /* 20px */
     cursor: text;
     display: flex;
+
+    > .GhostButton {
+      position: absolute;
+      top: 0.5rem;
+      right: 0.5rem;
+    }
 
     & pre {
       /* Different fonts may introduce vertical align issues */
@@ -279,42 +313,75 @@
   }
 
   .DemoCollapseButton {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    gap: var(--space-8);
+    border: none;
+    color: var(--color-foreground);
+    font-family: inherit;
     font-size: var(--font-size-13);
-    line-height: 1.25rem;
-    background-color: var(--gray-s2);
-    cursor: default;
-    width: 100%;
-    color: var(--gray-t2);
-    height: 2.25rem;
-    border-top: 1px solid var(--gray-c2);
-    border-bottom-left-radius: 0.375rem;
-    border-bottom-right-radius: 0.375rem;
-    border-bottom: 1px solid transparent;
-    background-clip: padding-box;
-    margin-bottom: -1px;
+    font-weight: 500;
+    line-height: 1;
+    vertical-align: top;
+    height: var(--space-28);
+    padding-inline: var(--space-12);
+    border-radius: var(--radius-pill);
+    background: linear-gradient(to bottom, hsl(0deg 0% 0% / 8%), hsl(0deg 0% 0% / 16%));
+    white-space: nowrap;
+    z-index: 2;
     -webkit-user-select: none;
     user-select: none;
+    -webkit-tap-highlight-color: transparent;
+
+    &::before {
+      content: '';
+      position: absolute;
+      z-index: -1;
+      inset: 1px;
+      border-radius: var(--radius-pill);
+      background: linear-gradient(to bottom, white 25%, hsl(0deg 0% 98%));
+      pointer-events: none;
+      box-shadow:
+        inset 0 0 0 1px white,
+        0 1px 1px hsl(0deg 0% 0% / 4%),
+        0 1px 2px hsl(0deg 0% 0% / 4%),
+        0 2px 4px -2px hsl(0deg 0% 0% / 4%);
+    }
 
     &[data-sticky] {
-      position: sticky;
-      bottom: -1px;
       z-index: 1;
     }
 
     @media (hover: hover) {
       &:hover {
-        background-color: var(--gray-c1);
+        background: linear-gradient(to bottom, hsl(0deg 0% 0% / 16%), hsl(0deg 0% 0% / 32%));
       }
     }
 
-    &:active {
-      background-color: color-mix(in oklch, var(--gray-c1), var(--gray-t2) 5%);
+    @media (prefers-color-scheme: dark) {
+      background: linear-gradient(to bottom, hsl(0deg 0% 100% / 16%), hsl(0deg 0% 100% / 24%));
+
+      &::before {
+        background: linear-gradient(to bottom, var(--gray-c2), var(--gray-c1));
+        box-shadow:
+          0 1px 1px hsl(0deg 0% 0% / 16%),
+          0 1px 2px hsl(0deg 0% 0% / 16%),
+          0 2px 4px -2px hsl(0deg 0% 0% / 24%);
+      }
+
+      @media (hover: hover) {
+        &:hover {
+          background: linear-gradient(to bottom, hsl(0deg 0% 100% / 24%), hsl(0deg 0% 100% / 36%));
+        }
+      }
     }
 
     &:focus-visible {
       outline: 2px solid var(--gray-t2);
       outline-offset: -1px;
-      z-index: 1;
     }
   }
 }

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -200,7 +200,7 @@
         position: absolute;
         inset: 0;
         align-items: flex-end;
-        padding-bottom: 0.5rem;
+        padding-bottom: 0.75rem;
       }
     }
 
@@ -210,8 +210,8 @@
         bottom: 0;
         align-self: stretch;
         align-items: flex-start;
-        padding-top: 0.5rem;
-        padding-bottom: 0.5rem;
+        padding-top: 0.75rem;
+        padding-bottom: 0.75rem;
       }
     }
   }

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -151,7 +151,7 @@
 
     @media (hover: hover) {
       &:hover:not([data-active]) {
-        border-color: var(--gray-c1);
+        border-color: var(--gray-s2);
 
         &::before {
           content: '';
@@ -159,7 +159,7 @@
           inset: 0 0 1px;
           border-top-left-radius: calc(var(--radius-8) - 1px);
           border-top-right-radius: calc(var(--radius-8) - 1px);
-          background-color: var(--gray-c1);
+          background-color: var(--gray-s2);
           pointer-events: none;
         }
       }

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -311,6 +311,7 @@
 
   .DemoCodeBlockCopyButton {
     position: absolute;
+    z-index: 3;
     top: 0.5rem;
     right: 0.5rem;
     background-color: color-mix(in srgb, var(--gray-s1), transparent 10%);

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -194,27 +194,24 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    border-top: 1px solid var(--gray-c2);
-    border-bottom-left-radius: var(--demo-radius);
-    border-bottom-right-radius: var(--demo-radius);
-    margin-top: -1px;
-    background-color: var(--gray-s1);
 
     &:not([data-open]) {
       .DemoCollapseButton {
         position: absolute;
-        left: 50%;
-        bottom: 0.5rem;
-        transform: translateX(-50%);
+        inset: 0;
+        align-items: flex-end;
+        padding-bottom: 0.5rem;
       }
     }
 
     &[data-open] {
       .DemoCollapseButton {
         position: sticky;
-        bottom: 0.5rem;
-        align-self: center;
-        margin-bottom: 0.5rem;
+        bottom: 0;
+        align-self: stretch;
+        align-items: flex-start;
+        padding-top: 0.5rem;
+        padding-bottom: 0.5rem;
       }
     }
   }
@@ -224,6 +221,11 @@
     flex-direction: column;
     position: relative;
     outline: 0;
+    border-top: 1px solid var(--gray-c2);
+    border-bottom-left-radius: var(--demo-radius);
+    border-bottom-right-radius: var(--demo-radius);
+    margin-top: -1px;
+    background-color: var(--gray-s1);
 
     &[data-closed] {
       &::before {
@@ -240,8 +242,8 @@
         border-bottom-right-radius: calc(var(--demo-radius) - 1px);
         background: linear-gradient(
           to bottom,
-          transparent 25%,
-          color-mix(in srgb, var(--gray-s1), transparent 30%) 100%
+          transparent 20%,
+          color-mix(in srgb, var(--gray-s1), transparent 20%) 100%
         );
       }
     }
@@ -273,12 +275,6 @@
     line-height: 1.25rem; /* 20px */
     cursor: text;
     display: flex;
-
-    > .GhostButton {
-      position: absolute;
-      top: 0.5rem;
-      right: 0.5rem;
-    }
 
     & pre {
       /* Different fonts may introduce vertical align issues */
@@ -312,29 +308,63 @@
     }
   }
 
+  .DemoCodeBlockCopyButton {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 3;
+  }
+
   .DemoCollapseButton {
+    box-sizing: border-box;
     position: relative;
-    display: inline-flex;
+    display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    gap: var(--space-8);
     border: none;
+    padding: 0;
     color: var(--color-foreground);
+    background: transparent;
     font-family: inherit;
     font-size: var(--font-size-13);
     font-weight: 500;
     line-height: 1;
     vertical-align: top;
+    cursor: default;
+    z-index: 2;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+    appearance: none;
+
+    &[data-sticky] {
+      z-index: 1;
+    }
+
+    &:focus-visible {
+      outline: 0;
+    }
+
+    &:focus-visible .DemoCollapseButtonVisual {
+      outline: 2px solid var(--gray-t2);
+      outline-offset: -1px;
+    }
+  }
+
+  .DemoCollapseButtonVisual {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-8);
     height: var(--space-28);
     padding-inline: var(--space-12);
     border-radius: var(--radius-pill);
     background: linear-gradient(to bottom, hsl(0deg 0% 0% / 8%), hsl(0deg 0% 0% / 16%));
     white-space: nowrap;
-    z-index: 2;
-    -webkit-user-select: none;
-    user-select: none;
-    -webkit-tap-highlight-color: transparent;
+    pointer-events: none;
+    z-index: 0;
 
     &::before {
       content: '';
@@ -351,12 +381,8 @@
         0 2px 4px -2px hsl(0deg 0% 0% / 4%);
     }
 
-    &[data-sticky] {
-      z-index: 1;
-    }
-
     @media (hover: hover) {
-      &:hover {
+      .DemoCollapseButton:hover & {
         background: linear-gradient(to bottom, hsl(0deg 0% 0% / 16%), hsl(0deg 0% 0% / 32%));
       }
     }
@@ -373,15 +399,10 @@
       }
 
       @media (hover: hover) {
-        &:hover {
+        .DemoCollapseButton:hover & {
           background: linear-gradient(to bottom, hsl(0deg 0% 100% / 24%), hsl(0deg 0% 100% / 36%));
         }
       }
-    }
-
-    &:focus-visible {
-      outline: 2px solid var(--gray-t2);
-      outline-offset: -1px;
     }
   }
 }

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -61,7 +61,7 @@
     align-items: end;
     gap: 1.5rem;
     height: 2.25rem;
-    padding: 0 0 0 0.5rem;
+    padding: 0 0 0 calc(0.25rem - 1px);
     -webkit-user-select: none;
     user-select: none;
 

--- a/docs/src/components/Demo/Demo.tsx
+++ b/docs/src/components/Demo/Demo.tsx
@@ -29,14 +29,12 @@ import './Demo.css';
 
 export type DemoProps = ContentProps<{
   defaultOpen?: boolean;
-  compact?: boolean;
   className?: string;
   showExtraPlaygroundLink?: boolean;
 }>;
 
 export function Demo({
   defaultOpen = false,
-  compact = false,
   showExtraPlaygroundLink = false,
   className,
   ...demoProps
@@ -192,63 +190,66 @@ export function Demo({
       </div>
       <Collapsible.Root open={demo.expanded} onOpenChange={onOpenChange}>
         <div role="figure" aria-label="Component demo code">
-          {(compact ? demo.expanded : true) && (
-            <div className="DemoToolbar">
-              <DemoFileSelector
-                files={demo.files}
-                selectedFileName={demo.selectedFileName}
-                selectFileName={onSelectFile}
-                onTabChange={demo.expand}
-              />
+          <div className="DemoToolbar">
+            <DemoFileSelector
+              files={demo.files}
+              selectedFileName={demo.selectedFileName}
+              selectFileName={onSelectFile}
+              onTabChange={demo.expand}
+            />
 
-              <div className="DemoToolbarActions">
-                {demo.variants.length > 1 && (
-                  <DemoVariantSelector
-                    onVariantChange={demo.expand}
-                    variants={demo.variants}
-                    selectedVariant={demo.selectedVariant}
-                    selectVariant={demo.selectVariant as any}
+            <div className="DemoToolbarActions">
+              {demo.variants.length > 1 && (
+                <DemoVariantSelector
+                  onVariantChange={demo.expand}
+                  variants={demo.variants}
+                  selectedVariant={demo.selectedVariant}
+                  selectVariant={demo.selectVariant as any}
+                />
+              )}
+              {externalPlaygroundLink}
+              <GhostButton aria-label="Copy code" onClick={demo.copy}>
+                Copy
+                {copyTimeout ? <CheckIcon /> : <CopyIcon />}
+              </GhostButton>
+
+              {githubUrl && (
+                <Menu.Root>
+                  <Menu.Trigger
+                    render={
+                      <GhostButton layout="icon" aria-label="More actions">
+                        <MoreVertIcon aria-hidden="true" />
+                      </GhostButton>
+                    }
                   />
-                )}
-                {externalPlaygroundLink}
-                <GhostButton aria-label="Copy code" onClick={demo.copy}>
-                  Copy
-                  {copyTimeout ? <CheckIcon /> : <CopyIcon />}
-                </GhostButton>
+                  <Menu.Popup align="end" alignOffset={-5}>
+                    <Menu.LinkItem
+                      href={githubUrl}
+                      target="_blank"
+                      rel="noopener"
+                      onClick={onViewSource}
+                    >
+                      <GitHubIcon aria-hidden="true" />
+                      View source on GitHub
+                      <ExternalLinkIcon aria-hidden="true" />
+                    </Menu.LinkItem>
 
-                {githubUrl && (
-                  <Menu.Root>
-                    <Menu.Trigger
-                      render={
-                        <GhostButton layout="icon" aria-label="More actions">
-                          <MoreVertIcon aria-hidden="true" />
-                        </GhostButton>
-                      }
-                    />
-                    <Menu.Popup align="end" alignOffset={-5}>
-                      <Menu.LinkItem href={githubUrl} target="_blank" onClick={onViewSource}>
-                        <GitHubIcon aria-hidden="true" />
-                        View source on GitHub
-                        <ExternalLinkIcon aria-hidden="true" />
-                      </Menu.LinkItem>
-
-                      <Menu.Item closeOnClick={false} onClick={onCopySourceLink}>
-                        {sourceLinkCopied ? (
-                          <CheckIcon aria-hidden="true" />
-                        ) : (
-                          <CopyIcon aria-hidden="true" />
-                        )}
-                        Copy link to source
-                        <span className="sr-only" aria-live="polite">
-                          {sourceLinkCopied && 'Link copied!'}
-                        </span>
-                      </Menu.Item>
-                    </Menu.Popup>
-                  </Menu.Root>
-                )}
-              </div>
+                    <Menu.Item closeOnClick={false} onClick={onCopySourceLink}>
+                      {sourceLinkCopied ? (
+                        <CheckIcon aria-hidden="true" />
+                      ) : (
+                        <CopyIcon aria-hidden="true" />
+                      )}
+                      Copy link to source
+                      <span className="sr-only" aria-live="polite">
+                        {sourceLinkCopied && 'Link copied!'}
+                      </span>
+                    </Menu.Item>
+                  </Menu.Popup>
+                </Menu.Root>
+              )}
             </div>
-          )}
+          </div>
 
           <DemoCodeBlock
             selectedFile={demo.selectedFile}
@@ -256,7 +257,6 @@ export function Demo({
             selectedFileLines={demo.selectedFileLines}
             collapsibleOpen={demo.expanded}
             collapsibleTriggerRef={collapsibleTriggerRef}
-            compact={compact}
           />
         </div>
       </Collapsible.Root>

--- a/docs/src/components/Demo/Demo.tsx
+++ b/docs/src/components/Demo/Demo.tsx
@@ -29,12 +29,14 @@ import './Demo.css';
 
 export type DemoProps = ContentProps<{
   defaultOpen?: boolean;
+  compact?: boolean;
   className?: string;
   showExtraPlaygroundLink?: boolean;
 }>;
 
 export function Demo({
   defaultOpen = false,
+  compact = false,
   showExtraPlaygroundLink = false,
   className,
   ...demoProps
@@ -188,68 +190,69 @@ export function Demo({
           )}
         </DemoPlayground>
       </div>
-      <Collapsible.Root open={demo.expanded} onOpenChange={onOpenChange}>
+      <Collapsible.Root
+        className="DemoCollapsibleRoot"
+        open={demo.expanded}
+        onOpenChange={onOpenChange}
+      >
         <div role="figure" aria-label="Component demo code">
-          <div className="DemoToolbar">
-            <DemoFileSelector
-              files={demo.files}
-              selectedFileName={demo.selectedFileName}
-              selectFileName={onSelectFile}
-              onTabChange={demo.expand}
-            />
+          {(compact ? demo.expanded : true) && (
+            <div className="DemoToolbar">
+              <DemoFileSelector
+                files={demo.files}
+                selectedFileName={demo.selectedFileName}
+                selectFileName={onSelectFile}
+                onTabChange={demo.expand}
+              />
 
-            <div className="DemoToolbarActions">
-              {demo.variants.length > 1 && (
-                <DemoVariantSelector
-                  onVariantChange={demo.expand}
-                  variants={demo.variants}
-                  selectedVariant={demo.selectedVariant}
-                  selectVariant={demo.selectVariant as any}
-                />
-              )}
-              {externalPlaygroundLink}
-              <GhostButton aria-label="Copy code" onClick={demo.copy}>
-                Copy
-                {copyTimeout ? <CheckIcon /> : <CopyIcon />}
-              </GhostButton>
-
-              {githubUrl && (
-                <Menu.Root>
-                  <Menu.Trigger
-                    render={
-                      <GhostButton layout="icon" aria-label="More actions">
-                        <MoreVertIcon aria-hidden="true" />
-                      </GhostButton>
-                    }
+              <div className="DemoToolbarActions">
+                {demo.variants.length > 1 && (
+                  <DemoVariantSelector
+                    onVariantChange={demo.expand}
+                    variants={demo.variants}
+                    selectedVariant={demo.selectedVariant}
+                    selectVariant={demo.selectVariant as any}
                   />
-                  <Menu.Popup align="end" alignOffset={-5}>
-                    <Menu.LinkItem
-                      href={githubUrl}
-                      target="_blank"
-                      rel="noopener"
-                      onClick={onViewSource}
-                    >
-                      <GitHubIcon aria-hidden="true" />
-                      View source on GitHub
-                      <ExternalLinkIcon aria-hidden="true" />
-                    </Menu.LinkItem>
+                )}
+                {externalPlaygroundLink}
+                {githubUrl && (
+                  <Menu.Root>
+                    <Menu.Trigger
+                      render={
+                        <GhostButton layout="icon" aria-label="More actions">
+                          <MoreVertIcon aria-hidden="true" />
+                        </GhostButton>
+                      }
+                    />
+                    <Menu.Popup align="end" alignOffset={-5}>
+                      <Menu.LinkItem
+                        href={githubUrl}
+                        target="_blank"
+                        rel="noopener"
+                        onClick={onViewSource}
+                      >
+                        <GitHubIcon aria-hidden="true" />
+                        View source on GitHub
+                        <ExternalLinkIcon aria-hidden="true" />
+                      </Menu.LinkItem>
 
-                    <Menu.Item closeOnClick={false} onClick={onCopySourceLink}>
-                      {sourceLinkCopied ? (
-                        <CheckIcon aria-hidden="true" />
-                      ) : (
-                        <CopyIcon aria-hidden="true" />
-                      )}
-                      Copy link to source
-                      <span className="sr-only" aria-live="polite">
-                        {sourceLinkCopied && 'Link copied!'}
-                      </span>
-                    </Menu.Item>
-                  </Menu.Popup>
-                </Menu.Root>
-              )}
+                      <Menu.Item closeOnClick={false} onClick={onCopySourceLink}>
+                        {sourceLinkCopied ? (
+                          <CheckIcon aria-hidden="true" />
+                        ) : (
+                          <CopyIcon aria-hidden="true" />
+                        )}
+                        Copy link to source
+                        <span className="sr-only" aria-live="polite">
+                          {sourceLinkCopied && 'Link copied!'}
+                        </span>
+                      </Menu.Item>
+                    </Menu.Popup>
+                  </Menu.Root>
+                )}
+              </div>
             </div>
-          </div>
+          )}
 
           <DemoCodeBlock
             selectedFile={demo.selectedFile}
@@ -257,6 +260,11 @@ export function Demo({
             selectedFileLines={demo.selectedFileLines}
             collapsibleOpen={demo.expanded}
             collapsibleTriggerRef={collapsibleTriggerRef}
+            copyButton={
+              <GhostButton layout="icon" aria-label="Copy code" onClick={demo.copy}>
+                {copyTimeout ? <CheckIcon /> : <CopyIcon />}
+              </GhostButton>
+            }
           />
         </div>
       </Collapsible.Root>

--- a/docs/src/components/Demo/Demo.tsx
+++ b/docs/src/components/Demo/Demo.tsx
@@ -261,7 +261,12 @@ export function Demo({
             collapsibleOpen={demo.expanded}
             collapsibleTriggerRef={collapsibleTriggerRef}
             copyButton={
-              <GhostButton layout="icon" aria-label="Copy code" onClick={demo.copy}>
+              <GhostButton
+                layout="icon"
+                aria-label="Copy code"
+                onClick={demo.copy}
+                className="DemoCodeBlockCopyButton"
+              >
                 {copyTimeout ? <CheckIcon /> : <CopyIcon />}
               </GhostButton>
             }

--- a/docs/src/components/Demo/Demo.tsx
+++ b/docs/src/components/Demo/Demo.tsx
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { Collapsible } from '@base-ui/react/collapsible';
 import * as Menu from 'docs/src/components/Menu';
 import { usePathname } from 'next/navigation';
@@ -41,7 +40,6 @@ export function Demo({
   className,
   ...demoProps
 }: DemoProps) {
-  const collapsibleTriggerRef = React.useRef<HTMLButtonElement>(null);
   const [copyTimeout, setCopyTimeout] = React.useState<number>(0);
   const [sourceLinkCopied, setSourceLinkCopied] = React.useState(false);
   const sourceLinkCopyResetTimeout = useTimeout();
@@ -127,25 +125,6 @@ export function Demo({
       label: demoId,
       params: { [action]: demoId, slug: demoSlug || '' },
     });
-
-    if (!nextOpen && collapsibleTriggerRef.current != null) {
-      const triggerEl = collapsibleTriggerRef.current;
-      const rectTopBeforeClose = triggerEl.getBoundingClientRect().top;
-
-      ReactDOM.flushSync(() => demo.setExpanded(nextOpen));
-
-      const rectTopAfterClose = triggerEl.getBoundingClientRect().top;
-      const delta = rectTopAfterClose - rectTopBeforeClose;
-      // don't scroll if the trigger is still in the viewport after closing
-      if (rectTopAfterClose < 0) {
-        window.scrollBy({
-          top: delta,
-          behavior: 'instant',
-        });
-      }
-      return;
-    }
-
     demo.setExpanded(nextOpen);
   });
 
@@ -256,10 +235,8 @@ export function Demo({
 
           <DemoCodeBlock
             selectedFile={demo.selectedFile}
-            selectedFileName={demo.selectedFileName}
             selectedFileLines={demo.selectedFileLines}
             collapsibleOpen={demo.expanded}
-            collapsibleTriggerRef={collapsibleTriggerRef}
             copyButton={
               <GhostButton
                 layout="icon"

--- a/docs/src/components/Demo/DemoCodeBlock.tsx
+++ b/docs/src/components/Demo/DemoCodeBlock.tsx
@@ -47,8 +47,8 @@ export function DemoCodeBlock({
       <Root>
         <ScrollArea.Viewport>
           <div className="DemoSourceBrowser">
-            {copyButton}
             {selectedFile}
+            {copyButton}
           </div>
         </ScrollArea.Viewport>
         <ScrollArea.Corner />
@@ -74,8 +74,8 @@ export function DemoCodeBlock({
           }
         >
           <div className="DemoSourceBrowser">
-            {copyButton}
             {selectedFile}
+            {copyButton}
           </div>
         </Collapsible.Panel>
 
@@ -84,7 +84,7 @@ export function DemoCodeBlock({
           className="DemoCollapseButton"
           data-sticky={collapsibleOpen ? '' : undefined}
         >
-          <span>{collapsibleOpen ? 'Hide' : 'Show'} code</span>
+          <span className="DemoCollapseButtonVisual">{collapsibleOpen ? 'Hide' : 'Show'} code</span>
         </Collapsible.Trigger>
 
         {collapsibleOpen && (

--- a/docs/src/components/Demo/DemoCodeBlock.tsx
+++ b/docs/src/components/Demo/DemoCodeBlock.tsx
@@ -4,12 +4,10 @@ import * as ScrollArea from '../ScrollArea';
 
 interface DemoCodeBlockProps {
   selectedFile: React.ReactNode;
-  selectedFileName: string | undefined;
   selectedFileLines: number;
   collapsibleOpen: boolean;
   /** How many lines should the code block have to get collapsed instead of rendering fully */
   collapsibleLinesThreshold?: number;
-  collapsibleTriggerRef: React.Ref<HTMLButtonElement>;
   copyButton: React.ReactNode;
 }
 
@@ -39,7 +37,6 @@ export function DemoCodeBlock({
   selectedFileLines,
   collapsibleOpen,
   collapsibleLinesThreshold = 12,
-  collapsibleTriggerRef,
   copyButton,
 }: DemoCodeBlockProps) {
   if (selectedFileLines < collapsibleLinesThreshold) {
@@ -57,7 +54,7 @@ export function DemoCodeBlock({
   }
 
   return (
-    <div className="DemoCodeBlockCollapsible" data-open={collapsibleOpen ? '' : undefined}>
+    <div className="DemoCodeBlockCollapsible">
       <Root data-closed={collapsibleOpen ? undefined : ''}>
         <Collapsible.Panel
           keepMounted
@@ -74,13 +71,11 @@ export function DemoCodeBlock({
           <div className="DemoSourceBrowser">{selectedFile}</div>
         </Collapsible.Panel>
 
-        <Collapsible.Trigger
-          ref={collapsibleTriggerRef}
-          className="DemoCollapseButton"
-          data-sticky={collapsibleOpen ? '' : undefined}
-        >
-          <span className="DemoCollapseButtonVisual">{collapsibleOpen ? 'Hide' : 'Show'} code</span>
-        </Collapsible.Trigger>
+        {!collapsibleOpen && (
+          <Collapsible.Trigger className="DemoCollapseButton">
+            <span className="DemoCollapseButtonVisual">Show code</span>
+          </Collapsible.Trigger>
+        )}
 
         {collapsibleOpen && (
           <React.Fragment>

--- a/docs/src/components/Demo/DemoCodeBlock.tsx
+++ b/docs/src/components/Demo/DemoCodeBlock.tsx
@@ -10,6 +10,7 @@ interface DemoCodeBlockProps {
   /** How many lines should the code block have to get collapsed instead of rendering fully */
   collapsibleLinesThreshold?: number;
   collapsibleTriggerRef: React.Ref<HTMLButtonElement>;
+  copyButton: React.ReactNode;
 }
 
 function Root(props: React.ComponentProps<typeof ScrollArea.Root>) {
@@ -39,12 +40,16 @@ export function DemoCodeBlock({
   collapsibleOpen,
   collapsibleLinesThreshold = 12,
   collapsibleTriggerRef,
+  copyButton,
 }: DemoCodeBlockProps) {
   if (selectedFileLines < collapsibleLinesThreshold) {
     return (
       <Root>
         <ScrollArea.Viewport>
-          <div className="DemoSourceBrowser">{selectedFile}</div>
+          <div className="DemoSourceBrowser">
+            {copyButton}
+            {selectedFile}
+          </div>
         </ScrollArea.Viewport>
         <ScrollArea.Corner />
         <ScrollArea.Scrollbar orientation="vertical" />
@@ -54,16 +59,33 @@ export function DemoCodeBlock({
   }
 
   return (
-    <React.Fragment>
-      <Root render={<Collapsible.Panel keepMounted hidden={false} />}>
-        <ScrollArea.Viewport
-          aria-hidden={!collapsibleOpen}
-          data-closed={collapsibleOpen ? undefined : ''}
-          className="DemoCodeBlockViewport"
-          {...(!collapsibleOpen && { tabIndex: undefined, style: { overflow: undefined } })}
+    <div className="DemoCodeBlockCollapsible" data-open={collapsibleOpen ? '' : undefined}>
+      <Root data-closed={collapsibleOpen ? undefined : ''}>
+        <Collapsible.Panel
+          keepMounted
+          hidden={false}
+          render={
+            <ScrollArea.Viewport
+              aria-hidden={!collapsibleOpen}
+              data-closed={collapsibleOpen ? undefined : ''}
+              className="DemoCodeBlockViewport"
+              {...(!collapsibleOpen && { tabIndex: undefined, style: { overflow: undefined } })}
+            />
+          }
         >
-          <div className="DemoSourceBrowser">{selectedFile}</div>
-        </ScrollArea.Viewport>
+          <div className="DemoSourceBrowser">
+            {copyButton}
+            {selectedFile}
+          </div>
+        </Collapsible.Panel>
+
+        <Collapsible.Trigger
+          ref={collapsibleTriggerRef}
+          className="DemoCollapseButton"
+          data-sticky={collapsibleOpen ? '' : undefined}
+        >
+          <span>{collapsibleOpen ? 'Hide' : 'Show'} code</span>
+        </Collapsible.Trigger>
 
         {collapsibleOpen && (
           <React.Fragment>
@@ -73,14 +95,6 @@ export function DemoCodeBlock({
           </React.Fragment>
         )}
       </Root>
-
-      <Collapsible.Trigger
-        ref={collapsibleTriggerRef}
-        className="DemoCollapseButton"
-        data-sticky={collapsibleOpen ? '' : undefined}
-      >
-        {collapsibleOpen ? 'Hide' : 'Show'} code
-      </Collapsible.Trigger>
-    </React.Fragment>
+    </div>
   );
 }

--- a/docs/src/components/Demo/DemoCodeBlock.tsx
+++ b/docs/src/components/Demo/DemoCodeBlock.tsx
@@ -10,8 +10,6 @@ interface DemoCodeBlockProps {
   /** How many lines should the code block have to get collapsed instead of rendering fully */
   collapsibleLinesThreshold?: number;
   collapsibleTriggerRef: React.Ref<HTMLButtonElement>;
-  /** When compact, we don't show a preview of the collapse code */
-  compact: boolean;
 }
 
 function Root(props: React.ComponentProps<typeof ScrollArea.Root>) {
@@ -38,7 +36,6 @@ function Root(props: React.ComponentProps<typeof ScrollArea.Root>) {
 export function DemoCodeBlock({
   selectedFile,
   selectedFileLines,
-  compact,
   collapsibleOpen,
   collapsibleLinesThreshold = 12,
   collapsibleTriggerRef,
@@ -58,14 +55,7 @@ export function DemoCodeBlock({
 
   return (
     <React.Fragment>
-      <Root
-        render={
-          <Collapsible.Panel
-            keepMounted={compact ? undefined : true}
-            hidden={compact ? undefined : false}
-          />
-        }
-      >
+      <Root render={<Collapsible.Panel keepMounted hidden={false} />}>
         <ScrollArea.Viewport
           aria-hidden={!collapsibleOpen}
           data-closed={collapsibleOpen ? undefined : ''}

--- a/docs/src/components/Demo/DemoCodeBlock.tsx
+++ b/docs/src/components/Demo/DemoCodeBlock.tsx
@@ -46,14 +46,12 @@ export function DemoCodeBlock({
     return (
       <Root>
         <ScrollArea.Viewport>
-          <div className="DemoSourceBrowser">
-            {selectedFile}
-            {copyButton}
-          </div>
+          <div className="DemoSourceBrowser">{selectedFile}</div>
         </ScrollArea.Viewport>
         <ScrollArea.Corner />
         <ScrollArea.Scrollbar orientation="vertical" />
         <ScrollArea.Scrollbar orientation="horizontal" />
+        {copyButton}
       </Root>
     );
   }
@@ -73,10 +71,7 @@ export function DemoCodeBlock({
             />
           }
         >
-          <div className="DemoSourceBrowser">
-            {selectedFile}
-            {copyButton}
-          </div>
+          <div className="DemoSourceBrowser">{selectedFile}</div>
         </Collapsible.Panel>
 
         <Collapsible.Trigger
@@ -94,6 +89,7 @@ export function DemoCodeBlock({
             <ScrollArea.Scrollbar orientation="horizontal" />
           </React.Fragment>
         )}
+        {copyButton}
       </Root>
     </div>
   );

--- a/docs/src/components/Demo/DemoFileSelector.tsx
+++ b/docs/src/components/Demo/DemoFileSelector.tsx
@@ -57,12 +57,8 @@ export function DemoFileSelector({
     }
   }, []);
 
-  if (files.length === 1) {
-    return (
-      <a className="DemoFilename" href={files[0].slug ? `#${files[0].slug}` : undefined}>
-        {files[0].name}
-      </a>
-    );
+  if (files.length <= 1) {
+    return null;
   }
 
   return (

--- a/docs/src/components/Demo/DemoFileSelector.tsx
+++ b/docs/src/components/Demo/DemoFileSelector.tsx
@@ -74,7 +74,7 @@ export function DemoFileSelector({
             nativeButton={false}
             onPointerDown={onTabPointerDown}
           >
-            {tab.name}
+            <span>{tab.name}</span>
           </Tabs.Tab>
         ))}
       </Tabs.List>

--- a/docs/src/components/DescriptionList.css
+++ b/docs/src/components/DescriptionList.css
@@ -40,7 +40,7 @@
     &.separator {
       &::before {
         content: '';
-        box-shadow: inset 0 1px 0 0 var(--gray-c2);
+        box-shadow: inset 0 1px 0 0 var(--color-border);
         position: absolute;
         top: 0;
         inset-inline: 0.75rem 1rem;

--- a/docs/src/components/GhostButton.css
+++ b/docs/src/components/GhostButton.css
@@ -31,12 +31,12 @@
     &:not(:focus-visible) {
       @media (hover: hover) {
         &:hover {
-          background-color: var(--gray-c2);
+          background-color: var(--gray-c1);
         }
       }
 
       &[data-popup-open] {
-        background-color: var(--gray-c2);
+        background-color: var(--gray-c1);
       }
     }
   }

--- a/docs/src/components/InstallationBlock/InstallationBlock.css
+++ b/docs/src/components/InstallationBlock/InstallationBlock.css
@@ -15,7 +15,7 @@
     position: relative;
     z-index: 0;
     outline: 0;
-    height: 2rem;
+    height: calc(2rem + 1px);
     padding-inline: 0.5rem;
     padding-top: 0.25rem;
     padding-bottom: 0.25rem;

--- a/docs/src/components/InstallationBlock/InstallationBlock.css
+++ b/docs/src/components/InstallationBlock/InstallationBlock.css
@@ -50,7 +50,7 @@
 
     &[data-active] {
       background-color: var(--color-content);
-      border-color: var(--gray-c2);
+      border-color: var(--color-border);
 
       &::before {
         content: '';
@@ -75,7 +75,7 @@
   }
 
   .InstallationBlockTabPanel {
-    border-top: 1px solid var(--gray-c2);
+    border-top: 1px solid var(--color-border);
     border-bottom-left-radius: var(--radius-4);
     border-bottom-right-radius: var(--radius-4);
     margin-top: -1px;

--- a/docs/src/components/InstallationBlock/InstallationBlock.css
+++ b/docs/src/components/InstallationBlock/InstallationBlock.css
@@ -1,82 +1,91 @@
 @layer components {
   .InstallationBlockTabsList {
+    position: relative;
     display: flex;
-    gap: 1rem;
+    align-self: flex-end;
+    gap: 0.125rem;
   }
 
   .InstallationBlockTab {
-    font-size: var(--font-size-13);
-    line-height: 1.25rem;
+    box-sizing: border-box;
+    font-family: var(--font-mono);
+    font-size: var(--font-size-14);
+    line-height: 1;
     cursor: default;
     position: relative;
     z-index: 0;
     outline: 0;
+    height: 2rem;
+    padding-inline: 0.5rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    border-top: 1px solid transparent;
+    border-right: 1px solid transparent;
+    border-left: 1px solid transparent;
+    border-top-left-radius: var(--radius-8);
+    border-top-right-radius: var(--radius-8);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    > span {
+      position: relative;
+    }
 
     @media (hover: hover) {
-      &:hover {
+      &:hover:not([data-active]) {
+        border-color: var(--gray-c1);
+
         &::before {
+          content: '';
+          position: absolute;
+          inset: 0 0 1px;
+          border-top-left-radius: calc(var(--radius-8) - 1px);
+          border-top-right-radius: calc(var(--radius-8) - 1px);
           background-color: var(--gray-c1);
+          pointer-events: none;
         }
       }
     }
 
-    &::before,
-    &::after {
-      content: '';
-      position: absolute;
-      z-index: -1;
-    }
-
-    &::before {
-      inset: -0.125rem -0.375rem;
-      border-radius: var(--radius-4);
-    }
-
-    /* Increase the clickable size */
-    &::after {
-      inset: -0.375rem -0.5rem;
-    }
-
     &[data-active] {
-      color: var(--color-foreground);
-      font-weight: var(--font-weight-700);
+      background-color: var(--color-content);
+      border-color: var(--gray-c2);
 
       &::before {
-        background-color: var(--gray-s1);
-        outline: 1px solid var(--gray-c3);
-        outline-offset: -1px;
-        box-shadow:
-          0 2px 3px -2px var(--gray-c3),
-          inset 0 -1px 1px var(--gray-c2);
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 1px;
+        background-color: var(--color-content);
+        pointer-events: none;
       }
     }
 
-    &:focus-visible::before {
+    &:focus-visible {
       outline: 2px solid var(--gray-t2);
-      outline-offset: -1px;
+      outline-offset: -2px;
+
+      &::before {
+        content: none;
+      }
     }
   }
 
-  .InstallationBlockTabLabel {
-    display: inline-grid;
-  }
-
-  .InstallationBlockTabLabel::before {
-    content: attr(data-text);
-    font-weight: var(--font-weight-700);
-    visibility: hidden;
-    height: 0;
-    pointer-events: none;
-    grid-area: 1 / 1;
-  }
-
   .InstallationBlockTabPanel {
+    border-top: 1px solid var(--gray-c2);
     border-bottom-left-radius: var(--radius-4);
     border-bottom-right-radius: var(--radius-4);
+    margin-top: -1px;
     outline: 0;
 
     &:focus-visible {
       outline: 2px solid var(--gray-t2);
+      outline-offset: -2px;
+      position: relative;
+      z-index: 1;
     }
   }
 }

--- a/docs/src/components/InstallationBlock/InstallationBlock.tsx
+++ b/docs/src/components/InstallationBlock/InstallationBlock.tsx
@@ -38,13 +38,18 @@ export function InstallationBlock(props: InstallationBlockProps) {
       onValueChange={handleValueChange}
     >
       <CodeBlock.Root>
-        <CodeBlock.Panel title="Installation command">
-          <Tabs.List className="InstallationBlockTabsList" aria-label="Package manager">
+        <CodeBlock.Panel
+          title="Installation command"
+          style={{ paddingLeft: '0.25rem', borderBottom: 'none' }}
+        >
+          <Tabs.List
+            className="InstallationBlockTabsList"
+            aria-label="Package manager"
+            activateOnFocus
+          >
             {INSTALLATION_PACKAGE_MANAGERS.map((pm) => (
               <Tabs.Tab key={pm.value} value={pm.value} className="InstallationBlockTab">
-                <span className="InstallationBlockTabLabel" data-text={pm.label}>
-                  {pm.label}
-                </span>
+                <span>{pm.label}</span>
               </Tabs.Tab>
             ))}
           </Tabs.List>

--- a/docs/src/components/InstallationBlock/InstallationBlock.tsx
+++ b/docs/src/components/InstallationBlock/InstallationBlock.tsx
@@ -40,7 +40,7 @@ export function InstallationBlock(props: InstallationBlockProps) {
       <CodeBlock.Root>
         <CodeBlock.Panel
           title="Installation command"
-          style={{ paddingLeft: '0.25rem', borderBottom: 'none' }}
+          style={{ paddingLeft: 'calc(0.125rem + 1px)', borderBottom: 'none' }}
         >
           <Tabs.List
             className="InstallationBlockTabsList"

--- a/docs/src/components/Menu.css
+++ b/docs/src/components/Menu.css
@@ -82,6 +82,6 @@
     height: 1px;
     margin-block: 0.25rem;
     margin-inline: 0.25rem;
-    background-color: var(--gray-c2);
+    background-color: var(--color-border);
   }
 }

--- a/docs/src/components/MobileNav.css
+++ b/docs/src/components/MobileNav.css
@@ -117,10 +117,10 @@
 
     box-shadow:
       0 10px 64px -10px rgb(36 40 52 / 20%),
-      0 0.25px 0 1px var(--gray-c2);
+      0 0.25px 0 1px var(--color-border);
 
     @media (prefers-color-scheme: dark) {
-      box-shadow: 0 0 0 1px var(--gray-c2);
+      box-shadow: 0 0 0 1px var(--color-border);
     }
 
     /* Make bottom overscroll edges soft; visible during extreme rubber band overscroll at the bottom */
@@ -169,7 +169,7 @@
       content: '';
       display: block;
       margin-top: -1px;
-      border-bottom: 1px solid var(--gray-c2);
+      border-bottom: 1px solid var(--color-border);
     }
   }
 
@@ -184,7 +184,7 @@
       content: '';
       display: block;
       margin-inline: var(--mobile-nav-item-padding-x);
-      border-bottom: 1px solid var(--gray-c2);
+      border-bottom: 1px solid var(--color-border);
     }
   }
 

--- a/docs/src/components/ReleaseTimeline/ReleaseTimeline.css
+++ b/docs/src/components/ReleaseTimeline/ReleaseTimeline.css
@@ -41,8 +41,8 @@
       background: linear-gradient(
         to bottom,
         transparent,
-        var(--gray-c2) 2.5rem,
-        var(--gray-c2) calc(100% - 2.5rem),
+        var(--color-border) 2.5rem,
+        var(--color-border) calc(100% - 2.5rem),
         transparent
       );
     }
@@ -89,7 +89,7 @@
       top: var(--dot-y);
       width: calc(var(--column-gap) / 2 - var(--dot-size) / 2);
       height: 1px;
-      background: var(--gray-c2);
+      background: var(--color-border);
     }
 
     .TimelineItem:nth-child(odd)::after {
@@ -108,7 +108,7 @@
     flex-direction: column;
     align-items: start;
     gap: 0.75rem;
-    background-color: var(--gray-c2);
+    background-color: var(--color-border);
     border-radius: var(--radius-8);
     padding: 1.25rem;
     font-size: var(--font-size-15);
@@ -133,8 +133,8 @@
     inset: 1px;
     border-radius: calc(var(--radius-8) - 1px);
     box-shadow:
-      0 1px 3px 0 var(--gray-c2),
-      0 1px 2px -1px var(--gray-c2);
+      0 1px 3px 0 var(--color-border),
+      0 1px 2px -1px var(--color-border);
     z-index: -1;
   }
 

--- a/docs/src/components/Search/Search.css
+++ b/docs/src/components/Search/Search.css
@@ -178,7 +178,7 @@
     border-radius: 1rem;
     background: var(--gray-s1);
     color: var(--gray-t2);
-    outline: 1px solid hsl(0deg 0% 0% / 4%);
+    outline: 1px solid var(--color-border);
     box-shadow:
       0 0.5px 1px hsl(0deg 0% 0% / 12%),
       0 1px 3px -1px hsl(0deg 0% 0% / 4%),

--- a/docs/src/components/Table.css
+++ b/docs/src/components/Table.css
@@ -5,7 +5,7 @@
     color: var(--gray-t1);
     border: 1px solid var(--gray-c2);
     border-collapse: separate;
-    border-radius: var(--radius-6);
+    border-radius: var(--radius-12);
     white-space: nowrap;
     overflow: hidden;
   }

--- a/docs/src/components/Table.css
+++ b/docs/src/components/Table.css
@@ -3,7 +3,7 @@
     font-size: var(--font-size-14);
     line-height: 1.25rem;
     color: var(--gray-t1);
-    border: 1px solid var(--gray-c2);
+    border: 1px solid var(--color-border);
     border-collapse: separate;
     border-radius: var(--radius-12);
     white-space: nowrap;
@@ -30,7 +30,8 @@
     font-weight: var(--font-weight-400);
     color: var(--color-foreground);
     background-color: var(--gray-s2);
-    border-bottom: 1px solid var(--gray-c2);
+    background-clip: padding-box;
+    border-bottom: 1px solid var(--color-border);
   }
 
   .TableCell {
@@ -38,7 +39,7 @@
     font-weight: var(--font-weight-400);
 
     :not(:last-child) > & {
-      border-bottom: 1px solid var(--gray-c2);
+      border-bottom: 1px solid var(--color-border);
     }
 
     &[data-scrollable] {

--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -282,7 +282,7 @@
       /* Functional colors */
       --color-content: black;
       --color-background: black;
-      --color-border: var(--whiteA-4);
+      --color-border: var(--whiteA-5);
       --color-popup: var(--gray-s1);
       --color-gridline: var(--gray-c1);
       --color-selection: hsl(0deg 0% 18%);

--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -143,6 +143,13 @@
     --blackA-5: hsl(0deg 0% 0% / 24%);
     --blackA-6: hsl(0deg 0% 0% / 64%);
 
+    --whiteA-1: hsl(0deg 0% 100% / 4%);
+    --whiteA-2: hsl(0deg 0% 100% / 8%);
+    --whiteA-3: hsl(0deg 0% 100% / 12%);
+    --whiteA-4: hsl(0deg 0% 100% / 16%);
+    --whiteA-5: hsl(0deg 0% 100% / 24%);
+    --whiteA-6: hsl(0deg 0% 100% / 64%);
+
     --poppy-t1: hsl(10deg 86% 48%);
     --blue-t1: hsl(211deg 100% 49%);
     --green-t1: hsl(156deg 81% 29%);
@@ -159,6 +166,7 @@
     --color-content: white;
     --color-background: var(--gray-s2);
     --color-foreground: var(--gray-t2);
+    --color-border: var(--blackA-2);
     --color-popup: white;
     --color-gridline: var(--gray-c3);
     --color-selection: hsl(0deg 0% 92%);
@@ -260,13 +268,6 @@
       --indigo-t1: hsl(214deg 93% 66%);
       --indigo-t2: hsl(210deg 100% 86%);
 
-      --blackA-1: transparent;
-      --blackA-2: transparent;
-      --blackA-3: transparent;
-      --blackA-4: transparent;
-      --blackA-5: transparent;
-      --blackA-6: transparent;
-
       --poppy-t1: hsl(10deg 96% 63%);
       --blue-t1: hsl(210deg 98% 66%);
       --green-t1: hsl(156deg 68% 54%);
@@ -281,6 +282,7 @@
       /* Functional colors */
       --color-content: black;
       --color-background: black;
+      --color-border: var(--whiteA-4);
       --color-popup: var(--gray-s1);
       --color-gridline: var(--gray-c1);
       --color-selection: hsl(0deg 0% 18%);
@@ -292,6 +294,13 @@
       --color-green: oklch(75% 25% 150deg);
       --color-navy: oklch(85% 25% 264deg);
       --color-violet: oklch(80% 60% 280deg);
+
+      /* Shadow */
+      --shadow-1: transparent;
+      --shadow-2: transparent;
+      --shadow-3: transparent;
+      --shadow-4: transparent;
+      --shadow-5: transparent;
     }
   }
 
@@ -326,6 +335,13 @@
     --blackA-5: initial;
     --blackA-6: initial;
 
+    --whiteA-1: initial;
+    --whiteA-2: initial;
+    --whiteA-3: initial;
+    --whiteA-4: initial;
+    --whiteA-5: initial;
+    --whiteA-6: initial;
+
     --poppy-t1: initial;
     --blue-t1: initial;
     --green-t1: initial;
@@ -358,6 +374,7 @@
     --color-content: initial;
     --color-background: initial;
     --color-foreground: initial;
+    --color-border: initial;
     --color-popup: initial;
     --color-gridline: initial;
     --color-highlight: initial;


### PR DESCRIPTION
Preview:
- Demo: https://deploy-preview-4983--base-ui.netlify.app/react/components/accordion
- Installation block: https://deploy-preview-4983--base-ui.netlify.app/react/overview/quick-start

Changes:
- Demos
  - Removes compact demos.
  - Reduces the height of the code block when collapsed, so only 4 lines are displayed.
  - The whole code block is clickable to expand the demo code block when collapsed.
  - New tabs style.
  - New "Show code" button styles.
  - Removes the "Hide code" button once it's expanded.
  - Moves the copy code button from the demo toolbar to the demo code block.
  - Hides file tabs when there's only one file (that's the case for most Tailwind demos).
- Updated installation block (present in [quick start page](https://deploy-preview-4983--base-ui.netlify.app/react/overview/quick-start)) styles so tabs have the same vibe as demo tabs.
- Removes the "Copy" visual label from regular code blocks.
- Updates regular code blocks, prop tables, etc., to match the demos' border radius.


|before|after|
|---|---|
|<img width="791" height="489" alt="Screenshot 2026-06-08 at 18 34 54" src="https://github.com/user-attachments/assets/15d8b6bc-f311-4a40-9027-10e6a00c71e0" />|<img width="799" height="378" alt="Screenshot 2026-06-12 at 15 02 21" src="https://github.com/user-attachments/assets/e715f625-3ab6-47ea-bb92-6556586db968" />|
|<img width="794" height="185" alt="Screenshot 2026-06-08 at 18 35 52" src="https://github.com/user-attachments/assets/a07429e9-68a3-453d-a272-e19cb079016d" />|<img width="789" height="185" alt="image" src="https://github.com/user-attachments/assets/cf8bc692-3e74-4424-9c24-0364243c6735" />|
