### PR TITLE
[code-infra] Drop renovate rules already inherited from the shared preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,15 +13,6 @@
       "schedule": null
     },
     {
-      "groupName": "Tailwind CSS",
-      "matchPackageNames": ["tailwindcss", "@tailwindcss/*", "prettier-plugin-tailwindcss"]
-    },
-    {
-      "groupName": "MUI public packages",
-      "matchPackageNames": ["@mui/*", "!@mui/internal-*", "!@mui/docs"],
-      "allowedVersions": "!/-dev/"
-    },
-    {
       "groupName": "jsdom",
       "description": "v28 is causing further performance issues and timeouts in our tests, so we will stay on v27 until the issues are resolved. https://github.com/mui/base-ui/pull/4372",
       "matchPackageNames": ["jsdom"],


### PR DESCRIPTION
## Summary

Both the `MUI public packages` and `Tailwind CSS` entries in `renovate.json` duplicate rules already provided by the shared `github>mui/mui-public//renovate/default` preset, so they add nothing once the config is resolved:

- **MUI public packages** — the preset already contains an identical rule (same `matchPackageNames` and `allowedVersions: "!/-dev/"`).
- **Tailwind CSS** — the preset groups Tailwind via `matchSourceUrls: ["https://github.com/tailwindlabs/**"]`, which covers `tailwindcss`, `@tailwindcss/*`, and `prettier-plugin-tailwindcss` (all published from the `tailwindlabs` org).

The repo-specific `Floating UI` and `jsdom` rules are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)