### PR TITLE
[progress] Fix custom min/max semantics to match the indicator

### DIFF
--- a/packages/react/src/progress/indicator/ProgressIndicator.tsx
+++ b/packages/react/src/progress/indicator/ProgressIndicator.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { valueToPercent } from '../../utils/valueToPercent';
 import type { ProgressRootState } from '../root/ProgressRoot';
 import { useProgressRootContext } from '../root/ProgressRootContext';
 import { progressStateAttributesMapping } from '../root/stateAttributesMapping';
@@ -19,10 +18,7 @@ export const ProgressIndicator = React.forwardRef(function ProgressIndicator(
 ) {
   const { render, className, style, ...elementProps } = componentProps;
 
-  const { max, min, value, state } = useProgressRootContext();
-
-  const percentageValue =
-    Number.isFinite(value) && value !== null ? valueToPercent(value, min, max) : null;
+  const { percentageValue, state } = useProgressRootContext();
 
   const indicatorStyle: React.CSSProperties =
     percentageValue == null

--- a/packages/react/src/progress/root/ProgressRoot.test.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.test.tsx
@@ -55,6 +55,46 @@ describe('<Progress.Root />', () => {
     });
   });
 
+  describe('range', () => {
+    it('normalizes the formatted value, aria-valuetext, and indicator within a custom range', async () => {
+      const expected = (0.5).toLocaleString(undefined, { style: 'percent' });
+
+      await render(
+        <Progress.Root min={20} max={40} value={30}>
+          <Progress.Value data-testid="value" />
+          <Progress.Track>
+            <Progress.Indicator data-testid="indicator" />
+          </Progress.Track>
+        </Progress.Root>,
+      );
+
+      const progressbar = screen.getByRole('progressbar');
+      expect(screen.getByTestId('indicator').style.width).toBe('50%');
+      expect(screen.getByTestId('value')).toHaveTextContent(expected);
+      expect(progressbar).toHaveAttribute('aria-valuetext', expected);
+    });
+
+    it('clamps aria-valuenow to the range when the value overshoots max', async () => {
+      await render(<Progress.Root min={0} max={40} value={50} />);
+
+      const progressbar = screen.getByRole('progressbar');
+      expect(progressbar).toHaveAttribute('aria-valuenow', '40');
+      expect(progressbar).toHaveAttribute('aria-valuemax', '40');
+    });
+
+    it('reports complete when the value reaches or exceeds max', async () => {
+      await render(
+        <Progress.Root min={0} max={40} value={45}>
+          <Progress.Track>
+            <Progress.Indicator />
+          </Progress.Track>
+        </Progress.Root>,
+      );
+
+      expect(screen.getByRole('progressbar')).toHaveAttribute('data-complete');
+    });
+  });
+
   describe('prop: format', () => {
     it('formats the value', async () => {
       const format: Intl.NumberFormatOptions = {
@@ -78,6 +118,26 @@ describe('<Progress.Root />', () => {
       const progressbar = screen.getByRole('progressbar');
       expect(value).toHaveTextContent(formatValue(30));
       expect(progressbar).toHaveAttribute('aria-valuetext', formatValue(30));
+    });
+
+    it('reflects format changes without lagging a commit', async () => {
+      const usd: Intl.NumberFormatOptions = { style: 'currency', currency: 'USD' };
+      const eur: Intl.NumberFormatOptions = { style: 'currency', currency: 'EUR' };
+      function formatValue(v: number, options: Intl.NumberFormatOptions) {
+        return new Intl.NumberFormat(undefined, options).format(v);
+      }
+
+      const { setProps } = await render(
+        <Progress.Root value={30} format={usd}>
+          <Progress.Value data-testid="value" />
+        </Progress.Root>,
+      );
+
+      const value = screen.getByTestId('value');
+      expect(value).toHaveTextContent(formatValue(30, usd));
+
+      await setProps({ format: eur });
+      expect(value).toHaveTextContent(formatValue(30, eur));
     });
   });
 

--- a/packages/react/src/progress/root/ProgressRoot.test.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.test.tsx
@@ -74,12 +74,24 @@ describe('<Progress.Root />', () => {
       expect(progressbar).toHaveAttribute('aria-valuetext', expected);
     });
 
-    it('clamps aria-valuenow to the range when the value overshoots max', async () => {
-      await render(<Progress.Root min={0} max={40} value={50} />);
+    it('clamps aria-valuenow, the value text, and the indicator when the value overshoots max', async () => {
+      const expected = (1).toLocaleString(undefined, { style: 'percent' });
+
+      await render(
+        <Progress.Root min={0} max={40} value={50}>
+          <Progress.Value data-testid="value" />
+          <Progress.Track>
+            <Progress.Indicator data-testid="indicator" />
+          </Progress.Track>
+        </Progress.Root>,
+      );
 
       const progressbar = screen.getByRole('progressbar');
       expect(progressbar).toHaveAttribute('aria-valuenow', '40');
       expect(progressbar).toHaveAttribute('aria-valuemax', '40');
+      expect(progressbar).toHaveAttribute('aria-valuetext', expected);
+      expect(screen.getByTestId('value')).toHaveTextContent(expected);
+      expect(screen.getByTestId('indicator').style.width).toBe('100%');
     });
 
     it('reports complete when the value reaches or exceeds max', async () => {

--- a/packages/react/src/progress/root/ProgressRoot.test.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.test.tsx
@@ -93,6 +93,25 @@ describe('<Progress.Root />', () => {
 
       expect(screen.getByRole('progressbar')).toHaveAttribute('data-complete');
     });
+
+    it('normalizes aria attributes when min equals max', async () => {
+      const expected = (0).toLocaleString(undefined, { style: 'percent' });
+
+      await render(
+        <Progress.Root min={5} max={5} value={5}>
+          <Progress.Value data-testid="value" />
+          <Progress.Track>
+            <Progress.Indicator data-testid="indicator" />
+          </Progress.Track>
+        </Progress.Root>,
+      );
+
+      const progressbar = screen.getByRole('progressbar');
+      expect(progressbar).toHaveAttribute('aria-valuenow', '5');
+      expect(progressbar).toHaveAttribute('aria-valuetext', expected);
+      expect(screen.getByTestId('value')).toHaveTextContent(expected);
+      expect(screen.getByTestId('indicator').style.width).toBe('0%');
+    });
   });
 
   describe('prop: format', () => {

--- a/packages/react/src/progress/root/ProgressRoot.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.tsx
@@ -1,8 +1,9 @@
 'use client';
 import * as React from 'react';
-import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { visuallyHidden } from '@base-ui/utils/visuallyHidden';
-import { formatNumberValue } from '../../utils/formatNumber';
+import { formatNumber } from '../../utils/formatNumber';
+import { valueToPercent } from '../../utils/valueToPercent';
+import { clamp } from '../../internals/clamp';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { ProgressRootContext } from './ProgressRootContext';
 import { progressStateAttributesMapping } from './stateAttributesMapping';
@@ -42,14 +43,25 @@ export const ProgressRoot = React.forwardRef(function ProgressRoot(
 
   const [labelId, setLabelId] = React.useState<string | undefined>();
 
-  const formatOptionsRef = useValueAsRef(format);
-
+  // `value === null` (or any non-finite value) keeps Progress indeterminate. Otherwise compute a
+  // single clamped value and normalized percentage so completion status, `aria-valuenow`, the
+  // formatted text, the default `aria-valuetext`, and the indicator width all stay in sync for any
+  // `min`/`max` (not just the default 0–100).
   let status: ProgressStatus = 'indeterminate';
-  if (Number.isFinite(value)) {
-    status = value === max ? 'complete' : 'progressing';
-  }
+  let percentageValue: number | null = null;
+  let clampedValue: number | null = null;
+  let formattedValue = '';
 
-  const formattedValue = formatNumberValue(value, locale, formatOptionsRef.current);
+  if (value != null && Number.isFinite(value)) {
+    percentageValue = clamp(valueToPercent(value, min, max), 0, 100);
+    clampedValue = clamp(value, min, max);
+    status = clampedValue === max ? 'complete' : 'progressing';
+    // Without an explicit `format`, the value is displayed as its position within the range so the
+    // text stays in sync with the indicator fill.
+    formattedValue = format
+      ? formatNumber(value, locale, format)
+      : formatNumber(percentageValue / 100, locale, { style: 'percent' });
+  }
 
   const state: ProgressRootState = React.useMemo(() => ({ status }), [status]);
 
@@ -57,7 +69,7 @@ export const ProgressRoot = React.forwardRef(function ProgressRoot(
     'aria-labelledby': labelId,
     'aria-valuemax': max,
     'aria-valuemin': min,
-    'aria-valuenow': value ?? undefined,
+    'aria-valuenow': clampedValue ?? undefined,
     'aria-valuetext': getAriaValueText(formattedValue, value),
     role: 'progressbar',
     children: (
@@ -75,12 +87,13 @@ export const ProgressRoot = React.forwardRef(function ProgressRoot(
       formattedValue,
       max,
       min,
+      percentageValue,
       setLabelId,
       state,
       status,
       value,
     }),
-    [formattedValue, max, min, setLabelId, state, status, value],
+    [formattedValue, max, min, percentageValue, setLabelId, state, status, value],
   );
 
   const element = useRenderElement('div', componentProps, {

--- a/packages/react/src/progress/root/ProgressRoot.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.tsx
@@ -53,7 +53,8 @@ export const ProgressRoot = React.forwardRef(function ProgressRoot(
   let formattedValue = '';
 
   if (value != null && Number.isFinite(value)) {
-    percentageValue = clamp(valueToPercent(value, min, max), 0, 100);
+    const rawPercentage = valueToPercent(value, min, max);
+    percentageValue = clamp(Number.isNaN(rawPercentage) ? 0 : rawPercentage, 0, 100);
     clampedValue = clamp(value, min, max);
     status = clampedValue === max ? 'complete' : 'progressing';
     // Without an explicit `format`, the value is displayed as its position within the range so the

--- a/packages/react/src/progress/root/ProgressRoot.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.tsx
@@ -14,7 +14,7 @@ function getDefaultAriaValueText(formattedValue: string | null, value: number | 
     return 'indeterminate progress';
   }
 
-  return formattedValue || `${value}%`;
+  return formattedValue ?? '';
 }
 
 /**

--- a/packages/react/src/progress/root/ProgressRootContext.tsx
+++ b/packages/react/src/progress/root/ProgressRootContext.tsx
@@ -16,6 +16,11 @@ export type ProgressRootContext = {
    */
   min: number;
   /**
+   * The value normalized to a `0`–`100` percentage of the range, clamped to those bounds.
+   * `null` while the progress is indeterminate.
+   */
+  percentageValue: number | null;
+  /**
    * Value of the component.
    */
   value: number | null;

--- a/packages/react/src/utils/formatNumber.ts
+++ b/packages/react/src/utils/formatNumber.ts
@@ -26,18 +26,3 @@ export function formatNumber(
   }
   return getFormatter(locale, options).format(value);
 }
-
-export function formatNumberValue(
-  value: number | null,
-  locale?: Intl.LocalesArgument,
-  format?: Intl.NumberFormatOptions,
-): string {
-  if (value == null) {
-    return '';
-  }
-  if (!format) {
-    return formatNumber(value / 100, locale, { style: 'percent' });
-  }
-
-  return formatNumber(value, locale, format);
-}


### PR DESCRIPTION
## Summary

`Progress.Indicator` already normalized the value against `min`/`max` (`valueToPercent`), but the rest of `Progress.Root` used the raw value, so custom-range progress bars were inconsistent. With `min={20} max={40} value={30}` the indicator filled to 50% while `Progress.Value` and `aria-valuetext` reported `30%`.

This mirrors the fix Meter already shipped (#4904): compute a single clamped value and normalized percentage once in the Root and use it everywhere.

## What changed

- **`ProgressRoot.tsx`** — for finite values, compute one `clampedValue` and one clamped `percentageValue`, then use them consistently:
  - completion status is now `clampedValue === max` (an overshoot like `value=45, max=40` correctly reports `complete` instead of `progressing`);
  - `aria-valuenow` is `clampedValue`, so it can no longer fall outside `aria-valuemin`/`aria-valuemax`;
  - the formatted text / default `aria-valuetext` use `formatNumber(percentageValue / 100, …, { style: 'percent' })` when no `format` is given, so they match the indicator for any range;
  - `format` is read directly instead of through `useValueAsRef`, removing the one-commit lag when `format` changes.
- **`ProgressRootContext.tsx`** — exposes `percentageValue` (clamped, `null` while indeterminate).
- **`ProgressIndicator.tsx`** — reads `percentageValue` from context instead of recomputing it, making the Root the single source of truth (this also clamps the indicator width).
- **`formatNumber.ts`** — removed the now-unused `formatNumberValue` helper that hard-coded `value / 100` and ignored `min`/`max`.

`value={null}` (indeterminate) behavior is unchanged.

## Tests

Added regression tests in `ProgressRoot.test.tsx` (verified failing before the fix, passing after):
- custom range `min=20 max=40 value=30` normalizes the value text, `aria-valuetext`, and indicator width to 50%;
- `aria-valuenow` is clamped to `max` when the value overshoots;
- `complete` is reported when the value reaches/exceeds `max`;
- a `format` change is reflected immediately (no stale-ref lag).

Full `Progress` and `Meter` jsdom suites pass; `pnpm typescript`, `pnpm eslint`, and `pnpm prettier` are clean.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).