### PR TITLE
[otp field] Fix Safari IME composition over-filling slots

### DIFF
--- a/packages/react/src/otp-field/input/OTPFieldInput.android.test.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.android.test.tsx
@@ -1,0 +1,52 @@
+import { expect, vi } from 'vitest';
+import * as React from 'react';
+import { act, fireEvent, screen } from '@mui/internal-test-utils';
+import { OTPField } from '@base-ui/react/otp-field';
+import { createRenderer } from '#test-utils';
+
+vi.mock('@base-ui/utils/platform', async () => {
+  const actual =
+    await vi.importActual<typeof import('@base-ui/utils/platform')>('@base-ui/utils/platform');
+
+  return {
+    ...actual,
+    platform: {
+      ...actual.platform,
+      os: { ...actual.platform.os, android: true },
+    },
+  };
+});
+
+describe('<OTPField.Input /> Android', () => {
+  const { render } = createRenderer();
+
+  it('commits each change during an IME composition', async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      <OTPField.Root length={3} validationType="alphanumeric" onValueChange={onValueChange}>
+        <OTPField.Input />
+        <OTPField.Input />
+        <OTPField.Input />
+      </OTPField.Root>,
+    );
+
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+
+    await act(async () => {
+      inputs[0].focus();
+    });
+
+    fireEvent.compositionStart(inputs[0]);
+    fireEvent.change(inputs[0], { target: { value: 'a' } });
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenLastCalledWith('a', expect.anything());
+    expect(document.activeElement).toBe(inputs[1]);
+
+    fireEvent.compositionEnd(inputs[0]);
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(inputs.map((input) => input.value)).toEqual(['a', '', '']);
+  });
+});

--- a/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
@@ -190,6 +190,38 @@ describe('<OTPField.Input />', () => {
     expect(firstInput.selectionEnd).toBe(1);
   });
 
+  it('commits an IME composition once on compositionend instead of per intermediate change', async () => {
+    const onValueChange = vi.fn();
+
+    await render(<OTPFieldTest validationType="alphanumeric" onValueChange={onValueChange} />);
+
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+    const firstInput = inputs[0];
+
+    await act(async () => {
+      firstInput.focus();
+    });
+
+    fireEvent.compositionStart(firstInput);
+
+    // Safari can surface in-progress IME text through `change` as an accumulating string.
+    fireEvent.change(firstInput, { target: { value: 'd' } });
+    fireEvent.change(firstInput, { target: { value: 'dd' } });
+    fireEvent.change(firstInput, { target: { value: 'ddd' } });
+
+    // No value commits while the composition is active; the text is only buffered for display.
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(inputs.map((input) => input.value)).toEqual(['ddd', '', '', '', '', '']);
+
+    fireEvent.compositionEnd(firstInput, { target: { value: 'ddd' } });
+
+    // The final composed value commits once across three slots, not six.
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenLastCalledWith('ddd', expect.anything());
+    expect(inputs.map((input) => input.value)).toEqual(['d', 'd', 'd', '', '', '']);
+    expect(document.activeElement).toBe(inputs[3]);
+  });
+
   it('selects the slot value on mousedown', async () => {
     await render(<OTPFieldTest defaultValue="1" />);
 

--- a/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
@@ -252,6 +252,41 @@ describe('<OTPField.Input />', () => {
     expect(document.activeElement).toBe(inputs[1]);
   });
 
+  it('ignores keyboard commands while a composition is buffered', async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      <OTPFieldTest
+        validationType="alphanumeric"
+        defaultValue="12"
+        onValueChange={onValueChange}
+      />,
+    );
+
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+    const thirdInput = inputs[2];
+
+    await act(async () => {
+      thirdInput.focus();
+    });
+
+    fireEvent.compositionStart(thirdInput);
+    fireEvent.change(thirdInput, { target: { value: 'a' } });
+
+    // iOS Safari fires a real `Backspace` keydown while the IME is still composing.
+    fireEvent.keyDown(thirdInput, { key: 'Backspace' });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(thirdInput);
+    expect(inputs.map((input) => input.value)).toEqual(['1', '2', 'a', '', '', '']);
+
+    // The IME deleted its own text, so the composition ends empty and nothing commits.
+    fireEvent.compositionEnd(thirdInput, { target: { value: '' } });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(inputs.map((input) => input.value)).toEqual(['1', '2', '', '', '', '']);
+  });
+
   (['disabled', 'readOnly'] as const).forEach((prop) => {
     it(`does not commit a composition that ends after the field becomes ${prop}`, async () => {
       const onValueChange = vi.fn();

--- a/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
@@ -252,6 +252,33 @@ describe('<OTPField.Input />', () => {
     expect(document.activeElement).toBe(inputs[1]);
   });
 
+  (['disabled', 'readOnly'] as const).forEach((prop) => {
+    it(`does not commit a composition that ends after the field becomes ${prop}`, async () => {
+      const onValueChange = vi.fn();
+
+      const { setProps } = await render(
+        <OTPFieldTest validationType="alphanumeric" onValueChange={onValueChange} />,
+      );
+
+      const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+      const firstInput = inputs[0];
+
+      await act(async () => {
+        firstInput.focus();
+      });
+
+      fireEvent.compositionStart(firstInput);
+      fireEvent.change(firstInput, { target: { value: 'abc' } });
+
+      await setProps({ [prop]: true });
+
+      fireEvent.compositionEnd(firstInput, { target: { value: 'abc' } });
+
+      expect(onValueChange).not.toHaveBeenCalled();
+      expect(inputs.map((input) => input.value)).toEqual(['', '', '', '', '', '']);
+    });
+  });
+
   it('selects the slot value on mousedown', async () => {
     await render(<OTPFieldTest defaultValue="1" />);
 

--- a/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
@@ -6,6 +6,7 @@ import { OTPField } from '@base-ui/react/otp-field';
 import { Field } from '@base-ui/react/field';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { REASONS } from '../../internals/reasons';
 
 describe('<OTPField.Input />', () => {
   const { render } = createRenderer();
@@ -220,6 +221,35 @@ describe('<OTPField.Input />', () => {
     expect(onValueChange).toHaveBeenLastCalledWith('ddd', expect.anything());
     expect(inputs.map((input) => input.value)).toEqual(['d', 'd', 'd', '', '', '']);
     expect(document.activeElement).toBe(inputs[3]);
+  });
+
+  it('reports characters rejected from a committed IME composition', async () => {
+    const onValueChange = vi.fn();
+    const onValueInvalid = vi.fn();
+
+    await render(<OTPFieldTest onValueChange={onValueChange} onValueInvalid={onValueInvalid} />);
+
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox');
+    const firstInput = inputs[0];
+
+    await act(async () => {
+      firstInput.focus();
+    });
+
+    fireEvent.compositionStart(firstInput);
+    fireEvent.change(firstInput, { target: { value: '1a' } });
+
+    expect(onValueInvalid).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(firstInput, { target: { value: '1a' } });
+
+    expect(onValueInvalid).toHaveBeenCalledTimes(1);
+    expect(onValueInvalid.mock.calls[0]?.[0]).toBe('1a');
+    expect(onValueInvalid.mock.calls[0]?.[1].reason).toBe(REASONS.inputChange);
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenLastCalledWith('1', expect.anything());
+    expect(inputs.map((input) => input.value)).toEqual(['1', '', '', '', '', '']);
+    expect(document.activeElement).toBe(inputs[1]);
   });
 
   it('selects the slot value on mousedown', async () => {

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { SafeReact } from '@base-ui/utils/safeReact';
 import { warn } from '@base-ui/utils/warn';
+import { platform } from '@base-ui/utils/platform';
 import { stopEvent } from '../../floating-ui-react/utils';
 import {
   IndexGuessBehavior,
@@ -71,6 +72,12 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const direction = useDirection();
 
+  // While an IME composition is active, Safari (and other WebKit/Gecko engines) can expose the
+  // in-progress text through `onChange` as an accumulating string (`d`, then `dd`, then `ddd`).
+  // Committing those intermediate values would treat them as bulk OTP input and fill too many slots.
+  // We buffer the displayed text in `composingValue` and commit once on `compositionend` instead.
+  const [composingValue, setComposingValue] = React.useState<string | null>(null);
+
   const slotValue = value[index] ?? '';
   const inputState = getOTPFieldInputState(state, slotValue, index);
   const slotAriaLabel = externalAriaLabel;
@@ -92,9 +99,61 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
     }, [index, slotAriaLabel]);
   }
 
+  function commitInputValue(
+    event: React.ChangeEvent<HTMLInputElement> | React.CompositionEvent<HTMLInputElement>,
+  ) {
+    const inputElement = event.currentTarget;
+    const rawValue = inputElement.value;
+    const [nextDigits, didRejectCharacters] = normalizeOTPValueWithDetails(
+      rawValue,
+      length,
+      validationType,
+      normalizeValue,
+    );
+
+    if (didRejectCharacters) {
+      reportValueInvalid(
+        rawValue,
+        createGenericEventDetails(REASONS.inputChange, event.nativeEvent),
+      );
+    }
+
+    if (nextDigits === '') {
+      if (rawValue === '') {
+        setValue(
+          removeOTPCharacter(value, index),
+          createChangeEventDetails(REASONS.inputClear, event.nativeEvent),
+        );
+      } else if (slotValue !== '') {
+        inputElement.value = slotValue;
+        inputElement.select();
+      }
+      return;
+    }
+
+    const nextValue = replaceOTPValue(
+      value,
+      index,
+      nextDigits,
+      length,
+      validationType,
+      normalizeValue,
+    );
+
+    const committedValue = setValue(
+      nextValue,
+      createChangeEventDetails(REASONS.inputChange, event.nativeEvent),
+    );
+
+    if (committedValue != null) {
+      const nextInput = Math.min(index + nextDigits.length, length - 1);
+      queueFocusInput(nextInput, committedValue);
+    }
+  }
+
   const inputProps: React.ComponentProps<'input'> = {
     id: getInputId(index),
-    value: slotValue,
+    value: composingValue ?? slotValue,
     type: mask ? 'password' : 'text',
     inputMode,
     autoComplete: index === 0 ? autoComplete : 'off',
@@ -134,57 +193,41 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
 
       handleInputBlur(event);
     },
+    onCompositionStart(event) {
+      // Android handles composition events inconsistently across keyboards (some report text as
+      // always-composing), so leave its input flowing through `onChange` unchanged.
+      if (platform.os.android) {
+        return;
+      }
+
+      setComposingValue(event.currentTarget.value);
+    },
+    onCompositionEnd(event) {
+      if (composingValue == null) {
+        return;
+      }
+
+      setComposingValue(null);
+
+      if (disabled || readOnly) {
+        return;
+      }
+
+      commitInputValue(event);
+    },
     onChange(event) {
       if (event.defaultPrevented || disabled || readOnly) {
         return;
       }
 
-      const rawValue = event.currentTarget.value;
-      const [nextDigits, didRejectCharacters] = normalizeOTPValueWithDetails(
-        rawValue,
-        length,
-        validationType,
-        normalizeValue,
-      );
-
-      if (didRejectCharacters) {
-        reportValueInvalid(
-          rawValue,
-          createGenericEventDetails(REASONS.inputChange, event.nativeEvent),
-        );
-      }
-
-      if (nextDigits === '') {
-        if (rawValue === '') {
-          setValue(
-            removeOTPCharacter(value, index),
-            createChangeEventDetails(REASONS.inputClear, event.nativeEvent),
-          );
-        } else if (slotValue !== '') {
-          event.currentTarget.value = slotValue;
-          event.currentTarget.select();
-        }
+      // Buffer intermediate IME text instead of committing it; the final value commits once on
+      // `compositionend` through the same normalization/replacement path.
+      if (composingValue != null) {
+        setComposingValue(event.currentTarget.value);
         return;
       }
 
-      const nextValue = replaceOTPValue(
-        value,
-        index,
-        nextDigits,
-        length,
-        validationType,
-        normalizeValue,
-      );
-
-      const committedValue = setValue(
-        nextValue,
-        createChangeEventDetails(REASONS.inputChange, event.nativeEvent),
-      );
-
-      if (committedValue != null) {
-        const nextInput = Math.min(index + nextDigits.length, length - 1);
-        queueFocusInput(nextInput, committedValue);
-      }
+      commitInputValue(event);
     },
     onKeyDown(event) {
       if (event.defaultPrevented || disabled) {

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -72,10 +72,10 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const direction = useDirection();
 
-  // While an IME composition is active, Safari (and other WebKit/Gecko engines) can expose the
-  // in-progress text through `onChange` as an accumulating string (`d`, then `dd`, then `ddd`).
-  // Committing those intermediate values would treat them as bulk OTP input and fill too many slots.
-  // We buffer the displayed text in `composingValue` and commit once on `compositionend` instead.
+  // While an IME composition is active, Safari exposes the in-progress text through `onChange`
+  // as an accumulating string (`d`, then `dd`, then `ddd`). Committing those intermediate values
+  // would treat them as bulk input and fill too many slots, so the text is only buffered here
+  // and committed once on `compositionend`.
   const [composingValue, setComposingValue] = React.useState<string | null>(null);
 
   const slotValue = value[index] ?? '';
@@ -99,9 +99,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
     }, [index, slotAriaLabel]);
   }
 
-  function commitInputValue(
-    event: React.ChangeEvent<HTMLInputElement> | React.CompositionEvent<HTMLInputElement>,
-  ) {
+  function commitInputValue(event: React.SyntheticEvent<HTMLInputElement>) {
     const inputElement = event.currentTarget;
     const rawValue = inputElement.value;
     const [nextDigits, didRejectCharacters] = normalizeOTPValueWithDetails(
@@ -193,35 +191,24 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
 
       handleInputBlur(event);
     },
-    onCompositionStart(event) {
-      // Android handles composition events inconsistently across keyboards (some report text as
-      // always-composing), so leave its input flowing through `onChange` unchanged.
-      if (platform.os.android) {
-        return;
+    onCompositionStart() {
+      // Some Android keyboards report all text as always-composing, so Android keeps
+      // committing through `onChange`.
+      if (!platform.os.android) {
+        setComposingValue(slotValue);
       }
-
-      setComposingValue(event.currentTarget.value);
     },
     onCompositionEnd(event) {
-      if (composingValue == null) {
-        return;
+      if (composingValue != null) {
+        setComposingValue(null);
+        commitInputValue(event);
       }
-
-      setComposingValue(null);
-
-      if (disabled || readOnly) {
-        return;
-      }
-
-      commitInputValue(event);
     },
     onChange(event) {
       if (event.defaultPrevented || disabled || readOnly) {
         return;
       }
 
-      // Buffer intermediate IME text instead of committing it; the final value commits once on
-      // `compositionend` through the same normalization/replacement path.
       if (composingValue != null) {
         setComposingValue(event.currentTarget.value);
         return;

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -192,8 +192,13 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
       }
     },
     onCompositionEnd(event) {
-      if (composingValue != null) {
-        setComposingValue(null);
+      if (composingValue == null) {
+        return;
+      }
+
+      setComposingValue(null);
+
+      if (!disabled && !readOnly) {
         commitValue(event.currentTarget.value, REASONS.inputChange, event);
       }
     },

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -99,9 +99,11 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
     }, [index, slotAriaLabel]);
   }
 
-  function commitInputValue(event: React.SyntheticEvent<HTMLInputElement>) {
-    const inputElement = event.currentTarget;
-    const rawValue = inputElement.value;
+  function commitValue(
+    rawValue: string,
+    reason: typeof REASONS.inputChange | typeof REASONS.inputPaste,
+    event: React.SyntheticEvent<HTMLInputElement>,
+  ) {
     const [nextDigits, didRejectCharacters] = normalizeOTPValueWithDetails(
       rawValue,
       length,
@@ -110,42 +112,33 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
     );
 
     if (didRejectCharacters) {
-      reportValueInvalid(
-        rawValue,
-        createGenericEventDetails(REASONS.inputChange, event.nativeEvent),
-      );
+      reportValueInvalid(rawValue, createGenericEventDetails(reason, event.nativeEvent));
     }
 
     if (nextDigits === '') {
-      if (rawValue === '') {
-        setValue(
-          removeOTPCharacter(value, index),
-          createChangeEventDetails(REASONS.inputClear, event.nativeEvent),
-        );
-      } else if (slotValue !== '') {
-        inputElement.value = slotValue;
-        inputElement.select();
+      // Typed input edits the slot in place: clear it, or restore its character when every
+      // typed character was rejected. An empty or fully rejected paste changes nothing.
+      if (reason === REASONS.inputChange) {
+        if (rawValue === '') {
+          setValue(
+            removeOTPCharacter(value, index),
+            createChangeEventDetails(REASONS.inputClear, event.nativeEvent),
+          );
+        } else if (slotValue !== '') {
+          event.currentTarget.value = slotValue;
+          event.currentTarget.select();
+        }
       }
       return;
     }
 
-    const nextValue = replaceOTPValue(
-      value,
-      index,
-      nextDigits,
-      length,
-      validationType,
-      normalizeValue,
-    );
-
     const committedValue = setValue(
-      nextValue,
-      createChangeEventDetails(REASONS.inputChange, event.nativeEvent),
+      replaceOTPValue(value, index, nextDigits, length, validationType, normalizeValue),
+      createChangeEventDetails(reason, event.nativeEvent),
     );
 
     if (committedValue != null) {
-      const nextInput = Math.min(index + nextDigits.length, length - 1);
-      queueFocusInput(nextInput, committedValue);
+      queueFocusInput(Math.min(index + nextDigits.length, length - 1), committedValue);
     }
   }
 
@@ -201,7 +194,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
     onCompositionEnd(event) {
       if (composingValue != null) {
         setComposingValue(null);
-        commitInputValue(event);
+        commitValue(event.currentTarget.value, REASONS.inputChange, event);
       }
     },
     onChange(event) {
@@ -214,7 +207,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
         return;
       }
 
-      commitInputValue(event);
+      commitValue(event.currentTarget.value, REASONS.inputChange, event);
     },
     onKeyDown(event) {
       if (event.defaultPrevented || disabled) {
@@ -322,34 +315,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
       }
 
       event.preventDefault();
-
-      const [nextDigits, didRejectCharacters] = normalizeOTPValueWithDetails(
-        rawValue,
-        length,
-        validationType,
-        normalizeValue,
-      );
-
-      if (didRejectCharacters) {
-        reportValueInvalid(
-          rawValue,
-          createGenericEventDetails(REASONS.inputPaste, event.nativeEvent),
-        );
-      }
-
-      if (nextDigits === '') {
-        return;
-      }
-
-      const committedValue = setValue(
-        replaceOTPValue(value, index, nextDigits, length, validationType, normalizeValue),
-        createChangeEventDetails(REASONS.inputPaste, event.nativeEvent),
-      );
-
-      if (committedValue != null) {
-        const nextInput = Math.min(index + nextDigits.length, length - 1);
-        queueFocusInput(nextInput, committedValue);
-      }
+      commitValue(rawValue, REASONS.inputPaste, event);
     },
   };
 

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -215,7 +215,9 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
       commitValue(event.currentTarget.value, REASONS.inputChange, event);
     },
     onKeyDown(event) {
-      if (event.defaultPrevented || disabled) {
+      // WebKit delivers real key names (such as `Backspace`) for keydowns inside a composition.
+      // The IME owns editing until `compositionend`, so OTP commands must not run on them.
+      if (event.defaultPrevented || disabled || composingValue != null) {
         return;
       }
 


### PR DESCRIPTION
## Summary

`OTPField.Input` committed every IME `onChange` value during composition. In Safari, the in-progress text can arrive as accumulating values (`d`, `dd`, `ddd`), so the field wrote each intermediate value into the slots and could end up with `dddddd` instead of the final `ddd`. Chrome does not reproduce the same over-fill in the reported flow.

## Changes

This makes OTP input composition-aware, following the Combobox pattern:

- Track active composition and keep the temporary text in local input state.
- During composition, let `onChange` update only that temporary text.
- On `compositionend`, commit the final value once through the normal normalization/replacement path.
- Reuse that commit path for normal input and composition end, preserving paste, autofill, invalid-character reporting, cancellation, and focus movement.
- Keep the Android guard used by Combobox for inconsistent keyboard composition events.

Fixes https://github.com/mui/base-ui/issues/5091