### PR TITLE
[scroll area] Add overscroll feedback to the scrollbar thumb

### DIFF
--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.test.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.test.tsx
@@ -1,5 +1,6 @@
 import { expect } from 'vitest';
 import { ScrollArea } from '@base-ui/react/scroll-area';
+import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { createRenderer, isJSDOM, describeConformance } from '#test-utils';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { SCROLL_TIMEOUT } from '../constants';
@@ -106,6 +107,167 @@ describe('<ScrollArea.Viewport />', () => {
         expect(viewport).toHaveAttribute('data-overflow-y-end');
       });
       /* eslint-enable testing-library/no-wait-for-multiple-assertions */
+    });
+  });
+
+  // Only Safari reports an out-of-range `scrollTop`/`scrollLeft` while rubber-banding, and the
+  // browser clamps the property on assignment, so the getter is mocked to emulate it against
+  // real layout.
+  describe.skipIf(isJSDOM)('overscroll feedback', () => {
+    const VIEWPORT_SIZE = 200;
+    const CONTENT_SIZE = 1000;
+    const MAX_SCROLL = CONTENT_SIZE - VIEWPORT_SIZE;
+
+    async function renderScrollArea(
+      orientation: 'vertical' | 'horizontal',
+      textDirection: 'ltr' | 'rtl' = 'ltr',
+    ) {
+      await render(
+        <DirectionProvider direction={textDirection}>
+          <ScrollArea.Root
+            style={{ width: VIEWPORT_SIZE, height: VIEWPORT_SIZE, direction: textDirection }}
+          >
+            <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
+              <div
+                style={{
+                  width: orientation === 'horizontal' ? CONTENT_SIZE : '100%',
+                  height: orientation === 'vertical' ? CONTENT_SIZE : '100%',
+                }}
+              />
+            </ScrollArea.Viewport>
+            <ScrollArea.Scrollbar orientation={orientation} data-testid="scrollbar" keepMounted>
+              <ScrollArea.Thumb data-testid="thumb" />
+            </ScrollArea.Scrollbar>
+          </ScrollArea.Root>
+        </DirectionProvider>,
+      );
+
+      const viewport = screen.getByTestId('viewport') as HTMLDivElement;
+      const scrollbar = screen.getByTestId('scrollbar');
+      const thumb = screen.getByTestId('thumb');
+      const axis = orientation === 'vertical' ? 'height' : 'width';
+      await waitFor(() => expect(thumb.getBoundingClientRect()[axis]).toBeGreaterThan(0));
+
+      return { viewport, scrollbar, thumb };
+    }
+
+    function overscroll(viewport: HTMLDivElement, prop: 'scrollTop' | 'scrollLeft', value: number) {
+      Object.defineProperty(viewport, prop, { configurable: true, get: () => value });
+      fireEvent.scroll(viewport);
+    }
+
+    it('shrinks and pins the thumb to the start edge while overscrolling past the top', async () => {
+      const { viewport, scrollbar, thumb } = await renderScrollArea('vertical');
+
+      const restingHeight = thumb.getBoundingClientRect().height;
+
+      overscroll(viewport, 'scrollTop', -50);
+
+      // Shrinks, but damped by the content length rather than subtracting the raw pixels
+      // (a 1:1 subtraction of 50px would collapse this thumb to its minimum size).
+      await waitFor(() => expect(thumb.getBoundingClientRect().height).toBeLessThan(restingHeight));
+      expect(thumb.getBoundingClientRect().height).toBeGreaterThan(restingHeight * 0.9);
+      // Pinned to the top edge of the track.
+      expect(thumb.getBoundingClientRect().top).toBeCloseTo(
+        scrollbar.getBoundingClientRect().top,
+        0,
+      );
+    });
+
+    it('shrinks and pins the thumb to the end edge while overscrolling past the bottom', async () => {
+      const { viewport, scrollbar, thumb } = await renderScrollArea('vertical');
+
+      const restingHeight = thumb.getBoundingClientRect().height;
+
+      overscroll(viewport, 'scrollTop', MAX_SCROLL + 50);
+
+      await waitFor(() => expect(thumb.getBoundingClientRect().height).toBeLessThan(restingHeight));
+      expect(thumb.getBoundingClientRect().height).toBeGreaterThan(restingHeight * 0.9);
+      // Pinned to the bottom edge of the track.
+      expect(thumb.getBoundingClientRect().bottom).toBeCloseTo(
+        scrollbar.getBoundingClientRect().bottom,
+        0,
+      );
+    });
+
+    it('restores the resting thumb size once the viewport settles back into range', async () => {
+      const { viewport, thumb } = await renderScrollArea('vertical');
+
+      const restingHeight = thumb.getBoundingClientRect().height;
+
+      overscroll(viewport, 'scrollTop', -50);
+      await waitFor(() => expect(thumb.getBoundingClientRect().height).toBeLessThan(restingHeight));
+
+      overscroll(viewport, 'scrollTop', 100);
+      await waitFor(() =>
+        expect(thumb.getBoundingClientRect().height).toBeCloseTo(restingHeight, 0),
+      );
+    });
+
+    it('shrinks and pins the horizontal thumb to the inline start while overscrolling (LTR)', async () => {
+      const { viewport, scrollbar, thumb } = await renderScrollArea('horizontal');
+
+      const restingWidth = thumb.getBoundingClientRect().width;
+
+      overscroll(viewport, 'scrollLeft', -50);
+
+      await waitFor(() => expect(thumb.getBoundingClientRect().width).toBeLessThan(restingWidth));
+      expect(thumb.getBoundingClientRect().width).toBeGreaterThan(restingWidth * 0.9);
+      // Inline start is the left edge in LTR.
+      expect(thumb.getBoundingClientRect().left).toBeCloseTo(
+        scrollbar.getBoundingClientRect().left,
+        0,
+      );
+    });
+
+    it('shrinks and pins the horizontal thumb to the inline end while overscrolling (LTR)', async () => {
+      const { viewport, scrollbar, thumb } = await renderScrollArea('horizontal');
+
+      const restingWidth = thumb.getBoundingClientRect().width;
+
+      overscroll(viewport, 'scrollLeft', MAX_SCROLL + 50);
+
+      await waitFor(() => expect(thumb.getBoundingClientRect().width).toBeLessThan(restingWidth));
+      expect(thumb.getBoundingClientRect().width).toBeGreaterThan(restingWidth * 0.9);
+      // Inline end is the right edge in LTR.
+      expect(thumb.getBoundingClientRect().right).toBeCloseTo(
+        scrollbar.getBoundingClientRect().right,
+        0,
+      );
+    });
+
+    it('shrinks and pins the horizontal thumb to the inline start while overscrolling (RTL)', async () => {
+      const { viewport, scrollbar, thumb } = await renderScrollArea('horizontal', 'rtl');
+
+      const restingWidth = thumb.getBoundingClientRect().width;
+
+      // RTL scrolls from 0 toward `-MAX_SCROLL`; overscrolling the inline start goes positive.
+      overscroll(viewport, 'scrollLeft', 50);
+
+      await waitFor(() => expect(thumb.getBoundingClientRect().width).toBeLessThan(restingWidth));
+      expect(thumb.getBoundingClientRect().width).toBeGreaterThan(restingWidth * 0.9);
+      // Inline start is the right edge in RTL.
+      expect(thumb.getBoundingClientRect().right).toBeCloseTo(
+        scrollbar.getBoundingClientRect().right,
+        0,
+      );
+    });
+
+    it('shrinks and pins the horizontal thumb to the inline end while overscrolling (RTL)', async () => {
+      const { viewport, scrollbar, thumb } = await renderScrollArea('horizontal', 'rtl');
+
+      const restingWidth = thumb.getBoundingClientRect().width;
+
+      // RTL overscroll past the inline end goes beyond `-MAX_SCROLL`.
+      overscroll(viewport, 'scrollLeft', -(MAX_SCROLL + 50));
+
+      await waitFor(() => expect(thumb.getBoundingClientRect().width).toBeLessThan(restingWidth));
+      expect(thumb.getBoundingClientRect().width).toBeGreaterThan(restingWidth * 0.9);
+      // Inline end is the left edge in RTL.
+      expect(thumb.getBoundingClientRect().left).toBeCloseTo(
+        scrollbar.getBoundingClientRect().left,
+        0,
+      );
     });
   });
 });

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -12,6 +12,7 @@ import { useDirection } from '../../internals/direction-context/DirectionContext
 import { getOffset } from '../utils/getOffset';
 import { MIN_THUMB_SIZE } from '../constants';
 import { clamp } from '../../internals/clamp';
+import { ScrollAreaScrollbarCssVars } from '../scrollbar/ScrollAreaScrollbarCssVars';
 import { styleDisableScrollbar } from '../../utils/styles';
 import { scrollAreaStateAttributesMapping } from '../root/stateAttributes';
 import type { HiddenState, ScrollAreaRootState } from '../root/ScrollAreaRoot';
@@ -220,13 +221,16 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     if (scrollbarYEl && thumbYEl) {
       const maxThumbOffsetY =
         scrollbarYEl.offsetHeight - clampedNextHeight - scrollbarYOffset - thumbYOffset;
-      const scrollRangeY = scrollableContentHeight - viewportHeight;
-      const scrollRatioY = scrollRangeY === 0 ? 0 : scrollTop / scrollRangeY;
 
-      // In Safari, don't allow it to go negative or too far as `scrollTop` considers the rubber
-      // band effect.
-      const thumbOffsetY = Math.min(maxThumbOffsetY, Math.max(0, scrollRatioY * maxThumbOffsetY));
-
+      const thumbOffsetY = applyOverscrollThumb(
+        thumbYEl,
+        ScrollAreaScrollbarCssVars.scrollAreaThumbHeight,
+        scrollTop,
+        maxScrollTop,
+        scrollableContentHeight,
+        clampedNextHeight,
+        maxThumbOffsetY,
+      );
       thumbYEl.style.transform = `translate3d(0,${thumbOffsetY}px,0)`;
     }
 
@@ -234,17 +238,20 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     if (scrollbarXEl && thumbXEl) {
       const maxThumbOffsetX =
         scrollbarXEl.offsetWidth - clampedNextWidth - scrollbarXOffset - thumbXOffset;
-      const scrollRangeX = scrollableContentWidth - viewportWidth;
-      const scrollRatioX = scrollRangeX === 0 ? 0 : scrollLeft / scrollRangeX;
+      // RTL scrolls from 0 down to `-maxScrollLeft`; measure from the inline start edge so the
+      // overscroll math is direction-agnostic, then flip the resulting offset back below.
+      const scrollFromStart = direction === 'rtl' ? -scrollLeft : scrollLeft;
 
-      // In Safari, don't allow it to go negative or too far as `scrollLeft` considers the rubber
-      // band effect.
-      const thumbOffsetX =
-        direction === 'rtl'
-          ? clamp(scrollRatioX * maxThumbOffsetX, -maxThumbOffsetX, 0)
-          : clamp(scrollRatioX * maxThumbOffsetX, 0, maxThumbOffsetX);
-
-      thumbXEl.style.transform = `translate3d(${thumbOffsetX}px,0,0)`;
+      const offsetX = applyOverscrollThumb(
+        thumbXEl,
+        ScrollAreaScrollbarCssVars.scrollAreaThumbWidth,
+        scrollFromStart,
+        maxScrollLeft,
+        scrollableContentWidth,
+        clampedNextWidth,
+        maxThumbOffsetX,
+      );
+      thumbXEl.style.transform = `translate3d(${direction === 'rtl' ? -offsetX : offsetX}px,0,0)`;
     }
 
     const overflowMetricsPx: Array<[ScrollAreaViewportCssVars, number]> = [
@@ -488,4 +495,31 @@ function mergeHiddenState(prevState: HiddenState, nextState: HiddenState) {
   }
 
   return nextState;
+}
+
+/**
+ * Sizes the thumb and returns its axis offset. On overscroll (Safari rubber-band only) it shrinks
+ * against the pinned edge, damped by `content / (content + overscroll)` to match native feedback;
+ * the size flows through the thumb-size variable so the resting `var(...)` still applies.
+ */
+function applyOverscrollThumb(
+  thumbEl: HTMLElement,
+  sizeVar: ScrollAreaScrollbarCssVars,
+  scrollFromStart: number,
+  maxScroll: number,
+  content: number,
+  size: number,
+  maxThumbOffset: number,
+): number {
+  const clamped = clamp(scrollFromStart, 0, maxScroll);
+  const overscroll = scrollFromStart - clamped;
+  const nextSize = Math.max(MIN_THUMB_SIZE, (size * content) / (content + Math.abs(overscroll)));
+
+  // Passing an empty string removes the override, restoring the resting `var(...)` size.
+  thumbEl.style.setProperty(sizeVar, overscroll ? `${nextSize}px` : '');
+
+  // Slide proportionally; at the end edge push down by the shrink so the thumb stays pinned to
+  // it, while a start overscroll pins to offset 0.
+  const offset = maxScroll ? (clamped / maxScroll) * maxThumbOffset : 0;
+  return offset + (overscroll > 0 ? size - nextSize : 0);
 }


### PR DESCRIPTION
Closes #4682

In Safari/WebKit, overscroll any scroll area (left sidebar, or the demos): https://deploy-preview-5145--base-ui.netlify.app/react/components/scroll-area

## Summary

Adds native-style overscroll feedback to the Scroll Area scrollbar: while the viewport rubber-bands past an edge, the thumb shrinks against that edge instead of staying pinned at full size, mirroring the macOS native scrollbar behavior shown in the issue.

## Details

`computeThumbPosition` already had to clamp away the rubber-band, since Safari is the only engine that reports an out-of-range `scrollTop`/`scrollLeft`. Instead of discarding that value, it now drives the shrink:

- The overscroll distance is `scrollPos - clamp(scrollPos, 0, maxScroll)` — `0` on every engine except Safari (Chrome/Firefox clamp the scroll position), so this is a no-op elsewhere.
- The thumb's `height`/`width` shrinks by the overscroll amount (floored at `MIN_THUMB_SIZE`) and stays pinned to the overscrolled edge.
- The horizontal case measures from the inline-start edge, so the same math covers LTR and RTL with a single sign flip on the final translate.

The size change is applied via `height`/`width` rather than a `scaleY`/`scaleX` transform, so rounded thumb caps stay round during the overscroll.

## Testing

The overscroll path is only reachable in Safari — jsdom has no layout and Chromium clamps the scroll position on assignment, so it can't be exercised in CI. Verified manually in Safari (vertical + horizontal, rounded thumb, both edges). The in-range behavior is unchanged and remains covered by the existing Chromium test suite.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
