### PR TITLE
[composite] Fix nested list reorder detection

### DIFF
--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -1,4 +1,6 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
+import * as React from 'react';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';
 import { CompositeList } from './CompositeList';
 import { useCompositeListItem } from './useCompositeListItem';
@@ -7,11 +9,16 @@ describe('<CompositeList />', () => {
   const { render } = createRenderer();
 
   describe('prop: elementsRef', () => {
+    function Item(props: { label?: string }) {
+      const { ref, index } = useCompositeListItem();
+      return (
+        <div ref={ref} data-testid={props.label} data-index={props.label ? index : undefined}>
+          {props.label}
+        </div>
+      );
+    }
+
     it('cleans up refs on unmount', async () => {
-      function Item() {
-        const { ref } = useCompositeListItem();
-        return <div ref={ref} />;
-      }
       const elementsRef = {
         current: [] as Array<HTMLElement | null>,
       };
@@ -32,6 +39,121 @@ describe('<CompositeList />', () => {
       unmount();
       expect(elementsRef.current).toHaveLength(0);
       expect(labelsRef.current).toHaveLength(0);
+    });
+
+    it('updates indexes when keyed groups reorder', async () => {
+      function App() {
+        const [reordered, setReordered] = React.useState(false);
+        const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
+        const labelsRef = React.useRef<Array<string | null>>([]);
+        const groups = reordered ? ['b', 'a'] : ['a', 'b'];
+
+        return (
+          <CompositeList elementsRef={elementsRef} labelsRef={labelsRef}>
+            <button type="button" onClick={() => setReordered(true)}>
+              Reorder
+            </button>
+            <div>
+              {groups.map((group) => (
+                <section key={group}>
+                  <Item label={group} />
+                </section>
+              ))}
+            </div>
+          </CompositeList>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      expect(screen.getByTestId('a')).toHaveAttribute('data-index', '0');
+      expect(screen.getByTestId('b')).toHaveAttribute('data-index', '1');
+
+      await user.click(screen.getByRole('button', { name: 'Reorder' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('b')).toHaveAttribute('data-index', '0');
+      });
+      expect(screen.getByTestId('a')).toHaveAttribute('data-index', '1');
+    });
+
+    it('updates indexes when grouped items reorder alongside unrelated mutations', async () => {
+      function App() {
+        const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
+        const labelsRef = React.useRef<Array<string | null>>([]);
+
+        return (
+          <CompositeList elementsRef={elementsRef} labelsRef={labelsRef}>
+            <div data-testid="list">
+              <section data-testid="group-a">
+                <Item label="a" />
+              </section>
+              <section data-testid="group-b">
+                <Item label="b" />
+              </section>
+            </div>
+          </CompositeList>
+        );
+      }
+
+      await render(<App />);
+
+      expect(screen.getByTestId('a')).toHaveAttribute('data-index', '0');
+      expect(screen.getByTestId('b')).toHaveAttribute('data-index', '1');
+
+      const list = screen.getByTestId('list');
+      const groupA = screen.getByTestId('group-a');
+      const groupB = screen.getByTestId('group-b');
+      const badge = list.ownerDocument.createElement('span');
+      badge.setAttribute('data-testid', 'badge');
+
+      list.insertBefore(groupB, groupA);
+      list.appendChild(badge);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('b')).toHaveAttribute('data-index', '0');
+      });
+      expect(screen.getByTestId('a')).toHaveAttribute('data-index', '1');
+      expect(screen.getByTestId('badge')).toBeInTheDocument();
+    });
+
+    it('ignores mutations for unrelated leaf nodes', async () => {
+      function App(props: { onMapChange: (map: Map<Element, unknown>) => void }) {
+        const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
+        const labelsRef = React.useRef<Array<string | null>>([]);
+
+        return (
+          <CompositeList
+            elementsRef={elementsRef}
+            labelsRef={labelsRef}
+            onMapChange={props.onMapChange}
+          >
+            <button type="button" onClick={() => screen.getByTestId('badge').remove()}>
+              Remove badge
+            </button>
+            <div data-testid="list">
+              <Item label="a" />
+              <span data-testid="badge" />
+              <Item label="b" />
+            </div>
+          </CompositeList>
+        );
+      }
+
+      const onMapChange = vi.fn();
+      const { user } = await render(<App onMapChange={onMapChange} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('b')).toHaveAttribute('data-index', '1');
+      });
+      onMapChange.mockClear();
+
+      await user.click(screen.getByRole('button', { name: 'Remove badge' }));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('badge')).toBe(null);
+      });
+      expect(onMapChange).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -64,7 +64,9 @@ describe('<CompositeList />', () => {
         );
       }
 
-      const { user } = await render(<App />);
+      // StrictMode masks the bug: it re-runs the item registration effects when
+      // the groups move, which re-sorts the indices even without the fix.
+      const { user } = await render(<App />, { strict: false });
 
       expect(screen.getByTestId('a')).toHaveAttribute('data-index', '0');
       expect(screen.getByTestId('b')).toHaveAttribute('data-index', '1');

--- a/packages/react/src/internals/composite/list/CompositeList.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.tsx
@@ -4,9 +4,7 @@ import * as React from 'react';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { contains } from '../../shadowDom';
 import { CompositeListContext } from './CompositeListContext';
-import { isElement } from '@floating-ui/utils/dom';
 
 export type CompositeMetadata<CustomMetadata> = {
   index?: number | null | undefined;
@@ -49,29 +47,34 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     setMapTick(lastTickRef.current);
   });
 
-  const { sortedMap, sortedNodes } = React.useMemo(() => {
+  const sortedMap = React.useMemo(() => {
     // `mapTick` is the `useMemo` trigger as `map` is stable.
     disableEslintWarning(mapTick);
 
-    const nextSortedMap = new Map<Element, CompositeMetadata<Metadata>>();
+    const newMap = new Map<Element, CompositeMetadata<Metadata>>();
     // Filter out disconnected elements before sorting to avoid inconsistent
     // compareDocumentPosition results when elements are detached from the DOM.
-    const nextSortedNodes = Array.from(map.keys())
+    const sortedNodes = Array.from(map.keys())
       .filter((node) => node.isConnected)
       .sort(sortByDocumentPosition);
 
-    nextSortedNodes.forEach((node, index) => {
+    sortedNodes.forEach((node, index) => {
       const metadata = map.get(node) ?? ({} as CompositeMetadata<Metadata>);
-      nextSortedMap.set(node, { ...metadata, index });
+      newMap.set(node, { ...metadata, index });
     });
 
-    return { sortedMap: nextSortedMap, sortedNodes: nextSortedNodes };
+    return newMap;
   }, [map, mapTick]);
 
   useIsoLayoutEffect(() => {
-    if (typeof MutationObserver !== 'function' || sortedNodes.length < 2) {
+    // A single item can't reorder.
+    if (typeof MutationObserver !== 'function' || sortedMap.size < 2) {
       return undefined;
     }
+
+    // `sortedMap` is populated in sorted order, so its keys are the last known
+    // document order of the items.
+    const sortedNodes = Array.from(sortedMap.keys());
 
     // Rather than observing the whole composite container, observe the smallest
     // direct-child lists whose order can affect registered item order. For flat
@@ -83,15 +86,18 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     }
 
     const mutationObserver = new MutationObserver((entries) => {
-      if (!entries.some((entry) => hasSortedNode(entry, sortedNodes))) {
+      // Only verify the order after a move: a node that was removed and later
+      // re-added within the same batch. Additions and removals alone can't
+      // change the relative order of the remaining items, and items that mount
+      // or unmount re-sort through `register`/`unregister`.
+      if (!hasMovedNode(entries)) {
         return;
       }
 
       let previousConnectedNode: Element | null = null;
 
-      // `sortedNodes` is the last known document order. If any connected node now
-      // appears before the previous connected node, wrappers/items moved and the
-      // index map needs to be rebuilt.
+      // If any connected node now appears before the previous connected node,
+      // wrappers/items moved and the index map needs to be rebuilt.
       for (const node of sortedNodes) {
         if (!node.isConnected) {
           continue;
@@ -115,7 +121,7 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     return () => {
       mutationObserver.disconnect();
     };
-  }, [sortedNodes]);
+  }, [sortedMap]);
 
   useIsoLayoutEffect(() => {
     const shouldUpdateLengths = lastTickRef.current === mapTick;
@@ -195,35 +201,41 @@ function getAdjacentNodeRoots(nodes: Element[]) {
 function getCommonAncestor(firstNode: Element, lastNode: Element) {
   let ancestor = firstNode.parentElement;
 
-  while (ancestor && !contains(ancestor, lastNode)) {
+  // The `parentElement` walk cannot cross shadow boundaries, so the native
+  // `contains` is sufficient here.
+  while (ancestor && !ancestor.contains(lastNode)) {
     ancestor = ancestor.parentElement;
   }
 
   return ancestor;
 }
 
-function hasSortedNode(entry: MutationRecord, sortedNodes: Element[]) {
-  for (let i = 0; i < entry.addedNodes.length; i += 1) {
-    if (containsSortedNode(entry.addedNodes[i], sortedNodes)) {
-      return true;
+function hasMovedNode(entries: MutationRecord[]) {
+  const removed = new Set<Node>();
+
+  // The records are chronological: an addition following a removal is a move,
+  // while a removal following an addition is a net removal.
+  for (const entry of entries) {
+    for (let i = 0; i < entry.addedNodes.length; i += 1) {
+      if (removed.has(entry.addedNodes[i])) {
+        return true;
+      }
+    }
+
+    for (let i = 0; i < entry.removedNodes.length; i += 1) {
+      removed.add(entry.removedNodes[i]);
     }
   }
 
-  for (let i = 0; i < entry.removedNodes.length; i += 1) {
-    if (containsSortedNode(entry.removedNodes[i], sortedNodes)) {
+  // A removed node that is still connected was reparented into a container
+  // this observer doesn't watch.
+  for (const node of removed) {
+    if (node.isConnected) {
       return true;
     }
   }
 
   return false;
-}
-
-function containsSortedNode(node: Node, sortedNodes: Element[]) {
-  if (!isElement(node)) {
-    return false;
-  }
-
-  return sortedNodes.some((sortedNode) => contains(node, sortedNode));
 }
 
 function sortByDocumentPosition(a: Element, b: Element) {

--- a/packages/react/src/internals/composite/list/CompositeList.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.tsx
@@ -4,7 +4,9 @@ import * as React from 'react';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { contains } from '../../shadowDom';
 import { CompositeListContext } from './CompositeListContext';
+import { isElement } from '@floating-ui/utils/dom';
 
 export type CompositeMetadata<CustomMetadata> = {
   index?: number | null | undefined;
@@ -47,53 +49,73 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     setMapTick(lastTickRef.current);
   });
 
-  const sortedMap = React.useMemo(() => {
+  const { sortedMap, sortedNodes } = React.useMemo(() => {
     // `mapTick` is the `useMemo` trigger as `map` is stable.
     disableEslintWarning(mapTick);
 
-    const newMap = new Map<Element, CompositeMetadata<Metadata>>();
+    const nextSortedMap = new Map<Element, CompositeMetadata<Metadata>>();
     // Filter out disconnected elements before sorting to avoid inconsistent
     // compareDocumentPosition results when elements are detached from the DOM.
-    const sortedNodes = Array.from(map.keys())
+    const nextSortedNodes = Array.from(map.keys())
       .filter((node) => node.isConnected)
       .sort(sortByDocumentPosition);
 
-    sortedNodes.forEach((node, index) => {
+    nextSortedNodes.forEach((node, index) => {
       const metadata = map.get(node) ?? ({} as CompositeMetadata<Metadata>);
-      newMap.set(node, { ...metadata, index });
+      nextSortedMap.set(node, { ...metadata, index });
     });
 
-    return newMap;
+    return { sortedMap: nextSortedMap, sortedNodes: nextSortedNodes };
   }, [map, mapTick]);
 
   useIsoLayoutEffect(() => {
-    if (typeof MutationObserver !== 'function' || sortedMap.size === 0) {
+    if (typeof MutationObserver !== 'function' || sortedNodes.length < 2) {
+      return undefined;
+    }
+
+    // Rather than observing the whole composite container, observe the smallest
+    // direct-child lists whose order can affect registered item order. For flat
+    // lists this is the item parent; for grouped lists this includes the group
+    // wrapper boundary between adjacent items.
+    const roots = getAdjacentNodeRoots(sortedNodes);
+    if (roots.size === 0) {
       return undefined;
     }
 
     const mutationObserver = new MutationObserver((entries) => {
-      const diff = new Set<Node>();
-      const updateDiff = (node: Node) => (diff.has(node) ? diff.delete(node) : diff.add(node));
-      entries.forEach((entry) => {
-        entry.removedNodes.forEach(updateDiff);
-        entry.addedNodes.forEach(updateDiff);
-      });
-      if (diff.size === 0) {
-        lastTickRef.current += 1;
-        setMapTick(lastTickRef.current);
+      if (!entries.some((entry) => hasSortedNode(entry, sortedNodes))) {
+        return;
+      }
+
+      let previousConnectedNode: Element | null = null;
+
+      // `sortedNodes` is the last known document order. If any connected node now
+      // appears before the previous connected node, wrappers/items moved and the
+      // index map needs to be rebuilt.
+      for (const node of sortedNodes) {
+        if (!node.isConnected) {
+          continue;
+        }
+
+        if (previousConnectedNode && sortByDocumentPosition(previousConnectedNode, node) > 0) {
+          mutationObserver.disconnect();
+          lastTickRef.current += 1;
+          setMapTick(lastTickRef.current);
+          return;
+        }
+
+        previousConnectedNode = node;
       }
     });
 
-    sortedMap.forEach((_, node) => {
-      if (node.parentElement) {
-        mutationObserver.observe(node.parentElement, { childList: true });
-      }
+    roots.forEach((root) => {
+      mutationObserver.observe(root, { childList: true });
     });
 
     return () => {
       mutationObserver.disconnect();
     };
-  }, [sortedMap]);
+  }, [sortedNodes]);
 
   useIsoLayoutEffect(() => {
     const shouldUpdateLengths = lastTickRef.current === mapTick;
@@ -151,6 +173,57 @@ function createMap<Metadata>() {
 
 function createListeners() {
   return new Set<Function>();
+}
+
+function getAdjacentNodeRoots(nodes: Element[]) {
+  const roots = new Set<Element>();
+
+  // A reorder that changes item indexes must invert at least one adjacent pair
+  // from the previous sorted order. Observing each pair's common parent catches
+  // both direct item moves and ancestor wrapper moves at the boundary.
+  for (let i = 1; i < nodes.length; i += 1) {
+    const ancestor = getCommonAncestor(nodes[i - 1], nodes[i]);
+
+    if (ancestor) {
+      roots.add(ancestor);
+    }
+  }
+
+  return roots;
+}
+
+function getCommonAncestor(firstNode: Element, lastNode: Element) {
+  let ancestor = firstNode.parentElement;
+
+  while (ancestor && !contains(ancestor, lastNode)) {
+    ancestor = ancestor.parentElement;
+  }
+
+  return ancestor;
+}
+
+function hasSortedNode(entry: MutationRecord, sortedNodes: Element[]) {
+  for (let i = 0; i < entry.addedNodes.length; i += 1) {
+    if (containsSortedNode(entry.addedNodes[i], sortedNodes)) {
+      return true;
+    }
+  }
+
+  for (let i = 0; i < entry.removedNodes.length; i += 1) {
+    if (containsSortedNode(entry.removedNodes[i], sortedNodes)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function containsSortedNode(node: Node, sortedNodes: Element[]) {
+  if (!isElement(node)) {
+    return false;
+  }
+
+  return sortedNodes.some((sortedNode) => contains(node, sortedNode));
 }
 
 function sortByDocumentPosition(a: Element, b: Element) {

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -1,6 +1,13 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
-import { act, createRenderer, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
+import {
+  act,
+  createRenderer,
+  fireEvent,
+  flushMicrotasks,
+  screen,
+  waitFor,
+} from '@mui/internal-test-utils';
 import { isJSDOM } from '#test-utils';
 import { DirectionProvider } from '../../../direction-provider';
 import { CompositeItem } from '../item/CompositeItem';
@@ -201,6 +208,41 @@ describe('Composite', () => {
       await user.keyboard('{ArrowDown}');
       expect(item3).toHaveFocus();
     });
+
+    it.skipIf(isJSDOM)(
+      'updates the order of items when their containers are reordered',
+      async () => {
+        function App(props: { groups: string[] }) {
+          return (
+            <CompositeRoot>
+              {props.groups.map((group) => (
+                <div key={group} role="group">
+                  <CompositeItem data-testid={group}>{group}</CompositeItem>
+                </div>
+              ))}
+            </CompositeRoot>
+          );
+        }
+        // StrictMode masks the bug: it re-runs the item registration effects when
+        // the containers move, which re-sorts the indices even without the fix.
+        const { user, rerender } = render(<App groups={['a', 'b', 'c']} />, { strict: false });
+        rerender(<App groups={['b', 'a', 'c']} />);
+
+        const itemA = screen.getByTestId('a');
+        const itemB = screen.getByTestId('b');
+
+        // The re-sort commits asynchronously (MutationObserver); once it does,
+        // the roving tab stop (highlighted index 0) belongs to the first item in
+        // the new DOM order.
+        await waitFor(() => {
+          expect(itemB).toHaveAttribute('tabindex', '0');
+        });
+
+        act(() => itemB.focus());
+        await user.keyboard('{ArrowDown}');
+        expect(itemA).toHaveFocus();
+      },
+    );
 
     describe('Home and End keys', () => {
       it('Home key moves focus to the first item', async () => {


### PR DESCRIPTION
Fixes #5125 

## Summary

- Walks up the DOM tree to find the common ancestor of each adjacent pair of registered items, and observes those boundaries for child-list mutations, covering nested/grouped list changes.
- Only re-sorts when a mutation batch contains a moved node and the registered items are no longer in their last known document order.

## Why

`CompositeList` derives item indexes from DOM order so keyboard navigation and typeahead can move through the same order the user sees. Before this change, reorder detection watched each registered item's immediate parent:

```ts
mutationObserver.observe(node.parentElement, { childList: true });
```

That works for a flat list where items are direct siblings. If React moves an item from one position to another under the same parent, that parent receives child-list mutations and `CompositeList` can re-sort the map.

Grouped lists are different. Items are often nested under group wrappers:

```txt
List
  Group: API Reference
    Item: Tabs > Tab
    Item: Tabs > Root
  Group: Components
    Item: Tabs
```

If the item keeps the same key (`key={item.id}`), React can preserve the component and DOM node which means it doesn't unmount/remount. That is usually desirable, but in this case, if a later query moves the highlighted item's _group_ elsewhere in the list (`key={group.id}`), the `register`/`unregister` callbacks do not fire for the item, nor the mutation observer, so the item keeps the index it had before the reorder.

If `CompositeList` misses that move, the item may still think it has composite index `0`, so `activeIndex = 0` continues to highlight it even though another item is now visually first, and this created the strange keyboard navigation ordering.

Observing the common ancestor of each adjacent pair of items fixes this by watching the boundaries that actually own the composite ordering: a reorder that changes item indexes must invert at least one adjacent pair, and the mutation that causes it happens at that pair's common ancestor. For a flat list this collapses to the single item parent; for grouped lists it includes the group wrapper boundaries.

## Performance Notes

The observer still only watches child-list mutations (no `subtree`), and observes one node per adjacent-pair boundary instead of every item's parent, so a flat list collapses to a single observation. The callback also filters out batches that contain no moved node, and verifies the items' relative document order actually changed before re-sorting.


