### PR TITLE
[test] Stabilize flaky popup tests

### DIFF
--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -165,6 +165,9 @@ describe('<Popover.Root />', () => {
 
         await user.click(trigger);
         await waitFor(() => {
+          expect(trigger).toHaveAttribute('data-popup-open');
+        });
+        await waitFor(() => {
           expect(screen.queryByRole('dialog')).not.toBe(null);
         });
 
@@ -172,7 +175,7 @@ describe('<Popover.Root />', () => {
         await waitFor(() => {
           expect(trigger).not.toHaveAttribute('data-popup-open');
         });
-        expect(screen.queryByRole('dialog')).not.toBe(null);
+        expect(screen.queryByText('Content')).not.toBe(null);
 
         await user.click(screen.getByRole('button', { name: 'Open externally' }));
         await waitFor(() => {
@@ -181,7 +184,7 @@ describe('<Popover.Root />', () => {
 
         await user.click(trigger);
         await waitFor(() => {
-          expect(screen.queryByRole('dialog')).toBe(null);
+          expect(screen.queryByText('Content')).toBe(null);
         });
       });
 
@@ -660,6 +663,9 @@ describe('<Popover.Root />', () => {
 
         await user.click(trigger);
         await waitFor(() => {
+          expect(trigger).toHaveAttribute('data-popup-open');
+        });
+        await waitFor(() => {
           expect(screen.queryByRole('dialog')).not.toBe(null);
         });
 
@@ -667,7 +673,7 @@ describe('<Popover.Root />', () => {
         await waitFor(() => {
           expect(trigger).not.toHaveAttribute('data-popup-open');
         });
-        expect(screen.queryByRole('dialog')).not.toBe(null);
+        expect(screen.queryByText('Content')).not.toBe(null);
 
         await user.click(trigger);
         await waitFor(() => {
@@ -676,7 +682,7 @@ describe('<Popover.Root />', () => {
 
         await user.click(trigger);
         await waitFor(() => {
-          expect(screen.queryByRole('dialog')).toBe(null);
+          expect(screen.queryByText('Content')).toBe(null);
         });
       });
     });
@@ -869,6 +875,10 @@ describe('<Popover.Root />', () => {
           );
 
           const comboboxInput = screen.getByTestId('combobox-input');
+          await waitFor(() => {
+            expect(comboboxInput).toHaveFocus();
+          });
+
           await user.click(comboboxInput);
           await flushMicrotasks();
 
@@ -915,6 +925,10 @@ describe('<Popover.Root />', () => {
           );
 
           const comboboxInput = screen.getByTestId('combobox-input');
+          await waitFor(() => {
+            expect(comboboxInput).toHaveFocus();
+          });
+
           await user.click(comboboxInput);
           await flushMicrotasks();
 

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -5573,13 +5573,17 @@ describe('<Select.Root />', () => {
       const optionA = screen.getByRole('option', { name: 'a' });
       await user.hover(optionA);
 
+      const popup = screen.getByRole('listbox');
+      await waitFor(() => {
+        expect(popup).toHaveFocus();
+      });
+
       await user.keyboard('{ArrowDown}');
 
       await waitFor(() => {
         expect(optionA).toHaveAttribute('data-highlighted');
       });
 
-      const popup = screen.getByRole('listbox');
       await user.unhover(popup);
 
       await waitFor(() => {


### PR DESCRIPTION
This stabilizes popup-related tests that were racing async focus and mounted-state updates under suite load.

These were found when running the suite locally (CI seems ok), but it harms agent verification, so I wanted to fix them.

## Changes

- Wait for default-open Select and Popover focus handoffs before sending keyboard input.
- Wait for Popover open state before testing preventUnmountOnClose close cycles.
- Assert prevented unmounts with DOM content presence instead of role visibility after close.