### PR TITLE
[drawer] Fix scroll handling when focus moves while the virtual keyboard is open

### DIFF
--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
@@ -1528,6 +1528,760 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
   );
 
   it.skipIf(isJSDOM)(
+    'overrides the incoming field geometry when focus moves without a tap while the keyboard is open',
+    async () => {
+      const restoreInnerHeight = mockWindowInnerHeight(800);
+      const visualViewport = mockVisualViewport(800);
+
+      try {
+        await render(
+          <Drawer.Root open modal={false}>
+            <Drawer.VirtualKeyboardProvider>
+              <Drawer.Portal>
+                <Drawer.Viewport>
+                  <Drawer.Popup>
+                    <input data-testid="first" type="text" />
+                    <input data-testid="second" type="text" />
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.VirtualKeyboardProvider>
+          </Drawer.Root>,
+        );
+
+        const first = screen.getByTestId('first');
+        const second = screen.getByTestId('second');
+
+        await act(async () => {
+          first.focus();
+          visualViewport.resize(500);
+        });
+
+        // The provider's capture-phase focusout listener runs before this bubble-phase one,
+        // so the geometry override must already be applied when it fires.
+        let transformDuringFocusChange: string | null = null;
+        const onFocusOut = () => {
+          transformDuringFocusChange = second.style.transform;
+        };
+        document.addEventListener('focusout', onFocusOut);
+        const blurSpy = vi.spyOn(second, 'blur');
+
+        try {
+          // Simulates the iOS keyboard's next-field arrow: focus moves with no touch events.
+          await act(async () => {
+            second.focus();
+          });
+
+          expect(transformDuringFocusChange).toContain('translateY');
+          expect(second.style.transform).toBe('');
+          expect(second.style.opacity).toBe('');
+          expect(blurSpy).not.toHaveBeenCalled();
+          expect(second).toHaveFocus();
+        } finally {
+          document.removeEventListener('focusout', onFocusOut);
+          blurSpy.mockRestore();
+        }
+      } finally {
+        visualViewport.restore();
+        restoreInnerHeight();
+      }
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    'centers a field focused without a tap inside the scrollable body',
+    async () => {
+      const restoreInnerHeight = mockWindowInnerHeight(800);
+      const visualViewport = mockVisualViewport(800);
+
+      try {
+        await render(
+          <Drawer.Root open modal={false}>
+            <Drawer.VirtualKeyboardProvider>
+              <Drawer.Portal>
+                <Drawer.Viewport>
+                  <Drawer.Popup>
+                    <Drawer.Content
+                      data-testid="scroll"
+                      style={{ height: 420, overflowY: 'auto', paddingBottom: 20 }}
+                    >
+                      <input data-testid="first" type="text" />
+                      <div style={{ height: 900 }} />
+                      <input data-testid="second" type="text" />
+                    </Drawer.Content>
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.VirtualKeyboardProvider>
+          </Drawer.Root>,
+        );
+
+        const scroll = screen.getByTestId('scroll');
+        const first = screen.getByTestId('first');
+        const second = screen.getByTestId('second');
+
+        Object.defineProperties(scroll, {
+          clientHeight: { configurable: true, value: 420 },
+          scrollHeight: { configurable: true, value: 1200 },
+        });
+        scroll.getBoundingClientRect = () =>
+          ({
+            top: 300,
+            bottom: 720,
+            height: 420,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: 300,
+            toJSON: () => {},
+          }) as DOMRect;
+        // `first` sits at the center of the visible band above the keyboard, so the
+        // initial alignment leaves the scroll position at 0.
+        first.getBoundingClientRect = () => {
+          const top = 380 - scroll.scrollTop;
+          return {
+            top,
+            bottom: top + 40,
+            height: 40,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: top,
+            toJSON: () => {},
+          } as DOMRect;
+        };
+        second.getBoundingClientRect = () => {
+          const top = 650 - scroll.scrollTop;
+          return {
+            top,
+            bottom: top + 40,
+            height: 40,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: top,
+            toJSON: () => {},
+          } as DOMRect;
+        };
+        scroll.scrollTo = ((options?: ScrollToOptions | number) => {
+          if (typeof options === 'object' && options !== null && options.top !== undefined) {
+            scroll.scrollTop = options.top;
+          }
+        }) as typeof scroll.scrollTo;
+
+        const keyboardViewportHeight = 500;
+        await act(async () => {
+          first.focus();
+          scroll.scrollTop = 0;
+          visualViewport.resize(keyboardViewportHeight);
+        });
+
+        // Simulates the iOS keyboard's next-field arrow: focus moves with no touch events.
+        await act(async () => {
+          second.focus();
+        });
+
+        await waitFor(() => {
+          const scrollRect = scroll.getBoundingClientRect();
+          const secondRect = second.getBoundingClientRect();
+          const secondCenter = (secondRect.top + secondRect.bottom) / 2;
+          const visibleCenter = (scrollRect.top + keyboardViewportHeight) / 2;
+          expect(secondCenter).toBeCloseTo(visibleCenter, 0);
+        });
+      } finally {
+        visualViewport.restore();
+        restoreInnerHeight();
+      }
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    'does not restart a settled alignment scroll on the delayed realign passes',
+    async () => {
+      const restoreInnerHeight = mockWindowInnerHeight(800);
+      const visualViewport = mockVisualViewport(800);
+
+      try {
+        await render(
+          <Drawer.Root open modal={false}>
+            <Drawer.VirtualKeyboardProvider>
+              <Drawer.Portal>
+                <Drawer.Viewport>
+                  <Drawer.Popup>
+                    <Drawer.Content
+                      data-testid="scroll"
+                      style={{ height: 420, overflowY: 'auto', paddingBottom: 20 }}
+                    >
+                      <input data-testid="first" type="text" />
+                      <div style={{ height: 900 }} />
+                      <input data-testid="second" type="text" />
+                    </Drawer.Content>
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.VirtualKeyboardProvider>
+          </Drawer.Root>,
+        );
+
+        const scroll = screen.getByTestId('scroll');
+        const first = screen.getByTestId('first');
+        const second = screen.getByTestId('second');
+
+        Object.defineProperties(scroll, {
+          clientHeight: { configurable: true, value: 420 },
+          scrollHeight: { configurable: true, value: 1200 },
+        });
+        scroll.getBoundingClientRect = () =>
+          ({
+            top: 300,
+            bottom: 720,
+            height: 420,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: 300,
+            toJSON: () => {},
+          }) as DOMRect;
+        first.getBoundingClientRect = () => {
+          const top = 380 - scroll.scrollTop;
+          return {
+            top,
+            bottom: top + 40,
+            height: 40,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: top,
+            toJSON: () => {},
+          } as DOMRect;
+        };
+        second.getBoundingClientRect = () => {
+          const top = 650 - scroll.scrollTop;
+          return {
+            top,
+            bottom: top + 40,
+            height: 40,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: top,
+            toJSON: () => {},
+          } as DOMRect;
+        };
+        // The mock arrives instantly, standing in for a healthy smooth scroll: later
+        // realign passes must observe it at the destination and stay inert.
+        const scrollToSpy = vi.fn((options?: ScrollToOptions | number) => {
+          if (typeof options === 'object' && options !== null && options.top !== undefined) {
+            scroll.scrollTop = options.top;
+          }
+        });
+        scroll.scrollTo = scrollToSpy as unknown as typeof scroll.scrollTo;
+
+        await act(async () => {
+          first.focus();
+          visualViewport.resize(500);
+        });
+
+        scrollToSpy.mockClear();
+
+        await act(async () => {
+          second.focus();
+        });
+
+        await waitFor(() => {
+          expect(scroll.scrollTop).toBe(270);
+        });
+
+        // Wait out all delayed realign passes (4 × 150ms).
+        await act(async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 750);
+          });
+        });
+
+        expect(scrollToSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        visualViewport.restore();
+        restoreInnerHeight();
+      }
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    're-issues the alignment scroll when a delayed realign pass finds it stalled',
+    async () => {
+      const restoreInnerHeight = mockWindowInnerHeight(800);
+      const visualViewport = mockVisualViewport(800);
+
+      try {
+        await render(
+          <Drawer.Root open modal={false}>
+            <Drawer.VirtualKeyboardProvider>
+              <Drawer.Portal>
+                <Drawer.Viewport>
+                  <Drawer.Popup>
+                    <Drawer.Content
+                      data-testid="scroll"
+                      style={{ height: 420, overflowY: 'auto', paddingBottom: 20 }}
+                    >
+                      <input data-testid="first" type="text" />
+                      <div style={{ height: 900 }} />
+                      <input data-testid="second" type="text" />
+                    </Drawer.Content>
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.VirtualKeyboardProvider>
+          </Drawer.Root>,
+        );
+
+        const scroll = screen.getByTestId('scroll');
+        const first = screen.getByTestId('first');
+        const second = screen.getByTestId('second');
+
+        Object.defineProperties(scroll, {
+          clientHeight: { configurable: true, value: 420 },
+          scrollHeight: { configurable: true, value: 1200 },
+        });
+        scroll.getBoundingClientRect = () =>
+          ({
+            top: 300,
+            bottom: 720,
+            height: 420,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: 300,
+            toJSON: () => {},
+          }) as DOMRect;
+        first.getBoundingClientRect = () => {
+          const top = 380 - scroll.scrollTop;
+          return {
+            top,
+            bottom: top + 40,
+            height: 40,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: top,
+            toJSON: () => {},
+          } as DOMRect;
+        };
+        second.getBoundingClientRect = () => {
+          const top = 650 - scroll.scrollTop;
+          return {
+            top,
+            bottom: top + 40,
+            height: 40,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: top,
+            toJSON: () => {},
+          } as DOMRect;
+        };
+        // The mock never moves, standing in for a smooth scroll canceled by WebKit's
+        // native reveal resolution: a later realign pass must re-issue it.
+        const scrollToSpy = vi.fn();
+        scroll.scrollTo = scrollToSpy as unknown as typeof scroll.scrollTo;
+
+        await act(async () => {
+          first.focus();
+          visualViewport.resize(500);
+        });
+
+        scrollToSpy.mockClear();
+
+        await act(async () => {
+          second.focus();
+        });
+
+        await waitFor(() => {
+          expect(scrollToSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+        });
+        expect(scrollToSpy).toHaveBeenLastCalledWith(expect.objectContaining({ top: 270 }));
+      } finally {
+        visualViewport.restore();
+        restoreInnerHeight();
+      }
+    },
+  );
+
+  it.skipIf(isJSDOM)('defers the alignment scroll until the destination stops moving', async () => {
+    const restoreInnerHeight = mockWindowInnerHeight(800);
+    const visualViewport = mockVisualViewport(800);
+
+    try {
+      await render(
+        <Drawer.Root open modal={false}>
+          <Drawer.VirtualKeyboardProvider>
+            <Drawer.Portal>
+              <Drawer.Viewport>
+                <Drawer.Popup>
+                  <Drawer.Content data-testid="scroll" style={{ height: 420, overflowY: 'auto' }}>
+                    <div style={{ height: 900 }} />
+                    <input data-testid="input" type="text" />
+                  </Drawer.Content>
+                </Drawer.Popup>
+              </Drawer.Viewport>
+            </Drawer.Portal>
+          </Drawer.VirtualKeyboardProvider>
+        </Drawer.Root>,
+      );
+
+      const scroll = screen.getByTestId('scroll');
+      const input = screen.getByTestId('input');
+
+      Object.defineProperties(scroll, {
+        clientHeight: { configurable: true, value: 420 },
+        scrollHeight: { configurable: true, value: 1200 },
+      });
+      // The scroller's bottom edge moves after focus (like a footer resizing over a
+      // CSS transition): squeezed at first, settled a frame later.
+      let scrollBottom = 380;
+      scroll.getBoundingClientRect = () =>
+        ({
+          top: 300,
+          bottom: scrollBottom,
+          height: scrollBottom - 300,
+          left: 0,
+          right: 320,
+          width: 320,
+          x: 0,
+          y: 300,
+          toJSON: () => {},
+        }) as DOMRect;
+      input.getBoundingClientRect = () => {
+        const top = 650 - scroll.scrollTop;
+        return {
+          top,
+          bottom: top + 40,
+          height: 40,
+          left: 0,
+          right: 320,
+          width: 320,
+          x: 0,
+          y: top,
+          toJSON: () => {},
+        } as DOMRect;
+      };
+      const scrollToSpy = vi.fn((options?: ScrollToOptions | number) => {
+        if (typeof options === 'object' && options !== null && options.top !== undefined) {
+          scroll.scrollTop = options.top;
+        }
+      });
+      scroll.scrollTo = scrollToSpy as unknown as typeof scroll.scrollTo;
+
+      await act(async () => {
+        visualViewport.resize(500);
+      });
+
+      await act(async () => {
+        input.focus();
+      });
+
+      // Let the first alignment check measure the squeezed geometry, then settle it.
+      await act(async () => {
+        await new Promise((resolve) => {
+          requestAnimationFrame(() => resolve(undefined));
+        });
+        scrollBottom = 480;
+      });
+
+      // Squeezed destination: visible band [316, 364] → center 340, input center 670
+      // → scrollTop 330. Settled: band [316, 464] → center 390 → scrollTop 280. The
+      // squeezed destination must never be scrolled to.
+      await waitFor(() => {
+        expect(scroll.scrollTop).toBe(280);
+      });
+      expect(scrollToSpy).toHaveBeenCalledTimes(1);
+      expect(scrollToSpy).not.toHaveBeenCalledWith(expect.objectContaining({ top: 330 }));
+    } finally {
+      visualViewport.restore();
+      restoreInnerHeight();
+    }
+  });
+
+  it.skipIf(isJSDOM)(
+    'realigns a tapped field in the scrollable body when the keyboard is already open for a field outside it',
+    async () => {
+      const restoreInnerHeight = mockWindowInnerHeight(800);
+      const visualViewport = mockVisualViewport(800);
+
+      try {
+        await render(
+          <Drawer.Root open modal={false}>
+            <Drawer.VirtualKeyboardProvider>
+              <Drawer.Portal>
+                <Drawer.Viewport>
+                  <Drawer.Popup>
+                    <Drawer.Content data-testid="scroll" style={{ height: 420, overflowY: 'auto' }}>
+                      <div style={{ height: 900 }} />
+                      <textarea data-testid="textarea" />
+                    </Drawer.Content>
+                    <div>
+                      <input data-testid="footer-input" type="text" />
+                    </div>
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.VirtualKeyboardProvider>
+          </Drawer.Root>,
+        );
+
+        const scroll = screen.getByTestId('scroll');
+        const textarea = screen.getByTestId('textarea');
+        const footerInput = screen.getByTestId('footer-input');
+
+        Object.defineProperties(scroll, {
+          clientHeight: { configurable: true, value: 420 },
+          scrollHeight: { configurable: true, value: 1200 },
+        });
+        // The scroller is squeezed while the footer field holds focus (the demo footer
+        // grows by the keyboard inset via `:focus-within`); it expands back over a CSS
+        // transition once focus moves into the body.
+        let scrollBottom = 380;
+        scroll.getBoundingClientRect = () =>
+          ({
+            top: 100,
+            bottom: scrollBottom,
+            height: scrollBottom - 100,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: 100,
+            toJSON: () => {},
+          }) as DOMRect;
+        textarea.getBoundingClientRect = () => {
+          const top = 650 - scroll.scrollTop;
+          return {
+            top,
+            bottom: top + 40,
+            height: 40,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: top,
+            toJSON: () => {},
+          } as DOMRect;
+        };
+        scroll.scrollTo = ((options?: ScrollToOptions | number) => {
+          if (typeof options === 'object' && options !== null && options.top !== undefined) {
+            scroll.scrollTop = options.top;
+          }
+        }) as typeof scroll.scrollTo;
+
+        const keyboardViewportHeight = 500;
+        await act(async () => {
+          footerInput.focus();
+          visualViewport.resize(keyboardViewportHeight);
+        });
+
+        const originalElementFromPoint = document.elementFromPoint;
+        document.elementFromPoint = () => textarea;
+
+        try {
+          fireEvent.touchStart(textarea, {
+            touches: [createTouch(textarea, { clientX: 24, clientY: 300 })],
+          });
+
+          await act(async () => {
+            textarea.dispatchEvent(createNativeTouchEnd(textarea, { clientX: 24, clientY: 300 }));
+            await flushMicrotasks();
+          });
+
+          expect(textarea).toHaveFocus();
+
+          // The frame-scheduled pass centers against the squeezed geometry:
+          // visible band [116, 364] → center 240, textarea center 670 → scrollTop 430.
+          await waitFor(() => {
+            expect(scroll.scrollTop).toBe(430);
+          });
+
+          // The footer's shrink transition settles; only the delayed realign passes see
+          // the expanded scroller (the keyboard stays open, so no viewport events fire).
+          scrollBottom = 480;
+
+          await waitFor(() => {
+            const scrollRect = scroll.getBoundingClientRect();
+            const textareaRect = textarea.getBoundingClientRect();
+            const textareaCenter = (textareaRect.top + textareaRect.bottom) / 2;
+            const visibleCenter =
+              (scrollRect.top + Math.min(scrollRect.bottom, keyboardViewportHeight)) / 2;
+            expect(textareaCenter).toBeCloseTo(visibleCenter, 0);
+          });
+        } finally {
+          document.elementFromPoint = originalElementFromPoint;
+        }
+      } finally {
+        visualViewport.restore();
+        restoreInnerHeight();
+      }
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    'does not blur and re-focus for focus changes while the keyboard is closed',
+    async () => {
+      const restoreInnerHeight = mockWindowInnerHeight(800);
+      const visualViewport = mockVisualViewport(800);
+
+      try {
+        await render(
+          <Drawer.Root open modal={false}>
+            <Drawer.VirtualKeyboardProvider>
+              <Drawer.Portal>
+                <Drawer.Viewport>
+                  <Drawer.Popup>
+                    <input data-testid="first" type="text" />
+                    <input data-testid="second" type="text" />
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.VirtualKeyboardProvider>
+          </Drawer.Root>,
+        );
+
+        const first = screen.getByTestId('first');
+        const second = screen.getByTestId('second');
+
+        await act(async () => {
+          first.focus();
+        });
+
+        const blurSpy = vi.spyOn(second, 'blur');
+        const focusSpy = vi.spyOn(second, 'focus');
+
+        try {
+          await act(async () => {
+            second.focus();
+          });
+
+          expect(blurSpy).not.toHaveBeenCalled();
+          expect(focusSpy).toHaveBeenCalledTimes(1);
+          expect(second).toHaveFocus();
+        } finally {
+          blurSpy.mockRestore();
+          focusSpy.mockRestore();
+        }
+      } finally {
+        visualViewport.restore();
+        restoreInnerHeight();
+      }
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    'restores the page scroll position when a modal drawer page scrolls while the keyboard is open',
+    async () => {
+      const restoreInnerHeight = mockWindowInnerHeight(800);
+      const visualViewport = mockVisualViewport(800);
+      const originalScrollYDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollY');
+
+      try {
+        await render(
+          <Drawer.Root open>
+            <Drawer.VirtualKeyboardProvider>
+              <Drawer.Portal>
+                <Drawer.Viewport>
+                  <Drawer.Popup>
+                    <input data-testid="input" type="text" />
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.VirtualKeyboardProvider>
+          </Drawer.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+
+        await act(async () => {
+          input.focus();
+          visualViewport.resize(500);
+        });
+
+        const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+        try {
+          // Simulates WebKit's native reveal scroll escaping the scroll lock.
+          Object.defineProperty(window, 'scrollY', { configurable: true, value: 120 });
+          window.dispatchEvent(new Event('scroll'));
+
+          expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+        } finally {
+          scrollToSpy.mockRestore();
+          if (originalScrollYDescriptor) {
+            Object.defineProperty(window, 'scrollY', originalScrollYDescriptor);
+          }
+        }
+      } finally {
+        visualViewport.restore();
+        restoreInnerHeight();
+      }
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    'does not restore the page scroll position for a non-modal drawer',
+    async () => {
+      const restoreInnerHeight = mockWindowInnerHeight(800);
+      const visualViewport = mockVisualViewport(800);
+      const originalScrollYDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollY');
+
+      try {
+        await render(
+          <Drawer.Root open modal={false}>
+            <Drawer.VirtualKeyboardProvider>
+              <Drawer.Portal>
+                <Drawer.Viewport>
+                  <Drawer.Popup>
+                    <input data-testid="input" type="text" />
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.VirtualKeyboardProvider>
+          </Drawer.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+
+        await act(async () => {
+          input.focus();
+          visualViewport.resize(500);
+        });
+
+        const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+        try {
+          Object.defineProperty(window, 'scrollY', { configurable: true, value: 120 });
+          window.dispatchEvent(new Event('scroll'));
+
+          expect(scrollToSpy).not.toHaveBeenCalled();
+        } finally {
+          scrollToSpy.mockRestore();
+          if (originalScrollYDescriptor) {
+            Object.defineProperty(window, 'scrollY', originalScrollYDescriptor);
+          }
+        }
+      } finally {
+        visualViewport.restore();
+        restoreInnerHeight();
+      }
+    },
+  );
+
+  it.skipIf(isJSDOM)(
     'does not treat a small visual viewport reduction as the software keyboard',
     async () => {
       const restoreInnerHeight = mockWindowInnerHeight(800);

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
@@ -1916,6 +1916,188 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
     },
   );
 
+  it.skipIf(isJSDOM)(
+    'stops the delayed realign passes once the user starts scrolling',
+    async () => {
+      const restoreInnerHeight = mockWindowInnerHeight(800);
+      const visualViewport = mockVisualViewport(800);
+
+      try {
+        await render(
+          <Drawer.Root open modal={false}>
+            <Drawer.VirtualKeyboardProvider>
+              <Drawer.Portal>
+                <Drawer.Viewport>
+                  <Drawer.Popup>
+                    <Drawer.Content
+                      data-testid="scroll"
+                      style={{ height: 420, overflowY: 'auto', paddingBottom: 20 }}
+                    >
+                      <input data-testid="first" type="text" />
+                      <div style={{ height: 900 }} />
+                      <input data-testid="second" type="text" />
+                    </Drawer.Content>
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.VirtualKeyboardProvider>
+          </Drawer.Root>,
+        );
+
+        const scroll = screen.getByTestId('scroll');
+        const first = screen.getByTestId('first');
+        const second = screen.getByTestId('second');
+
+        Object.defineProperties(scroll, {
+          clientHeight: { configurable: true, value: 420 },
+          scrollHeight: { configurable: true, value: 1200 },
+        });
+        scroll.getBoundingClientRect = () =>
+          ({
+            top: 300,
+            bottom: 720,
+            height: 420,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: 300,
+            toJSON: () => {},
+          }) as DOMRect;
+        first.getBoundingClientRect = () => {
+          const top = 380 - scroll.scrollTop;
+          return {
+            top,
+            bottom: top + 40,
+            height: 40,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: top,
+            toJSON: () => {},
+          } as DOMRect;
+        };
+        second.getBoundingClientRect = () => {
+          const top = 650 - scroll.scrollTop;
+          return {
+            top,
+            bottom: top + 40,
+            height: 40,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: top,
+            toJSON: () => {},
+          } as DOMRect;
+        };
+        // The mock never moves, standing in for a smooth scroll canceled by WebKit's native
+        // reveal resolution — the exact stall a delayed pass would re-issue. A user scroll
+        // stops at a stationary position the same way, so a pointer going down must cancel the
+        // passes rather than let one mistake the manual scroll for a canceled reveal and yank
+        // the drawer back to center.
+        const scrollToSpy = vi.fn();
+        scroll.scrollTo = scrollToSpy as unknown as typeof scroll.scrollTo;
+
+        await act(async () => {
+          first.focus();
+          visualViewport.resize(500);
+        });
+
+        scrollToSpy.mockClear();
+
+        await act(async () => {
+          second.focus();
+          // The user immediately puts a finger down on the drawer body to scroll it.
+          scroll.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+        });
+
+        // Wait out all delayed realign passes (4 × 150ms).
+        await act(async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 750);
+          });
+        });
+
+        // Only the initial alignment scroll was issued; the passes stayed cancelled.
+        expect(scrollToSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        visualViewport.restore();
+        restoreInnerHeight();
+      }
+    },
+  );
+
+  it.skipIf(isJSDOM)('clears keyboard state when a tapped input redirects focus away', async () => {
+    const restoreInnerHeight = mockWindowInnerHeight(800);
+    const visualViewport = mockVisualViewport(500);
+
+    try {
+      await render(
+        <Drawer.Root open modal={false}>
+          <Drawer.VirtualKeyboardProvider>
+            <Drawer.Portal>
+              <Drawer.Viewport data-testid="viewport">
+                <Drawer.Popup>
+                  <input data-testid="input" type="text" />
+                  <button data-testid="other" type="button" />
+                </Drawer.Popup>
+              </Drawer.Viewport>
+            </Drawer.Portal>
+          </Drawer.VirtualKeyboardProvider>
+        </Drawer.Root>,
+      );
+
+      const viewport = screen.getByTestId('viewport');
+      const input = screen.getByTestId('input');
+      const other = screen.getByTestId('other');
+
+      // A consumer redirects focus off the field the moment it focuses (validation,
+      // auto-advance, composite focus). Listening on `focusin` at the target matches React's
+      // `onFocus`: it runs after the provider's capture-phase `focusin` has already recorded
+      // the input, so the provider must reconcile when focus lands on a non-keyboard element.
+      input.addEventListener('focusin', () => {
+        other.focus();
+      });
+
+      const originalElementFromPoint = document.elementFromPoint;
+      document.elementFromPoint = () => input;
+
+      try {
+        fireEvent.touchStart(input, {
+          touches: [createTouch(input, { clientX: 12, clientY: 34 })],
+        });
+
+        const touchEnd = createNativeTouchEnd(input, { clientX: 12, clientY: 34 });
+        await act(async () => {
+          input.dispatchEvent(touchEnd);
+          await flushMicrotasks();
+        });
+
+        expect(other).toHaveFocus();
+
+        // Wait past any alignment frame and delayed realign passes that a stale target would
+        // have kept alive.
+        await act(async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 300);
+          });
+        });
+
+        // Focus stays on the redirected element and the drawer left no keyboard inset
+        // behind for the abandoned input.
+        expect(other).toHaveFocus();
+        expect(viewport.style.getPropertyValue('--drawer-keyboard-inset')).toBe('0px');
+      } finally {
+        document.elementFromPoint = originalElementFromPoint;
+      }
+    } finally {
+      visualViewport.restore();
+      restoreInnerHeight();
+    }
+  });
+
   it.skipIf(isJSDOM)('defers the alignment scroll until the destination stops moving', async () => {
     const restoreInnerHeight = mockWindowInnerHeight(800);
     const visualViewport = mockVisualViewport(800);

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
@@ -1910,7 +1910,7 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
   );
 
   it.skipIf(isJSDOM)(
-    'stops the delayed realign passes once the user starts scrolling',
+    'stops pending realignment once the user starts scrolling while geometry is changing',
     async () => {
       const restoreInnerHeight = mockWindowInnerHeight(800);
       const visualViewport = mockVisualViewport(800);
@@ -1946,11 +1946,12 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
           clientHeight: { configurable: true, value: 420 },
           scrollHeight: { configurable: true, value: 1200 },
         });
+        let scrollBottom = 380;
         scroll.getBoundingClientRect = () =>
           ({
             top: 300,
-            bottom: 720,
-            height: 420,
+            bottom: scrollBottom,
+            height: scrollBottom - 300,
             left: 0,
             right: 320,
             width: 320,
@@ -2003,13 +2004,22 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
 
         await act(async () => {
           second.focus();
-          // The user immediately puts a finger down on the drawer body to scroll it.
+          // Let the first settle check observe the squeezed body before the user takes over.
+          vi.advanceTimersToNextFrame();
           scroll.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+
+          // The body continues expanding after pointer-down, then the destination settles.
+          // A live frame loop would eventually center the field against the final geometry.
+          for (const bottom of [400, 440, 480, 480]) {
+            scrollBottom = bottom;
+            vi.advanceTimersToNextFrame();
+          }
+
           await vi.runAllTimersAsync();
         });
 
-        // Only the initial alignment scroll was issued; the passes stayed cancelled.
-        expect(scrollToSpy).toHaveBeenCalledTimes(1);
+        // Pointer-down cancels both the pending frame alignment and delayed passes.
+        expect(scrollToSpy).not.toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
         visualViewport.restore();
@@ -2084,6 +2094,7 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
   it.skipIf(isJSDOM)('defers the alignment scroll until the destination stops moving', async () => {
     const restoreInnerHeight = mockWindowInnerHeight(800);
     const visualViewport = mockVisualViewport(800);
+    vi.useFakeTimers();
 
     try {
       await render(
@@ -2156,21 +2167,19 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
 
       // Let the first alignment check measure the squeezed geometry, then settle it.
       await act(async () => {
-        await new Promise((resolve) => {
-          requestAnimationFrame(() => resolve(undefined));
-        });
+        vi.advanceTimersToNextFrame();
         scrollBottom = 480;
+        await vi.runAllTimersAsync();
       });
 
       // Squeezed destination: visible band [316, 364] → center 340, input center 670
       // → scrollTop 330. Settled: band [316, 464] → center 390 → scrollTop 280. The
       // squeezed destination must never be scrolled to.
-      await waitFor(() => {
-        expect(scroll.scrollTop).toBe(280);
-      });
+      expect(scroll.scrollTop).toBe(280);
       expect(scrollToSpy).toHaveBeenCalledTimes(1);
       expect(scrollToSpy).not.toHaveBeenCalledWith(expect.objectContaining({ top: 330 }));
     } finally {
+      vi.useRealTimers();
       visualViewport.restore();
       restoreInnerHeight();
     }

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
@@ -1703,6 +1703,7 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
     async () => {
       const restoreInnerHeight = mockWindowInnerHeight(800);
       const visualViewport = mockVisualViewport(800);
+      vi.useFakeTimers();
 
       try {
         await render(
@@ -1792,21 +1793,13 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
 
         await act(async () => {
           second.focus();
+          await vi.runAllTimersAsync();
         });
 
-        await waitFor(() => {
-          expect(scroll.scrollTop).toBe(270);
-        });
-
-        // Wait out all delayed realign passes (4 × 150ms).
-        await act(async () => {
-          await new Promise((resolve) => {
-            setTimeout(resolve, 750);
-          });
-        });
-
+        expect(scroll.scrollTop).toBe(270);
         expect(scrollToSpy).toHaveBeenCalledTimes(1);
       } finally {
+        vi.useRealTimers();
         visualViewport.restore();
         restoreInnerHeight();
       }
@@ -1921,6 +1914,7 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
     async () => {
       const restoreInnerHeight = mockWindowInnerHeight(800);
       const visualViewport = mockVisualViewport(800);
+      vi.useFakeTimers();
 
       try {
         await render(
@@ -2011,18 +2005,13 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
           second.focus();
           // The user immediately puts a finger down on the drawer body to scroll it.
           scroll.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
-        });
-
-        // Wait out all delayed realign passes (4 × 150ms).
-        await act(async () => {
-          await new Promise((resolve) => {
-            setTimeout(resolve, 750);
-          });
+          await vi.runAllTimersAsync();
         });
 
         // Only the initial alignment scroll was issued; the passes stayed cancelled.
         expect(scrollToSpy).toHaveBeenCalledTimes(1);
       } finally {
+        vi.useRealTimers();
         visualViewport.restore();
         restoreInnerHeight();
       }
@@ -2032,6 +2021,7 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
   it.skipIf(isJSDOM)('clears keyboard state when a tapped input redirects focus away', async () => {
     const restoreInnerHeight = mockWindowInnerHeight(800);
     const visualViewport = mockVisualViewport(500);
+    vi.useFakeTimers();
 
     try {
       await render(
@@ -2073,18 +2063,10 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
         await act(async () => {
           input.dispatchEvent(touchEnd);
           await flushMicrotasks();
+          await vi.runAllTimersAsync();
         });
 
         expect(other).toHaveFocus();
-
-        // Wait past any alignment frame and delayed realign passes that a stale target would
-        // have kept alive.
-        await act(async () => {
-          await new Promise((resolve) => {
-            setTimeout(resolve, 300);
-          });
-        });
-
         // Focus stays on the redirected element and the drawer left no keyboard inset
         // behind for the abandoned input.
         expect(other).toHaveFocus();
@@ -2093,6 +2075,7 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
         document.elementFromPoint = originalElementFromPoint;
       }
     } finally {
+      vi.useRealTimers();
       visualViewport.restore();
       restoreInnerHeight();
     }

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
@@ -130,6 +130,15 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
     };
   }
 
+  async function flushAnimationFrames(count: number) {
+    for (let i = 0; i < count; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => {
+        requestAnimationFrame(resolve);
+      });
+    }
+  }
+
   it.skipIf(isJSDOM)(
     'adds scroll slack and centers the focused input while the visual viewport is reduced',
     async () => {
@@ -2076,7 +2085,6 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
           await vi.runAllTimersAsync();
         });
 
-        expect(other).toHaveFocus();
         // Focus stays on the redirected element and the drawer left no keyboard inset
         // behind for the abandoned input.
         expect(other).toHaveFocus();
@@ -2086,6 +2094,107 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
       }
     } finally {
       vi.useRealTimers();
+      visualViewport.restore();
+      restoreInnerHeight();
+    }
+  });
+
+  it.skipIf(isJSDOM)('clears keyboard state when a tapped input blurs itself', async () => {
+    const restoreInnerHeight = mockWindowInnerHeight(800);
+    const visualViewport = mockVisualViewport(500);
+
+    try {
+      await render(
+        <Drawer.Root open modal={false}>
+          <Drawer.VirtualKeyboardProvider>
+            <Drawer.Portal>
+              <Drawer.Viewport data-testid="viewport">
+                <Drawer.Popup>
+                  <Drawer.Content
+                    data-testid="scroll"
+                    style={{
+                      height: 420,
+                      overflowY: 'auto',
+                      overflowAnchor: 'auto',
+                      paddingBottom: 20,
+                    }}
+                  >
+                    <div style={{ height: 900 }} />
+                    <input data-testid="input" type="text" />
+                  </Drawer.Content>
+                </Drawer.Popup>
+              </Drawer.Viewport>
+            </Drawer.Portal>
+          </Drawer.VirtualKeyboardProvider>
+        </Drawer.Root>,
+      );
+
+      const viewport = screen.getByTestId('viewport');
+      const scroll = screen.getByTestId('scroll');
+      const input = screen.getByTestId('input');
+
+      Object.defineProperties(scroll, {
+        clientHeight: { configurable: true, value: 420 },
+        scrollHeight: { configurable: true, value: 1200 },
+      });
+      scroll.getBoundingClientRect = () =>
+        ({
+          top: 300,
+          bottom: 720,
+          height: 420,
+          left: 0,
+          right: 320,
+          width: 320,
+          x: 0,
+          y: 300,
+          toJSON: () => {},
+        }) as DOMRect;
+      input.getBoundingClientRect = () =>
+        ({
+          top: 650,
+          bottom: 690,
+          height: 40,
+          left: 0,
+          right: 320,
+          width: 320,
+          x: 0,
+          y: 650,
+          toJSON: () => {},
+        }) as DOMRect;
+
+      // A consumer that opens its own picker instead of the software keyboard blurs the field
+      // from `onFocus`. The `focusout` arrives before `.focus()` returns, and focus ends on the
+      // body, so no `focusin` follows to reconcile from: that `focusout` is the provider's only
+      // chance to drop the field. Focus does eventually return to the popup, but only on a
+      // later task, so a retained target keeps aligning against the blurred field until then.
+      input.addEventListener('focusin', () => {
+        input.blur();
+      });
+
+      const originalElementFromPoint = document.elementFromPoint;
+      document.elementFromPoint = () => input;
+
+      try {
+        fireEvent.touchStart(input, {
+          touches: [createTouch(input, { clientX: 12, clientY: 34 })],
+        });
+
+        const touchEnd = createNativeTouchEnd(input, { clientX: 12, clientY: 34 });
+        await act(async () => {
+          input.dispatchEvent(touchEnd);
+          // Let the frame-scheduled alignment run: it is what applies the inset and slack to a
+          // target the `focusout` failed to clear.
+          await flushAnimationFrames(3);
+        });
+
+        expect(input).not.toHaveFocus();
+        expect(viewport.style.getPropertyValue('--drawer-keyboard-inset')).toBe('0px');
+        expect(scroll.style.paddingBottom).toBe('20px');
+        expect(scroll.style.scrollPaddingBottom).toBe('');
+      } finally {
+        document.elementFromPoint = originalElementFromPoint;
+      }
+    } finally {
       visualViewport.restore();
       restoreInnerHeight();
     }

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
@@ -2218,7 +2218,9 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
           Object.defineProperty(window, 'scrollY', { configurable: true, value: 120 });
           window.dispatchEvent(new Event('scroll'));
 
-          expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+          // Must restore instantly so the following measurements read the resting page; the
+          // two-argument form would obey a global `scroll-behavior: smooth` and animate.
+          expect(scrollToSpy).toHaveBeenCalledWith({ left: 0, top: 0, behavior: 'instant' });
         } finally {
           scrollToSpy.mockRestore();
           if (originalScrollYDescriptor) {

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
@@ -105,7 +105,6 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
   const keyboardScrollAdjustmentRef = React.useRef<ScrollAdjustment | null>(null);
   const programmaticKeyboardFocusRef = React.useRef(false);
   const keyboardFocusFrame = useAnimationFrame();
-  const preemptedFocusFrame = useAnimationFrame();
   const keyboardRealignTimeout = useTimeout();
 
   const restoreKeyboardScrollAdjustment = useStableCallback(() => {
@@ -189,16 +188,12 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
     const win = ownerWindow(rootElement);
     const visualViewport = win.visualViewport;
 
-    // Alignment scroll bookkeeping: the last computed destination, how many consecutive
-    // checks it has been moving (settle gate), and whether a scroll toward it was issued
-    // (so later passes can tell an in-flight scroll from a stalled one via `observed`).
-    let keyboardScrollState: {
-      element: HTMLElement;
-      destination: number;
-      checks: number;
-      committed: boolean;
-      observed: number;
-    } | null = null;
+    // Alignment scroll bookkeeping: destination stability, whether a scroll was issued,
+    // and the last observed progress so delayed passes can distinguish moving from stalled.
+    let keyboardScrollElement: HTMLElement | null = null;
+    let keyboardScrollDestination = 0;
+    let keyboardScrollChecks = 0;
+    let keyboardScrollObserved = -1;
 
     const setDrawerKeyboardInset = (inset: number) => {
       rootElement.style.setProperty(
@@ -207,14 +202,10 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       );
     };
 
-    const resetDrawerKeyboardInset = () => {
-      setDrawerKeyboardInset(0);
-    };
-
     const clearFocusedKeyboardTarget = () => {
       focusedKeyboardTargetRef.current = null;
-      keyboardScrollState = null;
-      resetDrawerKeyboardInset();
+      keyboardScrollElement = null;
+      setDrawerKeyboardInset(0);
       restoreKeyboardScrollAdjustment();
       keyboardFocusFrame.cancel();
       keyboardRealignTimeout.clear();
@@ -253,12 +244,8 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
     let restorePreemptedFocus: (() => void) | null = null;
 
     const consumePreemptedFocus = () => {
-      if (!restorePreemptedFocus) {
-        return;
-      }
-      restorePreemptedFocus();
+      restorePreemptedFocus?.();
       restorePreemptedFocus = null;
-      preemptedFocusFrame.cancel();
     };
 
     const preemptFocusReveal = (target: HTMLElement, keyboardViewport: KeyboardVisualViewport) => {
@@ -269,23 +256,25 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       // the field as already centered in the visible band above the keyboard instead makes
       // both the in-page reveal and the viewport pan no-ops.
       const rect = target.getBoundingClientRect();
-      const visibleCenter = (keyboardViewport.top + keyboardViewport.bottom) / 2;
-      const rectCenter = (rect.top + rect.bottom) / 2;
 
-      restorePreemptedFocus = overrideGeometryDuringFocus(target, visibleCenter - rectCenter);
-      // If focus never lands on the target (no `focusin` follows), restore on the next
-      // frame so the field doesn't stay hidden.
-      preemptedFocusFrame.request(consumePreemptedFocus);
+      restorePreemptedFocus = overrideGeometryDuringFocus(
+        target,
+        (keyboardViewport.top + keyboardViewport.bottom - rect.top - rect.bottom) / 2,
+      );
     };
 
     const alignFocusedKeyboardTarget = () => {
+      // If focus never lands on a preempted target, the focusout-scheduled alignment still
+      // restores it on the next frame before paint.
+      consumePreemptedFocus();
+
       const target = focusedKeyboardTargetRef.current;
       // If the focused field is removed from the DOM without firing `focusout` (e.g. it is
       // conditionally rendered away), any applied scroll slack is restored here on the next
       // focus/viewport event or when the drawer closes. This self-corrects rather than
       // tracking each field's lifecycle.
       if (nestedDrawerOpen || !target || !contains(rootElement, target)) {
-        resetDrawerKeyboardInset();
+        setDrawerKeyboardInset(0);
         restoreKeyboardScrollAdjustment();
         return;
       }
@@ -296,12 +285,12 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
 
       const keyboardViewport = getKeyboardVisualViewport(win);
       if (!keyboardViewport) {
-        resetDrawerKeyboardInset();
+        setDrawerKeyboardInset(0);
         restoreKeyboardScrollAdjustment();
         return;
       }
 
-      setDrawerKeyboardInset(getDrawerKeyboardInset(win, keyboardViewport));
+      setDrawerKeyboardInset(Math.max(0, win.innerHeight - keyboardViewport.bottom));
 
       const scrollTarget = findKeyboardScrollTarget(target, rootElement);
       if (!scrollTarget) {
@@ -310,7 +299,7 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       }
 
       if (!scrollTarget.isConnected || !contains(rootElement, scrollTarget)) {
-        resetDrawerKeyboardInset();
+        setDrawerKeyboardInset(0);
         restoreKeyboardScrollAdjustment();
         return;
       }
@@ -333,16 +322,14 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       }
 
       const targetRect = target.getBoundingClientRect();
-      const targetCenter = (targetRect.top + targetRect.bottom) / 2;
-      const visibleCenter = (visibleTop + visibleBottom) / 2;
-      const nextScrollTop = scrollTarget.scrollTop + targetCenter - visibleCenter;
+      const nextScrollTop =
+        scrollTarget.scrollTop +
+        (targetRect.top + targetRect.bottom - visibleTop - visibleBottom) / 2;
       const destination = Math.round(clamp(nextScrollTop, 0, maxScrollTop));
 
-      const state = keyboardScrollState;
       const settled =
-        state !== null &&
-        state.element === scrollTarget &&
-        Math.abs(state.destination - destination) <= 1;
+        keyboardScrollElement === scrollTarget &&
+        Math.abs(keyboardScrollDestination - destination) <= 1;
 
       if (!settled) {
         // Commit the scroll only once the destination holds across two consecutive checks.
@@ -351,20 +338,17 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
         // mid-transition destination overshoots, then visibly pulls back once corrected.
         // The destination is scroll-position-invariant, so an in-flight scroll of the
         // container itself never defers the commit.
-        const checks = state && state.element === scrollTarget ? state.checks + 1 : 1;
-        keyboardScrollState = {
-          element: scrollTarget,
-          destination,
-          checks,
-          committed: false,
-          observed: scrollTarget.scrollTop,
-        };
+        const checks = keyboardScrollElement === scrollTarget ? keyboardScrollChecks + 1 : 1;
+        keyboardScrollElement = scrollTarget;
+        keyboardScrollDestination = destination;
+        keyboardScrollChecks = checks;
+        keyboardScrollObserved = -1;
         // Re-check next frame; give up and scroll anyway if layout never settles.
         if (checks <= KEYBOARD_SETTLE_FRAME_LIMIT) {
           keyboardFocusFrame.request(alignFocusedKeyboardTarget);
           return;
         }
-      } else if (state.committed) {
+      } else if (keyboardScrollObserved >= 0) {
         // A scroll toward this destination is already out. Leave it alone while it has
         // arrived or is still progressing — re-issuing restarts the smooth-scroll easing
         // curve, a visible stutter on every realign pass — and re-issue only when it
@@ -374,19 +358,16 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
         if (Math.abs(current - destination) <= 1) {
           return;
         }
-        if (current !== state.observed) {
-          state.observed = current;
+        if (current !== keyboardScrollObserved) {
+          keyboardScrollObserved = current;
           return;
         }
       }
 
-      keyboardScrollState = {
-        element: scrollTarget,
-        destination,
-        checks: 0,
-        committed: true,
-        observed: scrollTarget.scrollTop,
-      };
+      keyboardScrollElement = scrollTarget;
+      keyboardScrollDestination = destination;
+      keyboardScrollChecks = 0;
+      keyboardScrollObserved = scrollTarget.scrollTop;
       animateKeyboardScroll(scrollTarget, destination);
     };
 
@@ -403,11 +384,11 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
     // until both settle; the alignment's scroll bookkeeping observes before re-issuing,
     // so passes that find the scroll on course are inert.
     const scheduleDelayedKeyboardRealign = () => {
-      let passes = 0;
+      let remainingPasses = KEYBOARD_REALIGN_MAX_PASSES;
       const realign = () => {
         alignFocusedKeyboardTarget();
-        passes += 1;
-        if (passes < KEYBOARD_REALIGN_MAX_PASSES) {
+        remainingPasses -= 1;
+        if (remainingPasses > 0) {
           keyboardRealignTimeout.start(KEYBOARD_REALIGN_INTERVAL, realign);
         }
       };
@@ -429,7 +410,7 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       // A new field starts a fresh alignment; the scroll bookkeeping must not carry
       // over from the previous field's scroll.
       if (focusedKeyboardTargetRef.current !== target) {
-        keyboardScrollState = null;
+        keyboardScrollElement = null;
       }
       focusedKeyboardTargetRef.current = target;
       return true;
@@ -521,7 +502,6 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
     mounted,
     nestedDrawerOpen,
     open,
-    preemptedFocusFrame,
     restoreKeyboardScrollAdjustment,
     rootElement,
     setKeyboardScrollSlack,
@@ -613,7 +593,7 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       // reposition the caret, rather than blurring and re-focusing the same input.
       if (
         activeElement(ownerDocument(keyboardFocusTarget)) === keyboardFocusTarget &&
-        isKeyboardVisualViewportOpen(win)
+        (!win.visualViewport || getKeyboardVisualViewport(win) != null)
       ) {
         resetTouchTrackingState();
         return;
@@ -852,12 +832,4 @@ function getKeyboardVisualViewport(win: Window): KeyboardVisualViewport | null {
     top,
     bottom: Math.min(win.innerHeight, top + visualViewport.height),
   };
-}
-
-function getDrawerKeyboardInset(win: Window, keyboardViewport: KeyboardVisualViewport): number {
-  return Math.max(0, win.innerHeight - keyboardViewport.bottom);
-}
-
-function isKeyboardVisualViewportOpen(win: Window): boolean {
-  return !win.visualViewport || getKeyboardVisualViewport(win) != null;
 }

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
@@ -421,6 +421,12 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
     };
 
     const handleFocusIn = (event: FocusEvent) => {
+      // The programmatic transition is over once focus lands, which happens before
+      // `.focus()` returns. Any later `focusout` is the consumer's own — an `onFocus`
+      // handler that blurs or moves focus — and must be reconciled rather than
+      // suppressed, so stop suppressing here instead of waiting for `.focus()` to return.
+      programmaticKeyboardFocusRef.current = false;
+
       consumePreemptedFocus();
 
       if (!captureFocusedKeyboardTarget(getTarget(event))) {
@@ -429,6 +435,8 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
         // `focusout` via `programmaticKeyboardFocusRef`, so a consumer `onFocus` handler that
         // redirects focus out of the drawer would otherwise leave a stale target holding its
         // inset, slack, and pending realign. Reconcile against the real focus here.
+        // A handler that ends focus entirely emits no `focusin` to reconcile from; that case
+        // is covered by clearing the suppression flag above so its `focusout` is handled.
         if (focusedKeyboardTargetRef.current) {
           clearFocusedKeyboardTarget();
         }
@@ -625,7 +633,9 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       // iOS only opens the software keyboard when focus happens synchronously
       // inside the touch gesture. The flag suppresses the `focusout` cleanup the
       // intermediate blur would otherwise trigger, so the keyboard inset isn't
-      // dropped for a frame between the blur and the re-focus.
+      // dropped for a frame between the blur and the re-focus. It is cleared by the
+      // `focusin` that lands, so only that blur is suppressed; the `finally` is the
+      // backstop for a target that never takes focus.
       event.preventDefault();
       programmaticKeyboardFocusRef.current = true;
       try {

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
@@ -490,19 +490,21 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       }
     };
 
-    // Once the user puts a finger down they own the scroll position. The delayed realign
-    // passes can't tell a user scroll from a reveal scroll WebKit canceled, so stop them
-    // rather than risk pulling the drawer back to center under the user; a later focus or
-    // viewport change reschedules alignment if it's still needed.
-    const cancelDelayedRealignOnPointerDown = () => {
+    // Once the user puts a finger down they own the scroll position. Stop both the frame settle
+    // loop, which can center after changing layout settles, and the delayed passes, which can't
+    // distinguish a user scroll from a reveal scroll WebKit canceled. A later focus or viewport
+    // change reschedules alignment if it's still needed.
+    const cancelKeyboardRealignOnPointerDown = () => {
+      keyboardFocusFrame.cancel();
       keyboardRealignTimeout.clear();
+      keyboardScrollElement = null;
     };
 
     cleanupListeners.push(
       addEventListener(doc, 'focusin', handleFocusIn, true),
       addEventListener(doc, 'focusout', handleFocusOut, true),
       addEventListener(win, 'scroll', handleWindowScroll),
-      addEventListener(doc, 'pointerdown', cancelDelayedRealignOnPointerDown, true),
+      addEventListener(doc, 'pointerdown', cancelKeyboardRealignOnPointerDown, true),
     );
 
     if (captureFocusedKeyboardTarget(activeElement(doc))) {

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
@@ -5,6 +5,7 @@ import { addEventListener } from '@base-ui/utils/addEventListener';
 import { ownerDocument, ownerWindow } from '@base-ui/utils/owner';
 import { useAnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import { useTimeout } from '@base-ui/utils/useTimeout';
 import { useDialogRootContext } from '../../dialog/root/DialogRootContext';
 import { clamp } from '../../internals/clamp';
 import {
@@ -27,6 +28,15 @@ const KEYBOARD_VISIBILITY_MARGIN = 16;
 // keyboard overlap, so the field can be scrolled clear of the keyboard instead of
 // ending up flush against it. Only applied when there is actual overlap.
 const KEYBOARD_SCROLL_SLACK = 48;
+// Cadence of the settle-watching realign passes after focus moves with the keyboard open:
+// long enough for a smooth scroll to show progress between passes, short enough to recover
+// quickly from a scroll canceled by WebKit's reveal; the pass count covers CSS transitions
+// reacting to the focus change (e.g. a 260ms footer resize) with room to spare.
+const KEYBOARD_REALIGN_INTERVAL = 150;
+const KEYBOARD_REALIGN_MAX_PASSES = 4;
+// Frames the alignment waits for the scroll destination to stop moving (layout reacting to
+// the focus change, e.g. a footer resizing over a CSS transition) before scrolling anyway.
+const KEYBOARD_SETTLE_FRAME_LIMIT = 60;
 const INPUT_TAP_MOVE_THRESHOLD = 10;
 const INPUT_TAP_HIT_SLOP = 16;
 const KEYBOARD_INPUT_TYPES = new Set([
@@ -79,6 +89,7 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
 
   const open = store.useState('open');
   const mounted = store.useState('mounted');
+  const modal = store.useState('modal');
   const nestedOpenDialogCount = store.useState('nestedOpenDialogCount');
   const viewportElement = store.useState('viewportElement');
 
@@ -92,7 +103,10 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
   const keyboardTouchStartRef = React.useRef<{ x: number; y: number } | null>(null);
   const focusedKeyboardTargetRef = React.useRef<HTMLElement | null>(null);
   const keyboardScrollAdjustmentRef = React.useRef<ScrollAdjustment | null>(null);
+  const programmaticKeyboardFocusRef = React.useRef(false);
   const keyboardFocusFrame = useAnimationFrame();
+  const preemptedFocusFrame = useAnimationFrame();
+  const keyboardRealignTimeout = useTimeout();
 
   const restoreKeyboardScrollAdjustment = useStableCallback(() => {
     const adjustment = keyboardScrollAdjustmentRef.current;
@@ -175,6 +189,17 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
     const win = ownerWindow(rootElement);
     const visualViewport = win.visualViewport;
 
+    // Alignment scroll bookkeeping: the last computed destination, how many consecutive
+    // checks it has been moving (settle gate), and whether a scroll toward it was issued
+    // (so later passes can tell an in-flight scroll from a stalled one via `observed`).
+    let keyboardScrollState: {
+      element: HTMLElement;
+      destination: number;
+      checks: number;
+      committed: boolean;
+      observed: number;
+    } | null = null;
+
     const setDrawerKeyboardInset = (inset: number) => {
       rootElement.style.setProperty(
         DrawerViewportCssVars.keyboardInset,
@@ -188,9 +213,69 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
 
     const clearFocusedKeyboardTarget = () => {
       focusedKeyboardTargetRef.current = null;
+      keyboardScrollState = null;
       resetDrawerKeyboardInset();
       restoreKeyboardScrollAdjustment();
       keyboardFocusFrame.cancel();
+      keyboardRealignTimeout.clear();
+    };
+
+    // WebKit's native reveal scroll can move the page even while the scroll lock hides
+    // overflow (e.g. when the software keyboard's previous/next field arrows move focus).
+    // While the drawer is modal, any window scroll during keyboard interaction is spurious,
+    // so pin the page to the position it had when the drawer opened.
+    const baseScrollX = win.scrollX;
+    const baseScrollY = win.scrollY;
+
+    const restoreWindowScroll = (): boolean => {
+      if (
+        modal !== true ||
+        nestedDrawerOpen ||
+        !focusedKeyboardTargetRef.current ||
+        getKeyboardVisualViewport(win) == null
+      ) {
+        return false;
+      }
+
+      if (win.scrollX !== baseScrollX || win.scrollY !== baseScrollY) {
+        win.scrollTo(baseScrollX, baseScrollY);
+        return true;
+      }
+
+      return false;
+    };
+
+    // Focus moved by the drawer itself goes through `focusKeyboardInputWithoutPageScroll`,
+    // but native focus changes (the iOS keyboard's previous/next field arrows) commit
+    // WebKit's reveal scroll before `focusin` reaches us — cancelling it afterwards
+    // visibly jitters the sheet. `focusout` on the outgoing field fires before focus
+    // lands, so override the incoming field's geometry there and restore it in `focusin`.
+    let restorePreemptedFocus: (() => void) | null = null;
+
+    const consumePreemptedFocus = () => {
+      if (!restorePreemptedFocus) {
+        return;
+      }
+      restorePreemptedFocus();
+      restorePreemptedFocus = null;
+      preemptedFocusFrame.cancel();
+    };
+
+    const preemptFocusReveal = (target: HTMLElement, keyboardViewport: KeyboardVisualViewport) => {
+      consumePreemptedFocus();
+
+      // Native focus carries no preventScroll, so a fake off-screen rect would make WebKit
+      // scroll the drawer's own scroll containers thousands of pixels chasing it. Presenting
+      // the field as already centered in the visible band above the keyboard instead makes
+      // both the in-page reveal and the viewport pan no-ops.
+      const rect = target.getBoundingClientRect();
+      const visibleCenter = (keyboardViewport.top + keyboardViewport.bottom) / 2;
+      const rectCenter = (rect.top + rect.bottom) / 2;
+
+      restorePreemptedFocus = overrideGeometryDuringFocus(target, visibleCenter - rectCenter);
+      // If focus never lands on the target (no `focusin` follows), restore on the next
+      // frame so the field doesn't stay hidden.
+      preemptedFocusFrame.request(consumePreemptedFocus);
     };
 
     const alignFocusedKeyboardTarget = () => {
@@ -204,6 +289,10 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
         restoreKeyboardScrollAdjustment();
         return;
       }
+
+      // Undo any reveal scroll WebKit applied to the locked page before measuring, so the
+      // keyboard inset and alignment are computed against the resting viewport.
+      restoreWindowScroll();
 
       const keyboardViewport = getKeyboardVisualViewport(win);
       if (!keyboardViewport) {
@@ -247,12 +336,82 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       const targetCenter = (targetRect.top + targetRect.bottom) / 2;
       const visibleCenter = (visibleTop + visibleBottom) / 2;
       const nextScrollTop = scrollTarget.scrollTop + targetCenter - visibleCenter;
+      const destination = Math.round(clamp(nextScrollTop, 0, maxScrollTop));
 
-      animateKeyboardScroll(scrollTarget, clamp(nextScrollTop, 0, maxScrollTop));
+      const state = keyboardScrollState;
+      const settled =
+        state !== null &&
+        state.element === scrollTarget &&
+        Math.abs(state.destination - destination) <= 1;
+
+      if (!settled) {
+        // Commit the scroll only once the destination holds across two consecutive checks.
+        // Layout may still be reacting to the focus change (e.g. a footer sized by
+        // `:focus-within` resizing over a transition), and scrolling toward a
+        // mid-transition destination overshoots, then visibly pulls back once corrected.
+        // The destination is scroll-position-invariant, so an in-flight scroll of the
+        // container itself never defers the commit.
+        const checks = state && state.element === scrollTarget ? state.checks + 1 : 1;
+        keyboardScrollState = {
+          element: scrollTarget,
+          destination,
+          checks,
+          committed: false,
+          observed: scrollTarget.scrollTop,
+        };
+        // Re-check next frame; give up and scroll anyway if layout never settles.
+        if (checks <= KEYBOARD_SETTLE_FRAME_LIMIT) {
+          keyboardFocusFrame.request(alignFocusedKeyboardTarget);
+          return;
+        }
+      } else if (state.committed) {
+        // A scroll toward this destination is already out. Leave it alone while it has
+        // arrived or is still progressing — re-issuing restarts the smooth-scroll easing
+        // curve, a visible stutter on every realign pass — and re-issue only when it
+        // stalled short (WebKit cancels in-flight smooth scrolls when its native reveal
+        // for the focus resolves).
+        const current = scrollTarget.scrollTop;
+        if (Math.abs(current - destination) <= 1) {
+          return;
+        }
+        if (current !== state.observed) {
+          state.observed = current;
+          return;
+        }
+      }
+
+      keyboardScrollState = {
+        element: scrollTarget,
+        destination,
+        checks: 0,
+        committed: true,
+        observed: scrollTarget.scrollTop,
+      };
+      animateKeyboardScroll(scrollTarget, destination);
     };
 
     const scheduleKeyboardFocusAlignment = () => {
       keyboardFocusFrame.request(alignFocusedKeyboardTarget);
+    };
+
+    // When focus moves with the keyboard already up, no viewport resize events follow to
+    // re-run alignment, and the single frame-scheduled pass is unreliable: WebKit resolves
+    // the reveal for the focus asynchronously (a UI-process round trip) and cancels any
+    // in-flight scroll the pass started when it lands, and layout reacting to the focus
+    // change (e.g. a footer sized by `:focus-within` and the keyboard inset) settles only
+    // after its transition, so the pass measures stale geometry. Re-align on an interval
+    // until both settle; the alignment's scroll bookkeeping observes before re-issuing,
+    // so passes that find the scroll on course are inert.
+    const scheduleDelayedKeyboardRealign = () => {
+      let passes = 0;
+      const realign = () => {
+        alignFocusedKeyboardTarget();
+        passes += 1;
+        if (passes < KEYBOARD_REALIGN_MAX_PASSES) {
+          keyboardRealignTimeout.start(KEYBOARD_REALIGN_INTERVAL, realign);
+        }
+      };
+      keyboardRealignTimeout.start(KEYBOARD_REALIGN_INTERVAL, realign);
     };
 
     const captureFocusedKeyboardTarget = (eventTarget: EventTarget | null) => {
@@ -267,18 +426,47 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
         return false;
       }
 
+      // A new field starts a fresh alignment; the scroll bookkeeping must not carry
+      // over from the previous field's scroll.
+      if (focusedKeyboardTargetRef.current !== target) {
+        keyboardScrollState = null;
+      }
       focusedKeyboardTargetRef.current = target;
       return true;
     };
 
     const handleFocusIn = (event: FocusEvent) => {
-      if (captureFocusedKeyboardTarget(getTarget(event))) {
-        scheduleKeyboardFocusAlignment();
+      consumePreemptedFocus();
+
+      if (!captureFocusedKeyboardTarget(getTarget(event))) {
+        return;
       }
+
+      // Covers every way focus can land with the keyboard already up: native moves (the
+      // keyboard's previous/next arrows) and the tap path (which suppresses `focusout`
+      // handling via the programmatic flag).
+      if (getKeyboardVisualViewport(win) != null) {
+        scheduleDelayedKeyboardRealign();
+      }
+
+      scheduleKeyboardFocusAlignment();
     };
 
     const handleFocusOut = (event: FocusEvent) => {
+      // The blur inside `focusKeyboardInputWithoutPageScroll` is followed synchronously by
+      // a re-focus; clearing state here would drop the keyboard inset for a frame.
+      if (programmaticKeyboardFocusRef.current) {
+        return;
+      }
+
       if (captureFocusedKeyboardTarget(event.relatedTarget)) {
+        const target = focusedKeyboardTargetRef.current;
+        const keyboardViewport = target ? getKeyboardVisualViewport(win) : null;
+        // The delayed realign passes are scheduled by the `focusin` that follows once
+        // focus lands on the captured target.
+        if (target && keyboardViewport) {
+          preemptFocusReveal(target, keyboardViewport);
+        }
         scheduleKeyboardFocusAlignment();
         return;
       }
@@ -301,9 +489,18 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       );
     }
 
+    const handleWindowScroll = () => {
+      if (restoreWindowScroll()) {
+        // Recompute the keyboard inset once the page is back at rest; measurements taken
+        // mid-reveal (a non-zero visual viewport offset) inflate it and push the popup up.
+        scheduleKeyboardFocusAlignment();
+      }
+    };
+
     cleanupListeners.push(
       addEventListener(doc, 'focusin', handleFocusIn, true),
       addEventListener(doc, 'focusout', handleFocusOut, true),
+      addEventListener(win, 'scroll', handleWindowScroll),
     );
 
     if (captureFocusedKeyboardTarget(activeElement(doc))) {
@@ -312,15 +509,19 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
 
     return () => {
       cleanupListeners.forEach((cleanup) => cleanup());
+      consumePreemptedFocus();
       clearFocusedKeyboardTarget();
       rootElement.style.removeProperty(DrawerViewportCssVars.keyboardInset);
     };
   }, [
     animateKeyboardScroll,
     keyboardFocusFrame,
+    keyboardRealignTimeout,
+    modal,
     mounted,
     nestedDrawerOpen,
     open,
+    preemptedFocusFrame,
     restoreKeyboardScrollAdjustment,
     rootElement,
     setKeyboardScrollSlack,
@@ -419,9 +620,15 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       }
 
       // iOS only opens the software keyboard when focus happens synchronously
-      // inside the touch gesture.
+      // inside the touch gesture. The flag stops the `focusin` handler from
+      // re-running the same blur/re-focus trick a second time.
       event.preventDefault();
-      focusKeyboardInputWithoutPageScroll(keyboardFocusTarget);
+      programmaticKeyboardFocusRef.current = true;
+      try {
+        focusKeyboardInputWithoutPageScroll(keyboardFocusTarget);
+      } finally {
+        programmaticKeyboardFocusRef.current = false;
+      }
       // Preventing the touchend default also suppresses the compatibility mouse
       // events, including `click`; redispatch an untrusted replacement on the
       // original tap target so click handlers still run with the tap coordinates.
@@ -580,25 +787,37 @@ function dispatchKeyboardClick(target: HTMLElement, touch: Pick<Touch, 'clientX'
 
 function focusKeyboardInputWithoutPageScroll(target: HTMLElement) {
   const wasFocused = activeElement(ownerDocument(target)) === target;
-  const previousOpacity = target.style.opacity;
-  const previousTransform = target.style.transform;
-  const previousTransition = target.style.transition;
-
   // iOS Safari can still scroll the page for transformed sheets even with preventScroll.
-  // Move the input off-screen only for the synchronous focus call.
-  target.style.transition = 'none';
-  target.style.opacity = '0';
-  target.style.transform = 'translateY(-2000px)';
+  // Move the input off-screen only for the synchronous focus call; `preventScroll`
+  // suppresses the in-page ancestor scrolling that would otherwise chase the fake rect.
+  const restoreStyles = overrideGeometryDuringFocus(target, -2000);
   try {
     if (wasFocused) {
       target.blur();
     }
     target.focus({ preventScroll: true });
   } finally {
+    restoreStyles();
+  }
+}
+
+// Overrides the painted geometry WebKit samples when an element gains focus. The rect is
+// hidden (opacity) rather than detached so layout is unaffected; the caller must restore
+// synchronously before the next paint.
+function overrideGeometryDuringFocus(target: HTMLElement, translateY: number): () => void {
+  const previousOpacity = target.style.opacity;
+  const previousTransform = target.style.transform;
+  const previousTransition = target.style.transition;
+
+  target.style.transition = 'none';
+  target.style.opacity = '0';
+  target.style.transform = `translateY(${translateY}px)`;
+
+  return () => {
     target.style.opacity = previousOpacity;
     target.style.transform = previousTransform;
     target.style.transition = previousTransition;
-  }
+  };
 }
 
 function findKeyboardScrollTarget(target: HTMLElement, root: HTMLElement): HTMLElement | null {

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
@@ -229,7 +229,11 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       }
 
       if (win.scrollX !== baseScrollX || win.scrollY !== baseScrollY) {
-        win.scrollTo(baseScrollX, baseScrollY);
+        // Force an instant jump: the two-argument form defaults `behavior` to `auto`, which
+        // obeys the page's `scroll-behavior`, so a global `scroll-behavior: smooth` would
+        // animate the restore. The measurements that follow assume the page is already back
+        // at rest, and a smooth restore also re-emits `scroll`, re-entering this handler.
+        win.scrollTo({ left: baseScrollX, top: baseScrollY, behavior: 'instant' });
         return true;
       }
 

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
@@ -424,6 +424,14 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       consumePreemptedFocus();
 
       if (!captureFocusedKeyboardTarget(getTarget(event))) {
+        // Focus landed outside any drawer keyboard input. The `focusout` on the previous
+        // field normally clears the tracked target, but the tap path suppresses that
+        // `focusout` via `programmaticKeyboardFocusRef`, so a consumer `onFocus` handler that
+        // redirects focus out of the drawer would otherwise leave a stale target holding its
+        // inset, slack, and pending realign. Reconcile against the real focus here.
+        if (focusedKeyboardTargetRef.current) {
+          clearFocusedKeyboardTarget();
+        }
         return;
       }
 
@@ -482,10 +490,19 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       }
     };
 
+    // Once the user puts a finger down they own the scroll position. The delayed realign
+    // passes can't tell a user scroll from a reveal scroll WebKit canceled, so stop them
+    // rather than risk pulling the drawer back to center under the user; a later focus or
+    // viewport change reschedules alignment if it's still needed.
+    const cancelDelayedRealignOnPointerDown = () => {
+      keyboardRealignTimeout.clear();
+    };
+
     cleanupListeners.push(
       addEventListener(doc, 'focusin', handleFocusIn, true),
       addEventListener(doc, 'focusout', handleFocusOut, true),
       addEventListener(win, 'scroll', handleWindowScroll),
+      addEventListener(doc, 'pointerdown', cancelDelayedRealignOnPointerDown, true),
     );
 
     if (captureFocusedKeyboardTarget(activeElement(doc))) {
@@ -604,8 +621,9 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
       }
 
       // iOS only opens the software keyboard when focus happens synchronously
-      // inside the touch gesture. The flag stops the `focusin` handler from
-      // re-running the same blur/re-focus trick a second time.
+      // inside the touch gesture. The flag suppresses the `focusout` cleanup the
+      // intermediate blur would otherwise trigger, so the keyboard inset isn't
+      // dropped for a frame between the blur and the re-focus.
       event.preventDefault();
       programmaticKeyboardFocusRef.current = true;
       try {


### PR DESCRIPTION
Steps (bug A):
1. [Virtual keyboard aware demo](https://deploy-preview-5179--base-ui.netlify.app/react/components/drawer#virtual-keyboard-aware)
2. Tap an input on iOS
3. Press arrow navigation keys to go between inputs (up/down)
4. Should not use native handling

Steps (bug B):
1. [Virtual keyboard aware demo](https://deploy-preview-5179--base-ui.netlify.app/react/components/drawer#virtual-keyboard-aware)
2. Tap the footer input on iOS
3. Scroll the drawer container down to reach textarea
4. Tap textarea
5. Should correctly scroll it into view



With the keyboard already open, moving focus without a fresh tap broke the drawer's scroll containment:

- The iOS keyboard's previous/next arrows move focus natively (no touch events, no `preventScroll`), so WebKit's reveal scroll panned the page and pushed the drawer offscreen.
- Tapping a field in the scrollable body while a pinned footer field held focus didn't scroll it into view — no viewport events follow, and the single alignment pass measured layout still reacting to the focus change.

Fixes in `DrawerVirtualKeyboardProvider`:

- Preempt the native reveal in `focusout`: briefly present the incoming field as already visible above the keyboard so WebKit has nothing to reveal, restoring in `focusin`.
- Commit the centering scroll only once its destination stops moving between checks, so it never chases mid-transition layout.
- Re-run alignment on a short interval after keyboard-open focus changes, re-issuing only scrolls that stalled (WebKit cancels in-flight smooth scrolls when its reveal resolves) — never restarting one in progress.
- Pin the page scroll for modal drawers as a recovery net.

Verified on a physical iPhone (taps, arrows both directions, footer→body transitions, keyboard open/close); each mechanism has Chromium tests with a mocked visual viewport.
