### PR TITLE
[button][docs] Announce the loading state in the loading demo

### DIFF
--- a/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.module.css
@@ -62,3 +62,15 @@
     }
   }
 }
+
+.VisuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.module.css
@@ -62,15 +62,3 @@
     }
   }
 }
-
-.VisuallyHidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}

--- a/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.tsx
@@ -7,18 +7,23 @@ export default function ExampleButton() {
   const [loading, setLoading] = React.useState(false);
 
   return (
-    <Button
-      className={styles.Button}
-      disabled={loading}
-      focusableWhenDisabled
-      onClick={() => {
-        setLoading(true);
-        setTimeout(() => {
-          setLoading(false);
-        }, 4000);
-      }}
-    >
-      {loading ? 'Submitting' : 'Submit'}
-    </Button>
+    <React.Fragment>
+      <Button
+        className={styles.Button}
+        disabled={loading}
+        focusableWhenDisabled
+        onClick={() => {
+          setLoading(true);
+          setTimeout(() => {
+            setLoading(false);
+          }, 4000);
+        }}
+      >
+        {loading ? 'Submitting' : 'Submit'}
+      </Button>
+      <span role="status" className={styles.VisuallyHidden}>
+        {loading ? 'Submitting' : null}
+      </span>
+    </React.Fragment>
   );
 }

--- a/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.tsx
@@ -7,23 +7,19 @@ export default function ExampleButton() {
   const [loading, setLoading] = React.useState(false);
 
   return (
-    <React.Fragment>
-      <Button
-        className={styles.Button}
-        disabled={loading}
-        focusableWhenDisabled
-        onClick={() => {
-          setLoading(true);
-          setTimeout(() => {
-            setLoading(false);
-          }, 4000);
-        }}
-      >
-        {loading ? 'Submitting' : 'Submit'}
-      </Button>
-      <span role="status" className={styles.VisuallyHidden}>
-        {loading ? 'Submitting' : null}
-      </span>
-    </React.Fragment>
+    <Button
+      aria-live="polite"
+      className={styles.Button}
+      disabled={loading}
+      focusableWhenDisabled
+      onClick={() => {
+        setLoading(true);
+        setTimeout(() => {
+          setLoading(false);
+        }, 4000);
+      }}
+    >
+      {loading ? 'Submitting' : 'Submit'}
+    </Button>
   );
 }

--- a/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.tsx
@@ -7,23 +7,19 @@ export default function ExampleButton() {
   const [loading, setLoading] = React.useState(false);
 
   return (
-    <React.Fragment>
-      <Button
-        className={styles.Button}
-        disabled={loading}
-        focusableWhenDisabled
-        onClick={() => {
-          setLoading(true);
-          setTimeout(() => {
-            setLoading(false);
-          }, 4000);
-        }}
-      >
-        {loading ? 'Submitting' : 'Submit'}
-      </Button>
-      <span role="status" className={styles.VisuallyHidden}>
-        {loading ? 'Submitting' : null}
-      </span>
-    </React.Fragment>
+    <Button
+      className={styles.Button}
+      disabled={loading}
+      focusableWhenDisabled
+      aria-labelledby="label"
+      onClick={() => {
+        setLoading(true);
+        setTimeout(() => {
+          setLoading(false);
+        }, 4000);
+      }}
+    >
+      <span id="label">{loading ? 'Submitting' : 'Submit'}</span>
+    </Button>
   );
 }

--- a/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.tsx
@@ -7,19 +7,23 @@ export default function ExampleButton() {
   const [loading, setLoading] = React.useState(false);
 
   return (
-    <Button
-      aria-live="polite"
-      className={styles.Button}
-      disabled={loading}
-      focusableWhenDisabled
-      onClick={() => {
-        setLoading(true);
-        setTimeout(() => {
-          setLoading(false);
-        }, 4000);
-      }}
-    >
-      {loading ? 'Submitting' : 'Submit'}
-    </Button>
+    <React.Fragment>
+      <Button
+        className={styles.Button}
+        disabled={loading}
+        focusableWhenDisabled
+        onClick={() => {
+          setLoading(true);
+          setTimeout(() => {
+            setLoading(false);
+          }, 4000);
+        }}
+      >
+        {loading ? 'Submitting' : 'Submit'}
+      </Button>
+      <span role="status" className={styles.VisuallyHidden}>
+        {loading ? 'Submitting' : null}
+      </span>
+    </React.Fragment>
   );
 }

--- a/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/css-modules/index.tsx
@@ -5,13 +5,14 @@ import styles from './index.module.css';
 
 export default function ExampleButton() {
   const [loading, setLoading] = React.useState(false);
+  const labelId = React.useId();
 
   return (
     <Button
       className={styles.Button}
       disabled={loading}
       focusableWhenDisabled
-      aria-labelledby="label"
+      aria-labelledby={labelId}
       onClick={() => {
         setLoading(true);
         setTimeout(() => {
@@ -19,7 +20,7 @@ export default function ExampleButton() {
         }, 4000);
       }}
     >
-      <span id="label">{loading ? 'Submitting' : 'Submit'}</span>
+      <span id={labelId}>{loading ? 'Submitting' : 'Submit'}</span>
     </Button>
   );
 }

--- a/docs/src/app/(docs)/react/components/button/demos/loading/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/tailwind/index.tsx
@@ -6,18 +6,23 @@ export default function ExampleButton() {
   const [loading, setLoading] = React.useState(false);
 
   return (
-    <Button
-      className="flex h-8 items-center justify-center gap-2 rounded-none border border-neutral-950 bg-white px-3 text-sm leading-none whitespace-nowrap font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 active:not-data-disabled:bg-neutral-200 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-neutral-950 dark:focus-visible:outline-white data-disabled:border-neutral-500 data-disabled:text-neutral-500 disabled:border-neutral-500 disabled:text-neutral-500 dark:border-white dark:bg-neutral-950 dark:text-white dark:hover:not-data-disabled:bg-neutral-800 dark:active:not-data-disabled:bg-neutral-700 dark:data-disabled:border-neutral-400 dark:data-disabled:text-neutral-400"
-      disabled={loading}
-      focusableWhenDisabled
-      onClick={() => {
-        setLoading(true);
-        setTimeout(() => {
-          setLoading(false);
-        }, 4000);
-      }}
-    >
-      {loading ? 'Submitting' : 'Submit'}
-    </Button>
+    <React.Fragment>
+      <Button
+        className="flex h-8 items-center justify-center gap-2 rounded-none border border-neutral-950 bg-white px-3 text-sm leading-none whitespace-nowrap font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 active:not-data-disabled:bg-neutral-200 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-neutral-950 dark:focus-visible:outline-white data-disabled:border-neutral-500 data-disabled:text-neutral-500 disabled:border-neutral-500 disabled:text-neutral-500 dark:border-white dark:bg-neutral-950 dark:text-white dark:hover:not-data-disabled:bg-neutral-800 dark:active:not-data-disabled:bg-neutral-700 dark:data-disabled:border-neutral-400 dark:data-disabled:text-neutral-400"
+        disabled={loading}
+        focusableWhenDisabled
+        onClick={() => {
+          setLoading(true);
+          setTimeout(() => {
+            setLoading(false);
+          }, 4000);
+        }}
+      >
+        {loading ? 'Submitting' : 'Submit'}
+      </Button>
+      <span role="status" className="sr-only">
+        {loading ? 'Submitting' : null}
+      </span>
+    </React.Fragment>
   );
 }

--- a/docs/src/app/(docs)/react/components/button/demos/loading/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/tailwind/index.tsx
@@ -6,23 +6,19 @@ export default function ExampleButton() {
   const [loading, setLoading] = React.useState(false);
 
   return (
-    <React.Fragment>
-      <Button
-        className="flex h-8 items-center justify-center gap-2 rounded-none border border-neutral-950 bg-white px-3 text-sm leading-none whitespace-nowrap font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 active:not-data-disabled:bg-neutral-200 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-neutral-950 dark:focus-visible:outline-white data-disabled:border-neutral-500 data-disabled:text-neutral-500 disabled:border-neutral-500 disabled:text-neutral-500 dark:border-white dark:bg-neutral-950 dark:text-white dark:hover:not-data-disabled:bg-neutral-800 dark:active:not-data-disabled:bg-neutral-700 dark:data-disabled:border-neutral-400 dark:data-disabled:text-neutral-400"
-        disabled={loading}
-        focusableWhenDisabled
-        onClick={() => {
-          setLoading(true);
-          setTimeout(() => {
-            setLoading(false);
-          }, 4000);
-        }}
-      >
-        {loading ? 'Submitting' : 'Submit'}
-      </Button>
-      <span role="status" className="sr-only">
-        {loading ? 'Submitting' : null}
-      </span>
-    </React.Fragment>
+    <Button
+      aria-live="polite"
+      className="flex h-8 items-center justify-center gap-2 rounded-none border border-neutral-950 bg-white px-3 text-sm leading-none whitespace-nowrap font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 active:not-data-disabled:bg-neutral-200 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-neutral-950 dark:focus-visible:outline-white data-disabled:border-neutral-500 data-disabled:text-neutral-500 disabled:border-neutral-500 disabled:text-neutral-500 dark:border-white dark:bg-neutral-950 dark:text-white dark:hover:not-data-disabled:bg-neutral-800 dark:active:not-data-disabled:bg-neutral-700 dark:data-disabled:border-neutral-400 dark:data-disabled:text-neutral-400"
+      disabled={loading}
+      focusableWhenDisabled
+      onClick={() => {
+        setLoading(true);
+        setTimeout(() => {
+          setLoading(false);
+        }, 4000);
+      }}
+    >
+      {loading ? 'Submitting' : 'Submit'}
+    </Button>
   );
 }

--- a/docs/src/app/(docs)/react/components/button/demos/loading/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/tailwind/index.tsx
@@ -4,13 +4,14 @@ import { Button } from '@base-ui/react/button';
 
 export default function ExampleButton() {
   const [loading, setLoading] = React.useState(false);
+  const labelId = React.useId();
 
   return (
     <Button
       className="flex h-8 items-center justify-center gap-2 rounded-none border border-neutral-950 bg-white px-3 text-sm leading-none whitespace-nowrap font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 active:not-data-disabled:bg-neutral-200 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-neutral-950 dark:focus-visible:outline-white data-disabled:border-neutral-500 data-disabled:text-neutral-500 disabled:border-neutral-500 disabled:text-neutral-500 dark:border-white dark:bg-neutral-950 dark:text-white dark:hover:not-data-disabled:bg-neutral-800 dark:active:not-data-disabled:bg-neutral-700 dark:data-disabled:border-neutral-400 dark:data-disabled:text-neutral-400"
       disabled={loading}
       focusableWhenDisabled
-      aria-labelledby="label"
+      aria-labelledby={labelId}
       onClick={() => {
         setLoading(true);
         setTimeout(() => {
@@ -18,7 +19,7 @@ export default function ExampleButton() {
         }, 4000);
       }}
     >
-      <span id="label">{loading ? 'Submitting' : 'Submit'}</span>
+      <span id={labelId}>{loading ? 'Submitting' : 'Submit'}</span>
     </Button>
   );
 }

--- a/docs/src/app/(docs)/react/components/button/demos/loading/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/tailwind/index.tsx
@@ -6,19 +6,23 @@ export default function ExampleButton() {
   const [loading, setLoading] = React.useState(false);
 
   return (
-    <Button
-      aria-live="polite"
-      className="flex h-8 items-center justify-center gap-2 rounded-none border border-neutral-950 bg-white px-3 text-sm leading-none whitespace-nowrap font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 active:not-data-disabled:bg-neutral-200 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-neutral-950 dark:focus-visible:outline-white data-disabled:border-neutral-500 data-disabled:text-neutral-500 disabled:border-neutral-500 disabled:text-neutral-500 dark:border-white dark:bg-neutral-950 dark:text-white dark:hover:not-data-disabled:bg-neutral-800 dark:active:not-data-disabled:bg-neutral-700 dark:data-disabled:border-neutral-400 dark:data-disabled:text-neutral-400"
-      disabled={loading}
-      focusableWhenDisabled
-      onClick={() => {
-        setLoading(true);
-        setTimeout(() => {
-          setLoading(false);
-        }, 4000);
-      }}
-    >
-      {loading ? 'Submitting' : 'Submit'}
-    </Button>
+    <React.Fragment>
+      <Button
+        className="flex h-8 items-center justify-center gap-2 rounded-none border border-neutral-950 bg-white px-3 text-sm leading-none whitespace-nowrap font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 active:not-data-disabled:bg-neutral-200 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-neutral-950 dark:focus-visible:outline-white data-disabled:border-neutral-500 data-disabled:text-neutral-500 disabled:border-neutral-500 disabled:text-neutral-500 dark:border-white dark:bg-neutral-950 dark:text-white dark:hover:not-data-disabled:bg-neutral-800 dark:active:not-data-disabled:bg-neutral-700 dark:data-disabled:border-neutral-400 dark:data-disabled:text-neutral-400"
+        disabled={loading}
+        focusableWhenDisabled
+        onClick={() => {
+          setLoading(true);
+          setTimeout(() => {
+            setLoading(false);
+          }, 4000);
+        }}
+      >
+        {loading ? 'Submitting' : 'Submit'}
+      </Button>
+      <span role="status" className="sr-only">
+        {loading ? 'Submitting' : null}
+      </span>
+    </React.Fragment>
   );
 }

--- a/docs/src/app/(docs)/react/components/button/demos/loading/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/button/demos/loading/tailwind/index.tsx
@@ -6,23 +6,19 @@ export default function ExampleButton() {
   const [loading, setLoading] = React.useState(false);
 
   return (
-    <React.Fragment>
-      <Button
-        className="flex h-8 items-center justify-center gap-2 rounded-none border border-neutral-950 bg-white px-3 text-sm leading-none whitespace-nowrap font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 active:not-data-disabled:bg-neutral-200 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-neutral-950 dark:focus-visible:outline-white data-disabled:border-neutral-500 data-disabled:text-neutral-500 disabled:border-neutral-500 disabled:text-neutral-500 dark:border-white dark:bg-neutral-950 dark:text-white dark:hover:not-data-disabled:bg-neutral-800 dark:active:not-data-disabled:bg-neutral-700 dark:data-disabled:border-neutral-400 dark:data-disabled:text-neutral-400"
-        disabled={loading}
-        focusableWhenDisabled
-        onClick={() => {
-          setLoading(true);
-          setTimeout(() => {
-            setLoading(false);
-          }, 4000);
-        }}
-      >
-        {loading ? 'Submitting' : 'Submit'}
-      </Button>
-      <span role="status" className="sr-only">
-        {loading ? 'Submitting' : null}
-      </span>
-    </React.Fragment>
+    <Button
+      className="flex h-8 items-center justify-center gap-2 rounded-none border border-neutral-950 bg-white px-3 text-sm leading-none whitespace-nowrap font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 active:not-data-disabled:bg-neutral-200 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-neutral-950 dark:focus-visible:outline-white data-disabled:border-neutral-500 data-disabled:text-neutral-500 disabled:border-neutral-500 disabled:text-neutral-500 dark:border-white dark:bg-neutral-950 dark:text-white dark:hover:not-data-disabled:bg-neutral-800 dark:active:not-data-disabled:bg-neutral-700 dark:data-disabled:border-neutral-400 dark:data-disabled:text-neutral-400"
+      disabled={loading}
+      focusableWhenDisabled
+      aria-labelledby="label"
+      onClick={() => {
+        setLoading(true);
+        setTimeout(() => {
+          setLoading(false);
+        }, 4000);
+      }}
+    >
+      <span id="label">{loading ? 'Submitting' : 'Submit'}</span>
+    </Button>
   );
 }

--- a/docs/src/app/(docs)/react/components/button/page.mdx
+++ b/docs/src/app/(docs)/react/components/button/page.mdx
@@ -50,7 +50,7 @@ If a link needs to look like a button visually, style the `<a>` element directly
 
 ### Loading states
 
-For buttons that enter a loading state after activation, specify `focusableWhenDisabled` so focus remains on the button while it is disabled. Because some browser and screen reader combinations do not reliably announce changes to a focused button's descendant text, use [`aria-labelledby`](https://www.w3.org/TR/wai-aria-1.2/#aria-labelledby) to make the changing text the button's explicit accessible name.
+For buttons that enter a loading state after activation, specify `focusableWhenDisabled` so focus remains on the button while it is disabled. Because some browser and screen reader combinations do not reliably announce changes to a focused button's descendant text, use [`aria-labelledby`](https://www.w3.org/TR/accname-1.2/#computation-steps) to make the changing text the button's explicit accessible name.
 
 import { DemoButtonLoading } from './demos/loading';
 

--- a/docs/src/app/(docs)/react/components/button/page.mdx
+++ b/docs/src/app/(docs)/react/components/button/page.mdx
@@ -50,7 +50,7 @@ If a link needs to look like a button visually, style the `<a>` element directly
 
 ### Loading states
 
-For buttons that enter a loading state after being clicked, specify the `focusableWhenDisabled` prop to ensure focus remains on the button when it becomes disabled. This prevents focus from being lost and maintains the tab order.
+For buttons that enter a loading state after activation, specify `focusableWhenDisabled` so focus remains on the button while it is disabled. Because some browser and screen reader combinations do not reliably announce changes to a focused button's descendant text, use [`aria-labelledby`](https://www.w3.org/TR/wai-aria-1.2/#aria-labelledby) to make the changing text the button's explicit accessible name.
 
 import { DemoButtonLoading } from './demos/loading';
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #4249

The loading demo swaps its label from Submit to Submitting, but NVDA announces only "unavailable" when the button becomes disabled — the label change itself is never spoken.

This PR makes the changing label the button's explicit accessible name: the label text is wrapped in a `<span>` with an id (from `React.useId()`) that the button references via `aria-labelledby`. Per the [accessible name computation](https://www.w3.org/TR/accname-1.2/#computation-steps), the label swap then surfaces as a name change on the focused button, which screen readers announce — see [the NVDA Speech Viewer output](https://github.com/mui/base-ui/pull/5246#issuecomment-5493155836) for this approach.

Earlier revisions of this PR tried two other mechanisms, both abandoned:

- A visually hidden sibling `role="status"` region mirroring the loading state. It works and is the common ecosystem pattern, but it needs an extra element plus CSS, and clearing the region at the end of loading is not announced, so completion stayed silent.
- `aria-live="polite"` on the button itself. Testing on NVDA + Chrome (Assistiv Labs) confirmed it announces both transitions, but every announcement was doubled ("Submitting, Submitting"), and there is no precedent for rooting a live region on an interactive control.

The Loading states section in `page.mdx` now explains the pattern and links the spec. Both demo variants updated.
