### PR TITLE
[combobox][autocomplete] Reset list scroll position on filter

### DIFF
--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -845,8 +845,12 @@ describe('<Autocomplete.Root />', () => {
     const manyItems = Array.from({ length: 50 }, (_, index) => `item-${index}`);
 
     it.skipIf(isJSDOM)('resets the list scroll position to the top when typing', async () => {
+      const filteringItems = Array.from({ length: 50 }, (_, index) =>
+        index < 25 ? `alpha-${index}` : `beta-${index - 25}`,
+      );
+
       const { user } = await render(
-        <Autocomplete.Root items={manyItems}>
+        <Autocomplete.Root items={filteringItems} openOnInputClick>
           <Autocomplete.Input data-testid="input" />
           <Autocomplete.Portal>
             <Autocomplete.Positioner>
@@ -866,14 +870,13 @@ describe('<Autocomplete.Root />', () => {
 
       const input = screen.getByTestId('input');
       await user.click(input);
-      // Open and keep every item so the list is scrollable.
-      await user.type(input, 'item');
 
       const list = screen.getByRole('listbox');
       list.scrollTop = 40;
       expect(list.scrollTop).toBeGreaterThan(0);
 
-      await user.type(input, '-1');
+      // Remove the current first item while keeping enough matches for the list to scroll.
+      await user.type(input, 'b');
 
       await waitFor(() => {
         expect(list.scrollTop).toBe(0);

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -841,6 +841,87 @@ describe('<Autocomplete.Root />', () => {
     });
   });
 
+  describe('scroll reset on input value change', () => {
+    const manyItems = Array.from({ length: 50 }, (_, index) => `item-${index}`);
+
+    it.skipIf(isJSDOM)('resets the list scroll position to the top when typing', async () => {
+      const { user } = await render(
+        <Autocomplete.Root items={manyItems}>
+          <Autocomplete.Input data-testid="input" />
+          <Autocomplete.Portal>
+            <Autocomplete.Positioner>
+              <Autocomplete.Popup>
+                <Autocomplete.List style={{ maxHeight: 100, overflowY: 'auto' }}>
+                  {(item: string) => (
+                    <Autocomplete.Item key={item} value={item}>
+                      {item}
+                    </Autocomplete.Item>
+                  )}
+                </Autocomplete.List>
+              </Autocomplete.Popup>
+            </Autocomplete.Positioner>
+          </Autocomplete.Portal>
+        </Autocomplete.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+      // Open and keep every item so the list is scrollable.
+      await user.type(input, 'item');
+
+      const list = screen.getByRole('listbox');
+      list.scrollTop = 40;
+      expect(list.scrollTop).toBeGreaterThan(0);
+
+      await user.type(input, '-1');
+
+      await waitFor(() => {
+        expect(list.scrollTop).toBe(0);
+      });
+    });
+
+    it.skipIf(isJSDOM)(
+      'mode="both": inline navigation does not reset the scroll to the top',
+      async () => {
+        const { user } = await render(
+          <Autocomplete.Root mode="both" items={manyItems}>
+            <Autocomplete.Input data-testid="input" />
+            <Autocomplete.Portal>
+              <Autocomplete.Positioner>
+                <Autocomplete.Popup>
+                  <Autocomplete.List style={{ maxHeight: 100, overflowY: 'auto' }}>
+                    {(item: string) => (
+                      <Autocomplete.Item key={item} value={item}>
+                        {item}
+                      </Autocomplete.Item>
+                    )}
+                  </Autocomplete.List>
+                </Autocomplete.Popup>
+              </Autocomplete.Positioner>
+            </Autocomplete.Portal>
+          </Autocomplete.Root>,
+        );
+
+        const input = screen.getByTestId<HTMLInputElement>('input');
+        await user.click(input);
+        // Keep every item in the filtered list so navigation can scroll far down.
+        await user.type(input, 'item');
+
+        // Navigate to an item that sits below the visible viewport. Inline autocompletion
+        // rewrites the input value on each step, but that must not reset the scroll to the top.
+        for (let i = 0; i < 20; i += 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await user.keyboard('{ArrowDown}');
+        }
+
+        const list = screen.getByRole('listbox');
+        await waitFor(() => {
+          expect(list.scrollTop).toBeGreaterThan(0);
+        });
+      },
+    );
+  });
+
   describe('prop: filter', () => {
     it.each(['list', 'both'] as const)(
       'mode="%s": uses a custom filter instead of the locale-aware default',

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -867,7 +867,8 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       // rewriting the input during navigation doesn't reset the scroll. `block: 'nearest'` scrolls
       // only the overflowing ancestor, not the page. Virtualized lists own their scroller, so skip.
       if (!store.state.virtualized) {
-        store.state.listRef.current[0]?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        // `scrollIntoView` is optional-called because JSDOM doesn't implement it.
+        store.state.listRef.current[0]?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
       }
       if (pendingHighlight.hasQuery) {
         if (autoHighlightMode) {

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -10,7 +10,7 @@ import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidd
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { Store, useStore } from '@base-ui/utils/store';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from '@base-ui/utils/empty';
-import { isHTMLElement } from '@floating-ui/utils/dom';
+import { getComputedStyle, isHTMLElement } from '@floating-ui/utils/dom';
 import {
   ElementProps,
   getOverflowAncestors,
@@ -870,9 +870,21 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     const list = store.state.listElement;
     if (!store.state.virtualized && list) {
       const dialog = inline ? list.closest<HTMLElement>('[role="dialog"]') : null;
-      const scrollContainer = getOverflowAncestors(list.firstElementChild ?? list)[0];
+      let scrollContainer: HTMLElement | null = null;
 
-      if (isHTMLElement(scrollContainer) && scrollContainer !== dialog) {
+      for (const ancestor of getOverflowAncestors(list.firstElementChild ?? list)) {
+        if (!isHTMLElement(ancestor) || ancestor === dialog) {
+          break;
+        }
+
+        const { overflowY } = getComputedStyle(ancestor);
+        if ((overflowY === 'auto' || overflowY === 'scroll') && ancestor.clientHeight > 0) {
+          scrollContainer = ancestor;
+          break;
+        }
+      }
+
+      if (scrollContainer) {
         scrollContainer.scrollTop = 0;
       }
     }

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -862,6 +862,13 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   useIsoLayoutEffect(() => {
     const pendingHighlight = pendingQueryHighlightRef.current;
     if (pendingHighlight) {
+      // The user typed, so the list was re-filtered: bring the first item into view so it starts at
+      // the top. Keyed on the typed-input signal, not `query`/`inputValue`, so inline autocompletion
+      // rewriting the input during navigation doesn't reset the scroll. `block: 'nearest'` scrolls
+      // only the overflowing ancestor, not the page. Virtualized lists own their scroller, so skip.
+      if (!store.state.virtualized) {
+        store.state.listRef.current[0]?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      }
       if (pendingHighlight.hasQuery) {
         if (autoHighlightMode) {
           store.set('activeIndex', 0);

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -864,8 +864,9 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     if (pendingHighlight) {
       // The user typed, so the list was re-filtered: bring the first item into view so it starts at
       // the top. Keyed on the typed-input signal, not `query`/`inputValue`, so inline autocompletion
-      // rewriting the input during navigation doesn't reset the scroll. `block: 'nearest'` scrolls
-      // only the overflowing ancestor, not the page. Virtualized lists own their scroller, so skip.
+      // rewriting the input during navigation doesn't reset the scroll. Nearest-edge alignment
+      // avoids moving outer scroll containers when the list is already visible within them.
+      // Virtualized lists own their scroller, so skip.
       if (!store.state.virtualized) {
         // `scrollIntoView` is optional-called because JSDOM doesn't implement it.
         store.state.listRef.current[0]?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -10,8 +10,10 @@ import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidd
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { Store, useStore } from '@base-ui/utils/store';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from '@base-ui/utils/empty';
+import { isHTMLElement } from '@floating-ui/utils/dom';
 import {
   ElementProps,
+  getOverflowAncestors,
   useDismiss,
   useFloatingRootContext,
   useListNavigation,
@@ -863,14 +865,18 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
     pendingQueryScrollRef.current = false;
 
-    // Virtualized lists own their scroller. For regular lists, the registry can still contain
-    // detached items until the composite list recomputes its map, so skip stale entries.
-    if (!store.state.virtualized) {
-      const firstConnectedItem = store.state.listRef.current.find((item) => item?.isConnected);
-      // `scrollIntoView` is optional-called because JSDOM doesn't implement it.
-      firstConnectedItem?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+    // Virtualized lists own their scroller. Reset regular lists directly so a stale composite
+    // registry cannot select a reordered item and scrolling cannot escape into the page/dialog.
+    const list = store.state.listElement;
+    if (!store.state.virtualized && list) {
+      const dialog = inline ? list.closest<HTMLElement>('[role="dialog"]') : null;
+      const scrollContainer = getOverflowAncestors(list.firstElementChild ?? list)[0];
+
+      if (isHTMLElement(scrollContainer) && scrollContainer !== dialog) {
+        scrollContainer.scrollTop = 0;
+      }
     }
-  }, [inputValue, store]);
+  }, [inputValue, inline, store]);
 
   useIsoLayoutEffect(() => {
     if (items) {

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -10,7 +10,7 @@ import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidd
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { Store, useStore } from '@base-ui/utils/store';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from '@base-ui/utils/empty';
-import { getComputedStyle, isHTMLElement } from '@floating-ui/utils/dom';
+import { isHTMLElement } from '@floating-ui/utils/dom';
 import {
   ElementProps,
   getOverflowAncestors,
@@ -45,6 +45,7 @@ import { createCollatorItemFilter } from './utils';
 import { useCoreFilter } from './utils/useFilter';
 import { useTransitionStatus } from '../../internals/useTransitionStatus';
 import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
+import { isScrollableY } from '../../utils/scrollable';
 import type { BaseUIEvent, HTMLProps } from '../../internals/types';
 import { useValueChanged } from '../../internals/useValueChanged';
 import { NOOP } from '../../internals/noop';
@@ -869,16 +870,20 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     // registry cannot select a reordered item and scrolling cannot escape into the page/dialog.
     const list = store.state.listElement;
     if (!store.state.virtualized && list) {
-      const dialog = inline ? list.closest<HTMLElement>('[role="dialog"]') : null;
       let scrollContainer: HTMLElement | null = null;
 
       for (const ancestor of getOverflowAncestors(list.firstElementChild ?? list)) {
-        if (!isHTMLElement(ancestor) || ancestor === dialog) {
+        if (!isHTMLElement(ancestor)) {
           break;
         }
 
-        const { overflowY } = getComputedStyle(ancestor);
-        if ((overflowY === 'auto' || overflowY === 'scroll') && ancestor.clientHeight > 0) {
+        // Stop at a surrounding dialog composed around an inline combobox so the reset
+        // scrolls the list's own overflow container, not the dialog or page behind it.
+        if (inline && ancestor.getAttribute('role') === 'dialog') {
+          break;
+        }
+
+        if (isScrollableY(ancestor, true)) {
           scrollContainer = ancestor;
           break;
         }

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -156,6 +156,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   const selectionEventRef = React.useRef<MouseEvent | PointerEvent | KeyboardEvent | null>(null);
   const lastHighlightRef = React.useRef(INITIAL_LAST_HIGHLIGHT);
   const pendingQueryHighlightRef = React.useRef<null | { hasQuery: boolean }>(null);
+  const pendingQueryScrollRef = React.useRef(false);
 
   /**
    * Contains the currently visible list of item values post-filtering.
@@ -541,6 +542,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
           // Defer index updates until after the filtered items have been derived to ensure
           // `onItemHighlighted` receives the latest item.
           pendingQueryHighlightRef.current = { hasQuery };
+          pendingQueryScrollRef.current = true;
           if (hasQuery && autoHighlightMode && store.state.activeIndex == null) {
             store.set('activeIndex', 0);
           }
@@ -852,6 +854,24 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     ],
   );
 
+  // Consume the reset before the registry sync below truncates entries that still use their
+  // pre-filter indexes in this commit.
+  useIsoLayoutEffect(() => {
+    if (!pendingQueryScrollRef.current) {
+      return;
+    }
+
+    pendingQueryScrollRef.current = false;
+
+    // Virtualized lists own their scroller. For regular lists, the registry can still contain
+    // detached items until the composite list recomputes its map, so skip stale entries.
+    if (!store.state.virtualized) {
+      const firstConnectedItem = store.state.listRef.current.find((item) => item?.isConnected);
+      // `scrollIntoView` is optional-called because JSDOM doesn't implement it.
+      firstConnectedItem?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+    }
+  }, [inputValue, store]);
+
   useIsoLayoutEffect(() => {
     if (items) {
       valuesRef.current = flatFilteredItems;
@@ -862,15 +882,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   useIsoLayoutEffect(() => {
     const pendingHighlight = pendingQueryHighlightRef.current;
     if (pendingHighlight) {
-      // The user typed, so the list was re-filtered: bring the first item into view so it starts at
-      // the top. Keyed on the typed-input signal, not `query`/`inputValue`, so inline autocompletion
-      // rewriting the input during navigation doesn't reset the scroll. Nearest-edge alignment
-      // avoids moving outer scroll containers when the list is already visible within them.
-      // Virtualized lists own their scroller, so skip.
-      if (!store.state.virtualized) {
-        // `scrollIntoView` is optional-called because JSDOM doesn't implement it.
-        store.state.listRef.current[0]?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
-      }
       if (pendingHighlight.hasQuery) {
         if (autoHighlightMode) {
           store.set('activeIndex', 0);

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -159,7 +159,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   const selectionEventRef = React.useRef<MouseEvent | PointerEvent | KeyboardEvent | null>(null);
   const lastHighlightRef = React.useRef(INITIAL_LAST_HIGHLIGHT);
   const pendingQueryHighlightRef = React.useRef<null | { hasQuery: boolean }>(null);
-  const pendingQueryScrollRef = React.useRef(false);
 
   /**
    * Contains the currently visible list of item values post-filtering.
@@ -545,7 +544,28 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
           // Defer index updates until after the filtered items have been derived to ensure
           // `onItemHighlighted` receives the latest item.
           pendingQueryHighlightRef.current = { hasQuery };
-          pendingQueryScrollRef.current = true;
+
+          // Virtualized lists own their scroller. Reset regular lists directly so a stale
+          // composite registry cannot select a reordered item and scrolling cannot escape
+          // the popup.
+          const list = store.state.listElement;
+          if (!store.state.virtualized && list) {
+            const popup = popupRef.current;
+            for (const ancestor of getOverflowAncestors(list.firstElementChild ?? list)) {
+              if (
+                !isHTMLElement(ancestor) ||
+                (popup ? !contains(popup, ancestor) : ancestor.getAttribute('role') === 'dialog')
+              ) {
+                break;
+              }
+
+              if (isScrollableY(ancestor)) {
+                ancestor.scrollTop = 0;
+                break;
+              }
+            }
+          }
+
           if (hasQuery && autoHighlightMode && store.state.activeIndex == null) {
             store.set('activeIndex', 0);
           }
@@ -856,44 +876,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       setIndices,
     ],
   );
-
-  // Consume the reset before the registry sync below truncates entries that still use their
-  // pre-filter indexes in this commit.
-  useIsoLayoutEffect(() => {
-    if (!pendingQueryScrollRef.current) {
-      return;
-    }
-
-    pendingQueryScrollRef.current = false;
-
-    // Virtualized lists own their scroller. Reset regular lists directly so a stale composite
-    // registry cannot select a reordered item and scrolling cannot escape into the page/dialog.
-    const list = store.state.listElement;
-    if (!store.state.virtualized && list) {
-      let scrollContainer: HTMLElement | null = null;
-
-      for (const ancestor of getOverflowAncestors(list.firstElementChild ?? list)) {
-        if (!isHTMLElement(ancestor)) {
-          break;
-        }
-
-        // Stop at a surrounding dialog composed around an inline combobox so the reset
-        // scrolls the list's own overflow container, not the dialog or page behind it.
-        if (inline && ancestor.getAttribute('role') === 'dialog') {
-          break;
-        }
-
-        if (isScrollableY(ancestor, true)) {
-          scrollContainer = ancestor;
-          break;
-        }
-      }
-
-      if (scrollContainer) {
-        scrollContainer.scrollTop = 0;
-      }
-    }
-  }, [inputValue, inline, store]);
 
   useIsoLayoutEffect(() => {
     if (items) {

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -4497,11 +4497,11 @@ describe('<Combobox.Root />', () => {
     );
 
     it.skipIf(isJSDOM)(
-      'resets a scrollable wrapper up to the surrounding dialog when composed inline',
+      'resets only the nearest scrollable wrapper when composed in a scrollable dialog',
       async () => {
         const { user } = await render(
           <Combobox.Root items={manyItems} inline open>
-            <div role="dialog">
+            <div role="dialog" data-testid="dialog" style={{ maxHeight: 80, overflowY: 'auto' }}>
               <Combobox.Input data-testid="input" />
               <div data-testid="viewport" style={{ maxHeight: 100, overflowY: 'auto' }}>
                 <Combobox.List>
@@ -4517,15 +4517,20 @@ describe('<Combobox.Root />', () => {
         );
 
         const input = screen.getByTestId('input');
+        const dialog = screen.getByTestId('dialog');
         const viewport = screen.getByTestId('viewport');
+        await user.click(input);
+        dialog.scrollTop = 20;
         viewport.scrollTop = 40;
+        expect(dialog.scrollTop).toBeGreaterThan(0);
         expect(viewport.scrollTop).toBeGreaterThan(0);
 
-        await user.type(input, 'item-1');
+        await user.keyboard('item-1');
 
         await waitFor(() => {
           expect(viewport.scrollTop).toBe(0);
         });
+        expect(dialog.scrollTop).toBe(20);
       },
     );
   });

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -4521,6 +4521,44 @@ describe('<Combobox.Root />', () => {
       },
     );
 
+    it.skipIf(isJSDOM)('skips clipping ancestors when finding the scroll container', async () => {
+      const { user } = await render(
+        <Combobox.Root items={manyItems}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <div data-testid="viewport" style={{ height: 100, overflowY: 'auto' }}>
+                  <div style={{ overflowY: 'clip' }}>
+                    <Combobox.List>
+                      {(item: string) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      )}
+                    </Combobox.List>
+                  </div>
+                </div>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+
+      const viewport = screen.getByTestId('viewport');
+      viewport.scrollTop = 40;
+      expect(viewport.scrollTop).toBeGreaterThan(0);
+
+      await user.type(input, 'item-1');
+
+      await waitFor(() => {
+        expect(viewport.scrollTop).toBe(0);
+      });
+    });
+
     it.skipIf(isJSDOM)(
       'keeps the auto-highlighted first item in view after the query changes',
       async () => {

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -4558,13 +4558,70 @@ describe('<Combobox.Root />', () => {
     );
 
     it.skipIf(isJSDOM)(
+      'resets the scroll container when filtering reorders retained items',
+      async () => {
+        const items = Array.from({ length: 10 }, (_, index) => `item-${index}`);
+
+        function ReorderingCombobox() {
+          const [inputValue, setInputValue] = React.useState('');
+          const filteredItems = inputValue === '' ? items : [...items].reverse();
+
+          return (
+            <Combobox.Root
+              filteredItems={filteredItems}
+              inputValue={inputValue}
+              onInputValueChange={setInputValue}
+            >
+              <Combobox.Input data-testid="input" />
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.List style={{ maxHeight: 60, overflowY: 'auto' }}>
+                      {(item: string) => (
+                        <Combobox.Item key={item} value={item} style={{ height: 24 }}>
+                          {item}
+                        </Combobox.Item>
+                      )}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          );
+        }
+
+        const { user } = await render(<ReorderingCombobox />);
+        const input = screen.getByTestId('input');
+        await user.click(input);
+
+        const list = screen.getByRole('listbox');
+        list.scrollTop = 40;
+        expect(list.scrollTop).toBeGreaterThan(0);
+
+        await user.type(input, 'x');
+
+        await waitFor(() => {
+          expect(screen.getAllByRole('option')[0]).toHaveTextContent('item-9');
+        });
+        await waitFor(() => {
+          expect(list.scrollTop).toBe(0);
+        });
+      },
+    );
+
+    it.skipIf(isJSDOM)(
       'resets only the nearest scrollable wrapper when composed in a scrollable dialog',
       async () => {
         const { user } = await render(
           <Combobox.Root items={manyItems} inline open>
-            <div role="dialog" data-testid="dialog" style={{ maxHeight: 80, overflowY: 'auto' }}>
+            <div
+              role="dialog"
+              data-testid="dialog"
+              style={{ height: 80, overflowY: 'auto', overflowAnchor: 'none' }}
+            >
+              <div style={{ height: 100 }} />
               <Combobox.Input data-testid="input" />
-              <div data-testid="viewport" style={{ maxHeight: 100, overflowY: 'auto' }}>
+              <div data-testid="viewport" style={{ height: 100, overflowY: 'auto' }}>
                 <Combobox.List>
                   {(item: string) => (
                     <Combobox.Item key={item} value={item}>
@@ -4581,8 +4638,9 @@ describe('<Combobox.Root />', () => {
         const dialog = screen.getByTestId('dialog');
         const viewport = screen.getByTestId('viewport');
         await user.click(input);
-        dialog.scrollTop = 20;
+        dialog.scrollTop = 150;
         viewport.scrollTop = 40;
+        const dialogScrollTop = dialog.scrollTop;
         expect(dialog.scrollTop).toBeGreaterThan(0);
         expect(viewport.scrollTop).toBeGreaterThan(0);
 
@@ -4591,7 +4649,7 @@ describe('<Combobox.Root />', () => {
         await waitFor(() => {
           expect(viewport.scrollTop).toBe(0);
         });
-        expect(dialog.scrollTop).toBe(20);
+        expect(dialog.scrollTop).toBe(dialogScrollTop);
       },
     );
   });

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -4492,7 +4492,7 @@ describe('<Combobox.Root />', () => {
               <Combobox.Positioner>
                 <Combobox.Popup>
                   <div data-testid="viewport" style={{ maxHeight: 100, overflowY: 'auto' }}>
-                    <Combobox.List>
+                    <Combobox.List style={{ overflowY: 'auto' }}>
                       {(item: string) => (
                         <Combobox.Item key={item} value={item}>
                           {item}
@@ -4690,6 +4690,47 @@ describe('<Combobox.Root />', () => {
         expect(dialog.scrollTop).toBe(dialogScrollTop);
       },
     );
+
+    it.skipIf(isJSDOM)('does not reset a surrounding dialog', async () => {
+      const dialogRef = React.createRef<HTMLDivElement>();
+      const { user } = await render(
+        <Combobox.Root items={manyItems} open>
+          <div
+            ref={dialogRef}
+            role="dialog"
+            data-testid="dialog"
+            style={{ height: 80, overflowY: 'auto', overflowAnchor: 'none' }}
+          >
+            <div style={{ height: 100 }} />
+            <Combobox.Input data-testid="input" />
+            <Combobox.Portal container={dialogRef}>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <Combobox.List>
+                    {(item: string) => (
+                      <Combobox.Item key={item} value={item}>
+                        {item}
+                      </Combobox.Item>
+                    )}
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </div>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      const dialog = screen.getByTestId('dialog');
+      await user.click(input);
+      dialog.scrollTop = dialog.scrollHeight;
+      const dialogScrollTop = dialog.scrollTop;
+      expect(dialogScrollTop).toBeGreaterThan(0);
+
+      await user.keyboard('item-1');
+
+      expect(dialog.scrollTop).toBe(dialogScrollTop);
+    });
   });
 
   describe('prop: autoHighlight', () => {

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -4381,6 +4381,155 @@ describe('<Combobox.Root />', () => {
     });
   });
 
+  describe('scroll reset on input value change', () => {
+    const manyItems = Array.from({ length: 50 }, (_, index) => `item-${index}`);
+
+    it.skipIf(isJSDOM)(
+      'resets the list scroll position to the top when the query changes',
+      async () => {
+        const { user } = await render(
+          <Combobox.Root items={manyItems}>
+            <Combobox.Input data-testid="input" />
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <Combobox.List style={{ maxHeight: 100, overflowY: 'auto' }}>
+                    {(item: string) => (
+                      <Combobox.Item key={item} value={item}>
+                        {item}
+                      </Combobox.Item>
+                    )}
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+        await user.click(input);
+
+        const list = screen.getByRole('listbox');
+        list.scrollTop = 40;
+        expect(list.scrollTop).toBeGreaterThan(0);
+
+        await user.type(input, 'item-1');
+
+        await waitFor(() => {
+          expect(list.scrollTop).toBe(0);
+        });
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'resets the scroll position of a scrollable wrapper around the list',
+      async () => {
+        const { user } = await render(
+          <Combobox.Root items={manyItems}>
+            <Combobox.Input data-testid="input" />
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <div data-testid="viewport" style={{ maxHeight: 100, overflowY: 'auto' }}>
+                    <Combobox.List>
+                      {(item: string) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      )}
+                    </Combobox.List>
+                  </div>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+        await user.click(input);
+
+        const viewport = screen.getByTestId('viewport');
+        viewport.scrollTop = 40;
+        expect(viewport.scrollTop).toBeGreaterThan(0);
+
+        await user.type(input, 'item-1');
+
+        await waitFor(() => {
+          expect(viewport.scrollTop).toBe(0);
+        });
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'keeps the auto-highlighted first item in view after the query changes',
+      async () => {
+        const { user } = await render(
+          <Combobox.Root items={manyItems} autoHighlight>
+            <Combobox.Input data-testid="input" />
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <Combobox.List style={{ maxHeight: 100, overflowY: 'auto' }}>
+                    {(item: string) => (
+                      <Combobox.Item key={item} value={item}>
+                        {item}
+                      </Combobox.Item>
+                    )}
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+        await user.click(input);
+
+        const list = screen.getByRole('listbox');
+        list.scrollTop = 40;
+
+        await user.type(input, 'item-1');
+
+        await waitFor(() => {
+          expect(list.scrollTop).toBe(0);
+        });
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'resets a scrollable wrapper up to the surrounding dialog when composed inline',
+      async () => {
+        const { user } = await render(
+          <Combobox.Root items={manyItems} inline open>
+            <div role="dialog">
+              <Combobox.Input data-testid="input" />
+              <div data-testid="viewport" style={{ maxHeight: 100, overflowY: 'auto' }}>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </div>
+            </div>
+          </Combobox.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+        const viewport = screen.getByTestId('viewport');
+        viewport.scrollTop = 40;
+        expect(viewport.scrollTop).toBeGreaterThan(0);
+
+        await user.type(input, 'item-1');
+
+        await waitFor(() => {
+          expect(viewport.scrollTop).toBe(0);
+        });
+      },
+    );
+  });
+
   describe('prop: autoHighlight', () => {
     it('does not auto-highlight on initial open when no selection', async () => {
       await render(

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -4387,8 +4387,12 @@ describe('<Combobox.Root />', () => {
     it.skipIf(isJSDOM)(
       'resets the list scroll position to the top when the query changes',
       async () => {
+        const filteringItems = Array.from({ length: 50 }, (_, index) =>
+          index < 25 ? `alpha-${index}` : `beta-${index - 25}`,
+        );
+
         const { user } = await render(
-          <Combobox.Root items={manyItems}>
+          <Combobox.Root items={filteringItems}>
             <Combobox.Input data-testid="input" />
             <Combobox.Portal>
               <Combobox.Positioner>
@@ -4413,11 +4417,68 @@ describe('<Combobox.Root />', () => {
         list.scrollTop = 40;
         expect(list.scrollTop).toBeGreaterThan(0);
 
-        await user.type(input, 'item-1');
+        // Remove the current first item while keeping enough matches for the list to scroll.
+        await user.type(input, 'b');
 
         await waitFor(() => {
           expect(list.scrollTop).toBe(0);
         });
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'resets manually filtered children without deferring the reset until hover',
+      async () => {
+        const filteringItems = Array.from({ length: 50 }, (_, index) =>
+          index < 25 ? `alpha-${index}` : `beta-${index - 25}`,
+        );
+
+        function ManuallyFilteredCombobox() {
+          const [inputValue, setInputValue] = React.useState('');
+          const visibleItems = filteringItems.filter((item) => item.startsWith(inputValue));
+
+          return (
+            <Combobox.Root inputValue={inputValue} onInputValueChange={setInputValue}>
+              <Combobox.Input data-testid="input" />
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.List style={{ maxHeight: 100, overflowY: 'auto' }}>
+                      {visibleItems.map((item) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      ))}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          );
+        }
+
+        const { user } = await render(<ManuallyFilteredCombobox />);
+        const input = screen.getByTestId('input');
+        await user.click(input);
+
+        const list = screen.getByRole('listbox');
+        list.scrollTop = 40;
+        expect(list.scrollTop).toBeGreaterThan(0);
+
+        await user.type(input, 'b');
+
+        await waitFor(() => {
+          expect(list.scrollTop).toBe(0);
+        });
+
+        // A later highlight must not consume a typed-input reset that should already be cleared.
+        list.scrollTop = 40;
+        const visibleOption = screen.getByRole('option', { name: 'beta-5' });
+        fireEvent.mouseMove(visibleOption, { pointerType: 'mouse' });
+        await waitFor(() => {
+          expect(visibleOption).toHaveAttribute('data-highlighted');
+        });
+        expect(list.scrollTop).toBe(40);
       },
     );
 

--- a/packages/react/src/utils/scrollable.ts
+++ b/packages/react/src/utils/scrollable.ts
@@ -7,15 +7,14 @@ import {
 
 export type ScrollAxis = 'horizontal' | 'vertical';
 
-// When `allowOverflowIntent` is true, a container that overflows only once extra space is
-// added (e.g. drawer keyboard scroll slack) still counts, as long as it has layout size on
-// the axis.
-
 export function isScrollableY(element: HTMLElement, allowOverflowIntent = false): boolean {
   const { overflowY } = getComputedStyle(element);
   if (overflowY !== 'auto' && overflowY !== 'scroll') {
     return false;
   }
+  // When `allowOverflowIntent` is true, a container that overflows only once extra space is
+  // added (e.g. drawer keyboard scroll slack) still counts, as long as it has layout size on
+  // the axis.
   return allowOverflowIntent
     ? element.clientHeight > 0
     : element.scrollHeight > element.clientHeight;

--- a/packages/react/src/utils/scrollable.ts
+++ b/packages/react/src/utils/scrollable.ts
@@ -7,30 +7,36 @@ import {
 
 export type ScrollAxis = 'horizontal' | 'vertical';
 
-export function isScrollable(
-  element: HTMLElement,
-  axis: ScrollAxis,
-  // When true, a container that overflows only once extra space is added (e.g. drawer
-  // keyboard scroll slack) still counts, as long as it has layout size on the axis.
-  allowOverflowIntent = false,
-): boolean {
-  const style = getComputedStyle(element);
+// When `allowOverflowIntent` is true, a container that overflows only once extra space is
+// added (e.g. drawer keyboard scroll slack) still counts, as long as it has layout size on
+// the axis.
 
-  if (axis === 'vertical') {
-    const overflowY = style.overflowY;
-    if (overflowY !== 'auto' && overflowY !== 'scroll') {
-      return false;
-    }
-    return allowOverflowIntent
-      ? element.clientHeight > 0
-      : element.scrollHeight > element.clientHeight;
+export function isScrollableY(element: HTMLElement, allowOverflowIntent = false): boolean {
+  const { overflowY } = getComputedStyle(element);
+  if (overflowY !== 'auto' && overflowY !== 'scroll') {
+    return false;
   }
+  return allowOverflowIntent
+    ? element.clientHeight > 0
+    : element.scrollHeight > element.clientHeight;
+}
 
-  const overflowX = style.overflowX;
+export function isScrollableX(element: HTMLElement, allowOverflowIntent = false): boolean {
+  const { overflowX } = getComputedStyle(element);
   if (overflowX !== 'auto' && overflowX !== 'scroll') {
     return false;
   }
   return allowOverflowIntent ? element.clientWidth > 0 : element.scrollWidth > element.clientWidth;
+}
+
+export function isScrollable(
+  element: HTMLElement,
+  axis: ScrollAxis,
+  allowOverflowIntent = false,
+): boolean {
+  return axis === 'vertical'
+    ? isScrollableY(element, allowOverflowIntent)
+    : isScrollableX(element, allowOverflowIntent);
 }
 
 export function hasScrollableAncestor(


### PR DESCRIPTION
Closes #5204

When the input value changes and the list re-filters, the scroll position stayed where it was — the user could be left looking at the middle of a fresh result set (and with `autoHighlight`, the highlighted first item scrolled out of view). Autocomplete, built on the same internals, had the same bug.

On a typed-input change, the nearest list overflow container is now reset directly to the top. It is keyed on the typed-input signal rather than the input value, so inline autocompletion (`mode="both"`/`"inline"`) rewriting the input during arrow navigation does not reset the scroll. Resetting the container directly avoids scrolling a surrounding dialog or page and does not depend on stale composite registry order when retained items are reordered. Virtualized lists own their scroll element and are left untouched.

Playground: https://stackblitz.com/edit/ouhpah4p?file=src%2FApp.tsx