### PR TITLE
[docs] Reword shadcn/ui info

### DIFF
--- a/docs/src/app/(docs)/react/overview/community/page.mdx
+++ b/docs/src/app/(docs)/react/overview/community/page.mdx
@@ -6,9 +6,9 @@
   content="Learn how to use Base UI with styles, where to get help, how to stay up to date, and how to contribute."
 />
 
-## shadcn/ui integration
+## shadcn/ui
 
-Base UI now has a first-class [shadcn/ui](https://ui.shadcn.com/create?base=base) integration. So if you want wrapper components styled with Tailwind—rather than handling the styling and API surface yourself—you can [create](https://ui.shadcn.com/create?base=base) a component library via the shadcn/ui create tool with Base UI as its foundation. Alternatively, choose Base UI when installing components using the shadcn/ui CLI.
+[shadcn/ui](https://ui.shadcn.com/) uses Base UI as its unstyled foundation. If you want Tailwind-styled wrapper components and higher-level APIs without building that layer yourself, you can create a component library with the shadcn/ui [create](https://ui.shadcn.com/create) tool.
 
 ## Styled libraries
 

--- a/docs/src/app/(docs)/react/overview/page.mdx
+++ b/docs/src/app/(docs)/react/overview/page.mdx
@@ -80,7 +80,7 @@ The Base UI ecosystem, support channels, and ways to stay up to date.
 
 - Keywords: Base UI Community, Base UI shadcn, Base UI shadcn/ui, Base UI GitHub, Base UI Discord, Base UI X, Base UI Bluesky, Base UI Styling, Base UI Ecosystem, Base UI Support, Headless React Community, Accessible React Components
 - Sections:
-  - shadcn/ui integration
+  - shadcn/ui
   - Styled libraries
   - Unofficial ports
   - Get help and contribute

--- a/docs/src/app/(docs)/react/overview/quick-start/page.mdx
+++ b/docs/src/app/(docs)/react/overview/quick-start/page.mdx
@@ -59,7 +59,7 @@ import { DemoPopoverHero } from '../../components/popover/demos/hero';
 
 ## Pre-styled components
 
-[shadcn/ui](https://ui.shadcn.com/create?base=base) is a great place to start if you need pre-styled components with higher-level abstractions while using Base UI under the hood.
+[shadcn/ui](https://ui.shadcn.com/) is a great place to start if you need pre-styled components with higher-level abstractions. It uses Base UI as its unstyled foundation.
 
 Take a look at the [Community](/react/overview/community) page to see more styled libraries powered by Base UI.
 


### PR DESCRIPTION
Now that shadcn/ui defaults to Base UI, let's update the docs accordingly.

https://x.com/shadcn/status/2073021571342520343