### PR TITLE
[toast] Render content passed via the render prop in Action

### DIFF
--- a/packages/react/src/toast/action/ToastAction.test.tsx
+++ b/packages/react/src/toast/action/ToastAction.test.tsx
@@ -140,4 +140,47 @@ describe('<Toast.Action />', () => {
 
     expect(screen.getByText('0')).not.toBe(null);
   });
+
+  it('renders a numeric zero child', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <Toast.Root toast={toast}>
+            <Toast.Action>{0}</Toast.Action>
+          </Toast.Root>
+        </Toast.Viewport>
+      </Toast.Provider>,
+    );
+
+    expect(screen.getByText('0')).not.toBe(null);
+  });
+
+  it('does not render an empty-array child', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <Toast.Root toast={toast}>
+            <Toast.Action data-testid="action-render">{[]}</Toast.Action>
+          </Toast.Root>
+        </Toast.Viewport>
+      </Toast.Provider>,
+    );
+
+    expect(screen.queryByTestId('action-render')).toBe(null);
+  });
+
+  it('does not render when a render function returns no element', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <Toast.Root toast={toast} data-testid="root">
+            <Toast.Action data-testid="action-render" render={(() => null) as any} />
+          </Toast.Root>
+        </Toast.Viewport>
+      </Toast.Provider>,
+    );
+
+    expect(screen.getByTestId('root')).not.toBe(null);
+    expect(screen.queryByTestId('action-render')).toBe(null);
+  });
 });

--- a/packages/react/src/toast/action/ToastAction.test.tsx
+++ b/packages/react/src/toast/action/ToastAction.test.tsx
@@ -126,4 +126,18 @@ describe('<Toast.Action />', () => {
 
     expect(screen.queryByTestId('action-render')).toBe(null);
   });
+
+  it('renders a numeric render prop child such as 0', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <Toast.Root toast={toast}>
+            <Toast.Action render={<button type="button">{0}</button>} />
+          </Toast.Root>
+        </Toast.Viewport>
+      </Toast.Provider>,
+    );
+
+    expect(screen.getByText('0')).not.toBe(null);
+  });
 });

--- a/packages/react/src/toast/action/ToastAction.test.tsx
+++ b/packages/react/src/toast/action/ToastAction.test.tsx
@@ -78,4 +78,52 @@ describe('<Toast.Action />', () => {
     const actionElement = screen.queryByTestId('action');
     expect(actionElement).toBe(null);
   });
+
+  it('renders content passed through the render prop', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <Toast.Root toast={toast}>
+            <Toast.Action render={<button type="button">render prop action</button>} />
+          </Toast.Root>
+        </Toast.Viewport>
+      </Toast.Provider>,
+    );
+
+    expect(screen.getByText('render prop action')).not.toBe(null);
+  });
+
+  it('renders content passed through a render function', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <Toast.Root toast={toast}>
+            <Toast.Action
+              render={(props) => (
+                <button type="button" {...props}>
+                  render fn action
+                </button>
+              )}
+            />
+          </Toast.Root>
+        </Toast.Viewport>
+      </Toast.Provider>,
+    );
+
+    expect(screen.getByText('render fn action')).not.toBe(null);
+  });
+
+  it('does not render a childless render prop when there is no action content', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <Toast.Root toast={toast}>
+            <Toast.Action render={<button type="button" data-testid="action-render" />} />
+          </Toast.Root>
+        </Toast.Viewport>
+      </Toast.Provider>,
+    );
+
+    expect(screen.queryByTestId('action-render')).toBe(null);
+  });
 });

--- a/packages/react/src/toast/action/ToastAction.tsx
+++ b/packages/react/src/toast/action/ToastAction.tsx
@@ -4,6 +4,7 @@ import type { BaseUIComponentProps, NativeButtonProps } from '../../internals/ty
 import { useToastRootContext } from '../root/ToastRootContext';
 import { useButton } from '../../internals/use-button/useButton';
 import { useRenderElement } from '../../internals/useRenderElement';
+import { isRenderableNode } from '../utils/isRenderableNode';
 
 /**
  * Performs an action when clicked.
@@ -51,8 +52,8 @@ export const ToastAction = React.forwardRef(function ToastAction(
   });
 
   const shouldRender =
-    React.isValidElement(element) &&
-    Boolean((element.props as { children?: React.ReactNode }).children);
+    React.isValidElement<{ children?: React.ReactNode }>(element) &&
+    isRenderableNode(element.props.children);
 
   if (!shouldRender) {
     return null;

--- a/packages/react/src/toast/action/ToastAction.tsx
+++ b/packages/react/src/toast/action/ToastAction.tsx
@@ -27,7 +27,6 @@ export const ToastAction = React.forwardRef(function ToastAction(
   const { toast } = useToastRootContext();
 
   const computedChildren = toast.actionProps?.children ?? elementProps.children;
-  const shouldRender = Boolean(computedChildren);
 
   const { getButtonProps, buttonRef } = useButton({
     disabled,
@@ -50,6 +49,10 @@ export const ToastAction = React.forwardRef(function ToastAction(
       },
     ],
   });
+
+  const shouldRender =
+    React.isValidElement(element) &&
+    Boolean((element.props as { children?: React.ReactNode }).children);
 
   if (!shouldRender) {
     return null;

--- a/packages/react/src/toast/utils/isRenderableNode.test.ts
+++ b/packages/react/src/toast/utils/isRenderableNode.test.ts
@@ -21,5 +21,7 @@ describe('isRenderableNode', () => {
     expect(isRenderableNode([])).toBe(false);
     expect(isRenderableNode([null, undefined, false])).toBe(false);
     expect(isRenderableNode([null, 0])).toBe(true);
+    expect(isRenderableNode([[null]])).toBe(false);
+    expect(isRenderableNode([[0]])).toBe(true);
   });
 });

--- a/packages/react/src/toast/utils/isRenderableNode.test.ts
+++ b/packages/react/src/toast/utils/isRenderableNode.test.ts
@@ -1,0 +1,25 @@
+import { expect } from 'vitest';
+import { isRenderableNode } from './isRenderableNode';
+
+describe('isRenderableNode', () => {
+  it('treats renderable primitives as content', () => {
+    expect(isRenderableNode(0)).toBe(true);
+    expect(isRenderableNode(0n)).toBe(true);
+    expect(isRenderableNode(Number.NaN)).toBe(true);
+    expect(isRenderableNode('text')).toBe(true);
+  });
+
+  it('treats non-rendering values as empty', () => {
+    expect(isRenderableNode(null)).toBe(false);
+    expect(isRenderableNode(undefined)).toBe(false);
+    expect(isRenderableNode(true)).toBe(false);
+    expect(isRenderableNode(false)).toBe(false);
+    expect(isRenderableNode('')).toBe(false);
+  });
+
+  it('recurses into arrays', () => {
+    expect(isRenderableNode([])).toBe(false);
+    expect(isRenderableNode([null, undefined, false])).toBe(false);
+    expect(isRenderableNode([null, 0])).toBe(true);
+  });
+});

--- a/packages/react/src/toast/utils/isRenderableNode.ts
+++ b/packages/react/src/toast/utils/isRenderableNode.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export function isRenderableNode(node: React.ReactNode): boolean {
+  if (node == null || typeof node === 'boolean' || node === '') {
+    return false;
+  }
+  if (Array.isArray(node)) {
+    return node.some(isRenderableNode);
+  }
+  return true;
+}


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Description

`Toast.Action` gates rendering on the presence of resolved children (`toast.actionProps?.children ?? children`). When the action is provided through the `render` prop with content but no children — `<Toast.Action render={<button>Undo</button>} />` — that content was dropped: `shouldRender` was `false` and the element never mounted.

The fix gates on the **evaluated element's resolved children**, so a `render` that carries content mounts, while a childless, styling-only `render={<MyButton />}` — used purely to customize the element in a shared template, with the action content coming from `toast.actionProps` — stays conditional and does not force-mount an empty button for every toast. Whether resolved children count as content is decided by a shared `isRenderableNode` predicate matching React renderability (numeric/bigint children including `0` are content; nullish values, booleans, empty strings, and arrays containing only those are not), behind a `React.isValidElement` check so a render function returning null can't crash the children lookup.

### Linked Issues

Related to #2809 (same root cause, for Title and Description).

### Additional context

Follow-up to #5210, kept separate to scope that PR to the reported issue. The shared util `packages/react/src/toast/utils/isRenderableNode.ts` (+ tests) is included byte-identically on both PRs, so whichever merges second resolves it cleanly and its squash then effectively touches only the `Toast.Action` files. Tests cover the `render` prop as an element and as a function, the childless-render case, a render function returning null, numeric `0` as render-prop and plain child, and empty-array children.
