### PR TITLE
[popups] Remove dead code and enum retention in dialog and popover

### DIFF
--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
@@ -1228,7 +1228,7 @@ describe('<AlertDialog.Root />', () => {
 });
 
 function AlertDialogState(props: React.HTMLAttributes<HTMLDivElement>) {
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
   const modal = store.useState('modal');
   const disablePointerDismissal = store.useState('disablePointerDismissal');
   const role = store.useState('role');

--- a/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
+++ b/packages/react/src/dialog/backdrop/DialogBackdrop.tsx
@@ -25,7 +25,7 @@ export const DialogBackdrop = React.forwardRef(function DialogBackdrop(
 ) {
   const { render, className, style, forceRender = false, ...elementProps } = componentProps;
 
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
 
   const open = store.useState('open');
   const nested = store.useState('nested');

--- a/packages/react/src/dialog/close/DialogClose.tsx
+++ b/packages/react/src/dialog/close/DialogClose.tsx
@@ -26,7 +26,7 @@ export const DialogClose = React.forwardRef(function DialogClose(
     ...elementProps
   } = componentProps;
 
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
   const open = store.useState('open');
 
   const { getButtonProps, buttonRef } = useButton({

--- a/packages/react/src/dialog/description/DialogDescription.tsx
+++ b/packages/react/src/dialog/description/DialogDescription.tsx
@@ -17,7 +17,7 @@ export const DialogDescription = React.forwardRef(function DialogDescription(
 ) {
   const { render, className, style, id: idProp, ...elementProps } = componentProps;
 
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
 
   const id = useBaseUiId(idProp);
 

--- a/packages/react/src/dialog/popup/DialogPopup.test.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.test.tsx
@@ -19,6 +19,18 @@ describe('<Dialog.Popup />', () => {
     },
   }));
 
+  it('throws a descriptive error when rendered outside <Dialog.Root>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Dialog.Popup />)).rejects.toThrow(
+        'Base UI: DialogRootContext is missing. Dialog parts must be placed within <Dialog.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   describe('prop: keepMounted', () => {
     [
       [true, true],

--- a/packages/react/src/dialog/popup/DialogPopup.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.tsx
@@ -6,23 +6,11 @@ import { useDialogRootContext } from '../root/DialogRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { type BaseUIComponentProps } from '../../internals/types';
 import { type TransitionStatus } from '../../internals/useTransitionStatus';
-import { type StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
-import { DialogPopupCssVars } from './DialogPopupCssVars';
-import { DialogPopupDataAttributes } from './DialogPopupDataAttributes';
 import { useDialogPortalContext } from '../portal/DialogPortalContext';
 import { useOpenChangeComplete } from '../../internals/useOpenChangeComplete';
 import { COMPOSITE_KEYS } from '../../internals/composite/composite';
 import { FOCUSABLE_POPUP_PROPS, createDefaultInitialFocus } from '../../utils/popups';
-
-const stateAttributesMapping: StateAttributesMapping<DialogPopupState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-  nestedDialogOpen(value) {
-    return value ? { [DialogPopupDataAttributes.nestedDialogOpen]: '' } : null;
-  },
-};
+import { dialogStateAttributesMapping } from '../utils/stateAttributesMapping';
 
 /**
  * A container for the dialog contents.
@@ -36,7 +24,7 @@ export const DialogPopup = React.forwardRef(function DialogPopup(
 ) {
   const { render, className, style, finalFocus, initialFocus, ...elementProps } = componentProps;
 
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
 
   const descriptionElementId = store.useState('descriptionElementId');
   const disablePointerDismissal = store.useState('disablePointerDismissal');
@@ -52,8 +40,6 @@ export const DialogPopup = React.forwardRef(function DialogPopup(
   const transitionStatus = store.useState('transitionStatus');
   const role = store.useState('role');
   const floatingId = floatingRootContext.useState('floatingId');
-
-  const popupId = elementProps.id ?? floatingId;
 
   useDialogPortalContext();
 
@@ -86,9 +72,9 @@ export const DialogPopup = React.forwardRef(function DialogPopup(
     props: [
       rootPopupProps,
       {
-        id: popupId,
-        'aria-labelledby': titleElementId ?? undefined,
-        'aria-describedby': descriptionElementId ?? undefined,
+        id: floatingId,
+        'aria-labelledby': titleElementId,
+        'aria-describedby': descriptionElementId,
         role,
         ...FOCUSABLE_POPUP_PROPS,
         hidden: !mounted,
@@ -98,13 +84,13 @@ export const DialogPopup = React.forwardRef(function DialogPopup(
           }
         },
         style: {
-          [DialogPopupCssVars.nestedDialogs]: nestedOpenDialogCount,
+          '--nested-dialogs': nestedOpenDialogCount,
         } as React.CSSProperties,
       },
       elementProps,
     ],
     ref: [forwardedRef, store.context.popupRef, setPopupElement],
-    stateAttributesMapping,
+    stateAttributesMapping: dialogStateAttributesMapping,
   });
 
   return (

--- a/packages/react/src/dialog/portal/DialogPortal.tsx
+++ b/packages/react/src/dialog/portal/DialogPortal.tsx
@@ -19,7 +19,7 @@ export const DialogPortal = React.forwardRef(function DialogPortal(
 ) {
   const { keepMounted = false, ...portalProps } = props;
 
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
   const mounted = store.useState('mounted');
   const modal = store.useState('modal');
   const open = store.useState('open');

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -1737,7 +1737,7 @@ function DialogOpenChangeSpy(props: {
   onOpenChange: (details: { open: boolean; reason: string | null | undefined }) => void;
 }) {
   const { onOpenChange } = props;
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
   const floatingRootContext = store.useState('floatingRootContext');
 
   React.useEffect(() => {

--- a/packages/react/src/dialog/root/DialogRootContext.ts
+++ b/packages/react/src/dialog/root/DialogRootContext.ts
@@ -2,24 +2,20 @@
 import * as React from 'react';
 import { DialogStore } from '../store/DialogStore';
 
-export interface DialogRootContext<Payload = unknown> {
-  store: DialogStore<Payload>;
-}
-
 export const IsDrawerContext = React.createContext(false);
 
-export const DialogRootContext = React.createContext<DialogRootContext | undefined>(undefined);
+export const DialogRootContext = React.createContext<DialogStore<unknown> | undefined>(undefined);
 
-export function useDialogRootContext(optional?: false): DialogRootContext;
-export function useDialogRootContext(optional: true): DialogRootContext | undefined;
+export function useDialogRootContext(optional?: false): DialogStore<unknown>;
+export function useDialogRootContext(optional: true): DialogStore<unknown> | undefined;
 export function useDialogRootContext(optional?: boolean) {
-  const dialogRootContext = React.useContext(DialogRootContext);
+  const store = React.useContext(DialogRootContext);
 
-  if (optional === false && dialogRootContext === undefined) {
+  if (!optional && store === undefined) {
     throw new Error(
       'Base UI: DialogRootContext is missing. Dialog parts must be placed within <Dialog.Root>.',
     );
   }
 
-  return dialogRootContext;
+  return store;
 }

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -4,40 +4,8 @@ import { useScrollLock } from '@base-ui/utils/useScrollLock';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { useDismiss } from '../../floating-ui-react';
 import { contains, getTarget } from '../../floating-ui-react/utils';
-import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
-import { REASONS } from '../../internals/reasons';
-import { type DialogRoot } from './DialogRoot';
 import { DialogStore } from '../store/DialogStore';
-import {
-  useImplicitActiveTrigger,
-  useOpenStateTransitions,
-  usePopupInteractionProps,
-  usePopupRootSync,
-} from '../../utils/popups';
-
-export function useDialogRoot(params: UseDialogRootParameters): void {
-  const { store, actionsRef } = params;
-
-  const open = store.useState('open');
-  usePopupRootSync(store, open);
-  useImplicitActiveTrigger(store);
-  const { forceUnmount } = useOpenStateTransitions(open, store);
-
-  const handleImperativeClose = React.useCallback(() => {
-    store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction));
-  }, [store]);
-
-  React.useImperativeHandle(
-    actionsRef,
-    () => ({ unmount: forceUnmount, close: handleImperativeClose }),
-    [forceUnmount, handleImperativeClose],
-  );
-}
-
-export interface UseDialogRootParameters {
-  store: DialogStore<any>;
-  actionsRef?: DialogRoot.Props['actionsRef'] | undefined;
-}
+import { usePopupInteractionProps } from '../../utils/popups';
 
 export function DialogInteractions({
   store,
@@ -100,9 +68,11 @@ export function DialogInteractions({
         // This supports multiple modal dialogs that aren't nested in the React tree:
         // https://github.com/mui/base-ui/issues/1320
         if (modal) {
-          return store.context.internalBackdropRef.current || store.context.backdropRef.current
-            ? store.context.internalBackdropRef.current === target ||
-                store.context.backdropRef.current === target ||
+          const internalBackdrop = store.context.internalBackdropRef.current;
+          const backdrop = store.context.backdropRef.current;
+          return internalBackdrop || backdrop
+            ? internalBackdrop === target ||
+                backdrop === target ||
                 (contains(target, popupElement) && !target?.hasAttribute('data-base-ui-portal'))
             : true;
         }
@@ -116,43 +86,40 @@ export function DialogInteractions({
   useScrollLock(open && modal === true, popupElement);
 
   // Listen for nested open/close events on this store to maintain the counts.
+  // A close notification is an open notification with zeroed counts.
   store.useContextCallback('onNestedDialogOpen', (dialogCount, drawerCount) => {
     setOwnNestedOpenDialogs(dialogCount);
     setOwnNestedOpenDrawers(drawerCount);
   });
 
-  store.useContextCallback('onNestedDialogClose', () => {
-    setOwnNestedOpenDialogs(0);
-    setOwnNestedOpenDrawers(0);
-  });
-
   // Notify parent of our open/close state using parent callbacks, if any
   React.useEffect(() => {
-    if (parentContext?.onNestedDialogOpen && open) {
-      parentContext.onNestedDialogOpen(
-        ownNestedOpenDialogs + 1,
-        ownNestedOpenDrawers + (isDrawer ? 1 : 0),
-      );
-    }
-    if (parentContext?.onNestedDialogClose && !open) {
-      parentContext.onNestedDialogClose();
+    if (parentContext?.onNestedDialogOpen) {
+      if (open) {
+        parentContext.onNestedDialogOpen(
+          ownNestedOpenDialogs + 1,
+          ownNestedOpenDrawers + (isDrawer ? 1 : 0),
+        );
+      } else {
+        parentContext.onNestedDialogOpen(0, 0);
+      }
     }
     return () => {
-      if (parentContext?.onNestedDialogClose && open) {
-        parentContext.onNestedDialogClose();
+      if (parentContext?.onNestedDialogOpen && open) {
+        parentContext.onNestedDialogOpen(0, 0);
       }
     };
   }, [isDrawer, open, ownNestedOpenDialogs, ownNestedOpenDrawers, parentContext]);
 
-  const activeTriggerProps = dismiss.reference ?? EMPTY_OBJECT;
-  const inactiveTriggerProps = dismiss.trigger ?? EMPTY_OBJECT;
+  // `dismiss.trigger` is always the same object as `dismiss.reference`.
+  const triggerProps = dismiss.reference ?? EMPTY_OBJECT;
   // Consumers (DialogPopup/DrawerPopup) already spread `FOCUSABLE_POPUP_PROPS`
   // directly, so the popup props only need to carry the dismiss handlers.
   const popupProps = dismiss.floating ?? EMPTY_OBJECT;
 
   usePopupInteractionProps(store, {
-    activeTriggerProps,
-    inactiveTriggerProps,
+    activeTriggerProps: triggerProps,
+    inactiveTriggerProps: triggerProps,
     popupProps,
     nestedOpenDialogCount: ownNestedOpenDialogs,
     nestedOpenDrawerCount: ownNestedOpenDrawers,

--- a/packages/react/src/dialog/root/useRenderDialogRoot.tsx
+++ b/packages/react/src/dialog/root/useRenderDialogRoot.tsx
@@ -1,11 +1,17 @@
 'use client';
 import * as React from 'react';
-import { DialogInteractions, useDialogRoot } from './useDialogRoot';
+import { DialogInteractions } from './useDialogRoot';
 import { DialogRootContext, IsDrawerContext, useDialogRootContext } from './DialogRootContext';
-import { DialogStore, type State as DialogStoreState } from '../store/DialogStore';
+import { DialogStore } from '../store/DialogStore';
 import type { DialogRootProps } from './DialogRoot';
-import type { DialogHandle } from '../store/DialogHandle';
-import { usePopupRootStore } from '../../utils/popups';
+import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
+import { REASONS } from '../../internals/reasons';
+import {
+  useImplicitActiveTrigger,
+  useOpenStateTransitions,
+  usePopupRootStore,
+  usePopupRootSync,
+} from '../../utils/popups';
 
 export function useRenderDialogRoot<Payload>(
   props: DialogRootProps<Payload>,
@@ -31,17 +37,30 @@ export function useRenderDialogRoot<Payload>(
   const disablePointerDismissal = isAlertDialog || disablePointerDismissalProp;
   const role: 'dialog' | 'alertdialog' = isAlertDialog ? 'alertdialog' : 'dialog';
 
-  const parentDialogRootContext = useDialogRootContext(true);
-  const nested = Boolean(parentDialogRootContext);
+  const parentStore = useDialogRootContext(true);
+  const nested = parentStore != null;
   const rootState = { modal, disablePointerDismissal, nested, role };
 
-  const store = useDialogRootStore(handle, {
-    open: defaultOpen,
-    openProp,
-    activeTriggerId: defaultTriggerIdProp,
-    triggerIdProp,
-    ...rootState,
-  });
+  // The store is owned by this Root instance and created exactly once. It is not tied to the handle:
+  // the handle attaches to it, so swapping the handle re-attaches rather than recreating state.
+  // Default values are only initial values; controlled values and root state are synced after creation.
+  // Dialogs pass the popup element to Floating UI as the floating element (`treatPopupAsFloatingElement`).
+  const store = usePopupRootStore(
+    handle,
+    (floatingId, floatingNested) =>
+      new DialogStore<Payload>(
+        {
+          open: defaultOpen,
+          openProp,
+          activeTriggerId: defaultTriggerIdProp,
+          triggerIdProp,
+          ...rootState,
+        },
+        floatingId,
+        floatingNested,
+      ),
+    true,
+  );
 
   store.useControlledProp('openProp', openProp);
   store.useControlledProp('triggerIdProp', triggerIdProp);
@@ -54,19 +73,28 @@ export function useRenderDialogRoot<Payload>(
   const mounted = store.useState('mounted');
   const payload = store.useState('payload') as Payload | undefined;
 
-  useDialogRoot({ store, actionsRef });
+  usePopupRootSync(store, open);
+  useImplicitActiveTrigger(store);
+  const { forceUnmount } = useOpenStateTransitions(open, store);
+
+  React.useImperativeHandle(
+    actionsRef,
+    () => ({
+      unmount: forceUnmount,
+      close: () => store.setOpen(false, createChangeEventDetails(REASONS.imperativeAction)),
+    }),
+    [forceUnmount, store],
+  );
 
   const shouldRenderInteractions = open || mounted;
 
-  const contextValue: DialogRootContext<Payload> = React.useMemo(() => ({ store }), [store]);
-
   return (
     <IsDrawerContext.Provider value={false}>
-      <DialogRootContext.Provider value={contextValue as DialogRootContext}>
+      <DialogRootContext.Provider value={store as DialogStore<unknown>}>
         {shouldRenderInteractions && (
           <DialogInteractions
             store={store}
-            parentContext={parentDialogRootContext?.store.context}
+            parentContext={parentStore?.context}
             isDrawer={isDrawer}
           />
         )}
@@ -77,18 +105,3 @@ export function useRenderDialogRoot<Payload>(
 }
 
 type DialogRootMode = 'dialog' | 'drawer' | 'alert-dialog';
-
-function useDialogRootStore<Payload>(
-  handle: DialogHandle<Payload> | undefined,
-  initialState: Partial<DialogStoreState<Payload>>,
-) {
-  // The store is owned by this Root instance and created exactly once. It is not tied to the handle:
-  // the handle attaches to it, so swapping the handle re-attaches rather than recreating state.
-  // Default values are only initial values; controlled values and root state are synced after creation.
-  // Dialogs pass the popup element to Floating UI as the floating element (`treatPopupAsFloatingElement`).
-  return usePopupRootStore(
-    handle,
-    (floatingId, nested) => new DialogStore<Payload>(initialState, floatingId, nested),
-    true,
-  );
-}

--- a/packages/react/src/dialog/store/DialogHandle.ts
+++ b/packages/react/src/dialog/store/DialogHandle.ts
@@ -52,10 +52,7 @@ export class DialogHandle<Payload> extends BasePopupHandle<
     }
 
     attachedStore.set('payload', payload);
-    attachedStore.setOpen(
-      true,
-      createChangeEventDetails(REASONS.imperativeAction, undefined, undefined),
-    );
+    attachedStore.setOpen(true, createChangeEventDetails(REASONS.imperativeAction));
   }
 
   /**

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -33,7 +33,6 @@ type Context = PopupStoreContext<DialogRoot.ChangeEventDetails> & {
   readonly internalBackdropRef: React.RefObject<HTMLDivElement | null>;
   readonly outsidePressEnabledRef: React.MutableRefObject<boolean>;
   readonly onNestedDialogOpen?: ((dialogCount: number, drawerCount: number) => void) | undefined;
-  readonly onNestedDialogClose?: (() => void) | undefined;
 };
 
 const selectors = {
@@ -130,7 +129,6 @@ function createInitialState<Payload>(
     ...createInitialPopupStoreState<Payload>(),
     modal: true,
     disablePointerDismissal: false,
-    popupElement: null,
     viewportElement: null,
     descriptionElementId: undefined,
     titleElementId: undefined,

--- a/packages/react/src/dialog/title/DialogTitle.tsx
+++ b/packages/react/src/dialog/title/DialogTitle.tsx
@@ -17,7 +17,7 @@ export const DialogTitle = React.forwardRef(function DialogTitle(
 ) {
   const { render, className, style, id: idProp, ...elementProps } = componentProps;
 
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
 
   const id = useBaseUiId(idProp);
 

--- a/packages/react/src/dialog/trigger/DialogTrigger.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.tsx
@@ -34,9 +34,9 @@ export const DialogTrigger = React.forwardRef(function DialogTrigger(
     ...elementProps
   } = componentProps;
 
-  const dialogRootContext = useDialogRootContext(true);
+  const dialogRootStore = useDialogRootContext(true);
   const handleStore = usePopupHandleStore(handle);
-  const store = handleStore ?? dialogRootContext?.store;
+  const store = handleStore ?? dialogRootStore;
   if (!store) {
     throw new Error(
       'Base UI: <Dialog.Trigger> must be used within <Dialog.Root> or provided with a handle.',
@@ -64,7 +64,7 @@ export const DialogTrigger = React.forwardRef(function DialogTrigger(
     native: nativeButton,
   });
 
-  const click = useClick(floatingContext, { enabled: floatingContext != null });
+  const click = useClick(floatingContext);
   const interactionTypeProps = useOpenMethodTriggerProps(
     () => store.select('open'),
     (interactionType) => {

--- a/packages/react/src/dialog/utils/stateAttributesMapping.ts
+++ b/packages/react/src/dialog/utils/stateAttributesMapping.ts
@@ -1,0 +1,21 @@
+import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
+import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
+import { popupStateMapping } from '../../utils/popupStateMapping';
+import type { TransitionStatus } from '../../internals/useTransitionStatus';
+
+/**
+ * Shared by `Dialog.Popup` and `Dialog.Viewport`, whose states have the same shape.
+ * `nested` is not mapped: unmapped `true` booleans already render as `data-nested`.
+ */
+export const dialogStateAttributesMapping: StateAttributesMapping<{
+  open: boolean;
+  transitionStatus: TransitionStatus;
+  nested: boolean;
+  nestedDialogOpen: boolean;
+}> = {
+  ...popupStateMapping,
+  ...transitionStatusMapping,
+  nestedDialogOpen(value) {
+    return value ? { 'data-nested-dialog-open': '' } : null;
+  },
+};

--- a/packages/react/src/dialog/viewport/DialogViewport.tsx
+++ b/packages/react/src/dialog/viewport/DialogViewport.tsx
@@ -3,23 +3,9 @@ import * as React from 'react';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { type BaseUIComponentProps } from '../../internals/types';
 import { type TransitionStatus } from '../../internals/useTransitionStatus';
-import { type StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { popupStateMapping as baseMapping } from '../../utils/popupStateMapping';
-import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
 import { useDialogRootContext } from '../root/DialogRootContext';
 import { useDialogPortalContext } from '../portal/DialogPortalContext';
-import { DialogViewportDataAttributes } from './DialogViewportDataAttributes';
-
-const stateAttributesMapping: StateAttributesMapping<DialogViewportState> = {
-  ...baseMapping,
-  ...transitionStatusMapping,
-  nested(value) {
-    return value ? { [DialogViewportDataAttributes.nested]: '' } : null;
-  },
-  nestedDialogOpen(value) {
-    return value ? { [DialogViewportDataAttributes.nestedDialogOpen]: '' } : null;
-  },
-};
+import { dialogStateAttributesMapping } from '../utils/stateAttributesMapping';
 
 /**
  * A positioning container for the dialog popup that can be made scrollable.
@@ -34,7 +20,7 @@ export const DialogViewport = React.forwardRef(function DialogViewport(
   const { render, className, style, children, ...elementProps } = componentProps;
 
   const keepMounted = useDialogPortalContext();
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
 
   const open = store.useState('open');
   const nested = store.useState('nested');
@@ -59,7 +45,7 @@ export const DialogViewport = React.forwardRef(function DialogViewport(
     enabled: shouldRender,
     state,
     ref: [forwardedRef, setViewportElement],
-    stateAttributesMapping,
+    stateAttributesMapping: dialogStateAttributesMapping,
     props: [
       {
         role: 'presentation',

--- a/packages/react/src/drawer/backdrop/DrawerBackdrop.tsx
+++ b/packages/react/src/drawer/backdrop/DrawerBackdrop.tsx
@@ -27,7 +27,7 @@ export const DrawerBackdrop = React.forwardRef(function DrawerBackdrop(
 ) {
   const { render, className, style, forceRender = false, ...elementProps } = componentProps;
 
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
 
   const open = store.useState('open');
   const nested = store.useState('nested');

--- a/packages/react/src/drawer/popup/DrawerPopup.tsx
+++ b/packages/react/src/drawer/popup/DrawerPopup.tsx
@@ -120,7 +120,7 @@ export const DrawerPopup = React.forwardRef(function DrawerPopup(
 ) {
   const { render, className, style, finalFocus, initialFocus, ...elementProps } = componentProps;
 
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
   const popupRef = store.context.popupRef;
 
   const {

--- a/packages/react/src/drawer/root/DrawerRoot.tsx
+++ b/packages/react/src/drawer/root/DrawerRoot.tsx
@@ -425,7 +425,7 @@ function DrawerProviderReporter() {
   const drawerId = useId();
 
   const providerContext = useDrawerProviderContext(true);
-  const { store } = useDialogRootContext(false);
+  const store = useDialogRootContext(false);
 
   const open = store.useState('open');
   const nestedOpenDialogCount = store.useState('nestedOpenDialogCount');

--- a/packages/react/src/drawer/root/useDrawerSnapPoints.ts
+++ b/packages/react/src/drawer/root/useDrawerSnapPoints.ts
@@ -82,7 +82,7 @@ function findClosestSnapPoint(
 }
 
 export function useDrawerSnapPoints() {
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
   const { snapPoints, activeSnapPoint, setActiveSnapPoint, popupHeight } = useDrawerRootContext();
   const viewportElement = store.useState('viewportElement');
 

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
@@ -91,7 +91,7 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
     ...elementProps
   } = componentProps;
 
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
   const { swipeDirection, frontmostHeight, swipeAreaActiveRef } = useDrawerRootContext();
   const providerContext = useDrawerProviderContext(true);
 

--- a/packages/react/src/drawer/viewport/DrawerViewport.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.tsx
@@ -70,7 +70,7 @@ export const DrawerViewport = React.forwardRef(function DrawerViewport(
 ) {
   const { render, className, style, children, ...elementProps } = props;
 
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
   const popupRef = store.context.popupRef;
   const backdropRef = store.context.backdropRef;
 

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
@@ -75,7 +75,7 @@ const KEYBOARD_TAP_BLOCKED = Symbol('KeyboardTapBlocked');
 export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvider.Props) {
   const { children } = props;
 
-  const { store } = useDialogRootContext();
+  const store = useDialogRootContext();
 
   const open = store.useState('open');
   const mounted = store.useState('mounted');

--- a/packages/react/src/popover/arrow/PopoverArrow.tsx
+++ b/packages/react/src/popover/arrow/PopoverArrow.tsx
@@ -19,7 +19,7 @@ export const PopoverArrow = React.forwardRef(function PopoverArrow(
 ) {
   const { render, className, style, ...elementProps } = componentProps;
 
-  const { store } = usePopoverRootContext();
+  const store = usePopoverRootContext();
   const open = store.useState('open');
   const { arrowRef, side, align, arrowUncentered, arrowStyles } = usePopoverPositionerContext();
 

--- a/packages/react/src/popover/backdrop/PopoverBackdrop.tsx
+++ b/packages/react/src/popover/backdrop/PopoverBackdrop.tsx
@@ -26,7 +26,7 @@ export const PopoverBackdrop = React.forwardRef(function PopoverBackdrop(
 ) {
   const { render, className, style, ...elementProps } = props;
 
-  const { store } = usePopoverRootContext();
+  const store = usePopoverRootContext();
 
   const open = store.useState('open');
   const mounted = store.useState('mounted');
@@ -40,7 +40,7 @@ export const PopoverBackdrop = React.forwardRef(function PopoverBackdrop(
 
   const element = useRenderElement('div', props, {
     state,
-    ref: [store.context.backdropRef, forwardedRef],
+    ref: forwardedRef,
     props: [
       {
         role: 'presentation',

--- a/packages/react/src/popover/close/PopoverClose.tsx
+++ b/packages/react/src/popover/close/PopoverClose.tsx
@@ -33,7 +33,7 @@ export const PopoverClose = React.forwardRef(function PopoverClose(
     native: nativeButton,
   });
 
-  const { store } = usePopoverRootContext();
+  const store = usePopoverRootContext();
   useClosePartRegistration();
 
   const element = useRenderElement('button', componentProps, {

--- a/packages/react/src/popover/description/PopoverDescription.tsx
+++ b/packages/react/src/popover/description/PopoverDescription.tsx
@@ -17,7 +17,7 @@ export const PopoverDescription = React.forwardRef(function PopoverDescription(
 ) {
   const { render, className, style, ...elementProps } = componentProps;
 
-  const { store } = usePopoverRootContext();
+  const store = usePopoverRootContext();
 
   const id = useBaseUiId(elementProps.id);
 

--- a/packages/react/src/popover/popup/PopoverPopup.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.tsx
@@ -17,7 +17,7 @@ import { REASONS } from '../../internals/reasons';
 import { COMPOSITE_KEYS } from '../../internals/composite/composite';
 import { useToolbarRootContext } from '../../toolbar/root/ToolbarRootContext';
 import { getDisabledMountTransitionStyles } from '../../utils/getDisabledMountTransitionStyles';
-import { ClosePartProvider, useClosePartCount } from '../../utils/closePart';
+import { ClosePartContext, useClosePartCount } from '../../utils/closePart';
 import { FOCUSABLE_POPUP_PROPS, createDefaultInitialFocus } from '../../utils/popups';
 
 const stateAttributesMapping: StateAttributesMapping<PopoverPopupState> = {
@@ -37,7 +37,7 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
 ) {
   const { render, className, style, initialFocus, finalFocus, ...elementProps } = componentProps;
 
-  const { store } = usePopoverRootContext();
+  const store = usePopoverRootContext();
 
   const positioner = usePopoverPositionerContext();
   const insideToolbar = useToolbarRootContext(true) != null;
@@ -60,8 +60,6 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
   const openOnHover = store.useState('openOnHover');
   const closeDelay = store.useState('closeDelay');
 
-  const popupId = elementProps.id ?? floatingId;
-
   useOpenChangeComplete({
     open,
     ref: store.context.popupRef,
@@ -80,12 +78,7 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
   const focusManagerModal = modal !== false && hasClosePart;
   store.useSyncedValue('focusManagerModal', focusManagerModal);
 
-  const setPopupElement = React.useCallback(
-    (element: HTMLElement | null) => {
-      store.set('popupElement', element);
-    },
-    [store],
-  );
+  const setPopupElement = store.useStateSetter('popupElement');
 
   const state: PopoverPopupState = {
     open,
@@ -101,7 +94,7 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
     props: [
       popupProps,
       {
-        id: popupId,
+        id: floatingId,
         role: 'dialog',
         ...FOCUSABLE_POPUP_PROPS,
         'aria-labelledby': titleId,
@@ -133,7 +126,7 @@ export const PopoverPopup = React.forwardRef(function PopoverPopup(
       nextFocusableElement={store.context.triggerFocusTargetRef}
       beforeContentFocusGuardRef={store.context.beforeContentFocusGuardRef}
     >
-      <ClosePartProvider value={closePartContext}>{element}</ClosePartProvider>
+      <ClosePartContext.Provider value={closePartContext}>{element}</ClosePartContext.Provider>
     </FloatingFocusManager>
   );
 });

--- a/packages/react/src/popover/portal/PopoverPortal.tsx
+++ b/packages/react/src/popover/portal/PopoverPortal.tsx
@@ -17,7 +17,7 @@ export const PopoverPortal = React.forwardRef(function PopoverPortal(
 ) {
   const { keepMounted = false, ...portalProps } = props;
 
-  const { store } = usePopoverRootContext();
+  const store = usePopoverRootContext();
   const mounted = store.useState('mounted');
 
   const shouldRender = mounted || keepMounted;

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -36,21 +36,23 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     className,
     style,
     anchor,
-    positionMethod = 'absolute',
-    side = 'bottom',
-    align = 'center',
-    sideOffset = 0,
-    alignOffset = 0,
+    // `useAnchorPositioning` applies the same defaults to the undefined values; the names
+    // remain destructured to exclude the props from `elementProps`.
+    positionMethod,
+    side,
+    align,
+    sideOffset,
+    alignOffset,
     collisionBoundary = 'clipping-ancestors',
-    collisionPadding = 5,
-    arrowPadding = 5,
-    sticky = false,
+    collisionPadding,
+    arrowPadding,
+    sticky,
     disableAnchorTracking = false,
     collisionAvoidance = POPUP_COLLISION_AVOIDANCE,
     ...elementProps
   } = componentProps;
 
-  const { store } = usePopoverRootContext();
+  const store = usePopoverRootContext();
   const keepMounted = usePopoverPortalContext();
   const nodeId = useFloatingNodeId();
 
@@ -121,19 +123,16 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     return undefined;
   }, [domReference, runOnceAnimationsFinish, store]);
 
+  const trueModalNonHover = modal === true && openReason !== REASONS.triggerHover;
+
   useAnchoredPopupScrollLock(
-    open && modal === true && openReason !== REASONS.triggerHover,
+    open && trueModalNonHover,
     openMethod === 'touch',
     positionerElement,
     triggerElement,
   );
 
-  const setPositionerElement = React.useCallback(
-    (element: HTMLElement | null) => {
-      store.set('positionerElement', element);
-    },
-    [store],
-  );
+  const setPositionerElement = store.useStateSetter('positionerElement');
 
   const state: PopoverPositionerState = {
     open,
@@ -154,12 +153,8 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
 
   return (
     <PopoverPositionerContext.Provider value={positioning}>
-      {mounted && modal === true && openReason !== REASONS.triggerHover && (
-        <InternalBackdrop
-          ref={store.context.internalBackdropRef}
-          inert={inertValue(!open)}
-          cutout={triggerElement}
-        />
+      {mounted && trueModalNonHover && (
+        <InternalBackdrop inert={inertValue(!open)} cutout={triggerElement} />
       )}
       <FloatingNode id={nodeId}>{element}</FloatingNode>
     </PopoverPositionerContext.Provider>

--- a/packages/react/src/popover/root/PopoverRoot.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
-import { useDismiss, FloatingTree, useFloatingParentNodeId } from '../../floating-ui-react';
+import { useDismiss, FloatingTree } from '../../floating-ui-react';
 import { PopoverRootContext, usePopoverRootContext } from './PopoverRootContext';
 import { PopoverStore, type State as PopoverStoreState } from '../store/PopoverStore';
 import { PopoverHandle } from '../store/PopoverHandle';
@@ -11,7 +11,6 @@ import {
 } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 import {
-  FOCUSABLE_POPUP_PROPS,
   useImplicitActiveTrigger,
   usePopupRootStore,
   useOpenStateTransitions,
@@ -19,7 +18,6 @@ import {
   usePopupRootSync,
   type PayloadChildRenderFunction,
 } from '../../utils/popups';
-import { mergeProps } from '../../merge-props';
 
 function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Payload> }) {
   const {
@@ -48,7 +46,6 @@ function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Pay
   const open = store.useState('open');
   const mounted = store.useState('mounted');
   const payload = store.useState('payload') as Payload | undefined;
-  const nested = useFloatingParentNodeId() != null;
 
   store.useContextCallback('onOpenChange', onOpenChange);
   store.useContextCallback('onOpenChangeComplete', onOpenChangeComplete);
@@ -61,7 +58,6 @@ function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Pay
 
   store.useSyncedValues({
     modal,
-    nested,
   });
 
   React.useEffect(() => {
@@ -82,15 +78,8 @@ function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Pay
 
   const shouldRenderInteractions = open || mounted;
 
-  const popoverContext: PopoverRootContext<Payload> = React.useMemo(
-    () => ({
-      store,
-    }),
-    [store],
-  );
-
   return (
-    <PopoverRootContext.Provider value={popoverContext as PopoverRootContext<unknown>}>
+    <PopoverRootContext.Provider value={store as PopoverRootContext<unknown>}>
       {shouldRenderInteractions && <PopoverInteractions store={store} modal={modal} />}
       {typeof children === 'function' ? children({ payload }) : children}
     </PopoverRootContext.Provider>
@@ -250,16 +239,15 @@ function PopoverInteractions({
     },
   });
 
-  const activeTriggerProps = dismiss.reference ?? EMPTY_OBJECT;
-  const inactiveTriggerProps = dismiss.trigger ?? EMPTY_OBJECT;
-  const popupProps = React.useMemo(
-    () => mergeProps(FOCUSABLE_POPUP_PROPS, dismiss.floating),
-    [dismiss.floating],
-  );
+  // `dismiss.trigger` is always the same object as `dismiss.reference`.
+  const triggerProps = dismiss.reference ?? EMPTY_OBJECT;
+  // PopoverPopup already spreads `FOCUSABLE_POPUP_PROPS` directly, so the popup
+  // props only need to carry the dismiss handlers.
+  const popupProps = dismiss.floating ?? EMPTY_OBJECT;
 
   usePopupInteractionProps(store, {
-    activeTriggerProps,
-    inactiveTriggerProps,
+    activeTriggerProps: triggerProps,
+    inactiveTriggerProps: triggerProps,
     popupProps,
   });
 

--- a/packages/react/src/popover/root/PopoverRootContext.ts
+++ b/packages/react/src/popover/root/PopoverRootContext.ts
@@ -2,9 +2,7 @@
 import * as React from 'react';
 import type { PopoverStore } from '../store/PopoverStore';
 
-export interface PopoverRootContext<Payload = unknown> {
-  store: PopoverStore<Payload>;
-}
+export type PopoverRootContext<Payload = unknown> = PopoverStore<Payload>;
 
 export const PopoverRootContext = React.createContext<PopoverRootContext | undefined>(undefined);
 

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -29,7 +29,6 @@ export type State<Payload> = PopupStoreState<Payload> & {
   openMethod: InteractionType | null;
   openChangeReason: PopoverRoot.ChangeEventReason | null;
   stickIfOpen: boolean;
-  nested: boolean;
   titleElementId: string | undefined;
   descriptionElementId: string | undefined;
   openOnHover: boolean;
@@ -39,8 +38,6 @@ export type State<Payload> = PopupStoreState<Payload> & {
 
 type Context = PopupStoreContext<PopoverRoot.ChangeEventDetails> & {
   readonly popupRef: React.RefObject<HTMLElement | null>;
-  readonly backdropRef: React.RefObject<HTMLDivElement | null>;
-  readonly internalBackdropRef: React.RefObject<HTMLDivElement | null>;
   readonly triggerFocusTargetRef: React.RefObject<HTMLElement | null>;
   readonly beforeContentFocusGuardRef: React.RefObject<HTMLElement | null>;
   readonly stickIfOpenTimeout: Timeout;
@@ -160,13 +157,15 @@ export class PopoverStore<Payload> extends ReactStore<
       changeState();
     }
 
-    if (isKeyboardClick || isDismissClose) {
-      this.set('instantType', isKeyboardClick ? 'click' : 'dismiss');
+    let instantType: State<Payload>['instantType'];
+    if (isKeyboardClick) {
+      instantType = 'click';
+    } else if (isDismissClose) {
+      instantType = 'dismiss';
     } else if (eventDetails.reason === REASONS.focusOut) {
-      this.set('instantType', 'focus');
-    } else {
-      this.set('instantType', undefined);
+      instantType = 'focus';
     }
+    this.set('instantType', instantType);
   };
 }
 
@@ -205,7 +204,6 @@ function createInitialState<Payload>(
     titleElementId: undefined,
     descriptionElementId: undefined,
     stickIfOpen: true,
-    nested: false,
     openOnHover: false,
     closeDelay: 0,
     hasViewport: false,
@@ -224,8 +222,6 @@ function createInitialState<Payload>(
 function createInitialContext(triggerElements: PopupTriggerMap): Context {
   return {
     popupRef: React.createRef<HTMLElement>(),
-    backdropRef: React.createRef<HTMLDivElement>(),
-    internalBackdropRef: React.createRef<HTMLDivElement>(),
     onOpenChange: undefined,
     onOpenChangeComplete: undefined,
     triggerFocusTargetRef: React.createRef<HTMLElement>(),

--- a/packages/react/src/popover/title/PopoverTitle.tsx
+++ b/packages/react/src/popover/title/PopoverTitle.tsx
@@ -17,7 +17,7 @@ export const PopoverTitle = React.forwardRef(function PopoverTitle(
 ) {
   const { render, className, style, ...elementProps } = componentProps;
 
-  const { store } = usePopoverRootContext();
+  const store = usePopoverRootContext();
 
   const id = useBaseUiId(elementProps.id);
 

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -45,9 +45,9 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
     ...elementProps
   } = componentProps;
 
-  const rootContext = usePopoverRootContext(true);
+  const rootStore = usePopoverRootContext(true);
   const handleStore = usePopupHandleStore(handle);
-  const store = handleStore ?? rootContext?.store;
+  const store = handleStore ?? rootStore;
   if (!store) {
     throw new Error(
       'Base UI: <Popover.Trigger> must be either used within a <Popover.Root> component or provided with a handle.',
@@ -81,10 +81,7 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
 
   const hoverProps = useHoverReferenceInteraction(floatingContext, {
     enabled:
-      !disabled &&
-      floatingContext != null &&
-      openOnHover &&
-      (openMethod !== 'touch' || openReason !== REASONS.triggerPress),
+      !disabled && openOnHover && (openMethod !== 'touch' || openReason !== REASONS.triggerPress),
     mouseOnly: true,
     move: false,
     handleClose: safePolygon(),
@@ -97,7 +94,7 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
     isClosing: () => store.select('transitionStatus') === 'ending',
   });
 
-  const click = useClick(floatingContext, { enabled: floatingContext != null, stickIfOpen });
+  const click = useClick(floatingContext, { stickIfOpen });
   const interactionTypeProps = useOpenMethodTriggerProps(
     () => store.select('open'),
     (interactionType) => {
@@ -153,18 +150,19 @@ export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
 
   // A fragment with key is required to ensure that the `element` is mounted to the same DOM node
   // regardless of whether the focus guards are rendered or not.
+  const keyedElement = <React.Fragment key={thisTriggerId}>{element}</React.Fragment>;
 
   if (isMountedByThisTrigger && !focusManagerModal) {
     return (
       <React.Fragment>
         <FocusGuard ref={preFocusGuardRef} onFocus={handlePreFocusGuardFocus} />
-        <React.Fragment key={thisTriggerId}>{element}</React.Fragment>
+        {keyedElement}
         <FocusGuard ref={store.context.triggerFocusTargetRef} onFocus={handleFocusTargetFocus} />
       </React.Fragment>
     );
   }
 
-  return <React.Fragment key={thisTriggerId}>{element}</React.Fragment>;
+  return keyedElement;
 }) as PopoverTrigger;
 
 export interface PopoverTrigger {

--- a/packages/react/src/popover/viewport/PopoverViewport.tsx
+++ b/packages/react/src/popover/viewport/PopoverViewport.tsx
@@ -31,7 +31,7 @@ export const PopoverViewport = React.forwardRef(function PopoverViewport(
 ) {
   const { render, className, style, children, ...elementProps } = componentProps;
 
-  const { store } = usePopoverRootContext();
+  const store = usePopoverRootContext();
   const { side } = usePopoverPositionerContext();
 
   const instantType = store.useState('instantType');

--- a/packages/react/src/utils/closePart.tsx
+++ b/packages/react/src/utils/closePart.tsx
@@ -7,7 +7,7 @@ interface ClosePartContextValue {
   register: () => () => void;
 }
 
-const ClosePartContext = React.createContext<ClosePartContextValue | undefined>(undefined);
+export const ClosePartContext = React.createContext<ClosePartContextValue | undefined>(undefined);
 
 export function useClosePartCount() {
   const [closePartCount, setClosePartCount] = React.useState(0);
@@ -26,15 +26,6 @@ export function useClosePartCount() {
     context,
     hasClosePart: closePartCount > 0,
   };
-}
-
-export function ClosePartProvider(props: {
-  value: ClosePartContextValue;
-  children: React.ReactNode;
-}) {
-  const { value, children } = props;
-
-  return <ClosePartContext.Provider value={value}>{children}</ClosePartContext.Provider>;
 }
 
 export function useClosePartRegistration() {

--- a/packages/react/src/utils/popupStateMapping.ts
+++ b/packages/react/src/utils/popupStateMapping.ts
@@ -45,25 +45,27 @@ export enum CommonTriggerDataAttributes {
   pressed = 'data-pressed',
 }
 
+// Literal keys (instead of enum member references) keep the docs-only enums above
+// tree-shakeable: a runtime reference would retain the whole enum IIFE in every bundle.
 const TRIGGER_HOOK = {
-  [CommonTriggerDataAttributes.popupOpen]: '',
+  'data-popup-open': '',
 };
 
 const PRESSABLE_TRIGGER_HOOK = {
-  [CommonTriggerDataAttributes.popupOpen]: '',
-  [CommonTriggerDataAttributes.pressed]: '',
+  'data-popup-open': '',
+  'data-pressed': '',
 };
 
 const POPUP_OPEN_HOOK = {
-  [CommonPopupDataAttributes.open]: '',
+  'data-open': '',
 };
 
 const POPUP_CLOSED_HOOK = {
-  [CommonPopupDataAttributes.closed]: '',
+  'data-closed': '',
 };
 
 const ANCHOR_HIDDEN_HOOK = {
-  [CommonPopupDataAttributes.anchorHidden]: '',
+  'data-anchor-hidden': '',
 };
 
 export const triggerOpenStateMapping = {

--- a/packages/react/src/utils/popups/popupHandle.ts
+++ b/packages/react/src/utils/popups/popupHandle.ts
@@ -64,14 +64,6 @@ export class BasePopupHandle<
   Store extends HandleStore & PopupHandleStoreWithOpen,
 > implements PopupHandleStoreProvider<HandleStore> {
   /**
-   * Inert, closed store handed to detached triggers while no root is attached, so they can render
-   * and register without a mounted root. Triggers register into whichever store `store` currently
-   * resolves to, so while detached they live in this store's trigger map and migrate themselves to
-   * the root's store (and back) as it attaches/detaches.
-   */
-  private readonly fallbackStoreValue: HandleStore;
-
-  /**
    * Stores of every root currently using this handle, in attach order. A handle is meant to be used
    * by a single mounted root, but roots can transiently overlap (e.g. during an animated route
    * transition), so this stack lets `attachStore`'s cleanup restore the previous root instead of
@@ -93,7 +85,10 @@ export class BasePopupHandle<
   /**
    * Creates a handle backed by the store used while no root is attached.
    *
-   * @param fallbackStore Inert store exposed to detached triggers before a root mounts.
+   * @param fallbackStore Inert, closed store handed to detached triggers while no root is attached,
+   * so they can render and register without a mounted root. Triggers register into whichever store
+   * `store` currently resolves to, so while detached they live in this store's trigger map and
+   * migrate themselves to the root's store (and back) as it attaches/detaches.
    * @param componentName Component name used to prefix dev warnings, e.g. `'Menu'` produces
    * `MenuHandle.open()` in warning text.
    * @param throwOnMissingTrigger Whether `open(triggerId)` throws when no trigger with that id is
@@ -101,19 +96,13 @@ export class BasePopupHandle<
    * so they throw; Dialog is not anchored and instead opens unassociated with a dev warning.
    */
   constructor(
-    fallbackStore: HandleStore,
+    protected readonly fallbackStore: HandleStore,
     private readonly componentName: string,
     private readonly throwOnMissingTrigger: boolean = true,
-  ) {
-    this.fallbackStoreValue = fallbackStore;
-  }
+  ) {}
 
   protected get attachedStore() {
     return this.attachedStoreValue;
-  }
-
-  protected get fallbackStore() {
-    return this.fallbackStoreValue;
   }
 
   /**
@@ -122,7 +111,7 @@ export class BasePopupHandle<
    * @internal
    */
   get store(): HandleStore {
-    return this.attachedStoreValue ?? this.fallbackStoreValue;
+    return this.attachedStoreValue ?? this.fallbackStore;
   }
 
   /**
@@ -189,17 +178,10 @@ export class BasePopupHandle<
   private setActiveStore(store: Store | null) {
     if (this.attachedStoreValue !== store) {
       this.attachedStoreValue = store;
-      this.notifyStoreListeners();
+      this.storeListeners.forEach((listener) => {
+        listener();
+      });
     }
-  }
-
-  /**
-   * Notifies subscribers that the attached store pointer changed.
-   */
-  private notifyStoreListeners() {
-    this.storeListeners.forEach((listener) => {
-      listener();
-    });
   }
 
   /**
@@ -286,9 +268,6 @@ export class BasePopupHandle<
       return;
     }
 
-    attachedStore.setOpen(
-      false,
-      createChangeEventDetails(REASONS.imperativeAction, undefined, undefined),
-    );
+    attachedStore.setOpen(false, createChangeEventDetails(REASONS.imperativeAction));
   }
 }

--- a/packages/react/src/utils/popups/popupTriggerMap.ts
+++ b/packages/react/src/utils/popups/popupTriggerMap.ts
@@ -1,14 +1,13 @@
 /**
  * Data structure to keep track of popup trigger elements by their IDs.
- * Uses both a set of Elements and a map of IDs to Elements for efficient lookups.
+ *
+ * Element lookups iterate the id map; trigger counts are single digits, so linear
+ * scans on event-frequency paths are cheaper than maintaining a parallel Set.
  */
 export class PopupTriggerMap {
-  private elementsSet: Set<Element>;
-
   private idMap: Map<string, Element>;
 
   constructor() {
-    this.elementsSet = new Set();
     this.idMap = new Map();
   }
 
@@ -18,54 +17,34 @@ export class PopupTriggerMap {
    * Note: The provided element is assumed to not be registered under multiple IDs.
    */
   public add(id: string, element: Element) {
-    const existingElement = this.idMap.get(id);
-    if (existingElement === element) {
-      return;
-    }
-
-    if (existingElement !== undefined) {
-      // We assume that the same element won't be registered under multiple ids.
-      // This is safe considering how useTriggerRegistration is implemented.
-      this.elementsSet.delete(existingElement);
-    }
-
-    this.elementsSet.add(element);
     this.idMap.set(id, element);
-
-    if (process.env.NODE_ENV !== 'production') {
-      if (this.elementsSet.size !== this.idMap.size) {
-        // TODO: fix mui/no-guarded-throw
-        // eslint-disable-next-line mui/no-guarded-throw
-        throw new Error(
-          'Base UI: A trigger element cannot be registered under multiple IDs in PopupTriggerMap.',
-        );
-      }
-    }
   }
 
   /**
    * Removes the trigger element with the given ID.
    */
   public delete(id: string) {
-    const element = this.idMap.get(id);
-    if (element) {
-      this.elementsSet.delete(element);
-      this.idMap.delete(id);
-    }
+    this.idMap.delete(id);
   }
 
   /**
    * Whether the given element is registered as a trigger.
    */
   public hasElement(element: Element): boolean {
-    return this.elementsSet.has(element);
+    for (const registered of this.idMap.values()) {
+      if (registered === element) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**
    * Whether there is a registered trigger element matching the given predicate.
    */
   public hasMatchingElement(predicate: (el: Element) => boolean): boolean {
-    for (const element of this.elementsSet) {
+    for (const element of this.idMap.values()) {
       if (predicate(element)) {
         return true;
       }
@@ -92,7 +71,7 @@ export class PopupTriggerMap {
    * Returns an iterable of all registered trigger elements.
    */
   public elements(): IterableIterator<Element> {
-    return this.elementsSet.values();
+    return this.idMap.values();
   }
 
   /**

--- a/packages/react/src/utils/popups/popupTriggerMap.ts
+++ b/packages/react/src/utils/popups/popupTriggerMap.ts
@@ -17,6 +17,18 @@ export class PopupTriggerMap {
    * Note: The provided element is assumed to not be registered under multiple IDs.
    */
   public add(id: string, element: Element) {
+    if (process.env.NODE_ENV !== 'production') {
+      for (const [existingId, existingElement] of this.idMap) {
+        if (existingElement === element && existingId !== id) {
+          // TODO: fix mui/no-guarded-throw
+          // eslint-disable-next-line mui/no-guarded-throw
+          throw new Error(
+            'Base UI: A trigger element cannot be registered under multiple IDs in PopupTriggerMap.',
+          );
+        }
+      }
+    }
+
     this.idMap.set(id, element);
   }
 


### PR DESCRIPTION
Removes dead code across the popup components: enum members referenced from runtime code (which retained the whole enum), a redundant element `Set` mirroring the id map in `PopupTriggerMap`, write-only popover store members, always-true guards, and the `{ store }` context wrapper objects in dialog and popover. Also fixes `useDialogRootContext` so the intended missing-context error actually throws.

Trims ~9.4 kB parsed / ~2.1 kB gzip across 14 entrypoints, led by dialog (−1,503 / −330) and alert-dialog (−1,506 / −282). Overlaps trivially with #5192 in `DialogPopup`, `DialogViewport`, and `popupStateMapping`; whichever lands second needs a rebase.
