### PR TITLE
[code-infra] Validate npm publishing as part of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: pnpm release:build
       - name: Publish packages
         if: matrix.os == 'ubuntu-latest'
-        uses: mui/mui-public/.github/actions/ci-publish@00cd0db0b3f3e2bc38ac8fb6af4edbfb2d5f88f6 # master
+        uses: mui/mui-public/.github/actions/ci-publish@8f94045cbcc17cafc21465beb6c29721313542f6 # master
         with:
           pr-comment: true
       - name: Extract Vale version


### PR DESCRIPTION
This makes sure that any breaking change in npm publishing is caught early on.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
