### PR TITLE
[menu] Fix submenu item VoiceOver announcement when opened by keyboard

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -447,9 +447,10 @@ export function useListNavigation(
             // omitted here so attribute-disabled items (`disabled`/`aria-disabled`) are skipped
             // on open even when the consumer passes an empty `disabledIndices` array. Passing it
             // would regress that behavior (see mui/base-ui#2604).
-            // macOS Safari VoiceOver can miss this first focus event as a freshly mounted
-            // submenu enters the accessibility tree. Delay only DOM focus; activeIndex still
-            // updates immediately so visual highlight and navigation state are not delayed.
+            // With macOS VoiceOver, WebKit can miss this first focus event as a freshly
+            // mounted submenu enters the accessibility tree. Delay only DOM focus for this
+            // engine-specific path; activeIndex still updates immediately so visual highlight
+            // and navigation state are not delayed.
             delayInitialFocusRef.current =
               platform.os.mac &&
               platform.screenReader.voiceOver &&

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useAnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { ownerDocument } from '@base-ui/utils/owner';
+import { platform } from '@base-ui/utils/platform';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { isHTMLElement } from '@floating-ui/utils/dom';
@@ -294,6 +295,7 @@ export function useListNavigation(
   const previousOpenRef = React.useRef(open);
   const forceSyncFocusRef = React.useRef(false);
   const forceScrollIntoViewRef = React.useRef(false);
+  const delayInitialFocusRef = React.useRef(false);
   const cancelQueuedFocusRef = React.useRef<(() => void) | null>(null);
 
   const disabledIndicesRef = useValueAsRef(disabledIndices);
@@ -302,15 +304,16 @@ export function useListNavigation(
   const resetOnPointerLeaveRef = useValueAsRef(resetOnPointerLeave);
 
   const focusFrame = useAnimationFrame();
+  const delayFocusFrame = useAnimationFrame();
   const waitForListPopulatedFrame = useAnimationFrame();
 
   const focusItem = useStableCallback(() => {
-    function runFocus(item: HTMLElement) {
+    function runFocus(item: HTMLElement, sync = forceSyncFocusRef.current) {
       if (virtual) {
         tree?.events.emit('virtualfocus', item);
       } else {
         cancelQueuedFocusRef.current = enqueueFocus(item, {
-          sync: forceSyncFocusRef.current,
+          sync,
           preventScroll: true,
         });
       }
@@ -318,8 +321,10 @@ export function useListNavigation(
 
     const initialItem = listRef.current[indexRef.current];
     const forceScrollIntoView = forceScrollIntoViewRef.current;
+    const shouldDelayInitialFocus =
+      delayInitialFocusRef.current && !forceSyncFocusRef.current && !virtual;
 
-    if (initialItem) {
+    if (initialItem && !shouldDelayInitialFocus) {
       runFocus(initialItem);
     }
 
@@ -331,10 +336,21 @@ export function useListNavigation(
       const waitedItem = listRef.current[indexRef.current] || initialItem;
 
       if (!waitedItem) {
+        delayInitialFocusRef.current = false;
         return;
       }
 
-      if (!initialItem) {
+      if (shouldDelayInitialFocus) {
+        delayInitialFocusRef.current = false;
+        delayFocusFrame.request(() => {
+          if (!latestOpenRef.current) {
+            return;
+          }
+
+          const latestItem = listRef.current[indexRef.current] || waitedItem;
+          runFocus(latestItem, true);
+        });
+      } else if (!initialItem) {
         runFocus(waitedItem);
       }
 
@@ -386,6 +402,8 @@ export function useListNavigation(
     }
     if (!open) {
       forceSyncFocusRef.current = false;
+      delayInitialFocusRef.current = false;
+      delayFocusFrame.cancel();
       return;
     }
     if (!floatingElement) {
@@ -429,6 +447,16 @@ export function useListNavigation(
             // omitted here so attribute-disabled items (`disabled`/`aria-disabled`) are skipped
             // on open even when the consumer passes an empty `disabledIndices` array. Passing it
             // would regress that behavior (see mui/base-ui#2604).
+            // macOS Safari VoiceOver can miss this first focus event as a freshly mounted
+            // submenu enters the accessibility tree. Delay only DOM focus; activeIndex still
+            // updates immediately so visual highlight and navigation state are not delayed.
+            delayInitialFocusRef.current =
+              platform.os.mac &&
+              platform.screenReader.voiceOver &&
+              platform.engine.webkit &&
+              nested &&
+              keyRef.current != null &&
+              !previousMountedRef.current;
             indexRef.current =
               keyRef.current == null ||
               isMainOrientationToEndKey(keyRef.current, orientation, rtl) ||
@@ -459,6 +487,7 @@ export function useListNavigation(
     rtl,
     onNavigate,
     focusItem,
+    delayFocusFrame,
     waitForListPopulatedFrame,
   ]);
 

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.webkit.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.webkit.test.tsx
@@ -1,0 +1,180 @@
+import { vi, it, describe, expect } from 'vitest';
+import * as React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { isJSDOM, useTestInteractions } from '#test-utils';
+import { useFloating, useListNavigation } from '../index';
+
+vi.mock('@base-ui/utils/platform', async () => {
+  const actual =
+    await vi.importActual<typeof import('@base-ui/utils/platform')>('@base-ui/utils/platform');
+
+  return {
+    ...actual,
+    platform: {
+      ...actual.platform,
+      os: { ...actual.platform.os, mac: true, apple: true },
+      engine: { ...actual.platform.engine, webkit: true },
+      screenReader: { ...actual.platform.screenReader, voiceOver: true },
+    },
+  };
+});
+
+function NestedKeyboardMenu({ keepMountedAfterOpen = false }: { keepMountedAfterOpen?: boolean }) {
+  const [open, setOpen] = React.useState(false);
+  const [wasOpened, setWasOpened] = React.useState(false);
+  const listRef = React.useRef<Array<HTMLLIElement | null>>([]);
+  const [activeIndex, setActiveIndex] = React.useState<null | number>(null);
+  const { refs, context } = useFloating({
+    open,
+    onOpenChange(nextOpen) {
+      setOpen(nextOpen);
+      if (nextOpen) {
+        setWasOpened(true);
+      }
+    },
+  });
+  const { getReferenceProps, getFloatingProps, getItemProps } = useTestInteractions([
+    useListNavigation(context, {
+      listRef,
+      activeIndex,
+      nested: true,
+      parentOrientation: 'vertical',
+      onNavigate: setActiveIndex,
+    }),
+  ]);
+
+  const mounted = open || (keepMountedAfterOpen && wasOpened);
+
+  return (
+    <React.Fragment>
+      <button {...getReferenceProps({ ref: refs.setReference })}>Open</button>
+      <button type="button" onClick={() => setOpen(false)}>
+        Close
+      </button>
+      {mounted && (
+        <div role="menu" {...getFloatingProps({ ref: refs.setFloating })}>
+          <ul>
+            <li
+              data-testid="item-0"
+              role="menuitem"
+              data-active={activeIndex === 0 ? '' : undefined}
+              tabIndex={-1}
+              {...getItemProps({
+                ref(node: HTMLLIElement | null) {
+                  listRef.current[0] = node;
+                },
+              })}
+            >
+              One
+            </li>
+          </ul>
+        </div>
+      )}
+    </React.Fragment>
+  );
+}
+
+function mockAnimationFrames() {
+  const frameCallbacks = new Map<number, FrameRequestCallback>();
+  let frameId = 0;
+
+  const requestAnimationFrameSpy = vi
+    .spyOn(window, 'requestAnimationFrame')
+    .mockImplementation((callback) => {
+      frameId += 1;
+      frameCallbacks.set(frameId, callback);
+      return frameId;
+    });
+  const cancelAnimationFrameSpy = vi
+    .spyOn(window, 'cancelAnimationFrame')
+    .mockImplementation((id) => {
+      frameCallbacks.delete(id);
+    });
+
+  function flushAnimationFrames() {
+    let flushes = 0;
+
+    while (frameCallbacks.size > 0) {
+      if (flushes === 5) {
+        throw new Error('Expected queued animation frames to settle');
+      }
+
+      act(() => {
+        const callbacks = Array.from(frameCallbacks.values());
+        frameCallbacks.clear();
+        callbacks.forEach((callback) => callback(performance.now()));
+      });
+
+      flushes += 1;
+    }
+  }
+
+  function restore() {
+    requestAnimationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+  }
+
+  return {
+    flushAnimationFrames,
+    restore,
+  };
+}
+
+describe('useListNavigation WebKit VoiceOver behavior', () => {
+  it.skipIf(isJSDOM)('delays initial DOM focus while activating the item immediately', async () => {
+    const user = userEvent.setup();
+    const animationFrames = mockAnimationFrames();
+
+    try {
+      render(<NestedKeyboardMenu />);
+
+      await user.tab();
+      await user.keyboard('{ArrowRight}');
+
+      const item = await screen.findByTestId('item-0');
+
+      await waitFor(() => {
+        expect(item).toHaveAttribute('data-active');
+      });
+      expect(item).not.toHaveFocus();
+
+      animationFrames.flushAnimationFrames();
+
+      expect(item).toHaveFocus();
+    } finally {
+      animationFrames.restore();
+    }
+  });
+
+  it.skipIf(isJSDOM)(
+    'does not move focus into a submenu that closed before focus landed',
+    async () => {
+      const user = userEvent.setup();
+      const animationFrames = mockAnimationFrames();
+
+      try {
+        render(<NestedKeyboardMenu keepMountedAfterOpen />);
+
+        await user.tab();
+        await user.keyboard('{ArrowRight}');
+
+        const item = await screen.findByTestId('item-0');
+
+        await waitFor(() => {
+          expect(item).toHaveAttribute('data-active');
+        });
+        expect(item).not.toHaveFocus();
+
+        await user.click(screen.getByRole('button', { name: 'Close' }));
+
+        animationFrames.flushAnimationFrames();
+
+        expect(item).not.toHaveFocus();
+        expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus();
+      } finally {
+        animationFrames.restore();
+      }
+    },
+  );
+});

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -469,7 +469,10 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
         {
           id: floatingId,
           role: 'menu' as const,
-          'aria-labelledby': activeTriggerElement?.id,
+          'aria-labelledby':
+            parent.type === 'menu' && open && lastOpenChangeReason === REASONS.listNavigation
+              ? undefined
+              : activeTriggerElement?.id,
           onMouseMove() {
             store.set('allowMouseEnter', true);
             if (parent.type === 'menu') {
@@ -498,6 +501,8 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     [
       activeTriggerElement,
       floatingId,
+      lastOpenChangeReason,
+      open,
       parent.type,
       store,
       typeahead.floating,

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -43,7 +43,7 @@ import {
   usePopupInteractionProps,
 } from '../../utils/popups';
 import { useMenuSubmenuRootContext } from '../submenu-root/MenuSubmenuRootContext';
-import { isMacVoiceOver } from '../utils/isMacVoiceOver';
+import { isMacVoiceOverKeyboardOpen } from '../utils/isMacVoiceOverKeyboardOpen';
 
 /**
  * Groups all parts of the menu.
@@ -473,8 +473,10 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
           'aria-labelledby':
             parent.type === 'menu' &&
             open &&
-            lastOpenChangeReason === REASONS.listNavigation &&
-            isMacVoiceOver()
+            isMacVoiceOverKeyboardOpen(
+              lastOpenChangeReason,
+              floatingRootContext.context.dataRef.current.openEvent,
+            )
               ? undefined
               : activeTriggerElement?.id,
           onMouseMove() {
@@ -505,6 +507,7 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     [
       activeTriggerElement,
       floatingId,
+      floatingRootContext,
       lastOpenChangeReason,
       open,
       parent.type,

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -43,6 +43,7 @@ import {
   usePopupInteractionProps,
 } from '../../utils/popups';
 import { useMenuSubmenuRootContext } from '../submenu-root/MenuSubmenuRootContext';
+import { isMacVoiceOver } from '../utils/isMacVoiceOver';
 
 /**
  * Groups all parts of the menu.
@@ -470,7 +471,10 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
           id: floatingId,
           role: 'menu' as const,
           'aria-labelledby':
-            parent.type === 'menu' && open && lastOpenChangeReason === REASONS.listNavigation
+            parent.type === 'menu' &&
+            open &&
+            lastOpenChangeReason === REASONS.listNavigation &&
+            isMacVoiceOver()
               ? undefined
               : activeTriggerElement?.id,
           onMouseMove() {

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
@@ -40,7 +40,7 @@ describe('<Menu.SubmenuTrigger />', () => {
                   <Menu.SubmenuTrigger>2</Menu.SubmenuTrigger>
                   <Menu.Portal>
                     <Menu.Positioner>
-                      <Menu.Popup>
+                      <Menu.Popup data-testid="submenu">
                         <Menu.Item>2.1</Menu.Item>
                         <Menu.Item>2.2</Menu.Item>
                       </Menu.Popup>
@@ -91,6 +91,94 @@ describe('<Menu.SubmenuTrigger />', () => {
         expect(item).not.toHaveAttribute('data-highlighted');
       });
     });
+  });
+
+  it('defers the ARIA relationship while a keyboard-opened submenu trigger keeps focus', async () => {
+    await render(
+      <Menu.Root open>
+        <Menu.Trigger>Open menu</Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.SubmenuRoot>
+                <Menu.SubmenuTrigger>More</Menu.SubmenuTrigger>
+                <Menu.Portal>
+                  <Menu.Positioner>
+                    <Menu.Popup data-testid="submenu" />
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.SubmenuRoot>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>,
+    );
+
+    const submenuTrigger = screen.getByText('More');
+
+    fireEvent.focus(submenuTrigger);
+    fireEvent.keyDown(submenuTrigger, { key: 'ArrowRight' });
+
+    const submenu = await screen.findByTestId('submenu');
+
+    expect(submenuTrigger).toHaveFocus();
+    expect(submenuTrigger).toHaveAttribute('aria-expanded', 'false');
+    expect(submenuTrigger).not.toHaveAttribute('aria-controls');
+    expect(submenuTrigger).toHaveAttribute('data-popup-open');
+    expect(submenu).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('keeps the ARIA relationship deferred after keyboard focus moves into the submenu', async () => {
+    await render(<TestComponent direction="ltr" />);
+    const submenuTrigger = screen.getByText('2');
+
+    fireEvent.focus(submenuTrigger);
+    fireEvent.keyDown(submenuTrigger, { key: 'ArrowRight' });
+
+    const submenuItem = screen.getByText('2.1');
+    await waitFor(() => {
+      expect(submenuItem).toHaveFocus();
+    });
+
+    const submenu = screen.getByTestId('submenu');
+
+    expect(submenuTrigger).toHaveAttribute('aria-expanded', 'false');
+    expect(submenuTrigger).not.toHaveAttribute('aria-controls');
+    expect(submenu).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('exposes the ARIA relationship immediately when the submenu is opened by click', async () => {
+    const { user } = await render(
+      <Menu.Root open>
+        <Menu.Trigger>Open menu</Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.SubmenuRoot>
+                <Menu.SubmenuTrigger openOnHover={false}>More</Menu.SubmenuTrigger>
+                <Menu.Portal>
+                  <Menu.Positioner>
+                    <Menu.Popup data-testid="submenu">
+                      <Menu.Item>Child</Menu.Item>
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.SubmenuRoot>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>,
+    );
+
+    const submenuTrigger = screen.getByText('More');
+
+    await user.click(submenuTrigger);
+
+    const submenu = await screen.findByTestId('submenu');
+
+    expect(submenuTrigger).toHaveAttribute('aria-expanded', 'true');
+    expect(submenuTrigger).toHaveAttribute('aria-controls', submenu.id);
+    expect(submenu).toHaveAttribute('aria-labelledby', submenuTrigger.id);
   });
 
   it('sets tabIndex to 0 on the submenu trigger after opening the submenu with a keydown event', async () => {

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, waitFor, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Menu } from '@base-ui/react/menu';
+import { REASONS } from '../../internals/reasons';
 import { isMacVoiceOver } from '../utils/isMacVoiceOver';
 
 vi.mock('../utils/isMacVoiceOver', () => {
@@ -172,6 +173,49 @@ describe('<Menu.SubmenuTrigger />', () => {
 
       const submenu = await screen.findByTestId('submenu');
 
+      expect(submenuTrigger).toHaveFocus();
+      expect(submenuTrigger).toHaveAttribute('data-popup-open');
+      expect(submenuTrigger).toHaveAttribute('aria-expanded', 'false');
+      expect(submenuTrigger).not.toHaveAttribute('aria-controls');
+      expect(submenu).not.toHaveAttribute('aria-labelledby');
+    });
+
+    it.each([
+      ['Enter', '[Enter]'],
+      ['Space', '[Space]'],
+    ])('defers the ARIA relationship when opened with %s', async (_keyName, key) => {
+      const handleOpenChange = vi.fn();
+
+      const { user } = await render(
+        <Menu.Root open>
+          <Menu.Trigger>Open menu</Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.SubmenuRoot onOpenChange={handleOpenChange}>
+                  <Menu.SubmenuTrigger>More</Menu.SubmenuTrigger>
+                  <Menu.Portal>
+                    <Menu.Positioner>
+                      <Menu.Popup data-testid="submenu" />
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.SubmenuRoot>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const submenuTrigger = screen.getByText('More');
+
+      await user.click(submenuTrigger);
+      await user.keyboard(key);
+
+      const submenu = await screen.findByTestId('submenu');
+
+      expect(handleOpenChange).toHaveBeenCalledTimes(1);
+      expect(handleOpenChange.mock.lastCall?.[0]).toBe(true);
+      expect(handleOpenChange.mock.lastCall?.[1].reason).toBe(REASONS.triggerPress);
       expect(submenuTrigger).toHaveFocus();
       expect(submenuTrigger).toHaveAttribute('data-popup-open');
       expect(submenuTrigger).toHaveAttribute('aria-expanded', 'false');

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
@@ -3,11 +3,22 @@ import { fireEvent, waitFor, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Menu } from '@base-ui/react/menu';
+import { isMacVoiceOver } from '../utils/isMacVoiceOver';
+
+vi.mock('../utils/isMacVoiceOver', () => {
+  return {
+    isMacVoiceOver: vi.fn(() => false),
+  };
+});
 
 type TextDirection = 'ltr' | 'rtl';
 
 describe('<Menu.SubmenuTrigger />', () => {
   const { render } = createRenderer();
+
+  beforeEach(() => {
+    vi.mocked(isMacVoiceOver).mockReturnValue(false);
+  });
 
   describeConformance(<Menu.SubmenuTrigger />, () => ({
     refInstanceof: window.HTMLDivElement,
@@ -93,8 +104,8 @@ describe('<Menu.SubmenuTrigger />', () => {
     });
   });
 
-  it('defers the ARIA relationship while a keyboard-opened submenu trigger keeps focus', async () => {
-    await render(
+  it('exposes the ARIA relationship when opened with keyboard', async () => {
+    const { user } = await render(
       <Menu.Root open>
         <Menu.Trigger>Open menu</Menu.Trigger>
         <Menu.Portal>
@@ -116,69 +127,110 @@ describe('<Menu.SubmenuTrigger />', () => {
 
     const submenuTrigger = screen.getByText('More');
 
-    fireEvent.focus(submenuTrigger);
-    fireEvent.keyDown(submenuTrigger, { key: 'ArrowRight' });
+    await user.click(submenuTrigger);
+    await user.keyboard('{ArrowRight}');
 
     const submenu = await screen.findByTestId('submenu');
 
     expect(submenuTrigger).toHaveFocus();
-    expect(submenuTrigger).toHaveAttribute('aria-expanded', 'false');
-    expect(submenuTrigger).not.toHaveAttribute('aria-controls');
     expect(submenuTrigger).toHaveAttribute('data-popup-open');
-    expect(submenu).not.toHaveAttribute('aria-labelledby');
-  });
-
-  it('keeps the ARIA relationship deferred after keyboard focus moves into the submenu', async () => {
-    await render(<TestComponent direction="ltr" />);
-    const submenuTrigger = screen.getByText('2');
-
-    fireEvent.focus(submenuTrigger);
-    fireEvent.keyDown(submenuTrigger, { key: 'ArrowRight' });
-
-    const submenuItem = screen.getByText('2.1');
-    await waitFor(() => {
-      expect(submenuItem).toHaveFocus();
-    });
-
-    const submenu = screen.getByTestId('submenu');
-
-    expect(submenuTrigger).toHaveAttribute('aria-expanded', 'false');
-    expect(submenuTrigger).not.toHaveAttribute('aria-controls');
-    expect(submenu).not.toHaveAttribute('aria-labelledby');
-  });
-
-  it('exposes the ARIA relationship immediately when the submenu is opened by click', async () => {
-    const { user } = await render(
-      <Menu.Root open>
-        <Menu.Trigger>Open menu</Menu.Trigger>
-        <Menu.Portal>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.SubmenuRoot>
-                <Menu.SubmenuTrigger openOnHover={false}>More</Menu.SubmenuTrigger>
-                <Menu.Portal>
-                  <Menu.Positioner>
-                    <Menu.Popup data-testid="submenu">
-                      <Menu.Item>Child</Menu.Item>
-                    </Menu.Popup>
-                  </Menu.Positioner>
-                </Menu.Portal>
-              </Menu.SubmenuRoot>
-            </Menu.Popup>
-          </Menu.Positioner>
-        </Menu.Portal>
-      </Menu.Root>,
-    );
-
-    const submenuTrigger = screen.getByText('More');
-
-    await user.click(submenuTrigger);
-
-    const submenu = await screen.findByTestId('submenu');
-
     expect(submenuTrigger).toHaveAttribute('aria-expanded', 'true');
     expect(submenuTrigger).toHaveAttribute('aria-controls', submenu.id);
     expect(submenu).toHaveAttribute('aria-labelledby', submenuTrigger.id);
+  });
+
+  describe('macOS VoiceOver', () => {
+    beforeEach(() => {
+      vi.mocked(isMacVoiceOver).mockReturnValue(true);
+    });
+
+    it('defers the ARIA relationship while a keyboard-opened submenu trigger keeps focus', async () => {
+      const { user } = await render(
+        <Menu.Root open>
+          <Menu.Trigger>Open menu</Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.SubmenuRoot>
+                  <Menu.SubmenuTrigger>More</Menu.SubmenuTrigger>
+                  <Menu.Portal>
+                    <Menu.Positioner>
+                      <Menu.Popup data-testid="submenu" />
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.SubmenuRoot>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const submenuTrigger = screen.getByText('More');
+
+      await user.click(submenuTrigger);
+      await user.keyboard('{ArrowRight}');
+
+      const submenu = await screen.findByTestId('submenu');
+
+      expect(submenuTrigger).toHaveFocus();
+      expect(submenuTrigger).toHaveAttribute('data-popup-open');
+      expect(submenuTrigger).toHaveAttribute('aria-expanded', 'false');
+      expect(submenuTrigger).not.toHaveAttribute('aria-controls');
+      expect(submenu).not.toHaveAttribute('aria-labelledby');
+    });
+
+    it('keeps the ARIA relationship deferred after keyboard focus moves into the submenu', async () => {
+      const { user } = await render(<TestComponent direction="ltr" />);
+      const submenuTrigger = screen.getByText('2');
+
+      await user.click(submenuTrigger);
+      await user.keyboard('{ArrowRight}');
+
+      const submenuItem = screen.getByText('2.1');
+      await waitFor(() => {
+        expect(submenuItem).toHaveFocus();
+      });
+
+      const submenu = screen.getByTestId('submenu');
+
+      expect(submenuTrigger).toHaveAttribute('aria-expanded', 'false');
+      expect(submenuTrigger).not.toHaveAttribute('aria-controls');
+      expect(submenu).not.toHaveAttribute('aria-labelledby');
+    });
+
+    it('exposes the ARIA relationship when the submenu is opened by click', async () => {
+      const { user } = await render(
+        <Menu.Root open>
+          <Menu.Trigger>Open menu</Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.SubmenuRoot>
+                  <Menu.SubmenuTrigger openOnHover={false}>More</Menu.SubmenuTrigger>
+                  <Menu.Portal>
+                    <Menu.Positioner>
+                      <Menu.Popup data-testid="submenu">
+                        <Menu.Item>Child</Menu.Item>
+                      </Menu.Popup>
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.SubmenuRoot>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const submenuTrigger = screen.getByText('More');
+
+      await user.click(submenuTrigger);
+
+      const submenu = await screen.findByTestId('submenu');
+
+      expect(submenuTrigger).toHaveAttribute('aria-expanded', 'true');
+      expect(submenuTrigger).toHaveAttribute('aria-controls', submenu.id);
+      expect(submenu).toHaveAttribute('aria-labelledby', submenuTrigger.id);
+    });
   });
 
   it('sets tabIndex to 0 on the submenu trigger after opening the submenu with a keydown event', async () => {

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -6,7 +6,7 @@ import { warn } from '@base-ui/utils/warn';
 import { SafeReact } from '@base-ui/utils/safeReact';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { safePolygon, useClick, useHoverReferenceInteraction } from '../../floating-ui-react';
-import { BaseUIComponentProps, NonNativeButtonProps } from '../../internals/types';
+import type { BaseUIComponentProps, NonNativeButtonProps } from '../../internals/types';
 import { useMenuRootContext } from '../root/MenuRootContext';
 import { useBaseUiId } from '../../internals/useBaseUiId';
 import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
@@ -16,8 +16,7 @@ import { useRenderElement } from '../../internals/useRenderElement';
 import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 import { useTriggerRegistration } from '../../utils/popups';
 import { useMenuSubmenuRootContext } from '../submenu-root/MenuSubmenuRootContext';
-import { REASONS } from '../../internals/reasons';
-import { isMacVoiceOver } from '../utils/isMacVoiceOver';
+import { isMacVoiceOverKeyboardOpen } from '../utils/isMacVoiceOverKeyboardOpen';
 
 /**
  * A menu item that opens a submenu.
@@ -163,6 +162,12 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
   delete rootTriggerProps.id;
 
   const state: MenuSubmenuTriggerState = { disabled, highlighted, open };
+  const macVoiceOverKeyboardOpen =
+    open &&
+    isMacVoiceOverKeyboardOpen(
+      lastOpenChangeReason,
+      floatingRootContext.context.dataRef.current.openEvent,
+    );
 
   const element = useRenderElement('div', componentProps, {
     state,
@@ -172,7 +177,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
       hoverProps,
       rootTriggerProps,
       itemProps,
-      open && lastOpenChangeReason === REASONS.listNavigation && isMacVoiceOver()
+      macVoiceOverKeyboardOpen
         ? {
             'aria-controls': undefined,
             'aria-expanded': false,

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -17,6 +17,7 @@ import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 import { useTriggerRegistration } from '../../utils/popups';
 import { useMenuSubmenuRootContext } from '../submenu-root/MenuSubmenuRootContext';
 import { REASONS } from '../../internals/reasons';
+import { isMacVoiceOver } from '../utils/isMacVoiceOver';
 
 /**
  * A menu item that opens a submenu.
@@ -171,13 +172,16 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
       hoverProps,
       rootTriggerProps,
       itemProps,
+      open && lastOpenChangeReason === REASONS.listNavigation && isMacVoiceOver()
+        ? {
+            'aria-controls': undefined,
+            'aria-expanded': false,
+          }
+        : {
+            'aria-controls': popupId,
+            'aria-expanded': rootTriggerProps['aria-expanded'],
+          },
       {
-        'aria-controls':
-          open && lastOpenChangeReason === REASONS.listNavigation ? undefined : popupId,
-        'aria-expanded':
-          open && lastOpenChangeReason === REASONS.listNavigation
-            ? false
-            : rootTriggerProps['aria-expanded'],
         tabIndex: open || highlighted ? 0 : -1,
         onBlur() {
           if (highlighted) {

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -16,6 +16,7 @@ import { useRenderElement } from '../../internals/useRenderElement';
 import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 import { useTriggerRegistration } from '../../utils/popups';
 import { useMenuSubmenuRootContext } from '../submenu-root/MenuSubmenuRootContext';
+import { REASONS } from '../../internals/reasons';
 
 /**
  * A menu item that opens a submenu.
@@ -48,6 +49,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
 
   const thisTriggerId = useBaseUiId(idProp);
   const open = store.useState('open');
+  const lastOpenChangeReason = store.useState('lastOpenChangeReason');
   const floatingRootContext = store.useState('floatingRootContext');
   const floatingTreeRoot = store.useState('floatingTreeRoot');
   const popupId = store.useState('triggerPopupId', thisTriggerId);
@@ -170,7 +172,12 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
       rootTriggerProps,
       itemProps,
       {
-        'aria-controls': popupId,
+        'aria-controls':
+          open && lastOpenChangeReason === REASONS.listNavigation ? undefined : popupId,
+        'aria-expanded':
+          open && lastOpenChangeReason === REASONS.listNavigation
+            ? false
+            : rootTriggerProps['aria-expanded'],
         tabIndex: open || highlighted ? 0 : -1,
         onBlur() {
           if (highlighted) {

--- a/packages/react/src/menu/utils/isMacVoiceOver.ts
+++ b/packages/react/src/menu/utils/isMacVoiceOver.ts
@@ -1,0 +1,5 @@
+import { platform } from '@base-ui/utils/platform';
+
+export function isMacVoiceOver() {
+  return platform.os.mac && platform.screenReader.voiceOver;
+}

--- a/packages/react/src/menu/utils/isMacVoiceOverKeyboardOpen.ts
+++ b/packages/react/src/menu/utils/isMacVoiceOverKeyboardOpen.ts
@@ -1,0 +1,25 @@
+import { REASONS, type BaseUIEventReason } from '../../internals/reasons';
+import { isMacVoiceOver } from './isMacVoiceOver';
+
+export function isMacVoiceOverKeyboardOpen(
+  reason: BaseUIEventReason | null,
+  openEvent: Event | undefined,
+) {
+  return (
+    isMacVoiceOver() &&
+    (reason === REASONS.listNavigation ||
+      (reason === REASONS.triggerPress && isKeyboardLikeOpenEvent(openEvent)))
+  );
+}
+
+function isKeyboardLikeOpenEvent(openEvent: Event | undefined) {
+  if (!openEvent) {
+    return false;
+  }
+
+  if (openEvent.type === 'keydown' || openEvent.type === 'keyup') {
+    return true;
+  }
+
+  return openEvent.type === 'click' && (openEvent as MouseEvent).detail === 0;
+}


### PR DESCRIPTION
Fixes a bug where VoiceOver (reproed with Chrome & Safari) doesn't announce the initially focused submenu item when the submenu opens via keyboard (arrow keys, enter space), recording:

https://github.com/user-attachments/assets/6f7b9f6e-fcd2-41c3-a370-74ee0bf42b0e

With the fix:

https://github.com/user-attachments/assets/952493a5-a480-4ce9-9682-277d5750ee49

This doesn't occur with NVDA

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
