### PR TITLE
[docs] Use Paper Mono in CSS Modules demos

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
@@ -349,8 +349,8 @@
   padding: 0 0.25rem;
   font-size: 0.625rem;
   font-family:
-    'Paper Mono', ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo,
-    monospace;
+    'Paper Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
   font-weight: 400;
   line-height: 1;
   color: oklch(43.9% 0 0deg);

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/command-palette/css-modules/index.module.css
@@ -349,7 +349,8 @@
   padding: 0 0.25rem;
   font-size: 0.625rem;
   font-family:
-    ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
+    'Paper Mono', ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo,
+    monospace;
   font-weight: 400;
   line-height: 1;
   color: oklch(43.9% 0 0deg);

--- a/docs/src/app/(docs)/react/components/otp-field/demos/alphanumeric/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/otp-field/demos/alphanumeric/css-modules/index.module.css
@@ -69,6 +69,6 @@
 
 .Code {
   font-family:
-    'Paper Mono', ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo,
-    monospace;
+    'Paper Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
 }

--- a/docs/src/app/(docs)/react/components/otp-field/demos/alphanumeric/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/otp-field/demos/alphanumeric/css-modules/index.module.css
@@ -69,5 +69,6 @@
 
 .Code {
   font-family:
-    ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
+    'Paper Mono', ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo,
+    monospace;
 }

--- a/docs/src/app/(docs)/react/components/otp-field/demos/password/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/otp-field/demos/password/css-modules/index.module.css
@@ -70,6 +70,6 @@
 
 .Code {
   font-family:
-    'Paper Mono', ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo,
-    monospace;
+    'Paper Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
 }

--- a/docs/src/app/(docs)/react/components/otp-field/demos/password/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/otp-field/demos/password/css-modules/index.module.css
@@ -70,5 +70,6 @@
 
 .Code {
   font-family:
-    ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
+    'Paper Mono', ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo,
+    monospace;
 }

--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -87,7 +87,9 @@
   --color-green-700: oklch(52.7% 0.154 150.069deg);
 
   /* Typography */
-  --font-mono: 'Paper Mono', monospace;
+  --font-mono:
+    'Paper Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
   --font-sans: 'die grotesk a', system-ui, sans-serif;
   --font-serif: Georgia, 'Times New Roman', Times, 'Noto Serif', 'DejaVu Serif', serif;
 }


### PR DESCRIPTION
Use `Paper Mono` first in CSS Modules demo monospace font stacks to match Tailwind demos. `Paper Mono` will be ignored in Stackblitz/CodeSandbox if the user doesn't have the font installed.