### PR TITLE
[composite] Always skip natively disabled items during list navigation

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useTypeahead.ts
+++ b/packages/react/src/floating-ui-react/hooks/useTypeahead.ts
@@ -28,17 +28,17 @@ export interface UseTypeaheadProps {
   /**
    * Optional list of item elements that correspond to `listRef` indices.
    * When an element exists for an index, typeahead skips it if it is hidden by
-   * `display: none`, `visibility: hidden|collapse`, or other
-   * browser-reported visibility checks.
+   * `display: none`, `visibility: hidden|collapse`, other browser-reported
+   * visibility checks, or native disabled state.
    */
   elementsRef?: React.RefObject<Array<HTMLElement | null>> | undefined;
   /**
    * Indices that are disabled, either as an array or a predicate (the same shape as
    * `useListNavigation`'s `disabledIndices`). Disabled items are skipped while matching,
    * so a single keypress advances to the next selectable item (matching native `<select>`
-   * and arrow-key navigation). The disabled check doesn't read `elementsRef`, so consumers
-   * whose items stay mounted-but-hidden while closed can still skip disabled items without
-   * passing `elementsRef`.
+   * and arrow-key navigation). The explicit disabled check doesn't read `elementsRef`, so
+   * consumers whose items stay mounted-but-hidden while closed can still skip disabled items
+   * without passing `elementsRef`.
    */
   disabledIndices?: DisabledIndices | undefined;
   /**
@@ -94,19 +94,20 @@ export function useTypeahead(
   const matchIndexRef = React.useRef<number | null>(null);
 
   const onKeyDown = useStableCallback((event: React.KeyboardEvent) => {
-    function isVisible(index: number) {
-      const element = elementsRef?.current[index];
-      return !element || isElementVisible(element);
+    function getElement(index: number) {
+      return elementsRef?.current[index];
     }
 
     function isItemAvailable(index: number) {
-      if (!isVisible(index)) {
+      const element = getElement(index);
+      if ((element && !isElementVisible(element)) || element?.matches(':disabled')) {
         return false;
       }
-      // Visibility is handled above; pass an empty element list so `isListIndexDisabled`
-      // resolves only the explicit `disabledIndices` (array/predicate) and skips its own
-      // visibility/attribute fallbacks. Consumers that don't opt in keep matching every
-      // visible item.
+      // Visibility and native disabled state are handled above; pass an empty
+      // element list so `isListIndexDisabled` resolves only the explicit
+      // `disabledIndices` (array/predicate) and skips its own fallbacks.
+      // Consumers that don't pass `disabledIndices` keep matching every visible
+      // item except native disabled elements provided through `elementsRef`.
       return disabledIndices == null || !isListIndexDisabled(EMPTY_ARRAY, index, disabledIndices);
     }
 

--- a/packages/react/src/floating-ui-react/utils/composite.test.ts
+++ b/packages/react/src/floating-ui-react/utils/composite.test.ts
@@ -1,4 +1,4 @@
-import { isElementVisible, isHiddenByStyles } from './composite';
+import { isElementVisible, isHiddenByStyles, isListIndexDisabled } from './composite';
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -42,4 +42,25 @@ it('uses CSS visibility fallbacks when checkVisibility is unavailable', () => {
   expect(isElementVisible(displayHidden)).toBe(false);
   expect(isElementVisible(displayContents)).toBe(false);
   expect(isElementVisible(contentHidden)).toBe(true);
+});
+
+it('always treats natively disabled elements as disabled, unlike aria-disabled ones', () => {
+  const nativeDisabled = document.createElement('button');
+  nativeDisabled.disabled = true;
+  const ariaDisabled = document.createElement('button');
+  ariaDisabled.setAttribute('aria-disabled', 'true');
+
+  document.body.append(nativeDisabled, ariaDisabled);
+  const list = [nativeDisabled, ariaDisabled];
+
+  expect(isListIndexDisabled(list, 0)).toBe(true);
+  expect(isListIndexDisabled(list, 1)).toBe(true);
+
+  // An empty `disabledIndices` marks every item as enabled, but natively
+  // disabled elements can never receive focus, so they stay disabled.
+  expect(isListIndexDisabled(list, 0, [])).toBe(true);
+  expect(isListIndexDisabled(list, 1, [])).toBe(false);
+
+  expect(isListIndexDisabled(list, 0, () => false)).toBe(true);
+  expect(isListIndexDisabled(list, 1, () => false)).toBe(false);
 });

--- a/packages/react/src/floating-ui-react/utils/composite.ts
+++ b/packages/react/src/floating-ui-react/utils/composite.ts
@@ -492,6 +492,13 @@ export function isListIndexDisabled(
     return true;
   }
 
+  // A natively disabled element can never receive focus, so it must always be
+  // skipped, even when `disabledIndices` marks it as enabled. Only
+  // `aria-disabled` items can be focusable-while-disabled.
+  if (element.matches(':disabled')) {
+    return true;
+  }
+
   return (
     !disabledIndices &&
     (element.hasAttribute('disabled') || element.getAttribute('aria-disabled') === 'true')

--- a/packages/react/src/menu/item/MenuItem.test.tsx
+++ b/packages/react/src/menu/item/MenuItem.test.tsx
@@ -253,5 +253,38 @@ describe('<Menu.Item />', () => {
       expect(handleKeyUp.mock.calls.length).toBe(0);
       expect(handleClick.mock.calls.length).toBe(0);
     });
+
+    it('skips a natively disabled item during keyboard navigation', async () => {
+      const { user } = await render(
+        <Menu.Root open>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Item>1</Menu.Item>
+                <Menu.Item nativeButton render={<button type="button" disabled />}>
+                  2
+                </Menu.Item>
+                <Menu.Item>3</Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const [firstItem, , lastItem] = screen.getAllByRole('menuitem');
+      await act(async () => {
+        firstItem.focus();
+      });
+
+      await user.keyboard('{ArrowDown}');
+      await waitFor(() => {
+        expect(lastItem).toHaveFocus();
+      });
+
+      await user.keyboard('{ArrowUp}');
+      await waitFor(() => {
+        expect(firstItem).toHaveFocus();
+      });
+    });
   });
 });

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -257,6 +257,43 @@ describe('<Menu.Root />', () => {
           expect(hiddenItem).toHaveAttribute('tabindex', '-1');
         });
 
+        it.skipIf(isJSDOM)('skips natively disabled items in text navigation', async () => {
+          const itemElements = [
+            <Menu.Item key="apple">Apple</Menu.Item>,
+            <Menu.Item
+              key="banana"
+              data-testid="item-banana"
+              nativeButton
+              render={<button type="button" disabled />}
+            >
+              Banana
+            </Menu.Item>,
+            <Menu.Item key="blueberry" data-testid="item-blueberry">
+              Blueberry
+            </Menu.Item>,
+          ];
+
+          const { user } = await render(
+            <TestMenu rootProps={{ open: true }} popupProps={{ children: itemElements }} />,
+          );
+
+          const appleItem = screen.getByText('Apple');
+          const bananaItem = screen.getByTestId('item-banana');
+          const blueberryItem = screen.getByTestId('item-blueberry');
+
+          await act(async () => {
+            appleItem.focus();
+          });
+
+          await user.keyboard('b');
+          await waitFor(() => {
+            expect(blueberryItem).toHaveFocus();
+          });
+
+          expect(bananaItem).toHaveAttribute('tabindex', '-1');
+          expect(bananaItem).not.toHaveAttribute('data-highlighted');
+        });
+
         it.skipIf(!isJSDOM)(
           'changes the highlighted item using text navigation on label prop',
           async () => {

--- a/packages/react/src/tabs/list/TabsList.test.tsx
+++ b/packages/react/src/tabs/list/TabsList.test.tsx
@@ -106,6 +106,57 @@ describe('<Tabs.List />', () => {
     });
   });
 
+  describe('keyboard navigation', () => {
+    it('moves focus to a tab disabled with the `disabled` prop', async () => {
+      await render(
+        <Tabs.Root value={0}>
+          <Tabs.List>
+            <Tabs.Tab value={0} />
+            <Tabs.Tab value={1} disabled />
+            <Tabs.Tab value={2} />
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      const [firstTab, disabledTab] = screen.getAllByRole('tab');
+      await act(async () => {
+        firstTab.focus();
+      });
+
+      fireEvent.keyDown(firstTab, { key: 'ArrowRight' });
+      await flushMicrotasks();
+
+      expect(disabledTab).toHaveFocus();
+    });
+
+    it('skips a natively disabled tab in a single keypress', async () => {
+      await render(
+        <Tabs.Root value={0}>
+          <Tabs.List>
+            <Tabs.Tab value={0} />
+            <Tabs.Tab value={1} render={<button type="button" disabled />} />
+            <Tabs.Tab value={2} />
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      const [firstTab, , lastTab] = screen.getAllByRole('tab');
+      await act(async () => {
+        firstTab.focus();
+      });
+
+      fireEvent.keyDown(firstTab, { key: 'ArrowRight' });
+      await flushMicrotasks();
+
+      expect(lastTab).toHaveFocus();
+
+      fireEvent.keyDown(lastTab, { key: 'ArrowLeft' });
+      await flushMicrotasks();
+
+      expect(firstTab).toHaveFocus();
+    });
+  });
+
   it('can be named via `aria-label`', async () => {
     await render(
       <Tabs.Root defaultValue={0}>


### PR DESCRIPTION
`isListIndexDisabled` let a `disabledIndices` override mark natively disabled elements as enabled. `Tabs.List` passes an empty `disabledIndices` so that disabled tabs stay focusable, but that also applied to elements carrying a native `disabled` attribute, e.g. `<Tabs.Tab render={<button disabled />} />`. The composite moved its active index onto such a tab and the `focus()` call silently failed, leaving keyboard navigation stuck: pressing ArrowRight from tab A focused A again, and only the next press reached C.

Natively disabled elements can never receive focus, so `isListIndexDisabled` now always skips them, regardless of `disabledIndices`. `aria-disabled` items are unaffected and remain focusable while disabled (the APG default). Menu and Select pass the same override, so the same applies there; tests cover Tabs and Menu. This also means both APG conventions are now reachable: the `disabled` prop keeps an item in the focus order, while rendering a natively disabled element removes it.

Closes #5132