### PR TITLE
[docs] Inline code tags adjustments

### DIFF
--- a/docs/src/components/Code.css
+++ b/docs/src/components/Code.css
@@ -6,7 +6,7 @@
     p &[data-inline],
     li &[data-inline] {
       font-size: 0.96875em; /* 16px becomes 15.5px */
-      letter-spacing: -0.02em;
+      letter-spacing: -0.01em;
       word-spacing: -0.2em;
       line-height: normal;
     }

--- a/docs/src/components/Code.css
+++ b/docs/src/components/Code.css
@@ -3,7 +3,8 @@
     letter-spacing: normal;
     color: var(--color-blue);
 
-    p &[data-inline] {
+    p &[data-inline],
+    li &[data-inline] {
       letter-spacing: -0.01em;
       word-spacing: -0.2em;
       line-height: normal;
@@ -29,6 +30,10 @@
           text-decoration-color: currentColor;
         }
       }
+    }
+
+    .Link & {
+      text-decoration: inherit;
     }
   }
 }

--- a/docs/src/components/Code.css
+++ b/docs/src/components/Code.css
@@ -5,6 +5,7 @@
 
     p &[data-inline],
     li &[data-inline] {
+      font-size: 0.96875em; /* 16px becomes 15.5px */
       letter-spacing: -0.02em;
       word-spacing: -0.2em;
       line-height: normal;

--- a/docs/src/components/Code.css
+++ b/docs/src/components/Code.css
@@ -5,7 +5,7 @@
 
     p &[data-inline],
     li &[data-inline] {
-      letter-spacing: -0.01em;
+      letter-spacing: -0.02em;
       word-spacing: -0.2em;
       line-height: normal;
     }

--- a/docs/src/css/fonts/index.css
+++ b/docs/src/css/fonts/index.css
@@ -28,7 +28,7 @@
   src: url('/fonts/paper-mono.woff2') format('woff2');
   font-variation-settings: 'wght' 415;
   /* Reduce the size to balance with the sans-serif fonts */
-  size-adjust: calc(100% * 13.5 / 14);
+  size-adjust: calc(100% * 14.95 / 16);
 }
 
 @font-face {
@@ -37,5 +37,5 @@
   src: url('/fonts/paper-mono.woff2') format('woff2');
   font-variation-settings: 'wght' 650;
   /* Reduce the size to balance with the sans-serif fonts */
-  size-adjust: calc(100% * 13.5 / 14);
+  size-adjust: calc(100% * 14.95 / 16);
 }

--- a/docs/src/css/fonts/index.css
+++ b/docs/src/css/fonts/index.css
@@ -28,7 +28,7 @@
   src: url('/fonts/paper-mono.woff2') format('woff2');
   font-variation-settings: 'wght' 415;
   /* Reduce the size to balance with the sans-serif fonts */
-  size-adjust: calc(100% * 14.95 / 16);
+  size-adjust: calc(100% * 13.5 / 14);
 }
 
 @font-face {
@@ -37,5 +37,5 @@
   src: url('/fonts/paper-mono.woff2') format('woff2');
   font-variation-settings: 'wght' 650;
   /* Reduce the size to balance with the sans-serif fonts */
-  size-adjust: calc(100% * 14.95 / 16);
+  size-adjust: calc(100% * 13.5 / 14);
 }

--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -162,9 +162,9 @@
     --color-popup: white;
     --color-gridline: var(--gray-c3);
     --color-selection: hsl(0deg 0% 92%);
-    --color-line-highlight: oklch(80% 28% 264deg / 20%);
-    --color-line-highlight-strong: oklch(80% 28% 264deg / 35%);
-    --color-line-highlight-strong-mark: oklch(80% 28% 264deg / 50%);
+    --color-line-highlight: hsl(205deg 100% 96%);
+    --color-line-highlight-strong: hsl(205deg 100% 90%);
+    --color-line-highlight-strong-mark: hsl(205deg 100% 80%);
 
     /* Syntax highlighting */
     --color-gray: var(--gray-t1);
@@ -284,9 +284,9 @@
       --color-popup: var(--gray-s1);
       --color-gridline: var(--gray-c1);
       --color-selection: hsl(0deg 0% 18%);
-      --color-line-highlight: oklch(50% 50% 264deg / 20%);
-      --color-line-highlight-strong: oklch(50% 50% 264deg / 35%);
-      --color-line-highlight-strong-mark: oklch(50% 50% 264deg / 50%);
+      --color-line-highlight: hsl(205deg 45% 12%);
+      --color-line-highlight-strong: hsl(205deg 55% 16%);
+      --color-line-highlight-strong-mark: hsl(205deg 65% 20%);
 
       /* Syntax highlighting */
       --color-green: oklch(75% 25% 150deg);

--- a/docs/src/css/syntax.css
+++ b/docs/src/css/syntax.css
@@ -244,9 +244,6 @@
 
   /* Inline code and highlighted characters - collapse most colors to blue */
   .MdCode[data-inline] {
-    display: inline-block;
-    padding: 0.05em 0.2em;
-
     --color-prettylights-syntax-comment: var(--color-blue);
     --color-prettylights-syntax-constant: var(--color-blue);
     --color-prettylights-syntax-entity: var(--color-blue);
@@ -258,15 +255,9 @@
   }
 
   .MdCode[data-inline]:not(:has(> .di-ht)) {
+    display: inline-block;
     background-color: var(--color-line-highlight);
-  }
-
-  .MdCode[data-inline]:has(> .di-ht) {
-    background-color: hsl(156deg 55% 95%);
-
-    @media (prefers-color-scheme: dark) {
-      background-color: hsl(156deg 35% 12%);
-    }
+    padding: 0.05em 0.2em;
   }
 
   /* Frame highlighting */

--- a/docs/src/css/syntax.css
+++ b/docs/src/css/syntax.css
@@ -255,6 +255,7 @@
   }
 
   .MdCode[data-inline]:not(:has(> .di-ht)) {
+    display: inline-block;
     background-color: var(--color-line-highlight);
     border-radius: var(--radius-3);
     padding: 0.05em 0.2em;

--- a/docs/src/css/syntax.css
+++ b/docs/src/css/syntax.css
@@ -244,6 +244,9 @@
 
   /* Inline code and highlighted characters - collapse most colors to blue */
   .MdCode[data-inline] {
+    display: inline-block;
+    padding: 0.05em 0.2em;
+
     --color-prettylights-syntax-comment: var(--color-blue);
     --color-prettylights-syntax-constant: var(--color-blue);
     --color-prettylights-syntax-entity: var(--color-blue);
@@ -255,9 +258,15 @@
   }
 
   .MdCode[data-inline]:not(:has(> .di-ht)) {
-    display: inline-block;
     background-color: var(--color-line-highlight);
-    padding: 0.05em 0.2em;
+  }
+
+  .MdCode[data-inline]:has(> .di-ht) {
+    background-color: hsl(156deg 55% 95%);
+
+    @media (prefers-color-scheme: dark) {
+      background-color: hsl(156deg 35% 12%);
+    }
   }
 
   /* Frame highlighting */

--- a/docs/src/css/syntax.css
+++ b/docs/src/css/syntax.css
@@ -257,7 +257,6 @@
   .MdCode[data-inline]:not(:has(> .di-ht)) {
     display: inline-block;
     background-color: var(--color-line-highlight);
-    border-radius: var(--radius-3);
     padding: 0.05em 0.2em;
   }
 


### PR DESCRIPTION
Preview:
- Regular inline code tags (blue): https://deploy-preview-5009--base-ui.netlify.app/react/handbook/animation#javascript-animations
- Code highlighted lines and terms: https://deploy-preview-5009--base-ui.netlify.app/react/handbook/forms#react-hook-form-integrate-components

Some adjustments for inline code tags:
- Slightly reduces the font-size on inline code tags.
- Adjusts the blue highlight color, used in inline code tags and code blocks highlighted lines.