### PR TITLE
[all components] Export CssVariables and DataAttributes

### DIFF
--- a/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
+++ b/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
@@ -907,6 +907,54 @@ type AccordionPanelState = {
 
 ## Additional Types
 
+### AccordionHeaderDataAttributes
+
+| Member   | Value           | Description                                  |
+| :------- | :-------------- | :------------------------------------------- |
+| index    | \`data-index\`    | Indicates the index of the accordion item.   |
+| disabled | \`data-disabled\` | Present when the accordion item is disabled. |
+| open     | \`data-open\`     | Present when the accordion item is open.     |
+
+### AccordionItemDataAttributes
+
+| Member   | Value           | Description                                  |
+| :------- | :-------------- | :------------------------------------------- |
+| index    | \`data-index\`    | Indicates the index of the accordion item.   |
+| disabled | \`data-disabled\` | Present when the accordion item is disabled. |
+| open     | \`data-open\`     | Present when the accordion item is open.     |
+
+### AccordionPanelCssVars
+
+| Member               | Value                      | Description                   |
+| :------------------- | :------------------------- | :---------------------------- |
+| accordionPanelHeight | \`--accordion-panel-height\` | The accordion panel's height. |
+| accordionPanelWidth  | \`--accordion-panel-width\`  | The accordion panel's width.  |
+
+### AccordionPanelDataAttributes
+
+| Member        | Value                 | Description                                  |
+| :------------ | :-------------------- | :------------------------------------------- |
+| index         | \`data-index\`          | Indicates the index of the accordion item.   |
+| open          | \`data-open\`           | Present when the accordion panel is open.    |
+| orientation   | \`data-orientation\`    | Indicates the orientation of the accordion.  |
+| disabled      | \`data-disabled\`       | Present when the accordion item is disabled. |
+| startingStyle | \`data-starting-style\` | Present when the panel begins animating in.  |
+| endingStyle   | \`data-ending-style\`   | Present when the panel is animating out.     |
+
+### AccordionRootDataAttributes
+
+| Member      | Value              | Description                                 |
+| :---------- | :----------------- | :------------------------------------------ |
+| disabled    | \`data-disabled\`    | Present when the accordion is disabled.     |
+| orientation | \`data-orientation\` | Indicates the orientation of the accordion. |
+
+### AccordionTriggerDataAttributes
+
+| Member    | Value             | Description                                  |
+| :-------- | :---------------- | :------------------------------------------- |
+| panelOpen | \`data-panel-open\` | Present when the accordion panel is open.    |
+| disabled  | \`data-disabled\`   | Present when the accordion item is disabled. |
+
 ### AccordionValue
 
 \`\`\`typescript
@@ -928,7 +976,7 @@ type Orientation = 'horizontal' | 'vertical';
 - \`Accordion.Header\`: \`Accordion.Header\`, \`Accordion.Header.State\`, \`Accordion.Header.Props\`
 - \`Accordion.Trigger\`: \`Accordion.Trigger\`, \`Accordion.Trigger.State\`, \`Accordion.Trigger.Props\`
 - \`Accordion.Panel\`: \`Accordion.Panel\`, \`Accordion.Panel.State\`, \`Accordion.Panel.Props\`
-- \`Default\`: \`AccordionValue\`, \`AccordionRootState\`, \`AccordionRootProps\`, \`AccordionRootChangeEventReason\`, \`AccordionRootChangeEventDetails\`, \`AccordionItemState\`, \`AccordionItemProps\`, \`AccordionItemChangeEventReason\`, \`AccordionItemChangeEventDetails\`, \`AccordionHeaderState\`, \`AccordionHeaderProps\`, \`AccordionTriggerState\`, \`AccordionTriggerProps\`, \`AccordionPanelState\`, \`AccordionPanelProps\`
+- \`Default\`: \`AccordionPanelCssVars\`, \`AccordionHeaderDataAttributes\`, \`AccordionItemDataAttributes\`, \`AccordionPanelDataAttributes\`, \`AccordionRootDataAttributes\`, \`AccordionTriggerDataAttributes\`, \`AccordionValue\`, \`AccordionRootState\`, \`AccordionRootProps\`, \`AccordionRootChangeEventReason\`, \`AccordionRootChangeEventDetails\`, \`AccordionItemState\`, \`AccordionItemProps\`, \`AccordionItemChangeEventReason\`, \`AccordionItemChangeEventDetails\`, \`AccordionHeaderState\`, \`AccordionHeaderProps\`, \`AccordionTriggerState\`, \`AccordionTriggerProps\`, \`AccordionPanelState\`, \`AccordionPanelProps\`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/accordion/types.md
+++ b/docs/src/app/(docs)/react/components/accordion/types.md
@@ -352,6 +352,54 @@ type AccordionPanelState = {
 
 ## Additional Types
 
+### AccordionHeaderDataAttributes
+
+| Member   | Value           | Description                                  |
+| :------- | :-------------- | :------------------------------------------- |
+| index    | `data-index`    | Indicates the index of the accordion item.   |
+| disabled | `data-disabled` | Present when the accordion item is disabled. |
+| open     | `data-open`     | Present when the accordion item is open.     |
+
+### AccordionItemDataAttributes
+
+| Member   | Value           | Description                                  |
+| :------- | :-------------- | :------------------------------------------- |
+| index    | `data-index`    | Indicates the index of the accordion item.   |
+| disabled | `data-disabled` | Present when the accordion item is disabled. |
+| open     | `data-open`     | Present when the accordion item is open.     |
+
+### AccordionPanelCssVars
+
+| Member               | Value                      | Description                   |
+| :------------------- | :------------------------- | :---------------------------- |
+| accordionPanelHeight | `--accordion-panel-height` | The accordion panel's height. |
+| accordionPanelWidth  | `--accordion-panel-width`  | The accordion panel's width.  |
+
+### AccordionPanelDataAttributes
+
+| Member        | Value                 | Description                                  |
+| :------------ | :-------------------- | :------------------------------------------- |
+| index         | `data-index`          | Indicates the index of the accordion item.   |
+| open          | `data-open`           | Present when the accordion panel is open.    |
+| orientation   | `data-orientation`    | Indicates the orientation of the accordion.  |
+| disabled      | `data-disabled`       | Present when the accordion item is disabled. |
+| startingStyle | `data-starting-style` | Present when the panel begins animating in.  |
+| endingStyle   | `data-ending-style`   | Present when the panel is animating out.     |
+
+### AccordionRootDataAttributes
+
+| Member      | Value              | Description                                 |
+| :---------- | :----------------- | :------------------------------------------ |
+| disabled    | `data-disabled`    | Present when the accordion is disabled.     |
+| orientation | `data-orientation` | Indicates the orientation of the accordion. |
+
+### AccordionTriggerDataAttributes
+
+| Member    | Value             | Description                                  |
+| :-------- | :---------------- | :------------------------------------------- |
+| panelOpen | `data-panel-open` | Present when the accordion panel is open.    |
+| disabled  | `data-disabled`   | Present when the accordion item is disabled. |
+
 ### AccordionValue
 
 ```typescript
@@ -373,7 +421,7 @@ type Orientation = 'horizontal' | 'vertical';
 - `Accordion.Header`: `Accordion.Header`, `Accordion.Header.State`, `Accordion.Header.Props`
 - `Accordion.Trigger`: `Accordion.Trigger`, `Accordion.Trigger.State`, `Accordion.Trigger.Props`
 - `Accordion.Panel`: `Accordion.Panel`, `Accordion.Panel.State`, `Accordion.Panel.Props`
-- `Default`: `AccordionValue`, `AccordionRootState`, `AccordionRootProps`, `AccordionRootChangeEventReason`, `AccordionRootChangeEventDetails`, `AccordionItemState`, `AccordionItemProps`, `AccordionItemChangeEventReason`, `AccordionItemChangeEventDetails`, `AccordionHeaderState`, `AccordionHeaderProps`, `AccordionTriggerState`, `AccordionTriggerProps`, `AccordionPanelState`, `AccordionPanelProps`
+- `Default`: `AccordionPanelCssVars`, `AccordionHeaderDataAttributes`, `AccordionItemDataAttributes`, `AccordionPanelDataAttributes`, `AccordionRootDataAttributes`, `AccordionTriggerDataAttributes`, `AccordionValue`, `AccordionRootState`, `AccordionRootProps`, `AccordionRootChangeEventReason`, `AccordionRootChangeEventDetails`, `AccordionItemState`, `AccordionItemProps`, `AccordionItemChangeEventReason`, `AccordionItemChangeEventDetails`, `AccordionHeaderState`, `AccordionHeaderProps`, `AccordionTriggerState`, `AccordionTriggerProps`, `AccordionPanelState`, `AccordionPanelProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/alert-dialog/types.md
+++ b/docs/src/app/(docs)/react/components/alert-dialog/types.md
@@ -405,6 +405,15 @@ Closes the dialog.
 
 This method should only be called in an event handler or an effect (not during rendering).
 
+## Additional Types
+
+### AlertDialogTriggerDataAttributes
+
+| Member    | Value             | Description                                          |
+| :-------- | :---------------- | :--------------------------------------------------- |
+| disabled  | `data-disabled`   | Present when the trigger is disabled.                |
+| popupOpen | `data-popup-open` | Present when the corresponding alert dialog is open. |
+
 ## External Types
 
 ### PayloadChildRenderFunction
@@ -438,7 +447,7 @@ type InteractionType = 'mouse' | 'touch' | 'pen' | 'keyboard' | '';
 - `AlertDialog.Viewport`: `AlertDialog.Viewport`, `AlertDialog.Viewport.State`, `AlertDialog.Viewport.Props`
 - `AlertDialog.Handle`
 - `AlertDialog.createHandle`
-- `Default`: `AlertDialogBackdropProps`, `AlertDialogBackdropState`, `AlertDialogCloseProps`, `AlertDialogCloseState`, `AlertDialogDescriptionProps`, `AlertDialogDescriptionState`, `AlertDialogPopupProps`, `AlertDialogPopupState`, `AlertDialogPortalProps`, `AlertDialogPortalState`, `AlertDialogTitleProps`, `AlertDialogTitleState`, `AlertDialogViewportProps`, `AlertDialogViewportState`, `AlertDialogRootState`, `AlertDialogRootProps`, `AlertDialogRootActions`, `AlertDialogRootChangeEventReason`, `AlertDialogRootChangeEventDetails`, `AlertDialogTriggerProps`, `AlertDialogTriggerState`
+- `Default`: `AlertDialogBackdropProps`, `AlertDialogBackdropState`, `AlertDialogCloseProps`, `AlertDialogCloseState`, `AlertDialogDescriptionProps`, `AlertDialogDescriptionState`, `AlertDialogPopupProps`, `AlertDialogPopupState`, `AlertDialogPortalProps`, `AlertDialogPortalState`, `AlertDialogTitleProps`, `AlertDialogTitleState`, `AlertDialogViewportProps`, `AlertDialogViewportState`, `AlertDialogTriggerDataAttributes`, `AlertDialogRootState`, `AlertDialogRootProps`, `AlertDialogRootActions`, `AlertDialogRootChangeEventReason`, `AlertDialogRootChangeEventDetails`, `AlertDialogTriggerProps`, `AlertDialogTriggerState`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/autocomplete/types.md
+++ b/docs/src/app/(docs)/react/components/autocomplete/types.md
@@ -973,6 +973,48 @@ type AutocompleteFilterOptions = {
 };
 ```
 
+### AutocompleteInputGroupDataAttributes
+
+| Member    | Value             | Description                                                                        |
+| :-------- | :---------------- | :--------------------------------------------------------------------------------- |
+| popupOpen | `data-popup-open` | Present when the corresponding popup is open.                                      |
+| pressed   | `data-pressed`    | Present when the input group is pressed.                                           |
+| disabled  | `data-disabled`   | Present when the component is disabled.                                            |
+| readonly  | `data-readonly`   | Present when the component is readonly.                                            |
+| popupSide | `data-popup-side` | Indicates which side the corresponding popup is positioned relative to its anchor. |
+| valid     | `data-valid`      | Present when the component is in a valid state (when wrapped in Field.Root).       |
+| invalid   | `data-invalid`    | Present when the component is in an invalid state (when wrapped in Field.Root).    |
+| touched   | `data-touched`    | Present when the component has been touched (when wrapped in Field.Root).          |
+| dirty     | `data-dirty`      | Present when the component's value has changed (when wrapped in Field.Root).       |
+| filled    | `data-filled`     | Present when the component has a value (when wrapped in Field.Root).               |
+| focused   | `data-focused`    | Present when the component is focused (when wrapped in Field.Root).                |
+| listEmpty | `data-list-empty` | Present when the corresponding items list is empty.                                |
+
+### AutocompleteItemDataAttributes
+
+| Member      | Value              | Description                           |
+| :---------- | :----------------- | :------------------------------------ |
+| highlighted | `data-highlighted` | Present when the item is highlighted. |
+| disabled    | `data-disabled`    | Present when the item is disabled.    |
+
+### AutocompleteTriggerDataAttributes
+
+| Member    | Value             | Description                                                                        |
+| :-------- | :---------------- | :--------------------------------------------------------------------------------- |
+| popupOpen | `data-popup-open` | Present when the corresponding popup is open.                                      |
+| pressed   | `data-pressed`    | Present when the trigger is pressed.                                               |
+| disabled  | `data-disabled`   | Present when the component is disabled.                                            |
+| readonly  | `data-readonly`   | Present when the component is readonly.                                            |
+| popupSide | `data-popup-side` | Indicates which side the corresponding popup is positioned relative to its anchor. |
+| required  | `data-required`   | Present when the component is required.                                            |
+| valid     | `data-valid`      | Present when the component is in a valid state (when wrapped in Field.Root).       |
+| invalid   | `data-invalid`    | Present when the component is in an invalid state (when wrapped in Field.Root).    |
+| touched   | `data-touched`    | Present when the component has been touched (when wrapped in Field.Root).          |
+| dirty     | `data-dirty`      | Present when the component's value has changed (when wrapped in Field.Root).       |
+| filled    | `data-filled`     | Present when the component has a value (when wrapped in Field.Root).               |
+| focused   | `data-focused`    | Present when the trigger is focused (when wrapped in Field.Root).                  |
+| listEmpty | `data-list-empty` | Present when the corresponding items list is empty.                                |
+
 ## External Types
 
 ### Side
@@ -1035,7 +1077,7 @@ type Orientation = 'horizontal' | 'vertical';
 - `Autocomplete.Separator`: `Autocomplete.Separator`, `Autocomplete.Separator.Props`, `Autocomplete.Separator.State`
 - `Autocomplete.useFilter`
 - `Autocomplete.useFilteredItems`
-- `Default`: `AutocompleteInputProps`, `AutocompleteInputState`, `AutocompleteIconProps`, `AutocompleteIconState`, `AutocompleteClearProps`, `AutocompleteClearState`, `AutocompletePopupProps`, `AutocompletePopupState`, `AutocompletePositionerProps`, `AutocompletePositionerState`, `AutocompleteListProps`, `AutocompleteListState`, `AutocompleteRowProps`, `AutocompleteRowState`, `AutocompleteArrowProps`, `AutocompleteArrowState`, `AutocompleteBackdropProps`, `AutocompleteBackdropState`, `AutocompletePortalProps`, `AutocompletePortalState`, `AutocompleteGroupProps`, `AutocompleteGroupState`, `AutocompleteGroupLabelProps`, `AutocompleteGroupLabelState`, `AutocompleteEmptyProps`, `AutocompleteEmptyState`, `AutocompleteStatusProps`, `AutocompleteStatusState`, `AutocompleteCollectionState`, `AutocompleteCollectionProps`, `AutocompleteFilter`, `AutocompleteFilterOptions`, `AutocompleteRootState`, `AutocompleteRootActions`, `AutocompleteRootChangeEventReason`, `AutocompleteRootChangeEventDetails`, `AutocompleteRootHighlightEventReason`, `AutocompleteRootHighlightEventDetails`, `AutocompleteRootProps`, `AutocompleteTriggerState`, `AutocompleteTriggerProps`, `AutocompleteInputGroupState`, `AutocompleteInputGroupProps`, `AutocompleteItemState`, `AutocompleteItemProps`, `AutocompleteValueState`, `AutocompleteValueProps`
+- `Default`: `AutocompleteInputProps`, `AutocompleteInputState`, `AutocompleteIconProps`, `AutocompleteIconState`, `AutocompleteClearProps`, `AutocompleteClearState`, `AutocompletePopupProps`, `AutocompletePopupState`, `AutocompletePositionerProps`, `AutocompletePositionerState`, `AutocompleteListProps`, `AutocompleteListState`, `AutocompleteRowProps`, `AutocompleteRowState`, `AutocompleteArrowProps`, `AutocompleteArrowState`, `AutocompleteBackdropProps`, `AutocompleteBackdropState`, `AutocompletePortalProps`, `AutocompletePortalState`, `AutocompleteGroupProps`, `AutocompleteGroupState`, `AutocompleteGroupLabelProps`, `AutocompleteGroupLabelState`, `AutocompleteEmptyProps`, `AutocompleteEmptyState`, `AutocompleteStatusProps`, `AutocompleteStatusState`, `AutocompleteCollectionState`, `AutocompleteCollectionProps`, `AutocompleteFilter`, `AutocompleteFilterOptions`, `AutocompleteInputGroupDataAttributes`, `AutocompleteItemDataAttributes`, `AutocompleteTriggerDataAttributes`, `AutocompleteRootState`, `AutocompleteRootActions`, `AutocompleteRootChangeEventReason`, `AutocompleteRootChangeEventDetails`, `AutocompleteRootHighlightEventReason`, `AutocompleteRootHighlightEventDetails`, `AutocompleteRootProps`, `AutocompleteTriggerState`, `AutocompleteTriggerProps`, `AutocompleteInputGroupState`, `AutocompleteInputGroupProps`, `AutocompleteItemState`, `AutocompleteItemProps`, `AutocompleteValueState`, `AutocompleteValueProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/avatar/types.md
+++ b/docs/src/app/(docs)/react/components/avatar/types.md
@@ -95,6 +95,13 @@ type AvatarFallbackState = {
 
 ## Additional Types
 
+### AvatarImageDataAttributes
+
+| Member        | Value                 | Description                                 |
+| :------------ | :-------------------- | :------------------------------------------ |
+| startingStyle | `data-starting-style` | Present when the image begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the image is animating out.    |
+
 ### ImageLoadingStatus
 
 ```typescript
@@ -106,7 +113,7 @@ type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error';
 - `Avatar.Root`: `Avatar.Root`, `Avatar.Root.State`, `Avatar.Root.Props`
 - `Avatar.Image`: `Avatar.Image`, `Avatar.Image.State`, `Avatar.Image.Props`
 - `Avatar.Fallback`: `Avatar.Fallback`, `Avatar.Fallback.State`, `Avatar.Fallback.Props`
-- `Default`: `ImageLoadingStatus`, `AvatarRootState`, `AvatarRootProps`, `AvatarImageState`, `AvatarImageProps`, `AvatarFallbackState`, `AvatarFallbackProps`
+- `Default`: `AvatarImageDataAttributes`, `ImageLoadingStatus`, `AvatarRootState`, `AvatarRootProps`, `AvatarImageState`, `AvatarImageProps`, `AvatarFallbackState`, `AvatarFallbackProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/checkbox-group/types.md
+++ b/docs/src/app/(docs)/react/components/checkbox-group/types.md
@@ -77,6 +77,14 @@ type CheckboxGroupChangeEventDetails = {
 };
 ```
 
+## Additional Types
+
+### CheckboxGroupDataAttributes
+
+| Member   | Value           | Description                                  |
+| :------- | :-------------- | :------------------------------------------- |
+| disabled | `data-disabled` | Present when the checkbox group is disabled. |
+
 ## Canonical Types
 
 Maps `Canonical`: `Alias` — Use Canonical when its namespace is already imported; otherwise use Alias.

--- a/docs/src/app/(docs)/react/components/checkbox/types.md
+++ b/docs/src/app/(docs)/react/components/checkbox/types.md
@@ -173,11 +173,49 @@ type CheckboxIndicatorState = {
 };
 ```
 
+## Additional Types
+
+### CheckboxIndicatorDataAttributes
+
+| Member        | Value                 | Description                                                                    |
+| :------------ | :-------------------- | :----------------------------------------------------------------------------- |
+| checked       | `data-checked`        | Present when the checkbox is checked.                                          |
+| unchecked     | `data-unchecked`      | Present when the checkbox is not checked.                                      |
+| indeterminate | `data-indeterminate`  | Present when the checkbox is in an indeterminate state.                        |
+| disabled      | `data-disabled`       | Present when the checkbox is disabled.                                         |
+| readonly      | `data-readonly`       | Present when the checkbox is readonly.                                         |
+| required      | `data-required`       | Present when the checkbox is required.                                         |
+| startingStyle | `data-starting-style` | Present when the checkbox indicator begins animating in.                       |
+| endingStyle   | `data-ending-style`   | Present when the checkbox indicator is animating out.                          |
+| valid         | `data-valid`          | Present when the checkbox is in a valid state (when wrapped in Field.Root).    |
+| invalid       | `data-invalid`        | Present when the checkbox is in an invalid state (when wrapped in Field.Root). |
+| touched       | `data-touched`        | Present when the checkbox has been touched (when wrapped in Field.Root).       |
+| dirty         | `data-dirty`          | Present when the checkbox's value has changed (when wrapped in Field.Root).    |
+| filled        | `data-filled`         | Present when the checkbox is checked (when wrapped in Field.Root).             |
+| focused       | `data-focused`        | Present when the checkbox is focused (when wrapped in Field.Root).             |
+
+### CheckboxRootDataAttributes
+
+| Member        | Value                | Description                                                                    |
+| :------------ | :------------------- | :----------------------------------------------------------------------------- |
+| checked       | `data-checked`       | Present when the checkbox is checked.                                          |
+| unchecked     | `data-unchecked`     | Present when the checkbox is not checked.                                      |
+| indeterminate | `data-indeterminate` | Present when the checkbox is in an indeterminate state.                        |
+| disabled      | `data-disabled`      | Present when the checkbox is disabled.                                         |
+| readonly      | `data-readonly`      | Present when the checkbox is readonly.                                         |
+| required      | `data-required`      | Present when the checkbox is required.                                         |
+| valid         | `data-valid`         | Present when the checkbox is in a valid state (when wrapped in Field.Root).    |
+| invalid       | `data-invalid`       | Present when the checkbox is in an invalid state (when wrapped in Field.Root). |
+| touched       | `data-touched`       | Present when the checkbox has been touched (when wrapped in Field.Root).       |
+| dirty         | `data-dirty`         | Present when the checkbox's value has changed (when wrapped in Field.Root).    |
+| filled        | `data-filled`        | Present when the checkbox is checked (when wrapped in Field.Root).             |
+| focused       | `data-focused`       | Present when the checkbox is focused (when wrapped in Field.Root).             |
+
 ## Export Groups
 
 - `Checkbox.Root`: `Checkbox.Root`, `Checkbox.Root.State`, `Checkbox.Root.Props`, `Checkbox.Root.ChangeEventReason`, `Checkbox.Root.ChangeEventDetails`
 - `Checkbox.Indicator`: `Checkbox.Indicator`, `Checkbox.Indicator.State`, `Checkbox.Indicator.Props`
-- `Default`: `CheckboxRootState`, `CheckboxRootProps`, `CheckboxRootChangeEventReason`, `CheckboxRootChangeEventDetails`, `CheckboxIndicatorState`, `CheckboxIndicatorProps`
+- `Default`: `CheckboxIndicatorDataAttributes`, `CheckboxRootDataAttributes`, `CheckboxRootState`, `CheckboxRootProps`, `CheckboxRootChangeEventReason`, `CheckboxRootChangeEventDetails`, `CheckboxIndicatorState`, `CheckboxIndicatorProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/collapsible/types.md
+++ b/docs/src/app/(docs)/react/components/collapsible/types.md
@@ -156,12 +156,45 @@ type CollapsiblePanelState = {
 };
 ```
 
+## Additional Types
+
+### CollapsiblePanelCssVars
+
+| Member                 | Value                        | Description                     |
+| :--------------------- | :--------------------------- | :------------------------------ |
+| collapsiblePanelHeight | `--collapsible-panel-height` | The collapsible panel's height. |
+| collapsiblePanelWidth  | `--collapsible-panel-width`  | The collapsible panel's width.  |
+
+### CollapsiblePanelDataAttributes
+
+| Member        | Value                 | Description                                   |
+| :------------ | :-------------------- | :-------------------------------------------- |
+| open          | `data-open`           | Present when the collapsible panel is open.   |
+| closed        | `data-closed`         | Present when the collapsible panel is closed. |
+| startingStyle | `data-starting-style` | Present when the panel begins animating in.   |
+| endingStyle   | `data-ending-style`   | Present when the panel is animating out.      |
+
+### CollapsibleRootDataAttributes
+
+| Member        | Value                 | Description                                       |
+| :------------ | :-------------------- | :------------------------------------------------ |
+| open          | `data-open`           | Present when the collapsible is open.             |
+| closed        | `data-closed`         | Present when the collapsible is closed.           |
+| startingStyle | `data-starting-style` | Present when the collapsible begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the collapsible is animating out.    |
+
+### CollapsibleTriggerDataAttributes
+
+| Member    | Value             | Description                                 |
+| :-------- | :---------------- | :------------------------------------------ |
+| panelOpen | `data-panel-open` | Present when the collapsible panel is open. |
+
 ## Export Groups
 
 - `Collapsible.Root`: `Collapsible.Root`, `Collapsible.Root.State`, `Collapsible.Root.Props`, `Collapsible.Root.ChangeEventReason`, `Collapsible.Root.ChangeEventDetails`
 - `Collapsible.Trigger`: `Collapsible.Trigger`, `Collapsible.Trigger.State`, `Collapsible.Trigger.Props`
 - `Collapsible.Panel`: `Collapsible.Panel`, `Collapsible.Panel.State`, `Collapsible.Panel.Props`
-- `Default`: `CollapsibleRootState`, `CollapsibleRootProps`, `CollapsibleRootChangeEventReason`, `CollapsibleRootChangeEventDetails`, `CollapsibleTriggerState`, `CollapsibleTriggerProps`, `CollapsiblePanelState`, `CollapsiblePanelProps`
+- `Default`: `CollapsiblePanelCssVars`, `CollapsiblePanelDataAttributes`, `CollapsibleRootDataAttributes`, `CollapsibleTriggerDataAttributes`, `CollapsibleRootState`, `CollapsibleRootProps`, `CollapsibleRootChangeEventReason`, `CollapsibleRootChangeEventDetails`, `CollapsibleTriggerState`, `CollapsibleTriggerProps`, `CollapsiblePanelState`, `CollapsiblePanelProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/combobox/types.md
+++ b/docs/src/app/(docs)/react/components/combobox/types.md
@@ -1116,6 +1116,35 @@ type ReturnValue = T[];
 
 ## Additional Types
 
+### ComboboxArrowDataAttributes
+
+| Member     | Value             | Description                                                           |
+| :--------- | :---------------- | :-------------------------------------------------------------------- |
+| open       | `data-open`       | Present when the popup is open.                                       |
+| closed     | `data-closed`     | Present when the popup is closed.                                     |
+| side       | `data-side`       | Indicates which side the popup is positioned relative to the trigger. |
+| align      | `data-align`      | Indicates how the popup is aligned relative to specified side.        |
+| uncentered | `data-uncentered` | Present when the arrow is uncentered.                                 |
+
+### ComboboxBackdropDataAttributes
+
+| Member        | Value                 | Description                                 |
+| :------------ | :-------------------- | :------------------------------------------ |
+| open          | `data-open`           | Present when the popup is open.             |
+| closed        | `data-closed`         | Present when the popup is closed.           |
+| startingStyle | `data-starting-style` | Present when the popup begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the popup is animating out.    |
+
+### ComboboxClearDataAttributes
+
+| Member        | Value                 | Description                                   |
+| :------------ | :-------------------- | :-------------------------------------------- |
+| popupOpen     | `data-popup-open`     | Present when the corresponding popup is open. |
+| disabled      | `data-disabled`       | Present when the button is disabled.          |
+| visible       | `data-visible`        | Present when the clear button is visible.     |
+| startingStyle | `data-starting-style` | Present when the button begins animating in.  |
+| endingStyle   | `data-ending-style`   | Present when the button is animating out.     |
+
 ### ComboboxFilter
 
 ```typescript
@@ -1147,6 +1176,110 @@ type ComboboxFilterOptions = {
   locale?: Intl.LocalesArgument;
 };
 ```
+
+### ComboboxInputDataAttributes
+
+| Member    | Value             | Description                                                                        |
+| :-------- | :---------------- | :--------------------------------------------------------------------------------- |
+| popupOpen | `data-popup-open` | Present when the corresponding popup is open.                                      |
+| pressed   | `data-pressed`    | Present when the input is pressed.                                                 |
+| disabled  | `data-disabled`   | Present when the component is disabled.                                            |
+| readonly  | `data-readonly`   | Present when the component is readonly.                                            |
+| popupSide | `data-popup-side` | Indicates which side the corresponding popup is positioned relative to its anchor. |
+| required  | `data-required`   | Present when the component is required.                                            |
+| valid     | `data-valid`      | Present when the component is in a valid state (when wrapped in Field.Root).       |
+| invalid   | `data-invalid`    | Present when the component is in an invalid state (when wrapped in Field.Root).    |
+| touched   | `data-touched`    | Present when the component has been touched (when wrapped in Field.Root).          |
+| dirty     | `data-dirty`      | Present when the component's value has changed (when wrapped in Field.Root).       |
+| filled    | `data-filled`     | Present when the component has a value (when wrapped in Field.Root).               |
+| focused   | `data-focused`    | Present when the input is focused (when wrapped in Field.Root).                    |
+| listEmpty | `data-list-empty` | Present when the corresponding items list is empty.                                |
+
+### ComboboxInputGroupDataAttributes
+
+| Member      | Value              | Description                                                                        |
+| :---------- | :----------------- | :--------------------------------------------------------------------------------- |
+| popupOpen   | `data-popup-open`  | Present when the corresponding popup is open.                                      |
+| pressed     | `data-pressed`     | Present when the input group is pressed.                                           |
+| disabled    | `data-disabled`    | Present when the component is disabled.                                            |
+| readonly    | `data-readonly`    | Present when the component is readonly.                                            |
+| popupSide   | `data-popup-side`  | Indicates which side the corresponding popup is positioned relative to its anchor. |
+| valid       | `data-valid`       | Present when the component is in a valid state (when wrapped in Field.Root).       |
+| invalid     | `data-invalid`     | Present when the component is in an invalid state (when wrapped in Field.Root).    |
+| touched     | `data-touched`     | Present when the component has been touched (when wrapped in Field.Root).          |
+| dirty       | `data-dirty`       | Present when the component's value has changed (when wrapped in Field.Root).       |
+| filled      | `data-filled`      | Present when the component has a value (when wrapped in Field.Root).               |
+| focused     | `data-focused`     | Present when the component is focused (when wrapped in Field.Root).                |
+| listEmpty   | `data-list-empty`  | Present when the corresponding items list is empty.                                |
+| placeholder | `data-placeholder` | Present when the combobox doesn't have a value.                                    |
+
+### ComboboxItemDataAttributes
+
+| Member      | Value              | Description                           |
+| :---------- | :----------------- | :------------------------------------ |
+| selected    | `data-selected`    | Present when the item is selected.    |
+| highlighted | `data-highlighted` | Present when the item is highlighted. |
+| disabled    | `data-disabled`    | Present when the item is disabled.    |
+
+### ComboboxItemIndicatorDataAttributes
+
+| Member        | Value                 | Description                                     |
+| :------------ | :-------------------- | :---------------------------------------------- |
+| startingStyle | `data-starting-style` | Present when the indicator begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the indicator is animating out.    |
+
+### ComboboxPopupDataAttributes
+
+| Member        | Value                 | Description                                                           |
+| :------------ | :-------------------- | :-------------------------------------------------------------------- |
+| open          | `data-open`           | Present when the popup is open.                                       |
+| closed        | `data-closed`         | Present when the popup is closed.                                     |
+| startingStyle | `data-starting-style` | Present when the popup begins animating in.                           |
+| endingStyle   | `data-ending-style`   | Present when the popup is animating out.                              |
+| side          | `data-side`           | Indicates which side the popup is positioned relative to the trigger. |
+| align         | `data-align`          | Indicates how the popup is aligned relative to specified side.        |
+| instant       | `data-instant`        | Present if animations should be instant.                              |
+| empty         | `data-empty`          | Present when the items list is empty.                                 |
+
+### ComboboxPositionerCssVars
+
+| Member          | Value                | Description                                                                            |
+| :-------------- | :------------------- | :------------------------------------------------------------------------------------- |
+| availableWidth  | `--available-width`  | The available width between the trigger and the edge of the viewport.                  |
+| availableHeight | `--available-height` | The available height between the trigger and the edge of the viewport.                 |
+| anchorWidth     | `--anchor-width`     | The anchor's width.                                                                    |
+| anchorHeight    | `--anchor-height`    | The anchor's height.                                                                   |
+| transformOrigin | `--transform-origin` | The coordinates that this element is anchored to. Used for animations and transitions. |
+
+### ComboboxPositionerDataAttributes
+
+| Member       | Value                | Description                                                           |
+| :----------- | :------------------- | :-------------------------------------------------------------------- |
+| open         | `data-open`          | Present when the popup is open.                                       |
+| closed       | `data-closed`        | Present when the popup is closed.                                     |
+| anchorHidden | `data-anchor-hidden` | Present when the anchor is hidden.                                    |
+| side         | `data-side`          | Indicates which side the popup is positioned relative to the trigger. |
+| align        | `data-align`         | Indicates how the popup is aligned relative to specified side.        |
+| empty        | `data-empty`         | Present when the items list is empty.                                 |
+
+### ComboboxTriggerDataAttributes
+
+| Member      | Value              | Description                                                                        |
+| :---------- | :----------------- | :--------------------------------------------------------------------------------- |
+| popupOpen   | `data-popup-open`  | Present when the corresponding popup is open.                                      |
+| pressed     | `data-pressed`     | Present when the trigger is pressed.                                               |
+| disabled    | `data-disabled`    | Present when the component is disabled.                                            |
+| readonly    | `data-readonly`    | Present when the component is readonly.                                            |
+| popupSide   | `data-popup-side`  | Indicates which side the corresponding popup is positioned relative to its anchor. |
+| required    | `data-required`    | Present when the component is required.                                            |
+| valid       | `data-valid`       | Present when the component is in a valid state (when wrapped in Field.Root).       |
+| invalid     | `data-invalid`     | Present when the component is in an invalid state (when wrapped in Field.Root).    |
+| touched     | `data-touched`     | Present when the component has been touched (when wrapped in Field.Root).          |
+| dirty       | `data-dirty`       | Present when the component's value has changed (when wrapped in Field.Root).       |
+| filled      | `data-filled`      | Present when the component has a value (when wrapped in Field.Root).               |
+| focused     | `data-focused`     | Present when the trigger is focused (when wrapped in Field.Root).                  |
+| listEmpty   | `data-list-empty`  | Present when the corresponding items list is empty.                                |
+| placeholder | `data-placeholder` | Present when the combobox doesn't have a value.                                    |
 
 ## External Types
 
@@ -1215,7 +1348,7 @@ type Orientation = 'horizontal' | 'vertical';
 - `Combobox.Separator`: `Combobox.Separator`, `Combobox.Separator.Props`, `Combobox.Separator.State`
 - `Combobox.useFilter`
 - `Combobox.useFilteredItems`
-- `Default`: `ComboboxFilter`, `ComboboxFilterOptions`, `ComboboxRootProps`, `ComboboxRootState`, `ComboboxRootActions`, `ComboboxRootChangeEventReason`, `ComboboxRootChangeEventDetails`, `ComboboxRootHighlightEventReason`, `ComboboxRootHighlightEventDetails`, `ComboboxLabelState`, `ComboboxLabelProps`, `ComboboxTriggerState`, `ComboboxTriggerProps`, `ComboboxInputState`, `ComboboxInputProps`, `ComboboxInputGroupState`, `ComboboxInputGroupProps`, `ComboboxPopupState`, `ComboboxPopupProps`, `ComboboxPositionerState`, `ComboboxPositionerProps`, `ComboboxListState`, `ComboboxListProps`, `ComboboxItemState`, `ComboboxItemProps`, `ComboboxItemIndicatorProps`, `ComboboxItemIndicatorState`, `ComboboxValueState`, `ComboboxValueProps`, `ComboboxIconState`, `ComboboxIconProps`, `ComboboxArrowState`, `ComboboxArrowProps`, `ComboboxBackdropProps`, `ComboboxBackdropState`, `ComboboxPortalState`, `ComboboxPortalProps`, `ComboboxEmptyState`, `ComboboxEmptyProps`, `ComboboxGroupState`, `ComboboxGroupProps`, `ComboboxGroupLabelState`, `ComboboxGroupLabelProps`, `ComboboxRowState`, `ComboboxRowProps`, `ComboboxChipsState`, `ComboboxChipsProps`, `ComboboxChipState`, `ComboboxChipProps`, `ComboboxChipRemoveState`, `ComboboxChipRemoveProps`, `ComboboxClearState`, `ComboboxClearProps`, `ComboboxStatusState`, `ComboboxStatusProps`, `ComboboxCollectionState`, `ComboboxCollectionProps`
+- `Default`: `ComboboxFilter`, `ComboboxFilterOptions`, `ComboboxPositionerCssVars`, `ComboboxArrowDataAttributes`, `ComboboxBackdropDataAttributes`, `ComboboxClearDataAttributes`, `ComboboxInputGroupDataAttributes`, `ComboboxInputDataAttributes`, `ComboboxItemIndicatorDataAttributes`, `ComboboxItemDataAttributes`, `ComboboxPopupDataAttributes`, `ComboboxPositionerDataAttributes`, `ComboboxTriggerDataAttributes`, `ComboboxRootProps`, `ComboboxRootState`, `ComboboxRootActions`, `ComboboxRootChangeEventReason`, `ComboboxRootChangeEventDetails`, `ComboboxRootHighlightEventReason`, `ComboboxRootHighlightEventDetails`, `ComboboxLabelState`, `ComboboxLabelProps`, `ComboboxTriggerState`, `ComboboxTriggerProps`, `ComboboxInputState`, `ComboboxInputProps`, `ComboboxInputGroupState`, `ComboboxInputGroupProps`, `ComboboxPopupState`, `ComboboxPopupProps`, `ComboboxPositionerState`, `ComboboxPositionerProps`, `ComboboxListState`, `ComboboxListProps`, `ComboboxItemState`, `ComboboxItemProps`, `ComboboxItemIndicatorProps`, `ComboboxItemIndicatorState`, `ComboboxValueState`, `ComboboxValueProps`, `ComboboxIconState`, `ComboboxIconProps`, `ComboboxArrowState`, `ComboboxArrowProps`, `ComboboxBackdropProps`, `ComboboxBackdropState`, `ComboboxPortalState`, `ComboboxPortalProps`, `ComboboxEmptyState`, `ComboboxEmptyProps`, `ComboboxGroupState`, `ComboboxGroupProps`, `ComboboxGroupLabelState`, `ComboboxGroupLabelProps`, `ComboboxRowState`, `ComboboxRowProps`, `ComboboxChipsState`, `ComboboxChipsProps`, `ComboboxChipState`, `ComboboxChipProps`, `ComboboxChipRemoveState`, `ComboboxChipRemoveProps`, `ComboboxClearState`, `ComboboxClearProps`, `ComboboxStatusState`, `ComboboxStatusProps`, `ComboboxCollectionState`, `ComboboxCollectionProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/context-menu/types.md
+++ b/docs/src/app/(docs)/react/components/context-menu/types.md
@@ -967,6 +967,15 @@ type ContextMenuLinkItemState = {
 };
 ```
 
+## Additional Types
+
+### ContextMenuTriggerDataAttributes
+
+| Member    | Value             | Description                                          |
+| :-------- | :---------------- | :--------------------------------------------------- |
+| popupOpen | `data-popup-open` | Present when the corresponding context menu is open. |
+| pressed   | `data-pressed`    | Present when the trigger is pressed.                 |
+
 ## External Types
 
 ### Orientation
@@ -1031,7 +1040,7 @@ type preventUnmountOnClose = () => void;
 - `ContextMenu.SubmenuRoot`: `ContextMenu.SubmenuRoot`, `ContextMenu.SubmenuRoot.Props`, `ContextMenu.SubmenuRoot.State`, `ContextMenu.SubmenuRoot.ChangeEventReason`, `ContextMenu.SubmenuRoot.ChangeEventDetails`
 - `ContextMenu.SubmenuTrigger`: `ContextMenu.SubmenuTrigger`, `ContextMenu.SubmenuTrigger.Props`, `ContextMenu.SubmenuTrigger.State`
 - `ContextMenu.Separator`: `ContextMenu.Separator`, `ContextMenu.Separator.Props`, `ContextMenu.Separator.State`
-- `Default`: `ContextMenuBackdropProps`, `ContextMenuBackdropState`, `ContextMenuPortalProps`, `ContextMenuPortalState`, `ContextMenuPositionerProps`, `ContextMenuPositionerState`, `ContextMenuPopupProps`, `ContextMenuPopupState`, `ContextMenuArrowProps`, `ContextMenuArrowState`, `ContextMenuGroupProps`, `ContextMenuGroupState`, `ContextMenuGroupLabelProps`, `ContextMenuGroupLabelState`, `ContextMenuItemProps`, `ContextMenuItemState`, `ContextMenuLinkItemProps`, `ContextMenuLinkItemState`, `ContextMenuCheckboxItemProps`, `ContextMenuCheckboxItemState`, `ContextMenuCheckboxItemIndicatorProps`, `ContextMenuCheckboxItemIndicatorState`, `ContextMenuRadioGroupProps`, `ContextMenuRadioGroupState`, `ContextMenuRadioItemProps`, `ContextMenuRadioItemState`, `ContextMenuRadioItemIndicatorProps`, `ContextMenuRadioItemIndicatorState`, `ContextMenuSubmenuRootProps`, `ContextMenuSubmenuRootState`, `ContextMenuSubmenuTriggerProps`, `ContextMenuSubmenuTriggerState`, `ContextMenuRootState`, `ContextMenuRootProps`, `ContextMenuRootActions`, `ContextMenuRootChangeEventReason`, `ContextMenuRootChangeEventDetails`, `ContextMenuTriggerState`, `ContextMenuTriggerProps`
+- `Default`: `ContextMenuBackdropProps`, `ContextMenuBackdropState`, `ContextMenuPortalProps`, `ContextMenuPortalState`, `ContextMenuPositionerProps`, `ContextMenuPositionerState`, `ContextMenuPopupProps`, `ContextMenuPopupState`, `ContextMenuArrowProps`, `ContextMenuArrowState`, `ContextMenuGroupProps`, `ContextMenuGroupState`, `ContextMenuGroupLabelProps`, `ContextMenuGroupLabelState`, `ContextMenuItemProps`, `ContextMenuItemState`, `ContextMenuLinkItemProps`, `ContextMenuLinkItemState`, `ContextMenuCheckboxItemProps`, `ContextMenuCheckboxItemState`, `ContextMenuCheckboxItemIndicatorProps`, `ContextMenuCheckboxItemIndicatorState`, `ContextMenuRadioGroupProps`, `ContextMenuRadioGroupState`, `ContextMenuRadioItemProps`, `ContextMenuRadioItemState`, `ContextMenuRadioItemIndicatorProps`, `ContextMenuRadioItemIndicatorState`, `ContextMenuSubmenuRootProps`, `ContextMenuSubmenuRootState`, `ContextMenuSubmenuTriggerProps`, `ContextMenuSubmenuTriggerState`, `ContextMenuTriggerDataAttributes`, `ContextMenuRootState`, `ContextMenuRootProps`, `ContextMenuRootActions`, `ContextMenuRootChangeEventReason`, `ContextMenuRootChangeEventDetails`, `ContextMenuTriggerState`, `ContextMenuTriggerProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/dialog/types.md
+++ b/docs/src/app/(docs)/react/components/dialog/types.md
@@ -407,6 +407,58 @@ Closes the dialog.
 
 This method should only be called in an event handler or an effect (not during rendering).
 
+## Additional Types
+
+### DialogBackdropDataAttributes
+
+| Member        | Value                 | Description                                  |
+| :------------ | :-------------------- | :------------------------------------------- |
+| open          | `data-open`           | Present when the dialog is open.             |
+| closed        | `data-closed`         | Present when the dialog is closed.           |
+| startingStyle | `data-starting-style` | Present when the dialog begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the dialog is animating out.    |
+
+### DialogCloseDataAttributes
+
+| Member   | Value           | Description                          |
+| :------- | :-------------- | :----------------------------------- |
+| disabled | `data-disabled` | Present when the button is disabled. |
+
+### DialogPopupCssVars
+
+| Member        | Value              | Description                                   |
+| :------------ | :----------------- | :-------------------------------------------- |
+| nestedDialogs | `--nested-dialogs` | Indicates how many dialogs are nested within. |
+
+### DialogPopupDataAttributes
+
+| Member           | Value                     | Description                                                      |
+| :--------------- | :------------------------ | :--------------------------------------------------------------- |
+| open             | `data-open`               | Present when the dialog is open.                                 |
+| closed           | `data-closed`             | Present when the dialog is closed.                               |
+| startingStyle    | `data-starting-style`     | Present when the dialog begins animating in.                     |
+| endingStyle      | `data-ending-style`       | Present when the dialog is animating out.                        |
+| nested           | `data-nested`             | Present when the dialog is nested within another dialog.         |
+| nestedDialogOpen | `data-nested-dialog-open` | Present when the dialog has other open dialogs nested within it. |
+
+### DialogTriggerDataAttributes
+
+| Member    | Value             | Description                                    |
+| :-------- | :---------------- | :--------------------------------------------- |
+| disabled  | `data-disabled`   | Present when the trigger is disabled.          |
+| popupOpen | `data-popup-open` | Present when the corresponding dialog is open. |
+
+### DialogViewportDataAttributes
+
+| Member           | Value                     | Description                                                      |
+| :--------------- | :------------------------ | :--------------------------------------------------------------- |
+| open             | `data-open`               | Present when the dialog is open.                                 |
+| closed           | `data-closed`             | Present when the dialog is closed.                               |
+| startingStyle    | `data-starting-style`     | Present when the dialog begins animating in.                     |
+| endingStyle      | `data-ending-style`       | Present when the dialog is animating out.                        |
+| nested           | `data-nested`             | Present when the dialog is nested within another dialog.         |
+| nestedDialogOpen | `data-nested-dialog-open` | Present when the dialog has other open dialogs nested within it. |
+
 ## External Types
 
 ### InteractionType
@@ -440,7 +492,7 @@ type preventUnmountOnClose = () => void;
 - `Dialog.Trigger`: `Dialog.Trigger`, `Dialog.Trigger.Props`, `Dialog.Trigger.State`
 - `Dialog.createHandle`
 - `Dialog.Handle`
-- `Default`: `DialogRootState`, `DialogRootProps`, `DialogRootActions`, `DialogRootChangeEventReason`, `DialogRootChangeEventDetails`, `DialogTriggerProps`, `DialogTriggerState`, `DialogPortalState`, `DialogPortalProps`, `DialogPopupProps`, `DialogPopupState`, `DialogBackdropProps`, `DialogBackdropState`, `DialogTitleProps`, `DialogTitleState`, `DialogDescriptionProps`, `DialogDescriptionState`, `DialogCloseProps`, `DialogCloseState`, `DialogViewportState`, `DialogViewportProps`
+- `Default`: `DialogPopupCssVars`, `DialogBackdropDataAttributes`, `DialogCloseDataAttributes`, `DialogPopupDataAttributes`, `DialogTriggerDataAttributes`, `DialogViewportDataAttributes`, `DialogRootState`, `DialogRootProps`, `DialogRootActions`, `DialogRootChangeEventReason`, `DialogRootChangeEventDetails`, `DialogTriggerProps`, `DialogTriggerState`, `DialogPortalState`, `DialogPortalProps`, `DialogPopupProps`, `DialogPopupState`, `DialogBackdropProps`, `DialogBackdropState`, `DialogTitleProps`, `DialogTitleState`, `DialogDescriptionProps`, `DialogDescriptionState`, `DialogCloseProps`, `DialogCloseState`, `DialogViewportState`, `DialogViewportProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/drawer/types.md
+++ b/docs/src/app/(docs)/react/components/drawer/types.md
@@ -642,6 +642,82 @@ Re-export of [VirtualKeyboardProvider](#virtualkeyboardprovider) props.
 type DrawerVirtualKeyboardProviderState = {};
 ```
 
+## Additional Types
+
+### DRAWER_CONTENT_ATTRIBUTE
+
+```typescript
+type DRAWER_CONTENT_ATTRIBUTE = 'data-drawer-content';
+```
+
+### DrawerBackdropCssVars
+
+| Member        | Value                     | Description                               |
+| :------------ | :------------------------ | :---------------------------------------- |
+| swipeProgress | `--drawer-swipe-progress` | The swipe progress of the drawer gesture. |
+
+### DrawerBackdropDataAttributes
+
+| Member        | Value                 | Description                                  |
+| :------------ | :-------------------- | :------------------------------------------- |
+| open          | `data-open`           | Present when the drawer is open.             |
+| closed        | `data-closed`         | Present when the drawer is closed.           |
+| startingStyle | `data-starting-style` | Present when the drawer begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the drawer is animating out.    |
+
+### DrawerPopupCssVars
+
+| Member          | Value                        | Description                                                                  |
+| :-------------- | :--------------------------- | :--------------------------------------------------------------------------- |
+| nestedDrawers   | `--nested-drawers`           | The number of nested drawers that are currently open.                        |
+| height          | `--drawer-height`            | The height of the drawer popup.                                              |
+| frontmostHeight | `--drawer-frontmost-height`  | The height of the frontmost open drawer in the current nested drawer stack.  |
+| swipeMovementX  | `--drawer-swipe-movement-x`  | The swipe movement on the X axis.                                            |
+| swipeMovementY  | `--drawer-swipe-movement-y`  | The swipe movement on the Y axis.                                            |
+| snapPointOffset | `--drawer-snap-point-offset` | The snap point offset used for translating the drawer.                       |
+| swipeStrength   | `--drawer-swipe-strength`    | A scalar (0.1-1) used to scale the swipe release transition duration in CSS. |
+
+### DrawerPopupDataAttributes
+
+| Member              | Value                        | Description                                                          |
+| :------------------ | :--------------------------- | :------------------------------------------------------------------- |
+| open                | `data-open`                  | Present when the drawer is open.                                     |
+| closed              | `data-closed`                | Present when the drawer is closed.                                   |
+| startingStyle       | `data-starting-style`        | Present when the drawer begins animating in.                         |
+| endingStyle         | `data-ending-style`          | Present when the drawer is animating out.                            |
+| expanded            | `data-expanded`              | Present when the drawer is at the expanded (full-height) snap point. |
+| nestedDrawerOpen    | `data-nested-drawer-open`    | Present when a nested drawer is open.                                |
+| nestedDrawerSwiping | `data-nested-drawer-swiping` | Present when a nested drawer is being swiped.                        |
+| swipeDismiss        | `data-swipe-dismiss`         | Present when the drawer is dismissed by swiping.                     |
+| swipeDirection      | `data-swipe-direction`       | Indicates the swipe direction.                                       |
+| swiping             | `data-swiping`               | Present when the drawer is being swiped.                             |
+
+### DrawerSwipeAreaDataAttributes
+
+| Member         | Value                  | Description                              |
+| :------------- | :--------------------- | :--------------------------------------- |
+| open           | `data-open`            | Present when the drawer is open.         |
+| closed         | `data-closed`          | Present when the drawer is closed.       |
+| disabled       | `data-disabled`        | Present when the swipe area is disabled. |
+| swipeDirection | `data-swipe-direction` | Indicates the swipe direction.           |
+| swiping        | `data-swiping`         | Present when the drawer is being swiped. |
+
+### DrawerViewportCssVars
+
+| Member        | Value                     | Description                                                                                                                                                         |
+| :------------ | :------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| keyboardInset | `--drawer-keyboard-inset` | The software keyboard inset, measured from the bottom edge of the layout viewport.&#xA;Present only when the drawer is wrapped in `Drawer.VirtualKeyboardProvider`. |
+
+### DrawerViewportDataAttributes
+
+| Member        | Value                 | Description                                              |
+| :------------ | :-------------------- | :------------------------------------------------------- |
+| open          | `data-open`           | Present when the drawer is open.                         |
+| closed        | `data-closed`         | Present when the drawer is closed.                       |
+| startingStyle | `data-starting-style` | Present when the drawer begins animating in.             |
+| endingStyle   | `data-ending-style`   | Present when the drawer is animating out.                |
+| nested        | `data-nested`         | Present when the drawer is nested within another drawer. |
+
 ## External Types
 
 ### InteractionType
@@ -699,7 +775,7 @@ type SwipeDirection = 'up' | 'down' | 'left' | 'right';
 - `Drawer.VirtualKeyboardProvider`: `Drawer.VirtualKeyboardProvider`, `Drawer.VirtualKeyboardProvider.State`, `Drawer.VirtualKeyboardProvider.Props`
 - `Drawer.createHandle`
 - `Drawer.Handle`
-- `Default`: `DrawerRootState`, `DrawerRootProps`, `DrawerRootActions`, `DrawerRootChangeEventReason`, `DrawerRootChangeEventDetails`, `DrawerRootSnapPointChangeEventReason`, `DrawerRootSnapPointChangeEventDetails`, `DrawerProviderState`, `DrawerProviderProps`, `DrawerIndentState`, `DrawerIndentProps`, `DrawerIndentBackgroundState`, `DrawerIndentBackgroundProps`, `DrawerTriggerProps`, `DrawerTriggerState`, `DrawerPortalState`, `DrawerPortalProps`, `DrawerPopupProps`, `DrawerPopupState`, `DrawerSwipeAreaProps`, `DrawerSwipeAreaState`, `DrawerContentProps`, `DrawerContentState`, `DrawerBackdropProps`, `DrawerBackdropState`, `DrawerViewportState`, `DrawerViewportProps`, `DrawerTitleProps`, `DrawerTitleState`, `DrawerDescriptionProps`, `DrawerDescriptionState`, `DrawerCloseProps`, `DrawerCloseState`, `DrawerVirtualKeyboardProviderState`, `DrawerVirtualKeyboardProviderProps`
+- `Default`: `DrawerBackdropCssVars`, `DrawerPopupCssVars`, `DrawerViewportCssVars`, `DrawerBackdropDataAttributes`, `DRAWER_CONTENT_ATTRIBUTE`, `DrawerPopupDataAttributes`, `DrawerSwipeAreaDataAttributes`, `DrawerViewportDataAttributes`, `DrawerRootState`, `DrawerRootProps`, `DrawerRootActions`, `DrawerRootChangeEventReason`, `DrawerRootChangeEventDetails`, `DrawerRootSnapPointChangeEventReason`, `DrawerRootSnapPointChangeEventDetails`, `DrawerProviderState`, `DrawerProviderProps`, `DrawerIndentState`, `DrawerIndentProps`, `DrawerIndentBackgroundState`, `DrawerIndentBackgroundProps`, `DrawerTriggerProps`, `DrawerTriggerState`, `DrawerPortalState`, `DrawerPortalProps`, `DrawerPopupProps`, `DrawerPopupState`, `DrawerSwipeAreaProps`, `DrawerSwipeAreaState`, `DrawerContentProps`, `DrawerContentState`, `DrawerBackdropProps`, `DrawerBackdropState`, `DrawerViewportState`, `DrawerViewportProps`, `DrawerTitleProps`, `DrawerTitleState`, `DrawerDescriptionProps`, `DrawerDescriptionState`, `DrawerCloseProps`, `DrawerCloseState`, `DrawerVirtualKeyboardProviderState`, `DrawerVirtualKeyboardProviderProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/field/types.md
+++ b/docs/src/app/(docs)/react/components/field/types.md
@@ -415,6 +415,80 @@ type FieldValidityData = {
 };
 ```
 
+### FieldControlDataAttributes
+
+| Member   | Value           | Description                                    |
+| :------- | :-------------- | :--------------------------------------------- |
+| disabled | `data-disabled` | Present when the field is disabled.            |
+| valid    | `data-valid`    | Present when the field is in a valid state.    |
+| invalid  | `data-invalid`  | Present when the field is in an invalid state. |
+| touched  | `data-touched`  | Present when the field has been touched.       |
+| dirty    | `data-dirty`    | Present when the field's value has changed.    |
+| filled   | `data-filled`   | Present when the field is filled.              |
+| focused  | `data-focused`  | Present when the field control is focused.     |
+
+### FieldDescriptionDataAttributes
+
+| Member   | Value           | Description                                    |
+| :------- | :-------------- | :--------------------------------------------- |
+| disabled | `data-disabled` | Present when the field is disabled.            |
+| valid    | `data-valid`    | Present when the field is in a valid state.    |
+| invalid  | `data-invalid`  | Present when the field is in an invalid state. |
+| touched  | `data-touched`  | Present when the field has been touched.       |
+| dirty    | `data-dirty`    | Present when the field's value has changed.    |
+| filled   | `data-filled`   | Present when the field is filled.              |
+| focused  | `data-focused`  | Present when the field control is focused.     |
+
+### FieldErrorDataAttributes
+
+| Member        | Value                 | Description                                         |
+| :------------ | :-------------------- | :-------------------------------------------------- |
+| disabled      | `data-disabled`       | Present when the field is disabled.                 |
+| valid         | `data-valid`          | Present when the field is in a valid state.         |
+| invalid       | `data-invalid`        | Present when the field is in an invalid state.      |
+| touched       | `data-touched`        | Present when the field has been touched.            |
+| dirty         | `data-dirty`          | Present when the field's value has changed.         |
+| filled        | `data-filled`         | Present when the field is filled.                   |
+| focused       | `data-focused`        | Present when the field control is focused.          |
+| startingStyle | `data-starting-style` | Present when the error message begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the error message is animating out.    |
+
+### FieldItemDataAttributes
+
+| Member   | Value           | Description                                    |
+| :------- | :-------------- | :--------------------------------------------- |
+| disabled | `data-disabled` | Present when the field is disabled.            |
+| valid    | `data-valid`    | Present when the field is in a valid state.    |
+| invalid  | `data-invalid`  | Present when the field is in an invalid state. |
+| touched  | `data-touched`  | Present when the field has been touched.       |
+| dirty    | `data-dirty`    | Present when the field's value has changed.    |
+| filled   | `data-filled`   | Present when the field is filled.              |
+| focused  | `data-focused`  | Present when the field control is focused.     |
+
+### FieldLabelDataAttributes
+
+| Member   | Value           | Description                                    |
+| :------- | :-------------- | :--------------------------------------------- |
+| disabled | `data-disabled` | Present when the field is disabled.            |
+| valid    | `data-valid`    | Present when the field is in a valid state.    |
+| invalid  | `data-invalid`  | Present when the field is in an invalid state. |
+| touched  | `data-touched`  | Present when the field has been touched.       |
+| dirty    | `data-dirty`    | Present when the field's value has changed.    |
+| filled   | `data-filled`   | Present when the field is filled.              |
+| focused  | `data-focused`  | Present when the field control is focused.     |
+
+### FieldRootDataAttributes
+
+| Member   | Value           | Description                                 |
+| :------- | :-------------- | :------------------------------------------ |
+| disabled | `data-disabled` | Present when the field is disabled.         |
+| touched  | `data-touched`  | Present when the field has been touched.    |
+| dirty    | `data-dirty`    | Present when the field's value has changed. |
+| valid    | `data-valid`    | Present when the field is valid.            |
+| invalid  | `data-invalid`  | Present when the field is invalid.          |
+| filled   | `data-filled`   | Present when the field is filled.           |
+| focused  | `data-focused`  | Present when the field control is focused.  |
+
 ## External Types
 
 ### ValidationMode
@@ -432,7 +506,7 @@ type ValidationMode = 'onSubmit' | 'onBlur' | 'onChange';
 - `Field.Control`: `Field.Control`, `Field.Control.State`, `Field.Control.Props`, `Field.Control.ChangeEventReason`, `Field.Control.ChangeEventDetails`
 - `Field.Validity`: `Field.Validity`, `Field.Validity.State`, `Field.Validity.Props`
 - `Field.Item`: `Field.Item`, `Field.Item.State`, `Field.Item.Props`
-- `Default`: `Field.ValidityData`, `FieldValidityData`, `FieldRootActions`, `FieldRootState`, `FieldRootProps`, `FieldLabelState`, `FieldLabelProps`, `FieldDescriptionState`, `FieldDescriptionProps`, `FieldErrorState`, `FieldErrorProps`, `FieldControlState`, `FieldControlProps`, `FieldControlChangeEventReason`, `FieldControlChangeEventDetails`, `FieldValidityState`, `FieldValidityProps`, `FieldItemState`, `FieldItemProps`
+- `Default`: `Field.ValidityData`, `FieldControlDataAttributes`, `FieldDescriptionDataAttributes`, `FieldErrorDataAttributes`, `FieldItemDataAttributes`, `FieldLabelDataAttributes`, `FieldRootDataAttributes`, `FieldValidityData`, `FieldRootActions`, `FieldRootState`, `FieldRootProps`, `FieldLabelState`, `FieldLabelProps`, `FieldDescriptionState`, `FieldDescriptionProps`, `FieldErrorState`, `FieldErrorProps`, `FieldControlState`, `FieldControlProps`, `FieldControlChangeEventReason`, `FieldControlChangeEventDetails`, `FieldValidityState`, `FieldValidityProps`, `FieldItemState`, `FieldItemProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/input/types.md
+++ b/docs/src/app/(docs)/react/components/input/types.md
@@ -82,6 +82,20 @@ type InputChangeEventDetails = {
 };
 ```
 
+## Additional Types
+
+### InputDataAttributes
+
+| Member   | Value           | Description                                                                 |
+| :------- | :-------------- | :-------------------------------------------------------------------------- |
+| disabled | `data-disabled` | Present when the input is disabled.                                         |
+| valid    | `data-valid`    | Present when the input is in a valid state (when wrapped in Field.Root).    |
+| invalid  | `data-invalid`  | Present when the input is in an invalid state (when wrapped in Field.Root). |
+| touched  | `data-touched`  | Present when the input has been touched (when wrapped in Field.Root).       |
+| dirty    | `data-dirty`    | Present when the input's value has changed (when wrapped in Field.Root).    |
+| filled   | `data-filled`   | Present when the input is filled (when wrapped in Field.Root).              |
+| focused  | `data-focused`  | Present when the input is focused (when wrapped in Field.Root).             |
+
 ## Canonical Types
 
 Maps `Canonical`: `Alias` — Use Canonical when its namespace is already imported; otherwise use Alias.

--- a/docs/src/app/(docs)/react/components/menu/types.md
+++ b/docs/src/app/(docs)/react/components/menu/types.md
@@ -1083,6 +1083,57 @@ type MenuLinkItemState = {
 
 ## Additional Types
 
+### MenuArrowDataAttributes
+
+| Member     | Value             | Description                                                           |
+| :--------- | :---------------- | :-------------------------------------------------------------------- |
+| open       | `data-open`       | Present when the menu popup is open.                                  |
+| closed     | `data-closed`     | Present when the menu popup is closed.                                |
+| side       | `data-side`       | Indicates which side the popup is positioned relative to the trigger. |
+| align      | `data-align`      | Indicates how the popup is aligned relative to specified side.        |
+| uncentered | `data-uncentered` | Present when the menu arrow is uncentered.                            |
+
+### MenuBackdropDataAttributes
+
+| Member        | Value                 | Description                                |
+| :------------ | :-------------------- | :----------------------------------------- |
+| open          | `data-open`           | Present when the menu is open.             |
+| closed        | `data-closed`         | Present when the menu is closed.           |
+| startingStyle | `data-starting-style` | Present when the menu begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the menu is animating out.    |
+
+### MenuCheckboxItemDataAttributes
+
+| Member      | Value              | Description                                         |
+| :---------- | :----------------- | :-------------------------------------------------- |
+| checked     | `data-checked`     | Present when the menu checkbox item is checked.     |
+| unchecked   | `data-unchecked`   | Present when the menu checkbox item is not checked. |
+| disabled    | `data-disabled`    | Present when the menu checkbox item is disabled.    |
+| highlighted | `data-highlighted` | Present when the menu checkbox item is highlighted. |
+
+### MenuCheckboxItemIndicatorDataAttributes
+
+| Member        | Value                 | Description                                         |
+| :------------ | :-------------------- | :-------------------------------------------------- |
+| checked       | `data-checked`        | Present when the menu checkbox item is checked.     |
+| unchecked     | `data-unchecked`      | Present when the menu checkbox item is not checked. |
+| disabled      | `data-disabled`       | Present when the menu checkbox item is disabled.    |
+| startingStyle | `data-starting-style` | Present when the indicator begins animating in.     |
+| endingStyle   | `data-ending-style`   | Present when the indicator is animating out.        |
+
+### MenuItemDataAttributes
+
+| Member      | Value              | Description                                |
+| :---------- | :----------------- | :----------------------------------------- |
+| highlighted | `data-highlighted` | Present when the menu item is highlighted. |
+| disabled    | `data-disabled`    | Present when the menu item is disabled.    |
+
+### MenuLinkItemDataAttributes
+
+| Member      | Value              | Description                           |
+| :---------- | :----------------- | :------------------------------------ |
+| highlighted | `data-highlighted` | Present when the link is highlighted. |
+
 ### MenuParent
 
 ```typescript
@@ -1093,6 +1144,91 @@ type MenuParent =
   | { type: 'nested-context-menu'; context: ContextMenuRootContext; menuContext: MenuRootContext }
   | { type: undefined };
 ```
+
+### MenuPopupDataAttributes
+
+| Member        | Value                 | Description                                                           |
+| :------------ | :-------------------- | :-------------------------------------------------------------------- |
+| open          | `data-open`           | Present when the menu is open.                                        |
+| closed        | `data-closed`         | Present when the menu is closed.                                      |
+| startingStyle | `data-starting-style` | Present when the menu begins animating in.                            |
+| endingStyle   | `data-ending-style`   | Present when the menu is animating out.                               |
+| side          | `data-side`           | Indicates which side the popup is positioned relative to the trigger. |
+| align         | `data-align`          | Indicates how the popup is aligned relative to specified side.        |
+| instant       | `data-instant`        | Present if animations should be instant.                              |
+
+### MenuPositionerCssVars
+
+| Member           | Value                 | Description                                                                                                                    |
+| :--------------- | :-------------------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| availableWidth   | `--available-width`   | The available width between the trigger and the edge of the viewport.                                                          |
+| availableHeight  | `--available-height`  | The available height between the trigger and the edge of the viewport.                                                         |
+| anchorWidth      | `--anchor-width`      | The anchor's width.                                                                                                            |
+| anchorHeight     | `--anchor-height`     | The anchor's height.                                                                                                           |
+| transformOrigin  | `--transform-origin`  | The coordinates that this element is anchored to. Used for animations and transitions.                                         |
+| positionerWidth  | `--positioner-width`  | The width of the menu's positioner.&#xA;It is important to set `width` to this value when using CSS to animate size changes.   |
+| positionerHeight | `--positioner-height` | The height of the menu's positioner.&#xA;It is important to set `height` to this value when using CSS to animate size changes. |
+
+### MenuPositionerDataAttributes
+
+| Member       | Value                | Description                                                           |
+| :----------- | :------------------- | :-------------------------------------------------------------------- |
+| open         | `data-open`          | Present when the menu popup is open.                                  |
+| closed       | `data-closed`        | Present when the menu popup is closed.                                |
+| anchorHidden | `data-anchor-hidden` | Present when the anchor is hidden.                                    |
+| side         | `data-side`          | Indicates which side the popup is positioned relative to the trigger. |
+| align        | `data-align`         | Indicates how the popup is aligned relative to specified side.        |
+
+### MenuRadioItemDataAttributes
+
+| Member      | Value              | Description                                       |
+| :---------- | :----------------- | :------------------------------------------------ |
+| checked     | `data-checked`     | Present when the menu radio item is selected.     |
+| unchecked   | `data-unchecked`   | Present when the menu radio item is not selected. |
+| disabled    | `data-disabled`    | Present when the menu radio item is disabled.     |
+| highlighted | `data-highlighted` | Present when the menu radio item is highlighted.  |
+
+### MenuRadioItemIndicatorDataAttributes
+
+| Member        | Value                 | Description                                           |
+| :------------ | :-------------------- | :---------------------------------------------------- |
+| checked       | `data-checked`        | Present when the menu radio item is selected.         |
+| unchecked     | `data-unchecked`      | Present when the menu radio item is not selected.     |
+| disabled      | `data-disabled`       | Present when the menu radio item is disabled.         |
+| startingStyle | `data-starting-style` | Present when the radio indicator begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the radio indicator is animating out.    |
+
+### MenuSubmenuTriggerDataAttributes
+
+| Member      | Value              | Description                                      |
+| :---------- | :----------------- | :----------------------------------------------- |
+| popupOpen   | `data-popup-open`  | Present when the corresponding submenu is open.  |
+| highlighted | `data-highlighted` | Present when the submenu trigger is highlighted. |
+| disabled    | `data-disabled`    | Present when the submenu trigger is disabled.    |
+
+### MenuTriggerDataAttributes
+
+| Member    | Value             | Description                                  |
+| :-------- | :---------------- | :------------------------------------------- |
+| popupOpen | `data-popup-open` | Present when the corresponding menu is open. |
+| pressed   | `data-pressed`    | Present when the trigger is pressed.         |
+
+### MenuViewportCssVars
+
+| Member      | Value            | Description                                                                                                                                                                                                                                                           |
+| :---------- | :--------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| popupWidth  | `--popup-width`  | The width of the parent popup.&#xA;This variable is placed on the 'previous' container and stores the width of the popup when the previous content was rendered.&#xA;It can be used to freeze the dimensions of the popup when animating between different content.   |
+| popupHeight | `--popup-height` | The height of the parent popup.&#xA;This variable is placed on the 'previous' container and stores the height of the popup when the previous content was rendered.&#xA;It can be used to freeze the dimensions of the popup when animating between different content. |
+
+### MenuViewportDataAttributes
+
+| Member              | Value                       | Description                                                                                                                                                                                                                        |
+| :------------------ | :-------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| current             | `data-current`              | Applied to the direct child of the viewport when no transitions are present or the new content when it's entering.                                                                                                                 |
+| previous            | `data-previous`             | Applied to the direct child of the viewport that contains the exiting content when transitions are present.                                                                                                                        |
+| activationDirection | `data-activation-direction` | Indicates the direction from which the popup was activated.&#xA;This can be used to create directional animations based on how the popup was triggered.&#xA;Contains space-separated values for both horizontal and vertical axes. |
+| transitioning       | `data-transitioning`        | Indicates that the viewport is currently transitioning between old and new content.                                                                                                                                                |
+| instant             | `data-instant`              | Present if animations should be instant.                                                                                                                                                                                           |
 
 ## External Types
 
@@ -1161,7 +1297,7 @@ type PayloadChildRenderFunction = (arg: { payload: unknown | undefined }) => Rea
 - `Menu.SubmenuTrigger`: `Menu.SubmenuTrigger`, `Menu.SubmenuTrigger.Props`, `Menu.SubmenuTrigger.State`
 - `Menu.Handle`
 - `Menu.createHandle`
-- `Default`: `MenuRootState`, `MenuRootProps`, `MenuRootActions`, `MenuRootChangeEventReason`, `MenuRootChangeEventDetails`, `MenuRootOrientation`, `MenuParent`, `MenuArrowState`, `MenuArrowProps`, `MenuBackdropState`, `MenuBackdropProps`, `MenuCheckboxItemState`, `MenuCheckboxItemProps`, `MenuCheckboxItemChangeEventReason`, `MenuCheckboxItemChangeEventDetails`, `MenuCheckboxItemIndicatorProps`, `MenuCheckboxItemIndicatorState`, `MenuGroupLabelProps`, `MenuGroupLabelState`, `MenuGroupProps`, `MenuGroupState`, `MenuItemState`, `MenuItemProps`, `MenuLinkItemState`, `MenuLinkItemProps`, `MenuPopupProps`, `MenuPopupState`, `MenuPortalState`, `MenuPortalProps`, `MenuPositionerState`, `MenuPositionerProps`, `MenuRadioGroupProps`, `MenuRadioGroupState`, `MenuRadioGroupChangeEventReason`, `MenuRadioGroupChangeEventDetails`, `MenuRadioItemState`, `MenuRadioItemProps`, `MenuRadioItemIndicatorProps`, `MenuRadioItemIndicatorState`, `MenuSubmenuRootProps`, `MenuSubmenuRootState`, `MenuSubmenuRootChangeEventReason`, `MenuSubmenuRootChangeEventDetails`, `MenuTriggerProps`, `MenuTriggerState`, `MenuSubmenuTriggerState`, `MenuSubmenuTriggerProps`, `MenuViewportState`, `MenuViewportProps`
+- `Default`: `MenuPositionerCssVars`, `MenuViewportCssVars`, `MenuArrowDataAttributes`, `MenuBackdropDataAttributes`, `MenuCheckboxItemIndicatorDataAttributes`, `MenuCheckboxItemDataAttributes`, `MenuItemDataAttributes`, `MenuLinkItemDataAttributes`, `MenuPopupDataAttributes`, `MenuPositionerDataAttributes`, `MenuRadioItemIndicatorDataAttributes`, `MenuRadioItemDataAttributes`, `MenuSubmenuTriggerDataAttributes`, `MenuTriggerDataAttributes`, `MenuViewportDataAttributes`, `MenuRootState`, `MenuRootProps`, `MenuRootActions`, `MenuRootChangeEventReason`, `MenuRootChangeEventDetails`, `MenuRootOrientation`, `MenuParent`, `MenuArrowState`, `MenuArrowProps`, `MenuBackdropState`, `MenuBackdropProps`, `MenuCheckboxItemState`, `MenuCheckboxItemProps`, `MenuCheckboxItemChangeEventReason`, `MenuCheckboxItemChangeEventDetails`, `MenuCheckboxItemIndicatorProps`, `MenuCheckboxItemIndicatorState`, `MenuGroupLabelProps`, `MenuGroupLabelState`, `MenuGroupProps`, `MenuGroupState`, `MenuItemState`, `MenuItemProps`, `MenuLinkItemState`, `MenuLinkItemProps`, `MenuPopupProps`, `MenuPopupState`, `MenuPortalState`, `MenuPortalProps`, `MenuPositionerState`, `MenuPositionerProps`, `MenuRadioGroupProps`, `MenuRadioGroupState`, `MenuRadioGroupChangeEventReason`, `MenuRadioGroupChangeEventDetails`, `MenuRadioItemState`, `MenuRadioItemProps`, `MenuRadioItemIndicatorProps`, `MenuRadioItemIndicatorState`, `MenuSubmenuRootProps`, `MenuSubmenuRootState`, `MenuSubmenuRootChangeEventReason`, `MenuSubmenuRootChangeEventDetails`, `MenuTriggerProps`, `MenuTriggerState`, `MenuSubmenuTriggerState`, `MenuSubmenuTriggerProps`, `MenuViewportState`, `MenuViewportProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/menubar/types.md
+++ b/docs/src/app/(docs)/react/components/menubar/types.md
@@ -45,6 +45,16 @@ type MenubarState = {
 };
 ```
 
+## Additional Types
+
+### MenubarDataAttributes
+
+| Member         | Value                   | Description                                          |
+| :------------- | :---------------------- | :--------------------------------------------------- |
+| modal          | `data-modal`            | Present when the corresponding menubar is modal.     |
+| orientation    | `data-orientation`      | Determines the orientation of the menubar.           |
+| hasSubmenuOpen | `data-has-submenu-open` | Present when any submenu within the menubar is open. |
+
 ## External Types
 
 ### Orientation

--- a/docs/src/app/(docs)/react/components/navigation-menu/types.md
+++ b/docs/src/app/(docs)/react/components/navigation-menu/types.md
@@ -566,6 +566,98 @@ type NavigationMenuLinkState = {
 };
 ```
 
+## Additional Types
+
+### NavigationMenuArrowDataAttributes
+
+| Member     | Value             | Description                                                           |
+| :--------- | :---------------- | :-------------------------------------------------------------------- |
+| open       | `data-open`       | Present when the popup is open.                                       |
+| closed     | `data-closed`     | Present when the popup is closed.                                     |
+| side       | `data-side`       | Indicates which side the popup is positioned relative to the trigger. |
+| align      | `data-align`      | Indicates how the popup is aligned relative to specified side.        |
+| uncentered | `data-uncentered` | Present when the popup arrow is uncentered.                           |
+
+### NavigationMenuBackdropDataAttributes
+
+| Member        | Value                 | Description                                 |
+| :------------ | :-------------------- | :------------------------------------------ |
+| open          | `data-open`           | Present when the popup is open.             |
+| closed        | `data-closed`         | Present when the popup is closed.           |
+| startingStyle | `data-starting-style` | Present when the popup begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the popup is animating out.    |
+
+### NavigationMenuContentDataAttributes
+
+| Member              | Value                       | Description                                         |
+| :------------------ | :-------------------------- | :-------------------------------------------------- |
+| open                | `data-open`                 | Present when the popup is open.                     |
+| closed              | `data-closed`               | Present when the popup is closed.                   |
+| startingStyle       | `data-starting-style`       | Present when the content begins animating in.       |
+| endingStyle         | `data-ending-style`         | Present when the content is animating out.          |
+| activationDirection | `data-activation-direction` | Which direction another trigger was activated from. |
+
+### NavigationMenuIconDataAttributes
+
+| Member    | Value             | Description                                                      |
+| :-------- | :---------------- | :--------------------------------------------------------------- |
+| popupOpen | `data-popup-open` | Present when the navigation menu is open and the item is active. |
+
+### NavigationMenuLinkDataAttributes
+
+| Member | Value         | Description                                         |
+| :----- | :------------ | :-------------------------------------------------- |
+| active | `data-active` | Present when the link is the currently active page. |
+
+### NavigationMenuPopupCssVars
+
+| Member      | Value            | Description                            |
+| :---------- | :--------------- | :------------------------------------- |
+| popupWidth  | `--popup-width`  | The fixed width of the popup element.  |
+| popupHeight | `--popup-height` | The fixed height of the popup element. |
+
+### NavigationMenuPopupDataAttributes
+
+| Member        | Value                 | Description                                                           |
+| :------------ | :-------------------- | :-------------------------------------------------------------------- |
+| open          | `data-open`           | Present when the popup is open.                                       |
+| closed        | `data-closed`         | Present when the popup is closed.                                     |
+| startingStyle | `data-starting-style` | Present when the popup begins animating in.                           |
+| endingStyle   | `data-ending-style`   | Present when the popup is animating out.                              |
+| anchorHidden  | `data-anchor-hidden`  | Present when the anchor is hidden.                                    |
+| side          | `data-side`           | Indicates which side the popup is positioned relative to the trigger. |
+| align         | `data-align`          | Indicates how the popup is aligned relative to the specified side.    |
+
+### NavigationMenuPositionerCssVars
+
+| Member           | Value                 | Description                                                                            |
+| :--------------- | :-------------------- | :------------------------------------------------------------------------------------- |
+| availableWidth   | `--available-width`   | The available width between the trigger and the edge of the viewport.                  |
+| availableHeight  | `--available-height`  | The available height between the trigger and the edge of the viewport.                 |
+| anchorWidth      | `--anchor-width`      | The anchor's width.                                                                    |
+| anchorHeight     | `--anchor-height`     | The anchor's height.                                                                   |
+| transformOrigin  | `--transform-origin`  | The coordinates that this element is anchored to. Used for animations and transitions. |
+| positionerWidth  | `--positioner-width`  | The fixed width of the positioner element.                                             |
+| positionerHeight | `--positioner-height` | The fixed height of the positioner element.                                            |
+
+### NavigationMenuPositionerDataAttributes
+
+| Member       | Value                | Description                                                           |
+| :----------- | :------------------- | :-------------------------------------------------------------------- |
+| open         | `data-open`          | Present when the popup is open.                                       |
+| closed       | `data-closed`        | Present when the popup is closed.                                     |
+| anchorHidden | `data-anchor-hidden` | Present when the anchor is hidden.                                    |
+| side         | `data-side`          | Indicates which side the popup is positioned relative to the trigger. |
+| align        | `data-align`         | Indicates how the popup is aligned relative to the specified side.    |
+| instant      | `data-instant`       | Present if animations should be instant.                              |
+
+### NavigationMenuTriggerDataAttributes
+
+| Member    | Value             | Description                                             |
+| :-------- | :---------------- | :------------------------------------------------------ |
+| popupOpen | `data-popup-open` | Present when the corresponding navigation menu is open. |
+| pressed   | `data-pressed`    | Present when the trigger is pressed.                    |
+
 ## External Types
 
 ### Side
@@ -606,7 +698,7 @@ type OffsetFunction = (data: {
 - `NavigationMenu.Arrow`: `NavigationMenu.Arrow`, `NavigationMenu.Arrow.State`, `NavigationMenu.Arrow.Props`
 - `NavigationMenu.Link`: `NavigationMenu.Link`, `NavigationMenu.Link.State`, `NavigationMenu.Link.Props`
 - `NavigationMenu.Icon`: `NavigationMenu.Icon`, `NavigationMenu.Icon.State`, `NavigationMenu.Icon.Props`
-- `Default`: `NavigationMenuRootState`, `NavigationMenuRootProps`, `NavigationMenuRootActions`, `NavigationMenuRootChangeEventReason`, `NavigationMenuRootChangeEventDetails`, `NavigationMenuTriggerState`, `NavigationMenuTriggerProps`, `NavigationMenuPortalState`, `NavigationMenuPortalProps`, `NavigationMenuPositionerState`, `NavigationMenuPositionerProps`, `NavigationMenuViewportState`, `NavigationMenuViewportProps`, `NavigationMenuListState`, `NavigationMenuListProps`, `NavigationMenuItemState`, `NavigationMenuItemProps`, `NavigationMenuContentState`, `NavigationMenuContentProps`, `NavigationMenuPopupState`, `NavigationMenuPopupProps`, `NavigationMenuBackdropState`, `NavigationMenuBackdropProps`, `NavigationMenuArrowState`, `NavigationMenuArrowProps`, `NavigationMenuLinkState`, `NavigationMenuLinkProps`, `NavigationMenuIconState`, `NavigationMenuIconProps`
+- `Default`: `NavigationMenuPopupCssVars`, `NavigationMenuPositionerCssVars`, `NavigationMenuArrowDataAttributes`, `NavigationMenuBackdropDataAttributes`, `NavigationMenuContentDataAttributes`, `NavigationMenuIconDataAttributes`, `NavigationMenuLinkDataAttributes`, `NavigationMenuPopupDataAttributes`, `NavigationMenuPositionerDataAttributes`, `NavigationMenuTriggerDataAttributes`, `NavigationMenuRootState`, `NavigationMenuRootProps`, `NavigationMenuRootActions`, `NavigationMenuRootChangeEventReason`, `NavigationMenuRootChangeEventDetails`, `NavigationMenuTriggerState`, `NavigationMenuTriggerProps`, `NavigationMenuPortalState`, `NavigationMenuPortalProps`, `NavigationMenuPositionerState`, `NavigationMenuPositionerProps`, `NavigationMenuViewportState`, `NavigationMenuViewportProps`, `NavigationMenuListState`, `NavigationMenuListProps`, `NavigationMenuItemState`, `NavigationMenuItemProps`, `NavigationMenuContentState`, `NavigationMenuContentProps`, `NavigationMenuPopupState`, `NavigationMenuPopupProps`, `NavigationMenuBackdropState`, `NavigationMenuBackdropProps`, `NavigationMenuArrowState`, `NavigationMenuArrowProps`, `NavigationMenuLinkState`, `NavigationMenuLinkProps`, `NavigationMenuIconState`, `NavigationMenuIconProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/number-field/types.md
+++ b/docs/src/app/(docs)/react/components/number-field/types.md
@@ -534,6 +534,113 @@ type NumberFieldIncrementState = {
 };
 ```
 
+## Additional Types
+
+### NumberFieldDecrementDataAttributes
+
+| Member    | Value            | Description                                                                        |
+| :-------- | :--------------- | :--------------------------------------------------------------------------------- |
+| scrubbing | `data-scrubbing` | Present while scrubbing.                                                           |
+| disabled  | `data-disabled`  | Present when the number field is disabled.                                         |
+| readonly  | `data-readonly`  | Present when the number field is readonly.                                         |
+| required  | `data-required`  | Present when the number field is required.                                         |
+| valid     | `data-valid`     | Present when the number field is in a valid state (when wrapped in Field.Root).    |
+| invalid   | `data-invalid`   | Present when the number field is in an invalid state (when wrapped in Field.Root). |
+| touched   | `data-touched`   | Present when the number field has been touched (when wrapped in Field.Root).       |
+| dirty     | `data-dirty`     | Present when the number field's value has changed (when wrapped in Field.Root).    |
+| filled    | `data-filled`    | Present when the number field is filled (when wrapped in Field.Root).              |
+| focused   | `data-focused`   | Present when the number field is focused (when wrapped in Field.Root).             |
+
+### NumberFieldGroupDataAttributes
+
+| Member    | Value            | Description                                                                        |
+| :-------- | :--------------- | :--------------------------------------------------------------------------------- |
+| scrubbing | `data-scrubbing` | Present while scrubbing.                                                           |
+| disabled  | `data-disabled`  | Present when the number field is disabled.                                         |
+| readonly  | `data-readonly`  | Present when the number field is readonly.                                         |
+| required  | `data-required`  | Present when the number field is required.                                         |
+| valid     | `data-valid`     | Present when the number field is in a valid state (when wrapped in Field.Root).    |
+| invalid   | `data-invalid`   | Present when the number field is in an invalid state (when wrapped in Field.Root). |
+| touched   | `data-touched`   | Present when the number field has been touched (when wrapped in Field.Root).       |
+| dirty     | `data-dirty`     | Present when the number field's value has changed (when wrapped in Field.Root).    |
+| filled    | `data-filled`    | Present when the number field is filled (when wrapped in Field.Root).              |
+| focused   | `data-focused`   | Present when the number field is focused (when wrapped in Field.Root).             |
+
+### NumberFieldIncrementDataAttributes
+
+| Member    | Value            | Description                                                                        |
+| :-------- | :--------------- | :--------------------------------------------------------------------------------- |
+| scrubbing | `data-scrubbing` | Present while scrubbing.                                                           |
+| disabled  | `data-disabled`  | Present when the number field is disabled.                                         |
+| readonly  | `data-readonly`  | Present when the number field is readonly.                                         |
+| required  | `data-required`  | Present when the number field is required.                                         |
+| valid     | `data-valid`     | Present when the number field is in a valid state (when wrapped in Field.Root).    |
+| invalid   | `data-invalid`   | Present when the number field is in an invalid state (when wrapped in Field.Root). |
+| touched   | `data-touched`   | Present when the number field has been touched (when wrapped in Field.Root).       |
+| dirty     | `data-dirty`     | Present when the number field's value has changed (when wrapped in Field.Root).    |
+| filled    | `data-filled`    | Present when the number field is filled (when wrapped in Field.Root).              |
+| focused   | `data-focused`   | Present when the number field is focused (when wrapped in Field.Root).             |
+
+### NumberFieldInputDataAttributes
+
+| Member    | Value            | Description                                                                        |
+| :-------- | :--------------- | :--------------------------------------------------------------------------------- |
+| scrubbing | `data-scrubbing` | Present while scrubbing.                                                           |
+| disabled  | `data-disabled`  | Present when the number field is disabled.                                         |
+| readonly  | `data-readonly`  | Present when the number field is readonly.                                         |
+| required  | `data-required`  | Present when the number field is required.                                         |
+| valid     | `data-valid`     | Present when the number field is in a valid state (when wrapped in Field.Root).    |
+| invalid   | `data-invalid`   | Present when the number field is in an invalid state (when wrapped in Field.Root). |
+| touched   | `data-touched`   | Present when the number field has been touched (when wrapped in Field.Root).       |
+| dirty     | `data-dirty`     | Present when the number field's value has changed (when wrapped in Field.Root).    |
+| filled    | `data-filled`    | Present when the number field is filled (when wrapped in Field.Root).              |
+| focused   | `data-focused`   | Present when the number field is focused (when wrapped in Field.Root).             |
+
+### NumberFieldRootDataAttributes
+
+| Member    | Value            | Description                                                                        |
+| :-------- | :--------------- | :--------------------------------------------------------------------------------- |
+| scrubbing | `data-scrubbing` | Present while scrubbing.                                                           |
+| disabled  | `data-disabled`  | Present when the number field is disabled.                                         |
+| readonly  | `data-readonly`  | Present when the number field is readonly.                                         |
+| required  | `data-required`  | Present when the number field is required.                                         |
+| valid     | `data-valid`     | Present when the number field is in a valid state (when wrapped in Field.Root).    |
+| invalid   | `data-invalid`   | Present when the number field is in an invalid state (when wrapped in Field.Root). |
+| touched   | `data-touched`   | Present when the number field has been touched (when wrapped in Field.Root).       |
+| dirty     | `data-dirty`     | Present when the number field's value has changed (when wrapped in Field.Root).    |
+| filled    | `data-filled`    | Present when the number field is filled (when wrapped in Field.Root).              |
+| focused   | `data-focused`   | Present when the number field is focused (when wrapped in Field.Root).             |
+
+### NumberFieldScrubAreaCursorDataAttributes
+
+| Member    | Value            | Description                                                                        |
+| :-------- | :--------------- | :--------------------------------------------------------------------------------- |
+| scrubbing | `data-scrubbing` | Present while scrubbing.                                                           |
+| disabled  | `data-disabled`  | Present when the number field is disabled.                                         |
+| readonly  | `data-readonly`  | Present when the number field is readonly.                                         |
+| required  | `data-required`  | Present when the number field is required.                                         |
+| valid     | `data-valid`     | Present when the number field is in a valid state (when wrapped in Field.Root).    |
+| invalid   | `data-invalid`   | Present when the number field is in an invalid state (when wrapped in Field.Root). |
+| touched   | `data-touched`   | Present when the number field has been touched (when wrapped in Field.Root).       |
+| dirty     | `data-dirty`     | Present when the number field's value has changed (when wrapped in Field.Root).    |
+| filled    | `data-filled`    | Present when the number field is filled (when wrapped in Field.Root).              |
+| focused   | `data-focused`   | Present when the number field is focused (when wrapped in Field.Root).             |
+
+### NumberFieldScrubAreaDataAttributes
+
+| Member    | Value            | Description                                                                        |
+| :-------- | :--------------- | :--------------------------------------------------------------------------------- |
+| scrubbing | `data-scrubbing` | Present while scrubbing.                                                           |
+| disabled  | `data-disabled`  | Present when the number field is disabled.                                         |
+| readonly  | `data-readonly`  | Present when the number field is readonly.                                         |
+| required  | `data-required`  | Present when the number field is required.                                         |
+| valid     | `data-valid`     | Present when the number field is in a valid state (when wrapped in Field.Root).    |
+| invalid   | `data-invalid`   | Present when the number field is in an invalid state (when wrapped in Field.Root). |
+| touched   | `data-touched`   | Present when the number field has been touched (when wrapped in Field.Root).       |
+| dirty     | `data-dirty`     | Present when the number field's value has changed (when wrapped in Field.Root).    |
+| filled    | `data-filled`    | Present when the number field is filled (when wrapped in Field.Root).              |
+| focused   | `data-focused`   | Present when the number field is focused (when wrapped in Field.Root).             |
+
 ## External Types
 
 ### Direction
@@ -551,7 +658,7 @@ type Direction = -1 | 1;
 - `NumberField.Input`: `NumberField.Input`, `NumberField.Input.State`, `NumberField.Input.Props`
 - `NumberField.ScrubArea`: `NumberField.ScrubArea`, `NumberField.ScrubArea.State`, `NumberField.ScrubArea.Props`
 - `NumberField.ScrubAreaCursor`: `NumberField.ScrubAreaCursor`, `NumberField.ScrubAreaCursor.State`, `NumberField.ScrubAreaCursor.Props`
-- `Default`: `NumberFieldRootProps`, `NumberFieldRootState`, `NumberFieldRootChangeEventReason`, `NumberFieldRootChangeEventDetails`, `NumberFieldRootCommitEventReason`, `NumberFieldRootCommitEventDetails`, `NumberFieldGroupState`, `NumberFieldGroupProps`, `NumberFieldIncrementState`, `NumberFieldIncrementProps`, `NumberFieldDecrementState`, `NumberFieldDecrementProps`, `NumberFieldInputState`, `NumberFieldInputProps`, `NumberFieldScrubAreaState`, `NumberFieldScrubAreaProps`, `NumberFieldScrubAreaCursorState`, `NumberFieldScrubAreaCursorProps`
+- `Default`: `NumberFieldDecrementDataAttributes`, `NumberFieldGroupDataAttributes`, `NumberFieldIncrementDataAttributes`, `NumberFieldInputDataAttributes`, `NumberFieldRootDataAttributes`, `NumberFieldScrubAreaCursorDataAttributes`, `NumberFieldScrubAreaDataAttributes`, `NumberFieldRootProps`, `NumberFieldRootState`, `NumberFieldRootChangeEventReason`, `NumberFieldRootChangeEventDetails`, `NumberFieldRootCommitEventReason`, `NumberFieldRootCommitEventDetails`, `NumberFieldGroupState`, `NumberFieldGroupProps`, `NumberFieldIncrementState`, `NumberFieldIncrementProps`, `NumberFieldDecrementState`, `NumberFieldDecrementProps`, `NumberFieldInputState`, `NumberFieldInputProps`, `NumberFieldScrubAreaState`, `NumberFieldScrubAreaProps`, `NumberFieldScrubAreaCursorState`, `NumberFieldScrubAreaCursorProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/otp-field/types.md
+++ b/docs/src/app/(docs)/react/components/otp-field/types.md
@@ -235,6 +235,38 @@ type OTPFieldSeparatorState = {
 };
 ```
 
+## Additional Types
+
+### OTPFieldInputDataAttributes
+
+| Member   | Value           | Description                                                                     |
+| :------- | :-------------- | :------------------------------------------------------------------------------ |
+| complete | `data-complete` | Present when all slots are filled.                                              |
+| filled   | `data-filled`   | Present when the input contains a character.                                    |
+| disabled | `data-disabled` | Present when the OTP field is disabled.                                         |
+| readonly | `data-readonly` | Present when the OTP field is readonly.                                         |
+| required | `data-required` | Present when the OTP field is required.                                         |
+| valid    | `data-valid`    | Present when the OTP field is in a valid state (when wrapped in Field.Root).    |
+| invalid  | `data-invalid`  | Present when the OTP field is in an invalid state (when wrapped in Field.Root). |
+| touched  | `data-touched`  | Present when the OTP field has been touched (when wrapped in Field.Root).       |
+| dirty    | `data-dirty`    | Present when the OTP field's value has changed (when wrapped in Field.Root).    |
+| focused  | `data-focused`  | Present when any OTP field input is focused.                                    |
+
+### OTPFieldRootDataAttributes
+
+| Member   | Value           | Description                                                                     |
+| :------- | :-------------- | :------------------------------------------------------------------------------ |
+| complete | `data-complete` | Present when all slots are filled.                                              |
+| disabled | `data-disabled` | Present when the OTP field is disabled.                                         |
+| readonly | `data-readonly` | Present when the OTP field is readonly.                                         |
+| required | `data-required` | Present when the OTP field is required.                                         |
+| valid    | `data-valid`    | Present when the OTP field is in a valid state (when wrapped in Field.Root).    |
+| invalid  | `data-invalid`  | Present when the OTP field is in an invalid state (when wrapped in Field.Root). |
+| touched  | `data-touched`  | Present when the OTP field has been touched (when wrapped in Field.Root).       |
+| dirty    | `data-dirty`    | Present when the OTP field's value has changed (when wrapped in Field.Root).    |
+| filled   | `data-filled`   | Present when the OTP field contains at least one character.                     |
+| focused  | `data-focused`  | Present when one of the OTP field inputs is focused.                            |
+
 ## External Types
 
 ### ValidationType
@@ -254,7 +286,7 @@ type Orientation = 'horizontal' | 'vertical';
 - `OTPField.Root`: `OTPField.Root`, `OTPField.Root.State`, `OTPField.Root.Props`, `OTPField.Root.ValidationType`, `OTPField.Root.ChangeEventReason`, `OTPField.Root.ChangeEventDetails`, `OTPField.Root.InvalidEventReason`, `OTPField.Root.InvalidEventDetails`, `OTPField.Root.CompleteEventReason`, `OTPField.Root.CompleteEventDetails`
 - `OTPField.Input`: `OTPField.Input`, `OTPField.Input.State`, `OTPField.Input.Props`
 - `OTPField.Separator`: `OTPField.Separator`, `OTPField.Separator.Props`, `OTPField.Separator.State`
-- `Default`: `OTPFieldRootProps`, `OTPFieldRootState`, `OTPFieldRootChangeEventReason`, `OTPFieldRootChangeEventDetails`, `OTPFieldRootInvalidEventReason`, `OTPFieldRootInvalidEventDetails`, `OTPFieldRootCompleteEventReason`, `OTPFieldRootCompleteEventDetails`, `OTPFieldInputState`, `OTPFieldInputProps`
+- `Default`: `OTPFieldInputDataAttributes`, `OTPFieldRootDataAttributes`, `OTPFieldRootProps`, `OTPFieldRootState`, `OTPFieldRootChangeEventReason`, `OTPFieldRootChangeEventDetails`, `OTPFieldRootInvalidEventReason`, `OTPFieldRootInvalidEventDetails`, `OTPFieldRootCompleteEventReason`, `OTPFieldRootCompleteEventDetails`, `OTPFieldInputState`, `OTPFieldInputProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -368,7 +368,7 @@ Provides shared state to a series of checkboxes.
   - CheckboxGroup
     - Props: allValues, className, defaultValue, disabled, onValueChange, render, style, value
     - Data Attributes: data-disabled
-- Types: CheckboxGroup.ChangeEventDetails, CheckboxGroup.ChangeEventReason, CheckboxGroup.Props, CheckboxGroup.State
+- Types: CheckboxGroup.ChangeEventDetails, CheckboxGroup.ChangeEventReason, CheckboxGroup.Props, CheckboxGroup.State, CheckboxGroupDataAttributes
 
 </details>
 
@@ -895,7 +895,7 @@ A native input element that automatically works with [Field](/react/components/f
   - Input
     - Props: className, defaultValue, onValueChange, render, style, value
     - Data Attributes: data-dirty, data-disabled, data-filled, data-focused, data-invalid, data-touched, data-valid
-- Types: Input.ChangeEventDetails, Input.ChangeEventReason, Input.Props, Input.State
+- Types: Input.ChangeEventDetails, Input.ChangeEventReason, Input.Props, Input.State, InputDataAttributes
 
 </details>
 
@@ -1031,7 +1031,7 @@ A menu bar providing commands and options for your application.
   - Menubar
     - Props: className, disabled, loopFocus, modal, orientation, render, style
     - Data Attributes: data-has-submenu-open, data-modal, data-orientation
-- Types: Menubar.Props, Menubar.State
+- Types: Menubar.Props, Menubar.State, MenubarDataAttributes
 
 </details>
 
@@ -1602,7 +1602,7 @@ A separator element accessible to screen readers.
   - Separator
     - Props: className, orientation, render, style
     - Data Attributes: data-orientation
-- Types: Separator.Props, Separator.State
+- Types: Separator.Props, Separator.State, SeparatorDataAttributes
 
 </details>
 
@@ -1834,7 +1834,7 @@ A two-state button that can be on or off.
   - Toggle
     - Props: className, defaultPressed, disabled, nativeButton, onPressedChange, pressed, render, style, value
     - Data Attributes: data-disabled, data-pressed
-- Types: Toggle.ChangeEventDetails, Toggle.ChangeEventReason, Toggle.Props, Toggle.State
+- Types: Toggle.ChangeEventDetails, Toggle.ChangeEventReason, Toggle.Props, Toggle.State, ToggleDataAttributes
 
 </details>
 
@@ -1858,7 +1858,7 @@ Provides a shared state to a series of toggle buttons.
   - ToggleGroup
     - Props: className, defaultValue, disabled, loopFocus, multiple, onValueChange, orientation, render, style, value
     - Data Attributes: data-disabled, data-multiple, data-orientation
-- Types: ToggleGroup.ChangeEventDetails, ToggleGroup.ChangeEventReason, ToggleGroup.Props, ToggleGroup.State
+- Types: ToggleGroup.ChangeEventDetails, ToggleGroup.ChangeEventReason, ToggleGroup.Props, ToggleGroup.State, ToggleGroupDataAttributes
 
 </details>
 

--- a/docs/src/app/(docs)/react/components/popover/types.md
+++ b/docs/src/app/(docs)/react/components/popover/types.md
@@ -548,6 +548,92 @@ Closes the popover.
 
 This method should only be called in an event handler or an effect (not during rendering).
 
+## Additional Types
+
+### PopoverArrowDataAttributes
+
+| Member     | Value             | Description                                                           |
+| :--------- | :---------------- | :-------------------------------------------------------------------- |
+| open       | `data-open`       | Present when the popup is open.                                       |
+| closed     | `data-closed`     | Present when the popup is closed.                                     |
+| side       | `data-side`       | Indicates which side the popup is positioned relative to the trigger. |
+| align      | `data-align`      | Indicates how the popup is aligned relative to specified side.        |
+| uncentered | `data-uncentered` | Present when the popover arrow is uncentered.                         |
+
+### PopoverBackdropDataAttributes
+
+| Member        | Value                 | Description                                 |
+| :------------ | :-------------------- | :------------------------------------------ |
+| open          | `data-open`           | Present when the popup is open.             |
+| closed        | `data-closed`         | Present when the popup is closed.           |
+| startingStyle | `data-starting-style` | Present when the popup begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the popup is animating out.    |
+
+### PopoverPopupCssVars
+
+| Member      | Value            | Description              |
+| :---------- | :--------------- | :----------------------- |
+| popupWidth  | `--popup-width`  | The width of the popup.  |
+| popupHeight | `--popup-height` | The height of the popup. |
+
+### PopoverPopupDataAttributes
+
+| Member        | Value                 | Description                                                           |
+| :------------ | :-------------------- | :-------------------------------------------------------------------- |
+| open          | `data-open`           | Present when the popup is open.                                       |
+| closed        | `data-closed`         | Present when the popup is closed.                                     |
+| startingStyle | `data-starting-style` | Present when the popup begins animating in.                           |
+| endingStyle   | `data-ending-style`   | Present when the popup is animating out.                              |
+| side          | `data-side`           | Indicates which side the popup is positioned relative to the trigger. |
+| align         | `data-align`          | Indicates how the popup is aligned relative to specified side.        |
+| instant       | `data-instant`        | Present if animations should be instant.                              |
+
+### PopoverPositionerCssVars
+
+| Member           | Value                 | Description                                                                                                                       |
+| :--------------- | :-------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| availableWidth   | `--available-width`   | The available width between the trigger and the edge of the viewport.                                                             |
+| availableHeight  | `--available-height`  | The available height between the trigger and the edge of the viewport.                                                            |
+| anchorWidth      | `--anchor-width`      | The anchor's width.                                                                                                               |
+| anchorHeight     | `--anchor-height`     | The anchor's height.                                                                                                              |
+| transformOrigin  | `--transform-origin`  | The coordinates that this element is anchored to. Used for animations and transitions.                                            |
+| positionerWidth  | `--positioner-width`  | The width of the popover's positioner.&#xA;It is important to set `width` to this value when using CSS to animate size changes.   |
+| positionerHeight | `--positioner-height` | The height of the popover's positioner.&#xA;It is important to set `height` to this value when using CSS to animate size changes. |
+
+### PopoverPositionerDataAttributes
+
+| Member       | Value                | Description                                                           |
+| :----------- | :------------------- | :-------------------------------------------------------------------- |
+| open         | `data-open`          | Present when the popup is open.                                       |
+| closed       | `data-closed`        | Present when the popup is closed.                                     |
+| anchorHidden | `data-anchor-hidden` | Present when the anchor is hidden.                                    |
+| side         | `data-side`          | Indicates which side the popup is positioned relative to the trigger. |
+| align        | `data-align`         | Indicates how the popup is aligned relative to specified side.        |
+
+### PopoverTriggerDataAttributes
+
+| Member    | Value             | Description                                     |
+| :-------- | :---------------- | :---------------------------------------------- |
+| popupOpen | `data-popup-open` | Present when the corresponding popover is open. |
+| pressed   | `data-pressed`    | Present when the trigger is pressed.            |
+
+### PopoverViewportCssVars
+
+| Member      | Value            | Description                                                                                                                                                                                                                                                           |
+| :---------- | :--------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| popupWidth  | `--popup-width`  | The width of the parent popup.&#xA;This variable is placed on the 'previous' container and stores the width of the popup when the previous content was rendered.&#xA;It can be used to freeze the dimensions of the popup when animating between different content.   |
+| popupHeight | `--popup-height` | The height of the parent popup.&#xA;This variable is placed on the 'previous' container and stores the height of the popup when the previous content was rendered.&#xA;It can be used to freeze the dimensions of the popup when animating between different content. |
+
+### PopoverViewportDataAttributes
+
+| Member              | Value                       | Description                                                                                                                                                                                                                        |
+| :------------------ | :-------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| current             | `data-current`              | Applied to the direct child of the viewport when no transitions are present or the new content when it's entering.                                                                                                                 |
+| previous            | `data-previous`             | Applied to the direct child of the viewport that contains the exiting content when transitions are present.                                                                                                                        |
+| activationDirection | `data-activation-direction` | Indicates the direction from which the popup was activated.&#xA;This can be used to create directional animations based on how the popup was triggered.&#xA;Contains space-separated values for both horizontal and vertical axes. |
+| transitioning       | `data-transitioning`        | Indicates that the viewport is currently transitioning between old and new content.                                                                                                                                                |
+| instant             | `data-instant`              | Present if animations should be instant.                                                                                                                                                                                           |
+
 ## External Types
 
 ### PayloadChildRenderFunction
@@ -606,7 +692,7 @@ type InteractionType = 'mouse' | 'touch' | 'pen' | 'keyboard' | '';
 - `Popover.Viewport`: `Popover.Viewport`, `Popover.Viewport.Props`, `Popover.Viewport.State`
 - `Popover.createHandle`
 - `Popover.Handle`
-- `Default`: `PopoverRootState`, `PopoverRootProps`, `PopoverRootActions`, `PopoverRootChangeEventReason`, `PopoverRootChangeEventDetails`, `PopoverTriggerState`, `PopoverTriggerProps`, `PopoverPortalState`, `PopoverPortalProps`, `PopoverPositionerState`, `PopoverPositionerProps`, `PopoverPopupState`, `PopoverPopupProps`, `PopoverArrowState`, `PopoverArrowProps`, `PopoverBackdropState`, `PopoverBackdropProps`, `PopoverTitleState`, `PopoverTitleProps`, `PopoverDescriptionState`, `PopoverDescriptionProps`, `PopoverCloseState`, `PopoverCloseProps`, `PopoverViewportState`, `PopoverViewportProps`
+- `Default`: `PopoverPopupCssVars`, `PopoverPositionerCssVars`, `PopoverViewportCssVars`, `PopoverArrowDataAttributes`, `PopoverBackdropDataAttributes`, `PopoverPopupDataAttributes`, `PopoverPositionerDataAttributes`, `PopoverTriggerDataAttributes`, `PopoverViewportDataAttributes`, `PopoverRootState`, `PopoverRootProps`, `PopoverRootActions`, `PopoverRootChangeEventReason`, `PopoverRootChangeEventDetails`, `PopoverTriggerState`, `PopoverTriggerProps`, `PopoverPortalState`, `PopoverPortalProps`, `PopoverPositionerState`, `PopoverPositionerProps`, `PopoverPopupState`, `PopoverPopupProps`, `PopoverArrowState`, `PopoverArrowProps`, `PopoverBackdropState`, `PopoverBackdropProps`, `PopoverTitleState`, `PopoverTitleProps`, `PopoverDescriptionState`, `PopoverDescriptionProps`, `PopoverCloseState`, `PopoverCloseProps`, `PopoverViewportState`, `PopoverViewportProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/preview-card/types.md
+++ b/docs/src/app/(docs)/react/components/preview-card/types.md
@@ -457,6 +457,83 @@ Closes the preview card.
 
 This method should only be called in an event handler or an effect (not during rendering).
 
+## Additional Types
+
+### PreviewCardArrowDataAttributes
+
+| Member     | Value             | Description                                                           |
+| :--------- | :---------------- | :-------------------------------------------------------------------- |
+| open       | `data-open`       | Present when the preview card is open.                                |
+| closed     | `data-closed`     | Present when the preview card is closed.                              |
+| side       | `data-side`       | Indicates which side the popup is positioned relative to the trigger. |
+| align      | `data-align`      | Indicates how the popup is aligned relative to specified side.        |
+| uncentered | `data-uncentered` | Present when the preview card arrow is uncentered.                    |
+
+### PreviewCardBackdropDataAttributes
+
+| Member        | Value                 | Description                                        |
+| :------------ | :-------------------- | :------------------------------------------------- |
+| open          | `data-open`           | Present when the preview card is open.             |
+| closed        | `data-closed`         | Present when the preview card is closed.           |
+| startingStyle | `data-starting-style` | Present when the preview card begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the preview card is animating out.    |
+
+### PreviewCardPopupDataAttributes
+
+| Member        | Value                 | Description                                                           |
+| :------------ | :-------------------- | :-------------------------------------------------------------------- |
+| open          | `data-open`           | Present when the preview card is open.                                |
+| closed        | `data-closed`         | Present when the preview card is closed.                              |
+| startingStyle | `data-starting-style` | Present when the preview card begins animating in.                    |
+| endingStyle   | `data-ending-style`   | Present when the preview card is animating out.                       |
+| side          | `data-side`           | Indicates which side the popup is positioned relative to the trigger. |
+| align         | `data-align`          | Indicates how the popup is aligned relative to specified side.        |
+
+### PreviewCardPositionerCssVars
+
+| Member           | Value                 | Description                                                                                                                            |
+| :--------------- | :-------------------- | :------------------------------------------------------------------------------------------------------------------------------------- |
+| availableWidth   | `--available-width`   | The available width between the trigger and the edge of the viewport.                                                                  |
+| availableHeight  | `--available-height`  | The available height between the trigger and the edge of the viewport.                                                                 |
+| anchorWidth      | `--anchor-width`      | The anchor's width.                                                                                                                    |
+| anchorHeight     | `--anchor-height`     | The anchor's height.                                                                                                                   |
+| transformOrigin  | `--transform-origin`  | The coordinates that this element is anchored to. Used for animations and transitions.                                                 |
+| positionerWidth  | `--positioner-width`  | The width of the preview card's positioner.&#xA;It is important to set `width` to this value when using CSS to animate size changes.   |
+| positionerHeight | `--positioner-height` | The height of the preview card's positioner.&#xA;It is important to set `height` to this value when using CSS to animate size changes. |
+
+### PreviewCardPositionerDataAttributes
+
+| Member       | Value                | Description                                                           |
+| :----------- | :------------------- | :-------------------------------------------------------------------- |
+| open         | `data-open`          | Present when the preview card is open.                                |
+| closed       | `data-closed`        | Present when the preview card is closed.                              |
+| anchorHidden | `data-anchor-hidden` | Present when the anchor is hidden.                                    |
+| side         | `data-side`          | Indicates which side the popup is positioned relative to the trigger. |
+| align        | `data-align`         | Indicates how the popup is aligned relative to specified side.        |
+
+### PreviewCardTriggerDataAttributes
+
+| Member    | Value             | Description                                          |
+| :-------- | :---------------- | :--------------------------------------------------- |
+| popupOpen | `data-popup-open` | Present when the corresponding preview card is open. |
+
+### PreviewCardViewportCssVars
+
+| Member      | Value            | Description                                                                                                                                                                                                                                                           |
+| :---------- | :--------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| popupWidth  | `--popup-width`  | The width of the parent popup.&#xA;This variable is placed on the 'previous' container and stores the width of the popup when the previous content was rendered.&#xA;It can be used to freeze the dimensions of the popup when animating between different content.   |
+| popupHeight | `--popup-height` | The height of the parent popup.&#xA;This variable is placed on the 'previous' container and stores the height of the popup when the previous content was rendered.&#xA;It can be used to freeze the dimensions of the popup when animating between different content. |
+
+### PreviewCardViewportDataAttributes
+
+| Member              | Value                       | Description                                                                                                                                                                                                                        |
+| :------------------ | :-------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| current             | `data-current`              | Applied to the direct child of the viewport when no transitions are present or the new content when it's entering.                                                                                                                 |
+| previous            | `data-previous`             | Applied to the direct child of the viewport that contains the exiting content when transitions are present.                                                                                                                        |
+| activationDirection | `data-activation-direction` | Indicates the direction from which the popup was activated.&#xA;This can be used to create directional animations based on how the popup was triggered.&#xA;Contains space-separated values for both horizontal and vertical axes. |
+| transitioning       | `data-transitioning`        | Indicates that the viewport is currently transitioning between old and new content.                                                                                                                                                |
+| instant             | `data-instant`              | Present if animations should be instant.                                                                                                                                                                                           |
+
 ## External Types
 
 ### PayloadChildRenderFunction
@@ -506,7 +583,7 @@ type OffsetFunction = (data: {
 - `PreviewCard.Viewport`: `PreviewCard.Viewport`, `PreviewCard.Viewport.Props`, `PreviewCard.Viewport.State`
 - `PreviewCard.createHandle`
 - `PreviewCard.Handle`
-- `Default`: `PreviewCardRootState`, `PreviewCardRootProps`, `PreviewCardRootActions`, `PreviewCardRootChangeEventReason`, `PreviewCardRootChangeEventDetails`, `PreviewCardTriggerState`, `PreviewCardTriggerProps`, `PreviewCardPortalState`, `PreviewCardPortalProps`, `PreviewCardPositionerState`, `PreviewCardPositionerProps`, `PreviewCardPopupState`, `PreviewCardPopupProps`, `PreviewCardArrowState`, `PreviewCardArrowProps`, `PreviewCardViewportState`, `PreviewCardViewportProps`, `PreviewCardBackdropState`, `PreviewCardBackdropProps`
+- `Default`: `PreviewCardPositionerCssVars`, `PreviewCardViewportCssVars`, `PreviewCardArrowDataAttributes`, `PreviewCardBackdropDataAttributes`, `PreviewCardPopupDataAttributes`, `PreviewCardPositionerDataAttributes`, `PreviewCardTriggerDataAttributes`, `PreviewCardViewportDataAttributes`, `PreviewCardRootState`, `PreviewCardRootProps`, `PreviewCardRootActions`, `PreviewCardRootChangeEventReason`, `PreviewCardRootChangeEventDetails`, `PreviewCardTriggerState`, `PreviewCardTriggerProps`, `PreviewCardPortalState`, `PreviewCardPortalProps`, `PreviewCardPositionerState`, `PreviewCardPositionerProps`, `PreviewCardPopupState`, `PreviewCardPopupProps`, `PreviewCardArrowState`, `PreviewCardArrowProps`, `PreviewCardViewportState`, `PreviewCardViewportProps`, `PreviewCardBackdropState`, `PreviewCardBackdropProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/progress/types.md
+++ b/docs/src/app/(docs)/react/components/progress/types.md
@@ -190,6 +190,46 @@ type ProgressLabelState = {
 type ProgressStatus = 'indeterminate' | 'progressing' | 'complete';
 ```
 
+### ProgressIndicatorDataAttributes
+
+| Member        | Value                | Description                                          |
+| :------------ | :------------------- | :--------------------------------------------------- |
+| complete      | `data-complete`      | Present when the progress has completed.             |
+| indeterminate | `data-indeterminate` | Present when the progress is in indeterminate state. |
+| progressing   | `data-progressing`   | Present while the progress is progressing.           |
+
+### ProgressLabelDataAttributes
+
+| Member        | Value                | Description                                          |
+| :------------ | :------------------- | :--------------------------------------------------- |
+| complete      | `data-complete`      | Present when the progress has completed.             |
+| indeterminate | `data-indeterminate` | Present when the progress is in indeterminate state. |
+| progressing   | `data-progressing`   | Present while the progress is progressing.           |
+
+### ProgressRootDataAttributes
+
+| Member        | Value                | Description                                          |
+| :------------ | :------------------- | :--------------------------------------------------- |
+| complete      | `data-complete`      | Present when the progress has completed.             |
+| indeterminate | `data-indeterminate` | Present when the progress is in indeterminate state. |
+| progressing   | `data-progressing`   | Present while the progress is progressing.           |
+
+### ProgressTrackDataAttributes
+
+| Member        | Value                | Description                                          |
+| :------------ | :------------------- | :--------------------------------------------------- |
+| complete      | `data-complete`      | Present when the progress has completed.             |
+| indeterminate | `data-indeterminate` | Present when the progress is in indeterminate state. |
+| progressing   | `data-progressing`   | Present while the progress is progressing.           |
+
+### ProgressValueDataAttributes
+
+| Member        | Value                | Description                                          |
+| :------------ | :------------------- | :--------------------------------------------------- |
+| complete      | `data-complete`      | Present when the progress has completed.             |
+| indeterminate | `data-indeterminate` | Present when the progress is in indeterminate state. |
+| progressing   | `data-progressing`   | Present while the progress is progressing.           |
+
 ## Export Groups
 
 - `Progress.Root`: `Progress.Root`, `Progress.Root.State`, `Progress.Root.Props`
@@ -197,7 +237,7 @@ type ProgressStatus = 'indeterminate' | 'progressing' | 'complete';
 - `Progress.Indicator`: `Progress.Indicator`, `Progress.Indicator.State`, `Progress.Indicator.Props`
 - `Progress.Value`: `Progress.Value`, `Progress.Value.State`, `Progress.Value.Props`
 - `Progress.Label`: `Progress.Label`, `Progress.Label.State`, `Progress.Label.Props`
-- `Default`: `Progress.Status`, `ProgressStatus`, `ProgressRootState`, `ProgressRootProps`, `ProgressIndicatorState`, `ProgressIndicatorProps`, `ProgressLabelState`, `ProgressLabelProps`, `ProgressTrackState`, `ProgressTrackProps`, `ProgressValueState`, `ProgressValueProps`
+- `Default`: `Progress.Status`, `ProgressIndicatorDataAttributes`, `ProgressLabelDataAttributes`, `ProgressRootDataAttributes`, `ProgressTrackDataAttributes`, `ProgressValueDataAttributes`, `ProgressStatus`, `ProgressRootState`, `ProgressRootProps`, `ProgressIndicatorState`, `ProgressIndicatorProps`, `ProgressLabelState`, `ProgressLabelProps`, `ProgressTrackState`, `ProgressTrackProps`, `ProgressValueState`, `ProgressValueProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/radio-group/types.md
+++ b/docs/src/app/(docs)/react/components/radio-group/types.md
@@ -86,6 +86,14 @@ type RadioGroupChangeEventDetails = {
 };
 ```
 
+## Additional Types
+
+### RadioGroupDataAttributes
+
+| Member   | Value           | Description                               |
+| :------- | :-------------- | :---------------------------------------- |
+| disabled | `data-disabled` | Present when the radio group is disabled. |
+
 ## Canonical Types
 
 Maps `Canonical`: `Alias` — Use Canonical when its namespace is already imported; otherwise use Alias.

--- a/docs/src/app/(docs)/react/components/radio/types.md
+++ b/docs/src/app/(docs)/react/components/radio/types.md
@@ -131,11 +131,47 @@ type RadioIndicatorState = {
 };
 ```
 
+## Additional Types
+
+### RadioIndicatorDataAttributes
+
+| Member        | Value                 | Description                                                                 |
+| :------------ | :-------------------- | :-------------------------------------------------------------------------- |
+| checked       | `data-checked`        | Present when the radio is checked.                                          |
+| unchecked     | `data-unchecked`      | Present when the radio is not checked.                                      |
+| disabled      | `data-disabled`       | Present when the radio is disabled.                                         |
+| readonly      | `data-readonly`       | Present when the radio is readonly.                                         |
+| required      | `data-required`       | Present when the radio is required.                                         |
+| startingStyle | `data-starting-style` | Present when the radio indicator begins animating in.                       |
+| endingStyle   | `data-ending-style`   | Present when the radio indicator is animating out.                          |
+| valid         | `data-valid`          | Present when the radio is in a valid state (when wrapped in Field.Root).    |
+| invalid       | `data-invalid`        | Present when the radio is in an invalid state (when wrapped in Field.Root). |
+| touched       | `data-touched`        | Present when the radio has been touched (when wrapped in Field.Root).       |
+| dirty         | `data-dirty`          | Present when the radio's value has changed (when wrapped in Field.Root).    |
+| filled        | `data-filled`         | Present when the radio is checked (when wrapped in Field.Root).             |
+| focused       | `data-focused`        | Present when the radio is focused (when wrapped in Field.Root).             |
+
+### RadioRootDataAttributes
+
+| Member    | Value            | Description                                                                 |
+| :-------- | :--------------- | :-------------------------------------------------------------------------- |
+| checked   | `data-checked`   | Present when the radio is checked.                                          |
+| unchecked | `data-unchecked` | Present when the radio is not checked.                                      |
+| disabled  | `data-disabled`  | Present when the radio is disabled.                                         |
+| readonly  | `data-readonly`  | Present when the radio is readonly.                                         |
+| required  | `data-required`  | Present when the radio is required.                                         |
+| valid     | `data-valid`     | Present when the radio is in a valid state (when wrapped in Field.Root).    |
+| invalid   | `data-invalid`   | Present when the radio is in an invalid state (when wrapped in Field.Root). |
+| touched   | `data-touched`   | Present when the radio has been touched (when wrapped in Field.Root).       |
+| dirty     | `data-dirty`     | Present when the radio's value has changed (when wrapped in Field.Root).    |
+| filled    | `data-filled`    | Present when the radio is checked (when wrapped in Field.Root).             |
+| focused   | `data-focused`   | Present when the radio is focused (when wrapped in Field.Root).             |
+
 ## Export Groups
 
 - `Radio.Root`: `Radio.Root`, `Radio.Root.State`, `Radio.Root.Props`
 - `Radio.Indicator`: `Radio.Indicator`, `Radio.Indicator.Props`, `Radio.Indicator.State`
-- `Default`: `RadioRootState`, `RadioRootProps`, `RadioIndicatorProps`, `RadioIndicatorState`
+- `Default`: `RadioIndicatorDataAttributes`, `RadioRootDataAttributes`, `RadioRootState`, `RadioRootProps`, `RadioIndicatorProps`, `RadioIndicatorState`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/scroll-area/types.md
+++ b/docs/src/app/(docs)/react/components/scroll-area/types.md
@@ -322,6 +322,86 @@ type HiddenState = { x: boolean; y: boolean; corner: boolean };
 type OverflowEdges = { xStart: boolean; xEnd: boolean; yStart: boolean; yEnd: boolean };
 ```
 
+### ScrollAreaContentDataAttributes
+
+| Member         | Value                   | Description                                                       |
+| :------------- | :---------------------- | :---------------------------------------------------------------- |
+| scrolling      | `data-scrolling`        | Present when the user scrolls inside the scroll area.             |
+| hasOverflowX   | `data-has-overflow-x`   | Present when the scroll area content is wider than the viewport.  |
+| hasOverflowY   | `data-has-overflow-y`   | Present when the scroll area content is taller than the viewport. |
+| overflowXStart | `data-overflow-x-start` | Present when there is overflow on the horizontal start side.      |
+| overflowXEnd   | `data-overflow-x-end`   | Present when there is overflow on the horizontal end side.        |
+| overflowYStart | `data-overflow-y-start` | Present when there is overflow on the vertical start side.        |
+| overflowYEnd   | `data-overflow-y-end`   | Present when there is overflow on the vertical end side.          |
+
+### ScrollAreaRootCssVars
+
+| Member                 | Value                         | Description                      |
+| :--------------------- | :---------------------------- | :------------------------------- |
+| scrollAreaCornerHeight | `--scroll-area-corner-height` | The scroll area's corner height. |
+| scrollAreaCornerWidth  | `--scroll-area-corner-width`  | The scroll area's corner width.  |
+
+### ScrollAreaRootDataAttributes
+
+| Member         | Value                   | Description                                                       |
+| :------------- | :---------------------- | :---------------------------------------------------------------- |
+| scrolling      | `data-scrolling`        | Present when the user scrolls inside the scroll area.             |
+| hasOverflowX   | `data-has-overflow-x`   | Present when the scroll area content is wider than the viewport.  |
+| hasOverflowY   | `data-has-overflow-y`   | Present when the scroll area content is taller than the viewport. |
+| overflowXStart | `data-overflow-x-start` | Present when there is overflow on the horizontal start side.      |
+| overflowXEnd   | `data-overflow-x-end`   | Present when there is overflow on the horizontal end side.        |
+| overflowYStart | `data-overflow-y-start` | Present when there is overflow on the vertical start side.        |
+| overflowYEnd   | `data-overflow-y-end`   | Present when there is overflow on the vertical end side.          |
+
+### ScrollAreaScrollbarCssVars
+
+| Member                | Value                        | Description                     |
+| :-------------------- | :--------------------------- | :------------------------------ |
+| scrollAreaThumbHeight | `--scroll-area-thumb-height` | The scroll area thumb's height. |
+| scrollAreaThumbWidth  | `--scroll-area-thumb-width`  | The scroll area thumb's width.  |
+
+### ScrollAreaScrollbarDataAttributes
+
+| Member         | Value                   | Description                                                       |
+| :------------- | :---------------------- | :---------------------------------------------------------------- |
+| orientation    | `data-orientation`      | Indicates the orientation of the scrollbar.                       |
+| hovering       | `data-hovering`         | Present when the pointer is over the scroll area.                 |
+| scrolling      | `data-scrolling`        | Present when the user scrolls inside the scroll area.             |
+| hasOverflowX   | `data-has-overflow-x`   | Present when the scroll area content is wider than the viewport.  |
+| hasOverflowY   | `data-has-overflow-y`   | Present when the scroll area content is taller than the viewport. |
+| overflowXStart | `data-overflow-x-start` | Present when there is overflow on the horizontal start side.      |
+| overflowXEnd   | `data-overflow-x-end`   | Present when there is overflow on the horizontal end side.        |
+| overflowYStart | `data-overflow-y-start` | Present when there is overflow on the vertical start side.        |
+| overflowYEnd   | `data-overflow-y-end`   | Present when there is overflow on the vertical end side.          |
+
+### ScrollAreaThumbDataAttributes
+
+| Member      | Value              | Description                                           |
+| :---------- | :----------------- | :---------------------------------------------------- |
+| orientation | `data-orientation` | Indicates the orientation of the scrollbar.           |
+| scrolling   | `data-scrolling`   | Present when the user scrolls inside the scroll area. |
+
+### ScrollAreaViewportCssVars
+
+| Member                   | Value                            | Description                                            |
+| :----------------------- | :------------------------------- | :----------------------------------------------------- |
+| scrollAreaOverflowXStart | `--scroll-area-overflow-x-start` | The distance from the horizontal start edge in pixels. |
+| scrollAreaOverflowXEnd   | `--scroll-area-overflow-x-end`   | The distance from the horizontal end edge in pixels.   |
+| scrollAreaOverflowYStart | `--scroll-area-overflow-y-start` | The distance from the vertical start edge in pixels.   |
+| scrollAreaOverflowYEnd   | `--scroll-area-overflow-y-end`   | The distance from the vertical end edge in pixels.     |
+
+### ScrollAreaViewportDataAttributes
+
+| Member         | Value                   | Description                                                       |
+| :------------- | :---------------------- | :---------------------------------------------------------------- |
+| scrolling      | `data-scrolling`        | Present when the user scrolls inside the scroll area.             |
+| hasOverflowX   | `data-has-overflow-x`   | Present when the scroll area content is wider than the viewport.  |
+| hasOverflowY   | `data-has-overflow-y`   | Present when the scroll area content is taller than the viewport. |
+| overflowXStart | `data-overflow-x-start` | Present when there is overflow on the horizontal start side.      |
+| overflowXEnd   | `data-overflow-x-end`   | Present when there is overflow on the horizontal end side.        |
+| overflowYStart | `data-overflow-y-start` | Present when there is overflow on the vertical start side.        |
+| overflowYEnd   | `data-overflow-y-end`   | Present when there is overflow on the vertical end side.          |
+
 ### Size
 
 ```typescript
@@ -336,7 +416,7 @@ type Size = { width: number; height: number };
 - `ScrollArea.Content`: `ScrollArea.Content`, `ScrollArea.Content.State`, `ScrollArea.Content.Props`
 - `ScrollArea.Thumb`: `ScrollArea.Thumb`, `ScrollArea.Thumb.State`, `ScrollArea.Thumb.Props`
 - `ScrollArea.Corner`: `ScrollArea.Corner`, `ScrollArea.Corner.State`, `ScrollArea.Corner.Props`
-- `Default`: `HiddenState`, `OverflowEdges`, `Size`, `Coords`, `ScrollAreaRootState`, `ScrollAreaRootProps`, `ScrollAreaViewportProps`, `ScrollAreaViewportState`, `ScrollAreaScrollbarState`, `ScrollAreaScrollbarProps`, `ScrollAreaContentState`, `ScrollAreaContentProps`, `ScrollAreaThumbState`, `ScrollAreaThumbProps`, `ScrollAreaCornerState`, `ScrollAreaCornerProps`
+- `Default`: `ScrollAreaRootCssVars`, `ScrollAreaScrollbarCssVars`, `ScrollAreaViewportCssVars`, `ScrollAreaContentDataAttributes`, `ScrollAreaRootDataAttributes`, `ScrollAreaScrollbarDataAttributes`, `ScrollAreaThumbDataAttributes`, `ScrollAreaViewportDataAttributes`, `HiddenState`, `OverflowEdges`, `Size`, `Coords`, `ScrollAreaRootState`, `ScrollAreaRootProps`, `ScrollAreaViewportProps`, `ScrollAreaViewportState`, `ScrollAreaScrollbarState`, `ScrollAreaScrollbarProps`, `ScrollAreaContentState`, `ScrollAreaContentProps`, `ScrollAreaThumbState`, `ScrollAreaThumbProps`, `ScrollAreaCornerState`, `ScrollAreaCornerProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/select/types.md
+++ b/docs/src/app/(docs)/react/components/select/types.md
@@ -802,6 +802,123 @@ Re-export of [ScrollDownArrow](#scrolldownarrow) props.
 type SelectScrollDownArrowState = {};
 ```
 
+## Additional Types
+
+### SelectArrowDataAttributes
+
+| Member     | Value             | Description                                                           |
+| :--------- | :---------------- | :-------------------------------------------------------------------- |
+| open       | `data-open`       | Present when the select popup is open.                                |
+| closed     | `data-closed`     | Present when the select popup is closed.                              |
+| side       | `data-side`       | Indicates which side the popup is positioned relative to the trigger. |
+| align      | `data-align`      | Indicates how the popup is aligned relative to specified side.        |
+| uncentered | `data-uncentered` | Present when the select arrow is uncentered.                          |
+
+### SelectBackdropDataAttributes
+
+| Member        | Value                 | Description                                  |
+| :------------ | :-------------------- | :------------------------------------------- |
+| open          | `data-open`           | Present when the select is open.             |
+| closed        | `data-closed`         | Present when the select is closed.           |
+| startingStyle | `data-starting-style` | Present when the select begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the select is animating out.    |
+
+### SelectIconDataAttributes
+
+| Member    | Value             | Description                                   |
+| :-------- | :---------------- | :-------------------------------------------- |
+| popupOpen | `data-popup-open` | Present when the corresponding popup is open. |
+
+### SelectItemDataAttributes
+
+| Member      | Value              | Description                                  |
+| :---------- | :----------------- | :------------------------------------------- |
+| selected    | `data-selected`    | Present when the select item is selected.    |
+| highlighted | `data-highlighted` | Present when the select item is highlighted. |
+| disabled    | `data-disabled`    | Present when the select item is disabled.    |
+
+### SelectItemIndicatorDataAttributes
+
+| Member        | Value                 | Description                                     |
+| :------------ | :-------------------- | :---------------------------------------------- |
+| startingStyle | `data-starting-style` | Present when the indicator begins animating in. |
+| endingStyle   | `data-ending-style`   | Present when the indicator is animating out.    |
+
+### SelectPopupDataAttributes
+
+| Member        | Value                 | Description                                                           |
+| :------------ | :-------------------- | :-------------------------------------------------------------------- |
+| open          | `data-open`           | Present when the select is open.                                      |
+| closed        | `data-closed`         | Present when the select is closed.                                    |
+| startingStyle | `data-starting-style` | Present when the select begins animating in.                          |
+| endingStyle   | `data-ending-style`   | Present when the select is animating out.                             |
+| side          | `data-side`           | Indicates which side the popup is positioned relative to the trigger. |
+| align         | `data-align`          | Indicates how the popup is aligned relative to specified side.        |
+
+### SelectPositionerCssVars
+
+| Member          | Value                | Description                                                                            |
+| :-------------- | :------------------- | :------------------------------------------------------------------------------------- |
+| availableWidth  | `--available-width`  | The available width between the trigger and the edge of the viewport.                  |
+| availableHeight | `--available-height` | The available height between the trigger and the edge of the viewport.                 |
+| anchorWidth     | `--anchor-width`     | The anchor's width.                                                                    |
+| anchorHeight    | `--anchor-height`    | The anchor's height.                                                                   |
+| transformOrigin | `--transform-origin` | The coordinates that this element is anchored to. Used for animations and transitions. |
+
+### SelectPositionerDataAttributes
+
+| Member       | Value                | Description                                                           |
+| :----------- | :------------------- | :-------------------------------------------------------------------- |
+| open         | `data-open`          | Present when the select popup is open.                                |
+| closed       | `data-closed`        | Present when the select popup is closed.                              |
+| anchorHidden | `data-anchor-hidden` | Present when the anchor is hidden.                                    |
+| side         | `data-side`          | Indicates which side the popup is positioned relative to the trigger. |
+| align        | `data-align`         | Indicates how the popup is aligned relative to specified side.        |
+
+### SelectScrollDownArrowDataAttributes
+
+| Member        | Value                 | Description                                                           |
+| :------------ | :-------------------- | :-------------------------------------------------------------------- |
+| startingStyle | `data-starting-style` | Present when the scroll arrow begins animating in.                    |
+| endingStyle   | `data-ending-style`   | Present when the scroll arrow is animating out.                       |
+| direction     | `data-direction`      | Indicates the direction of the scroll arrow.                          |
+| visible       | `data-visible`        | Present when the scroll arrow is visible.                             |
+| side          | `data-side`           | Indicates which side the popup is positioned relative to the trigger. |
+
+### SelectScrollUpArrowDataAttributes
+
+| Member        | Value                 | Description                                                           |
+| :------------ | :-------------------- | :-------------------------------------------------------------------- |
+| startingStyle | `data-starting-style` | Present when the scroll arrow begins animating in.                    |
+| endingStyle   | `data-ending-style`   | Present when the scroll arrow is animating out.                       |
+| direction     | `data-direction`      | Indicates the direction of the scroll arrow.                          |
+| visible       | `data-visible`        | Present when the scroll arrow is visible.                             |
+| side          | `data-side`           | Indicates which side the popup is positioned relative to the trigger. |
+
+### SelectTriggerDataAttributes
+
+| Member      | Value              | Description                                                                        |
+| :---------- | :----------------- | :--------------------------------------------------------------------------------- |
+| popupOpen   | `data-popup-open`  | Present when the corresponding select is open.                                     |
+| pressed     | `data-pressed`     | Present when the trigger is pressed.                                               |
+| disabled    | `data-disabled`    | Present when the select is disabled.                                               |
+| readonly    | `data-readonly`    | Present when the select is readonly.                                               |
+| popupSide   | `data-popup-side`  | Indicates which side the corresponding popup is positioned relative to its anchor. |
+| required    | `data-required`    | Present when the select is required.                                               |
+| valid       | `data-valid`       | Present when the select is in a valid state (when wrapped in Field.Root).          |
+| invalid     | `data-invalid`     | Present when the select is in an invalid state (when wrapped in Field.Root).       |
+| touched     | `data-touched`     | Present when the select has been touched (when wrapped in Field.Root).             |
+| dirty       | `data-dirty`       | Present when the select's value has changed (when wrapped in Field.Root).          |
+| filled      | `data-filled`      | Present when the select has a value (when wrapped in Field.Root).                  |
+| focused     | `data-focused`     | Present when the select trigger is focused (when wrapped in Field.Root).           |
+| placeholder | `data-placeholder` | Present when the select doesn't have a value.                                      |
+
+### SelectValueDataAttributes
+
+| Member      | Value              | Description                                   |
+| :---------- | :----------------- | :-------------------------------------------- |
+| placeholder | `data-placeholder` | Present when the select doesn't have a value. |
+
 ## External Types
 
 ### Side
@@ -860,7 +977,7 @@ type Orientation = 'horizontal' | 'vertical';
 - `Select.Group`: `Select.Group`, `Select.Group.State`, `Select.Group.Props`
 - `Select.GroupLabel`: `Select.GroupLabel`, `Select.GroupLabel.State`, `Select.GroupLabel.Props`
 - `Select.Separator`: `Select.Separator`, `Select.Separator.Props`, `Select.Separator.State`
-- `Default`: `SelectRootProps`, `SelectRootState`, `SelectRootActions`, `SelectRootChangeEventReason`, `SelectRootChangeEventDetails`, `SelectLabelState`, `SelectLabelProps`, `SelectTriggerState`, `SelectTriggerProps`, `SelectValueState`, `SelectValueProps`, `SelectIconState`, `SelectIconProps`, `SelectPortalState`, `SelectPortalProps`, `SelectBackdropState`, `SelectBackdropProps`, `SelectPositionerState`, `SelectPositionerProps`, `SelectPopupProps`, `SelectPopupState`, `SelectListProps`, `SelectListState`, `SelectItemState`, `SelectItemProps`, `SelectItemIndicatorState`, `SelectItemIndicatorProps`, `SelectItemTextState`, `SelectItemTextProps`, `SelectArrowState`, `SelectArrowProps`, `SelectScrollDownArrowState`, `SelectScrollDownArrowProps`, `SelectScrollUpArrowState`, `SelectScrollUpArrowProps`, `SelectGroupState`, `SelectGroupProps`, `SelectGroupLabelState`, `SelectGroupLabelProps`
+- `Default`: `SelectPositionerCssVars`, `SelectArrowDataAttributes`, `SelectBackdropDataAttributes`, `SelectIconDataAttributes`, `SelectItemIndicatorDataAttributes`, `SelectItemDataAttributes`, `SelectPopupDataAttributes`, `SelectPositionerDataAttributes`, `SelectScrollDownArrowDataAttributes`, `SelectScrollUpArrowDataAttributes`, `SelectTriggerDataAttributes`, `SelectValueDataAttributes`, `SelectRootProps`, `SelectRootState`, `SelectRootActions`, `SelectRootChangeEventReason`, `SelectRootChangeEventDetails`, `SelectLabelState`, `SelectLabelProps`, `SelectTriggerState`, `SelectTriggerProps`, `SelectValueState`, `SelectValueProps`, `SelectIconState`, `SelectIconProps`, `SelectPortalState`, `SelectPortalProps`, `SelectBackdropState`, `SelectBackdropProps`, `SelectPositionerState`, `SelectPositionerProps`, `SelectPopupProps`, `SelectPopupState`, `SelectListProps`, `SelectListState`, `SelectItemState`, `SelectItemProps`, `SelectItemIndicatorState`, `SelectItemIndicatorProps`, `SelectItemTextState`, `SelectItemTextProps`, `SelectArrowState`, `SelectArrowProps`, `SelectScrollDownArrowState`, `SelectScrollDownArrowProps`, `SelectScrollUpArrowState`, `SelectScrollUpArrowProps`, `SelectGroupState`, `SelectGroupProps`, `SelectGroupLabelState`, `SelectGroupLabelProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/separator/types.md
+++ b/docs/src/app/(docs)/react/components/separator/types.md
@@ -37,6 +37,14 @@ type SeparatorState = {
 };
 ```
 
+## Additional Types
+
+### SeparatorDataAttributes
+
+| Member      | Value              | Description                                 |
+| :---------- | :----------------- | :------------------------------------------ |
+| orientation | `data-orientation` | Indicates the orientation of the separator. |
+
 ## External Types
 
 ### Orientation

--- a/docs/src/app/(docs)/react/components/slider/types.md
+++ b/docs/src/app/(docs)/react/components/slider/types.md
@@ -583,6 +583,32 @@ type SliderLabelState = {
 
 ## Additional Types
 
+### SliderControlDataAttributes
+
+| Member      | Value              | Description                                                                  |
+| :---------- | :----------------- | :--------------------------------------------------------------------------- |
+| dragging    | `data-dragging`    | Present while the user is dragging.                                          |
+| orientation | `data-orientation` | Indicates the orientation of the slider.                                     |
+| disabled    | `data-disabled`    | Present when the slider is disabled.                                         |
+| valid       | `data-valid`       | Present when the slider is in a valid state (when wrapped in Field.Root).    |
+| invalid     | `data-invalid`     | Present when the slider is in an invalid state (when wrapped in Field.Root). |
+| touched     | `data-touched`     | Present when the slider has been touched (when wrapped in Field.Root).       |
+| dirty       | `data-dirty`       | Present when the slider's value has changed (when wrapped in Field.Root).    |
+| focused     | `data-focused`     | Present when the slider is focused (when wrapped in Field.Root).             |
+
+### SliderIndicatorDataAttributes
+
+| Member      | Value              | Description                                                                  |
+| :---------- | :----------------- | :--------------------------------------------------------------------------- |
+| dragging    | `data-dragging`    | Present while the user is dragging.                                          |
+| orientation | `data-orientation` | Indicates the orientation of the slider.                                     |
+| disabled    | `data-disabled`    | Present when the slider is disabled.                                         |
+| valid       | `data-valid`       | Present when the slider is in a valid state (when wrapped in Field.Root).    |
+| invalid     | `data-invalid`     | Present when the slider is in an invalid state (when wrapped in Field.Root). |
+| touched     | `data-touched`     | Present when the slider has been touched (when wrapped in Field.Root).       |
+| dirty       | `data-dirty`       | Present when the slider's value has changed (when wrapped in Field.Root).    |
+| focused     | `data-focused`     | Present when the slider is focused (when wrapped in Field.Root).             |
+
 ### SliderRootChangeEventCustomProperties
 
 ```typescript
@@ -591,6 +617,59 @@ type SliderRootChangeEventCustomProperties = {
   activeThumbIndex: number;
 };
 ```
+
+### SliderRootDataAttributes
+
+| Member      | Value              | Description                                                                  |
+| :---------- | :----------------- | :--------------------------------------------------------------------------- |
+| dragging    | `data-dragging`    | Present while the user is dragging.                                          |
+| orientation | `data-orientation` | Indicates the orientation of the slider.                                     |
+| disabled    | `data-disabled`    | Present when the slider is disabled.                                         |
+| valid       | `data-valid`       | Present when the slider is in a valid state (when wrapped in Field.Root).    |
+| invalid     | `data-invalid`     | Present when the slider is in an invalid state (when wrapped in Field.Root). |
+| touched     | `data-touched`     | Present when the slider has been touched (when wrapped in Field.Root).       |
+| dirty       | `data-dirty`       | Present when the slider's value has changed (when wrapped in Field.Root).    |
+| focused     | `data-focused`     | Present when the slider is focused (when wrapped in Field.Root).             |
+
+### SliderThumbDataAttributes
+
+| Member      | Value              | Description                                                                  |
+| :---------- | :----------------- | :--------------------------------------------------------------------------- |
+| index       | `data-index`       | Indicates the index of the thumb in range sliders.                           |
+| dragging    | `data-dragging`    | Present while the user is dragging.                                          |
+| orientation | `data-orientation` | Indicates the orientation of the slider.                                     |
+| disabled    | `data-disabled`    | Present when the slider is disabled.                                         |
+| valid       | `data-valid`       | Present when the slider is in a valid state (when wrapped in Field.Root).    |
+| invalid     | `data-invalid`     | Present when the slider is in an invalid state (when wrapped in Field.Root). |
+| touched     | `data-touched`     | Present when the slider has been touched (when wrapped in Field.Root).       |
+| dirty       | `data-dirty`       | Present when the slider's value has changed (when wrapped in Field.Root).    |
+| focused     | `data-focused`     | Present when the slider is focused (when wrapped in Field.Root).             |
+
+### SliderTrackDataAttributes
+
+| Member      | Value              | Description                                                                  |
+| :---------- | :----------------- | :--------------------------------------------------------------------------- |
+| dragging    | `data-dragging`    | Present while the user is dragging.                                          |
+| orientation | `data-orientation` | Indicates the orientation of the slider.                                     |
+| disabled    | `data-disabled`    | Present when the slider is disabled.                                         |
+| valid       | `data-valid`       | Present when the slider is in a valid state (when wrapped in Field.Root).    |
+| invalid     | `data-invalid`     | Present when the slider is in an invalid state (when wrapped in Field.Root). |
+| touched     | `data-touched`     | Present when the slider has been touched (when wrapped in Field.Root).       |
+| dirty       | `data-dirty`       | Present when the slider's value has changed (when wrapped in Field.Root).    |
+| focused     | `data-focused`     | Present when the slider is focused (when wrapped in Field.Root).             |
+
+### SliderValueDataAttributes
+
+| Member      | Value              | Description                                                                  |
+| :---------- | :----------------- | :--------------------------------------------------------------------------- |
+| dragging    | `data-dragging`    | Present while the user is dragging.                                          |
+| orientation | `data-orientation` | Indicates the orientation of the slider.                                     |
+| disabled    | `data-disabled`    | Present when the slider is disabled.                                         |
+| valid       | `data-valid`       | Present when the slider is in a valid state (when wrapped in Field.Root).    |
+| invalid     | `data-invalid`     | Present when the slider is in an invalid state (when wrapped in Field.Root). |
+| touched     | `data-touched`     | Present when the slider has been touched (when wrapped in Field.Root).       |
+| dirty       | `data-dirty`       | Present when the slider's value has changed (when wrapped in Field.Root).    |
+| focused     | `data-focused`     | Present when the slider is focused (when wrapped in Field.Root).             |
 
 ### ThumbMetadata
 
@@ -615,7 +694,7 @@ type Orientation = 'horizontal' | 'vertical';
 - `Slider.Track`: `Slider.Track`, `Slider.Track.State`, `Slider.Track.Props`
 - `Slider.Thumb`: `Slider.Thumb`, `Slider.Thumb.State`, `Slider.Thumb.Props`
 - `Slider.Indicator`: `Slider.Indicator`, `Slider.Indicator.State`, `Slider.Indicator.Props`
-- `Default`: `SliderRootState`, `SliderRootProps`, `SliderRootChangeEventCustomProperties`, `SliderRootChangeEventReason`, `SliderRootChangeEventDetails`, `SliderRootCommitEventReason`, `SliderRootCommitEventDetails`, `SliderLabelState`, `SliderLabelProps`, `SliderValueState`, `SliderValueProps`, `SliderControlState`, `SliderControlProps`, `SliderTrackState`, `SliderTrackProps`, `ThumbMetadata`, `SliderThumbState`, `SliderThumbProps`, `SliderIndicatorState`, `SliderIndicatorProps`
+- `Default`: `SliderControlDataAttributes`, `SliderIndicatorDataAttributes`, `SliderRootDataAttributes`, `SliderThumbDataAttributes`, `SliderTrackDataAttributes`, `SliderValueDataAttributes`, `SliderRootState`, `SliderRootProps`, `SliderRootChangeEventCustomProperties`, `SliderRootChangeEventReason`, `SliderRootChangeEventDetails`, `SliderRootCommitEventReason`, `SliderRootCommitEventDetails`, `SliderLabelState`, `SliderLabelProps`, `SliderValueState`, `SliderValueProps`, `SliderControlState`, `SliderControlProps`, `SliderTrackState`, `SliderTrackProps`, `ThumbMetadata`, `SliderThumbState`, `SliderThumbProps`, `SliderIndicatorState`, `SliderIndicatorProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/switch/types.md
+++ b/docs/src/app/(docs)/react/components/switch/types.md
@@ -160,11 +160,45 @@ type SwitchThumbState = {
 };
 ```
 
+## Additional Types
+
+### SwitchRootDataAttributes
+
+| Member    | Value            | Description                                                                  |
+| :-------- | :--------------- | :--------------------------------------------------------------------------- |
+| checked   | `data-checked`   | Present when the switch is checked.                                          |
+| unchecked | `data-unchecked` | Present when the switch is not checked.                                      |
+| disabled  | `data-disabled`  | Present when the switch is disabled.                                         |
+| readonly  | `data-readonly`  | Present when the switch is readonly.                                         |
+| required  | `data-required`  | Present when the switch is required.                                         |
+| valid     | `data-valid`     | Present when the switch is in a valid state (when wrapped in Field.Root).    |
+| invalid   | `data-invalid`   | Present when the switch is in an invalid state (when wrapped in Field.Root). |
+| touched   | `data-touched`   | Present when the switch has been touched (when wrapped in Field.Root).       |
+| dirty     | `data-dirty`     | Present when the switch's value has changed (when wrapped in Field.Root).    |
+| filled    | `data-filled`    | Present when the switch is active (when wrapped in Field.Root).              |
+| focused   | `data-focused`   | Present when the switch is focused (when wrapped in Field.Root).             |
+
+### SwitchThumbDataAttributes
+
+| Member    | Value            | Description                                                                  |
+| :-------- | :--------------- | :--------------------------------------------------------------------------- |
+| checked   | `data-checked`   | Present when the switch is checked.                                          |
+| unchecked | `data-unchecked` | Present when the switch is not checked.                                      |
+| disabled  | `data-disabled`  | Present when the switch is disabled.                                         |
+| readonly  | `data-readonly`  | Present when the switch is readonly.                                         |
+| required  | `data-required`  | Present when the switch is required.                                         |
+| valid     | `data-valid`     | Present when the switch is in a valid state (when wrapped in Field.Root).    |
+| invalid   | `data-invalid`   | Present when the switch is in an invalid state (when wrapped in Field.Root). |
+| touched   | `data-touched`   | Present when the switch has been touched (when wrapped in Field.Root).       |
+| dirty     | `data-dirty`     | Present when the switch's value has changed (when wrapped in Field.Root).    |
+| filled    | `data-filled`    | Present when the switch is active (when wrapped in Field.Root).              |
+| focused   | `data-focused`   | Present when the switch is focused (when wrapped in Field.Root).             |
+
 ## Export Groups
 
 - `Switch.Root`: `Switch.Root`, `Switch.Root.State`, `Switch.Root.Props`, `Switch.Root.ChangeEventReason`, `Switch.Root.ChangeEventDetails`
 - `Switch.Thumb`: `Switch.Thumb`, `Switch.Thumb.Props`, `Switch.Thumb.State`
-- `Default`: `SwitchRootState`, `SwitchRootProps`, `SwitchRootChangeEventReason`, `SwitchRootChangeEventDetails`, `SwitchThumbProps`, `SwitchThumbState`
+- `Default`: `SwitchRootDataAttributes`, `SwitchThumbDataAttributes`, `SwitchRootState`, `SwitchRootProps`, `SwitchRootChangeEventReason`, `SwitchRootChangeEventDetails`, `SwitchThumbProps`, `SwitchThumbState`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/tabs/types.md
+++ b/docs/src/app/(docs)/react/components/tabs/types.md
@@ -297,6 +297,60 @@ type TabsTabPosition = { left: number; right: number; top: number; bottom: numbe
 type TabsTabSize = { width: number; height: number };
 ```
 
+## Additional Types
+
+### TabsIndicatorCssVars
+
+| Member          | Value                 | Description                                                                                 |
+| :-------------- | :-------------------- | :------------------------------------------------------------------------------------------ |
+| activeTabLeft   | `--active-tab-left`   | Indicates the distance on the left side from the parent's container if the tab is active.   |
+| activeTabRight  | `--active-tab-right`  | Indicates the distance on the right side from the parent's container if the tab is active.  |
+| activeTabTop    | `--active-tab-top`    | Indicates the distance on the top side from the parent's container if the tab is active.    |
+| activeTabBottom | `--active-tab-bottom` | Indicates the distance on the bottom side from the parent's container if the tab is active. |
+| activeTabWidth  | `--active-tab-width`  | Indicates the width of the tab if it is active.                                             |
+| activeTabHeight | `--active-tab-height` | Indicates the height of the tab if it is active.                                            |
+
+### TabsIndicatorDataAttributes
+
+| Member              | Value                       | Description                                                                   |
+| :------------------ | :-------------------------- | :---------------------------------------------------------------------------- |
+| activationDirection | `data-activation-direction` | Indicates the direction of the activation (based on the previous active tab). |
+| orientation         | `data-orientation`          | Indicates the orientation of the tabs.                                        |
+
+### TabsListDataAttributes
+
+| Member              | Value                       | Description                                                                   |
+| :------------------ | :-------------------------- | :---------------------------------------------------------------------------- |
+| activationDirection | `data-activation-direction` | Indicates the direction of the activation (based on the previous active tab). |
+| orientation         | `data-orientation`          | Indicates the orientation of the tabs.                                        |
+
+### TabsPanelDataAttributes
+
+| Member              | Value                       | Description                                                                   |
+| :------------------ | :-------------------------- | :---------------------------------------------------------------------------- |
+| index               | `data-index`                | Indicates the index of the tab panel.                                         |
+| activationDirection | `data-activation-direction` | Indicates the direction of the activation (based on the previous active tab). |
+| orientation         | `data-orientation`          | Indicates the orientation of the tabs.                                        |
+| hidden              | `data-hidden`               | Present when the panel is hidden.                                             |
+| startingStyle       | `data-starting-style`       | Present when the panel begins animating in.                                   |
+| endingStyle         | `data-ending-style`         | Present when the panel is animating out.                                      |
+
+### TabsRootDataAttributes
+
+| Member              | Value                       | Description                                                                   |
+| :------------------ | :-------------------------- | :---------------------------------------------------------------------------- |
+| activationDirection | `data-activation-direction` | Indicates the direction of the activation (based on the previous active tab). |
+| orientation         | `data-orientation`          | Indicates the orientation of the tabs.                                        |
+
+### TabsTabDataAttributes
+
+| Member              | Value                       | Description                                                                   |
+| :------------------ | :-------------------------- | :---------------------------------------------------------------------------- |
+| activationDirection | `data-activation-direction` | Indicates the direction of the activation (based on the previous active tab). |
+| orientation         | `data-orientation`          | Indicates the orientation of the tabs.                                        |
+| disabled            | `data-disabled`             | Present when the tab is disabled.                                             |
+| active              | `data-active`               | Present when the tab is active.                                               |
+
 ## Export Groups
 
 - `Tabs.Root`: `Tabs.Root`, `Tabs.Root.State`, `Tabs.Root.Props`, `Tabs.Root.Orientation`, `Tabs.Root.ChangeEventReason`, `Tabs.Root.ChangeEventDetails`
@@ -304,7 +358,7 @@ type TabsTabSize = { width: number; height: number };
 - `Tabs.Indicator`: `Tabs.Indicator`, `Tabs.Indicator.State`, `Tabs.Indicator.Props`
 - `Tabs.Panel`: `Tabs.Panel`, `Tabs.Panel.Metadata`, `Tabs.Panel.State`, `Tabs.Panel.Props`
 - `Tabs.List`: `Tabs.List`, `Tabs.List.State`, `Tabs.List.Props`
-- `Default`: `TabsRootOrientation`, `TabsRootState`, `TabsRootProps`, `TabsRootChangeEventReason`, `TabsRootChangeEventDetails`, `TabsIndicatorState`, `TabsIndicatorProps`, `TabsTabValue`, `TabsTabActivationDirection`, `TabsTabPosition`, `TabsTabSize`, `TabsTabMetadata`, `TabsTabState`, `TabsTabProps`, `TabsPanelMetadata`, `TabsPanelState`, `TabsPanelProps`, `TabsListState`, `TabsListProps`
+- `Default`: `TabsIndicatorCssVars`, `TabsIndicatorDataAttributes`, `TabsListDataAttributes`, `TabsPanelDataAttributes`, `TabsRootDataAttributes`, `TabsTabDataAttributes`, `TabsRootOrientation`, `TabsRootState`, `TabsRootProps`, `TabsRootChangeEventReason`, `TabsRootChangeEventDetails`, `TabsIndicatorState`, `TabsIndicatorProps`, `TabsTabValue`, `TabsTabActivationDirection`, `TabsTabPosition`, `TabsTabSize`, `TabsTabMetadata`, `TabsTabState`, `TabsTabProps`, `TabsPanelMetadata`, `TabsPanelState`, `TabsPanelProps`, `TabsListState`, `TabsListProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -577,6 +577,39 @@ type ToastObject<Data extends {}> = {
 };
 ```
 
+### ToastActionDataAttributes
+
+| Member | Value       | Description            |
+| :----- | :---------- | :--------------------- |
+| type   | `data-type` | The type of the toast. |
+
+### ToastArrowDataAttributes
+
+| Member     | Value             | Description                                                          |
+| :--------- | :---------------- | :------------------------------------------------------------------- |
+| side       | `data-side`       | Indicates which side the toast is positioned relative to the anchor. |
+| align      | `data-align`      | Indicates how the toast is aligned relative to specified side.       |
+| uncentered | `data-uncentered` | Present when the toast arrow is uncentered.                          |
+
+### ToastCloseDataAttributes
+
+| Member | Value       | Description            |
+| :----- | :---------- | :--------------------- |
+| type   | `data-type` | The type of the toast. |
+
+### ToastContentDataAttributes
+
+| Member   | Value           | Description                                                        |
+| :------- | :-------------- | :----------------------------------------------------------------- |
+| expanded | `data-expanded` | Present when the toast viewport is expanded.                       |
+| behind   | `data-behind`   | Present when the toast is behind the frontmost toast in the stack. |
+
+### ToastDescriptionDataAttributes
+
+| Member | Value       | Description            |
+| :----- | :---------- | :--------------------- |
+| type   | `data-type` | The type of the toast. |
+
 ### ToastManager
 
 ```typescript
@@ -861,6 +894,64 @@ type ToastManagerUpdateOptions<Data extends {}> = {
 };
 ```
 
+### ToastPositionerCssVars
+
+| Member          | Value                | Description                                                                            |
+| :-------------- | :------------------- | :------------------------------------------------------------------------------------- |
+| availableWidth  | `--available-width`  | The available width between the anchor and the edge of the viewport.                   |
+| availableHeight | `--available-height` | The available height between the anchor and the edge of the viewport.                  |
+| anchorWidth     | `--anchor-width`     | The anchor's width.                                                                    |
+| anchorHeight    | `--anchor-height`    | The anchor's height.                                                                   |
+| transformOrigin | `--transform-origin` | The coordinates that this element is anchored to. Used for animations and transitions. |
+
+### ToastPositionerDataAttributes
+
+| Member       | Value                | Description                                                           |
+| :----------- | :------------------- | :-------------------------------------------------------------------- |
+| anchorHidden | `data-anchor-hidden` | Present when the anchor is hidden.                                    |
+| side         | `data-side`          | Indicates which side the toast is positioned relative to the trigger. |
+| align        | `data-align`         | Indicates how the toast is aligned relative to specified side.        |
+
+### ToastRootCssVars
+
+| Member         | Value                      | Description                                                                  |
+| :------------- | :------------------------- | :--------------------------------------------------------------------------- |
+| index          | `--toast-index`            | Indicates the index of the toast in the list.                                |
+| offsetY        | `--toast-offset-y`         | Indicates the vertical pixels offset of the toast in the list when expanded. |
+| height         | `--toast-height`           | Indicates the measured natural height of the toast in pixels.                |
+| swipeMovementX | `--toast-swipe-movement-x` | Indicates the horizontal swipe movement of the toast.                        |
+| swipeMovementY | `--toast-swipe-movement-y` | Indicates the vertical swipe movement of the toast.                          |
+
+### ToastRootDataAttributes
+
+| Member         | Value                  | Description                                                              |
+| :------------- | :--------------------- | :----------------------------------------------------------------------- |
+| expanded       | `data-expanded`        | Present when the toast is expanded in the viewport.                      |
+| limited        | `data-limited`         | Present when the toast was limited because the toast limit was exceeded. |
+| type           | `data-type`            | The type of the toast.                                                   |
+| swiping        | `data-swiping`         | Present when the toast is being swiped.                                  |
+| swipeDirection | `data-swipe-direction` | The direction the toast was swiped.                                      |
+| startingStyle  | `data-starting-style`  | Present when the toast begins animating in.                              |
+| endingStyle    | `data-ending-style`    | Present when the toast is animating out.                                 |
+
+### ToastTitleDataAttributes
+
+| Member | Value       | Description            |
+| :----- | :---------- | :--------------------- |
+| type   | `data-type` | The type of the toast. |
+
+### ToastViewportCssVars
+
+| Member          | Value                      | Description                                  |
+| :-------------- | :------------------------- | :------------------------------------------- |
+| frontmostHeight | `--toast-frontmost-height` | Indicates the height of the frontmost toast. |
+
+### ToastViewportDataAttributes
+
+| Member   | Value           | Description                                    |
+| :------- | :-------------- | :--------------------------------------------- |
+| expanded | `data-expanded` | Indicates toasts are expanded in the viewport. |
+
 ### UseToastManagerReturnValue
 
 ```typescript
@@ -916,7 +1007,7 @@ type OffsetFunction = (data: {
 - `Toast.Arrow`: `Toast.Arrow`, `Toast.Arrow.State`, `Toast.Arrow.Props`
 - `Toast.useToastManager`
 - `Toast.createToastManager`
-- `Default`: `ToastRootToastObject`, `ToastRootState`, `ToastRootProps`, `ToastProviderState`, `ToastProviderProps`, `ToastViewportState`, `ToastViewportProps`, `ToastContentState`, `ToastContentProps`, `ToastDescriptionState`, `ToastDescriptionProps`, `ToastTitleState`, `ToastTitleProps`, `ToastCloseState`, `ToastCloseProps`, `ToastActionState`, `ToastActionProps`, `ToastPortalState`, `ToastPortalProps`, `ToastPositionerState`, `ToastPositionerProps`, `ToastArrowState`, `ToastArrowProps`, `ToastObject`, `ToastManagerPositionerProps`, `UseToastManagerReturnValue`, `ToastManagerAddOptions`, `ToastManagerUpdateOptions`, `ToastManagerPromiseOptions`, `ToastManager`, `ToastManagerEvent`
+- `Default`: `ToastPositionerCssVars`, `ToastRootCssVars`, `ToastViewportCssVars`, `ToastActionDataAttributes`, `ToastArrowDataAttributes`, `ToastCloseDataAttributes`, `ToastContentDataAttributes`, `ToastDescriptionDataAttributes`, `ToastPositionerDataAttributes`, `ToastRootDataAttributes`, `ToastTitleDataAttributes`, `ToastViewportDataAttributes`, `ToastRootToastObject`, `ToastRootState`, `ToastRootProps`, `ToastProviderState`, `ToastProviderProps`, `ToastViewportState`, `ToastViewportProps`, `ToastContentState`, `ToastContentProps`, `ToastDescriptionState`, `ToastDescriptionProps`, `ToastTitleState`, `ToastTitleProps`, `ToastCloseState`, `ToastCloseProps`, `ToastActionState`, `ToastActionProps`, `ToastPortalState`, `ToastPortalProps`, `ToastPositionerState`, `ToastPositionerProps`, `ToastArrowState`, `ToastArrowProps`, `ToastObject`, `ToastManagerPositionerProps`, `UseToastManagerReturnValue`, `ToastManagerAddOptions`, `ToastManagerUpdateOptions`, `ToastManagerPromiseOptions`, `ToastManager`, `ToastManagerEvent`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/toggle-group/types.md
+++ b/docs/src/app/(docs)/react/components/toggle-group/types.md
@@ -80,6 +80,16 @@ type ToggleGroupChangeEventDetails = {
 };
 ```
 
+## Additional Types
+
+### ToggleGroupDataAttributes
+
+| Member      | Value              | Description                                                                                        |
+| :---------- | :----------------- | :------------------------------------------------------------------------------------------------- |
+| disabled    | `data-disabled`    | Present when the toggle group is disabled.                                                         |
+| orientation | `data-orientation` | Indicates the orientation of the toggle group.                                                     |
+| multiple    | `data-multiple`    | Present when the toggle group allows multiple buttons to be in the pressed state at the same time. |
+
 ## External Types
 
 ### Orientation

--- a/docs/src/app/(docs)/react/components/toggle/types.md
+++ b/docs/src/app/(docs)/react/components/toggle/types.md
@@ -72,6 +72,15 @@ type ToggleChangeEventDetails = {
 };
 ```
 
+## Additional Types
+
+### ToggleDataAttributes
+
+| Member   | Value           | Description                                 |
+| :------- | :-------------- | :------------------------------------------ |
+| pressed  | `data-pressed`  | Present when the toggle button is pressed.  |
+| disabled | `data-disabled` | Present when the toggle button is disabled. |
+
 ## Canonical Types
 
 Maps `Canonical`: `Alias` — Use Canonical when its namespace is already imported; otherwise use Alias.

--- a/docs/src/app/(docs)/react/components/toolbar/types.md
+++ b/docs/src/app/(docs)/react/components/toolbar/types.md
@@ -245,6 +245,48 @@ type ToolbarLinkState = {
 type ToolbarOrientation = 'horizontal' | 'vertical';
 ```
 
+### ToolbarButtonDataAttributes
+
+| Member      | Value              | Description                                              |
+| :---------- | :----------------- | :------------------------------------------------------- |
+| disabled    | `data-disabled`    | Present when the button is disabled.                     |
+| orientation | `data-orientation` | Indicates the orientation of the toolbar.                |
+| focusable   | `data-focusable`   | Present when the button remains focusable when disabled. |
+
+### ToolbarGroupDataAttributes
+
+| Member      | Value              | Description                               |
+| :---------- | :----------------- | :---------------------------------------- |
+| disabled    | `data-disabled`    | Present when the group is disabled.       |
+| orientation | `data-orientation` | Indicates the orientation of the toolbar. |
+
+### ToolbarInputDataAttributes
+
+| Member      | Value              | Description                                             |
+| :---------- | :----------------- | :------------------------------------------------------ |
+| disabled    | `data-disabled`    | Present when the input is disabled.                     |
+| orientation | `data-orientation` | Indicates the orientation of the toolbar.               |
+| focusable   | `data-focusable`   | Present when the input remains focusable when disabled. |
+
+### ToolbarLinkDataAttributes
+
+| Member      | Value              | Description                               |
+| :---------- | :----------------- | :---------------------------------------- |
+| orientation | `data-orientation` | Indicates the orientation of the toolbar. |
+
+### ToolbarRootDataAttributes
+
+| Member      | Value              | Description                               |
+| :---------- | :----------------- | :---------------------------------------- |
+| disabled    | `data-disabled`    | Present when the toolbar is disabled.     |
+| orientation | `data-orientation` | Indicates the orientation of the toolbar. |
+
+### ToolbarSeparatorDataAttributes
+
+| Member      | Value              | Description                                                                        |
+| :---------- | :----------------- | :--------------------------------------------------------------------------------- |
+| orientation | `data-orientation` | Indicates the orientation of the separator, which is perpendicular to the toolbar. |
+
 ## Export Groups
 
 - `Toolbar.Separator`: `Toolbar.Separator`, `Toolbar.Separator.State`, `Toolbar.Separator.Props`
@@ -253,7 +295,7 @@ type ToolbarOrientation = 'horizontal' | 'vertical';
 - `Toolbar.Button`: `Toolbar.Button`, `Toolbar.Button.State`, `Toolbar.Button.Props`
 - `Toolbar.Link`: `Toolbar.Link`, `Toolbar.Link.State`, `Toolbar.Link.Props`
 - `Toolbar.Input`: `Toolbar.Input`, `Toolbar.Input.State`, `Toolbar.Input.Props`
-- `Default`: `Toolbar.Orientation`, `Orientation`, `ToolbarRootItemMetadata`, `ToolbarRootOrientation`, `ToolbarRootState`, `ToolbarRootProps`, `ToolbarGroupState`, `ToolbarGroupProps`, `ToolbarButtonState`, `ToolbarButtonProps`, `ToolbarLinkState`, `ToolbarLinkProps`, `ToolbarInputState`, `ToolbarInputProps`, `ToolbarSeparatorState`, `ToolbarSeparatorProps`
+- `Default`: `Toolbar.Orientation`, `Orientation`, `ToolbarButtonDataAttributes`, `ToolbarGroupDataAttributes`, `ToolbarInputDataAttributes`, `ToolbarLinkDataAttributes`, `ToolbarRootDataAttributes`, `ToolbarSeparatorDataAttributes`, `ToolbarRootItemMetadata`, `ToolbarRootOrientation`, `ToolbarRootState`, `ToolbarRootProps`, `ToolbarGroupState`, `ToolbarGroupProps`, `ToolbarButtonState`, `ToolbarButtonProps`, `ToolbarLinkState`, `ToolbarLinkProps`, `ToolbarInputState`, `ToolbarInputProps`, `ToolbarSeparatorState`, `ToolbarSeparatorProps`
 
 ## Canonical Types
 

--- a/docs/src/app/(docs)/react/components/tooltip/types.md
+++ b/docs/src/app/(docs)/react/components/tooltip/types.md
@@ -456,6 +456,77 @@ Closes the tooltip.
 
 This method should only be called in an event handler or an effect (not during rendering).
 
+## Additional Types
+
+### TooltipArrowDataAttributes
+
+| Member     | Value             | Description                                                           |
+| :--------- | :---------------- | :-------------------------------------------------------------------- |
+| open       | `data-open`       | Present when the tooltip is open.                                     |
+| closed     | `data-closed`     | Present when the tooltip is closed.                                   |
+| side       | `data-side`       | Indicates which side the popup is positioned relative to the trigger. |
+| align      | `data-align`      | Indicates how the popup is aligned relative to specified side.        |
+| uncentered | `data-uncentered` | Present when the tooltip arrow is uncentered.                         |
+| instant    | `data-instant`    | Present if animations should be instant.                              |
+
+### TooltipPopupDataAttributes
+
+| Member        | Value                 | Description                                                           |
+| :------------ | :-------------------- | :-------------------------------------------------------------------- |
+| open          | `data-open`           | Present when the tooltip is open.                                     |
+| closed        | `data-closed`         | Present when the tooltip is closed.                                   |
+| startingStyle | `data-starting-style` | Present when the tooltip begins animating in.                         |
+| endingStyle   | `data-ending-style`   | Present when the tooltip is animating out.                            |
+| side          | `data-side`           | Indicates which side the popup is positioned relative to the trigger. |
+| align         | `data-align`          | Indicates how the popup is aligned relative to specified side.        |
+| instant       | `data-instant`        | Present if animations should be instant.                              |
+
+### TooltipPositionerCssVars
+
+| Member           | Value                 | Description                                                                                                                       |
+| :--------------- | :-------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| availableWidth   | `--available-width`   | The available width between the trigger and the edge of the viewport.                                                             |
+| availableHeight  | `--available-height`  | The available height between the trigger and the edge of the viewport.                                                            |
+| anchorWidth      | `--anchor-width`      | The anchor's width.                                                                                                               |
+| anchorHeight     | `--anchor-height`     | The anchor's height.                                                                                                              |
+| transformOrigin  | `--transform-origin`  | The coordinates that this element is anchored to. Used for animations and transitions.                                            |
+| positionerWidth  | `--positioner-width`  | The width of the tooltip's positioner.&#xA;It is important to set `width` to this value when using CSS to animate size changes.   |
+| positionerHeight | `--positioner-height` | The height of the tooltip's positioner.&#xA;It is important to set `height` to this value when using CSS to animate size changes. |
+
+### TooltipPositionerDataAttributes
+
+| Member       | Value                | Description                                                           |
+| :----------- | :------------------- | :-------------------------------------------------------------------- |
+| open         | `data-open`          | Present when the tooltip is open.                                     |
+| closed       | `data-closed`        | Present when the tooltip is closed.                                   |
+| anchorHidden | `data-anchor-hidden` | Present when the anchor is hidden.                                    |
+| side         | `data-side`          | Indicates which side the popup is positioned relative to the trigger. |
+| align        | `data-align`         | Indicates how the popup is aligned relative to specified side.        |
+
+### TooltipTriggerDataAttributes
+
+| Member          | Value                   | Description                                                                                                    |
+| :-------------- | :---------------------- | :------------------------------------------------------------------------------------------------------------- |
+| popupOpen       | `data-popup-open`       | Present when the corresponding tooltip is open.                                                                |
+| triggerDisabled | `data-trigger-disabled` | Present when the trigger is disabled, either by the `disabled` prop or by a parent `<Tooltip.Root>` component. |
+
+### TooltipViewportCssVars
+
+| Member      | Value            | Description                                                                                                                                                                                                                                                           |
+| :---------- | :--------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| popupWidth  | `--popup-width`  | The width of the parent popup.&#xA;This variable is placed on the 'previous' container and stores the width of the popup when the previous content was rendered.&#xA;It can be used to freeze the dimensions of the popup when animating between different content.   |
+| popupHeight | `--popup-height` | The height of the parent popup.&#xA;This variable is placed on the 'previous' container and stores the height of the popup when the previous content was rendered.&#xA;It can be used to freeze the dimensions of the popup when animating between different content. |
+
+### TooltipViewportDataAttributes
+
+| Member              | Value                       | Description                                                                                                                                                                                                                        |
+| :------------------ | :-------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| current             | `data-current`              | Applied to the direct child of the viewport when no transitions are present or the new content when it's entering.                                                                                                                 |
+| previous            | `data-previous`             | Applied to the direct child of the viewport that contains the exiting content when transitions are present.                                                                                                                        |
+| activationDirection | `data-activation-direction` | Indicates the direction from which the popup was activated.&#xA;This can be used to create directional animations based on how the popup was triggered.&#xA;Contains space-separated values for both horizontal and vertical axes. |
+| transitioning       | `data-transitioning`        | Indicates that the viewport is currently transitioning between old and new content.                                                                                                                                                |
+| instant             | `data-instant`              | Present if animations should be instant.                                                                                                                                                                                           |
+
 ## External Types
 
 ### PayloadChildRenderFunction
@@ -505,7 +576,7 @@ type OffsetFunction = (data: {
 - `Tooltip.Viewport`: `Tooltip.Viewport`, `Tooltip.Viewport.Props`, `Tooltip.Viewport.State`
 - `Tooltip.createHandle`
 - `Tooltip.Handle`
-- `Default`: `TooltipProviderState`, `TooltipProviderProps`, `TooltipRootState`, `TooltipRootProps`, `TooltipRootActions`, `TooltipRootChangeEventReason`, `TooltipRootChangeEventDetails`, `TooltipTriggerState`, `TooltipTriggerProps`, `TooltipPortalState`, `TooltipPortalProps`, `TooltipPositionerState`, `TooltipPositionerProps`, `TooltipPopupState`, `TooltipPopupProps`, `TooltipViewportState`, `TooltipViewportProps`, `TooltipArrowState`, `TooltipArrowProps`
+- `Default`: `TooltipPositionerCssVars`, `TooltipViewportCssVars`, `TooltipArrowDataAttributes`, `TooltipPopupDataAttributes`, `TooltipPositionerDataAttributes`, `TooltipTriggerDataAttributes`, `TooltipViewportDataAttributes`, `TooltipProviderState`, `TooltipProviderProps`, `TooltipRootState`, `TooltipRootProps`, `TooltipRootActions`, `TooltipRootChangeEventReason`, `TooltipRootChangeEventDetails`, `TooltipTriggerState`, `TooltipTriggerProps`, `TooltipPortalState`, `TooltipPortalProps`, `TooltipPositionerState`, `TooltipPositionerProps`, `TooltipPopupState`, `TooltipPopupProps`, `TooltipViewportState`, `TooltipViewportProps`, `TooltipArrowState`, `TooltipArrowProps`
 
 ## Canonical Types
 

--- a/packages/react/src/accordion/index.ts
+++ b/packages/react/src/accordion/index.ts
@@ -5,3 +5,11 @@ export type * from './item/AccordionItem';
 export type * from './header/AccordionHeader';
 export type * from './trigger/AccordionTrigger';
 export type * from './panel/AccordionPanel';
+
+export { AccordionPanelCssVars } from './panel/AccordionPanelCssVars';
+
+export { AccordionHeaderDataAttributes } from './header/AccordionHeaderDataAttributes';
+export { AccordionItemDataAttributes } from './item/AccordionItemDataAttributes';
+export { AccordionPanelDataAttributes } from './panel/AccordionPanelDataAttributes';
+export { AccordionRootDataAttributes } from './root/AccordionRootDataAttributes';
+export { AccordionTriggerDataAttributes } from './trigger/AccordionTriggerDataAttributes';

--- a/packages/react/src/alert-dialog/index.ts
+++ b/packages/react/src/alert-dialog/index.ts
@@ -31,3 +31,5 @@ export type {
   DialogViewportProps as AlertDialogViewportProps,
   DialogViewportState as AlertDialogViewportState,
 } from '../dialog/viewport/DialogViewport';
+
+export { AlertDialogTriggerDataAttributes } from './trigger/AlertDialogTriggerDataAttributes';

--- a/packages/react/src/autocomplete/index.ts
+++ b/packages/react/src/autocomplete/index.ts
@@ -71,3 +71,7 @@ export type {
   Filter as AutocompleteFilter,
   UseFilterOptions as AutocompleteFilterOptions,
 } from '../combobox/root/utils/useFilter';
+
+export { AutocompleteInputGroupDataAttributes } from './input-group/AutocompleteInputGroupDataAttributes';
+export { AutocompleteItemDataAttributes } from './item/AutocompleteItemDataAttributes';
+export { AutocompleteTriggerDataAttributes } from './trigger/AutocompleteTriggerDataAttributes';

--- a/packages/react/src/avatar/index.ts
+++ b/packages/react/src/avatar/index.ts
@@ -3,3 +3,5 @@ export * as Avatar from './index.parts';
 export type * from './root/AvatarRoot';
 export type * from './image/AvatarImage';
 export type * from './fallback/AvatarFallback';
+
+export { AvatarImageDataAttributes } from './image/AvatarImageDataAttributes';

--- a/packages/react/src/checkbox-group/index.ts
+++ b/packages/react/src/checkbox-group/index.ts
@@ -1,2 +1,4 @@
 export { CheckboxGroup } from './CheckboxGroup';
 export type * from './CheckboxGroup';
+
+export { CheckboxGroupDataAttributes } from './CheckboxGroupDataAttributes';

--- a/packages/react/src/checkbox/index.ts
+++ b/packages/react/src/checkbox/index.ts
@@ -2,3 +2,6 @@ export * as Checkbox from './index.parts';
 
 export type * from './root/CheckboxRoot';
 export type * from './indicator/CheckboxIndicator';
+
+export { CheckboxIndicatorDataAttributes } from './indicator/CheckboxIndicatorDataAttributes';
+export { CheckboxRootDataAttributes } from './root/CheckboxRootDataAttributes';

--- a/packages/react/src/collapsible/index.ts
+++ b/packages/react/src/collapsible/index.ts
@@ -3,3 +3,9 @@ export * as Collapsible from './index.parts';
 export type * from './root/CollapsibleRoot';
 export type * from './trigger/CollapsibleTrigger';
 export type * from './panel/CollapsiblePanel';
+
+export { CollapsiblePanelCssVars } from './panel/CollapsiblePanelCssVars';
+
+export { CollapsiblePanelDataAttributes } from './panel/CollapsiblePanelDataAttributes';
+export { CollapsibleRootDataAttributes } from './root/CollapsibleRootDataAttributes';
+export { CollapsibleTriggerDataAttributes } from './trigger/CollapsibleTriggerDataAttributes';

--- a/packages/react/src/combobox/index.ts
+++ b/packages/react/src/combobox/index.ts
@@ -30,3 +30,16 @@ export type {
   Filter as ComboboxFilter,
   UseComboboxFilterOptions as ComboboxFilterOptions,
 } from '../combobox/root/utils/useFilter';
+
+export { ComboboxPositionerCssVars } from './positioner/ComboboxPositionerCssVars';
+
+export { ComboboxArrowDataAttributes } from './arrow/ComboboxArrowDataAttributes';
+export { ComboboxBackdropDataAttributes } from './backdrop/ComboboxBackdropDataAttributes';
+export { ComboboxClearDataAttributes } from './clear/ComboboxClearDataAttributes';
+export { ComboboxInputGroupDataAttributes } from './input-group/ComboboxInputGroupDataAttributes';
+export { ComboboxInputDataAttributes } from './input/ComboboxInputDataAttributes';
+export { ComboboxItemIndicatorDataAttributes } from './item-indicator/ComboboxItemIndicatorDataAttributes';
+export { ComboboxItemDataAttributes } from './item/ComboboxItemDataAttributes';
+export { ComboboxPopupDataAttributes } from './popup/ComboboxPopupDataAttributes';
+export { ComboboxPositionerDataAttributes } from './positioner/ComboboxPositionerDataAttributes';
+export { ComboboxTriggerDataAttributes } from './trigger/ComboboxTriggerDataAttributes';

--- a/packages/react/src/context-menu/index.ts
+++ b/packages/react/src/context-menu/index.ts
@@ -67,3 +67,5 @@ export type {
   MenuSubmenuTriggerProps as ContextMenuSubmenuTriggerProps,
   MenuSubmenuTriggerState as ContextMenuSubmenuTriggerState,
 } from '../menu/submenu-trigger/MenuSubmenuTrigger';
+
+export { ContextMenuTriggerDataAttributes } from './trigger/ContextMenuTriggerDataAttributes';

--- a/packages/react/src/dialog/index.ts
+++ b/packages/react/src/dialog/index.ts
@@ -9,3 +9,11 @@ export type * from './title/DialogTitle';
 export type * from './description/DialogDescription';
 export type * from './close/DialogClose';
 export type * from './viewport/DialogViewport';
+
+export { DialogPopupCssVars } from './popup/DialogPopupCssVars';
+
+export { DialogBackdropDataAttributes } from './backdrop/DialogBackdropDataAttributes';
+export { DialogCloseDataAttributes } from './close/DialogCloseDataAttributes';
+export { DialogPopupDataAttributes } from './popup/DialogPopupDataAttributes';
+export { DialogTriggerDataAttributes } from './trigger/DialogTriggerDataAttributes';
+export { DialogViewportDataAttributes } from './viewport/DialogViewportDataAttributes';

--- a/packages/react/src/drawer/index.ts
+++ b/packages/react/src/drawer/index.ts
@@ -15,3 +15,13 @@ export type * from './title/DrawerTitle';
 export type * from './description/DrawerDescription';
 export type * from './close/DrawerClose';
 export type * from './virtual-keyboard-provider/DrawerVirtualKeyboardProvider';
+
+export { DrawerBackdropCssVars } from './backdrop/DrawerBackdropCssVars';
+export { DrawerPopupCssVars } from './popup/DrawerPopupCssVars';
+export { DrawerViewportCssVars } from './viewport/DrawerViewportCssVars';
+
+export { DrawerBackdropDataAttributes } from './backdrop/DrawerBackdropDataAttributes';
+export { DRAWER_CONTENT_ATTRIBUTE } from './content/DrawerContentDataAttributes';
+export { DrawerPopupDataAttributes } from './popup/DrawerPopupDataAttributes';
+export { DrawerSwipeAreaDataAttributes } from './swipe-area/DrawerSwipeAreaDataAttributes';
+export { DrawerViewportDataAttributes } from './viewport/DrawerViewportDataAttributes';

--- a/packages/react/src/field/index.ts
+++ b/packages/react/src/field/index.ts
@@ -7,3 +7,10 @@ export type * from './error/FieldError';
 export type * from './control/FieldControl';
 export type * from './validity/FieldValidity';
 export type * from './item/FieldItem';
+
+export { FieldControlDataAttributes } from './control/FieldControlDataAttributes';
+export { FieldDescriptionDataAttributes } from './description/FieldDescriptionDataAttributes';
+export { FieldErrorDataAttributes } from './error/FieldErrorDataAttributes';
+export { FieldItemDataAttributes } from './item/FieldItemDataAttributes';
+export { FieldLabelDataAttributes } from './label/FieldLabelDataAttributes';
+export { FieldRootDataAttributes } from './root/FieldRootDataAttributes';

--- a/packages/react/src/input/index.ts
+++ b/packages/react/src/input/index.ts
@@ -1,3 +1,5 @@
 export { Input } from './Input';
 
 export type * from './Input';
+
+export { InputDataAttributes } from './InputDataAttributes';

--- a/packages/react/src/menu/index.ts
+++ b/packages/react/src/menu/index.ts
@@ -19,3 +19,20 @@ export type * from './submenu-root/MenuSubmenuRoot';
 export type * from './trigger/MenuTrigger';
 export type * from './submenu-trigger/MenuSubmenuTrigger';
 export type * from './viewport/MenuViewport';
+
+export { MenuPositionerCssVars } from './positioner/MenuPositionerCssVars';
+export { MenuViewportCssVars } from './viewport/MenuViewportCssVars';
+
+export { MenuArrowDataAttributes } from './arrow/MenuArrowDataAttributes';
+export { MenuBackdropDataAttributes } from './backdrop/MenuBackdropDataAttributes';
+export { MenuCheckboxItemIndicatorDataAttributes } from './checkbox-item-indicator/MenuCheckboxItemIndicatorDataAttributes';
+export { MenuCheckboxItemDataAttributes } from './checkbox-item/MenuCheckboxItemDataAttributes';
+export { MenuItemDataAttributes } from './item/MenuItemDataAttributes';
+export { MenuLinkItemDataAttributes } from './link-item/MenuLinkItemDataAttributes';
+export { MenuPopupDataAttributes } from './popup/MenuPopupDataAttributes';
+export { MenuPositionerDataAttributes } from './positioner/MenuPositionerDataAttributes';
+export { MenuRadioItemIndicatorDataAttributes } from './radio-item-indicator/MenuRadioItemIndicatorDataAttributes';
+export { MenuRadioItemDataAttributes } from './radio-item/MenuRadioItemDataAttributes';
+export { MenuSubmenuTriggerDataAttributes } from './submenu-trigger/MenuSubmenuTriggerDataAttributes';
+export { MenuTriggerDataAttributes } from './trigger/MenuTriggerDataAttributes';
+export { MenuViewportDataAttributes } from './viewport/MenuViewportDataAttributes';

--- a/packages/react/src/menubar/index.ts
+++ b/packages/react/src/menubar/index.ts
@@ -1,3 +1,5 @@
 export { Menubar } from './Menubar';
 
 export type * from './Menubar';
+
+export { MenubarDataAttributes } from './MenubarDataAttributes';

--- a/packages/react/src/navigation-menu/index.ts
+++ b/packages/react/src/navigation-menu/index.ts
@@ -13,3 +13,15 @@ export type * from './backdrop/NavigationMenuBackdrop';
 export type * from './arrow/NavigationMenuArrow';
 export type * from './link/NavigationMenuLink';
 export type * from './icon/NavigationMenuIcon';
+
+export { NavigationMenuPopupCssVars } from './popup/NavigationMenuPopupCssVars';
+export { NavigationMenuPositionerCssVars } from './positioner/NavigationMenuPositionerCssVars';
+
+export { NavigationMenuArrowDataAttributes } from './arrow/NavigationMenuArrowDataAttributes';
+export { NavigationMenuBackdropDataAttributes } from './backdrop/NavigationMenuBackdropDataAttributes';
+export { NavigationMenuContentDataAttributes } from './content/NavigationMenuContentDataAttributes';
+export { NavigationMenuIconDataAttributes } from './icon/NavigationMenuIconDataAttributes';
+export { NavigationMenuLinkDataAttributes } from './link/NavigationMenuLinkDataAttributes';
+export { NavigationMenuPopupDataAttributes } from './popup/NavigationMenuPopupDataAttributes';
+export { NavigationMenuPositionerDataAttributes } from './positioner/NavigationMenuPositionerDataAttributes';
+export { NavigationMenuTriggerDataAttributes } from './trigger/NavigationMenuTriggerDataAttributes';

--- a/packages/react/src/number-field/index.ts
+++ b/packages/react/src/number-field/index.ts
@@ -7,3 +7,11 @@ export type * from './decrement/NumberFieldDecrement';
 export type * from './input/NumberFieldInput';
 export type * from './scrub-area/NumberFieldScrubArea';
 export type * from './scrub-area-cursor/NumberFieldScrubAreaCursor';
+
+export { NumberFieldDecrementDataAttributes } from './decrement/NumberFieldDecrementDataAttributes';
+export { NumberFieldGroupDataAttributes } from './group/NumberFieldGroupDataAttributes';
+export { NumberFieldIncrementDataAttributes } from './increment/NumberFieldIncrementDataAttributes';
+export { NumberFieldInputDataAttributes } from './input/NumberFieldInputDataAttributes';
+export { NumberFieldRootDataAttributes } from './root/NumberFieldRootDataAttributes';
+export { NumberFieldScrubAreaCursorDataAttributes } from './scrub-area-cursor/NumberFieldScrubAreaCursorDataAttributes';
+export { NumberFieldScrubAreaDataAttributes } from './scrub-area/NumberFieldScrubAreaDataAttributes';

--- a/packages/react/src/otp-field/index.ts
+++ b/packages/react/src/otp-field/index.ts
@@ -2,3 +2,6 @@ export * as OTPField from './index.parts';
 
 export type * from './root/OTPFieldRoot';
 export type * from './input/OTPFieldInput';
+
+export { OTPFieldInputDataAttributes } from './input/OTPFieldInputDataAttributes';
+export { OTPFieldRootDataAttributes } from './root/OTPFieldRootDataAttributes';

--- a/packages/react/src/popover/index.ts
+++ b/packages/react/src/popover/index.ts
@@ -11,3 +11,14 @@ export type * from './title/PopoverTitle';
 export type * from './description/PopoverDescription';
 export type * from './close/PopoverClose';
 export type * from './viewport/PopoverViewport';
+
+export { PopoverPopupCssVars } from './popup/PopoverPopupCssVars';
+export { PopoverPositionerCssVars } from './positioner/PopoverPositionerCssVars';
+export { PopoverViewportCssVars } from './viewport/PopoverViewportCssVars';
+
+export { PopoverArrowDataAttributes } from './arrow/PopoverArrowDataAttributes';
+export { PopoverBackdropDataAttributes } from './backdrop/PopoverBackdropDataAttributes';
+export { PopoverPopupDataAttributes } from './popup/PopoverPopupDataAttributes';
+export { PopoverPositionerDataAttributes } from './positioner/PopoverPositionerDataAttributes';
+export { PopoverTriggerDataAttributes } from './trigger/PopoverTriggerDataAttributes';
+export { PopoverViewportDataAttributes } from './viewport/PopoverViewportDataAttributes';

--- a/packages/react/src/preview-card/index.ts
+++ b/packages/react/src/preview-card/index.ts
@@ -8,3 +8,13 @@ export type * from './popup/PreviewCardPopup';
 export type * from './arrow/PreviewCardArrow';
 export type * from './viewport/PreviewCardViewport';
 export type * from './backdrop/PreviewCardBackdrop';
+
+export { PreviewCardPositionerCssVars } from './positioner/PreviewCardPositionerCssVars';
+export { PreviewCardViewportCssVars } from './viewport/PreviewCardViewportCssVars';
+
+export { PreviewCardArrowDataAttributes } from './arrow/PreviewCardArrowDataAttributes';
+export { PreviewCardBackdropDataAttributes } from './backdrop/PreviewCardBackdropDataAttributes';
+export { PreviewCardPopupDataAttributes } from './popup/PreviewCardPopupDataAttributes';
+export { PreviewCardPositionerDataAttributes } from './positioner/PreviewCardPositionerDataAttributes';
+export { PreviewCardTriggerDataAttributes } from './trigger/PreviewCardTriggerDataAttributes';
+export { PreviewCardViewportDataAttributes } from './viewport/PreviewCardViewportDataAttributes';

--- a/packages/react/src/progress/index.ts
+++ b/packages/react/src/progress/index.ts
@@ -5,3 +5,9 @@ export type * from './indicator/ProgressIndicator';
 export type * from './label/ProgressLabel';
 export type * from './track/ProgressTrack';
 export type * from './value/ProgressValue';
+
+export { ProgressIndicatorDataAttributes } from './indicator/ProgressIndicatorDataAttributes';
+export { ProgressLabelDataAttributes } from './label/ProgressLabelDataAttributes';
+export { ProgressRootDataAttributes } from './root/ProgressRootDataAttributes';
+export { ProgressTrackDataAttributes } from './track/ProgressTrackDataAttributes';
+export { ProgressValueDataAttributes } from './value/ProgressValueDataAttributes';

--- a/packages/react/src/radio-group/index.ts
+++ b/packages/react/src/radio-group/index.ts
@@ -1,3 +1,5 @@
 export { RadioGroup } from './RadioGroup';
 
 export type * from './RadioGroup';
+
+export { RadioGroupDataAttributes } from './RadioGroupDataAttributes';

--- a/packages/react/src/radio/index.ts
+++ b/packages/react/src/radio/index.ts
@@ -2,3 +2,6 @@ export * as Radio from './index.parts';
 
 export type * from './root/RadioRoot';
 export type * from './indicator/RadioIndicator';
+
+export { RadioIndicatorDataAttributes } from './indicator/RadioIndicatorDataAttributes';
+export { RadioRootDataAttributes } from './root/RadioRootDataAttributes';

--- a/packages/react/src/scroll-area/index.ts
+++ b/packages/react/src/scroll-area/index.ts
@@ -6,3 +6,13 @@ export type * from './scrollbar/ScrollAreaScrollbar';
 export type * from './content/ScrollAreaContent';
 export type * from './thumb/ScrollAreaThumb';
 export type * from './corner/ScrollAreaCorner';
+
+export { ScrollAreaRootCssVars } from './root/ScrollAreaRootCssVars';
+export { ScrollAreaScrollbarCssVars } from './scrollbar/ScrollAreaScrollbarCssVars';
+export { ScrollAreaViewportCssVars } from './viewport/ScrollAreaViewportCssVars';
+
+export { ScrollAreaContentDataAttributes } from './content/ScrollAreaContentDataAttributes';
+export { ScrollAreaRootDataAttributes } from './root/ScrollAreaRootDataAttributes';
+export { ScrollAreaScrollbarDataAttributes } from './scrollbar/ScrollAreaScrollbarDataAttributes';
+export { ScrollAreaThumbDataAttributes } from './thumb/ScrollAreaThumbDataAttributes';
+export { ScrollAreaViewportDataAttributes } from './viewport/ScrollAreaViewportDataAttributes';

--- a/packages/react/src/select/index.ts
+++ b/packages/react/src/select/index.ts
@@ -18,3 +18,17 @@ export type * from './scroll-down-arrow/SelectScrollDownArrow';
 export type * from './scroll-up-arrow/SelectScrollUpArrow';
 export type * from './group/SelectGroup';
 export type * from './group-label/SelectGroupLabel';
+
+export { SelectPositionerCssVars } from './positioner/SelectPositionerCssVars';
+
+export { SelectArrowDataAttributes } from './arrow/SelectArrowDataAttributes';
+export { SelectBackdropDataAttributes } from './backdrop/SelectBackdropDataAttributes';
+export { SelectIconDataAttributes } from './icon/SelectIconDataAttributes';
+export { SelectItemIndicatorDataAttributes } from './item-indicator/SelectItemIndicatorDataAttributes';
+export { SelectItemDataAttributes } from './item/SelectItemDataAttributes';
+export { SelectPopupDataAttributes } from './popup/SelectPopupDataAttributes';
+export { SelectPositionerDataAttributes } from './positioner/SelectPositionerDataAttributes';
+export { SelectScrollDownArrowDataAttributes } from './scroll-down-arrow/SelectScrollDownArrowDataAttributes';
+export { SelectScrollUpArrowDataAttributes } from './scroll-up-arrow/SelectScrollUpArrowDataAttributes';
+export { SelectTriggerDataAttributes } from './trigger/SelectTriggerDataAttributes';
+export { SelectValueDataAttributes } from './value/SelectValueDataAttributes';

--- a/packages/react/src/separator/index.ts
+++ b/packages/react/src/separator/index.ts
@@ -1,3 +1,5 @@
 export { Separator } from './Separator';
 
 export type * from './Separator';
+
+export { SeparatorDataAttributes } from './SeparatorDataAttributes';

--- a/packages/react/src/slider/index.ts
+++ b/packages/react/src/slider/index.ts
@@ -7,3 +7,10 @@ export type * from './control/SliderControl';
 export type * from './track/SliderTrack';
 export type * from './thumb/SliderThumb';
 export type * from './indicator/SliderIndicator';
+
+export { SliderControlDataAttributes } from './control/SliderControlDataAttributes';
+export { SliderIndicatorDataAttributes } from './indicator/SliderIndicatorDataAttributes';
+export { SliderRootDataAttributes } from './root/SliderRootDataAttributes';
+export { SliderThumbDataAttributes } from './thumb/SliderThumbDataAttributes';
+export { SliderTrackDataAttributes } from './track/SliderTrackDataAttributes';
+export { SliderValueDataAttributes } from './value/SliderValueDataAttributes';

--- a/packages/react/src/switch/index.ts
+++ b/packages/react/src/switch/index.ts
@@ -2,3 +2,6 @@ export * as Switch from './index.parts';
 
 export type * from './root/SwitchRoot';
 export type * from './thumb/SwitchThumb';
+
+export { SwitchRootDataAttributes } from './root/SwitchRootDataAttributes';
+export { SwitchThumbDataAttributes } from './thumb/SwitchThumbDataAttributes';

--- a/packages/react/src/tabs/index.ts
+++ b/packages/react/src/tabs/index.ts
@@ -5,3 +5,11 @@ export type * from './indicator/TabsIndicator';
 export type * from './tab/TabsTab';
 export type * from './panel/TabsPanel';
 export type * from './list/TabsList';
+
+export { TabsIndicatorCssVars } from './indicator/TabsIndicatorCssVars';
+
+export { TabsIndicatorDataAttributes } from './indicator/TabsIndicatorDataAttributes';
+export { TabsListDataAttributes } from './list/TabsListDataAttributes';
+export { TabsPanelDataAttributes } from './panel/TabsPanelDataAttributes';
+export { TabsRootDataAttributes } from './root/TabsRootDataAttributes';
+export { TabsTabDataAttributes } from './tab/TabsTabDataAttributes';

--- a/packages/react/src/toast/index.ts
+++ b/packages/react/src/toast/index.ts
@@ -13,3 +13,17 @@ export type * from './positioner/ToastPositioner';
 export type * from './arrow/ToastArrow';
 export type * from './useToastManager';
 export type * from './createToastManager';
+
+export { ToastPositionerCssVars } from './positioner/ToastPositionerCssVars';
+export { ToastRootCssVars } from './root/ToastRootCssVars';
+export { ToastViewportCssVars } from './viewport/ToastViewportCssVars';
+
+export { ToastActionDataAttributes } from './action/ToastActionDataAttributes';
+export { ToastArrowDataAttributes } from './arrow/ToastArrowDataAttributes';
+export { ToastCloseDataAttributes } from './close/ToastCloseDataAttributes';
+export { ToastContentDataAttributes } from './content/ToastContentDataAttributes';
+export { ToastDescriptionDataAttributes } from './description/ToastDescriptionDataAttributes';
+export { ToastPositionerDataAttributes } from './positioner/ToastPositionerDataAttributes';
+export { ToastRootDataAttributes } from './root/ToastRootDataAttributes';
+export { ToastTitleDataAttributes } from './title/ToastTitleDataAttributes';
+export { ToastViewportDataAttributes } from './viewport/ToastViewportDataAttributes';

--- a/packages/react/src/toggle-group/index.ts
+++ b/packages/react/src/toggle-group/index.ts
@@ -1,3 +1,5 @@
 export { ToggleGroup } from './ToggleGroup';
 
 export type * from './ToggleGroup';
+
+export { ToggleGroupDataAttributes } from './ToggleGroupDataAttributes';

--- a/packages/react/src/toggle/index.ts
+++ b/packages/react/src/toggle/index.ts
@@ -1,3 +1,5 @@
 export { Toggle } from './Toggle';
 
 export type * from './Toggle';
+
+export { ToggleDataAttributes } from './ToggleDataAttributes';

--- a/packages/react/src/toolbar/index.ts
+++ b/packages/react/src/toolbar/index.ts
@@ -7,3 +7,10 @@ export type * from './button/ToolbarButton';
 export type * from './link/ToolbarLink';
 export type * from './input/ToolbarInput';
 export type * from './separator/ToolbarSeparator';
+
+export { ToolbarButtonDataAttributes } from './button/ToolbarButtonDataAttributes';
+export { ToolbarGroupDataAttributes } from './group/ToolbarGroupDataAttributes';
+export { ToolbarInputDataAttributes } from './input/ToolbarInputDataAttributes';
+export { ToolbarLinkDataAttributes } from './link/ToolbarLinkDataAttributes';
+export { ToolbarRootDataAttributes } from './root/ToolbarRootDataAttributes';
+export { ToolbarSeparatorDataAttributes } from './separator/ToolbarSeparatorDataAttributes';

--- a/packages/react/src/tooltip/index.ts
+++ b/packages/react/src/tooltip/index.ts
@@ -8,3 +8,12 @@ export type * from './positioner/TooltipPositioner';
 export type * from './popup/TooltipPopup';
 export type * from './viewport/TooltipViewport';
 export type * from './arrow/TooltipArrow';
+
+export { TooltipPositionerCssVars } from './positioner/TooltipPositionerCssVars';
+export { TooltipViewportCssVars } from './viewport/TooltipViewportCssVars';
+
+export { TooltipArrowDataAttributes } from './arrow/TooltipArrowDataAttributes';
+export { TooltipPopupDataAttributes } from './popup/TooltipPopupDataAttributes';
+export { TooltipPositionerDataAttributes } from './positioner/TooltipPositionerDataAttributes';
+export { TooltipTriggerDataAttributes } from './trigger/TooltipTriggerDataAttributes';
+export { TooltipViewportDataAttributes } from './viewport/TooltipViewportDataAttributes';


### PR DESCRIPTION
Related to #5242 

35 components now export their `CssVariables`/`DataAttributes` constants publicly.

Includes component-specific aliases for borrowed Drawer and separator parts, a checked public export inventory with rendered-attribute tests, and a CSS-in-JS usage example in the styling handbook.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


---

### Tree-shaking and consumer cost

The barrel-export design was checked with production ESM consumer builds using the published packages at `f25fa280` (this PR) and `0c34027c` (#5608). For the latter, the comparison added its modern constant exports to the existing component barrels instead of requiring `/metadata` imports.

- **Vite 8.2.2:** adding the exports produced byte-identical output (**0 B parsed / gzip**) for selective `Dialog`, `Menu`, `Select`, and `Button` imports from the root/component entrypoints, retaining the `Dialog` component namespace, and statically accessing parts through a namespace import. Both the existing enums and modern constants passed these comparisons.
- **Next.js 16.3.4 App Router:** clean webpack and Turbopack production builds with the modern constants re-exported from the barrels produced byte-identical client JavaScript (**0 B parsed / gzip**). The fixture included Server and Client Component imports from root/component entrypoints. No custom `optimizePackageImports` configuration was used.

The bundle checker's default fixture imports and retains the entire entrypoint namespace (`import * as everything; console.log(everything)`), so all newly exported metadata survives. That case grew by **9,873 B gzip** for the modern constants at the root entrypoint. It does not represent the cost to consumers whose unused exports are tree-shaken. Likewise, summing overlapping entrypoint deltas into a total consumer cost is misleading; the loss of constant inlining reported in #5608 did not occur in the selective-import comparisons.

A separate Vite fixture, before the public `CssVariables` rename, retaining all 199 metadata namespaces (974 entries, including derived-component aliases) produced **8,688 B gzip** without any components. Much of the size is the retained public names, string values, and namespace getter/object machinery; it should not all be attributed to lost constant inlining. Accessing only `DialogPopupCssVariables.nestedDialogs` compiled to the literal string `"--nested-dialogs"` with no retained namespace object. A fresh build after the rename also confirmed that `DialogPopupDataAttributes.open` and the handwritten `"data-open"` literal produce byte-identical output. These are measured fixtures, not a fixed cost per application.

These zero-delta results apply to the tested production tree-shaken bundles. Unbundled Node ESM and CommonJS imports still evaluate the re-exported metadata modules, even when consumers select only a component; separate metadata subpaths would isolate that module-loading cost.

Separate `/metadata` subpaths are therefore unnecessary to protect the tested production client bundles. #5608 was closed in favor of this design. This PR has been rebased onto current master and updated to the current constants, with derived-component aliases and public export tests included. After completing the missing metadata exports, the selective Vite fixtures remain byte-identical; retaining the entire root entrypoint adds **10,037 B gzip**. The current public inventory contains 205 metadata namespace exports with 982 entries, including aliases. Public export tests passed in jsdom and Chromium, alongside the package build, TypeScript, ESLint, Stylelint, API generation, documentation snapshot, and formatting checks.
