### PR TITLE
[menu] Fix detached-trigger store sync and context-menu navigation

### DIFF
--- a/docs/src/app/(docs)/react/components/menu/types.md
+++ b/docs/src/app/(docs)/react/components/menu/types.md
@@ -1078,7 +1078,6 @@ type MenuParent =
   | { type: 'menu'; store: MenuStore<unknown> }
   | { type: 'menubar'; context: MenubarContext }
   | { type: 'context-menu'; context: ContextMenuRootContext }
-  | { type: 'nested-context-menu'; context: ContextMenuRootContext; menuContext: MenuRootContext }
   | { type: undefined };
 ```
 

--- a/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
+++ b/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
@@ -1,5 +1,6 @@
 import { vi, expect } from 'vitest';
 import {
+  act,
   fireEvent,
   flushMicrotasks,
   ignoreActWarnings,
@@ -230,6 +231,78 @@ describe('<ContextMenu.Root />', () => {
 
       expect(screen.queryByTestId('context-popup')).toBe(null);
       expect(onOpenChange.mock.calls.length).toBe(0);
+    });
+  });
+
+  describe.skipIf(isJSDOM)('keyboard navigation', () => {
+    it('does not close the root context menu on the cross-orientation close key, but closes its submenus', async () => {
+      const rootOnOpenChange = vi.fn();
+
+      const { user } = await render(
+        <ContextMenu.Root onOpenChange={rootOnOpenChange}>
+          <ContextMenu.Trigger data-testid="context-trigger">Surface</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner>
+              <ContextMenu.Popup data-testid="context-root-popup">
+                <ContextMenu.SubmenuRoot>
+                  <ContextMenu.SubmenuTrigger data-testid="context-submenu-trigger">
+                    More options
+                  </ContextMenu.SubmenuTrigger>
+                  <ContextMenu.Portal>
+                    <ContextMenu.Positioner>
+                      <ContextMenu.Popup data-testid="context-submenu-popup">
+                        <ContextMenu.Item data-testid="context-submenu-item">
+                          Deep action
+                        </ContextMenu.Item>
+                      </ContextMenu.Popup>
+                    </ContextMenu.Positioner>
+                  </ContextMenu.Portal>
+                </ContextMenu.SubmenuRoot>
+              </ContextMenu.Popup>
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('context-trigger');
+      fireEvent.contextMenu(trigger, { clientX: 10, clientY: 10, button: 2 });
+      await flushMicrotasks();
+
+      await screen.findByTestId('context-root-popup');
+
+      const submenuTrigger = screen.getByTestId('context-submenu-trigger');
+      await act(async () => {
+        submenuTrigger.focus();
+      });
+      await waitFor(() => {
+        expect(submenuTrigger).toHaveFocus();
+      });
+
+      // ArrowRight opens the (nested) submenu and moves focus to its first item.
+      await user.keyboard('[ArrowRight]');
+      await screen.findByTestId('context-submenu-popup');
+      const submenuItem = screen.getByTestId('context-submenu-item');
+      await waitFor(() => {
+        expect(submenuItem).toHaveFocus();
+      });
+
+      // ArrowLeft closes the submenu because it is nested, returning focus to its trigger.
+      await user.keyboard('[ArrowLeft]');
+      await waitFor(() => {
+        expect(screen.queryByTestId('context-submenu-popup')).toBe(null);
+      });
+      expect(screen.queryByTestId('context-root-popup')).not.toBe(null);
+      await waitFor(() => {
+        expect(submenuTrigger).toHaveFocus();
+      });
+
+      // ArrowLeft on the root context menu must NOT close it: unlike a submenu, a root context
+      // menu has no parent list to return to, and native context menus never close on this key.
+      await user.keyboard('[ArrowLeft]');
+      await flushMicrotasks();
+
+      expect(screen.queryByTestId('context-root-popup')).not.toBe(null);
+      expect(rootOnOpenChange.mock.calls.some((call) => call[0] === false)).toBe(false);
     });
   });
 

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -298,11 +298,7 @@ export const MenuPositioner = React.forwardRef(function MenuPositioner(
     <MenuPositionerContext.Provider value={positioner}>
       {shouldRenderBackdrop && (
         <InternalBackdrop
-          ref={
-            parent.type === 'context-menu' || parent.type === 'nested-context-menu'
-              ? parent.context.internalBackdropRef
-              : null
-          }
+          ref={parent.type === 'context-menu' ? parent.context.internalBackdropRef : null}
           inert={inertValue(!open)}
           cutout={backdropCutout}
         />

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -6,6 +6,7 @@ import { useId } from '@base-ui/utils/useId';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { fastComponent } from '@base-ui/utils/fastHooks';
+import { warn } from '@base-ui/utils/warn';
 import {
   FloatingTree,
   useDismiss,
@@ -147,8 +148,10 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
 
   if (process.env.NODE_ENV !== 'production') {
     if (parent.type !== undefined && modalProp !== undefined) {
-      console.warn(
-        'Base UI: The `modal` prop is not supported on nested menus. It will be ignored.',
+      // `warn` dedupes, so this won't spam on every render. `parent.type !== undefined` also
+      // covers menubar and context menus, not just submenus.
+      warn(
+        'The `modal` prop is not supported on submenus, menubar menus, or context menus. It will be ignored.',
       );
     }
   }
@@ -238,6 +241,22 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
         return;
       }
 
+      const nativeEvent = eventDetails.event as Event;
+
+      // Prevent the menu from closing on mobile devices that have a delayed click event.
+      // In some cases the menu, when tapped, will fire the focus event first and then the click
+      // event. Without this guard, the menu will close immediately after opening.
+      // This must bail before notifying `onOpenChange` and dispatching the open change, otherwise
+      // controlled consumers (and floating-ui's own state) would close the menu regardless.
+      if (
+        nextOpen === false &&
+        nativeEvent?.type === 'click' &&
+        (nativeEvent as PointerEvent).pointerType === 'touch' &&
+        !allowTouchToCloseRef.current
+      ) {
+        return;
+      }
+
       const shouldPreventUnmountOnClose = attachPreventUnmountOnClose(
         eventDetails as MenuRoot.ChangeEventDetails,
       );
@@ -256,19 +275,8 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
 
       store.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);
 
-      const nativeEvent = eventDetails.event as Event;
-      if (
-        nextOpen === false &&
-        nativeEvent?.type === 'click' &&
-        (nativeEvent as PointerEvent).pointerType === 'touch' &&
-        !allowTouchToCloseRef.current
-      ) {
-        return;
-      }
-
-      // Prevent the menu from closing on mobile devices that have a delayed click event.
-      // In some cases the menu, when tapped, will fire the focus event first and then the click event.
-      // Without this guard, the menu will close immediately after opening.
+      // Reset the touch-to-close guard so a delayed click after a focus-driven open is ignored
+      // (see the early return above).
       if (nextOpen && reason === REASONS.triggerFocus) {
         allowTouchToCloseRef.current = false;
         allowTouchToCloseTimeout.start(300, () => {
@@ -394,7 +402,10 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     enabled: !disabled,
     listRef: store.context.itemDomElements,
     activeIndex,
-    nested: parent.type !== undefined,
+    // A root context menu has no parent menu to return to, so it must not be treated as nested:
+    // otherwise the cross-orientation close key (e.g. ArrowLeft) would close it, which native
+    // context menus never do. Its submenus are regular menus with `parent.type === 'menu'`.
+    nested: parent.type !== undefined && parent.type !== 'context-menu',
     loopFocus,
     orientation,
     parentOrientation: parent.type === 'menubar' ? parent.context.orientation : undefined,
@@ -665,11 +676,6 @@ export type MenuParent =
   | {
       type: 'context-menu';
       context: ContextMenuRootContext;
-    }
-  | {
-      type: 'nested-context-menu';
-      context: ContextMenuRootContext;
-      menuContext: MenuRootContext;
     }
   | {
       type: undefined;

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -275,8 +275,9 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
 
       store.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);
 
-      // Reset the touch-to-close guard so a delayed click after a focus-driven open is ignored
-      // (see the early return above).
+      // Arm the touch-to-close guard for 300ms after a focus-driven open, so the delayed click
+      // that follows a tap is ignored (see the early return above). Any other open/close clears
+      // the guard so a normal click can close the menu right away.
       if (nextOpen && reason === REASONS.triggerFocus) {
         allowTouchToCloseRef.current = false;
         allowTouchToCloseTimeout.start(300, () => {

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -246,10 +246,14 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
       // Prevent the menu from closing on mobile devices that have a delayed click event.
       // In some cases the menu, when tapped, will fire the focus event first and then the click
       // event. Without this guard, the menu will close immediately after opening.
+      // Scoped to `triggerPress` so it only swallows the trigger's own delayed click: a genuine
+      // close from within the popup (e.g. tapping an item, reason `itemPress`) must still go
+      // through even within the guard window.
       // This must bail before notifying `onOpenChange` and dispatching the open change, otherwise
       // controlled consumers (and floating-ui's own state) would close the menu regardless.
       if (
         nextOpen === false &&
+        reason === REASONS.triggerPress &&
         nativeEvent?.type === 'click' &&
         (nativeEvent as PointerEvent).pointerType === 'touch' &&
         !allowTouchToCloseRef.current
@@ -276,8 +280,8 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
       store.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);
 
       // Arm the touch-to-close guard for 300ms after a focus-driven open, so the delayed click
-      // that follows a tap is ignored (see the early return above). Any other open/close clears
-      // the guard so a normal click can close the menu right away.
+      // that follows a tap is ignored (see the early return above). Any other open/close disarms
+      // the guard (and clears the timer) so a normal click can close the menu right away.
       if (nextOpen && reason === REASONS.triggerFocus) {
         allowTouchToCloseRef.current = false;
         allowTouchToCloseTimeout.start(300, () => {
@@ -399,14 +403,18 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     [store],
   );
 
+  // A root context menu has no parent menu to return to, so list navigation must not treat it as
+  // nested: otherwise the cross-orientation close key (e.g. ArrowLeft) would close it, which native
+  // context menus never do. Its submenus are regular menus with `parent.type === 'menu'`.
+  // Named separately from the floating-tree `nested` above (`floatingParentNodeId != null`) since
+  // the two predicates answer different questions.
+  const treatAsNestedForListNav = parent.type !== undefined && parent.type !== 'context-menu';
+
   const listNavigation = useListNavigation(floatingRootContext, {
     enabled: !disabled,
     listRef: store.context.itemDomElements,
     activeIndex,
-    // A root context menu has no parent menu to return to, so it must not be treated as nested:
-    // otherwise the cross-orientation close key (e.g. ArrowLeft) would close it, which native
-    // context menus never do. Its submenus are regular menus with `parent.type === 'menu'`.
-    nested: parent.type !== undefined && parent.type !== 'context-menu',
+    nested: treatAsNestedForListNav,
     loopFocus,
     orientation,
     parentOrientation: parent.type === 'menubar' ? parent.context.orientation : undefined,

--- a/packages/react/src/menu/store/MenuStore.test.tsx
+++ b/packages/react/src/menu/store/MenuStore.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { createRenderer } from '#test-utils';
 import { MenuStore } from './MenuStore';
 
 // A leaked subscription is otherwise behaviorally invisible, so the regression tests below assert
@@ -10,6 +10,10 @@ function subscriberCount(store: MenuStore<unknown>) {
 }
 
 describe('MenuStore', () => {
+  // `createRenderer` renders under StrictMode (the repo default), which mounts → unmounts →
+  // remounts effects. The parent-subscription lifecycle must survive that remount.
+  const { render } = createRenderer();
+
   describe('parent store subscription', () => {
     it('tears down the previous parent subscription when the parent changes', () => {
       const parent = new MenuStore<unknown>({ rootId: 'root-1' });
@@ -38,7 +42,7 @@ describe('MenuStore', () => {
       expect(childListener).not.toHaveBeenCalled();
     });
 
-    it('removes the internal store subscription from the parent when the menu unmounts', () => {
+    it('stays subscribed to its parent under StrictMode and removes it on unmount', async () => {
       const parent = new MenuStore<unknown>({ rootId: 'root-1' });
       const baseline = subscriberCount(parent);
 
@@ -47,14 +51,38 @@ describe('MenuStore', () => {
         return null;
       }
 
-      const { unmount } = render(<Probe />);
+      const { unmount } = await render(<Probe />);
+      // StrictMode mounts, unmounts, then remounts the effect. The subscription must be re-armed on
+      // the remount rather than left severed by the simulated unmount's cleanup.
       expect(subscriberCount(parent)).toBe(baseline + 1);
 
       unmount();
       expect(subscriberCount(parent)).toBe(baseline);
     });
 
-    it('does not dispose an externally-provided store on unmount', () => {
+    it('re-arms the internal store subscription when the handle prop toggles', async () => {
+      const parent = new MenuStore<unknown>({ rootId: 'root-1' });
+      const externalStore = new MenuStore<unknown>({});
+      const baseline = subscriberCount(parent);
+
+      function Probe({ handle }: { handle: MenuStore<unknown> | undefined }) {
+        MenuStore.useStore(handle, { parent: { type: 'menu', store: parent } });
+        return null;
+      }
+
+      const { rerender } = await render(<Probe handle={undefined} />);
+      expect(subscriberCount(parent)).toBe(baseline + 1);
+
+      // Switching to an external handle disconnects the now-unused internal store.
+      await rerender(<Probe handle={externalStore} />);
+      expect(subscriberCount(parent)).toBe(baseline);
+
+      // Switching back must re-establish the subscription, not leave it permanently severed.
+      await rerender(<Probe handle={undefined} />);
+      expect(subscriberCount(parent)).toBe(baseline + 1);
+    });
+
+    it('does not dispose an externally-provided store on unmount', async () => {
       const parent = new MenuStore<unknown>({ rootId: 'root-1' });
       const externalChild = new MenuStore<unknown>({ parent: { type: 'menu', store: parent } });
       const baseline = subscriberCount(parent);
@@ -64,7 +92,7 @@ describe('MenuStore', () => {
         return null;
       }
 
-      const { unmount } = render(<Probe />);
+      const { unmount } = await render(<Probe />);
       unmount();
 
       // The external store is owned by the consumer and may outlive the menu, so unmounting must
@@ -73,6 +101,23 @@ describe('MenuStore', () => {
 
       parent.set('rootId', 'root-2');
       expect(externalChild.select('rootId')).toBe('root-2');
+    });
+  });
+
+  describe('allowMouseUpTriggerRef', () => {
+    it('borrows the parent ref while attached and restores its own ref at the root', () => {
+      const parent = new MenuStore<unknown>({});
+      const child = new MenuStore<unknown>({});
+
+      const ownRef = child.context.allowMouseUpTriggerRef;
+      expect(ownRef).not.toBe(parent.context.allowMouseUpTriggerRef);
+
+      child.set('parent', { type: 'menu', store: parent });
+      expect(child.context.allowMouseUpTriggerRef).toBe(parent.context.allowMouseUpTriggerRef);
+
+      // Back at the root, the menu stops borrowing the parent's ref and uses its own again.
+      child.set('parent', { type: undefined });
+      expect(child.context.allowMouseUpTriggerRef).toBe(ownRef);
     });
   });
 });

--- a/packages/react/src/menu/store/MenuStore.test.tsx
+++ b/packages/react/src/menu/store/MenuStore.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { MenuStore } from './MenuStore';
+
+// A leaked subscription is otherwise behaviorally invisible, so the regression tests below assert
+// against the parent store's internal listener set directly.
+function subscriberCount(store: MenuStore<unknown>) {
+  return (store as unknown as { listeners: Set<unknown> }).listeners.size;
+}
+
+describe('MenuStore', () => {
+  describe('parent store subscription', () => {
+    it('tears down the previous parent subscription when the parent changes', () => {
+      const parent = new MenuStore<unknown>({ rootId: 'root-1' });
+      const child = new MenuStore<unknown>({});
+
+      const baseline = subscriberCount(parent);
+
+      const childListener = vi.fn();
+      child.subscribe(childListener);
+
+      child.set('parent', { type: 'menu', store: parent });
+      expect(subscriberCount(parent)).toBe(baseline + 1);
+
+      // Parent updates propagate to the child while attached.
+      childListener.mockClear();
+      parent.set('rootId', 'root-2');
+      expect(childListener).toHaveBeenCalledTimes(1);
+
+      // Detaching the parent removes the subscription instead of clobbering or leaking it.
+      child.set('parent', { type: undefined });
+      expect(subscriberCount(parent)).toBe(baseline);
+
+      // Later parent updates no longer reach the detached child.
+      childListener.mockClear();
+      parent.set('rootId', 'root-3');
+      expect(childListener).not.toHaveBeenCalled();
+    });
+
+    it('removes the internal store subscription from the parent when the menu unmounts', () => {
+      const parent = new MenuStore<unknown>({ rootId: 'root-1' });
+      const baseline = subscriberCount(parent);
+
+      function Probe() {
+        MenuStore.useStore(undefined, { parent: { type: 'menu', store: parent } });
+        return null;
+      }
+
+      const { unmount } = render(<Probe />);
+      expect(subscriberCount(parent)).toBe(baseline + 1);
+
+      unmount();
+      expect(subscriberCount(parent)).toBe(baseline);
+    });
+
+    it('does not dispose an externally-provided store on unmount', () => {
+      const parent = new MenuStore<unknown>({ rootId: 'root-1' });
+      const externalChild = new MenuStore<unknown>({ parent: { type: 'menu', store: parent } });
+      const baseline = subscriberCount(parent);
+
+      function Probe() {
+        MenuStore.useStore(externalChild, {});
+        return null;
+      }
+
+      const { unmount } = render(<Probe />);
+      unmount();
+
+      // The external store is owned by the consumer and may outlive the menu, so unmounting must
+      // not tear down its parent subscription.
+      expect(subscriberCount(parent)).toBe(baseline);
+
+      parent.set('rootId', 'root-2');
+      expect(externalChild.select('rootId')).toBe('root-2');
+    });
+  });
+});

--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { createSelector, ReactStore } from '@base-ui/utils/store';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
@@ -192,10 +193,30 @@ export class MenuStore<Payload> extends ReactStore<
       return new MenuStore<Payload>(initialState);
     }).current;
 
+    // Only the internally-created store is owned by this component. An external `handle` store is
+    // owned by the consumer and may outlive the menu, so it must not be disposed here.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(
+      () => (externalStore ? undefined : internalStore.disposeEffect()),
+      [externalStore, internalStore],
+    );
+
     return externalStore ?? internalStore;
   }
 
   private unsubscribeParentStore: (() => void) | null = null;
+
+  // Tears down the subscription this store holds on its parent store. Without this, a submenu's
+  // store (which subscribes into the parent menu's store) stays referenced by the parent's listener
+  // set after it unmounts, leaking the child store on every open/close cycle. The `observe` listener
+  // itself is registered on this store, so it is collected together with the store and needs no
+  // explicit cleanup.
+  private disposeEffect = () => {
+    return () => {
+      this.unsubscribeParentStore?.();
+      this.unsubscribeParentStore = null;
+    };
+  };
 }
 
 function createInitialState<Payload>(): State<Payload> {

--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -131,13 +131,62 @@ export class MenuStore<Payload> extends ReactStore<
     );
 
     // This menu's own mouse-up gate, used when it has no parent to borrow from.
-    const ownAllowMouseUpTriggerRef = this.context.allowMouseUpTriggerRef;
+    this.ownAllowMouseUpTriggerRef = this.context.allowMouseUpTriggerRef;
 
-    // Set up propagation of state from parent menu if applicable.
-    // `observe` fires the listener synchronously here and again on every `parent` change. The
-    // observer's own unsubscriber (`unsubscribeParentObserver`) and the per-parent store
-    // subscription (`unsubscribeParentStore`) live in separate fields so re-running the listener
-    // only tears down the previous parent's subscription, never the observer itself.
+    // Wire up parent-state propagation. External (`handle`) stores never run the effect in
+    // `useStore`, so they rely on this constructor-time setup; internal stores re-arm it from the
+    // effect (see `connectEffect`) so the subscription survives StrictMode remounts and `handle`
+    // prop toggles.
+    this.connectParentObserver();
+  }
+
+  setOpen(open: boolean, eventDetails: Omit<MenuRoot.ChangeEventDetails, 'preventUnmountOnClose'>) {
+    this.state.floatingRootContext.context.events.emit('setOpen', { open, eventDetails });
+  }
+
+  public static useStore<Payload>(
+    externalStore: MenuStore<Payload> | undefined,
+    initialState: Partial<State<Payload>>,
+  ) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const internalStore = useRefWithInit(() => {
+      return new MenuStore<Payload>(initialState);
+    }).current;
+
+    // Only the internally-created store is owned by this component. An external `handle` store is
+    // owned by the consumer and may outlive the menu, so it must not be connected/disposed here.
+    // The internal store re-arms its parent observer on every mount and tears it down on every
+    // unmount, keeping the lifecycle symmetric: a one-time constructor setup would be permanently
+    // severed by the first effect cleanup (a StrictMode remount, or the `handle` prop toggling
+    // defined → undefined → defined), leaving the submenu unable to react to parent changes.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(
+      () => (externalStore ? undefined : internalStore.connectEffect()),
+      [externalStore, internalStore],
+    );
+
+    return externalStore ?? internalStore;
+  }
+
+  // This menu's own mouse-up gate, captured before any parent ref is borrowed so the root branch of
+  // `connectParentObserver` can restore it.
+  private ownAllowMouseUpTriggerRef: React.RefObject<boolean>;
+
+  private unsubscribeParentStore: (() => void) | null = null;
+
+  private unsubscribeParentObserver: (() => void) | null = null;
+
+  // (Re-)establishes the observer that propagates parent-menu state. Idempotent: any existing
+  // observer/subscription is torn down first, so calling it again (e.g. from the mount effect after
+  // a StrictMode unmount/remount) never double-subscribes.
+  //
+  // `observe` fires the listener synchronously here and again on every `parent` change. The
+  // observer's own unsubscriber (`unsubscribeParentObserver`) and the per-parent store subscription
+  // (`unsubscribeParentStore`) live in separate fields so re-running the listener only tears down
+  // the previous parent's subscription, never the observer itself.
+  private connectParentObserver() {
+    this.disconnectParentObserver();
+
     this.unsubscribeParentObserver = this.observe('parent', (parent) => {
       this.unsubscribeParentStore?.();
       this.unsubscribeParentStore = null;
@@ -176,50 +225,27 @@ export class MenuStore<Payload> extends ReactStore<
       }
 
       // Back at the root: stop borrowing a parent's ref so mouse-up state stays isolated.
-      this.context.allowMouseUpTriggerRef = ownAllowMouseUpTriggerRef;
+      this.context.allowMouseUpTriggerRef = this.ownAllowMouseUpTriggerRef;
     });
   }
 
-  setOpen(open: boolean, eventDetails: Omit<MenuRoot.ChangeEventDetails, 'preventUnmountOnClose'>) {
-    this.state.floatingRootContext.context.events.emit('setOpen', { open, eventDetails });
+  // Tears down the parent observer and any per-parent subscription this store created. Releasing
+  // `unsubscribeParentStore` is essential: a submenu's store subscribes into the parent menu's
+  // store, so without this the parent's listener set keeps the child store referenced after it
+  // unmounts, leaking the child store on every open/close cycle.
+  private disconnectParentObserver() {
+    this.unsubscribeParentStore?.();
+    this.unsubscribeParentStore = null;
+    this.unsubscribeParentObserver?.();
+    this.unsubscribeParentObserver = null;
   }
 
-  public static useStore<Payload>(
-    externalStore: MenuStore<Payload> | undefined,
-    initialState: Partial<State<Payload>>,
-  ) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const internalStore = useRefWithInit(() => {
-      return new MenuStore<Payload>(initialState);
-    }).current;
-
-    // Only the internally-created store is owned by this component. An external `handle` store is
-    // owned by the consumer and may outlive the menu, so it must not be disposed here.
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(
-      () => (externalStore ? undefined : internalStore.disposeEffect()),
-      [externalStore, internalStore],
-    );
-
-    return externalStore ?? internalStore;
-  }
-
-  private unsubscribeParentStore: (() => void) | null = null;
-
-  private unsubscribeParentObserver: (() => void) | null = null;
-
-  // Tears down both subscriptions this store created. Without releasing `unsubscribeParentStore`, a
-  // submenu's store (which subscribes into the parent menu's store) stays referenced by the
-  // parent's listener set after it unmounts, leaking the child store on every open/close cycle.
-  // `unsubscribeParentObserver` releases this store's own `observe` self-subscription; it would be
-  // collected with the store anyway, but releasing it keeps cleanup symmetric and future-proof.
-  private disposeEffect = () => {
-    return () => {
-      this.unsubscribeParentStore?.();
-      this.unsubscribeParentStore = null;
-      this.unsubscribeParentObserver?.();
-      this.unsubscribeParentObserver = null;
-    };
+  // Effect body for internally-owned stores: re-arm the parent observer on mount, tear it down on
+  // unmount. Symmetric setup/teardown is what keeps the subscription alive across StrictMode
+  // remounts and `handle` toggles (see the comment in `useStore`).
+  private connectEffect = () => {
+    this.connectParentObserver();
+    return () => this.disconnectParentObserver();
   };
 }
 

--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -134,11 +134,11 @@ export class MenuStore<Payload> extends ReactStore<
     const ownAllowMouseUpTriggerRef = this.context.allowMouseUpTriggerRef;
 
     // Set up propagation of state from parent menu if applicable.
-    // `observe` fires the listener synchronously here and again on every `parent` change, so the
-    // observer's own unsubscriber and the per-parent store subscription must live in separate
-    // fields — otherwise the synchronous first call clobbers one with the other and the first
-    // parent change tears down the observer itself.
-    this.observe('parent', (parent) => {
+    // `observe` fires the listener synchronously here and again on every `parent` change. The
+    // observer's own unsubscriber (`unsubscribeParentObserver`) and the per-parent store
+    // subscription (`unsubscribeParentStore`) live in separate fields so re-running the listener
+    // only tears down the previous parent's subscription, never the observer itself.
+    this.unsubscribeParentObserver = this.observe('parent', (parent) => {
       this.unsubscribeParentStore?.();
       this.unsubscribeParentStore = null;
 
@@ -206,15 +206,19 @@ export class MenuStore<Payload> extends ReactStore<
 
   private unsubscribeParentStore: (() => void) | null = null;
 
-  // Tears down the subscription this store holds on its parent store. Without this, a submenu's
-  // store (which subscribes into the parent menu's store) stays referenced by the parent's listener
-  // set after it unmounts, leaking the child store on every open/close cycle. The `observe` listener
-  // itself is registered on this store, so it is collected together with the store and needs no
-  // explicit cleanup.
+  private unsubscribeParentObserver: (() => void) | null = null;
+
+  // Tears down both subscriptions this store created. Without releasing `unsubscribeParentStore`, a
+  // submenu's store (which subscribes into the parent menu's store) stays referenced by the
+  // parent's listener set after it unmounts, leaking the child store on every open/close cycle.
+  // `unsubscribeParentObserver` releases this store's own `observe` self-subscription; it would be
+  // collected with the store anyway, but releasing it keeps cleanup symmetric and future-proof.
   private disposeEffect = () => {
     return () => {
       this.unsubscribeParentStore?.();
       this.unsubscribeParentStore = null;
+      this.unsubscribeParentObserver?.();
+      this.unsubscribeParentObserver = null;
     };
   };
 }

--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -129,16 +129,24 @@ export class MenuStore<Payload> extends ReactStore<
       selectors,
     );
 
+    // This menu's own mouse-up gate, used when it has no parent to borrow from.
+    const ownAllowMouseUpTriggerRef = this.context.allowMouseUpTriggerRef;
+
     // Set up propagation of state from parent menu if applicable.
-    this.unsubscribeParentListener = this.observe('parent', (parent) => {
-      this.unsubscribeParentListener?.();
+    // `observe` fires the listener synchronously here and again on every `parent` change, so the
+    // observer's own unsubscriber and the per-parent store subscription must live in separate
+    // fields — otherwise the synchronous first call clobbers one with the other and the first
+    // parent change tears down the observer itself.
+    this.observe('parent', (parent) => {
+      this.unsubscribeParentStore?.();
+      this.unsubscribeParentStore = null;
 
       if (parent.type === 'menu') {
         let rootId = parent.store.select('rootId');
         let floatingTreeRoot = parent.store.select('floatingTreeRoot');
         let keyboardEventRelay = parent.store.select('keyboardEventRelay');
 
-        this.unsubscribeParentListener = parent.store.subscribe(() => {
+        this.unsubscribeParentStore = parent.store.subscribe(() => {
           const nextRootId = parent.store.select('rootId');
           const nextFloatingTreeRoot = parent.store.select('floatingTreeRoot');
           const nextKeyboardEventRelay = parent.store.select('keyboardEventRelay');
@@ -163,9 +171,11 @@ export class MenuStore<Payload> extends ReactStore<
 
       if (parent.type !== undefined) {
         this.context.allowMouseUpTriggerRef = parent.context.allowMouseUpTriggerRef;
+        return;
       }
 
-      this.unsubscribeParentListener = null;
+      // Back at the root: stop borrowing a parent's ref so mouse-up state stays isolated.
+      this.context.allowMouseUpTriggerRef = ownAllowMouseUpTriggerRef;
     });
   }
 
@@ -185,7 +195,7 @@ export class MenuStore<Payload> extends ReactStore<
     return externalStore ?? internalStore;
   }
 
-  private unsubscribeParentListener: (() => void) | null = null;
+  private unsubscribeParentStore: (() => void) | null = null;
 }
 
 function createInitialState<Payload>(): State<Payload> {

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -157,7 +157,6 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
   const localInteractionProps = click.reference ?? EMPTY_OBJECT;
 
   const rootTriggerProps = store.useState('triggerProps', true);
-  delete rootTriggerProps.id;
 
   const state: MenuSubmenuTriggerState = { disabled, highlighted, open };
 

--- a/packages/react/src/menu/trigger/MenuTrigger.test.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';
 import { Popover } from '@base-ui/react/popover';
 import { describeConformance, createRenderer } from '#test-utils';
@@ -464,5 +464,65 @@ describe('<Menu.Trigger />', () => {
 
     const button = screen.getByTestId('menu-trigger');
     expect(button).toHaveAttribute('role', 'button');
+  });
+
+  describe('hover-open document listeners', () => {
+    it('removes the document mouseup listener when a hover-opened menu closes without a mouseup', async () => {
+      const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+      const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
+
+      try {
+        await render(
+          <Menu.Root modal={false}>
+            <Menu.Trigger delay={0} openOnHover>
+              Open
+            </Menu.Trigger>
+            <Menu.Portal>
+              <Menu.Positioner data-testid="positioner">
+                <Menu.Popup data-testid="menu" />
+              </Menu.Positioner>
+            </Menu.Portal>
+          </Menu.Root>,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Open' });
+
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        await flushMicrotasks();
+        expect(screen.queryByTestId('menu')).not.toBe(null);
+
+        // The hover-open effect arms a `{ once: true }` document `mouseup` listener.
+        let documentMouseUpHandler: EventListenerOrEventListenerObject | undefined;
+        for (let i = addEventListenerSpy.mock.calls.length - 1; i >= 0; i -= 1) {
+          const [eventName, listener, options] = addEventListenerSpy.mock.calls[i];
+          if (eventName === 'mouseup' && typeof options === 'object' && options?.once === true) {
+            documentMouseUpHandler = listener;
+            break;
+          }
+        }
+        expect(documentMouseUpHandler).toEqual(expect.any(Function));
+
+        // Hovering out closes the menu without ever firing a `mouseup`. The listener must be
+        // removed, otherwise it stays armed and fires on an unrelated later interaction.
+        const positioner = screen.getByTestId('positioner');
+        fireEvent.mouseEnter(positioner);
+        fireEvent.mouseLeave(positioner);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('menu')).toBe(null);
+        });
+
+        expect(removeEventListenerSpy).toHaveBeenCalledWith(
+          'mouseup',
+          documentMouseUpHandler,
+          expect.objectContaining({ once: true }),
+        );
+      } finally {
+        addEventListenerSpy.mockRestore();
+        removeEventListenerSpy.mockRestore();
+      }
+    });
   });
 });

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useTimeout } from '@base-ui/utils/useTimeout';
+import { addEventListener } from '@base-ui/utils/addEventListener';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { fastComponentRef } from '@base-ui/utils/fastHooks';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
@@ -138,8 +139,7 @@ export const MenuTrigger = fastComponentRef(function MenuTrigger(
 
     if (
       contains(triggerRef.current, mouseUpTarget) ||
-      contains(store.select('positionerElement'), mouseUpTarget) ||
-      mouseUpTarget === triggerRef.current
+      contains(store.select('positionerElement'), mouseUpTarget)
     ) {
       return;
     }
@@ -165,8 +165,12 @@ export const MenuTrigger = fastComponentRef(function MenuTrigger(
   React.useEffect(() => {
     if (isOpenedByThisTrigger && store.select('lastOpenChangeReason') === REASONS.triggerHover) {
       const doc = ownerDocument(triggerRef.current);
-      doc.addEventListener('mouseup', handleDocumentMouseUp, { once: true });
+      // A hover-open can close again (hover out) without ever seeing a mouseup, leaving the
+      // `{ once: true }` listener armed to fire on an unrelated later interaction. Returning the
+      // cleanup removes it.
+      return addEventListener(doc, 'mouseup', handleDocumentMouseUp, { once: true });
     }
+    return undefined;
   }, [isOpenedByThisTrigger, handleDocumentMouseUp, store]);
 
   const parentMenubarHasSubmenuOpen = isInMenubar && parent.context.hasSubmenuOpen;
@@ -189,7 +193,8 @@ export const MenuTrigger = fastComponentRef(function MenuTrigger(
     isClosing: () => store.select('transitionStatus') === 'ending',
   });
 
-  // Whether to ignore clicks to open the menu.
+  // Whether to keep the menu open when the trigger is clicked shortly after a hover-open
+  // (i.e. ignore the click that would otherwise close it).
   // `lastOpenChangeReason` doesn't need to be reactive here, as we need to run this
   // only when `isOpenedByThisTrigger` changes.
   const stickIfOpen = useStickIfOpen(isOpenedByThisTrigger, store.select('lastOpenChangeReason'));
@@ -369,7 +374,7 @@ function useStickIfOpen(open: boolean, openReason: string | null) {
   const stickIfOpenTimeout = useTimeout();
   const [stickIfOpen, setStickIfOpen] = React.useState(false);
   useIsoLayoutEffect(() => {
-    if (open && openReason === 'trigger-hover') {
+    if (open && openReason === REASONS.triggerHover) {
       // Only allow "patient" clicks to close the menu if it's open.
       // If they clicked within 500ms of the menu opening, keep it open.
       setStickIfOpen(true);

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -1051,6 +1051,78 @@ describe('<Menubar />', () => {
       expect(handleClick).not.toHaveBeenCalled();
     });
   });
+
+  // Driven in jsdom: it forces `:focus-visible` to match so a programmatic focus reproduces the
+  // mobile "focus opens, delayed click would close" sequence that arms this guard. The guard logic
+  // under test lives in `MenuRoot` and is environment-independent.
+  describe.skipIf(!isJSDOM)('touch-to-close guard', () => {
+    it('keeps a controlled menu open on a delayed touch click after a focus-driven open', async () => {
+      const editOnOpenChange = vi.fn();
+
+      function App() {
+        const [editOpen, setEditOpen] = React.useState(false);
+        return (
+          <Menubar>
+            <Menu.Root>
+              <Menu.Trigger data-testid="file-trigger">File</Menu.Trigger>
+              <Menu.Portal>
+                <Menu.Positioner data-testid="file-menu">
+                  <Menu.Popup>
+                    <Menu.Item>Open</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
+            <Menu.Root
+              open={editOpen}
+              onOpenChange={(open, details) => {
+                editOnOpenChange(open, details);
+                setEditOpen(open);
+              }}
+            >
+              <Menu.Trigger data-testid="edit-trigger">Edit</Menu.Trigger>
+              <Menu.Portal>
+                <Menu.Positioner data-testid="edit-menu">
+                  <Menu.Popup>
+                    <Menu.Item>Copy</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
+          </Menubar>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      const fileTrigger = screen.getByTestId('file-trigger');
+      const editTrigger = screen.getByTestId('edit-trigger');
+
+      // Open the File menu so the menubar has an open menu (this enables focus-to-open on siblings).
+      await user.click(fileTrigger);
+      await screen.findByTestId('file-menu');
+
+      // Focusing the Edit trigger opens its menu via `triggerFocus`, which arms the touch-to-close
+      // guard for the next 300ms.
+      await act(async () => {
+        editTrigger.focus();
+      });
+      await screen.findByTestId('edit-menu');
+      expect(editOnOpenChange).toHaveBeenLastCalledWith(true, expect.anything());
+
+      editOnOpenChange.mockClear();
+
+      // The delayed synthetic touch `click` that follows a tap must not close the just-opened menu.
+      // Before the guard ran ahead of `onOpenChange`, the controlled menu closed regardless.
+      fireEvent(
+        editTrigger,
+        new PointerEvent('click', { pointerType: 'touch', bubbles: true, cancelable: true }),
+      );
+
+      expect(editOnOpenChange).not.toHaveBeenCalledWith(false, expect.anything());
+      expect(screen.queryByTestId('edit-menu')).not.toBe(null);
+    });
+  });
 });
 
 function ContainedTriggerMenubar(props: Menubar.Props) {

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -1122,6 +1122,70 @@ describe('<Menubar />', () => {
       expect(editOnOpenChange).not.toHaveBeenCalledWith(false, expect.anything());
       expect(screen.queryByTestId('edit-menu')).not.toBe(null);
     });
+
+    it('still closes the menu when an item is tapped within the guard window', async () => {
+      const editOnOpenChange = vi.fn();
+
+      function App() {
+        const [editOpen, setEditOpen] = React.useState(false);
+        return (
+          <Menubar>
+            <Menu.Root>
+              <Menu.Trigger data-testid="file-trigger">File</Menu.Trigger>
+              <Menu.Portal>
+                <Menu.Positioner data-testid="file-menu">
+                  <Menu.Popup>
+                    <Menu.Item>Open</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
+            <Menu.Root
+              open={editOpen}
+              onOpenChange={(open, details) => {
+                editOnOpenChange(open, details);
+                setEditOpen(open);
+              }}
+            >
+              <Menu.Trigger data-testid="edit-trigger">Edit</Menu.Trigger>
+              <Menu.Portal>
+                <Menu.Positioner data-testid="edit-menu">
+                  <Menu.Popup>
+                    <Menu.Item data-testid="edit-item">Copy</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
+          </Menubar>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      const fileTrigger = screen.getByTestId('file-trigger');
+      const editTrigger = screen.getByTestId('edit-trigger');
+
+      await user.click(fileTrigger);
+      await screen.findByTestId('file-menu');
+
+      // Focusing the Edit trigger opens its menu via `triggerFocus`, arming the touch-to-close guard.
+      await act(async () => {
+        editTrigger.focus();
+      });
+      const editItem = await screen.findByTestId('edit-item');
+      expect(editOnOpenChange).toHaveBeenLastCalledWith(true, expect.anything());
+
+      editOnOpenChange.mockClear();
+
+      // A genuine item tap inside the guard window must still close the menu: the guard only
+      // suppresses the trigger's own delayed click (`triggerPress`), not an `itemPress` close.
+      fireEvent(
+        editItem,
+        new PointerEvent('click', { pointerType: 'touch', bubbles: true, cancelable: true }),
+      );
+
+      expect(editOnOpenChange).toHaveBeenCalledWith(false, expect.anything());
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Correctness fixes around the menu store lifecycle, detached triggers, and context menus, plus cleanup.

### Bugs
- **`MenuStore` parent observer no longer detaches itself / leaks its subscription.** `ReactStore.observe` fires its listener synchronously before returning, so the single unsubscriber field was clobbered at construction (leaking the per-parent store subscription) and a later `parent` change tore down the observer itself. The observer's own unsubscriber and the per-parent subscription now live in separate fields, and the root-level branch restores this menu's own `allowMouseUpTriggerRef` rather than keeping a borrowed parent ref.
- **Hover-open `mouseup` listener is now cleaned up.** A hover-open that closed again without a `mouseup` left a `{ once: true }` document listener armed to fire on an unrelated later interaction.
- **Touch-to-close guard runs before `onOpenChange` / `dispatchOpenChange`.** Previously the guard bailed *after* already notifying controlled consumers (and floating-ui's own state), so a controlled menu closed anyway.
- **ArrowLeft no longer closes a root context menu.** A root context menu was treated as `nested`, so the cross-orientation close key closed it; native context menus don't (there's no parent list to return to). Its submenus remain regular `parent.type === 'menu'` menus.

### Cleanup
- Remove the never-constructed `nested-context-menu` `MenuParent` variant.
- Drop the no-op render-time `delete rootTriggerProps.id`.
- Use the deduping `warn` util for the modal-on-child-menu warning (was `console.warn` on every render) with corrected wording; use `REASONS.triggerHover` instead of the string literal; fix the `stickIfOpen` comment.

The duplicated trigger drag-release bounds check is kept inline for now (a shared helper is a planned follow-up).

Typecheck, eslint, prettier, and the Menu / Menubar / ContextMenu suites pass. Based on current `master`.
