### PR TITLE
[number field] Fix keyboard editing with multi-character format symbols

### DIFF
--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -18,6 +18,7 @@ import {
   ANY_PLUS_RE,
   ANY_MINUS_DETECT_RE,
   ANY_PLUS_DETECT_RE,
+  FORMAT_CONTROL_DETECT_RE,
 } from '../utils/parse';
 import type { NumberFieldRootState } from '../root/NumberFieldRoot';
 import { stateAttributesMapping } from '../utils/stateAttributesMapping';
@@ -262,7 +263,13 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       // composition/partial input while still providing live numeric updates when possible.
       const allowedNonNumericKeys = getAllowedNonNumericKeys();
       const isValidCharacterString = Array.from(targetValue).every(
-        (ch) => isNumeralChar(ch) || ANY_MINUS_DETECT_RE.test(ch) || allowedNonNumericKeys.has(ch),
+        (ch) =>
+          isNumeralChar(ch) ||
+          ANY_MINUS_DETECT_RE.test(ch) ||
+          allowedNonNumericKeys.has(ch) ||
+          // Bidi/format controls are stripped by `parseNumber`; don't let them reject the string
+          // (RTL locales insert them around exponent/currency signs, e.g. scientific notation).
+          FORMAT_CONTROL_DETECT_RE.test(ch),
       );
 
       if (!isValidCharacterString) {

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -607,24 +607,16 @@ describe('<NumberField />', () => {
       expect(onValueChange.mock.calls[0][0]).toBe(1500);
     });
 
-    it('accepts bidi format controls in the value (RTL scientific notation)', async () => {
+    it('ignores bidi/format control characters in the value (e.g. RTL exponent signs)', async () => {
       const onValueChange = vi.fn();
       const format: Intl.NumberFormatOptions = { notation: 'scientific' };
-      await render(
-        <NumberField
-          defaultValue={0.1}
-          locale="fa-IR"
-          format={format}
-          onValueChange={onValueChange}
-        />,
-      );
+      await render(<NumberField locale="en-US" format={format} onValueChange={onValueChange} />);
       const input = screen.getByRole('textbox');
 
-      // The fa-IR scientific form of a sub-1 value has a negative exponent whose minus sign is
-      // preceded by a U+200E control character. Editing the value must not be rejected for it.
-      const formatted = new Intl.NumberFormat('fa-IR', format).format(0.5);
-      expect(Array.from(formatted).some((ch) => /\p{Cf}/u.test(ch))).toBe(true);
-      fireEvent.change(input, { target: { value: formatted } });
+      // RTL locales (e.g. fa-IR) insert a U+200E LEFT-TO-RIGHT MARK around the exponent sign in
+      // scientific notation. Inject one into an otherwise-valid value so the test is deterministic
+      // across ICU versions: the validator must ignore the control character rather than reject it.
+      fireEvent.change(input, { target: { value: '5E\u200E-1' } });
 
       expect(onValueChange.mock.calls.length).toBe(1);
       expect(onValueChange.mock.calls[0][0]).toBe(0.5);

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -550,6 +550,86 @@ describe('<NumberField />', () => {
       expect(onValueChange.mock.calls[1][0]).toBe(12);
     });
 
+    it('accepts multi-character currency symbols while typing (e.g. pt-BR BRL)', async () => {
+      const onValueChange = vi.fn();
+      const format: Intl.NumberFormatOptions = { style: 'currency', currency: 'BRL' };
+      await render(
+        <NumberField
+          defaultValue={1234.56}
+          locale="pt-BR"
+          format={format}
+          onValueChange={onValueChange}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+      const formatted = new Intl.NumberFormat('pt-BR', format).format(1234.56);
+
+      // Type a trailing digit. Previously every keystroke was rejected because the multi-character
+      // `R$` symbol failed the per-character validation in the change handler.
+      fireEvent.change(input, { target: { value: `${formatted}7` } });
+
+      expect(input).toHaveValue(`${formatted}7`);
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.calls[0][0]).toBe(1234.567);
+    });
+
+    it('accepts multi-character unit symbols while typing (e.g. km/h)', async () => {
+      const onValueChange = vi.fn();
+      await render(
+        <NumberField
+          locale="en-US"
+          format={{ style: 'unit', unit: 'kilometer-per-hour' }}
+          onValueChange={onValueChange}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+
+      // The `km/h` unit must not block editing the numeric region.
+      fireEvent.change(input, { target: { value: '1 km/h' } });
+      fireEvent.change(input, { target: { value: '12 km/h' } });
+
+      expect(onValueChange.mock.calls.length).toBe(2);
+      expect(onValueChange.mock.calls[0][0]).toBe(1);
+      expect(onValueChange.mock.calls[1][0]).toBe(12);
+    });
+
+    it('accepts exponent separators while typing (scientific notation)', async () => {
+      const onValueChange = vi.fn();
+      const format: Intl.NumberFormatOptions = { notation: 'scientific' };
+      await render(<NumberField locale="en-US" format={format} onValueChange={onValueChange} />);
+      const input = screen.getByRole('textbox');
+
+      // `1.5E3` should parse to 1500 rather than being rejected for the `E` separator.
+      fireEvent.change(input, { target: { value: '1.5E3' } });
+
+      expect(input).toHaveValue('1.5E3');
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.calls[0][0]).toBe(1500);
+    });
+
+    it('accepts bidi format controls in the value (RTL scientific notation)', async () => {
+      const onValueChange = vi.fn();
+      const format: Intl.NumberFormatOptions = { notation: 'scientific' };
+      await render(
+        <NumberField
+          defaultValue={0.1}
+          locale="fa-IR"
+          format={format}
+          onValueChange={onValueChange}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+
+      // The fa-IR scientific form of a sub-1 value has a negative exponent whose minus sign is
+      // preceded by a U+200E control character. Editing the value must not be rejected for it.
+      const formatted = new Intl.NumberFormat('fa-IR', format).format(0.5);
+      expect(Array.from(formatted).some((ch) => /\p{Cf}/u.test(ch))).toBe(true);
+      fireEvent.change(input, { target: { value: formatted } });
+
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(onValueChange.mock.calls[0][0]).toBe(0.5);
+    });
+
     it('allows deleting trailing currency symbols with locale literals', async () => {
       const onValueChange = vi.fn();
       const format: Intl.NumberFormatOptions = {

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -20,6 +20,7 @@ import type { BaseUIComponentProps } from '../../internals/types';
 import { stateAttributesMapping } from '../utils/stateAttributesMapping';
 import { useRenderElement } from '../../internals/useRenderElement';
 import {
+  getFormatParts,
   getNumberLocaleDetails,
   PERMILLE,
   PERCENTAGES,
@@ -145,43 +146,52 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
   const [inputMode, setInputMode] = React.useState<InputMode>('numeric');
 
   const getAllowedNonNumericKeys = useStableCallback(() => {
-    const { decimal, group, currency, literal } = getNumberLocaleDetails(locale, format);
+    const parts = getFormatParts(locale, format);
 
     const keys = new Set<string>();
     BASE_NON_NUMERIC_SYMBOLS.forEach((symbol) => keys.add(symbol));
+
+    // Integer formats omit the decimal from `parts`, so fall back to the locale's separator in that
+    // case; it must stay typeable regardless of whether the format renders a fraction.
+    const decimal =
+      parts.find((part) => part.type === 'decimal')?.value ??
+      getNumberLocaleDetails(locale, format).decimal;
     if (decimal) {
       keys.add(decimal);
     }
-    if (group) {
-      keys.add(group);
-      if (SPACE_SEPARATOR_RE.test(group)) {
+
+    // Allow every non-digit character the formatter renders — separators, currency symbols, units
+    // (e.g. `km/h`, `°C`), exponent separators, and locale literals — decomposed per character
+    // because the input validates the typed string one character at a time. Deriving these from
+    // the formatter covers multi-character and locale-specific symbols of every part type
+    // uniformly. `compact` suffixes (e.g. `K`/`M`) are excluded because `parseNumber` can't reverse
+    // them, so allowing them would yield a silently incorrect value.
+    parts.forEach((part) => {
+      if (
+        part.type === 'integer' ||
+        part.type === 'fraction' ||
+        part.type === 'exponentInteger' ||
+        part.type === 'compact'
+      ) {
+        return;
+      }
+      Array.from(part.value).forEach((char) => keys.add(char));
+      if (SPACE_SEPARATOR_RE.test(part.value)) {
         keys.add(' ');
       }
-    }
+    });
 
     const allowPercentSymbols =
       formatStyle === 'percent' || (formatStyle === 'unit' && format?.unit === 'percent');
     const allowPermilleSymbols =
       formatStyle === 'percent' || (formatStyle === 'unit' && format?.unit === 'permille');
 
+    // Tolerate percent/permille variants the formatter doesn't emit but users may type or paste.
     if (allowPercentSymbols) {
       PERCENTAGES.forEach((key) => keys.add(key));
     }
     if (allowPermilleSymbols) {
       PERMILLE.forEach((key) => keys.add(key));
-    }
-
-    if (formatStyle === 'currency' && currency) {
-      keys.add(currency);
-    }
-
-    if (literal) {
-      // Some locales (e.g. de-DE) insert a literal space character between the number
-      // and the symbol, so allow those characters to be typed/removed.
-      Array.from(literal).forEach((char) => keys.add(char));
-      if (SPACE_SEPARATOR_RE.test(literal)) {
-        keys.add(' ');
-      }
     }
 
     // Allow plus sign in all cases; minus sign when negatives are valid, or when out-of-range

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -91,7 +91,7 @@ export const ANY_PLUS_RE = new RegExp(ANY_PLUS_CLASS, 'gu');
 export const ANY_MINUS_DETECT_RE = new RegExp(ANY_MINUS_CLASS);
 export const ANY_PLUS_DETECT_RE = new RegExp(ANY_PLUS_CLASS);
 
-// A representative value with two grouping separators and a fractional part, so that the formatter
+// A representative value with a grouping separator and a fractional part, so that the formatter
 // emits every locale-specific part (group, decimal, currency, unit, literal, exponent, …). Shared
 // so the locale-detail and allowed-character derivations enumerate the same parts.
 const SAMPLE_FORMAT_NUMBER = 11111.1;

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -65,6 +65,11 @@ export const BASE_NON_NUMERIC_SYMBOLS = [
   '٬',
 ] as const;
 export const SPACE_SEPARATOR_RE = /\p{Zs}/u;
+// Format/bidi control characters (e.g. the LRM/ALM marks RTL locales insert around exponent and
+// currency signs). `parseNumber` strips these, so input validation must treat them as ignorable
+// rather than rejecting the typed string. Non-global so it's safe for repeated `.test(char)`.
+export const FORMAT_CONTROL_DETECT_RE = /\p{Cf}/u;
+const FORMAT_CONTROL_GLOBAL_RE = new RegExp(FORMAT_CONTROL_DETECT_RE.source, 'gu');
 export const PLUS_SIGNS_WITH_ASCII = ['+', ...UNICODE_PLUS_SIGNS];
 export const MINUS_SIGNS_WITH_ASCII = ['-', ...UNICODE_MINUS_SIGNS];
 
@@ -86,11 +91,24 @@ export const ANY_PLUS_RE = new RegExp(ANY_PLUS_CLASS, 'gu');
 export const ANY_MINUS_DETECT_RE = new RegExp(ANY_MINUS_CLASS);
 export const ANY_PLUS_DETECT_RE = new RegExp(ANY_PLUS_CLASS);
 
+// A representative value with two grouping separators and a fractional part, so that the formatter
+// emits every locale-specific part (group, decimal, currency, unit, literal, exponent, …). Shared
+// so the locale-detail and allowed-character derivations enumerate the same parts.
+const SAMPLE_FORMAT_NUMBER = 11111.1;
+
+/**
+ * Returns the `Intl.NumberFormat` parts of a representative number, which surface every
+ * non-numeric symbol a given locale/format renders.
+ */
+export function getFormatParts(locale?: Intl.LocalesArgument, options?: Intl.NumberFormatOptions) {
+  return getFormatter(locale, options).formatToParts(SAMPLE_FORMAT_NUMBER);
+}
+
 export function getNumberLocaleDetails(
   locale?: Intl.LocalesArgument,
   options?: Intl.NumberFormatOptions,
 ) {
-  const parts = getFormatter(locale, options).formatToParts(11111.1);
+  const parts = getFormatParts(locale, options);
   const result: Partial<Record<Intl.NumberFormatPartTypes, string | undefined>> = {};
 
   parts.forEach((part) => {
@@ -121,9 +139,7 @@ export function parseNumber(
   }
 
   // Normalize control characters and whitespace; remove bidi/format controls
-  let input = String(formattedNumber)
-    .replace(/\p{Cf}/gu, '')
-    .trim();
+  let input = String(formattedNumber).replace(FORMAT_CONTROL_GLOBAL_RE, '').trim();
 
   // Normalize unicode minus/plus to ASCII, handle leading/trailing signs
   input = input.replace(ANY_MINUS_RE, '-').replace(ANY_PLUS_RE, '+');


### PR DESCRIPTION
Closes #5107

## Problem

A `NumberField` whose `Intl` format produces a **multi-character symbol** could not be edited by typing — every keystroke was silently rejected, the text reverted, and the caret jumped to the end. The reported case is pt-BR currency (`R$ 1.234,56`), but the same flaw affected any multi-character or non-enumerated decoration:

| `format` | locale | displayed | typing before | after |
| --- | --- | --- | :---: | :---: |
| `{ style: 'currency', currency: 'BRL' }` | `pt-BR` | `R$ 1.234,56` | ❌ | ✅ |
| `{ style: 'unit', unit: 'kilometer-per-hour' }` | `en-US` | `12 km/h` | ❌ | ✅ |
| `{ notation: 'scientific' }` | `en-US` | `1.5E3` | ❌ | ✅ |
| `{ notation: 'scientific' }` | `fa-IR` | `۱×۱۰^‎−۱` | ❌ | ✅ |
| `{ style: 'currency', currency: 'USD' }` | `en-US` | `$1,234.56` | ✅ | ✅ |

## Cause

`getAllowedNonNumericKeys` added the currency symbol to the allowed set as a **whole string** (`keys.add(currency)` → `"R$"`), but the input's change handler validates the typed text **one character at a time** (`allowedNonNumericKeys.has(ch)`). `"R"` and `"$"` were never in the set, so the whole value failed validation and the edit was reverted. Single-character symbols like `$` happened to work because the set entry matched the single char; units and exponent separators were never added at all.

## Fix

1. **Derive the allowed characters from `Intl.NumberFormat.formatToParts`, per character.** This covers multi-character and locale-specific symbols of every part type uniformly (currency, unit, exponent separator, literals) and replaced the previous per-symbol `currency`/`literal`/`group` branches. `compact` suffixes (`K`/`M`) are intentionally excluded — `parseNumber` can't reverse them (`11K` → `11`), so allowing them would produce silently-wrong values.

2. **Ignore Unicode format/bidi controls (`\p{Cf}`) in the validator.** RTL locales insert marks such as `U+200E` around the exponent sign in scientific notation, and `parseNumber` already strips them, so the validator must treat them as ignorable rather than discarding the keystroke.

Also extracted the shared `11111.1` sample (already used by `getNumberLocaleDetails`) into a `getFormatParts` helper so both derivations enumerate the same parts.

## Testing

Added tests for the currency (issue repro), unit, scientific-notation, and RTL-scientific (`fa-IR`, with bidi controls) cases — each confirmed to fail before the fix. Existing input-masking tests still pass. Full `NumberField` suite passes in jsdom and Chromium (the issue was browser-confirmed).

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).