### PR TITLE
[switch] Fix focus-visible keyboard activation

### DIFF
--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -128,6 +128,45 @@ describe('<Switch.Root />', () => {
           });
         },
       );
+
+      it.skipIf(isJSDOM)(
+        `does not emit extra blur and focus events when restoring :focus-visible with ${key}`,
+        async () => {
+          const focusSpy = vi.fn((event) => event.target);
+          const blurSpy = vi.fn((event) => event.target);
+          const { userEvent: nativeUser } = await import('vitest/browser');
+
+          await render(
+            <Switch.Root
+              onFocus={focusSpy}
+              onBlur={blurSpy}
+              style={{ display: 'inline-block', width: 20, height: 20 }}
+            />,
+          );
+
+          const switchEl = screen.getByRole('switch');
+
+          await act(async () => nativeUser.click(switchEl));
+          expect(switchEl).toHaveAttribute('aria-checked', 'true');
+          expect(switchEl).toHaveFocus();
+
+          await waitFor(() => {
+            expect(focusSpy).toHaveBeenCalledTimes(1);
+          });
+          expect(focusSpy.mock.results[0]?.value).toBe(switchEl);
+          expect(blurSpy).not.toHaveBeenCalled();
+
+          await act(async () => nativeUser.keyboard(`[${key}]`));
+          expect(switchEl).toHaveAttribute('aria-checked', 'false');
+          expect(switchEl).toHaveFocus();
+
+          await waitFor(() => {
+            expect(switchEl.matches(':focus-visible')).toBe(true);
+          });
+          expect(focusSpy).toHaveBeenCalledTimes(1);
+          expect(blurSpy).not.toHaveBeenCalled();
+        },
+      );
     });
   });
 

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -84,6 +84,50 @@ describe('<Switch.Root />', () => {
         await user.keyboard(`[${key}]`);
         expect(switchEl).toHaveAttribute('aria-checked', 'true');
       });
+
+      it.skipIf(isJSDOM)(`preserves :focus-visible after ${key} key activation`, async () => {
+        const { userEvent: nativeUser } = await import('vitest/browser');
+        await render(<Switch.Root />);
+
+        const switchEl = screen.getByRole('switch');
+
+        await act(async () => nativeUser.keyboard('[Tab]'));
+        expect(switchEl).toHaveFocus();
+
+        await waitFor(() => {
+          expect(switchEl.matches(':focus-visible')).toBe(true);
+        });
+
+        await act(async () => nativeUser.keyboard(`[${key}]`));
+        expect(switchEl).toHaveAttribute('aria-checked', 'true');
+        expect(switchEl).toHaveFocus();
+
+        await waitFor(() => {
+          expect(switchEl.matches(':focus-visible')).toBe(true);
+        });
+      });
+
+      it.skipIf(isJSDOM)(
+        `shows :focus-visible after ${key} key activation following a pointer press`,
+        async () => {
+          const { userEvent: nativeUser } = await import('vitest/browser');
+          await render(<Switch.Root style={{ display: 'inline-block', width: 20, height: 20 }} />);
+
+          const switchEl = screen.getByRole('switch');
+
+          await act(async () => nativeUser.click(switchEl));
+          expect(switchEl).toHaveAttribute('aria-checked', 'true');
+          expect(switchEl).toHaveFocus();
+
+          await act(async () => nativeUser.keyboard(`[${key}]`));
+          expect(switchEl).toHaveAttribute('aria-checked', 'false');
+          expect(switchEl).toHaveFocus();
+
+          await waitFor(() => {
+            expect(switchEl.matches(':focus-visible')).toBe(true);
+          });
+        },
+      );
     });
   });
 

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -24,6 +24,7 @@ import { createChangeEventDetails } from '../../internals/createBaseUIEventDetai
 import { REASONS } from '../../internals/reasons';
 import type { BaseUIChangeEventDetails } from '../../types';
 import { useValueChanged } from '../../internals/useValueChanged';
+import { matchesFocusVisible } from '../../floating-ui-react/utils/element';
 
 /**
  * Represents the switch itself.
@@ -78,6 +79,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
   const handleInputRef = useMergedRefs(inputRef, externalInputRef, validation.inputRef);
 
   const switchRef = React.useRef<HTMLButtonElement | null>(null);
+  const restoringFocusVisibleRef = React.useRef(false);
 
   const id = useBaseUiId();
 
@@ -130,12 +132,24 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     'aria-readonly': readOnly || undefined,
     'aria-required': required || undefined,
     'aria-labelledby': ariaLabelledBy,
-    onFocus() {
+    onFocus(event) {
+      const isRestoringFocusVisible = restoringFocusVisibleRef.current;
+      restoringFocusVisibleRef.current = false;
+
       if (!disabled) {
         setFocused(true);
       }
+
+      if (isRestoringFocusVisible) {
+        event.stopPropagation();
+      }
     },
-    onBlur() {
+    onBlur(event) {
+      if (restoringFocusVisibleRef.current) {
+        event.stopPropagation();
+        return;
+      }
+
       const element = inputRef.current;
       if (!element || disabled) {
         return;
@@ -146,6 +160,29 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
 
       if (validationMode === 'onBlur') {
         validation.commit(element.checked);
+      }
+    },
+    onKeyDown(event) {
+      if (
+        nativeButton ||
+        readOnly ||
+        disabled ||
+        event.defaultPrevented ||
+        event.target !== event.currentTarget ||
+        (event.key !== 'Enter' && event.key !== ' ')
+      ) {
+        return;
+      }
+
+      const element = event.currentTarget;
+
+      if (!matchesFocusVisible(element)) {
+        restoringFocusVisibleRef.current = true;
+        element.blur();
+        element.focus({
+          preventScroll: true,
+          focusVisible: true,
+        });
       }
     },
     onClick(event) {

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -7,7 +7,11 @@ import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidd
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { ownerWindow } from '@base-ui/utils/owner';
 import { useRenderElement } from '../../internals/useRenderElement';
-import type { BaseUIComponentProps, NonNativeButtonProps } from '../../internals/types';
+import type {
+  BaseUIComponentProps,
+  BaseUIEvent,
+  NonNativeButtonProps,
+} from '../../internals/types';
 import { mergeProps } from '../../merge-props';
 import { useBaseUiId } from '../../internals/useBaseUiId';
 import { useButton } from '../../internals/use-button';
@@ -132,24 +136,12 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     'aria-readonly': readOnly || undefined,
     'aria-required': required || undefined,
     'aria-labelledby': ariaLabelledBy,
-    onFocus(event) {
-      const isRestoringFocusVisible = restoringFocusVisibleRef.current;
-      restoringFocusVisibleRef.current = false;
-
+    onFocus() {
       if (!disabled) {
         setFocused(true);
       }
-
-      if (isRestoringFocusVisible) {
-        event.stopPropagation();
-      }
     },
-    onBlur(event) {
-      if (restoringFocusVisibleRef.current) {
-        event.stopPropagation();
-        return;
-      }
-
+    onBlur() {
       const element = inputRef.current;
       if (!element || disabled) {
         return;
@@ -206,6 +198,24 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
           metaKey: event.metaKey,
         }),
       );
+    },
+  };
+
+  const focusVisibleRestoreGuardProps: React.ComponentPropsWithRef<'span'> = {
+    onFocus(event) {
+      const isRestoringFocusVisible = restoringFocusVisibleRef.current;
+      restoringFocusVisibleRef.current = false;
+
+      if (isRestoringFocusVisible) {
+        (event as unknown as BaseUIEvent<React.FocusEvent>).preventBaseUIHandler();
+        event.stopPropagation();
+      }
+    },
+    onBlur(event) {
+      if (restoringFocusVisibleRef.current) {
+        (event as unknown as BaseUIEvent<React.FocusEvent>).preventBaseUIHandler();
+        event.stopPropagation();
+      }
     },
   };
 
@@ -271,6 +281,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     props: [
       rootProps,
       elementProps,
+      focusVisibleRestoreGuardProps,
       getButtonProps,
       (props) => validation.getValidationProps(disabled, props),
     ],


### PR DESCRIPTION
Fixes the Firefox case where a Switch remains focused after pointer interaction followed by Space/Enter activation, but does not match `:focus-visible`.

Changes:
- Restore visible focus for non-native Switch keyboard activation when the element is focused but not `:focus-visible`.
- Suppress the internal blur/refocus from marking the field touched or committing blur validation.
- Add browser-only regression coverage for Tab activation and pointer-then-keyboard activation with Enter and Space.

Validation:
- `pnpm exec prettier --check packages/react/src/switch/root/SwitchRoot.tsx packages/react/src/switch/root/SwitchRoot.test.tsx`
- `pnpm eslint packages/react/src/switch/root/SwitchRoot.tsx packages/react/src/switch/root/SwitchRoot.test.tsx`
- `pnpm test:jsdom SwitchRoot --no-watch`
- `pnpm test:chromium SwitchRoot --no-watch`
- `pnpm test:chromium SwitchRoot --no-watch -t "focus-visible"`
- `pnpm test:firefox SwitchRoot --no-watch -t "focus-visible"`
- `pnpm test:webkit SwitchRoot --no-watch -t "focus-visible"`

Fixes https://github.com/mui/base-ui/issues/5130