### PR TITLE
[accordion] Remove root dir attribute, use implicit value

### DIFF
--- a/packages/react/src/accordion/root/AccordionRoot.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.tsx
@@ -6,7 +6,6 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { warn } from '@base-ui/utils/warn';
 import { BaseUIComponentProps, Orientation } from '../../internals/types';
 import { CompositeList } from '../../internals/composite/list/CompositeList';
-import { useDirection } from '../../internals/direction-context/DirectionContext';
 import { AccordionRootContext } from './AccordionRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { type BaseUIChangeEventDetails } from '../../internals/createBaseUIEventDetails';
@@ -41,8 +40,6 @@ export const AccordionRoot = React.forwardRef(function AccordionRoot<Value = any
     style,
     ...elementProps
   } = componentProps;
-
-  const direction = useDirection();
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -130,12 +127,7 @@ export const AccordionRoot = React.forwardRef(function AccordionRoot<Value = any
   const element = useRenderElement('div', componentProps, {
     state,
     ref: forwardedRef,
-    props: [
-      {
-        dir: direction,
-      },
-      elementProps,
-    ],
+    props: elementProps,
     stateAttributesMapping: rootStateAttributesMapping,
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR proposes a tiny update to remove the `dir` attribute from `Accordion.Root` because it is the only component setting it explicitly, and this behavior does not appear to be documented. This should improve consistency for developers.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
