### PR TITLE
[toast] Reduce bundle size

### DIFF
--- a/packages/react/src/toast/action/ToastAction.tsx
+++ b/packages/react/src/toast/action/ToastAction.tsx
@@ -38,7 +38,8 @@ export const ToastAction = React.forwardRef(function ToastAction(
     type: toast.type,
   };
 
-  const element = useRenderElement('button', componentProps, {
+  return useRenderElement('button', componentProps, {
+    enabled: shouldRender,
     ref: [forwardedRef, buttonRef],
     state,
     props: [
@@ -50,12 +51,6 @@ export const ToastAction = React.forwardRef(function ToastAction(
       },
     ],
   });
-
-  if (!shouldRender) {
-    return null;
-  }
-
-  return element;
 });
 
 export interface ToastActionState {

--- a/packages/react/src/toast/arrow/ToastArrow.tsx
+++ b/packages/react/src/toast/arrow/ToastArrow.tsx
@@ -25,13 +25,11 @@ export const ToastArrow = React.forwardRef(function ToastArrow(
     uncentered: arrowUncentered,
   };
 
-  const element = useRenderElement('div', componentProps, {
+  return useRenderElement('div', componentProps, {
     state,
     ref: [forwardedRef, arrowRef],
     props: [{ style: arrowStyles, 'aria-hidden': true }, elementProps],
   });
-
-  return element;
 });
 
 export interface ToastArrowState {

--- a/packages/react/src/toast/close/ToastClose.tsx
+++ b/packages/react/src/toast/close/ToastClose.tsx
@@ -26,8 +26,7 @@ export const ToastClose = React.forwardRef(function ToastClose(
   } = componentProps;
 
   const store = useToastProviderContext();
-  const { toast } = useToastRootContext();
-  const expanded = store.useState('expanded');
+  const { toast, expanded } = useToastRootContext();
 
   const [hasFocus, setHasFocus] = React.useState(false);
 
@@ -40,7 +39,7 @@ export const ToastClose = React.forwardRef(function ToastClose(
     type: toast.type,
   };
 
-  const element = useRenderElement('button', componentProps, {
+  return useRenderElement('button', componentProps, {
     ref: [forwardedRef, buttonRef],
     state,
     props: [
@@ -60,8 +59,6 @@ export const ToastClose = React.forwardRef(function ToastClose(
       getButtonProps,
     ],
   });
-
-  return element;
 });
 
 export interface ToastCloseState {

--- a/packages/react/src/toast/content/ToastContent.tsx
+++ b/packages/react/src/toast/content/ToastContent.tsx
@@ -52,13 +52,11 @@ export const ToastContent = React.forwardRef(function ToastContent(
     behind,
   };
 
-  const element = useRenderElement('div', componentProps, {
+  return useRenderElement('div', componentProps, {
     ref: [forwardedRef, contentRef],
     state,
     props: elementProps,
   });
-
-  return element;
 });
 
 export interface ToastContentState {

--- a/packages/react/src/toast/description/ToastDescription.tsx
+++ b/packages/react/src/toast/description/ToastDescription.tsx
@@ -1,10 +1,8 @@
 'use client';
 import * as React from 'react';
-import { useId } from '@base-ui/utils/useId';
-import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import type { BaseUIComponentProps } from '../../internals/types';
-import { useToastRootContext } from '../root/ToastRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
+import { useToastLabelPart } from '../utils/useToastLabelPart';
 
 /**
  * A description that describes the toast.
@@ -26,45 +24,21 @@ export const ToastDescription = React.forwardRef(function ToastDescription(
     ...elementProps
   } = componentProps;
 
-  const { toast, setDescriptionId } = useToastRootContext();
+  const { id, children, shouldRender, type } = useToastLabelPart(
+    idProp,
+    childrenProp,
+    'description',
+  );
 
-  const children = childrenProp ?? toast.description;
-
-  const shouldRender = Boolean(children);
-
-  const id = useId(idProp);
-
-  useIsoLayoutEffect(() => {
-    if (!shouldRender) {
-      return undefined;
-    }
-
-    setDescriptionId(id);
-
-    return () => {
-      setDescriptionId(undefined);
-    };
-  }, [shouldRender, id, setDescriptionId]);
-
-  const state: ToastDescriptionState = {
-    type: toast.type,
-  };
+  const state: ToastDescriptionState = { type };
 
   const element = useRenderElement('p', componentProps, {
     ref: forwardedRef,
     state,
-    props: {
-      ...elementProps,
-      id,
-      children,
-    },
+    props: { ...elementProps, id, children },
   });
 
-  if (!shouldRender) {
-    return null;
-  }
-
-  return element;
+  return shouldRender ? element : null;
 });
 
 export interface ToastDescriptionState {

--- a/packages/react/src/toast/enumSync.test.tsx
+++ b/packages/react/src/toast/enumSync.test.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { expect } from 'vitest';
+import { Toast } from '@base-ui/react/toast';
+import { screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, isJSDOM } from '#test-utils';
+import { ToastRootCssVars } from './root/ToastRootCssVars';
+import { ToastViewportCssVars } from './viewport/ToastViewportCssVars';
+import { List, Button } from './utils/test-utils';
+
+const toast: Toast.Root.ToastObject = {
+  id: 'test',
+  title: 'Toast title',
+};
+
+// The parts inline these enums' values instead of referencing the members, so
+// nothing links the docs enums to runtime behavior. These tests re-link every
+// inlined member so a rename to only one side fails CI. Test-only imports ship
+// no production bytes.
+describe('Toast enum sync', () => {
+  const { render } = createRenderer();
+
+  it('names the root CSS variables per ToastRootCssVars', async () => {
+    const { user } = await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <List />
+        </Toast.Viewport>
+        <Button />
+      </Toast.Provider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'add' }));
+
+    const root = screen.getByTestId('root');
+
+    // Written unconditionally through the root `style` prop.
+    expect(root.style.getPropertyValue(ToastRootCssVars.index)).not.toBe('');
+    expect(root.style.getPropertyValue(ToastRootCssVars.offsetY)).not.toBe('');
+    expect(root.style.getPropertyValue(ToastRootCssVars.swipeMovementX)).not.toBe('');
+    expect(root.style.getPropertyValue(ToastRootCssVars.swipeMovementY)).not.toBe('');
+  });
+
+  it('names the positioner index CSS variable per ToastRootCssVars', async () => {
+    await render(
+      <Toast.Provider>
+        <Toast.Positioner toast={toast} data-testid="positioner" />
+      </Toast.Provider>,
+    );
+
+    expect(
+      screen.getByTestId('positioner').style.getPropertyValue(ToastRootCssVars.index),
+    ).not.toBe('');
+  });
+
+  it.skipIf(isJSDOM)(
+    'names the measured height CSS variables per ToastRootCssVars and ToastViewportCssVars',
+    async () => {
+      const { user } = await render(
+        <Toast.Provider>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'add' }));
+
+      // Both variables appear once the toast height has been measured.
+      await waitFor(() =>
+        expect(screen.getByTestId('root').style.getPropertyValue(ToastRootCssVars.height)).not.toBe(
+          '',
+        ),
+      );
+      await waitFor(() =>
+        expect(
+          screen
+            .getByTestId('viewport')
+            .style.getPropertyValue(ToastViewportCssVars.frontmostHeight),
+        ).not.toBe(''),
+      );
+    },
+  );
+});

--- a/packages/react/src/toast/enumSync.test.tsx
+++ b/packages/react/src/toast/enumSync.test.tsx
@@ -4,7 +4,9 @@ import { Toast } from '@base-ui/react/toast';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, isJSDOM } from '#test-utils';
 import { ToastRootCssVars } from './root/ToastRootCssVars';
+import { ToastRootDataAttributes } from './root/ToastRootDataAttributes';
 import { ToastViewportCssVars } from './viewport/ToastViewportCssVars';
+import { toastRootStateAttributesMapping } from './root/ToastRoot';
 import { List, Button } from './utils/test-utils';
 
 const toast: Toast.Root.ToastObject = {
@@ -18,6 +20,11 @@ const toast: Toast.Root.ToastObject = {
 // no production bytes.
 describe('Toast enum sync', () => {
   const { render } = createRenderer();
+
+  it('names the swipe direction attribute per ToastRootDataAttributes', () => {
+    const emitted = toastRootStateAttributesMapping.swipeDirection!('left');
+    expect(Object.keys(emitted!)[0]).toBe(ToastRootDataAttributes.swipeDirection);
+  });
 
   it('names the root CSS variables per ToastRootCssVars', async () => {
     const { user } = await render(

--- a/packages/react/src/toast/positioner/ToastPositioner.tsx
+++ b/packages/react/src/toast/positioner/ToastPositioner.tsx
@@ -14,7 +14,6 @@ import { ToastPositionerContext } from './ToastPositionerContext';
 import { useFloatingRootContext } from '../../floating-ui-react';
 import { NOOP } from '../../internals/noop';
 import type { ToastObject } from '../useToastManager';
-import { ToastRootCssVars } from '../root/ToastRootCssVars';
 import { useToastProviderContext } from '../provider/ToastProviderContext';
 import { usePositioner } from '../../utils/usePositioner';
 
@@ -89,20 +88,16 @@ export const ToastPositioner = React.forwardRef(function ToastPositioner(
     collisionAvoidance,
   });
 
-  const state: ToastPositionerState = React.useMemo(
-    () => ({
-      side: positioning.side,
-      align: positioning.align,
-      anchorHidden: positioning.anchorHidden,
-    }),
-    [positioning.side, positioning.align, positioning.anchorHidden],
-  );
+  const state: ToastPositionerState = {
+    side: positioning.side,
+    align: positioning.align,
+    anchorHidden: positioning.anchorHidden,
+  };
 
   const element = usePositioner(componentProps, state, {
     styles: {
       ...positioning.positionerStyles,
-      [ToastRootCssVars.index as string]:
-        toast.transitionStatus === 'ending' ? domIndex : visibleIndex,
+      ['--toast-index' as string]: toast.transitionStatus === 'ending' ? domIndex : visibleIndex,
     },
     transitionStatus: toast.transitionStatus,
     props: elementProps,

--- a/packages/react/src/toast/provider/ToastProvider.tsx
+++ b/packages/react/src/toast/provider/ToastProvider.tsx
@@ -59,7 +59,7 @@ export const ToastProvider: React.FC<ToastProvider.Props> = function ToastProvid
   // `limit` needs custom syncing because changing it must also recompute each
   // toast's `limited` flag; `useSyncedValues` would only update the raw value.
   useIsoLayoutEffect(() => {
-    store.syncProviderProps({ timeout, limit });
+    store.syncProviderProps(timeout, limit);
   }, [store, timeout, limit]);
 
   return <ToastContext.Provider value={store}>{children}</ToastContext.Provider>;

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -86,6 +86,66 @@ describe('<Toast.Root />', () => {
     },
   }));
 
+  it('keeps dynamic title and description ids synchronized with mounted label parts', async () => {
+    function App() {
+      const [mode, setMode] = React.useState<'fallback' | 'explicit' | 'none' | 'restored'>(
+        'fallback',
+      );
+      const showLabels = mode !== 'none';
+      const explicit = mode === 'explicit';
+
+      return (
+        <Toast.Provider>
+          <button type="button" onClick={() => setMode('explicit')}>
+            explicit
+          </button>
+          <button type="button" onClick={() => setMode('none')}>
+            none
+          </button>
+          <button type="button" onClick={() => setMode('restored')}>
+            restore
+          </button>
+          <Toast.Viewport>
+            <Toast.Root toast={{ ...toast, description: 'Toast description' }} data-testid="root">
+              {showLabels && (
+                <React.Fragment>
+                  <Toast.Title data-testid="title">
+                    {explicit ? 'Explicit title' : undefined}
+                  </Toast.Title>
+                  <Toast.Description data-testid="description">
+                    {explicit ? 'Explicit description' : undefined}
+                  </Toast.Description>
+                </React.Fragment>
+              )}
+            </Toast.Root>
+          </Toast.Viewport>
+        </Toast.Provider>
+      );
+    }
+
+    const { user } = await render(<App />);
+    const root = screen.getByTestId('root');
+
+    expect(root).toHaveAttribute('aria-labelledby', screen.getByTestId('title').id);
+    expect(root).toHaveAttribute('aria-describedby', screen.getByTestId('description').id);
+
+    await user.click(screen.getByRole('button', { name: 'explicit' }));
+    expect(root).toHaveAttribute('aria-labelledby', screen.getByTestId('title').id);
+    expect(root).toHaveAttribute('aria-describedby', screen.getByTestId('description').id);
+    expect(screen.getByTestId('title')).toHaveTextContent('Explicit title');
+    expect(screen.getByTestId('description')).toHaveTextContent('Explicit description');
+
+    await user.click(screen.getByRole('button', { name: 'none' }));
+    expect(root).not.toHaveAttribute('aria-labelledby');
+    expect(root).not.toHaveAttribute('aria-describedby');
+
+    await user.click(screen.getByRole('button', { name: 'restore' }));
+    expect(root).toHaveAttribute('aria-labelledby', screen.getByTestId('title').id);
+    expect(root).toHaveAttribute('aria-describedby', screen.getByTestId('description').id);
+    expect(screen.getByTestId('title')).toHaveTextContent('Toast title');
+    expect(screen.getByTestId('description')).toHaveTextContent('Toast description');
+  });
+
   it.skipIf(isJSDOM)('recalculates height when content mutates', async () => {
     function ToastList() {
       return Toast.useToastManager().toasts.map((toastItem) => (
@@ -232,6 +292,58 @@ describe('<Toast.Root />', () => {
         </Toast.Root>
       ));
     }
+
+    it.each([
+      ['left', -60, 0],
+      ['right', 60, 0],
+      ['up', 0, -60],
+      ['down', 0, 60],
+    ] as const)('dismisses with a real %s pointer swipe', async (direction, deltaX, deltaY) => {
+      const { user } = await render(
+        <Toast.Provider>
+          <Toast.Viewport>
+            <SwipeTestToast swipeDirection={direction} />
+          </Toast.Viewport>
+          <SwipeTestButton />
+        </Toast.Provider>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'add toast' }));
+      const toastElement = screen.getByTestId('toast-root');
+      Object.defineProperty(toastElement, 'setPointerCapture', {
+        configurable: true,
+        value: () => {},
+      });
+      Object.defineProperty(toastElement, 'releasePointerCapture', {
+        configurable: true,
+        value: () => {},
+      });
+      const rect = toastElement.getBoundingClientRect();
+      const start = {
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+      };
+
+      await user.pointer([
+        { target: toastElement, coords: start, keys: '[TouchA>]' },
+        {
+          target: toastElement,
+          pointerName: 'TouchA',
+          coords: {
+            clientX: start.clientX + Math.sign(deltaX),
+            clientY: start.clientY + Math.sign(deltaY),
+          },
+        },
+        {
+          target: toastElement,
+          pointerName: 'TouchA',
+          coords: { clientX: start.clientX + deltaX, clientY: start.clientY + deltaY },
+        },
+        { keys: '[/TouchA]' },
+      ]);
+
+      await waitFor(() => expect(screen.queryByTestId('toast-root')).toBe(null));
+    });
 
     it('closes toast when swiping in the specified direction beyond threshold', async () => {
       await render(

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -16,7 +16,6 @@ import { useToastProviderContext } from '../provider/ToastProviderContext';
 import { StateAttributesMapping } from '../../internals/getStateAttributesProps';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useOpenChangeComplete } from '../../internals/useOpenChangeComplete';
-import { ToastRootCssVars } from './ToastRootCssVars';
 import {
   BASE_UI_SWIPE_IGNORE_SELECTOR,
   LEGACY_SWIPE_IGNORE_SELECTOR,
@@ -71,7 +70,6 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
   >(undefined);
   const [isSwiping, setIsSwiping] = React.useState(false);
   const [isRealSwipe, setIsRealSwipe] = React.useState(false);
-  const [dragDismissed, setDragDismissed] = React.useState(false);
   const [dragOffset, setDragOffset] = React.useState({ x: 0, y: 0 });
   const [initialTransform, setInitialTransform] = React.useState({ x: 0, y: 0, scale: 1 });
   const [titleId, setTitleId] = React.useState<string | undefined>();
@@ -129,7 +127,7 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
       store.updateToastInternal(toast.id, {
         ref: rootRef,
         height,
-        ...(toast.transitionStatus === 'starting' ? { transitionStatus: undefined } : {}),
+        transitionStatus: undefined,
       });
     }
 
@@ -154,40 +152,22 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
   }, []);
 
   function applyDirectionalDamping(deltaX: number, deltaY: number) {
-    let newDeltaX = deltaX;
-    let newDeltaY = deltaY;
+    const damp = (delta: number) =>
+      delta > 0
+        ? delta ** OPPOSITE_DIRECTION_DAMPING_FACTOR
+        : -(Math.abs(delta) ** OPPOSITE_DIRECTION_DAMPING_FACTOR);
 
-    if (!swipeDirections.includes('left') && !swipeDirections.includes('right')) {
-      newDeltaX =
-        deltaX > 0
-          ? deltaX ** OPPOSITE_DIRECTION_DAMPING_FACTOR
-          : -(Math.abs(deltaX) ** OPPOSITE_DIRECTION_DAMPING_FACTOR);
-    } else {
-      if (!swipeDirections.includes('right') && deltaX > 0) {
-        newDeltaX = deltaX ** OPPOSITE_DIRECTION_DAMPING_FACTOR;
-      }
+    const dampX =
+      (deltaX > 0 && !swipeDirections.includes('right')) ||
+      (deltaX < 0 && !swipeDirections.includes('left'));
+    const dampY =
+      (deltaY > 0 && !swipeDirections.includes('down')) ||
+      (deltaY < 0 && !swipeDirections.includes('up'));
 
-      if (!swipeDirections.includes('left') && deltaX < 0) {
-        newDeltaX = -(Math.abs(deltaX) ** OPPOSITE_DIRECTION_DAMPING_FACTOR);
-      }
-    }
-
-    if (!swipeDirections.includes('up') && !swipeDirections.includes('down')) {
-      newDeltaY =
-        deltaY > 0
-          ? deltaY ** OPPOSITE_DIRECTION_DAMPING_FACTOR
-          : -(Math.abs(deltaY) ** OPPOSITE_DIRECTION_DAMPING_FACTOR);
-    } else {
-      if (!swipeDirections.includes('down') && deltaY > 0) {
-        newDeltaY = deltaY ** OPPOSITE_DIRECTION_DAMPING_FACTOR;
-      }
-
-      if (!swipeDirections.includes('up') && deltaY < 0) {
-        newDeltaY = -(Math.abs(deltaY) ** OPPOSITE_DIRECTION_DAMPING_FACTOR);
-      }
-    }
-
-    return { x: newDeltaX, y: newDeltaY };
+    return {
+      x: dampX ? damp(deltaX) : deltaX,
+      y: dampY ? damp(deltaY) : deltaY,
+    };
   }
 
   const handleSwipeEnd = useStableCallback((event: React.PointerEvent | PointerEvent) => {
@@ -210,50 +190,20 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
       return;
     }
 
-    let shouldClose = false;
     const resolvedDragOffset = dragOffsetRef.current;
     const deltaX = resolvedDragOffset.x - resolvedInitialTransform.x;
     const deltaY = resolvedDragOffset.y - resolvedInitialTransform.y;
     let dismissDirection: 'up' | 'down' | 'left' | 'right' | undefined;
 
     for (const direction of swipeDirections) {
-      switch (direction) {
-        case 'right':
-          if (deltaX > SWIPE_THRESHOLD) {
-            shouldClose = true;
-            dismissDirection = 'right';
-          }
-          break;
-        case 'left':
-          if (deltaX < -SWIPE_THRESHOLD) {
-            shouldClose = true;
-            dismissDirection = 'left';
-          }
-          break;
-        case 'down':
-          if (deltaY > SWIPE_THRESHOLD) {
-            shouldClose = true;
-            dismissDirection = 'down';
-          }
-          break;
-        case 'up':
-          if (deltaY < -SWIPE_THRESHOLD) {
-            shouldClose = true;
-            dismissDirection = 'up';
-          }
-          break;
-        default:
-          break;
-      }
-
-      if (shouldClose) {
+      if (getDisplacement(direction, deltaX, deltaY) > SWIPE_THRESHOLD) {
+        dismissDirection = direction;
         break;
       }
     }
 
-    if (shouldClose) {
+    if (dismissDirection) {
       setCurrentSwipeDirection(dismissDirection);
-      setDragDismissed(true);
       store.closeToast(toast.id);
     } else {
       setResolvedDragOffset({ x: resolvedInitialTransform.x, y: resolvedInitialTransform.y });
@@ -272,9 +222,9 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
 
     const target = getTarget(event.nativeEvent) as HTMLElement | null;
 
-    const isInteractiveElement = target
-      ? target.closest(`button,a,input,textarea,[role="button"],${TOAST_SWIPE_IGNORE_SELECTOR}`)
-      : false;
+    const isInteractiveElement = target?.closest(
+      `button,a,input,textarea,[role="button"],${TOAST_SWIPE_IGNORE_SELECTOR}`,
+    );
 
     if (isInteractiveElement) {
       return;
@@ -297,7 +247,7 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
       });
     }
 
-    store.setHovering(true);
+    store.set('hovering', true);
     setIsSwiping(true);
     setIsRealSwipe(false);
     setLockedDirection(null);
@@ -416,22 +366,15 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     let newOffsetX = initialTransformRef.current.x;
     let newOffsetY = initialTransformRef.current.y;
 
-    if (lockedDirection === 'horizontal') {
-      if (swipeDirections.includes('left') || swipeDirections.includes('right')) {
-        newOffsetX += dampedDelta.x;
-      }
-    } else if (lockedDirection === 'vertical') {
-      if (swipeDirections.includes('up') || swipeDirections.includes('down')) {
-        newOffsetY += dampedDelta.y;
-      }
-    } else {
-      if (swipeDirections.includes('left') || swipeDirections.includes('right')) {
-        newOffsetX += dampedDelta.x;
-      }
+    const hasHorizontalDir = swipeDirections.includes('left') || swipeDirections.includes('right');
+    const hasVerticalDir = swipeDirections.includes('up') || swipeDirections.includes('down');
 
-      if (swipeDirections.includes('up') || swipeDirections.includes('down')) {
-        newOffsetY += dampedDelta.y;
-      }
+    if (lockedDirection !== 'vertical' && hasHorizontalDir) {
+      newOffsetX += dampedDelta.x;
+    }
+
+    if (lockedDirection !== 'horizontal' && hasVerticalDir) {
+      newOffsetY += dampedDelta.y;
     }
 
     setResolvedDragOffset({ x: newOffsetX, y: newOffsetY });
@@ -477,18 +420,6 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
   }, [swipeEnabled]);
 
   function getDragStyles() {
-    if (
-      !isSwiping &&
-      dragOffset.x === initialTransform.x &&
-      dragOffset.y === initialTransform.y &&
-      !dragDismissed
-    ) {
-      return {
-        [ToastRootCssVars.swipeMovementX]: '0px',
-        [ToastRootCssVars.swipeMovementY]: '0px',
-      };
-    }
-
     const deltaX = dragOffset.x - initialTransform.x;
     const deltaY = dragOffset.y - initialTransform.y;
 
@@ -499,8 +430,8 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
       transform: isSwiping
         ? `translateX(${dragOffset.x}px) translateY(${dragOffset.y}px) scale(${initialTransform.scale})`
         : undefined,
-      [ToastRootCssVars.swipeMovementX]: `${deltaX}px`,
-      [ToastRootCssVars.swipeMovementY]: `${deltaY}px`,
+      ['--toast-swipe-movement-x']: `${deltaX}px`,
+      ['--toast-swipe-movement-y']: `${deltaY}px`,
     };
   }
 
@@ -521,39 +452,22 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     inert: inertValue(toast.limited),
     style: {
       ...getDragStyles(),
-      [ToastRootCssVars.index as string]:
-        toast.transitionStatus === 'ending' ? domIndex : visibleIndex,
-      [ToastRootCssVars.offsetY as string]: `${offsetY}px`,
-      [ToastRootCssVars.height as string]: toast.height ? `${toast.height}px` : undefined,
+      ['--toast-index' as string]: toast.transitionStatus === 'ending' ? domIndex : visibleIndex,
+      ['--toast-offset-y' as string]: `${offsetY}px`,
+      ['--toast-height' as string]: toast.height ? `${toast.height}px` : undefined,
     },
   };
 
   const toastRoot: ToastRootContext = React.useMemo(
     () => ({
-      rootRef,
       toast,
-      titleId,
       setTitleId,
-      descriptionId,
       setDescriptionId,
-      swiping: isSwiping,
-      swipeDirection: currentSwipeDirection,
       recalculateHeight,
-      index: domIndex,
       visibleIndex,
       expanded,
     }),
-    [
-      toast,
-      titleId,
-      descriptionId,
-      isSwiping,
-      currentSwipeDirection,
-      recalculateHeight,
-      domIndex,
-      visibleIndex,
-      expanded,
-    ],
+    [toast, setTitleId, setDescriptionId, recalculateHeight, visibleIndex, expanded],
   );
 
   const state: ToastRootState = {
@@ -561,12 +475,12 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     expanded,
     limited: toast.limited || false,
     type: toast.type,
-    swiping: toastRoot.swiping,
-    swipeDirection: toastRoot.swipeDirection,
+    swiping: isSwiping,
+    swipeDirection: currentSwipeDirection,
   };
 
   const element = useRenderElement('div', componentProps, {
-    ref: [forwardedRef, toastRoot.rootRef],
+    ref: [forwardedRef, rootRef],
     state,
     stateAttributesMapping,
     props: [defaultProps, elementProps],

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../internals/constants';
 import { getDisplacement, getElementTransform } from '../../utils/useSwipeDismiss';
 
-const stateAttributesMapping: StateAttributesMapping<ToastRootState> = {
+export const toastRootStateAttributesMapping: StateAttributesMapping<ToastRootState> = {
   ...transitionStatusMapping,
   swipeDirection(value) {
     return value ? { 'data-swipe-direction': value } : null;
@@ -482,7 +482,7 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
   const element = useRenderElement('div', componentProps, {
     ref: [forwardedRef, rootRef],
     state,
-    stateAttributesMapping,
+    stateAttributesMapping: toastRootStateAttributesMapping,
     props: [defaultProps, elementProps],
   });
 

--- a/packages/react/src/toast/root/ToastRootContext.ts
+++ b/packages/react/src/toast/root/ToastRootContext.ts
@@ -4,14 +4,8 @@ import type { ToastObject } from '../useToastManager';
 
 export interface ToastRootContext {
   toast: ToastObject<any>;
-  rootRef: React.RefObject<HTMLElement | null>;
-  titleId: string | undefined;
   setTitleId: React.Dispatch<React.SetStateAction<string | undefined>>;
-  descriptionId: string | undefined;
   setDescriptionId: React.Dispatch<React.SetStateAction<string | undefined>>;
-  swiping: boolean;
-  swipeDirection: 'up' | 'down' | 'left' | 'right' | undefined;
-  index: number;
   visibleIndex: number;
   expanded: boolean;
   recalculateHeight: (flushSync?: boolean) => void;

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -54,7 +54,7 @@ describe('ToastStore', () => {
     expectToastMetadataToMatchToasts(store);
     expect(selectors.toast(store.state, 'middle')?.transitionStatus).toBe('ending');
 
-    store.removeToast('middle', { skipOnRemove: true });
+    store.removeToast('middle', true);
 
     expectToastMetadataToMatchToasts(store);
 
@@ -68,12 +68,12 @@ describe('ToastStore', () => {
       // Ordered newest-first, matching how `addToast` prepends.
       const store = createStore([{ id: 'c' }, { id: 'b' }, { id: 'a' }]);
 
-      store.syncProviderProps({ timeout: 0, limit: 1 });
+      store.syncProviderProps(0, 1);
       expect(selectors.toast(store.state, 'c')?.limited).toBe(false);
       expect(selectors.toast(store.state, 'b')?.limited).toBe(true);
       expect(selectors.toast(store.state, 'a')?.limited).toBe(true);
 
-      store.syncProviderProps({ timeout: 0, limit: 3 });
+      store.syncProviderProps(0, 3);
       expect(selectors.toast(store.state, 'c')?.limited).toBe(false);
       expect(selectors.toast(store.state, 'b')?.limited).toBe(false);
       expect(selectors.toast(store.state, 'a')?.limited).toBe(false);

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -63,6 +63,25 @@ describe('ToastStore', () => {
     expectToastMetadataToMatchToasts(store);
   });
 
+  it('ignores height recalculations while a toast is transitioning out', () => {
+    const store = createStore([{ id: 'a', height: 40 }]);
+
+    store.closeToast('a');
+    expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe('ending');
+
+    // Mirrors the write `recalculateHeight` makes when a content observer fires:
+    // it always includes `transitionStatus: undefined`. The ending toast must stay
+    // ending so `useOpenChangeComplete` still removes it.
+    store.updateToastInternal('a', { height: 80, transitionStatus: undefined });
+
+    const toast = selectors.toast(store.state, 'a');
+    expect(toast?.transitionStatus).toBe('ending');
+    expect(toast?.height).toBe(0);
+
+    store.removeToast('a', true);
+    expect(selectors.toast(store.state, 'a')).toBe(undefined);
+  });
+
   describe('limit', () => {
     it('recomputes limited flags when the limit changes', () => {
       // Ordered newest-first, matching how `addToast` prepends.

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -13,13 +13,6 @@ import { activeElement, contains, getTarget } from '../floating-ui-react/utils';
 import { isFocusVisible } from './utils/focusVisible';
 
 type ToastInternalUpdateOptions<Data extends object> = Partial<Omit<ToastObject<Data>, 'id'>>;
-type UpdateToastBehavior = {
-  resetTimer?: boolean | undefined;
-  markUpdated?: boolean | undefined;
-};
-type RemoveToastBehavior = {
-  skipOnRemove?: boolean | undefined;
-};
 
 export type State = {
   toasts: ToastObject<any>[];
@@ -103,7 +96,6 @@ export const selectors = {
     toastMetadataSelector,
     (toastMetadata, id: string) => toastMetadata.get(id)?.visibleIndex ?? -1,
   ),
-  hovering: createSelector((state: State) => state.hovering),
   focused: createSelector((state: State) => state.focused),
   expanded: createSelector((state: State) => state.hovering || state.focused),
   expandedOrOutOfFocus: createSelector(
@@ -128,40 +120,24 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     );
   }
 
-  setFocused(focused: boolean) {
-    this.set('focused', focused);
-  }
-
-  setHovering(hovering: boolean) {
-    this.set('hovering', hovering);
-  }
-
-  setIsWindowFocused(isWindowFocused: boolean) {
-    this.set('isWindowFocused', isWindowFocused);
-  }
-
-  setPrevFocusElement(prevFocusElement: HTMLElement | null) {
-    this.set('prevFocusElement', prevFocusElement);
-  }
-
   setViewport = (viewport: HTMLElement | null) => {
     this.set('viewport', viewport);
   };
 
-  syncProviderProps(props: Pick<State, 'timeout' | 'limit'>) {
-    const limitChanged = this.state.limit !== props.limit;
+  syncProviderProps(timeout: number, limit: number) {
+    const limitChanged = this.state.limit !== limit;
 
-    if (this.state.timeout === props.timeout && !limitChanged) {
+    if (this.state.timeout === timeout && !limitChanged) {
       return;
     }
 
     const updates: Partial<State> = {
-      timeout: props.timeout,
-      limit: props.limit,
+      timeout,
+      limit,
     };
 
     if (limitChanged) {
-      const newToasts = applyLimited(this.state.toasts, props.limit);
+      const newToasts = applyLimited(this.state.toasts, limit);
       updates.toasts = newToasts;
       updates.toastMetadata = createToastMetadata(newToasts);
     }
@@ -178,14 +154,14 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     };
   };
 
-  removeToast(toastId: string, behavior: RemoveToastBehavior = {}) {
+  removeToast(toastId: string, skipOnRemove: boolean = false) {
     const index = selectors.toastIndex(this.state, toastId);
     if (index === -1) {
       return;
     }
 
     const toast = this.state.toasts[index];
-    if (!behavior.skipOnRemove) {
+    if (!skipOnRemove) {
       toast?.onRemove?.();
     }
 
@@ -203,13 +179,10 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
 
       if (existingToast) {
         if (existingToast.transitionStatus === 'ending') {
-          this.removeToast(toast.id, { skipOnRemove: true });
+          this.removeToast(toast.id, true);
         } else {
           const { id: ignoredId, transitionStatus: ignoredTransitionStatus, ...updates } = toast;
-          this.updateToastInternal(toast.id, updates, {
-            resetTimer: true,
-            markUpdated: true,
-          });
+          this.updateToastInternal(toast.id, updates, true, true);
           return toast.id;
         }
       }
@@ -238,16 +211,17 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
   };
 
   updateToast = <Data extends object>(id: string, updates: ToastManagerUpdateOptions<Data>) => {
-    this.updateToastInternal(id, updates, { markUpdated: true });
+    this.updateToastInternal(id, updates, false, true);
   };
 
   updateToastInternal = <Data extends object>(
     id: string,
     updates: ToastInternalUpdateOptions<Data>,
-    behavior: UpdateToastBehavior = {},
+    resetTimer: boolean = false,
+    markUpdated: boolean = false,
   ) => {
     const { timeout, toasts } = this.state;
-    const prevToast = selectors.toast(this.state, id) ?? null;
+    const prevToast = selectors.toast(this.state, id);
     if (!prevToast) {
       return;
     }
@@ -262,7 +236,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     const nextToast: ToastObject<Data> = {
       ...prevToast,
       ...updates,
-      ...(behavior.markUpdated && {
+      ...(markUpdated && {
         updateKey: (prevToast.updateKey ?? 0) + 1,
       }),
     };
@@ -270,7 +244,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     this.setToasts(toasts.map((toast) => (toast.id === id ? nextToast : toast)));
 
     const nextTimeout = nextToast.timeout ?? timeout;
-    const prevTimeout = prevToast?.timeout ?? timeout;
+    const prevTimeout = prevToast.timeout ?? timeout;
 
     const timeoutUpdated = Object.hasOwn(updates, 'timeout');
 
@@ -279,7 +253,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
 
     const hasTimer = this.timers.has(id);
     const timeoutChanged = prevTimeout !== nextTimeout;
-    const wasLoading = prevToast?.type === 'loading';
+    const wasLoading = prevToast.type === 'loading';
 
     if (!shouldHaveTimer && hasTimer) {
       this.clearTimer(id);
@@ -289,7 +263,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     // Schedule or reschedule timer if needed
     if (
       shouldHaveTimer &&
-      (!hasTimer || timeoutChanged || timeoutUpdated || wasLoading || behavior.resetTimer)
+      (!hasTimer || timeoutChanged || timeoutUpdated || wasLoading || resetTimer)
     ) {
       this.clearTimer(id);
 
@@ -324,17 +298,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
         : item,
     );
     const newToasts = applyLimited(endingToasts, limit);
-
-    const updates: Partial<State> = {
-      toasts: newToasts,
-      toastMetadata: createToastMetadata(newToasts),
-    };
-    const hasActiveToasts = newToasts.some((toast) => toast.transitionStatus !== 'ending');
-    if (!hasActiveToasts) {
-      updates.hovering = false;
-      updates.focused = false;
-    }
-    this.update(updates);
+    this.setToasts(newToasts, !newToasts.some((toast) => toast.transitionStatus !== 'ending'));
 
     toastsToClose.forEach((toast) => {
       if (toast.transitionStatus !== 'ending') {
@@ -450,7 +414,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
 
     this.timers.set(id, {
       timeout: currentTimeout,
-      start: shouldStartActive ? start : 0,
+      start,
       delay,
       remaining: delay,
       callback,
@@ -486,12 +450,15 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     }
   }
 
-  private setToasts(newToasts: ToastObject<any>[]) {
+  private setToasts(
+    newToasts: ToastObject<any>[],
+    clearInteraction: boolean = newToasts.length === 0,
+  ) {
     const updates: Partial<State> = {
       toasts: newToasts,
       toastMetadata: createToastMetadata(newToasts),
     };
-    if (newToasts.length === 0) {
+    if (clearInteraction) {
       updates.hovering = false;
       updates.focused = false;
     }
@@ -515,29 +482,18 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
 
     const toasts = selectors.toasts(this.state);
     const currentIndex = selectors.toastIndex(this.state, toastId);
-    let nextToast: ToastObject<any> | null = null;
 
-    // Try to find the next toast that isn't animating out
-    let index = currentIndex + 1;
-    while (index < toasts.length) {
-      if (toasts[index].transitionStatus !== 'ending') {
-        nextToast = toasts[index];
-        break;
-      }
-      index += 1;
-    }
-
-    // Go backwards if no next toast is found
-    if (!nextToast) {
-      index = currentIndex - 1;
-      while (index >= 0) {
+    const scan = (from: number, step: number) => {
+      for (let index = from; index >= 0 && index < toasts.length; index += step) {
         if (toasts[index].transitionStatus !== 'ending') {
-          nextToast = toasts[index];
-          break;
+          return toasts[index];
         }
-        index -= 1;
       }
-    }
+      return null;
+    };
+
+    // Try to find the next toast that isn't animating out, then fall back to the previous one.
+    const nextToast = scan(currentIndex + 1, 1) ?? scan(currentIndex - 1, -1);
 
     if (nextToast) {
       nextToast.ref?.current?.focus();

--- a/packages/react/src/toast/title/ToastTitle.tsx
+++ b/packages/react/src/toast/title/ToastTitle.tsx
@@ -1,10 +1,8 @@
 'use client';
 import * as React from 'react';
-import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { useId } from '@base-ui/utils/useId';
 import type { BaseUIComponentProps } from '../../internals/types';
-import { useToastRootContext } from '../root/ToastRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
+import { useToastLabelPart } from '../utils/useToastLabelPart';
 
 /**
  * A title that labels the toast.
@@ -25,45 +23,17 @@ export const ToastTitle = React.forwardRef(function ToastTitle(
     ...elementProps
   } = componentProps;
 
-  const { toast, setTitleId } = useToastRootContext();
+  const { id, children, shouldRender, type } = useToastLabelPart(idProp, childrenProp, 'title');
 
-  const children = childrenProp ?? toast.title;
-
-  const shouldRender = Boolean(children);
-
-  const id = useId(idProp);
-
-  useIsoLayoutEffect(() => {
-    if (!shouldRender) {
-      return undefined;
-    }
-
-    setTitleId(id);
-
-    return () => {
-      setTitleId(undefined);
-    };
-  }, [shouldRender, id, setTitleId]);
-
-  const state: ToastTitleState = {
-    type: toast.type,
-  };
+  const state: ToastTitleState = { type };
 
   const element = useRenderElement('h2', componentProps, {
     ref: forwardedRef,
     state,
-    props: {
-      ...elementProps,
-      id,
-      children,
-    },
+    props: { ...elementProps, id, children },
   });
 
-  if (!shouldRender) {
-    return null;
-  }
-
-  return element;
+  return shouldRender ? element : null;
 });
 
 export interface ToastTitleState {

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -1,17 +1,13 @@
 'use client';
 import * as React from 'react';
-import { ToastContext } from './provider/ToastProviderContext';
+import { useToastProviderContext } from './provider/ToastProviderContext';
 import type { ToastPositionerProps } from './positioner/ToastPositioner';
 
 /**
  * Returns the array of toasts and methods to manage them.
  */
 export function useToastManager<Data extends object = any>(): UseToastManagerReturnValue<Data> {
-  const store = React.useContext(ToastContext);
-
-  if (!store) {
-    throw new Error('Base UI: useToastManager must be used within <Toast.Provider>.');
-  }
+  const store = useToastProviderContext();
 
   const toasts = store.useState('toasts');
 

--- a/packages/react/src/toast/utils/useToastLabelPart.ts
+++ b/packages/react/src/toast/utils/useToastLabelPart.ts
@@ -1,0 +1,39 @@
+'use client';
+import * as React from 'react';
+import { useId } from '@base-ui/utils/useId';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useToastRootContext } from '../root/ToastRootContext';
+
+/**
+ * Shared logic for `Toast.Title` and `Toast.Description`, which only differ by the rendered tag,
+ * the fallback content, and which id setter they register with. Resolves the content, registers the
+ * generated id with the root while the part renders, and returns the pieces each part passes to
+ * `useRenderElement`.
+ */
+export function useToastLabelPart(
+  idProp: string | undefined,
+  childrenProp: React.ReactNode,
+  part: 'title' | 'description',
+) {
+  const { toast, setTitleId, setDescriptionId } = useToastRootContext();
+
+  const setId = part === 'title' ? setTitleId : setDescriptionId;
+  const children = childrenProp ?? (part === 'title' ? toast.title : toast.description);
+  const shouldRender = Boolean(children);
+
+  const id = useId(idProp);
+
+  useIsoLayoutEffect(() => {
+    if (!shouldRender) {
+      return undefined;
+    }
+
+    setId(id);
+
+    return () => {
+      setId(undefined);
+    };
+  }, [shouldRender, id, setId]);
+
+  return { id, children, shouldRender, type: toast.type };
+}

--- a/packages/react/src/toast/viewport/ToastViewport.test.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.test.tsx
@@ -1,7 +1,9 @@
 import { expect, vi } from 'vitest';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { Toast } from '@base-ui/react/toast';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { act, fireEvent, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { List, Button } from '../utils/test-utils';
 
 describe('<Toast.Viewport />', () => {
@@ -13,6 +15,109 @@ describe('<Toast.Viewport />', () => {
       return render(<Toast.Provider>{node}</Toast.Provider>);
     },
   }));
+
+  it.skipIf(!isJSDOM)(
+    'rebinds owner-document listeners once across empty store cycles',
+    async () => {
+      const iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+      const iframeWindow = iframe.contentWindow;
+      const iframeDocument = iframe.contentDocument;
+      if (!iframeWindow || !iframeDocument) {
+        throw new Error('Expected iframe window and document.');
+      }
+      const iframeGlobal = iframeWindow as Window & typeof globalThis;
+
+      const portalContainer = iframeDocument.createElement('div');
+      iframeDocument.body.appendChild(portalContainer);
+      const addWindowListener = vi.spyOn(iframeWindow, 'addEventListener');
+      const removeWindowListener = vi.spyOn(iframeWindow, 'removeEventListener');
+      const addDocumentListener = vi.spyOn(iframeDocument, 'addEventListener');
+      const removeDocumentListener = vi.spyOn(iframeDocument, 'removeEventListener');
+
+      function Controls() {
+        const { add, close, toasts } = Toast.useToastManager();
+        return (
+          <React.Fragment>
+            <button type="button" onClick={() => add({ title: 'title' })}>
+              add alternate toast
+            </button>
+            <button type="button" onClick={() => close(toasts[0]?.id)}>
+              close alternate toast
+            </button>
+          </React.Fragment>
+        );
+      }
+
+      try {
+        const { user } = await render(
+          <Toast.Provider timeout={0}>
+            {ReactDOM.createPortal(
+              <Toast.Viewport data-testid="alternate-viewport">
+                <List />
+              </Toast.Viewport>,
+              portalContainer,
+            )}
+            <Controls />
+          </Toast.Provider>,
+        );
+
+        const add = screen.getByRole('button', { name: 'add alternate toast' });
+        const close = screen.getByRole('button', { name: 'close alternate toast' });
+
+        await user.click(add);
+        await waitFor(() =>
+          expect(iframeDocument.querySelector('[data-testid="root"]')).not.toBe(null),
+        );
+
+        expect(addWindowListener.mock.calls.filter(([type]) => type === 'keydown')).toHaveLength(1);
+        expect(addWindowListener.mock.calls.filter(([type]) => type === 'blur')).toHaveLength(1);
+        expect(addWindowListener.mock.calls.filter(([type]) => type === 'focus')).toHaveLength(1);
+        expect(
+          addDocumentListener.mock.calls.filter(([type]) => type === 'pointerdown'),
+        ).toHaveLength(1);
+
+        await act(async () => {
+          iframeWindow.dispatchEvent(new iframeGlobal.KeyboardEvent('keydown', { key: 'F6' }));
+        });
+        expect(iframeDocument.activeElement).toBe(
+          iframeDocument.querySelector('[data-testid="alternate-viewport"]'),
+        );
+
+        await user.click(close);
+        await waitFor(() =>
+          expect(iframeDocument.querySelector('[data-testid="root"]')).toBe(null),
+        );
+        expect(removeWindowListener.mock.calls.filter(([type]) => type === 'keydown')).toHaveLength(
+          1,
+        );
+        expect(removeWindowListener.mock.calls.filter(([type]) => type === 'blur')).toHaveLength(1);
+        expect(removeWindowListener.mock.calls.filter(([type]) => type === 'focus')).toHaveLength(
+          1,
+        );
+        expect(
+          removeDocumentListener.mock.calls.filter(([type]) => type === 'pointerdown'),
+        ).toHaveLength(1);
+
+        await user.click(add);
+        await waitFor(() =>
+          expect(iframeDocument.querySelector('[data-testid="root"]')).not.toBe(null),
+        );
+        expect(addWindowListener.mock.calls.filter(([type]) => type === 'keydown')).toHaveLength(2);
+        expect(addWindowListener.mock.calls.filter(([type]) => type === 'blur')).toHaveLength(2);
+        expect(addWindowListener.mock.calls.filter(([type]) => type === 'focus')).toHaveLength(2);
+        expect(
+          addDocumentListener.mock.calls.filter(([type]) => type === 'pointerdown'),
+        ).toHaveLength(2);
+      } finally {
+        addWindowListener.mockRestore();
+        removeWindowListener.mockRestore();
+        addDocumentListener.mockRestore();
+        removeDocumentListener.mockRestore();
+        iframe.remove();
+      }
+    },
+  );
 
   it('gets focused when F6 is pressed', async () => {
     const { user } = await render(

--- a/packages/react/src/toast/viewport/ToastViewport.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.tsx
@@ -11,7 +11,6 @@ import type { BaseUIComponentProps, HTMLProps } from '../../internals/types';
 import { useToastProviderContext } from '../provider/ToastProviderContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { isFocusVisible } from '../utils/focusVisible';
-import { ToastViewportCssVars } from './ToastViewportCssVars';
 
 /**
  * A container viewport for toasts.
@@ -37,56 +36,40 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
   const focused = store.useState('focused');
   const expanded = store.useState('expanded');
   const prevFocusElement = store.useState('prevFocusElement');
-  const frontmostHeight = toasts[0]?.height ?? 0;
+  const frontmostHeight = toasts[0]?.height;
 
-  const hasTransitioningToasts = React.useMemo(
-    () => toasts.some((toast) => toast.transitionStatus === 'ending'),
-    [toasts],
-  );
-  const highPriorityToasts = React.useMemo(
-    () => toasts.filter((toast) => toast.priority === 'high'),
-    [toasts],
-  );
-
-  // Listen globally for F6 so we can force-focus the viewport.
-  React.useEffect(() => {
-    const viewport = store.state.viewport;
-    if (!viewport) {
-      return undefined;
-    }
-
-    function handleGlobalKeyDown(event: KeyboardEvent) {
-      if (isEmpty) {
-        return;
-      }
-
-      if (event.key === 'F6' && getTarget(event) !== viewport) {
-        event.preventDefault();
-        store.setPrevFocusElement(activeElement(ownerDocument(viewport)) as HTMLElement | null);
-        viewport?.focus({ preventScroll: true });
-        store.pauseTimers();
-        store.setFocused(true);
-      }
-    }
-
-    const win = ownerWindow(viewport);
-    return addEventListener(win, 'keydown', handleGlobalKeyDown);
-  }, [store, isEmpty]);
+  const hasTransitioningToasts = toasts.some((toast) => toast.transitionStatus === 'ending');
+  const highPriorityToasts = toasts.filter((toast) => toast.priority === 'high');
 
   React.useEffect(() => {
+    // `store.state.viewport` isn't available on the first render, since the portal node hasn't yet
+    // been created. Depending on `isEmpty` ensures the listeners are attached once toasts exist and
+    // the viewport ref is available.
     const viewport = store.state.viewport;
     if (!viewport || isEmpty) {
       return undefined;
     }
 
     const win = ownerWindow(viewport);
+    const doc = ownerDocument(viewport);
+
+    // Listen globally for F6 so we can force-focus the viewport.
+    function handleGlobalKeyDown(event: KeyboardEvent) {
+      if (event.key === 'F6' && getTarget(event) !== viewport) {
+        event.preventDefault();
+        store.set('prevFocusElement', activeElement(doc) as HTMLElement | null);
+        viewport?.focus({ preventScroll: true });
+        store.pauseTimers();
+        store.set('focused', true);
+      }
+    }
 
     function handleWindowBlur(event: FocusEvent) {
       if (getTarget(event) !== win) {
         return;
       }
 
-      store.setIsWindowFocused(false);
+      store.set('isWindowFocused', false);
       store.pauseTimers();
     }
 
@@ -106,32 +89,16 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
       }
 
       // Wait for the `handleFocus` event to fire.
-      windowFocusTimeout.start(0, () => store.setIsWindowFocused(true));
+      windowFocusTimeout.start(0, () => store.set('isWindowFocused', true));
     }
 
     return mergeCleanups(
+      addEventListener(win, 'keydown', handleGlobalKeyDown),
       addEventListener(win, 'blur', handleWindowBlur, true),
       addEventListener(win, 'focus', handleWindowFocus, true),
+      addEventListener(doc, 'pointerdown', store.handleDocumentPointerDown, true),
     );
-  }, [
-    store,
-    windowFocusTimeout,
-    // `store.state.viewport` isn't available on the first render,
-    // since the portal node hasn't yet been created.
-    // By adding this dependency, we ensure the window listeners
-    // are added when toasts have been created, once the ref is available.
-    isEmpty,
-  ]);
-
-  React.useEffect(() => {
-    const viewport = store.state.viewport;
-    if (!viewport || isEmpty) {
-      return undefined;
-    }
-
-    const doc = ownerDocument(viewport);
-    return addEventListener(doc, 'pointerdown', store.handleDocumentPointerDown, true);
-  }, [isEmpty, store]);
+  }, [store, windowFocusTimeout, isEmpty]);
 
   function handleFocusGuard(event: React.FocusEvent) {
     const viewport = store.state.viewport;
@@ -183,7 +150,7 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
     if (store.state.isWindowFocused) {
       store.resumeTimers();
     }
-    store.setHovering(false);
+    store.set('hovering', false);
     markedReadyForMouseLeaveRef.current = false;
   }
 
@@ -191,7 +158,7 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
 
   function handleMouseEnter() {
     store.pauseTimers();
-    store.setHovering(true);
+    store.set('hovering', true);
     markedReadyForMouseLeaveRef.current = false;
   }
 
@@ -202,16 +169,10 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
   }
 
   function handleMouseLeave() {
-    const hasEndingToasts = store.state.toasts.some((toast) => toast.transitionStatus === 'ending');
-
-    if (hasEndingToasts || touchActiveRef.current) {
-      // When swiping to dismiss, wait until the transitions have settled
-      // or the touch interaction ends to avoid collapsing mid-gesture.
-      markedReadyForMouseLeaveRef.current = true;
-    } else {
-      resumeTimersIfWindowFocused();
-      store.setHovering(false);
-    }
+    // Defer to `flushMouseLeave`: while toasts are transitioning out or a touch gesture is active it
+    // records the intent and collapses later; otherwise it collapses immediately.
+    markedReadyForMouseLeaveRef.current = true;
+    flushMouseLeave();
   }
 
   function handlePointerDown(event: React.PointerEvent) {
@@ -243,7 +204,7 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
     // This prevents the viewport from staying expanded when clicking inside without
     // keyboard navigation.
     if (isFocusVisible(activeElement(ownerDocument(store.state.viewport)))) {
-      store.setFocused(true);
+      store.set('focused', true);
       store.pauseTimers();
     }
   }
@@ -253,7 +214,7 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
       return;
     }
 
-    store.setFocused(false);
+    store.set('focused', false);
     resumeTimersIfWindowFocused();
   }
 
@@ -274,31 +235,29 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
     onPointerDown: handlePointerDown,
     onPointerUp: handlePointerEnd,
     onPointerCancel: handlePointerEnd,
+    style: {
+      ['--toast-frontmost-height' as string]: frontmostHeight ? `${frontmostHeight}px` : undefined,
+    },
   };
 
   const state: ToastViewportState = {
     expanded,
   };
 
+  const focusGuard = !isEmpty && prevFocusElement && <FocusGuard onFocus={handleFocusGuard} />;
+
   const element = useRenderElement('div', componentProps, {
     ref: [forwardedRef, store.setViewport],
     state,
     props: [
       defaultProps,
-      {
-        style: {
-          [ToastViewportCssVars.frontmostHeight as string]: frontmostHeight
-            ? `${frontmostHeight}px`
-            : undefined,
-        },
-      },
       elementProps,
       {
         children: (
           <React.Fragment>
-            {!isEmpty && prevFocusElement && <FocusGuard onFocus={handleFocusGuard} />}
+            {focusGuard}
             {children}
-            {!isEmpty && prevFocusElement && <FocusGuard onFocus={handleFocusGuard} />}
+            {focusGuard}
           </React.Fragment>
         ),
       },
@@ -307,7 +266,7 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
 
   return (
     <React.Fragment>
-      {!isEmpty && prevFocusElement && <FocusGuard onFocus={handleFocusGuard} />}
+      {focusGuard}
       {element}
       {!focused && highPriorityToasts.length > 0 && (
         <div style={visuallyHidden}>


### PR DESCRIPTION
Reduces the `@base-ui/react/toast` bundle size without changing behavior or the public API. The bundle bot is authoritative for the current size impact.

This removes dead context members and selectors, deduplicates Title and Description logic, consolidates store and effect logic, and inlines internal CSS-variable enum values. Regression and enum-sync tests cover the retained behavior and strings.
