### PR TITLE
[dialog][alert dialog][drawer] Make the Root part own the store

### DIFF
--- a/docs/src/app/(docs)/react/components/alert-dialog/page.mdx
+++ b/docs/src/app/(docs)/react/components/alert-dialog/page.mdx
@@ -99,6 +99,9 @@ For simple, one-off interactions, place the `<AlertDialog.Trigger>` inside `<Ale
 However, if defining the alert dialog's content next to its trigger is not practical, you can use a detached trigger.
 This involves placing the `<AlertDialog.Trigger>` outside of `<AlertDialog.Root>` and linking them with a `handle` created by the `AlertDialog.createHandle()` function.
 
+The imperative methods on the handle, such as `open()` and `openWithPayload()`, require an `<AlertDialog.Root>` using the same handle to be mounted.
+Calls made before the root is attached to the handle are ignored; the root owns fresh state each time it mounts.
+
 ```jsx title="Detached triggers"
 const demoAlertDialog = AlertDialog.createHandle();
 

--- a/docs/src/app/(docs)/react/components/alert-dialog/page.mdx
+++ b/docs/src/app/(docs)/react/components/alert-dialog/page.mdx
@@ -100,7 +100,7 @@ However, if defining the alert dialog's content next to its trigger is not pract
 This involves placing the `<AlertDialog.Trigger>` outside of `<AlertDialog.Root>` and linking them with a `handle` created by the `AlertDialog.createHandle()` function.
 
 The imperative methods on the handle, such as `open()` and `openWithPayload()`, require an `<AlertDialog.Root>` using the same handle to be mounted.
-Calls made before the root is attached to the handle are ignored; the root owns fresh state each time it mounts.
+Calls made while no root is attached to the handle, before one mounts or after it unmounts, are ignored; the root owns fresh state each time it mounts.
 
 ```jsx title="Detached triggers"
 const demoAlertDialog = AlertDialog.createHandle();

--- a/docs/src/app/(docs)/react/components/alert-dialog/page.mdx
+++ b/docs/src/app/(docs)/react/components/alert-dialog/page.mdx
@@ -100,7 +100,7 @@ However, if defining the alert dialog's content next to its trigger is not pract
 This involves placing the `<AlertDialog.Trigger>` outside of `<AlertDialog.Root>` and linking them with a `handle` created by the `AlertDialog.createHandle()` function.
 
 The imperative methods on the handle, such as `open()` and `openWithPayload()`, require an `<AlertDialog.Root>` using the same handle to be mounted.
-Calls made while no root is attached to the handle, before one mounts or after it unmounts, are ignored; the root owns fresh state each time it mounts.
+Calls made while no root is attached to the handle — before one mounts, or after it unmounts — are ignored. Each time a root mounts, it starts from fresh state: a call made while no root was attached is not replayed, and no open state carries over from a previous mount.
 
 ```jsx title="Detached triggers"
 const demoAlertDialog = AlertDialog.createHandle();

--- a/docs/src/app/(docs)/react/components/alert-dialog/types.md
+++ b/docs/src/app/(docs)/react/components/alert-dialog/types.md
@@ -366,10 +366,12 @@ type ReturnValue = AlertDialog.Handle<Payload>;
 
 ### Handle
 
-A handle to control an Alert Dialog imperatively and to associate detached triggers with it.
+Controls an Alert Dialog imperatively and associates detached `AlertDialog.Trigger` components with
+an `AlertDialog.Root`. Create one with `AlertDialog.createHandle()` and pass it to the `handle`
+prop of the root and of any triggers rendered outside of it.
 
-The imperative methods on the handle require an AlertDialog.Root using the same handle to be mounted.
-Calls made before the root is attached to the handle are ignored; the root owns fresh state when it mounts.
+The imperative methods take effect only while a root using this handle is mounted; calls made
+before a root attaches (or after it unmounts) are ignored.
 
 **Properties:**
 

--- a/docs/src/app/(docs)/react/components/alert-dialog/types.md
+++ b/docs/src/app/(docs)/react/components/alert-dialog/types.md
@@ -369,19 +369,13 @@ type ReturnValue = AlertDialog.Handle<Payload>;
 A handle to control an Alert Dialog imperatively and to associate detached triggers with it.
 
 The imperative methods on the handle require an AlertDialog.Root using the same handle to be mounted.
-Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
-
-**Constructor Parameters:**
-
-| Parameter | Type                   | Default | Description                              |
-| :-------- | :--------------------- | :------ | :--------------------------------------- |
-| store?    | `DialogStore<Payload>` | -       | Internal store holding the dialog state. |
+Calls made before the root is attached to the handle are ignored; the root owns fresh state when it mounts.
 
 **Properties:**
 
-| Property | Type      | Modifiers | Description                                     |
-| :------- | :-------- | :-------- | :---------------------------------------------- |
-| isOpen   | `boolean` | readonly  | Indicates whether the dialog is currently open. |
+| Property | Type      | Modifiers | Description                                                                                    |
+| :------- | :-------- | :-------- | :--------------------------------------------------------------------------------------------- |
+| isOpen   | `boolean` | readonly  | Whether the dialog is currently open. Returns `false` while no root is attached to the handle. |
 
 **Methods:**
 
@@ -389,8 +383,7 @@ Calls made before the root is attached to the handle are ignored; the store is r
 function open(triggerId: string | null): void;
 ```
 
-Opens the dialog and associates it with the trigger with the given id.
-The trigger, if provided, must be a matching Trigger component with this handle passed as a prop.
+Opens the dialog, optionally associating it with a trigger.
 
 This method should only be called in an event handler or an effect (not during rendering).
 
@@ -398,14 +391,17 @@ This method should only be called in an event handler or an effect (not during r
 function openWithPayload(payload: Payload): void;
 ```
 
-Opens the dialog and sets the payload.
-Does not associate the dialog with any trigger.
+Opens the dialog with the given payload, without associating it with any trigger.
+
+This method should only be called in an event handler or an effect (not during rendering).
 
 ```typescript
 function close(): void;
 ```
 
 Closes the dialog.
+
+This method should only be called in an event handler or an effect (not during rendering).
 
 ## External Types
 

--- a/docs/src/app/(docs)/react/components/alert-dialog/types.md
+++ b/docs/src/app/(docs)/react/components/alert-dialog/types.md
@@ -369,7 +369,7 @@ type ReturnValue = AlertDialog.Handle<Payload>;
 A handle to control an Alert Dialog imperatively and to associate detached triggers with it.
 
 The imperative methods on the handle require an AlertDialog.Root using the same handle to be mounted.
-Calls made before the root is attached to the handle are not queued for a later mount.
+Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
 
 **Constructor Parameters:**
 

--- a/docs/src/app/(docs)/react/components/alert-dialog/types.md
+++ b/docs/src/app/(docs)/react/components/alert-dialog/types.md
@@ -368,6 +368,9 @@ type ReturnValue = AlertDialog.Handle<Payload>;
 
 A handle to control an Alert Dialog imperatively and to associate detached triggers with it.
 
+The imperative methods on the handle require an AlertDialog.Root using the same handle to be mounted.
+Calls made before the root is attached to the handle are not queued for a later mount.
+
 **Constructor Parameters:**
 
 | Parameter | Type                   | Default | Description                              |

--- a/docs/src/app/(docs)/react/components/dialog/page.mdx
+++ b/docs/src/app/(docs)/react/components/dialog/page.mdx
@@ -195,7 +195,7 @@ However, if defining the dialog's content next to its trigger is not practical, 
 This involves placing the `<Dialog.Trigger>` outside of `<Dialog.Root>` and linking them with a `handle` created by the `Dialog.createHandle()` function.
 
 The imperative methods on the handle, such as `open()` and `openWithPayload()`, require a `<Dialog.Root>` using the same handle to be mounted.
-Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
+Calls made before the root is attached to the handle are ignored; the root owns fresh state each time it mounts.
 
 ```jsx title="Detached triggers"
 const demoDialog = Dialog.createHandle();

--- a/docs/src/app/(docs)/react/components/dialog/page.mdx
+++ b/docs/src/app/(docs)/react/components/dialog/page.mdx
@@ -195,7 +195,7 @@ However, if defining the dialog's content next to its trigger is not practical, 
 This involves placing the `<Dialog.Trigger>` outside of `<Dialog.Root>` and linking them with a `handle` created by the `Dialog.createHandle()` function.
 
 The imperative methods on the handle, such as `open()` and `openWithPayload()`, require a `<Dialog.Root>` using the same handle to be mounted.
-Calls made while no root is attached to the handle, before one mounts or after it unmounts, are ignored; the root owns fresh state each time it mounts.
+Calls made while no root is attached to the handle — before one mounts, or after it unmounts — are ignored. Each time a root mounts, it starts from fresh state: a call made while no root was attached is not replayed, and no open state carries over from a previous mount.
 
 ```jsx title="Detached triggers"
 const demoDialog = Dialog.createHandle();

--- a/docs/src/app/(docs)/react/components/dialog/page.mdx
+++ b/docs/src/app/(docs)/react/components/dialog/page.mdx
@@ -195,7 +195,7 @@ However, if defining the dialog's content next to its trigger is not practical, 
 This involves placing the `<Dialog.Trigger>` outside of `<Dialog.Root>` and linking them with a `handle` created by the `Dialog.createHandle()` function.
 
 The imperative methods on the handle, such as `open()` and `openWithPayload()`, require a `<Dialog.Root>` using the same handle to be mounted.
-Calls made before the root is attached to the handle are ignored; the root owns fresh state each time it mounts.
+Calls made while no root is attached to the handle, before one mounts or after it unmounts, are ignored; the root owns fresh state each time it mounts.
 
 ```jsx title="Detached triggers"
 const demoDialog = Dialog.createHandle();

--- a/docs/src/app/(docs)/react/components/dialog/page.mdx
+++ b/docs/src/app/(docs)/react/components/dialog/page.mdx
@@ -194,6 +194,9 @@ For simple, one-off interactions, place the `<Dialog.Trigger>` inside `<Dialog.R
 However, if defining the dialog's content next to its trigger is not practical, you can use a detached trigger.
 This involves placing the `<Dialog.Trigger>` outside of `<Dialog.Root>` and linking them with a `handle` created by the `Dialog.createHandle()` function.
 
+The imperative methods on the handle, such as `open()` and `openWithPayload()`, require a `<Dialog.Root>` using the same handle to be mounted.
+Calls made before the root is attached to the handle are not queued for a later mount.
+
 ```jsx title="Detached triggers"
 const demoDialog = Dialog.createHandle();
 

--- a/docs/src/app/(docs)/react/components/dialog/page.mdx
+++ b/docs/src/app/(docs)/react/components/dialog/page.mdx
@@ -195,7 +195,7 @@ However, if defining the dialog's content next to its trigger is not practical, 
 This involves placing the `<Dialog.Trigger>` outside of `<Dialog.Root>` and linking them with a `handle` created by the `Dialog.createHandle()` function.
 
 The imperative methods on the handle, such as `open()` and `openWithPayload()`, require a `<Dialog.Root>` using the same handle to be mounted.
-Calls made before the root is attached to the handle are not queued for a later mount.
+Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
 
 ```jsx title="Detached triggers"
 const demoDialog = Dialog.createHandle();

--- a/docs/src/app/(docs)/react/components/dialog/types.md
+++ b/docs/src/app/(docs)/react/components/dialog/types.md
@@ -370,6 +370,9 @@ type ReturnValue = Dialog.Handle<Payload>;
 
 A handle to control a Dialog imperatively and to associate detached triggers with it.
 
+The imperative methods on the handle require the associated root component using the same handle to be mounted.
+Calls made before the root is attached to the handle are not queued for a later mount.
+
 **Constructor Parameters:**
 
 | Parameter | Type                   | Default | Description |

--- a/docs/src/app/(docs)/react/components/dialog/types.md
+++ b/docs/src/app/(docs)/react/components/dialog/types.md
@@ -373,8 +373,7 @@ Controls a Dialog imperatively and associates detached `Dialog.Trigger` componen
 root and of any triggers rendered outside of it.
 
 The imperative methods take effect only while a root using this handle is mounted; calls made
-before a root attaches (or after it unmounts) are ignored. Each attached root owns fresh state,
-so dialog state never leaks from one mounted root to the next.
+before a root attaches (or after it unmounts) are ignored.
 
 **Properties:**
 

--- a/docs/src/app/(docs)/react/components/dialog/types.md
+++ b/docs/src/app/(docs)/react/components/dialog/types.md
@@ -368,22 +368,19 @@ type ReturnValue = Dialog.Handle<Payload>;
 
 ### Handle
 
-A handle to control a Dialog imperatively and to associate detached triggers with it.
+Controls a Dialog imperatively and associates detached `Dialog.Trigger` components with a
+`Dialog.Root`. Create one with `Dialog.createHandle()` and pass it to the `handle` prop of the
+root and of any triggers rendered outside of it.
 
-The imperative methods on the handle require the associated root component using the same handle to be mounted.
-Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
-
-**Constructor Parameters:**
-
-| Parameter | Type                   | Default | Description |
-| :-------- | :--------------------- | :------ | :---------- |
-| store?    | `DialogStore<Payload>` | -       | -           |
+The imperative methods take effect only while a root using this handle is mounted; calls made
+before a root attaches (or after it unmounts) are ignored. Each attached root owns fresh state,
+so dialog state never leaks from one mounted root to the next.
 
 **Properties:**
 
-| Property | Type      | Modifiers | Description                                     |
-| :------- | :-------- | :-------- | :---------------------------------------------- |
-| isOpen   | `boolean` | readonly  | Indicates whether the dialog is currently open. |
+| Property | Type      | Modifiers | Description                                                                                    |
+| :------- | :-------- | :-------- | :--------------------------------------------------------------------------------------------- |
+| isOpen   | `boolean` | readonly  | Whether the dialog is currently open. Returns `false` while no root is attached to the handle. |
 
 **Methods:**
 
@@ -391,8 +388,7 @@ Calls made before the root is attached to the handle are ignored; the store is r
 function open(triggerId: string | null): void;
 ```
 
-Opens the dialog and associates it with the trigger with the given id.
-The trigger, if provided, must be a matching Trigger component with this handle passed as a prop.
+Opens the dialog, optionally associating it with a trigger.
 
 This method should only be called in an event handler or an effect (not during rendering).
 
@@ -400,14 +396,17 @@ This method should only be called in an event handler or an effect (not during r
 function openWithPayload(payload: Payload): void;
 ```
 
-Opens the dialog and sets the payload.
-Does not associate the dialog with any trigger.
+Opens the dialog with the given payload, without associating it with any trigger.
+
+This method should only be called in an event handler or an effect (not during rendering).
 
 ```typescript
 function close(): void;
 ```
 
 Closes the dialog.
+
+This method should only be called in an event handler or an effect (not during rendering).
 
 ## External Types
 

--- a/docs/src/app/(docs)/react/components/dialog/types.md
+++ b/docs/src/app/(docs)/react/components/dialog/types.md
@@ -371,7 +371,7 @@ type ReturnValue = Dialog.Handle<Payload>;
 A handle to control a Dialog imperatively and to associate detached triggers with it.
 
 The imperative methods on the handle require the associated root component using the same handle to be mounted.
-Calls made before the root is attached to the handle are not queued for a later mount.
+Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
 
 **Constructor Parameters:**
 

--- a/docs/src/app/(docs)/react/components/drawer/page.mdx
+++ b/docs/src/app/(docs)/react/components/drawer/page.mdx
@@ -217,7 +217,7 @@ A drawer can be controlled by a trigger located either inside or outside the `<D
 However, if defining the drawer's content next to its trigger is not practical, you can use a detached trigger. This involves placing the `<Drawer.Trigger>` outside of `<Drawer.Root>` and linking them with a `handle` created by the `Drawer.createHandle()` function.
 
 The imperative methods on the handle, such as `open()` and `openWithPayload()`, require a `<Drawer.Root>` using the same handle to be mounted.
-Calls made before the root is attached to the handle are ignored; the root owns fresh state each time it mounts.
+Calls made while no root is attached to the handle, before one mounts or after it unmounts, are ignored; the root owns fresh state each time it mounts.
 
 ```jsx title="Detached triggers"
 const demoDrawer = Drawer.createHandle();

--- a/docs/src/app/(docs)/react/components/drawer/page.mdx
+++ b/docs/src/app/(docs)/react/components/drawer/page.mdx
@@ -217,7 +217,7 @@ A drawer can be controlled by a trigger located either inside or outside the `<D
 However, if defining the drawer's content next to its trigger is not practical, you can use a detached trigger. This involves placing the `<Drawer.Trigger>` outside of `<Drawer.Root>` and linking them with a `handle` created by the `Drawer.createHandle()` function.
 
 The imperative methods on the handle, such as `open()` and `openWithPayload()`, require a `<Drawer.Root>` using the same handle to be mounted.
-Calls made while no root is attached to the handle, before one mounts or after it unmounts, are ignored; the root owns fresh state each time it mounts.
+Calls made while no root is attached to the handle — before one mounts, or after it unmounts — are ignored. Each time a root mounts, it starts from fresh state: a call made while no root was attached is not replayed, and no open state carries over from a previous mount.
 
 ```jsx title="Detached triggers"
 const demoDrawer = Drawer.createHandle();

--- a/docs/src/app/(docs)/react/components/drawer/page.mdx
+++ b/docs/src/app/(docs)/react/components/drawer/page.mdx
@@ -216,6 +216,9 @@ A drawer can be controlled by a trigger located either inside or outside the `<D
 
 However, if defining the drawer's content next to its trigger is not practical, you can use a detached trigger. This involves placing the `<Drawer.Trigger>` outside of `<Drawer.Root>` and linking them with a `handle` created by the `Drawer.createHandle()` function.
 
+The imperative methods on the handle, such as `open()` and `openWithPayload()`, require a `<Drawer.Root>` using the same handle to be mounted.
+Calls made before the root is attached to the handle are ignored; the root owns fresh state each time it mounts.
+
 ```jsx title="Detached triggers"
 const demoDrawer = Drawer.createHandle();
 

--- a/docs/src/app/(docs)/react/components/drawer/types.md
+++ b/docs/src/app/(docs)/react/components/drawer/types.md
@@ -488,6 +488,9 @@ type ReturnValue = Drawer.Handle<Payload>;
 
 A handle to control a Dialog imperatively and to associate detached triggers with it.
 
+The imperative methods on the handle require the associated root component using the same handle to be mounted.
+Calls made before the root is attached to the handle are not queued for a later mount.
+
 **Constructor Parameters:**
 
 | Parameter | Type                   | Default | Description |

--- a/docs/src/app/(docs)/react/components/drawer/types.md
+++ b/docs/src/app/(docs)/react/components/drawer/types.md
@@ -486,22 +486,19 @@ type ReturnValue = Drawer.Handle<Payload>;
 
 ### Handle
 
-A handle to control a Dialog imperatively and to associate detached triggers with it.
+Controls a Dialog imperatively and associates detached `Dialog.Trigger` components with a
+`Dialog.Root`. Create one with `Dialog.createHandle()` and pass it to the `handle` prop of the
+root and of any triggers rendered outside of it.
 
-The imperative methods on the handle require the associated root component using the same handle to be mounted.
-Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
-
-**Constructor Parameters:**
-
-| Parameter | Type                   | Default | Description |
-| :-------- | :--------------------- | :------ | :---------- |
-| store?    | `DialogStore<Payload>` | -       | -           |
+The imperative methods take effect only while a root using this handle is mounted; calls made
+before a root attaches (or after it unmounts) are ignored. Each attached root owns fresh state,
+so dialog state never leaks from one mounted root to the next.
 
 **Properties:**
 
-| Property | Type      | Modifiers | Description                                     |
-| :------- | :-------- | :-------- | :---------------------------------------------- |
-| isOpen   | `boolean` | readonly  | Indicates whether the dialog is currently open. |
+| Property | Type      | Modifiers | Description                                                                                    |
+| :------- | :-------- | :-------- | :--------------------------------------------------------------------------------------------- |
+| isOpen   | `boolean` | readonly  | Whether the dialog is currently open. Returns `false` while no root is attached to the handle. |
 
 **Methods:**
 
@@ -509,8 +506,7 @@ Calls made before the root is attached to the handle are ignored; the store is r
 function open(triggerId: string | null): void;
 ```
 
-Opens the dialog and associates it with the trigger with the given id.
-The trigger, if provided, must be a matching Trigger component with this handle passed as a prop.
+Opens the dialog, optionally associating it with a trigger.
 
 This method should only be called in an event handler or an effect (not during rendering).
 
@@ -518,14 +514,17 @@ This method should only be called in an event handler or an effect (not during r
 function openWithPayload(payload: Payload): void;
 ```
 
-Opens the dialog and sets the payload.
-Does not associate the dialog with any trigger.
+Opens the dialog with the given payload, without associating it with any trigger.
+
+This method should only be called in an event handler or an effect (not during rendering).
 
 ```typescript
 function close(): void;
 ```
 
 Closes the dialog.
+
+This method should only be called in an event handler or an effect (not during rendering).
 
 ### Indent
 

--- a/docs/src/app/(docs)/react/components/drawer/types.md
+++ b/docs/src/app/(docs)/react/components/drawer/types.md
@@ -168,7 +168,7 @@ Renders a `<button>` element.
 
 | Prop         | Type                                                                                         | Default | Description                                                                                                                                                                                          |
 | :----------- | :------------------------------------------------------------------------------------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| handle       | `DrawerHandle<Payload>`                                                                      | -       | A handle to associate the trigger with a drawer.&#xA;Can be created with the Drawer.createHandle() method.                                                                                           |
+| handle       | `Drawer.Handle<Payload>`                                                                     | -       | A handle to associate the trigger with a drawer.&#xA;Can be created with the Drawer.createHandle() method.                                                                                           |
 | nativeButton | `boolean`                                                                                    | `true`  | Whether the component renders a native `<button>` element when replacing it&#xA;via the `render` prop.&#xA;Set to `false` if the rendered element is not a button (for example, `<div>`).            |
 | payload      | `Payload`                                                                                    | -       | A payload to pass to the drawer when it is opened.                                                                                                                                                   |
 | id           | `string`                                                                                     | -       | ID of the trigger. In addition to being forwarded to the rendered element,&#xA;it is also used to specify the active trigger for drawers in controlled mode (with the Drawer.Root `triggerId` prop). |
@@ -476,7 +476,7 @@ type DrawerViewportState = {
 
 ### createHandle
 
-Creates a new handle to connect a Dialog.Root with detached Dialog.Trigger components.
+Creates a new handle to connect a Drawer.Root with detached Drawer.Trigger components.
 
 **Return Value:**
 
@@ -486,8 +486,8 @@ type ReturnValue = Drawer.Handle<Payload>;
 
 ### Handle
 
-Controls a Dialog imperatively and associates detached `Dialog.Trigger` components with a
-`Dialog.Root`. Create one with `Dialog.createHandle()` and pass it to the `handle` prop of the
+Controls a Drawer imperatively and associates detached `Drawer.Trigger` components with a
+`Drawer.Root`. Create one with `Drawer.createHandle()` and pass it to the `handle` prop of the
 root and of any triggers rendered outside of it.
 
 The imperative methods take effect only while a root using this handle is mounted; calls made

--- a/docs/src/app/(docs)/react/components/drawer/types.md
+++ b/docs/src/app/(docs)/react/components/drawer/types.md
@@ -489,7 +489,7 @@ type ReturnValue = Drawer.Handle<Payload>;
 A handle to control a Dialog imperatively and to associate detached triggers with it.
 
 The imperative methods on the handle require the associated root component using the same handle to be mounted.
-Calls made before the root is attached to the handle are not queued for a later mount.
+Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
 
 **Constructor Parameters:**
 

--- a/docs/src/app/(docs)/react/components/drawer/types.md
+++ b/docs/src/app/(docs)/react/components/drawer/types.md
@@ -491,8 +491,7 @@ Controls a Dialog imperatively and associates detached `Dialog.Trigger` componen
 root and of any triggers rendered outside of it.
 
 The imperative methods take effect only while a root using this handle is mounted; calls made
-before a root attaches (or after it unmounts) are ignored. Each attached root owns fresh state,
-so dialog state never leaks from one mounted root to the next.
+before a root attaches (or after it unmounts) are ignored.
 
 **Properties:**
 

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -140,7 +140,6 @@ A dialog that requires a user response to proceed.
     - Data Attributes: data-closed, data-ending-style, data-nested, data-nested-dialog-open, data-open, data-starting-style
   - Alert Dialog - createHandle
   - Alert Dialog - Handle
-    - Parameters: store
 - Types: AlertDialog.Backdrop.Props, AlertDialog.Backdrop.State, AlertDialog.Close.Props, AlertDialog.Close.State, AlertDialog.Description.Props, AlertDialog.Description.State, AlertDialog.Popup.Props, AlertDialog.Popup.State, AlertDialog.Portal.Props, AlertDialog.Portal.State, AlertDialog.Root.Actions, AlertDialog.Root.ChangeEventDetails, AlertDialog.Root.ChangeEventReason, AlertDialog.Root.Props, AlertDialog.Root.State, AlertDialog.Title.Props, AlertDialog.Title.State, AlertDialog.Trigger.Props, AlertDialog.Trigger.State, AlertDialog.Viewport.Props, AlertDialog.Viewport.State
 
 </details>
@@ -683,7 +682,6 @@ A popup that opens on top of the entire page.
     - Data Attributes: data-closed, data-ending-style, data-nested, data-nested-dialog-open, data-open, data-starting-style
   - Dialog - createHandle
   - Dialog - Handle
-    - Parameters: store
 - Types: Dialog.Backdrop.Props, Dialog.Backdrop.State, Dialog.Close.Props, Dialog.Close.State, Dialog.Description.Props, Dialog.Description.State, Dialog.Popup.Props, Dialog.Popup.State, Dialog.Portal.Props, Dialog.Portal.State, Dialog.Root.Actions, Dialog.Root.ChangeEventDetails, Dialog.Root.ChangeEventReason, Dialog.Root.Props, Dialog.Root.State, Dialog.Title.Props, Dialog.Title.State, Dialog.Trigger.Props, Dialog.Trigger.State, Dialog.Viewport.Props, Dialog.Viewport.State
 
 </details>
@@ -765,7 +763,6 @@ A panel that slides in from the edge of the screen.
     - CSS Variables: --drawer-keyboard-inset
   - Drawer - createHandle
   - Drawer - Handle
-    - Parameters: store
   - Drawer - Indent
     - Props: className, render, style
   - Drawer - IndentBackground

--- a/docs/src/app/(private)/experiments/dialog/unmount-remount.tsx
+++ b/docs/src/app/(private)/experiments/dialog/unmount-remount.tsx
@@ -23,6 +23,7 @@ export default function DialogUnmountRemountExperiment() {
       <div className={styles.Container}>
         <Dialog.Trigger
           handle={dialogHandle}
+          id="unmount-remount-trigger-1"
           className={clsx(demoStyles.Button, styles.Button)}
           disabled={!mounted}
         >
@@ -31,6 +32,7 @@ export default function DialogUnmountRemountExperiment() {
 
         <Dialog.Trigger
           handle={dialogHandle}
+          id="unmount-remount-trigger-2"
           className={clsx(demoStyles.Button, styles.Button)}
           disabled={!mounted}
         >

--- a/docs/src/app/(private)/experiments/dialog/unmount-remount.tsx
+++ b/docs/src/app/(private)/experiments/dialog/unmount-remount.tsx
@@ -1,0 +1,99 @@
+'use client';
+import * as React from 'react';
+import clsx from 'clsx';
+import { Dialog } from '@base-ui/react/dialog';
+import demoStyles from 'docs/src/app/(docs)/react/components/dialog/demos/hero/css-modules/index.module.css';
+import styles from './dialog.module.css';
+
+const dialogHandle = Dialog.createHandle();
+
+export default function DialogUnmountRemountExperiment() {
+  const [mounted, setMounted] = React.useState(true);
+  const [mountCount, setMountCount] = React.useState(1);
+
+  function remountDialog() {
+    setMountCount((count) => count + 1);
+    setMounted(true);
+  }
+
+  return (
+    <div className={styles.Page}>
+      <h1>Dialog unmount/remount with handle</h1>
+
+      <div className={styles.Container}>
+        <Dialog.Trigger
+          handle={dialogHandle}
+          className={clsx(demoStyles.Button, styles.Button)}
+          disabled={!mounted}
+        >
+          Open dialog
+        </Dialog.Trigger>
+
+        <button
+          type="button"
+          className={clsx(demoStyles.Button, styles.Button)}
+          onClick={() => setMounted(false)}
+          disabled={!mounted}
+        >
+          Unmount dialog subtree
+        </button>
+
+        <button
+          type="button"
+          className={clsx(demoStyles.Button, styles.Button)}
+          onClick={remountDialog}
+          disabled={mounted}
+        >
+          Remount dialog subtree
+        </button>
+      </div>
+
+      <div className={styles.DialogSection}>
+        <p>
+          Mount state: {mounted ? 'mounted' : 'unmounted'} (mount #{mountCount})
+        </p>
+        <p>
+          Open the dialog, press "Unmount dialog subtree" inside it, then remount it. The
+          module-scoped handle should not preserve the pre-unmount open state.
+        </p>
+      </div>
+
+      {mounted && <ReproDialog key={mountCount} onUnmount={() => setMounted(false)} />}
+    </div>
+  );
+}
+
+interface ReproDialogProps {
+  onUnmount: () => void;
+}
+
+function ReproDialog(props: ReproDialogProps) {
+  return (
+    <Dialog.Root handle={dialogHandle}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className={demoStyles.Backdrop} />
+        <Dialog.Popup className={demoStyles.Popup}>
+          <Dialog.Title className={demoStyles.Title}>Dialog with handle</Dialog.Title>
+          <Dialog.Description className={demoStyles.Description}>
+            This dialog is unmounted while open, then mounted again with the same handle.
+          </Dialog.Description>
+
+          <div className={styles.DialogSection}>
+            <p>This simulates navigating away while a detached-trigger dialog is open.</p>
+          </div>
+
+          <div className={clsx(demoStyles.Actions, styles.Actions)}>
+            <button
+              type="button"
+              className={clsx(demoStyles.Button, styles.Button)}
+              onClick={props.onUnmount}
+            >
+              Unmount dialog subtree
+            </button>
+            <Dialog.Close className={clsx(demoStyles.Button, styles.Button)}>Close</Dialog.Close>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/docs/src/app/(private)/experiments/dialog/unmount-remount.tsx
+++ b/docs/src/app/(private)/experiments/dialog/unmount-remount.tsx
@@ -29,6 +29,14 @@ export default function DialogUnmountRemountExperiment() {
           Open dialog
         </Dialog.Trigger>
 
+        <Dialog.Trigger
+          handle={dialogHandle}
+          className={clsx(demoStyles.Button, styles.Button)}
+          disabled={!mounted}
+        >
+          Open dialog from second trigger
+        </Dialog.Trigger>
+
         <button
           type="button"
           className={clsx(demoStyles.Button, styles.Button)}

--- a/packages/react/src/alert-dialog/handle.ts
+++ b/packages/react/src/alert-dialog/handle.ts
@@ -9,6 +9,9 @@ export const alertDialogState = {
 
 /**
  * A handle to control an Alert Dialog imperatively and to associate detached triggers with it.
+ *
+ * The imperative methods on the handle require an AlertDialog.Root using the same handle to be mounted.
+ * Calls made before the root is attached to the handle are not queued for a later mount.
  */
 export class AlertDialogHandle<Payload> extends DialogHandle<Payload> {
   private readonly __alertDialogBrand!: never;

--- a/packages/react/src/alert-dialog/handle.ts
+++ b/packages/react/src/alert-dialog/handle.ts
@@ -9,6 +9,8 @@ import { DialogHandle } from '../dialog/store/DialogHandle';
  * before a root attaches (or after it unmounts) are ignored.
  */
 export class AlertDialogHandle<Payload> extends DialogHandle<Payload> {
+  // Nominal brand: makes this handle type distinct from `DialogHandle` and sibling handles so they
+  // can't be passed interchangeably. Type-only; has no runtime presence.
   private readonly __alertDialogBrand!: never;
 }
 

--- a/packages/react/src/alert-dialog/handle.ts
+++ b/packages/react/src/alert-dialog/handle.ts
@@ -1,10 +1,12 @@
 import { DialogHandle } from '../dialog/store/DialogHandle';
 
 /**
- * A handle to control an Alert Dialog imperatively and to associate detached triggers with it.
+ * Controls an Alert Dialog imperatively and associates detached `AlertDialog.Trigger` components with
+ * an `AlertDialog.Root`. Create one with `AlertDialog.createHandle()` and pass it to the `handle`
+ * prop of the root and of any triggers rendered outside of it.
  *
- * The imperative methods on the handle require an AlertDialog.Root using the same handle to be mounted.
- * Calls made before the root is attached to the handle are ignored; the root owns fresh state when it mounts.
+ * The imperative methods take effect only while a root using this handle is mounted; calls made
+ * before a root attaches (or after it unmounts) are ignored.
  */
 export class AlertDialogHandle<Payload> extends DialogHandle<Payload> {
   private readonly __alertDialogBrand!: never;

--- a/packages/react/src/alert-dialog/handle.ts
+++ b/packages/react/src/alert-dialog/handle.ts
@@ -11,7 +11,7 @@ export const alertDialogState = {
  * A handle to control an Alert Dialog imperatively and to associate detached triggers with it.
  *
  * The imperative methods on the handle require an AlertDialog.Root using the same handle to be mounted.
- * Calls made before the root is attached to the handle are not queued for a later mount.
+ * Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
  */
 export class AlertDialogHandle<Payload> extends DialogHandle<Payload> {
   private readonly __alertDialogBrand!: never;

--- a/packages/react/src/alert-dialog/handle.ts
+++ b/packages/react/src/alert-dialog/handle.ts
@@ -1,30 +1,13 @@
 import { DialogHandle } from '../dialog/store/DialogHandle';
-import { DialogStore } from '../dialog/store/DialogStore';
-
-export const alertDialogState = {
-  modal: true,
-  disablePointerDismissal: true,
-  role: 'alertdialog',
-} as const;
 
 /**
  * A handle to control an Alert Dialog imperatively and to associate detached triggers with it.
  *
  * The imperative methods on the handle require an AlertDialog.Root using the same handle to be mounted.
- * Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
+ * Calls made before the root is attached to the handle are ignored; the root owns fresh state when it mounts.
  */
 export class AlertDialogHandle<Payload> extends DialogHandle<Payload> {
   private readonly __alertDialogBrand!: never;
-
-  constructor(store?: DialogStore<Payload>) {
-    const alertDialogStore = store ?? new DialogStore<Payload>(alertDialogState);
-    super(alertDialogStore);
-
-    if (store) {
-      // Supplied stores may have been created as plain dialogs; enforce alert-dialog state.
-      this.store.update(alertDialogState);
-    }
-  }
 }
 
 /**

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
@@ -699,9 +699,10 @@ describe('<AlertDialog.Root />', () => {
       expect(trigger.getAttribute('aria-controls')).toBe(popup.getAttribute('id'));
 
       await user.click(screen.getByRole('presentation', { hidden: true }));
-      await waitFor(() => {
-        expect(screen.queryByRole('alertdialog')).not.toBe(null);
-      });
+      await flushMicrotasks();
+
+      expect(screen.queryByRole('alertdialog')).not.toBe(null);
+      expect(testDialog.isOpen).toBe(true);
     });
 
     it('keeps detached triggers clickable when reparented (remove wrappers)', async () => {

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
@@ -1,7 +1,7 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import type { UserEvent } from '@testing-library/user-event';
-import { act, screen, waitFor } from '@mui/internal-test-utils';
+import { act, screen, waitFor, within } from '@mui/internal-test-utils';
 import { AlertDialog } from '@base-ui/react/alert-dialog';
 import { createRenderer, isJSDOM, popupConformanceTests } from '#test-utils';
 import { DialogStore } from '../../dialog/store/DialogStore';
@@ -643,6 +643,66 @@ describe('<AlertDialog.Root />', () => {
       await user.click(trigger3);
       await waitFor(() => {
         expect(screen.queryByText('Alert dialog content')).not.toBe(null);
+      });
+    });
+
+    it('resets the handle store when the root remounts after being unmounted while open', async () => {
+      const testDialog = AlertDialog.createHandle();
+
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+
+        return (
+          <div>
+            <AlertDialog.Trigger handle={testDialog} id="trigger">
+              Trigger
+            </AlertDialog.Trigger>
+            {!mounted && (
+              <button type="button" onClick={() => setMounted(true)}>
+                Remount root
+              </button>
+            )}
+
+            {mounted && (
+              <AlertDialog.Root handle={testDialog}>
+                <AlertDialog.Portal>
+                  <AlertDialog.Popup>
+                    Alert dialog content
+                    <button type="button" onClick={() => setMounted(false)}>
+                      Unmount root
+                    </button>
+                  </AlertDialog.Popup>
+                </AlertDialog.Portal>
+              </AlertDialog.Root>
+            )}
+          </div>
+        );
+      }
+
+      const { user } = await render(<App />);
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      await user.click(trigger);
+
+      let popup = await screen.findByRole('alertdialog');
+      expect(trigger.getAttribute('aria-controls')).toBe(popup.getAttribute('id'));
+
+      await user.click(within(popup).getByRole('button', { name: 'Unmount root' }));
+      expect(screen.queryByRole('alertdialog')).toBe(null);
+
+      await user.click(screen.getByRole('button', { name: 'Remount root' }));
+      expect(screen.queryByRole('alertdialog')).toBe(null);
+      expect(testDialog.store.select('role')).toBe('alertdialog');
+      expect(testDialog.store.select('disablePointerDismissal')).toBe(true);
+
+      await user.click(trigger);
+
+      popup = await screen.findByRole('alertdialog');
+      expect(trigger.getAttribute('aria-controls')).toBe(popup.getAttribute('id'));
+
+      await user.click(screen.getByRole('presentation', { hidden: true }));
+      await waitFor(() => {
+        expect(screen.queryByRole('alertdialog')).not.toBe(null);
       });
     });
 

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
@@ -1,10 +1,11 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import type { UserEvent } from '@testing-library/user-event';
-import { act, screen, waitFor, within } from '@mui/internal-test-utils';
+import { act, flushMicrotasks, screen, waitFor, within } from '@mui/internal-test-utils';
 import { AlertDialog } from '@base-ui/react/alert-dialog';
 import { createRenderer, isJSDOM, popupConformanceTests } from '#test-utils';
 import { REASONS } from '../../internals/reasons';
+import { useDialogRootContext } from '../../dialog/root/DialogRootContext';
 
 describe('<AlertDialog.Root />', () => {
   const { render } = createRenderer();
@@ -870,6 +871,7 @@ describe('<AlertDialog.Root />', () => {
         <React.Fragment>
           <AlertDialog.Trigger handle={handle}>Open</AlertDialog.Trigger>
           <AlertDialog.Root handle={handle}>
+            <AlertDialogState data-testid="alert-dialog-state" />
             <AlertDialog.Portal>
               <AlertDialog.Popup>Content</AlertDialog.Popup>
             </AlertDialog.Portal>
@@ -877,14 +879,23 @@ describe('<AlertDialog.Root />', () => {
         </React.Fragment>,
       );
 
+      expect(screen.getByTestId('alert-dialog-state')).toHaveAttribute('data-modal', 'true');
+      expect(screen.getByTestId('alert-dialog-state')).toHaveAttribute(
+        'data-disable-pointer-dismissal',
+        'true',
+      );
+      expect(screen.getByTestId('alert-dialog-state')).toHaveAttribute('data-role', 'alertdialog');
+
       await user.click(screen.getByRole('button', { name: 'Open' }));
 
       expect(await screen.findByRole('alertdialog')).not.toBe(null);
+      expect(handle.isOpen).toBe(true);
 
       await user.click(screen.getByRole('presentation', { hidden: true }));
-      await waitFor(() => {
-        expect(screen.queryByRole('alertdialog')).not.toBe(null);
-      });
+      await flushMicrotasks();
+
+      expect(screen.queryByRole('alertdialog')).not.toBe(null);
+      expect(handle.isOpen).toBe(true);
     });
 
     it('keeps the alert dialog open when the backdrop is clicked', async () => {
@@ -910,10 +921,10 @@ describe('<AlertDialog.Root />', () => {
 
       const backdrop = await screen.findByRole('presentation', { hidden: true });
       await user.click(backdrop);
+      await flushMicrotasks();
 
-      await waitFor(() => {
-        expect(screen.queryByRole('alertdialog')).not.toBe(null);
-      });
+      expect(screen.queryByRole('alertdialog')).not.toBe(null);
+      expect(handle.isOpen).toBe(true);
     });
 
     it('opens and closes the dialog', async () => {
@@ -1214,3 +1225,19 @@ describe('<AlertDialog.Root />', () => {
     });
   });
 });
+
+function AlertDialogState(props: React.HTMLAttributes<HTMLDivElement>) {
+  const { store } = useDialogRootContext();
+  const modal = store.useState('modal');
+  const disablePointerDismissal = store.useState('disablePointerDismissal');
+  const role = store.useState('role');
+
+  return (
+    <div
+      {...props}
+      data-modal={modal}
+      data-disable-pointer-dismissal={disablePointerDismissal}
+      data-role={role}
+    />
+  );
+}

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
@@ -4,7 +4,6 @@ import type { UserEvent } from '@testing-library/user-event';
 import { act, screen, waitFor, within } from '@mui/internal-test-utils';
 import { AlertDialog } from '@base-ui/react/alert-dialog';
 import { createRenderer, isJSDOM, popupConformanceTests } from '#test-utils';
-import { DialogStore } from '../../dialog/store/DialogStore';
 import { REASONS } from '../../internals/reasons';
 
 describe('<AlertDialog.Root />', () => {
@@ -646,7 +645,7 @@ describe('<AlertDialog.Root />', () => {
       });
     });
 
-    it('resets the handle store when the root remounts after being unmounted while open', async () => {
+    it('attaches fresh root state when the root remounts after being unmounted while open', async () => {
       const testDialog = AlertDialog.createHandle();
 
       function App() {
@@ -692,8 +691,6 @@ describe('<AlertDialog.Root />', () => {
 
       await user.click(screen.getByRole('button', { name: 'Remount root' }));
       expect(screen.queryByRole('alertdialog')).toBe(null);
-      expect(testDialog.store.select('role')).toBe('alertdialog');
-      expect(testDialog.store.select('disablePointerDismissal')).toBe(true);
 
       await user.click(trigger);
 
@@ -866,13 +863,28 @@ describe('<AlertDialog.Root />', () => {
   });
 
   describe('imperative actions on the handle', () => {
-    it('enforces alert dialog state when constructed with a plain store', () => {
-      const store = new DialogStore();
-      const handle = new AlertDialog.Handle(store);
+    it('enforces alert dialog state for handle-backed roots', async () => {
+      const handle = AlertDialog.createHandle();
 
-      expect(handle.store.select('modal')).toBe(true);
-      expect(handle.store.select('disablePointerDismissal')).toBe(true);
-      expect(handle.store.select('role')).toBe('alertdialog');
+      const { user } = await render(
+        <React.Fragment>
+          <AlertDialog.Trigger handle={handle}>Open</AlertDialog.Trigger>
+          <AlertDialog.Root handle={handle}>
+            <AlertDialog.Portal>
+              <AlertDialog.Popup>Content</AlertDialog.Popup>
+            </AlertDialog.Portal>
+          </AlertDialog.Root>
+        </React.Fragment>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Open' }));
+
+      expect(await screen.findByRole('alertdialog')).not.toBe(null);
+
+      await user.click(screen.getByRole('presentation', { hidden: true }));
+      await waitFor(() => {
+        expect(screen.queryByRole('alertdialog')).not.toBe(null);
+      });
     });
 
     it('keeps the alert dialog open when the backdrop is clicked', async () => {

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -436,6 +436,43 @@ describe('<Dialog.Root />', () => {
         consoleWarn.mockRestore();
       });
 
+      it('keeps the newer root attached after the older root unmounts', async () => {
+        const handle = Dialog.createHandle();
+
+        function TransitioningRoots({ phase }: { phase: 'outgoing' | 'overlap' | 'incoming' }) {
+          return (
+            <React.Fragment>
+              {(phase === 'outgoing' || phase === 'overlap') && (
+                <Dialog.Root key="outgoing" handle={handle}>
+                  <Dialog.Portal>
+                    <Dialog.Popup>Outgoing</Dialog.Popup>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              )}
+              {(phase === 'overlap' || phase === 'incoming') && (
+                <Dialog.Root key="incoming" handle={handle}>
+                  <Dialog.Portal>
+                    <Dialog.Popup>Incoming</Dialog.Popup>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              )}
+            </React.Fragment>
+          );
+        }
+
+        const { setProps } = await render(<TransitioningRoots phase="outgoing" />);
+        await setProps({ phase: 'overlap' });
+        await setProps({ phase: 'incoming' });
+
+        clock.tick(20);
+
+        await act(() => handle.open(null));
+
+        expect(screen.getByText('Incoming')).toBeVisible();
+        expect(screen.queryByText('Outgoing')).toBe(null);
+        expect(handle.isOpen).toBe(true);
+      });
+
       it('warns when a handle stays attached to more than one mounted root', async () => {
         const handle = Dialog.createHandle();
         const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -6,7 +6,7 @@ import { Dialog } from '@base-ui/react/dialog';
 import { createRenderer, isJSDOM } from '#test-utils';
 
 describe('<Dialog.Root />', () => {
-  const { render } = createRenderer();
+  const { render, clock } = createRenderer();
 
   beforeEach(() => {
     globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
@@ -386,6 +386,81 @@ describe('<Dialog.Root />', () => {
       expect(trigger.getAttribute('aria-controls')).toBe(
         screen.getByRole('dialog').getAttribute('id'),
       );
+    });
+
+    describe('multiple roots sharing one handle', () => {
+      // Fake timers so the deferred overlap check only runs when ticked, after the handoff settles.
+      clock.withFakeTimers();
+
+      const overlapWarned = (consoleWarn: ReturnType<typeof vi.spyOn>) =>
+        consoleWarn.mock.calls.some(
+          ([message]: unknown[]) =>
+            typeof message === 'string' && message.includes('more than one mounted root'),
+        );
+
+      it('does not warn when one root replaces another during a route transition', async () => {
+        const handle = Dialog.createHandle();
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        function TransitioningRoots({ phase }: { phase: 'outgoing' | 'overlap' | 'incoming' }) {
+          return (
+            <React.Fragment>
+              {(phase === 'outgoing' || phase === 'overlap') && (
+                <Dialog.Root key="outgoing" handle={handle}>
+                  <Dialog.Portal>
+                    <Dialog.Popup>Outgoing</Dialog.Popup>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              )}
+              {(phase === 'overlap' || phase === 'incoming') && (
+                <Dialog.Root key="incoming" handle={handle}>
+                  <Dialog.Portal>
+                    <Dialog.Popup>Incoming</Dialog.Popup>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              )}
+            </React.Fragment>
+          );
+        }
+
+        const { setProps } = await render(<TransitioningRoots phase="outgoing" />);
+        // The incoming root mounts while the outgoing one is still mounted (overlap)...
+        await setProps({ phase: 'overlap' });
+        // ...then the outgoing root unmounts, completing a clean handoff, all before the deferred
+        // check runs.
+        await setProps({ phase: 'incoming' });
+
+        clock.tick(20);
+
+        expect(overlapWarned(consoleWarn)).toBe(false);
+        consoleWarn.mockRestore();
+      });
+
+      it('warns when a handle stays attached to more than one mounted root', async () => {
+        const handle = Dialog.createHandle();
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        await render(
+          <React.Fragment>
+            <Dialog.Root handle={handle}>
+              <Dialog.Portal>
+                <Dialog.Popup>First</Dialog.Popup>
+              </Dialog.Portal>
+            </Dialog.Root>
+            <Dialog.Root handle={handle}>
+              <Dialog.Portal>
+                <Dialog.Popup>Second</Dialog.Popup>
+              </Dialog.Portal>
+            </Dialog.Root>
+          </React.Fragment>,
+        );
+
+        // Both roots stay mounted, so the deferred check still sees the overlap and warns.
+        clock.tick(20);
+
+        expect(overlapWarned(consoleWarn)).toBe(true);
+        consoleWarn.mockRestore();
+      });
     });
   });
 

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -2,6 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import type { UserEvent } from '@testing-library/user-event';
 import { act, fireEvent, screen, waitFor, within } from '@mui/internal-test-utils';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { Dialog } from '@base-ui/react/dialog';
 import { createRenderer, isJSDOM } from '#test-utils';
 
@@ -386,6 +387,55 @@ describe('<Dialog.Root />', () => {
       expect(trigger.getAttribute('aria-controls')).toBe(
         screen.getByRole('dialog').getAttribute('id'),
       );
+    });
+
+    it('associates the requested trigger when opened by id in the same commit a root attaches', async () => {
+      const handle = Dialog.createHandle<number>();
+
+      function OpenOnMount() {
+        // A layout effect runs in the same commit the root first attaches, after the root's attach
+        // effect but before the detached triggers have re-registered into the root's store.
+        useIsoLayoutEffect(() => {
+          handle.open('trigger');
+        }, []);
+        return null;
+      }
+
+      await render(
+        <React.Fragment>
+          <Dialog.Trigger handle={handle} id="other" payload={9}>
+            Other
+          </Dialog.Trigger>
+          <Dialog.Trigger handle={handle} id="trigger" payload={5}>
+            Trigger
+          </Dialog.Trigger>
+          <Dialog.Root handle={handle}>
+            {({ payload }: NumberPayload) => (
+              <React.Fragment>
+                <span data-testid="payload">{payload ?? 'No payload'}</span>
+                <Dialog.Portal>
+                  <Dialog.Popup>Dialog Content</Dialog.Popup>
+                </Dialog.Portal>
+              </React.Fragment>
+            )}
+          </Dialog.Root>
+          <OpenOnMount />
+        </React.Fragment>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+
+      // The requested trigger is associated (ARIA + its own payload), not the other detached trigger.
+      const requestedTrigger = screen.getByRole('button', { name: 'Trigger', hidden: true });
+      const otherTrigger = screen.getByRole('button', { name: 'Other', hidden: true });
+      expect(requestedTrigger).toHaveAttribute('aria-expanded', 'true');
+      expect(requestedTrigger.getAttribute('aria-controls')).toBe(
+        screen.getByRole('dialog').getAttribute('id'),
+      );
+      expect(otherTrigger).not.toHaveAttribute('aria-controls');
+      expect(screen.getByTestId('payload').textContent).toBe('5');
     });
 
     describe('multiple roots sharing one handle', () => {

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -473,6 +473,51 @@ describe('<Dialog.Root />', () => {
         expect(handle.isOpen).toBe(true);
       });
 
+      it('restores control to the previous root when a newer overlapping root detaches', async () => {
+        const handle = Dialog.createHandle();
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        function TransitioningRoots({ phase }: { phase: 'outgoing' | 'overlap' | 'incoming' }) {
+          return (
+            <React.Fragment>
+              {(phase === 'outgoing' || phase === 'overlap') && (
+                <Dialog.Root key="outgoing" handle={handle}>
+                  <Dialog.Portal>
+                    <Dialog.Popup>Outgoing</Dialog.Popup>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              )}
+              {(phase === 'overlap' || phase === 'incoming') && (
+                <Dialog.Root key="incoming" handle={handle}>
+                  <Dialog.Portal>
+                    <Dialog.Popup>Incoming</Dialog.Popup>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              )}
+            </React.Fragment>
+          );
+        }
+
+        const { setProps } = await render(<TransitioningRoots phase="outgoing" />);
+        // The incoming root mounts while the outgoing one is still mounted (overlap)...
+        await setProps({ phase: 'overlap' });
+        // ...then the transition is canceled: the newer (incoming) root unmounts first while the
+        // older (outgoing) root stays mounted.
+        await setProps({ phase: 'outgoing' });
+
+        clock.tick(20);
+
+        // The still-mounted outgoing root regains control of the handle instead of being left inert.
+        await act(() => handle.open(null));
+
+        expect(screen.getByText('Outgoing')).toBeVisible();
+        expect(screen.queryByText('Incoming')).toBe(null);
+        expect(handle.isOpen).toBe(true);
+        // A canceled transient overlap should not warn.
+        expect(overlapWarned(consoleWarn)).toBe(false);
+        consoleWarn.mockRestore();
+      });
+
       it('keeps the root attached through Strict Mode effect replay', async () => {
         const handle = Dialog.createHandle();
         const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -520,6 +520,80 @@ describe('<Dialog.Root />', () => {
       expect(screen.getByTestId('payload').textContent).toBe('No payload');
     });
 
+    it('notifies persistent detached triggers after resetting the handle store on remount', async () => {
+      const testDialog = Dialog.createHandle();
+
+      const HeaderTrigger = React.memo(function HeaderTrigger() {
+        return (
+          <Dialog.Trigger handle={testDialog} id="trigger">
+            Trigger
+          </Dialog.Trigger>
+        );
+      });
+
+      function RouteRoot() {
+        const [mounted, setMounted] = React.useState(true);
+
+        return (
+          <React.Fragment>
+            {!mounted && (
+              <button type="button" onClick={() => setMounted(true)}>
+                Remount root
+              </button>
+            )}
+
+            {mounted && (
+              <Dialog.Root handle={testDialog}>
+                <Dialog.Portal>
+                  <Dialog.Popup>
+                    Dialog Content
+                    <button type="button" onClick={() => setMounted(false)}>
+                      Unmount root
+                    </button>
+                  </Dialog.Popup>
+                </Dialog.Portal>
+              </Dialog.Root>
+            )}
+          </React.Fragment>
+        );
+      }
+
+      function App() {
+        return (
+          <React.Fragment>
+            <HeaderTrigger />
+            <RouteRoot />
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      await user.click(trigger);
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(trigger.getAttribute('aria-controls')).toBe(
+        screen.getByRole('dialog').getAttribute('id'),
+      );
+
+      await user.click(
+        within(screen.getByRole('dialog')).getByRole('button', { name: 'Unmount root' }),
+      );
+      expect(screen.queryByText('Dialog Content')).toBe(null);
+
+      await user.click(screen.getByRole('button', { name: 'Remount root' }));
+      expect(screen.queryByText('Dialog Content')).toBe(null);
+
+      await waitFor(() => {
+        expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      });
+      expect(trigger).not.toHaveAttribute('aria-controls');
+    });
+
     it('resets stale controlled open state when a handle-backed root remounts uncontrolled', async () => {
       const testDialog = Dialog.createHandle();
 

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -59,6 +59,82 @@ describe('<Dialog.Root />', () => {
       expect(screen.getByTestId('payload').textContent).toBe('1');
     });
 
+    it('ignores imperative handle calls made after the root is detached', async () => {
+      const handle = Dialog.createHandle<number>();
+
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+
+        return (
+          <React.Fragment>
+            <Dialog.Trigger handle={handle} id="trigger" payload={1}>
+              Trigger
+            </Dialog.Trigger>
+            {!mounted && (
+              <button type="button" onClick={() => setMounted(true)}>
+                Remount root
+              </button>
+            )}
+            {mounted && (
+              <Dialog.Root handle={handle}>
+                {({ payload }: NumberPayload) => (
+                  <React.Fragment>
+                    <span data-testid="payload">{payload ?? 'No payload'}</span>
+                    <Dialog.Portal>
+                      <Dialog.Popup>
+                        Dialog Content
+                        <button type="button" onClick={() => setMounted(false)}>
+                          Unmount root
+                        </button>
+                      </Dialog.Popup>
+                    </Dialog.Portal>
+                  </React.Fragment>
+                )}
+              </Dialog.Root>
+            )}
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      await user.click(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeVisible();
+      });
+      expect(screen.getByTestId('payload').textContent).toBe('1');
+
+      await user.click(
+        within(screen.getByRole('dialog')).getByRole('button', { name: 'Unmount root' }),
+      );
+      expect(handle.isOpen).toBe(false);
+      expect(screen.queryByRole('dialog')).toBe(null);
+
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      handle.openWithPayload(8);
+      handle.open('trigger');
+      handle.close();
+      const detachedWarnings = consoleWarn.mock.calls.filter(
+        ([message]) =>
+          typeof message === 'string' && message.includes('no root using this handle is mounted'),
+      );
+      consoleWarn.mockRestore();
+
+      expect(handle.isOpen).toBe(false);
+      expect(detachedWarnings).toHaveLength(3);
+
+      await user.click(screen.getByRole('button', { name: 'Remount root' }));
+      expect(screen.queryByRole('dialog')).toBe(null);
+      expect(screen.getByTestId('payload').textContent).toBe('No payload');
+
+      await user.click(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeVisible();
+      });
+      expect(screen.getByTestId('payload').textContent).toBe('1');
+    });
+
     it('does not attach a replacement root store from an abandoned transition render', async () => {
       const handle = Dialog.createHandle<number>();
       const replacementRender = vi.fn();

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -1763,7 +1763,11 @@ describe('<Dialog.Root />', () => {
           expect(screen.getByText('Dialog Content')).toBeVisible();
         });
         expect(aTrigger).toHaveAttribute('aria-expanded', 'false');
-        expect(consoleWarn).toHaveBeenCalled();
+        expect(
+          consoleWarn.mock.calls.some(
+            ([message]) => typeof message === 'string' && message.includes('No trigger found'),
+          ),
+        ).toBe(true);
       } finally {
         consoleWarn.mockRestore();
       }

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -399,6 +399,116 @@ describe('<Dialog.Root />', () => {
       });
     });
 
+    it('resets the handle store when the root remounts after being unmounted while open', async () => {
+      const testDialog = Dialog.createHandle();
+
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+
+        return (
+          <div>
+            <Dialog.Trigger handle={testDialog}>Trigger 1</Dialog.Trigger>
+            <Dialog.Trigger handle={testDialog}>Trigger 2</Dialog.Trigger>
+            {!mounted && (
+              <button type="button" onClick={() => setMounted(true)}>
+                Remount root
+              </button>
+            )}
+
+            {mounted && (
+              <Dialog.Root handle={testDialog}>
+                <Dialog.Portal>
+                  <Dialog.Popup>
+                    Dialog Content
+                    <button type="button" onClick={() => setMounted(false)}>
+                      Unmount root
+                    </button>
+                  </Dialog.Popup>
+                </Dialog.Portal>
+              </Dialog.Root>
+            )}
+          </div>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      await user.click(screen.getByRole('button', { name: 'Trigger 1' }));
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Unmount root' }));
+      expect(screen.queryByText('Dialog Content')).toBe(null);
+
+      await user.click(screen.getByRole('button', { name: 'Remount root' }));
+      expect(screen.queryByText('Dialog Content')).toBe(null);
+
+      await user.click(screen.getByRole('button', { name: 'Trigger 2' }));
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+    });
+
+    it('resets stale controlled open state when a handle-backed root remounts uncontrolled', async () => {
+      const testDialog = Dialog.createHandle();
+
+      function App() {
+        const [mode, setMode] = React.useState<'controlled' | 'unmounted' | 'uncontrolled'>(
+          'controlled',
+        );
+
+        return (
+          <div>
+            <Dialog.Trigger handle={testDialog} id="trigger">
+              Trigger
+            </Dialog.Trigger>
+            <button type="button" onClick={() => setMode('unmounted')}>
+              Unmount root
+            </button>
+            {mode === 'unmounted' && (
+              <button type="button" onClick={() => setMode('uncontrolled')}>
+                Remount uncontrolled root
+              </button>
+            )}
+
+            {mode === 'controlled' && (
+              <Dialog.Root handle={testDialog} open triggerId="trigger">
+                <Dialog.Portal>
+                  <Dialog.Popup>
+                    Dialog Content
+                    <button type="button" onClick={() => setMode('unmounted')}>
+                      Unmount root
+                    </button>
+                  </Dialog.Popup>
+                </Dialog.Portal>
+              </Dialog.Root>
+            )}
+
+            {mode === 'uncontrolled' && (
+              <Dialog.Root handle={testDialog}>
+                <Dialog.Portal>
+                  <Dialog.Popup>Dialog Content</Dialog.Popup>
+                </Dialog.Portal>
+              </Dialog.Root>
+            )}
+          </div>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Unmount root' }));
+      expect(screen.queryByText('Dialog Content')).toBe(null);
+
+      await user.click(screen.getByRole('button', { name: 'Remount uncontrolled root' }));
+      expect(screen.queryByText('Dialog Content')).toBe(null);
+    });
+
     it('keeps detached triggers clickable when reparented (remove wrappers)', async () => {
       const testDialog = Dialog.createHandle();
       const { user, setProps } = await render(

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import type { UserEvent } from '@testing-library/user-event';
 import { act, screen, waitFor, within } from '@mui/internal-test-utils';
@@ -407,8 +407,12 @@ describe('<Dialog.Root />', () => {
 
         return (
           <div>
-            <Dialog.Trigger handle={testDialog}>Trigger 1</Dialog.Trigger>
-            <Dialog.Trigger handle={testDialog}>Trigger 2</Dialog.Trigger>
+            <Dialog.Trigger handle={testDialog} id="trigger-1">
+              Trigger 1
+            </Dialog.Trigger>
+            <Dialog.Trigger handle={testDialog} id="trigger-2">
+              Trigger 2
+            </Dialog.Trigger>
             {!mounted && (
               <button type="button" onClick={() => setMounted(true)}>
                 Remount root
@@ -432,8 +436,10 @@ describe('<Dialog.Root />', () => {
       }
 
       const { user } = await render(<App />);
+      const trigger1 = screen.getByRole('button', { name: 'Trigger 1' });
+      const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
 
-      await user.click(screen.getByRole('button', { name: 'Trigger 1' }));
+      await user.click(trigger1);
       await waitFor(() => {
         expect(screen.getByText('Dialog Content')).toBeVisible();
       });
@@ -443,11 +449,75 @@ describe('<Dialog.Root />', () => {
 
       await user.click(screen.getByRole('button', { name: 'Remount root' }));
       expect(screen.queryByText('Dialog Content')).toBe(null);
+      await waitFor(() => {
+        expect(trigger1).toHaveAttribute('aria-expanded', 'false');
+      });
 
-      await user.click(screen.getByRole('button', { name: 'Trigger 2' }));
+      await user.click(trigger1);
       await waitFor(() => {
         expect(screen.getByText('Dialog Content')).toBeVisible();
       });
+
+      expect(trigger1).toHaveAttribute('aria-expanded', 'true');
+      expect(trigger1.getAttribute('aria-controls')).toBe(
+        screen.getByRole('dialog').getAttribute('id'),
+      );
+      expect(trigger2).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('resets stale payload when a handle-backed root remounts', async () => {
+      const testDialog = Dialog.createHandle<number>();
+
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+
+        return (
+          <div>
+            {!mounted && (
+              <button type="button" onClick={() => setMounted(true)}>
+                Remount root
+              </button>
+            )}
+
+            {mounted && (
+              <Dialog.Root handle={testDialog}>
+                {({ payload }: NumberPayload) => (
+                  <React.Fragment>
+                    <span data-testid="payload">{payload ?? 'No payload'}</span>
+                    <Dialog.Portal>
+                      <Dialog.Popup>
+                        Dialog Content
+                        <button type="button" onClick={() => setMounted(false)}>
+                          Unmount root
+                        </button>
+                      </Dialog.Popup>
+                    </Dialog.Portal>
+                  </React.Fragment>
+                )}
+              </Dialog.Root>
+            )}
+          </div>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      expect(screen.getByTestId('payload').textContent).toBe('No payload');
+
+      await act(() => testDialog.openWithPayload(8));
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+      expect(screen.getByTestId('payload').textContent).toBe('8');
+
+      await user.click(
+        within(screen.getByRole('dialog')).getByRole('button', { name: 'Unmount root' }),
+      );
+      expect(screen.queryByTestId('payload')).toBe(null);
+
+      await user.click(screen.getByRole('button', { name: 'Remount root' }));
+      expect(screen.queryByRole('dialog')).toBe(null);
+      expect(screen.getByTestId('payload').textContent).toBe('No payload');
     });
 
     it('resets stale controlled open state when a handle-backed root remounts uncontrolled', async () => {
@@ -509,6 +579,73 @@ describe('<Dialog.Root />', () => {
 
       await user.click(screen.getByRole('button', { name: 'Remount uncontrolled root' }));
       expect(screen.queryByText('Dialog Content')).toBe(null);
+    });
+
+    it('does not warn when a handle-backed root remounts controlled after being uncontrolled', async () => {
+      const testDialog = Dialog.createHandle();
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        function App() {
+          const [mode, setMode] = React.useState<'uncontrolled' | 'unmounted' | 'controlled'>(
+            'uncontrolled',
+          );
+
+          return (
+            <div>
+              <Dialog.Trigger handle={testDialog} id="trigger">
+                Trigger
+              </Dialog.Trigger>
+              <button type="button" onClick={() => setMode('unmounted')}>
+                Unmount root
+              </button>
+              {mode === 'unmounted' && (
+                <button type="button" onClick={() => setMode('controlled')}>
+                  Remount controlled root
+                </button>
+              )}
+
+              {mode === 'uncontrolled' && (
+                <Dialog.Root handle={testDialog}>
+                  <Dialog.Portal>
+                    <Dialog.Popup>Dialog Content</Dialog.Popup>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              )}
+
+              {mode === 'controlled' && (
+                <Dialog.Root handle={testDialog} open triggerId="trigger">
+                  <Dialog.Portal>
+                    <Dialog.Popup>Dialog Content</Dialog.Popup>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              )}
+            </div>
+          );
+        }
+
+        const { user } = await render(<App />);
+
+        await user.click(screen.getByRole('button', { name: 'Unmount root' }));
+        expect(screen.queryByText('Dialog Content')).toBe(null);
+
+        await user.click(screen.getByRole('button', { name: 'Remount controlled root' }));
+        await waitFor(() => {
+          expect(screen.getByText('Dialog Content')).toBeVisible();
+        });
+
+        expect(
+          consoleError.mock.calls.some(([message]) => {
+            return (
+              typeof message === 'string' &&
+              message.includes('controlled state of openProp') &&
+              message.includes('controlled')
+            );
+          }),
+        ).toBe(false);
+      } finally {
+        consoleError.mockRestore();
+      }
     });
 
     it('keeps detached triggers clickable when reparented (remove wrappers)', async () => {

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -1,7 +1,7 @@
 import { expect } from 'vitest';
 import * as React from 'react';
 import type { UserEvent } from '@testing-library/user-event';
-import { act, screen, waitFor } from '@mui/internal-test-utils';
+import { act, screen, waitFor, within } from '@mui/internal-test-utils';
 import { Dialog } from '@base-ui/react/dialog';
 import { createRenderer, isJSDOM } from '#test-utils';
 
@@ -502,7 +502,9 @@ describe('<Dialog.Root />', () => {
         expect(screen.getByText('Dialog Content')).toBeVisible();
       });
 
-      await user.click(screen.getByRole('button', { name: 'Unmount root' }));
+      await user.click(
+        within(screen.getByRole('dialog')).getByRole('button', { name: 'Unmount root' }),
+      );
       expect(screen.queryByText('Dialog Content')).toBe(null);
 
       await user.click(screen.getByRole('button', { name: 'Remount uncontrolled root' }));

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -1398,6 +1398,62 @@ describe('<Dialog.Root />', () => {
       expect(screen.getByTestId('payload').textContent).toBe('7');
     });
 
+    it('stops resolving a handle-A trigger after the root switches to handle B', async () => {
+      const handleA = Dialog.createHandle<number>();
+      const handleB = Dialog.createHandle<number>();
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        function App() {
+          const [handle, setHandle] = React.useState(handleA);
+          return (
+            <div>
+              <Dialog.Trigger handle={handleA} id="a" payload={1}>
+                A trigger
+              </Dialog.Trigger>
+              <button type="button" onClick={() => setHandle(handleB)}>
+                Switch root to B
+              </button>
+              <Dialog.Root handle={handle} modal={false} disablePointerDismissal>
+                <Dialog.Portal>
+                  <Dialog.Popup>Dialog Content</Dialog.Popup>
+                </Dialog.Portal>
+              </Dialog.Root>
+            </div>
+          );
+        }
+
+        const { user } = await render(<App />);
+        const aTrigger = screen.getByRole('button', { name: 'A trigger' });
+
+        // Positive control: while the root is on handle A, opening by the A-trigger's id associates it.
+        await act(() => handleA.open('a'));
+        await waitFor(() => {
+          expect(screen.getByText('Dialog Content')).toBeVisible();
+        });
+        expect(aTrigger).toHaveAttribute('aria-expanded', 'true');
+        await act(() => handleA.close());
+        await waitFor(() => {
+          expect(screen.queryByText('Dialog Content')).toBe(null);
+        });
+
+        // The A-trigger stays mounted on handle A; only the root moves to handle B.
+        await user.click(screen.getByRole('button', { name: 'Switch root to B' }));
+
+        // Handle B's root must no longer resolve the handle-A trigger: the trigger followed its own
+        // handle's store off the root's store, so open-by-id finds nothing and warns.
+        consoleWarn.mockClear();
+        await act(() => handleB.open('a'));
+        await waitFor(() => {
+          expect(screen.getByText('Dialog Content')).toBeVisible();
+        });
+        expect(aTrigger).toHaveAttribute('aria-expanded', 'false');
+        expect(consoleWarn).toHaveBeenCalled();
+      } finally {
+        consoleWarn.mockRestore();
+      }
+    });
+
     it('sets the payload assosiated with the trigger', async () => {
       const dialog = Dialog.createHandle<number>();
       await render(

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -473,6 +473,31 @@ describe('<Dialog.Root />', () => {
         expect(handle.isOpen).toBe(true);
       });
 
+      it('keeps the root attached through Strict Mode effect replay', async () => {
+        const handle = Dialog.createHandle();
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        await render(
+          <React.StrictMode>
+            <Dialog.Root handle={handle}>
+              <Dialog.Portal>
+                <Dialog.Popup>Strict Mode Dialog</Dialog.Popup>
+              </Dialog.Portal>
+            </Dialog.Root>
+          </React.StrictMode>,
+        );
+
+        clock.tick(20);
+
+        expect(overlapWarned(consoleWarn)).toBe(false);
+        consoleWarn.mockRestore();
+
+        await act(() => handle.open(null));
+
+        expect(screen.getByText('Strict Mode Dialog')).toBeVisible();
+        expect(handle.isOpen).toBe(true);
+      });
+
       it('warns when a handle stays attached to more than one mounted root', async () => {
         const handle = Dialog.createHandle();
         const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -18,11 +18,18 @@ describe('<Dialog.Root />', () => {
     it('ignores imperative handle calls made before a root is attached', async () => {
       const handle = Dialog.createHandle<number>();
 
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       handle.open('trigger');
       handle.openWithPayload(8);
       handle.close();
+      const detachedWarnings = consoleWarn.mock.calls.filter(
+        ([message]) =>
+          typeof message === 'string' && message.includes('no root using this handle is mounted'),
+      );
+      consoleWarn.mockRestore();
 
       expect(handle.isOpen).toBe(false);
+      expect(detachedWarnings).toHaveLength(3);
 
       const { user } = await render(
         <React.Fragment>

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -1,7 +1,7 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import type { UserEvent } from '@testing-library/user-event';
-import { act, screen, waitFor, within } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor, within } from '@mui/internal-test-utils';
 import { Dialog } from '@base-ui/react/dialog';
 import { createRenderer, isJSDOM } from '#test-utils';
 
@@ -10,6 +10,300 @@ describe('<Dialog.Root />', () => {
 
   beforeEach(() => {
     globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+  });
+
+  describe('handle-backed root ownership', () => {
+    type NumberPayload = { payload: number | undefined };
+
+    it('ignores imperative handle calls made before a root is attached', async () => {
+      const handle = Dialog.createHandle<number>();
+
+      handle.open('trigger');
+      handle.openWithPayload(8);
+      handle.close();
+
+      expect(handle.isOpen).toBe(false);
+
+      const { user } = await render(
+        <React.Fragment>
+          <Dialog.Trigger handle={handle} id="trigger" payload={1}>
+            Trigger
+          </Dialog.Trigger>
+          <Dialog.Root handle={handle}>
+            {({ payload }: NumberPayload) => (
+              <React.Fragment>
+                <span data-testid="payload">{payload ?? 'No payload'}</span>
+                <Dialog.Portal>
+                  <Dialog.Popup>Dialog Content</Dialog.Popup>
+                </Dialog.Portal>
+              </React.Fragment>
+            )}
+          </Dialog.Root>
+        </React.Fragment>,
+      );
+
+      expect(screen.queryByRole('dialog')).toBe(null);
+      expect(screen.getByTestId('payload').textContent).toBe('No payload');
+
+      await user.click(screen.getByRole('button', { name: 'Trigger' }));
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeVisible();
+      });
+      expect(screen.getByTestId('payload').textContent).toBe('1');
+    });
+
+    it('does not attach a replacement root store from an abandoned transition render', async () => {
+      const handle = Dialog.createHandle<number>();
+      const replacementRender = vi.fn();
+      const never = new Promise(() => {});
+
+      function SuspendingReplacement(): React.JSX.Element {
+        replacementRender();
+        throw never;
+      }
+
+      function App() {
+        const [showReplacement, setShowReplacement] = React.useState(false);
+        const [, startTransition] = React.useTransition();
+
+        return (
+          <React.Fragment>
+            <Dialog.Trigger handle={handle} id="trigger" payload={5}>
+              Trigger
+            </Dialog.Trigger>
+            <button
+              type="button"
+              onClick={() => {
+                startTransition(() => {
+                  setShowReplacement(true);
+                });
+              }}
+            >
+              Start replacement
+            </button>
+            <button type="button" onClick={() => setShowReplacement(false)}>
+              Cancel replacement
+            </button>
+
+            <Dialog.Root handle={handle} modal={false} disablePointerDismissal>
+              {({ payload }: NumberPayload) => (
+                <Dialog.Portal>
+                  <Dialog.Popup>
+                    Current dialog
+                    <span data-testid="payload">{payload ?? 'No payload'}</span>
+                  </Dialog.Popup>
+                </Dialog.Portal>
+              )}
+            </Dialog.Root>
+
+            <React.Suspense fallback={<div>Loading</div>}>
+              {showReplacement && (
+                <Dialog.Root handle={handle} modal={false} disablePointerDismissal>
+                  <SuspendingReplacement />
+                  <Dialog.Portal>
+                    <Dialog.Popup>Replacement dialog</Dialog.Popup>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              )}
+            </React.Suspense>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      await user.click(trigger);
+      await waitFor(() => {
+        expect(screen.getByText('Current dialog')).toBeVisible();
+      });
+      expect(screen.getByTestId('payload').textContent).toBe('5');
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(handle.isOpen).toBe(true);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Start replacement' }));
+      expect(replacementRender).toHaveBeenCalled();
+
+      expect(screen.queryByText('Replacement dialog')).toBe(null);
+      expect(screen.getByText('Current dialog')).toBeVisible();
+      expect(screen.getByTestId('payload').textContent).toBe('5');
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(handle.isOpen).toBe(true);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel replacement' }));
+
+      expect(screen.queryByText('Replacement dialog')).toBe(null);
+      expect(screen.getByText('Current dialog')).toBeVisible();
+      expect(screen.getByTestId('payload').textContent).toBe('5');
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(handle.isOpen).toBe(true);
+    });
+
+    it('attaches a fresh root store when the handle prop changes to a previously dirtied handle', async () => {
+      const handleA = Dialog.createHandle<number>();
+      const handleB = Dialog.createHandle<number>();
+
+      function App() {
+        const [phase, setPhase] = React.useState<'dirty' | 'main'>('dirty');
+        const [handle, setHandle] = React.useState(handleA);
+
+        if (phase === 'dirty') {
+          return (
+            <Dialog.Root handle={handleB}>
+              {({ payload }: NumberPayload) => (
+                <React.Fragment>
+                  <span data-testid="dirty-payload">{payload ?? 'No payload'}</span>
+                  <Dialog.Portal>
+                    <Dialog.Popup>
+                      Dirty dialog
+                      <button type="button" onClick={() => setPhase('main')}>
+                        Unmount dirty root
+                      </button>
+                    </Dialog.Popup>
+                  </Dialog.Portal>
+                </React.Fragment>
+              )}
+            </Dialog.Root>
+          );
+        }
+
+        return (
+          <React.Fragment>
+            <Dialog.Trigger handle={handle} id="trigger" payload={1}>
+              Trigger
+            </Dialog.Trigger>
+            <button type="button" onClick={() => setHandle(handleB)}>
+              Switch to handle B
+            </button>
+            <Dialog.Root handle={handle}>
+              {({ payload }: NumberPayload) => (
+                <React.Fragment>
+                  <span data-testid="payload">{payload ?? 'No payload'}</span>
+                  <Dialog.Portal>
+                    <Dialog.Popup>Dialog Content</Dialog.Popup>
+                  </Dialog.Portal>
+                </React.Fragment>
+              )}
+            </Dialog.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      await act(() => handleB.openWithPayload(8));
+      await waitFor(() => {
+        expect(screen.getByText('Dirty dialog')).toBeVisible();
+      });
+      expect(screen.getByTestId('dirty-payload').textContent).toBe('8');
+
+      await user.click(screen.getByRole('button', { name: 'Unmount dirty root' }));
+      expect(handleB.isOpen).toBe(false);
+      expect(screen.queryByRole('dialog')).toBe(null);
+      expect(screen.getByTestId('payload').textContent).toBe('No payload');
+
+      await user.click(screen.getByRole('button', { name: 'Switch to handle B' }));
+      expect(handleB.isOpen).toBe(false);
+      expect(screen.queryByRole('dialog')).toBe(null);
+      expect(screen.getByTestId('payload').textContent).toBe('No payload');
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+      expect(screen.getByTestId('payload').textContent).toBe('1');
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('keeps a handle-backed dialog open and controllable across handle swaps on a live root', async () => {
+      const handleA = Dialog.createHandle();
+      const handleB = Dialog.createHandle();
+
+      function App() {
+        const [handle, setHandle] = React.useState(handleA);
+
+        return (
+          <React.Fragment>
+            <Dialog.Trigger handle={handle} id="trigger">
+              Trigger
+            </Dialog.Trigger>
+            <button type="button" onClick={() => setHandle(handleA)}>
+              Use handle A
+            </button>
+            <button type="button" onClick={() => setHandle(handleB)}>
+              Use handle B
+            </button>
+            <Dialog.Root handle={handle} modal={false} disablePointerDismissal>
+              <Dialog.Portal>
+                <Dialog.Popup>Dialog Content</Dialog.Popup>
+              </Dialog.Portal>
+            </Dialog.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      await user.click(trigger);
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+
+      // The store is owned by the Root, so swapping the handle re-attaches it without resetting state.
+      await user.click(screen.getByRole('button', { name: 'Use handle B' }));
+      expect(screen.getByText('Dialog Content')).toBeVisible();
+      expect(handleB.isOpen).toBe(true);
+      expect(handleA.isOpen).toBe(false);
+      await waitFor(() => {
+        expect(trigger.getAttribute('aria-controls')).toBe(
+          screen.getByRole('dialog').getAttribute('id'),
+        );
+      });
+
+      // Swapping back to a previously-attached handle keeps working (no stale registrations).
+      await user.click(screen.getByRole('button', { name: 'Use handle A' }));
+      expect(screen.getByText('Dialog Content')).toBeVisible();
+      expect(handleA.isOpen).toBe(true);
+      expect(handleB.isOpen).toBe(false);
+
+      // The currently-attached handle controls the live dialog.
+      await act(() => handleA.close());
+      await waitFor(() => {
+        expect(screen.queryByText('Dialog Content')).toBe(null);
+      });
+    });
+
+    it('registers a detached trigger declared after the root', async () => {
+      const handle = Dialog.createHandle();
+
+      const { user } = await render(
+        <React.Fragment>
+          <Dialog.Root handle={handle}>
+            <Dialog.Portal>
+              <Dialog.Popup>Dialog Content</Dialog.Popup>
+            </Dialog.Portal>
+          </Dialog.Root>
+          <Dialog.Trigger handle={handle} id="trigger">
+            Trigger
+          </Dialog.Trigger>
+        </React.Fragment>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      await user.click(trigger);
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(trigger.getAttribute('aria-controls')).toBe(
+        screen.getByRole('dialog').getAttribute('id'),
+      );
+    });
   });
 
   describe.skipIf(isJSDOM)('multiple triggers within Root', () => {
@@ -399,7 +693,7 @@ describe('<Dialog.Root />', () => {
       });
     });
 
-    it('resets the handle store when the root remounts after being unmounted while open', async () => {
+    it('attaches fresh root state when the root remounts after being unmounted while open', async () => {
       const testDialog = Dialog.createHandle();
 
       function App() {
@@ -520,7 +814,7 @@ describe('<Dialog.Root />', () => {
       expect(screen.getByTestId('payload').textContent).toBe('No payload');
     });
 
-    it('notifies persistent detached triggers after resetting the handle store on remount', async () => {
+    it('notifies persistent detached triggers after attaching fresh root state on remount', async () => {
       const testDialog = Dialog.createHandle();
 
       const HeaderTrigger = React.memo(function HeaderTrigger() {

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -1325,6 +1325,79 @@ describe('<Dialog.Root />', () => {
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
     });
 
+    it('associates an imperative open-by-id with a persistent detached trigger after the root remounts', async () => {
+      const dialog = Dialog.createHandle<number>();
+
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+
+        return (
+          <div>
+            <Dialog.Trigger handle={dialog} id="trigger" payload={7}>
+              Trigger
+            </Dialog.Trigger>
+            {!mounted && (
+              <button type="button" onClick={() => setMounted(true)}>
+                Remount root
+              </button>
+            )}
+            {mounted && (
+              <Dialog.Root handle={dialog}>
+                {({ payload }: { payload: number | undefined }) => (
+                  <React.Fragment>
+                    <span data-testid="payload">{payload ?? 'No payload'}</span>
+                    <Dialog.Portal>
+                      <Dialog.Popup>
+                        Dialog Content
+                        <button type="button" onClick={() => setMounted(false)}>
+                          Unmount root
+                        </button>
+                      </Dialog.Popup>
+                    </Dialog.Portal>
+                  </React.Fragment>
+                )}
+              </Dialog.Root>
+            )}
+          </div>
+        );
+      }
+
+      const { user } = await render(<App />);
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      await act(() => dialog.open('trigger'));
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(trigger.getAttribute('aria-controls')).toBe(
+        screen.getByRole('dialog').getAttribute('id'),
+      );
+      expect(screen.getByTestId('payload').textContent).toBe('7');
+
+      await user.click(
+        within(screen.getByRole('dialog')).getByRole('button', { name: 'Unmount root' }),
+      );
+      expect(screen.queryByRole('dialog')).toBe(null);
+
+      await user.click(screen.getByRole('button', { name: 'Remount root' }));
+      await waitFor(() => {
+        expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      });
+
+      // The trigger stayed mounted across the remount, so an imperative open-by-id must still
+      // associate it (ARIA + payload), not open unassociated.
+      await act(() => dialog.open('trigger'));
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(trigger.getAttribute('aria-controls')).toBe(
+        screen.getByRole('dialog').getAttribute('id'),
+      );
+      expect(screen.getByTestId('payload').textContent).toBe('7');
+    });
+
     it('sets the payload assosiated with the trigger', async () => {
       const dialog = Dialog.createHandle<number>();
       await render(

--- a/packages/react/src/dialog/root/useRenderDialogRoot.tsx
+++ b/packages/react/src/dialog/root/useRenderDialogRoot.tsx
@@ -1,10 +1,15 @@
 'use client';
 import * as React from 'react';
-import { useOnFirstRender } from '@base-ui/utils/useOnFirstRender';
+import { useId } from '@base-ui/utils/useId';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { DialogInteractions, useDialogRoot } from './useDialogRoot';
 import { DialogRootContext, IsDrawerContext, useDialogRootContext } from './DialogRootContext';
-import { DialogStore } from '../store/DialogStore';
+import { DialogStore, type State as DialogStoreState } from '../store/DialogStore';
 import type { DialogRootProps } from './DialogRoot';
+import type { DialogHandle } from '../store/DialogHandle';
+import { useFloatingParentNodeId } from '../../floating-ui-react/components/FloatingTree';
+import { useSyncedFloatingRootContext } from '../../floating-ui-react/hooks/useSyncedFloatingRootContext';
 
 export function useRenderDialogRoot<Payload>(
   props: DialogRootProps<Payload>,
@@ -34,27 +39,12 @@ export function useRenderDialogRoot<Payload>(
   const nested = Boolean(parentDialogRootContext);
   const rootState = { modal, disablePointerDismissal, nested, role };
 
-  const store = DialogStore.useStore(handle?.store, {
+  const store = useDialogRootStore(handle, {
     open: defaultOpen,
     openProp,
     activeTriggerId: defaultTriggerIdProp,
     triggerIdProp,
     ...rootState,
-  });
-
-  // Support initially open state when uncontrolled
-  useOnFirstRender(() => {
-    const nextState =
-      openProp === undefined && store.state.open === false && defaultOpen === true
-        ? { open: true, activeTriggerId: defaultTriggerIdProp }
-        : null;
-
-    if (isAlertDialog) {
-      // Handles can reuse plain Dialog stores; alert dialog invariants must exist immediately.
-      store.update(nextState ? { ...rootState, ...nextState } : rootState);
-    } else if (nextState) {
-      store.update(nextState);
-    }
   });
 
   store.useControlledProp('openProp', openProp);
@@ -91,3 +81,37 @@ export function useRenderDialogRoot<Payload>(
 }
 
 type DialogRootMode = 'dialog' | 'drawer' | 'alert-dialog';
+
+function useDialogRootStore<Payload>(
+  handle: DialogHandle<Payload> | undefined,
+  initialState: Partial<DialogStoreState<Payload>>,
+) {
+  const floatingId = useId();
+  const floatingNested = useFloatingParentNodeId() != null;
+
+  // The store is owned by this Root instance and created exactly once. It is not tied to the handle:
+  // the handle attaches to it below, so swapping the handle re-attaches rather than recreating state.
+  // Default values are only initial values; controlled values and root state are synced after creation.
+  const store = useRefWithInit(
+    () => new DialogStore<Payload>(initialState, floatingId, floatingNested),
+  ).current;
+
+  useSyncedFloatingRootContext({
+    popupStore: store,
+    treatPopupAsFloatingElement: true,
+    floatingRootContext: store.state.floatingRootContext,
+    floatingId,
+    nested: floatingNested,
+    onOpenChange: store.setOpen,
+  });
+
+  useIsoLayoutEffect(() => {
+    if (!handle) {
+      return undefined;
+    }
+
+    return handle.attachStore(store);
+  }, [handle, store]);
+
+  return store;
+}

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -6,7 +6,7 @@ import { REASONS } from '../../internals/reasons';
  * A handle to control a Dialog imperatively and to associate detached triggers with it.
  *
  * The imperative methods on the handle require the associated root component using the same handle to be mounted.
- * Calls made before the root is attached to the handle are not queued for a later mount.
+ * Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
  */
 export class DialogHandle<Payload> {
   /**

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -1,3 +1,4 @@
+import { AnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import { DialogStore, NullDialogStore, type DialogHandleStore } from './DialogStore';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
@@ -155,18 +156,37 @@ export class DialogHandle<Payload> {
    */
   attachStore(newStore: DialogStore<Payload>) {
     if (this.attachedStore !== newStore) {
-      if (process.env.NODE_ENV !== 'production' && this.attachedStore !== null) {
-        console.warn(
-          'Base UI: A handle is attached to more than one mounted root at the same time. ' +
-            'The most recently mounted root takes over and the previous one stops being controlled by the handle. ' +
-            'A handle should be used by a single root that stays mounted for the lifetime of the handle.',
-        );
-      }
       this.attachedStore = newStore;
       this.notifyStoreListeners();
     }
 
+    if (process.env.NODE_ENV !== 'production') {
+      // The overlap bookkeeping only exists in development; the fields are created lazily so they
+      // never appear on instances in production (like `controlledValues` in `ReactStore`).
+      const dev = this as any;
+      dev.attachedRootCount = (dev.attachedRootCount ?? 0) + 1;
+      if (dev.attachedRootCount > 1) {
+        // More than one root is attached at once. This is usually a transient overlap during an
+        // animated route transition, where the outgoing root unmounts a frame after the incoming
+        // one mounts. Defer the check by a frame so a clean handoff doesn't warn, and only warn if
+        // the overlap is still present once the transition has settled (the previous root didn't
+        // unmount).
+        (dev.overlapWarningFrame ??= AnimationFrame.create()).request(() => {
+          if (dev.attachedRootCount > 1) {
+            console.warn(
+              'Base UI: A handle is attached to more than one mounted root at the same time. ' +
+                'The most recently mounted root takes over and the previous one stops being controlled by the handle. ' +
+                'A handle should be used by a single root that stays mounted for the lifetime of the handle.',
+            );
+          }
+        });
+      }
+    }
+
     return () => {
+      if (process.env.NODE_ENV !== 'production') {
+        (this as any).attachedRootCount -= 1;
+      }
       if (this.attachedStore === newStore) {
         this.attachedStore = null;
         this.notifyStoreListeners();

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -4,6 +4,9 @@ import { REASONS } from '../../internals/reasons';
 
 /**
  * A handle to control a Dialog imperatively and to associate detached triggers with it.
+ *
+ * The imperative methods on the handle require the associated root component using the same handle to be mounted.
+ * Calls made before the root is attached to the handle are not queued for a later mount.
  */
 export class DialogHandle<Payload> {
   /**

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -22,8 +22,16 @@ export class DialogHandle<Payload> {
   private readonly fallbackStore = createNullDialogStore<Payload>();
 
   /**
-   * Store owned by the currently mounted root, or `null` when no root is attached. Imperative
-   * methods are no-ops while this is `null`.
+   * Stores of every root currently using this handle, in attach order. A handle is meant to be used
+   * by a single mounted root, but roots can transiently overlap (e.g. during an animated route
+   * transition), so this stack lets `attachStore`'s cleanup restore the previous root instead of
+   * leaving a still-mounted root uncontrollable when a newer overlapping root detaches first.
+   */
+  private readonly attachedStores: DialogStore<Payload>[] = [];
+
+  /**
+   * Store of the root that currently controls the handle: the most recently attached one still
+   * mounted, or `null` when no root is attached. Imperative methods are no-ops while this is `null`.
    */
   private attachedStore: DialogStore<Payload> | null = null;
 
@@ -153,24 +161,21 @@ export class DialogHandle<Payload> {
    * @internal
    */
   attachStore(newStore: DialogStore<Payload>) {
-    if (this.attachedStore !== newStore) {
-      this.attachedStore = newStore;
-      this.notifyStoreListeners();
-    }
+    this.attachedStores.push(newStore);
+    this.setActiveStore(newStore);
 
     if (process.env.NODE_ENV !== 'production') {
-      // The overlap bookkeeping only exists in development; the fields are created lazily so they
-      // never appear on instances in production (like `controlledValues` in `ReactStore`).
-      const dev = this as any;
-      dev.attachedRootCount = (dev.attachedRootCount ?? 0) + 1;
-      if (dev.attachedRootCount > 1) {
+      if (this.attachedStores.length > 1) {
         // More than one root is attached at once. This is usually a transient overlap during an
         // animated route transition, where the outgoing root unmounts shortly after the incoming
         // one mounts. Defer the check by a frame and only warn if the overlap is still present once
-        // the transition has settled (the previous root didn't unmount), so a clean handoff doesn't
+        // the transition has settled (more than one root stayed mounted), so a clean handoff doesn't
         // warn regardless of the exact unmount timing.
+        // The warning frame only exists in development; it is created lazily so it never appears on
+        // instances in production (like `controlledValues` in `ReactStore`).
+        const dev = this as any;
         (dev.overlapWarningFrame ??= AnimationFrame.create()).request(() => {
-          if (dev.attachedRootCount > 1) {
+          if (this.attachedStores.length > 1) {
             console.warn(
               'Base UI: A handle is attached to more than one mounted root at the same time. ' +
                 'The most recently mounted root takes over and the previous one stops being controlled by the handle. ' +
@@ -182,14 +187,26 @@ export class DialogHandle<Payload> {
     }
 
     return () => {
-      if (process.env.NODE_ENV !== 'production') {
-        (this as any).attachedRootCount -= 1;
+      const index = this.attachedStores.lastIndexOf(newStore);
+      if (index !== -1) {
+        this.attachedStores.splice(index, 1);
       }
-      if (this.attachedStore === newStore) {
-        this.attachedStore = null;
-        this.notifyStoreListeners();
-      }
+      // Restore control to the most recently attached root that is still mounted (or detach fully if
+      // none remain). Clearing unconditionally would leave a still-mounted older root uncontrollable
+      // when a newer overlapping root detaches first (e.g. a canceled route transition).
+      this.setActiveStore(this.attachedStores[this.attachedStores.length - 1] ?? null);
     };
+  }
+
+  /**
+   * Sets the store that currently controls the handle and notifies subscribers when it changes, so
+   * detached triggers re-render and migrate their registration to the new store.
+   */
+  private setActiveStore(store: DialogStore<Payload> | null) {
+    if (this.attachedStore !== store) {
+      this.attachedStore = store;
+      this.notifyStoreListeners();
+    }
   }
 
   /**

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -1,5 +1,5 @@
 import { AnimationFrame } from '@base-ui/utils/useAnimationFrame';
-import { DialogStore, NullDialogStore, type DialogHandleStore } from './DialogStore';
+import { DialogStore, createNullDialogStore, type DialogHandleStore } from './DialogStore';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 
@@ -19,7 +19,7 @@ export class DialogHandle<Payload> {
    * detached they live in this store's trigger map and migrate themselves to the root's store (and
    * back) as it attaches/detaches.
    */
-  private readonly fallbackStore = new NullDialogStore<Payload>();
+  private readonly fallbackStore = createNullDialogStore<Payload>();
 
   /**
    * Store owned by the currently mounted root, or `null` when no root is attached. Imperative

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -1,35 +1,56 @@
-import { DialogStore } from './DialogStore';
+import { DialogStore, NullDialogStore, type DialogHandleStore } from './DialogStore';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
+import { PopupTriggerMap } from '../../utils/popups';
 
 /**
- * A handle to control a Dialog imperatively and to associate detached triggers with it.
+ * Controls a Dialog imperatively and associates detached `Dialog.Trigger` components with a
+ * `Dialog.Root`. Create one with `Dialog.createHandle()` and pass it to the `handle` prop of the
+ * root and of any triggers rendered outside of it.
  *
- * The imperative methods on the handle require the associated root component using the same handle to be mounted.
- * Calls made before the root is attached to the handle are ignored; the store is reset when the root first mounts.
+ * The imperative methods take effect only while a root using this handle is mounted; calls made
+ * before a root attaches (or after it unmounts) are ignored.
  */
 export class DialogHandle<Payload> {
   /**
-   * Internal store holding the dialog state.
-   * @internal
+   * Trigger registrations captured while no root store is attached. Detached triggers register here
+   * (through the fallback store) and the entries are drained into the real store when a root attaches.
    */
-  public readonly store: DialogStore<Payload>;
-
-  constructor(store?: DialogStore<Payload>) {
-    this.store = store ?? new DialogStore<Payload>();
-  }
+  private readonly pendingTriggerRegistrations = new PopupTriggerMap();
 
   /**
-   * Opens the dialog and associates it with the trigger with the given id.
-   * The trigger, if provided, must be a matching Trigger component with this handle passed as a prop.
+   * Inert, closed store handed to detached triggers while no root is attached, so they can render
+   * and register without a mounted root. Backed by `pendingTriggerRegistrations`.
+   */
+  private readonly fallbackStore = new NullDialogStore<Payload>(this.pendingTriggerRegistrations);
+
+  /**
+   * Store owned by the currently mounted root, or `null` when no root is attached. Imperative
+   * methods are no-ops while this is `null`.
+   */
+  private attachedStore: DialogStore<Payload> | null = null;
+
+  /**
+   * Listeners notified when `attachedStore` changes, so detached triggers can follow the store pointer.
+   */
+  private readonly storeListeners = new Set<() => void>();
+
+  /**
+   * Opens the dialog, optionally associating it with a trigger.
    *
    * This method should only be called in an event handler or an effect (not during rendering).
    *
-   * @param triggerId ID of the trigger to associate with the dialog. If null, the dialog will open without a trigger association.
+   * @param triggerId ID of the trigger to associate with the dialog. The trigger must be a matching
+   * `Dialog.Trigger` with this handle passed as a prop. Pass `null` to open without associating any trigger.
    */
   open(triggerId: string | null) {
+    if (this.attachedStore === null) {
+      return;
+    }
+
+    // While a root is attached, registered triggers live in its store (the pending buffer is empty).
     const triggerElement = triggerId
-      ? (this.store.context.triggerElements.getById(triggerId) as HTMLElement | undefined)
+      ? (this.attachedStore.context.triggerElements.getById(triggerId) as HTMLElement | undefined)
       : undefined;
 
     if (process.env.NODE_ENV !== 'production') {
@@ -40,21 +61,26 @@ export class DialogHandle<Payload> {
       }
     }
 
-    this.store.setOpen(
+    this.attachedStore.setOpen(
       true,
       createChangeEventDetails(REASONS.imperativeAction, undefined, triggerElement),
     );
   }
 
   /**
-   * Opens the dialog and sets the payload.
-   * Does not associate the dialog with any trigger.
+   * Opens the dialog with the given payload, without associating it with any trigger.
    *
-   * @param payload Payload to set when opening the dialog.
+   * This method should only be called in an event handler or an effect (not during rendering).
+   *
+   * @param payload Payload to set when opening the dialog. It is exposed to the root's render-prop children.
    */
   openWithPayload(payload: Payload) {
-    this.store.set('payload', payload);
-    this.store.setOpen(
+    if (this.attachedStore === null) {
+      return;
+    }
+
+    this.attachedStore.set('payload', payload);
+    this.attachedStore.setOpen(
       true,
       createChangeEventDetails(REASONS.imperativeAction, undefined, undefined),
     );
@@ -62,19 +88,90 @@ export class DialogHandle<Payload> {
 
   /**
    * Closes the dialog.
+   *
+   * This method should only be called in an event handler or an effect (not during rendering).
    */
   close() {
-    this.store.setOpen(
+    if (this.attachedStore === null) {
+      return;
+    }
+
+    this.attachedStore.setOpen(
       false,
       createChangeEventDetails(REASONS.imperativeAction, undefined, undefined),
     );
   }
 
   /**
-   * Indicates whether the dialog is currently open.
+   * Whether the dialog is currently open. Returns `false` while no root is attached to the handle.
    */
   get isOpen() {
-    return this.store.select('open');
+    return this.attachedStore?.select('open') ?? false;
+  }
+
+  /**
+   * Store that detached triggers read from: the attached root's store, or an inert fallback store
+   * used while no root is attached.
+   * @internal
+   */
+  get store(): DialogHandleStore<Payload> {
+    return this.attachedStore ?? this.fallbackStore;
+  }
+
+  /**
+   * Subscribes to changes of the attached store pointer so detached triggers re-render and re-bind
+   * when a root attaches or detaches. Returns a function that removes the listener.
+   * @internal
+   */
+  subscribeStore(listener: () => void) {
+    this.storeListeners.add(listener);
+
+    return () => {
+      this.storeListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Attaches a root's store to this handle and drains any trigger registrations captured while
+   * detached into it. Returns a cleanup function that detaches the store again. Called by `Dialog.Root`.
+   * @internal
+   */
+  attachStore(newStore: DialogStore<Payload>) {
+    const previousStore = this.attachedStore;
+
+    if (previousStore !== newStore) {
+      this.attachedStore = newStore;
+
+      // Triggers that mounted before this root registered into the pending buffer (via the fallback
+      // store). Their registration ref is a stable callback that does not re-fire when the store
+      // pointer swaps, so draining here is the only path that moves them into the attached store.
+      // Do it before notifying subscribers so the store is immediately consistent for its
+      // trigger-derived logic (e.g. resolving an imperative `open(triggerId)` or the active trigger).
+      const { triggerElements } = newStore.context;
+      for (const [id, element] of this.pendingTriggerRegistrations.entries()) {
+        triggerElements.add(id, element);
+      }
+      this.pendingTriggerRegistrations.clear();
+
+      newStore.set('triggerCount', triggerElements.size);
+      this.notifyStoreListeners();
+    }
+
+    return () => {
+      if (this.attachedStore === newStore) {
+        this.attachedStore = null;
+        this.notifyStoreListeners();
+      }
+    };
+  }
+
+  /**
+   * Notifies subscribers that the attached store pointer changed.
+   */
+  private notifyStoreListeners() {
+    this.storeListeners.forEach((listener) => {
+      listener();
+    });
   }
 }
 

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -1,7 +1,6 @@
-import { DialogStore, NullDialogStore, type DialogHandleStore } from './DialogStore';
+import { DialogStore } from './DialogStore';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
-import { PopupTriggerMap } from '../../utils/popups';
 
 /**
  * Controls a Dialog imperatively and associates detached `Dialog.Trigger` components with a
@@ -13,16 +12,12 @@ import { PopupTriggerMap } from '../../utils/popups';
  */
 export class DialogHandle<Payload> {
   /**
-   * Trigger registrations captured while no root store is attached. Detached triggers register here
-   * (through the fallback store) and the entries are drained into the real store when a root attaches.
+   * Closed, never-attached store handed to detached triggers while no root is attached, so they can
+   * render and register without a mounted root. Its trigger map doubles as the pending-registration
+   * buffer: detached triggers register into it, and the entries are drained into the real store when
+   * a root attaches.
    */
-  private readonly pendingTriggerRegistrations = new PopupTriggerMap();
-
-  /**
-   * Inert, closed store handed to detached triggers while no root is attached, so they can render
-   * and register without a mounted root. Backed by `pendingTriggerRegistrations`.
-   */
-  private readonly fallbackStore = new NullDialogStore<Payload>(this.pendingTriggerRegistrations);
+  private readonly fallbackStore = new DialogStore<Payload>();
 
   /**
    * Store owned by the currently mounted root, or `null` when no root is attached. Imperative
@@ -114,7 +109,7 @@ export class DialogHandle<Payload> {
    * used while no root is attached.
    * @internal
    */
-  get store(): DialogHandleStore<Payload> {
+  get store(): DialogStore<Payload> {
     return this.attachedStore ?? this.fallbackStore;
   }
 
@@ -142,16 +137,17 @@ export class DialogHandle<Payload> {
     if (previousStore !== newStore) {
       this.attachedStore = newStore;
 
-      // Triggers that mounted before this root registered into the pending buffer (via the fallback
-      // store). Their registration ref is a stable callback that does not re-fire when the store
-      // pointer swaps, so draining here is the only path that moves them into the attached store.
-      // Do it before notifying subscribers so the store is immediately consistent for its
-      // trigger-derived logic (e.g. resolving an imperative `open(triggerId)` or the active trigger).
+      // Triggers that mounted before this root registered into the fallback store's trigger map.
+      // Their registration ref is a stable callback that does not re-fire when the store pointer
+      // swaps, so draining here is the only path that moves them into the attached store. Do it
+      // before notifying subscribers so the store is immediately consistent for its trigger-derived
+      // logic (e.g. resolving an imperative `open(triggerId)` or the active trigger).
+      const pending = this.fallbackStore.context.triggerElements;
       const { triggerElements } = newStore.context;
-      for (const [id, element] of this.pendingTriggerRegistrations.entries()) {
+      for (const [id, element] of pending.entries()) {
         triggerElements.add(id, element);
       }
-      this.pendingTriggerRegistrations.clear();
+      pending.clear();
 
       newStore.set('triggerCount', triggerElements.size);
       this.notifyStoreListeners();

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -165,10 +165,10 @@ export class DialogHandle<Payload> {
       dev.attachedRootCount = (dev.attachedRootCount ?? 0) + 1;
       if (dev.attachedRootCount > 1) {
         // More than one root is attached at once. This is usually a transient overlap during an
-        // animated route transition, where the outgoing root unmounts a frame after the incoming
-        // one mounts. Defer the check by a frame so a clean handoff doesn't warn, and only warn if
-        // the overlap is still present once the transition has settled (the previous root didn't
-        // unmount).
+        // animated route transition, where the outgoing root unmounts shortly after the incoming
+        // one mounts. Defer the check by a frame and only warn if the overlap is still present once
+        // the transition has settled (the previous root didn't unmount), so a clean handoff doesn't
+        // warn regardless of the exact unmount timing.
         (dev.overlapWarningFrame ??= AnimationFrame.create()).request(() => {
           if (dev.attachedRootCount > 1) {
             console.warn(

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -40,10 +40,16 @@ export class DialogHandle<Payload> {
    */
   open(triggerId: string | null) {
     if (this.attachedStore === null) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          'Base UI: DialogHandle.open() was called while no root using this handle is mounted. ' +
+            'The call was ignored; mount a root with this handle before opening it imperatively.',
+        );
+      }
       return;
     }
 
-    // While a root is attached, registered triggers live in its store (the pending buffer is empty).
+    // While a root is attached, registered triggers live in its store, so resolve the trigger from there.
     const triggerElement = triggerId
       ? (this.attachedStore.context.triggerElements.getById(triggerId) as HTMLElement | undefined)
       : undefined;
@@ -71,6 +77,12 @@ export class DialogHandle<Payload> {
    */
   openWithPayload(payload: Payload) {
     if (this.attachedStore === null) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          'Base UI: DialogHandle.openWithPayload() was called while no root using this handle is mounted. ' +
+            'The call and its payload were ignored; mount a root with this handle before opening it imperatively.',
+        );
+      }
       return;
     }
 
@@ -88,6 +100,12 @@ export class DialogHandle<Payload> {
    */
   close() {
     if (this.attachedStore === null) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          'Base UI: DialogHandle.close() was called while no root using this handle is mounted. ' +
+            'The call was ignored.',
+        );
+      }
       return;
     }
 
@@ -134,6 +152,13 @@ export class DialogHandle<Payload> {
    */
   attachStore(newStore: DialogStore<Payload>) {
     if (this.attachedStore !== newStore) {
+      if (process.env.NODE_ENV !== 'production' && this.attachedStore !== null) {
+        console.warn(
+          'Base UI: A handle is attached to more than one mounted root at the same time. ' +
+            'The most recently mounted root takes over and the previous one stops being controlled by the handle. ' +
+            'A handle should be used by a single root that stays mounted for the lifetime of the handle.',
+        );
+      }
       this.attachedStore = newStore;
       this.notifyStoreListeners();
     }

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -1,4 +1,4 @@
-import { DialogStore } from './DialogStore';
+import { DialogStore, NullDialogStore, type DialogHandleStore } from './DialogStore';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 
@@ -12,12 +12,13 @@ import { REASONS } from '../../internals/reasons';
  */
 export class DialogHandle<Payload> {
   /**
-   * Closed, never-attached store handed to detached triggers while no root is attached, so they can
-   * render and register without a mounted root. Triggers register into whichever store `store`
-   * currently resolves to, so while detached they live in this store's trigger map and migrate
-   * themselves to the root's store (and back) as it attaches/detaches.
+   * Inert, closed store handed to detached triggers while no root is attached, so they can render
+   * and register without a mounted root. Its reads always reflect a closed dialog and its mutations
+   * are no-ops. Triggers register into whichever store `store` currently resolves to, so while
+   * detached they live in this store's trigger map and migrate themselves to the root's store (and
+   * back) as it attaches/detaches.
    */
-  private readonly fallbackStore = new DialogStore<Payload>();
+  private readonly fallbackStore = new NullDialogStore<Payload>();
 
   /**
    * Store owned by the currently mounted root, or `null` when no root is attached. Imperative
@@ -119,7 +120,9 @@ export class DialogHandle<Payload> {
    * Whether the dialog is currently open. Returns `false` while no root is attached to the handle.
    */
   get isOpen() {
-    return this.attachedStore?.select('open') ?? false;
+    // The fallback store is always closed, so reading through `store` is equivalent to guarding on
+    // `attachedStore` and keeps `isOpen` and `store` reading from the same source.
+    return this.store.select('open');
   }
 
   /**
@@ -127,7 +130,7 @@ export class DialogHandle<Payload> {
    * used while no root is attached.
    * @internal
    */
-  get store(): DialogStore<Payload> {
+  get store(): DialogHandleStore<Payload> {
     return this.attachedStore ?? this.fallbackStore;
   }
 

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -121,9 +121,7 @@ export class DialogHandle<Payload> {
    * Whether the dialog is currently open. Returns `false` while no root is attached to the handle.
    */
   get isOpen() {
-    // The fallback store is always closed, so reading through `store` is equivalent to guarding on
-    // `attachedStore` and keeps `isOpen` and `store` reading from the same source.
-    return this.store.select('open');
+    return this.attachedStore?.select('open') ?? false;
   }
 
   /**

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -59,9 +59,15 @@ export class DialogHandle<Payload> {
       return;
     }
 
-    // While a root is attached, registered triggers live in its store, so resolve the trigger from there.
+    // Registered triggers normally live in the attached root's store. During the commit in which a
+    // root first attaches, a still-mounted detached trigger has not re-registered into the root store
+    // yet (it migrates on its next render), but it is still registered in the fallback store. Fall
+    // back to that map so an imperative open-by-id (e.g. called from a layout effect in the same
+    // commit the root mounts) stays associated with the requested trigger instead of opening
+    // unassociated and letting another detached trigger claim the open popup first.
     const triggerElement = triggerId
-      ? (this.attachedStore.context.triggerElements.getById(triggerId) as HTMLElement | undefined)
+      ? ((this.attachedStore.context.triggerElements.getById(triggerId) ??
+          this.fallbackStore.context.triggerElements.getById(triggerId)) as HTMLElement | undefined)
       : undefined;
 
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -155,6 +155,18 @@ export class DialogHandle<Payload> {
 
     return () => {
       if (this.attachedStore === newStore) {
+        // Move the still-registered triggers back into the pending buffer. Detached triggers can
+        // outlive the root (e.g. a persistent header trigger while a route-owned root unmounts);
+        // their registration ref is a stable callback that does not re-fire on the store-pointer
+        // swap, so without this they would be lost when the store is destroyed and the next root
+        // would attach with an empty trigger map — breaking imperative open-by-id / payload / ARIA
+        // until the trigger is clicked. The departing store's own map is left intact (it may survive
+        // a handle swap), and re-draining on the next attach is idempotent.
+        const pending = this.fallbackStore.context.triggerElements;
+        for (const [id, element] of newStore.context.triggerElements.entries()) {
+          pending.add(id, element);
+        }
+
         this.attachedStore = null;
         this.notifyStoreListeners();
       }

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -13,9 +13,9 @@ import { REASONS } from '../../internals/reasons';
 export class DialogHandle<Payload> {
   /**
    * Closed, never-attached store handed to detached triggers while no root is attached, so they can
-   * render and register without a mounted root. Its trigger map doubles as the pending-registration
-   * buffer: detached triggers register into it, and the entries are drained into the real store when
-   * a root attaches.
+   * render and register without a mounted root. Triggers register into whichever store `store`
+   * currently resolves to, so while detached they live in this store's trigger map and migrate
+   * themselves to the root's store (and back) as it attaches/detaches.
    */
   private readonly fallbackStore = new DialogStore<Payload>();
 
@@ -127,46 +127,19 @@ export class DialogHandle<Payload> {
   }
 
   /**
-   * Attaches a root's store to this handle and drains any trigger registrations captured while
-   * detached into it. Returns a cleanup function that detaches the store again. Called by `Dialog.Root`.
+   * Points the handle at a root's store and notifies subscribers so detached triggers re-render and
+   * re-register into it (their registration ref re-fires on the store-pointer change). Returns a
+   * cleanup function that detaches the store again. Called by `Dialog.Root`.
    * @internal
    */
   attachStore(newStore: DialogStore<Payload>) {
-    const previousStore = this.attachedStore;
-
-    if (previousStore !== newStore) {
+    if (this.attachedStore !== newStore) {
       this.attachedStore = newStore;
-
-      // Triggers that mounted before this root registered into the fallback store's trigger map.
-      // Their registration ref is a stable callback that does not re-fire when the store pointer
-      // swaps, so draining here is the only path that moves them into the attached store. Do it
-      // before notifying subscribers so the store is immediately consistent for its trigger-derived
-      // logic (e.g. resolving an imperative `open(triggerId)` or the active trigger).
-      const pending = this.fallbackStore.context.triggerElements;
-      const { triggerElements } = newStore.context;
-      for (const [id, element] of pending.entries()) {
-        triggerElements.add(id, element);
-      }
-      pending.clear();
-
-      newStore.set('triggerCount', triggerElements.size);
       this.notifyStoreListeners();
     }
 
     return () => {
       if (this.attachedStore === newStore) {
-        // Move the still-registered triggers back into the pending buffer. Detached triggers can
-        // outlive the root (e.g. a persistent header trigger while a route-owned root unmounts);
-        // their registration ref is a stable callback that does not re-fire on the store-pointer
-        // swap, so without this they would be lost when the store is destroyed and the next root
-        // would attach with an empty trigger map — breaking imperative open-by-id / payload / ARIA
-        // until the trigger is clicked. The departing store's own map is left intact (it may survive
-        // a handle swap), and re-draining on the next attach is idempotent.
-        const pending = this.fallbackStore.context.triggerElements;
-        for (const [id, element] of newStore.context.triggerElements.entries()) {
-          pending.add(id, element);
-        }
-
         this.attachedStore = null;
         this.notifyStoreListeners();
       }

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createSelector, ReactStore, useStore } from '@base-ui/utils/store';
-import { NOOP } from '@base-ui/utils/empty';
+import { createSelector, ReactStore } from '@base-ui/utils/store';
 import { type InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import { type DialogRoot } from '../root/DialogRoot';
+import { NullStore } from '../../utils/NullStore';
 import {
   createPopupFloatingRootContext,
   createInitialPopupStoreState,
@@ -51,7 +51,7 @@ const selectors = {
 
 /**
  * The subset of `DialogStore` that detached handle-backed triggers rely on. Both the real
- * `DialogStore` and the inert `NullDialogStore` satisfy it, so a trigger can read from whichever
+ * `DialogStore` and the inert fallback store satisfy it, so a trigger can read from whichever
  * store the handle currently exposes.
  */
 export type DialogHandleStore<Payload> = Pick<
@@ -72,19 +72,7 @@ export class DialogStore<Payload> extends ReactStore<
     const triggerElements = new PopupTriggerMap();
     const state = createInitialState<Payload>(initialState, triggerElements, floatingId, nested);
 
-    super(
-      state,
-      {
-        popupRef: React.createRef<HTMLElement>(),
-        backdropRef: React.createRef<HTMLDivElement>(),
-        internalBackdropRef: React.createRef<HTMLDivElement>(),
-        outsidePressEnabledRef: { current: true },
-        triggerElements,
-        onOpenChange: undefined,
-        onOpenChangeComplete: undefined,
-      },
-      selectors,
-    );
+    super(state, createInitialContext(triggerElements), selectors);
   }
 
   public setOpen = (
@@ -120,65 +108,18 @@ export class DialogStore<Payload> extends ReactStore<
 }
 
 /**
- * Inert, immutable, closed store handed to detached handle-backed triggers while no root is
- * attached, so they can render and register without a mounted root. Reads always reflect a closed
- * dialog and mutations are no-ops; its own trigger map holds detached registrations until they
- * migrate to the attached root's store.
- * @internal
+ * Creates the inert fallback store used by detached handle-backed triggers while no
+ * `Dialog.Root` is attached. It preserves a dialog-specific trigger registry in context so
+ * detached triggers can register before migrating to the live root store.
  */
-export class NullDialogStore<Payload> implements DialogHandleStore<Payload> {
-  readonly state: Readonly<State<Payload>>;
+export function createNullDialogStore<Payload>(): DialogHandleStore<Payload> {
+  const triggerElements = new PopupTriggerMap();
 
-  readonly context: Context;
-
-  constructor() {
-    const triggerElements = new PopupTriggerMap();
-    this.state = Object.freeze(createInitialState<Payload>(undefined, triggerElements));
-    this.context = Object.freeze({
-      popupRef: React.createRef<HTMLElement>(),
-      backdropRef: React.createRef<HTMLDivElement>(),
-      internalBackdropRef: React.createRef<HTMLDivElement>(),
-      outsidePressEnabledRef: { current: true },
-      triggerElements,
-      onOpenChange: undefined,
-      onOpenChangeComplete: undefined,
-    });
-  }
-
-  subscribe = () => NOOP;
-
-  getSnapshot = () => this.state;
-
-  select: DialogStore<Payload>['select'] = ((key: keyof typeof selectors, a1, a2, a3) => {
-    return (
-      selectors[key] as (
-        state: Readonly<State<Payload>>,
-        a1?: unknown,
-        a2?: unknown,
-        a3?: unknown,
-      ) => unknown
-    )(this.state, a1, a2, a3);
-  }) as DialogStore<Payload>['select'];
-
-  update() {}
-
-  set() {}
-
-  useState: DialogStore<Payload>['useState'] = ((key: keyof typeof selectors, a1, a2, a3) => {
-    React.useDebugValue(key);
-    return useStore(
-      this,
-      selectors[key] as (
-        state: Readonly<State<Payload>>,
-        a1?: unknown,
-        a2?: unknown,
-        a3?: unknown,
-      ) => unknown,
-      a1,
-      a2,
-      a3,
-    );
-  }) as DialogStore<Payload>['useState'];
+  return new NullStore<Readonly<State<Payload>>, Context, typeof selectors>(
+    Object.freeze(createInitialState<Payload>(undefined, triggerElements)),
+    Object.freeze(createInitialContext(triggerElements)),
+    selectors,
+  );
 }
 
 function createInitialState<Payload>(
@@ -206,4 +147,16 @@ function createInitialState<Payload>(
   state.floatingRootContext = createPopupFloatingRootContext(triggerElements, floatingId, nested);
 
   return state;
+}
+
+function createInitialContext(triggerElements: PopupTriggerMap): Context {
+  return {
+    popupRef: React.createRef<HTMLElement>(),
+    backdropRef: React.createRef<HTMLDivElement>(),
+    internalBackdropRef: React.createRef<HTMLDivElement>(),
+    outsidePressEnabledRef: { current: true },
+    triggerElements,
+    onOpenChange: undefined,
+    onOpenChangeComplete: undefined,
+  };
 }

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -59,8 +59,8 @@ export class DialogStore<Payload> extends ReactStore<
     floatingId?: string | undefined,
     nested = false,
   ) {
-    const state = createInitialState<Payload>(initialState);
     const triggerElements = new PopupTriggerMap();
+    const state = createInitialState<Payload>(initialState);
 
     state.floatingRootContext = createPopupFloatingRootContext(triggerElements, floatingId, nested);
 
@@ -77,10 +77,7 @@ export class DialogStore<Payload> extends ReactStore<
       },
       selectors,
     );
-    this.triggerElements = triggerElements;
   }
-
-  private triggerElements: PopupTriggerMap;
 
   public setOpen = (
     nextOpen: boolean,
@@ -115,7 +112,7 @@ export class DialogStore<Payload> extends ReactStore<
 
   public initialize(initialState?: Partial<State<Payload>>) {
     const state = createInitialState<Payload>(initialState);
-    state.floatingRootContext = createPopupFloatingRootContext(this.triggerElements);
+    state.floatingRootContext = createPopupFloatingRootContext(this.context.triggerElements);
 
     if (process.env.NODE_ENV !== 'production') {
       // A handle store can outlive a single Root instance, so the dev-only controlledness cache

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { createSelector, ReactStore } from '@base-ui/utils/store';
+import { createSelector, ReactStore, useStore } from '@base-ui/utils/store';
+import { NOOP } from '@base-ui/utils/empty';
 import { type InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import { type DialogRoot } from '../root/DialogRoot';
 import {
@@ -47,6 +48,16 @@ const selectors = {
   viewportElement: createSelector((state: State<unknown>) => state.viewportElement),
   role: createSelector((state: State<unknown>) => state.role),
 };
+
+/**
+ * The subset of `DialogStore` that detached handle-backed triggers rely on. Both the real
+ * `DialogStore` and the inert `NullDialogStore` satisfy it, so a trigger can read from whichever
+ * store the handle currently exposes.
+ */
+export type DialogHandleStore<Payload> = Pick<
+  DialogStore<Payload>,
+  'context' | 'select' | 'set' | 'state' | 'update' | 'useState'
+>;
 
 export class DialogStore<Payload> extends ReactStore<
   Readonly<State<Payload>>,
@@ -106,6 +117,68 @@ export class DialogStore<Payload> extends ReactStore<
 
     this.update(updatedState);
   };
+}
+
+/**
+ * Inert, immutable, closed store handed to detached handle-backed triggers while no root is
+ * attached, so they can render and register without a mounted root. Reads always reflect a closed
+ * dialog and mutations are no-ops; its own trigger map holds detached registrations until they
+ * migrate to the attached root's store.
+ * @internal
+ */
+export class NullDialogStore<Payload> implements DialogHandleStore<Payload> {
+  readonly state: Readonly<State<Payload>>;
+
+  readonly context: Context;
+
+  constructor() {
+    const triggerElements = new PopupTriggerMap();
+    this.state = Object.freeze(createInitialState<Payload>(undefined, triggerElements));
+    this.context = Object.freeze({
+      popupRef: React.createRef<HTMLElement>(),
+      backdropRef: React.createRef<HTMLDivElement>(),
+      internalBackdropRef: React.createRef<HTMLDivElement>(),
+      outsidePressEnabledRef: { current: true },
+      triggerElements,
+      onOpenChange: undefined,
+      onOpenChangeComplete: undefined,
+    });
+  }
+
+  subscribe = () => NOOP;
+
+  getSnapshot = () => this.state;
+
+  select: DialogStore<Payload>['select'] = ((key: keyof typeof selectors, a1, a2, a3) => {
+    return (
+      selectors[key] as (
+        state: Readonly<State<Payload>>,
+        a1?: unknown,
+        a2?: unknown,
+        a3?: unknown,
+      ) => unknown
+    )(this.state, a1, a2, a3);
+  }) as DialogStore<Payload>['select'];
+
+  update() {}
+
+  set() {}
+
+  useState: DialogStore<Payload>['useState'] = ((key: keyof typeof selectors, a1, a2, a3) => {
+    React.useDebugValue(key);
+    return useStore(
+      this,
+      selectors[key] as (
+        state: Readonly<State<Payload>>,
+        a1?: unknown,
+        a2?: unknown,
+        a3?: unknown,
+      ) => unknown,
+      a1,
+      a2,
+      a3,
+    );
+  }) as DialogStore<Payload>['useState'];
 }
 
 function createInitialState<Payload>(

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { createSelector, ReactStore, useStore } from '@base-ui/utils/store';
-import { NOOP } from '@base-ui/utils/empty';
+import { createSelector, ReactStore } from '@base-ui/utils/store';
 import { type InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import { type DialogRoot } from '../root/DialogRoot';
 import {
@@ -48,11 +47,6 @@ const selectors = {
   viewportElement: createSelector((state: State<unknown>) => state.viewportElement),
   role: createSelector((state: State<unknown>) => state.role),
 };
-
-export type DialogHandleStore<Payload> = Pick<
-  DialogStore<Payload>,
-  'context' | 'select' | 'set' | 'state' | 'update' | 'useState'
->;
 
 export class DialogStore<Payload> extends ReactStore<
   Readonly<State<Payload>>,
@@ -112,64 +106,6 @@ export class DialogStore<Payload> extends ReactStore<
 
     this.update(updatedState);
   };
-}
-
-/**
- * Immutable closed store used by detached handle-backed triggers while no root is attached.
- * @internal
- */
-export class NullDialogStore<Payload> implements DialogHandleStore<Payload> {
-  readonly state: Readonly<State<Payload>>;
-
-  readonly context: Context;
-
-  constructor(triggerElements: PopupTriggerMap) {
-    this.state = Object.freeze(createInitialState<Payload>(undefined, triggerElements));
-    this.context = Object.freeze({
-      popupRef: React.createRef<HTMLElement>(),
-      backdropRef: React.createRef<HTMLDivElement>(),
-      internalBackdropRef: React.createRef<HTMLDivElement>(),
-      outsidePressEnabledRef: { current: true },
-      triggerElements,
-      onOpenChange: undefined,
-      onOpenChangeComplete: undefined,
-    });
-  }
-
-  subscribe = () => NOOP;
-
-  getSnapshot = () => this.state;
-
-  select: DialogStore<Payload>['select'] = ((key: keyof typeof selectors, a1, a2, a3) => {
-    return (
-      selectors[key] as (
-        state: Readonly<State<Payload>>,
-        a1?: unknown,
-        a2?: unknown,
-        a3?: unknown,
-      ) => unknown
-    )(this.state, a1, a2, a3);
-  }) as DialogStore<Payload>['select'];
-
-  update() {}
-
-  set() {}
-
-  useState: DialogStore<Payload>['useState'] = ((key: keyof typeof selectors, a1, a2, a3) => {
-    React.useDebugValue(key);
-    return useStore(
-      this,
-      selectors[key] as (
-        state: Readonly<State<Payload>>,
-        a1?: unknown,
-        a2?: unknown,
-        a3?: unknown,
-      ) => unknown,
-      a1,
-      a2,
-      a3,
-    );
-  }) as DialogStore<Payload>['useState'];
 }
 
 function createInitialState<Payload>(

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -133,7 +133,11 @@ export class DialogStore<Payload> extends ReactStore<
     initialState?: Partial<State<Payload>>,
   ) {
     /* eslint-disable react-hooks/rules-of-hooks */
-    const store = usePopupStore(
+    const store = usePopupStore<
+      Readonly<State<Payload>>,
+      Omit<DialogRoot.ChangeEventDetails, 'preventUnmountOnClose'>,
+      DialogStore<Payload>
+    >(
       externalStore,
       (floatingId, nested) => new DialogStore<Payload>(initialState, floatingId, nested),
       true,

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -8,6 +8,7 @@ import {
   createInitialPopupStoreState,
   PopupStoreContext,
   popupStoreSelectors,
+  PopupTriggerDataStore,
   PopupStoreState,
   PopupTriggerMap,
   setPopupOpenState,
@@ -54,10 +55,7 @@ const selectors = {
  * `DialogStore` and the inert fallback store satisfy it, so a trigger can read from whichever
  * store the handle currently exposes.
  */
-export type DialogHandleStore<Payload> = Pick<
-  DialogStore<Payload>,
-  'context' | 'select' | 'set' | 'state' | 'update' | 'useState'
->;
+export type DialogHandleStore<Payload> = PopupTriggerDataStore<State<Payload>>;
 
 export class DialogStore<Payload> extends ReactStore<
   Readonly<State<Payload>>,

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -60,9 +60,7 @@ export class DialogStore<Payload> extends ReactStore<
     nested = false,
   ) {
     const triggerElements = new PopupTriggerMap();
-    const state = createInitialState<Payload>(initialState);
-
-    state.floatingRootContext = createPopupFloatingRootContext(triggerElements, floatingId, nested);
+    const state = createInitialState<Payload>(initialState, triggerElements, floatingId, nested);
 
     super(
       state,
@@ -111,8 +109,7 @@ export class DialogStore<Payload> extends ReactStore<
   };
 
   public initialize(initialState?: Partial<State<Payload>>) {
-    const state = createInitialState<Payload>(initialState);
-    state.floatingRootContext = createPopupFloatingRootContext(this.context.triggerElements);
+    const state = createInitialState<Payload>(initialState, this.context.triggerElements);
 
     if (process.env.NODE_ENV !== 'production') {
       // A handle store can outlive a single Root instance, so the dev-only controlledness cache
@@ -148,8 +145,13 @@ export class DialogStore<Payload> extends ReactStore<
   }
 }
 
-function createInitialState<Payload>(initialState: Partial<State<Payload>> = {}): State<Payload> {
-  return {
+function createInitialState<Payload>(
+  initialState: Partial<State<Payload>> = {},
+  triggerElements?: PopupTriggerMap | undefined,
+  floatingId?: string | undefined,
+  nested = false,
+): State<Payload> {
+  const state: State<Payload> = {
     ...createInitialPopupStoreState<Payload>(),
     modal: true,
     disablePointerDismissal: false,
@@ -164,4 +166,10 @@ function createInitialState<Payload>(initialState: Partial<State<Payload>> = {})
     role: 'dialog',
     ...initialState,
   };
+
+  if (triggerElements !== undefined) {
+    state.floatingRootContext = createPopupFloatingRootContext(triggerElements, floatingId, nested);
+  }
+
+  return state;
 }

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { createSelector, ReactStore } from '@base-ui/utils/store';
+import { createSelector, ReactStore, useStore } from '@base-ui/utils/store';
+import { NOOP } from '@base-ui/utils/empty';
 import { type InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import { type DialogRoot } from '../root/DialogRoot';
 import {
@@ -10,7 +11,6 @@ import {
   PopupStoreState,
   PopupTriggerMap,
   setPopupOpenState,
-  usePopupStore,
 } from '../../utils/popups';
 
 export type State<Payload> = PopupStoreState<Payload> & {
@@ -48,6 +48,11 @@ const selectors = {
   viewportElement: createSelector((state: State<unknown>) => state.viewportElement),
   role: createSelector((state: State<unknown>) => state.role),
 };
+
+export type DialogHandleStore<Payload> = Pick<
+  DialogStore<Payload>,
+  'context' | 'select' | 'set' | 'state' | 'update' | 'useState'
+>;
 
 export class DialogStore<Payload> extends ReactStore<
   Readonly<State<Payload>>,
@@ -107,47 +112,69 @@ export class DialogStore<Payload> extends ReactStore<
 
     this.update(updatedState);
   };
+}
 
-  public initialize(initialState?: Partial<State<Payload>>) {
-    const state = createInitialState<Payload>(initialState, this.context.triggerElements);
+/**
+ * Immutable closed store used by detached handle-backed triggers while no root is attached.
+ * @internal
+ */
+export class NullDialogStore<Payload> implements DialogHandleStore<Payload> {
+  readonly state: Readonly<State<Payload>>;
 
-    if (process.env.NODE_ENV !== 'production') {
-      // A handle store can outlive a single Root instance, so the dev-only controlledness cache
-      // must not carry over when the next Root attaches to the same store.
-      delete (this as { controlledValues?: Map<keyof State<Payload>, boolean> | undefined })
-        .controlledValues;
-    }
+  readonly context: Context;
 
-    // Avoid notifying detached trigger subscribers while Dialog.Root is rendering.
-    this.state = state;
+  constructor(triggerElements: PopupTriggerMap) {
+    this.state = Object.freeze(createInitialState<Payload>(undefined, triggerElements));
+    this.context = Object.freeze({
+      popupRef: React.createRef<HTMLElement>(),
+      backdropRef: React.createRef<HTMLDivElement>(),
+      internalBackdropRef: React.createRef<HTMLDivElement>(),
+      outsidePressEnabledRef: { current: true },
+      triggerElements,
+      onOpenChange: undefined,
+      onOpenChangeComplete: undefined,
+    });
   }
 
-  static useStore<Payload>(
-    externalStore: DialogStore<Payload> | undefined,
-    initialState?: Partial<State<Payload>>,
-  ) {
-    /* eslint-disable react-hooks/rules-of-hooks */
-    const store = usePopupStore<
-      Readonly<State<Payload>>,
-      Omit<DialogRoot.ChangeEventDetails, 'preventUnmountOnClose'>,
-      DialogStore<Payload>
-    >(
-      externalStore,
-      (floatingId, nested) => new DialogStore<Payload>(initialState, floatingId, nested),
-      true,
-      (storeInstance) => {
-        storeInstance.initialize(initialState);
-      },
-    ).store;
-    /* eslint-enable react-hooks/rules-of-hooks */
+  subscribe = () => NOOP;
 
-    return store;
-  }
+  getSnapshot = () => this.state;
+
+  select: DialogStore<Payload>['select'] = ((key: keyof typeof selectors, a1, a2, a3) => {
+    return (
+      selectors[key] as (
+        state: Readonly<State<Payload>>,
+        a1?: unknown,
+        a2?: unknown,
+        a3?: unknown,
+      ) => unknown
+    )(this.state, a1, a2, a3);
+  }) as DialogStore<Payload>['select'];
+
+  update() {}
+
+  set() {}
+
+  useState: DialogStore<Payload>['useState'] = ((key: keyof typeof selectors, a1, a2, a3) => {
+    React.useDebugValue(key);
+    return useStore(
+      this,
+      selectors[key] as (
+        state: Readonly<State<Payload>>,
+        a1?: unknown,
+        a2?: unknown,
+        a3?: unknown,
+      ) => unknown,
+      a1,
+      a2,
+      a3,
+    );
+  }) as DialogStore<Payload>['useState'];
 }
 
 function createInitialState<Payload>(
-  initialState: Partial<State<Payload>> = {},
-  triggerElements?: PopupTriggerMap | undefined,
+  initialState: Partial<State<Payload>> | undefined,
+  triggerElements: PopupTriggerMap,
   floatingId?: string | undefined,
   nested = false,
 ): State<Payload> {
@@ -167,9 +194,7 @@ function createInitialState<Payload>(
     ...initialState,
   };
 
-  if (triggerElements !== undefined) {
-    state.floatingRootContext = createPopupFloatingRootContext(triggerElements, floatingId, nested);
-  }
+  state.floatingRootContext = createPopupFloatingRootContext(triggerElements, floatingId, nested);
 
   return state;
 }

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -59,8 +59,8 @@ export class DialogStore<Payload> extends ReactStore<
     floatingId?: string | undefined,
     nested = false,
   ) {
-    const triggerElements = new PopupTriggerMap();
     const state = createInitialState<Payload>(initialState);
+    const triggerElements = new PopupTriggerMap();
 
     state.floatingRootContext = createPopupFloatingRootContext(triggerElements, floatingId, nested);
 
@@ -77,7 +77,10 @@ export class DialogStore<Payload> extends ReactStore<
       },
       selectors,
     );
+    this.triggerElements = triggerElements;
   }
+
+  private triggerElements: PopupTriggerMap;
 
   public setOpen = (
     nextOpen: boolean,
@@ -110,6 +113,21 @@ export class DialogStore<Payload> extends ReactStore<
     this.update(updatedState);
   };
 
+  public initialize(initialState?: Partial<State<Payload>>) {
+    const state = createInitialState<Payload>(initialState);
+    state.floatingRootContext = createPopupFloatingRootContext(this.triggerElements);
+
+    if (process.env.NODE_ENV !== 'production') {
+      // A handle store can outlive a single Root instance, so the dev-only controlledness cache
+      // must not carry over when the next Root attaches to the same store.
+      delete (this as { controlledValues?: Map<keyof State<Payload>, boolean> | undefined })
+        .controlledValues;
+    }
+
+    // Avoid notifying detached trigger subscribers while Dialog.Root is rendering.
+    this.state = state;
+  }
+
   static useStore<Payload>(
     externalStore: DialogStore<Payload> | undefined,
     initialState?: Partial<State<Payload>>,
@@ -119,6 +137,9 @@ export class DialogStore<Payload> extends ReactStore<
       externalStore,
       (floatingId, nested) => new DialogStore<Payload>(initialState, floatingId, nested),
       true,
+      (storeInstance) => {
+        storeInstance.initialize(initialState);
+      },
     ).store;
     /* eslint-enable react-hooks/rules-of-hooks */
 

--- a/packages/react/src/dialog/store/useDialogHandleStore.ts
+++ b/packages/react/src/dialog/store/useDialogHandleStore.ts
@@ -1,0 +1,26 @@
+'use client';
+import * as React from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
+import type { DialogHandle } from './DialogHandle';
+import type { DialogHandleStore } from './DialogStore';
+
+export function useDialogHandleStore<Payload>(
+  handle: DialogHandle<Payload> | undefined,
+): DialogHandleStore<Payload> | undefined {
+  const subscribe = React.useCallback(
+    (listener: () => void) => {
+      if (handle === undefined) {
+        return () => {};
+      }
+
+      return handle.subscribeStore(listener);
+    },
+    [handle],
+  );
+
+  const getSnapshot = React.useCallback(() => {
+    return handle === undefined ? undefined : handle.store;
+  }, [handle]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/packages/react/src/dialog/store/useDialogHandleStore.ts
+++ b/packages/react/src/dialog/store/useDialogHandleStore.ts
@@ -2,11 +2,11 @@
 import * as React from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import type { DialogHandle } from './DialogHandle';
-import type { DialogHandleStore } from './DialogStore';
+import type { DialogStore } from './DialogStore';
 
 export function useDialogHandleStore<Payload>(
   handle: DialogHandle<Payload> | undefined,
-): DialogHandleStore<Payload> | undefined {
+): DialogStore<Payload> | undefined {
   const subscribe = React.useCallback(
     (listener: () => void) => {
       if (handle === undefined) {

--- a/packages/react/src/dialog/store/useDialogHandleStore.ts
+++ b/packages/react/src/dialog/store/useDialogHandleStore.ts
@@ -2,11 +2,11 @@
 import * as React from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import type { DialogHandle } from './DialogHandle';
-import type { DialogStore } from './DialogStore';
+import type { DialogHandleStore } from './DialogStore';
 
 export function useDialogHandleStore<Payload>(
   handle: DialogHandle<Payload> | undefined,
-): DialogStore<Payload> | undefined {
+): DialogHandleStore<Payload> | undefined {
   const subscribe = React.useCallback(
     (listener: () => void) => {
       if (handle === undefined) {

--- a/packages/react/src/dialog/trigger/DialogTrigger.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.tsx
@@ -7,6 +7,7 @@ import type { BaseUIComponentProps, NativeButtonProps } from '../../internals/ty
 import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
 import { CLICK_TRIGGER_IDENTIFIER } from '../../internals/constants';
 import { DialogHandle } from '../store/DialogHandle';
+import { useDialogHandleStore } from '../store/useDialogHandleStore';
 import { useTriggerDataForwarding } from '../../utils/popups';
 import { useBaseUiId } from '../../internals/useBaseUiId';
 import { useClick } from '../../floating-ui-react';
@@ -35,7 +36,8 @@ export const DialogTrigger = React.forwardRef(function DialogTrigger(
   } = componentProps;
 
   const dialogRootContext = useDialogRootContext(true);
-  const store = handle?.store ?? dialogRootContext?.store;
+  const handleStore = useDialogHandleStore(handle);
+  const store = handleStore ?? dialogRootContext?.store;
   if (!store) {
     throw new Error(
       'Base UI: <Dialog.Trigger> must be used within <Dialog.Root> or provided with a handle.',

--- a/packages/react/src/drawer/handle.ts
+++ b/packages/react/src/drawer/handle.ts
@@ -9,6 +9,8 @@ import { DialogHandle } from '../dialog/store/DialogHandle';
  * before a root attaches (or after it unmounts) are ignored.
  */
 export class DrawerHandle<Payload> extends DialogHandle<Payload> {
+  // Nominal brand: makes this handle type distinct from `DialogHandle` and sibling handles so they
+  // can't be passed interchangeably. Type-only; has no runtime presence.
   private readonly __drawerBrand!: never;
 }
 

--- a/packages/react/src/drawer/handle.ts
+++ b/packages/react/src/drawer/handle.ts
@@ -1,0 +1,20 @@
+import { DialogHandle } from '../dialog/store/DialogHandle';
+
+/**
+ * Controls a Drawer imperatively and associates detached `Drawer.Trigger` components with a
+ * `Drawer.Root`. Create one with `Drawer.createHandle()` and pass it to the `handle` prop of the
+ * root and of any triggers rendered outside of it.
+ *
+ * The imperative methods take effect only while a root using this handle is mounted; calls made
+ * before a root attaches (or after it unmounts) are ignored.
+ */
+export class DrawerHandle<Payload> extends DialogHandle<Payload> {
+  private readonly __drawerBrand!: never;
+}
+
+/**
+ * Creates a new handle to connect a Drawer.Root with detached Drawer.Trigger components.
+ */
+export function createDrawerHandle<Payload>(): DrawerHandle<Payload> {
+  return new DrawerHandle<Payload>();
+}

--- a/packages/react/src/drawer/index.parts.ts
+++ b/packages/react/src/drawer/index.parts.ts
@@ -13,7 +13,4 @@ export { DrawerTitle as Title } from './title/DrawerTitle';
 export { DrawerTrigger as Trigger } from './trigger/DrawerTrigger';
 export { DrawerViewport as Viewport } from './viewport/DrawerViewport';
 export { DrawerVirtualKeyboardProvider as VirtualKeyboardProvider } from './virtual-keyboard-provider/DrawerVirtualKeyboardProvider';
-export {
-  createDialogHandle as createHandle,
-  DialogHandle as Handle,
-} from '../dialog/store/DialogHandle';
+export { createDrawerHandle as createHandle, DrawerHandle as Handle } from './handle';

--- a/packages/react/src/drawer/root/DrawerRoot.test.tsx
+++ b/packages/react/src/drawer/root/DrawerRoot.test.tsx
@@ -799,6 +799,60 @@ describe('<Drawer.Root />', () => {
     expect(screen.getByTestId('payload').textContent).toBe('2');
   });
 
+  it('supports imperative actions with handles', async () => {
+    const handle = Drawer.createHandle<number>();
+
+    await render(
+      <div>
+        <Drawer.Trigger handle={handle} id="trigger-1" payload={1}>
+          Trigger 1
+        </Drawer.Trigger>
+        <Drawer.Trigger handle={handle} id="trigger-2" payload={2}>
+          Trigger 2
+        </Drawer.Trigger>
+        <Drawer.Root handle={handle}>
+          {({ payload }: { payload: number | undefined }) => (
+            <Drawer.Portal>
+              <Drawer.Viewport>
+                <Drawer.Popup data-testid="content">{payload}</Drawer.Popup>
+              </Drawer.Viewport>
+            </Drawer.Portal>
+          )}
+        </Drawer.Root>
+      </div>,
+    );
+
+    const trigger1 = screen.getByRole('button', { name: 'Trigger 1' });
+    const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
+    expect(screen.queryByRole('dialog')).toBe(null);
+
+    await act(() => handle.open('trigger-2'));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBe(null);
+    });
+
+    expect(screen.getByTestId('content').textContent).toBe('2');
+    expect(trigger2).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger2.getAttribute('aria-controls')).toBe(
+      screen.getByRole('dialog').getAttribute('id'),
+    );
+    expect(trigger1).toHaveAttribute('aria-expanded', 'false');
+
+    await act(() => handle.close());
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBe(null);
+    });
+    expect(trigger2).toHaveAttribute('aria-expanded', 'false');
+
+    await act(() => handle.openWithPayload(8));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBe(null);
+    });
+    expect(screen.getByTestId('content').textContent).toBe('8');
+    expect(trigger1).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger2).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it('attaches fresh root state when a handle-backed root remounts', async () => {
     const handle = Drawer.createHandle<number>();
 
@@ -839,28 +893,54 @@ describe('<Drawer.Root />', () => {
     }
 
     const { user } = await render(<App />);
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
 
     expect(screen.getByTestId('payload').textContent).toBe('No payload');
 
-    await user.click(screen.getByRole('button', { name: 'Trigger' }));
+    await user.click(trigger);
     await waitFor(() => {
       expect(screen.getByText('Drawer content')).toBeVisible();
     });
     expect(screen.getByTestId('payload').textContent).toBe('1');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger.getAttribute('aria-controls')).toBe(
+      screen.getByRole('dialog').getAttribute('id'),
+    );
 
     await user.click(screen.getByRole('button', { name: 'Unmount root' }));
     expect(handle.isOpen).toBe(false);
     expect(screen.queryByText('Drawer content')).toBe(null);
 
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    handle.openWithPayload(8);
+    handle.open('trigger');
+    handle.close();
+    const detachedWarnings = consoleWarn.mock.calls.filter(
+      ([message]) =>
+        typeof message === 'string' && message.includes('no root using this handle is mounted'),
+    );
+    consoleWarn.mockRestore();
+
+    expect(handle.isOpen).toBe(false);
+    expect(detachedWarnings).toHaveLength(3);
+
     await user.click(screen.getByRole('button', { name: 'Remount root' }));
     expect(screen.getByTestId('payload').textContent).toBe('No payload');
     expect(screen.queryByText('Drawer content')).toBe(null);
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+    expect(trigger).not.toHaveAttribute('aria-controls');
 
-    await user.click(screen.getByRole('button', { name: 'Trigger' }));
+    await user.click(trigger);
     await waitFor(() => {
       expect(screen.getByText('Drawer content')).toBeVisible();
     });
     expect(screen.getByTestId('payload').textContent).toBe('1');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger.getAttribute('aria-controls')).toBe(
+      screen.getByRole('dialog').getAttribute('id'),
+    );
   });
 
   it('synchronizes trigger aria-controls with the popup id', async () => {

--- a/packages/react/src/drawer/root/DrawerRoot.test.tsx
+++ b/packages/react/src/drawer/root/DrawerRoot.test.tsx
@@ -799,6 +799,70 @@ describe('<Drawer.Root />', () => {
     expect(screen.getByTestId('payload').textContent).toBe('2');
   });
 
+  it('attaches fresh root state when a handle-backed root remounts', async () => {
+    const handle = Drawer.createHandle<number>();
+
+    function App() {
+      const [mounted, setMounted] = React.useState(true);
+
+      return (
+        <React.Fragment>
+          <Drawer.Trigger handle={handle} id="trigger" payload={1}>
+            Trigger
+          </Drawer.Trigger>
+          {!mounted && (
+            <button type="button" onClick={() => setMounted(true)}>
+              Remount root
+            </button>
+          )}
+          {mounted && (
+            <Drawer.Root handle={handle}>
+              {({ payload }: { payload: number | undefined }) => (
+                <React.Fragment>
+                  <span data-testid="payload">{payload ?? 'No payload'}</span>
+                  <Drawer.Portal>
+                    <Drawer.Viewport>
+                      <Drawer.Popup>
+                        Drawer content
+                        <button type="button" onClick={() => setMounted(false)}>
+                          Unmount root
+                        </button>
+                      </Drawer.Popup>
+                    </Drawer.Viewport>
+                  </Drawer.Portal>
+                </React.Fragment>
+              )}
+            </Drawer.Root>
+          )}
+        </React.Fragment>
+      );
+    }
+
+    const { user } = await render(<App />);
+
+    expect(screen.getByTestId('payload').textContent).toBe('No payload');
+
+    await user.click(screen.getByRole('button', { name: 'Trigger' }));
+    await waitFor(() => {
+      expect(screen.getByText('Drawer content')).toBeVisible();
+    });
+    expect(screen.getByTestId('payload').textContent).toBe('1');
+
+    await user.click(screen.getByRole('button', { name: 'Unmount root' }));
+    expect(handle.isOpen).toBe(false);
+    expect(screen.queryByText('Drawer content')).toBe(null);
+
+    await user.click(screen.getByRole('button', { name: 'Remount root' }));
+    expect(screen.getByTestId('payload').textContent).toBe('No payload');
+    expect(screen.queryByText('Drawer content')).toBe(null);
+
+    await user.click(screen.getByRole('button', { name: 'Trigger' }));
+    await waitFor(() => {
+      expect(screen.getByText('Drawer content')).toBeVisible();
+    });
+    expect(screen.getByTestId('payload').textContent).toBe('1');
+  });
+
   it('synchronizes trigger aria-controls with the popup id', async () => {
     const { user } = await render(
       <Drawer.Root>

--- a/packages/react/src/drawer/root/DrawerRoot.tsx
+++ b/packages/react/src/drawer/root/DrawerRoot.tsx
@@ -21,7 +21,7 @@ import {
 import { REASONS } from '../../internals/reasons';
 import { IsDrawerContext, useDialogRootContext } from '../../dialog/root/DialogRootContext';
 import { useDrawerProviderContext } from '../provider/DrawerProviderContext';
-import type { DialogHandle } from '../../dialog/store/DialogHandle';
+import type { DrawerHandle } from '../handle';
 import type { PayloadChildRenderFunction } from '../../utils/popups';
 
 /**
@@ -299,7 +299,7 @@ export interface DrawerRootProps<Payload = unknown> {
    * If specified, allows detached triggers to control the drawer's open state.
    * Can be created with the Drawer.createHandle() method.
    */
-  handle?: DialogHandle<Payload> | undefined;
+  handle?: DrawerHandle<Payload> | undefined;
   /**
    * ID of the trigger that the drawer is associated with.
    * This is useful in conjunction with the `open` prop to create a controlled drawer.

--- a/packages/react/src/drawer/trigger/DrawerTrigger.tsx
+++ b/packages/react/src/drawer/trigger/DrawerTrigger.tsx
@@ -1,7 +1,7 @@
 'use client';
 import type * as React from 'react';
 import { DialogTrigger } from '../../dialog/trigger/DialogTrigger';
-import type { DialogHandle as DrawerHandle } from '../../dialog/store/DialogHandle';
+import type { DrawerHandle } from '../handle';
 import type { BaseUIComponentProps, NativeButtonProps } from '../../internals/types';
 
 /**

--- a/packages/react/src/utils/NullStore.ts
+++ b/packages/react/src/utils/NullStore.ts
@@ -1,0 +1,23 @@
+import { ReactStore } from '@base-ui/utils/store';
+
+type SelectorFunction<State> = (state: State, ...args: any[]) => any;
+
+/**
+ * A `ReactStore` whose state never changes.
+ *
+ * Useful for fallback stores that need to support normal store reads while detached from the
+ * component that owns real state. Context values may still contain mutable refs or maps.
+ */
+export class NullStore<
+  State extends object,
+  Context = Record<string, never>,
+  Selectors extends Record<string, SelectorFunction<State>> = Record<string, never>,
+> extends ReactStore<State, Context, Selectors> {
+  setState(_newState: State) {}
+
+  update(_changes: Partial<State>) {}
+
+  set<T>(_key: keyof State, _value: T) {}
+
+  notifyAll() {}
+}

--- a/packages/react/src/utils/NullStore.ts
+++ b/packages/react/src/utils/NullStore.ts
@@ -13,6 +13,9 @@ export class NullStore<
   Context = Record<string, never>,
   Selectors extends Record<string, SelectorFunction<State>> = Record<string, never>,
 > extends ReactStore<State, Context, Selectors> {
+  // `update`/`set`/`notifyAll` funnel through `setState` in the base `Store`, so overriding
+  // `setState` alone would neutralize them today. They are overridden explicitly so the store stays
+  // inert even if a future base-class change stops routing a mutator through `setState`.
   setState(_newState: State) {}
 
   update(_changes: Partial<State>) {}

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -50,7 +50,7 @@ type PopupStoreWithOpen<
 
 /**
  * The subset of a popup store that trigger registration and data forwarding rely on. Narrow enough
- * that an inert store (e.g. the dialog handle's `NullDialogStore`) can be passed while detached.
+ * that an inert store (e.g. the dialog handle's fallback store) can be passed while detached.
  */
 type PopupTriggerDataStore<State extends PopupStoreState<unknown>> = Pick<
   ReactStore<Readonly<State>, PopupStoreContext<never>, PopupStoreSelectors>,

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -48,6 +48,11 @@ type PopupStoreWithOpen<
   setOpen(open: boolean, eventDetails: SetOpenEventDetails): void;
 };
 
+type PopupTriggerDataStore<State extends PopupStoreState<unknown>> = Pick<
+  ReactStore<Readonly<State>, PopupStoreContext<never>, PopupStoreSelectors>,
+  'context' | 'select' | 'set' | 'state' | 'update' | 'useState'
+>;
+
 export function usePopupStore<
   State extends PopupStoreState<unknown>,
   SetOpenEventDetails extends BaseUIChangeEventDetails<string>,
@@ -56,7 +61,6 @@ export function usePopupStore<
   externalStore: Store | undefined,
   createStore: (floatingId: string | undefined, nested: boolean) => Store,
   treatPopupAsFloatingElement = false,
-  initializeExternalStore?: ((store: Store) => void) | undefined,
 ) {
   const floatingId = useId();
   const nested = useFloatingParentNodeId() != null;
@@ -67,14 +71,6 @@ export function usePopupStore<
   }
 
   const store = externalStore ?? internalStoreRef.current!;
-  const notifyAfterInitializeRef = React.useRef(false);
-
-  useOnFirstRender(() => {
-    if (externalStore !== undefined && initializeExternalStore !== undefined) {
-      initializeExternalStore(store);
-      notifyAfterInitializeRef.current = true;
-    }
-  });
 
   useSyncedFloatingRootContext({
     popupStore: store,
@@ -84,13 +80,6 @@ export function usePopupStore<
     nested,
     onOpenChange: store.setOpen,
   });
-
-  useIsoLayoutEffect(() => {
-    if (notifyAfterInitializeRef.current) {
-      notifyAfterInitializeRef.current = false;
-      store.notifyAll();
-    }
-  }, [store]);
 
   return { store, internalStore: internalStoreRef.current };
 }
@@ -102,7 +91,7 @@ export function usePopupStore<
  */
 export function useTriggerRegistration<State extends PopupStoreState<unknown>>(
   id: string | undefined,
-  store: ReactStore<State, PopupStoreContext<never>, PopupStoreSelectors>,
+  store: PopupTriggerDataStore<State>,
 ) {
   // Keep track of the currently registered element to unregister it on unmount or id change.
   const registeredElementIdRef = React.useRef<string | null>(null);
@@ -282,7 +271,7 @@ export function useInitialOpenSync<State extends PopupStoreState<unknown>>(
 export function useTriggerDataForwarding<State extends PopupStoreState<unknown>>(
   triggerId: string | undefined,
   triggerElementRef: React.RefObject<Element | null>,
-  store: ReactStore<State, PopupStoreContext<never>, typeof popupStoreSelectors>,
+  store: PopupTriggerDataStore<State>,
   stateUpdates: Omit<Partial<State>, 'activeTriggerId' | 'activeTriggerElement'>,
 ) {
   const isMountedByThisTrigger = store.useState('isMountedByTrigger', triggerId);

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -48,6 +48,15 @@ type PopupStoreWithOpen<
   setOpen(open: boolean, eventDetails: SetOpenEventDetails): void;
 };
 
+/**
+ * The subset of a popup store that trigger registration and data forwarding rely on. Narrow enough
+ * that an inert store (e.g. the dialog handle's `NullDialogStore`) can be passed while detached.
+ */
+type PopupTriggerDataStore<State extends PopupStoreState<unknown>> = Pick<
+  ReactStore<Readonly<State>, PopupStoreContext<never>, PopupStoreSelectors>,
+  'context' | 'select' | 'set' | 'state' | 'update' | 'useState'
+>;
+
 export function usePopupStore<
   State extends PopupStoreState<unknown>,
   SetOpenEventDetails extends BaseUIChangeEventDetails<string>,
@@ -86,7 +95,7 @@ export function usePopupStore<
  */
 export function useTriggerRegistration<State extends PopupStoreState<unknown>>(
   id: string | undefined,
-  store: ReactStore<State, PopupStoreContext<never>, PopupStoreSelectors>,
+  store: PopupTriggerDataStore<State>,
 ) {
   // Keep track of the currently registered element to unregister it on unmount or id change.
   const registeredElementIdRef = React.useRef<string | null>(null);
@@ -266,7 +275,7 @@ export function useInitialOpenSync<State extends PopupStoreState<unknown>>(
 export function useTriggerDataForwarding<State extends PopupStoreState<unknown>>(
   triggerId: string | undefined,
   triggerElementRef: React.RefObject<Element | null>,
-  store: ReactStore<State, PopupStoreContext<never>, PopupStoreSelectors>,
+  store: PopupTriggerDataStore<State>,
   stateUpdates: Omit<Partial<State>, 'activeTriggerId' | 'activeTriggerElement'>,
 ) {
   const isMountedByThisTrigger = store.useState('isMountedByTrigger', triggerId);

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -67,10 +67,12 @@ export function usePopupStore<
   }
 
   const store = externalStore ?? internalStoreRef.current!;
+  const notifyAfterInitializeRef = React.useRef(false);
 
   useOnFirstRender(() => {
-    if (externalStore !== undefined) {
-      initializeExternalStore?.(store);
+    if (externalStore !== undefined && initializeExternalStore !== undefined) {
+      initializeExternalStore(store);
+      notifyAfterInitializeRef.current = true;
     }
   });
 
@@ -82,6 +84,13 @@ export function usePopupStore<
     nested,
     onOpenChange: store.setOpen,
   });
+
+  useIsoLayoutEffect(() => {
+    if (notifyAfterInitializeRef.current) {
+      notifyAfterInitializeRef.current = false;
+      store.notifyAll();
+    }
+  }, [store]);
 
   return { store, internalStore: internalStoreRef.current };
 }

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -273,13 +273,10 @@ export function useTriggerDataForwarding<State extends PopupStoreState<unknown>>
 
   const baseRegisterTrigger = useTriggerRegistration(triggerId, store);
 
-  const registerTrigger = useStableCallback((element: Element | null) => {
-    baseRegisterTrigger(element);
-
-    if (!element) {
-      return;
-    }
-
+  // Applies trigger-owned state (active-trigger ownership and payload) when the trigger registers.
+  // Stable so payload/`stateUpdates` changes do not change the ref identity (which would needlessly
+  // churn registration); it reads the latest closure values when invoked.
+  const applyTriggerData = useStableCallback((element: Element) => {
     const open = store.select('open');
     const activeTriggerId = store.select('activeTriggerId');
 
@@ -302,6 +299,20 @@ export function useTriggerDataForwarding<State extends PopupStoreState<unknown>>
       } as Partial<State>);
     }
   });
+
+  // Intentionally NOT stable: the identity changes with `[store, triggerId]` (via
+  // `baseRegisterTrigger`), so when a handle-backed trigger's store pointer swaps, the merged ref
+  // re-fires — unregistering from the previous store and registering into the new one. This lets a
+  // detached trigger follow its handle's currently-attached store across attach/detach/remount.
+  const registerTrigger = React.useCallback(
+    (element: Element | null) => {
+      baseRegisterTrigger(element);
+      if (element) {
+        applyTriggerData(element);
+      }
+    },
+    [baseRegisterTrigger, applyTriggerData],
+  );
 
   useIsoLayoutEffect(() => {
     if (isMountedByThisTrigger) {

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -56,6 +56,7 @@ export function usePopupStore<
   externalStore: Store | undefined,
   createStore: (floatingId: string | undefined, nested: boolean) => Store,
   treatPopupAsFloatingElement = false,
+  initializeExternalStore?: ((store: Store) => void) | undefined,
 ) {
   const floatingId = useId();
   const nested = useFloatingParentNodeId() != null;
@@ -66,6 +67,12 @@ export function usePopupStore<
   }
 
   const store = externalStore ?? internalStoreRef.current!;
+
+  useOnFirstRender(() => {
+    if (externalStore !== undefined) {
+      initializeExternalStore?.(store);
+    }
+  });
 
   useSyncedFloatingRootContext({
     popupStore: store,

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -24,6 +24,7 @@ import {
   PopupStoreContext,
   popupStoreSelectors,
   PopupStoreSelectors,
+  PopupTriggerDataStore,
 } from './store';
 
 export const FOCUSABLE_POPUP_PROPS = {
@@ -47,15 +48,6 @@ type PopupStoreWithOpen<
 > = ReactStore<State, PopupStoreContext<never>, PopupStoreSelectors> & {
   setOpen(open: boolean, eventDetails: SetOpenEventDetails): void;
 };
-
-/**
- * The subset of a popup store that trigger registration and data forwarding rely on. Narrow enough
- * that an inert store (e.g. the dialog handle's fallback store) can be passed while detached.
- */
-type PopupTriggerDataStore<State extends PopupStoreState<unknown>> = Pick<
-  ReactStore<Readonly<State>, PopupStoreContext<never>, PopupStoreSelectors>,
-  'context' | 'select' | 'set' | 'state' | 'update' | 'useState'
->;
 
 export function usePopupStore<
   State extends PopupStoreState<unknown>,

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -301,10 +301,11 @@ export function useTriggerDataForwarding<State extends PopupStoreState<unknown>>
     }
   });
 
-  // Intentionally NOT stable: the identity changes with `[store, triggerId]` (via
-  // `baseRegisterTrigger`), so when a handle-backed trigger's store pointer swaps, the merged ref
-  // re-fires — unregistering from the previous store and registering into the new one. This lets a
-  // detached trigger follow its handle's currently-attached store across attach/detach/remount.
+  // Intentionally NOT stable. Its identity is derived from `baseRegisterTrigger`, which is keyed on
+  // `[store, id]`, so when a handle-backed trigger's store pointer swaps the merged ref re-fires —
+  // unregistering from the previous store and registering into the new one. This lets a detached
+  // trigger follow its handle's currently-attached store across attach/detach/remount. (A stable
+  // callback would keep its identity and never re-fire on a store swap.)
   const registerTrigger = React.useCallback(
     (element: Element | null) => {
       baseRegisterTrigger(element);

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -48,11 +48,6 @@ type PopupStoreWithOpen<
   setOpen(open: boolean, eventDetails: SetOpenEventDetails): void;
 };
 
-type PopupTriggerDataStore<State extends PopupStoreState<unknown>> = Pick<
-  ReactStore<Readonly<State>, PopupStoreContext<never>, PopupStoreSelectors>,
-  'context' | 'select' | 'set' | 'state' | 'update' | 'useState'
->;
-
 export function usePopupStore<
   State extends PopupStoreState<unknown>,
   SetOpenEventDetails extends BaseUIChangeEventDetails<string>,
@@ -91,7 +86,7 @@ export function usePopupStore<
  */
 export function useTriggerRegistration<State extends PopupStoreState<unknown>>(
   id: string | undefined,
-  store: PopupTriggerDataStore<State>,
+  store: ReactStore<State, PopupStoreContext<never>, PopupStoreSelectors>,
 ) {
   // Keep track of the currently registered element to unregister it on unmount or id change.
   const registeredElementIdRef = React.useRef<string | null>(null);
@@ -271,7 +266,7 @@ export function useInitialOpenSync<State extends PopupStoreState<unknown>>(
 export function useTriggerDataForwarding<State extends PopupStoreState<unknown>>(
   triggerId: string | undefined,
   triggerElementRef: React.RefObject<Element | null>,
-  store: PopupTriggerDataStore<State>,
+  store: ReactStore<State, PopupStoreContext<never>, PopupStoreSelectors>,
   stateUpdates: Omit<Partial<State>, 'activeTriggerId' | 'activeTriggerElement'>,
 ) {
   const isMountedByThisTrigger = store.useState('isMountedByTrigger', triggerId);

--- a/packages/react/src/utils/popups/popupTriggerMap.test.ts
+++ b/packages/react/src/utils/popups/popupTriggerMap.test.ts
@@ -42,6 +42,21 @@ describe('PopupTriggerMap', () => {
     expect(map.size).toBe(0);
   });
 
+  it('clears all registered elements', () => {
+    const map = new PopupTriggerMap();
+    const first = document.createElement('button');
+    const second = document.createElement('button');
+
+    map.add('first', first);
+    map.add('second', second);
+    map.clear();
+
+    expect(map.size).toBe(0);
+    expect(map.getById('first')).toBeUndefined();
+    expect(map.hasElement(first)).toBe(false);
+    expect(map.hasElement(second)).toBe(false);
+  });
+
   it('does not duplicate when the same element is added twice with the same id', () => {
     const map = new PopupTriggerMap();
     const button = document.createElement('button');

--- a/packages/react/src/utils/popups/popupTriggerMap.test.ts
+++ b/packages/react/src/utils/popups/popupTriggerMap.test.ts
@@ -42,21 +42,6 @@ describe('PopupTriggerMap', () => {
     expect(map.size).toBe(0);
   });
 
-  it('clears all registered elements', () => {
-    const map = new PopupTriggerMap();
-    const first = document.createElement('button');
-    const second = document.createElement('button');
-
-    map.add('first', first);
-    map.add('second', second);
-    map.clear();
-
-    expect(map.size).toBe(0);
-    expect(map.getById('first')).toBeUndefined();
-    expect(map.hasElement(first)).toBe(false);
-    expect(map.hasElement(second)).toBe(false);
-  });
-
   it('does not duplicate when the same element is added twice with the same id', () => {
     const map = new PopupTriggerMap();
     const button = document.createElement('button');

--- a/packages/react/src/utils/popups/popupTriggerMap.ts
+++ b/packages/react/src/utils/popups/popupTriggerMap.ts
@@ -55,14 +55,6 @@ export class PopupTriggerMap {
   }
 
   /**
-   * Removes all registered trigger elements.
-   */
-  public clear() {
-    this.elementsSet.clear();
-    this.idMap.clear();
-  }
-
-  /**
    * Whether the given element is registered as a trigger.
    */
   public hasElement(element: Element): boolean {

--- a/packages/react/src/utils/popups/popupTriggerMap.ts
+++ b/packages/react/src/utils/popups/popupTriggerMap.ts
@@ -55,6 +55,14 @@ export class PopupTriggerMap {
   }
 
   /**
+   * Removes all registered trigger elements.
+   */
+  public clear() {
+    this.elementsSet.clear();
+    this.idMap.clear();
+  }
+
+  /**
    * Whether the given element is registered as a trigger.
    */
   public hasElement(element: Element): boolean {

--- a/packages/react/src/utils/popups/store.ts
+++ b/packages/react/src/utils/popups/store.ts
@@ -225,7 +225,9 @@ export type PopupStoreSelectors = typeof popupStoreSelectors;
 
 /**
  * The subset of a popup store that trigger registration and data forwarding rely on. Narrow enough
- * that an inert store can be passed while detached.
+ * that an inert store can be passed while detached. `set`/`update` are included only for
+ * trigger-count and trigger-data bookkeeping; on a detached (inert) store they are intentionally
+ * no-ops, so a write through this type is not guaranteed to be durable.
  */
 export type PopupTriggerDataStore<State extends PopupStoreState<unknown>> = Pick<
   ReactStore<Readonly<State>, PopupStoreContext<never>, PopupStoreSelectors>,

--- a/packages/react/src/utils/popups/store.ts
+++ b/packages/react/src/utils/popups/store.ts
@@ -1,4 +1,4 @@
-import { createSelector } from '@base-ui/utils/store';
+import { createSelector, type ReactStore } from '@base-ui/utils/store';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { FloatingRootContext } from '../../floating-ui-react';
 import { FloatingRootStore } from '../../floating-ui-react/components/FloatingRootStore';
@@ -222,3 +222,12 @@ export const popupStoreSelectors = {
 };
 
 export type PopupStoreSelectors = typeof popupStoreSelectors;
+
+/**
+ * The subset of a popup store that trigger registration and data forwarding rely on. Narrow enough
+ * that an inert store can be passed while detached.
+ */
+export type PopupTriggerDataStore<State extends PopupStoreState<unknown>> = Pick<
+  ReactStore<Readonly<State>, PopupStoreContext<never>, PopupStoreSelectors>,
+  'context' | 'select' | 'set' | 'state' | 'update' | 'useState'
+>;

--- a/packages/utils/src/useOnMount.ts
+++ b/packages/utils/src/useOnMount.ts
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
-
-const EMPTY = [] as unknown[];
+import { EMPTY_ARRAY } from './empty';
 
 /**
  * A React.useEffect equivalent that runs once, when the component is mounted.
@@ -9,6 +8,6 @@ const EMPTY = [] as unknown[];
 export function useOnMount(fn: React.EffectCallback) {
   // TODO: uncomment once we enable eslint-plugin-react-compiler // eslint-disable-next-line react-compiler/react-compiler -- no need to put `fn` in the dependency array
   /* eslint-disable react-hooks/exhaustive-deps */
-  React.useEffect(fn, EMPTY);
+  React.useEffect(fn, EMPTY_ARRAY);
   /* eslint-enable react-hooks/exhaustive-deps */
 }


### PR DESCRIPTION
Fixes #4951.

## Summary

A module-scoped `Dialog.createHandle()` used to preserve stale open state after its `<Dialog.Root>` was unmounted while open, so the next root mounted with the same handle reopened immediately.

This changes the ownership model: each `<Dialog.Root>` now creates and owns its own store (via `useRefWithInit`) instead of reusing the handle's store. The handle holds a pointer to the currently mounted root's store and attaches/detaches as roots mount and unmount, so every mount starts from fresh state. Detached triggers follow the handle's store pointer and re-register into the attached root's store when it changes. Imperative handle methods (`open`, `openWithPayload`, `close`) are no-ops while no root is attached (with a dev-only warning), and `isOpen` returns `false`.

## Note

Using a single handle with two roots mounted at the same time is not supported: the most recently mounted root takes over (a dev-only warning is logged). Handles are expected to be stable and used by a single mounted root for their lifetime.

## Changes

- Make the dialog store owned by `Dialog.Root` (created once per root) and have the handle attach to it, so reused handles no longer carry stale state across remounts.
- Make detached triggers follow the handle's attached store, migrating their registration as roots attach/detach.
- Make imperative handle methods no-ops (with a dev-only warning) while no root is attached, and warn in dev when a second root attaches to a live handle.
- Add regression coverage for unmounting/remounting handle-backed roots (Dialog, AlertDialog, Drawer).
- Add a private experiment for manually testing the unmount/remount scenario.
- Update Dialog, AlertDialog, and generated handle API docs.
