### PR TITLE
[autocomplete][docs] Clarify that the item value type constraint is unconditional

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/page.mdx
+++ b/docs/src/app/(docs)/react/components/autocomplete/page.mdx
@@ -63,7 +63,7 @@ import { Autocomplete } from '@base-ui/react/autocomplete';
 ## TypeScript inference
 
 Autocomplete infers the item type from the `items` prop passed to `<Autocomplete.Root>`.
-If using `itemToStringValue`, the value prop on the `<Autocomplete.Item>` must match the type of an item in the `items` array.
+The `value` prop on `<Autocomplete.Item>` must match the type of an item in the `items` array, which also ensures that props like `itemToStringValue` infer the correct item type.
 
 ## Examples
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #3853

The TypeScript inference section implied the `value` prop constraint only applies when using `itemToStringValue`; it always applies. Reworded to state the constraint unconditionally and tie `itemToStringValue` to type inference rather than display behaviour, following the discussion in the issue.
