### PR TITLE
[popups] Fix non-modal focus-out close and tabindex management

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -792,6 +792,31 @@ describe('FloatingFocusManager', () => {
         expect(screen.getByTestId('last')).toHaveFocus();
       });
 
+      test('closeOnFocusOut: false keeps a non-modal element open when focus leaves', async () => {
+        render(<App modal={false} closeOnFocusOut={false} />);
+
+        fireEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating')).toBeInTheDocument();
+
+        await userEvent.tab();
+        expect(screen.getByTestId('two')).toHaveFocus();
+
+        await userEvent.tab();
+        expect(screen.getByTestId('three')).toHaveFocus();
+
+        // Move focus out of the floating element entirely.
+        await userEvent.tab();
+
+        // Wait for the (potential) setTimeout that wraps onOpenChange(false).
+        await act(() => new Promise((resolve) => setTimeout(resolve)));
+
+        // With `closeOnFocusOut={false}`, focus leaving the floating element does not close it.
+        expect(screen.getByTestId('floating')).toBeInTheDocument();
+        expect(screen.getByTestId('last')).toHaveFocus();
+      });
+
       test('false - comboboxes do not hide all other nodes', async () => {
         function App() {
           const [open, setOpen] = React.useState(false);

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -817,6 +817,48 @@ describe('FloatingFocusManager', () => {
         expect(screen.getByTestId('last')).toHaveFocus();
       });
 
+      test('clicking a nested click trigger does not suppress the next focus-out close', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+          const { refs, context } = useFloating({
+            open,
+            onOpenChange: setOpen,
+          });
+
+          return (
+            <>
+              <button
+                data-testid="reference"
+                ref={refs.setReference}
+                onClick={() => setOpen(true)}
+              />
+              {open && (
+                <FloatingFocusManager context={context} modal={false}>
+                  <div role="dialog" ref={refs.setFloating} data-testid="floating">
+                    <button data-base-ui-click-trigger="" data-testid="nested-trigger" />
+                  </div>
+                </FloatingFocusManager>
+              )}
+              <button data-testid="last" />
+            </>
+          );
+        }
+
+        render(<App />);
+
+        await userEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        await userEvent.click(screen.getByTestId('nested-trigger'));
+        await act(() => new Promise((resolve) => setTimeout(resolve)));
+
+        await userEvent.tab();
+        await act(() => new Promise((resolve) => setTimeout(resolve)));
+
+        expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
+        expect(screen.getByTestId('last')).toHaveFocus();
+      });
+
       test('false - comboboxes do not hide all other nodes', async () => {
         function App() {
           const [open, setOpen] = React.useState(false);
@@ -2050,6 +2092,44 @@ describe('FloatingFocusManager', () => {
       await flushMicrotasks();
 
       expect(screen.getByTestId('floating')).toHaveAttribute('tabindex', '0');
+    });
+
+    test('floating element with managed tabIndex is downgraded once content becomes tabbable', async () => {
+      function App({ hasTabbableContent = false }: { hasTabbableContent?: boolean }) {
+        const { refs, context } = useFloating({
+          open: true,
+          onOpenChange() {},
+        });
+
+        return (
+          <>
+            <button data-testid="reference" ref={refs.setReference} />
+            <FloatingFocusManager context={context} initialFocus={false} modal={false}>
+              <div ref={refs.setFloating} data-testid="floating" role="dialog">
+                {hasTabbableContent && <button data-testid="inside" />}
+              </div>
+            </FloatingFocusManager>
+          </>
+        );
+      }
+
+      const { rerender } = render(<App />);
+      await flushMicrotasks();
+
+      const reference = screen.getByTestId('reference');
+      reference.focus();
+
+      expect(screen.getByTestId('floating')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('floating')).toHaveAttribute('data-tabindex', '0');
+
+      rerender(<App hasTabbableContent />);
+      await flushMicrotasks();
+
+      fireEvent.focusOut(reference, { relatedTarget: screen.getByTestId('inside') });
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('floating')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByTestId('floating')).toHaveAttribute('data-tabindex', '-1');
     });
 
     test('floating element with listbox role ignores tabIndex setting', async () => {

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -1358,6 +1358,69 @@ describe('FloatingFocusManager', () => {
 
         expect(screen.getByTestId('reference')).toHaveFocus();
       });
+
+      test('clears outside pointer state between keep-mounted open sessions', async () => {
+        let readInsideReactTree = () => false;
+
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          readInsideReactTree = () => context.dataRef.current.insideReactTree;
+
+          const click = useClick(context);
+          const dismiss = useDismiss(context);
+
+          const { getReferenceProps, getFloatingProps } = useTestInteractions([click, dismiss]);
+
+          return (
+            <>
+              <span data-testid="open-state">{String(isOpen)}</span>
+              <button data-testid="before" />
+              <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
+              <FloatingPortal>
+                <FloatingFocusManager context={context} disabled={!isOpen} modal={false}>
+                  <div ref={refs.setFloating} data-testid="floating" {...getFloatingProps()}>
+                    <button data-testid="child" />
+                  </div>
+                </FloatingFocusManager>
+              </FloatingPortal>
+              <button data-testid="after" />
+            </>
+          );
+        }
+
+        render(<App />);
+
+        await userEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('child')).toHaveFocus();
+        });
+
+        fireEvent.pointerDown(screen.getByTestId('after'));
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('open-state')).toHaveTextContent('false');
+
+        await userEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('child')).toHaveFocus();
+        });
+
+        fireEvent.focusOut(screen.getByTestId('child'), {
+          relatedTarget: screen.getByTestId('after'),
+        });
+
+        expect(readInsideReactTree()).toBe(true);
+      });
     });
 
     describe('non-modal + FloatingPortal', () => {

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -130,6 +130,9 @@ function handleTabIndex(floatingFocusElement: HTMLElement) {
   if (tabbableContent.length === 0) {
     if (tabIndex !== '0') {
       floatingFocusElement.setAttribute('tabindex', '0');
+      // Mark our own write so the externally-managed early-return above doesn't
+      // mistake it for a user-authored `tabindex` and freeze management.
+      floatingFocusElement.setAttribute('data-tabindex', '0');
     }
   } else if (
     tabIndex !== '-1' ||
@@ -371,6 +374,11 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
 
       if (target?.closest(`[${CLICK_TRIGGER_IDENTIFIER}]`)) {
         isPointerDownRef.current = true;
+        // Reset on the next tick so a single click on a click-trigger doesn't
+        // permanently suppress focus-out closing for the lifetime of the instance.
+        pointerDownTimeout.start(0, () => {
+          isPointerDownRef.current = false;
+        });
       }
     }
 
@@ -383,6 +391,11 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
       addEventListener(doc, 'pointerup', clearPointerDownOutside, true),
       addEventListener(doc, 'pointercancel', clearPointerDownOutside, true),
       addEventListener(doc, 'keydown', onKeyDown, true),
+      () => {
+        // Avoid a stale `true` leaking into the next open (e.g. keep-mounted popups)
+        // if the popup dismissed between pointerdown and pointerup.
+        pointerDownOutsideRef.current = false;
+      },
     );
   }, [
     disabled,
@@ -391,6 +404,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
     floatingFocusElement,
     open,
     portalContext,
+    pointerDownTimeout,
     getResolvedInsideElements,
   ]);
 

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -391,11 +391,9 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
       addEventListener(doc, 'pointerup', clearPointerDownOutside, true),
       addEventListener(doc, 'pointercancel', clearPointerDownOutside, true),
       addEventListener(doc, 'keydown', onKeyDown, true),
-      () => {
-        // Avoid a stale `true` leaking into the next open (e.g. keep-mounted popups)
-        // if the popup dismissed between pointerdown and pointerup.
-        pointerDownOutsideRef.current = false;
-      },
+      // Avoid a stale `true` leaking into the next open (e.g. keep-mounted popups)
+      // if the popup dismissed between pointerdown and pointerup.
+      clearPointerDownOutside,
     );
   }, [
     disabled,


### PR DESCRIPTION
Three focus-management fixes in `FloatingFocusManager` (the shared focus manager used by Dialog, Popover, Menu, etc.):

- **Reset `isPointerDownRef` after a click-trigger pointerdown.** It was set when pointerdown landed on a `[data-base-ui-click-trigger]` element but only ever reset by the Safari workaround on the reference, so clicking a nested click-trigger inside a non-modal popup permanently suppressed every later focus-out close for the lifetime of the instance (and across sessions for keep-mounted popups).
- **Mark `data-tabindex` when writing `tabindex="0"`.** The empty-content branch of `handleTabIndex` wrote `tabindex="0"` without the marker, so the externally-managed early-return then treated our own write as user-authored and could never downgrade the container back to `-1` once content became tabbable.
- **Reset `pointerDownOutsideRef` on effect teardown** so a stale `true` doesn't leak into a keep-mounted popup's next open.

Adds a `closeOnFocusOut={false}` regression test.
