### PR TITLE
[docs] Increase sidenav bottom padding

### DIFF
--- a/docs/src/components/SideNav.css
+++ b/docs/src/components/SideNav.css
@@ -50,7 +50,7 @@
         var(--side-nav-scrollbar-gap-left) + var(--side-nav-scrollbar-width) / 2 +
           var(--side-nav-scrollbar-thumb-width) / 2
       )
-      0.75rem var(--side-nav-link-padding-x);
+      2.5rem var(--side-nav-link-padding-x);
 
     /* Scroll containers are focusable */
     outline: 0;


### PR DESCRIPTION
Increase the side nav's bottom padding so the browser's url overlay that's displayed when hovering the npm link is not forced to move to the bottom-right corner.

before

<img width="1051" height="212" alt="Screenshot 2026-06-18 at 16 24 16" src="https://github.com/user-attachments/assets/db609418-b313-45c1-ba11-3a91f04fb7fb" />




after

<img width="405" height="263" alt="Screenshot 2026-06-18 at 16 23 30" src="https://github.com/user-attachments/assets/cce971f2-d56f-4c7a-b15d-ea7eee4546e3" />

