### PR TITLE
[popups] Fix rendered trigger id ownership

### DIFF
--- a/packages/react/src/tooltip/root/TooltipRoot.detached-triggers.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.detached-triggers.test.tsx
@@ -157,6 +157,49 @@ describe('<Tooltip.Root />', () => {
       expect(screen.getByTestId('content').textContent).toBe('2');
     });
 
+    it('hands off open state and payload to a trigger with its own DOM id while open', async () => {
+      await render(
+        <Tooltip.Root>
+          {({ payload }: NumberPayload) => (
+            <React.Fragment>
+              <Tooltip.Trigger payload={1} delay={0} closeDelay={0}>
+                Trigger 1
+              </Tooltip.Trigger>
+              <Tooltip.Trigger
+                payload={2}
+                delay={0}
+                closeDelay={0}
+                render={<button id="custom-button" type="button" />}
+              >
+                Trigger 2
+              </Tooltip.Trigger>
+
+              <Tooltip.Portal>
+                <Tooltip.Positioner>
+                  <Tooltip.Popup>
+                    <span data-testid="content">{payload}</span>
+                  </Tooltip.Popup>
+                </Tooltip.Positioner>
+              </Tooltip.Portal>
+            </React.Fragment>
+          )}
+        </Tooltip.Root>,
+      );
+
+      const trigger1 = screen.getByRole('button', { name: 'Trigger 1' });
+      const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
+
+      // Focus handoff keeps the popup open across the switch, so `open`/`triggerCount` do not change.
+      await act(async () => trigger1.focus());
+      await flushMicrotasks();
+      expect(screen.getByTestId('content').textContent).toBe('1');
+
+      await act(async () => trigger2.focus());
+      await flushMicrotasks();
+      expect(trigger2).toHaveAttribute('data-popup-open');
+      expect(screen.getByTestId('content').textContent).toBe('2');
+    });
+
     it('should close when the active trigger unmounts', async () => {
       let removeFirstTrigger: () => void = () => {};
 

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.test.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.test.tsx
@@ -57,6 +57,36 @@ describe('<Tooltip.Trigger />', () => {
     expect(screen.getByText('Content')).not.toBe(null);
   });
 
+  it('opens when the rendered trigger element has its own id', async () => {
+    const { user } = await render(
+      <Tooltip.Root>
+        <Tooltip.Trigger
+          delay={0}
+          closeDelay={0}
+          render={<button id="custom-button" data-testid="trigger" type="button" />}
+        >
+          Trigger
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Positioner>
+            <Tooltip.Popup data-testid="popup">Content</Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+
+    expect(trigger).toHaveAttribute('id', 'custom-button');
+
+    await user.hover(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('popup')).not.toBe(null);
+    });
+    expect(trigger).toHaveAttribute('data-popup-open');
+  });
+
   it.skipIf(isJSDOM)(
     'opens on delayed hover when rendered as a disabled toolbar button',
     async () => {

--- a/packages/react/src/utils/popups/popupStoreUtils.test.tsx
+++ b/packages/react/src/utils/popups/popupStoreUtils.test.tsx
@@ -389,6 +389,44 @@ describe('useTriggerRegistration', () => {
     expect(store.setOpen).not.toHaveBeenCalled();
   });
 
+  it('reassociates the active trigger when ownership moves to another rendered-id trigger while open', async () => {
+    const store = createStore();
+    const first = document.createElement('button');
+    const second = document.createElement('button');
+    second.id = 'dom-id-2';
+
+    store.update({
+      open: true,
+      activeTriggerId: 'registered-1',
+      activeTriggerElement: first,
+    });
+
+    render(
+      <React.Fragment>
+        <TestTrigger id="registered-1" store={store} element={first} />
+        <TestTrigger id="registered-2" store={store} element={second} />
+        <CloseOnActiveTriggerUnmountTest store={store} />
+      </React.Fragment>,
+    );
+
+    await flushMicrotasks();
+
+    expect(store.state.activeTriggerId).toBe('registered-1');
+
+    // A handoff to the second trigger updates the active id from its DOM id (as `setPopupOpenState`
+    // does), without changing `open` or `triggerCount`.
+    act(() => {
+      store.update({ activeTriggerId: 'dom-id-2', activeTriggerElement: second });
+    });
+
+    await flushMicrotasks();
+
+    expect(store.state.activeTriggerId).toBe('registered-2');
+    expect(store.state.activeTriggerElement).toBe(second);
+    expect(store.state.open).toBe(true);
+    expect(store.setOpen).not.toHaveBeenCalled();
+  });
+
   it('preserves active trigger ownership without closing by default', async () => {
     const store = createStore();
     const first = document.createElement('button');

--- a/packages/react/src/utils/popups/popupStoreUtils.test.tsx
+++ b/packages/react/src/utils/popups/popupStoreUtils.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import * as React from 'react';
 import { act, render, waitFor } from '@testing-library/react';
+import { flushMicrotasks } from '@mui/internal-test-utils';
 import { ReactStore } from '@base-ui/utils/store';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import {
@@ -350,15 +351,40 @@ describe('useTriggerRegistration', () => {
       </React.Fragment>,
     );
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushMicrotasks();
 
     expect(store.context.triggerElements.getById('first')).toBe(replacement);
     expect(store.context.triggerElements.getById('second')).toBe(second);
     expect(store.state.triggerCount).toBe(2);
     expect(store.state.activeTriggerId).toBe('first');
     expect(store.state.activeTriggerElement).toBe(replacement);
+    expect(store.state.open).toBe(true);
+    expect(store.setOpen).not.toHaveBeenCalled();
+  });
+
+  it('keeps the popup open when the active trigger element is registered with another id', async () => {
+    const store = createStore();
+    const element = document.createElement('button');
+    element.id = 'dom-id';
+
+    store.update({
+      open: true,
+      activeTriggerId: 'dom-id',
+      activeTriggerElement: element,
+    });
+
+    render(
+      <React.Fragment>
+        <TestTrigger id="registered-id" store={store} element={element} />
+        <CloseOnActiveTriggerUnmountTest store={store} />
+      </React.Fragment>,
+    );
+
+    await flushMicrotasks();
+
+    expect(store.state.triggerCount).toBe(1);
+    expect(store.state.activeTriggerId).toBe('registered-id');
+    expect(store.state.activeTriggerElement).toBe(element);
     expect(store.state.open).toBe(true);
     expect(store.setOpen).not.toHaveBeenCalled();
   });

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -351,7 +351,7 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
   const reactiveTriggerCount = store.useState('triggerCount');
   // Subscribe to the active trigger id so the reconciliation below reruns when ownership moves to
   // another trigger while the popup stays open (e.g. a focus/hover handoff between triggers).
-  const reactiveActiveTriggerId = store.useState('activeTriggerId');
+  const activeTriggerId = store.useState('activeTriggerId');
 
   useIsoLayoutEffect(() => {
     if (!open) {
@@ -368,11 +368,11 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       stateUpdates.triggerCount = triggerCount;
     }
 
-    const activeTriggerId = store.select('activeTriggerId');
+    const currentActiveTriggerId = store.select('activeTriggerId');
     let lostActiveTriggerId: string | null = null;
 
-    if (activeTriggerId) {
-      const activeTriggerElement = store.context.triggerElements.getById(activeTriggerId);
+    if (currentActiveTriggerId) {
+      const activeTriggerElement = store.context.triggerElements.getById(currentActiveTriggerId);
       if (!activeTriggerElement) {
         for (const [triggerId, triggerElement] of store.context.triggerElements.entries()) {
           if (triggerElement === store.state.activeTriggerElement) {
@@ -383,14 +383,14 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
         }
 
         if (stateUpdates.activeTriggerId === undefined) {
-          lostActiveTriggerId = activeTriggerId;
+          lostActiveTriggerId = currentActiveTriggerId;
         }
       } else if (activeTriggerElement !== store.state.activeTriggerElement) {
         stateUpdates.activeTriggerElement = activeTriggerElement;
       }
     }
 
-    if (!lostActiveTriggerId && !activeTriggerId && triggerCount === 1) {
+    if (!lostActiveTriggerId && !currentActiveTriggerId && triggerCount === 1) {
       const iteratorResult = store.context.triggerElements.entries().next();
       if (!iteratorResult.done) {
         const [implicitTriggerId, implicitTriggerElement] = iteratorResult.value;
@@ -430,7 +430,7 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
         });
       }
     }
-  }, [open, store, reactiveTriggerCount, reactiveActiveTriggerId, closeOnActiveTriggerUnmount]);
+  }, [open, store, reactiveTriggerCount, activeTriggerId, closeOnActiveTriggerUnmount]);
 }
 
 /**

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -325,9 +325,12 @@ export type PayloadChildRenderFunction<Payload> = (arg: {
  *
  * When a popup opens without an explicit trigger id and exactly one trigger is registered, that
  * trigger is claimed as the active trigger. When the active trigger id is still registered but its
- * element changed, the active element is refreshed. When the active trigger unregisters, the
- * default path preserves existing ownership so non-closing popup families do not silently claim a
- * different trigger while staying open.
+ * element changed, the active element is refreshed. When the active trigger id is missing from the
+ * registry but the same element is still registered under a different id (e.g. the rendered trigger
+ * carries its own DOM `id` that differs from Base UI's internal trigger id), the active id is
+ * reassociated to the registered id instead of being treated as lost. When the active trigger
+ * unregisters, the default path preserves existing ownership so non-closing popup families do not
+ * silently claim a different trigger while staying open.
  *
  * If `closeOnActiveTriggerUnmount` is enabled, unregistering the active trigger requests a close
  * after a microtask so a same-tick replacement trigger with the same id can register first.

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -349,6 +349,9 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
   const { closeOnActiveTriggerUnmount = false } = options;
   const open = store.useState('open');
   const reactiveTriggerCount = store.useState('triggerCount');
+  // Subscribe to the active trigger id so the reconciliation below reruns when ownership moves to
+  // another trigger while the popup stays open (e.g. a focus/hover handoff between triggers).
+  const reactiveActiveTriggerId = store.useState('activeTriggerId');
 
   useIsoLayoutEffect(() => {
     if (!open) {
@@ -427,7 +430,7 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
         });
       }
     }
-  }, [open, store, reactiveTriggerCount, closeOnActiveTriggerUnmount]);
+  }, [open, store, reactiveTriggerCount, reactiveActiveTriggerId, closeOnActiveTriggerUnmount]);
 }
 
 /**

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -368,7 +368,17 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
     if (activeTriggerId) {
       const activeTriggerElement = store.context.triggerElements.getById(activeTriggerId);
       if (!activeTriggerElement) {
-        lostActiveTriggerId = activeTriggerId;
+        for (const [triggerId, triggerElement] of store.context.triggerElements.entries()) {
+          if (triggerElement === store.state.activeTriggerElement) {
+            stateUpdates.activeTriggerId = triggerId;
+            stateUpdates.activeTriggerElement = triggerElement;
+            break;
+          }
+        }
+
+        if (stateUpdates.activeTriggerId === undefined) {
+          lostActiveTriggerId = activeTriggerId;
+        }
       } else if (activeTriggerElement !== store.state.activeTriggerElement) {
         stateUpdates.activeTriggerElement = activeTriggerElement;
       }


### PR DESCRIPTION
Fixes #5108

A trigger rendered with an element that already has its own `id` (e.g. `render={<button id="custom-button" />}`) detaches the trigger's DOM `id` from the internal id Base UI registers it under. The active trigger is tracked by DOM `id` (`setPopupOpenState` reads `trigger.id`), while the registry and ownership selectors key off the internal id, so the trigger is never recognized as active. This affects every popup family that shares `useImplicitActiveTrigger`, at two severity levels:

## Affected components & severity

### 🔴 Closes immediately after opening — Tooltip, Preview Card

Both enable `closeOnActiveTriggerUnmount`, so the failed registry lookup is treated as the active trigger unmounting and the popup closes right after it opens. This is the #5108 regression introduced in #4886 (`[tooltip][preview card]`) — 1.6.0 fails, 1.5.0 works.

### 🟡 Opens, but trigger ownership / ARIA is wrong — Popover, Menu, Dialog

No close-on-unmount, so the popup stays open, but the trigger never registers as active: `data-popup-open` is missing and `aria-expanded` / `aria-controls` are stale. This one is pre-existing (independent of #4886), surfaced by the same id mismatch.

> Passing the id directly to the trigger (`<Popover.Trigger id="custom-button">`) instead of to the rendered element sidesteps all of this and already works on 1.6.0.

## Root cause

`setPopupOpenState` records `activeTriggerId` from the trigger's DOM `id`. When a `render` id overrides Base UI's internal id, that value is not in the trigger registry, so `getById` misses and the ownership selectors (`isOpenedByTrigger`, etc.) never match the trigger.

## Fix

In `useImplicitActiveTrigger`, when the active id misses a direct registry lookup, scan for the same element registered under a different id and reassociate to the registered id instead of treating it as lost. The reconciliation is also made reactive to active-trigger-id changes so it covers trigger-to-trigger handoffs while the popup stays open.

## Perf

The scan only runs after the fast `getById` lookup misses, and it is self-healing (subsequent lookups hit the fast path). Measured across the multi-trigger suite: **0 scans in normal flows** (108 effect runs → 5 scans total, all in the rare custom-id / lost-trigger paths), ~1.4 iterations per scan, bounded by the number of registered triggers.

## Changes

- Reassociate stale active trigger ids with the registered element before closing; rerun the reconciliation on active-trigger handoffs.
- Add Tooltip store + component coverage for rendered trigger ids and handoffs.
