### PR TITLE
[docs] Fix side nav focus ring

### DIFF
--- a/docs/src/components/SideNav.css
+++ b/docs/src/components/SideNav.css
@@ -56,15 +56,13 @@
     outline: 0;
 
     /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-    .SideNavRoot:has(&:focus-visible)::before {
+    .SideNavRoot:has(&:focus-visible)::after {
       content: '';
-      inset: 0;
+      inset: 0 -2px;
       pointer-events: none;
       position: absolute;
       outline: 2px solid var(--gray-t2);
       outline-offset: -2px;
-      /* Don't inset the outline on the right */
-      right: -2px;
     }
   }
 


### PR DESCRIPTION
Fixes the docs side nav focus frame so active items do not visually collide with the scroll area outline.

The side nav uses a negative link margin to align text while allowing the active pill to extend left. This adds matching focus padding around the scroll viewport and draws the viewport focus frame after the content.

| Before | After |
| --- | --- |
| <img width="654" height="800" alt="CleanShot 2026-06-18 at 21 55 59" src="https://github.com/user-attachments/assets/0475c344-c581-4b89-8af3-3be0cfab081c" /> | <img width="701" height="800" alt="CleanShot 2026-06-18 at 21 55 23" src="https://github.com/user-attachments/assets/46b21ae2-0c07-44e9-aad4-76ed658f787e" /> |