### PR TITLE
[docs] Adjust cursor for demo playground link and file tabs

### DIFF
--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -14,6 +14,12 @@
     right: 1.125rem;
   }
 
+  /* The external playground link opens a new tab, so use a link-style cursor
+     even though it's rendered as a plain button. */
+  .DemoExternalPlaygroundButton {
+    cursor: pointer;
+  }
+
   .DemoPlayground {
     position: relative;
 
@@ -192,6 +198,8 @@
     position: relative;
     z-index: 0;
     outline: 0;
+    /* Rendered as an anchor, but behaves like a tab, so use the default cursor. */
+    cursor: default;
     height: 2.25rem;
     padding-inline: 0.75rem;
     padding-top: 0.25rem;

--- a/docs/src/components/Demo/Demo.tsx
+++ b/docs/src/components/Demo/Demo.tsx
@@ -159,12 +159,22 @@ export function Demo({ className, ...demoProps }: DemoProps) {
   }, []);
 
   const externalPlaygroundLink = fallbackToCodeSandbox ? (
-    <GhostButton aria-label="Open in CodeSandbox" type="button" onClick={demo.openCodeSandbox}>
+    <GhostButton
+      className="DemoExternalPlaygroundButton"
+      aria-label="Open in CodeSandbox"
+      type="button"
+      onClick={demo.openCodeSandbox}
+    >
       CodeSandbox
       <ExternalLinkIcon />
     </GhostButton>
   ) : (
-    <GhostButton aria-label="Open in StackBlitz" type="button" onClick={demo.openStackBlitz}>
+    <GhostButton
+      className="DemoExternalPlaygroundButton"
+      aria-label="Open in StackBlitz"
+      type="button"
+      onClick={demo.openStackBlitz}
+    >
       StackBlitz
       <ExternalLinkIcon />
     </GhostButton>


### PR DESCRIPTION
## What changed

Two cursor tweaks in the docs demo chrome:

- **"Open in StackBlitz" / "Open in CodeSandbox" button** now uses `cursor: pointer` to indicate it opens in a new tab, despite not being a link.
- **Demo file tabs** (`.DemoTab`) now use `cursor: default`. They're rendered as `<a>` anchors (which default to `pointer`) but behave like in-page tabs, because left-click goes nowhere (only right-click has a special `<a>` affordance).

## Why

The cursor should reflect behavior, not the underlying element: the playground link opens an external playground in a new tab (link-like), while the file tabs switch the displayed source in place (tab-like). The goal is to make the `cursor` style feel less random rather than attempting to strictly adhere to tag/`<a>` conventions