### PR TITLE
[toast] Clean up aborted close animations

### DIFF
--- a/packages/react/src/internals/useAnimationsFinished.ts
+++ b/packages/react/src/internals/useAnimationsFinished.ts
@@ -72,18 +72,21 @@ export function useAnimationsFinished(
               return;
             }
 
-            const currentAnimations = resolvedElement.getAnimations();
+            if (signal?.aborted) {
+              return;
+            }
 
-            if (
-              !signal?.aborted &&
-              currentAnimations.length > 0 &&
-              currentAnimations.some(
-                (animation) => animation.pending || animation.playState !== 'finished',
-              )
-            ) {
+            const currentAnimations = resolvedElement.getAnimations();
+            const hasActiveAnimations = currentAnimations.some(
+              (animation) => animation.pending || animation.playState !== 'finished',
+            );
+
+            if (hasActiveAnimations) {
               // Sometimes animations can be aborted because a property they depend on changes while the animation plays.
               // In such cases, we need to re-check if any new animations have started.
               exec();
+            } else {
+              done();
             }
           });
       }

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Toast } from '@base-ui/react/toast';
 import { act, screen, fireEvent, waitFor } from '@mui/internal-test-utils';
@@ -189,6 +189,56 @@ describe('<Toast.Root />', () => {
     await user.keyboard('{Escape}');
 
     expect(screen.queryByTestId('root')).toBe(null);
+  });
+
+  it('removes the toast when a closing animation is aborted and no animations remain', async () => {
+    const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+    try {
+      const { user } = await render(
+        <Toast.Provider>
+          <Toast.Viewport>
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'add' }));
+
+      const toastRoot = screen.getByTestId('root');
+      let getAnimationsCallCount = 0;
+
+      Object.defineProperty(toastRoot, 'getAnimations', {
+        configurable: true,
+        value: vi.fn(() => {
+          getAnimationsCallCount += 1;
+
+          if (getAnimationsCallCount === 1) {
+            return [
+              {
+                finished: Promise.reject(new Error('Animation was aborted')),
+                pending: false,
+                playState: 'idle',
+              },
+            ];
+          }
+
+          return [];
+        }),
+      });
+
+      await user.click(screen.getByLabelText('close-press'));
+
+      expect(toastRoot).toHaveAttribute('data-ending-style');
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('root')).toBe(null);
+      });
+    } finally {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
+    }
   });
 
   describe.skipIf(isJSDOM)('swipe behavior', () => {


### PR DESCRIPTION
## Summary

- Treat aborted close animations with no remaining active animations as complete.
- Add a Toast.Root regression test for an aborted closing animation that leaves no animations to wait for.

## Root cause

`useOpenChangeComplete` waits for `animation.finished` before removing a closing toast. When a closing animation is aborted and `getAnimations()` then returns no active animations, the previous `useAnimationsFinished` catch path neither retried nor completed, so the toast could remain mounted with `data-ending-style` indefinitely.

## Validation

- `pnpm test:jsdom ToastRoot --no-watch`
- `pnpm test:chromium ToastRoot --no-watch`
- `pnpm exec prettier --check packages/react/src/internals/useAnimationsFinished.ts packages/react/src/toast/root/ToastRoot.test.tsx`
- `pnpm exec eslint packages/react/src/internals/useAnimationsFinished.ts packages/react/src/toast/root/ToastRoot.test.tsx --max-warnings 0`
- `pnpm typescript`
- `git diff --check`