### PR TITLE
[popups] Prevent unwanted flip with capped scrollable content

### DIFF
--- a/packages/react/src/combobox/positioner/ComboboxPositioner.test.tsx
+++ b/packages/react/src/combobox/positioner/ComboboxPositioner.test.tsx
@@ -1,7 +1,7 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
-import { waitFor } from '@mui/internal-test-utils';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -73,6 +73,47 @@ describe('<Combobox.Positioner />', () => {
       );
     },
   }));
+
+  // https://github.com/mui/base-ui/issues/5118
+  it.skipIf(isJSDOM)(
+    'keeps the popup on the preferred side when its capped height fits below tall content',
+    async () => {
+      const items = Array.from({ length: 40 }, (_, index) => `item-${index}`);
+
+      await render(
+        // Anchor fixed near the bottom of the viewport: less room below than above,
+        // but still more than the List's capped height.
+        <div style={{ position: 'fixed', bottom: 120, left: 100 }}>
+          <Combobox.Root open items={items}>
+            <Combobox.Input />
+            <Combobox.Portal>
+              <Combobox.Positioner data-testid="positioner" side="bottom" sideOffset={0}>
+                <Combobox.Popup>
+                  <Combobox.List
+                    style={{ maxHeight: 'min(80px, var(--available-height))', overflowY: 'auto' }}
+                  >
+                    {(item: string) => (
+                      <Combobox.Item key={item} value={item} style={{ height: 30 }}>
+                        {item}
+                      </Combobox.Item>
+                    )}
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>
+        </div>,
+      );
+
+      // The 40-item list (~1200px) overflows the room below the anchor, but the List is
+      // capped to 80px which fits. The `--available-height` var must be seeded before
+      // `size()` runs, otherwise `min(80px, var(--available-height))` is invalid on the
+      // first `flip()` pass, the list is measured at full height, and the popup flips up.
+      await waitFor(() => {
+        expect(screen.getByTestId('positioner')).toHaveAttribute('data-side', 'bottom');
+      });
+    },
+  );
 
   describe.skipIf(isJSDOM)('default anchor', () => {
     it('uses the input when input group is absent', async () => {

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -462,6 +462,7 @@ export function useAnchorPositioning(
     const base: React.CSSProperties & Record<string, unknown> = adaptiveOrigin
       ? { position: resolvedPosition, [sideX]: x, [sideY]: y }
       : { position: resolvedPosition, ...originalFloatingStyles };
+
     // Seed the available size vars so consumer `max-height: min(x, var(--available-height))` rules
     // resolve to a valid length on the first positioning pass, before `size()` writes the real
     // values. Without a fallback the unresolved `var()` invalidates the whole declaration, so the
@@ -473,6 +474,7 @@ export function useAnchorPositioning(
     // values and leaving the popup unconstrained.
     base[AVAILABLE_WIDTH_VAR] = '100vw';
     base[AVAILABLE_HEIGHT_VAR] = '100vh';
+
     if (!isPositioned) {
       base.opacity = 0;
     }

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -30,6 +30,9 @@ import { arrow } from '../floating-ui-react/middleware/arrow';
 import { hide } from './hideMiddleware';
 import { DEFAULT_SIDES } from './adaptiveOriginMiddleware';
 
+const AVAILABLE_WIDTH_VAR = '--available-width';
+const AVAILABLE_HEIGHT_VAR = '--available-height';
+
 function getLogicalSide(sideParam: Side, renderedSide: PhysicalSide, isRtl: boolean): Side {
   const isLogicalSideParam = sideParam === 'inline-start' || sideParam === 'inline-end';
   const logicalRight = isRtl ? 'inline-start' : 'inline-end';
@@ -337,8 +340,8 @@ export function useAnchorPositioning(
         }
 
         const floatingStyle = floating.style;
-        floatingStyle.setProperty('--available-width', `${availableWidth}px`);
-        floatingStyle.setProperty('--available-height', `${availableHeight}px`);
+        floatingStyle.setProperty(AVAILABLE_WIDTH_VAR, `${availableWidth}px`);
+        floatingStyle.setProperty(AVAILABLE_HEIGHT_VAR, `${availableHeight}px`);
 
         // Snap anchor dimensions to device pixels to ensure the popup's visual width matches the anchor's one.
         const dpr = ownerWindow(floating).devicePixelRatio || 1;
@@ -456,9 +459,20 @@ export function useAnchorPositioning(
   const resolvedPosition: 'absolute' | 'fixed' = isPositioned ? positionMethod : 'fixed';
 
   const floatingStyles = React.useMemo<React.CSSProperties>(() => {
-    const base = adaptiveOrigin
+    const base: React.CSSProperties & Record<string, unknown> = adaptiveOrigin
       ? { position: resolvedPosition, [sideX]: x, [sideY]: y }
       : { position: resolvedPosition, ...originalFloatingStyles };
+    // Seed the available size vars so consumer `max-height: min(x, var(--available-height))` rules
+    // resolve to a valid length on the first positioning pass, before `size()` writes the real
+    // values. Without a fallback the unresolved `var()` invalidates the whole declaration, so the
+    // popup is measured unconstrained while `flip()` picks its side, against the full content
+    // height rather than the capped one. Seeded unconditionally (not only while `!isPositioned`):
+    // the keys must stay present with a constant value so React's per-property style diff never
+    // rewrites them after mount, preserving the px values `size()` sets imperatively. Moving them
+    // into the `!isPositioned` branch makes React remove them once positioned, wiping `size()`'s
+    // values and leaving the popup unconstrained.
+    base[AVAILABLE_WIDTH_VAR] = '100vw';
+    base[AVAILABLE_HEIGHT_VAR] = '100vh';
     if (!isPositioned) {
       base.opacity = 0;
     }


### PR DESCRIPTION
## Summary

Fixes #5118.

When a popup's scrollable content is taller than the viewport and capped with the documented `max-height: min(<x>, var(--available-height))` pattern, the popup could open on the wrong side: it flipped away from its preferred side even when the capped popup fit there comfortably (e.g. a combobox in the lower half of the viewport opening upward despite plenty of room below).

**Root cause:** `flip()` runs before `size()` sets `--available-height`. On the first positioning pass that variable is undefined, so `min(<x>, var(--available-height))` resolves to an invalid value and the whole `max-height` declaration is dropped. The list is therefore measured at its full, uncapped content height while `flip()` decides the side, so it picks the side with more raw space rather than the side where the capped popup actually fits.

## Fix

Seed `--available-width: 100vw` and `--available-height: 100vh` on the positioner before `size()` writes the real values. This keeps the consumer's `min(<x>, var(--available-height))` valid on the first `flip()` pass, so the popup is measured at its capped height and the side is chosen correctly. `size()` overwrites the vars with the real px values immediately, and React's style reconciliation does not clobber those imperative values (the seeded value string is constant across renders, so React never rewrites the property after mount).

No changes to the docs demos are required — the existing patterns now behave as intended.

## Testing

- Added a Chromium regression test in `ComboboxPositioner.test.tsx` (fails without the fix: the popup flips to `top`; passes with it).
- All positioner suites pass: Combobox, Select, Menu, Navigation Menu, Popover, Tooltip, Preview Card.
