### PR TITLE
[docs] Add shared Base UI review skill

### DIFF
--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -1,22 +1,23 @@
 ---
 name: base-ui-review
-description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post findings as inline PR comments, or --fix to apply the findings to the working tree after the review.'
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post findings as inline PR comments, or --fix to apply the findings to the working tree after the review.'
 ---
 
 # Base UI Review
 
 Review the current diff and report **regressions and correctness bugs** alongside
 **cleanup** (reuse / simplification / efficiency), scaling depth to the chosen effort
-level. The effort level (`low` / `medium` / `high`, default `medium`) controls how
-many areas are reviewed, whether work fans out to subagents, and the precision/recall
-bias - see [Effort levels](#effort-levels) for the canonical behavior of each.
+level. The effort level (`low` / `medium` / `high` / `xhigh` / `max`, default
+`medium`) controls how many areas are reviewed, whether work fans out to subagents,
+and the precision/recall bias - see [Effort levels](#effort-levels) for the
+canonical behavior of each.
 
-Argument hint: `[low|medium|high] [--fix] [--comment] [<target>]`
+Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment] [<target>]`
 
 You are reviewing for **precision** at medium effort: every finding you surface
-should be one a maintainer would act on. At **high** the bias shifts to **recall**
-to catch every real bug a careful reviewer would catch; a missed bug ships, so err
-on the side of surfacing (uncertain findings are allowed, labeled).
+should be one a maintainer would act on. At **high**, **xhigh**, and especially
+**max**, the bias shifts toward **recall**; a missed bug ships, so surface uncertain
+findings when the mechanism is realistic and label them clearly.
 
 ## Scope
 
@@ -28,15 +29,16 @@ that target instead.
 
 ## Phase 1 - Find candidates
 
-Review the four main areas below: Bugs, Tests, Simplifications, and Docs. At
-`medium` (default) do this locally in the main agent with no subagents; at `high`
-run those four areas as **independent subagents**. At `low`, only Area 1 (Bugs)
-applies, and only its high-confidence runtime-correctness subset - see
-[Effort levels](#effort-levels). Each area surfaces actionable candidate findings
-with `file`, `line`, a one-line `summary`, a `severity` (🔴 / 🟡 / ℹ️ - see
-[Output](#output) for the rubric), and a concrete `failure_scenario`. Do NOT let
-one area's conclusions suppress another's - if two areas flag the same line for
-different reasons, record both.
+Review the four main areas below: Bugs, Tests, Simplifications, and Docs. At `low`,
+only Area 1 (Bugs) applies, and only its high-confidence runtime-correctness subset.
+At `medium` (default), do this locally in the main agent; if the change is large,
+risky, or touches fragile behavior, also spawn an independent bug/regression hunter
+subagent. At `high`, `xhigh`, and `max`, run the four areas as **independent
+subagents** - see [Effort levels](#effort-levels). Each area surfaces actionable
+candidate findings with `file`, `line`, a one-line `summary`, a `severity` (🟣 / 🔴 /
+🟠 / 🟡 / ℹ️ - see [Output](#output) for the rubric), and a concrete
+`failure_scenario`. Do NOT let one area's conclusions suppress another's - if two
+areas flag the same line for different reasons, record both.
 
 Pass every candidate with a nameable failure scenario through - finders that
 silently drop half-believed candidates bypass the verify step and are the
@@ -128,7 +130,8 @@ This specialist is not part of the default four-area fan-out. Skip it entirely a
 `low`. At `medium`, include it in the main-agent pass when the diff adds or changes
 a public API surface: a component, prop, event, hook, provider, imperative method,
 exported type, value shape, behavior contract, or docs example that teaches an API.
-At `high`, run it as an independent API design subagent when triggered.
+At `high`, `xhigh`, and `max`, run it as an independent API design subagent when
+triggered.
 
 Heavily critique the taste of the API: naming, mental model, consistency with
 nearby APIs in the same codebase, controlled/uncontrolled ergonomics, composition,
@@ -144,8 +147,8 @@ This specialist is not part of the default four-area fan-out. Skip it entirely a
 runtime performance: render hot paths, large item collections, virtualization,
 positioning, layout measurement, scroll/resize/pointer/keyboard handlers,
 observers, animations, repeated DOM reads/writes, state updates in loops, or
-component registration/lookup paths. At `high`, run it as an independent runtime
-performance subagent when triggered.
+component registration/lookup paths. At `high`, `xhigh`, and `max`, run it as an
+independent runtime performance subagent when triggered.
 
 Prefer concrete measurement when feasible: existing perf tests, targeted benchmark
 scripts, or a small reproducible measurement. If measuring is not practical, state
@@ -165,7 +168,7 @@ review is ordered.
 
 Dedup candidates that point at the same line/mechanism, keeping the one with the
 most concrete failure scenario. By default, verify candidates locally in the main
-agent. At `high` effort, run **one verifier** as a subagent for each remaining
+agent. At `max` effort, run **one verifier** as a subagent for each remaining
 candidate when subagents are available and authorized: give it the diff, the
 relevant file(s), and the candidate, and have it return exactly one of:
 
@@ -178,7 +181,7 @@ relevant file(s), and the candidate, and have it return exactly one of:
 
 Keep candidates where the vote is CONFIRMED or PLAUSIBLE.
 
-At **high**, verify is recall-biased - **PLAUSIBLE by default**: do not
+At **max**, verify is recall-biased - **PLAUSIBLE by default**: do not
 refute a candidate for being "speculative" or "depends on runtime state" when the
 state is realistic (concurrency races, nil/undefined on a rare-but-reachable path,
 falsy-zero treated as missing, off-by-one on a boundary the code does not exclude,
@@ -186,16 +189,17 @@ retry storms / partial failures, regex/allowlist that lost an anchor). REFUTE on
 when constructible from the code: factually wrong, provably impossible, already
 handled in this diff, or pure style with no observable effect.
 
-## Phase 3 - Sweep for gaps (high effort)
+## Phase 3 - Sweep for gaps (xhigh / max effort)
 
-Run **one more finder** as a fresh reviewer who has the verified list. Re-read the
-diff and enclosing functions looking ONLY for defects not already listed. Do not
-re-derive or re-confirm anything already there - the job is gaps. Focus on what the
-first pass tends to miss: moved/extracted code that dropped a guard or anchor;
-second-tier footguns (dataclass default evaluated once, `hash()` non-determinism,
-lock-scope shrink, predicate methods with side effects); setup/teardown asymmetry in
-tests; config defaults flipped. Surface additional candidates that name a defect not
-already on the list. If nothing new, return an empty sweep - do not pad.
+At `xhigh` and `max`, run **one more finder** as a fresh reviewer who has the
+current finding list. Re-read the diff and enclosing functions looking ONLY for
+defects not already listed. Do not re-derive or re-confirm anything already there -
+the job is gaps. Focus on what the first pass tends to miss: moved/extracted code
+that dropped a guard or anchor; second-tier footguns (dataclass default evaluated
+once, `hash()` non-determinism, lock-scope shrink, predicate methods with side
+effects); setup/teardown asymmetry in tests; config defaults flipped. Surface
+additional candidates that name a defect not already on the list. If nothing new,
+return an empty sweep - do not pad.
 
 ## Output
 
@@ -207,23 +211,29 @@ explains a specific finding or limitation.
 
 Prefix every finding title with a severity marker:
 
-- 🔴 **high / critical - blocking.** A regression or correctness bug that breaks
-  behavior, loses data, crashes, or ships a broken public contract. Should block
-  merge until fixed.
-- 🟡 **low / medium - non-blocking.** A real issue worth fixing but not
-  merge-blocking: a minor bug on a rare path, a simplification, a missing test, or
-  stale docs.
+- 🟣 **critical - blocking.** A severe correctness issue that can crash common
+  flows, lose user data, create a security/privacy problem, or ship a broken public
+  contract. Must block merge.
+- 🔴 **high - blocking.** A regression or correctness bug that breaks important
+  behavior for realistic usage, but without critical severity. Should block merge
+  until fixed.
+- 🟠 **medium - non-blocking.** A real issue worth fixing before merge when
+  practical: a narrow bug, meaningful missing test, stale public docs, or cleanup
+  that avoids likely future mistakes.
+- 🟡 **low - non-blocking.** A minor edge-case bug, small test/doc gap, or modest
+  simplification that is useful but easy for maintainers to defer.
 - ℹ️ **note.** Informational - an observation, heads-up, or optional suggestion the
   maintainer may reasonably decline.
 
-Within each section, order findings 🔴 -> 🟡 -> ℹ️. Include the same marker in the
-inline PR comment body when posting with `--comment`.
+Within each section, order findings 🟣 -> 🔴 -> 🟠 -> 🟡 -> ℹ️. Include the same
+marker in the inline PR comment body when posting with `--comment`.
 
 End the review with a `## Verdict` line derived from those markers:
 
-- **Request changes** - at least one 🔴 finding.
-- **Approve after nits** - no 🔴, but one or more 🟡 findings worth addressing.
-- **Approve** - no 🔴 and no 🟡 (only ℹ️ notes, or nothing).
+- **Request changes** - at least one 🟣 or 🔴 finding.
+- **Approve after nits** - no 🟣 or 🔴, but one or more 🟠 or 🟡 findings worth
+  addressing.
+- **Approve** - no 🟣, 🔴, 🟠, or 🟡 findings (only ℹ️ notes, or nothing).
 
 Follow the verdict with one clause naming the deciding factor.
 
@@ -246,7 +256,7 @@ harness you are actually running in. Always include this footer, including on th
 
 One to three sentences summarizing the concrete risk, most important theme, and
 any meaningful verification limit. State up front whether anything is merge-blocking
-(any 🔴). If there are no actionable findings, say that clearly.
+(any 🟣 or 🔴). If there are no actionable findings, say that clearly.
 
 ## Bugs ({count})
 
@@ -302,10 +312,17 @@ these `##` sections, in order, when there are findings: `Bugs`, `Tests`,
   high-confidence runtime-correctness bugs visible from the hunk alone.
 - **medium** (default) -> main agent reviews Bugs, Tests, Simplifications, and Docs
   locally, includes API design and runtime performance locally when the diff
-  warrants them, then verifies locally. Precision bias. No subagents.
-- **high** -> run the four main areas as independent fan-out subagents, run verifier
-  subagents for surviving candidates, trigger API design/perf specialist subagents
-  when warranted, add the Phase 3 sweep. Recall bias.
+  warrants them, then verifies locally. Precision bias. If the change is large,
+  risky, or touches fragile behavior, also spawn an independent bug/regression hunter
+  subagent and merge its candidates into the local review before verification.
+- **high** -> run Bugs, Tests, Simplifications, and Docs as independent fan-out
+  subagents; trigger API design/perf specialist subagents when warranted; then dedup
+  and sanity-check locally. Do not run verifier subagents or the Phase 3 sweep.
+- **xhigh** -> same as `high`, plus the Phase 3 sweep re-check. Do not run verifier
+  subagents.
+- **max** -> current most expensive mode: run the independent fan-out subagents, run
+  verifier subagents for surviving candidates, trigger API design/perf specialist
+  subagents when warranted, and add the Phase 3 sweep. Strong recall bias.
 
 ## Posting to GitHub (--comment)
 

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -3,7 +3,7 @@ name: base-ui-review
 description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post findings as inline PR comments, or --fix to apply the findings to the working tree after the review.'
 ---
 
-# Base UI Review
+# Base UI Review
 
 Review the current diff and report **regressions and correctness bugs** alongside
 **cleanup** (reuse / simplification / efficiency), scaling depth to the chosen effort
@@ -58,7 +58,7 @@ The core regression and correctness pass. Cover all of the following sub-angles:
   interactions, keyboard/focus flows, controlled/uncontrolled contracts, SSR,
   integrations between components, and public API examples.
 - **Repository/framework correctness lens.** Apply the invariants of the codebase
-  under review, not just generic language bugs. For Base UI / React component
+  under review, not just generic language bugs. For Base UI / React component
   changes, check controlled vs uncontrolled behavior, event ordering, ref
   forwarding/merging, context registration cleanup, nested component coordination,
   portals, focus management, keyboard navigation, ARIA attributes, disabled/read-only
@@ -82,10 +82,11 @@ The core regression and correctness pass. Cover all of the following sub-angles:
   instance the diff introduces.
 - **Wrapper/proxy correctness.** When the PR adds or modifies a type that wraps
   another (cache, proxy, decorator, adapter): check that every method routes to the
-  wrapped instance and not back through a registry/session/global - e.g. a caching
-  provider holding a `delegate` field that resolves IDs via `session.get(...)`
-  instead of `delegate.get(...)` will re-enter the cache or recurse. Also check that
-  the wrapper forwards all the methods the callers actually use.
+  wrapped instance and not back through a registry/session/global - for example, a
+  caching provider holding a `delegate` field that resolves IDs via
+  `session.get(...)` instead of `delegate.get(...)` will re-enter the cache or
+  recurse. Also check that the wrapper forwards all the methods the callers actually
+  use.
 
 ### Area 2 - Tests
 

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: base-ui-review
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post findings as inline PR comments, or --fix to apply the findings to the working tree after the review.'
+---
+
+# Base UI Review
+
+Review the current diff and report **regressions and correctness bugs** alongside
+**cleanup** (reuse / simplification / efficiency), scaling depth to the chosen effort
+level. The effort level (`low` / `medium` / `high`, default `medium`) controls how
+many areas are reviewed, whether work fans out to subagents, and the precision/recall
+bias - see [Effort levels](#effort-levels) for the canonical behavior of each.
+
+Argument hint: `[low|medium|high] [--fix] [--comment] [<target>]`
+
+You are reviewing for **precision** at medium effort: every finding you surface
+should be one a maintainer would act on. At **high** the bias shifts to **recall**
+to catch every real bug a careful reviewer would catch; a missed bug ships, so err
+on the side of surfacing (uncertain findings are allowed, labeled).
+
+## Scope
+
+For a local review, diff the branch against its upstream
+(`git diff @{upstream}...HEAD`, falling back to `main` / `master`, or `HEAD~1`), and
+fold in any uncommitted and untracked changes - the review often runs before the
+commit. If a PR link, branch name, or file path is passed as an argument, review
+that target instead.
+
+## Phase 1 - Find candidates
+
+Review the four main areas below: Bugs, Tests, Simplifications, and Docs. At
+`medium` (default) do this locally in the main agent with no subagents; at `high`
+run those four areas as **independent subagents**. At `low`, only Area 1 (Bugs)
+applies, and only its high-confidence runtime-correctness subset - see
+[Effort levels](#effort-levels). Each area surfaces actionable candidate findings
+with `file`, `line`, a one-line `summary`, a `severity` (🔴 / 🟡 / ℹ️ - see
+[Output](#output) for the rubric), and a concrete `failure_scenario`. Do NOT let
+one area's conclusions suppress another's - if two areas flag the same line for
+different reasons, record both.
+
+Pass every candidate with a nameable failure scenario through - finders that
+silently drop half-believed candidates bypass the verify step and are the
+dominant cause of misses.
+
+### Area 1 - Bugs
+
+The core regression and correctness pass. Cover all of the following sub-angles:
+
+- **Line-by-line diff scan.** Read every hunk, line by line. Then read the
+  enclosing function for each hunk - bugs in unchanged lines of a touched function
+  are in scope (the PR re-exposes or fails to fix them). For every line ask: what
+  input, state, timing, or platform makes this line wrong? Look for inverted/wrong
+  conditions, off-by-one, null/undefined deref, missing `await`, falsy-zero checks,
+  wrong-variable copy-paste, error swallowed in catch, unescaped regex metachars.
+- **Regression hunting.** For each changed guard, branch, state transition, public
+  contract, test expectation, or documented example, ask what behavior previously
+  worked and could now break. Bias toward regressions in edge paths, accessibility
+  interactions, keyboard/focus flows, controlled/uncontrolled contracts, SSR,
+  integrations between components, and public API examples.
+- **Repository/framework correctness lens.** Apply the invariants of the codebase
+  under review, not just generic language bugs. For Base UI / React component
+  changes, check controlled vs uncontrolled behavior, event ordering, ref
+  forwarding/merging, context registration cleanup, nested component coordination,
+  portals, focus management, keyboard navigation, ARIA attributes, disabled/read-only
+  states, form integration, SSR/hydration safety, Strict Mode behavior, and shadow
+  DOM-safe DOM access (`contains`, `getTarget`, `activeElement`, `ownerDocument`,
+  `ownerWindow`).
+- **Removed-behavior auditor.** For every line the diff DELETES or replaces, name
+  the invariant or behavior it enforced, then search the new code for where that
+  invariant is re-established. If you can't find it, that's a candidate: a removed
+  guard, a dropped error path, a narrowed validation, a deleted test that was
+  covering a real case.
+- **Cross-file tracer.** For each function the diff changes, find its callers (Grep
+  for the symbol) and check whether the change breaks any call site: a new
+  precondition, a changed return shape, a new exception, a timing/ordering
+  dependency. Also check callees: does a parallel change in the same PR make a call
+  unsafe?
+- **Language-pitfall specialist.** Scan for the classic pitfalls of the diff's
+  language/framework - for example: JS falsy-zero, `==` coercion, closure-captured
+  loop var; Python mutable default args, late-binding closures; Go nil-map write,
+  range-var capture; SQL injection; timezone/DST drift; float equality. Flag any
+  instance the diff introduces.
+- **Wrapper/proxy correctness.** When the PR adds or modifies a type that wraps
+  another (cache, proxy, decorator, adapter): check that every method routes to the
+  wrapped instance and not back through a registry/session/global - e.g. a caching
+  provider holding a `delegate` field that resolves IDs via `session.get(...)`
+  instead of `delegate.get(...)` will re-enter the cache or recurse. Also check that
+  the wrapper forwards all the methods the callers actually use.
+
+### Area 2 - Tests
+
+Review the test changes and the tests that _should_ have changed. Flag: new or
+changed behavior with no test exercising it; assertions that don't actually pin the
+behavior (asserting a mock was called instead of the result, snapshot-only coverage,
+asserting on a value the test itself computed); missing edge/error-path cases the
+diff introduces (null, empty, boundary, failure, concurrency); setup/teardown
+asymmetry (state leaked between tests, fixtures not reset); over-mocking that hides
+the real contract; and tests deleted or weakened without justification. Name the
+specific case that is untested or under-asserted.
+
+### Area 3 - Simplifications
+
+Flag changes that can be simpler, smaller, or implemented at a better altitude
+without changing intended behavior. Look for: a heavy dependency pulled in for
+something a few lines (or an existing util) would do; non-tree-shakeable or
+whole-package imports (`import _ from 'lodash'` vs a single function, namespace
+imports of side-effectful modules); duplicated logic that re-implements something
+the codebase already has - Grep shared/utility modules and files adjacent to the
+change, and name the existing helper to call instead; dead code left behind;
+redundant or derivable state; polyfills/large constants/data inlined that could be
+loaded lazily or dropped; and special cases layered on shared infrastructure when
+the underlying mechanism should be generalized. Name the smaller or better-shaped
+form that does the same job, and the approximate cost avoided.
+
+### Area 4 - Docs
+
+Flag documentation and comments the diff makes wrong or leaves stale: comments that
+describe the old behavior after the code changed; JSDoc/docstrings whose params,
+return type, or thrown errors no longer match the signature; README / API docs /
+changelog entries that contradict the change; examples that no longer compile or run;
+TODO/FIXME the change resolved but didn't remove; and new non-obvious code with no
+explanation where one is warranted. Quote the stale line and state what it should say.
+
+### Conditional specialist - API design
+
+This specialist is not part of the default four-area fan-out. Skip it entirely at
+`low`. At `medium`, include it in the main-agent pass when the diff adds or changes
+a public API surface: a component, prop, event, hook, provider, imperative method,
+exported type, value shape, behavior contract, or docs example that teaches an API.
+At `high`, run it as an independent API design subagent when triggered.
+
+Heavily critique the taste of the API: naming, mental model, consistency with
+nearby APIs in the same codebase, controlled/uncontrolled ergonomics, composition,
+escape hatches, type shape, default behavior, future extensibility, migration risk,
+and likely user footguns. Prefer findings that prevent awkward public contracts before they ship.
+Report API design findings under Bugs when they create likely user-visible footguns
+or regressions, otherwise under Simplifications.
+
+### Conditional specialist - Runtime performance
+
+This specialist is not part of the default four-area fan-out. Skip it entirely at
+`low`. At `medium`, include it in the main-agent pass when the diff likely affects
+runtime performance: render hot paths, large item collections, virtualization,
+positioning, layout measurement, scroll/resize/pointer/keyboard handlers,
+observers, animations, repeated DOM reads/writes, state updates in loops, or
+component registration/lookup paths. At `high`, run it as an independent runtime
+performance subagent when triggered.
+
+Prefer concrete measurement when feasible: existing perf tests, targeted benchmark
+scripts, or a small reproducible measurement. If measuring is not practical, state
+the expected complexity or browser work and what would confirm it. Report runtime
+performance findings under Bugs when users can see lag, jank, hangs, or excessive
+work, otherwise under Simplifications.
+
+---
+
+Simplification, test, and docs candidates use the same `file`/`line`/`summary`
+shape; in `failure_scenario`, state the concrete cost (what is duplicated, wasted,
+untested, stale, or harder to maintain) instead of a crash. Regressions and
+correctness bugs always outrank simplification, test, and docs findings when the
+review is ordered.
+
+## Phase 2 - Verify (1-vote, 3-state)
+
+Dedup candidates that point at the same line/mechanism, keeping the one with the
+most concrete failure scenario. By default, verify candidates locally in the main
+agent. At `high` effort, run **one verifier** as a subagent for each remaining
+candidate when subagents are available and authorized: give it the diff, the
+relevant file(s), and the candidate, and have it return exactly one of:
+
+- **CONFIRMED** - can name the inputs/state that trigger it and the wrong output or
+  crash. Quote the line.
+- **PLAUSIBLE** - mechanism is real, trigger is uncertain (timing, env, config).
+  State what would confirm it.
+- **REFUTED** - factually wrong (code doesn't say that) or guarded elsewhere. Quote
+  the line that proves it.
+
+Keep candidates where the vote is CONFIRMED or PLAUSIBLE.
+
+At **high**, verify is recall-biased - **PLAUSIBLE by default**: do not
+refute a candidate for being "speculative" or "depends on runtime state" when the
+state is realistic (concurrency races, nil/undefined on a rare-but-reachable path,
+falsy-zero treated as missing, off-by-one on a boundary the code does not exclude,
+retry storms / partial failures, regex/allowlist that lost an anchor). REFUTE only
+when constructible from the code: factually wrong, provably impossible, already
+handled in this diff, or pure style with no observable effect.
+
+## Phase 3 - Sweep for gaps (high effort)
+
+Run **one more finder** as a fresh reviewer who has the verified list. Re-read the
+diff and enclosing functions looking ONLY for defects not already listed. Do not
+re-derive or re-confirm anything already there - the job is gaps. Focus on what the
+first pass tends to miss: moved/extracted code that dropped a guard or anchor;
+second-tier footguns (dataclass default evaluated once, `hash()` non-determinism,
+lock-scope shrink, predicate methods with side effects); setup/teardown asymmetry in
+tests; config defaults flipped. Surface additional candidates that name a defect not
+already on the list. If nothing new, return an empty sweep - do not pad.
+
+## Output
+
+Reply in Markdown using this structure. Do not wrap the main result in JSON or a
+code fence. Use sentence case for the `#` heading and all finding titles; do not
+use title case. Do not open with generic target/base filler such as "Reviewed
+`owner/repo#123` against `branch`." Only mention the target or base branch when it
+explains a specific finding or limitation.
+
+Prefix every finding title with a severity marker:
+
+- 🔴 **high / critical - blocking.** A regression or correctness bug that breaks
+  behavior, loses data, crashes, or ships a broken public contract. Should block
+  merge until fixed.
+- 🟡 **low / medium - non-blocking.** A real issue worth fixing but not
+  merge-blocking: a minor bug on a rare path, a simplification, a missing test, or
+  stale docs.
+- ℹ️ **note.** Informational - an observation, heads-up, or optional suggestion the
+  maintainer may reasonably decline.
+
+Within each section, order findings 🔴 -> 🟡 -> ℹ️. Include the same marker in the
+inline PR comment body when posting with `--comment`.
+
+End the review with a `## Verdict` line derived from those markers:
+
+- **Request changes** - at least one 🔴 finding.
+- **Approve after nits** - no 🔴, but one or more 🟡 findings worth addressing.
+- **Approve** - no 🔴 and no 🟡 (only ℹ️ notes, or nothing).
+
+Follow the verdict with one clause naming the deciding factor.
+
+Then close the review with a footer: a `---` horizontal rule, a blank line, then a
+single line of plain text:
+
+```
+---
+
+🤖 Review generated with Claude Code
+```
+
+Use **Claude Code** when this skill is being executed by the Claude Code harness, or
+**Codex** when it is being executed by the Codex harness - pick the label for the
+harness you are actually running in. Always include this footer, including on the
+`No findings.` path below.
+
+````md
+# PR review
+
+One to three sentences summarizing the concrete risk, most important theme, and
+any meaningful verification limit. State up front whether anything is merge-blocking
+(any 🔴). If there are no actionable findings, say that clearly.
+
+## Bugs ({count})
+
+### 1. {severity marker} {Sentence-case title}
+
+**Location:** `path/to/file.ext:123`
+
+```tsx
+// Small relevant code excerpt from the reviewed file.
+```
+
+{Description of what is wrong and why it matters.}
+
+**Failure scenario:** {Simple, obvious user-facing or example issue someone would
+see.}
+
+**Fix:** {Specific recommended change.}
+
+## Tests ({count})
+
+## Simplifications ({count})
+
+## Docs ({count})
+
+## Verdict
+
+**{Request changes | Approve after nits | Approve}** - {one clause on the deciding factor}.
+
+---
+
+🤖 Review generated with {Claude Code | Codex}
+````
+
+Use the same per-finding shape for Tests, Simplifications, and Docs. For Tests,
+make the failure scenario the missing case or weak assertion. For Simplifications,
+make it the concrete duplicated, heavier, or harder-to-maintain code path. For Docs,
+make it the stale or missing public/developer-facing information.
+
+Do not cap findings by count. Report every verified, actionable finding that a
+maintainer would reasonably fix before merging. Do not pad the review with weak,
+stylistic, speculative, or low-importance notes. If many findings survive, group
+related issues under one finding when they share the same root cause. If nothing
+survives verification, return `# PR review` followed by `No findings.`, a brief note
+of any residual test gaps or risk, a `## Verdict` of **Approve**, and the
+`🤖 Review generated with ...` footer. Use exactly
+these `##` sections, in order, when there are findings: `Bugs`, `Tests`,
+`Simplifications`, `Docs`, `Verdict`. For any section whose count is `(0)`, write exactly `No findings.` under that heading.
+
+### Effort levels
+
+- **low** -> single inline diff pass, no subagents, no verifier pass. Only the Bugs
+  area applies; skip Tests, Simplifications, Docs, and test/fixture hunks. Flag only
+  high-confidence runtime-correctness bugs visible from the hunk alone.
+- **medium** (default) -> main agent reviews Bugs, Tests, Simplifications, and Docs
+  locally, includes API design and runtime performance locally when the diff
+  warrants them, then verifies locally. Precision bias. No subagents.
+- **high** -> run the four main areas as independent fan-out subagents, run verifier
+  subagents for surviving candidates, trigger API design/perf specialist subagents
+  when warranted, add the Phase 3 sweep. Recall bias.
+
+## Posting to GitHub (--comment)
+
+The `--comment` flag was passed. After producing the findings list, if the review
+target is a GitHub PR, post each finding as an inline PR comment via `gh api`
+(`repos/{owner}/{repo}/pulls/{pr}/comments`), one call per finding, including a
+suggestion block only when it fully fixes the issue. (If a GitHub inline-comment MCP
+tool is available in this session, use it instead.) If the target is not a PR, print
+the findings to the terminal and note that `--comment` was ignored.
+
+## Applying fixes (--fix)
+
+The `--fix` flag was passed. After producing the findings list, apply the findings to
+the working tree instead of stopping at the report: fix each one directly -
+correctness bugs and reuse/simplification/efficiency cleanups alike. Skip any finding
+whose fix would change intended behavior, require changes well outside the reviewed
+diff, or that you judge to be a false positive - note the skip rather than arguing
+with it. Finish with a brief summary of what was fixed and what was skipped.

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base-ui-review
-description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post findings as inline PR comments, or --fix to apply the findings to the working tree after the review.'
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
 ---
 
 # Base UI Review
@@ -11,7 +11,7 @@ Review the current diff and report **regressions and correctness bugs** alongsid
 areas across subagents, `xhigh` adds a sweep, and `max` adds verifier subagents.
 See [Effort levels](#effort-levels).
 
-Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment] [<target>]`
+Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment [inline]] [<target>]`
 
 You are reviewing for **precision** at medium effort: every finding you surface
 should be one a maintainer would act on. At **high**, **xhigh**, and especially
@@ -235,7 +235,7 @@ consumer usage, accessibility behavior, form behavior, focus management, SSR, or
 public API/docs contract. Do not reserve 🔴 high only for outage-level failures.
 
 Within each section, order findings 🟣 -> 🔴 -> 🟠 -> 🟡 -> ℹ️. Include the same
-marker in the inline PR comment body when posting with `--comment`.
+marker in each inline PR comment body when posting with `--comment inline`.
 
 End the review with a `## Verdict` line derived from those markers:
 
@@ -333,12 +333,14 @@ these `##` sections, in order, when there are findings: `Bugs`, `Tests`,
 ## Posting to GitHub (--comment)
 
 If the `--comment` flag was passed in the arguments, then after producing the
-findings list, if the review target is a GitHub PR, post each finding as an inline
-PR comment via `gh api` (`repos/{owner}/{repo}/pulls/{pr}/comments`), one call per
-finding, including a suggestion block only when it fully fixes the issue. (If a
-GitHub inline-comment MCP tool is available in this session, use it instead.) If
-the target is not a PR, print the findings to the terminal and note that
-`--comment` was ignored.
+findings list, post to GitHub only when the review target is a GitHub PR. Plain
+`--comment` posts the Markdown review as one top-level PR comment via
+`gh pr comment`. `--comment inline` posts each finding as an inline PR comment via
+`gh api` (`repos/{owner}/{repo}/pulls/{pr}/comments`), one call per finding,
+including a suggestion block only when it fully fixes the issue. (If a GitHub
+inline-comment MCP tool is available in this session, use it instead.) If the
+target is not a PR, print the findings to the terminal and note that `--comment`
+was ignored.
 
 ## Applying fixes (--fix)
 

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -211,19 +211,30 @@ explains a specific finding or limitation.
 
 Prefix every finding title with a severity marker:
 
-- 🟣 **critical - blocking.** A severe correctness issue that can crash common
-  flows, lose user data, create a security/privacy problem, or ship a broken public
-  contract. Must block merge.
-- 🔴 **high - blocking.** A regression or correctness bug that breaks important
-  behavior for realistic usage, but without critical severity. Should block merge
-  until fixed.
+- 🟣 **critical - blocking.** A correctness issue that can crash common flows, lose
+  user data, create a security/privacy problem, make a public component contract
+  unusable, or create broad cross-component accessibility, focus, form, or SSR
+  breakage. Must block merge.
+- 🔴 **high - blocking.** A realistic user-visible regression in normal component
+  usage, accessibility, keyboard/focus behavior, controlled/uncontrolled behavior,
+  form integration, SSR/hydration, public API behavior, or a public docs example. It
+  should block merge even when the affected path has a workaround or is not the most
+  common path.
 - 🟠 **medium - non-blocking.** A real issue worth fixing before merge when
-  practical: a narrow bug, meaningful missing test, stale public docs, or cleanup
-  that avoids likely future mistakes.
+  practical but not normally blocking: a narrow or uncommon bug, meaningful missing
+  test, stale public docs, or cleanup that avoids likely future mistakes. Use this
+  only when the issue does not break a public contract and does not affect
+  accessibility, focus, forms, SSR, or normal component usage.
 - 🟡 **low - non-blocking.** A minor edge-case bug, small test/doc gap, or modest
   simplification that is useful but easy for maintainers to defer.
 - ℹ️ **note.** Informational - an observation, heads-up, or optional suggestion the
   maintainer may reasonably decline.
+
+Base UI has a stricter quality bar than most apps because small component-library
+regressions are multiplied across many downstream products. When choosing between
+adjacent severities, choose the higher severity if the failure reaches realistic
+consumer usage, accessibility behavior, form behavior, focus management, SSR, or a
+public API/docs contract. Do not reserve 🔴 high only for outage-level failures.
 
 Within each section, order findings 🟣 -> 🔴 -> 🟠 -> 🟡 -> ℹ️. Include the same
 marker in the inline PR comment body when posting with `--comment`.

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -266,8 +266,8 @@ harness you are actually running in. Always include this footer, including on th
 # PR review
 
 One to three sentences summarizing the concrete risk, most important theme, and
-any meaningful verification limit. State up front whether anything is merge-blocking
-(any 🟣 or 🔴). If there are no actionable findings, say that clearly.
+any meaningful verification limit. State up front whether anything is merge-blocking.
+If there are no actionable findings, say that clearly.
 
 ## Bugs ({count})
 

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -6,11 +6,10 @@ description: 'Review the current diff for regressions, correctness bugs, tests, 
 # Base UI Review
 
 Review the current diff and report **regressions and correctness bugs** alongside
-**cleanup** (reuse / simplification / efficiency), scaling depth to the chosen effort
-level. The effort level (`low` / `medium` / `high` / `xhigh` / `max`, default
-`medium`) controls how many areas are reviewed, whether work fans out to subagents,
-and the precision/recall bias - see [Effort levels](#effort-levels) for the
-canonical behavior of each.
+**cleanup** (reuse / simplification / efficiency). Effort defaults to `medium`:
+`low` is bug-only, `medium` is the normal single-agent review, `high` splits the
+areas across subagents, `xhigh` adds a sweep, and `max` adds verifier subagents.
+See [Effort levels](#effort-levels).
 
 Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment] [<target>]`
 
@@ -29,12 +28,11 @@ that target instead.
 
 ## Phase 1 - Find candidates
 
-Review the four main areas below: Bugs, Tests, Simplifications, and Docs. At `low`,
-only Area 1 (Bugs) applies, and only its high-confidence runtime-correctness subset.
-At `medium` (default), do this locally in the main agent; if the change is large,
-risky, or touches fragile behavior, also spawn an independent bug/regression hunter
-subagent. At `high`, `xhigh`, and `max`, run the four areas as **independent
-subagents** - see [Effort levels](#effort-levels). Each area surfaces actionable
+Review the four main areas below: Bugs, Tests, Simplifications, and Docs. `low`
+reviews only high-confidence bug regressions. `medium` reviews all areas locally
+and may add one bug/regression subagent for large or risky diffs. `high` and above
+run the four areas as **independent subagents** - see
+[Effort levels](#effort-levels). Each area surfaces actionable
 candidate findings with `file`, `line`, a one-line `summary`, a `severity` (🟣 / 🔴 /
 🟠 / 🟡 / ℹ️ - see [Output](#output) for the rubric), and a concrete
 `failure_scenario`. Do NOT let one area's conclusions suppress another's - if two
@@ -318,22 +316,19 @@ these `##` sections, in order, when there are findings: `Bugs`, `Tests`,
 
 ### Effort levels
 
-- **low** -> single inline diff pass, no subagents, no verifier pass. Only the Bugs
-  area applies; skip Tests, Simplifications, Docs, and test/fixture hunks. Flag only
-  high-confidence runtime-correctness bugs visible from the hunk alone.
-- **medium** (default) -> main agent reviews Bugs, Tests, Simplifications, and Docs
-  locally, includes API design and runtime performance locally when the diff
-  warrants them, then verifies locally. Precision bias. If the change is large,
-  risky, or touches fragile behavior, also spawn an independent bug/regression hunter
-  subagent and merge its candidates into the local review before verification.
-- **high** -> run Bugs, Tests, Simplifications, and Docs as independent fan-out
-  subagents; trigger API design/perf specialist subagents when warranted; then dedup
-  and sanity-check locally. Do not run verifier subagents or the Phase 3 sweep.
-- **xhigh** -> same as `high`, plus the Phase 3 sweep re-check. Do not run verifier
+- **low** -> fastest: bug-only hunk pass. Skip Tests, Simplifications, Docs, and
+  test/fixture hunks. Flag only high-confidence runtime-correctness bugs visible
+  from the hunk alone.
+- **medium** (default) -> one agent reviews Bugs, Tests, Simplifications, Docs, and
+  any triggered API design/performance concerns, then verifies locally. Precision
+  bias. Add one bug/regression subagent only for large, risky, or fragile diffs.
+- **high** -> independent subagents review the four areas, plus triggered API
+  design/performance specialists. Main agent dedups and sanity-checks. No verifier
+  subagents or sweep.
+- **xhigh** -> `high` plus one fresh sweep for missed findings. No verifier
   subagents.
-- **max** -> current most expensive mode: run the independent fan-out subagents, run
-  verifier subagents for surviving candidates, trigger API design/perf specialist
-  subagents when warranted, and add the Phase 3 sweep. Strong recall bias.
+- **max** -> `xhigh` plus verifier subagents for surviving candidates. Highest cost,
+  strongest recall bias.
 
 ## Posting to GitHub (--comment)
 

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -215,14 +215,15 @@ Prefix every finding title with a severity marker:
   breakage. Must block merge.
 - 🔴 **high - blocking.** A realistic user-visible regression in normal component
   usage, accessibility, keyboard/focus behavior, controlled/uncontrolled behavior,
-  form integration, SSR/hydration, public API behavior, or a public docs example. It
-  should block merge even when the affected path has a workaround or is not the most
-  common path.
+  form integration, SSR/hydration, public API behavior, or a public docs example
+  that no longer compiles or teaches broken API usage. It should block merge even
+  when the affected path has a workaround or is not the most common path.
 - 🟠 **medium - non-blocking.** A real issue worth fixing before merge when
   practical but not normally blocking: a narrow or uncommon bug, meaningful missing
-  test, stale public docs, or cleanup that avoids likely future mistakes. Use this
-  only when the issue does not break a public contract and does not affect
-  accessibility, focus, forms, SSR, or normal component usage.
+  test, stale public-doc prose that does not break copy-pasted code, or cleanup that
+  avoids likely future mistakes. Use this only when the issue does not break a public
+  contract and does not affect accessibility, focus, forms, SSR, or normal component
+  usage.
 - 🟡 **low - non-blocking.** A minor edge-case bug, small test/doc gap, or modest
   simplification that is useful but easy for maintainers to defer.
 - ℹ️ **note.** Informational - an observation, heads-up, or optional suggestion the
@@ -232,7 +233,8 @@ Base UI has a stricter quality bar than most apps because small component-libra
 regressions are multiplied across many downstream products. When choosing between
 adjacent severities, choose the higher severity if the failure reaches realistic
 consumer usage, accessibility behavior, form behavior, focus management, SSR, or a
-public API/docs contract. Do not reserve 🔴 high only for outage-level failures.
+public API contract or broken public docs example. Do not reserve 🔴 high only for
+outage-level failures.
 
 Within each section, order findings 🟣 -> 🔴 -> 🟠 -> 🟡 -> ℹ️. Include the same
 marker in each inline PR comment body when posting with `--comment inline`.

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -5,253 +5,247 @@ description: 'Review the current diff for regressions, correctness bugs, tests, 
 
 # Base UI Review
 
-Review the current diff and report **regressions and correctness bugs** alongside
-**cleanup** (reuse / simplification / efficiency). Effort defaults to `medium`; use
-[Effort levels](#effort-levels) to choose review depth, subagent fan-out, and
-precision/recall bias.
+Review current diff. Report **regressions and correctness bugs** plus
+**cleanup** (reuse / simplification / efficiency). Effort default `medium`; use
+[Effort levels](#effort-levels) for depth, subagent fan-out, precision/recall bias.
 
 Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment [inline]] [<target>]`
 
-You are reviewing for **precision** at medium effort: every finding you surface
-should be one a maintainer would act on. At **high**, **xhigh**, and especially
-**max**, the bias shifts toward **recall**; a missed bug ships, so surface uncertain
-findings when the mechanism is realistic and label them clearly.
+Medium effort = **precision** bias: every finding actionable. **high**, **xhigh**,
+**max** shift to **recall**; missed bug ships. Surface uncertain findings when
+mechanism realistic, label clearly.
 
 ## Scope
 
-For a local review, diff the branch against its upstream
-(`git diff @{upstream}...HEAD`, falling back to `main` / `master`, or `HEAD~1`), and
-fold in any uncommitted and untracked changes - the review often runs before the
-commit. If a PR link, branch name, or file path is passed as an argument, review
-that target instead.
+Local review: diff branch against upstream
+(`git diff @{upstream}...HEAD`, fall back to `main` / `master`, or `HEAD~1`).
+Fold in uncommitted + untracked changes — review often runs pre-commit. If PR link,
+branch name, or file path passed as argument, review that target instead.
 
 ## Effort levels
 
-- **low** -> fastest: bug-only hunk pass. Skip Tests, Simplifications, Docs, and
+- **low** — fastest: bug-only hunk pass. Skip Tests, Simplifications, Docs,
   test/fixture hunks. Flag only high-confidence runtime-correctness bugs visible
-  from the hunk alone.
-- **medium** (default) -> one agent reviews Bugs, Tests, Simplifications, Docs, and
-  any triggered API design/performance concerns, then verifies locally. Precision
-  bias. Add one bug/regression subagent only for large, risky, or fragile diffs.
-- **high** -> independent subagents review the four areas, plus triggered API
-  design/performance specialists. Main agent dedups and sanity-checks. No verifier
+  from hunk alone.
+- **medium** (default) — one agent reviews Bugs, Tests, Simplifications, Docs, plus
+  triggered API design/performance concerns, then verifies locally. Precision
+  bias. Add one bug/regression subagent only for large, risky, fragile diffs.
+- **high** — independent subagents review four areas, plus triggered API
+  design/performance specialists. Main agent dedups + sanity-checks. No verifier
   subagents or sweep.
-- **xhigh** -> `high` plus one fresh sweep for missed findings. No verifier
+- **xhigh** — `high` plus one fresh sweep for missed findings. No verifier
   subagents.
-- **max** -> `xhigh` plus verifier subagents for surviving candidates. Highest cost,
+- **max** — `xhigh` plus verifier subagents for surviving candidates. Highest cost,
   strongest recall bias.
 
 ## Phase 1 - Find candidates
 
-Use the selected [effort level](#effort-levels) to decide whether this phase runs
-locally or fans out to subagents. Except at `low`, review the four main areas below:
-Bugs, Tests, Simplifications, and Docs. Each area surfaces actionable candidate
-findings with `file`, `line`, a one-line `summary`, a `severity` (🟣 / 🔴 / 🟠 / 🟡 /
-ℹ️ - see [Output](#output) for the rubric), and a concrete `failure_scenario`. Do
-NOT let one area's conclusions suppress another's - if two areas flag the same line
-for different reasons, record both.
+Selected [effort level](#effort-levels) decides local vs subagent fan-out. Except at
+`low`, review four main areas: Bugs, Tests, Simplifications, Docs. Each area
+surfaces candidates with `file`, `line`, one-line `summary`, `severity` (🟣 / 🔴 / 🟠 / 🟡 /
+ℹ️ — see [Output](#output) for rubric), concrete `failure_scenario`. Do
+NOT let one area suppress another — two areas flag same line for different reasons,
+record both.
 
-Pass every candidate with a nameable failure scenario through - finders that
-silently drop half-believed candidates bypass the verify step and are the
-dominant cause of misses.
+Pass every candidate with nameable failure scenario through. Finders that
+silently drop half-believed candidates bypass verify step — dominant cause of misses.
 
 ### Area 1 - Bugs
 
-The core regression and correctness pass. Cover all of the following sub-angles:
+Core regression + correctness pass. Cover all sub-angles:
 
-- **Line-by-line diff scan.** Read every hunk, line by line. Then read the
-  enclosing function for each hunk - bugs in unchanged lines of a touched function
-  are in scope (the PR re-exposes or fails to fix them). For every line ask: what
-  input, state, timing, or platform makes this line wrong? Look for inverted/wrong
+- **Line-by-line diff scan.** Read every hunk, line by line. Then read enclosing
+  function for each hunk — bugs in unchanged lines of touched function
+  in scope (PR re-exposes or fails to fix them). For every line ask: what
+  input, state, timing, platform makes line wrong? Look for inverted/wrong
   conditions, off-by-one, null/undefined deref, missing `await`, falsy-zero checks,
   wrong-variable copy-paste, error swallowed in catch, unescaped regex metachars.
 - **Regression hunting.** For each changed guard, branch, state transition, public
-  contract, test expectation, or documented example, ask what behavior previously
-  worked and could now break. Bias toward regressions in edge paths, accessibility
+  contract, test expectation, documented example, ask what behavior previously
+  worked and could break. Bias toward regressions in edge paths, accessibility
   interactions, keyboard/focus flows, controlled/uncontrolled contracts, SSR,
-  integrations between components, and public API examples.
-- **Repository/framework correctness lens.** Apply the invariants of the codebase
+  integrations between components, public API examples.
+- **Repository/framework correctness lens.** Apply invariants of codebase
   under review, not just generic language bugs. For Base UI / React component
-  changes, check controlled vs uncontrolled behavior, event ordering, ref
+  changes: controlled vs uncontrolled behavior, event ordering, ref
   forwarding/merging, context registration cleanup, nested component coordination,
   portals, focus management, keyboard navigation, ARIA attributes, disabled/read-only
-  states, form integration, SSR/hydration safety, Strict Mode behavior, and shadow
+  states, form integration, SSR/hydration safety, Strict Mode behavior, shadow
   DOM-safe DOM access (`contains`, `getTarget`, `activeElement`, `ownerDocument`,
   `ownerWindow`).
-- **Removed-behavior auditor.** For every line the diff DELETES or replaces, name
-  the invariant or behavior it enforced, then search the new code for where that
-  invariant is re-established. If you can't find it, that's a candidate: a removed
-  guard, a dropped error path, a narrowed validation, a deleted test that was
-  covering a real case.
-- **Cross-file tracer.** For each function the diff changes, find its callers (Grep
-  for the symbol) and check whether the change breaks any call site: a new
-  precondition, a changed return shape, a new exception, a timing/ordering
-  dependency. Also check callees: does a parallel change in the same PR make a call
+- **Removed-behavior auditor.** For every line diff DELETES or replaces, name
+  invariant/behavior it enforced, then search new code for where invariant
+  re-established. Can't find it? Candidate: removed
+  guard, dropped error path, narrowed validation, deleted test covering real case.
+- **Cross-file tracer.** For each function diff changes, find callers (Grep
+  symbol) and check if change breaks any call site: new
+  precondition, changed return shape, new exception, timing/ordering
+  dependency. Also check callees: parallel change in same PR make call
   unsafe?
-- **Language-pitfall specialist.** Scan for the classic pitfalls of the diff's
-  language/framework - for example: JS falsy-zero, `==` coercion, closure-captured
+- **Language-pitfall specialist.** Scan classic pitfalls of diff's
+  language/framework — example: JS falsy-zero, `==` coercion, closure-captured
   loop var; Python mutable default args, late-binding closures; Go nil-map write,
   range-var capture; SQL injection; timezone/DST drift; float equality. Flag any
-  instance the diff introduces.
-- **Wrapper/proxy correctness.** When the PR adds or modifies a type that wraps
-  another (cache, proxy, decorator, adapter): check that every method routes to the
-  wrapped instance and not back through a registry/session/global - for example, a
-  caching provider holding a `delegate` field that resolves IDs via
-  `session.get(...)` instead of `delegate.get(...)` will re-enter the cache or
-  recurse. Also check that the wrapper forwards all the methods the callers actually
+  instance diff introduces.
+- **Wrapper/proxy correctness.** When PR adds/modifies type wrapping
+  another (cache, proxy, decorator, adapter): check every method routes to
+  wrapped instance not back through registry/session/global — example, caching
+  provider holding `delegate` field resolving IDs via
+  `session.get(...)` instead of `delegate.get(...)` will re-enter cache or
+  recurse. Also check wrapper forwards all methods callers actually
   use.
 
 ### Area 2 - Tests
 
-Review the test changes and the tests that _should_ have changed. Flag: new or
-changed behavior with no test exercising it; assertions that don't actually pin the
-behavior (asserting a mock was called instead of the result, snapshot-only coverage,
-asserting on a value the test itself computed); missing edge/error-path cases the
+Review test changes and tests that _should_ have changed. Flag: new/
+changed behavior with no test exercising it; assertions not actually pinning
+behavior (asserting mock called instead of result, snapshot-only coverage,
+asserting on value test itself computed); missing edge/error-path cases
 diff introduces (null, empty, boundary, failure, concurrency); setup/teardown
-asymmetry (state leaked between tests, fixtures not reset); over-mocking that hides
-the real contract; and tests deleted or weakened without justification. Name the
-specific case that is untested or under-asserted.
+asymmetry (state leaked between tests, fixtures not reset); over-mocking hiding
+real contract; tests deleted or weakened without justification. Name
+specific case untested or under-asserted.
 
 ### Area 3 - Simplifications
 
-Flag changes that can be simpler, smaller, or implemented at a better altitude
-without changing intended behavior. Look for: a heavy dependency pulled in for
-something a few lines (or an existing util) would do; non-tree-shakeable or
-whole-package imports (`import _ from 'lodash'` vs a single function, namespace
-imports of side-effectful modules); duplicated logic that re-implements something
-the codebase already has - Grep shared/utility modules and files adjacent to the
-change, and name the existing helper to call instead; dead code left behind;
+Flag changes that can be simpler, smaller, at better altitude
+without changing intended behavior. Look for: heavy dependency pulled in for
+something a few lines (or existing util) would do; non-tree-shakeable or
+whole-package imports (`import _ from 'lodash'` vs single function, namespace
+imports of side-effectful modules); duplicated logic re-implementing something
+codebase already has — Grep shared/utility modules and files adjacent to
+change, name existing helper to call instead; dead code left behind;
 redundant or derivable state; polyfills/large constants/data inlined that could be
-loaded lazily or dropped; and special cases layered on shared infrastructure when
-the underlying mechanism should be generalized. Name the smaller or better-shaped
-form that does the same job, and the approximate cost avoided.
+loaded lazily or dropped; special cases layered on shared infrastructure when
+underlying mechanism should be generalized. Name smaller or better-shaped
+form doing same job, and approximate cost avoided.
 
 ### Area 4 - Docs
 
-Flag documentation and comments the diff makes wrong or leaves stale: comments that
-describe the old behavior after the code changed; JSDoc/docstrings whose params,
-return type, or thrown errors no longer match the signature; README / API docs /
-changelog entries that contradict the change; examples that no longer compile or run;
-TODO/FIXME the change resolved but didn't remove; and new non-obvious code with no
-explanation where one is warranted. Quote the stale line and state what it should say.
+Flag documentation and comments diff makes wrong or leaves stale: comments
+describing old behavior after code changed; JSDoc/docstrings whose params,
+return type, thrown errors no longer match signature; README / API docs /
+changelog entries contradicting change; examples no longer compile or run;
+TODO/FIXME change resolved but didn't remove; new non-obvious code with no
+explanation where warranted. Quote stale line and state what it should say.
 
 ### Conditional specialist - API design
 
-This specialist is not part of the default four-area fan-out. Skip it entirely at
-`low`. At `medium`, include it in the main-agent pass when the diff adds or changes
-a public API surface: a component, prop, event, hook, provider, imperative method,
-exported type, value shape, behavior contract, or docs example that teaches an API.
-At `high`, `xhigh`, and `max`, run it as an independent API design subagent when
+Not part of default four-area fan-out. Skip entirely at
+`low`. At `medium`, include in main-agent pass when diff adds/changes
+public API surface: component, prop, event, hook, provider, imperative method,
+exported type, value shape, behavior contract, docs example teaching API.
+At `high`, `xhigh`, `max`, run as independent API design subagent when
 triggered.
 
-Heavily critique the taste of the API: naming, mental model, consistency with
-nearby APIs in the same codebase, controlled/uncontrolled ergonomics, composition,
+Heavily critique API taste: naming, mental model, consistency with
+nearby APIs in same codebase, controlled/uncontrolled ergonomics, composition,
 escape hatches, type shape, default behavior, future extensibility, migration risk,
-and likely user footguns. Prefer findings that prevent awkward public contracts before they ship.
+likely user footguns. Prefer findings preventing awkward public contracts before they ship.
 Report API design findings under Bugs when they create likely user-visible footguns
 or regressions, otherwise under Simplifications.
 
 ### Conditional specialist - Runtime performance
 
-This specialist is not part of the default four-area fan-out. Skip it entirely at
-`low`. At `medium`, include it in the main-agent pass when the diff likely affects
+Not part of default four-area fan-out. Skip entirely at
+`low`. At `medium`, include in main-agent pass when diff likely affects
 runtime performance: render hot paths, large item collections, virtualization,
 positioning, layout measurement, scroll/resize/pointer/keyboard handlers,
-observers, animations, repeated DOM reads/writes, state updates in loops, or
-component registration/lookup paths. At `high`, `xhigh`, and `max`, run it as an
+observers, animations, repeated DOM reads/writes, state updates in loops,
+component registration/lookup paths. At `high`, `xhigh`, `max`, run as
 independent runtime performance subagent when triggered.
 
 Prefer concrete measurement when feasible: existing perf tests, targeted benchmark
-scripts, or a small reproducible measurement. If measuring is not practical, state
-the expected complexity or browser work and what would confirm it. Report runtime
-performance findings under Bugs when users can see lag, jank, hangs, or excessive
+scripts, small reproducible measurement. If measuring not practical, state
+expected complexity or browser work and what would confirm it. Report runtime
+performance findings under Bugs when users can see lag, jank, hangs, excessive
 work, otherwise under Simplifications.
 
 ---
 
-Simplification, test, and docs candidates use the same `file`/`line`/`summary`
-shape; in `failure_scenario`, state the concrete cost (what is duplicated, wasted,
-untested, stale, or harder to maintain) instead of a crash. Regressions and
-correctness bugs always outrank simplification, test, and docs findings when the
-review is ordered.
+Simplification, test, docs candidates use same `file`/`line`/`summary`
+shape; in `failure_scenario`, state concrete cost (what duplicated, wasted,
+untested, stale, harder to maintain) instead of crash. Regressions and
+correctness bugs always outrank simplification, test, docs findings when
+review ordered.
 
 ## Phase 2 - Verify candidates (local by default; max adds subagent votes)
 
-Dedup candidates that point at the same line/mechanism, keeping the one with the
-most concrete failure scenario. Verify candidates locally in the main agent by
-default. At `max` effort, also run **one verifier** as a subagent for each
-remaining candidate when subagents are available and authorized: give it the diff,
-the relevant file(s), and the candidate, and have it return exactly one of:
+Dedup candidates pointing at same line/mechanism, keep one with
+most concrete failure scenario. Verify candidates locally in main agent by
+default. At `max` effort, also run **one verifier** as subagent for each
+remaining candidate when subagents available and authorized: give it diff,
+relevant file(s), candidate, have it return exactly one of:
 
-- **CONFIRMED** - can name the inputs/state that trigger it and the wrong output or
-  crash. Quote the line.
-- **PLAUSIBLE** - mechanism is real, trigger is uncertain (timing, env, config).
+- **CONFIRMED** — can name inputs/state triggering it and wrong output or
+  crash. Quote line.
+- **PLAUSIBLE** — mechanism real, trigger uncertain (timing, env, config).
   State what would confirm it.
-- **REFUTED** - factually wrong (code doesn't say that) or guarded elsewhere. Quote
-  the line that proves it.
+- **REFUTED** — factually wrong (code doesn't say that) or guarded elsewhere. Quote
+  line proving it.
 
-Keep candidates where the vote is CONFIRMED or PLAUSIBLE.
+Keep candidates where vote CONFIRMED or PLAUSIBLE.
 
-At **max**, verify is recall-biased - **PLAUSIBLE by default**: do not
-refute a candidate for being "speculative" or "depends on runtime state" when the
-state is realistic (concurrency races, nil/undefined on a rare-but-reachable path,
-falsy-zero treated as missing, off-by-one on a boundary the code does not exclude,
-retry storms / partial failures, regex/allowlist that lost an anchor). REFUTE only
-when constructible from the code: factually wrong, provably impossible, already
-handled in this diff, or pure style with no observable effect.
+At **max**, verify recall-biased — **PLAUSIBLE by default**: do not
+refute candidate for being "speculative" or "depends on runtime state" when
+state realistic (concurrency races, nil/undefined on rare-but-reachable path,
+falsy-zero treated as missing, off-by-one on boundary code doesn't exclude,
+retry storms / partial failures, regex/allowlist lost anchor). REFUTE only
+when constructible from code: factually wrong, provably impossible, already
+handled in this diff, pure style with no observable effect.
 
 ## Phase 3 - Sweep for gaps (xhigh / max effort)
 
-At `xhigh` and `max`, run **one more finder** as a fresh reviewer who has the
-current finding list. Re-read the diff and enclosing functions looking ONLY for
-defects not already listed. Do not re-derive or re-confirm anything already there -
-the job is gaps. Focus on what the first pass tends to miss: moved/extracted code
-that dropped a guard or anchor; second-tier footguns (dataclass default evaluated
+At `xhigh` and `max`, run **one more finder** as fresh reviewer with
+current finding list. Re-read diff and enclosing functions looking ONLY for
+defects not already listed. Do not re-derive or re-confirm anything already there —
+job is gaps. Focus on what first pass misses: moved/extracted code
+dropping guard or anchor; second-tier footguns (dataclass default evaluated
 once, `hash()` non-determinism, lock-scope shrink, predicate methods with side
 effects); setup/teardown asymmetry in tests; config defaults flipped. Surface
-additional candidates that name a defect not already on the list. If nothing new,
-return an empty sweep - do not pad.
+additional candidates naming defect not already on list. If nothing new,
+return empty sweep — do not pad.
 
 ## Output
 
-Reply in Markdown. Do not wrap the main result in JSON or a code fence. Use
-sentence case for the `#` heading and all finding titles; do not use title case. Do
-not open with generic target/base filler such as "Reviewed `owner/repo#123` against
-`branch`." Only mention the target or base branch when it explains a specific
+Reply in Markdown. Do not wrap main result in JSON or code fence. Use
+sentence case for `#` heading and all finding titles; no title case. Do
+not open with generic target/base filler like "Reviewed `owner/repo#123` against
+`branch`." Only mention target or base branch when explaining specific
 finding or limitation.
 
-When there are findings, use exactly these `##` sections, in order: `Bugs`,
-`Tests`, `Simplifications`, `Docs`, `Verdict`. For any section whose count is
+When findings exist, use exactly these `##` sections, in order: `Bugs`,
+`Tests`, `Simplifications`, `Docs`, `Verdict`. Any section whose count is
 `(0)`, write exactly `No findings.` under that heading.
 
 ### Severity rubric
 
 Prefix every finding title with one severity marker:
 
-- 🟣 **critical - blocking.** A correctness issue that can crash common flows, lose
-  user data, create a security/privacy problem, make a public component contract
-  unusable, or create broad cross-component accessibility, focus, form, or SSR
+- 🟣 **critical - blocking.** Correctness issue crashing common flows, losing
+  user data, creating security/privacy problem, making public component contract
+  unusable, or creating broad cross-component accessibility, focus, form, SSR
   breakage. Must block merge.
-- 🔴 **high - blocking.** A realistic user-visible regression in normal component
+- 🔴 **high - blocking.** Realistic user-visible regression in normal component
   usage, accessibility, keyboard/focus behavior, controlled/uncontrolled behavior,
-  form integration, SSR/hydration, public API behavior, or a public docs example
-  that no longer compiles or teaches broken API usage. It should block merge even
-  when the affected path has a workaround or is not the most common path.
-- 🟠 **medium - non-blocking.** A real issue worth fixing before merge when
-  practical but not normally blocking: a narrow or uncommon bug, meaningful missing
-  test, stale public-doc prose that does not break copy-pasted code, or cleanup that
-  avoids likely future mistakes. Use this only when the issue does not break a public
-  contract and does not affect accessibility, focus, forms, SSR, or normal component
+  form integration, SSR/hydration, public API behavior, or public docs example
+  no longer compiling or teaching broken API usage. Should block merge even
+  when affected path has workaround or not most common path.
+- 🟠 **medium - non-blocking.** Real issue worth fixing before merge when
+  practical but not normally blocking: narrow or uncommon bug, meaningful missing
+  test, stale public-doc prose not breaking copy-pasted code, cleanup
+  avoiding likely future mistakes. Use only when issue doesn't break public
+  contract and doesn't affect accessibility, focus, forms, SSR, or normal component
   usage.
-- 🟡 **low - non-blocking.** A minor edge-case bug, small test/doc gap, or modest
-  simplification that is useful but easy for maintainers to defer.
-- ℹ️ **note.** Informational - an observation, heads-up, or optional suggestion the
+- 🟡 **low - non-blocking.** Minor edge-case bug, small test/doc gap, modest
+  simplification useful but easy for maintainers to defer.
+- ℹ️ **note.** Informational — observation, heads-up, optional suggestion the
   maintainer may reasonably decline.
 
-Base UI has a stricter quality bar than most apps because small component-library
-regressions are multiplied across many downstream products. When choosing between
-adjacent severities, choose the higher severity if the failure reaches realistic
-consumer usage, accessibility behavior, form behavior, focus management, SSR, or a
+Base UI has stricter quality bar than most apps — small component-library
+regressions multiplied across many downstream products. When choosing between
+adjacent severities, choose higher severity if failure reaches realistic
+consumer usage, accessibility behavior, form behavior, focus management, SSR,
 public API contract or broken public docs example. Do not reserve 🔴 high only for
 outage-level failures.
 
@@ -259,14 +253,14 @@ Within each section, order findings 🟣 -> 🔴 -> 🟠 -> 🟡 -> ℹ️.
 
 ### Verdict
 
-End the review with a `## Verdict` line derived from those markers:
+End review with `## Verdict` line derived from markers:
 
-- **Request changes** - at least one 🟣 or 🔴 finding.
-- **Approve after nits** - no 🟣 or 🔴, but one or more 🟠 or 🟡 findings worth
+- **Request changes** — at least one 🟣 or 🔴 finding.
+- **Approve after nits** — no 🟣 or 🔴, but one or more 🟠 or 🟡 findings worth
   addressing.
-- **Approve** - no 🟣, 🔴, 🟠, or 🟡 findings (only ℹ️ notes, or nothing).
+- **Approve** — no 🟣, 🔴, 🟠, 🟡 findings (only ℹ️ notes, or nothing).
 
-Follow the verdict with one clause naming the deciding factor.
+Follow verdict with one clause naming deciding factor.
 
 ### Finding format
 
@@ -311,61 +305,60 @@ see.}
 🤖 Review generated with {Claude Code | Codex}
 ````
 
-Use the same per-finding shape for Tests, Simplifications, and Docs. For Tests,
-make the failure scenario the missing case or weak assertion. For Simplifications,
-make it the concrete duplicated, heavier, or harder-to-maintain code path. For Docs,
-make it the stale or missing public/developer-facing information.
+Same per-finding shape for Tests, Simplifications, Docs. For Tests,
+make failure scenario the missing case or weak assertion. For Simplifications,
+make it concrete duplicated, heavier, or harder-to-maintain code path. For Docs,
+make it stale or missing public/developer-facing information.
 
 ### Finding quality
 
-Do not cap findings by count. Report every verified, actionable finding that a
-maintainer would reasonably fix before merging. Do not pad the review with weak,
-stylistic, speculative, or low-importance notes. If many findings survive, group
-related issues under one finding when they share the same root cause.
+Do not cap findings by count. Report every verified, actionable finding
+maintainer would reasonably fix before merging. Do not pad review with weak,
+stylistic, speculative, low-importance notes. If many findings survive, group
+related issues under one finding when they share same root cause.
 
 ### No findings
 
 If nothing survives verification, return `# PR review` followed by `No findings.`,
-a brief note of any residual test gaps or risk, a `## Verdict` of **Approve**, and
-the `🤖 Review generated with ...` footer.
+brief note of any residual test gaps or risk, `## Verdict` of **Approve**, and
+`🤖 Review generated with ...` footer.
 
-Always close the review with a `---` horizontal rule, a blank line, then
+Always close review with `---` horizontal rule, blank line, then
 `🤖 Review generated with {Claude Code | Codex}`. Use **Claude Code** when this
-skill is being executed by the Claude Code harness, or **Codex** when it is being
-executed by the Codex harness.
+skill executed by Claude Code harness, **Codex** when executed by Codex harness.
 
 ## Posting to GitHub (--comment)
 
-Post to GitHub only when the target is a GitHub PR and the arguments include a
+Post to GitHub only when target is GitHub PR and arguments include
 comment mode:
 
-- No `--comment` -> do not post to GitHub; if `--fix` is also absent, stop at the
+- No `--comment` — do not post to GitHub; if `--fix` also absent, stop at
   Markdown review report.
-- `--comment` -> post the Markdown review as one top-level PR comment via
+- `--comment` — post Markdown review as one top-level PR comment via
   `gh pr comment`.
-- `--comment inline` -> post inline comments for findings that map to PR diff
-  lines, and include all non-diff findings in a top-level fallback comment.
+- `--comment inline` — post inline comments for findings mapping to PR diff
+  lines, include all non-diff findings in top-level fallback comment.
 
-For `--comment inline`, include the same severity marker in each inline comment
-body. Use the latest PR head `commit_id`, `path`, `line`, and `side`, and post via
+For `--comment inline`, include same severity marker in each inline comment
+body. Use latest PR head `commit_id`, `path`, `line`, `side`, post via
 `gh api` (`repos/{owner}/{repo}/pulls/{pr}/comments`), one call per finding. Include
-a suggestion block only when it fully fixes the issue. (If a GitHub inline-comment
-MCP tool is available in this session, use it instead.)
+suggestion block only when it fully fixes issue. (If GitHub inline-comment
+MCP tool available in session, use instead.)
 
-Inline comments can only attach to lines present in the PR diff. Put findings
-outside the PR diff, such as unchanged lines in touched functions, in the top-level
-fallback comment via `gh pr comment`; do not drop them or stop posting the rest of
-the review because one inline comment is not commentable. If the target is not a
-PR, print the findings to the terminal and note that `--comment` was ignored.
+Inline comments can only attach to lines present in PR diff. Put findings
+outside PR diff (unchanged lines in touched functions) in top-level
+fallback comment via `gh pr comment`; do not drop them or stop posting rest of
+review because one inline comment not commentable. If target not
+PR, print findings to terminal and note `--comment` was ignored.
 
 ## Applying fixes (--fix)
 
-If the `--fix` flag was passed in the arguments, then after producing the findings
-list, apply the findings to the working tree instead of stopping at the report: fix
-each one directly - correctness bugs and reuse/simplification/efficiency cleanups
+If `--fix` flag passed in arguments, after producing findings
+list, apply findings to working tree instead of stopping at report: fix
+each one directly — correctness bugs and reuse/simplification/efficiency cleanups
 alike. Skip any finding whose fix would change intended behavior, require changes
-well outside the reviewed diff, or that you judge to be a false positive - note the
-skip rather than arguing with it. Finish with a brief summary of what was fixed and
-what was skipped.
+well outside reviewed diff, or you judge false positive — note
+skip rather than arguing with it. Finish with brief summary of what fixed and
+what skipped.
 
-If neither `--comment` nor `--fix` was passed, stop at the Markdown review report.
+If neither `--comment` nor `--fix` passed, stop at Markdown review report.

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -336,11 +336,15 @@ If the `--comment` flag was passed in the arguments, then after producing the
 findings list, post to GitHub only when the review target is a GitHub PR. Plain
 `--comment` posts the Markdown review as one top-level PR comment via
 `gh pr comment`. `--comment inline` posts each finding as an inline PR comment via
-`gh api` (`repos/{owner}/{repo}/pulls/{pr}/comments`), one call per finding,
-including a suggestion block only when it fully fixes the issue. (If a GitHub
-inline-comment MCP tool is available in this session, use it instead.) If the
-target is not a PR, print the findings to the terminal and note that `--comment`
-was ignored.
+`gh api` (`repos/{owner}/{repo}/pulls/{pr}/comments`) only when the finding maps to
+a line present in the PR diff. Use the latest PR head `commit_id`, `path`, `line`,
+and `side` for each inline comment, one call per finding, including a suggestion
+block only when it fully fixes the issue. (If a GitHub inline-comment MCP tool is
+available in this session, use it instead.) Put findings outside the PR diff, such
+as unchanged lines in touched functions, in a top-level fallback comment via
+`gh pr comment`; do not drop them or stop posting the rest of the review because
+one inline comment is not commentable. If the target is not a PR, print the
+findings to the terminal and note that `--comment` was ignored.
 
 ## Applying fixes (--fix)
 

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -332,18 +332,22 @@ these `##` sections, in order, when there are findings: `Bugs`, `Tests`,
 
 ## Posting to GitHub (--comment)
 
-The `--comment` flag was passed. After producing the findings list, if the review
-target is a GitHub PR, post each finding as an inline PR comment via `gh api`
-(`repos/{owner}/{repo}/pulls/{pr}/comments`), one call per finding, including a
-suggestion block only when it fully fixes the issue. (If a GitHub inline-comment MCP
-tool is available in this session, use it instead.) If the target is not a PR, print
-the findings to the terminal and note that `--comment` was ignored.
+If the `--comment` flag was passed in the arguments, then after producing the
+findings list, if the review target is a GitHub PR, post each finding as an inline
+PR comment via `gh api` (`repos/{owner}/{repo}/pulls/{pr}/comments`), one call per
+finding, including a suggestion block only when it fully fixes the issue. (If a
+GitHub inline-comment MCP tool is available in this session, use it instead.) If
+the target is not a PR, print the findings to the terminal and note that
+`--comment` was ignored.
 
 ## Applying fixes (--fix)
 
-The `--fix` flag was passed. After producing the findings list, apply the findings to
-the working tree instead of stopping at the report: fix each one directly -
-correctness bugs and reuse/simplification/efficiency cleanups alike. Skip any finding
-whose fix would change intended behavior, require changes well outside the reviewed
-diff, or that you judge to be a false positive - note the skip rather than arguing
-with it. Finish with a brief summary of what was fixed and what was skipped.
+If the `--fix` flag was passed in the arguments, then after producing the findings
+list, apply the findings to the working tree instead of stopping at the report: fix
+each one directly - correctness bugs and reuse/simplification/efficiency cleanups
+alike. Skip any finding whose fix would change intended behavior, require changes
+well outside the reviewed diff, or that you judge to be a false positive - note the
+skip rather than arguing with it. Finish with a brief summary of what was fixed and
+what was skipped.
+
+If neither `--comment` nor `--fix` was passed, stop at the Markdown review report.

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -6,10 +6,9 @@ description: 'Review the current diff for regressions, correctness bugs, tests, 
 # Base UI Review
 
 Review the current diff and report **regressions and correctness bugs** alongside
-**cleanup** (reuse / simplification / efficiency). Effort defaults to `medium`:
-`low` is bug-only, `medium` is the normal single-agent review, `high` splits the
-areas across subagents, `xhigh` adds a sweep, and `max` adds verifier subagents.
-See [Effort levels](#effort-levels).
+**cleanup** (reuse / simplification / efficiency). Effort defaults to `medium`; use
+[Effort levels](#effort-levels) to choose review depth, subagent fan-out, and
+precision/recall bias.
 
 Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment [inline]] [<target>]`
 
@@ -26,17 +25,31 @@ fold in any uncommitted and untracked changes - the review often runs before the
 commit. If a PR link, branch name, or file path is passed as an argument, review
 that target instead.
 
+## Effort levels
+
+- **low** -> fastest: bug-only hunk pass. Skip Tests, Simplifications, Docs, and
+  test/fixture hunks. Flag only high-confidence runtime-correctness bugs visible
+  from the hunk alone.
+- **medium** (default) -> one agent reviews Bugs, Tests, Simplifications, Docs, and
+  any triggered API design/performance concerns, then verifies locally. Precision
+  bias. Add one bug/regression subagent only for large, risky, or fragile diffs.
+- **high** -> independent subagents review the four areas, plus triggered API
+  design/performance specialists. Main agent dedups and sanity-checks. No verifier
+  subagents or sweep.
+- **xhigh** -> `high` plus one fresh sweep for missed findings. No verifier
+  subagents.
+- **max** -> `xhigh` plus verifier subagents for surviving candidates. Highest cost,
+  strongest recall bias.
+
 ## Phase 1 - Find candidates
 
-Review the four main areas below: Bugs, Tests, Simplifications, and Docs. `low`
-reviews only high-confidence bug regressions. `medium` reviews all areas locally
-and may add one bug/regression subagent for large or risky diffs. `high` and above
-run the four areas as **independent subagents** - see
-[Effort levels](#effort-levels). Each area surfaces actionable
-candidate findings with `file`, `line`, a one-line `summary`, a `severity` (🟣 / 🔴 /
-🟠 / 🟡 / ℹ️ - see [Output](#output) for the rubric), and a concrete
-`failure_scenario`. Do NOT let one area's conclusions suppress another's - if two
-areas flag the same line for different reasons, record both.
+Use the selected [effort level](#effort-levels) to decide whether this phase runs
+locally or fans out to subagents. Except at `low`, review the four main areas below:
+Bugs, Tests, Simplifications, and Docs. Each area surfaces actionable candidate
+findings with `file`, `line`, a one-line `summary`, a `severity` (🟣 / 🔴 / 🟠 / 🟡 /
+ℹ️ - see [Output](#output) for the rubric), and a concrete `failure_scenario`. Do
+NOT let one area's conclusions suppress another's - if two areas flag the same line
+for different reasons, record both.
 
 Pass every candidate with a nameable failure scenario through - finders that
 silently drop half-believed candidates bypass the verify step and are the
@@ -162,13 +175,13 @@ untested, stale, or harder to maintain) instead of a crash. Regressions and
 correctness bugs always outrank simplification, test, and docs findings when the
 review is ordered.
 
-## Phase 2 - Verify (1-vote, 3-state)
+## Phase 2 - Verify candidates (local by default; max adds subagent votes)
 
 Dedup candidates that point at the same line/mechanism, keeping the one with the
-most concrete failure scenario. By default, verify candidates locally in the main
-agent. At `max` effort, run **one verifier** as a subagent for each remaining
-candidate when subagents are available and authorized: give it the diff, the
-relevant file(s), and the candidate, and have it return exactly one of:
+most concrete failure scenario. Verify candidates locally in the main agent by
+default. At `max` effort, also run **one verifier** as a subagent for each
+remaining candidate when subagents are available and authorized: give it the diff,
+the relevant file(s), and the candidate, and have it return exactly one of:
 
 - **CONFIRMED** - can name the inputs/state that trigger it and the wrong output or
   crash. Quote the line.
@@ -201,13 +214,19 @@ return an empty sweep - do not pad.
 
 ## Output
 
-Reply in Markdown using this structure. Do not wrap the main result in JSON or a
-code fence. Use sentence case for the `#` heading and all finding titles; do not
-use title case. Do not open with generic target/base filler such as "Reviewed
-`owner/repo#123` against `branch`." Only mention the target or base branch when it
-explains a specific finding or limitation.
+Reply in Markdown. Do not wrap the main result in JSON or a code fence. Use
+sentence case for the `#` heading and all finding titles; do not use title case. Do
+not open with generic target/base filler such as "Reviewed `owner/repo#123` against
+`branch`." Only mention the target or base branch when it explains a specific
+finding or limitation.
 
-Prefix every finding title with a severity marker:
+When there are findings, use exactly these `##` sections, in order: `Bugs`,
+`Tests`, `Simplifications`, `Docs`, `Verdict`. For any section whose count is
+`(0)`, write exactly `No findings.` under that heading.
+
+### Severity rubric
+
+Prefix every finding title with one severity marker:
 
 - 🟣 **critical - blocking.** A correctness issue that can crash common flows, lose
   user data, create a security/privacy problem, make a public component contract
@@ -236,8 +255,9 @@ consumer usage, accessibility behavior, form behavior, focus management, SSR, or
 public API contract or broken public docs example. Do not reserve 🔴 high only for
 outage-level failures.
 
-Within each section, order findings 🟣 -> 🔴 -> 🟠 -> 🟡 -> ℹ️. Include the same
-marker in each inline PR comment body when posting with `--comment inline`.
+Within each section, order findings 🟣 -> 🔴 -> 🟠 -> 🟡 -> ℹ️.
+
+### Verdict
 
 End the review with a `## Verdict` line derived from those markers:
 
@@ -248,19 +268,9 @@ End the review with a `## Verdict` line derived from those markers:
 
 Follow the verdict with one clause naming the deciding factor.
 
-Then close the review with a footer: a `---` horizontal rule, a blank line, then a
-single line of plain text:
+### Finding format
 
-```text
----
-
-🤖 Review generated with Claude Code
-```
-
-Use **Claude Code** when this skill is being executed by the Claude Code harness, or
-**Codex** when it is being executed by the Codex harness - pick the label for the
-harness you are actually running in. Always include this footer, including on the
-`No findings.` path below.
+Use this structure:
 
 ````md
 # PR review
@@ -306,47 +316,47 @@ make the failure scenario the missing case or weak assertion. For Simplification
 make it the concrete duplicated, heavier, or harder-to-maintain code path. For Docs,
 make it the stale or missing public/developer-facing information.
 
+### Finding quality
+
 Do not cap findings by count. Report every verified, actionable finding that a
 maintainer would reasonably fix before merging. Do not pad the review with weak,
 stylistic, speculative, or low-importance notes. If many findings survive, group
-related issues under one finding when they share the same root cause. If nothing
-survives verification, return `# PR review` followed by `No findings.`, a brief note
-of any residual test gaps or risk, a `## Verdict` of **Approve**, and the
-`🤖 Review generated with ...` footer. Use exactly
-these `##` sections, in order, when there are findings: `Bugs`, `Tests`,
-`Simplifications`, `Docs`, `Verdict`. For any section whose count is `(0)`, write exactly `No findings.` under that heading.
+related issues under one finding when they share the same root cause.
 
-### Effort levels
+### No findings
 
-- **low** -> fastest: bug-only hunk pass. Skip Tests, Simplifications, Docs, and
-  test/fixture hunks. Flag only high-confidence runtime-correctness bugs visible
-  from the hunk alone.
-- **medium** (default) -> one agent reviews Bugs, Tests, Simplifications, Docs, and
-  any triggered API design/performance concerns, then verifies locally. Precision
-  bias. Add one bug/regression subagent only for large, risky, or fragile diffs.
-- **high** -> independent subagents review the four areas, plus triggered API
-  design/performance specialists. Main agent dedups and sanity-checks. No verifier
-  subagents or sweep.
-- **xhigh** -> `high` plus one fresh sweep for missed findings. No verifier
-  subagents.
-- **max** -> `xhigh` plus verifier subagents for surviving candidates. Highest cost,
-  strongest recall bias.
+If nothing survives verification, return `# PR review` followed by `No findings.`,
+a brief note of any residual test gaps or risk, a `## Verdict` of **Approve**, and
+the `🤖 Review generated with ...` footer.
+
+Always close the review with a `---` horizontal rule, a blank line, then
+`🤖 Review generated with {Claude Code | Codex}`. Use **Claude Code** when this
+skill is being executed by the Claude Code harness, or **Codex** when it is being
+executed by the Codex harness.
 
 ## Posting to GitHub (--comment)
 
-If the `--comment` flag was passed in the arguments, then after producing the
-findings list, post to GitHub only when the review target is a GitHub PR. Plain
-`--comment` posts the Markdown review as one top-level PR comment via
-`gh pr comment`. `--comment inline` posts each finding as an inline PR comment via
-`gh api` (`repos/{owner}/{repo}/pulls/{pr}/comments`) only when the finding maps to
-a line present in the PR diff. Use the latest PR head `commit_id`, `path`, `line`,
-and `side` for each inline comment, one call per finding, including a suggestion
-block only when it fully fixes the issue. (If a GitHub inline-comment MCP tool is
-available in this session, use it instead.) Put findings outside the PR diff, such
-as unchanged lines in touched functions, in a top-level fallback comment via
-`gh pr comment`; do not drop them or stop posting the rest of the review because
-one inline comment is not commentable. If the target is not a PR, print the
-findings to the terminal and note that `--comment` was ignored.
+Post to GitHub only when the target is a GitHub PR and the arguments include a
+comment mode:
+
+- No `--comment` -> do not post to GitHub; if `--fix` is also absent, stop at the
+  Markdown review report.
+- `--comment` -> post the Markdown review as one top-level PR comment via
+  `gh pr comment`.
+- `--comment inline` -> post inline comments for findings that map to PR diff
+  lines, and include all non-diff findings in a top-level fallback comment.
+
+For `--comment inline`, include the same severity marker in each inline comment
+body. Use the latest PR head `commit_id`, `path`, `line`, and `side`, and post via
+`gh api` (`repos/{owner}/{repo}/pulls/{pr}/comments`), one call per finding. Include
+a suggestion block only when it fully fixes the issue. (If a GitHub inline-comment
+MCP tool is available in this session, use it instead.)
+
+Inline comments can only attach to lines present in the PR diff. Put findings
+outside the PR diff, such as unchanged lines in touched functions, in the top-level
+fallback comment via `gh pr comment`; do not drop them or stop posting the rest of
+the review because one inline comment is not commentable. If the target is not a
+PR, print the findings to the terminal and note that `--comment` was ignored.
 
 ## Applying fixes (--fix)
 

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -229,7 +229,7 @@ Follow the verdict with one clause naming the deciding factor.
 Then close the review with a footer: a `---` horizontal rule, a blank line, then a
 single line of plain text:
 
-```
+```text
 ---
 
 🤖 Review generated with Claude Code

--- a/.agents/skills/base-ui-review/agents/openai.yaml
+++ b/.agents/skills/base-ui-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: 'Base UI Review'
-  short_description: 'Review Base UI diffs for regressions'
+  short_description: 'Review Base UI diffs for bugs, tests, cleanup, docs'
   default_prompt: 'Use $base-ui-review to review my current diff.'

--- a/.agents/skills/base-ui-review/agents/openai.yaml
+++ b/.agents/skills/base-ui-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Base UI Review'
+  short_description: 'Review Base UI diffs for regressions'
+  default_prompt: 'Use $base-ui-review to review my current diff.'

--- a/.claude/skills/base-ui-review
+++ b/.claude/skills/base-ui-review
@@ -1,1 +1,0 @@
-../../.agents/skills/base-ui-review

--- a/.claude/skills/base-ui-review
+++ b/.claude/skills/base-ui-review
@@ -1,0 +1,1 @@
+../../.agents/skills/base-ui-review

--- a/.claude/skills/base-ui-review/SKILL.md
+++ b/.claude/skills/base-ui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base-ui-review
-description: 'Review Base UI diffs across bugs, tests, simplifications, docs, and triggered API design or performance concerns.'
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
 ---
 
 # Base UI Review

--- a/.claude/skills/base-ui-review/SKILL.md
+++ b/.claude/skills/base-ui-review/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: base-ui-review
+description: 'Review Base UI diffs across bugs, tests, simplifications, docs, and triggered API design or performance concerns.'
+---
+
+# Base UI Review
+
+This is the Claude Code entrypoint for the shared repo skill.
+
+Before reviewing, read `.agents/skills/base-ui-review/SKILL.md` completely and
+follow that canonical workflow. Pass through any user arguments such as `low`,
+`medium`, `high`, `xhigh`, `max`, `--comment`, `--fix`, or a review target.

--- a/.claude/skills/base-ui-review/SKILL.md
+++ b/.claude/skills/base-ui-review/SKILL.md
@@ -9,4 +9,5 @@ This is the Claude Code entrypoint for the shared repo skill.
 
 Before reviewing, read `.agents/skills/base-ui-review/SKILL.md` completely and
 follow that canonical workflow. Pass through any user arguments such as `low`,
-`medium`, `high`, `xhigh`, `max`, `--comment`, `--fix`, or a review target.
+`medium`, `high`, `xhigh`, `max`, `--comment`, `--comment inline`, `--fix`, or a
+review target.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This repository contains the source code and documentation for Base UI: a headl
 ## Agent skills
 
 - The shared `/base-ui-review` skill lives in `.agents/skills/base-ui-review/SKILL.md`. Update that file when the Base UI review workflow changes.
-- Claude Code discovers the same shared skill through `.claude/skills/base-ui-review`, which is a symlink to the `.agents` copy.
+- Claude Code discovers the same shared skill through `.claude/skills/base-ui-review/SKILL.md`, which delegates to the `.agents` copy.
 
 ## Code guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,12 @@ This repository contains the source code and documentation for Base UI: a headl
 - Public documentation is located at `docs/src/app/(docs)/react/`. Alter the docs where necessary when changes must be visible to library users.
 - When creating public demos on the docs, refer to the `hero` demo for the given component and largely follow its styles (both CSS Modules and Tailwind CSS versions). Other demos may also contain relevant styling. Do not add custom styling beyond the critical layout styles necessary for new demos.
 
+## Agent skills
+
+- The shared `/base-ui-review` skill lives in `.agents/skills/base-ui-review/SKILL.md`. Update that file when the Base UI review workflow changes.
+- Claude Code users can install it personally without adding a repo-local `.claude/skills` folder:
+  `mkdir -p ~/.claude/skills && ln -s "$PWD/.agents/skills/base-ui-review" ~/.claude/skills/base-ui-review`.
+
 ## Code guidelines
 
 - Always use the `useTimeout` utility from `@base-ui/utils/useTimeout` instead of `window.setTimeout`, and `useAnimationFrame` from `@base-ui/utils/useAnimationFrame` instead of `requestAnimationFrame`. Search for other example usage in the codebase if unsure how to use them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,7 @@ This repository contains the source code and documentation for Base UI: a headl
 ## Agent skills
 
 - The shared `/base-ui-review` skill lives in `.agents/skills/base-ui-review/SKILL.md`. Update that file when the Base UI review workflow changes.
-- Claude Code users can install it personally without adding a repo-local `.claude/skills` folder:
-  `mkdir -p ~/.claude/skills && ln -s "$PWD/.agents/skills/base-ui-review" ~/.claude/skills/base-ui-review`.
+- Claude Code discovers the same shared skill through `.claude/skills/base-ui-review`, which is a symlink to the `.agents` copy.
 
 ## Code guidelines
 


### PR DESCRIPTION
Adds a shared Base UI review skill so agents can use and improve the same review workflow from the repo.

The skill reviews diffs across bugs/regressions, tests, simplifications, and docs. It also calls out when API design or runtime performance specialists should join the review.

## Changes

- Add the `base-ui-review` skill under `.agents/skills`.
- Add OpenAI skill metadata for the shared skill.
- Add a Claude Code discovery entrypoint under `.claude/skills/base-ui-review`.
- Document the shared skill location in `AGENTS.md`.

## Usage

Invoke it as `/base-ui-review [effort] [--fix] [--comment [inline]] [target]`. Plain `--comment` posts one top-level PR comment; `--comment inline` posts inline finding comments when they map to PR diff lines and falls back to a top-level comment for non-diff findings.

Effort controls review depth and cost:

- `low`: Fastest bug-only pass.
- `medium` (default): One agent checks bugs, tests, simplifications, docs, and any triggered API design/performance concerns; may add a bug/regression subagent for large or risky diffs.
- `high`: Separate subagents for each review area, plus API design/performance specialists when triggered.
- `xhigh`: `high` plus a fresh sweep for missed findings.
- `max`: `xhigh` plus verifier subagents for surviving candidates.

Use higher effort when missed regressions would be expensive.