### PR TITLE
[menu] Remove invalid aria-owns owner span from menu portals

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
@@ -1,8 +1,8 @@
 import { expect } from 'vitest';
 import * as React from 'react';
 import { fireEvent, flushMicrotasks, render, screen } from '@mui/internal-test-utils';
-import { isJSDOM } from '#test-utils';
-import { FloatingPortal, useFloating } from '../index';
+import { isJSDOM, useTestInteractions } from '#test-utils';
+import { FloatingFocusManager, FloatingPortal, useClick, useFloating } from '../index';
 import { FloatingPortalLite } from '../../utils/FloatingPortalLite';
 import type { UseFloatingPortalNodeProps } from './FloatingPortal';
 
@@ -23,6 +23,28 @@ function App(props: AppProps) {
       <FloatingPortal {...props}>
         {open && <div ref={refs.setFloating} data-testid="floating" />}
       </FloatingPortal>
+    </React.Fragment>
+  );
+}
+
+function GuardedApp(props: { renderOwner?: boolean }) {
+  const [open, setOpen] = React.useState(false);
+  const { refs, context } = useFloating({ open, onOpenChange: setOpen });
+  const click = useClick(context);
+  const { getReferenceProps, getFloatingProps } = useTestInteractions([click]);
+
+  return (
+    <React.Fragment>
+      <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
+      {open && (
+        <FloatingPortal renderOwner={props.renderOwner}>
+          <FloatingFocusManager context={context} modal={false}>
+            <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating">
+              <button data-testid="inside" />
+            </div>
+          </FloatingFocusManager>
+        </FloatingPortal>
+      )}
     </React.Fragment>
   );
 }
@@ -149,5 +171,29 @@ describe.skipIf(!isJSDOM)('FloatingPortal', () => {
 
     const portal = document.querySelector('[data-testid="lite-portal"]');
     expect(portal).not.toBeNull();
+  });
+
+  test('renders the owner node by default', async () => {
+    render(<GuardedApp />);
+
+    fireEvent.click(screen.getByTestId('reference'));
+    await flushMicrotasks();
+
+    const portal = screen.getByTestId('floating').closest('[data-base-ui-portal]');
+    expect(portal?.id).toBeTruthy();
+    expect(document.querySelector(`span[aria-owns="${portal!.id}"]`)).not.toBeNull();
+  });
+
+  test('omits the owner node when renderOwner is false but keeps the focus guards', async () => {
+    render(<GuardedApp renderOwner={false} />);
+
+    fireEvent.click(screen.getByTestId('reference'));
+    await flushMicrotasks();
+
+    const portal = screen.getByTestId('floating').closest('[data-base-ui-portal]');
+    expect(portal?.id).toBeTruthy();
+    expect(document.querySelector(`span[aria-owns="${portal!.id}"]`)).toBeNull();
+    // The focus guards remain so tab order is still managed.
+    expect(document.querySelectorAll('[data-base-ui-focus-guard]').length).toBeGreaterThan(0);
   });
 });

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -162,11 +162,22 @@ export function useFloatingPortalNode(
  * @internal
  */
 export const FloatingPortal = React.forwardRef(function FloatingPortal(
-  componentProps: FloatingPortal.Props<any> & { renderGuards?: boolean | undefined },
+  componentProps: FloatingPortal.Props<any> & {
+    renderGuards?: boolean | undefined;
+    renderOwner?: boolean | undefined;
+  },
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { render, className, style, children, container, renderGuards, ...elementProps } =
-    componentProps;
+  const {
+    render,
+    className,
+    style,
+    children,
+    container,
+    renderGuards,
+    renderOwner = true,
+    ...elementProps
+  } = componentProps;
 
   const { portalNode, portalSubtree } = useFloatingPortalNode({
     container,
@@ -263,7 +274,13 @@ export const FloatingPortal = React.forwardRef(function FloatingPortal(
             }}
           />
         )}
-        {shouldRenderGuards && portalNode && (
+        {/*
+          The owner span only matters alongside the guards (it keeps VoiceOver's
+          virtual cursor in order between them), so it shares their gate.
+          `renderOwner` opts out of just the span when the relationship is already
+          conveyed elsewhere, e.g. a menu trigger's `aria-controls`.
+        */}
+        {renderOwner && shouldRenderGuards && portalNode && (
           <span aria-owns={portalNode.id} style={ownerVisuallyHidden} />
         )}
         {portalNode && ReactDOM.createPortal(children, portalNode)}

--- a/packages/react/src/menu/portal/MenuPortal.test.tsx
+++ b/packages/react/src/menu/portal/MenuPortal.test.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { expect } from 'vitest';
+import { screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -11,4 +13,25 @@ describe('<Menu.Portal />', () => {
       return render(<Menu.Root>{node}</Menu.Root>);
     },
   }));
+
+  // The menu trigger already conveys the popup relationship via
+  // aria-haspopup/aria-controls/aria-expanded, so the owner `span[aria-owns]`
+  // is both redundant and invalid as a child of the menu role.
+  it('does not render the aria-owns owner span', async () => {
+    await render(
+      <Menu.Root open>
+        <Menu.Trigger>Toggle</Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.Item>Item</Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>,
+    );
+
+    await screen.findByRole('menu');
+    expect(document.querySelector('span[aria-owns]')).toBe(null);
+  });
 });

--- a/packages/react/src/menu/portal/MenuPortal.tsx
+++ b/packages/react/src/menu/portal/MenuPortal.tsx
@@ -27,7 +27,13 @@ export const MenuPortal = React.forwardRef(function MenuPortal(
 
   return (
     <MenuPortalContext.Provider value={keepMounted}>
-      <FloatingPortal ref={forwardedRef} {...portalProps} />
+      {/*
+        The menu trigger already conveys the popup relationship through
+        `aria-haspopup` + `aria-controls` + `aria-expanded`, so the owner span
+        is redundant. It also trips `aria-required-children` because a bare
+        `span` is not an allowed child of the `menu`/`menubar` role.
+      */}
+      <FloatingPortal ref={forwardedRef} {...portalProps} renderOwner={false} />
     </MenuPortalContext.Provider>
   );
 });


### PR DESCRIPTION
Fixes #4004

`Menu.Portal` renders a visually hidden `<span aria-owns>` inside the
menu/menubar. axe flags it under `aria-required-children` because a bare
`span` is not an allowed child of the `menu`/`menubar` role
([WAI-ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#menu)).

## Root cause

The span comes from `FloatingPortal`, which renders `<span aria-owns={portalId}>`
to keep VoiceOver's virtual cursor in document order for generic portaled
panels. The span and the focus guards share one gate (`shouldRenderGuards`),
so the span can't be dropped without also losing tab-order management.

For a menu the span is redundant: the trigger already exposes the popup
through `aria-haspopup`, `aria-controls`, and `aria-expanded`.

## Changes

- Add a `renderOwner` flag to `FloatingPortal` (mirroring the existing
  `renderGuards` flag) that suppresses only the owner span, leaving the
  focus guards and tab-order handling in place.
- Pass `renderOwner={false}` from `Menu.Portal`. Submenus and `Menubar`
  go through the same portal, so they're covered too. Other portals are
  unchanged and still render the span.
- Add tests: the menu portal no longer renders `span[aria-owns]`, and the
  generic portal still does while keeping its focus guards.

## Notes

This removes the node outright rather than hiding it with `aria-hidden`
(as in #4027). Adding `aria-hidden` to the owner is contested upstream
(floating-ui/floating-ui#3403) because it can defeat the virtual-cursor
ordering the span exists for. Since the span is redundant in menus,
dropping it avoids that trade-off.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).