### PR TITLE
[test] Reset the shared animation frame scheduler between tests

### DIFF
--- a/packages/utils/src/useAnimationFrame.ts
+++ b/packages/utils/src/useAnimationFrame.ts
@@ -80,7 +80,28 @@ class Scheduler {
   }
 }
 
-const scheduler = new Scheduler();
+let scheduler = new Scheduler();
+
+/**
+ * Replaces the shared scheduler and drops all pending animation frame callbacks.
+ *
+ * For test environments only. The scheduler is process-global, so a callback scheduled in one test
+ * but never run (e.g. requested under fake timers that were torn down before the frame fired) would
+ * otherwise survive into a later test and run there against stale state. Call between tests to drop
+ * such leftovers.
+ */
+export function resetAnimationFrameScheduler() {
+  const previous = scheduler;
+  scheduler = new Scheduler();
+  // Continue the id sequence so `cancel()` calls from `AnimationFrame` instances created before the
+  // reset cannot cancel callbacks scheduled after it.
+  scheduler.nextId = previous.nextId;
+  scheduler.startId = previous.nextId;
+  // A frame requested before the reset may still be pending and holds the previous scheduler's
+  // `tick`; empty its queue in place so that frame runs nothing when it eventually fires.
+  previous.callbacks = [];
+  previous.callbacksCount = 0;
+}
 
 export class AnimationFrame {
   static create() {

--- a/test/setupVitest.ts
+++ b/test/setupVitest.ts
@@ -4,6 +4,7 @@ import setupVitest from '@mui/internal-test-utils/setupVitest';
 import '../packages/react/test/addVitestMatchers';
 import '@testing-library/jest-dom/vitest';
 import { reset as resetBuiltError } from '@base-ui/utils/error';
+import { resetAnimationFrameScheduler as resetBuiltScheduler } from '@base-ui/utils/useAnimationFrame';
 
 declare global {
   // eslint-disable-next-line vars-on-top
@@ -11,6 +12,7 @@ declare global {
 }
 
 let resetSourceError = () => {};
+let resetSourceScheduler = () => {};
 
 setupVitest();
 
@@ -19,12 +21,21 @@ beforeAll(async () => {
   // can be loaded as separate instances, so reset the source copy too.
   // eslint-disable-next-line import/no-relative-packages
   ({ reset: resetSourceError } = await import('../packages/utils/src/error'));
+  ({ resetAnimationFrameScheduler: resetSourceScheduler } = await import(
+    // eslint-disable-next-line import/no-relative-packages
+    '../packages/utils/src/useAnimationFrame'
+  ));
 });
 
 afterEach(() => {
   vi.resetAllMocks();
   resetBuiltError();
   resetSourceError();
+  // Drop animation frame callbacks that were scheduled but never ran (e.g. under fake timers torn
+  // down before the frame fired). The scheduler is process-global, so without this they would leak
+  // into a later test and run there against stale state.
+  resetBuiltScheduler();
+  resetSourceScheduler();
 });
 
 globalThis.BASE_UI_ANIMATIONS_DISABLED = true;


### PR DESCRIPTION
The `AnimationFrame` scheduler in `@base-ui/utils/useAnimationFrame` is process-global: every consumer's callback lands in one shared queue drained by a single native `requestAnimationFrame`.

In tests this global queue leaks across test boundaries. A callback scheduled in one test but never run — typically requested under sinon fake timers that were torn down before the (fake) frame fired — stays in the queue. A later test's rAF tick then drains it, running the stale callback against that test's state. A pending real rAF from a previous real-timer test can also fire mid-way through a later fake-timer test and drain its freshly scheduled callbacks prematurely.

This caused intermittent failures in the handle-attachment suites, where the deferred overlapping-roots dev warning fired in tests that assert it does not (e.g. `DialogRoot.detached-triggers.test.tsx` in full-suite runs). The failures never reproduced in isolation, only in multi-file runs.

Fix: export `resetAnimationFrameScheduler()` from `@base-ui/utils/useAnimationFrame` and call it in the global `afterEach` (following the existing pattern used for `@base-ui/utils/error`). The reset:

- swaps in a fresh scheduler so subsequent requests are scheduled under the current timer regime,
- empties the previous queue in place, so an already-pending frame that still holds the old `tick` runs nothing when it eventually fires,
- continues the id sequence, so `cancel()` calls from `AnimationFrame` instances created before the reset cannot cancel callbacks scheduled after it.

Production code paths are unchanged; the scheduler behaves exactly as before outside of the explicit reset call.

Verified by stress-running the previously flaky combination (Menu/Popover/Tooltip/PreviewCard/Dialog root suites, which failed roughly 1 in 3 runs before): 12 consecutive runs with zero scheduler-related failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)