### PR TITLE
[docs] Fix v1.6.0 release date inconsistency

### DIFF
--- a/docs/src/data/releases.ts
+++ b/docs/src/data/releases.ts
@@ -11,7 +11,7 @@ export const releases: Release[] = [
     latest: true,
     version: 'v1.6.0',
     versionSlug: 'v1-6-0',
-    date: '2026-06-17',
+    date: '2026-06-18',
     highlights: [
       '`OTPField` is now stable.',
       'Align `Accordion` keyboard navigation with APG.',


### PR DESCRIPTION
## What

The releases page showed two different dates for v1.6.0:

- `docs/src/data/releases.ts` listed the date as `2026-06-17` (drives the release timeline)
- `docs/src/app/(docs)/react/overview/releases/v1-6-0/page.mdx` shows `Jun 18, 2026` (subtitle + meta description)

This updates the data file to `2026-06-18` so both agree.

## Why

The `v1.6.0` git tag and the `[release] v1.6.0` commit are both dated `2026-06-18`, so June 18 is the actual release date — the data file held the stale one. Every other release entry already has its `releases.ts` date matching its `page.mdx` subtitle; v1.6.0 was the only mismatch.