### PR TITLE
[radio] Remove unnecessary ARIA attributes from RadioRoot component

### DIFF
--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -138,8 +138,6 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
   const rootProps: React.ComponentPropsWithRef<'span'> = {
     role: 'radio',
     'aria-checked': checked,
-    'aria-required': required || undefined,
-    'aria-readonly': readOnly || undefined,
     'aria-labelledby': ariaLabelledBy,
     [ACTIVE_COMPOSITE_ITEM as string]: checked ? '' : undefined,
     id: nativeButton ? inputId : id,


### PR DESCRIPTION
Per WAI-ARIA 1.2 aria-required / aria-readonly aren't supported on role=`radio` element, instead they are supported on `radiogroup` role

**Supported states for radio role**

<img width="595" height="337" alt="image" src="https://github.com/user-attachments/assets/148b104b-c1c3-451f-80a4-b9dc95fe8d49" />

**Supported states for radiogroup role**

<img width="596" height="358" alt="image" src="https://github.com/user-attachments/assets/07e035d5-88e6-4002-b42d-278a95646561" />
