### PR TITLE
[docs][preview card] Remove text-wrap pretty

### DIFF
--- a/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-controlled/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-controlled/tailwind/index.tsx
@@ -14,7 +14,7 @@ const cardContents = {
         src="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=448&h=300"
         alt="Station Hofplein signage in Rotterdam, Netherlands"
       />
-      <p className="m-0 text-sm">
+      <p className="text-sm">
         <strong>Typography</strong> is the art and science of arranging type.
       </p>
     </div>
@@ -28,7 +28,7 @@ const cardContents = {
         src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/Braun_ABW30_%28schwarz%29.jpg/250px-Braun_ABW30_%28schwarz%29.jpg"
         alt="Braun ABW30"
       />
-      <p className="m-0 text-sm">
+      <p className="text-sm">
         A <strong>design</strong> is the concept or proposal for an object, process, or system.
       </p>
     </div>
@@ -42,7 +42,7 @@ const cardContents = {
         src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5f/MonaLisa_sfumato.jpeg/250px-MonaLisa_sfumato.jpeg"
         alt="Mona Lisa"
       />
-      <p className="m-0 text-sm">
+      <p className="text-sm">
         <strong>Art</strong> is a diverse range of cultural activity centered around works utilizing
         creative or imaginative talents, which are expected to evoke a worthwhile experience,
         generally through an expression of emotional power, conceptual ideas, technical proficiency,
@@ -64,7 +64,7 @@ export default function PreviewCardDetachedTriggersControlledDemo() {
   return (
     <div>
       <div className="flex flex-wrap items-baseline justify-center gap-2">
-        <p className="m-0 text-base text-neutral-950 text-balance dark:text-white">
+        <p className="text-base text-neutral-950 text-balance dark:text-white">
           Discover{' '}
           <PreviewCard.Trigger
             className="text-neutral-950 underline decoration-neutral-950/60 decoration-1 underline-offset-2 outline-0 hover:decoration-neutral-950 data-popup-open:decoration-neutral-950 focus-visible:no-underline focus-visible:outline-2 focus-visible:outline-neutral-950 dark:text-white dark:decoration-white/60 dark:hover:decoration-white dark:data-popup-open:decoration-white dark:focus-visible:outline-white"

--- a/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-controlled/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-controlled/tailwind/index.tsx
@@ -14,7 +14,7 @@ const cardContents = {
         src="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=448&h=300"
         alt="Station Hofplein signage in Rotterdam, Netherlands"
       />
-      <p className="m-0 text-sm text-pretty">
+      <p className="m-0 text-sm">
         <strong>Typography</strong> is the art and science of arranging type.
       </p>
     </div>
@@ -28,7 +28,7 @@ const cardContents = {
         src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/Braun_ABW30_%28schwarz%29.jpg/250px-Braun_ABW30_%28schwarz%29.jpg"
         alt="Braun ABW30"
       />
-      <p className="m-0 text-sm text-pretty">
+      <p className="m-0 text-sm">
         A <strong>design</strong> is the concept or proposal for an object, process, or system.
       </p>
     </div>
@@ -42,7 +42,7 @@ const cardContents = {
         src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5f/MonaLisa_sfumato.jpeg/250px-MonaLisa_sfumato.jpeg"
         alt="Mona Lisa"
       />
-      <p className="m-0 text-sm text-pretty">
+      <p className="m-0 text-sm">
         <strong>Art</strong> is a diverse range of cultural activity centered around works utilizing
         creative or imaginative talents, which are expected to evoke a worthwhile experience,
         generally through an expression of emotional power, conceptual ideas, technical proficiency,

--- a/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-full/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-full/css-modules/index.module.css
@@ -148,7 +148,6 @@
   margin: 0;
   font-size: 0.875rem;
   line-height: 1.25rem;
-  text-wrap: pretty;
 }
 
 .Paragraph {

--- a/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-full/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-full/tailwind/index.tsx
@@ -14,7 +14,7 @@ const cardContents = {
         src="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=448&h=300"
         alt="Station Hofplein signage in Rotterdam, Netherlands"
       />
-      <p className="m-0 text-sm">
+      <p className="text-sm">
         <strong>Typography</strong> is the art and science of arranging type.
       </p>
     </div>
@@ -28,7 +28,7 @@ const cardContents = {
         src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/Braun_ABW30_%28schwarz%29.jpg/250px-Braun_ABW30_%28schwarz%29.jpg"
         alt="Braun ABW30"
       />
-      <p className="m-0 text-sm">
+      <p className="text-sm">
         A <strong>design</strong> is the concept or proposal for an object, process, or system.
       </p>
     </div>
@@ -42,7 +42,7 @@ const cardContents = {
         src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5f/MonaLisa_sfumato.jpeg/250px-MonaLisa_sfumato.jpeg"
         alt="Mona Lisa"
       />
-      <p className="m-0 text-sm">
+      <p className="text-sm">
         <strong>Art</strong> is a diverse range of cultural activity centered around works utilizing
         creative or imaginative talents, which are expected to evoke a worthwhile experience,
         generally through an expression of emotional power, conceptual ideas, technical proficiency,
@@ -55,7 +55,7 @@ const cardContents = {
 export default function PreviewCardDetachedTriggersFullDemo() {
   return (
     <div>
-      <p className="m-0 text-base text-neutral-950 text-balance dark:text-white">
+      <p className="text-base text-neutral-950 text-balance dark:text-white">
         Discover{' '}
         <PreviewCard.Trigger
           className="text-neutral-950 underline decoration-neutral-950/60 decoration-1 underline-offset-2 outline-0 hover:decoration-neutral-950 data-popup-open:decoration-neutral-950 focus-visible:no-underline focus-visible:outline-2 focus-visible:outline-neutral-950 dark:text-white dark:decoration-white/60 dark:hover:decoration-white dark:data-popup-open:decoration-white dark:focus-visible:outline-white"

--- a/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-full/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-full/tailwind/index.tsx
@@ -14,7 +14,7 @@ const cardContents = {
         src="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=448&h=300"
         alt="Station Hofplein signage in Rotterdam, Netherlands"
       />
-      <p className="m-0 text-sm text-pretty">
+      <p className="m-0 text-sm">
         <strong>Typography</strong> is the art and science of arranging type.
       </p>
     </div>
@@ -28,7 +28,7 @@ const cardContents = {
         src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/Braun_ABW30_%28schwarz%29.jpg/250px-Braun_ABW30_%28schwarz%29.jpg"
         alt="Braun ABW30"
       />
-      <p className="m-0 text-sm text-pretty">
+      <p className="m-0 text-sm">
         A <strong>design</strong> is the concept or proposal for an object, process, or system.
       </p>
     </div>
@@ -42,7 +42,7 @@ const cardContents = {
         src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5f/MonaLisa_sfumato.jpeg/250px-MonaLisa_sfumato.jpeg"
         alt="Mona Lisa"
       />
-      <p className="m-0 text-sm text-pretty">
+      <p className="m-0 text-sm">
         <strong>Art</strong> is a diverse range of cultural activity centered around works utilizing
         creative or imaginative talents, which are expected to evoke a worthwhile experience,
         generally through an expression of emotional power, conceptual ideas, technical proficiency,

--- a/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-simple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-simple/tailwind/index.tsx
@@ -6,7 +6,7 @@ const demoPreviewCard = PreviewCard.createHandle();
 export default function PreviewCardDetachedTriggersSimpleDemo() {
   return (
     <div>
-      <p className="m-0 text-base text-neutral-950 text-balance dark:text-white">
+      <p className="text-base text-neutral-950 text-balance dark:text-white">
         The principles of good{' '}
         <PreviewCard.Trigger
           className="text-neutral-950 underline decoration-neutral-950/60 decoration-1 underline-offset-2 outline-0 hover:decoration-neutral-950 data-popup-open:decoration-neutral-950 focus-visible:no-underline focus-visible:outline-2 focus-visible:outline-neutral-950 dark:text-white dark:decoration-white/60 dark:hover:decoration-white dark:data-popup-open:decoration-white dark:focus-visible:outline-white"
@@ -31,7 +31,7 @@ export default function PreviewCardDetachedTriggersSimpleDemo() {
                   src="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=448&h=300"
                   alt="Station Hofplein signage in Rotterdam, Netherlands"
                 />
-                <p className="m-0 text-sm">
+                <p className="text-sm">
                   <strong>Typography</strong> is the art and science of arranging type to make
                   written language clear, visually appealing, and effective in communication.
                 </p>

--- a/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-simple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/preview-card/demos/detached-triggers-simple/tailwind/index.tsx
@@ -31,7 +31,7 @@ export default function PreviewCardDetachedTriggersSimpleDemo() {
                   src="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=448&h=300"
                   alt="Station Hofplein signage in Rotterdam, Netherlands"
                 />
-                <p className="m-0 text-sm text-pretty">
+                <p className="m-0 text-sm">
                   <strong>Typography</strong> is the art and science of arranging type to make
                   written language clear, visually appealing, and effective in communication.
                 </p>

--- a/docs/src/app/(docs)/react/components/preview-card/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/preview-card/demos/hero/tailwind/index.tsx
@@ -3,7 +3,7 @@ import { PreviewCard } from '@base-ui/react/preview-card';
 export default function ExamplePreviewCard() {
   return (
     <PreviewCard.Root>
-      <p className="m-0 text-base text-neutral-950 text-balance dark:text-white">
+      <p className="text-base text-neutral-950 text-balance dark:text-white">
         The principles of good{' '}
         <PreviewCard.Trigger
           className="text-neutral-950 underline decoration-neutral-950/60 decoration-1 underline-offset-2 outline-0 hover:decoration-neutral-950 data-popup-open:decoration-neutral-950 focus-visible:no-underline focus-visible:outline-2 focus-visible:outline-neutral-950 dark:text-white dark:decoration-white/60 dark:hover:decoration-white dark:data-popup-open:decoration-white dark:focus-visible:outline-white"
@@ -26,7 +26,7 @@ export default function ExamplePreviewCard() {
                 src="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=448&h=300"
                 alt="Station Hofplein signage in Rotterdam, Netherlands"
               />
-              <p className="m-0 text-sm">
+              <p className="text-sm">
                 <strong>Typography</strong> is the art and science of arranging type to make written
                 language clear, visually appealing, and effective in communication.
               </p>

--- a/docs/src/app/(docs)/react/components/preview-card/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/preview-card/demos/hero/tailwind/index.tsx
@@ -26,7 +26,7 @@ export default function ExamplePreviewCard() {
                 src="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=448&h=300"
                 alt="Station Hofplein signage in Rotterdam, Netherlands"
               />
-              <p className="m-0 text-sm text-pretty">
+              <p className="m-0 text-sm">
                 <strong>Typography</strong> is the art and science of arranging type to make written
                 language clear, visually appealing, and effective in communication.
               </p>

--- a/docs/src/app/(docs)/react/components/preview-card/demos/index.module.css
+++ b/docs/src/app/(docs)/react/components/preview-card/demos/index.module.css
@@ -96,7 +96,6 @@
   margin: 0;
   font-size: 0.875rem;
   line-height: 1.25rem;
-  text-wrap: pretty;
 }
 
 .Container {


### PR DESCRIPTION
Safari sucks at `text-wrap: pretty`, so removing it. It doesn't provide any value in this case anyway.

||before|after|
|---|---|---|
|Safari 26.5|<img width="266" height="295" alt="safari-before" src="https://github.com/user-attachments/assets/d1ab406d-4f4b-4fcf-b8f1-3066fdecdd60" />|<img width="262" height="273" alt="safari-after" src="https://github.com/user-attachments/assets/6d3d4a8e-b5c3-4b49-b2bf-89b627f2d814" />|
|Chrome 149|<img width="260" height="275" alt="chrome-before" src="https://github.com/user-attachments/assets/0ce098c7-3f95-40d6-87d0-ffde79604158" />|<img width="258" height="276" alt="chrome-after" src="https://github.com/user-attachments/assets/f44cc533-a7f4-4c5c-924c-d314c31bda30" />|

