### PR TITLE
[radio group] Align form values with native submission

### DIFF
--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -44,7 +44,7 @@ function isEligibleInput(input: HTMLInputElement, formElement: HTMLFormElement |
 
 /**
  * Picks the input whose native validity should represent a field that owns several inputs (such as a
- * checkbox group). Prefers the first eligible currently-invalid input, where "first" follows
+ * checkbox or radio group). Prefers the first eligible currently-invalid input, where "first" follows
  * registration order (mount order), and otherwise returns the first eligible input.
  */
 function findRepresentativeInput(
@@ -95,9 +95,9 @@ export function useFieldValidation(
   const registeredInputs = useRefWithInit<RegisteredInputs>(() => new Map()).current;
   const validationCommitIdRef = React.useRef(0);
 
-  // Checkbox groups register several inputs against a single field. Track them so a `required`
-  // checkbox can't be satisfied by another input in the group, matching native per-checkbox
-  // behavior, and so focus and form-value projection use the same live controls.
+  // Groups register several inputs against a single field so focus, validation, and form-value
+  // projection can use the same live controls. This also ensures a `required` checkbox can't be
+  // satisfied by another input in the group, matching native per-checkbox behavior.
   const registerInput = React.useCallback(
     (element: HTMLInputElement | null, registration: RegisteredInput) => {
       if (!element) {
@@ -158,9 +158,9 @@ export function useFieldValidation(
       setValidityData(nextValidityData);
     }
 
-    // A field can own several inputs (a checkbox group), but only the last-mounted one wins the shared
-    // `inputRef`. Validate against the registry instead so every input counts; `inputRef` is the
-    // fallback only when no inputs are registered.
+    // A field can own several inputs (such as a checkbox or radio group), but only the last-mounted
+    // one wins the shared `inputRef`. Validate against the registry instead so every input counts;
+    // `inputRef` is the fallback only when no inputs are registered.
     const element =
       registeredInputs.size > 0
         ? findRepresentativeInput(registeredInputs, elementRef.current)

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1259,6 +1259,64 @@ describe('<RadioGroup />', () => {
       expect(handleSubmit.mock.calls[0][0]).toEqual({ test: null });
     });
 
+    it('unblocks submission after every radio in the group unmounts', async () => {
+      const handleSubmit = vi.fn();
+
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+        return (
+          <Form onFormSubmit={handleSubmit}>
+            <Field.Root name="choice">
+              <RadioGroup required>{mounted && <Radio.Root value="a" />}</RadioGroup>
+            </Field.Root>
+            <button type="button" onClick={() => setMounted(false)}>
+              Remove
+            </button>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      const { user } = await renderFakeTimers(<App />);
+
+      await user.click(screen.getByText('Submit'));
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      await user.click(screen.getByText('Remove'));
+      await user.click(screen.getByText('Submit'));
+
+      expect(handleSubmit.mock.lastCall?.[0]).toEqual({ choice: null });
+    });
+
+    it('runs the custom validator after every radio in the group unmounts', async () => {
+      const handleSubmit = vi.fn();
+      const validate = vi.fn(() => 'always invalid');
+
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+        return (
+          <Form onFormSubmit={handleSubmit}>
+            <Field.Root name="choice" validate={validate}>
+              <RadioGroup>{mounted && <Radio.Root value="a" />}</RadioGroup>
+              <Field.Error data-testid="error" />
+            </Field.Root>
+            <button type="button" onClick={() => setMounted(false)}>
+              Remove
+            </button>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      const { user } = await renderFakeTimers(<App />);
+
+      await user.click(screen.getByText('Remove'));
+      await user.click(screen.getByText('Submit'));
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+      expect(screen.getByTestId('error')).toHaveTextContent('always invalid');
+    });
+
     it('excludes a disabled selected radio from onFormSubmit to match native form data', async () => {
       const handleSubmit = vi.fn();
 
@@ -1471,6 +1529,38 @@ describe('<RadioGroup />', () => {
 
       expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: null });
     });
+
+    it.skipIf(isJSDOM)(
+      'submits null when the selected radio in a required group is disabled, matching native validity',
+      async () => {
+        const handleSubmit = vi.fn();
+
+        await renderFakeTimers(
+          <Form onFormSubmit={handleSubmit} data-testid="form">
+            <Field.Root name="choice">
+              <RadioGroup required defaultValue="a">
+                <Radio.Root value="a" disabled data-testid="item-a" />
+                <Radio.Root value="b" data-testid="item-b" />
+              </RadioGroup>
+              <Field.Error match="valueMissing" data-testid="error">
+                required
+              </Field.Error>
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>,
+        );
+
+        const form = screen.getByTestId('form') as HTMLFormElement;
+        expect(new FormData(form).getAll('choice')).toEqual([]);
+
+        fireEvent.click(screen.getByText('Submit'));
+
+        // Natively, a disabled checked radio still satisfies its radio group's `valueMissing`
+        // constraint even though its value is not submitted.
+        expect(screen.queryByTestId('error')).toBe(null);
+        expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: null });
+      },
+    );
 
     it('clears required validation when a value is selected', async () => {
       const { user } = await renderFakeTimers(

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1,5 +1,6 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { RadioGroup } from '@base-ui/react/radio-group';
 import { Radio } from '@base-ui/react/radio';
 import { Field } from '@base-ui/react/field';
@@ -1529,6 +1530,36 @@ describe('<RadioGroup />', () => {
 
       expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: null });
     });
+
+    it.skipIf(isJSDOM)(
+      'omits a context-portaled radio without native form association',
+      async () => {
+        const handleSubmit = vi.fn();
+        const portalContainer = document.createElement('div');
+        document.body.append(portalContainer);
+
+        await renderFakeTimers(
+          <Form onFormSubmit={handleSubmit} data-testid="form">
+            <Field.Root name="choice">
+              <RadioGroup defaultValue="a">
+                {ReactDOM.createPortal(<Radio.Root value="a" />, portalContainer)}
+              </RadioGroup>
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>,
+        );
+
+        const form = screen.getByTestId('form') as HTMLFormElement;
+        // The radio is portaled out of the form with no `form` association, so its value is not
+        // submitted, matching native successful-control semantics.
+        expect(new FormData(form).getAll('choice')).toEqual([]);
+
+        fireEvent.click(screen.getByText('Submit'));
+
+        expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: null });
+        portalContainer.remove();
+      },
+    );
 
     it.skipIf(isJSDOM)(
       'submits null when the selected radio in a required group is disabled, matching native validity',

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1407,6 +1407,44 @@ describe('<RadioGroup />', () => {
       },
     );
 
+    it.skipIf(isJSDOM)(
+      'includes a selected radio after its ancestor fieldset is enabled',
+      async () => {
+        const handleSubmit = vi.fn();
+
+        function App() {
+          const [disabled, setDisabled] = React.useState(true);
+          return (
+            <Form onFormSubmit={handleSubmit} data-testid="form">
+              <fieldset disabled={disabled}>
+                <Field.Root name="choice">
+                  <RadioGroup defaultValue="a">
+                    <Radio.Root value="a" />
+                    <Radio.Root value="b" />
+                  </RadioGroup>
+                </Field.Root>
+              </fieldset>
+              <button type="button" onClick={() => setDisabled(false)}>
+                Enable
+              </button>
+              <button type="submit">Submit</button>
+            </Form>
+          );
+        }
+
+        await renderFakeTimers(<App />);
+
+        const form = screen.getByTestId('form') as HTMLFormElement;
+        expect(new FormData(form).getAll('choice')).toEqual([]);
+
+        fireEvent.click(screen.getByText('Enable'));
+        expect(new FormData(form).getAll('choice')).toEqual(['a']);
+
+        fireEvent.click(screen.getByText('Submit'));
+        expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: 'a' });
+      },
+    );
+
     it.skipIf(isJSDOM)('omits a radio associated to another form via the `form` prop', async () => {
       const handleSubmit = vi.fn();
 
@@ -1526,6 +1564,41 @@ describe('<RadioGroup />', () => {
 
       expect(document.activeElement).toBe(radioA);
     });
+
+    it.skipIf(isJSDOM)(
+      'validates and focuses the first radio after its ancestor fieldset is enabled',
+      async () => {
+        function App() {
+          const [disabled, setDisabled] = React.useState(true);
+
+          return (
+            <Form>
+              <fieldset disabled={disabled}>
+                <Field.Root name="test">
+                  <RadioGroup required>
+                    <Radio.Root value="a" data-testid="item-a" />
+                    <Radio.Root value="b" />
+                  </RadioGroup>
+                  <Field.Error match="valueMissing">required</Field.Error>
+                </Field.Root>
+              </fieldset>
+              <button type="button" onClick={() => setDisabled(false)}>
+                Enable
+              </button>
+              <button type="submit">Submit</button>
+            </Form>
+          );
+        }
+
+        const { user } = await renderFakeTimers(<App />);
+
+        await user.click(screen.getByText('Enable'));
+        await user.click(screen.getByText('Submit'));
+
+        expect(screen.getByText('required')).toBeVisible();
+        expect(screen.getByTestId('item-a')).toHaveFocus();
+      },
+    );
 
     it('clears external errors on change', async () => {
       await renderFakeTimers(

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1351,6 +1351,89 @@ describe('<RadioGroup />', () => {
       expect(handleSubmit.mock.calls[0][0]).toEqual({ test: null });
     });
 
+    it.skipIf(isJSDOM)(
+      'projects an enabled selected radio, matching native form data',
+      async () => {
+        const handleSubmit = vi.fn();
+
+        await renderFakeTimers(
+          <Form onFormSubmit={handleSubmit} data-testid="form">
+            <Field.Root name="choice">
+              <RadioGroup defaultValue="a">
+                <Radio.Root value="a" data-testid="item-a" />
+                <Radio.Root value="b" data-testid="item-b" />
+              </RadioGroup>
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>,
+        );
+
+        const form = screen.getByTestId('form') as HTMLFormElement;
+        expect(new FormData(form).getAll('choice')).toEqual(['a']);
+
+        fireEvent.click(screen.getByText('Submit'));
+
+        expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: 'a' });
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'excludes a radio disabled through an ancestor <fieldset disabled> to match native form data',
+      async () => {
+        const handleSubmit = vi.fn();
+
+        await renderFakeTimers(
+          <Form onFormSubmit={handleSubmit} data-testid="form">
+            <fieldset disabled>
+              <Field.Root name="choice">
+                <RadioGroup defaultValue="a">
+                  <Radio.Root value="a" data-testid="item-a" />
+                  <Radio.Root value="b" data-testid="item-b" />
+                </RadioGroup>
+              </Field.Root>
+            </fieldset>
+            <button type="submit">Submit</button>
+          </Form>,
+        );
+
+        const form = screen.getByTestId('form') as HTMLFormElement;
+        // Native submission omits controls disabled by an ancestor fieldset, even though
+        // their `disabled` property is `false`.
+        expect(new FormData(form).getAll('choice')).toEqual([]);
+
+        fireEvent.click(screen.getByText('Submit'));
+
+        expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: null });
+      },
+    );
+
+    it.skipIf(isJSDOM)('omits a radio associated to another form via the `form` prop', async () => {
+      const handleSubmit = vi.fn();
+
+      await renderFakeTimers(
+        <React.Fragment>
+          <form id="external-form" />
+          <Form onFormSubmit={handleSubmit} data-testid="form">
+            <Field.Root name="choice">
+              <RadioGroup form="external-form" defaultValue="a">
+                <Radio.Root value="a" data-testid="item-a" />
+                <Radio.Root value="b" data-testid="item-b" />
+              </RadioGroup>
+            </Field.Root>
+            <button type="submit">Submit</button>
+          </Form>
+        </React.Fragment>,
+      );
+
+      const form = screen.getByTestId('form') as HTMLFormElement;
+      // The radio is associated to #external-form, so this form excludes it natively.
+      expect(new FormData(form).getAll('choice')).toEqual([]);
+
+      fireEvent.click(screen.getByText('Submit'));
+
+      expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: null });
+    });
+
     it('clears required validation when a value is selected', async () => {
       const { user } = await renderFakeTimers(
         <Form>

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -88,7 +88,15 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     },
   );
 
-  const controlRef = React.useRef<HTMLElement>(null);
+  const getInputControl = validation.getInputControl;
+  const controlRef = React.useMemo<React.RefObject<HTMLElement | null>>(
+    () => ({
+      get current() {
+        return getInputControl();
+      },
+    }),
+    [getInputControl],
+  );
   const groupInputRef = React.useRef<HTMLInputElement | null>(null);
   const firstEnabledInputRef = React.useRef<HTMLInputElement | null>(null);
 
@@ -109,30 +117,8 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     return cleanup;
   }
 
-  const registerControlRef = useStableCallback(
-    (element: HTMLElement | null, isDisabled = false) => {
-      if (!element) {
-        return;
-      }
-
-      if (isDisabled) {
-        if (controlRef.current === element) {
-          controlRef.current = null;
-        }
-        return;
-      }
-
-      if (controlRef.current == null) {
-        controlRef.current = element;
-      }
-    },
-  );
-
   const registerInputRef = useStableCallback((input: HTMLInputElement | null) => {
-    // `:disabled` also matches inputs disabled through an ancestor `<fieldset disabled>`,
-    // which the `disabled` property alone misses. Such inputs are ineligible to represent
-    // the group for focus and validation, matching native form submission.
-    if (!input || input.matches(':disabled')) {
+    if (!input || input.disabled) {
       return undefined;
     }
 
@@ -141,7 +127,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     }
 
     const currentInput = groupInputRef.current;
-    if (input.checked || currentInput == null || currentInput.matches(':disabled')) {
+    if (input.checked || currentInput == null || currentInput.disabled) {
       return setInputRef(input);
     }
 
@@ -149,21 +135,18 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
   });
 
   const getFormValue = useStableCallback(() => {
-    // Only project the value that native form submission would include: the winning input
-    // must be checked, enabled (`:disabled` also covers a disabled ancestor `<fieldset>`),
-    // and — when inside a Form — associated with that form element. A radio submitted-excluded
-    // natively (disabled, or associated to another form) shouldn't be reported as the value.
-    const input = groupInputRef.current;
-    if (
-      !input ||
-      !input.checked ||
-      input.matches(':disabled') ||
-      (elementRef.current != null && input.form !== elementRef.current)
-    ) {
-      return null;
+    const formElement = elementRef.current;
+    if (!formElement) {
+      return checkedValue ?? null;
     }
 
-    return checkedValue ?? null;
+    for (const input of validation.registeredInputs.keys()) {
+      if (input.checked && !input.matches(':disabled') && input.form === formElement) {
+        return checkedValue ?? null;
+      }
+    }
+
+    return null;
   });
 
   useRegisterFieldControl(controlRef, id, checkedValue ?? null, getFormValue, !disabled, nameProp);
@@ -177,7 +160,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     validation.change(checkedValue);
 
     const fallbackInput = firstEnabledInputRef.current;
-    if (checkedValue == null && fallbackInput && !fallbackInput.matches(':disabled')) {
+    if (checkedValue == null && fallbackInput && !fallbackInput.disabled) {
       // Imperative re-point outside React's ref lifecycle; the ref-callback cleanup isn't tracked here.
       void setInputRef(fallbackInput);
     }
@@ -200,7 +183,6 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
       validation,
       name,
       readOnly,
-      registerControlRef,
       registerInputRef,
       required,
       setCheckedValue,
@@ -214,7 +196,6 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
       validation,
       name,
       readOnly,
-      registerControlRef,
       registerInputRef,
       required,
       setCheckedValue,

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -100,6 +100,10 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
   const groupInputRef = React.useRef<HTMLInputElement | null>(null);
   const firstEnabledInputRef = React.useRef<HTMLInputElement | null>(null);
 
+  // Only forwards the public `inputRef` and tracks the current representative for that forwarding.
+  // The registry (`validation.registeredInputs`) is authoritative for validation and form-value
+  // projection, so the group must not write `validation.inputRef`: a stale, unmounted radio left
+  // there would become the Field's fallback once the registry empties and keep blocking submission.
   function setInputRef(hiddenInput: HTMLInputElement | null) {
     let cleanup: void | (() => void) | undefined = undefined;
 
@@ -112,7 +116,6 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     }
 
     groupInputRef.current = hiddenInput;
-    validation.inputRef.current = hiddenInput;
 
     return cleanup;
   }

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -61,7 +61,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     validityData,
   } = useFieldRootContext();
   const { labelId } = useLabelableContext();
-  const { clearErrors } = useFormContext();
+  const { clearErrors, elementRef } = useFormContext();
   const fieldsetContext = useFieldsetRootContext(true);
 
   const disabled = fieldDisabled || disabledProp;
@@ -129,7 +129,10 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
   );
 
   const registerInputRef = useStableCallback((input: HTMLInputElement | null) => {
-    if (!input || input.disabled) {
+    // `:disabled` also matches inputs disabled through an ancestor `<fieldset disabled>`,
+    // which the `disabled` property alone misses. Such inputs are ineligible to represent
+    // the group for focus and validation, matching native form submission.
+    if (!input || input.matches(':disabled')) {
       return undefined;
     }
 
@@ -138,7 +141,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     }
 
     const currentInput = groupInputRef.current;
-    if (input.checked || currentInput == null || currentInput.disabled) {
+    if (input.checked || currentInput == null || currentInput.matches(':disabled')) {
       return setInputRef(input);
     }
 
@@ -146,10 +149,17 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
   });
 
   const getFormValue = useStableCallback(() => {
-    // Disabled radios are excluded from native form submission, so a disabled
-    // selection shouldn't be reported as the field's value either.
+    // Only project the value that native form submission would include: the winning input
+    // must be checked, enabled (`:disabled` also covers a disabled ancestor `<fieldset>`),
+    // and — when inside a Form — associated with that form element. A radio submitted-excluded
+    // natively (disabled, or associated to another form) shouldn't be reported as the value.
     const input = groupInputRef.current;
-    if (!input || input.disabled || !input.checked) {
+    if (
+      !input ||
+      !input.checked ||
+      input.matches(':disabled') ||
+      (elementRef.current != null && input.form !== elementRef.current)
+    ) {
       return null;
     }
 
@@ -167,7 +177,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     validation.change(checkedValue);
 
     const fallbackInput = firstEnabledInputRef.current;
-    if (checkedValue == null && fallbackInput && !fallbackInput.disabled) {
+    if (checkedValue == null && fallbackInput && !fallbackInput.matches(':disabled')) {
       // Imperative re-point outside React's ref lifecycle; the ref-callback cleanup isn't tracked here.
       void setInputRef(fallbackInput);
     }

--- a/packages/react/src/radio-group/RadioGroupContext.ts
+++ b/packages/react/src/radio-group/RadioGroupContext.ts
@@ -18,7 +18,6 @@ export interface RadioGroupContext<Value> {
   touched: boolean;
   setTouched: React.Dispatch<React.SetStateAction<boolean>>;
   validation?: UseFieldValidationReturnValue | undefined;
-  registerControlRef: (element: HTMLElement | null, disabled?: boolean) => void;
   registerInputRef: (element: HTMLInputElement | null) => void;
 }
 

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import type { BaseUIComponentProps, HTMLProps, NonNativeButtonProps } from '../../internals/types';
@@ -64,7 +63,6 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
     name,
     setCheckedValue = NOOP,
     setTouched = NOOP,
-    registerControlRef = NOOP,
     registerInputRef = NOOP,
   } = groupContext ?? {};
 
@@ -87,15 +85,13 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
   const radioRef = React.useRef<HTMLElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
-  const handleControlRef = useStableCallback((element: HTMLElement | null) => {
-    if (!element) {
-      return;
-    }
-
-    registerControlRef(element, disabled);
-  });
-
-  const mergedInputRef = useMergedRefs(inputRefProp, inputRef, registerInputRef);
+  const registerFieldInput = validation?.registerInput;
+  const registerInput = React.useCallback(
+    (element: HTMLInputElement | null) =>
+      registerFieldInput?.(element, { controlRef: radioRef, value: undefined }),
+    [registerFieldInput],
+  );
+  const mergedInputRef = useMergedRefs(inputRefProp, inputRef, registerInputRef, registerInput);
 
   useIsoLayoutEffect(() => {
     if (inputRef.current?.checked) {
@@ -113,12 +109,8 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
       return;
     }
 
-    if (radioRef.current) {
-      registerControlRef(radioRef.current, disabled);
-    }
-
     registerInputRef(inputRef.current);
-  }, [checked, disabled, registerControlRef, registerInputRef]);
+  }, [checked, disabled, registerInputRef]);
 
   const id = useBaseUiId();
   const inputId = useLabelableId({
@@ -238,7 +230,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
 
   const isRadioGroup = groupContext !== undefined;
 
-  const refs = [forwardedRef, radioRef, buttonRef, handleControlRef];
+  const refs = [forwardedRef, radioRef, buttonRef];
   const props = [
     rootProps,
     elementProps,


### PR DESCRIPTION
## Problem

`RadioGroup` projected its Field/Form value from a single representative hidden input. That diverged from native successful-control semantics when the selected radio was disabled through an ancestor `<fieldset disabled>` or associated with another form.

Filtering that representative during ref registration also made the state stale when a fieldset started disabled and was later enabled, because changing an ancestor attribute does not rerun the radio input refs.

## Fix

Radio roots now register their hidden inputs in the shared Field validation registry, matching Checkbox Group. Form-value projection, native validation, and invalid-focus targeting resolve against the live inputs and require the selected input to be checked, not match `:disabled`, and belong to the submitted form.

The public single-representative `inputRef` behavior and the logical Radio Group value remain unchanged.

## Tests

Coverage now verifies:

- an enabled selection matches native `FormData`;
- fieldset-disabled and externally associated selections are omitted;
- enabling an initially disabled fieldset restores the submitted value;
- validation and invalid focus recover after the fieldset is enabled.
