### PR TITLE
[otp field] Keep focus on the invalid field when autoSubmit is blocked

### DIFF
--- a/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
@@ -1247,6 +1247,31 @@ describe('<OTPField.Root />', () => {
         }
       });
 
+      it('keeps focus on the first invalid field when auto-submit is blocked', async () => {
+        await render(
+          <Form>
+            <Field.Root name="email" validate={() => 'Required'}>
+              <Field.Label>Email</Field.Label>
+              <Field.Control />
+              <Field.Error />
+            </Field.Root>
+            <Field.Root name="otp">
+              <OTPField autoSubmit />
+            </Field.Root>
+          </Form>,
+        );
+
+        const emailInput = screen.getByRole('textbox', { name: 'Email' });
+        const otpInputs = screen
+          .getAllByRole<HTMLInputElement>('textbox')
+          .filter((input) => input !== emailInput);
+
+        fireEvent.change(otpInputs[0], { target: { value: '123456' } });
+
+        expect(emailInput).toHaveAttribute('aria-invalid', 'true');
+        expect(emailInput).toHaveFocus();
+      });
+
       it('does not submit the owning form before the OTP becomes complete when enabled', async () => {
         const handleSubmit = vi.fn((event: React.FormEvent<HTMLFormElement>) => {
           event.preventDefault();

--- a/packages/react/src/otp-field/root/OTPFieldRoot.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.tsx
@@ -199,16 +199,6 @@ export const OTPFieldRoot = React.forwardRef(function OTPFieldRoot(
 
     validation.change(value);
 
-    const pendingCompleteValue = pendingCompleteValueRef.current;
-
-    if (pendingCompleteValue != null) {
-      pendingCompleteValueRef.current = null;
-
-      if (pendingCompleteValue.value === value) {
-        completeValue(value, pendingCompleteValue.eventDetails);
-      }
-    }
-
     const pendingFocus = pendingFocusRef.current;
 
     if (pendingFocus != null) {
@@ -216,6 +206,16 @@ export const OTPFieldRoot = React.forwardRef(function OTPFieldRoot(
 
       if (pendingFocus.value === value) {
         focusInput(pendingFocus.index);
+      }
+    }
+
+    const pendingCompleteValue = pendingCompleteValueRef.current;
+
+    if (pendingCompleteValue != null) {
+      pendingCompleteValueRef.current = null;
+
+      if (pendingCompleteValue.value === value) {
+        completeValue(value, pendingCompleteValue.eventDetails);
       }
     }
   });


### PR DESCRIPTION
Fixes #5088.

This is a small attempt to fix the OTP Field auto-submit focus behavior. When an OTP value becomes complete, the field currently handles completion before its pending slot focus. If `autoSubmit` calls `requestSubmit()` and Base UI Form blocks submission because an earlier field is invalid, the form focuses that invalid control, but the OTP pending focus then moves focus back to the final OTP slot.

This PR processes the OTP pending focus before the completion callback. That keeps the normal accepted-value focus behavior, while allowing Form's invalid-field focus to be the final focus update when auto-submit is blocked.

If this order is not the intended behavior, I am happy to adjust or leave the maintainers to take a different fix.

Reproduction: https://stackblitz.com/edit/fg7exrjh?file=src%2FApp.tsx

Validation:
- `pnpm test:jsdom OTPFieldRoot --no-watch`
- `pnpm test:chromium OTPFieldRoot --no-watch`
- `pnpm test:jsdom OTPField --no-watch`
- `pnpm test:chromium OTPField --no-watch`
- `pnpm exec eslint packages/react/src/otp-field/root/OTPFieldRoot.tsx packages/react/src/otp-field/root/OTPFieldRoot.test.tsx --max-warnings 0`
- `pnpm exec prettier --check packages/react/src/otp-field/root/OTPFieldRoot.tsx packages/react/src/otp-field/root/OTPFieldRoot.test.tsx`
