### PR TITLE
[slider] Fix touchend listener accumulation leak

### DIFF
--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -336,6 +336,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
 
     // Cancel move in case some other element consumed a pointerup event and it was not fired.
     if (nativeEvent.type === 'pointermove' && (nativeEvent as PointerEvent).buttons === 0) {
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
       handleTouchEnd(nativeEvent);
       return;
     }
@@ -359,7 +360,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
     }
   });
 
-  function handleTouchEnd(nativeEvent: TouchEvent | PointerEvent) {
+  const handleTouchEnd = useStableCallback((nativeEvent: TouchEvent | PointerEvent) => {
     setActive(-1);
     setDragging(false);
 
@@ -387,7 +388,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
     currentInteractionValueRef.current = null;
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     stopListening();
-  }
+  });
 
   const handleTouchStart = useStableCallback((nativeEvent: TouchEvent) => {
     if (disabled) {

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -1335,6 +1335,94 @@ describe('<Slider.Root />', () => {
       },
     );
 
+    it.skipIf(isJSDOM || isWebKit)(
+      'does not call onValueCommitted on outside taps after a touch interaction',
+      async () => {
+        const handleValueCommitted = vi.fn();
+
+        await render(<TestSlider defaultValue={0} onValueCommitted={handleValueCommitted} />);
+
+        const sliderControl = screen.getByTestId('control');
+        vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(
+          getHorizontalSliderRect,
+        );
+
+        // Drag the slider with touch.
+        fireEvent.touchStart(
+          sliderControl,
+          createTouches([{ identifier: 1, clientX: 5, clientY: 0 }]),
+        );
+        fireEvent.touchMove(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 10, clientY: 0 }]),
+        );
+        fireEvent.touchEnd(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 20, clientY: 0 }]),
+        );
+
+        expect(handleValueCommitted.mock.calls.length).toBe(1);
+
+        // Tapping elsewhere on the page must not commit again.
+        fireEvent.touchStart(
+          document.body,
+          createTouches([{ identifier: 2, clientX: 80, clientY: 50 }]),
+        );
+        fireEvent.touchEnd(
+          document.body,
+          createTouches([{ identifier: 2, clientX: 80, clientY: 50 }]),
+        );
+
+        expect(handleValueCommitted.mock.calls.length).toBe(1);
+      },
+    );
+
+    it.skipIf(isJSDOM || isWebKit)(
+      'removes the document touchend listener after a touch interaction',
+      async () => {
+        await render(<TestSlider defaultValue={0} />);
+
+        const sliderControl = screen.getByTestId('control');
+        vi.spyOn(sliderControl, 'getBoundingClientRect').mockImplementation(
+          getHorizontalSliderRect,
+        );
+
+        const addedListeners: EventListenerOrEventListenerObject[] = [];
+        const removedListeners: EventListenerOrEventListenerObject[] = [];
+        const originalAdd = document.addEventListener.bind(document);
+        const originalRemove = document.removeEventListener.bind(document);
+        vi.spyOn(document, 'addEventListener').mockImplementation((type, listener, options) => {
+          if (type === 'touchend' && listener != null) {
+            addedListeners.push(listener);
+          }
+          return originalAdd(type, listener, options);
+        });
+        vi.spyOn(document, 'removeEventListener').mockImplementation((type, listener, options) => {
+          if (type === 'touchend' && listener != null) {
+            removedListeners.push(listener);
+          }
+          return originalRemove(type, listener, options);
+        });
+
+        fireEvent.touchStart(
+          sliderControl,
+          createTouches([{ identifier: 1, clientX: 5, clientY: 0 }]),
+        );
+        fireEvent.touchMove(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 10, clientY: 0 }]),
+        );
+        fireEvent.touchEnd(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 20, clientY: 0 }]),
+        );
+
+        // Every `touchend` listener that was added must have been removed.
+        expect(addedListeners.length).toBeGreaterThan(0);
+        expect(addedListeners.every((listener) => removedListeners.includes(listener))).toBe(true);
+      },
+    );
+
     it.skipIf(isJSDOM)('should hedge against a dropped mouseup event', async () => {
       const handleValueChange = vi.fn();
 


### PR DESCRIPTION
Fixes #5068

## Problem

After a touch interaction on the slider (tap or drag), tapping anywhere else on the page fired `onValueCommitted`. This was originally reported for desktop in #3311 and fixed for the pointer path in #3312 (`{ once: true }` on `pointerup`), but it persisted on touch devices (Safari iOS, Chrome with emulated touch).

## Root cause

`handleTouchEnd` was a plain function recreated on every render, unlike its siblings (`handleTouchMove`, `handleTouchStart`, `stopListening`), which use `useStableCallback`. The slider re-renders during an interaction (via `setValue`/`setDragging`), so:

- `handleTouchStart` registers `document.addEventListener('touchend', handleTouchEnd)` with one function instance, and
- `stopListening` later calls `removeEventListener('touchend', handleTouchEnd)` with a *different* (later-render) instance.

The references don't match, so the `touchend` listener is never removed and leaks onto the document, re-firing on every subsequent tap. On v1.5.0 (where `handleTouchEnd` committed unconditionally) this surfaced as the reported spurious `onValueCommitted`. On `master`, #4937's `currentInteractionValueRef` gate masks the commit, but the underlying listener leak remains.

## Fix

Wrap `handleTouchEnd` in `useStableCallback` so `addEventListener`/`removeEventListener` use the same stable reference and the listener is reliably removed. This also matches the repo convention of using `useStableCallback` for functions invoked from event handlers.

## Tests

Added two Chromium regression tests:

- `does not call onValueCommitted on outside taps after a touch interaction` — the user-facing contract.
- `removes the document touchend listener after a touch interaction` — targets the root cause (red before this change, green after).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
