### PR TITLE
[menu] Fix duplicate onOpenChange calls when closing a submenu

### DIFF
--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -817,6 +817,50 @@ describe('<Menu.Root />', () => {
       });
 
       it.skipIf(isJSDOM)(
+        'calls onOpenChange with false exactly once per menu when a submenu item is clicked',
+        async () => {
+          const rootOnOpenChange = vi.fn();
+          const submenuOnOpenChange = vi.fn();
+
+          const { user } = await render(
+            <TestMenu
+              rootProps={{ onOpenChange: rootOnOpenChange }}
+              submenuProps={{ onOpenChange: submenuOnOpenChange }}
+              submenuTriggerProps={{ delay: 0 }}
+            />,
+          );
+
+          await user.click(screen.getByRole('button', { name: 'Toggle' }));
+          await screen.findByTestId('menu');
+
+          const submenuTrigger = await screen.findByTestId('submenu-trigger');
+          await user.hover(submenuTrigger);
+
+          await waitFor(() => {
+            expect(screen.queryByTestId('submenu')).not.toBe(null);
+          });
+
+          // Click the item directly. Moving the pointer to it teleports it out of the
+          // submenu trigger, closing the submenu before the click could land.
+          fireEvent.click(screen.getByTestId('item-4_1'));
+
+          await waitFor(() => {
+            expect(screen.queryByTestId('menu')).toBe(null);
+          });
+
+          // Wait out pending hover close timers; they must not refire a close.
+          await wait(100);
+
+          const rootCloseCalls = rootOnOpenChange.mock.calls.filter((args) => args[0] === false);
+          const submenuCloseCalls = submenuOnOpenChange.mock.calls.filter(
+            (args) => args[0] === false,
+          );
+          expect(rootCloseCalls.length).toBe(1);
+          expect(submenuCloseCalls.length).toBe(1);
+        },
+      );
+
+      it.skipIf(isJSDOM)(
         'returns focus to submenu triggers when closing nested menus',
         async () => {
           const { user } = await render(<TestMenu />);

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -826,7 +826,7 @@ describe('<Menu.Root />', () => {
             <TestMenu
               rootProps={{ onOpenChange: rootOnOpenChange }}
               submenuProps={{ onOpenChange: submenuOnOpenChange }}
-              submenuTriggerProps={{ delay: 0 }}
+              submenuTriggerProps={{ delay: 0, closeDelay: 50 }}
             />,
           );
 
@@ -840,8 +840,8 @@ describe('<Menu.Root />', () => {
             expect(screen.queryByTestId('submenu')).not.toBe(null);
           });
 
-          // Click the item directly. Moving the pointer to it teleports it out of the
-          // submenu trigger, closing the submenu before the click could land.
+          // Schedule a delayed hover close, then click the item before it fires.
+          fireEvent.mouseLeave(submenuTrigger);
           fireEvent.click(screen.getByTestId('item-4_1'));
 
           await waitFor(() => {
@@ -855,8 +855,12 @@ describe('<Menu.Root />', () => {
           const submenuCloseCalls = submenuOnOpenChange.mock.calls.filter(
             (args) => args[0] === false,
           );
+          const staleHoverCloseCalls = submenuCloseCalls.filter(
+            (args) => args[1].reason === REASONS.triggerHover,
+          );
           expect(rootCloseCalls.length).toBe(1);
           expect(submenuCloseCalls.length).toBe(1);
+          expect(staleHoverCloseCalls.length).toBe(0);
         },
       );
 

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -229,6 +229,12 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     ) => {
       const reason = eventDetails.reason;
 
+      // Read the store directly, as relayed tree events and stale hover timers can request
+      // a close after the state changed but before this component re-rendered.
+      if (!nextOpen && !store.select('open')) {
+        return;
+      }
+
       if (
         open === nextOpen &&
         eventDetails.trigger === activeTriggerElement &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

When a submenu item is clicked, the submenu's `onOpenChange(false)` currently fires three times for a single close (reproducible on published 1.6.0 and master with trusted pointer input):

1. The legit close from the tree-wide `close` event emitted by the item press.
2. A duplicate: when the root closes, the child's `onParentClose` relay in `MenuPositioner` closes the already-closed submenu again. The redundancy guard in `setOpen` doesn't catch it because the relayed event arrives in the same tick as the first close (the render-closure `open` is still `true`), and its `trigger` is compared against `activeTriggerElement` before the trigger normalization runs.
3. A stale `trigger-hover` close from a pending hover timer, which passes the guard because its reason differs from the last one.

## Fix

`setOpen` now ignores a close request when the menu is already closed, reading the synchronous store state (`store.select('open')`) rather than the render closure so same-tick relays are caught too. Since the `open` selector resolves to `openProp ?? state.open`, a controlled menu whose owner rejects a close keeps receiving close events, and the intentional same-open refire used for detached-trigger switching is unaffected (the guard only applies when the next state is closed).

The regression test asserts each of the root's and submenu's `onOpenChange` receives exactly one `false` call in the nested item-click scenario; it fails 2/2 (contained + detached triggers) without the fix. The item click is dispatched with `fireEvent` because the synthetic pointer teleport of `user.click` closes the submenu via hover before the click lands.
