### PR TITLE
[popups] Trim shared popup boilerplate

### DIFF
--- a/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
+++ b/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
@@ -4,14 +4,7 @@ import { useDialogRootContext } from '../root/DialogRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { type TransitionStatus } from '../../internals/useTransitionStatus';
 import { type BaseUIComponentProps } from '../../internals/types';
-import { type StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
-
-const stateAttributesMapping: StateAttributesMapping<DialogBackdropState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 
 /**
  * An overlay displayed beneath the popup.
@@ -40,7 +33,7 @@ export const DialogBackdrop = React.forwardRef(function DialogBackdrop(
   return useRenderElement('div', componentProps, {
     state,
     ref: [store.context.backdropRef, forwardedRef],
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
     props: [
       {
         role: 'presentation',

--- a/packages/react/src/drawer/backdrop/DrawerBackdrop.tsx
+++ b/packages/react/src/drawer/backdrop/DrawerBackdrop.tsx
@@ -4,16 +4,9 @@ import { useDialogRootContext } from '../../dialog/root/DialogRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { type TransitionStatus } from '../../internals/useTransitionStatus';
 import { type BaseUIComponentProps } from '../../internals/types';
-import { type StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import { DrawerPopupCssVars } from '../popup/DrawerPopupCssVars';
 import { DrawerBackdropCssVars } from './DrawerBackdropCssVars';
-
-const stateAttributesMapping: StateAttributesMapping<DrawerBackdropState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
 
 /**
  * An overlay displayed beneath the popup.
@@ -42,7 +35,7 @@ export const DrawerBackdrop = React.forwardRef(function DrawerBackdrop(
   return useRenderElement('div', componentProps, {
     state,
     ref: [store.context.backdropRef, forwardedRef],
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
     props: [
       {
         role: 'presentation',

--- a/packages/react/src/drawer/popup/DrawerPopup.tsx
+++ b/packages/react/src/drawer/popup/DrawerPopup.tsx
@@ -12,8 +12,7 @@ import { useRenderElement } from '../../internals/useRenderElement';
 import type { BaseUIComponentProps } from '../../internals/types';
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
 import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import { DrawerBackdropCssVars } from '../backdrop/DrawerBackdropCssVars';
 import { DrawerPopupCssVars } from './DrawerPopupCssVars';
 import { DrawerPopupDataAttributes } from './DrawerPopupDataAttributes';
@@ -89,8 +88,7 @@ function removeCSSVariableInheritance() {
 }
 
 const stateAttributesMapping: StateAttributesMapping<DrawerPopupState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
+  ...popupTransitionStateMapping,
   expanded(value) {
     return value ? { [DrawerPopupDataAttributes.expanded]: '' } : null;
   },

--- a/packages/react/src/menu/backdrop/MenuBackdrop.tsx
+++ b/packages/react/src/menu/backdrop/MenuBackdrop.tsx
@@ -3,17 +3,10 @@ import * as React from 'react';
 import { useMenuRootContext } from '../root/MenuRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import type { BaseUIComponentProps } from '../../internals/types';
-import { type StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
 import { useContextMenuRootContext } from '../../context-menu/root/ContextMenuRootContext';
 import { REASONS } from '../../internals/reasons';
-
-const stateAttributesMapping: StateAttributesMapping<MenuBackdropState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
 
 /**
  * An overlay displayed beneath the menu popup.
@@ -45,7 +38,7 @@ export const MenuBackdrop = React.forwardRef(function MenuBackdrop(
       ? [forwardedRef, contextMenuContext.backdropRef]
       : forwardedRef,
     state,
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
     props: [
       {
         role: 'presentation',

--- a/packages/react/src/menu/popup/MenuPopup.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.tsx
@@ -7,22 +7,15 @@ import type { MenuRoot } from '../root/MenuRoot';
 import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import type { BaseUIComponentProps } from '../../internals/types';
-import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
 import type { Side, Align } from '../../utils/useAnchorPositioning';
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import { useOpenChangeComplete } from '../../internals/useOpenChangeComplete';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 import { useToolbarRootContext } from '../../toolbar/root/ToolbarRootContext';
 import { COMPOSITE_KEYS } from '../../internals/composite/composite';
 import { getDisabledMountTransitionStyles } from '../../utils/getDisabledMountTransitionStyles';
-
-const stateAttributesMapping: StateAttributesMapping<MenuPopupState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
 
 /**
  * A container for the menu items.
@@ -108,7 +101,7 @@ export const MenuPopup = React.forwardRef(function MenuPopup(
   const element = useRenderElement('div', componentProps, {
     state,
     ref: [forwardedRef, store.context.popupRef, setPopupElement],
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
     props: [
       popupProps,
       {

--- a/packages/react/src/menu/viewport/MenuViewport.tsx
+++ b/packages/react/src/menu/viewport/MenuViewport.tsx
@@ -4,18 +4,7 @@ import { useMenuRootContext } from '../root/MenuRootContext';
 import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 import { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { usePopupViewport } from '../../utils/usePopupViewport';
-import { MenuViewportCssVars } from './MenuViewportCssVars';
-
-const stateAttributesMapping: StateAttributesMapping<MenuViewportState> = {
-  activationDirection: (value) =>
-    value
-      ? {
-          'data-activation-direction': value,
-        }
-      : null,
-};
+import { popupViewportStateMapping, usePopupViewport } from '../../utils/usePopupViewport';
 
 /**
  * A viewport for displaying content transitions.
@@ -39,7 +28,6 @@ export const MenuViewport = React.forwardRef(function MenuViewport(
   const { children: childrenToRender, state: viewportState } = usePopupViewport({
     store,
     side,
-    cssVars: MenuViewportCssVars,
     children,
   });
 
@@ -53,7 +41,7 @@ export const MenuViewport = React.forwardRef(function MenuViewport(
     state,
     ref: forwardedRef,
     props: [elementProps, { children: childrenToRender }],
-    stateAttributesMapping,
+    stateAttributesMapping: popupViewportStateMapping,
   });
 });
 

--- a/packages/react/src/navigation-menu/backdrop/NavigationMenuBackdrop.tsx
+++ b/packages/react/src/navigation-menu/backdrop/NavigationMenuBackdrop.tsx
@@ -4,14 +4,7 @@ import type { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useNavigationMenuRootContext } from '../root/NavigationMenuRootContext';
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
-import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-
-const stateAttributesMapping: StateAttributesMapping<NavigationMenuBackdropState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 
 /**
  * A backdrop for the navigation menu popup.
@@ -46,7 +39,7 @@ export const NavigationMenuBackdrop = React.forwardRef(function NavigationMenuBa
       },
       elementProps,
     ],
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
   });
 
   return element;

--- a/packages/react/src/navigation-menu/popup/NavigationMenuPopup.tsx
+++ b/packages/react/src/navigation-menu/popup/NavigationMenuPopup.tsx
@@ -4,19 +4,12 @@ import type { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useNavigationMenuRootContext } from '../root/NavigationMenuRootContext';
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
 import { useBaseUiId } from '../../internals/useBaseUiId';
 import { useNavigationMenuPositionerContext } from '../positioner/NavigationMenuPositionerContext';
 import { useDirection } from '../../internals/direction-context/DirectionContext';
-import { StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import { Align, Side } from '../../utils/useAnchorPositioning';
 import { getDisabledMountTransitionStyles } from '../../utils/getDisabledMountTransitionStyles';
-
-const stateAttributesMapping: StateAttributesMapping<NavigationMenuPopupState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
 
 /**
  * A container for the navigation menu contents.
@@ -71,7 +64,7 @@ export const NavigationMenuPopup = React.forwardRef(function NavigationMenuPopup
       getDisabledMountTransitionStyles(transitionStatus),
       elementProps,
     ],
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
   });
 
   return element;

--- a/packages/react/src/popover/backdrop/PopoverBackdrop.tsx
+++ b/packages/react/src/popover/backdrop/PopoverBackdrop.tsx
@@ -2,17 +2,10 @@
 import * as React from 'react';
 import { usePopoverRootContext } from '../root/PopoverRootContext';
 import type { BaseUIComponentProps } from '../../internals/types';
-import { type StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { REASONS } from '../../internals/reasons';
-
-const stateAttributesMapping: StateAttributesMapping<PopoverBackdropState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
 
 /**
  * An overlay displayed beneath the popover.
@@ -53,7 +46,7 @@ export const PopoverBackdrop = React.forwardRef(function PopoverBackdrop(
       },
       elementProps,
     ],
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
   });
 
   return element;

--- a/packages/react/src/popover/popup/PopoverPopup.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.tsx
@@ -7,10 +7,8 @@ import { usePopoverRootContext } from '../root/PopoverRootContext';
 import { usePopoverPositionerContext } from '../positioner/PopoverPositionerContext';
 import type { Side, Align } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../internals/types';
-import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import { useOpenChangeComplete } from '../../internals/useOpenChangeComplete';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { REASONS } from '../../internals/reasons';
@@ -19,11 +17,6 @@ import { useToolbarRootContext } from '../../toolbar/root/ToolbarRootContext';
 import { getDisabledMountTransitionStyles } from '../../utils/getDisabledMountTransitionStyles';
 import { ClosePartContext, useClosePartCount } from '../../utils/closePart';
 import { FOCUSABLE_POPUP_PROPS, createDefaultInitialFocus } from '../../utils/popups';
-
-const stateAttributesMapping: StateAttributesMapping<PopoverPopupState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
 
 /**
  * A container for the popover contents.
@@ -108,7 +101,7 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
       getDisabledMountTransitionStyles(transitionStatus),
       elementProps,
     ],
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
   });
 
   return (

--- a/packages/react/src/popover/root/PopoverRoot.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.tsx
@@ -66,14 +66,13 @@ function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Pay
     }
   }, [store, open]);
 
-  const handleImperativeClose = React.useCallback(() => {
-    store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction));
-  }, [store]);
-
   React.useImperativeHandle(
     props.actionsRef,
-    () => ({ unmount: forceUnmount, close: handleImperativeClose }),
-    [forceUnmount, handleImperativeClose],
+    () => ({
+      unmount: forceUnmount,
+      close: () => store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction)),
+    }),
+    [forceUnmount, store],
   );
 
   const shouldRenderInteractions = open || mounted;

--- a/packages/react/src/popover/viewport/PopoverViewport.tsx
+++ b/packages/react/src/popover/viewport/PopoverViewport.tsx
@@ -4,18 +4,7 @@ import { usePopoverRootContext } from '../root/PopoverRootContext';
 import { usePopoverPositionerContext } from '../positioner/PopoverPositionerContext';
 import { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { PopoverViewportCssVars } from './PopoverViewportCssVars';
-import { usePopupViewport } from '../../utils/usePopupViewport';
-
-const stateAttributesMapping: StateAttributesMapping<PopoverViewportState> = {
-  activationDirection: (value) =>
-    value
-      ? {
-          'data-activation-direction': value,
-        }
-      : null,
-};
+import { popupViewportStateMapping, usePopupViewport } from '../../utils/usePopupViewport';
 
 /**
  * A viewport for displaying content transitions.
@@ -39,7 +28,6 @@ export const PopoverViewport = React.forwardRef(function PopoverViewport(
   const { children: childrenToRender, state: viewportState } = usePopupViewport({
     store,
     side,
-    cssVars: PopoverViewportCssVars,
     children,
   });
 
@@ -53,7 +41,7 @@ export const PopoverViewport = React.forwardRef(function PopoverViewport(
     state,
     ref: forwardedRef,
     props: [elementProps, { children: childrenToRender }],
-    stateAttributesMapping,
+    stateAttributesMapping: popupViewportStateMapping,
   });
 });
 

--- a/packages/react/src/preview-card/backdrop/PreviewCardBackdrop.tsx
+++ b/packages/react/src/preview-card/backdrop/PreviewCardBackdrop.tsx
@@ -2,16 +2,9 @@
 import * as React from 'react';
 import { usePreviewCardRootContext } from '../root/PreviewCardContext';
 import type { BaseUIComponentProps } from '../../internals/types';
-import { type StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
 import { useRenderElement } from '../../internals/useRenderElement';
-
-const stateAttributesMapping: StateAttributesMapping<PreviewCardBackdropState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
 
 /**
  * A presentational overlay displayed beneath the popup.
@@ -50,7 +43,7 @@ export const PreviewCardBackdrop = React.forwardRef(function PreviewCardBackdrop
       },
       elementProps,
     ],
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
   });
 
   return element;

--- a/packages/react/src/preview-card/popup/PreviewCardPopup.tsx
+++ b/packages/react/src/preview-card/popup/PreviewCardPopup.tsx
@@ -1,23 +1,15 @@
 'use client';
 import * as React from 'react';
-import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { usePreviewCardRootContext } from '../root/PreviewCardContext';
 import { usePreviewCardPositionerContext } from '../positioner/PreviewCardPositionerContext';
-import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
 import type { BaseUIComponentProps } from '../../internals/types';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../internals/useOpenChangeComplete';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { getDisabledMountTransitionStyles } from '../../utils/getDisabledMountTransitionStyles';
 import { useHoverFloatingInteraction } from '../../floating-ui-react';
-
-const stateAttributesMapping: StateAttributesMapping<PreviewCardPopupState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
 
 /**
  * A container for the preview card contents.
@@ -39,6 +31,7 @@ export const PreviewCardPopup = React.forwardRef(function PreviewCardPopup(
   const transitionStatus = store.useState('transitionStatus');
   const popupProps = store.useState('popupProps');
   const floatingContext = store.useState('floatingRootContext');
+  const closeDelay = store.useState('closeDelay');
 
   useOpenChangeComplete({
     open,
@@ -50,10 +43,8 @@ export const PreviewCardPopup = React.forwardRef(function PreviewCardPopup(
     },
   });
 
-  const getCloseDelay = useStableCallback(() => store.context.closeDelayRef.current);
-
   useHoverFloatingInteraction(floatingContext, {
-    closeDelay: getCloseDelay,
+    closeDelay,
   });
 
   const state: PreviewCardPopupState = {
@@ -68,7 +59,7 @@ export const PreviewCardPopup = React.forwardRef(function PreviewCardPopup(
     state,
     ref: [forwardedRef, store.context.popupRef, store.useStateSetter('popupElement')],
     props: [popupProps, getDisabledMountTransitionStyles(transitionStatus), elementProps],
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
   });
 
   return element;

--- a/packages/react/src/preview-card/root/PreviewCardRoot.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import { fastComponent } from '@base-ui/utils/fastHooks';
-import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useDismiss, FloatingTree } from '../../floating-ui-react';
 import { PreviewCardRootContext, usePreviewCardRootContext } from './PreviewCardContext';
@@ -74,14 +73,13 @@ function PreviewCardRootComponent<Payload>(props: PreviewCardRoot.Props<Payload>
     }
   }, [store, activeTriggerId, open]);
 
-  const handleImperativeClose = React.useCallback(() => {
-    store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction));
-  }, [store]);
-
   React.useImperativeHandle(
     actionsRef,
-    () => ({ unmount: forceUnmount, close: handleImperativeClose }),
-    [forceUnmount, handleImperativeClose],
+    () => ({
+      unmount: forceUnmount,
+      close: () => store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction)),
+    }),
+    [forceUnmount, store],
   );
 
   const shouldRenderInteractions = open || mounted;
@@ -98,16 +96,16 @@ function PreviewCardInteractions<Payload>({ store }: { store: PreviewCardStore<P
   const floatingRootContext = store.useState('floatingRootContext');
 
   const dismiss = useDismiss(floatingRootContext);
-  const activeTriggerProps = dismiss.reference ?? EMPTY_OBJECT;
-  const inactiveTriggerProps = dismiss.trigger ?? EMPTY_OBJECT;
   const popupProps = React.useMemo(
     () => mergeProps(FOCUSABLE_POPUP_PROPS, dismiss.floating),
     [dismiss.floating],
   );
 
   usePopupInteractionProps(store, {
-    activeTriggerProps,
-    inactiveTriggerProps,
+    // `enabled` is not passed to `useDismiss`, so its props are always defined,
+    // and `trigger` is the same object as `reference`.
+    activeTriggerProps: dismiss.reference!,
+    inactiveTriggerProps: dismiss.trigger!,
     popupProps,
   });
 

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -20,10 +20,10 @@ import { CLOSE_DELAY } from '../utils/constants';
 export type State<Payload> = PopupStoreState<Payload> & {
   instantType: 'dismiss' | 'focus' | undefined;
   hasViewport: boolean;
+  closeDelay: number;
 };
 
 export type Context = PopupStoreContext<PreviewCardRoot.ChangeEventDetails> & {
-  closeDelayRef: React.RefObject<number>;
   inlineRectCoordsRef: React.MutableRefObject<InlineRectCoords | undefined>;
 };
 
@@ -31,6 +31,7 @@ const selectors = {
   ...popupStoreSelectors,
   instantType: createSelector((state: State<unknown>) => state.instantType),
   hasViewport: createSelector((state: State<unknown>) => state.hasViewport),
+  closeDelay: createSelector((state: State<unknown>) => state.closeDelay),
 };
 
 type Selectors = typeof selectors;
@@ -125,6 +126,7 @@ function createInitialState<Payload>(
     ...createInitialPopupStoreState<Payload>(),
     instantType: undefined,
     hasViewport: false,
+    closeDelay: CLOSE_DELAY,
     ...initialState,
   };
 
@@ -139,7 +141,6 @@ function createInitialContext(triggerElements: PopupTriggerMap): Context {
     onOpenChange: undefined,
     onOpenChangeComplete: undefined,
     triggerElements,
-    closeDelayRef: { current: CLOSE_DELAY },
     inlineRectCoordsRef: { current: undefined },
   };
 }

--- a/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
+++ b/packages/react/src/preview-card/trigger/PreviewCardTrigger.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import { fastComponentRef } from '@base-ui/utils/fastHooks';
-import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { usePreviewCardRootContext } from '../root/PreviewCardContext';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
@@ -64,14 +63,9 @@ export const PreviewCardTrigger = fastComponentRef(function PreviewCardTrigger(
     store,
     {
       payload,
+      closeDelay: closeDelayWithDefault,
     },
   );
-
-  useIsoLayoutEffect(() => {
-    if (isMountedByThisTrigger) {
-      store.context.closeDelayRef.current = closeDelayWithDefault;
-    }
-  }, [store, isMountedByThisTrigger, closeDelayWithDefault]);
 
   const hoverProps = useHoverReferenceInteraction(floatingRootContext, {
     mouseOnly: true,

--- a/packages/react/src/preview-card/viewport/PreviewCardViewport.tsx
+++ b/packages/react/src/preview-card/viewport/PreviewCardViewport.tsx
@@ -4,18 +4,7 @@ import { usePreviewCardRootContext } from '../root/PreviewCardContext';
 import { usePreviewCardPositionerContext } from '../positioner/PreviewCardPositionerContext';
 import { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { PreviewCardViewportCssVars } from './PreviewCardViewportCssVars';
-import { usePopupViewport } from '../../utils/usePopupViewport';
-
-const stateAttributesMapping: StateAttributesMapping<PreviewCardViewportState> = {
-  activationDirection: (value) =>
-    value
-      ? {
-          'data-activation-direction': value,
-        }
-      : null,
-};
+import { popupViewportStateMapping, usePopupViewport } from '../../utils/usePopupViewport';
 
 /**
  * A viewport for displaying content transitions.
@@ -39,7 +28,6 @@ export const PreviewCardViewport = React.forwardRef(function PreviewCardViewport
   const { children: childrenToRender, state: viewportState } = usePopupViewport({
     store,
     side: positioner.side,
-    cssVars: PreviewCardViewportCssVars,
     children,
   });
 
@@ -53,7 +41,7 @@ export const PreviewCardViewport = React.forwardRef(function PreviewCardViewport
     state,
     ref: forwardedRef,
     props: [elementProps, { children: childrenToRender }],
-    stateAttributesMapping,
+    stateAttributesMapping: popupViewportStateMapping,
   });
 });
 

--- a/packages/react/src/select/arrow/SelectArrow.tsx
+++ b/packages/react/src/select/arrow/SelectArrow.tsx
@@ -5,16 +5,9 @@ import { useSelectPositionerContext } from '../positioner/SelectPositionerContex
 import { useSelectRootContext } from '../root/SelectRootContext';
 import type { BaseUIComponentProps } from '../../internals/types';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
-import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { selectors } from '../store';
-
-const stateAttributesMapping: StateAttributesMapping<SelectArrowState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
 
 /**
  * Displays an element positioned against the select popup anchor.
@@ -45,7 +38,7 @@ export const SelectArrow = React.forwardRef(function SelectArrow(
     state,
     ref: [arrowRef, forwardedRef],
     props: [{ style: arrowStyles, 'aria-hidden': true }, elementProps],
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
   });
 
   if (alignItemWithTriggerActive) {

--- a/packages/react/src/tooltip/popup/TooltipPopup.tsx
+++ b/packages/react/src/tooltip/popup/TooltipPopup.tsx
@@ -4,19 +4,12 @@ import { useTooltipRootContext } from '../root/TooltipRootContext';
 import { useTooltipPositionerContext } from '../positioner/TooltipPositionerContext';
 import type { BaseUIComponentProps } from '../../internals/types';
 import type { Align, Side } from '../../utils/useAnchorPositioning';
-import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
+import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../internals/useOpenChangeComplete';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { getDisabledMountTransitionStyles } from '../../utils/getDisabledMountTransitionStyles';
 import { useHoverFloatingInteraction } from '../../floating-ui-react';
-
-const stateAttributesMapping: StateAttributesMapping<TooltipPopupState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-};
 
 /**
  * A container for the tooltip contents.
@@ -70,7 +63,7 @@ export const TooltipPopup = React.forwardRef(function TooltipPopup(
     state,
     ref: [forwardedRef, store.context.popupRef, setPopupElement],
     props: [popupProps, getDisabledMountTransitionStyles(transitionStatus), elementProps],
-    stateAttributesMapping,
+    stateAttributesMapping: popupTransitionStateMapping,
   });
 
   return element;

--- a/packages/react/src/tooltip/provider/TooltipProvider.tsx
+++ b/packages/react/src/tooltip/provider/TooltipProvider.tsx
@@ -12,18 +12,10 @@ import { TooltipProviderContext } from './TooltipProviderContext';
 export const TooltipProvider: React.FC<TooltipProvider.Props> = function TooltipProvider(props) {
   const { delay, closeDelay, timeout = 400 } = props;
 
-  const contextValue: TooltipProviderContext = React.useMemo(
-    () => ({
-      delay,
-      closeDelay,
-    }),
-    [delay, closeDelay],
-  );
-
   const delayValue = React.useMemo(() => ({ open: delay, close: closeDelay }), [delay, closeDelay]);
 
   return (
-    <TooltipProviderContext.Provider value={contextValue}>
+    <TooltipProviderContext.Provider value={delay}>
       <FloatingDelayGroup delay={delayValue} timeoutMs={timeout}>
         {props.children}
       </FloatingDelayGroup>

--- a/packages/react/src/tooltip/provider/TooltipProviderContext.ts
+++ b/packages/react/src/tooltip/provider/TooltipProviderContext.ts
@@ -1,15 +1,11 @@
 'use client';
 import * as React from 'react';
 
-export interface TooltipProviderContext {
-  delay: number | undefined;
-  closeDelay: number | undefined;
-}
+/**
+ * Holds the provider's `delay` value. `closeDelay` is handled by the delay group.
+ */
+export const TooltipProviderContext = React.createContext<number | undefined>(undefined);
 
-export const TooltipProviderContext = React.createContext<TooltipProviderContext | undefined>(
-  undefined,
-);
-
-export function useTooltipProviderContext(): TooltipProviderContext | undefined {
+export function useTooltipProviderContext(): number | undefined {
   return React.useContext(TooltipProviderContext);
 }

--- a/packages/react/src/tooltip/root/TooltipRoot.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.tsx
@@ -76,9 +76,8 @@ export const TooltipRoot = fastComponent(function TooltipRoot<Payload>(
   store.useSyncedValues({
     trackCursorAxis,
     disableHoverablePopup,
+    disabled,
   });
-
-  store.useSyncedValue('disabled', disabled);
 
   useImplicitActiveTrigger(store, { closeOnActiveTriggerUnmount: true });
   const { forceUnmount, transitionStatus } = useOpenStateTransitions(open, store);
@@ -125,14 +124,13 @@ export const TooltipRoot = fastComponent(function TooltipRoot<Payload>(
     }
   }, [store, activeTriggerId, open]);
 
-  const handleImperativeClose = React.useCallback(() => {
-    store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction));
-  }, [store]);
-
   React.useImperativeHandle(
     actionsRef,
-    () => ({ unmount: forceUnmount, close: handleImperativeClose }),
-    [forceUnmount, handleImperativeClose],
+    () => ({
+      unmount: forceUnmount,
+      close: () => store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction)),
+    }),
+    [forceUnmount, store],
   );
 
   const shouldRenderInteractions = open || mounted || (!disabled && trackCursorAxis !== 'none');
@@ -264,22 +262,20 @@ function TooltipInteractions<Payload>({
     axis: trackCursorAxis === 'none' ? undefined : trackCursorAxis,
   });
 
-  const activeTriggerProps = React.useMemo(
+  // Both hooks return `trigger: reference` (same object identity), so the active and
+  // inactive trigger props can never differ. `useClientPoint` has no floating-side props.
+  const triggerProps = React.useMemo(
     () => mergeProps(clientPoint.reference, dismiss.reference),
     [clientPoint.reference, dismiss.reference],
   );
-  const inactiveTriggerProps = React.useMemo(
-    () => mergeProps(clientPoint.trigger, dismiss.trigger),
-    [clientPoint.trigger, dismiss.trigger],
-  );
   const popupProps = React.useMemo(
-    () => mergeProps(FOCUSABLE_POPUP_PROPS, clientPoint.floating, dismiss.floating),
-    [clientPoint.floating, dismiss.floating],
+    () => mergeProps(FOCUSABLE_POPUP_PROPS, dismiss.floating),
+    [dismiss.floating],
   );
 
   usePopupInteractionProps(store, {
-    activeTriggerProps,
-    inactiveTriggerProps,
+    activeTriggerProps: triggerProps,
+    inactiveTriggerProps: triggerProps,
     popupProps,
   });
 

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -22,7 +22,6 @@ import { contains } from '../../floating-ui-react/utils/element';
 import { isMouseLikePointerType } from '../../floating-ui-react/utils/event';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
-import { TooltipTriggerDataAttributes } from './TooltipTriggerDataAttributes';
 import { useHoverInteractionSharedState } from '../../floating-ui-react/hooks/useHoverInteractionSharedState';
 
 import { OPEN_DELAY } from '../utils/constants';
@@ -51,14 +50,9 @@ function getTargetElement(event: Event): Element | null {
 function closestEnabledTooltipTrigger(element: Element | null): Element | null {
   let current = element;
   while (current) {
-    if (current.hasAttribute(TOOLTIP_TRIGGER_IDENTIFIER)) {
-      return current;
-    }
-
-    const parentElement = current.parentElement;
-    if (parentElement) {
-      current = parentElement;
-      continue;
+    const trigger = current.closest(`[${TOOLTIP_TRIGGER_IDENTIFIER}]`);
+    if (trigger) {
+      return trigger;
     }
 
     const root = current.getRootNode();
@@ -122,7 +116,7 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
     },
   );
 
-  const providerContext = useTooltipProviderContext();
+  const providerDelay = useTooltipProviderContext();
   const { delayRef, isInstantPhase, hasProvider } = useDelayGroup(floatingRootContext, {
     open: isOpenedByThisTrigger,
   });
@@ -142,19 +136,11 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
   const pointerTypeRef = React.useRef<string | undefined>(undefined);
 
   function getOpenDelay() {
-    const providerDelay = providerContext?.delay;
-    const groupOpenValue = typeof delayRef.current === 'object' ? delayRef.current.open : undefined;
-
-    let computedOpenDelay = delayWithDefault;
-    if (hasProvider) {
-      if (groupOpenValue !== 0) {
-        computedOpenDelay = delay ?? providerDelay ?? delayWithDefault;
-      } else {
-        computedOpenDelay = 0;
-      }
+    if (!hasProvider) {
+      return delayWithDefault;
     }
-
-    return computedOpenDelay;
+    const groupOpenValue = typeof delayRef.current === 'object' ? delayRef.current.open : undefined;
+    return groupOpenValue === 0 ? 0 : (delay ?? providerDelay ?? OPEN_DELAY);
   }
 
   function isEnabledNestedTriggerTarget(target: Element | null) {
@@ -189,16 +175,12 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
     handleClose: !disableHoverablePopup && trackCursorAxis !== 'both' ? safePolygon() : null,
     restMs: getOpenDelay,
     delay() {
-      const closeValue = typeof delayRef.current === 'object' ? delayRef.current.close : undefined;
-
-      let computedCloseDelay: number | undefined = closeDelayWithDefault;
       if (closeDelay == null && hasProvider) {
-        computedCloseDelay = closeValue;
+        return {
+          close: typeof delayRef.current === 'object' ? delayRef.current.close : undefined,
+        };
       }
-
-      return {
-        close: computedCloseDelay,
-      };
+      return { close: closeDelayWithDefault };
     },
     triggerElementRef,
     isActiveTrigger: isTriggerActive,
@@ -300,7 +282,7 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
           }
         },
         id: thisTriggerId,
-        [TooltipTriggerDataAttributes.triggerDisabled]: disabled ? '' : undefined,
+        'data-trigger-disabled': disabled ? '' : undefined,
         [TOOLTIP_TRIGGER_IDENTIFIER]: disabled ? undefined : '',
       } as React.HTMLAttributes<Element>,
       elementProps,

--- a/packages/react/src/tooltip/viewport/TooltipViewport.tsx
+++ b/packages/react/src/tooltip/viewport/TooltipViewport.tsx
@@ -4,18 +4,7 @@ import { useTooltipRootContext } from '../root/TooltipRootContext';
 import { useTooltipPositionerContext } from '../positioner/TooltipPositionerContext';
 import { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { TooltipViewportCssVars } from './TooltipViewportCssVars';
-import { usePopupViewport } from '../../utils/usePopupViewport';
-
-const stateAttributesMapping: StateAttributesMapping<TooltipViewportState> = {
-  activationDirection: (value) =>
-    value
-      ? {
-          'data-activation-direction': value,
-        }
-      : null,
-};
+import { popupViewportStateMapping, usePopupViewport } from '../../utils/usePopupViewport';
 
 /**
  * A viewport for displaying content transitions.
@@ -39,7 +28,6 @@ export const TooltipViewport = React.forwardRef(function TooltipViewport(
   const { children: childrenToRender, state: viewportState } = usePopupViewport({
     store,
     side: positioner.side,
-    cssVars: TooltipViewportCssVars,
     children,
   });
 
@@ -53,7 +41,7 @@ export const TooltipViewport = React.forwardRef(function TooltipViewport(
     state,
     ref: forwardedRef,
     props: [elementProps, { children: childrenToRender }],
-    stateAttributesMapping,
+    stateAttributesMapping: popupViewportStateMapping,
   });
 });
 

--- a/packages/react/src/utils/popupStateMapping.ts
+++ b/packages/react/src/utils/popupStateMapping.ts
@@ -1,5 +1,9 @@
 import type { StateAttributesMapping } from '../internals/getStateAttributesProps';
-import { TransitionStatusDataAttributes } from '../internals/stateAttributesMapping';
+import {
+  TransitionStatusDataAttributes,
+  transitionStatusMapping,
+} from '../internals/stateAttributesMapping';
+import type { TransitionStatus } from '../internals/useTransitionStatus';
 
 export enum CommonPopupDataAttributes {
   /**
@@ -100,3 +104,12 @@ export const popupStateMapping = {
     return null;
   },
 } satisfies StateAttributesMapping<{ open: boolean; anchorHidden: boolean }>;
+
+export const popupTransitionStateMapping = {
+  ...popupStateMapping,
+  ...transitionStatusMapping,
+} satisfies StateAttributesMapping<{
+  open: boolean;
+  anchorHidden: boolean;
+  transitionStatus: TransitionStatus;
+}>;

--- a/packages/react/src/utils/usePopupViewport.tsx
+++ b/packages/react/src/utils/usePopupViewport.tsx
@@ -9,20 +9,21 @@ import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { ownerDocument } from '@base-ui/utils/owner';
 import type { ReactStore } from '@base-ui/utils/store';
 import { useAnimationsFinished } from '../internals/useAnimationsFinished';
+import type { StateAttributesMapping } from '../internals/getStateAttributesProps';
 import { usePopupAutoResize } from './usePopupAutoResize';
 import { Dimensions } from '../floating-ui-react/types';
 import { Side } from './useAnchorPositioning';
 import { useDirection } from '../direction-provider';
 
-export type PopupViewportCssVars = {
-  /**
-   * CSS variable name storing the popup width for the previous content snapshot.
-   */
-  popupWidth: string;
-  /**
-   * CSS variable name storing the popup height for the previous content snapshot.
-   */
-  popupHeight: string;
+export const popupViewportStateMapping: StateAttributesMapping<{
+  activationDirection: string | undefined;
+}> = {
+  activationDirection: (value) =>
+    value
+      ? {
+          'data-activation-direction': value,
+        }
+      : null,
 };
 
 export interface PopupViewportState {
@@ -48,10 +49,6 @@ export interface UsePopupViewportParameters {
    */
   side: Side;
   /**
-   * CSS variable names used for sizing the previous content snapshot.
-   */
-  cssVars: PopupViewportCssVars;
-  /**
    * Viewport children to render in the current container.
    */
   children?: React.ReactNode;
@@ -73,7 +70,7 @@ export interface UsePopupViewportResult {
  * Handles previous-content snapshots, auto-resize, and state attributes for transitions.
  */
 export function usePopupViewport(parameters: UsePopupViewportParameters): UsePopupViewportResult {
-  const { store, side, cssVars, children } = parameters;
+  const { store, side, children } = parameters;
 
   const direction = useDirection();
 
@@ -221,8 +218,8 @@ export function usePopupViewport(parameters: UsePopupViewportParameters): UsePop
             {
               ...(previousContentDimensions
                 ? {
-                    [cssVars.popupWidth]: `${previousContentDimensions.width}px`,
-                    [cssVars.popupHeight]: `${previousContentDimensions.height}px`,
+                    '--popup-width': `${previousContentDimensions.width}px`,
+                    '--popup-height': `${previousContentDimensions.height}px`,
                   }
                 : null),
               position: 'absolute',


### PR DESCRIPTION
Deduplicates copy-pasted popup state-attribute mappings and viewport CSS variable enums into shared constants, and removes dead branches across the popup components.

The branch is rebased onto current `master`. The conflict resolution keeps the shared Dialog state mapping already established on `master`; the remaining cleanup is behavior-preserving.

Measured against current `master`:

- `@base-ui/react` barrel: −1,332 B parsed / −349 B gzip
- `@base-ui/react/tooltip`: −534 B parsed / −171 B gzip
- `@base-ui/react/preview-card`: −190 B parsed / −73 B gzip
- `@base-ui/react/popover`: −150 B parsed / −59 B gzip
- `@base-ui/react/menu`: −123 B parsed / −50 B gzip

Focused popup suites pass 777 jsdom tests and 1,177 Chromium tests, along with TypeScript, formatting, and lint.