### PR TITLE
[field] Clear focused state when disabled

### DIFF
--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -89,6 +89,14 @@ export const FieldControl = React.forwardRef(function FieldControl(
     }
   }, [autoFocus, setFocused]);
 
+  // Disabling a focused control doesn't always fire a blur event, so the focused
+  // state must be cleared manually to avoid a lingering `data-focused` attribute.
+  useIsoLayoutEffect(() => {
+    if (disabled) {
+      setFocused(false);
+    }
+  }, [disabled, setFocused]);
+
   const [valueUnwrapped] = useControlled({
     controlled: valueProp,
     default: defaultValue,

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -1807,6 +1807,109 @@ describe('<Field.Root />', () => {
         expect(label).not.toHaveAttribute('data-focused');
         expect(description).not.toHaveAttribute('data-focused');
       });
+
+      it('removes [data-focused] when the field becomes disabled while focused', async () => {
+        function App() {
+          const [disabled, setDisabled] = React.useState(false);
+          return (
+            <div>
+              <Field.Root disabled={disabled} data-testid="root">
+                <Field.Control data-testid="control" />
+                <Field.Label data-testid="label" />
+                <Field.Description data-testid="description" />
+              </Field.Root>
+              <button onClick={() => setDisabled(true)}>disable</button>
+            </div>
+          );
+        }
+
+        await render(<App />);
+
+        const root = screen.getByTestId('root');
+        const control = screen.getByTestId('control');
+        const label = screen.getByTestId('label');
+        const description = screen.getByTestId('description');
+
+        fireEvent.focus(control);
+
+        expect(root).toHaveAttribute('data-focused', '');
+        expect(control).toHaveAttribute('data-focused', '');
+        expect(label).toHaveAttribute('data-focused', '');
+        expect(description).toHaveAttribute('data-focused', '');
+
+        // Disabling a focused control doesn't fire a blur event.
+        fireEvent.click(screen.getByRole('button', { name: 'disable' }));
+
+        expect(root).toHaveAttribute('data-disabled', '');
+        expect(root).not.toHaveAttribute('data-focused');
+        expect(control).not.toHaveAttribute('data-focused');
+        expect(label).not.toHaveAttribute('data-focused');
+        expect(description).not.toHaveAttribute('data-focused');
+      });
+
+      it('removes [data-focused] when the control becomes disabled while focused', async () => {
+        function App() {
+          const [disabled, setDisabled] = React.useState(false);
+          return (
+            <div>
+              <Field.Root data-testid="root">
+                <Field.Control disabled={disabled} data-testid="control" />
+                <Field.Label data-testid="label" />
+              </Field.Root>
+              <button onClick={() => setDisabled(true)}>disable</button>
+            </div>
+          );
+        }
+
+        await render(<App />);
+
+        const root = screen.getByTestId('root');
+        const control = screen.getByTestId('control');
+        const label = screen.getByTestId('label');
+
+        fireEvent.focus(control);
+
+        expect(root).toHaveAttribute('data-focused', '');
+        expect(control).toHaveAttribute('data-focused', '');
+        expect(label).toHaveAttribute('data-focused', '');
+
+        fireEvent.click(screen.getByRole('button', { name: 'disable' }));
+
+        expect(control).toHaveAttribute('data-disabled', '');
+        expect(root).not.toHaveAttribute('data-focused');
+        expect(control).not.toHaveAttribute('data-focused');
+        expect(label).not.toHaveAttribute('data-focused');
+      });
+
+      it('removes [data-focused] from a focused Checkbox when the field becomes disabled', async () => {
+        function App() {
+          const [disabled, setDisabled] = React.useState(false);
+          return (
+            <div>
+              <Field.Root disabled={disabled} data-testid="root">
+                <Checkbox.Root data-testid="checkbox" />
+              </Field.Root>
+              <button onClick={() => setDisabled(true)}>disable</button>
+            </div>
+          );
+        }
+
+        await render(<App />);
+
+        const root = screen.getByTestId('root');
+        const checkbox = screen.getByTestId('checkbox');
+
+        fireEvent.focus(checkbox);
+
+        expect(root).toHaveAttribute('data-focused', '');
+        expect(checkbox).toHaveAttribute('data-focused', '');
+
+        fireEvent.click(screen.getByRole('button', { name: 'disable' }));
+
+        expect(root).toHaveAttribute('data-disabled', '');
+        expect(root).not.toHaveAttribute('data-focused');
+        expect(checkbox).not.toHaveAttribute('data-focused');
+      });
     });
   });
 

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -66,6 +66,14 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
     }
   }, [dirtyProp]);
 
+  // Disabling a focused control doesn't always fire a blur event, so the focused
+  // state must be cleared manually to avoid a lingering `data-focused` attribute.
+  useIsoLayoutEffect(() => {
+    if (disabled) {
+      setFocused(false);
+    }
+  }, [disabled]);
+
   const setDirty: typeof setDirtyUnwrapped = useStableCallback((value) => {
     if (dirtyProp !== undefined) {
       return;


### PR DESCRIPTION
Fixes #3987

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Problem

When a focused control becomes disabled, no blur event fires, so the field's `focused` state is never reset and `data-focused` lingers on all Field parts alongside `data-disabled` until something else receives focus. Native `<input>` elements lose focus when disabled, so `data-focused` shouldn't stick around.

## Changes

- Clear the field's `focused` state when `Field.Root` (or an enclosing `Fieldset`) becomes disabled. Since the state lives in the field context, this covers any Base UI control inside the field (Checkbox, Select, Switch, etc.) when the field itself is disabled.
- Do the same in `Field.Control` (and therefore `Input`) when the control's own `disabled` prop becomes `true` without the field being disabled.
- Add regression coverage for both cases, plus a Checkbox inside a field that becomes disabled.

## Limitations

Disabling a control through its own `disabled` prop rather than through the field (e.g. `<Checkbox.Root disabled>` inside an enabled `Field.Root`) is not covered; handling that uniformly for every control is a larger change (previously attempted in #3996). This fixes the field-scoped part of the issue.