### PR TITLE
[utils] Add idle callback utility

### DIFF
--- a/packages/utils/src/useIdleCallback.test.tsx
+++ b/packages/utils/src/useIdleCallback.test.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import { createRenderer, waitFor } from '@mui/internal-test-utils';
+import { expect, vi } from 'vitest';
+import { IdleCallback, useIdleCallback } from './useIdleCallback';
+
+/**
+ * Waits for the specified number of milliseconds.
+ */
+async function wait(ms: number) {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+describe('IdleCallback', () => {
+  describe('IdleCallback class', () => {
+    it('create() returns a new instance each time', () => {
+      const a = IdleCallback.create();
+      const b = IdleCallback.create();
+      expect(a).toBeInstanceOf(IdleCallback);
+      expect(b).toBeInstanceOf(IdleCallback);
+      expect(a).not.toBe(b);
+    });
+
+    it('runs the scheduled callback after the current task', async () => {
+      const idleCallback = IdleCallback.create();
+      const fn = vi.fn();
+
+      idleCallback.start(fn);
+
+      // The callback runs after the current commit and paint, not synchronously.
+      expect(fn).not.toHaveBeenCalled();
+
+      await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+    });
+
+    it('clear() cancels a pending callback', async () => {
+      const idleCallback = IdleCallback.create();
+      const fn = vi.fn();
+
+      idleCallback.start(fn);
+      idleCallback.clear();
+
+      await wait(50);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it('start() clears any previously scheduled callback', async () => {
+      const idleCallback = IdleCallback.create();
+      const first = vi.fn();
+      const second = vi.fn();
+
+      idleCallback.start(first);
+      idleCallback.start(second);
+
+      await waitFor(() => expect(second).toHaveBeenCalledTimes(1));
+      expect(first).not.toHaveBeenCalled();
+    });
+
+    it('can be reused after the callback has run', async () => {
+      const idleCallback = IdleCallback.create();
+      const fn = vi.fn();
+
+      idleCallback.start(fn);
+      await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+
+      idleCallback.start(fn);
+      await waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
+    });
+
+    it('disposeEffect() returns the clear function', async () => {
+      const idleCallback = IdleCallback.create();
+      const fn = vi.fn();
+
+      idleCallback.start(fn);
+      const dispose = idleCallback.disposeEffect();
+      expect(dispose).toBe(idleCallback.clear);
+
+      dispose();
+
+      await wait(50);
+      expect(fn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useIdleCallback', () => {
+    const { render } = createRenderer();
+
+    it('returns a stable scheduler across re-renders', async () => {
+      let scheduler!: IdleCallback;
+
+      function Test() {
+        scheduler = useIdleCallback();
+        return null;
+      }
+
+      const { rerender } = await render(<Test />);
+      const afterMount = scheduler;
+      await rerender(<Test />);
+
+      expect(afterMount).toBeInstanceOf(IdleCallback);
+      expect(scheduler).toBe(afterMount);
+    });
+
+    it('cancels a pending callback on unmount', async () => {
+      const fn = vi.fn();
+      let scheduler!: IdleCallback;
+
+      function Test() {
+        scheduler = useIdleCallback();
+        return null;
+      }
+
+      const { unmount } = await render(<Test />);
+
+      scheduler.start(fn);
+      unmount();
+
+      await wait(50);
+      expect(fn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/utils/src/useIdleCallback.test.tsx
+++ b/packages/utils/src/useIdleCallback.test.tsx
@@ -28,7 +28,7 @@ describe('IdleCallback', () => {
 
       idleCallback.start(fn);
 
-      // The callback runs after the current commit and paint, not synchronously.
+      // The callback runs asynchronously after the current task, not synchronously.
       expect(fn).not.toHaveBeenCalled();
 
       await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
@@ -63,6 +63,9 @@ describe('IdleCallback', () => {
 
       idleCallback.start(fn);
       await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+
+      // The completed handle must be reset so a later `clear()` cannot cancel an unrelated callback.
+      expect(idleCallback.currentId).toBe(null);
 
       idleCallback.start(fn);
       await waitFor(() => expect(fn).toHaveBeenCalledTimes(2));

--- a/packages/utils/src/useIdleCallback.ts
+++ b/packages/utils/src/useIdleCallback.ts
@@ -4,6 +4,13 @@ import { useOnMount } from './useOnMount';
 
 const supportsIdleCallback = typeof requestIdleCallback === 'function';
 
+// Macrotask fallback for environments without `requestIdleCallback` (e.g. Safari),
+// which still runs after the current commit and paint.
+const requestCallback = supportsIdleCallback
+  ? requestIdleCallback
+  : (fn: () => void) => setTimeout(fn, 0);
+const cancelCallback = supportsIdleCallback ? cancelIdleCallback : clearTimeout;
+
 export class IdleCallback {
   static create() {
     return new IdleCallback();
@@ -11,37 +18,19 @@ export class IdleCallback {
 
   currentId: number | null = null;
 
-  // Macrotask fallback for environments without `requestIdleCallback` (e.g. Safari),
-  // which still runs after the current commit and paint.
-  timeoutId: ReturnType<typeof setTimeout> | null = null;
-
   /**
    * Schedules `fn` to run during idle time, after the current commit and paint, clearing any
    * previously scheduled call.
    */
   start(fn: () => void) {
     this.clear();
-    if (supportsIdleCallback) {
-      this.currentId = requestIdleCallback(() => {
-        this.currentId = null;
-        fn();
-      });
-    } else {
-      this.timeoutId = setTimeout(() => {
-        this.timeoutId = null;
-        fn();
-      }, 0);
-    }
+    this.currentId = requestCallback(fn);
   }
 
   clear = () => {
     if (this.currentId !== null) {
-      cancelIdleCallback(this.currentId);
+      cancelCallback(this.currentId);
       this.currentId = null;
-    }
-    if (this.timeoutId !== null) {
-      clearTimeout(this.timeoutId);
-      this.timeoutId = null;
     }
   };
 

--- a/packages/utils/src/useIdleCallback.ts
+++ b/packages/utils/src/useIdleCallback.ts
@@ -20,8 +20,10 @@ export class IdleCallback {
   currentId: number | null = null;
 
   /**
-   * Schedules `fn` to run during idle time, after the current commit and paint, clearing any
-   * previously scheduled call.
+   * Schedules `fn` to run asynchronously after the current task (and thus the current commit),
+   * clearing any previously scheduled call. With native `requestIdleCallback` the callback runs
+   * during idle time after the next paint; the `setTimeout(0)` fallback runs after the current task
+   * but is not guaranteed to run after the next paint.
    */
   start(fn: () => void) {
     this.clear();

--- a/packages/utils/src/useIdleCallback.ts
+++ b/packages/utils/src/useIdleCallback.ts
@@ -1,0 +1,61 @@
+'use client';
+import { useRefWithInit } from './useRefWithInit';
+import { useOnMount } from './useOnMount';
+import { Timeout } from './useTimeout';
+
+const supportsIdleCallback = typeof requestIdleCallback === 'function';
+
+export class IdleCallback {
+  static create() {
+    return new IdleCallback();
+  }
+
+  currentId: number | null = null;
+
+  // Macrotask fallback for environments without `requestIdleCallback` (e.g. Safari),
+  // which still runs after the current commit and paint.
+  timeout = new Timeout();
+
+  /**
+   * Schedules `fn` to run during idle time, after the current commit and paint, clearing any
+   * previously scheduled call.
+   */
+  start(fn: () => void) {
+    this.clear();
+    if (supportsIdleCallback) {
+      this.currentId = requestIdleCallback(() => {
+        this.currentId = null;
+        fn();
+      });
+    } else {
+      this.timeout.start(0, fn);
+    }
+  }
+
+  clear = () => {
+    if (this.currentId !== null) {
+      cancelIdleCallback(this.currentId);
+      this.currentId = null;
+    }
+    this.timeout.clear();
+  };
+
+  disposeEffect = () => {
+    return this.clear;
+  };
+}
+
+/**
+ * A `requestIdleCallback` with automatic cleanup and guard, mirroring `useTimeout`.
+ *
+ * Returns an imperative scheduler that runs a callback during idle time, after the current commit
+ * and paint. In environments without `requestIdleCallback` it falls back to a macrotask
+ * (`setTimeout(0)`), which also runs after the current commit and paint.
+ */
+export function useIdleCallback() {
+  const idleCallback = useRefWithInit(IdleCallback.create).current;
+
+  useOnMount(idleCallback.disposeEffect);
+
+  return idleCallback;
+}

--- a/packages/utils/src/useIdleCallback.ts
+++ b/packages/utils/src/useIdleCallback.ts
@@ -24,7 +24,10 @@ export class IdleCallback {
    */
   start(fn: () => void) {
     this.clear();
-    this.currentId = requestCallback(fn);
+    this.currentId = requestCallback(() => {
+      this.currentId = null;
+      fn();
+    });
   }
 
   clear = () => {

--- a/packages/utils/src/useIdleCallback.ts
+++ b/packages/utils/src/useIdleCallback.ts
@@ -1,7 +1,6 @@
 'use client';
 import { useRefWithInit } from './useRefWithInit';
 import { useOnMount } from './useOnMount';
-import { Timeout } from './useTimeout';
 
 const supportsIdleCallback = typeof requestIdleCallback === 'function';
 
@@ -14,7 +13,7 @@ export class IdleCallback {
 
   // Macrotask fallback for environments without `requestIdleCallback` (e.g. Safari),
   // which still runs after the current commit and paint.
-  timeout = new Timeout();
+  timeoutId: ReturnType<typeof setTimeout> | null = null;
 
   /**
    * Schedules `fn` to run during idle time, after the current commit and paint, clearing any
@@ -28,7 +27,10 @@ export class IdleCallback {
         fn();
       });
     } else {
-      this.timeout.start(0, fn);
+      this.timeoutId = setTimeout(() => {
+        this.timeoutId = null;
+        fn();
+      }, 0);
     }
   }
 
@@ -37,7 +39,10 @@ export class IdleCallback {
       cancelIdleCallback(this.currentId);
       this.currentId = null;
     }
-    this.timeout.clear();
+    if (this.timeoutId !== null) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
   };
 
   disposeEffect = () => {

--- a/packages/utils/src/useIdleCallback.ts
+++ b/packages/utils/src/useIdleCallback.ts
@@ -4,8 +4,9 @@ import { useOnMount } from './useOnMount';
 
 const supportsIdleCallback = typeof requestIdleCallback === 'function';
 
-// Macrotask fallback for environments without `requestIdleCallback` (e.g. Safari),
-// which still runs after the current commit and paint.
+// Macrotask fallback for environments without `requestIdleCallback` (e.g. older Safari).
+// It runs after the current task (and thus the current commit), but — unlike
+// `requestIdleCallback` — is not guaranteed to run after the next paint.
 const requestCallback = supportsIdleCallback
   ? requestIdleCallback
   : (fn: () => void) => setTimeout(fn, 0);
@@ -47,7 +48,8 @@ export class IdleCallback {
  *
  * Returns an imperative scheduler that runs a callback during idle time, after the current commit
  * and paint. In environments without `requestIdleCallback` it falls back to a macrotask
- * (`setTimeout(0)`), which also runs after the current commit and paint.
+ * (`setTimeout(0)`), which runs after the current commit but is not guaranteed to run after the
+ * next paint.
  */
 export function useIdleCallback() {
   const idleCallback = useRefWithInit(IdleCallback.create).current;


### PR DESCRIPTION

Adds `useIdleCallback`, a cancellable idle-time scheduler with a Safari-compatible `Timeout` fallback, plus coverage for scheduling and lifecycle cleanup.
