### PR TITLE
[docs] Tweak header side padding

### DIFF
--- a/docs/src/app/(docs)/layout.css
+++ b/docs/src/app/(docs)/layout.css
@@ -48,20 +48,25 @@
 
   .ContentLayoutRoot {
     --sidebar-width: 17.5rem;
+    --content-layout-padding-x: 1.5rem;
 
     display: grid;
     align-items: start;
     padding-top: var(--header-height);
-    padding-inline: 1.5rem;
+    padding-inline: var(--content-layout-padding-x);
     grid-template-columns: 1fr;
 
     @media (--sm) {
-      padding-inline: 2.5rem;
+      --content-layout-padding-x: 2.5rem;
+    }
+
+    @media (--md) {
+      --content-layout-padding-x: 3rem;
     }
 
     @media (--show-side-nav) {
+      --content-layout-padding-x: 0rem;
       padding-top: 0;
-      padding-inline: 0;
       grid-template-columns: var(--sidebar-width) 1fr 3rem;
     }
 

--- a/docs/src/components/Header.css
+++ b/docs/src/components/Header.css
@@ -16,7 +16,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding-inline: 1.5rem;
+    padding-inline: var(--content-layout-padding-x);
     position: fixed;
     top: 0;
     inset-inline: 0;


### PR DESCRIPTION
Aligns the header content with the main content at certain viewports and increases the side padding in others.

||before|after|
|---|---|---|
|640px|<img width="624" height="402" alt="before-1" src="https://github.com/user-attachments/assets/19ab1204-892b-41cd-89bf-4094fc024baf" />|<img width="623" height="399" alt="after-1" src="https://github.com/user-attachments/assets/04db1ac8-0f2b-4e67-87ce-d4021278a619" />|
|1023px|<img width="1005" height="345" alt="before-2" src="https://github.com/user-attachments/assets/3142e721-c089-4039-9a36-bb70d8ea2e1d" />|<img width="1006" height="330" alt="after-2" src="https://github.com/user-attachments/assets/cac69336-7f92-4468-9a20-ba7523c804be" />|


