### PR TITLE
[all components] Clarify `data-starting-style` attribute description

### DIFF
--- a/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
+++ b/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
@@ -862,7 +862,7 @@ Renders a \`<div>\` element.
 | data-orientation    | -        | Indicates the orientation of the accordion.  |
 | data-disabled       | -        | Present when the accordion item is disabled. |
 | data-index          | \`number\` | Indicates the index of the accordion item.   |
-| data-starting-style | -        | Present when the panel is animating in.      |
+| data-starting-style | -        | Present when the panel begins animating in.  |
 | data-ending-style   | -        | Present when the panel is animating out.     |
 
 **Panel CSS Variables:**

--- a/docs/src/app/(docs)/react/components/accordion/types.md
+++ b/docs/src/app/(docs)/react/components/accordion/types.md
@@ -307,7 +307,7 @@ Renders a `<div>` element.
 | data-orientation    | -        | Indicates the orientation of the accordion.  |
 | data-disabled       | -        | Present when the accordion item is disabled. |
 | data-index          | `number` | Indicates the index of the accordion item.   |
-| data-starting-style | -        | Present when the panel is animating in.      |
+| data-starting-style | -        | Present when the panel begins animating in.  |
 | data-ending-style   | -        | Present when the panel is animating out.     |
 
 **Panel CSS Variables:**

--- a/docs/src/app/(docs)/react/components/alert-dialog/types.md
+++ b/docs/src/app/(docs)/react/components/alert-dialog/types.md
@@ -159,12 +159,12 @@ Renders a `<div>` element.
 
 **Backdrop Data Attributes:**
 
-| Attribute           | Type | Description                               |
-| :------------------ | :--- | :---------------------------------------- |
-| data-open           | -    | Present when the dialog is open.          |
-| data-closed         | -    | Present when the dialog is closed.        |
-| data-starting-style | -    | Present when the dialog is animating in.  |
-| data-ending-style   | -    | Present when the dialog is animating out. |
+| Attribute           | Type | Description                                  |
+| :------------------ | :--- | :------------------------------------------- |
+| data-open           | -    | Present when the dialog is open.             |
+| data-closed         | -    | Present when the dialog is closed.           |
+| data-starting-style | -    | Present when the dialog begins animating in. |
+| data-ending-style   | -    | Present when the dialog is animating out.    |
 
 ### Backdrop.Props
 
@@ -204,7 +204,7 @@ Renders a `<div>` element.
 | data-closed             | -    | Present when the dialog is closed.                               |
 | data-nested             | -    | Present when the dialog is nested within another dialog.         |
 | data-nested-dialog-open | -    | Present when the dialog has other open dialogs nested within it. |
-| data-starting-style     | -    | Present when the dialog is animating in.                         |
+| data-starting-style     | -    | Present when the dialog begins animating in.                     |
 | data-ending-style       | -    | Present when the dialog is animating out.                        |
 
 **Popup CSS Variables:**
@@ -332,7 +332,7 @@ Renders a `<div>` element.
 | data-closed             | -    | Present when the dialog is closed.                               |
 | data-nested             | -    | Present when the dialog is nested within another dialog.         |
 | data-nested-dialog-open | -    | Present when the dialog has other open dialogs nested within it. |
-| data-starting-style     | -    | Present when the dialog is animating in.                         |
+| data-starting-style     | -    | Present when the dialog begins animating in.                     |
 | data-ending-style       | -    | Present when the dialog is animating out.                        |
 
 ### Viewport.Props

--- a/docs/src/app/(docs)/react/components/autocomplete/types.md
+++ b/docs/src/app/(docs)/react/components/autocomplete/types.md
@@ -319,7 +319,7 @@ Renders a `<button>` element.
 | data-popup-open     | -    | Present when the corresponding popup is open. |
 | data-disabled       | -    | Present when the button is disabled.          |
 | data-visible        | -    | Present when the clear button is visible.     |
-| data-starting-style | -    | Present when the button is animating in.      |
+| data-starting-style | -    | Present when the button begins animating in.  |
 | data-ending-style   | -    | Present when the button is animating out.     |
 
 ### Clear.Props
@@ -409,12 +409,12 @@ Renders a `<div>` element.
 
 **Backdrop Data Attributes:**
 
-| Attribute           | Type | Description                              |
-| :------------------ | :--- | :--------------------------------------- |
-| data-open           | -    | Present when the popup is open.          |
-| data-closed         | -    | Present when the popup is closed.        |
-| data-starting-style | -    | Present when the popup is animating in.  |
-| data-ending-style   | -    | Present when the popup is animating out. |
+| Attribute           | Type | Description                                 |
+| :------------------ | :--- | :------------------------------------------ |
+| data-open           | -    | Present when the popup is open.             |
+| data-closed         | -    | Present when the popup is closed.           |
+| data-starting-style | -    | Present when the popup begins animating in. |
+| data-ending-style   | -    | Present when the popup is animating out.    |
 
 ### Backdrop.Props
 
@@ -555,7 +555,7 @@ Renders a `<div>` element.
 | data-empty          | -                                                                          | Present when the items list is empty.                                 |
 | data-instant        | `'click' \| 'dismiss'`                                                     | Present if animations should be instant.                              |
 | data-side           | `'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
-| data-starting-style | -                                                                          | Present when the popup is animating in.                               |
+| data-starting-style | -                                                                          | Present when the popup begins animating in.                           |
 | data-ending-style   | -                                                                          | Present when the popup is animating out.                              |
 
 ### Popup.Props

--- a/docs/src/app/(docs)/react/components/avatar/types.md
+++ b/docs/src/app/(docs)/react/components/avatar/types.md
@@ -46,10 +46,10 @@ Renders an `<img>` element.
 
 **Image Data Attributes:**
 
-| Attribute           | Type | Description                              |
-| :------------------ | :--- | :--------------------------------------- |
-| data-starting-style | -    | Present when the image is animating in.  |
-| data-ending-style   | -    | Present when the image is animating out. |
+| Attribute           | Type | Description                                 |
+| :------------------ | :--- | :------------------------------------------ |
+| data-starting-style | -    | Present when the image begins animating in. |
+| data-ending-style   | -    | Present when the image is animating out.    |
 
 ### Image.Props
 

--- a/docs/src/app/(docs)/react/components/checkbox/types.md
+++ b/docs/src/app/(docs)/react/components/checkbox/types.md
@@ -137,7 +137,7 @@ Renders a `<span>` element.
 | data-filled         | -    | Present when the checkbox is checked (when wrapped in Field.Root).             |
 | data-focused        | -    | Present when the checkbox is focused (when wrapped in Field.Root).             |
 | data-indeterminate  | -    | Present when the checkbox is in an indeterminate state.                        |
-| data-starting-style | -    | Present when the checkbox indicator is animating in.                           |
+| data-starting-style | -    | Present when the checkbox indicator begins animating in.                       |
 | data-ending-style   | -    | Present when the checkbox indicator is animating out.                          |
 
 ### Indicator.Props

--- a/docs/src/app/(docs)/react/components/collapsible/types.md
+++ b/docs/src/app/(docs)/react/components/collapsible/types.md
@@ -23,12 +23,12 @@ Renders a `<div>` element.
 
 **Root Data Attributes:**
 
-| Attribute           | Type | Description                                    |
-| :------------------ | :--- | :--------------------------------------------- |
-| data-open           | -    | Present when the collapsible is open.          |
-| data-closed         | -    | Present when the collapsible is closed.        |
-| data-starting-style | -    | Present when the collapsible is animating in.  |
-| data-ending-style   | -    | Present when the collapsible is animating out. |
+| Attribute           | Type | Description                                       |
+| :------------------ | :--- | :------------------------------------------------ |
+| data-open           | -    | Present when the collapsible is open.             |
+| data-closed         | -    | Present when the collapsible is closed.           |
+| data-starting-style | -    | Present when the collapsible begins animating in. |
+| data-ending-style   | -    | Present when the collapsible is animating out.    |
 
 ### Root.Props
 
@@ -129,7 +129,7 @@ Renders a `<div>` element.
 | :------------------ | :--- | :-------------------------------------------- |
 | data-open           | -    | Present when the collapsible panel is open.   |
 | data-closed         | -    | Present when the collapsible panel is closed. |
-| data-starting-style | -    | Present when the panel is animating in.       |
+| data-starting-style | -    | Present when the panel begins animating in.   |
 | data-ending-style   | -    | Present when the panel is animating out.      |
 
 **Panel CSS Variables:**

--- a/docs/src/app/(docs)/react/components/combobox/types.md
+++ b/docs/src/app/(docs)/react/components/combobox/types.md
@@ -331,7 +331,7 @@ Renders a `<button>` element.
 | data-popup-open     | -    | Present when the corresponding popup is open. |
 | data-disabled       | -    | Present when the button is disabled.          |
 | data-visible        | -    | Present when the clear button is visible.     |
-| data-starting-style | -    | Present when the button is animating in.      |
+| data-starting-style | -    | Present when the button begins animating in.  |
 | data-ending-style   | -    | Present when the button is animating out.     |
 
 ### Clear.Props
@@ -421,12 +421,12 @@ Renders a `<div>` element.
 
 **Backdrop Data Attributes:**
 
-| Attribute           | Type | Description                              |
-| :------------------ | :--- | :--------------------------------------- |
-| data-open           | -    | Present when the popup is open.          |
-| data-closed         | -    | Present when the popup is closed.        |
-| data-starting-style | -    | Present when the popup is animating in.  |
-| data-ending-style   | -    | Present when the popup is animating out. |
+| Attribute           | Type | Description                                 |
+| :------------------ | :--- | :------------------------------------------ |
+| data-open           | -    | Present when the popup is open.             |
+| data-closed         | -    | Present when the popup is closed.           |
+| data-starting-style | -    | Present when the popup begins animating in. |
+| data-ending-style   | -    | Present when the popup is animating out.    |
 
 ### Backdrop.Props
 
@@ -567,7 +567,7 @@ Renders a `<div>` element.
 | data-empty          | -                                                                          | Present when the items list is empty.                                 |
 | data-instant        | `'click' \| 'dismiss'`                                                     | Present if animations should be instant.                              |
 | data-side           | `'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
-| data-starting-style | -                                                                          | Present when the popup is animating in.                               |
+| data-starting-style | -                                                                          | Present when the popup begins animating in.                           |
 | data-ending-style   | -                                                                          | Present when the popup is animating out.                              |
 
 ### Popup.Props
@@ -1004,10 +1004,10 @@ Renders a `<span>` element.
 
 **ItemIndicator Data Attributes:**
 
-| Attribute           | Type | Description                                  |
-| :------------------ | :--- | :------------------------------------------- |
-| data-starting-style | -    | Present when the indicator is animating in.  |
-| data-ending-style   | -    | Present when the indicator is animating out. |
+| Attribute           | Type | Description                                     |
+| :------------------ | :--- | :---------------------------------------------- |
+| data-starting-style | -    | Present when the indicator begins animating in. |
+| data-ending-style   | -    | Present when the indicator is animating out.    |
 
 ### ItemIndicator.Props
 

--- a/docs/src/app/(docs)/react/components/context-menu/types.md
+++ b/docs/src/app/(docs)/react/components/context-menu/types.md
@@ -165,12 +165,12 @@ Renders a `<div>` element.
 
 **Backdrop Data Attributes:**
 
-| Attribute           | Type | Description                             |
-| :------------------ | :--- | :-------------------------------------- |
-| data-open           | -    | Present when the menu is open.          |
-| data-closed         | -    | Present when the menu is closed.        |
-| data-starting-style | -    | Present when the menu is animating in.  |
-| data-ending-style   | -    | Present when the menu is animating out. |
+| Attribute           | Type | Description                                |
+| :------------------ | :--- | :----------------------------------------- |
+| data-open           | -    | Present when the menu is open.             |
+| data-closed         | -    | Present when the menu is closed.           |
+| data-starting-style | -    | Present when the menu begins animating in. |
+| data-ending-style   | -    | Present when the menu is animating out.    |
 
 ### Backdrop.Props
 
@@ -313,7 +313,7 @@ Renders a `<div>` element.
 | data-align          | `'start' \| 'center' \| 'end'`                                             | Indicates how the popup is aligned relative to specified side.        |
 | data-instant        | `'click' \| 'dismiss' \| 'group' \| 'trigger-change'`                      | Present if animations should be instant.                              |
 | data-side           | `'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
-| data-starting-style | -                                                                          | Present when the menu is animating in.                                |
+| data-starting-style | -                                                                          | Present when the menu begins animating in.                            |
 | data-ending-style   | -                                                                          | Present when the menu is animating out.                               |
 
 ### Popup.Props
@@ -765,13 +765,13 @@ Renders a `<span>` element.
 
 **RadioItemIndicator Data Attributes:**
 
-| Attribute           | Type | Description                                        |
-| :------------------ | :--- | :------------------------------------------------- |
-| data-checked        | -    | Present when the menu radio item is selected.      |
-| data-unchecked      | -    | Present when the menu radio item is not selected.  |
-| data-disabled       | -    | Present when the menu radio item is disabled.      |
-| data-starting-style | -    | Present when the radio indicator is animating in.  |
-| data-ending-style   | -    | Present when the radio indicator is animating out. |
+| Attribute           | Type | Description                                           |
+| :------------------ | :--- | :---------------------------------------------------- |
+| data-checked        | -    | Present when the menu radio item is selected.         |
+| data-unchecked      | -    | Present when the menu radio item is not selected.     |
+| data-disabled       | -    | Present when the menu radio item is disabled.         |
+| data-starting-style | -    | Present when the radio indicator begins animating in. |
+| data-ending-style   | -    | Present when the radio indicator is animating out.    |
 
 ### RadioItemIndicator.Props
 
@@ -911,7 +911,7 @@ Renders a `<span>` element.
 | data-checked        | -    | Present when the menu checkbox item is checked.     |
 | data-unchecked      | -    | Present when the menu checkbox item is not checked. |
 | data-disabled       | -    | Present when the menu checkbox item is disabled.    |
-| data-starting-style | -    | Present when the indicator is animating in.         |
+| data-starting-style | -    | Present when the indicator begins animating in.     |
 | data-ending-style   | -    | Present when the indicator is animating out.        |
 
 ### CheckboxItemIndicator.Props

--- a/docs/src/app/(docs)/react/components/dialog/types.md
+++ b/docs/src/app/(docs)/react/components/dialog/types.md
@@ -161,12 +161,12 @@ Renders a `<div>` element.
 
 **Backdrop Data Attributes:**
 
-| Attribute           | Type | Description                               |
-| :------------------ | :--- | :---------------------------------------- |
-| data-open           | -    | Present when the dialog is open.          |
-| data-closed         | -    | Present when the dialog is closed.        |
-| data-starting-style | -    | Present when the dialog is animating in.  |
-| data-ending-style   | -    | Present when the dialog is animating out. |
+| Attribute           | Type | Description                                  |
+| :------------------ | :--- | :------------------------------------------- |
+| data-open           | -    | Present when the dialog is open.             |
+| data-closed         | -    | Present when the dialog is closed.           |
+| data-starting-style | -    | Present when the dialog begins animating in. |
+| data-ending-style   | -    | Present when the dialog is animating out.    |
 
 ### Backdrop.Props
 
@@ -206,7 +206,7 @@ Renders a `<div>` element.
 | data-closed             | -    | Present when the dialog is closed.                               |
 | data-nested             | -    | Present when the dialog is nested within another dialog.         |
 | data-nested-dialog-open | -    | Present when the dialog has other open dialogs nested within it. |
-| data-starting-style     | -    | Present when the dialog is animating in.                         |
+| data-starting-style     | -    | Present when the dialog begins animating in.                     |
 | data-ending-style       | -    | Present when the dialog is animating out.                        |
 
 **Popup CSS Variables:**
@@ -334,7 +334,7 @@ Renders a `<div>` element.
 | data-closed             | -    | Present when the dialog is closed.                               |
 | data-nested             | -    | Present when the dialog is nested within another dialog.         |
 | data-nested-dialog-open | -    | Present when the dialog has other open dialogs nested within it. |
-| data-starting-style     | -    | Present when the dialog is animating in.                         |
+| data-starting-style     | -    | Present when the dialog begins animating in.                     |
 | data-ending-style       | -    | Present when the dialog is animating out.                        |
 
 ### Viewport.Props

--- a/docs/src/app/(docs)/react/components/drawer/types.md
+++ b/docs/src/app/(docs)/react/components/drawer/types.md
@@ -233,12 +233,12 @@ Renders a `<div>` element.
 
 **Backdrop Data Attributes:**
 
-| Attribute           | Type | Description                               |
-| :------------------ | :--- | :---------------------------------------- |
-| data-open           | -    | Present when the drawer is open.          |
-| data-closed         | -    | Present when the drawer is closed.        |
-| data-starting-style | -    | Present when the drawer is animating in.  |
-| data-ending-style   | -    | Present when the drawer is animating out. |
+| Attribute           | Type | Description                                  |
+| :------------------ | :--- | :------------------------------------------- |
+| data-open           | -    | Present when the drawer is open.             |
+| data-closed         | -    | Present when the drawer is closed.           |
+| data-starting-style | -    | Present when the drawer begins animating in. |
+| data-ending-style   | -    | Present when the drawer is animating out.    |
 
 **Backdrop CSS Variables:**
 
@@ -288,7 +288,7 @@ Renders a `<div>` element.
 | data-swipe-direction       | `'up' \| 'down' \| 'left' \| 'right'` | Indicates the swipe direction.                                       |
 | data-swipe-dismiss         | -                                     | Present when the drawer is dismissed by swiping.                     |
 | data-swiping               | -                                     | Present when the drawer is being swiped.                             |
-| data-starting-style        | -                                     | Present when the drawer is animating in.                             |
+| data-starting-style        | -                                     | Present when the drawer begins animating in.                         |
 | data-ending-style          | -                                     | Present when the drawer is animating out.                            |
 
 **Popup CSS Variables:**
@@ -446,7 +446,7 @@ Renders a `<div>` element.
 | data-open           | -    | Present when the drawer is open.                         |
 | data-closed         | -    | Present when the drawer is closed.                       |
 | data-nested         | -    | Present when the drawer is nested within another drawer. |
-| data-starting-style | -    | Present when the drawer is animating in.                 |
+| data-starting-style | -    | Present when the drawer begins animating in.             |
 | data-ending-style   | -    | Present when the drawer is animating out.                |
 
 **Viewport CSS Variables:**

--- a/docs/src/app/(docs)/react/components/field/types.md
+++ b/docs/src/app/(docs)/react/components/field/types.md
@@ -310,17 +310,17 @@ Renders a `<div>` element.
 
 **Error Data Attributes:**
 
-| Attribute           | Type | Description                                      |
-| :------------------ | :--- | :----------------------------------------------- |
-| data-disabled       | -    | Present when the field is disabled.              |
-| data-valid          | -    | Present when the field is in a valid state.      |
-| data-invalid        | -    | Present when the field is in an invalid state.   |
-| data-dirty          | -    | Present when the field's value has changed.      |
-| data-touched        | -    | Present when the field has been touched.         |
-| data-filled         | -    | Present when the field is filled.                |
-| data-focused        | -    | Present when the field control is focused.       |
-| data-starting-style | -    | Present when the error message is animating in.  |
-| data-ending-style   | -    | Present when the error message is animating out. |
+| Attribute           | Type | Description                                         |
+| :------------------ | :--- | :-------------------------------------------------- |
+| data-disabled       | -    | Present when the field is disabled.                 |
+| data-valid          | -    | Present when the field is in a valid state.         |
+| data-invalid        | -    | Present when the field is in an invalid state.      |
+| data-dirty          | -    | Present when the field's value has changed.         |
+| data-touched        | -    | Present when the field has been touched.            |
+| data-filled         | -    | Present when the field is filled.                   |
+| data-focused        | -    | Present when the field control is focused.          |
+| data-starting-style | -    | Present when the error message begins animating in. |
+| data-ending-style   | -    | Present when the error message is animating out.    |
 
 ### Error.Props
 

--- a/docs/src/app/(docs)/react/components/menu/types.md
+++ b/docs/src/app/(docs)/react/components/menu/types.md
@@ -186,12 +186,12 @@ Renders a `<div>` element.
 
 **Backdrop Data Attributes:**
 
-| Attribute           | Type | Description                             |
-| :------------------ | :--- | :-------------------------------------- |
-| data-open           | -    | Present when the menu is open.          |
-| data-closed         | -    | Present when the menu is closed.        |
-| data-starting-style | -    | Present when the menu is animating in.  |
-| data-ending-style   | -    | Present when the menu is animating out. |
+| Attribute           | Type | Description                                |
+| :------------------ | :--- | :----------------------------------------- |
+| data-open           | -    | Present when the menu is open.             |
+| data-closed         | -    | Present when the menu is closed.           |
+| data-starting-style | -    | Present when the menu begins animating in. |
+| data-ending-style   | -    | Present when the menu is animating out.    |
 
 ### Backdrop.Props
 
@@ -334,7 +334,7 @@ Renders a `<div>` element.
 | data-align          | `'start' \| 'center' \| 'end'`                                             | Indicates how the popup is aligned relative to specified side.        |
 | data-instant        | `'click' \| 'dismiss' \| 'group' \| 'trigger-change'`                      | Present if animations should be instant.                              |
 | data-side           | `'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
-| data-starting-style | -                                                                          | Present when the menu is animating in.                                |
+| data-starting-style | -                                                                          | Present when the menu begins animating in.                            |
 | data-ending-style   | -                                                                          | Present when the menu is animating out.                               |
 
 ### Popup.Props
@@ -836,13 +836,13 @@ Renders a `<span>` element.
 
 **RadioItemIndicator Data Attributes:**
 
-| Attribute           | Type | Description                                        |
-| :------------------ | :--- | :------------------------------------------------- |
-| data-checked        | -    | Present when the menu radio item is selected.      |
-| data-unchecked      | -    | Present when the menu radio item is not selected.  |
-| data-disabled       | -    | Present when the menu radio item is disabled.      |
-| data-starting-style | -    | Present when the radio indicator is animating in.  |
-| data-ending-style   | -    | Present when the radio indicator is animating out. |
+| Attribute           | Type | Description                                           |
+| :------------------ | :--- | :---------------------------------------------------- |
+| data-checked        | -    | Present when the menu radio item is selected.         |
+| data-unchecked      | -    | Present when the menu radio item is not selected.     |
+| data-disabled       | -    | Present when the menu radio item is disabled.         |
+| data-starting-style | -    | Present when the radio indicator begins animating in. |
+| data-ending-style   | -    | Present when the radio indicator is animating out.    |
 
 ### RadioItemIndicator.Props
 
@@ -982,7 +982,7 @@ Renders a `<span>` element.
 | data-checked        | -    | Present when the menu checkbox item is checked.     |
 | data-unchecked      | -    | Present when the menu checkbox item is not checked. |
 | data-disabled       | -    | Present when the menu checkbox item is disabled.    |
-| data-starting-style | -    | Present when the indicator is animating in.         |
+| data-starting-style | -    | Present when the indicator begins animating in.     |
 | data-ending-style   | -    | Present when the indicator is animating out.        |
 
 ### CheckboxItemIndicator.Props

--- a/docs/src/app/(docs)/react/components/navigation-menu/types.md
+++ b/docs/src/app/(docs)/react/components/navigation-menu/types.md
@@ -225,12 +225,12 @@ Renders a `<div>` element.
 
 **Backdrop Data Attributes:**
 
-| Attribute           | Type | Description                              |
-| :------------------ | :--- | :--------------------------------------- |
-| data-open           | -    | Present when the popup is open.          |
-| data-closed         | -    | Present when the popup is closed.        |
-| data-starting-style | -    | Present when the popup is animating in.  |
-| data-ending-style   | -    | Present when the popup is animating out. |
+| Attribute           | Type | Description                                 |
+| :------------------ | :--- | :------------------------------------------ |
+| data-open           | -    | Present when the popup is open.             |
+| data-closed         | -    | Present when the popup is closed.           |
+| data-starting-style | -    | Present when the popup begins animating in. |
+| data-ending-style   | -    | Present when the popup is animating out.    |
 
 ### Backdrop.Props
 
@@ -370,7 +370,7 @@ Renders a `<nav>` element.
 | data-anchor-hidden  | -                                                                          | Present when the anchor is hidden.                                    |
 | data-align          | `'start' \| 'center' \| 'end'`                                             | Indicates how the popup is aligned relative to the specified side.    |
 | data-side           | `'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
-| data-starting-style | -                                                                          | Present when the popup is animating in.                               |
+| data-starting-style | -                                                                          | Present when the popup begins animating in.                           |
 | data-ending-style   | -                                                                          | Present when the popup is animating out.                              |
 
 **Popup CSS Variables:**
@@ -489,7 +489,7 @@ Renders a `<div>` element.
 | data-open                 | -                                     | Present when the popup is open.                     |
 | data-closed               | -                                     | Present when the popup is closed.                   |
 | data-activation-direction | `'left' \| 'right' \| 'up' \| 'down'` | Which direction another trigger was activated from. |
-| data-starting-style       | -                                     | Present when the content is animating in.           |
+| data-starting-style       | -                                     | Present when the content begins animating in.       |
 | data-ending-style         | -                                     | Present when the content is animating out.          |
 
 ### Content.Props

--- a/docs/src/app/(docs)/react/components/popover/types.md
+++ b/docs/src/app/(docs)/react/components/popover/types.md
@@ -166,12 +166,12 @@ Renders a `<div>` element.
 
 **Backdrop Data Attributes:**
 
-| Attribute           | Type | Description                              |
-| :------------------ | :--- | :--------------------------------------- |
-| data-open           | -    | Present when the popup is open.          |
-| data-closed         | -    | Present when the popup is closed.        |
-| data-starting-style | -    | Present when the popup is animating in.  |
-| data-ending-style   | -    | Present when the popup is animating out. |
+| Attribute           | Type | Description                                 |
+| :------------------ | :--- | :------------------------------------------ |
+| data-open           | -    | Present when the popup is open.             |
+| data-closed         | -    | Present when the popup is closed.           |
+| data-starting-style | -    | Present when the popup begins animating in. |
+| data-ending-style   | -    | Present when the popup is animating out.    |
 
 ### Backdrop.Props
 
@@ -312,7 +312,7 @@ Renders a `<div>` element.
 | data-align          | `'start' \| 'center' \| 'end'`                                             | Indicates how the popup is aligned relative to specified side.        |
 | data-instant        | `'click' \| 'dismiss' \| 'focus' \| 'trigger-change'`                      | Present if animations should be instant.                              |
 | data-side           | `'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
-| data-starting-style | -                                                                          | Present when the popup is animating in.                               |
+| data-starting-style | -                                                                          | Present when the popup begins animating in.                           |
 | data-ending-style   | -                                                                          | Present when the popup is animating out.                              |
 
 **Popup CSS Variables:**

--- a/docs/src/app/(docs)/react/components/preview-card/types.md
+++ b/docs/src/app/(docs)/react/components/preview-card/types.md
@@ -155,12 +155,12 @@ Renders a `<div>` element.
 
 **Backdrop Data Attributes:**
 
-| Attribute           | Type | Description                                     |
-| :------------------ | :--- | :---------------------------------------------- |
-| data-open           | -    | Present when the preview card is open.          |
-| data-closed         | -    | Present when the preview card is closed.        |
-| data-starting-style | -    | Present when the preview card is animating in.  |
-| data-ending-style   | -    | Present when the preview card is animating out. |
+| Attribute           | Type | Description                                        |
+| :------------------ | :--- | :------------------------------------------------- |
+| data-open           | -    | Present when the preview card is open.             |
+| data-closed         | -    | Present when the preview card is closed.           |
+| data-starting-style | -    | Present when the preview card begins animating in. |
+| data-ending-style   | -    | Present when the preview card is animating out.    |
 
 ### Backdrop.Props
 
@@ -298,7 +298,7 @@ Renders a `<div>` element.
 | data-closed         | -                                                                          | Present when the preview card is closed.                              |
 | data-align          | `'start' \| 'center' \| 'end'`                                             | Indicates how the popup is aligned relative to specified side.        |
 | data-side           | `'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
-| data-starting-style | -                                                                          | Present when the preview card is animating in.                        |
+| data-starting-style | -                                                                          | Present when the preview card begins animating in.                    |
 | data-ending-style   | -                                                                          | Present when the preview card is animating out.                       |
 
 ### Popup.Props

--- a/docs/src/app/(docs)/react/components/radio/types.md
+++ b/docs/src/app/(docs)/react/components/radio/types.md
@@ -97,7 +97,7 @@ Renders a `<span>` element.
 | data-touched        | -    | Present when the radio has been touched (when wrapped in Field.Root).       |
 | data-filled         | -    | Present when the radio is checked (when wrapped in Field.Root).             |
 | data-focused        | -    | Present when the radio is focused (when wrapped in Field.Root).             |
-| data-starting-style | -    | Present when the radio indicator is animating in.                           |
+| data-starting-style | -    | Present when the radio indicator begins animating in.                       |
 | data-ending-style   | -    | Present when the radio indicator is animating out.                          |
 
 ### Indicator.Props

--- a/docs/src/app/(docs)/react/components/select/types.md
+++ b/docs/src/app/(docs)/react/components/select/types.md
@@ -316,12 +316,12 @@ Renders a `<div>` element.
 
 **Backdrop Data Attributes:**
 
-| Attribute           | Type | Description                               |
-| :------------------ | :--- | :---------------------------------------- |
-| data-open           | -    | Present when the select is open.          |
-| data-closed         | -    | Present when the select is closed.        |
-| data-starting-style | -    | Present when the select is animating in.  |
-| data-ending-style   | -    | Present when the select is animating out. |
+| Attribute           | Type | Description                                  |
+| :------------------ | :--- | :------------------------------------------- |
+| data-open           | -    | Present when the select is open.             |
+| data-closed         | -    | Present when the select is closed.           |
+| data-starting-style | -    | Present when the select begins animating in. |
+| data-ending-style   | -    | Present when the select is animating out.    |
 
 ### Backdrop.Props
 
@@ -458,7 +458,7 @@ Renders a `<div>` element.
 | data-closed         | -                                                                                    | Present when the select is closed.                                    |
 | data-align          | `'start' \| 'center' \| 'end'`                                                       | Indicates how the popup is aligned relative to specified side.        |
 | data-side           | `'none' \| 'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
-| data-starting-style | -                                                                                    | Present when the select is animating in.                              |
+| data-starting-style | -                                                                                    | Present when the select begins animating in.                          |
 | data-ending-style   | -                                                                                    | Present when the select is animating out.                             |
 
 ### Popup.Props
@@ -714,10 +714,10 @@ Renders a `<span>` element.
 
 **ItemIndicator Data Attributes:**
 
-| Attribute           | Type | Description                                  |
-| :------------------ | :--- | :------------------------------------------- |
-| data-starting-style | -    | Present when the indicator is animating in.  |
-| data-ending-style   | -    | Present when the indicator is animating out. |
+| Attribute           | Type | Description                                     |
+| :------------------ | :--- | :---------------------------------------------- |
+| data-starting-style | -    | Present when the indicator begins animating in. |
+| data-ending-style   | -    | Present when the indicator is animating out.    |
 
 ### ItemIndicator.Props
 
@@ -755,7 +755,7 @@ Renders a `<div>` element.
 | data-direction      | `'up'`                                                                               | Indicates the direction of the scroll arrow.                          |
 | data-side           | `'none' \| 'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
 | data-visible        | -                                                                                    | Present when the scroll arrow is visible.                             |
-| data-starting-style | -                                                                                    | Present when the scroll arrow is animating in.                        |
+| data-starting-style | -                                                                                    | Present when the scroll arrow begins animating in.                    |
 | data-ending-style   | -                                                                                    | Present when the scroll arrow is animating out.                       |
 
 ### ScrollUpArrow.Props
@@ -789,7 +789,7 @@ Renders a `<div>` element.
 | data-direction      | `'down'`                                                                             | Indicates the direction of the scroll arrow.                          |
 | data-side           | `'none' \| 'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
 | data-visible        | -                                                                                    | Present when the scroll arrow is visible.                             |
-| data-starting-style | -                                                                                    | Present when the scroll arrow is animating in.                        |
+| data-starting-style | -                                                                                    | Present when the scroll arrow begins animating in.                    |
 | data-ending-style   | -                                                                                    | Present when the scroll arrow is animating out.                       |
 
 ### ScrollDownArrow.Props

--- a/docs/src/app/(docs)/react/components/tabs/types.md
+++ b/docs/src/app/(docs)/react/components/tabs/types.md
@@ -140,7 +140,7 @@ Renders a `<div>` element.
 | data-activation-direction | `'left' \| 'right' \| 'up' \| 'down' \| 'none'` | Indicates the direction of the activation (based on the previous active tab). |
 | data-hidden               | -                                               | Present when the panel is hidden.                                             |
 | data-index                | -                                               | Indicates the index of the tab panel.                                         |
-| data-starting-style       | -                                               | Present when the panel is animating in.                                       |
+| data-starting-style       | -                                               | Present when the panel begins animating in.                                   |
 | data-ending-style         | -                                               | Present when the panel is animating out.                                      |
 
 ### Panel.Props

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -28,7 +28,7 @@ Renders a `<div>` element.
 | data-swipe-direction | `'up' \| 'down' \| 'left' \| 'right'` | The direction the toast was swiped.                                      |
 | data-swiping         | `boolean`                             | Present when the toast is being swiped.                                  |
 | data-type            | `string`                              | The type of the toast.                                                   |
-| data-starting-style  | -                                     | Present when the toast is animating in.                                  |
+| data-starting-style  | -                                     | Present when the toast begins animating in.                              |
 | data-ending-style    | -                                     | Present when the toast is animating out.                                 |
 
 **Root CSS Variables:**

--- a/docs/src/app/(docs)/react/components/tooltip/types.md
+++ b/docs/src/app/(docs)/react/components/tooltip/types.md
@@ -294,7 +294,7 @@ Renders a `<div>` element.
 | data-align          | `'start' \| 'center' \| 'end'`                                             | Indicates how the popup is aligned relative to specified side.        |
 | data-instant        | `'delay' \| 'dismiss' \| 'focus'`                                          | Present if animations should be instant.                              |
 | data-side           | `'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
-| data-starting-style | -                                                                          | Present when the tooltip is animating in.                             |
+| data-starting-style | -                                                                          | Present when the tooltip begins animating in.                         |
 | data-ending-style   | -                                                                          | Present when the tooltip is animating out.                            |
 
 ### Popup.Props

--- a/packages/react/src/accordion/panel/AccordionPanelDataAttributes.ts
+++ b/packages/react/src/accordion/panel/AccordionPanelDataAttributes.ts
@@ -19,7 +19,7 @@ export enum AccordionPanelDataAttributes {
    */
   disabled = 'data-disabled',
   /**
-   * Present when the panel is animating in.
+   * Present when the panel begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/avatar/image/AvatarImageDataAttributes.ts
+++ b/packages/react/src/avatar/image/AvatarImageDataAttributes.ts
@@ -2,7 +2,7 @@ import { TransitionStatusDataAttributes } from '../../internals/stateAttributesM
 
 export enum AvatarImageDataAttributes {
   /**
-   * Present when the image is animating in.
+   * Present when the image begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/checkbox/indicator/CheckboxIndicatorDataAttributes.ts
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicatorDataAttributes.ts
@@ -26,7 +26,7 @@ export enum CheckboxIndicatorDataAttributes {
    */
   required = 'data-required',
   /**
-   * Present when the checkbox indicator is animating in.
+   * Present when the checkbox indicator begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/collapsible/panel/CollapsiblePanelDataAttributes.ts
+++ b/packages/react/src/collapsible/panel/CollapsiblePanelDataAttributes.ts
@@ -10,7 +10,7 @@ export enum CollapsiblePanelDataAttributes {
    */
   closed = 'data-closed',
   /**
-   * Present when the panel is animating in.
+   * Present when the panel begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/collapsible/root/CollapsibleRootDataAttributes.ts
+++ b/packages/react/src/collapsible/root/CollapsibleRootDataAttributes.ts
@@ -10,7 +10,7 @@ export enum CollapsibleRootDataAttributes {
    */
   closed = 'data-closed',
   /**
-   * Present when the collapsible is animating in.
+   * Present when the collapsible begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/combobox/backdrop/ComboboxBackdropDataAttributes.ts
+++ b/packages/react/src/combobox/backdrop/ComboboxBackdropDataAttributes.ts
@@ -10,7 +10,7 @@ export enum ComboboxBackdropDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the popup is animating in.
+   * Present when the popup begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/combobox/clear/ComboboxClearDataAttributes.ts
+++ b/packages/react/src/combobox/clear/ComboboxClearDataAttributes.ts
@@ -17,7 +17,7 @@ export enum ComboboxClearDataAttributes {
    */
   visible = 'data-visible',
   /**
-   * Present when the button is animating in.
+   * Present when the button begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/combobox/item-indicator/ComboboxItemIndicatorDataAttributes.ts
+++ b/packages/react/src/combobox/item-indicator/ComboboxItemIndicatorDataAttributes.ts
@@ -2,7 +2,7 @@ import { TransitionStatusDataAttributes } from '../../internals/stateAttributesM
 
 export enum ComboboxItemIndicatorDataAttributes {
   /**
-   * Present when the indicator is animating in.
+   * Present when the indicator begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/combobox/popup/ComboboxPopupDataAttributes.ts
+++ b/packages/react/src/combobox/popup/ComboboxPopupDataAttributes.ts
@@ -10,7 +10,7 @@ export enum ComboboxPopupDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the popup is animating in.
+   * Present when the popup begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/dialog/backdrop/DialogBackdropDataAttributes.ts
+++ b/packages/react/src/dialog/backdrop/DialogBackdropDataAttributes.ts
@@ -10,7 +10,7 @@ export enum DialogBackdropDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the dialog is animating in.
+   * Present when the dialog begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/dialog/popup/DialogPopupDataAttributes.ts
+++ b/packages/react/src/dialog/popup/DialogPopupDataAttributes.ts
@@ -10,7 +10,7 @@ export enum DialogPopupDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the dialog is animating in.
+   * Present when the dialog begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/dialog/viewport/DialogViewportDataAttributes.ts
+++ b/packages/react/src/dialog/viewport/DialogViewportDataAttributes.ts
@@ -10,7 +10,7 @@ export enum DialogViewportDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the dialog is animating in.
+   * Present when the dialog begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/drawer/backdrop/DrawerBackdropDataAttributes.ts
+++ b/packages/react/src/drawer/backdrop/DrawerBackdropDataAttributes.ts
@@ -10,7 +10,7 @@ export enum DrawerBackdropDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the drawer is animating in.
+   * Present when the drawer begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/drawer/popup/DrawerPopupDataAttributes.ts
+++ b/packages/react/src/drawer/popup/DrawerPopupDataAttributes.ts
@@ -10,7 +10,7 @@ export enum DrawerPopupDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the drawer is animating in.
+   * Present when the drawer begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/drawer/viewport/DrawerViewportDataAttributes.ts
+++ b/packages/react/src/drawer/viewport/DrawerViewportDataAttributes.ts
@@ -10,7 +10,7 @@ export enum DrawerViewportDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the drawer is animating in.
+   * Present when the drawer begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/field/error/FieldErrorDataAttributes.ts
+++ b/packages/react/src/field/error/FieldErrorDataAttributes.ts
@@ -30,7 +30,7 @@ export enum FieldErrorDataAttributes {
    */
   focused = 'data-focused',
   /**
-   * Present when the error message is animating in.
+   * Present when the error message begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/internals/stateAttributesMapping.ts
+++ b/packages/react/src/internals/stateAttributesMapping.ts
@@ -3,7 +3,7 @@ import type { StateAttributesMapping } from './getStateAttributesProps';
 
 export enum TransitionStatusDataAttributes {
   /**
-   * Present when the component is animating in.
+   * Present when the component begins animating in.
    */
   startingStyle = 'data-starting-style',
   /**

--- a/packages/react/src/menu/backdrop/MenuBackdropDataAttributes.ts
+++ b/packages/react/src/menu/backdrop/MenuBackdropDataAttributes.ts
@@ -10,7 +10,7 @@ export enum MenuBackdropDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the menu is animating in.
+   * Present when the menu begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicatorDataAttributes.ts
+++ b/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicatorDataAttributes.ts
@@ -14,7 +14,7 @@ export enum MenuCheckboxItemIndicatorDataAttributes {
    */
   disabled = 'data-disabled',
   /**
-   * Present when the indicator is animating in.
+   * Present when the indicator begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/menu/popup/MenuPopupDataAttributes.ts
+++ b/packages/react/src/menu/popup/MenuPopupDataAttributes.ts
@@ -10,7 +10,7 @@ export enum MenuPopupDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the menu is animating in.
+   * Present when the menu begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicatorDataAttributes.ts
+++ b/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicatorDataAttributes.ts
@@ -14,7 +14,7 @@ export enum MenuRadioItemIndicatorDataAttributes {
    */
   disabled = 'data-disabled',
   /**
-   * Present when the radio indicator is animating in.
+   * Present when the radio indicator begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/navigation-menu/backdrop/NavigationMenuBackdropDataAttributes.ts
+++ b/packages/react/src/navigation-menu/backdrop/NavigationMenuBackdropDataAttributes.ts
@@ -10,7 +10,7 @@ export enum NavigationMenuBackdropDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the popup is animating in.
+   * Present when the popup begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/navigation-menu/content/NavigationMenuContentDataAttributes.ts
+++ b/packages/react/src/navigation-menu/content/NavigationMenuContentDataAttributes.ts
@@ -10,7 +10,7 @@ export enum NavigationMenuContentDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the content is animating in.
+   * Present when the content begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/navigation-menu/popup/NavigationMenuPopupDataAttributes.ts
+++ b/packages/react/src/navigation-menu/popup/NavigationMenuPopupDataAttributes.ts
@@ -10,7 +10,7 @@ export enum NavigationMenuPopupDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the popup is animating in.
+   * Present when the popup begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/popover/backdrop/PopoverBackdropDataAttributes.ts
+++ b/packages/react/src/popover/backdrop/PopoverBackdropDataAttributes.ts
@@ -10,7 +10,7 @@ export enum PopoverBackdropDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the popup is animating in.
+   * Present when the popup begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/popover/popup/PopoverPopupDataAttributes.ts
+++ b/packages/react/src/popover/popup/PopoverPopupDataAttributes.ts
@@ -10,7 +10,7 @@ export enum PopoverPopupDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the popup is animating in.
+   * Present when the popup begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/preview-card/backdrop/PreviewCardBackdropDataAttributes.ts
+++ b/packages/react/src/preview-card/backdrop/PreviewCardBackdropDataAttributes.ts
@@ -10,7 +10,7 @@ export enum PreviewCardBackdropDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the preview card is animating in.
+   * Present when the preview card begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/preview-card/popup/PreviewCardPopupDataAttributes.ts
+++ b/packages/react/src/preview-card/popup/PreviewCardPopupDataAttributes.ts
@@ -10,7 +10,7 @@ export enum PreviewCardPopupDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the preview card is animating in.
+   * Present when the preview card begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/radio/indicator/RadioIndicatorDataAttributes.ts
+++ b/packages/react/src/radio/indicator/RadioIndicatorDataAttributes.ts
@@ -22,7 +22,7 @@ export enum RadioIndicatorDataAttributes {
    */
   required = 'data-required',
   /**
-   * Present when the radio indicator is animating in.
+   * Present when the radio indicator begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/select/backdrop/SelectBackdropDataAttributes.ts
+++ b/packages/react/src/select/backdrop/SelectBackdropDataAttributes.ts
@@ -10,7 +10,7 @@ export enum SelectBackdropDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the select is animating in.
+   * Present when the select begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/select/item-indicator/SelectItemIndicatorDataAttributes.ts
+++ b/packages/react/src/select/item-indicator/SelectItemIndicatorDataAttributes.ts
@@ -2,7 +2,7 @@ import { TransitionStatusDataAttributes } from '../../internals/stateAttributesM
 
 export enum SelectItemIndicatorDataAttributes {
   /**
-   * Present when the indicator is animating in.
+   * Present when the indicator begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/select/popup/SelectPopupDataAttributes.ts
+++ b/packages/react/src/select/popup/SelectPopupDataAttributes.ts
@@ -10,7 +10,7 @@ export enum SelectPopupDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the select is animating in.
+   * Present when the select begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/select/scroll-down-arrow/SelectScrollDownArrowDataAttributes.ts
+++ b/packages/react/src/select/scroll-down-arrow/SelectScrollDownArrowDataAttributes.ts
@@ -2,7 +2,7 @@ import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
 
 export enum SelectScrollDownArrowDataAttributes {
   /**
-   * Present when the scroll arrow is animating in.
+   * Present when the scroll arrow begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/select/scroll-up-arrow/SelectScrollUpArrowDataAttributes.ts
+++ b/packages/react/src/select/scroll-up-arrow/SelectScrollUpArrowDataAttributes.ts
@@ -2,7 +2,7 @@ import { CommonPopupDataAttributes } from '../../utils/popupStateMapping';
 
 export enum SelectScrollUpArrowDataAttributes {
   /**
-   * Present when the scroll arrow is animating in.
+   * Present when the scroll arrow begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/tabs/panel/TabsPanelDataAttributes.ts
+++ b/packages/react/src/tabs/panel/TabsPanelDataAttributes.ts
@@ -20,7 +20,7 @@ export enum TabsPanelDataAttributes {
    */
   hidden = 'data-hidden',
   /**
-   * Present when the panel is animating in.
+   * Present when the panel begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/toast/root/ToastRootDataAttributes.ts
+++ b/packages/react/src/toast/root/ToastRootDataAttributes.ts
@@ -27,7 +27,7 @@ export enum ToastRootDataAttributes {
    */
   swipeDirection = 'data-swipe-direction',
   /**
-   * Present when the toast is animating in.
+   * Present when the toast begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**

--- a/packages/react/src/tooltip/popup/TooltipPopupDataAttributes.ts
+++ b/packages/react/src/tooltip/popup/TooltipPopupDataAttributes.ts
@@ -10,7 +10,7 @@ export enum TooltipPopupDataAttributes {
    */
   closed = CommonPopupDataAttributes.closed,
   /**
-   * Present when the tooltip is animating in.
+   * Present when the tooltip begins animating in.
    */
   startingStyle = CommonPopupDataAttributes.startingStyle,
   /**

--- a/packages/react/src/utils/popupStateMapping.ts
+++ b/packages/react/src/utils/popupStateMapping.ts
@@ -11,7 +11,7 @@ export enum CommonPopupDataAttributes {
    */
   closed = 'data-closed',
   /**
-   * Present when the popup is animating in.
+   * Present when the popup begins animating in.
    */
   startingStyle = TransitionStatusDataAttributes.startingStyle,
   /**


### PR DESCRIPTION
## Summary

Reword the `data-starting-style` data attribute description across all components.

The old description read "Present when the _{component}_ is animating in.", which implies the attribute is present for the whole opening animation. In reality `data-starting-style` is applied for a single frame so CSS can transition _from_ it to the open styles, then it is removed. The new wording — "Present when the _{component}_ begins animating in." — conveys that it marks the start of the transition rather than its entire duration.

`data-ending-style` is intentionally left unchanged: it does stay present for the whole closing animation, so its existing wording is already accurate.

This lines the component reference up with the [Animation handbook](https://base-ui.com/react/handbook/animation#css-transitions), which is already accurate on this point.

## Context

The imprecise wording was raised in [issue No. 4915](https://github.com/mui/base-ui/issues/4915), where it was noted that the description implies `data-starting-style` is present for the whole animation.

The `[data-animating]` attribute also requested in that thread is a separate feature request and is **not** part of this PR — it should be filed on its own.

## Changes

- Updated the `startingStyle` JSDoc in every `*DataAttributes.ts` enum, plus the shared `popupStateMapping` / `stateAttributesMapping` sources.
- Regenerated the API reference tables (`pnpm docs:api`).
- Regenerated the `generateLlmTxt` snapshot.
