### PR TITLE
[checkbox][radio][switch] Stop internal input clicks from reaching ancestors

### DIFF
--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -64,6 +64,20 @@ describe('<Checkbox.Root />', () => {
       expect(screen.getByTestId('checkbox')).toHaveAttribute('aria-checked', 'true');
     });
 
+    it('propagates a single click event to ancestors with a native button', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <div onClick={handleParentClick}>
+          <Checkbox.Root nativeButton render={<button />} data-testid="checkbox" />
+        </div>,
+      );
+
+      fireEvent.click(screen.getByTestId('checkbox'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('checkbox')).toHaveAttribute('aria-checked', 'true');
+    });
+
     it('does not propagate to ancestors when stopPropagation() is called with a native button', async () => {
       const handleParentClick = vi.fn();
       await render(

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -35,6 +35,55 @@ describe('<Checkbox.Root />', () => {
     });
   });
 
+  describe('prop: onClick', () => {
+    it('propagates a single click event to ancestors per user click', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <div onClick={handleParentClick}>
+          <Checkbox.Root data-testid="checkbox" />
+        </div>,
+      );
+
+      fireEvent.click(screen.getByTestId('checkbox'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('checkbox')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('does not propagate to ancestors when stopPropagation() is called', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <div onClick={handleParentClick}>
+          <Checkbox.Root data-testid="checkbox" onClick={(event) => event.stopPropagation()} />
+        </div>,
+      );
+
+      fireEvent.click(screen.getByTestId('checkbox'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(0);
+      expect(screen.getByTestId('checkbox')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('does not propagate to ancestors when stopPropagation() is called with a native button', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <div onClick={handleParentClick}>
+          <Checkbox.Root
+            nativeButton
+            render={<button />}
+            data-testid="checkbox"
+            onClick={(event) => event.stopPropagation()}
+          />
+        </div>,
+      );
+
+      fireEvent.click(screen.getByTestId('checkbox'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(0);
+      expect(screen.getByTestId('checkbox')).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+
   describe('interactions', () => {
     it('should change its state when clicked', async () => {
       await render(<Checkbox.Root />);

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -264,6 +264,11 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
           setGroupValue(nextGroupValue, details);
         }
       },
+      onClick(event) {
+        // The click dispatched from the root's `onClick` is an implementation detail
+        // and must not reach ancestors, which already receive the original click.
+        event.stopPropagation();
+      },
       onFocus() {
         controlRef.current?.focus();
       },

--- a/packages/react/src/radio/root/RadioRoot.test.tsx
+++ b/packages/react/src/radio/root/RadioRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Radio } from '@base-ui/react/radio';
 import { RadioGroup } from '@base-ui/react/radio-group';
@@ -116,6 +116,64 @@ describe('<Radio.Root />', () => {
       expect(labelB.id).not.toBe('');
       expect(labelA.id).not.toBe(labelB.id);
       expect(radio).toHaveAttribute('aria-labelledby', labelB.id);
+    });
+  });
+
+  describe('prop: onClick', () => {
+    it('propagates a single click event to ancestors per user click', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <RadioGroup>
+          <div onClick={handleParentClick}>
+            <Radio.Root value="a" data-testid="radio" />
+          </div>
+        </RadioGroup>,
+      );
+
+      fireEvent.click(screen.getByTestId('radio'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('radio')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('does not propagate to ancestors when stopPropagation() is called', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <RadioGroup>
+          <div onClick={handleParentClick}>
+            <Radio.Root
+              value="a"
+              data-testid="radio"
+              onClick={(event) => event.stopPropagation()}
+            />
+          </div>
+        </RadioGroup>,
+      );
+
+      fireEvent.click(screen.getByTestId('radio'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(0);
+      expect(screen.getByTestId('radio')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('does not propagate a click to ancestors when selecting with arrow keys', async () => {
+      const handleParentClick = vi.fn();
+      const { user } = await render(
+        <div onClick={handleParentClick}>
+          <RadioGroup defaultValue="a">
+            <Radio.Root value="a" data-testid="radio-a" />
+            <Radio.Root value="b" data-testid="radio-b" />
+          </RadioGroup>
+        </div>,
+      );
+
+      await user.click(screen.getByTestId('radio-a'));
+      handleParentClick.mockClear();
+
+      await user.keyboard('{ArrowDown}');
+
+      expect(screen.getByTestId('radio-b')).toHaveAttribute('aria-checked', 'true');
+      expect(handleParentClick).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/packages/react/src/radio/root/RadioRoot.test.tsx
+++ b/packages/react/src/radio/root/RadioRoot.test.tsx
@@ -156,6 +156,22 @@ describe('<Radio.Root />', () => {
       expect(screen.getByTestId('radio')).toHaveAttribute('aria-checked', 'true');
     });
 
+    it('propagates a single click event to ancestors with a native button', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <RadioGroup>
+          <div onClick={handleParentClick}>
+            <Radio.Root value="a" nativeButton render={<button />} data-testid="radio" />
+          </div>
+        </RadioGroup>,
+      );
+
+      fireEvent.click(screen.getByTestId('radio'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('radio')).toHaveAttribute('aria-checked', 'true');
+    });
+
     it('does not propagate to ancestors when stopPropagation() is called with a native button', async () => {
       const handleParentClick = vi.fn();
       await render(

--- a/packages/react/src/radio/root/RadioRoot.test.tsx
+++ b/packages/react/src/radio/root/RadioRoot.test.tsx
@@ -156,6 +156,28 @@ describe('<Radio.Root />', () => {
       expect(screen.getByTestId('radio')).toHaveAttribute('aria-checked', 'true');
     });
 
+    it('does not propagate to ancestors when stopPropagation() is called with a native button', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <RadioGroup>
+          <div onClick={handleParentClick}>
+            <Radio.Root
+              value="a"
+              nativeButton
+              render={<button />}
+              data-testid="radio"
+              onClick={(event) => event.stopPropagation()}
+            />
+          </div>
+        </RadioGroup>,
+      );
+
+      fireEvent.click(screen.getByTestId('radio'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(0);
+      expect(screen.getByTestId('radio')).toHaveAttribute('aria-checked', 'true');
+    });
+
     it('does not propagate a click to ancestors when selecting with arrow keys', async () => {
       const handleParentClick = vi.fn();
       const { user } = await render(

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -221,6 +221,11 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
 
       setFieldTouched(true);
     },
+    onClick(event) {
+      // Clicks dispatched on the input from the root's `onClick` and `onFocus` are an
+      // implementation detail and must not reach ancestors.
+      event.stopPropagation();
+    },
     onFocus() {
       radioRef.current?.focus();
     },

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -253,6 +253,20 @@ describe('<Switch.Root />', () => {
       expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
     });
 
+    it('propagates a single click event to ancestors with a native button', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <div onClick={handleParentClick}>
+          <Switch.Root nativeButton render={<button />} />
+        </div>,
+      );
+
+      fireEvent.click(screen.getByRole('switch'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+    });
+
     it('does not propagate to ancestors when stopPropagation() is called with a native button', async () => {
       const handleParentClick = vi.fn();
       await render(

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -252,6 +252,24 @@ describe('<Switch.Root />', () => {
       expect(handleParentClick).toHaveBeenCalledTimes(0);
       expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
     });
+
+    it('does not propagate to ancestors when stopPropagation() is called with a native button', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <div onClick={handleParentClick}>
+          <Switch.Root
+            nativeButton
+            render={<button />}
+            onClick={(event) => event.stopPropagation()}
+          />
+        </div>,
+      );
+
+      fireEvent.click(screen.getByRole('switch'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(0);
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+    });
   });
 
   describe('prop: disabled', () => {

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -224,6 +224,34 @@ describe('<Switch.Root />', () => {
 
       expect(handleClick.mock.calls.length).toBe(1);
     });
+
+    it('propagates a single click event to ancestors per user click', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <div onClick={handleParentClick}>
+          <Switch.Root />
+        </div>,
+      );
+
+      fireEvent.click(screen.getByRole('switch'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('does not propagate to ancestors when stopPropagation() is called', async () => {
+      const handleParentClick = vi.fn();
+      await render(
+        <div onClick={handleParentClick}>
+          <Switch.Root onClick={(event) => event.stopPropagation()} />
+        </div>,
+      );
+
+      fireEvent.click(screen.getByRole('switch'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(0);
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+    });
   });
 
   describe('prop: disabled', () => {

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -207,6 +207,11 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
 
         setCheckedState(nextChecked);
       },
+      onClick(event) {
+        // The click dispatched from the root's `onClick` is an implementation detail
+        // and must not reach ancestors, which already receive the original click.
+        event.stopPropagation();
+      },
       onFocus() {
         switchRef.current?.focus();
       },


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #5175

Checkbox, Switch, and Radio re-dispatch a bubbling `click` on the hidden `<input>` so React's `onChange` fires there. That internal click also reached ancestors: `stopPropagation()` in `onClick` appeared to do nothing, and without it ancestors received two clicks per user click. Radio additionally leaked a click on arrow-key selection (`input.click()` in `onFocus`).

Fix: stop the internal click's propagation at the hidden input. Ancestors now receive exactly one click, targeting the root, with standard `stopPropagation()` semantics. The click still reaches the React root, so `onChange` keeps firing (which rules out a non-bubbling dispatch as in Radix's fix for the same bug).
