### PR TITLE
[field] Keep invalid state on disabled fields

### DIFF
--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -342,6 +342,45 @@ describe('<Field.Root />', () => {
       expect(label).toHaveAttribute('data-disabled', '');
       expect(message).toHaveAttribute('data-disabled', '');
     });
+
+    it('keeps an explicitly invalid field marked invalid while disabled', async () => {
+      await render(
+        <Field.Root data-testid="field" disabled invalid>
+          <Field.Control data-testid="control" />
+          <Field.Label data-testid="label" />
+          <Field.Description data-testid="description" />
+        </Field.Root>,
+      );
+
+      const field = screen.getByTestId('field');
+      const control = screen.getByTestId('control');
+      const label = screen.getByTestId('label');
+      const description = screen.getByTestId('description');
+
+      expect(field).toHaveAttribute('data-invalid', '');
+      expect(control).toHaveAttribute('data-invalid', '');
+      expect(label).toHaveAttribute('data-invalid', '');
+      expect(description).toHaveAttribute('data-invalid', '');
+
+      // It does not participate in native constraint validation.
+      expect(control).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('keeps a disabled field with form errors marked invalid', async () => {
+      await render(
+        <Form errors={{ name: 'Server error' }}>
+          <Field.Root name="name" disabled>
+            <Field.Control data-testid="control" />
+          </Field.Root>
+        </Form>,
+      );
+
+      const control = screen.getByTestId('control');
+
+      expect(control).toHaveAttribute('data-invalid', '');
+      // It does not participate in native constraint validation.
+      expect(control).not.toHaveAttribute('aria-invalid');
+    });
   });
 
   describe('prop: validate', () => {

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -108,7 +108,10 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
     initialValue: null,
   });
 
-  const valid = disabled ? null : !invalid && validityData.state.valid;
+  // App-controlled invalidity (the `invalid` prop and `<Form>` errors) keeps the field marked
+  // invalid even while disabled. Only computed validity (native constraints and `validate`)
+  // is suppressed when disabled, matching `:disabled` not participating in constraint validation.
+  const valid = !invalid && (disabled ? null : validityData.state.valid);
 
   const state: FieldRootState = React.useMemo(
     () => ({


### PR DESCRIPTION
Closes #5100

## Problem

When a field was marked invalid by the app — through the `invalid` prop or `<Form>` errors — `data-invalid` was removed as soon as the field became disabled. This used to work in 1.5.0 and changed in 1.6.0 (#4890), which started excluding disabled controls from validation.

## Fix

An app-set invalid state now stays on the field even while disabled. Only computed validity (native constraints and `validate`) is still suppressed when disabled, matching how `:disabled` controls don't take part in constraint validation.

`aria-invalid` is still not added to disabled controls, so this only restores the `data-invalid` styling hook.

This lines up with React Hook Form, which skips validation on disabled fields but keeps errors set by the app.

## Tests

Added tests for the `invalid` prop and `<Form>` errors on a disabled field.
