### PR TITLE
[field][form][fieldset] Reduce bundle size

### DIFF
--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -66,11 +66,6 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
     }
   }, [dirtyProp]);
 
-  const getRegisteredFieldId = React.useCallback(() => registeredFieldIdRef.current, []);
-  const setRegisteredFieldId = React.useCallback((id: string | undefined) => {
-    registeredFieldIdRef.current = id;
-  }, []);
-
   const setDirty: typeof setDirtyUnwrapped = useStableCallback((value) => {
     if (dirtyProp !== undefined) {
       return;
@@ -134,7 +129,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
     markedDirtyRef,
     state,
     shouldValidateOnChange,
-    getRegisteredFieldId,
+    registeredFieldIdRef,
   });
 
   const [validateFieldControl, registerFieldControl] = useFieldControlRegistration({
@@ -143,7 +138,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
     markedDirtyRef,
     name,
     setRegisteredFieldName,
-    setRegisteredFieldId,
+    registeredFieldIdRef,
     setValidityData,
     validityData,
   });
@@ -159,20 +154,13 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
       validityData,
       setValidityData,
       disabled,
-      touched,
       setTouched,
-      dirty,
       setDirty,
-      filled,
       setFilled,
-      focused,
       setFocused,
-      validate,
       validationMode,
-      validationDebounceTime,
       shouldValidateOnChange,
       state,
-      markedDirtyRef,
       registerFieldControl,
       validation,
     }),
@@ -181,17 +169,11 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
       effectiveName,
       validityData,
       disabled,
-      touched,
       setTouched,
-      dirty,
       setDirty,
-      filled,
       setFilled,
-      focused,
       setFocused,
-      validate,
       validationMode,
-      validationDebounceTime,
       shouldValidateOnChange,
       state,
       registerFieldControl,

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -15,27 +15,6 @@ import type { FieldValidityData, FieldRootState } from './FieldRoot';
 
 const validityKeys = Object.keys(DEFAULT_VALIDITY_STATE) as Array<keyof ValidityState>;
 
-function isOnlyValueMissing(state: Record<keyof ValidityState, boolean> | undefined) {
-  if (!state || state.valid || !state.valueMissing) {
-    return false;
-  }
-
-  let onlyValueMissing = false;
-
-  for (const key of validityKeys) {
-    if (key === 'valid') {
-      continue;
-    }
-    if (key === 'valueMissing') {
-      onlyValueMissing = state[key];
-    } else if (state[key]) {
-      onlyValueMissing = false;
-    }
-  }
-
-  return onlyValueMissing;
-}
-
 /**
  * Picks the input whose native validity should represent a field that owns several inputs (such as a
  * checkbox group). Prefers the first enabled currently-invalid input, where "first" follows Set
@@ -57,16 +36,10 @@ function findRepresentativeInput(inputs: Set<HTMLInputElement>): HTMLInputElemen
 }
 
 function clearCustomValidity(element: HTMLInputElement, inputs: Set<HTMLInputElement>) {
-  let didClearElement = false;
-
   for (const input of inputs) {
     input.setCustomValidity('');
-    didClearElement ||= input === element;
   }
-
-  if (!didClearElement) {
-    element.setCustomValidity('');
-  }
+  element.setCustomValidity('');
 }
 
 export function useFieldValidation(
@@ -83,7 +56,7 @@ export function useFieldValidation(
     markedDirtyRef,
     state,
     shouldValidateOnChange,
-    getRegisteredFieldId,
+    registeredFieldIdRef,
   } = params;
 
   const { controlId, getDescriptionProps } = useLabelableContext();
@@ -124,7 +97,7 @@ export function useFieldValidation(
       nextValidityData: FieldValidityData,
       externalInvalid = invalid,
     ) {
-      const fieldId = getRegisteredFieldId() ?? controlId;
+      const fieldId = registeredFieldIdRef.current ?? controlId;
       if (fieldId == null) {
         return;
       }
@@ -171,24 +144,7 @@ export function useFieldValidation(
         return;
       }
 
-      // Value is still missing, or other conditions apply.
-      // Let's use a representation of current validity for isOnlyValueMissing.
-      const currentNativeValidityObject = validityKeys.reduce(
-        (acc, key) => {
-          acc[key] = currentNativeValidity[key];
-          return acc;
-        },
-        {} as Record<keyof ValidityState, boolean>,
-      );
-
-      // If it's (still) natively invalid due to something other than just valueMissing,
-      // then bail from this revalidation on change to avoid "scolding" for other errors.
-      if (!currentNativeValidityObject.valid && !isOnlyValueMissing(currentNativeValidityObject)) {
-        return;
-      }
-
-      // If valueMissing is still true AND it's the only issue, or if the field is now natively valid,
-      // let it fall through to the main validation logic below.
+      // Value is still missing: fall through to the main validation logic below.
     }
 
     function getState(el: HTMLInputElement) {
@@ -351,7 +307,7 @@ export interface UseFieldValidationParameters {
   markedDirtyRef: React.RefObject<boolean>;
   state: FieldRootState;
   shouldValidateOnChange: () => boolean;
-  getRegisteredFieldId: () => string | undefined;
+  registeredFieldIdRef: React.RefObject<string | undefined>;
 }
 
 export interface UseFieldValidationReturnValue {

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -144,7 +144,17 @@ export function useFieldValidation(
         return;
       }
 
-      // Value is still missing: fall through to the main validation logic below.
+      // Avoid surfacing another error during change revalidation while the required value is
+      // still missing. The full validity state is published at the configured blur or submit
+      // boundary instead.
+      for (const key of validityKeys) {
+        if (key !== 'valid' && key !== 'valueMissing' && currentNativeValidity[key]) {
+          return;
+        }
+      }
+
+      // Value is still missing and it is the only native error: fall through to the main
+      // validation logic below.
     }
 
     function getState(el: HTMLInputElement) {

--- a/packages/react/src/field/validity/FieldValidity.test.tsx
+++ b/packages/react/src/field/validity/FieldValidity.test.tsx
@@ -1,10 +1,63 @@
 import { expect, vi } from 'vitest';
-import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
 
 describe('<Field.Validity />', () => {
   const { render } = createRenderer();
+
+  ['onBlur', 'onSubmit'].forEach((validationMode) => {
+    it(`defers a required field's stale custom error until the ${validationMode} boundary`, () => {
+      const handleValidity = vi.fn();
+
+      render(
+        <Form>
+          <Field.Root
+            validationMode={validationMode as 'onBlur' | 'onSubmit'}
+            validate={() => 'custom error'}
+          >
+            <Field.Control required />
+            <Field.Validity>{handleValidity}</Field.Validity>
+          </Field.Root>
+          <button type="submit">submit</button>
+        </Form>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('textbox');
+      const establishInvalidState = () => {
+        if (validationMode === 'onBlur') {
+          fireEvent.blur(input);
+        } else {
+          act(() => input.focus());
+          fireEvent.keyDown(input, { key: 'Enter' });
+        }
+      };
+
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: 'invalid' } });
+      establishInvalidState();
+
+      expect(handleValidity.mock.lastCall?.[0].value).toBe('invalid');
+      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
+      expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(false);
+
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '' } });
+
+      expect(handleValidity.mock.lastCall?.[0].value).toBe('invalid');
+      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
+      expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(false);
+
+      if (validationMode === 'onBlur') {
+        fireEvent.blur(input);
+      } else {
+        fireEvent.click(screen.getByText('submit'));
+      }
+
+      expect(handleValidity.mock.lastCall?.[0].value).toBe('');
+      expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(true);
+    });
+  });
 
   describe('validationMode=onSubmit', () => {
     it('should pass validity data', () => {

--- a/packages/react/src/field/validity/FieldValidity.tsx
+++ b/packages/react/src/field/validity/FieldValidity.tsx
@@ -23,6 +23,9 @@ export const FieldValidity: React.FC<FieldValidity.Props> = function FieldValidi
   const isInvalid = combinedFieldValidityData.state.valid === false;
   const { transitionStatus } = useTransitionStatus(isInvalid);
 
+  // `fieldValidityState` is handed straight to a public render prop, so its identity is observable:
+  // consumers can pass it to a memoized child. Keep it stable across unrelated field-state changes
+  // (focus, dirty, filled) so those children don't rerender when the validity itself is unchanged.
   const fieldValidityState: FieldValidityState = React.useMemo(() => {
     return {
       ...combinedFieldValidityData,

--- a/packages/react/src/fieldset/legend/FieldsetLegend.tsx
+++ b/packages/react/src/fieldset/legend/FieldsetLegend.tsx
@@ -30,7 +30,7 @@ export const FieldsetLegend = React.forwardRef(function FieldsetLegend(
   }, [setLegendId, id]);
 
   const state: FieldsetLegendState = {
-    disabled: disabled ?? false,
+    disabled,
   };
 
   const element = useRenderElement('div', componentProps, {

--- a/packages/react/src/fieldset/root/FieldsetRootContext.ts
+++ b/packages/react/src/fieldset/root/FieldsetRootContext.ts
@@ -4,7 +4,7 @@ import * as React from 'react';
 export interface FieldsetRootContext {
   legendId: string | undefined;
   setLegendId: React.Dispatch<React.SetStateAction<string | undefined>>;
-  disabled: boolean | undefined;
+  disabled: boolean;
 }
 
 export const FieldsetRootContext = React.createContext<FieldsetRootContext | undefined>(undefined);

--- a/packages/react/src/form/Form.test.tsx
+++ b/packages/react/src/form/Form.test.tsx
@@ -41,23 +41,27 @@ describe('<Form />', () => {
     const onFormSubmit = vi.fn();
     const select = vi.spyOn(HTMLInputElement.prototype, 'select');
 
-    const { user } = render(
-      <Form onFormSubmit={onFormSubmit}>
-        <Field.Root name="custom" validate={() => 'custom error'}>
-          <Field.Control data-testid="custom" />
-        </Field.Root>
-        <Field.Root name="native">
-          <Field.Control data-testid="native" required />
-        </Field.Root>
-        <button type="submit">Submit</button>
-      </Form>,
-    );
+    try {
+      const { user } = render(
+        <Form onFormSubmit={onFormSubmit}>
+          <Field.Root name="custom" validate={() => 'custom error'}>
+            <Field.Control data-testid="custom" />
+          </Field.Root>
+          <Field.Root name="native">
+            <Field.Control data-testid="native" required />
+          </Field.Root>
+          <button type="submit">Submit</button>
+        </Form>,
+      );
 
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
-    expect(onFormSubmit).not.toHaveBeenCalled();
-    expect(screen.getByTestId('custom')).toHaveFocus();
-    expect(select).toHaveBeenCalledTimes(1);
+      expect(onFormSubmit).not.toHaveBeenCalled();
+      expect(screen.getByTestId('custom')).toHaveFocus();
+      expect(select).toHaveBeenCalledTimes(1);
+    } finally {
+      select.mockRestore();
+    }
   });
 
   it('submits when a valid async validator is pending', async () => {

--- a/packages/react/src/form/Form.test.tsx
+++ b/packages/react/src/form/Form.test.tsx
@@ -5,7 +5,7 @@ import { Field } from '@base-ui/react/field';
 import { Fieldset } from '@base-ui/react/fieldset';
 import { NumberField } from '@base-ui/react/number-field';
 import { Switch } from '@base-ui/react/switch';
-import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
+import { createRenderer, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { describeConformance } from '../../test/describeConformance';
 
 describe('<Form />', () => {
@@ -35,6 +35,29 @@ describe('<Form />', () => {
 
     expect(screen.getByTestId('error')).toBeInTheDocument();
     expect(onSubmit.mock.calls.length > 0).toBe(false);
+  });
+
+  it('blocks submit and focuses the first invalid field across custom and native validation', async () => {
+    const onFormSubmit = vi.fn();
+    const select = vi.spyOn(HTMLInputElement.prototype, 'select');
+
+    const { user } = render(
+      <Form onFormSubmit={onFormSubmit}>
+        <Field.Root name="custom" validate={() => 'custom error'}>
+          <Field.Control data-testid="custom" />
+        </Field.Root>
+        <Field.Root name="native">
+          <Field.Control data-testid="native" required />
+        </Field.Root>
+        <button type="submit">Submit</button>
+      </Form>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(onFormSubmit).not.toHaveBeenCalled();
+    expect(screen.getByTestId('custom')).toHaveFocus();
+    expect(select).toHaveBeenCalledTimes(1);
   });
 
   it('submits when a valid async validator is pending', async () => {
@@ -383,6 +406,46 @@ describe('<Form />', () => {
 
       expect(screen.queryByTestId('error')).toBe(null);
       expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('focuses asynchronously replaced external errors and clears only the changed own property', async () => {
+      function App() {
+        const [errors, setErrors] = React.useState<Form.Props['errors']>();
+
+        return (
+          <Form
+            errors={errors}
+            onFormSubmit={() => {
+              const nextErrors = Object.create(null) as Record<string, string>;
+              nextErrors.first = 'First error';
+              nextErrors.second = 'Second error';
+              Promise.resolve().then(() => setErrors(nextErrors));
+            }}
+          >
+            <Field.Root name="first">
+              <Field.Control data-testid="first" />
+              <Field.Error data-testid="first-error" />
+            </Field.Root>
+            <Field.Root name="second">
+              <Field.Control data-testid="second" />
+              <Field.Error data-testid="second-error" />
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      const { user } = render(<App />);
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+      await waitFor(() => expect(screen.getByTestId('first')).toHaveFocus());
+      expect(screen.getByTestId('first-error')).toHaveTextContent('First error');
+      expect(screen.getByTestId('second-error')).toHaveTextContent('Second error');
+
+      await user.type(screen.getByTestId('first'), 'a');
+
+      expect(screen.queryByTestId('first-error')).toBe(null);
+      expect(screen.getByTestId('second-error')).toHaveTextContent('Second error');
     });
 
     function App() {
@@ -747,6 +810,74 @@ describe('<Form />', () => {
       await user.click(screen.getByText('validate'));
 
       await expect(screen.queryByTestId('error')).toHaveTextContent('number field error');
+    });
+
+    it('targets only the current Strict Mode registration after name, id, and control replacement', async () => {
+      const initialValidate = vi.fn(() => null);
+      const renamedValidate = vi.fn(() => null);
+      const replacementValidate = vi.fn(() => null);
+
+      function App() {
+        const actionsRef = React.useRef<Form.Actions>(null);
+        const [step, setStep] = React.useState(0);
+        const visible = step !== 2;
+        const name = step === 0 ? 'initial' : 'current';
+        let validate = initialValidate;
+        if (step === 1) {
+          validate = renamedValidate;
+        } else if (step > 1) {
+          validate = replacementValidate;
+        }
+
+        return (
+          <React.Fragment>
+            <Form actionsRef={actionsRef}>
+              {visible && (
+                <Field.Root key={step} name={name} validate={validate}>
+                  <Field.Control id={`control-${step}`} />
+                </Field.Root>
+              )}
+            </Form>
+            <button type="button" onClick={() => setStep(1)}>
+              Rename
+            </button>
+            <button type="button" onClick={() => setStep(2)}>
+              Unmount
+            </button>
+            <button type="button" onClick={() => setStep(3)}>
+              Replace
+            </button>
+            <button type="button" onClick={() => actionsRef.current?.validate('initial')}>
+              Validate initial
+            </button>
+            <button type="button" onClick={() => actionsRef.current?.validate('current')}>
+              Validate current
+            </button>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = render(
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Rename' }));
+      await user.click(screen.getByRole('button', { name: 'Validate initial' }));
+      await user.click(screen.getByRole('button', { name: 'Validate current' }));
+
+      expect(initialValidate).not.toHaveBeenCalled();
+      expect(renamedValidate).toHaveBeenCalledTimes(1);
+
+      await user.click(screen.getByRole('button', { name: 'Unmount' }));
+      await user.click(screen.getByRole('button', { name: 'Validate current' }));
+      expect(renamedValidate).toHaveBeenCalledTimes(1);
+
+      await user.click(screen.getByRole('button', { name: 'Replace' }));
+      await user.click(screen.getByRole('button', { name: 'Validate current' }));
+
+      expect(replacementValidate).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/react/src/form/Form.tsx
+++ b/packages/react/src/form/Form.tsx
@@ -10,7 +10,6 @@ import { REASONS } from '../internals/reasons';
 import type { BaseUIComponentProps } from '../internals/types';
 import { FormContext } from '../internals/form-context/FormContext';
 import { useRenderElement } from '../internals/useRenderElement';
-import { useValueChanged } from '../internals/useValueChanged';
 
 /**
  * A native form element with consolidated error handling.
@@ -39,21 +38,26 @@ export const Form = React.forwardRef(function Form<
   const submittedRef = React.useRef(false);
   const submitAttemptedRef = React.useRef(false);
 
-  const focusControl = useStableCallback((control: HTMLElement | null) => {
-    if (!control) {
-      return;
+  const focusFirstInvalid = useStableCallback(() => {
+    const invalidField = Array.from(formRef.current.fields.values()).find(
+      (field) => field.validityData.state.valid === false,
+    );
+    const control = invalidField?.controlRef.current;
+    if (control) {
+      control.focus();
+      if (control.tagName === 'INPUT') {
+        (control as HTMLInputElement).select();
+      }
     }
-    control.focus();
-    if (control.tagName === 'INPUT') {
-      (control as HTMLInputElement).select();
-    }
+    return invalidField !== undefined;
   });
 
   const [errors, setErrors] = React.useState(externalErrors);
-
-  useValueChanged(externalErrors, () => {
+  const [prevExternalErrors, setPrevExternalErrors] = React.useState(externalErrors);
+  if (prevExternalErrors !== externalErrors) {
+    setPrevExternalErrors(externalErrors);
     setErrors(externalErrors);
-  });
+  }
 
   React.useEffect(() => {
     if (!submittedRef.current) {
@@ -61,34 +65,26 @@ export const Form = React.forwardRef(function Form<
     }
 
     submittedRef.current = false;
+    focusFirstInvalid();
+  }, [errors, focusFirstInvalid]);
 
-    const invalidFields = Array.from(formRef.current.fields.values()).filter(
-      (field) => field.validityData.state.valid === false,
-    );
-
-    if (invalidFields.length) {
-      focusControl(invalidFields[0].controlRef.current);
-    }
-  }, [errors, focusControl]);
-
-  const handleImperativeValidate = React.useCallback((fieldName?: string | undefined) => {
-    const values = Array.from(formRef.current.fields.values());
-
-    if (fieldName) {
-      const namedField = values.find((field) => field.name === fieldName);
-      if (namedField) {
-        namedField.validate();
-      }
-    } else {
-      values.forEach((field) => {
-        field.validate();
-      });
-    }
-  }, []);
-
-  React.useImperativeHandle(actionsRef, () => ({ validate: handleImperativeValidate }), [
-    handleImperativeValidate,
-  ]);
+  React.useImperativeHandle(
+    actionsRef,
+    () => ({
+      validate(fieldName?: string) {
+        if (fieldName) {
+          Array.from(formRef.current.fields.values())
+            .find((field) => field.name === fieldName)
+            ?.validate();
+        } else {
+          formRef.current.fields.forEach((field) => {
+            field.validate();
+          });
+        }
+      },
+    }),
+    [],
+  );
 
   const element = useRenderElement('form', componentProps, {
     ref: forwardedRef,
@@ -98,36 +94,30 @@ export const Form = React.forwardRef(function Form<
         onSubmit(event) {
           submitAttemptedRef.current = true;
 
-          let values = Array.from(formRef.current.fields.values());
-
           // Async validation isn't supported to stop the submit event.
-          values.forEach((field) => {
+          formRef.current.fields.forEach((field) => {
             field.validate();
           });
 
-          values = Array.from(formRef.current.fields.values());
-
-          const invalidField = values.find((field) => field.validityData.state.valid === false);
-
-          if (invalidField) {
+          if (focusFirstInvalid()) {
             event.preventDefault();
-            focusControl(invalidField.controlRef.current);
-          } else {
-            submittedRef.current = true;
-            onSubmit?.(event as any);
+            return;
+          }
 
-            if (onFormSubmit) {
-              event.preventDefault();
+          submittedRef.current = true;
+          onSubmit?.(event as any);
 
-              const formValues = values.reduce((acc, field) => {
-                if (field.name) {
-                  (acc as Record<string, any>)[field.name] = field.getValue();
-                }
-                return acc;
-              }, {} as FormValues);
+          if (onFormSubmit) {
+            event.preventDefault();
 
-              onFormSubmit(formValues, createGenericEventDetails(REASONS.none, event.nativeEvent));
-            }
+            const formValues = {} as FormValues;
+            formRef.current.fields.forEach((field) => {
+              if (field.name) {
+                (formValues as Record<string, any>)[field.name] = field.getValue();
+              }
+            });
+
+            onFormSubmit(formValues, createGenericEventDetails(REASONS.none, event.nativeEvent));
           }
         },
       },
@@ -136,7 +126,7 @@ export const Form = React.forwardRef(function Form<
   });
 
   const clearErrors = useStableCallback((name: string | undefined) => {
-    if (name && errors && EMPTY_OBJECT.hasOwnProperty.call(errors, name)) {
+    if (name && errors && Object.hasOwn(errors, name)) {
       const nextErrors = { ...errors };
       delete nextErrors[name];
       setErrors(nextErrors);

--- a/packages/react/src/form/Form.tsx
+++ b/packages/react/src/form/Form.tsx
@@ -10,6 +10,7 @@ import { REASONS } from '../internals/reasons';
 import type { BaseUIComponentProps } from '../internals/types';
 import { FormContext } from '../internals/form-context/FormContext';
 import { useRenderElement } from '../internals/useRenderElement';
+import { useValueChanged } from '../internals/useValueChanged';
 
 /**
  * A native form element with consolidated error handling.
@@ -53,11 +54,10 @@ export const Form = React.forwardRef(function Form<
   });
 
   const [errors, setErrors] = React.useState(externalErrors);
-  const [prevExternalErrors, setPrevExternalErrors] = React.useState(externalErrors);
-  if (prevExternalErrors !== externalErrors) {
-    setPrevExternalErrors(externalErrors);
+
+  useValueChanged(externalErrors, () => {
     setErrors(externalErrors);
-  }
+  });
 
   React.useEffect(() => {
     if (!submittedRef.current) {

--- a/packages/react/src/internals/field-register-control/useFieldControlRegistration.ts
+++ b/packages/react/src/internals/field-register-control/useFieldControlRegistration.ts
@@ -21,7 +21,7 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
     markedDirtyRef,
     name,
     setRegisteredFieldName,
-    setRegisteredFieldId,
+    registeredFieldIdRef,
     setValidityData,
     validityData,
   } = params;
@@ -30,7 +30,6 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
 
   const activeFieldControlSourceRef = React.useRef<symbol | null>(null);
   const registrationRef = React.useRef<FieldControlRegistration | null>(null);
-  const fallbackControlRef = React.useRef<any>(null);
 
   const getValueForForm = useStableCallback(() => {
     const registration = registrationRef.current;
@@ -70,7 +69,7 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
     formRef.current.fields.set(registration.id, {
       getValue: getValueForForm,
       name: name ?? registration.name,
-      controlRef: registration.controlRef ?? fallbackControlRef,
+      controlRef: registration.controlRef,
       validityData: getCombinedFieldValidityData(validityData, invalid),
       validate,
     });
@@ -106,7 +105,7 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
     formRef.current.fields.set(registration.id, {
       getValue: getValueForForm,
       name: name ?? registration.name,
-      controlRef: registration.controlRef ?? fallbackControlRef,
+      controlRef: registration.controlRef,
       validityData: getCombinedFieldValidityData(validityData, invalid),
       validate,
     });
@@ -131,7 +130,7 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
           deleteRegistration();
           registrationRef.current = null;
           setRegisteredFieldName(undefined);
-          setRegisteredFieldId(undefined);
+          registeredFieldIdRef.current = undefined;
         }
         return;
       }
@@ -143,7 +142,7 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
       if (!name) {
         setRegisteredFieldName(registration.name);
       }
-      setRegisteredFieldId(registration.id);
+      registeredFieldIdRef.current = registration.id;
 
       if (previousId && previousId !== registration.id) {
         deleteRegistration(previousId);
@@ -163,7 +162,7 @@ export interface UseFieldControlRegistrationParameters {
   markedDirtyRef: React.RefObject<boolean>;
   name: string | undefined;
   setRegisteredFieldName: (name: string | undefined) => void;
-  setRegisteredFieldId: (id: string | undefined) => void;
+  registeredFieldIdRef: React.RefObject<string | undefined>;
   setValidityData: React.Dispatch<React.SetStateAction<FieldValidityData>>;
   validityData: FieldValidityData;
 }

--- a/packages/react/src/internals/field-register-control/useRegisterFieldControl.ts
+++ b/packages/react/src/internals/field-register-control/useRegisterFieldControl.ts
@@ -1,6 +1,6 @@
 'use client';
-import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { useFieldRootContext } from '../field-root-context/FieldRootContext';
 import type { FieldControlRegistration } from './useFieldControlRegistration';
 
@@ -13,16 +13,12 @@ export function useRegisterFieldControl(
   name?: FieldControlRegistration['name'],
 ) {
   const { registerFieldControl } = useFieldRootContext();
-  const sourceRef = React.useRef<symbol | null>(null);
-
-  if (!sourceRef.current) {
-    sourceRef.current = Symbol();
-  }
+  const sourceRef = useRefWithInit(() => Symbol());
 
   useIsoLayoutEffect(() => {
     const source = sourceRef.current;
 
-    if (!source || !enabled) {
+    if (!enabled) {
       return undefined;
     }
 
@@ -39,5 +35,5 @@ export function useRegisterFieldControl(
     return () => {
       registerFieldControl(source, undefined);
     };
-  }, [controlRef, enabled, getFormValueOverride, id, name, registerFieldControl, value]);
+  }, [controlRef, enabled, getFormValueOverride, id, name, registerFieldControl, sourceRef, value]);
 }

--- a/packages/react/src/internals/field-root-context/FieldRootContext.ts
+++ b/packages/react/src/internals/field-root-context/FieldRootContext.ts
@@ -2,11 +2,7 @@
 import * as React from 'react';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { NOOP } from '../noop';
-import {
-  DEFAULT_FIELD_ROOT_STATE,
-  DEFAULT_FIELD_STATE_ATTRIBUTES,
-  DEFAULT_VALIDITY_STATE,
-} from '../field-constants/constants';
+import { DEFAULT_FIELD_ROOT_STATE, DEFAULT_VALIDITY_STATE } from '../field-constants/constants';
 import type { FieldValidityData, FieldRootState } from '../../field/root/FieldRoot';
 import type { Form } from '../../form';
 import type { UseFieldValidationReturnValue } from '../../field/root/useFieldValidation';
@@ -19,23 +15,13 @@ export interface FieldRootContext {
   validityData: FieldValidityData;
   setValidityData: React.Dispatch<React.SetStateAction<FieldValidityData>>;
   disabled: boolean | undefined;
-  touched: boolean;
   setTouched: React.Dispatch<React.SetStateAction<boolean>>;
-  dirty: boolean;
   setDirty: React.Dispatch<React.SetStateAction<boolean>>;
-  filled: boolean;
   setFilled: React.Dispatch<React.SetStateAction<boolean>>;
-  focused: boolean;
   setFocused: React.Dispatch<React.SetStateAction<boolean>>;
-  validate: (
-    value: unknown,
-    formValues: Record<string, unknown>,
-  ) => string | string[] | null | Promise<string | string[] | null>;
   validationMode: Form.ValidationMode;
-  validationDebounceTime: number;
   shouldValidateOnChange: () => boolean;
   state: FieldRootState;
-  markedDirtyRef: React.RefObject<boolean>;
   registerFieldControl: (
     source: symbol,
     registration: FieldControlRegistration | undefined,
@@ -55,20 +41,13 @@ export const DEFAULT_FIELD_ROOT_CONTEXT: FieldRootContext = {
   },
   setValidityData: NOOP,
   disabled: undefined,
-  touched: DEFAULT_FIELD_STATE_ATTRIBUTES.touched,
   setTouched: NOOP,
-  dirty: DEFAULT_FIELD_STATE_ATTRIBUTES.dirty,
   setDirty: NOOP,
-  filled: DEFAULT_FIELD_STATE_ATTRIBUTES.filled,
   setFilled: NOOP,
-  focused: DEFAULT_FIELD_STATE_ATTRIBUTES.focused,
   setFocused: NOOP,
-  validate: () => null,
   validationMode: 'onSubmit',
-  validationDebounceTime: 0,
   shouldValidateOnChange: () => false,
   state: DEFAULT_FIELD_ROOT_STATE,
-  markedDirtyRef: { current: false },
   registerFieldControl: NOOP,
   validation: {
     getValidationProps: (_disabled: boolean, props: HTMLProps = EMPTY_OBJECT) => props,

--- a/packages/react/src/internals/labelable-provider/useLabelableId.ts
+++ b/packages/react/src/internals/labelable-provider/useLabelableId.ts
@@ -17,7 +17,7 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
 
   const controlIdForEffect = implicit ? controlId : undefined;
 
-  const controlSourceRef = useRefWithInit(() => Symbol('labelable-control'));
+  const controlSourceRef = useRefWithInit(() => Symbol());
   const hasRegisteredRef = React.useRef(false);
   const hadExplicitIdRef = React.useRef(id != null);
 


### PR DESCRIPTION
Removes dead and redundant code from Field, Form, and Fieldset. The bundle bot is authoritative for the current size impact.

The previously ineffective only-`valueMissing` revalidation bail now works as intended, deferring stale coexisting errors until blur or submit; `FieldValidity` regression tests pin this behavior.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
