### PR TITLE
[docs] Recover scrollBy behavior when collapsing code blocks

### DIFF
--- a/docs/src/components/Demo/Demo.tsx
+++ b/docs/src/components/Demo/Demo.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { Collapsible } from '@base-ui/react/collapsible';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import * as Menu from 'docs/src/components/Menu';
@@ -19,6 +20,7 @@ import { getGitHubDemoUrl } from 'docs/src/utils/getGitHubDemoUrl';
 import { platform } from '@base-ui/utils/platform';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useTimeout } from '@base-ui/utils/useTimeout';
+import { ownerWindow } from '@base-ui/utils/owner';
 import { useGoogleAnalytics } from 'docs/src/blocks/GoogleAnalyticsProvider';
 import { DemoVariantSelector } from './DemoVariantSelector';
 import { DemoFileSelector } from './DemoFileSelector';
@@ -32,6 +34,7 @@ export type DemoProps = ContentProps<{
 }>;
 
 export function Demo({ className, ...demoProps }: DemoProps) {
+  const collapsibleTriggerRef = React.useRef<HTMLSpanElement>(null);
   const [copyTimeout, setCopyTimeout] = React.useState<number>(0);
   const [sourceLinkCopied, setSourceLinkCopied] = React.useState(false);
   const sourceLinkCopyResetTimeout = useTimeout();
@@ -116,6 +119,25 @@ export function Demo({ className, ...demoProps }: DemoProps) {
       label: demoId,
       params: { [action]: demoId, slug: demoSlug || '' },
     });
+
+    if (!nextOpen && collapsibleTriggerRef.current != null) {
+      const buttonVisualEl = collapsibleTriggerRef.current;
+      const rectTopBeforeClose = buttonVisualEl.getBoundingClientRect().top;
+
+      ReactDOM.flushSync(() => demo.setExpanded(nextOpen));
+
+      const rectTopAfterClose = buttonVisualEl.getBoundingClientRect().top;
+      const delta = rectTopAfterClose - rectTopBeforeClose;
+      // Don't scroll if the collapse button is still in the viewport after closing.
+      if (rectTopAfterClose < 0) {
+        ownerWindow(buttonVisualEl).scrollBy({
+          top: delta,
+          behavior: 'instant',
+        });
+      }
+      return;
+    }
+
     demo.setExpanded(nextOpen);
   });
 
@@ -230,6 +252,7 @@ export function Demo({ className, ...demoProps }: DemoProps) {
             selectedFile={demo.selectedFile}
             selectedFileLines={demo.selectedFileLines}
             collapsibleOpen={demo.expanded}
+            collapsibleTriggerRef={collapsibleTriggerRef}
             copyButton={
               <GhostButton
                 layout="icon"

--- a/docs/src/components/Demo/DemoCodeBlock.tsx
+++ b/docs/src/components/Demo/DemoCodeBlock.tsx
@@ -8,6 +8,7 @@ interface DemoCodeBlockProps {
   collapsibleOpen: boolean;
   /** How many lines should the code block have to get collapsed instead of rendering fully */
   collapsibleLinesThreshold?: number;
+  collapsibleTriggerRef: React.Ref<HTMLSpanElement>;
   copyButton: React.ReactNode;
 }
 
@@ -37,6 +38,7 @@ export function DemoCodeBlock({
   selectedFileLines,
   collapsibleOpen,
   collapsibleLinesThreshold = 12,
+  collapsibleTriggerRef,
   copyButton,
 }: DemoCodeBlockProps) {
   if (selectedFileLines < collapsibleLinesThreshold) {
@@ -84,7 +86,7 @@ export function DemoCodeBlock({
           className="DemoCollapseButton"
           data-sticky={collapsibleOpen ? '' : undefined}
         >
-          <span className="DemoCollapseButtonVisual">
+          <span ref={collapsibleTriggerRef} className="DemoCollapseButtonVisual">
             {collapsibleOpen ? 'Hide code' : 'Show code'}
           </span>
         </Collapsible.Trigger>


### PR DESCRIPTION
https://github.com/mui/base-ui/pull/4983 removed the "hide code" button in demo code blocks. https://github.com/mui/base-ui/pull/5048 brought it back but the feature that kept the page scroll stable when collapsing code blocks was lost in translation.

More info about the actual feature: https://github.com/mui/base-ui/pull/5055#issuecomment-4735530030