### PR TITLE
[navigation-menu] Fix return value for nodeChildrenContains in isOutsideMenuEvent

### DIFF
--- a/packages/react/src/navigation-menu/utils/isOutsideMenuEvent.ts
+++ b/packages/react/src/navigation-menu/utils/isOutsideMenuEvent.ts
@@ -20,7 +20,7 @@ export function isOutsideMenuEvent({ currentTarget, relatedTarget }: Targets, pa
     ? getNodeChildren(tree.nodesRef.current, nodeId).some((node) =>
         contains(node.context?.elements.floating, relatedTarget),
       )
-    : [];
+    : false;
 
   // For nested scenarios without popupElement, we need to be more lenient
   // and only close if we're definitely outside the root


### PR DESCRIPTION
`nodeChildrenContains` falls back to `[]` instead of `false`, but it's only used as `!nodeChildrenContains` and `![] is false`, inverting the intended meaning.