### PR TITLE
[docs] Fix demo toolbar alignment

### DIFF
--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -152,6 +152,7 @@
   /* Inside the scroller — shown on mobile so the actions scroll with the tabs */
   .DemoToolbarActionsMobile {
     flex: 0 0 auto;
+    margin-left: auto;
 
     @media (--sm) {
       display: none;


### PR DESCRIPTION
Demo toolbar actions were left-aligned on small viewports when they should be right-aligned.

|before|after|
|---|---|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-16 at 21 23 52" src="https://github.com/user-attachments/assets/7ceb57e0-8fb2-4195-a4a1-a77561f7b83f" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-16 at 21 24 23" src="https://github.com/user-attachments/assets/818adf6f-330b-4796-99b2-903eb1bd21a7" />|


