### PR TITLE
[docs][performance] Reduce number of layers

### DIFF
--- a/docs/src/components/CodeBlock/CodeBlock.css
+++ b/docs/src/components/CodeBlock/CodeBlock.css
@@ -75,7 +75,11 @@
     outline: 0;
     border-bottom-right-radius: var(--radius-6);
     border-bottom-left-radius: var(--radius-6);
-    overscroll-behavior-x: contain;
+
+    &[data-has-overflow-x] {
+      /* Prevent Chrome/Safari page navigation gestures when scrolling horizontally */
+      overscroll-behavior-x: contain;
+    }
 
     &:focus-visible {
       outline: 2px solid var(--gray-t2);

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -219,8 +219,10 @@
   }
 
   .DemoCodeBlockViewport {
-    /* Prevent Chrome/Safari page navigation gestures when scrolling horizontally */
-    overscroll-behavior-x: contain;
+    &[data-has-overflow-x] {
+      /* Prevent Chrome/Safari page navigation gestures when scrolling horizontally */
+      overscroll-behavior-x: contain;
+    }
 
     /* Max height for code blocks, if we ever want to recover this (https://github.com/mui/base-ui/pull/1187) */
     /* max-height: clamp(8.75lh + 0.5rem, 80vh, 23.75lh + 0.5rem); */


### PR DESCRIPTION
Follow-up on https://github.com/mui/base-ui/pull/4476, reducing the number of layers even further, this time conditionally using `overscroll-behavior-x: contain` when code blocks are scrollable.

---

Measured at `1440×900`, 5 runs per demo, comparing against master. These are the numbers for Combobox demos:

| Demo | Layers master → current | Layerize master → current | Main-thread busy |
|---|---:|---:|---:|
| Hero | 56 → 41 (**−27%**) | 108.0 → 99.2 ms (**−8%**) | 1029.7 → 1025.5 ms |
| Grouped | 72 → 57 (**−21%**) | 407.6 → 323.8 ms (**−21%**) | 1052.9 → 1033.9 ms |
| Virtualized | 66 → 51 (**−23%**) | 445.8 → 335.7 ms (**−25%**) | 1173.2 → 1117.1 ms |

So the layer count drops consistently, and Layerize improves most where it matters: grouped and virtualized. The hero demo improves less because it’s higher on the page and already has fewer surrounding code/demo layers.

The total main-thread improvement is smaller because `FunctionCall` time is basically unchanged — this CSS change only addresses compositor/layer work, not pointer/highlight JS. Still, for the Layerize problem, this is a good desktop win.