### PR TITLE
[pnpm] Exclude nanoid@3.3.14 from the trust-downgrade check

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,3 +28,12 @@ trustPolicy: no-downgrade
 # TODO: drop once @babel/core stops depending on semver@^6.3.1 (no 6.x semver release has
 # provenance), and the other legacy packages restore provenance.
 trustPolicyIgnoreAfter: 525600
+# nanoid@3.3.14 (a transitive dep of postcss@8.5.15) shipped without trust evidence after an
+# earlier release published via staged publish, so pnpm rejects it as a trust downgrade. The
+# default jobs install from the frozen lockfile (pinned to nanoid@3.3.12) and are unaffected,
+# but the React 18 jobs re-resolve the tree without a frozen lockfile and pull this version.
+# The independent minimumReleaseAge gate still applies to it. nanoid restored provenance in
+# 3.3.15, so once that ages in the resolver moves past 3.3.14 and this exclude becomes inert.
+# TODO: drop once the resolved nanoid is >= 3.3.15.
+trustPolicyExclude:
+  - 'nanoid@3.3.14'


### PR DESCRIPTION
## Problem

The three **React 18** CircleCI jobs — `Typechecking (React 18)`, `JSDOM tests (React 18)`, and `Browser tests (React 18)` — fail at the "Install js dependencies" step on every open PR:

```
[ERR_PNPM_TRUST_DOWNGRADE] High-risk trust downgrade for "nanoid@3.3.14" (possible package takeover)
This error happened while installing the dependencies of postcss@8.5.15
```

This is pnpm 11's `trustPolicy: no-downgrade` guard (we set it in `pnpm-workspace.yaml`).

### Why only the React 18 jobs

The default (React 19) jobs install from the committed frozen lockfile, which is pinned to `nanoid@3.3.12`, and pass. The React 18 jobs switch the React version first (`code-infra set-version-overrides --pkg react@18`), which re-resolves the tree **without** a frozen lockfile. That re-resolution pulls the newest `nanoid@^3.3.12` past the `minimumReleaseAge` gate — currently `3.3.14` — which shipped without trust evidence after an earlier release used staged publish, so `no-downgrade` rejects it.

## Fix

Exclude the specific failing version from the trust-downgrade check via pnpm's [`trustPolicyExclude`](https://pnpm.io/settings#trustpolicyexclude). This is the same surgical mechanism the file already uses for legacy provenance gaps (`trustPolicyIgnoreAfter`), scoped to one package@version:

```yaml
trustPolicyExclude:
  - 'nanoid@3.3.14'
```

The independent `minimumReleaseAge` gate still applies to `nanoid`, so this only opts that one version out of the downgrade comparison — it does not blanket-trust the package. nanoid **restored provenance in `3.3.15`**, so once that version ages past `minimumReleaseAge` the resolver moves to it on its own and this exclude becomes inert (noted in a `TODO`).

## Verification

Reproduced the React 18 install path in an isolated project with the same pnpm 11.5.2 settings:

- Without the exclude → reproduces `ERR_PNPM_TRUST_DOWNGRADE` for `nanoid@3.3.14`.
- With the exclude → install succeeds, resolving `nanoid@3.3.14`.
- Confirmed `nanoid@3.3.15` (provenance restored) passes `no-downgrade` on its own.

The committed lockfile is untouched: trust-policy settings are verification-time only and are not embedded in `pnpm-lock.yaml`, so the default frozen-lockfile jobs are unaffected.
