### PR TITLE
[docs] Fix copy button z-index

### DIFF
--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -201,6 +201,7 @@
     display: flex;
     flex-direction: column;
     position: relative;
+    isolation: isolate;
     outline: 0;
     border-top: 1px solid var(--color-border);
     border-bottom-left-radius: var(--demo-radius);


### PR DESCRIPTION
The copy button inside demo code blocks displays on top of the global header.

<img width="610" height="173" alt="Screenshot 2026-06-15 at 17 01 59" src="https://github.com/user-attachments/assets/3a9c08e9-086d-4cf0-b5a7-1c55e7e4dbca" />
