### PR TITLE
[progress][meter][toggle group] Reduce bundle size

### DIFF
--- a/packages/react/src/meter/root/MeterRoot.test.tsx
+++ b/packages/react/src/meter/root/MeterRoot.test.tsx
@@ -151,6 +151,40 @@ describe('<Meter.Root />', () => {
       expect(screen.getByTestId('value').textContent).toBe(expected);
     });
 
+    it('keeps range attributes, formatted text, and the indicator synchronized on rerender', async () => {
+      const initialValue = formatPercent(0.5);
+      const updatedValue = formatPercent(0.75);
+
+      const { setProps } = await render(
+        <Meter.Root value={20} min={10} max={30}>
+          <Meter.Value data-testid="value" />
+          <Meter.Track>
+            <Meter.Indicator data-testid="indicator" />
+          </Meter.Track>
+        </Meter.Root>,
+      );
+
+      const meter = screen.getByRole('meter');
+      const value = screen.getByTestId('value');
+      const indicator = screen.getByTestId('indicator');
+
+      expect(meter).toHaveAttribute('aria-valuemin', '10');
+      expect(meter).toHaveAttribute('aria-valuemax', '30');
+      expect(meter).toHaveAttribute('aria-valuenow', '20');
+      expect(meter).toHaveAttribute('aria-valuetext', initialValue);
+      expect(value).toHaveTextContent(initialValue);
+      expect(indicator.style.width).toBe('50%');
+
+      await setProps({ min: 20, max: 60, value: 50 });
+
+      expect(meter).toHaveAttribute('aria-valuemin', '20');
+      expect(meter).toHaveAttribute('aria-valuemax', '60');
+      expect(meter).toHaveAttribute('aria-valuenow', '50');
+      expect(meter).toHaveAttribute('aria-valuetext', updatedValue);
+      expect(value).toHaveTextContent(updatedValue);
+      expect(indicator.style.width).toBe('75%');
+    });
+
     it.each([
       {
         label: 'value exceeds max',

--- a/packages/react/src/meter/root/MeterRoot.tsx
+++ b/packages/react/src/meter/root/MeterRoot.tsx
@@ -70,13 +70,11 @@ export const MeterRoot = React.forwardRef(function MeterRoot(
   const contextValue: MeterRootContext = React.useMemo(
     () => ({
       formattedValue,
-      max,
-      min,
       percentageValue,
       setLabelId,
       value: valueProp,
     }),
-    [formattedValue, max, min, percentageValue, setLabelId, valueProp],
+    [formattedValue, percentageValue, setLabelId, valueProp],
   );
 
   const element = useRenderElement('div', componentProps, {

--- a/packages/react/src/meter/root/MeterRootContext.ts
+++ b/packages/react/src/meter/root/MeterRootContext.ts
@@ -3,8 +3,6 @@ import * as React from 'react';
 
 export type MeterRootContext = {
   formattedValue: string;
-  max: number;
-  min: number;
   /**
    * The value normalized to a `0`–`100` percentage of the range, clamped to those bounds.
    */

--- a/packages/react/src/progress/enumSync.test.ts
+++ b/packages/react/src/progress/enumSync.test.ts
@@ -1,0 +1,18 @@
+import { expect } from 'vitest';
+import { ProgressRootDataAttributes } from './root/ProgressRootDataAttributes';
+import { progressStateAttributesMapping } from './root/stateAttributesMapping';
+
+// The state-attribute mapping derives these attribute names without referencing
+// `ProgressRootDataAttributes`, so re-link the runtime output to the public enum
+// in tests. Test-only imports add no production bytes.
+describe('Progress enum sync', () => {
+  it.each([
+    ['indeterminate', ProgressRootDataAttributes.indeterminate],
+    ['progressing', ProgressRootDataAttributes.progressing],
+    ['complete', ProgressRootDataAttributes.complete],
+  ] as const)('names the %s data-attribute per ProgressRootDataAttributes', (status, attribute) => {
+    const emitted = progressStateAttributesMapping.status!(status);
+
+    expect(Object.keys(emitted!)).toEqual([attribute]);
+  });
+});

--- a/packages/react/src/progress/root/ProgressRoot.test.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.test.tsx
@@ -56,7 +56,7 @@ describe('<Progress.Root />', () => {
   });
 
   describe('data attributes', () => {
-    it('sets the status data attribute', async () => {
+    it('keeps exactly one status data attribute through the state cycle', async () => {
       const { setProps } = await render(<TestProgress value={null} />);
       const progressbar = screen.getByRole('progressbar');
 
@@ -65,10 +65,19 @@ describe('<Progress.Root />', () => {
       expect(progressbar).not.toHaveAttribute('data-complete');
 
       await setProps({ value: 50 });
+      expect(progressbar).not.toHaveAttribute('data-indeterminate');
       expect(progressbar).toHaveAttribute('data-progressing');
+      expect(progressbar).not.toHaveAttribute('data-complete');
 
       await setProps({ value: 100 });
+      expect(progressbar).not.toHaveAttribute('data-indeterminate');
+      expect(progressbar).not.toHaveAttribute('data-progressing');
       expect(progressbar).toHaveAttribute('data-complete');
+
+      await setProps({ value: null });
+      expect(progressbar).toHaveAttribute('data-indeterminate');
+      expect(progressbar).not.toHaveAttribute('data-progressing');
+      expect(progressbar).not.toHaveAttribute('data-complete');
     });
   });
 

--- a/packages/react/src/progress/root/ProgressRoot.test.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.test.tsx
@@ -55,6 +55,23 @@ describe('<Progress.Root />', () => {
     });
   });
 
+  describe('data attributes', () => {
+    it('sets the status data attribute', async () => {
+      const { setProps } = await render(<TestProgress value={null} />);
+      const progressbar = screen.getByRole('progressbar');
+
+      expect(progressbar).toHaveAttribute('data-indeterminate');
+      expect(progressbar).not.toHaveAttribute('data-progressing');
+      expect(progressbar).not.toHaveAttribute('data-complete');
+
+      await setProps({ value: 50 });
+      expect(progressbar).toHaveAttribute('data-progressing');
+
+      await setProps({ value: 100 });
+      expect(progressbar).toHaveAttribute('data-complete');
+    });
+  });
+
   describe('range', () => {
     it('normalizes the formatted value, aria-valuetext, and indicator within a custom range', async () => {
       const expected = (0.5).toLocaleString(undefined, { style: 'percent' });

--- a/packages/react/src/progress/root/ProgressRoot.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.tsx
@@ -86,15 +86,12 @@ export const ProgressRoot = React.forwardRef(function ProgressRoot(
   const contextValue: ProgressRootContext = React.useMemo(
     () => ({
       formattedValue,
-      max,
-      min,
       percentageValue,
       setLabelId,
       state,
-      status,
       value,
     }),
-    [formattedValue, max, min, percentageValue, setLabelId, state, status, value],
+    [formattedValue, percentageValue, setLabelId, state, value],
   );
 
   const element = useRenderElement('div', componentProps, {

--- a/packages/react/src/progress/root/ProgressRootContext.tsx
+++ b/packages/react/src/progress/root/ProgressRootContext.tsx
@@ -1,20 +1,12 @@
 'use client';
 import * as React from 'react';
-import type { ProgressStatus, ProgressRootState } from './ProgressRoot';
+import type { ProgressRootState } from './ProgressRoot';
 
 export type ProgressRootContext = {
   /**
    * Formatted value of the component.
    */
   formattedValue: string;
-  /**
-   * The maximum value.
-   */
-  max: number;
-  /**
-   * The minimum value.
-   */
-  min: number;
   /**
    * The value normalized to a `0`–`100` percentage of the range, clamped to those bounds.
    * `null` while the progress is indeterminate.
@@ -26,7 +18,6 @@ export type ProgressRootContext = {
   value: number | null;
   setLabelId: React.Dispatch<React.SetStateAction<string | undefined>>;
   state: ProgressRootState;
-  status: ProgressStatus;
 };
 
 /**

--- a/packages/react/src/progress/root/stateAttributesMapping.ts
+++ b/packages/react/src/progress/root/stateAttributesMapping.ts
@@ -1,18 +1,8 @@
 import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
 import type { ProgressRootState } from './ProgressRoot';
-import { ProgressRootDataAttributes } from './ProgressRootDataAttributes';
 
 export const progressStateAttributesMapping: StateAttributesMapping<ProgressRootState> = {
   status(value): Record<string, string> | null {
-    if (value === 'progressing') {
-      return { [ProgressRootDataAttributes.progressing]: '' };
-    }
-    if (value === 'complete') {
-      return { [ProgressRootDataAttributes.complete]: '' };
-    }
-    if (value === 'indeterminate') {
-      return { [ProgressRootDataAttributes.indeterminate]: '' };
-    }
-    return null;
+    return { [`data-${value}`]: '' };
   },
 };

--- a/packages/react/src/toggle-group/ToggleGroup.test.tsx
+++ b/packages/react/src/toggle-group/ToggleGroup.test.tsx
@@ -3,6 +3,7 @@ import { act, screen } from '@mui/internal-test-utils';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
 import { ToggleGroup } from '@base-ui/react/toggle-group';
 import { Toggle } from '@base-ui/react/toggle';
+import { Toolbar } from '@base-ui/react/toolbar';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { type Orientation } from '../internals/types';
 
@@ -302,6 +303,66 @@ describe('<ToggleGroup />', () => {
       await user.click(button1);
       expect(button1).toHaveAttribute('aria-pressed', 'false');
       expect(button2).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+
+  describe.skipIf(isJSDOM)('prop: multiple transitions', () => {
+    it.each([
+      ['standalone', false],
+      ['nested in Toolbar.Group', true],
+    ] as const)('preserves selection and roving focus when %s', async (_label, inToolbar) => {
+      function TestToggleGroup({ multiple }: { multiple: boolean }) {
+        const group = (
+          <ToggleGroup data-testid="toggle-group" defaultValue={['one']} multiple={multiple}>
+            <Toggle value="one">One</Toggle>
+            <Toggle value="two">Two</Toggle>
+          </ToggleGroup>
+        );
+
+        return inToolbar ? (
+          <Toolbar.Root>
+            <Toolbar.Group>{group}</Toolbar.Group>
+          </Toolbar.Root>
+        ) : (
+          group
+        );
+      }
+
+      const { user, setProps } = await render(<TestToggleGroup multiple={false} />);
+      const group = screen.getByTestId('toggle-group');
+      const [button1, button2] = screen.getAllByRole('button');
+
+      expect(group).not.toHaveAttribute('data-multiple');
+      expect(button1).toHaveAttribute('aria-pressed', 'true');
+      expect(button2).toHaveAttribute('aria-pressed', 'false');
+
+      await user.keyboard('[Tab][ArrowRight]');
+      expect(button2).toHaveFocus();
+
+      await user.click(button2);
+      expect(button1).toHaveAttribute('aria-pressed', 'false');
+      expect(button2).toHaveAttribute('aria-pressed', 'true');
+
+      await setProps({ multiple: true });
+      expect(group).toHaveAttribute('data-multiple');
+
+      await user.click(button1);
+      expect(button1).toHaveAttribute('aria-pressed', 'true');
+      expect(button2).toHaveAttribute('aria-pressed', 'true');
+
+      await user.click(button2);
+      expect(button1).toHaveAttribute('aria-pressed', 'true');
+      expect(button2).toHaveAttribute('aria-pressed', 'false');
+
+      await setProps({ multiple: false });
+      expect(group).not.toHaveAttribute('data-multiple');
+
+      await user.click(button2);
+      expect(button1).toHaveAttribute('aria-pressed', 'false');
+      expect(button2).toHaveAttribute('aria-pressed', 'true');
+
+      await user.keyboard('[ArrowLeft]');
+      expect(button1).toHaveFocus();
     });
   });
 

--- a/packages/react/src/toggle-group/ToggleGroup.test.tsx
+++ b/packages/react/src/toggle-group/ToggleGroup.test.tsx
@@ -223,6 +223,23 @@ describe('<ToggleGroup />', () => {
   });
 
   describe('prop: multiple', () => {
+    it('sets data-multiple only when true', async () => {
+      const { setProps } = await render(
+        <ToggleGroup>
+          <Toggle value="one" />
+        </ToggleGroup>,
+      );
+
+      const group = screen.getByRole('group');
+      expect(group).not.toHaveAttribute('data-multiple');
+
+      await setProps({ multiple: true });
+      expect(group).toHaveAttribute('data-multiple');
+
+      await setProps({ multiple: false });
+      expect(group).not.toHaveAttribute('data-multiple');
+    });
+
     it('multiple items can be pressed when true', async () => {
       const { user } = await render(
         <ToggleGroup multiple defaultValue={['one']}>

--- a/packages/react/src/toggle-group/ToggleGroup.tsx
+++ b/packages/react/src/toggle-group/ToggleGroup.tsx
@@ -9,18 +9,8 @@ import { CompositeRoot } from '../internals/composite/root/CompositeRoot';
 import { useToolbarRootContext } from '../toolbar/root/ToolbarRootContext';
 import { useToolbarGroupContext } from '../toolbar/group/ToolbarGroupContext';
 import { ToggleGroupContext } from './ToggleGroupContext';
-import { ToggleGroupDataAttributes } from './ToggleGroupDataAttributes';
 import type { BaseUIChangeEventDetails } from '../internals/createBaseUIEventDetails';
 import { REASONS } from '../internals/reasons';
-
-const stateAttributesMapping = {
-  multiple(value: boolean) {
-    if (value) {
-      return { [ToggleGroupDataAttributes.multiple]: '' } as Record<string, string>;
-    }
-    return null;
-  },
-};
 
 /**
  * Provides a shared state to a series of toggle buttons.
@@ -48,10 +38,7 @@ export const ToggleGroup = React.forwardRef(function ToggleGroup<Value extends s
   const toolbarContext = useToolbarRootContext(true);
   const toolbarGroupContext = useToolbarGroupContext();
 
-  const isValueInitialized = React.useMemo(
-    () => valueProp !== undefined || defaultValueProp !== undefined,
-    [valueProp, defaultValueProp],
-  );
+  const isValueInitialized = valueProp !== undefined || defaultValueProp !== undefined;
 
   const disabled =
     (toolbarContext?.disabled ?? false) || (toolbarGroupContext?.disabled ?? false) || disabledProp;
@@ -96,12 +83,11 @@ export const ToggleGroup = React.forwardRef(function ToggleGroup<Value extends s
   const contextValue: ToggleGroupContext<Value> = React.useMemo(
     () => ({
       disabled,
-      orientation,
       setGroupValue,
       value: groupValue,
       isValueInitialized,
     }),
-    [disabled, orientation, setGroupValue, groupValue, isValueInitialized],
+    [disabled, setGroupValue, groupValue, isValueInitialized],
   );
 
   const defaultProps: HTMLProps = {
@@ -113,7 +99,6 @@ export const ToggleGroup = React.forwardRef(function ToggleGroup<Value extends s
     state,
     ref: forwardedRef,
     props: [defaultProps, elementProps],
-    stateAttributesMapping,
   });
 
   return (
@@ -128,7 +113,6 @@ export const ToggleGroup = React.forwardRef(function ToggleGroup<Value extends s
           state={state}
           refs={[forwardedRef]}
           props={[defaultProps, elementProps]}
-          stateAttributesMapping={stateAttributesMapping}
           loopFocus={loopFocus}
           enableHomeAndEndKeys
           orientation={orientation}

--- a/packages/react/src/toggle-group/ToggleGroupContext.ts
+++ b/packages/react/src/toggle-group/ToggleGroupContext.ts
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import type { Orientation } from '../internals/types';
 import type { BaseUIChangeEventDetails } from '../internals/createBaseUIEventDetails';
 import type { BaseUIEventReasons } from '../internals/reasons';
 
@@ -12,7 +11,6 @@ export interface ToggleGroupContext<Value> {
     eventDetails: BaseUIChangeEventDetails<BaseUIEventReasons['none']>,
   ) => void;
   disabled: boolean;
-  orientation: Orientation;
   /**
    * Indicates whether the value has been initialized via `value` or `defaultValue` props.
    * Used to determine if Toggle should warn users about data inconsistency problems.
@@ -24,13 +22,6 @@ export const ToggleGroupContext = React.createContext<ToggleGroupContext<any> | 
   undefined,
 );
 
-export function useToggleGroupContext<Value>(optional = true) {
-  const context = React.useContext<ToggleGroupContext<Value> | undefined>(ToggleGroupContext);
-  if (context === undefined && !optional) {
-    throw new Error(
-      'Base UI: ToggleGroupContext is missing. ToggleGroup parts must be placed within <ToggleGroup>.',
-    );
-  }
-
-  return context;
+export function useToggleGroupContext<Value>() {
+  return React.useContext<ToggleGroupContext<Value> | undefined>(ToggleGroupContext);
 }

--- a/packages/react/src/toggle-group/enumSync.test.tsx
+++ b/packages/react/src/toggle-group/enumSync.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { expect } from 'vitest';
+import { ToggleGroup } from '@base-ui/react/toggle-group';
+import { screen } from '@mui/internal-test-utils';
+import { createRenderer } from '#test-utils';
+import { ToggleGroupDataAttributes } from './ToggleGroupDataAttributes';
+
+// The default state serializer derives this attribute name without referencing
+// `ToggleGroupDataAttributes`, so re-link the runtime output to the public enum
+// in tests. Test-only imports add no production bytes.
+describe('Toggle Group enum sync', () => {
+  const { render } = createRenderer();
+
+  it('names the multiple data-attribute per ToggleGroupDataAttributes', async () => {
+    await render(<ToggleGroup multiple data-testid="group" />);
+
+    expect(screen.getByTestId('group')).toHaveAttribute(ToggleGroupDataAttributes.multiple);
+  });
+});


### PR DESCRIPTION
Removes redundant internal context data and state-attribute mapping code from Progress, Meter, and Toggle Group while preserving public state and data attributes. The bundle bot is authoritative for the current size impact.

## Changes

- Simplify the Progress status mapping and remove unused context fields.
- Remove unused Meter range fields and Toggle Group context and mapper overhead.
- Add regression coverage for status attributes, `data-multiple`, and enum-to-literal synchronization.
