### PR TITLE
[docs][context menu] Add usage guidelines and with menu demo

### DIFF
--- a/docs/src/app/(docs)/react/components/context-menu/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/hero/css-modules/index.module.css
@@ -12,7 +12,6 @@
   background-color: white;
   font-size: 0.875rem;
   line-height: 1.25rem;
-  font-weight: 400;
   color: oklch(14.5% 0 0deg);
   -webkit-user-select: none;
   user-select: none;

--- a/docs/src/app/(docs)/react/components/context-menu/demos/hero/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/hero/css-modules/index.module.css
@@ -3,12 +3,15 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 15rem;
-  height: 12rem;
+  width: 100%;
+  max-width: 16rem;
+  aspect-ratio: 5 / 3;
   outline: 0;
   border: 1px solid oklch(14.5% 0 0deg);
   border-radius: 0;
   background-color: white;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 400;
   color: oklch(14.5% 0 0deg);
   -webkit-user-select: none;

--- a/docs/src/app/(docs)/react/components/context-menu/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/hero/tailwind/index.tsx
@@ -3,7 +3,7 @@ import { ContextMenu } from '@base-ui/react/context-menu';
 export default function ExampleMenu() {
   return (
     <ContextMenu.Root>
-      <ContextMenu.Trigger className="flex h-[12rem] w-[15rem] items-center justify-center rounded-none border border-neutral-950 bg-white text-neutral-950 select-none font-normal dark:border-white dark:bg-neutral-950 dark:text-white">
+      <ContextMenu.Trigger className="flex aspect-5/3 w-full max-w-64 items-center justify-center rounded-none border border-neutral-950 bg-white text-neutral-950 select-none text-sm font-normal dark:border-white dark:bg-neutral-950 dark:text-white">
         Right click here
       </ContextMenu.Trigger>
       <ContextMenu.Portal>

--- a/docs/src/app/(docs)/react/components/context-menu/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/hero/tailwind/index.tsx
@@ -3,7 +3,7 @@ import { ContextMenu } from '@base-ui/react/context-menu';
 export default function ExampleMenu() {
   return (
     <ContextMenu.Root>
-      <ContextMenu.Trigger className="flex aspect-5/3 w-full max-w-64 items-center justify-center rounded-none border border-neutral-950 bg-white text-neutral-950 select-none text-sm font-normal dark:border-white dark:bg-neutral-950 dark:text-white">
+      <ContextMenu.Trigger className="flex aspect-5/3 w-full max-w-64 items-center justify-center rounded-none border border-neutral-950 bg-white text-neutral-950 select-none text-sm dark:border-white dark:bg-neutral-950 dark:text-white">
         Right click here
       </ContextMenu.Trigger>
       <ContextMenu.Portal>

--- a/docs/src/app/(docs)/react/components/context-menu/demos/submenu/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/submenu/css-modules/index.module.css
@@ -12,7 +12,6 @@
   background-color: white;
   font-size: 0.875rem;
   line-height: 1.25rem;
-  font-weight: 400;
   color: oklch(14.5% 0 0deg);
   -webkit-user-select: none;
   user-select: none;

--- a/docs/src/app/(docs)/react/components/context-menu/demos/submenu/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/submenu/css-modules/index.module.css
@@ -3,12 +3,15 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 15rem;
-  height: 12rem;
+  width: 100%;
+  max-width: 16rem;
+  aspect-ratio: 5 / 3;
   outline: 0;
   border: 1px solid oklch(14.5% 0 0deg);
   border-radius: 0;
   background-color: white;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 400;
   color: oklch(14.5% 0 0deg);
   -webkit-user-select: none;

--- a/docs/src/app/(docs)/react/components/context-menu/demos/submenu/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/submenu/tailwind/index.tsx
@@ -4,7 +4,7 @@ import { ContextMenu } from '@base-ui/react/context-menu';
 export default function ExampleContextMenu() {
   return (
     <ContextMenu.Root>
-      <ContextMenu.Trigger className="flex h-[12rem] w-[15rem] items-center justify-center rounded-none border border-neutral-950 bg-white text-neutral-950 select-none font-normal dark:border-white dark:bg-neutral-950 dark:text-white">
+      <ContextMenu.Trigger className="flex aspect-5/3 w-full max-w-64 items-center justify-center rounded-none border border-neutral-950 bg-white text-neutral-950 select-none text-sm font-normal dark:border-white dark:bg-neutral-950 dark:text-white">
         Right click here
       </ContextMenu.Trigger>
       <ContextMenu.Portal>

--- a/docs/src/app/(docs)/react/components/context-menu/demos/submenu/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/submenu/tailwind/index.tsx
@@ -4,7 +4,7 @@ import { ContextMenu } from '@base-ui/react/context-menu';
 export default function ExampleContextMenu() {
   return (
     <ContextMenu.Root>
-      <ContextMenu.Trigger className="flex aspect-5/3 w-full max-w-64 items-center justify-center rounded-none border border-neutral-950 bg-white text-neutral-950 select-none text-sm font-normal dark:border-white dark:bg-neutral-950 dark:text-white">
+      <ContextMenu.Trigger className="flex aspect-5/3 w-full max-w-64 items-center justify-center rounded-none border border-neutral-950 bg-white text-neutral-950 select-none text-sm dark:border-white dark:bg-neutral-950 dark:text-white">
         Right click here
       </ContextMenu.Trigger>
       <ContextMenu.Portal>

--- a/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/css-modules/index.module.css
@@ -1,0 +1,198 @@
+.Card {
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  overflow: hidden;
+  width: 100%;
+  max-width: 16rem;
+  outline: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  text-align: left;
+  -webkit-user-select: none;
+  user-select: none;
+
+  @media (prefers-color-scheme: dark) {
+    border-color: white;
+    background-color: oklch(14.5% 0 0deg);
+    color: white;
+  }
+}
+
+.Image {
+  display: block;
+  width: 100%;
+  height: 9rem;
+  object-fit: cover;
+}
+
+.Content {
+  padding: 0.5rem;
+}
+
+.Title {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.Metadata {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: oklch(55.6% 0 0deg);
+
+  @media (prefers-color-scheme: dark) {
+    color: oklch(70.8% 0 0deg);
+  }
+}
+
+.MenuTrigger {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  margin: 0;
+  outline: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 0;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+  opacity: 0;
+
+  &[data-pressed],
+  &:focus-visible,
+  .Card:hover & {
+    opacity: 1;
+  }
+
+  @media (any-pointer: coarse) {
+    opacity: 1;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    border-color: white;
+    background-color: oklch(14.5% 0 0deg);
+    color: white;
+  }
+
+  @media (hover: hover) {
+    &:hover:not([data-disabled]) {
+      background-color: oklch(97% 0 0deg);
+
+      @media (prefers-color-scheme: dark) {
+        background-color: oklch(26.9% 0 0deg);
+      }
+    }
+  }
+
+  &:active:not([data-disabled]),
+  &[data-popup-open] {
+    background-color: oklch(92.2% 0 0deg);
+
+    @media (prefers-color-scheme: dark) {
+      background-color: oklch(37.1% 0 0deg);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid oklch(14.5% 0 0deg);
+    outline-offset: -1px;
+
+    @media (prefers-color-scheme: dark) {
+      outline-color: white;
+    }
+  }
+}
+
+.Positioner {
+  outline: 0;
+}
+
+.Popup {
+  box-sizing: border-box;
+  outline: 0;
+  padding-block: 0.25rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 0;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+  transform-origin: var(--transform-origin);
+  transition:
+    transform 100ms ease-out,
+    opacity 100ms ease-out;
+
+  @media (prefers-color-scheme: dark) {
+    border-color: white;
+    background-color: oklch(14.5% 0 0deg);
+    color: white;
+    box-shadow: none;
+  }
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+}
+
+.Item {
+  position: relative;
+  display: flex;
+  padding-block: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 2rem;
+  outline: 0;
+  color: inherit;
+  font-size: 0.875rem;
+  line-height: 1rem;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+
+  &[data-highlighted] {
+    z-index: 0;
+    color: white;
+
+    @media (prefers-color-scheme: dark) {
+      color: oklch(14.5% 0 0deg);
+    }
+  }
+
+  &[data-highlighted]::before {
+    content: '';
+    z-index: -1;
+    position: absolute;
+    inset-block: 0;
+    inset-inline: 0.25rem;
+    background-color: oklch(14.5% 0 0deg);
+
+    @media (prefers-color-scheme: dark) {
+      background-color: white;
+    }
+  }
+}
+
+.ItemDestructive {
+  color: oklch(50.5% 0.213 27.518deg);
+}
+
+.Separator {
+  margin: 0.25rem;
+  height: 1px;
+  background-color: oklch(14.5% 0 0deg);
+
+  @media (prefers-color-scheme: dark) {
+    background-color: white;
+  }
+}

--- a/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/css-modules/index.tsx
@@ -27,7 +27,7 @@ export default function ContextMenuWithMenuDemo() {
           <Menu.Portal>
             <Menu.Positioner align="end" sideOffset={8} className={styles.Positioner}>
               <Menu.Popup className={styles.Popup}>
-                <SharedMenuItems Item={Menu.Item} Separator={Menu.Separator} />
+                <SharedMenuItems />
               </Menu.Popup>
             </Menu.Positioner>
           </Menu.Portal>
@@ -37,7 +37,7 @@ export default function ContextMenuWithMenuDemo() {
       <ContextMenu.Portal>
         <ContextMenu.Positioner className={styles.Positioner}>
           <ContextMenu.Popup className={styles.Popup}>
-            <SharedMenuItems Item={ContextMenu.Item} Separator={ContextMenu.Separator} />
+            <SharedMenuItems type="context-menu" />
           </ContextMenu.Popup>
         </ContextMenu.Positioner>
       </ContextMenu.Portal>
@@ -47,11 +47,9 @@ export default function ContextMenuWithMenuDemo() {
 
 const actions = ['Preview', 'Download', 'Copy link', 'Rename'];
 
-function SharedMenuItems(props: {
-  Item: typeof Menu.Item | typeof ContextMenu.Item;
-  Separator: typeof Menu.Separator | typeof ContextMenu.Separator;
-}) {
-  const { Item, Separator } = props;
+function SharedMenuItems({ type = 'menu' }: { type?: 'menu' | 'context-menu' }) {
+  const Item = type === 'context-menu' ? ContextMenu.Item : Menu.Item;
+  const Separator = type === 'context-menu' ? ContextMenu.Separator : Menu.Separator;
   return (
     <React.Fragment>
       {actions.map((action) => (

--- a/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/css-modules/index.tsx
@@ -1,0 +1,74 @@
+'use client';
+import * as React from 'react';
+import { ContextMenu } from '@base-ui/react/context-menu';
+import { Menu } from '@base-ui/react/menu';
+import styles from './index.module.css';
+
+export default function ContextMenuWithMenuDemo() {
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger className={styles.Card}>
+        <img
+          width="512"
+          height="288"
+          className={styles.Image}
+          src="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=512&h=288"
+          alt=""
+        />
+        <div className={styles.Content}>
+          <p className={styles.Title}>Station Hofplein</p>
+          <p className={styles.Metadata}>JPG, 2.4 MB</p>
+        </div>
+
+        <Menu.Root>
+          <Menu.Trigger aria-label="Image actions" className={styles.MenuTrigger}>
+            <MoreVertIcon />
+          </Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Positioner align="end" sideOffset={8} className={styles.Positioner}>
+              <Menu.Popup className={styles.Popup}>
+                <SharedMenuItems Item={Menu.Item} Separator={Menu.Separator} />
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
+      </ContextMenu.Trigger>
+
+      <ContextMenu.Portal>
+        <ContextMenu.Positioner className={styles.Positioner}>
+          <ContextMenu.Popup className={styles.Popup}>
+            <SharedMenuItems Item={ContextMenu.Item} Separator={ContextMenu.Separator} />
+          </ContextMenu.Popup>
+        </ContextMenu.Positioner>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
+  );
+}
+
+const actions = ['Preview', 'Download', 'Copy link', 'Rename'];
+
+function SharedMenuItems(props: {
+  Item: typeof Menu.Item | typeof ContextMenu.Item;
+  Separator: typeof Menu.Separator | typeof ContextMenu.Separator;
+}) {
+  const { Item, Separator } = props;
+  return (
+    <React.Fragment>
+      {actions.map((action) => (
+        <Item key={action} className={styles.Item}>
+          {action}
+        </Item>
+      ))}
+      <Separator className={styles.Separator} />
+      <Item className={`${styles.Item} ${styles.ItemDestructive}`}>Delete</Item>
+    </React.Fragment>
+  );
+}
+
+function MoreVertIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" {...props}>
+      <path d="M9.5 13c0 .8284-.67157 1.5-1.5 1.5s-1.5-.6716-1.5-1.5.67157-1.5 1.5-1.5 1.5.6716 1.5 1.5m0-5c0 .82843-.67157 1.5-1.5 1.5S6.5 8.82843 6.5 8 7.17157 6.5 8 6.5s1.5.67157 1.5 1.5m0-5c0 .82843-.67157 1.5-1.5 1.5S6.5 3.82843 6.5 3 7.17157 1.5 8 1.5s1.5.67157 1.5 1.5" />
+    </svg>
+  );
+}

--- a/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/index.ts
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/index.ts
@@ -1,0 +1,8 @@
+import { createDemoWithVariants } from 'docs/src/utils/createDemo';
+import CssModules from './css-modules';
+import Tailwind from './tailwind';
+
+export const DemoContextMenuWithMenu = createDemoWithVariants(import.meta.url, {
+  CssModules,
+  Tailwind,
+});

--- a/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/tailwind/index.tsx
@@ -29,7 +29,7 @@ export default function ContextMenuWithMenuDemo() {
           <Menu.Portal>
             <Menu.Positioner align="end" sideOffset={8} className="outline-hidden">
               <Menu.Popup className={popupClass}>
-                <SharedMenuItems Item={Menu.Item} Separator={Menu.Separator} />
+                <SharedMenuItems />
               </Menu.Popup>
             </Menu.Positioner>
           </Menu.Portal>
@@ -39,7 +39,7 @@ export default function ContextMenuWithMenuDemo() {
       <ContextMenu.Portal>
         <ContextMenu.Positioner className="outline-hidden">
           <ContextMenu.Popup className={popupClass}>
-            <SharedMenuItems Item={ContextMenu.Item} Separator={ContextMenu.Separator} />
+            <SharedMenuItems type="context-menu" />
           </ContextMenu.Popup>
         </ContextMenu.Positioner>
       </ContextMenu.Portal>
@@ -54,11 +54,9 @@ const itemClass =
 
 const actions = ['Preview', 'Download', 'Copy link', 'Rename'];
 
-function SharedMenuItems(props: {
-  Item: typeof Menu.Item | typeof ContextMenu.Item;
-  Separator: typeof Menu.Separator | typeof ContextMenu.Separator;
-}) {
-  const { Item, Separator } = props;
+function SharedMenuItems({ type = 'menu' }: { type?: 'menu' | 'context-menu' }) {
+  const Item = type === 'context-menu' ? ContextMenu.Item : Menu.Item;
+  const Separator = type === 'context-menu' ? ContextMenu.Separator : Menu.Separator;
   return (
     <React.Fragment>
       {actions.map((action) => (

--- a/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/context-menu/demos/with-menu/tailwind/index.tsx
@@ -1,0 +1,81 @@
+'use client';
+import * as React from 'react';
+import { ContextMenu } from '@base-ui/react/context-menu';
+import { Menu } from '@base-ui/react/menu';
+
+export default function ContextMenuWithMenuDemo() {
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger className="group relative w-full max-w-64 overflow-hidden border border-neutral-950 bg-white text-left text-neutral-950 select-none dark:border-white dark:bg-neutral-950 dark:text-white">
+        <img
+          width="512"
+          height="288"
+          className="h-36 w-full object-cover"
+          src="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=512&h=288"
+          alt=""
+        />
+        <div className="p-2">
+          <p className="text-sm leading-5">Station Hofplein</p>
+          <p className="text-xs leading-4 text-neutral-500 dark:text-neutral-400">JPG, 2.4 MB</p>
+        </div>
+
+        <Menu.Root>
+          <Menu.Trigger
+            aria-label="Image actions"
+            className="absolute top-2 right-2 flex size-8 items-center justify-center border border-neutral-950 bg-white text-neutral-950 opacity-0 select-none group-hover:opacity-100 data-pressed:opacity-100 any-pointer-coarse:opacity-100 hover:not-data-disabled:bg-neutral-100 active:not-data-disabled:bg-neutral-200 data-popup-open:bg-neutral-100 dark:border-white dark:bg-neutral-950 dark:text-white dark:hover:not-data-disabled:bg-neutral-800 dark:active:not-data-disabled:bg-neutral-700 dark:data-popup-open:bg-neutral-800 focus-visible:opacity-100 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-neutral-950 dark:focus-visible:outline-white"
+          >
+            <MoreVertIcon />
+          </Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Positioner align="end" sideOffset={8} className="outline-hidden">
+              <Menu.Popup className={popupClass}>
+                <SharedMenuItems Item={Menu.Item} Separator={Menu.Separator} />
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
+      </ContextMenu.Trigger>
+
+      <ContextMenu.Portal>
+        <ContextMenu.Positioner className="outline-hidden">
+          <ContextMenu.Popup className={popupClass}>
+            <SharedMenuItems Item={ContextMenu.Item} Separator={ContextMenu.Separator} />
+          </ContextMenu.Popup>
+        </ContextMenu.Positioner>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
+  );
+}
+
+const popupClass =
+  'origin-[var(--transform-origin)] border border-neutral-950 bg-white py-1 text-neutral-950 shadow-[0.25rem_0.25rem_0] shadow-black/12 outline-hidden transition-[scale,opacity] duration-100 ease-out data-ending-style:scale-[0.98] data-ending-style:opacity-0 data-starting-style:scale-[0.98] data-starting-style:opacity-0 dark:border-white dark:bg-neutral-950 dark:text-white dark:shadow-none';
+const itemClass =
+  "flex cursor-default py-2 pr-8 pl-4 text-sm leading-4 outline-hidden select-none data-highlighted:relative data-highlighted:z-0 data-highlighted:text-white data-highlighted:before:absolute data-highlighted:before:inset-x-1 data-highlighted:before:inset-y-0 data-highlighted:before:z-[-1] data-highlighted:before:bg-neutral-950 data-highlighted:before:content-[''] data-disabled:text-neutral-500 dark:data-highlighted:text-neutral-950 dark:data-highlighted:before:bg-white dark:data-disabled:text-neutral-400";
+
+const actions = ['Preview', 'Download', 'Copy link', 'Rename'];
+
+function SharedMenuItems(props: {
+  Item: typeof Menu.Item | typeof ContextMenu.Item;
+  Separator: typeof Menu.Separator | typeof ContextMenu.Separator;
+}) {
+  const { Item, Separator } = props;
+  return (
+    <React.Fragment>
+      {actions.map((action) => (
+        <Item key={action} className={itemClass}>
+          {action}
+        </Item>
+      ))}
+      <Separator className="mx-1 my-1 h-px bg-neutral-950 dark:bg-white" />
+      <Item className={`${itemClass} text-red-700`}>Delete</Item>
+    </React.Fragment>
+  );
+}
+
+function MoreVertIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" {...props}>
+      <path d="M9.5 13c0 .8284-.67157 1.5-1.5 1.5s-1.5-.6716-1.5-1.5.67157-1.5 1.5-1.5 1.5.6716 1.5 1.5m0-5c0 .82843-.67157 1.5-1.5 1.5S6.5 8.82843 6.5 8 7.17157 6.5 8 6.5s1.5.67157 1.5 1.5m0-5c0 .82843-.67157 1.5-1.5 1.5S6.5 3.82843 6.5 3 7.17157 1.5 8 1.5s1.5.67157 1.5 1.5" />
+    </svg>
+  );
+}

--- a/docs/src/app/(docs)/react/components/context-menu/page.mdx
+++ b/docs/src/app/(docs)/react/components/context-menu/page.mdx
@@ -12,7 +12,7 @@ import { DemoContextMenuHero } from './demos/hero';
 
 ## Usage guidelines
 
-- **Use context menus as an enhancement**: Don’t make a context menu the only way to access essential actions. Users may not discover or be able to open a context menu, especially on touch devices or with assistive technology.
+- **Use context menus as an enhancement**: Don't make a context menu the only way to perform actions. Users may not discover or be able to open a context menu, especially on touch devices or with assistive technology. Always provide visible controls for the actions that are available in the context menu.
 
 ## Anatomy
 
@@ -58,6 +58,14 @@ import { ContextMenu } from '@base-ui/react/context-menu';
 ## Examples
 
 [Menu](/react/components/menu#examples) displays additional demos, many of which apply to the context menu as well.
+
+### Using with Menu
+
+A context menu should supplement a primary way to perform the same actions. This image card exposes actions through a visible menu button and reuses them in the context menu for right-click and long-press users.
+
+import { DemoContextMenuWithMenu } from './demos/with-menu';
+
+<DemoContextMenuWithMenu />
 
 ### Nested menu
 

--- a/docs/src/app/(docs)/react/components/context-menu/page.mdx
+++ b/docs/src/app/(docs)/react/components/context-menu/page.mdx
@@ -10,6 +10,10 @@ import { DemoContextMenuHero } from './demos/hero';
 
 <DemoContextMenuHero />
 
+## Usage guidelines
+
+- **Use context menus as an enhancement**: Don’t make a context menu the only way to access essential actions. Users may not discover or be able to open a context menu, especially on touch devices or with assistive technology.
+
 ## Anatomy
 
 Import the components and place them together:

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -544,6 +544,7 @@ A menu that appears at the pointer on right click or long press.
   - Usage guidelines
   - Anatomy
   - Examples
+    - Using with Menu
     - Nested menu
   - API reference
     - Root

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -541,6 +541,7 @@ A menu that appears at the pointer on right click or long press.
 
 - Keywords: React Context Menu, Context Menu Component, Right Click Menu, Secondary Click Menu, Pointer Menu, Touch Hold Menu, Long Press Menu, Nested Menu React, Accessible Context Menu, Headless React Components, Base UI
 - Sections:
+  - Usage guidelines
   - Anatomy
   - Examples
     - Nested menu


### PR DESCRIPTION
Closes https://github.com/mui/base-ui/issues/4171

Preview: https://deploy-preview-5121--base-ui.netlify.app/react/components/context-menu

- Adds usage guidelines to recommend always adding visual controls to perform actions present in a context menu.
- Adds a demo using ContextMenu alongside Menu.
- Improves two existing demos by reducing font-size and avoiding them from becoming wider than the container on small viewports.