### PR TITLE
[composite] Remove unnecessary props memos

### DIFF
--- a/packages/react/src/internals/composite/item/useCompositeItem.ts
+++ b/packages/react/src/internals/composite/item/useCompositeItem.ts
@@ -23,26 +23,23 @@ export function useCompositeItem<Metadata>(params: UseCompositeItemParameters<Me
   const itemRef = React.useRef<HTMLElement | null>(null);
   const mergedRef = useMergedRefs(ref, itemRef);
 
-  const compositeProps = React.useMemo<HTMLProps>(
-    () => ({
-      tabIndex: isHighlighted ? 0 : -1,
-      onFocus() {
-        onHighlightedIndexChange(index);
-      },
-      onMouseMove() {
-        const item = itemRef.current;
-        if (!highlightItemOnHover || !item) {
-          return;
-        }
+  const compositeProps: HTMLProps = {
+    tabIndex: isHighlighted ? 0 : -1,
+    onFocus() {
+      onHighlightedIndexChange(index);
+    },
+    onMouseMove() {
+      const item = itemRef.current;
+      if (!highlightItemOnHover || !item) {
+        return;
+      }
 
-        const disabled = item.hasAttribute('disabled') || item.ariaDisabled === 'true';
-        if (!isHighlighted && !disabled) {
-          item.focus();
-        }
-      },
-    }),
-    [isHighlighted, onHighlightedIndexChange, index, highlightItemOnHover],
-  );
+      const disabled = item.hasAttribute('disabled') || item.ariaDisabled === 'true';
+      if (!isHighlighted && !disabled) {
+        item.focus();
+      }
+    },
+  };
 
   return {
     compositeProps,

--- a/packages/react/src/internals/composite/list/useCompositeListItem.ts
+++ b/packages/react/src/internals/composite/list/useCompositeListItem.ts
@@ -99,11 +99,5 @@ export function useCompositeListItem<Metadata>(
     });
   }, [externalIndex, subscribeMapChange, setIndex]);
 
-  return React.useMemo(
-    () => ({
-      ref,
-      index,
-    }),
-    [index, ref],
-  );
+  return { ref, index };
 }

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -188,240 +188,215 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
     },
   );
 
-  const props = React.useMemo<HTMLProps>(
-    () => ({
-      ref: mergedRef,
-      onFocus(event) {
-        const element = rootRef.current;
-        const target = getTarget(event.nativeEvent);
-        if (!element || target == null || !isNativeInput(target)) {
-          return;
-        }
-        target.setSelectionRange(0, target.value.length ?? 0);
-      },
-      onKeyDown(event) {
-        const RELEVANT_KEYS = enableHomeAndEndKeys ? COMPOSITE_KEYS : ARROW_KEYS;
-        if (!RELEVANT_KEYS.has(event.key)) {
-          return;
-        }
+  // Stable so that `relayKeyboardEvent` does not invalidate identity-sensitive
+  // consumers (the `CompositeRootContext` value and trigger data forwarding).
+  const onKeyDown = useStableCallback((event: React.KeyboardEvent) => {
+    const RELEVANT_KEYS = enableHomeAndEndKeys ? COMPOSITE_KEYS : ARROW_KEYS;
+    if (!RELEVANT_KEYS.has(event.key)) {
+      return;
+    }
 
-        if (isModifierKeySet(event, modifierKeys)) {
-          return;
-        }
+    if (isModifierKeySet(event, modifierKeys)) {
+      return;
+    }
 
-        const element = rootRef.current;
-        if (!element) {
-          return;
-        }
+    const element = rootRef.current;
+    if (!element) {
+      return;
+    }
 
-        const isRtl = direction === 'rtl';
+    const isRtl = direction === 'rtl';
 
-        const horizontalForwardKey = isRtl ? ARROW_LEFT : ARROW_RIGHT;
-        const forwardKey = {
-          horizontal: horizontalForwardKey,
-          vertical: ARROW_DOWN,
-          both: horizontalForwardKey,
-        }[orientation];
-        const horizontalBackwardKey = isRtl ? ARROW_RIGHT : ARROW_LEFT;
-        const backwardKey = {
-          horizontal: horizontalBackwardKey,
-          vertical: ARROW_UP,
-          both: horizontalBackwardKey,
-        }[orientation];
+    const horizontalForwardKey = isRtl ? ARROW_LEFT : ARROW_RIGHT;
+    const forwardKey = {
+      horizontal: horizontalForwardKey,
+      vertical: ARROW_DOWN,
+      both: horizontalForwardKey,
+    }[orientation];
+    const horizontalBackwardKey = isRtl ? ARROW_RIGHT : ARROW_LEFT;
+    const backwardKey = {
+      horizontal: horizontalBackwardKey,
+      vertical: ARROW_UP,
+      both: horizontalBackwardKey,
+    }[orientation];
 
-        const target = getTarget(event.nativeEvent);
-        if (target != null && isNativeInput(target) && !isElementDisabled(target)) {
-          const selectionStart = target.selectionStart;
-          const selectionEnd = target.selectionEnd;
-          const textContent = target.value ?? '';
-          // return to native textbox behavior when
-          // 1 - Shift is held to make a text selection, or if there already is a text selection
-          if (selectionStart == null || event.shiftKey || selectionStart !== selectionEnd) {
-            return;
-          }
-          // 2 - arrow-ing forward and not in the last position of the text
-          if (event.key !== backwardKey && selectionStart < textContent.length) {
-            return;
-          }
-          // 3 -arrow-ing backward and not in the first position of the text
-          if (event.key !== forwardKey && selectionStart > 0) {
-            return;
-          }
-        }
+    const target = getTarget(event.nativeEvent);
+    if (target != null && isNativeInput(target) && !isElementDisabled(target)) {
+      const selectionStart = target.selectionStart;
+      const selectionEnd = target.selectionEnd;
+      const textContent = target.value ?? '';
+      // return to native textbox behavior when
+      // 1 - Shift is held to make a text selection, or if there already is a text selection
+      if (selectionStart == null || event.shiftKey || selectionStart !== selectionEnd) {
+        return;
+      }
+      // 2 - arrow-ing forward and not in the last position of the text
+      if (event.key !== backwardKey && selectionStart < textContent.length) {
+        return;
+      }
+      // 3 -arrow-ing backward and not in the first position of the text
+      if (event.key !== forwardKey && selectionStart > 0) {
+        return;
+      }
+    }
 
-        let nextIndex = highlightedIndex;
-        const minIndex = getMinListIndex(elementsRef, disabledIndices);
-        const maxIndex = getMaxListIndex(elementsRef, disabledIndices);
+    let nextIndex = highlightedIndex;
+    const minIndex = getMinListIndex(elementsRef, disabledIndices);
+    const maxIndex = getMaxListIndex(elementsRef, disabledIndices);
 
-        if (isGrid) {
-          const sizes =
-            itemSizes ||
-            Array.from({ length: elementsRef.current.length }, () => ({
-              width: 1,
-              height: 1,
-            }));
-          // To calculate movements on the grid, we use hypothetical cell indices
-          // as if every item was 1x1, then convert back to real indices.
-          const cellMap = createGridCellMap(sizes, cols, dense);
-          const minGridIndex = cellMap.findIndex(
-            (index) =>
-              index != null && !isListIndexDisabled(elementsRef.current, index, disabledIndices),
-          );
-          // last enabled index
-          const maxGridIndex = cellMap.reduce(
-            (foundIndex: number, index, cellIndex) =>
-              index != null && !isListIndexDisabled(elementsRef.current, index, disabledIndices)
-                ? cellIndex
-                : foundIndex,
-            -1,
-          );
+    if (isGrid) {
+      const sizes =
+        itemSizes ||
+        Array.from({ length: elementsRef.current.length }, () => ({
+          width: 1,
+          height: 1,
+        }));
+      // To calculate movements on the grid, we use hypothetical cell indices
+      // as if every item was 1x1, then convert back to real indices.
+      const cellMap = createGridCellMap(sizes, cols, dense);
+      const minGridIndex = cellMap.findIndex(
+        (index) =>
+          index != null && !isListIndexDisabled(elementsRef.current, index, disabledIndices),
+      );
+      // last enabled index
+      const maxGridIndex = cellMap.reduce(
+        (foundIndex: number, index, cellIndex) =>
+          index != null && !isListIndexDisabled(elementsRef.current, index, disabledIndices)
+            ? cellIndex
+            : foundIndex,
+        -1,
+      );
 
-          nextIndex = cellMap[
-            getGridNavigatedIndex(
-              cellMap.map((itemIndex) =>
-                itemIndex != null ? elementsRef.current[itemIndex] : null,
-              ),
-              {
-                event,
-                orientation,
-                loopFocus,
-                onLoop: wrappedOnLoop,
-                cols,
-                // treat undefined (empty grid spaces) as disabled indices so we
-                // don't end up in them
-                disabledIndices: getGridCellIndices(
-                  [
-                    ...(disabledIndices ||
-                      elementsRef.current.map((_, index) =>
-                        isListIndexDisabled(elementsRef.current, index) ? index : undefined,
-                      )),
-                    undefined,
-                  ],
-                  cellMap,
-                ),
-                minIndex: minGridIndex,
-                maxIndex: maxGridIndex,
-                prevIndex: getGridCellIndexOfCorner(
-                  highlightedIndex > maxIndex ? minIndex : highlightedIndex,
-                  sizes,
-                  cellMap,
-                  cols,
-                  // use a corner matching the edge closest to the direction we're
-                  // moving in so we don't end up in the same item. Prefer
-                  // top/left over bottom/right.
-                  // eslint-disable-next-line no-nested-ternary
-                  event.key === ARROW_DOWN ? 'bl' : event.key === ARROW_RIGHT ? 'tr' : 'tl',
-                ),
-                rtl: isRtl,
-              },
-            )
-          ] as number; // navigated cell will never be nullish
-        }
+      nextIndex = cellMap[
+        getGridNavigatedIndex(
+          cellMap.map((itemIndex) => (itemIndex != null ? elementsRef.current[itemIndex] : null)),
+          {
+            event,
+            orientation,
+            loopFocus,
+            onLoop: wrappedOnLoop,
+            cols,
+            // treat undefined (empty grid spaces) as disabled indices so we
+            // don't end up in them
+            disabledIndices: getGridCellIndices(
+              [
+                ...(disabledIndices ||
+                  elementsRef.current.map((_, index) =>
+                    isListIndexDisabled(elementsRef.current, index) ? index : undefined,
+                  )),
+                undefined,
+              ],
+              cellMap,
+            ),
+            minIndex: minGridIndex,
+            maxIndex: maxGridIndex,
+            prevIndex: getGridCellIndexOfCorner(
+              highlightedIndex > maxIndex ? minIndex : highlightedIndex,
+              sizes,
+              cellMap,
+              cols,
+              // use a corner matching the edge closest to the direction we're
+              // moving in so we don't end up in the same item. Prefer
+              // top/left over bottom/right.
+              // eslint-disable-next-line no-nested-ternary
+              event.key === ARROW_DOWN ? 'bl' : event.key === ARROW_RIGHT ? 'tr' : 'tl',
+            ),
+            rtl: isRtl,
+          },
+        )
+      ] as number; // navigated cell will never be nullish
+    }
 
-        const forwardKeys = {
-          horizontal: [horizontalForwardKey],
-          vertical: [ARROW_DOWN],
-          both: [horizontalForwardKey, ARROW_DOWN],
-        }[orientation];
+    const forwardKeys = {
+      horizontal: [horizontalForwardKey],
+      vertical: [ARROW_DOWN],
+      both: [horizontalForwardKey, ARROW_DOWN],
+    }[orientation];
 
-        const backwardKeys = {
-          horizontal: [horizontalBackwardKey],
-          vertical: [ARROW_UP],
-          both: [horizontalBackwardKey, ARROW_UP],
+    const backwardKeys = {
+      horizontal: [horizontalBackwardKey],
+      vertical: [ARROW_UP],
+      both: [horizontalBackwardKey, ARROW_UP],
+    }[orientation];
+
+    const preventedKeys = isGrid
+      ? RELEVANT_KEYS
+      : {
+          horizontal: enableHomeAndEndKeys ? HORIZONTAL_KEYS_WITH_EXTRA_KEYS : HORIZONTAL_KEYS,
+          vertical: enableHomeAndEndKeys ? VERTICAL_KEYS_WITH_EXTRA_KEYS : VERTICAL_KEYS,
+          both: RELEVANT_KEYS,
         }[orientation];
 
-        const preventedKeys = isGrid
-          ? RELEVANT_KEYS
-          : {
-              horizontal: enableHomeAndEndKeys ? HORIZONTAL_KEYS_WITH_EXTRA_KEYS : HORIZONTAL_KEYS,
-              vertical: enableHomeAndEndKeys ? VERTICAL_KEYS_WITH_EXTRA_KEYS : VERTICAL_KEYS,
-              both: RELEVANT_KEYS,
-            }[orientation];
+    if (enableHomeAndEndKeys) {
+      if (event.key === HOME) {
+        nextIndex = minIndex;
+      } else if (event.key === END) {
+        nextIndex = maxIndex;
+      }
+    }
 
-        if (enableHomeAndEndKeys) {
-          if (event.key === HOME) {
-            nextIndex = minIndex;
-          } else if (event.key === END) {
-            nextIndex = maxIndex;
-          }
+    if (
+      nextIndex === highlightedIndex &&
+      (forwardKeys.includes(event.key) || backwardKeys.includes(event.key))
+    ) {
+      if (loopFocus && nextIndex === maxIndex && forwardKeys.includes(event.key)) {
+        nextIndex = minIndex;
+        if (onLoop) {
+          nextIndex = onLoop(event, highlightedIndex, nextIndex, elementsRef);
         }
-
-        if (
-          nextIndex === highlightedIndex &&
-          (forwardKeys.includes(event.key) || backwardKeys.includes(event.key))
-        ) {
-          if (loopFocus && nextIndex === maxIndex && forwardKeys.includes(event.key)) {
-            nextIndex = minIndex;
-            if (onLoop) {
-              nextIndex = onLoop(event, highlightedIndex, nextIndex, elementsRef);
-            }
-          } else if (loopFocus && nextIndex === minIndex && backwardKeys.includes(event.key)) {
-            nextIndex = maxIndex;
-            if (onLoop) {
-              nextIndex = onLoop(event, highlightedIndex, nextIndex, elementsRef);
-            }
-          } else {
-            nextIndex = findNonDisabledListIndex(elementsRef.current, {
-              startingIndex: nextIndex,
-              decrement: backwardKeys.includes(event.key),
-              disabledIndices,
-            });
-          }
+      } else if (loopFocus && nextIndex === minIndex && backwardKeys.includes(event.key)) {
+        nextIndex = maxIndex;
+        if (onLoop) {
+          nextIndex = onLoop(event, highlightedIndex, nextIndex, elementsRef);
         }
+      } else {
+        nextIndex = findNonDisabledListIndex(elementsRef.current, {
+          startingIndex: nextIndex,
+          decrement: backwardKeys.includes(event.key),
+          disabledIndices,
+        });
+      }
+    }
 
-        if (
-          nextIndex !== highlightedIndex &&
-          !isIndexOutOfListBounds(elementsRef.current, nextIndex)
-        ) {
-          if (stopEventPropagation) {
-            event.stopPropagation();
-          }
+    if (nextIndex !== highlightedIndex && !isIndexOutOfListBounds(elementsRef.current, nextIndex)) {
+      if (stopEventPropagation) {
+        event.stopPropagation();
+      }
 
-          if (preventedKeys.has(event.key)) {
-            event.preventDefault();
-          }
-          onHighlightedIndexChange(nextIndex, true);
+      if (preventedKeys.has(event.key)) {
+        event.preventDefault();
+      }
+      onHighlightedIndexChange(nextIndex, true);
 
-          // Wait for FocusManager `returnFocus` to execute.
-          queueMicrotask(() => {
-            elementsRef.current[nextIndex]?.focus();
-          });
-        }
-      },
-    }),
-    [
-      cols,
-      dense,
-      direction,
-      disabledIndices,
-      elementsRef,
-      enableHomeAndEndKeys,
-      highlightedIndex,
-      isGrid,
-      itemSizes,
-      loopFocus,
-      onLoop,
-      wrappedOnLoop,
-      mergedRef,
-      modifierKeys,
-      onHighlightedIndexChange,
-      orientation,
-      stopEventPropagation,
-    ],
-  );
+      // Wait for FocusManager `returnFocus` to execute.
+      queueMicrotask(() => {
+        elementsRef.current[nextIndex]?.focus();
+      });
+    }
+  });
 
-  return React.useMemo(
-    () => ({
-      props,
-      highlightedIndex,
-      onHighlightedIndexChange,
-      elementsRef,
-      disabledIndices,
-      onMapChange,
-      relayKeyboardEvent: props.onKeyDown!,
-    }),
-    [props, highlightedIndex, onHighlightedIndexChange, elementsRef, disabledIndices, onMapChange],
-  );
+  const props: HTMLProps = {
+    ref: mergedRef,
+    onFocus(event) {
+      const element = rootRef.current;
+      const target = getTarget(event.nativeEvent);
+      if (!element || target == null || !isNativeInput(target)) {
+        return;
+      }
+      target.setSelectionRange(0, target.value.length ?? 0);
+    },
+    onKeyDown,
+  };
+
+  return {
+    props,
+    highlightedIndex,
+    onHighlightedIndexChange,
+    elementsRef,
+    disabledIndices,
+    onMapChange,
+    relayKeyboardEvent: onKeyDown,
+  };
 }
 
 function isModifierKeySet(event: React.KeyboardEvent, ignoredModifierKeys: ModifierKey[]) {


### PR DESCRIPTION
The `props` object returned by `useCompositeRoot` is consumed only by `CompositeRoot`, which passes it into `useRenderElement` → `mergeProps` — re-merged unconditionally every render, so the object's identity is never compared. The memo's ~15-entry dep array included `highlightedIndex`, so it invalidated on every arrow-key navigation anyway, and was pure maintenance burden with stale-closure risk.

- `useCompositeRoot`: the props object is now created per render. `onKeyDown` is wrapped in `useStableCallback` because its identity (as `relayKeyboardEvent`) does matter: it flows into the `CompositeRootContext` value memo and into `useTriggerDataForwarding`'s effect deps via `Object.values(stateUpdates)`. It's now fully stable, where previously it changed on every navigation.
- `useCompositeRoot`: the return-value memo is also removed — `CompositeRoot` is the only consumer and destructures it immediately.
- `useCompositeItem`: `compositeProps` memo removed — both consumers (`CompositeItem`, `TabsTab`) only pass it into `useRenderElement` props arrays.
- `useCompositeListItem`: return-value memo removed — all consumers only access `.ref` (already `useCallback`'d, identity unchanged) and `.index`; the wrapper object identity is never used.

Tests: `Composite` (jsdom + Chromium), `Tabs` and `Menubar` (jsdom) all pass; `pnpm typescript` and eslint clean.