### PR TITLE
[scroll area] Reduce bundle size

### DIFF
--- a/packages/react/src/scroll-area/enumSync.test.tsx
+++ b/packages/react/src/scroll-area/enumSync.test.tsx
@@ -11,9 +11,11 @@ import { ScrollAreaScrollbarCssVars } from './scrollbar/ScrollAreaScrollbarCssVa
 import { ScrollAreaViewportCssVars } from './viewport/ScrollAreaViewportCssVars';
 
 // The parts inline these enums' values instead of referencing the members, so
-// nothing links the docs enums to runtime behavior. These tests re-link them so a
-// rename to only one side fails CI. Test-only imports ship no production bytes.
-describe('ScrollArea docs enum / runtime sync', () => {
+// nothing links the docs enums to runtime behavior. These tests re-link every
+// inlined member so a rename to only one side fails CI. Members that are not
+// inlined (emitted by the default state serializer) are out of scope. Test-only
+// imports ship no production bytes.
+describe('Scroll Area enum sync', () => {
   const { render } = createRenderer();
 
   it('names the overflow data-attributes per ScrollAreaRootDataAttributes', () => {
@@ -48,19 +50,24 @@ describe('ScrollArea docs enum / runtime sync', () => {
   it('names the corner and thumb CSS variables per the *CssVars enums', async () => {
     await render(
       <ScrollArea.Root data-testid="root">
-        <ScrollArea.Scrollbar orientation="vertical" keepMounted data-testid="scrollbar" />
+        <ScrollArea.Scrollbar orientation="vertical" keepMounted data-testid="scrollbar-y" />
+        <ScrollArea.Scrollbar orientation="horizontal" keepMounted data-testid="scrollbar-x" />
       </ScrollArea.Root>,
     );
 
     const root = screen.getByTestId('root');
-    const scrollbar = screen.getByTestId('scrollbar');
+    const scrollbarY = screen.getByTestId('scrollbar-y');
+    const scrollbarX = screen.getByTestId('scrollbar-x');
 
     // Both parts write these variables unconditionally through the `style` prop, so
     // the inline style carries them even without layout measurement.
     expect(root.style.getPropertyValue(ScrollAreaRootCssVars.scrollAreaCornerHeight)).not.toBe('');
     expect(root.style.getPropertyValue(ScrollAreaRootCssVars.scrollAreaCornerWidth)).not.toBe('');
     expect(
-      scrollbar.style.getPropertyValue(ScrollAreaScrollbarCssVars.scrollAreaThumbHeight),
+      scrollbarY.style.getPropertyValue(ScrollAreaScrollbarCssVars.scrollAreaThumbHeight),
+    ).not.toBe('');
+    expect(
+      scrollbarX.style.getPropertyValue(ScrollAreaScrollbarCssVars.scrollAreaThumbWidth),
     ).not.toBe('');
   });
 

--- a/packages/react/src/scroll-area/enumSync.test.tsx
+++ b/packages/react/src/scroll-area/enumSync.test.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { expect } from 'vitest';
+import { ScrollArea } from '@base-ui/react/scroll-area';
+import { screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, isJSDOM } from '#test-utils';
+import { scrollAreaStateAttributesMapping } from './root/stateAttributes';
+import { ScrollAreaRootDataAttributes } from './root/ScrollAreaRootDataAttributes';
+import { ScrollAreaScrollbarDataAttributes } from './scrollbar/ScrollAreaScrollbarDataAttributes';
+import { ScrollAreaRootCssVars } from './root/ScrollAreaRootCssVars';
+import { ScrollAreaScrollbarCssVars } from './scrollbar/ScrollAreaScrollbarCssVars';
+import { ScrollAreaViewportCssVars } from './viewport/ScrollAreaViewportCssVars';
+
+// The parts inline these enums' string values at runtime (instead of referencing
+// the members) so the enum objects stay tree-shakeable — the win that motivated
+// the bundle-size pass. That splits the source of truth: the enums feed generated
+// public documentation while the literals drive behavior, and TypeScript no longer
+// links the two. These tests re-establish the link so a rename applied to only one
+// side fails CI. They import the enums but ship no production bytes.
+describe('ScrollArea docs enum / runtime sync', () => {
+  const { render } = createRenderer();
+
+  it('names the overflow data-attributes per ScrollAreaRootDataAttributes', () => {
+    const keys = [
+      'hasOverflowX',
+      'hasOverflowY',
+      'overflowXStart',
+      'overflowXEnd',
+      'overflowYStart',
+      'overflowYEnd',
+    ] as const;
+
+    for (const key of keys) {
+      const emitted = scrollAreaStateAttributesMapping[key]!(true);
+      expect(Object.keys(emitted!)[0]).toBe(ScrollAreaRootDataAttributes[key]);
+    }
+  });
+
+  it('names the scrollbar orientation attribute per ScrollAreaScrollbarDataAttributes', async () => {
+    await render(
+      <ScrollArea.Root>
+        <ScrollArea.Scrollbar orientation="horizontal" keepMounted data-testid="scrollbar" />
+      </ScrollArea.Root>,
+    );
+
+    expect(screen.getByTestId('scrollbar')).toHaveAttribute(
+      ScrollAreaScrollbarDataAttributes.orientation,
+      'horizontal',
+    );
+  });
+
+  it('names the corner and thumb CSS variables per the *CssVars enums', async () => {
+    await render(
+      <ScrollArea.Root data-testid="root">
+        <ScrollArea.Scrollbar orientation="vertical" keepMounted data-testid="scrollbar" />
+      </ScrollArea.Root>,
+    );
+
+    const root = screen.getByTestId('root');
+    const scrollbar = screen.getByTestId('scrollbar');
+
+    // Both parts write these variables unconditionally through the `style` prop, so
+    // the inline style carries them even without layout measurement.
+    expect(root.style.getPropertyValue(ScrollAreaRootCssVars.scrollAreaCornerHeight)).not.toBe('');
+    expect(root.style.getPropertyValue(ScrollAreaRootCssVars.scrollAreaCornerWidth)).not.toBe('');
+    expect(
+      scrollbar.style.getPropertyValue(ScrollAreaScrollbarCssVars.scrollAreaThumbHeight),
+    ).not.toBe('');
+  });
+
+  it.skipIf(isJSDOM)('names the overflow CSS variables per ScrollAreaViewportCssVars', async () => {
+    await render(
+      <ScrollArea.Root style={{ width: 200, height: 200 }}>
+        <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
+          <div style={{ width: 1000, height: 1000 }} />
+        </ScrollArea.Viewport>
+        <ScrollArea.Scrollbar orientation="vertical" keepMounted />
+        <ScrollArea.Scrollbar orientation="horizontal" keepMounted />
+      </ScrollArea.Root>,
+    );
+
+    const viewport = screen.getByTestId('viewport');
+
+    await waitFor(() =>
+      expect(
+        viewport.style.getPropertyValue(ScrollAreaViewportCssVars.scrollAreaOverflowYStart),
+      ).not.toBe(''),
+    );
+    expect(
+      viewport.style.getPropertyValue(ScrollAreaViewportCssVars.scrollAreaOverflowYEnd),
+    ).not.toBe('');
+    expect(
+      viewport.style.getPropertyValue(ScrollAreaViewportCssVars.scrollAreaOverflowXStart),
+    ).not.toBe('');
+    expect(
+      viewport.style.getPropertyValue(ScrollAreaViewportCssVars.scrollAreaOverflowXEnd),
+    ).not.toBe('');
+  });
+});

--- a/packages/react/src/scroll-area/enumSync.test.tsx
+++ b/packages/react/src/scroll-area/enumSync.test.tsx
@@ -10,12 +10,9 @@ import { ScrollAreaRootCssVars } from './root/ScrollAreaRootCssVars';
 import { ScrollAreaScrollbarCssVars } from './scrollbar/ScrollAreaScrollbarCssVars';
 import { ScrollAreaViewportCssVars } from './viewport/ScrollAreaViewportCssVars';
 
-// The parts inline these enums' string values at runtime (instead of referencing
-// the members) so the enum objects stay tree-shakeable — the win that motivated
-// the bundle-size pass. That splits the source of truth: the enums feed generated
-// public documentation while the literals drive behavior, and TypeScript no longer
-// links the two. These tests re-establish the link so a rename applied to only one
-// side fails CI. They import the enums but ship no production bytes.
+// The parts inline these enums' values instead of referencing the members, so
+// nothing links the docs enums to runtime behavior. These tests re-link them so a
+// rename to only one side fails CI. Test-only imports ship no production bytes.
 describe('ScrollArea docs enum / runtime sync', () => {
   const { render } = createRenderer();
 

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.test.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.test.tsx
@@ -15,7 +15,7 @@ const SCROLLBAR_HEIGHT = 10;
 
 async function withMockResizeObserver(test: (notifyResizeObserver: () => void) => Promise<void>) {
   const originalResizeObserver = window.ResizeObserver;
-  let notifyResizeObserver: (() => void) | null = null;
+  const observers = new Set<ResizeObserverMock>();
 
   class ResizeObserverMock implements ResizeObserver {
     callback: ResizeObserverCallback;
@@ -25,14 +25,14 @@ async function withMockResizeObserver(test: (notifyResizeObserver: () => void) =
     }
 
     observe() {
-      notifyResizeObserver = () => {
-        this.callback([], this);
-      };
+      observers.add(this);
     }
 
     unobserve() {}
 
-    disconnect() {}
+    disconnect() {
+      observers.delete(this);
+    }
 
     takeRecords() {
       return [];
@@ -43,8 +43,8 @@ async function withMockResizeObserver(test: (notifyResizeObserver: () => void) =
 
   try {
     await test(() => {
-      expect(notifyResizeObserver).not.toBe(null);
-      notifyResizeObserver?.();
+      expect(observers.size).toBeGreaterThan(0);
+      observers.forEach((observer) => observer.callback([], observer));
     });
   } finally {
     window.ResizeObserver = originalResizeObserver;
@@ -254,60 +254,68 @@ describe('<ScrollArea.Root />', () => {
     });
 
     it('clears corner, overflow attributes, and metrics when content stops overflowing', async () => {
-      function App() {
-        const [contentSize, setContentSize] = React.useState(SCROLLABLE_CONTENT_SIZE);
+      await withMockResizeObserver(async (notifyResizeObserver) => {
+        function App() {
+          const [contentSize, setContentSize] = React.useState(SCROLLABLE_CONTENT_SIZE);
 
-        return (
-          <React.Fragment>
-            <button type="button" onClick={() => setContentSize(VIEWPORT_SIZE / 2)}>
-              shrink
-            </button>
-            <ScrollArea.Root
-              data-testid="root"
-              style={{ width: VIEWPORT_SIZE, height: VIEWPORT_SIZE }}
-            >
-              <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
-                <div style={{ width: contentSize, height: contentSize }} />
-              </ScrollArea.Viewport>
-              <ScrollArea.Scrollbar
-                orientation="vertical"
-                keepMounted
-                style={{ width: SCROLLBAR_WIDTH }}
+          return (
+            <React.Fragment>
+              <button type="button" onClick={() => setContentSize(VIEWPORT_SIZE / 2)}>
+                shrink
+              </button>
+              <ScrollArea.Root
+                data-testid="root"
+                style={{ width: VIEWPORT_SIZE, height: VIEWPORT_SIZE }}
               >
-                <ScrollArea.Thumb />
-              </ScrollArea.Scrollbar>
-              <ScrollArea.Scrollbar
-                orientation="horizontal"
-                keepMounted
-                style={{ height: SCROLLBAR_HEIGHT }}
-              >
-                <ScrollArea.Thumb />
-              </ScrollArea.Scrollbar>
-              <ScrollArea.Corner data-testid="corner" />
-            </ScrollArea.Root>
-          </React.Fragment>
-        );
-      }
+                <ScrollArea.Viewport
+                  data-testid="viewport"
+                  style={{ width: '100%', height: '100%' }}
+                >
+                  <div style={{ width: contentSize, height: contentSize }} />
+                </ScrollArea.Viewport>
+                <ScrollArea.Scrollbar
+                  orientation="vertical"
+                  keepMounted
+                  style={{ width: SCROLLBAR_WIDTH }}
+                >
+                  <ScrollArea.Thumb />
+                </ScrollArea.Scrollbar>
+                <ScrollArea.Scrollbar
+                  orientation="horizontal"
+                  keepMounted
+                  style={{ height: SCROLLBAR_HEIGHT }}
+                >
+                  <ScrollArea.Thumb />
+                </ScrollArea.Scrollbar>
+                <ScrollArea.Corner data-testid="corner" />
+              </ScrollArea.Root>
+            </React.Fragment>
+          );
+        }
 
-      const { user } = await render(<App />);
-      const root = screen.getByTestId('root');
-      const viewport = screen.getByTestId('viewport');
+        const { user } = await render(<App />);
+        const root = screen.getByTestId('root');
+        const viewport = screen.getByTestId('viewport');
 
-      await waitFor(() => expect(root).toHaveAttribute('data-has-overflow-x'));
-      await waitFor(() => expect(root).toHaveAttribute('data-has-overflow-y'));
-      expect(screen.getByTestId('corner')).toBeInTheDocument();
-      expect(viewport.style.getPropertyValue('--scroll-area-overflow-x-end')).not.toBe('0px');
-      expect(viewport.style.getPropertyValue('--scroll-area-overflow-y-end')).not.toBe('0px');
+        await waitFor(() => expect(root).toHaveAttribute('data-has-overflow-x'));
+        await waitFor(() => expect(root).toHaveAttribute('data-has-overflow-y'));
+        expect(screen.getByTestId('corner')).toBeInTheDocument();
+        expect(viewport.style.getPropertyValue('--scroll-area-overflow-x-end')).not.toBe('0px');
+        expect(viewport.style.getPropertyValue('--scroll-area-overflow-y-end')).not.toBe('0px');
 
-      await user.click(screen.getByRole('button', { name: 'shrink' }));
+        await user.click(screen.getByRole('button', { name: 'shrink' }));
+        await act(async () => {
+          notifyResizeObserver();
+        });
 
-      await waitFor(() => expect(root).not.toHaveAttribute('data-has-overflow-x'));
-      await waitFor(() => expect(root).not.toHaveAttribute('data-has-overflow-y'));
-      expect(screen.queryByTestId('corner')).toBe(null);
-      expect(viewport.style.getPropertyValue('--scroll-area-overflow-x-start')).toBe('0px');
-      expect(viewport.style.getPropertyValue('--scroll-area-overflow-x-end')).toBe('0px');
-      expect(viewport.style.getPropertyValue('--scroll-area-overflow-y-start')).toBe('0px');
-      expect(viewport.style.getPropertyValue('--scroll-area-overflow-y-end')).toBe('0px');
+        await waitFor(() => expect(root).not.toHaveAttribute('data-has-overflow-x'));
+        await waitFor(() => expect(root).not.toHaveAttribute('data-has-overflow-y'));
+        expect(screen.queryByTestId('corner')).toBe(null);
+        expect(viewport.style.getPropertyValue('--scroll-area-overflow-x-start')).toBe('0px');
+        expect(viewport.style.getPropertyValue('--scroll-area-overflow-x-end')).toBe('0px');
+        expect(viewport.style.getPropertyValue('--scroll-area-overflow-y-start')).toBe('0px');
+        expect(viewport.style.getPropertyValue('--scroll-area-overflow-y-end')).toBe('0px');
+      });
     });
 
     it('should correctly set thumb height and width based on scrollable content', async () => {

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.test.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.test.tsx
@@ -253,6 +253,63 @@ describe('<ScrollArea.Root />', () => {
       });
     });
 
+    it('clears corner, overflow attributes, and metrics when content stops overflowing', async () => {
+      function App() {
+        const [contentSize, setContentSize] = React.useState(SCROLLABLE_CONTENT_SIZE);
+
+        return (
+          <React.Fragment>
+            <button type="button" onClick={() => setContentSize(VIEWPORT_SIZE / 2)}>
+              shrink
+            </button>
+            <ScrollArea.Root
+              data-testid="root"
+              style={{ width: VIEWPORT_SIZE, height: VIEWPORT_SIZE }}
+            >
+              <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
+                <div style={{ width: contentSize, height: contentSize }} />
+              </ScrollArea.Viewport>
+              <ScrollArea.Scrollbar
+                orientation="vertical"
+                keepMounted
+                style={{ width: SCROLLBAR_WIDTH }}
+              >
+                <ScrollArea.Thumb />
+              </ScrollArea.Scrollbar>
+              <ScrollArea.Scrollbar
+                orientation="horizontal"
+                keepMounted
+                style={{ height: SCROLLBAR_HEIGHT }}
+              >
+                <ScrollArea.Thumb />
+              </ScrollArea.Scrollbar>
+              <ScrollArea.Corner data-testid="corner" />
+            </ScrollArea.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+      const root = screen.getByTestId('root');
+      const viewport = screen.getByTestId('viewport');
+
+      await waitFor(() => expect(root).toHaveAttribute('data-has-overflow-x'));
+      await waitFor(() => expect(root).toHaveAttribute('data-has-overflow-y'));
+      expect(screen.getByTestId('corner')).toBeInTheDocument();
+      expect(viewport.style.getPropertyValue('--scroll-area-overflow-x-end')).not.toBe('0px');
+      expect(viewport.style.getPropertyValue('--scroll-area-overflow-y-end')).not.toBe('0px');
+
+      await user.click(screen.getByRole('button', { name: 'shrink' }));
+
+      await waitFor(() => expect(root).not.toHaveAttribute('data-has-overflow-x'));
+      await waitFor(() => expect(root).not.toHaveAttribute('data-has-overflow-y'));
+      expect(screen.queryByTestId('corner')).toBe(null);
+      expect(viewport.style.getPropertyValue('--scroll-area-overflow-x-start')).toBe('0px');
+      expect(viewport.style.getPropertyValue('--scroll-area-overflow-x-end')).toBe('0px');
+      expect(viewport.style.getPropertyValue('--scroll-area-overflow-y-start')).toBe('0px');
+      expect(viewport.style.getPropertyValue('--scroll-area-overflow-y-end')).toBe('0px');
+    });
+
     it('should correctly set thumb height and width based on scrollable content', async () => {
       await render(
         <ScrollArea.Root style={{ width: VIEWPORT_SIZE, height: VIEWPORT_SIZE }}>

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
@@ -111,7 +111,7 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
     startXRef.current = event.clientX;
     // Literal instead of `ScrollAreaScrollbarDataAttributes.orientation`: referencing an
     // enum member retains its whole object in the bundle, so the strings are inlined and
-    // the enums kept for docs only. `enumSync.test.tsx` guards against drift.
+    // the enums kept for docs only.
     currentOrientationRef.current = event.currentTarget.getAttribute('data-orientation') as
       | 'vertical'
       | 'horizontal';

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
@@ -5,10 +5,8 @@ import { useTimeout } from '@base-ui/utils/useTimeout';
 import type { BaseUIComponentProps, HTMLProps } from '../../internals/types';
 import { ScrollAreaRootContext } from './ScrollAreaRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { ScrollAreaRootCssVars } from './ScrollAreaRootCssVars';
 import { SCROLL_TIMEOUT } from '../constants';
 import { getOffset } from '../utils/getOffset';
-import { ScrollAreaScrollbarDataAttributes } from '../scrollbar/ScrollAreaScrollbarDataAttributes';
 import { styleDisableScrollbar } from '../../utils/styles';
 import { useBaseUiId } from '../../internals/useBaseUiId';
 import { scrollAreaStateAttributesMapping } from './stateAttributes';
@@ -78,6 +76,15 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
   const currentOrientationRef = React.useRef<'vertical' | 'horizontal'>('vertical');
   const scrollPositionRef = React.useRef(DEFAULT_COORDS);
 
+  const startScrolling = (vertical: boolean) => {
+    const setScrolling = vertical ? setScrollingY : setScrollingX;
+    const timeout = vertical ? scrollYTimeout : scrollXTimeout;
+    setScrolling(true);
+    timeout.start(SCROLL_TIMEOUT, () => {
+      setScrolling(false);
+    });
+  };
+
   const handleScroll = useStableCallback((scrollPosition: Coords) => {
     const offsetX = scrollPosition.x - scrollPositionRef.current.x;
     const offsetY = scrollPosition.y - scrollPositionRef.current.y;
@@ -85,19 +92,11 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
     scrollPositionRef.current = scrollPosition;
 
     if (offsetY !== 0) {
-      setScrollingY(true);
-
-      scrollYTimeout.start(SCROLL_TIMEOUT, () => {
-        setScrollingY(false);
-      });
+      startScrolling(true);
     }
 
     if (offsetX !== 0) {
-      setScrollingX(true);
-
-      scrollXTimeout.start(SCROLL_TIMEOUT, () => {
-        setScrollingX(false);
-      });
+      startScrolling(false);
     }
   });
 
@@ -109,20 +108,18 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
     thumbDraggingRef.current = true;
     startYRef.current = event.clientY;
     startXRef.current = event.clientX;
-    currentOrientationRef.current = event.currentTarget.getAttribute(
-      ScrollAreaScrollbarDataAttributes.orientation,
-    ) as 'vertical' | 'horizontal';
+    currentOrientationRef.current = event.currentTarget.getAttribute('data-orientation') as
+      | 'vertical'
+      | 'horizontal';
 
     if (viewportRef.current) {
       startScrollTopRef.current = viewportRef.current.scrollTop;
       startScrollLeftRef.current = viewportRef.current.scrollLeft;
     }
-    if (thumbYRef.current && currentOrientationRef.current === 'vertical') {
-      thumbYRef.current.setPointerCapture(event.pointerId);
-    }
-    if (thumbXRef.current && currentOrientationRef.current === 'horizontal') {
-      thumbXRef.current.setPointerCapture(event.pointerId);
-    }
+
+    const thumb =
+      currentOrientationRef.current === 'vertical' ? thumbYRef.current : thumbXRef.current;
+    thumb?.setPointerCapture(event.pointerId);
   });
 
   const handlePointerMove = useStableCallback((event: React.PointerEvent) => {
@@ -130,85 +127,54 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
       return;
     }
 
-    const deltaY = event.clientY - startYRef.current;
-    const deltaX = event.clientX - startXRef.current;
-
-    if (viewportRef.current) {
-      const scrollableContentHeight = viewportRef.current.scrollHeight;
-      const viewportHeight = viewportRef.current.clientHeight;
-      const scrollableContentWidth = viewportRef.current.scrollWidth;
-      const viewportWidth = viewportRef.current.clientWidth;
-
-      if (
-        thumbYRef.current &&
-        scrollbarYRef.current &&
-        currentOrientationRef.current === 'vertical'
-      ) {
-        const scrollbarYOffset = getOffset(scrollbarYRef.current, 'padding', 'y');
-        const thumbYOffset = getOffset(thumbYRef.current, 'margin', 'y');
-        const thumbHeight = thumbYRef.current.offsetHeight;
-        const maxThumbOffsetY =
-          scrollbarYRef.current.offsetHeight - thumbHeight - scrollbarYOffset - thumbYOffset;
-        // A short or heavily padded track can drive `maxThumbOffsetY` to zero or
-        // negative once the thumb hits its `MIN_THUMB_SIZE` floor. Dividing by it
-        // would yield a non-finite (`Infinity`/`NaN`) or inverted `scrollTop`.
-        const scrollRatioY = maxThumbOffsetY <= 0 ? 0 : deltaY / maxThumbOffsetY;
-
-        viewportRef.current.scrollTop =
-          startScrollTopRef.current + scrollRatioY * (scrollableContentHeight - viewportHeight);
-        event.preventDefault();
-
-        setScrollingY(true);
-
-        scrollYTimeout.start(SCROLL_TIMEOUT, () => {
-          setScrollingY(false);
-        });
-      }
-
-      if (
-        thumbXRef.current &&
-        scrollbarXRef.current &&
-        currentOrientationRef.current === 'horizontal'
-      ) {
-        const scrollbarXOffset = getOffset(scrollbarXRef.current, 'padding', 'x');
-        const thumbXOffset = getOffset(thumbXRef.current, 'margin', 'x');
-        const thumbWidth = thumbXRef.current.offsetWidth;
-        const maxThumbOffsetX =
-          scrollbarXRef.current.offsetWidth - thumbWidth - scrollbarXOffset - thumbXOffset;
-        // See the vertical case: guard against a non-positive offset.
-        const scrollRatioX = maxThumbOffsetX <= 0 ? 0 : deltaX / maxThumbOffsetX;
-
-        viewportRef.current.scrollLeft =
-          startScrollLeftRef.current + scrollRatioX * (scrollableContentWidth - viewportWidth);
-        event.preventDefault();
-
-        setScrollingX(true);
-
-        scrollXTimeout.start(SCROLL_TIMEOUT, () => {
-          setScrollingX(false);
-        });
-      }
+    const viewportEl = viewportRef.current;
+    if (!viewportEl) {
+      return;
     }
+
+    const vertical = currentOrientationRef.current === 'vertical';
+    const thumbEl = vertical ? thumbYRef.current : thumbXRef.current;
+    const scrollbarEl = vertical ? scrollbarYRef.current : scrollbarXRef.current;
+    if (!thumbEl || !scrollbarEl) {
+      return;
+    }
+
+    const axis = vertical ? 'y' : 'x';
+    const scrollbarOffset = getOffset(scrollbarEl, 'padding', axis);
+    const thumbOffset = getOffset(thumbEl, 'margin', axis);
+    const thumbSizePx = vertical ? thumbEl.offsetHeight : thumbEl.offsetWidth;
+    const trackSize = vertical ? scrollbarEl.offsetHeight : scrollbarEl.offsetWidth;
+    const maxThumbOffset = trackSize - thumbSizePx - scrollbarOffset - thumbOffset;
+    // A short or heavily padded track can drive `maxThumbOffset` to zero or
+    // negative once the thumb hits its `MIN_THUMB_SIZE` floor. Dividing by it
+    // would yield a non-finite (`Infinity`/`NaN`) or inverted scroll position.
+    const delta = vertical ? event.clientY - startYRef.current : event.clientX - startXRef.current;
+    const scrollRatio = maxThumbOffset <= 0 ? 0 : delta / maxThumbOffset;
+
+    const scrollableSize = vertical ? viewportEl.scrollHeight : viewportEl.scrollWidth;
+    const viewportSize = vertical ? viewportEl.clientHeight : viewportEl.clientWidth;
+    const startScroll = vertical ? startScrollTopRef.current : startScrollLeftRef.current;
+    const nextScroll = startScroll + scrollRatio * (scrollableSize - viewportSize);
+
+    if (vertical) {
+      viewportEl.scrollTop = nextScroll;
+    } else {
+      viewportEl.scrollLeft = nextScroll;
+    }
+    event.preventDefault();
+
+    startScrolling(vertical);
   });
 
   const handlePointerUp = useStableCallback((event: React.PointerEvent) => {
     thumbDraggingRef.current = false;
 
+    const thumb =
+      currentOrientationRef.current === 'vertical' ? thumbYRef.current : thumbXRef.current;
     // `pointercancel` releases capture implicitly, so guard against releasing a
     // capture we no longer hold (which would throw).
-    if (
-      thumbYRef.current &&
-      currentOrientationRef.current === 'vertical' &&
-      thumbYRef.current.hasPointerCapture(event.pointerId)
-    ) {
-      thumbYRef.current.releasePointerCapture(event.pointerId);
-    }
-    if (
-      thumbXRef.current &&
-      currentOrientationRef.current === 'horizontal' &&
-      thumbXRef.current.hasPointerCapture(event.pointerId)
-    ) {
-      thumbXRef.current.releasePointerCapture(event.pointerId);
+    if (thumb?.hasPointerCapture(event.pointerId)) {
+      thumb.releasePointerCapture(event.pointerId);
     }
   });
 
@@ -249,8 +215,8 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
     },
     style: {
       position: 'relative',
-      [ScrollAreaRootCssVars.scrollAreaCornerHeight as string]: `${cornerSize.height}px`,
-      [ScrollAreaRootCssVars.scrollAreaCornerWidth as string]: `${cornerSize.width}px`,
+      ['--scroll-area-corner-height' as string]: `${cornerSize.height}px`,
+      ['--scroll-area-corner-width' as string]: `${cornerSize.width}px`,
     },
   };
 
@@ -282,7 +248,6 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
       hovering,
       setHovering,
       viewportRef,
-      rootRef,
       scrollbarYRef,
       scrollbarXRef,
       thumbYRef,
@@ -305,11 +270,8 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
       hasMeasuredScrollbar,
       touchModality,
       scrollingX,
-      setScrollingX,
       scrollingY,
-      setScrollingY,
       hovering,
-      setHovering,
       rootId,
       hiddenState,
       overflowEdges,
@@ -389,20 +351,15 @@ export namespace ScrollAreaRoot {
 function normalizeOverflowEdgeThreshold(
   threshold: ScrollAreaRoot.Props['overflowEdgeThreshold'] | undefined,
 ) {
-  if (typeof threshold === 'number') {
-    const value = Math.max(0, threshold);
-    return {
-      xStart: value,
-      xEnd: value,
-      yStart: value,
-      yEnd: value,
-    };
-  }
+  const thresholds =
+    typeof threshold === 'number'
+      ? { xStart: threshold, xEnd: threshold, yStart: threshold, yEnd: threshold }
+      : threshold;
 
   return {
-    xStart: Math.max(0, threshold?.xStart || 0),
-    xEnd: Math.max(0, threshold?.xEnd || 0),
-    yStart: Math.max(0, threshold?.yStart || 0),
-    yEnd: Math.max(0, threshold?.yEnd || 0),
+    xStart: Math.max(0, thresholds?.xStart || 0),
+    xEnd: Math.max(0, thresholds?.xEnd || 0),
+    yStart: Math.max(0, thresholds?.yStart || 0),
+    yEnd: Math.max(0, thresholds?.yEnd || 0),
   };
 }

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
@@ -76,14 +76,15 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
   const currentOrientationRef = React.useRef<'vertical' | 'horizontal'>('vertical');
   const scrollPositionRef = React.useRef(DEFAULT_COORDS);
 
-  const startScrolling = (vertical: boolean) => {
+  function startScrolling(vertical: boolean) {
     const setScrolling = vertical ? setScrollingY : setScrollingX;
     const timeout = vertical ? scrollYTimeout : scrollXTimeout;
+
     setScrolling(true);
     timeout.start(SCROLL_TIMEOUT, () => {
       setScrolling(false);
     });
-  };
+  }
 
   const handleScroll = useStableCallback((scrollPosition: Coords) => {
     const offsetX = scrollPosition.x - scrollPositionRef.current.x;

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
@@ -109,6 +109,9 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
     thumbDraggingRef.current = true;
     startYRef.current = event.clientY;
     startXRef.current = event.clientX;
+    // Literal instead of `ScrollAreaScrollbarDataAttributes.orientation`: referencing an
+    // enum member retains its whole object in the bundle, so the strings are inlined and
+    // the enums kept for docs only. `enumSync.test.tsx` guards against drift.
     currentOrientationRef.current = event.currentTarget.getAttribute('data-orientation') as
       | 'vertical'
       | 'horizontal';

--- a/packages/react/src/scroll-area/root/ScrollAreaRootContext.ts
+++ b/packages/react/src/scroll-area/root/ScrollAreaRootContext.ts
@@ -23,7 +23,6 @@ export interface ScrollAreaRootContext {
   scrollingY: boolean;
   setScrollingY: React.Dispatch<React.SetStateAction<boolean>>;
   viewportRef: React.RefObject<HTMLDivElement | null>;
-  rootRef: React.RefObject<HTMLDivElement | null>;
   scrollbarYRef: React.RefObject<HTMLDivElement | null>;
   thumbYRef: React.RefObject<HTMLDivElement | null>;
   scrollbarXRef: React.RefObject<HTMLDivElement | null>;

--- a/packages/react/src/scroll-area/root/stateAttributes.ts
+++ b/packages/react/src/scroll-area/root/stateAttributes.ts
@@ -1,13 +1,14 @@
 import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
 import type { ScrollAreaRootState } from './ScrollAreaRoot';
-import { ScrollAreaRootDataAttributes } from './ScrollAreaRootDataAttributes';
+
+const attr = (name: string) => (value: boolean) => (value ? { [name]: '' } : null);
 
 export const scrollAreaStateAttributesMapping: StateAttributesMapping<ScrollAreaRootState> = {
-  hasOverflowX: (value) => (value ? { [ScrollAreaRootDataAttributes.hasOverflowX]: '' } : null),
-  hasOverflowY: (value) => (value ? { [ScrollAreaRootDataAttributes.hasOverflowY]: '' } : null),
-  overflowXStart: (value) => (value ? { [ScrollAreaRootDataAttributes.overflowXStart]: '' } : null),
-  overflowXEnd: (value) => (value ? { [ScrollAreaRootDataAttributes.overflowXEnd]: '' } : null),
-  overflowYStart: (value) => (value ? { [ScrollAreaRootDataAttributes.overflowYStart]: '' } : null),
-  overflowYEnd: (value) => (value ? { [ScrollAreaRootDataAttributes.overflowYEnd]: '' } : null),
+  hasOverflowX: attr('data-has-overflow-x'),
+  hasOverflowY: attr('data-has-overflow-y'),
+  overflowXStart: attr('data-overflow-x-start'),
+  overflowXEnd: attr('data-overflow-x-end'),
+  overflowYStart: attr('data-overflow-y-start'),
+  overflowYEnd: attr('data-overflow-y-end'),
   cornerHidden: () => null,
 };

--- a/packages/react/src/scroll-area/root/stateAttributes.ts
+++ b/packages/react/src/scroll-area/root/stateAttributes.ts
@@ -1,6 +1,10 @@
 import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
 import type { ScrollAreaRootState } from './ScrollAreaRoot';
 
+// The data-attribute strings are inlined here instead of referencing
+// `ScrollAreaRootDataAttributes` so that enum stays a docs-only, tree-shakeable
+// object; a runtime reference would retain its whole IIFE in every bundle.
+// `enumSync.test.tsx` pins these literals to the enum so the two can't drift.
 const attr = (name: string) => (value: boolean) => (value ? { [name]: '' } : null);
 
 export const scrollAreaStateAttributesMapping: StateAttributesMapping<ScrollAreaRootState> = {

--- a/packages/react/src/scroll-area/root/stateAttributes.ts
+++ b/packages/react/src/scroll-area/root/stateAttributes.ts
@@ -1,10 +1,8 @@
 import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
 import type { ScrollAreaRootState } from './ScrollAreaRoot';
 
-// The data-attribute strings are inlined here instead of referencing
-// `ScrollAreaRootDataAttributes` so that enum stays a docs-only, tree-shakeable
-// object; a runtime reference would retain its whole IIFE in every bundle.
-// `enumSync.test.tsx` pins these literals to the enum so the two can't drift.
+// Data-attribute strings inlined so `ScrollAreaRootDataAttributes` tree-shakes out;
+// `enumSync.test.tsx` guards against drift.
 const attr = (name: string) => (value: boolean) => (value ? { [name]: '' } : null);
 
 export const scrollAreaStateAttributesMapping: StateAttributesMapping<ScrollAreaRootState> = {

--- a/packages/react/src/scroll-area/root/stateAttributes.ts
+++ b/packages/react/src/scroll-area/root/stateAttributes.ts
@@ -1,8 +1,7 @@
 import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
 import type { ScrollAreaRootState } from './ScrollAreaRoot';
 
-// Data-attribute strings inlined so `ScrollAreaRootDataAttributes` tree-shakes out;
-// `enumSync.test.tsx` guards against drift.
+// Data-attribute strings inlined so `ScrollAreaRootDataAttributes` tree-shakes out.
 const attr = (name: string) => (value: boolean) => (value ? { [name]: '' } : null);
 
 export const scrollAreaStateAttributesMapping: StateAttributesMapping<ScrollAreaRootState> = {

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -323,6 +323,80 @@ describe('<ScrollArea.Scrollbar />', () => {
     });
   });
 
+  // The vertical/horizontal track-click branches were consolidated into one
+  // axis-parameterized path. `getOffset` reads logical margins/paddings that jsdom
+  // doesn't compute, so exercise the merged branch against real layout here to pin
+  // the horizontal LTR path and the RTL inversion (jsdom track-click tests above
+  // assert the vertical path but pass vacuously on the offset math).
+  describe.skipIf(isJSDOM)('track click by axis', () => {
+    async function renderAxisTrack(
+      orientation: 'horizontal' | 'vertical',
+      direction: TextDirection,
+    ) {
+      await render(
+        <DirectionProvider direction={direction}>
+          <ScrollArea.Root style={{ width: 200, height: 200, direction }}>
+            <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
+              <div style={{ width: 1000, height: 1000 }} />
+            </ScrollArea.Viewport>
+            <ScrollArea.Scrollbar orientation={orientation} data-testid="scrollbar" keepMounted>
+              <ScrollArea.Thumb data-testid="thumb" />
+            </ScrollArea.Scrollbar>
+          </ScrollArea.Root>
+        </DirectionProvider>,
+      );
+
+      const viewport = screen.getByTestId('viewport') as HTMLDivElement;
+      const scrollbar = screen.getByTestId('scrollbar');
+      const thumb = screen.getByTestId('thumb');
+      await waitFor(() => expect(thumb.offsetWidth + thumb.offsetHeight).toBeGreaterThan(0));
+
+      return { viewport, scrollbar };
+    }
+
+    it('scrolls down when clicking below the thumb on a vertical track', async () => {
+      const { viewport, scrollbar } = await renderAxisTrack('vertical', 'ltr');
+      const rect = scrollbar.getBoundingClientRect();
+
+      fireEvent.pointerDown(scrollbar, {
+        button: 0,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.bottom - 5,
+        pointerId: 1,
+      });
+
+      expect(viewport.scrollTop).toBeGreaterThan(0);
+    });
+
+    it('scrolls right when clicking the end of a horizontal LTR track', async () => {
+      const { viewport, scrollbar } = await renderAxisTrack('horizontal', 'ltr');
+      const rect = scrollbar.getBoundingClientRect();
+
+      fireEvent.pointerDown(scrollbar, {
+        button: 0,
+        clientX: rect.right - 5,
+        clientY: rect.top + rect.height / 2,
+        pointerId: 1,
+      });
+
+      expect(viewport.scrollLeft).toBeGreaterThan(0);
+    });
+
+    it('scrolls into the negative RTL range when clicking a horizontal RTL track', async () => {
+      const { viewport, scrollbar } = await renderAxisTrack('horizontal', 'rtl');
+      const rect = scrollbar.getBoundingClientRect();
+
+      fireEvent.pointerDown(scrollbar, {
+        button: 0,
+        clientX: rect.left + 5,
+        clientY: rect.top + rect.height / 2,
+        pointerId: 1,
+      });
+
+      expect(viewport.scrollLeft).toBeLessThan(0);
+    });
+  });
+
   // A short or heavily padded track drives `maxThumbOffset` to zero or negative
   // once the thumb hits its `MIN_THUMB_SIZE` floor. Dragging the thumb then
   // divides by a non-positive offset, teleporting the scroll position to an

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
@@ -7,8 +7,6 @@ import { useScrollAreaRootContext } from '../root/ScrollAreaRootContext';
 import { ScrollAreaScrollbarContext } from './ScrollAreaScrollbarContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { getOffset } from '../utils/getOffset';
-import { ScrollAreaRootCssVars } from '../root/ScrollAreaRootCssVars';
-import { ScrollAreaScrollbarCssVars } from './ScrollAreaScrollbarCssVars';
 import { useDirection } from '../../internals/direction-context/DirectionContext';
 import { scrollAreaStateAttributesMapping } from '../root/stateAttributes';
 import type { ScrollAreaRootState } from '../root/ScrollAreaRoot';
@@ -37,7 +35,6 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
     scrollingX,
     scrollingY,
     hiddenState,
-    overflowEdges,
     scrollbarYRef,
     scrollbarXRef,
     viewportRef,
@@ -49,27 +46,21 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
     rootId,
     thumbSize,
     hasMeasuredScrollbar,
+    viewportState,
   } = useScrollAreaRootContext();
 
+  const vertical = orientation === 'vertical';
+
   const state: ScrollAreaScrollbarState = {
+    ...viewportState,
     hovering,
-    scrolling: {
-      horizontal: scrollingX,
-      vertical: scrollingY,
-    }[orientation],
+    scrolling: vertical ? scrollingY : scrollingX,
     orientation,
-    hasOverflowX: !hiddenState.x,
-    hasOverflowY: !hiddenState.y,
-    overflowXStart: overflowEdges.xStart,
-    overflowXEnd: overflowEdges.xEnd,
-    overflowYStart: overflowEdges.yStart,
-    overflowYEnd: overflowEdges.yEnd,
-    cornerHidden: hiddenState.corner,
   };
 
   const direction = useDirection();
   const hideTrackUntilMeasured = !hasMeasuredScrollbar && !keepMounted;
-  const isHidden = orientation === 'vertical' ? hiddenState.y : hiddenState.x;
+  const isHidden = vertical ? hiddenState.y : hiddenState.x;
   const shouldRender = keepMounted || !isHidden;
 
   React.useEffect(() => {
@@ -78,7 +69,7 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
     }
 
     const viewportEl = viewportRef.current;
-    const scrollbarEl = orientation === 'vertical' ? scrollbarYRef.current : scrollbarXRef.current;
+    const scrollbarEl = vertical ? scrollbarYRef.current : scrollbarXRef.current;
 
     if (!scrollbarEl) {
       return undefined;
@@ -89,7 +80,7 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
         return;
       }
 
-      const horizontal = orientation === 'horizontal';
+      const horizontal = !vertical;
       const scrollProperty = horizontal ? 'scrollLeft' : 'scrollTop';
       const delta = horizontal ? event.deltaX : event.deltaY;
       if (delta === 0) {
@@ -121,15 +112,7 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
     }
 
     return addEventListener(scrollbarEl, 'wheel', handleWheel, { passive: false });
-  }, [
-    direction,
-    handleScroll,
-    orientation,
-    scrollbarXRef,
-    scrollbarYRef,
-    shouldRender,
-    viewportRef,
-  ]);
+  }, [direction, handleScroll, vertical, scrollbarXRef, scrollbarYRef, shouldRender, viewportRef]);
 
   const props: HTMLProps = {
     ...(rootId && { 'data-id': `${rootId}-scrollbar` }),
@@ -139,82 +122,64 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
       }
 
       const target = getTarget(event.nativeEvent) as Element | null;
-      const thumb = orientation === 'vertical' ? thumbYRef.current : thumbXRef.current;
+      const thumbEl = vertical ? thumbYRef.current : thumbXRef.current;
 
       // Ignore clicks on thumb, including cases where React retargets the
       // synthetic event to the track host across a shadow boundary.
-      if (thumb && contains(thumb, target)) {
+      if (thumbEl && contains(thumbEl, target)) {
         return;
       }
 
-      if (!viewportRef.current) {
+      const viewportEl = viewportRef.current;
+      if (!viewportEl) {
         return;
       }
 
-      // Handle Y-axis (vertical) scroll
-      if (thumbYRef.current && scrollbarYRef.current && orientation === 'vertical') {
-        const thumbYOffset = getOffset(thumbYRef.current, 'margin', 'y');
-        const scrollbarYOffset = getOffset(scrollbarYRef.current, 'padding', 'y');
-        const thumbHeight = thumbYRef.current.offsetHeight;
-        const trackRectY = scrollbarYRef.current.getBoundingClientRect();
-        const clickY =
-          event.clientY - trackRectY.top - thumbHeight / 2 - scrollbarYOffset + thumbYOffset / 2;
+      const scrollbarEl = vertical ? scrollbarYRef.current : scrollbarXRef.current;
 
-        const scrollableContentHeight = viewportRef.current.scrollHeight;
-        const viewportHeight = viewportRef.current.clientHeight;
+      if (thumbEl && scrollbarEl) {
+        const axis = vertical ? 'y' : 'x';
+        const thumbOffset = getOffset(thumbEl, 'margin', axis);
+        const scrollbarOffset = getOffset(scrollbarEl, 'padding', axis);
+        const thumbSizePx = vertical ? thumbEl.offsetHeight : thumbEl.offsetWidth;
+        const trackRect = scrollbarEl.getBoundingClientRect();
+        const clickPosition = vertical
+          ? event.clientY - trackRect.top - thumbSizePx / 2 - scrollbarOffset + thumbOffset / 2
+          : event.clientX - trackRect.left - thumbSizePx / 2 - scrollbarOffset + thumbOffset / 2;
 
-        const maxThumbOffsetY =
-          scrollbarYRef.current.offsetHeight - thumbHeight - scrollbarYOffset - thumbYOffset;
-        // A short or heavily padded track can drive `maxThumbOffsetY` to zero or
+        const scrollableSize = vertical ? viewportEl.scrollHeight : viewportEl.scrollWidth;
+        const viewportSize = vertical ? viewportEl.clientHeight : viewportEl.clientWidth;
+        const trackSize = vertical ? scrollbarEl.offsetHeight : scrollbarEl.offsetWidth;
+
+        const maxThumbOffset = trackSize - thumbSizePx - scrollbarOffset - thumbOffset;
+        // A short or heavily padded track can drive `maxThumbOffset` to zero or
         // negative once the thumb hits its `MIN_THUMB_SIZE` floor. Dividing by it
-        // would yield a non-finite (`Infinity`/`NaN`) or inverted `scrollTop`.
-        if (maxThumbOffsetY <= 0) {
+        // would yield a non-finite (`Infinity`/`NaN`) or inverted scroll position.
+        if (maxThumbOffset <= 0) {
           return;
         }
 
-        const scrollRatioY = clickY / maxThumbOffsetY;
-        const newScrollTop = scrollRatioY * (scrollableContentHeight - viewportHeight);
+        const scrollRatio = clickPosition / maxThumbOffset;
+        const maxScrollDistance = scrollableSize - viewportSize;
 
-        viewportRef.current.scrollTop = newScrollTop;
-      }
-
-      if (thumbXRef.current && scrollbarXRef.current && orientation === 'horizontal') {
-        const thumbXOffset = getOffset(thumbXRef.current, 'margin', 'x');
-        const scrollbarXOffset = getOffset(scrollbarXRef.current, 'padding', 'x');
-        const thumbWidth = thumbXRef.current.offsetWidth;
-        const trackRectX = scrollbarXRef.current.getBoundingClientRect();
-        const clickX =
-          event.clientX - trackRectX.left - thumbWidth / 2 - scrollbarXOffset + thumbXOffset / 2;
-
-        const scrollableContentWidth = viewportRef.current.scrollWidth;
-        const viewportWidth = viewportRef.current.clientWidth;
-
-        const maxThumbOffsetX =
-          scrollbarXRef.current.offsetWidth - thumbWidth - scrollbarXOffset - thumbXOffset;
-        // See the vertical case: guard against a non-positive offset.
-        if (maxThumbOffsetX <= 0) {
-          return;
-        }
-
-        const scrollRatioX = clickX / maxThumbOffsetX;
-
-        let newScrollLeft: number;
-        if (direction === 'rtl') {
+        if (vertical) {
+          viewportEl.scrollTop = scrollRatio * maxScrollDistance;
+        } else if (direction === 'rtl') {
           // In RTL, invert the scroll direction
-          newScrollLeft = (1 - scrollRatioX) * (scrollableContentWidth - viewportWidth);
+          let newScrollLeft = (1 - scrollRatio) * maxScrollDistance;
 
           // Adjust for browsers that use negative scrollLeft in RTL
-          if (viewportRef.current.scrollLeft <= 0) {
+          if (viewportEl.scrollLeft <= 0) {
             newScrollLeft = -newScrollLeft;
           }
-        } else {
-          newScrollLeft = scrollRatioX * (scrollableContentWidth - viewportWidth);
-        }
 
-        viewportRef.current.scrollLeft = newScrollLeft;
+          viewportEl.scrollLeft = newScrollLeft;
+        } else {
+          viewportEl.scrollLeft = scrollRatio * maxScrollDistance;
+        }
       }
 
-      handleScroll({ x: viewportRef.current.scrollLeft, y: viewportRef.current.scrollTop });
+      handleScroll({ x: viewportEl.scrollLeft, y: viewportEl.scrollTop });
 
       handlePointerDown(event);
     },
@@ -228,36 +193,35 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
       WebkitUserSelect: 'none',
       userSelect: 'none',
       visibility: hideTrackUntilMeasured ? 'hidden' : undefined,
-      ...(orientation === 'vertical' && {
-        top: 0,
-        bottom: `var(${ScrollAreaRootCssVars.scrollAreaCornerHeight})`,
-        insetInlineEnd: 0,
-        [ScrollAreaScrollbarCssVars.scrollAreaThumbHeight as string]: `${thumbSize.height}px`,
-      }),
-      ...(orientation === 'horizontal' && {
-        insetInlineStart: 0,
-        insetInlineEnd: `var(${ScrollAreaRootCssVars.scrollAreaCornerWidth})`,
-        bottom: 0,
-        [ScrollAreaScrollbarCssVars.scrollAreaThumbWidth as string]: `${thumbSize.width}px`,
-      }),
+      ...(vertical
+        ? {
+            top: 0,
+            bottom: 'var(--scroll-area-corner-height)',
+            insetInlineEnd: 0,
+            ['--scroll-area-thumb-height' as string]: `${thumbSize.height}px`,
+          }
+        : {
+            insetInlineStart: 0,
+            insetInlineEnd: 'var(--scroll-area-corner-width)',
+            bottom: 0,
+            ['--scroll-area-thumb-width' as string]: `${thumbSize.width}px`,
+          }),
     },
   };
 
   const element = useRenderElement('div', componentProps, {
-    ref: [forwardedRef, orientation === 'vertical' ? scrollbarYRef : scrollbarXRef],
+    ref: [forwardedRef, vertical ? scrollbarYRef : scrollbarXRef],
     state,
     props: [props, elementProps],
     stateAttributesMapping: scrollAreaStateAttributesMapping,
   });
-
-  const contextValue = React.useMemo(() => ({ orientation }), [orientation]);
 
   if (!shouldRender) {
     return null;
   }
 
   return (
-    <ScrollAreaScrollbarContext.Provider value={contextValue}>
+    <ScrollAreaScrollbarContext.Provider value={orientation}>
       {element}
     </ScrollAreaScrollbarContext.Provider>
   );

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbarContext.ts
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbarContext.ts
@@ -1,9 +1,7 @@
 'use client';
 import * as React from 'react';
 
-export interface ScrollAreaScrollbarContext {
-  orientation: 'horizontal' | 'vertical';
-}
+export type ScrollAreaScrollbarContext = 'horizontal' | 'vertical';
 
 export const ScrollAreaScrollbarContext = React.createContext<
   ScrollAreaScrollbarContext | undefined

--- a/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
+++ b/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
@@ -1,8 +1,9 @@
-import { expect } from 'vitest';
-import { createRenderer } from '#test-utils';
+import { expect, vi } from 'vitest';
+import { createRenderer, isJSDOM } from '#test-utils';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { describeConformance } from '../../../test/describeConformance';
+import { DirectionProvider } from '../../direction-provider/DirectionProvider';
 import { SCROLL_TIMEOUT } from '../constants';
 
 describe('<ScrollArea.Thumb />', () => {
@@ -18,6 +19,85 @@ describe('<ScrollArea.Thumb />', () => {
       );
     },
   }));
+
+  describe.skipIf(isJSDOM)('horizontal dragging', () => {
+    async function renderHorizontal(direction: 'ltr' | 'rtl') {
+      const { user } = await render(
+        <DirectionProvider direction={direction}>
+          <ScrollArea.Root style={{ width: 200, height: 200, direction }}>
+            <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
+              <div style={{ width: 1000, height: 200 }} />
+            </ScrollArea.Viewport>
+            <ScrollArea.Scrollbar
+              orientation="horizontal"
+              data-testid="scrollbar"
+              keepMounted
+              style={{ display: 'flex', width: 200, height: 10 }}
+            >
+              <ScrollArea.Thumb data-testid="thumb" />
+            </ScrollArea.Scrollbar>
+          </ScrollArea.Root>
+        </DirectionProvider>,
+      );
+
+      const viewport = screen.getByTestId('viewport');
+      const scrollbar = screen.getByTestId('scrollbar');
+      const thumb = screen.getByTestId('thumb');
+      await waitFor(() => expect(thumb.offsetWidth).toBeGreaterThan(0));
+
+      return { scrollbar, thumb, user, viewport };
+    }
+
+    it('updates LTR scroll position and pointer capture state', async () => {
+      const { scrollbar, thumb, user, viewport } = await renderHorizontal('ltr');
+      const setPointerCapture = vi.spyOn(thumb, 'setPointerCapture').mockImplementation(() => {});
+      vi.spyOn(thumb, 'hasPointerCapture').mockReturnValue(true);
+      const releasePointerCapture = vi
+        .spyOn(thumb, 'releasePointerCapture')
+        .mockImplementation(() => {});
+      const rect = thumb.getBoundingClientRect();
+
+      await user.pointer({
+        target: thumb,
+        coords: { clientX: rect.left + rect.width / 2, clientY: rect.top + rect.height / 2 },
+        keys: '[MouseLeft>]',
+      });
+      await user.pointer({
+        target: thumb,
+        coords: { clientX: rect.left + rect.width / 2 + 20, clientY: rect.top + rect.height / 2 },
+      });
+
+      expect(setPointerCapture).toHaveBeenCalledTimes(1);
+      expect(viewport.scrollLeft).toBeGreaterThan(0);
+      expect(scrollbar).toHaveAttribute('data-scrolling');
+
+      await user.pointer({ keys: '[/MouseLeft]' });
+
+      expect(releasePointerCapture).toHaveBeenCalled();
+    });
+
+    it('uses the negative RTL range and clears scrolling on pointer cancel', async () => {
+      const { scrollbar, thumb, user, viewport } = await renderHorizontal('rtl');
+      const rect = thumb.getBoundingClientRect();
+
+      await user.pointer({
+        target: thumb,
+        coords: { clientX: rect.left + rect.width / 2, clientY: rect.top + rect.height / 2 },
+        keys: '[MouseLeft>]',
+      });
+      await user.pointer({
+        target: thumb,
+        coords: { clientX: rect.left + rect.width / 2 - 20, clientY: rect.top + rect.height / 2 },
+      });
+
+      expect(viewport.scrollLeft).toBeLessThan(0);
+      expect(scrollbar).toHaveAttribute('data-scrolling');
+      expect(() => fireEvent.pointerCancel(thumb, { pointerId: 1 })).not.toThrow();
+      await waitFor(() => expect(scrollbar).not.toHaveAttribute('data-scrolling'));
+
+      await user.pointer({ keys: '[/MouseLeft]' });
+    });
+  });
 
   it('clears scrolling state on pointer cancel without releasing stale capture', async () => {
     await render(

--- a/packages/react/src/scroll-area/thumb/ScrollAreaThumb.tsx
+++ b/packages/react/src/scroll-area/thumb/ScrollAreaThumb.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useScrollAreaRootContext } from '../root/ScrollAreaRootContext';
 import { useScrollAreaScrollbarContext } from '../scrollbar/ScrollAreaScrollbarContext';
-import { ScrollAreaScrollbarCssVars } from '../scrollbar/ScrollAreaScrollbarCssVars';
 import { useRenderElement } from '../../internals/useRenderElement';
 
 /**
@@ -31,25 +30,21 @@ export const ScrollAreaThumb = React.forwardRef(function ScrollAreaThumb(
     hasMeasuredScrollbar,
   } = useScrollAreaRootContext();
 
-  const { orientation } = useScrollAreaScrollbarContext();
+  const orientation = useScrollAreaScrollbarContext();
+  const vertical = orientation === 'vertical';
 
   const state: ScrollAreaThumbState = {
-    scrolling: orientation === 'horizontal' ? scrollingX : scrollingY,
+    scrolling: vertical ? scrollingY : scrollingX,
     orientation,
   };
 
   function endDrag(event: React.PointerEvent) {
-    if (orientation === 'vertical') {
-      setScrollingY(false);
-    }
-    if (orientation === 'horizontal') {
-      setScrollingX(false);
-    }
+    (vertical ? setScrollingY : setScrollingX)(false);
     handlePointerUp(event);
   }
 
   const element = useRenderElement('div', componentProps, {
-    ref: [forwardedRef, orientation === 'vertical' ? thumbYRef : thumbXRef],
+    ref: [forwardedRef, vertical ? thumbYRef : thumbXRef],
     state,
     props: [
       {
@@ -59,12 +54,9 @@ export const ScrollAreaThumb = React.forwardRef(function ScrollAreaThumb(
         onPointerCancel: endDrag,
         style: {
           visibility: hasMeasuredScrollbar ? undefined : 'hidden',
-          ...(orientation === 'vertical' && {
-            height: `var(${ScrollAreaScrollbarCssVars.scrollAreaThumbHeight})`,
-          }),
-          ...(orientation === 'horizontal' && {
-            width: `var(${ScrollAreaScrollbarCssVars.scrollAreaThumbWidth})`,
-          }),
+          ...(vertical
+            ? { height: 'var(--scroll-area-thumb-height)' }
+            : { width: 'var(--scroll-area-thumb-width)' }),
         },
       },
       elementProps,

--- a/packages/react/src/scroll-area/utils/getOffset.ts
+++ b/packages/react/src/scroll-area/utils/getOffset.ts
@@ -8,15 +8,14 @@ export function getOffset(
   }
 
   const styles = getComputedStyle(element);
-  const propAxis = axis === 'x' ? 'Inline' : 'Block';
+  const key = `${prop}${axis === 'x' ? 'Inline' : 'Block'}` as const;
+  const start = parseFloat(styles[`${key}Start`]);
 
   // Safari misreports `marginInlineEnd` in RTL.
   // We have to assume the start/end values are symmetrical, which is likely.
   if (axis === 'x' && prop === 'margin') {
-    return parseFloat(styles[`${prop}InlineStart`]) * 2;
+    return start * 2;
   }
 
-  return (
-    parseFloat(styles[`${prop}${propAxis}Start`]) + parseFloat(styles[`${prop}${propAxis}End`])
-  );
+  return start + parseFloat(styles[`${key}End`]);
 }

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -17,6 +17,9 @@ import { scrollAreaStateAttributesMapping } from '../root/stateAttributes';
 import type { HiddenState, ScrollAreaRootState } from '../root/ScrollAreaRoot';
 import { normalizeScrollOffset } from '../../utils/scrollEdges';
 
+// CSS variable names are inlined instead of read from `ScrollAreaViewportCssVars`
+// to keep that enum docs-only and tree-shakeable; `enumSync.test.tsx` guards the
+// literals here (and in the sibling parts) against drifting from the enum.
 const OVERFLOW_EDGE_VARS = [
   '--scroll-area-overflow-x-start',
   '--scroll-area-overflow-x-end',

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -12,12 +12,17 @@ import { useDirection } from '../../internals/direction-context/DirectionContext
 import { getOffset } from '../utils/getOffset';
 import { MIN_THUMB_SIZE } from '../constants';
 import { clamp } from '../../internals/clamp';
-import { ScrollAreaScrollbarCssVars } from '../scrollbar/ScrollAreaScrollbarCssVars';
 import { styleDisableScrollbar } from '../../utils/styles';
 import { scrollAreaStateAttributesMapping } from '../root/stateAttributes';
 import type { HiddenState, ScrollAreaRootState } from '../root/ScrollAreaRoot';
-import { ScrollAreaViewportCssVars } from './ScrollAreaViewportCssVars';
 import { normalizeScrollOffset } from '../../utils/scrollEdges';
+
+const OVERFLOW_EDGE_VARS = [
+  '--scroll-area-overflow-x-start',
+  '--scroll-area-overflow-x-end',
+  '--scroll-area-overflow-y-start',
+  '--scroll-area-overflow-y-end',
+];
 
 // Module-level flag to ensure we only register the CSS properties once,
 // regardless of how many Scroll Area components are mounted.
@@ -42,12 +47,7 @@ function removeCSSVariableInheritance() {
   }
 
   if (typeof CSS !== 'undefined' && 'registerProperty' in CSS) {
-    [
-      ScrollAreaViewportCssVars.scrollAreaOverflowXStart,
-      ScrollAreaViewportCssVars.scrollAreaOverflowXEnd,
-      ScrollAreaViewportCssVars.scrollAreaOverflowYStart,
-      ScrollAreaViewportCssVars.scrollAreaOverflowYEnd,
-    ].forEach((name) => {
+    OVERFLOW_EDGE_VARS.forEach((name) => {
       try {
         CSS.registerProperty({
           name,
@@ -94,10 +94,8 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     touchModality,
     setHovering,
     setOverflowEdges,
-    overflowEdges,
     overflowEdgeThreshold,
-    scrollingX,
-    scrollingY,
+    viewportState,
   } = useScrollAreaRootContext();
 
   const direction = useDirection();
@@ -158,21 +156,18 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     let scrollLeftFromStart = 0;
     let scrollLeftFromEnd = 0;
     if (!scrollbarXHidden) {
-      let rawScrollLeftFromStart = 0;
-      if (direction === 'rtl') {
-        rawScrollLeftFromStart = clamp(-scrollLeft, 0, maxScrollLeft);
-      } else {
-        rawScrollLeftFromStart = clamp(scrollLeft, 0, maxScrollLeft);
-      }
-      scrollLeftFromStart = normalizeScrollOffset(rawScrollLeftFromStart, maxScrollLeft);
+      // `normalizeScrollOffset` clamps internally.
+      scrollLeftFromStart = normalizeScrollOffset(
+        direction === 'rtl' ? -scrollLeft : scrollLeft,
+        maxScrollLeft,
+      );
       scrollLeftFromEnd = maxScrollLeft - scrollLeftFromStart;
     }
 
-    const rawScrollTopFromStart = !scrollbarYHidden ? clamp(scrollTop, 0, maxScrollTop) : 0;
-    const scrollTopFromStart = !scrollbarYHidden
-      ? normalizeScrollOffset(rawScrollTopFromStart, maxScrollTop)
-      : 0;
-    const scrollTopFromEnd = !scrollbarYHidden ? maxScrollTop - scrollTopFromStart : 0;
+    const scrollTopFromStart = scrollbarYHidden
+      ? 0
+      : normalizeScrollOffset(scrollTop, maxScrollTop);
+    const scrollTopFromEnd = scrollbarYHidden ? 0 : maxScrollTop - scrollTopFromStart;
     const nextWidth = scrollbarXHidden ? 0 : viewportWidth;
     const nextHeight = scrollbarYHidden ? 0 : viewportHeight;
 
@@ -207,16 +202,9 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     const clampedNextWidth = Math.max(MIN_THUMB_SIZE, maxNextWidth * ratioX);
     const clampedNextHeight = Math.max(MIN_THUMB_SIZE, maxNextHeight * ratioY);
 
-    setThumbSize((prevSize) => {
-      if (prevSize.height === clampedNextHeight && prevSize.width === clampedNextWidth) {
-        return prevSize;
-      }
-
-      return {
-        width: clampedNextWidth,
-        height: clampedNextHeight,
-      };
-    });
+    setThumbSize((prevSize) =>
+      pickState(prevSize, { width: clampedNextWidth, height: clampedNextHeight }),
+    );
 
     // Handle Y (vertical) scroll
     if (scrollbarYEl && thumbYEl) {
@@ -225,7 +213,7 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
 
       const thumbOffsetY = applyOverscrollThumb(
         thumbYEl,
-        ScrollAreaScrollbarCssVars.scrollAreaThumbHeight,
+        '--scroll-area-thumb-height',
         scrollTop,
         maxScrollTop,
         scrollableContentHeight,
@@ -245,7 +233,7 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
 
       const offsetX = applyOverscrollThumb(
         thumbXEl,
-        ScrollAreaScrollbarCssVars.scrollAreaThumbWidth,
+        '--scroll-area-thumb-width',
         scrollFromStart,
         maxScrollLeft,
         scrollableContentWidth,
@@ -255,35 +243,28 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
       thumbXEl.style.transform = `translate3d(${direction === 'rtl' ? -offsetX : offsetX}px,0,0)`;
     }
 
-    const overflowMetricsPx: Array<[ScrollAreaViewportCssVars, number]> = [
-      [ScrollAreaViewportCssVars.scrollAreaOverflowXStart, scrollLeftFromStart],
-      [ScrollAreaViewportCssVars.scrollAreaOverflowXEnd, scrollLeftFromEnd],
-      [ScrollAreaViewportCssVars.scrollAreaOverflowYStart, scrollTopFromStart],
-      [ScrollAreaViewportCssVars.scrollAreaOverflowYEnd, scrollTopFromEnd],
+    const overflowMetricsPx = [
+      scrollLeftFromStart,
+      scrollLeftFromEnd,
+      scrollTopFromStart,
+      scrollTopFromEnd,
     ];
 
-    for (const [cssVar, value] of overflowMetricsPx) {
-      viewportEl.style.setProperty(cssVar, `${value}px`);
-    }
+    OVERFLOW_EDGE_VARS.forEach((cssVar, index) => {
+      viewportEl.style.setProperty(cssVar, `${overflowMetricsPx[index]}px`);
+    });
 
     if (cornerEl) {
       // Bail when the size is unchanged (like `setThumbSize` above); otherwise a
       // fresh object literal on every scroll frame rebuilds the root context and
       // re-renders every scroll-area part.
-      if (scrollbarXHidden || scrollbarYHidden) {
-        setCornerSize((prevSize) =>
-          prevSize.width === 0 && prevSize.height === 0 ? prevSize : { width: 0, height: 0 },
-        );
-      } else if (!scrollbarXHidden && !scrollbarYHidden) {
-        setCornerSize((prevSize) =>
-          prevSize.width === nextCornerWidth && prevSize.height === nextCornerHeight
-            ? prevSize
-            : { width: nextCornerWidth, height: nextCornerHeight },
-        );
-      }
+      // `nextCornerWidth`/`nextCornerHeight` stay 0 when either scrollbar is hidden.
+      setCornerSize((prevSize) =>
+        pickState(prevSize, { width: nextCornerWidth, height: nextCornerHeight }),
+      );
     }
 
-    setHiddenState((prevState) => mergeHiddenState(prevState, nextHiddenState));
+    setHiddenState((prevState) => pickState(prevState, nextHiddenState));
 
     const nextOverflowEdges = {
       xStart: !scrollbarXHidden && scrollLeftFromStart > overflowEdgeThreshold.xStart,
@@ -292,17 +273,7 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
       yEnd: !scrollbarYHidden && scrollTopFromEnd > overflowEdgeThreshold.yEnd,
     };
 
-    setOverflowEdges((prev) => {
-      if (
-        prev.xStart === nextOverflowEdges.xStart &&
-        prev.xEnd === nextOverflowEdges.xEnd &&
-        prev.yStart === nextOverflowEdges.yStart &&
-        prev.yEnd === nextOverflowEdges.yEnd
-      ) {
-        return prev;
-      }
-      return nextOverflowEdges;
-    });
+    setOverflowEdges((prev) => pickState(prev, nextOverflowEdges));
   });
 
   useIsoLayoutEffect(() => {
@@ -432,20 +403,6 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
     onKeyDown: handleUserInteraction,
   };
 
-  const viewportState: ScrollAreaViewportState = React.useMemo(
-    () => ({
-      scrolling: scrollingX || scrollingY,
-      hasOverflowX: !hiddenState.x,
-      hasOverflowY: !hiddenState.y,
-      overflowXStart: overflowEdges.xStart,
-      overflowXEnd: overflowEdges.xEnd,
-      overflowYStart: overflowEdges.yStart,
-      overflowYEnd: overflowEdges.yEnd,
-      cornerHidden: hiddenState.corner,
-    }),
-    [scrollingX, scrollingY, hiddenState.x, hiddenState.y, hiddenState.corner, overflowEdges],
-  );
-
   const element = useRenderElement('div', componentProps, {
     ref: [forwardedRef, viewportRef],
     state: viewportState,
@@ -490,16 +447,18 @@ function getHiddenState(viewport: HTMLElement): HiddenState {
   };
 }
 
-function mergeHiddenState(prevState: HiddenState, nextState: HiddenState) {
-  if (
-    prevState.y === nextState.y &&
-    prevState.x === nextState.x &&
-    prevState.corner === nextState.corner
-  ) {
-    return prevState;
+/**
+ * Returns `prev` when `next` is shallow-equal to it so setState bails out and
+ * scroll-frame updates don't rebuild the root context.
+ */
+function pickState<T extends object>(prev: T, next: T): T {
+  for (const key in next) {
+    if (prev[key as keyof T] !== next[key as keyof T]) {
+      return next;
+    }
   }
 
-  return nextState;
+  return prev;
 }
 
 /**
@@ -509,7 +468,7 @@ function mergeHiddenState(prevState: HiddenState, nextState: HiddenState) {
  */
 function applyOverscrollThumb(
   thumbEl: HTMLElement,
-  sizeVar: ScrollAreaScrollbarCssVars,
+  sizeVar: string,
   scrollFromStart: number,
   maxScroll: number,
   content: number,

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -17,8 +17,7 @@ import { scrollAreaStateAttributesMapping } from '../root/stateAttributes';
 import type { HiddenState, ScrollAreaRootState } from '../root/ScrollAreaRoot';
 import { normalizeScrollOffset } from '../../utils/scrollEdges';
 
-// CSS variable names inlined so `ScrollAreaViewportCssVars` tree-shakes out;
-// `enumSync.test.tsx` guards against drift.
+// CSS variable names inlined so `ScrollAreaViewportCssVars` tree-shakes out.
 const OVERFLOW_EDGE_VARS = [
   '--scroll-area-overflow-x-start',
   '--scroll-area-overflow-x-end',

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -17,9 +17,8 @@ import { scrollAreaStateAttributesMapping } from '../root/stateAttributes';
 import type { HiddenState, ScrollAreaRootState } from '../root/ScrollAreaRoot';
 import { normalizeScrollOffset } from '../../utils/scrollEdges';
 
-// CSS variable names are inlined instead of read from `ScrollAreaViewportCssVars`
-// to keep that enum docs-only and tree-shakeable; `enumSync.test.tsx` guards the
-// literals here (and in the sibling parts) against drifting from the enum.
+// CSS variable names inlined so `ScrollAreaViewportCssVars` tree-shakes out;
+// `enumSync.test.tsx` guards against drift.
 const OVERFLOW_EDGE_VARS = [
   '--scroll-area-overflow-x-start',
   '--scroll-area-overflow-x-end',


### PR DESCRIPTION
Reduces the `@base-ui/react/scroll-area` bundle size with no public API change. The bundle bot is authoritative for the current size impact.

The vertical and horizontal branches in the scrollbar and root pointer handlers are consolidated into axis-parameterized paths, and the viewport reuses state already shared by the root. Internal enum members used only at runtime are inlined while their source enums remain for types and docs; an enum-sync test prevents the strings from drifting.

Emitted DOM attributes, CSS variables, and state remain unchanged.
