### PR TITLE
[code-infra] Pin node version in publish CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,9 @@ default-job: &default-job
     BROWSERSTACK_FORCE: << pipeline.parameters.browserstack-force >>
     COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
   working_directory: /tmp/base-ui
-  executor: code-infra/mui-node
+  executor:
+    name: code-infra/mui-node
+    node-version: '22.22.3'
 
 default-context: &default-context
   context:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22.18'
+          node-version: '22.22.3'
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: pnpm install
       - run: pnpm release:build
@@ -43,7 +43,6 @@ jobs:
         uses: mui/mui-public/.github/actions/ci-publish@76639fa2eabf73261070fa2a6a964209de10688d # master
         with:
           pr-comment: true
-          npm-dry-run: true
       - name: Extract Vale version
         if: ${{ matrix.os == 'ubuntu-latest' }}
         id: vale-version
@@ -62,3 +61,22 @@ jobs:
           # Required, set by GitHub actions automatically:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           token: ${{secrets.GITHUB_TOKEN}}
+
+  # Mirrors the real publish workflow environment (`publish.yml`) so an env
+  # mismatch — e.g. the Node version pinned by `publish-prepare` violating our
+  # engineStrict `engines` range — is caught here instead of during publishing.
+  publish-dry-run:
+    name: Publish Dry Run
+
+    if: ${{ github.repository_owner == 'mui' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Prepare for publishing
+        uses: mui/mui-public/.github/actions/publish-prepare@5a12855e473909291f8782c324f2c48983054337 # master
+        with:
+          node-version: '22.22.3'
+      - name: Dry run npm publishing
+        env:
+          IS_PUBLISH_TEST: 'true'
+        run: pnpm code-infra publish --ci --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,9 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0 # Fetch full history for proper git operations
       - name: Prepare for publishing
-        uses: mui/mui-public/.github/actions/publish-prepare@00cd0db0b3f3e2bc38ac8fb6af4edbfb2d5f88f6 # master
+        uses: mui/mui-public/.github/actions/publish-prepare@5a12855e473909291f8782c324f2c48983054337 # master
+        with:
+          node-version: '22.22.3'
       - name: Publish packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   command = "pnpm docs:build"
 
 [build.environment]
-  NODE_VERSION = "22.18"
+  NODE_VERSION = "22.22.3"
   PNPM_FLAGS = "--frozen-lockfile"
 
 [[plugins]]

--- a/package.json
+++ b/package.json
@@ -111,6 +111,6 @@
   "packageManager": "pnpm@11.5.2",
   "engines": {
     "pnpm": "11.5.2",
-    "node": ">=22.18.0"
+    "node": ">=22.22.3"
   }
 }


### PR DESCRIPTION
Pins and bumps the Node version used across CI and the publish workflow to `22.22.3`, fixing the `EBADENGINE` publish failure (npm@12 requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, so publishing on Node 22.18 fails).

- Pin `node-version: '22.22.3'` on `publish-prepare` in `.github/workflows/publish.yml`, bumping `publish-prepare` to the mui-public commit that exposes the `node-version` input.
- Add a standalone `publish-dry-run` job in `.github/workflows/ci.yml` mirroring the real publish environment (`pnpm code-infra publish --ci --dry-run`).
- Move the npm dry-run out of the `ci-publish` step into the dedicated `publish-dry-run` job.
- Bump `node-version` in `ci.yml` setup-node and `engines.node` to `>=22.22.3`.
- Pass `node-version: '22.22.3'` explicitly to the `code-infra/mui-node` CircleCI executor.

Depends on the mui-public param removal (mui/mui-public#1652) and Node bump (mui/mui-public#1653).

## Changelog

Pin and bump Node version to 22.22.3 in CI and the publish workflow.