### PR TITLE
[docs] Demo tabs UI refresh

### DIFF
--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -59,71 +59,106 @@
     background-clip: padding-box;
     display: flex;
     align-items: end;
-    gap: 1.5rem;
     height: 2.25rem;
-    padding: 0 0 0 calc(0.25rem - 1px);
+    border-top: 1px solid var(--color-border);
     -webkit-user-select: none;
     user-select: none;
+    overflow: hidden;
+  }
 
-    /* Scroll */
-    overflow: auto hidden;
-    overscroll-behavior-x: contain;
-    scrollbar-width: none;
+  /* The single horizontal scroller for the toolbar. On mobile it holds the tabs
+     and the (in-scroll) actions; at --sm+ it holds just the tabs and the sticky
+     actions sit outside it. */
+  .DemoToolbarScrollAreaRoot {
+    display: flex;
+    flex: 1 1 auto;
+    min-width: 0;
+    align-self: stretch;
+  }
 
-    &::-webkit-scrollbar {
-      display: none;
-    }
+  .DemoToolbarViewport {
+    display: flex;
+    flex: 1 1 auto;
+    min-width: 0;
+    width: calc(100% + 1px);
+    margin-left: -1px;
 
-    /* Scroll containers may be focusable */
+    /* ScrollArea hardcodes `overflow: scroll` on both axes; force horizontal-only
+       so a trackpad gesture can't rubber-band the (non-scrolling) vertical axis. */
+    overflow-y: hidden !important;
+
+    /* Edge-fade scroll indicators at every viewport, driven by the
+       distance-from-edge ScrollArea exposes (`--scroll-area-overflow-x-*`), so
+       each fade is absent at rest and grows in only once scrolled past that
+       edge. The second mask layer keeps the bottom 1px opaque so the active
+       tab's background can bridge the border into the code block below. */
+    --demo-tabs-fade: 1.5rem;
+    mask-image:
+      linear-gradient(
+        to right,
+        transparent,
+        #000 min(var(--demo-tabs-fade), var(--scroll-area-overflow-x-start, 0px)),
+        #000 calc(100% - min(var(--demo-tabs-fade), var(--scroll-area-overflow-x-end, 0px))),
+        transparent
+      ),
+      linear-gradient(#000, #000);
+    mask-repeat: no-repeat;
+    mask-position:
+      0 0,
+      0 100%;
+    mask-size:
+      100% calc(100% - 1px),
+      100% 1px;
+
     &:focus-visible {
-      position: relative;
       outline: 2px solid var(--gray-t2);
       outline-offset: -1px;
       z-index: 1;
     }
+
+    &[data-has-overflow-x] {
+      /* Prevent Chrome/Safari page navigation gestures when scrolling horizontally */
+      overscroll-behavior-x: contain;
+    }
   }
 
   .DemoToolbarActions {
-    position: relative;
-    right: 0;
     display: flex;
     align-items: center;
-    margin-left: auto;
-    padding-right: 0.5rem;
     height: 100%;
     gap: var(--space-4);
+    padding-inline: 0.5rem;
+  }
 
-    /* Apply sticky only on wider viewports to avoid actions taking up most of it */
-    @media (min-width: 48rem) {
-      position: sticky;
-      padding-left: 0.75rem;
+  /* Inside the scroller — shown on mobile so the actions scroll with the tabs */
+  .DemoToolbarActionsMobile {
+    flex: 0 0 auto;
 
-      &::before {
-        content: '';
-        position: absolute;
-        inset: 0 0 1px;
-        border-radius: inherit;
-        background-color: var(--color-content);
-        pointer-events: none;
-      }
-
-      &::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        bottom: 1px;
-        left: -24px;
-        width: 24px;
-        background: linear-gradient(to right, transparent, var(--color-content));
-        pointer-events: none;
-      }
+    @media (--sm) {
+      display: none;
     }
+  }
+
+  /* Outside the scroller — shown at --sm+, pinned to the toolbar's right edge */
+  .DemoToolbarActionsDesktop {
+    display: none;
+
+    @media (--sm) {
+      display: flex;
+      flex: 0 0 auto;
+      padding-inline-start: 1rem;
+    }
+  }
+
+  .DemoTabsRoot {
+    display: flex;
+    flex: 0 0 auto;
   }
 
   .DemoTabsList {
     display: flex;
     align-self: flex-end;
-    gap: 0.125rem;
+    width: max-content;
   }
 
   .DemoTab {
@@ -132,14 +167,11 @@
     z-index: 0;
     outline: 0;
     height: 2.25rem;
-    padding-inline: 0.5rem;
+    padding-inline: 0.75rem;
     padding-top: 0.25rem;
     padding-bottom: calc(0.25rem + 1px);
-    border-top: 1px solid transparent;
     border-right: 1px solid transparent;
     border-left: 1px solid transparent;
-    border-top-left-radius: var(--radius-8);
-    border-top-right-radius: var(--radius-8);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -151,14 +183,10 @@
 
     @media (hover: hover) {
       &:hover:not([data-active]) {
-        border-color: var(--gray-s2);
-
         &::before {
           content: '';
           position: absolute;
-          inset: 0 0 1px;
-          border-top-left-radius: calc(var(--radius-8) - 1px);
-          border-top-right-radius: calc(var(--radius-8) - 1px);
+          inset: 0 -1px 1px;
           background-color: var(--gray-s2);
           pointer-events: none;
         }

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -59,7 +59,10 @@
     background-clip: padding-box;
     display: flex;
     align-items: end;
-    height: 2.25rem;
+    /* Tab row (2.25rem) plus the top border. Without the extra 1px the tab would
+       overflow into the border strip that `overflow: hidden` clips, cutting the
+       top 1px of the tab's focus ring. */
+    height: calc(2.25rem + 1px);
     border-top: 1px solid var(--color-border);
     -webkit-user-select: none;
     user-select: none;
@@ -188,6 +191,7 @@
           position: absolute;
           inset: 0 -1px 1px;
           background-color: var(--gray-s2);
+          background-clip: padding-box;
           pointer-events: none;
         }
       }
@@ -223,6 +227,11 @@
     position: relative;
     display: flex;
     flex-direction: column;
+
+    /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
+    &:has(.DemoCodeBlockViewport:focus-visible) {
+      z-index: 1;
+    }
   }
 
   .DemoCodeBlockRoot {

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -73,10 +73,26 @@
      and the (in-scroll) actions; at --sm+ it holds just the tabs and the sticky
      actions sit outside it. */
   .DemoToolbarScrollAreaRoot {
+    position: relative;
     display: flex;
     flex: 1 1 auto;
     min-width: 0;
     align-self: stretch;
+  }
+
+  /* The viewport is focusable, but its own outline is unusable here: an inset
+     outline paints beneath the tabs, and the viewport's edge-fade mask erases it
+     at the edges. Draw the focus ring on this (unmasked, non-scrolling) wrapper
+     instead, overlaid above the tabs, when the viewport is focused. */
+  /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
+  .DemoToolbarScrollAreaRoot:has(.DemoToolbarViewport:focus-visible)::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    outline: 2px solid var(--gray-t2);
+    outline-offset: -2px;
+    pointer-events: none;
   }
 
   .DemoToolbarViewport {
@@ -113,10 +129,10 @@
       100% calc(100% - 1px),
       100% 1px;
 
+    /* Focus ring is drawn on `.DemoToolbarScrollAreaRoot` so it sits above the
+       tabs and outside this viewport's edge-fade mask. */
     &:focus-visible {
-      outline: 2px solid var(--gray-t2);
-      outline-offset: -1px;
-      z-index: 1;
+      outline: none;
     }
 
     &[data-has-overflow-x] {

--- a/docs/src/components/Demo/Demo.tsx
+++ b/docs/src/components/Demo/Demo.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import { Collapsible } from '@base-ui/react/collapsible';
+import { ScrollArea } from '@base-ui/react/scroll-area';
 import * as Menu from 'docs/src/components/Menu';
 import { usePathname } from 'next/navigation';
 import type { ContentProps } from '@mui/internal-docs-infra/CodeHighlighter/types';
@@ -148,6 +149,50 @@ export function Demo({ compact = false, className, ...demoProps }: DemoProps) {
     </GhostButton>
   );
 
+  const toolbarActions = (
+    <React.Fragment>
+      {demo.variants.length > 1 && (
+        <DemoVariantSelector
+          onVariantChange={demo.expand}
+          variants={demo.variants}
+          selectedVariant={demo.selectedVariant}
+          selectVariant={demo.selectVariant as any}
+        />
+      )}
+      {externalPlaygroundLink}
+      {githubUrl && (
+        <Menu.Root>
+          <Menu.Trigger
+            render={
+              <GhostButton layout="icon" aria-label="More actions">
+                <MoreVertIcon aria-hidden="true" />
+              </GhostButton>
+            }
+          />
+          <Menu.Popup align="end" alignOffset={-5}>
+            <Menu.LinkItem href={githubUrl} target="_blank" rel="noopener" onClick={onViewSource}>
+              <GitHubIcon aria-hidden="true" />
+              View source on GitHub
+              <ExternalLinkIcon aria-hidden="true" />
+            </Menu.LinkItem>
+
+            <Menu.Item closeOnClick={false} onClick={onCopySourceLink}>
+              {sourceLinkCopied ? (
+                <CheckIcon aria-hidden="true" />
+              ) : (
+                <CopyIcon aria-hidden="true" />
+              )}
+              Copy link to source
+              <span className="sr-only" aria-live="polite">
+                {sourceLinkCopied && 'Link copied!'}
+              </span>
+            </Menu.Item>
+          </Menu.Popup>
+        </Menu.Root>
+      )}
+    </React.Fragment>
+  );
+
   return (
     <div className={clsx('DemoRoot', className)}>
       {demo.allFilesSlugs.map(({ slug }) => (
@@ -164,59 +209,25 @@ export function Demo({ compact = false, className, ...demoProps }: DemoProps) {
         <div role="figure" aria-label="Component demo code">
           {(compact ? demo.expanded : true) && (
             <div className="DemoToolbar">
-              <DemoFileSelector
-                files={demo.files}
-                selectedFileName={demo.selectedFileName}
-                selectFileName={onSelectFile}
-                onTabChange={demo.expand}
-              />
-
-              <div className="DemoToolbarActions">
-                {demo.variants.length > 1 && (
-                  <DemoVariantSelector
-                    onVariantChange={demo.expand}
-                    variants={demo.variants}
-                    selectedVariant={demo.selectedVariant}
-                    selectVariant={demo.selectVariant as any}
+              {/* One ScrollArea drives the edge-fade indicators at every viewport.
+                  Below --sm the actions sit inside it (they scroll with the tabs);
+                  at --sm+ the in-scroll copy is hidden and the sticky copy outside
+                  takes over. Both copies stay mounted so state survives a resize. */}
+              <ScrollArea.Root className="DemoToolbarScrollAreaRoot">
+                <ScrollArea.Viewport className="DemoToolbarViewport">
+                  <DemoFileSelector
+                    files={demo.files}
+                    selectedFileName={demo.selectedFileName}
+                    selectFileName={onSelectFile}
+                    onTabChange={demo.expand}
                   />
-                )}
-                {externalPlaygroundLink}
-                {githubUrl && (
-                  <Menu.Root>
-                    <Menu.Trigger
-                      render={
-                        <GhostButton layout="icon" aria-label="More actions">
-                          <MoreVertIcon aria-hidden="true" />
-                        </GhostButton>
-                      }
-                    />
-                    <Menu.Popup align="end" alignOffset={-5}>
-                      <Menu.LinkItem
-                        href={githubUrl}
-                        target="_blank"
-                        rel="noopener"
-                        onClick={onViewSource}
-                      >
-                        <GitHubIcon aria-hidden="true" />
-                        View source on GitHub
-                        <ExternalLinkIcon aria-hidden="true" />
-                      </Menu.LinkItem>
+                  <div className="DemoToolbarActions DemoToolbarActionsMobile">
+                    {toolbarActions}
+                  </div>
+                </ScrollArea.Viewport>
+              </ScrollArea.Root>
 
-                      <Menu.Item closeOnClick={false} onClick={onCopySourceLink}>
-                        {sourceLinkCopied ? (
-                          <CheckIcon aria-hidden="true" />
-                        ) : (
-                          <CopyIcon aria-hidden="true" />
-                        )}
-                        Copy link to source
-                        <span className="sr-only" aria-live="polite">
-                          {sourceLinkCopied && 'Link copied!'}
-                        </span>
-                      </Menu.Item>
-                    </Menu.Popup>
-                  </Menu.Root>
-                )}
-              </div>
+              <div className="DemoToolbarActions DemoToolbarActionsDesktop">{toolbarActions}</div>
             </div>
           )}
 

--- a/docs/src/components/Demo/DemoFileSelector.tsx
+++ b/docs/src/components/Demo/DemoFileSelector.tsx
@@ -62,7 +62,7 @@ export function DemoFileSelector({
   }
 
   return (
-    <Tabs.Root value={selectedFileName} onValueChange={onValueChange}>
+    <Tabs.Root className="DemoTabsRoot" value={selectedFileName} onValueChange={onValueChange}>
       <Tabs.List className="DemoTabsList" aria-label="Files">
         {tabs.map((tab: Tab) => (
           <Tabs.Tab


### PR DESCRIPTION
Preview:
- Non-scrollable tabs: https://deploy-preview-5055--base-ui.netlify.app/react/components/accordion
- Scrollable tabs: https://deploy-preview-5055--base-ui.netlify.app/react/handbook/forms

We recently changed the design of the demo tabs in https://github.com/mui/base-ui/pull/4983, but I think this new design is nicer, probably less noisy, and does a better job at separating the demo playground from the toolbar+codeblock.

This new design uses ScrollArea to benefit from its data attributes and CSS vars to display subtle left/right scroll indicators.

It only adds `overscroll-behavior-x: contain` when `data-has-overflow-x` is present i.e. when the tabs' content overflows, so we don't create new layers that could [harm performance](https://github.com/mui/base-ui/pull/5022).

I'd like to improve the "jumping" borders when switching the active tab, so it behaves like e.g. VS Code, where borders between tabs are stable. Maybe another day. This thing got complex enough with focus rings and all.

|before|after|
|---|---|
|<img width="790" height="365" alt="Screenshot 2026-06-16 at 14 41 55" src="https://github.com/user-attachments/assets/162cd49f-4c50-46f6-9a6b-9d22f4cb2577" />|<img width="787" height="359" alt="Screenshot 2026-06-16 at 14 42 22" src="https://github.com/user-attachments/assets/5a44dec3-3947-4f20-aa88-e910d54b26a4" />|
|<img width="797" height="368" alt="Screenshot 2026-06-16 at 14 44 11" src="https://github.com/user-attachments/assets/662e566b-aec0-4c68-bda2-a4e7644e205a" />|<img width="791" height="368" alt="Screenshot 2026-06-16 at 14 44 28" src="https://github.com/user-attachments/assets/a8e4293c-5fc0-4142-81e5-5db48b3b3668" />|
|<img width="807" height="368" alt="Screenshot 2026-06-16 at 14 42 07" src="https://github.com/user-attachments/assets/7874021c-a9d3-47e5-a336-77972ba53d2e" />|<img width="805" height="370" alt="Screenshot 2026-06-16 at 14 42 35" src="https://github.com/user-attachments/assets/cfb13b51-cdc5-4243-ba83-e87dd7733b50" />|


