### PR TITLE
[checkbox group] Focus invalid checkbox

### DIFF
--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -1520,6 +1520,45 @@ describe('<CheckboxGroup />', () => {
       expect(screen.getByTestId('parent')).not.toHaveFocus();
     });
 
+    it('focuses a later invalid field when an inputless group is invalid without a control', async () => {
+      const { user } = render(
+        <Form>
+          <Field.Root name="group" validate={() => 'Invalid group'}>
+            <CheckboxGroup value={[]} />
+          </Field.Root>
+          <Field.Root name="email">
+            <Field.Control required data-testid="email" />
+          </Field.Root>
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      await user.click(screen.getByText('Submit'));
+
+      // The group is invalid but has no focusable control, so focus must skip to the next invalid field.
+      expect(screen.getByTestId('email')).toHaveFocus();
+    });
+
+    it('focuses a later invalid field when every checkbox in an invalid group is disabled', async () => {
+      const { user } = render(
+        <Form>
+          <Field.Root name="group" validate={() => 'Invalid group'}>
+            <CheckboxGroup defaultValue={[]}>
+              <Checkbox.Root value="one" disabled />
+            </CheckboxGroup>
+          </Field.Root>
+          <Field.Root name="email">
+            <Field.Control required data-testid="email" />
+          </Field.Root>
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      await user.click(screen.getByText('Submit'));
+
+      expect(screen.getByTestId('email')).toHaveFocus();
+    });
+
     it('excludes parent checkboxes from form submission', async () => {
       const allValues = ['fuji-apple', 'gala-apple', 'granny-smith-apple'];
 

--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -1,5 +1,6 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
 import { CheckboxGroup } from '@base-ui/react/checkbox-group';
 import { Checkbox } from '@base-ui/react/checkbox';
@@ -987,6 +988,536 @@ describe('<CheckboxGroup />', () => {
       expect(checkbox1).toHaveFocus();
       expect(checkbox1).toHaveAttribute('aria-invalid', 'true');
       expect(screen.queryByTestId('error')).toHaveTextContent('server error');
+    });
+
+    it('focuses the invalid checkbox when a later checkbox in the group fails validation', async () => {
+      const { user } = render(
+        <Form>
+          <Field.Root name="group">
+            <CheckboxGroup defaultValue={['one']}>
+              <Field.Item>
+                <Checkbox.Root value="one" data-testid="checkbox" />
+              </Field.Item>
+              <Field.Item>
+                <Checkbox.Root value="two" data-testid="checkbox" required />
+              </Field.Item>
+            </CheckboxGroup>
+            <Field.Error match="valueMissing" data-testid="error">
+              required
+            </Field.Error>
+          </Field.Root>
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      const checkboxes = screen.getAllByTestId('checkbox');
+
+      await user.click(screen.getByText('Submit'));
+
+      expect(screen.getByTestId('error')).toHaveTextContent('required');
+      expect(checkboxes[1]).toHaveFocus();
+    });
+
+    it('ignores required checkboxes associated with a different form', async () => {
+      const handleSubmit = vi.fn();
+
+      const { user } = render(
+        <React.Fragment>
+          <form id="external-form" />
+          <Form onFormSubmit={handleSubmit}>
+            <Field.Root name="group">
+              <CheckboxGroup defaultValue={[]}>
+                <Checkbox.Root value="external" form="external-form" required />
+                <Checkbox.Root value="current" />
+              </CheckboxGroup>
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>
+        </React.Fragment>,
+      );
+
+      await user.click(screen.getByText('Submit'));
+
+      expect(handleSubmit).toHaveBeenCalledOnce();
+    });
+
+    it('stops validating a checkbox after it changes form owner', async () => {
+      const handleSubmit = vi.fn();
+
+      function App() {
+        const [external, setExternal] = React.useState(false);
+
+        return (
+          <React.Fragment>
+            <form id="external-form" />
+            <Form onFormSubmit={handleSubmit}>
+              <Field.Root name="group">
+                <CheckboxGroup defaultValue={[]}>
+                  <Checkbox.Root
+                    value="checkbox"
+                    form={external ? 'external-form' : undefined}
+                    required
+                  />
+                </CheckboxGroup>
+              </Field.Root>
+              <button type="button" onClick={() => setExternal(true)}>
+                Move
+              </button>
+              <button type="submit">Submit</button>
+            </Form>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = render(<App />);
+
+      await user.click(screen.getByText('Submit'));
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      await user.click(screen.getByText('Move'));
+      await user.click(screen.getByText('Submit'));
+
+      expect(handleSubmit).toHaveBeenCalledOnce();
+    });
+
+    it('validates and focuses required portaled checkboxes within the form', async () => {
+      const handleSubmit = vi.fn();
+      const portalContainer = document.createElement('div');
+      document.body.append(portalContainer);
+
+      const { user } = render(
+        <Form onFormSubmit={handleSubmit}>
+          <Field.Root name="group">
+            <CheckboxGroup defaultValue={[]}>
+              {ReactDOM.createPortal(
+                <Checkbox.Root value="portaled" required data-testid="portaled" />,
+                portalContainer,
+              )}
+              <Checkbox.Root value="current" />
+            </CheckboxGroup>
+          </Field.Root>
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      await user.click(screen.getByText('Submit'));
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+      expect(screen.getByTestId('portaled')).toHaveFocus();
+
+      await user.click(screen.getByTestId('portaled'));
+      await user.click(screen.getByText('Submit'));
+
+      expect(handleSubmit).toHaveBeenCalledOnce();
+      portalContainer.remove();
+    });
+
+    it('ignores a checkbox portaled into another form without a form attribute', async () => {
+      const handleSubmit = vi.fn();
+      const externalForm = document.createElement('form');
+      document.body.append(externalForm);
+
+      const { user } = render(
+        <Form onFormSubmit={handleSubmit}>
+          <Field.Root name="group">
+            <CheckboxGroup defaultValue={[]}>
+              {ReactDOM.createPortal(<Checkbox.Root value="external" required />, externalForm)}
+            </CheckboxGroup>
+          </Field.Root>
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      await user.click(screen.getByText('Submit'));
+
+      expect(handleSubmit).toHaveBeenCalledOnce();
+      externalForm.remove();
+    });
+
+    it('skips a checkbox disabled by a fieldset when focusing Form errors', async () => {
+      function App() {
+        const [errors, setErrors] = React.useState<Form.Props['errors']>({});
+
+        return (
+          <Form
+            errors={errors}
+            onSubmit={(event) => {
+              event.preventDefault();
+              setErrors({ group: 'server error' });
+            }}
+          >
+            <Field.Root name="group">
+              <CheckboxGroup defaultValue={[]}>
+                <fieldset disabled>
+                  <Checkbox.Root value="disabled" data-testid="disabled" />
+                </fieldset>
+                <Checkbox.Root value="enabled" data-testid="enabled" />
+              </CheckboxGroup>
+              <Field.Error />
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      const { user } = render(<App />);
+
+      await user.click(screen.getByText('Submit'));
+
+      expect(screen.getByTestId('enabled')).toHaveFocus();
+      expect(screen.getByTestId('disabled')).not.toHaveFocus();
+    });
+
+    it('focuses a remaining checkbox when Form errors unmount the first checkbox', async () => {
+      function App() {
+        const [showFirst, setShowFirst] = React.useState(true);
+        const [errors, setErrors] = React.useState<Form.Props['errors']>({});
+
+        return (
+          <Form
+            errors={errors}
+            onSubmit={(event) => {
+              event.preventDefault();
+              setShowFirst(false);
+              setErrors({ group: 'server error' });
+            }}
+          >
+            <Field.Root name="group">
+              <CheckboxGroup defaultValue={[]}>
+                {showFirst && <Checkbox.Root value="one" data-testid="first" />}
+                <Checkbox.Root value="two" data-testid="second" />
+              </CheckboxGroup>
+              <Field.Error />
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      const { user } = render(<App />);
+
+      await user.click(screen.getByText('Submit'));
+
+      expect(screen.queryByTestId('first')).toBe(null);
+      expect(screen.getByTestId('second')).toHaveFocus();
+    });
+
+    it('unblocks submission after every checkbox in the group unmounts', async () => {
+      const handleSubmit = vi.fn();
+
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+
+        return (
+          <Form onFormSubmit={handleSubmit}>
+            <Field.Root name="group">
+              <CheckboxGroup defaultValue={[]}>
+                {mounted && <Checkbox.Root value="one" required data-testid="checkbox" />}
+              </CheckboxGroup>
+            </Field.Root>
+            <button type="button" onClick={() => setMounted(false)}>
+              Remove
+            </button>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      const { user } = render(<App />);
+
+      await user.click(screen.getByText('Submit'));
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      await user.click(screen.getByText('Remove'));
+      await user.click(screen.getByText('Submit'));
+
+      expect(handleSubmit).toHaveBeenCalledOnce();
+    });
+
+    it('still runs custom validation after every checkbox in the group unmounts', async () => {
+      const handleSubmit = vi.fn();
+      const validate = vi.fn((value: unknown) =>
+        (value as string[]).length > 0 ? null : 'required',
+      );
+
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+
+        return (
+          <Form onFormSubmit={handleSubmit}>
+            <Field.Root name="group" validate={validate}>
+              <CheckboxGroup defaultValue={[]}>
+                {mounted && <Checkbox.Root value="one" data-testid="checkbox" />}
+              </CheckboxGroup>
+            </Field.Root>
+            <button type="button" onClick={() => setMounted(false)}>
+              Remove
+            </button>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      const { user } = render(<App />);
+
+      await user.click(screen.getByText('Remove'));
+
+      validate.mockClear();
+      await user.click(screen.getByText('Submit'));
+
+      // The custom validator still runs against the preserved value and blocks submission, even
+      // though no checkbox is mounted to carry a native constraint.
+      expect(validate).toHaveBeenCalled();
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+
+    it('clears a custom error when an inputless group becomes valid after submission', async () => {
+      const handleSubmit = vi.fn();
+      const validate = vi.fn((value: unknown) =>
+        (value as string[]).length > 0 ? null : 'required',
+      );
+
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+        const [value, setValue] = React.useState<string[]>([]);
+
+        return (
+          <Form onFormSubmit={handleSubmit}>
+            <Field.Root name="group" validate={validate}>
+              <CheckboxGroup value={value}>
+                {mounted && <Checkbox.Root value="one" />}
+              </CheckboxGroup>
+              <Field.Error />
+            </Field.Root>
+            <button type="button" onClick={() => setMounted(false)}>
+              Remove
+            </button>
+            <button type="button" onClick={() => setValue(['one'])}>
+              Select
+            </button>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      const { user } = render(<App />);
+
+      await user.click(screen.getByText('Submit'));
+      expect(screen.getByText('required')).not.toBe(null);
+
+      await user.click(screen.getByText('Remove'));
+      await user.click(screen.getByText('Select'));
+
+      expect(screen.queryByText('required')).toBe(null);
+
+      await user.click(screen.getByText('Submit'));
+      expect(handleSubmit).toHaveBeenCalledOnce();
+    });
+
+    it.each(['onSubmit', 'onBlur'] as const)(
+      'does not validate on change with validationMode=%s after the final checkbox unmounts',
+      async (validationMode) => {
+        const validate = vi.fn(() => 'invalid');
+
+        function App() {
+          const [mounted, setMounted] = React.useState(true);
+          const [value, setValue] = React.useState<string[]>([]);
+
+          return (
+            <Form>
+              <Field.Root name="group" validationMode={validationMode} validate={validate}>
+                <CheckboxGroup value={value}>
+                  {mounted && <Checkbox.Root value="one" />}
+                </CheckboxGroup>
+              </Field.Root>
+              <button type="button" onClick={() => setMounted(false)}>
+                Remove
+              </button>
+              <button type="button" onClick={() => setValue(['one'])}>
+                Select
+              </button>
+              <button type="submit">Submit</button>
+            </Form>
+          );
+        }
+
+        const { user } = render(<App />);
+
+        await user.click(screen.getByText('Remove'));
+        validate.mockClear();
+        await user.click(screen.getByText('Select'));
+
+        expect(validate).not.toHaveBeenCalled();
+
+        await user.click(screen.getByText('Submit'));
+
+        expect(validate).toHaveBeenCalledOnce();
+        expect(validate).toHaveBeenCalledWith(['one'], { group: ['one'] });
+      },
+    );
+
+    it.each(['onSubmit', 'onBlur'] as const)(
+      'respects validationMode=%s when a controlled group starts without inputs',
+      async (validationMode) => {
+        const validate = vi.fn(() => 'invalid');
+
+        function App() {
+          const [value, setValue] = React.useState<string[]>([]);
+
+          return (
+            <Form>
+              <Field.Root name="group" validationMode={validationMode} validate={validate}>
+                <CheckboxGroup value={value} />
+              </Field.Root>
+              <button type="button" onClick={() => setValue(['one'])}>
+                Select one
+              </button>
+              <button type="button" onClick={() => setValue(['two'])}>
+                Select two
+              </button>
+              <button type="submit">Submit</button>
+            </Form>
+          );
+        }
+
+        const { user } = render(<App />);
+
+        validate.mockClear();
+        await user.click(screen.getByText('Select one'));
+
+        expect(validate).not.toHaveBeenCalled();
+
+        await user.click(screen.getByText('Submit'));
+
+        expect(validate).toHaveBeenCalledOnce();
+        expect(validate).toHaveBeenCalledWith(['one'], { group: ['one'] });
+
+        await user.click(screen.getByText('Select two'));
+
+        expect(validate).toHaveBeenCalledTimes(validationMode === 'onSubmit' ? 2 : 1);
+      },
+    );
+
+    it('validates an inputless controlled group on change with validationMode=onChange', async () => {
+      const validate = vi.fn(() => null);
+
+      function App() {
+        const [value, setValue] = React.useState<string[]>([]);
+
+        return (
+          <Field.Root name="group" validationMode="onChange" validate={validate}>
+            <CheckboxGroup value={value} />
+            <button type="button" onClick={() => setValue(['one'])}>
+              Select
+            </button>
+          </Field.Root>
+        );
+      }
+
+      const { user } = render(<App />);
+      validate.mockClear();
+
+      await user.click(screen.getByText('Select'));
+
+      expect(validate).toHaveBeenCalledOnce();
+      expect(validate).toHaveBeenCalledWith(['one'], { group: ['one'] });
+    });
+
+    it('validates an initially empty group through the imperative action', async () => {
+      const validate = vi.fn(() => 'invalid');
+
+      function App() {
+        const actionsRef = React.useRef<Field.Root.Actions>(null);
+
+        return (
+          <Field.Root name="group" actionsRef={actionsRef} validate={validate}>
+            <CheckboxGroup defaultValue={[]} />
+            <button type="button" onClick={() => actionsRef.current?.validate()}>
+              Validate
+            </button>
+          </Field.Root>
+        );
+      }
+
+      const { user } = render(<App />);
+      validate.mockClear();
+
+      await user.click(screen.getByText('Validate'));
+
+      expect(validate).toHaveBeenCalledOnce();
+      expect(validate).toHaveBeenCalledWith([], { group: [] });
+    });
+
+    it('skips a disabled representative checkbox on a later focus attempt', async () => {
+      function App() {
+        const [firstDisabled, setFirstDisabled] = React.useState(false);
+        const [errors, setErrors] = React.useState<Form.Props['errors']>({});
+
+        return (
+          <Form
+            errors={errors}
+            onSubmit={(event) => {
+              event.preventDefault();
+              setErrors({ group: 'server error' });
+            }}
+          >
+            <Field.Root name="group">
+              <CheckboxGroup defaultValue={[]}>
+                <Checkbox.Root value="one" data-testid="first" disabled={firstDisabled} />
+                <Checkbox.Root value="two" data-testid="second" />
+              </CheckboxGroup>
+              <Field.Error />
+            </Field.Root>
+            <button type="button" onClick={() => setFirstDisabled(true)}>
+              Disable first
+            </button>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      const { user } = render(<App />);
+
+      await user.click(screen.getByText('Submit'));
+      expect(screen.getByTestId('first')).toHaveFocus();
+
+      await user.click(screen.getByText('Disable first'));
+      await user.click(screen.getByText('Submit'));
+
+      expect(screen.getByTestId('second')).toHaveFocus();
+    });
+
+    it('focuses the first child checkbox instead of a parent checkbox for Form errors', async () => {
+      function App() {
+        const [errors, setErrors] = React.useState<Form.Props['errors']>({});
+
+        return (
+          <Form
+            errors={errors}
+            onSubmit={(event) => {
+              event.preventDefault();
+              setErrors({ group: 'server error' });
+            }}
+          >
+            <Field.Root name="group">
+              <CheckboxGroup defaultValue={[]} allValues={['one', 'two']}>
+                <Checkbox.Root parent data-testid="parent" />
+                <Checkbox.Root value="one" data-testid="first" />
+                <Checkbox.Root value="two" />
+              </CheckboxGroup>
+              <Field.Error />
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      const { user } = render(<App />);
+
+      await user.click(screen.getByText('Submit'));
+
+      expect(screen.getByTestId('first')).toHaveFocus();
+      expect(screen.getByTestId('parent')).not.toHaveFocus();
     });
 
     it('excludes parent checkboxes from form submission', async () => {

--- a/packages/react/src/checkbox-group/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.tsx
@@ -12,7 +12,6 @@ import { useRegisterFieldControl } from '../internals/field-register-control/use
 import { useLabelableContext } from '../internals/labelable-provider/LabelableContext';
 import type { BaseUIComponentProps } from '../internals/types';
 import { fieldValidityMapping } from '../internals/field-constants/constants';
-import { PARENT_CHECKBOX } from '../checkbox/root/CheckboxRoot';
 import { useCheckboxGroupParent } from './useCheckboxGroupParent';
 import type { BaseUIChangeEventDetails } from '../internals/createBaseUIEventDetails';
 import { REASONS } from '../internals/reasons';
@@ -85,14 +84,16 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
   });
 
   const id = useBaseUiId(idProp);
+  const getInputControl = validation.getInputControl;
 
-  const controlRef = React.useRef<HTMLButtonElement>(null);
-
-  const registerControlRef = React.useCallback((element: HTMLButtonElement | null) => {
-    if (controlRef.current == null && element != null && !element.hasAttribute(PARENT_CHECKBOX)) {
-      controlRef.current = element;
-    }
-  }, []);
+  const controlRef = React.useMemo<React.RefObject<HTMLElement | null>>(
+    () => ({
+      get current() {
+        return getInputControl();
+      },
+    }),
+    [getInputControl],
+  );
 
   useRegisterFieldControl(controlRef, id, value, undefined, !!fieldName && !disabled, fieldName);
 
@@ -127,9 +128,8 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
       parent,
       disabled,
       validation,
-      registerControlRef,
     }),
-    [allValues, value, defaultValue, setValue, parent, disabled, validation, registerControlRef],
+    [allValues, value, defaultValue, setValue, parent, disabled, validation],
   );
 
   const element = useRenderElement('div', componentProps, {

--- a/packages/react/src/checkbox-group/CheckboxGroupContext.ts
+++ b/packages/react/src/checkbox-group/CheckboxGroupContext.ts
@@ -16,7 +16,6 @@ export interface CheckboxGroupContext {
   parent: UseCheckboxGroupParentReturnValue;
   disabled: boolean;
   validation: UseFieldValidationReturnValue;
-  registerControlRef: (element: HTMLButtonElement | null) => void;
 }
 
 export const CheckboxGroupContext = React.createContext<CheckboxGroupContext | undefined>(

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -178,7 +178,14 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
   useRegisterFieldControl(controlRef, id, checked, undefined, !groupContext && !disabled, nameProp);
 
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const mergedInputRef = useMergedRefs(inputRefProp, inputRef, validation.registerInput);
+  const registerFieldInput = validation.registerInput;
+  const registeredInputValue = groupContext ? value : undefined;
+  const registerInput = React.useCallback(
+    (element: HTMLInputElement | null) =>
+      registerFieldInput(element, { controlRef, value: registeredInputValue }),
+    [registerFieldInput, registeredInputValue],
+  );
+  const mergedInputRef = useMergedRefs(inputRefProp, inputRef, parent ? undefined : registerInput);
   const ariaLabelledBy = useAriaLabelledBy(
     ariaLabelledByProp,
     labelId,
@@ -307,7 +314,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
 
   const element = useRenderElement('span', componentProps, {
     state,
-    ref: [buttonRef, controlRef, forwardedRef, groupContext?.registerControlRef],
+    ref: [buttonRef, controlRef, forwardedRef],
     props: [
       {
         id: nativeButton ? (inputId ?? undefined) : id,

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -15,12 +15,12 @@ import type { FieldValidityData, FieldRootState } from './FieldRoot';
 
 const validityKeys = Object.keys(DEFAULT_VALIDITY_STATE) as Array<keyof ValidityState>;
 
-type RegisteredInput = {
+export type RegisteredInput = {
   controlRef: React.RefObject<HTMLElement | null>;
   value: string | undefined;
 };
 
-type RegisteredInputs = Map<HTMLInputElement, RegisteredInput>;
+export type RegisteredInputs = Map<HTMLInputElement, RegisteredInput>;
 
 /**
  * Whether an input participates in the surrounding Base UI Form. Inputs that are effectively

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -15,16 +15,45 @@ import type { FieldValidityData, FieldRootState } from './FieldRoot';
 
 const validityKeys = Object.keys(DEFAULT_VALIDITY_STATE) as Array<keyof ValidityState>;
 
+type RegisteredInput = {
+  controlRef: React.RefObject<HTMLElement | null>;
+  value: string | undefined;
+};
+
+type RegisteredInputs = Map<HTMLInputElement, RegisteredInput>;
+
+/**
+ * Whether an input participates in the surrounding Base UI Form. Inputs that are effectively
+ * disabled, or whose `form` attribute explicitly associates them with another form, are excluded.
+ * DOM position is not considered: field registration is context-driven, so portaled inputs
+ * (for example inside a dialog) still belong to the form.
+ */
+function isEligibleInput(input: HTMLInputElement, formElement: HTMLFormElement | null) {
+  if (input.matches(':disabled')) {
+    return false;
+  }
+
+  if (!formElement || input.form === formElement) {
+    return true;
+  }
+
+  // React context crosses portal boundaries. An unassociated portaled input still participates in
+  // contextual validation, unless an explicit `form` attribute opts it out of the surrounding Form.
+  return input.form === null && !input.hasAttribute('form');
+}
+
 /**
  * Picks the input whose native validity should represent a field that owns several inputs (such as a
- * checkbox group). Prefers the first enabled currently-invalid input, where "first" follows Set
- * insertion order (mount order), and otherwise returns the first enabled input. Disabled inputs are
- * skipped because they don't participate in native constraint validation.
+ * checkbox group). Prefers the first eligible currently-invalid input, where "first" follows
+ * registration order (mount order), and otherwise returns the first eligible input.
  */
-function findRepresentativeInput(inputs: Set<HTMLInputElement>): HTMLInputElement | null {
+function findRepresentativeInput(
+  inputs: RegisteredInputs,
+  formElement: HTMLFormElement | null,
+): HTMLInputElement | null {
   let fallback: HTMLInputElement | null = null;
-  for (const input of inputs) {
-    if (input.disabled) {
+  for (const input of inputs.keys()) {
+    if (!isEligibleInput(input, formElement)) {
       continue;
     }
     if (!input.validity.valid) {
@@ -35,17 +64,17 @@ function findRepresentativeInput(inputs: Set<HTMLInputElement>): HTMLInputElemen
   return fallback;
 }
 
-function clearCustomValidity(element: HTMLInputElement, inputs: Set<HTMLInputElement>) {
-  for (const input of inputs) {
+function clearCustomValidity(element: HTMLInputElement | null, inputs: RegisteredInputs) {
+  for (const input of inputs.keys()) {
     input.setCustomValidity('');
   }
-  element.setCustomValidity('');
+  element?.setCustomValidity('');
 }
 
 export function useFieldValidation(
   params: UseFieldValidationParameters,
 ): UseFieldValidationReturnValue {
-  const { formRef } = useFormContext();
+  const { elementRef, formRef } = useFormContext();
 
   const {
     setValidityData,
@@ -63,17 +92,18 @@ export function useFieldValidation(
 
   const timeout = useTimeout();
   const inputRef = React.useRef<HTMLInputElement | null>(null);
-  const registeredInputs = useRefWithInit(() => new Set<HTMLInputElement>()).current;
+  const registeredInputs = useRefWithInit<RegisteredInputs>(() => new Map()).current;
   const validationCommitIdRef = React.useRef(0);
 
   // Checkbox groups register several inputs against a single field. Track them so a `required`
-  // checkbox can't be satisfied by another input in the group, matching native per-checkbox behavior.
+  // checkbox can't be satisfied by another input in the group, matching native per-checkbox
+  // behavior, and so focus and form-value projection use the same live controls.
   const registerInput = React.useCallback(
-    (element: HTMLInputElement | null) => {
+    (element: HTMLInputElement | null, registration: RegisteredInput) => {
       if (!element) {
         return undefined;
       }
-      registeredInputs.add(element);
+      registeredInputs.set(element, registration);
       return () => {
         registeredInputs.delete(element);
       };
@@ -81,15 +111,12 @@ export function useFieldValidation(
     [registeredInputs],
   );
 
-  const commit = useStableCallback(async (value: unknown, revalidate = false) => {
-    // A field can own several inputs (a checkbox group), but only the last-mounted one wins the shared
-    // `inputRef`. Validate against the registry instead so every input counts; `inputRef` is the
-    // fallback only when no registered input applies (none registered, or all of them disabled).
-    const element = findRepresentativeInput(registeredInputs) ?? inputRef.current;
-    if (!element) {
-      return;
-    }
+  const getInputControl = useStableCallback(() => {
+    const element = findRepresentativeInput(registeredInputs, elementRef.current);
+    return (element && registeredInputs.get(element)?.controlRef.current) || null;
+  });
 
+  const commit = useStableCallback(async (value: unknown, revalidate = false) => {
     validationCommitIdRef.current += 1;
     const validationCommitId = validationCommitIdRef.current;
 
@@ -118,8 +145,31 @@ export function useFieldValidation(
       });
     }
 
+    function publishAllValid(input: HTMLInputElement | null, externalInvalid?: boolean) {
+      const nextValidityData = {
+        value,
+        state: { ...DEFAULT_VALIDITY_STATE, valid: true },
+        error: '',
+        errors: [],
+        initialValue: validityData.initialValue,
+      };
+      clearCustomValidity(input, registeredInputs);
+      updateRegisteredFieldValidity(nextValidityData, externalInvalid);
+      setValidityData(nextValidityData);
+    }
+
+    // A field can own several inputs (a checkbox group), but only the last-mounted one wins the shared
+    // `inputRef`. Validate against the registry instead so every input counts; `inputRef` is the
+    // fallback only when no inputs are registered.
+    const element =
+      registeredInputs.size > 0
+        ? findRepresentativeInput(registeredInputs, elementRef.current)
+        : inputRef.current;
+    // A field with no eligible input has no native constraint, but its custom validator still
+    // applies to the logical value at the configured validation boundary.
+
     if (revalidate) {
-      if (state.valid !== false) {
+      if (state.valid !== false || !element) {
         return;
       }
 
@@ -129,18 +179,8 @@ export function useFieldValidation(
         // The 'valueMissing' (required) condition has been resolved by the user typing.
         // Temporarily mark the field as valid for this onChange event.
         // Other native errors (e.g., typeMismatch) will be caught by full validation on blur or submit.
-        const nextValidityData = {
-          value,
-          state: { ...DEFAULT_VALIDITY_STATE, valid: true },
-          error: '',
-          errors: [],
-          initialValue: validityData.initialValue,
-        };
-        clearCustomValidity(element, registeredInputs);
-
         // The required value is now present; ignore stale external invalid state for this pass.
-        updateRegisteredFieldValidity(nextValidityData, false);
-        setValidityData(nextValidityData);
+        publishAllValid(element, false);
         return;
       }
 
@@ -193,12 +233,16 @@ export function useFieldValidation(
     let result: null | string | string[] = null;
     let validationErrors: string[] = [];
 
-    const nextState = getState(element);
+    // With no representative input the field carries no native constraint, so start from an
+    // all-valid native state and let the custom `validate` result below decide the outcome.
+    const nextState: Record<keyof ValidityState, boolean> = element
+      ? getState(element)
+      : { ...DEFAULT_VALIDITY_STATE, valid: true };
 
     let defaultValidationMessage;
     const isValidatingOnChange = shouldValidateOnChange();
 
-    if (element.validationMessage && !isValidatingOnChange) {
+    if (element && element.validationMessage && !isValidatingOnChange) {
       // not validating on change, if there is a `validationMessage` from
       // native validity, set errors and skip calling the custom validate fn
       defaultValidationMessage = element.validationMessage;
@@ -234,10 +278,10 @@ export function useFieldValidation(
 
         if (Array.isArray(result)) {
           validationErrors = result;
-          element.setCustomValidity(result.join('\n'));
+          element?.setCustomValidity(result.join('\n'));
         } else if (result) {
           validationErrors = [result];
-          element.setCustomValidity(result);
+          element?.setCustomValidity(result);
         }
       } else if (isValidatingOnChange) {
         // validate function returned no errors, if validating on change
@@ -245,10 +289,10 @@ export function useFieldValidation(
         clearCustomValidity(element, registeredInputs);
         nextState.customError = false;
 
-        if (element.validationMessage) {
+        if (element && element.validationMessage) {
           defaultValidationMessage = element.validationMessage;
           validationErrors = [element.validationMessage];
-        } else if (element.validity.valid && !nextState.valid) {
+        } else if ((!element || element.validity.valid) && !nextState.valid) {
           nextState.valid = true;
         }
       }
@@ -297,11 +341,13 @@ export function useFieldValidation(
     () => ({
       getValidationProps,
       inputRef,
+      registeredInputs,
       registerInput,
+      getInputControl,
       commit,
       change,
     }),
-    [getValidationProps, registerInput, commit, change],
+    [getValidationProps, registeredInputs, registerInput, getInputControl, commit, change],
   );
 }
 
@@ -323,7 +369,12 @@ export interface UseFieldValidationParameters {
 export interface UseFieldValidationReturnValue {
   getValidationProps: (disabled: boolean, props?: HTMLProps) => HTMLProps;
   inputRef: React.RefObject<HTMLInputElement | null>;
-  registerInput: React.RefCallback<HTMLInputElement>;
+  registeredInputs: RegisteredInputs;
+  registerInput: (
+    element: HTMLInputElement | null,
+    registration: RegisteredInput,
+  ) => void | (() => void);
+  getInputControl: () => HTMLElement | null;
   commit: (value: unknown) => Promise<void>;
   change: (value: unknown) => void;
 }

--- a/packages/react/src/form/Form.tsx
+++ b/packages/react/src/form/Form.tsx
@@ -41,17 +41,25 @@ export const Form = React.forwardRef(function Form<
   const submitAttemptedRef = React.useRef(false);
 
   const focusFirstInvalid = useStableCallback(() => {
-    const invalidField = Array.from(formRef.current.fields.values()).find(
-      (field) => field.validityData.state.valid === false,
-    );
-    const control = invalidField?.controlRef.current;
-    if (control) {
-      control.focus();
-      if (control.tagName === 'INPUT') {
-        (control as HTMLInputElement).select();
+    // A field can be invalid without a focusable control (for example a checkbox group whose
+    // custom validation failed while every checkbox is unmounted, disabled, or reassociated).
+    // Keep submission blocked, but move focus to the first invalid field that has a usable control.
+    let hasInvalid = false;
+    for (const field of formRef.current.fields.values()) {
+      if (field.validityData.state.valid !== false) {
+        continue;
+      }
+      hasInvalid = true;
+      const control = field.controlRef.current;
+      if (control) {
+        control.focus();
+        if (control.tagName === 'INPUT') {
+          (control as HTMLInputElement).select();
+        }
+        return true;
       }
     }
-    return invalidField !== undefined;
+    return hasInvalid;
   });
 
   const [errors, setErrors] = React.useState(externalErrors);

--- a/packages/react/src/form/Form.tsx
+++ b/packages/react/src/form/Form.tsx
@@ -36,6 +36,7 @@ export const Form = React.forwardRef(function Form<
   const formRef = React.useRef<FormContext['formRef']['current']>({
     fields: new Map(),
   });
+  const elementRef = React.useRef<HTMLFormElement>(null);
   const submittedRef = React.useRef(false);
   const submitAttemptedRef = React.useRef(false);
 
@@ -87,7 +88,7 @@ export const Form = React.forwardRef(function Form<
   );
 
   const element = useRenderElement('form', componentProps, {
-    ref: forwardedRef,
+    ref: [forwardedRef, elementRef],
     props: [
       {
         noValidate: true,
@@ -135,6 +136,7 @@ export const Form = React.forwardRef(function Form<
 
   const contextValue: FormContext = React.useMemo(
     () => ({
+      elementRef,
       formRef,
       validationMode,
       errors: errors ?? EMPTY_OBJECT,

--- a/packages/react/src/internals/field-root-context/FieldRootContext.ts
+++ b/packages/react/src/internals/field-root-context/FieldRootContext.ts
@@ -52,7 +52,9 @@ export const DEFAULT_FIELD_ROOT_CONTEXT: FieldRootContext = {
   validation: {
     getValidationProps: (_disabled: boolean, props: HTMLProps = EMPTY_OBJECT) => props,
     inputRef: { current: null },
+    registeredInputs: new Map(),
     registerInput: NOOP,
+    getInputControl: () => null,
     commit: async () => {},
     change: NOOP,
   },

--- a/packages/react/src/internals/form-context/FormContext.ts
+++ b/packages/react/src/internals/form-context/FormContext.ts
@@ -9,6 +9,7 @@ export type Errors = Record<string, string | string[]>;
 export interface FormContext {
   errors: Errors;
   clearErrors: (name: string | undefined) => void;
+  elementRef: React.RefObject<HTMLFormElement | null>;
   formRef: React.RefObject<{
     fields: Map<
       string,
@@ -30,6 +31,7 @@ export interface FormContext {
 }
 
 export const FormContext = React.createContext<FormContext>({
+  elementRef: { current: null },
   formRef: {
     current: {
       fields: new Map(),


### PR DESCRIPTION
Fixes #5200

PR #5218 is a smaller dependent follow-up that uses the input registry introduced here.

## Changes

- Focuses the checkbox whose hidden input fails validation.
- Keeps input registration and focus targeting synchronized across disabled, unmounted, portaled, and reassociated checkboxes.
- Preserves validation mode boundaries when no eligible checkbox is mounted while still running custom validation at the configured boundary.
