### PR TITLE
[menubar] Fix menubar a11y tree to satisfy `aria-required-children`

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -1826,7 +1826,7 @@ describe('FloatingFocusManager', () => {
         const reference = screen.getByTestId('reference');
         const portalNode = screen.getByTestId('floating').closest('[data-base-ui-portal]');
         const portalNodeId = portalNode?.id ?? '';
-        const owner = document.querySelector('span[aria-owns]');
+        const owner = portalNode?.ownerDocument.querySelector('span[aria-owns]');
 
         expect(portalNodeId).not.toBe('');
         expect(owner).not.toHaveAttribute('role');
@@ -1867,7 +1867,11 @@ describe('FloatingFocusManager', () => {
         await userEvent.click(screen.getByTestId('reference'));
         await flushMicrotasks();
 
-        expect(document.querySelector('span[aria-owns]')).toHaveAttribute('role', 'group');
+        const portalNode = screen.getByTestId('floating').closest('[data-base-ui-portal]');
+        const owner = portalNode?.ownerDocument.querySelector('span[aria-owns]');
+
+        expect(portalNode).not.toBe(null);
+        expect(owner).toHaveAttribute('role', 'group');
       });
 
       test('shift+tab', async () => {

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -1790,6 +1790,86 @@ describe('FloatingFocusManager', () => {
         expect(screen.getByTestId('reference-sibling-2')).not.toHaveAttribute('data-base-ui-inert');
       });
 
+      test('renders the aria-owns owner without changing regular reference semantics', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+          const { refs, context } = useFloating({
+            open,
+            onOpenChange: setOpen,
+          });
+
+          return (
+            <>
+              <button
+                data-testid="reference"
+                ref={refs.setReference}
+                onClick={() => setOpen(true)}
+              />
+              <FloatingPortal>
+                {open && (
+                  <FloatingFocusManager context={context} modal={false}>
+                    <div data-testid="floating" ref={refs.setFloating}>
+                      <span tabIndex={0} data-testid="inside" />
+                    </div>
+                  </FloatingFocusManager>
+                )}
+              </FloatingPortal>
+            </>
+          );
+        }
+
+        render(<App />);
+
+        await userEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        const reference = screen.getByTestId('reference');
+        const portalNode = screen.getByTestId('floating').closest('[data-base-ui-portal]');
+        const portalNodeId = portalNode?.id ?? '';
+        const owner = document.querySelector('span[aria-owns]');
+
+        expect(portalNodeId).not.toBe('');
+        expect(owner).not.toHaveAttribute('role');
+        expect(owner).toHaveAttribute('aria-owns', portalNodeId);
+        expect(reference).not.toHaveAttribute('aria-owns');
+      });
+
+      test('supports setting the aria-owns owner role explicitly', async () => {
+        function App() {
+          const [open, setOpen] = React.useState(false);
+          const { refs, context } = useFloating({
+            open,
+            onOpenChange: setOpen,
+          });
+
+          return (
+            <>
+              <button
+                data-testid="reference"
+                ref={refs.setReference}
+                onClick={() => setOpen(true)}
+              />
+              <FloatingPortal portalOwnerRole="group">
+                {open && (
+                  <FloatingFocusManager context={context} modal={false}>
+                    <div data-testid="floating" ref={refs.setFloating}>
+                      <span tabIndex={0} data-testid="inside" />
+                    </div>
+                  </FloatingFocusManager>
+                )}
+              </FloatingPortal>
+            </>
+          );
+        }
+
+        render(<App />);
+
+        await userEvent.click(screen.getByTestId('reference'));
+        await flushMicrotasks();
+
+        expect(document.querySelector('span[aria-owns]')).toHaveAttribute('role', 'group');
+      });
+
       test('shift+tab', async () => {
         function App() {
           const [open, setOpen] = React.useState(false);

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -170,7 +170,8 @@ export const FloatingPortal = React.forwardRef(function FloatingPortal(
   componentProps: FloatingPortal.Props<any>,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { render, className, style, children, container, ...elementProps } = componentProps;
+  const { render, className, style, children, container, portalOwnerRole, ...elementProps } =
+    componentProps;
 
   const {
     node: portalNode,
@@ -270,7 +271,7 @@ export const FloatingPortal = React.forwardRef(function FloatingPortal(
           />
         )}
         {shouldRenderGuards && portalNode && (
-          <span aria-owns={portalNodeId} style={ownerVisuallyHidden} />
+          <span role={portalOwnerRole} aria-owns={portalNodeId} style={ownerVisuallyHidden} />
         )}
         {portalNode && ReactDOM.createPortal(children, portalNode)}
         {shouldRenderGuards && portalNode && (
@@ -309,5 +310,10 @@ export namespace FloatingPortal {
      * A parent element to render the portal element into.
      */
     container?: UseFloatingPortalNodeProps['container'] | undefined;
+    /**
+     * @ignore
+     * The role for the hidden `aria-owns` owner element.
+     */
+    portalOwnerRole?: React.AriaRole | undefined;
   }
 }

--- a/packages/react/src/menu/portal/MenuPortal.tsx
+++ b/packages/react/src/menu/portal/MenuPortal.tsx
@@ -20,15 +20,19 @@ export const MenuPortal = React.forwardRef(function MenuPortal(
 
   const { store } = useMenuRootContext();
   const mounted = store.useState('mounted');
+  const parent = store.useState('parent');
 
   const shouldRender = mounted || keepMounted;
   if (!shouldRender) {
     return null;
   }
 
+  const portalOwnerRole = parent.type === 'menu' || parent.type === 'menubar' ? 'group' : undefined;
+
   return (
     <MenuPortalContext.Provider value={keepMounted}>
-      <FloatingPortal ref={forwardedRef} {...portalProps} />
+      {/* The hidden `aria-owns` owner needs `group` only under role-constrained parents. */}
+      <FloatingPortal ref={forwardedRef} {...portalProps} portalOwnerRole={portalOwnerRole} />
     </MenuPortalContext.Provider>
   );
 });

--- a/packages/react/src/menu/portal/MenuPortal.tsx
+++ b/packages/react/src/menu/portal/MenuPortal.tsx
@@ -18,15 +18,17 @@ export const MenuPortal = React.forwardRef(function MenuPortal(
 ) {
   const { keepMounted = false, ...portalProps } = props;
 
-  const { store } = useMenuRootContext();
+  const { store, parent } = useMenuRootContext();
   const mounted = store.useState('mounted');
-  const parent = store.useState('parent');
 
   const shouldRender = mounted || keepMounted;
   if (!shouldRender) {
     return null;
   }
 
+  // The hidden `aria-owns` owner renders here, in the React tree, so the role must be decided by
+  // where this portal sits, not by the active trigger. `parent` comes from context (the `Menu.Root`
+  // position), unlike the store's `parent`, which a detached trigger overwrites with its own.
   const portalOwnerRole = parent.type === 'menu' || parent.type === 'menubar' ? 'group' : undefined;
 
   return (

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -815,6 +815,43 @@ describe('<Menu.Root />', () => {
         expect(await screen.findByTestId('item-4_1')).toHaveTextContent('Item 4.1');
       });
 
+      it('renders root menu portal ownership without an accessibility role', async () => {
+        const { user } = await render(<TestMenu />);
+
+        const mainTrigger = screen.getByRole('button', { name: 'Toggle' });
+        await user.click(mainTrigger);
+
+        const menu = await screen.findByTestId('menu');
+        const menuPortal = menu.closest('[data-base-ui-portal]');
+        const menuPortalId = menuPortal?.id ?? '';
+        const owner = menu.ownerDocument.querySelector('span[aria-owns]');
+
+        expect(menuPortalId).not.toBe('');
+        expect(owner).toHaveAttribute('aria-owns', menuPortalId);
+        expect(owner).not.toHaveAttribute('role');
+      });
+
+      it('renders submenu portal ownership as an allowed menu child', async () => {
+        const { user } = await render(<TestMenu submenuTriggerProps={{ openOnHover: false }} />);
+
+        const mainTrigger = screen.getByRole('button', { name: 'Toggle' });
+        await user.click(mainTrigger);
+
+        const menu = await screen.findByTestId('menu');
+        const submenuTrigger = await screen.findByTestId('submenu-trigger');
+        await user.click(submenuTrigger);
+
+        const submenu = await screen.findByTestId('submenu');
+        const submenuPortal = submenu.closest('[data-base-ui-portal]');
+        const submenuPortalId = submenuPortal?.id ?? '';
+        const owner = menu.querySelector('span[aria-owns]');
+
+        expect(submenuPortalId).not.toBe('');
+        expect(owner).toHaveAttribute('role', 'group');
+        expect(owner).toHaveAttribute('aria-owns', submenuPortalId);
+        expect(submenuTrigger).not.toHaveAttribute('aria-owns');
+      });
+
       it('keeps the root menu open when a submenu opens and the trigger `render` element has a custom id', async () => {
         const onOpenChange = vi.fn();
         const { user } = await render(

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -1108,6 +1108,24 @@ describe('<Menubar />', () => {
     expect(owner).toHaveAttribute('aria-owns', fileMenuPortalId);
   });
 
+  it('renders detached top-level portal ownership without an accessibility role', async () => {
+    const { user } = await render(<DetachedTriggerMenubar />);
+
+    await user.click(screen.getByTestId('file-trigger'));
+
+    const fileMenu = await screen.findByTestId('file-menu');
+    const fileMenuPortal = fileMenu.closest('[data-base-ui-portal]');
+    const fileMenuPortalId = fileMenuPortal?.id ?? '';
+    const owner = fileMenu.ownerDocument.querySelector('span[aria-owns]');
+
+    expect(fileMenuPortalId).not.toBe('');
+    expect(owner).toHaveAttribute('aria-owns', fileMenuPortalId);
+    // The portal renders outside the menubar, so the `group` workaround would only add a stray
+    // accessible group.
+    expect(screen.getByRole('menubar')).not.toContainElement(owner as HTMLElement | null);
+    expect(owner).not.toHaveAttribute('role');
+  });
+
   describe('disabled state', () => {
     it('keeps the menubar reachable when the first trigger is disabled', async () => {
       const { user } = await render(

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -1092,6 +1092,22 @@ describe('<Menubar />', () => {
     });
   });
 
+  it('renders contained top-level portal ownership as an allowed menubar child', async () => {
+    const { user } = await render(<ContainedTriggerMenubar />);
+
+    await user.click(screen.getByTestId('file-trigger'));
+
+    const fileMenu = await screen.findByTestId('file-menu');
+    const fileMenuPortal = fileMenu.closest('[data-base-ui-portal]');
+    const fileMenuPortalId = fileMenuPortal?.id ?? '';
+    const owner = screen.getByRole('menubar').querySelector('span[aria-owns]');
+
+    expect(fileMenuPortalId).not.toBe('');
+    expect(owner).toHaveAttribute('role', 'group');
+    expect(owner).not.toHaveAttribute('aria-hidden');
+    expect(owner).toHaveAttribute('aria-owns', fileMenuPortalId);
+  });
+
   describe('disabled state', () => {
     it('keeps the menubar reachable when the first trigger is disabled', async () => {
       const { user } = await render(


### PR DESCRIPTION
This is an alternative to https://github.com/mui/base-ui/pull/4027.
It renders the span with `aria-owns` with `role=group`. Groups are allowed within menus and an empty group does not mess up the accessibility tree.

Lighthouse does not complain anymore.

Fixes #4004