### PR TITLE
[docs][drawer] Remove `user-select: none`

### DIFF
--- a/docs/src/app/(docs)/react/components/drawer/demos/close-confirmation/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/close-confirmation/css-modules/index.module.css
@@ -148,11 +148,6 @@
     box-shadow: none;
   }
 
-  &[data-swiping] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
   &[data-starting-style],
   &[data-ending-style] {
     transform: translateX(calc(100% - var(--bleed) + var(--viewport-padding) + 2px));

--- a/docs/src/app/(docs)/react/components/drawer/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/hero/css-modules/index.module.css
@@ -138,11 +138,6 @@
     box-shadow: none;
   }
 
-  &[data-swiping] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
   &[data-starting-style],
   &[data-ending-style] {
     transform: translateX(calc(100% - var(--bleed) + var(--viewport-padding) + 2px));

--- a/docs/src/app/(docs)/react/components/drawer/demos/indent-provider/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/indent-provider/css-modules/index.module.css
@@ -181,11 +181,6 @@
     box-shadow: none;
   }
 
-  &[data-swiping] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
   &[data-starting-style],
   &[data-ending-style] {
     transform: translateY(calc(100% - var(--bleed) + 2px));

--- a/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/mobile-nav/css-modules/index.module.css
@@ -147,11 +147,6 @@
   will-change: transform;
   transform: translateY(var(--drawer-swipe-movement-y));
 
-  &[data-swiping] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
   @media (prefers-reduced-motion: reduce) {
     transition: none;
   }

--- a/docs/src/app/(docs)/react/components/drawer/demos/nested/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/nested/css-modules/index.module.css
@@ -161,11 +161,6 @@
     transition-duration: 0ms;
   }
 
-  &[data-swiping] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
   &::after {
     content: '';
     inset: 0;

--- a/docs/src/app/(docs)/react/components/drawer/demos/non-modal/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/non-modal/css-modules/index.module.css
@@ -142,11 +142,6 @@
     box-shadow: none;
   }
 
-  &[data-swiping] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
   &[data-starting-style],
   &[data-ending-style] {
     transform: translateX(calc(100% - var(--bleed) + var(--viewport-padding) + 2px));

--- a/docs/src/app/(docs)/react/components/drawer/demos/position/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/position/css-modules/index.module.css
@@ -126,11 +126,6 @@
     box-shadow: none;
   }
 
-  &[data-swiping] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
   &[data-starting-style],
   &[data-ending-style] {
     transform: translateY(calc(100% - var(--bleed) + 2px));

--- a/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/snap-points/css-modules/index.module.css
@@ -165,11 +165,6 @@
     pointer-events: none;
   }
 
-  &[data-swiping] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
   &[data-starting-style],
   &[data-ending-style] {
     transform: translateY(calc(100% + 2px));

--- a/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/swipe-area/css-modules/index.module.css
@@ -219,11 +219,6 @@
     box-shadow: none;
   }
 
-  &[data-swiping] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
   &[data-starting-style],
   &[data-ending-style] {
     transform: translateX(calc(100% - var(--bleed) + var(--viewport-padding) + 2px));

--- a/docs/src/app/(docs)/react/components/drawer/demos/uncontained/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/drawer/demos/uncontained/css-modules/index.module.css
@@ -118,11 +118,6 @@
   transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
   will-change: transform;
 
-  &[data-swiping] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
   &[data-starting-style],
   &[data-ending-style] {
     transform: translateY(calc(100% + 1rem + 2px));


### PR DESCRIPTION
These styles break text selection, so we're removing them.

```css
.Popup[data-swiping] {
  -webkit-user-select: none;
  user-select: none;
}
```