### PR TITLE
[docs-infra] Fix immutable cache headers for /_next/static assets

### DIFF
--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,4 +1,4 @@
-/_next/static/
+/_next/static/*
   Cache-Control: public, max-age=31536000, immutable
 
 /static/favicon.ico


### PR DESCRIPTION
`/_next/static/` in `_headers` lacked a splat, so Netlify matched only the exact path and hashed assets fell back to `max-age=0,must-revalidate`. Add `*` so fingerprinted assets get immutable caching.

Verify after deploy: `curl -sI https://base-ui.com/_next/static/chunks/webpack-*.js | grep -i cache-control`