### PR TITLE
[docs] Fix scrollable focus ring

### DIFF
--- a/docs/src/components/Accordion.css
+++ b/docs/src/components/Accordion.css
@@ -119,6 +119,22 @@
   .AccordionScrollable {
     overflow-x: hidden;
 
+    /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
+    &:has(.AccordionScrollableInner:focus-visible) {
+      position: relative;
+      z-index: 1;
+
+      &::before {
+        content: '';
+        position: absolute;
+        pointer-events: none;
+        inset: 0;
+        z-index: 1;
+        outline: 2px solid var(--gray-t2);
+        outline-offset: -1px;
+      }
+    }
+
     &[data-scrollable] {
       position: relative;
 
@@ -170,6 +186,10 @@
 
     &::-webkit-scrollbar {
       display: none;
+    }
+
+    &:focus-visible {
+      outline: 0;
     }
   }
 


### PR DESCRIPTION
## Summary
- draw the scrollable API cell focus ring on the outer cell
- hide the overflow fade while the cell is keyboard-focused

## Screenshots
| Before | After |
| --- | --- |
| <img width="800" height="588" alt="Before focus ring" src="https://github.com/user-attachments/assets/78694fd4-14d0-4ce6-99ef-9f7c4756a182" /> | <img width="800" height="638" alt="After focus ring" src="https://github.com/user-attachments/assets/e3a3cc4b-68d6-46ee-972e-8ab8c8e1a357" /> |

## Test plan
- pnpm stylelint docs/src/components/Accordion.css
- pnpm prettier docs/src/components/Accordion.css --check
- git diff --check -- docs/src/components/Accordion.css