### PR TITLE
[drawer] Fix unreliable swipe-to-open gestures

### DIFF
--- a/packages/react/src/drawer/root/DrawerRoot.test.tsx
+++ b/packages/react/src/drawer/root/DrawerRoot.test.tsx
@@ -63,6 +63,7 @@ async function simulateTimedRightSwipe(
 
     vi.setSystemTime(new Date(moveTime));
     fireEvent.pointerMove(element, {
+      buttons: 1,
       pointerId: 1,
       clientX: startX + 1,
       clientY: 100,
@@ -74,6 +75,7 @@ async function simulateTimedRightSwipe(
 
     vi.setSystemTime(new Date(endTime - 1));
     fireEvent.pointerMove(element, {
+      buttons: 1,
       pointerId: 1,
       clientX: endX,
       clientY: 100,
@@ -115,6 +117,7 @@ async function simulateTimedRightSwipe(
   });
 
   fireEvent.pointerMove(element, {
+    buttons: 1,
     pointerId: 1,
     clientX: startX + 1,
     clientY: 100,
@@ -128,6 +131,7 @@ async function simulateTimedRightSwipe(
   });
 
   fireEvent.pointerMove(element, {
+    buttons: 1,
     pointerId: 1,
     clientX: endX,
     clientY: 100,
@@ -177,6 +181,7 @@ async function simulateTimedDownSwipe(
 
     vi.setSystemTime(new Date(moveTime));
     fireEvent.pointerMove(element, {
+      buttons: 1,
       pointerId: 1,
       clientX: 100,
       clientY: startY + 1,
@@ -189,6 +194,7 @@ async function simulateTimedDownSwipe(
     if (resolvedSettleTime !== null) {
       vi.setSystemTime(new Date(resolvedSettleTime));
       fireEvent.pointerMove(element, {
+        buttons: 1,
         pointerId: 1,
         clientX: 100,
         clientY: settleY,
@@ -201,6 +207,7 @@ async function simulateTimedDownSwipe(
 
     vi.setSystemTime(new Date(endTime - 1));
     fireEvent.pointerMove(element, {
+      buttons: 1,
       pointerId: 1,
       clientX: 100,
       clientY: endY,
@@ -247,6 +254,7 @@ async function simulateTimedDownSwipe(
   });
 
   fireEvent.pointerMove(element, {
+    buttons: 1,
     pointerId: 1,
     clientX: 100,
     clientY: startY + 1,
@@ -262,6 +270,7 @@ async function simulateTimedDownSwipe(
     });
 
     fireEvent.pointerMove(element, {
+      buttons: 1,
       pointerId: 1,
       clientX: 100,
       clientY: settleY,
@@ -277,6 +286,7 @@ async function simulateTimedDownSwipe(
   });
 
   fireEvent.pointerMove(element, {
+    buttons: 1,
     pointerId: 1,
     clientX: 100,
     clientY: endY,
@@ -324,7 +334,7 @@ async function simulateTimedSwipe(element: HTMLElement, steps: TimedSwipeStep[])
     }
 
     if (step.type === 'move') {
-      fireEvent.pointerMove(element, baseEvent);
+      fireEvent.pointerMove(element, { ...baseEvent, buttons: 1 });
       return;
     }
 

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -173,6 +173,18 @@ function pressOutside(target: Element = document.body) {
   fireEvent.click(target);
 }
 
+// A real touch tap dispatches `pointerdown` alongside `touchstart`/`touchend`, so the swipe-open
+// guard re-enables on that fresh `pointerdown` before the dismissal fires — touch outside presses
+// dismiss just like mouse ones.
+function pressOutsideTouch(target: Element = document.body) {
+  const touch = createTouch(target, { clientX: 0, clientY: 0 });
+  fireEvent.pointerDown(target, { button: 0, buttons: 1, pointerId: 1, pointerType: 'touch' });
+  fireEvent.touchStart(target, { touches: [touch] });
+  fireEvent.touchEnd(target, { changedTouches: [touch], touches: [] });
+  fireEvent.pointerUp(target, { button: 0, buttons: 0, pointerId: 1, pointerType: 'touch' });
+  fireEvent.click(target);
+}
+
 async function swipeUp(element: HTMLElement, startY: number, endY: number, options?: SwipeOptions) {
   return swipe(element, { x: 10, y: startY }, { x: 10, y: endY }, options);
 }
@@ -343,6 +355,39 @@ describe('<Drawer.SwipeArea />', () => {
     });
 
     pressOutside();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('popup')).toBe(null);
+    });
+
+    expect(swipeArea).toHaveAttribute('data-closed', '');
+  });
+
+  it('re-enables outside press dismissal for a touch outside press after opening by swipe', async () => {
+    await render(
+      <Drawer.Root>
+        <Drawer.SwipeArea data-testid="swipe-area" />
+        <Drawer.Portal>
+          <Drawer.Viewport>
+            <Drawer.Popup data-testid="popup">Drawer</Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>,
+    );
+
+    const swipeArea = screen.getByTestId('swipe-area');
+
+    await swipeUp(swipeArea, 120, 40, { input: 'touch' });
+
+    expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+
+    await act(async () => {
+      await nextMacrotask();
+    });
+
+    // A touch outside press fires `pointerdown` alongside `touchstart`/`touchend`, so it must
+    // re-enable dismissal and close the swipe-opened drawer the same way a mouse press does.
+    pressOutsideTouch();
 
     await waitFor(() => {
       expect(screen.queryByTestId('popup')).toBe(null);

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -661,6 +661,66 @@ describe('<Drawer.SwipeArea />', () => {
     });
   });
 
+  it('commits a released-move quick flick exactly once when a real pointerup trails it', async () => {
+    // The `buttons: 0` move finishes the gesture by itself, but a real browser still delivers the
+    // trailing `pointerup` afterwards. That second `handleEnd` must be a no-op: the flick stays open
+    // and does not re-commit the release (no double open-change, no spurious close).
+    const handleOpenChange = vi.fn();
+
+    await render(
+      <Drawer.Root onOpenChange={handleOpenChange}>
+        <Drawer.SwipeArea data-testid="swipe-area" />
+        <Drawer.Portal>
+          <Drawer.Viewport>
+            <Drawer.Popup data-testid="popup">Drawer</Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>,
+    );
+
+    const swipeArea = screen.getByTestId('swipe-area');
+
+    fireEvent.pointerDown(swipeArea, {
+      button: 0,
+      buttons: 1,
+      pointerId: 1,
+      clientX: 10,
+      clientY: 120,
+      pointerType: 'mouse',
+      timeStamp: 0,
+    });
+    await flushMicrotasks();
+
+    fireEvent.pointerMove(swipeArea, {
+      pointerId: 1,
+      clientX: 10,
+      clientY: 40,
+      buttons: 0,
+      pointerType: 'mouse',
+      timeStamp: 16,
+    });
+    await flushMicrotasks();
+
+    expect(swipeArea).toHaveAttribute('data-open', '');
+    expect(handleOpenChange).toHaveBeenCalledTimes(1);
+    expect(handleOpenChange.mock.calls[0][0]).toBe(true);
+
+    // The trailing `pointerup` a real browser still delivers must not re-run the release.
+    fireEvent.pointerUp(swipeArea, {
+      pointerId: 1,
+      clientX: 10,
+      clientY: 40,
+      buttons: 0,
+      pointerType: 'mouse',
+      timeStamp: 32,
+    });
+    await flushMicrotasks();
+
+    expect(swipeArea).toHaveAttribute('data-open', '');
+    expect(swipeArea).not.toHaveAttribute('data-swiping');
+    expect(handleOpenChange).toHaveBeenCalledTimes(1);
+  });
+
   it('opens on a quick flick that lands its whole travel in a single touch move', async () => {
     // A fast touch flick on a low-refresh-rate display can produce a single `touchmove` carrying
     // the entire travel between `touchstart` and `touchend`. The first-move latency calibration

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -162,6 +162,15 @@ function nextMacrotask() {
   return wait(0);
 }
 
+// A real outside press always begins with a `pointerdown`; the swipe-open guard relies on that
+// fresh press to distinguish a deliberate dismissal from the `click` synthesized by the gesture's
+// own `pointerup`.
+function pressOutside(target: Element = document.body) {
+  fireEvent.pointerDown(target, { button: 0, buttons: 1, pointerType: 'mouse' });
+  fireEvent.pointerUp(target, { button: 0, buttons: 0, pointerType: 'mouse' });
+  fireEvent.click(target);
+}
+
 async function swipeUp(element: HTMLElement, startY: number, endY: number, options?: SwipeOptions) {
   return swipe(element, { x: 10, y: startY }, { x: 10, y: endY }, options);
 }
@@ -331,13 +340,49 @@ describe('<Drawer.SwipeArea />', () => {
       await nextMacrotask();
     });
 
-    fireEvent.click(document.body);
+    pressOutside();
 
     await waitFor(() => {
       expect(screen.queryByTestId('popup')).toBe(null);
     });
 
     expect(swipeArea).toHaveAttribute('data-closed', '');
+  });
+
+  it('does not dismiss from the click synthesized by the swipe-open pointerup', async () => {
+    // Dragging past the popup releases the pointer outside it, so the gesture's own pointerup
+    // synthesizes a `click` over the backdrop. That click (which has no fresh pointerdown) must not
+    // be read as an outside press and dismiss the drawer that was just opened — even when it lands a
+    // macrotask later, after a timer-based re-enable would have fired.
+    await render(
+      <Drawer.Root>
+        <Drawer.SwipeArea data-testid="swipe-area" />
+        <Drawer.Portal>
+          <Drawer.Viewport>
+            <Drawer.Popup data-testid="popup">Drawer</Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>,
+    );
+
+    const swipeArea = screen.getByTestId('swipe-area');
+
+    await swipeUp(swipeArea, 120, 40);
+
+    expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+
+    await act(async () => {
+      await nextMacrotask();
+    });
+
+    // Trailing synthesized click with no preceding fresh pointerdown.
+    fireEvent.click(document.body);
+
+    await act(async () => {
+      await nextMacrotask();
+    });
+
+    expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
   });
 
   it('re-enables outside press dismissal after an interrupted swipe-open gesture', async () => {
@@ -402,7 +447,7 @@ describe('<Drawer.SwipeArea />', () => {
       await nextMacrotask();
     });
 
-    fireEvent.click(document.body);
+    pressOutside();
 
     await waitFor(() => {
       expect(screen.queryByTestId('popup')).toBe(null);
@@ -478,7 +523,7 @@ describe('<Drawer.SwipeArea />', () => {
       await nextMacrotask();
     });
 
-    fireEvent.click(document.body);
+    pressOutside();
 
     await waitFor(() => {
       expect(screen.queryByTestId('popup')).toBe(null);

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -519,4 +519,130 @@ describe('<Drawer.SwipeArea />', () => {
 
     expect(swipeArea).toHaveAttribute('data-open', '');
   });
+
+  it('opens on a quick flick whose only move is already released (buttons: 0)', async () => {
+    // On a fast flick — especially on a low-refresh-rate display — the pointer can be lifted before
+    // the first `pointermove` is sampled, so the single move arrives with `buttons: 0` and no
+    // preceding pressed move. It must still commit the swipe-open instead of being discarded.
+    await render(
+      <Drawer.Root>
+        <Drawer.SwipeArea data-testid="swipe-area" />
+      </Drawer.Root>,
+    );
+
+    const swipeArea = screen.getByTestId('swipe-area');
+
+    fireEvent.pointerDown(swipeArea, {
+      button: 0,
+      buttons: 1,
+      pointerId: 1,
+      clientX: 10,
+      clientY: 120,
+      pointerType: 'mouse',
+      timeStamp: 0,
+    });
+    await flushMicrotasks();
+
+    fireEvent.pointerMove(swipeArea, {
+      pointerId: 1,
+      clientX: 10,
+      clientY: 40,
+      buttons: 0,
+      pointerType: 'mouse',
+      timeStamp: 16,
+    });
+    await flushMicrotasks();
+
+    fireEvent.pointerUp(swipeArea, {
+      pointerId: 1,
+      clientX: 10,
+      clientY: 40,
+      buttons: 0,
+      pointerType: 'mouse',
+      timeStamp: 32,
+    });
+    await flushMicrotasks();
+
+    expect(swipeArea).toHaveAttribute('data-open', '');
+  });
+
+  it('opens on a quick flick that lands its whole travel in a single touch move', async () => {
+    // A fast touch flick on a low-refresh-rate display can produce a single `touchmove` carrying
+    // the entire travel between `touchstart` and `touchend`. The first-move latency calibration
+    // must not discard it for the swipe-area (which doesn't track a dragged element).
+    await render(
+      <Drawer.Root>
+        <Drawer.SwipeArea data-testid="swipe-area" />
+      </Drawer.Root>,
+    );
+
+    const swipeArea = screen.getByTestId('swipe-area');
+
+    fireEvent.touchStart(swipeArea, {
+      bubbles: true,
+      touches: [createTouch(swipeArea, { clientX: 10, clientY: 120 })],
+    });
+    await flushMicrotasks();
+
+    fireEvent.touchMove(swipeArea, {
+      bubbles: true,
+      touches: [createTouch(swipeArea, { clientX: 10, clientY: 40 })],
+    });
+    await flushMicrotasks();
+
+    fireEvent.touchEnd(swipeArea, {
+      bubbles: true,
+      changedTouches: [createTouch(swipeArea, { clientX: 10, clientY: 40 })],
+    });
+    await flushMicrotasks();
+
+    expect(swipeArea).toHaveAttribute('data-open', '');
+  });
+
+  it('does not open on an in-place press-release without movement', async () => {
+    const handleOpenChange = vi.fn();
+
+    await render(
+      <Drawer.Root onOpenChange={handleOpenChange}>
+        <Drawer.SwipeArea data-testid="swipe-area" />
+      </Drawer.Root>,
+    );
+
+    const swipeArea = screen.getByTestId('swipe-area');
+
+    fireEvent.pointerDown(swipeArea, {
+      button: 0,
+      buttons: 1,
+      pointerId: 1,
+      clientX: 10,
+      clientY: 120,
+      pointerType: 'mouse',
+      timeStamp: 0,
+    });
+    await flushMicrotasks();
+
+    // Released in place: a `buttons: 0` move with no displacement must not open the drawer.
+    fireEvent.pointerMove(swipeArea, {
+      pointerId: 1,
+      clientX: 10,
+      clientY: 120,
+      buttons: 0,
+      pointerType: 'mouse',
+      timeStamp: 16,
+    });
+    await flushMicrotasks();
+
+    fireEvent.pointerUp(swipeArea, {
+      pointerId: 1,
+      clientX: 10,
+      clientY: 120,
+      buttons: 0,
+      pointerType: 'mouse',
+      timeStamp: 32,
+    });
+    await flushMicrotasks();
+
+    expect(swipeArea).toHaveAttribute('data-closed', '');
+    expect(handleOpenChange).not.toHaveBeenCalled();
+  });
 });

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -112,6 +112,7 @@ async function swipe(element: HTMLElement, start: Point, end: Point, options: Sw
     pointerId: 1,
     clientX: stepX,
     clientY: stepY,
+    buttons: 1,
     pointerType: 'mouse',
     ...(useTimeStamp ? { timeStamp } : null),
   });
@@ -126,6 +127,7 @@ async function swipe(element: HTMLElement, start: Point, end: Point, options: Sw
     pointerId: 1,
     clientX: end.x,
     clientY: end.y,
+    buttons: 1,
     pointerType: 'mouse',
     ...(useTimeStamp ? { timeStamp } : null),
   });
@@ -572,6 +574,11 @@ describe('<Drawer.SwipeArea />', () => {
     await render(
       <Drawer.Root>
         <Drawer.SwipeArea data-testid="swipe-area" />
+        <Drawer.Portal>
+          <Drawer.Viewport>
+            <Drawer.Popup data-testid="popup">Drawer</Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
       </Drawer.Root>,
     );
 
@@ -598,17 +605,15 @@ describe('<Drawer.SwipeArea />', () => {
     });
     await flushMicrotasks();
 
-    fireEvent.pointerUp(swipeArea, {
-      pointerId: 1,
-      clientX: 10,
-      clientY: 40,
-      buttons: 0,
-      pointerType: 'mouse',
-      timeStamp: 32,
-    });
-    await flushMicrotasks();
-
+    // No trailing `pointerup` follows; the released move must finish the gesture by itself.
     expect(swipeArea).toHaveAttribute('data-open', '');
+    expect(swipeArea).not.toHaveAttribute('data-swiping');
+
+    pressOutside();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('popup')).toBe(null);
+    });
   });
 
   it('opens on a quick flick that lands its whole travel in a single touch move', async () => {

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
@@ -6,6 +6,7 @@ import { useDialogRootContext } from '../../dialog/root/DialogRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import type { BaseUIComponentProps } from '../../internals/types';
 import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
+import { NOOP } from '../../internals/noop';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 import {
@@ -102,7 +103,7 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
   const closedOffsetRef = React.useRef<number | null>(null);
   const appliedSwipeStylesRef = React.useRef(false);
   const popupTransitionRef = React.useRef<string | null>(null);
-  const releaseGuardCleanupRef = React.useRef<(() => void) | null>(null);
+  const releaseGuardCleanupRef = React.useRef<() => void>(NOOP);
 
   const swipeAreaId = useBaseUiId(componentProps.id);
   const registerTrigger = useTriggerRegistration(swipeAreaId, store);
@@ -119,17 +120,17 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
   const enabled = !disabled && (!open || swipeActive);
 
   function disableDismissForSwipe() {
-    releaseGuardCleanupRef.current?.();
+    releaseGuardCleanupRef.current();
     store.context.outsidePressEnabledRef.current = false;
   }
 
   function enableDismissAfterRelease() {
-    releaseGuardCleanupRef.current?.();
+    releaseGuardCleanupRef.current();
 
     const doc = ownerDocument(swipeAreaRef.current);
 
     function restore() {
-      releaseGuardCleanupRef.current = null;
+      releaseGuardCleanupRef.current = NOOP;
       doc.removeEventListener('pointerdown', restore, true);
       store.context.outsidePressEnabledRef.current = true;
     }
@@ -407,7 +408,7 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
 
   React.useEffect(() => {
     return () => {
-      releaseGuardCleanupRef.current?.();
+      releaseGuardCleanupRef.current();
       store.context.outsidePressEnabledRef.current = true;
     };
   }, [store]);

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { useTimeout } from '@base-ui/utils/useTimeout';
+import { ownerDocument } from '@base-ui/utils/owner';
 import { useDialogRootContext } from '../../dialog/root/DialogRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import type { BaseUIComponentProps } from '../../internals/types';
@@ -95,7 +95,6 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
 
   const [swipeActive, setSwipeActive] = React.useState(false);
 
-  const releaseDismissTimeout = useTimeout();
   const swipeAreaRef = React.useRef<HTMLDivElement>(null);
   const swipeStartEventRef = React.useRef<PointerEvent | TouchEvent | null>(null);
   const openedBySwipeRef = React.useRef(false);
@@ -103,6 +102,7 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
   const closedOffsetRef = React.useRef<number | null>(null);
   const appliedSwipeStylesRef = React.useRef(false);
   const popupTransitionRef = React.useRef<string | null>(null);
+  const releaseGuardCleanupRef = React.useRef<(() => void) | null>(null);
 
   const swipeAreaId = useBaseUiId(componentProps.id);
   const registerTrigger = useTriggerRegistration(swipeAreaId, store);
@@ -119,16 +119,33 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
   const enabled = !disabled && (!open || swipeActive);
 
   function disableDismissForSwipe() {
-    releaseDismissTimeout.clear();
+    releaseGuardCleanupRef.current?.();
     store.context.outsidePressEnabledRef.current = false;
   }
 
   function enableDismissAfterRelease() {
-    // Safari can dispatch outside-press for the same swipe-open gesture
-    // after release, so defer re-enabling dismissal to the next macrotask.
-    releaseDismissTimeout.start(0, () => {
+    releaseGuardCleanupRef.current?.();
+
+    const doc = ownerDocument(swipeAreaRef.current);
+
+    function restore() {
+      releaseGuardCleanupRef.current = null;
+      doc.removeEventListener('pointerdown', restore, true);
       store.context.outsidePressEnabledRef.current = true;
-    });
+    }
+
+    // The pointerup that ends a swipe-open gesture synthesizes a `click`. When the drag released
+    // outside the popup (e.g. it was dragged past the popup's size), that click would be treated as
+    // an outside press and immediately dismiss the drawer that was just opened. Keep outside-press
+    // dismissal disabled until the next *fresh* pointer interaction: the synthesized click has no
+    // pointerdown of its own, so it is ignored, while a deliberate outside press always starts with
+    // a pointerdown and re-enables dismissal in time to close the drawer. This is deterministic,
+    // unlike re-enabling on a timer that can race the synthesized click and dismiss at random.
+    //
+    // `restore` runs in document capture, ahead of floating-ui's own outside-press check (which
+    // happens on the event target, after capture), so the triggering press still dismisses.
+    releaseGuardCleanupRef.current = restore;
+    doc.addEventListener('pointerdown', restore, true);
   }
 
   function resolvePopupSize() {
@@ -390,6 +407,7 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
 
   React.useEffect(() => {
     return () => {
+      releaseGuardCleanupRef.current?.();
       store.context.outsidePressEnabledRef.current = true;
     };
   }, [store]);

--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -2425,6 +2425,7 @@ describe('<Drawer.Viewport />', () => {
       await flushMicrotasks();
 
       fireEvent.pointerMove(viewport, {
+        buttons: 1,
         pointerId: 1,
         clientX: 0,
         clientY: 8,

--- a/packages/react/src/utils/useSwipeDismiss.test.tsx
+++ b/packages/react/src/utils/useSwipeDismiss.test.tsx
@@ -124,6 +124,7 @@ describe('useSwipeDismiss', () => {
 
       fireEvent.pointerMove(scroll, {
         pointerId: 1,
+        buttons: 1,
         clientX: 0,
         clientY: 150,
         bubbles: true,
@@ -161,6 +162,7 @@ describe('useSwipeDismiss', () => {
     // First move establishes the baseline (iOS pointermove delay handling).
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 100,
       bubbles: true,
@@ -173,6 +175,7 @@ describe('useSwipeDismiss', () => {
     // Move up (unsupported) should not block the default touch scroll behavior.
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 50,
       bubbles: true,
@@ -189,6 +192,7 @@ describe('useSwipeDismiss', () => {
     // Once a supported direction is detected, touchmove should still not be prevented.
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 150,
       bubbles: true,
@@ -229,6 +233,7 @@ describe('useSwipeDismiss', () => {
 
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 0,
       bubbles: true,
@@ -240,6 +245,7 @@ describe('useSwipeDismiss', () => {
 
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 50,
       clientY: 0,
       bubbles: true,
@@ -280,6 +286,7 @@ describe('useSwipeDismiss', () => {
     // Baseline move.
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 0,
       bubbles: true,
@@ -291,6 +298,7 @@ describe('useSwipeDismiss', () => {
 
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 50,
       clientY: 0,
       bubbles: true,
@@ -305,6 +313,7 @@ describe('useSwipeDismiss', () => {
     // Move past the starting point in the opposite direction; progress is clamped to 0.
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: -10,
       clientY: 0,
       bubbles: true,
@@ -319,6 +328,7 @@ describe('useSwipeDismiss', () => {
 
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: -20,
       clientY: 0,
       bubbles: true,
@@ -353,6 +363,7 @@ describe('useSwipeDismiss', () => {
 
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 100,
       bubbles: true,
@@ -364,6 +375,7 @@ describe('useSwipeDismiss', () => {
 
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 50,
       bubbles: true,
@@ -560,6 +572,7 @@ describe('useSwipeDismiss', () => {
     // Baseline move.
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 0,
       bubbles: true,
@@ -572,6 +585,7 @@ describe('useSwipeDismiss', () => {
     // Move beyond the custom 10px threshold.
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 20,
       bubbles: true,
@@ -1030,6 +1044,7 @@ describe('useSwipeDismiss', () => {
 
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 0,
       bubbles: true,
@@ -1041,6 +1056,7 @@ describe('useSwipeDismiss', () => {
 
     fireEvent.pointerMove(element, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 20,
       bubbles: true,
@@ -1110,6 +1126,7 @@ describe('useSwipeDismiss', () => {
       vi.setSystemTime(new Date(1100));
       fireEvent.pointerMove(element, {
         pointerId: 1,
+        buttons: 1,
         clientX: 0,
         clientY: 0,
         bubbles: true,
@@ -1123,6 +1140,7 @@ describe('useSwipeDismiss', () => {
       vi.setSystemTime(new Date(1200));
       fireEvent.pointerMove(element, {
         pointerId: 1,
+        buttons: 1,
         clientX: 50,
         clientY: 0,
         bubbles: true,
@@ -1199,6 +1217,7 @@ describe('useSwipeDismiss', () => {
       vi.setSystemTime(new Date(1100));
       fireEvent.pointerMove(element, {
         pointerId: 1,
+        buttons: 1,
         clientX: 0,
         clientY: 0,
         bubbles: true,
@@ -1212,6 +1231,7 @@ describe('useSwipeDismiss', () => {
       vi.setSystemTime(new Date(1200));
       fireEvent.pointerMove(element, {
         pointerId: 1,
+        buttons: 1,
         clientX: 50,
         clientY: 0,
         bubbles: true,
@@ -1225,6 +1245,7 @@ describe('useSwipeDismiss', () => {
       vi.setSystemTime(new Date(1216));
       fireEvent.pointerMove(element, {
         pointerId: 1,
+        buttons: 1,
         clientX: 70,
         clientY: 0,
         bubbles: true,
@@ -1301,6 +1322,7 @@ describe('useSwipeDismiss', () => {
       vi.setSystemTime(new Date(1005));
       fireEvent.pointerMove(element, {
         pointerId: 1,
+        buttons: 1,
         clientX: 0,
         clientY: 0,
         bubbles: true,
@@ -1314,6 +1336,7 @@ describe('useSwipeDismiss', () => {
       vi.setSystemTime(new Date(1010));
       fireEvent.pointerMove(element, {
         pointerId: 1,
+        buttons: 1,
         clientX: 30,
         clientY: 0,
         bubbles: true,
@@ -1389,6 +1412,7 @@ describe('useSwipeDismiss', () => {
 
     fireEvent.pointerMove(child, {
       pointerId: 1,
+      buttons: 1,
       clientX: 0,
       clientY: 150,
       bubbles: true,

--- a/packages/react/src/utils/useSwipeDismiss.ts
+++ b/packages/react/src/utils/useSwipeDismiss.ts
@@ -605,12 +605,13 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
 
     if (isFirstPointerMoveRef.current) {
       isFirstPointerMoveRef.current = false;
-      // Adjust the starting position to the current position on the first move to account for the
-      // delay between pointerdown and the first pointermove on iOS, which would otherwise make the
-      // dragged element jump. This only matters when an element is following the pointer; when
-      // `trackDrag` is false (e.g. the swipe-area that just opens the drawer) keeping the original
-      // press position is what lets a quick flick register — on a low-refresh-rate display the
-      // whole travel can land in this single first move, and discarding it would drop the gesture.
+      // Reset the drag origin to the first move's position to absorb the gap between the press and
+      // the first move event — notably on iOS touch, where the first `touchmove` arrives already
+      // offset from the `touchstart` — which would otherwise make the dragged element jump. This
+      // only matters when an element follows the pointer; when `trackDrag` is false (e.g. the
+      // swipe-area, which only opens the drawer) keep the original press position so a quick flick
+      // still registers: on a low-refresh-rate display the whole travel can land in this single
+      // first move, and discarding it would drop the gesture.
       if (trackDrag) {
         dragStartPosRef.current = position;
         const moveTime = getValidTimeStamp(event.timeStamp);

--- a/packages/react/src/utils/useSwipeDismiss.ts
+++ b/packages/react/src/utils/useSwipeDismiss.ts
@@ -564,7 +564,7 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
     pendingSwipeRef.current = true;
     pendingSwipeStartPosRef.current = startPos;
     swipeFromScrollableRef.current = false;
-    sawPrimaryButtonsOnMoveRef.current = false;
+    sawPrimaryButtonsOnMoveRef.current = !('touches' in event);
 
     const allowedToStart = canStart
       ? canStart(startPos, {

--- a/packages/react/src/utils/useSwipeDismiss.ts
+++ b/packages/react/src/utils/useSwipeDismiss.ts
@@ -604,14 +604,20 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
     }
 
     if (isFirstPointerMoveRef.current) {
-      // Adjust the starting position to the current position on the first move
-      // to account for the delay between pointerdown and the first pointermove on iOS.
-      dragStartPosRef.current = position;
-      const moveTime = getValidTimeStamp(event.timeStamp);
-      if (moveTime !== null) {
-        swipeStartTimeRef.current = moveTime;
-      }
       isFirstPointerMoveRef.current = false;
+      // Adjust the starting position to the current position on the first move to account for the
+      // delay between pointerdown and the first pointermove on iOS, which would otherwise make the
+      // dragged element jump. This only matters when an element is following the pointer; when
+      // `trackDrag` is false (e.g. the swipe-area that just opens the drawer) keeping the original
+      // press position is what lets a quick flick register — on a low-refresh-rate display the
+      // whole travel can land in this single first move, and discarding it would drop the gesture.
+      if (trackDrag) {
+        dragStartPosRef.current = position;
+        const moveTime = getValidTimeStamp(event.timeStamp);
+        if (moveTime !== null) {
+          swipeStartTimeRef.current = moveTime;
+        }
+      }
     }
 
     const clientX = position.x;


### PR DESCRIPTION
Two fixes for `Drawer.SwipeArea` swipe-to-open:

- **Quick flicks didn't open on low refresh displays.** The shared swipe gesture discards the first move's displacement to avoid the dragged element jumping, but on a fast flick (especially on a low-refresh display) the whole travel can land in that single move. The swipe area has no element to jump (`trackDrag: false`), so the gesture was lost — skip the calibration when `trackDrag` is false. This was only noticeable on a 60 Hz MacBook Neo; a 120 Hz MacBook Pro was unaffected (the higher sample rate splits the flick across multiple moves).
- **Dragging past the popup and releasing randomly dismissed.** The gesture's own pointerup synthesizes a `click` over the backdrop, which outside-press dismissal closed at random (the timer re-enabling dismissal raced that click). Re-enable on the next fresh pointerdown instead: the synthesized click has no pointerdown of its own so it's ignored, while a deliberate outside press still dismisses. Again, only noticeable on the 60 Hz Neo, not the Pro