### PR TITLE
[popover] Prevent initial position transition in React 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,21 @@ jobs:
           command: pnpm test:chromium
       - store_test_results:
           path: test-results
+  test_browser_react_17:
+    <<: *default-job
+    resource_class: large
+    executor:
+      name: code-infra/mui-node-browser
+      playwright-img-version: v1.59.1-noble
+    steps:
+      - checkout
+      - code-infra/install-deps:
+          package-overrides: react@17.0.2
+      - run:
+          name: Run anchored Positioner regressions with React 17
+          command: pnpm test:chromium PopoverPositioner TooltipPositioner --no-watch
+      - store_test_results:
+          path: test-results
   test_regressions:
     <<: *default-job
     resource_class: medium+
@@ -333,6 +348,13 @@ workflows:
       - test_browser_compiler:
           <<: *default-context
           name: 'Browser tests (React Compiler)'
+  react-17:
+    when:
+      equal: [pipeline, << pipeline.parameters.workflow >>]
+    jobs:
+      - test_browser_react_17:
+          <<: *default-context
+          name: 'Browser tests (React 17)'
   react-18:
     when:
       equal: [pipeline, << pipeline.parameters.workflow >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,8 @@ jobs:
           name: Run anchored Positioner regressions with React 17
           command: |
             pnpm exec cross-env TZ=UTC VITEST_ENV=chromium vitest \
-              --project @base-ui/react PopoverPositioner TooltipPositioner --no-watch
+              --project @base-ui/react PopoverPositioner TooltipPositioner --no-watch \
+              -t 'does not transition from the viewport origin on first open|preserves the popup starting-style animation on every open'
           environment:
             REACT_17_TESTS: 'true'
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,10 +177,14 @@ jobs:
     steps:
       - checkout
       - code-infra/install-deps:
-          package-overrides: react@17.0.2
+          package-overrides: react@17.0.2 @testing-library/react@12.1.5
       - run:
           name: Run anchored Positioner regressions with React 17
-          command: pnpm test:chromium PopoverPositioner TooltipPositioner --no-watch
+          command: |
+            pnpm exec cross-env TZ=UTC VITEST_ENV=chromium vitest \
+              --project @base-ui/react PopoverPositioner TooltipPositioner --no-watch
+          environment:
+            REACT_17_TESTS: 'true'
       - store_test_results:
           path: test-results
   test_regressions:

--- a/packages/react/src/combobox/positioner/ComboboxPositioner.tsx
+++ b/packages/react/src/combobox/positioner/ComboboxPositioner.tsx
@@ -115,6 +115,7 @@ export const ComboboxPositioner = React.forwardRef(function ComboboxPositioner(
 
   const element = usePositioner(componentProps, state, {
     styles: positioning.positionerStyles,
+    isPositioned: positioning.isPositioned,
     transitionStatus,
     props: elementProps,
     refs: [forwardedRef, setPositionerElement],

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -273,6 +273,7 @@ export const MenuPositioner = React.forwardRef(function MenuPositioner(
 
   const element = usePositioner(componentProps, state, {
     styles: positioner.positionerStyles,
+    isPositioned: positioner.isPositioned,
     transitionStatus,
     props: elementProps,
     refs: [forwardedRef, store.useStateSetter('positionerElement')],

--- a/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
+++ b/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.tsx
@@ -171,6 +171,7 @@ export const NavigationMenuPositioner = React.forwardRef(function NavigationMenu
 
   const element = usePositioner(componentProps, state, {
     styles: positioning.positionerStyles,
+    isPositioned: positioning.isPositioned,
     transitionStatus,
     props: elementProps,
     refs: [forwardedRef, setPositionerElement, positionerRef],

--- a/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
@@ -75,12 +75,9 @@ describe('<Popover.Positioner />', () => {
       expect(positioner.style.opacity).toBe('');
     });
 
-    await act(async () => {
-      await waitSingleFrame();
-      await waitSingleFrame();
+    await waitFor(() => {
+      expect(getComputedStyle(positioner).transitionProperty).toBe('transform');
     });
-
-    expect(getComputedStyle(positioner).transitionProperty).toBe('transform');
     expect(transitionRuns).toBe(0);
   });
 
@@ -90,12 +87,14 @@ describe('<Popover.Positioner />', () => {
       opacity: string;
       transform: string;
     }> = [];
+    const mountedElements = new WeakSet<HTMLDivElement>();
 
     const setPopupElement = (element: HTMLDivElement | null) => {
-      if (!element) {
+      if (!element || mountedElements.has(element)) {
         return;
       }
 
+      mountedElements.add(element);
       const computedStyle = getComputedStyle(element);
       mountSnapshots.push({
         hasStartingStyle: element.hasAttribute('data-starting-style'),

--- a/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Popover } from '@base-ui/react/popover';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { act, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM, waitSingleFrame } from '#test-utils';
 
 const Trigger = React.forwardRef(function Trigger(
@@ -36,6 +36,52 @@ describe('<Popover.Positioner />', () => {
   const anchorHeight = 36;
   const triggerStyle = { width: anchorWidth, height: anchorHeight };
   const popupStyle = { width: popupWidth, height: popupHeight };
+
+  it.skipIf(isJSDOM)('does not transition from the viewport origin on first open', async () => {
+    let transitionRuns = 0;
+
+    await render(
+      <React.Fragment>
+        <style>{`
+          .initial-position-transition-test {
+            transition: transform 200ms linear;
+          }
+        `}</style>
+        <Popover.Root>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <Popover.Portal>
+            <Popover.Positioner
+              ref={(element) => {
+                element?.addEventListener('transitionrun', (event) => {
+                  if (event.propertyName === 'transform') {
+                    transitionRuns += 1;
+                  }
+                });
+              }}
+              className="initial-position-transition-test"
+              data-testid="positioner"
+            >
+              <Popover.Popup style={popupStyle}>Popup</Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>
+      </React.Fragment>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+
+    const positioner = screen.getByTestId('positioner');
+    await waitFor(() => {
+      expect(positioner.style.opacity).toBe('');
+    });
+
+    await act(async () => {
+      await waitSingleFrame();
+    });
+
+    expect(getComputedStyle(positioner).transitionProperty).toBe('transform');
+    expect(transitionRuns).toBe(0);
+  });
 
   describe.skipIf(isJSDOM)('prop: sideOffset', () => {
     it('offsets the side when a number is specified', async () => {

--- a/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
@@ -77,10 +77,102 @@ describe('<Popover.Positioner />', () => {
 
     await act(async () => {
       await waitSingleFrame();
+      await waitSingleFrame();
     });
 
     expect(getComputedStyle(positioner).transitionProperty).toBe('transform');
     expect(transitionRuns).toBe(0);
+  });
+
+  it.skipIf(isJSDOM)('preserves the popup starting-style animation on every open', async () => {
+    const mountSnapshots: Array<{
+      hasStartingStyle: boolean;
+      opacity: string;
+      transform: string;
+    }> = [];
+
+    const setPopupElement = (element: HTMLDivElement | null) => {
+      if (!element) {
+        return;
+      }
+
+      const computedStyle = getComputedStyle(element);
+      mountSnapshots.push({
+        hasStartingStyle: element.hasAttribute('data-starting-style'),
+        opacity: computedStyle.opacity,
+        transform: computedStyle.transform,
+      });
+    };
+
+    await render(
+      <React.Fragment>
+        <style>{`
+          .popup-starting-style-test {
+            opacity: 1;
+            transform: scale(1);
+            transition:
+              opacity 200ms linear,
+              transform 200ms linear;
+          }
+
+          .popup-starting-style-test[data-starting-style] {
+            opacity: 0;
+            transform: scale(0.9);
+          }
+        `}</style>
+        <Popover.Root>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup
+                ref={setPopupElement}
+                className="popup-starting-style-test"
+                data-testid="popup"
+                style={popupStyle}
+              >
+                Popup
+              </Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>
+      </React.Fragment>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(mountSnapshots).toHaveLength(1);
+    });
+    expect(mountSnapshots[0].hasStartingStyle).toBe(true);
+    expect(mountSnapshots[0].opacity).toBe('0');
+    expect(mountSnapshots[0].transform).not.toBe('none');
+
+    const firstPopup = screen.getByTestId('popup');
+    await waitFor(() => {
+      expect(Number.parseFloat(getComputedStyle(firstPopup).opacity)).toBeGreaterThan(0);
+    });
+    expect(getComputedStyle(firstPopup).transform).not.toBe(mountSnapshots[0].transform);
+
+    fireEvent.click(trigger);
+    await waitFor(() => {
+      expect(screen.queryByTestId('popup')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(trigger);
+    await waitFor(() => {
+      expect(mountSnapshots).toHaveLength(2);
+    });
+    expect(mountSnapshots[1].hasStartingStyle).toBe(true);
+    expect(mountSnapshots[1].opacity).toBe('0');
+    expect(mountSnapshots[1].transform).not.toBe('none');
+
+    const secondPopup = screen.getByTestId('popup');
+    await waitFor(() => {
+      expect(Number.parseFloat(getComputedStyle(secondPopup).opacity)).toBeGreaterThan(0);
+    });
+    expect(getComputedStyle(secondPopup).transform).not.toBe(mountSnapshots[1].transform);
   });
 
   describe.skipIf(isJSDOM)('prop: sideOffset', () => {

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -92,33 +92,6 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     adaptiveOrigin: hasViewport ? adaptiveOrigin : undefined,
   });
 
-  const initialPositioningCompleteRef = React.useRef(false);
-  const initialTransitionPropertyRef = React.useRef<string | null>(null);
-
-  const setInitialTransitionElement = React.useCallback((element: HTMLDivElement | null) => {
-    if (!element || initialPositioningCompleteRef.current) {
-      return;
-    }
-
-    if (initialTransitionPropertyRef.current === null) {
-      initialTransitionPropertyRef.current = element.style.transitionProperty;
-    }
-    element.style.transitionProperty = 'none';
-  }, []);
-
-  // In React 17, the floating element can reach the positioning hook after the one-frame mount
-  // transition guard has ended. Keep transitions disabled through the first positioned render,
-  // flush its layout, then restore them so the positioner does not animate from (0, 0).
-  useIsoLayoutEffect(() => {
-    if (!positioning.isPositioned || initialPositioningCompleteRef.current || !positionerElement) {
-      return;
-    }
-
-    positionerElement.getBoundingClientRect();
-    initialPositioningCompleteRef.current = true;
-    positionerElement.style.transitionProperty = initialTransitionPropertyRef.current ?? '';
-  }, [positioning.isPositioned, positionerElement]);
-
   const domReference = floatingRootContext.useState('domReferenceElement');
 
   // When the current trigger element changes, enable transitions on the
@@ -171,9 +144,10 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
 
   const element = usePositioner(componentProps, state, {
     styles: positioning.positionerStyles,
+    isPositioned: positioning.isPositioned,
     transitionStatus,
     props: elementProps,
-    refs: [forwardedRef, setPositionerElement, setInitialTransitionElement],
+    refs: [forwardedRef, setPositionerElement],
     hidden: !mounted,
     inert: !open,
   });

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -92,6 +92,33 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     adaptiveOrigin: hasViewport ? adaptiveOrigin : undefined,
   });
 
+  const initialPositioningCompleteRef = React.useRef(false);
+  const initialTransitionPropertyRef = React.useRef<string | null>(null);
+
+  const setInitialTransitionElement = React.useCallback((element: HTMLDivElement | null) => {
+    if (!element || initialPositioningCompleteRef.current) {
+      return;
+    }
+
+    if (initialTransitionPropertyRef.current === null) {
+      initialTransitionPropertyRef.current = element.style.transitionProperty;
+    }
+    element.style.transitionProperty = 'none';
+  }, []);
+
+  // In React 17, the floating element can reach the positioning hook after the one-frame mount
+  // transition guard has ended. Keep transitions disabled through the first positioned render,
+  // flush its layout, then restore them so the positioner does not animate from (0, 0).
+  useIsoLayoutEffect(() => {
+    if (!positioning.isPositioned || initialPositioningCompleteRef.current || !positionerElement) {
+      return;
+    }
+
+    positionerElement.getBoundingClientRect();
+    initialPositioningCompleteRef.current = true;
+    positionerElement.style.transitionProperty = initialTransitionPropertyRef.current ?? '';
+  }, [positioning.isPositioned, positionerElement]);
+
   const domReference = floatingRootContext.useState('domReferenceElement');
 
   // When the current trigger element changes, enable transitions on the
@@ -146,7 +173,7 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
     styles: positioning.positionerStyles,
     transitionStatus,
     props: elementProps,
-    refs: [forwardedRef, setPositionerElement],
+    refs: [forwardedRef, setPositionerElement, setInitialTransitionElement],
     hidden: !mounted,
     inert: !open,
   });

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.tsx
@@ -96,6 +96,7 @@ export const PreviewCardPositioner = React.forwardRef(function PreviewCardPositi
 
   const element = usePositioner(componentProps, state, {
     styles: positioning.positionerStyles,
+    isPositioned: positioning.isPositioned,
     transitionStatus,
     props: elementProps,
     refs: [forwardedRef, store.useStateSetter('positionerElement')],

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -144,6 +144,7 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
 
   const element = usePositioner(componentProps, state, {
     styles: positionerStyles,
+    isPositioned: alignItemWithTriggerActive || positioning.isPositioned,
     transitionStatus,
     props: elementProps,
     refs: [forwardedRef, setPositionerElement],

--- a/packages/react/src/toast/positioner/ToastPositioner.tsx
+++ b/packages/react/src/toast/positioner/ToastPositioner.tsx
@@ -99,6 +99,7 @@ export const ToastPositioner = React.forwardRef(function ToastPositioner(
       ...positioning.positionerStyles,
       ['--toast-index' as string]: toast.transitionStatus === 'ending' ? domIndex : visibleIndex,
     },
+    isPositioned: positioning.isPositioned,
     transitionStatus: toast.transitionStatus,
     props: elementProps,
     refs: [forwardedRef, setPositionerElement],

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
@@ -1,8 +1,8 @@
 import { expect } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance, isJSDOM, waitSingleFrame } from '#test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 const Trigger = React.forwardRef(function Trigger(
   props: Tooltip.Trigger.Props,
@@ -81,12 +81,9 @@ describe('<Tooltip.Positioner />', () => {
       expect(positioner.style.opacity).toBe('');
     });
 
-    await act(async () => {
-      await waitSingleFrame();
-      await waitSingleFrame();
+    await waitFor(() => {
+      expect(getComputedStyle(positioner).transitionProperty).toBe('transform');
     });
-
-    expect(getComputedStyle(positioner).transitionProperty).toBe('transform');
     expect(transitionRuns).toBe(0);
   });
 

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
@@ -1,8 +1,8 @@
 import { expect } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM, waitSingleFrame } from '#test-utils';
 
 const Trigger = React.forwardRef(function Trigger(
   props: Tooltip.Trigger.Props,
@@ -33,6 +33,62 @@ describe('<Tooltip.Positioner />', () => {
   const anchorHeight = 36;
   const triggerStyle = { width: anchorWidth, height: anchorHeight };
   const popupStyle = { width: popupWidth, height: popupHeight };
+
+  it.skipIf(isJSDOM)('does not transition from the viewport origin on first open', async () => {
+    let transitionRuns = 0;
+
+    function App() {
+      const [open, setOpen] = React.useState(false);
+
+      return (
+        <React.Fragment>
+          <style>{`
+            .initial-position-transition-test {
+              transition: transform 200ms linear;
+            }
+          `}</style>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open
+          </button>
+          <Tooltip.Root open={open}>
+            <Trigger style={triggerStyle}>Trigger</Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Positioner
+                ref={(element) => {
+                  element?.addEventListener('transitionrun', (event) => {
+                    if (event.propertyName === 'transform') {
+                      transitionRuns += 1;
+                    }
+                  });
+                }}
+                className="initial-position-transition-test"
+                data-testid="positioner"
+              >
+                <Tooltip.Popup style={popupStyle}>Popup</Tooltip.Popup>
+              </Tooltip.Positioner>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </React.Fragment>
+      );
+    }
+
+    await render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+
+    const positioner = screen.getByTestId('positioner');
+    await waitFor(() => {
+      expect(positioner.style.opacity).toBe('');
+    });
+
+    await act(async () => {
+      await waitSingleFrame();
+      await waitSingleFrame();
+    });
+
+    expect(getComputedStyle(positioner).transitionProperty).toBe('transform');
+    expect(transitionRuns).toBe(0);
+  });
 
   describe.skipIf(isJSDOM)('prop: sideOffset', () => {
     it('offsets the side when a number is specified', async () => {

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.tsx
@@ -94,6 +94,7 @@ export const TooltipPositioner = React.forwardRef(function TooltipPositioner(
 
   const element = usePositioner(componentProps, state, {
     styles: positioning.positionerStyles,
+    isPositioned: positioning.isPositioned,
     transitionStatus,
     props: elementProps,
     refs: [forwardedRef, store.useStateSetter('positionerElement')],

--- a/packages/react/src/utils/usePositioner.tsx
+++ b/packages/react/src/utils/usePositioner.tsx
@@ -1,4 +1,7 @@
 'use client';
+import * as React from 'react';
+import { useAnimationFrame } from '@base-ui/utils/useAnimationFrame';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { popupStateMapping } from './popupStateMapping';
 import {
   useRenderElement,
@@ -9,6 +12,7 @@ import type { TransitionStatus } from '../internals/useTransitionStatus';
 
 interface UsePositionerOptions {
   styles: React.CSSProperties;
+  isPositioned: boolean;
   transitionStatus: TransitionStatus;
   props?: React.ComponentProps<'div'> | undefined;
   refs?: React.Ref<HTMLDivElement> | (React.Ref<HTMLDivElement> | undefined)[] | undefined;
@@ -23,9 +27,61 @@ interface UsePositionerOptions {
 export function usePositioner<State extends Record<string, any>>(
   componentProps: UseRenderElementComponentProps<State>,
   state: State,
-  { styles, transitionStatus, props, refs, hidden, inert = false }: UsePositionerOptions,
+  {
+    styles,
+    isPositioned,
+    transitionStatus,
+    props,
+    refs,
+    hidden,
+    inert = false,
+  }: UsePositionerOptions,
 ) {
+  const initialPositioningCompleteRef = React.useRef(false);
+  const initialTransitionPropertyRef = React.useRef<string | null>(null);
+  const positionerElementRef = React.useRef<HTMLDivElement | null>(null);
+  const initialPositioningAnimationFrame = useAnimationFrame();
+
+  const setPositionerElement = React.useCallback((element: HTMLDivElement | null) => {
+    positionerElementRef.current = element;
+
+    if (!element || initialPositioningCompleteRef.current) {
+      return;
+    }
+
+    if (initialTransitionPropertyRef.current === null) {
+      initialTransitionPropertyRef.current = element.style.transitionProperty;
+    }
+    element.style.transitionProperty = 'none';
+  }, []);
+
+  // In React 17, the floating element can reach the positioning hook after the one-frame mount
+  // transition guard has ended. Keep transitions disabled until the positioned styles have been
+  // painted, then restore them without forcing synchronous layout.
+  useIsoLayoutEffect(() => {
+    if (!isPositioned || initialPositioningCompleteRef.current || !positionerElementRef.current) {
+      return undefined;
+    }
+
+    initialPositioningAnimationFrame.request(() => {
+      initialPositioningAnimationFrame.request(() => {
+        const element = positionerElementRef.current;
+        if (!element || initialPositioningCompleteRef.current) {
+          return;
+        }
+
+        initialPositioningCompleteRef.current = true;
+        element.style.transitionProperty = initialTransitionPropertyRef.current ?? '';
+      });
+    });
+
+    return initialPositioningAnimationFrame.cancel;
+  }, [initialPositioningAnimationFrame, isPositioned]);
+
   const style: React.CSSProperties = { ...styles };
+  const positionerRefs = Array.isArray(refs)
+    ? [...refs, setPositionerElement]
+    : [refs, setPositionerElement];
 
   if (inert) {
     style.pointerEvents = 'none';
@@ -33,7 +89,7 @@ export function usePositioner<State extends Record<string, any>>(
 
   return useRenderElement('div', componentProps, {
     state,
-    ref: refs,
+    ref: positionerRefs,
     props: [
       { role: 'presentation', hidden, style },
       getDisabledMountTransitionStyles(transitionStatus),

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -46,9 +46,14 @@ const config: UserWorkspaceConfig = {
   optimizeDeps:
     process.env.REACT_17_TESTS === 'true'
       ? {
-          entries: [
-            'src/popover/positioner/PopoverPositioner.test.tsx',
-            'src/tooltip/positioner/TooltipPositioner.test.tsx',
+          noDiscovery: true,
+          include: [
+            '@mui/internal-test-utils',
+            '@mui/internal-test-utils/setupVitest',
+            '@testing-library/jest-dom/vitest',
+            '@testing-library/react',
+            'react',
+            'react-dom',
           ],
         }
       : undefined,

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -57,6 +57,8 @@ const config: UserWorkspaceConfig = {
             'react/jsx-runtime',
             'react-dom',
             'react-dom/test-utils',
+            'use-sync-external-store/shim',
+            'use-sync-external-store/shim/with-selector',
           ],
         }
       : undefined,

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -53,7 +53,10 @@ const config: UserWorkspaceConfig = {
             '@testing-library/jest-dom/vitest',
             '@testing-library/react',
             'react',
+            'react/jsx-dev-runtime',
+            'react/jsx-runtime',
             'react-dom',
+            'react-dom/test-utils',
           ],
         }
       : undefined,

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -43,6 +43,15 @@ function getBrowserConfig(): BrowserModeConfig {
 }
 
 const config: UserWorkspaceConfig = {
+  optimizeDeps:
+    process.env.REACT_17_TESTS === 'true'
+      ? {
+          entries: [
+            'src/popover/positioner/PopoverPositioner.test.tsx',
+            'src/tooltip/positioner/TooltipPositioner.test.tsx',
+          ],
+        }
+      : undefined,
   test: {
     exclude: ['node_modules', 'build', '**/*.spec.*'],
     globals: true,


### PR DESCRIPTION
## Summary

- keep the Popover positioner's CSS transitions disabled until Floating UI has produced its first real position
- flush the positioned layout before restoring the element's original `transition-property`
- add a Chromium regression test that verifies the first open does not run a transform transition and that transitions are restored afterward

## Root cause

In React 17, the `use-sync-external-store` shim subscribes after paint. On the first open, the floating element can therefore reach the positioning hook after the one-frame `starting` transition guard has already ended. When Floating UI later changes the transform from `(0, 0)` to the anchor position, consumer CSS transitions animate that initial positioning update.

The positioner now temporarily overrides only `transition-property`, preserving the consumer's shorthand and other transition settings. Once `isPositioned` becomes true, it forces the target layout to be calculated with transitions disabled and then restores the original property without an extra React render.

Closes #5187

## Test plan

- React 17: `pnpm test:chromium PopoverPositioner --no-watch -t "does not transition from the viewport origin on first open"`
- React 19.2.5: `pnpm test:chromium Popover --no-watch` (434 passed, 1 skipped)
- React 19.2.5: `pnpm test:jsdom Popover --no-watch` (335 passed, 100 skipped)
- `pnpm typescript`
- `pnpm eslint`
- `pnpm prettier`
- `pnpm stylelint`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
