### PR TITLE
[positioners] Clean up positioning middleware

### DIFF
--- a/packages/react/src/utils/hideMiddleware.ts
+++ b/packages/react/src/utils/hideMiddleware.ts
@@ -1,11 +1,13 @@
 import { hide as nativeHide, type Middleware } from '@floating-ui/react-dom';
 
+const nativeHideFn = nativeHide().fn;
+
 export const hide: Middleware = {
   name: 'hide',
   async fn(state) {
     const { width, height, x, y } = state.rects.reference;
     const anchorHidden = width === 0 && height === 0 && x === 0 && y === 0;
-    const nativeHideResult = await nativeHide().fn(state);
+    const nativeHideResult = await nativeHideFn(state);
     return {
       data: {
         referenceHidden: nativeHideResult.data?.referenceHidden || anchorHidden,

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -723,7 +723,6 @@ export interface UseAnchorPositioningSharedParameters {
 
 export interface UseAnchorPositioningParameters extends UseAnchorPositioningSharedParameters {
   keepMounted?: boolean | undefined;
-  trackCursorAxis?: 'none' | 'x' | 'y' | 'both' | undefined;
   floatingRootContext?: FloatingRootContext | undefined;
   mounted: boolean;
   disableAnchorTracking: boolean;
@@ -754,5 +753,3 @@ export interface UseAnchorPositioningReturnValue {
   isPositioned: boolean;
   update: () => void;
 }
-
-export interface UseAnchorPositioningState {}


### PR DESCRIPTION
This trims a couple of small positioning internals: the hide middleware reuses the Floating UI delegate, and unused anchor-positioning type surface is removed.

## Changes

- Reuse the Floating UI hide middleware function instead of recreating it for each positioning pass.
- Remove unused `useAnchorPositioning` parameter and empty state type.