### PR TITLE
[composite] Keep item refs populated across StrictMode remounts

### DIFF
--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';
 import { CompositeList } from './CompositeList';
-import { useCompositeListItem } from './useCompositeListItem';
+import { IndexGuessBehavior, useCompositeListItem } from './useCompositeListItem';
 
 describe('<CompositeList />', () => {
   const { render } = createRenderer();
@@ -39,6 +39,46 @@ describe('<CompositeList />', () => {
       unmount();
       expect(elementsRef.current).toHaveLength(0);
       expect(labelsRef.current).toHaveLength(0);
+    });
+
+    it('keeps refs populated for items whose guessed index is already correct', async () => {
+      function GuessedItem(props: { label: string }) {
+        const { ref } = useCompositeListItem({
+          label: props.label,
+          indexGuessBehavior: IndexGuessBehavior.GuessFromOrder,
+        });
+        return (
+          <div ref={ref} data-testid={props.label}>
+            {props.label}
+          </div>
+        );
+      }
+
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const labelsRef = {
+        current: [] as Array<string | null>,
+      };
+
+      await render(
+        <CompositeList elementsRef={elementsRef} labelsRef={labelsRef}>
+          <GuessedItem label="a" />
+          <GuessedItem label="b" />
+          <GuessedItem label="c" />
+        </CompositeList>,
+      );
+
+      // A StrictMode dev remount runs the cleanup that empties the ref arrays,
+      // but items whose index is unchanged don't re-render, so their ref
+      // callbacks can't refill the arrays. The map change subscription must
+      // write the refs back (https://github.com/mui/base-ui/issues/4698).
+      await waitFor(() => {
+        expect(elementsRef.current[0]).toBe(screen.getByTestId('a'));
+      });
+      expect(elementsRef.current[1]).toBe(screen.getByTestId('b'));
+      expect(elementsRef.current[2]).toBe(screen.getByTestId('c'));
+      expect(labelsRef.current).toEqual(['a', 'b', 'c']);
     });
 
     it('updates indexes when keyed groups reorder', async () => {

--- a/packages/react/src/internals/composite/list/useCompositeListItem.ts
+++ b/packages/react/src/internals/composite/list/useCompositeListItem.ts
@@ -50,24 +50,31 @@ export function useCompositeListItem<Metadata>(
         : -1),
   );
 
-  const componentRef = React.useRef<Element | null>(null);
+  const componentRef = React.useRef<HTMLElement | null>(null);
+
+  const syncRefs = React.useCallback(
+    (node: HTMLElement, i: number) => {
+      elementsRef.current[i] = node;
+
+      if (labelsRef) {
+        const isLabelDefined = label !== undefined;
+        labelsRef.current[i] = isLabelDefined
+          ? label
+          : (textRef?.current?.textContent ?? node.textContent);
+      }
+    },
+    [elementsRef, labelsRef, label, textRef],
+  );
 
   const ref = React.useCallback(
     (node: HTMLElement | null) => {
       componentRef.current = node;
 
       if (index !== -1 && node !== null) {
-        elementsRef.current[index] = node;
-
-        if (labelsRef) {
-          const isLabelDefined = label !== undefined;
-          labelsRef.current[index] = isLabelDefined
-            ? label
-            : (textRef?.current?.textContent ?? node.textContent);
-        }
+        syncRefs(node, index);
       }
     },
-    [index, elementsRef, labelsRef, label, textRef],
+    [index, syncRefs],
   );
 
   useIsoLayoutEffect(() => {
@@ -91,13 +98,21 @@ export function useCompositeListItem<Metadata>(
     }
 
     return subscribeMapChange((map) => {
-      const i = componentRef.current ? map.get(componentRef.current)?.index : null;
+      const node = componentRef.current;
+      const i = node ? map.get(node)?.index : null;
 
-      if (i != null) {
+      if (node && i != null) {
         setIndex(i);
+        // Write the refs even when the index didn't change and the item won't
+        // re-render: a React StrictMode dev remount re-runs `CompositeList`'s
+        // cleanup (which empties the ref arrays) without re-invoking the item
+        // ref callbacks that originally filled them.
+        if (elementsRef.current[i] !== node) {
+          syncRefs(node, i);
+        }
       }
     });
-  }, [externalIndex, subscribeMapChange, setIndex]);
+  }, [externalIndex, subscribeMapChange, setIndex, syncRefs, elementsRef]);
 
   return { ref, index };
 }

--- a/packages/react/src/select/item/SelectItem.test.tsx
+++ b/packages/react/src/select/item/SelectItem.test.tsx
@@ -234,6 +234,65 @@ describe('<Select.Item />', () => {
     });
   });
 
+  it('should highlight a hovered item and commit it with a mouse click', async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      <Select.Root onValueChange={onValueChange}>
+        <Select.Trigger data-testid="trigger">
+          <Select.Value data-testid="value" />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="one">one</Select.Item>
+              <Select.Item value="two">two</Select.Item>
+              <Select.Item value="three">three</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+
+    fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+    fireEvent.mouseDown(trigger);
+    fireEvent.pointerUp(trigger, { pointerType: 'mouse' });
+    fireEvent.mouseUp(trigger);
+    fireEvent.click(trigger);
+    await flushMicrotasks();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('listbox')).not.toBe(null);
+    });
+
+    const option = screen.getByRole('option', { name: 'two' });
+
+    // Hovering must highlight the item even after a StrictMode dev remount,
+    // which empties `CompositeList`'s `elementsRef` without re-invoking the
+    // item ref callbacks that originally filled it (https://github.com/mui/base-ui/issues/4698).
+    fireEvent.pointerEnter(option, { pointerType: 'mouse' });
+    fireEvent.mouseMove(option);
+
+    await waitFor(() => {
+      expect(option).toHaveAttribute('data-highlighted');
+    });
+
+    fireEvent.pointerDown(option, { pointerType: 'mouse' });
+    fireEvent.mouseDown(option);
+    fireEvent.pointerUp(option, { pointerType: 'mouse' });
+    fireEvent.mouseUp(option);
+    fireEvent.click(option);
+    await flushMicrotasks();
+
+    expect(onValueChange.mock.calls.length).toBe(1);
+    expect(onValueChange.mock.calls[0][0]).toBe('two');
+    await waitFor(() => {
+      expect(screen.getByTestId('value').textContent).toBe('two');
+    });
+  });
+
   it('should ignore an unhighlighted item with a generic virtual click', async () => {
     await render(
       <Select.Root defaultOpen highlightItemOnHover={false}>


### PR DESCRIPTION
Fixes #4698

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Problem

When a `CompositeList` subtree mounts in StrictMode dev, the simulated unmount runs the cleanup that empties `elementsRef`/`labelsRef`, and the simulated remount re-registers the items — but items whose index didn't change bail out of `setIndex`, so their ref callbacks never re-run and the arrays stay empty. `useListNavigation` then can't resolve hovered items (`listRef.current.indexOf(event.currentTarget) === -1`), so `activeIndex`/`data-highlighted` never update and mouse interaction breaks.

Whether this is user-visible depends on the exact React build, which is why it has been hard to reproduce (#4897):

- `react@19` stable: StrictMode reattaches refs during the simulated remount, refilling the arrays.
- `react@18.3.1` stable: the StrictMode double render double-invokes the `useState` initializer, which bumps the shared `nextIndexRef` twice per item, so `IndexGuessBehavior.GuessFromOrder` guesses are always off (`1, 3, 5, …`). Every index then shifts after registration, producing new ref callbacks that refill the arrays as a side effect.
- `react@18.3.0-canary-178c267a4e-20241218` (the build Next 14.2 vendors for the App Router, which the issue's repro runs on): guesses are already correct and refs are not reattached, so nothing repopulates the arrays and the select becomes unusable with the mouse, exactly as reported.

## Changes

- `useCompositeListItem` writes the element/label back into the ref arrays from the map-change subscription it already registers, whenever the stored element is stale. Compared to #4897 this adds no extra pass over the list: the per-item listener already runs for `setIndex`, and the `elementsRef.current[i] !== node` guard keeps the steady-state cost at one comparison per item, with no label/`textContent` reads unless the slot is actually stale.
- Test: `CompositeList` keeps the ref arrays populated for items whose guessed index is already correct.
- Test: hovering a `Select.Item` with the mouse sets `data-highlighted` and a subsequent click commits the value.

## Verification

Running the suite against the Next-vendored canary above, the two new tests plus five existing `SelectItem` tests (keyboard focus, Enter select, click select, `onClick` once, `data-selected`) fail on unmodified `master` in 3/3 runs and pass with this fix in 3/3 runs. The select, combobox, menu, and internals suites are green with the fix under `react@19.2.5`, `react@18.3.1`, and that canary.

Honest limitation: on the React versions CI runs (`19.2.5` and `^18` = `18.3.1`), the new tests also pass on `master` because of the accidental repopulation described above, so CI alone cannot demonstrate the regression — the canary runs are the fail-before-fix evidence.
