### PR TITLE
[all components] Restore visible focus after keyboard close

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -551,6 +551,58 @@ describe('FloatingFocusManager', () => {
         HTMLElement.prototype.focus = originalFocus;
       });
 
+      test('passes focusVisible when returning focus after keyboard close', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          const click = useClick(context);
+          const dismiss = useDismiss(context);
+
+          const { getReferenceProps, getFloatingProps } = useTestInteractions([click, dismiss]);
+
+          return (
+            <>
+              <button ref={refs.setReference} {...getReferenceProps()}>
+                reference
+              </button>
+              {isOpen && (
+                <FloatingFocusManager context={context}>
+                  <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating" />
+                </FloatingFocusManager>
+              )}
+            </>
+          );
+        }
+
+        render(<App />);
+
+        const reference = screen.getByText('reference');
+        await userEvent.click(reference);
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating')).toHaveFocus();
+
+        const focusSpy = vi.spyOn(reference, 'focus');
+
+        try {
+          await userEvent.keyboard('{Escape}');
+
+          await waitFor(() => {
+            expect(focusSpy).toHaveBeenCalledWith({
+              preventScroll: true,
+              focusVisible: true,
+            });
+          });
+        } finally {
+          focusSpy.mockRestore();
+        }
+      });
+
       test('does not insert fallback element when return element is falsy', async () => {
         function App() {
           const [isOpen, setIsOpen] = React.useState(false);

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -603,6 +603,60 @@ describe('FloatingFocusManager', () => {
         }
       });
 
+      test('omits focusVisible when returning focus after pointer close', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          const click = useClick(context);
+          const dismiss = useDismiss(context);
+
+          const { getReferenceProps, getFloatingProps } = useTestInteractions([click, dismiss]);
+
+          return (
+            <>
+              <button ref={refs.setReference} {...getReferenceProps()}>
+                reference
+              </button>
+              {isOpen && (
+                <FloatingFocusManager context={context}>
+                  <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating" />
+                </FloatingFocusManager>
+              )}
+            </>
+          );
+        }
+
+        render(<App />);
+
+        const reference = screen.getByText('reference');
+        await userEvent.click(reference);
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('floating')).toHaveFocus();
+
+        const focusSpy = vi.spyOn(reference, 'focus');
+
+        try {
+          // Closing with a pointer must not force `:focus-visible`; `focusVisible`
+          // is omitted entirely so the browser's own heuristics decide.
+          await userEvent.click(reference);
+
+          await waitFor(() => {
+            expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+          });
+          expect(focusSpy).not.toHaveBeenCalledWith(
+            expect.objectContaining({ focusVisible: true }),
+          );
+        } finally {
+          focusSpy.mockRestore();
+        }
+      });
+
       test('does not insert fallback element when return element is falsy', async () => {
         function App() {
           const [isOpen, setIsOpen] = React.useState(false);

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -870,7 +870,11 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
             ? isFocusInsideFloatingTree
             : true)
         ) {
-          tabbableReturnElement.focus({ preventScroll: true });
+          const focusOptions: FocusOptions = { preventScroll: true };
+          if (closeTypeRef.current === 'keyboard') {
+            focusOptions.focusVisible = true;
+          }
+          tabbableReturnElement.focus(focusOptions);
         }
 
         preventReturnFocusRef.current = false;


### PR DESCRIPTION
Fixes #5092

This is a tentative fix for a Safari/Firefox focus-visible issue observed across popup components that use the shared `FloatingFocusManager` return-focus path.

When a popup is opened with a pointer and dismissed with <kbd>Escape</kbd>, WebKit restores DOM focus to the trigger but does not mark it as `:focus-visible`. Since the focus manager already tracks keyboard dismissal, this change requests visible focus only for keyboard-driven return focus.

| Before | After |
| --- | --- |
| <img width="707" height="800" alt="Before: focus is restored without visible focus indication" src="https://github.com/user-attachments/assets/8b7a472a-a227-4f67-8b57-8c310d1cb1eb" /> | <img width="800" height="754" alt="After: focus is restored with visible focus indication" src="https://github.com/user-attachments/assets/5415c1f8-71e0-4441-8707-85f229453316" /> |

This PR is intentionally small and can be closed if this behavior should be handled differently.

Validation:

- `pnpm test:webkit MenuPopup --no-watch`
- manual Playwright WebKit check against the Menu e2e fixture: pointer open + Escape close returns focus with `:focus-visible`
