### PR TITLE
[select] Don't force-mount the popup on programmatic value changes

### DIFF
--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -2858,17 +2858,28 @@ describe('<Select.Root />', () => {
     });
   });
 
-  it('does not force-mount the popup on a programmatic value change when items are provided', async () => {
+  it('does not force-mount the popup on a programmatic value change', async () => {
     function App() {
-      const [value, setValue] = React.useState<string | null>(null);
+      const [withItems, setWithItems] = React.useState<string | null>(null);
+      const [withoutItems, setWithoutItems] = React.useState<string | null>(null);
       return (
         <div>
-          <button type="button" onClick={() => setValue('b')}>
+          <button
+            type="button"
+            onClick={() => {
+              setWithItems('b');
+              setWithoutItems('b');
+            }}
+          >
             set
           </button>
-          <Select.Root items={{ a: 'Apple', b: 'Banana' }} value={value} onValueChange={setValue}>
-            <Select.Trigger data-testid="trigger">
-              <Select.Value data-testid="value" />
+          <Select.Root
+            items={{ a: 'Apple', b: 'Banana' }}
+            value={withItems}
+            onValueChange={setWithItems}
+          >
+            <Select.Trigger>
+              <Select.Value data-testid="items-value" />
             </Select.Trigger>
             <Select.Portal>
               <Select.Positioner>
@@ -2879,20 +2890,34 @@ describe('<Select.Root />', () => {
               </Select.Positioner>
             </Select.Portal>
           </Select.Root>
+          <Select.Root value={withoutItems} onValueChange={setWithoutItems}>
+            <Select.Trigger>
+              <Select.Value data-testid="plain-value" />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup>
+                  <Select.Item value="a">a</Select.Item>
+                  <Select.Item value="b">b</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
         </div>
       );
     }
 
     const { user } = await render(<App />);
 
-    expect(screen.queryByRole('listbox', { hidden: true })).toBe(null);
+    expect(screen.queryAllByRole('listbox', { hidden: true })).toHaveLength(0);
 
     await user.click(screen.getByRole('button', { name: 'set' }));
 
-    // The label resolves directly from `items`, so the popup must stay unmounted instead of
-    // being force-mounted (which would leave it in the DOM permanently).
-    expect(screen.queryByRole('listbox', { hidden: true })).toBe(null);
-    expect(screen.getByTestId('value')).toHaveTextContent('Banana');
+    // A programmatic value change must not force-mount the popup (which would leave it in the DOM
+    // permanently). The label resolves without the list mounted, with or without `items`.
+    expect(screen.queryAllByRole('listbox', { hidden: true })).toHaveLength(0);
+    expect(screen.getByTestId('items-value')).toHaveTextContent('Banana');
+    expect(screen.getByTestId('plain-value')).toHaveTextContent('b');
   });
 
   describe('Form', () => {

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -2858,6 +2858,43 @@ describe('<Select.Root />', () => {
     });
   });
 
+  it('does not force-mount the popup on a programmatic value change when items are provided', async () => {
+    function App() {
+      const [value, setValue] = React.useState<string | null>(null);
+      return (
+        <div>
+          <button type="button" onClick={() => setValue('b')}>
+            set
+          </button>
+          <Select.Root items={{ a: 'Apple', b: 'Banana' }} value={value} onValueChange={setValue}>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value data-testid="value" />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup>
+                  <Select.Item value="a">Apple</Select.Item>
+                  <Select.Item value="b">Banana</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        </div>
+      );
+    }
+
+    const { user } = await render(<App />);
+
+    expect(screen.queryByRole('listbox', { hidden: true })).toBe(null);
+
+    await user.click(screen.getByRole('button', { name: 'set' }));
+
+    // The label resolves directly from `items`, so the popup must stay unmounted instead of
+    // being force-mounted (which would leave it in the DOM permanently).
+    expect(screen.queryByRole('listbox', { hidden: true })).toBe(null);
+    expect(screen.getByTestId('value')).toHaveTextContent('Banana');
+  });
+
   describe('Form', () => {
     const { render: renderFakeTimers, clock } = createRenderer({
       clockOptions: {

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -4585,6 +4585,42 @@ describe('<Select.Root />', () => {
       expect(valueEl.textContent).toBe('avocado');
     });
 
+    it('commits typeahead on a closed trigger when items are provided', async () => {
+      function App() {
+        const [value, setValue] = React.useState<string | null>(null);
+        return (
+          <Select.Root
+            items={{ apple: 'Apple', cherry: 'Cherry' }}
+            value={value}
+            onValueChange={setValue}
+          >
+            <Select.Trigger data-testid="trigger">
+              <Select.Value data-testid="value" />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup>
+                  <Select.Item value="apple">Apple</Select.Item>
+                  <Select.Item value="cherry">Cherry</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        );
+      }
+
+      const { user } = await render(<App />);
+      const trigger = screen.getByTestId('trigger');
+      const valueEl = screen.getByTestId('value');
+
+      // The popup is never opened. With `items` provided the value-change effect no longer
+      // force-mounts, so this pins the load-bearing claim that the trigger's own onFocus
+      // force-mount still registers the list for closed-trigger typeahead.
+      await act(async () => trigger.focus());
+      await user.keyboard('c');
+      expect(valueEl.textContent).toBe('Cherry');
+    });
+
     it('commits nothing when the only typeahead match is disabled (closed trigger)', async () => {
       function App() {
         const [value, setValue] = React.useState<string | null>(null);

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -209,11 +209,15 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     : value != null && stringifyAsValue(value, itemToStringValue) !== '';
 
   useIsoLayoutEffect(() => {
-    // Ensure the values and labels are registered for programmatic value changes.
-    if (value !== initialValueRef.current) {
+    // Ensure the selected label can be resolved for programmatic value changes. When `items` is
+    // provided, `Select.Value` resolves the label directly from `items` without the list mounted,
+    // and closed-trigger typeahead/autofill force-mount through their own paths. Mounting here would
+    // otherwise be sticky and keep the popup in the DOM forever once a controlled value settles
+    // after mount (e.g. an async/preference-resolved value applied in an effect after hydration).
+    if (value !== initialValueRef.current && items == null) {
       store.set('forceMount', true);
     }
-  }, [store, value]);
+  }, [store, value, items]);
 
   useIsoLayoutEffect(() => {
     setFilled(hasSelectedValue);

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -208,21 +208,6 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     ? Array.isArray(value) && value.length > 0
     : value != null && stringifyAsValue(value, itemToStringValue) !== '';
 
-  // Depend on whether `items` is provided rather than the `items` reference, so an unstable
-  // `items` prop (e.g. an inline object) doesn't re-run the effect below on every render.
-  const hasItemsProp = items != null;
-
-  useIsoLayoutEffect(() => {
-    // Ensure the selected label can be resolved for programmatic value changes. When `items` is
-    // provided, `Select.Value` resolves the label directly from `items` without the list mounted,
-    // and closed-trigger typeahead/autofill force-mount through their own paths. Mounting here would
-    // otherwise be sticky and keep the popup in the DOM forever once a controlled value settles
-    // after mount (e.g. an async/preference-resolved value applied in an effect after hydration).
-    if (value !== initialValueRef.current && !hasItemsProp) {
-      store.set('forceMount', true);
-    }
-  }, [store, value, hasItemsProp]);
-
   useIsoLayoutEffect(() => {
     setFilled(hasSelectedValue);
   }, [hasSelectedValue, setFilled]);

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -208,16 +208,20 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     ? Array.isArray(value) && value.length > 0
     : value != null && stringifyAsValue(value, itemToStringValue) !== '';
 
+  // Depend on whether `items` is provided rather than the `items` reference, so an unstable
+  // `items` prop (e.g. an inline object) doesn't re-run the effect below on every render.
+  const hasItemsProp = items != null;
+
   useIsoLayoutEffect(() => {
     // Ensure the selected label can be resolved for programmatic value changes. When `items` is
     // provided, `Select.Value` resolves the label directly from `items` without the list mounted,
     // and closed-trigger typeahead/autofill force-mount through their own paths. Mounting here would
     // otherwise be sticky and keep the popup in the DOM forever once a controlled value settles
     // after mount (e.g. an async/preference-resolved value applied in an effect after hydration).
-    if (value !== initialValueRef.current && items == null) {
+    if (value !== initialValueRef.current && !hasItemsProp) {
       store.set('forceMount', true);
     }
-  }, [store, value, items]);
+  }, [store, value, hasItemsProp]);
 
   useIsoLayoutEffect(() => {
     setFilled(hasSelectedValue);


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Spotted on the docs site: pages like the combobox one had a stack of empty `data-base-ui-portal` nodes mounted on load — one per demo toolbar's "Styling method" select.

## Cause

Each toolbar select is controlled, and its value resolves from a stored preference one tick after hydration (SSR renders the default, then the persisted variant is applied in an effect). That `value` change tripped this effect in `SelectRoot`:

```tsx
if (value !== initialValueRef.current) {
  store.set('forceMount', true);
}
```

`forceMount` is sticky and `SelectPortal` renders whenever `mounted || forceMount`, so the popup stayed mounted permanently — for every such select on the page.

## Fix

Remove the effect. It turns out to be redundant in the current implementation:

- `Select.Value` resolves the label from `value`/`items` via `resolveSelectedLabel`, never from the mounted list.
- `selectedIndex` and the selected-item text ref are restored by `SelectItem` registration when the popup mounts on open.
- Closed-trigger typeahead force-mounts via the trigger's `onFocus`, and autofill via the hidden input's `onChange`.

(The first iteration only gated the effect behind `items`; review surfaced that the whole effect is unnecessary, so it's removed outright — fixing every controlled select whose value settles after mount, not just `items`-based ones.)

## Testing

- Regression test: a programmatic value change (with and without `items`) doesn't force-mount the popup, and the label still updates.
- Test pinning closed-trigger typeahead with `items` (popup never opened) to guard the trigger-focus force-mount path the removal relies on.
- Full select suite passes in jsdom and Chromium; `pnpm typescript` / `eslint` / `prettier` clean. No public API change.