### PR TITLE
[docs-infra] Use versioned GitHub URLs

### DIFF
--- a/docs/src/utils/getGitHubDemoUrl.test.ts
+++ b/docs/src/utils/getGitHubDemoUrl.test.ts
@@ -1,11 +1,21 @@
-import { describe, it, expect } from 'vitest';
-import { getGitHubDemoUrl, GITHUB_BASE } from './getGitHubDemoUrl';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getGitHubDemoUrl } from './getGitHubDemoUrl';
 
 describe('getGitHubDemoUrl', () => {
+  const GITHUB_BASE = 'https://github.com/mui/base-ui/tree/v1.6.0';
   const unixUrl =
     'file:///home/user/base-ui/docs/src/app/(docs)/react/components/accordion/demos/hero/index.ts';
   const windowsUrl =
     'file:///C:/Users/Dev/base-ui/docs/src/app/(docs)/react/components/accordion/demos/hero/index.ts';
+
+  beforeEach(() => {
+    vi.stubEnv('SOURCE_CODE_REPO', 'https://github.com/mui/base-ui');
+    vi.stubEnv('LIB_VERSION', '1.6.0');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
 
   it('converts a Unix file URL to a GitHub directory URL', () => {
     expect(getGitHubDemoUrl(unixUrl)).toBe(
@@ -47,6 +57,18 @@ describe('getGitHubDemoUrl', () => {
 
   it('returns null when /docs/ is not in the path', () => {
     expect(getGitHubDemoUrl('file:///home/user/other-project/src/index.ts')).toBeNull();
+  });
+
+  it('returns null when source code repo metadata is unavailable', () => {
+    vi.stubEnv('SOURCE_CODE_REPO', '');
+
+    expect(getGitHubDemoUrl(unixUrl)).toBeNull();
+  });
+
+  it('returns null when library version metadata is unavailable', () => {
+    vi.stubEnv('LIB_VERSION', '');
+
+    expect(getGitHubDemoUrl(unixUrl)).toBeNull();
   });
 
   it('handles encoded URI components', () => {

--- a/docs/src/utils/getGitHubDemoUrl.ts
+++ b/docs/src/utils/getGitHubDemoUrl.ts
@@ -1,6 +1,15 @@
 import kebabCase from 'es-toolkit/compat/kebabCase';
 
-export const GITHUB_BASE = 'https://github.com/mui/base-ui/tree/HEAD';
+function getGitHubBaseUrl() {
+  const sourceCodeRepo = process.env.SOURCE_CODE_REPO;
+  const sourceCodeRef = process.env.LIB_VERSION ? `v${process.env.LIB_VERSION}` : undefined;
+
+  if (!sourceCodeRepo || !sourceCodeRef) {
+    return null;
+  }
+
+  return `${sourceCodeRepo}/tree/${sourceCodeRef}`;
+}
 
 /**
  * Converts a file:// URL from import.meta.url to a GitHub source URL
@@ -36,7 +45,13 @@ export function getGitHubDemoUrl(
       dirPath += `/${kebabCase(selectedVariant)}`;
     }
 
-    return `${GITHUB_BASE}/${dirPath}`;
+    const githubBase = getGitHubBaseUrl();
+
+    if (githubBase == null) {
+      return null;
+    }
+
+    return `${githubBase}/${dirPath}`;
   } catch {
     return null;
   }


### PR DESCRIPTION
Point 18. in #2766.

Use the lib version instead of HEAD for the "View source on GitHub" and the "Copy link to source" demo links (visible under the three dot menu).

Old: https://github.com/mui/base-ui/tree/HEAD/docs/src/app/(docs)/react/components/accordion/demos/hero/css-modules
New: https://github.com/mui/base-ui/tree/v1.6.0/docs/src/app/(docs)/react/components/accordion/demos/hero/css-modules

Preview: https://deploy-preview-5082--base-ui.netlify.app/react/components/context-menu