### PR TITLE
[all components] Reduce selector bundle size

### DIFF
--- a/packages/react/src/combobox/store.ts
+++ b/packages/react/src/combobox/store.ts
@@ -1,4 +1,4 @@
-import { Store, createSelector } from '@base-ui/utils/store';
+import { Store } from '@base-ui/utils/store';
 import type { InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import type { TransitionStatus } from '../internals/useTransitionStatus';
 import type { HTMLProps } from '../internals/types';
@@ -91,18 +91,18 @@ export type State = {
 export type ComboboxStore = Store<State>;
 
 export const selectors = {
-  id: createSelector((state: State) => state.id),
-  labelId: createSelector((state: State) => state.labelId),
+  id: (state: State) => state.id,
+  labelId: (state: State) => state.labelId,
 
-  items: createSelector((state: State) => state.items),
+  items: (state: State) => state.items,
 
-  selectedValue: createSelector((state: State) => state.selectedValue),
-  hasSelectionChips: createSelector((state: State) => {
+  selectedValue: (state: State) => state.selectedValue,
+  hasSelectionChips: (state: State) => {
     const selectedValue = state.selectedValue;
     return Array.isArray(selectedValue) && selectedValue.length > 0;
-  }),
+  },
 
-  hasSelectedValue: createSelector((state: State) => {
+  hasSelectedValue: (state: State) => {
     const { selectedValue, selectionMode } = state;
     if (selectedValue == null) {
       return false;
@@ -111,22 +111,22 @@ export const selectors = {
       return selectedValue.length > 0;
     }
     return true;
-  }),
+  },
 
-  hasNullItemLabel: createSelector((state: State, enabled: boolean) => {
+  hasNullItemLabel: (state: State, enabled: boolean) => {
     return enabled ? hasNullItemLabel(state.items) : false;
-  }),
+  },
 
-  open: createSelector((state: State) => state.open),
-  mounted: createSelector((state: State) => state.mounted),
-  forceMounted: createSelector((state: State) => state.forceMounted),
+  open: (state: State) => state.open,
+  mounted: (state: State) => state.mounted,
+  forceMounted: (state: State) => state.forceMounted,
 
-  inline: createSelector((state: State) => state.inline),
+  inline: (state: State) => state.inline,
 
-  activeIndex: createSelector((state: State) => state.activeIndex),
-  selectedIndex: createSelector((state: State) => state.selectedIndex),
-  isActive: createSelector((state: State, index: number) => state.activeIndex === index),
-  isSelected: createSelector((state: State, itemValue: any) => {
+  activeIndex: (state: State) => state.activeIndex,
+  selectedIndex: (state: State) => state.selectedIndex,
+  isActive: (state: State, index: number) => state.activeIndex === index,
+  isSelected: (state: State, itemValue: any) => {
     const comparer = state.isItemEqualToValue;
     const selectedValue = state.selectedValue;
     if (Array.isArray(selectedValue)) {
@@ -135,39 +135,39 @@ export const selectors = {
       );
     }
     return compareItemEquality(itemValue, selectedValue, comparer);
-  }),
+  },
 
-  transitionStatus: createSelector((state: State) => state.transitionStatus),
+  transitionStatus: (state: State) => state.transitionStatus,
 
-  popupProps: createSelector((state: State) => state.popupProps),
-  inputProps: createSelector((state: State) => state.inputProps),
-  triggerProps: createSelector((state: State) => state.triggerProps),
-  itemProps: createSelector((state: State) => state.itemProps),
+  popupProps: (state: State) => state.popupProps,
+  inputProps: (state: State) => state.inputProps,
+  triggerProps: (state: State) => state.triggerProps,
+  itemProps: (state: State) => state.itemProps,
 
-  positionerElement: createSelector((state: State) => state.positionerElement),
-  listElement: createSelector((state: State) => state.listElement),
-  popupId: createSelector((state: State) => state.popupId),
-  triggerElement: createSelector((state: State) => state.triggerElement),
-  inputElement: createSelector((state: State) => state.inputElement),
-  inputGroupElement: createSelector((state: State) => state.inputGroupElement),
-  popupSide: createSelector((state: State) => state.popupSide),
+  positionerElement: (state: State) => state.positionerElement,
+  listElement: (state: State) => state.listElement,
+  popupId: (state: State) => state.popupId,
+  triggerElement: (state: State) => state.triggerElement,
+  inputElement: (state: State) => state.inputElement,
+  inputGroupElement: (state: State) => state.inputGroupElement,
+  popupSide: (state: State) => state.popupSide,
 
-  openMethod: createSelector((state: State) => state.openMethod),
+  openMethod: (state: State) => state.openMethod,
 
-  inputInsidePopup: createSelector((state: State) => state.inputInsidePopup),
-  inputOwnsFormValue: createSelector((state: State) => state.inputOwnsFormValue),
+  inputInsidePopup: (state: State) => state.inputInsidePopup,
+  inputOwnsFormValue: (state: State) => state.inputOwnsFormValue,
 
-  selectionMode: createSelector((state: State) => state.selectionMode),
+  selectionMode: (state: State) => state.selectionMode,
 
-  name: createSelector((state: State) => state.name),
-  form: createSelector((state: State) => state.form),
-  disabled: createSelector((state: State) => state.disabled),
-  readOnly: createSelector((state: State) => state.readOnly),
-  required: createSelector((state: State) => state.required),
-  grid: createSelector((state: State) => state.grid),
-  virtualized: createSelector((state: State) => state.virtualized),
-  itemToStringLabel: createSelector((state: State) => state.itemToStringLabel),
-  isItemEqualToValue: createSelector((state: State) => state.isItemEqualToValue),
-  modal: createSelector((state: State) => state.modal),
-  autoHighlight: createSelector((state: State) => state.autoHighlight),
+  name: (state: State) => state.name,
+  form: (state: State) => state.form,
+  disabled: (state: State) => state.disabled,
+  readOnly: (state: State) => state.readOnly,
+  required: (state: State) => state.required,
+  grid: (state: State) => state.grid,
+  virtualized: (state: State) => state.virtualized,
+  itemToStringLabel: (state: State) => state.itemToStringLabel,
+  isItemEqualToValue: (state: State) => state.isItemEqualToValue,
+  modal: (state: State) => state.modal,
+  autoHighlight: (state: State) => state.autoHighlight,
 };

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createSelector, ReactStore } from '@base-ui/utils/store';
+import { ReactStore } from '@base-ui/utils/store';
 import { type InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import { type DialogRoot } from '../root/DialogRoot';
 import { NullStore } from '../../utils/NullStore';
@@ -37,16 +37,16 @@ type Context = PopupStoreContext<DialogRoot.ChangeEventDetails> & {
 
 const selectors = {
   ...popupStoreSelectors,
-  modal: createSelector((state: State<unknown>) => state.modal),
-  nested: createSelector((state: State<unknown>) => state.nested),
-  nestedOpenDialogCount: createSelector((state: State<unknown>) => state.nestedOpenDialogCount),
-  nestedOpenDrawerCount: createSelector((state: State<unknown>) => state.nestedOpenDrawerCount),
-  disablePointerDismissal: createSelector((state: State<unknown>) => state.disablePointerDismissal),
-  openMethod: createSelector((state: State<unknown>) => state.openMethod),
-  descriptionElementId: createSelector((state: State<unknown>) => state.descriptionElementId),
-  titleElementId: createSelector((state: State<unknown>) => state.titleElementId),
-  viewportElement: createSelector((state: State<unknown>) => state.viewportElement),
-  role: createSelector((state: State<unknown>) => state.role),
+  modal: (state: State<unknown>) => state.modal,
+  nested: (state: State<unknown>) => state.nested,
+  nestedOpenDialogCount: (state: State<unknown>) => state.nestedOpenDialogCount,
+  nestedOpenDrawerCount: (state: State<unknown>) => state.nestedOpenDrawerCount,
+  disablePointerDismissal: (state: State<unknown>) => state.disablePointerDismissal,
+  openMethod: (state: State<unknown>) => state.openMethod,
+  descriptionElementId: (state: State<unknown>) => state.descriptionElementId,
+  titleElementId: (state: State<unknown>) => state.titleElementId,
+  viewportElement: (state: State<unknown>) => state.viewportElement,
+  role: (state: State<unknown>) => state.role,
 };
 
 /**

--- a/packages/react/src/floating-ui-react/components/FloatingRootStore.ts
+++ b/packages/react/src/floating-ui-react/components/FloatingRootStore.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createSelector, ReactStore } from '@base-ui/utils/store';
+import { ReactStore } from '@base-ui/utils/store';
 import type { FloatingEvents, ContextData, ReferenceType } from '../types';
 import { type BaseUIChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { createEventEmitter } from '../utils/createEventEmitter';
@@ -32,14 +32,12 @@ export interface FloatingRootStoreContext {
 }
 
 const selectors = {
-  open: createSelector((state: FloatingRootState) => state.open),
-  transitionStatus: createSelector((state: FloatingRootState) => state.transitionStatus),
-  domReferenceElement: createSelector((state: FloatingRootState) => state.domReferenceElement),
-  referenceElement: createSelector(
-    (state: FloatingRootState) => state.positionReference ?? state.referenceElement,
-  ),
-  floatingElement: createSelector((state: FloatingRootState) => state.floatingElement),
-  floatingId: createSelector((state: FloatingRootState) => state.floatingId),
+  open: (state: FloatingRootState) => state.open,
+  transitionStatus: (state: FloatingRootState) => state.transitionStatus,
+  domReferenceElement: (state: FloatingRootState) => state.domReferenceElement,
+  referenceElement: (state: FloatingRootState) => state.positionReference ?? state.referenceElement,
+  floatingElement: (state: FloatingRootState) => state.floatingElement,
+  floatingId: (state: FloatingRootState) => state.floatingId,
 };
 
 interface FloatingRootStoreOptions {

--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createSelector, ReactStore } from '@base-ui/utils/store';
+import { ReactStore } from '@base-ui/utils/store';
 import { EMPTY_OBJECT, NOOP } from '@base-ui/utils/empty';
 import type { InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import { MenuParent, MenuRoot } from '../root/MenuRoot';
@@ -50,62 +50,54 @@ type Context = PopupStoreContext<MenuRoot.ChangeEventDetails> & {
 
 const selectors = {
   ...popupStoreSelectors,
-  disabled: createSelector((state: State<unknown>) =>
+  disabled: (state: State<unknown>) =>
     state.parent.type === 'menubar'
       ? state.parent.context.disabled || state.disabled
       : state.disabled,
-  ),
-  modal: createSelector(
-    (state: State<unknown>) =>
-      (state.parent.type === undefined || state.parent.type === 'context-menu') &&
-      (state.modal ?? true),
-  ),
-  openMethod: createSelector((state: State<unknown>) => state.openMethod),
+  modal: (state: State<unknown>) =>
+    (state.parent.type === undefined || state.parent.type === 'context-menu') &&
+    (state.modal ?? true),
+  openMethod: (state: State<unknown>) => state.openMethod,
 
-  allowMouseEnter: createSelector((state: State<unknown>) => state.allowMouseEnter),
-  highlightItemOnHover: createSelector((state: State<unknown>) => state.highlightItemOnHover),
-  parent: createSelector((state: State<unknown>) => state.parent),
-  rootId: createSelector((state: State<unknown>): string | undefined => {
+  allowMouseEnter: (state: State<unknown>) => state.allowMouseEnter,
+  highlightItemOnHover: (state: State<unknown>) => state.highlightItemOnHover,
+  parent: (state: State<unknown>) => state.parent,
+  rootId: (state: State<unknown>): string | undefined => {
     if (state.parent.type === 'menu') {
       return state.parent.store.select('rootId');
     }
 
     return state.parent.type !== undefined ? state.parent.context.rootId : state.rootId;
-  }),
-  activeIndex: createSelector((state: State<unknown>) => state.activeIndex),
-  isActive: createSelector(
-    (state: State<unknown>, itemIndex: number) => state.activeIndex === itemIndex,
-  ),
-  hoverEnabled: createSelector((state: State<unknown>) => state.hoverEnabled),
-  instantType: createSelector((state: State<unknown>) => state.instantType),
-  lastOpenChangeReason: createSelector((state: State<unknown>) => state.openChangeReason),
-  floatingTreeRoot: createSelector((state: State<unknown>): FloatingTreeStore => {
+  },
+  activeIndex: (state: State<unknown>) => state.activeIndex,
+  isActive: (state: State<unknown>, itemIndex: number) => state.activeIndex === itemIndex,
+  hoverEnabled: (state: State<unknown>) => state.hoverEnabled,
+  instantType: (state: State<unknown>) => state.instantType,
+  lastOpenChangeReason: (state: State<unknown>) => state.openChangeReason,
+  floatingTreeRoot: (state: State<unknown>): FloatingTreeStore => {
     if (state.parent.type === 'menu') {
       return state.parent.store.select('floatingTreeRoot');
     }
 
     return state.floatingTreeRoot;
-  }),
-  floatingNodeId: createSelector((state: State<unknown>) => state.floatingNodeId),
-  floatingParentNodeId: createSelector((state: State<unknown>) => state.floatingParentNodeId),
-  itemProps: createSelector((state: State<unknown>) => state.itemProps),
-  closeDelay: createSelector((state: State<unknown>) => state.closeDelay),
-  adaptiveOrigin: createSelector(
-    (state: State<unknown>): AdaptiveOriginMiddleware | undefined => state.adaptiveOrigin,
-  ),
-  keyboardEventRelay: createSelector(
-    (state: State<unknown>): React.KeyboardEventHandler<any> | undefined => {
-      if (state.keyboardEventRelay) {
-        return state.keyboardEventRelay;
-      }
+  },
+  floatingNodeId: (state: State<unknown>) => state.floatingNodeId,
+  floatingParentNodeId: (state: State<unknown>) => state.floatingParentNodeId,
+  itemProps: (state: State<unknown>) => state.itemProps,
+  closeDelay: (state: State<unknown>) => state.closeDelay,
+  adaptiveOrigin: (state: State<unknown>): AdaptiveOriginMiddleware | undefined =>
+    state.adaptiveOrigin,
+  keyboardEventRelay: (state: State<unknown>): React.KeyboardEventHandler<any> | undefined => {
+    if (state.keyboardEventRelay) {
+      return state.keyboardEventRelay;
+    }
 
-      if (state.parent.type === 'menu') {
-        return state.parent.store.select('keyboardEventRelay');
-      }
+    if (state.parent.type === 'menu') {
+      return state.parent.store.select('keyboardEventRelay');
+    }
 
-      return undefined;
-    },
-  ),
+    return undefined;
+  },
 };
 
 type Selectors = typeof selectors;

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { ReactStore, createSelector } from '@base-ui/utils/store';
+import { ReactStore } from '@base-ui/utils/store';
 import { Timeout } from '@base-ui/utils/useTimeout';
 import { NOOP } from '@base-ui/utils/empty';
 import { type InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
@@ -46,20 +46,19 @@ type Context = PopupStoreContext<PopoverRoot.ChangeEventDetails> & {
 
 const selectors = {
   ...popupStoreSelectors,
-  disabled: createSelector((state: State<unknown>) => state.disabled),
-  instantType: createSelector((state: State<unknown>) => state.instantType),
-  openMethod: createSelector((state: State<unknown>) => state.openMethod),
-  openChangeReason: createSelector((state: State<unknown>) => state.openChangeReason),
-  modal: createSelector((state: State<unknown>) => state.modal),
-  focusManagerModal: createSelector((state: State<unknown>) => state.focusManagerModal),
-  stickIfOpen: createSelector((state: State<unknown>) => state.stickIfOpen),
-  titleElementId: createSelector((state: State<unknown>) => state.titleElementId),
-  descriptionElementId: createSelector((state: State<unknown>) => state.descriptionElementId),
-  openOnHover: createSelector((state: State<unknown>) => state.openOnHover),
-  closeDelay: createSelector((state: State<unknown>) => state.closeDelay),
-  adaptiveOrigin: createSelector(
-    (state: State<unknown>): AdaptiveOriginMiddleware | undefined => state.adaptiveOrigin,
-  ),
+  disabled: (state: State<unknown>) => state.disabled,
+  instantType: (state: State<unknown>) => state.instantType,
+  openMethod: (state: State<unknown>) => state.openMethod,
+  openChangeReason: (state: State<unknown>) => state.openChangeReason,
+  modal: (state: State<unknown>) => state.modal,
+  focusManagerModal: (state: State<unknown>) => state.focusManagerModal,
+  stickIfOpen: (state: State<unknown>) => state.stickIfOpen,
+  titleElementId: (state: State<unknown>) => state.titleElementId,
+  descriptionElementId: (state: State<unknown>) => state.descriptionElementId,
+  openOnHover: (state: State<unknown>) => state.openOnHover,
+  closeDelay: (state: State<unknown>) => state.closeDelay,
+  adaptiveOrigin: (state: State<unknown>): AdaptiveOriginMiddleware | undefined =>
+    state.adaptiveOrigin,
 };
 
 type Selectors = typeof selectors;

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createSelector, ReactStore } from '@base-ui/utils/store';
+import { ReactStore } from '@base-ui/utils/store';
 import {
   applyPopupOpenChange,
   createPopupFloatingRootContext,
@@ -30,11 +30,10 @@ export type Context = PopupStoreContext<PreviewCardRoot.ChangeEventDetails> & {
 
 const selectors = {
   ...popupStoreSelectors,
-  instantType: createSelector((state: State<unknown>) => state.instantType),
-  adaptiveOrigin: createSelector(
-    (state: State<unknown>): AdaptiveOriginMiddleware | undefined => state.adaptiveOrigin,
-  ),
-  closeDelay: createSelector((state: State<unknown>) => state.closeDelay),
+  instantType: (state: State<unknown>) => state.instantType,
+  adaptiveOrigin: (state: State<unknown>): AdaptiveOriginMiddleware | undefined =>
+    state.adaptiveOrigin,
+  closeDelay: (state: State<unknown>) => state.closeDelay,
 };
 
 type Selectors = typeof selectors;

--- a/packages/react/src/select/store.ts
+++ b/packages/react/src/select/store.ts
@@ -1,4 +1,4 @@
-import { ReactStore, createSelector } from '@base-ui/utils/store';
+import { ReactStore } from '@base-ui/utils/store';
 import { type InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import type { TransitionStatus } from '../internals/useTransitionStatus';
 import type { HTMLProps } from '../internals/types';
@@ -48,17 +48,17 @@ export type State = {
 export type SelectStore = ReactStore<State>;
 
 export const selectors = {
-  id: createSelector((state: State) => state.id),
-  labelId: createSelector((state: State) => state.labelId),
-  modal: createSelector((state: State) => state.modal),
+  id: (state: State) => state.id,
+  labelId: (state: State) => state.labelId,
+  modal: (state: State) => state.modal,
 
-  items: createSelector((state: State) => state.items),
-  itemToStringLabel: createSelector((state: State) => state.itemToStringLabel),
-  isItemEqualToValue: createSelector((state: State) => state.isItemEqualToValue),
+  items: (state: State) => state.items,
+  itemToStringLabel: (state: State) => state.itemToStringLabel,
+  isItemEqualToValue: (state: State) => state.isItemEqualToValue,
 
-  value: createSelector((state: State) => state.value),
+  value: (state: State) => state.value,
 
-  hasSelectedValue: createSelector((state: State) => {
+  hasSelectedValue: (state: State) => {
     const { value, multiple, itemToStringValue } = state;
     if (value == null) {
       return false;
@@ -68,23 +68,23 @@ export const selectors = {
     }
 
     return stringifyAsValue(value, itemToStringValue) !== '';
-  }),
+  },
 
-  hasNullItemLabel: createSelector((state: State, enabled: boolean) => {
+  hasNullItemLabel: (state: State, enabled: boolean) => {
     return enabled ? hasNullItemLabel(state.items) : false;
-  }),
+  },
 
-  open: createSelector((state: State) => state.open),
-  mounted: createSelector((state: State) => state.mounted),
-  forceMount: createSelector((state: State) => state.forceMount),
-  transitionStatus: createSelector((state: State) => state.transitionStatus),
-  openMethod: createSelector((state: State) => state.openMethod),
+  open: (state: State) => state.open,
+  mounted: (state: State) => state.mounted,
+  forceMount: (state: State) => state.forceMount,
+  transitionStatus: (state: State) => state.transitionStatus,
+  openMethod: (state: State) => state.openMethod,
 
-  activeIndex: createSelector((state: State) => state.activeIndex),
-  selectedIndex: createSelector((state: State) => state.selectedIndex),
-  isActive: createSelector((state: State, index: number) => state.activeIndex === index),
+  activeIndex: (state: State) => state.activeIndex,
+  selectedIndex: (state: State) => state.selectedIndex,
+  isActive: (state: State, index: number) => state.activeIndex === index,
 
-  isSelected: createSelector((state: State, itemValue: any) => {
+  isSelected: (state: State, itemValue: any) => {
     const comparer = state.isItemEqualToValue;
     const storeValue = state.value;
 
@@ -99,20 +99,20 @@ export const selectors = {
     // value changes while the popup is open, where the index sync is deferred) must not
     // keep a previously selected item marked as selected.
     return compareItemEquality(itemValue, storeValue, comparer);
-  }),
-  isSelectedByFocus: createSelector((state: State, index: number) => {
+  },
+  isSelectedByFocus: (state: State, index: number) => {
     return state.selectedIndex === index;
-  }),
+  },
 
-  popupProps: createSelector((state: State) => state.popupProps),
-  triggerProps: createSelector((state: State) => state.triggerProps),
-  triggerElement: createSelector((state: State) => state.triggerElement),
-  positionerElement: createSelector((state: State) => state.positionerElement),
-  listElement: createSelector((state: State) => state.listElement),
-  popupSide: createSelector((state: State) => state.popupSide),
+  popupProps: (state: State) => state.popupProps,
+  triggerProps: (state: State) => state.triggerProps,
+  triggerElement: (state: State) => state.triggerElement,
+  positionerElement: (state: State) => state.positionerElement,
+  listElement: (state: State) => state.listElement,
+  popupSide: (state: State) => state.popupSide,
 
-  scrollUpArrowVisible: createSelector((state: State) => state.scrollUpArrowVisible),
-  scrollDownArrowVisible: createSelector((state: State) => state.scrollDownArrowVisible),
+  scrollUpArrowVisible: (state: State) => state.scrollUpArrowVisible,
+  scrollDownArrowVisible: (state: State) => state.scrollDownArrowVisible,
 
-  hasScrollArrows: createSelector((state: State) => state.hasScrollArrows),
+  hasScrollArrows: (state: State) => state.hasScrollArrows,
 };

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -1,4 +1,4 @@
-import { ReactStore, createSelector } from '@base-ui/utils/store';
+import { ReactStore } from '@base-ui/utils/store';
 import { generateId } from '@base-ui/utils/generateId';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { Timeout } from '@base-ui/utils/useTimeout';
@@ -83,33 +83,17 @@ function applyLimited(toasts: StoredToast[], limit: number): StoredToast[] {
   });
 }
 
-const toastMetadataSelector = (state: State) => state.toastMetadata;
-
 export const selectors = {
-  toasts: createSelector((state: State) => state.toasts),
-  isEmpty: createSelector((state: State) => state.toasts.length === 0),
-  toast: createSelector(
-    toastMetadataSelector,
-    (toastMetadata, id: string) => toastMetadata.get(id)?.value,
-  ),
-  toastIndex: createSelector(
-    toastMetadataSelector,
-    (toastMetadata, id: string) => toastMetadata.get(id)?.domIndex ?? -1,
-  ),
-  toastOffsetY: createSelector(
-    toastMetadataSelector,
-    (toastMetadata, id: string) => toastMetadata.get(id)?.offsetY ?? 0,
-  ),
-  toastVisibleIndex: createSelector(
-    toastMetadataSelector,
-    (toastMetadata, id: string) => toastMetadata.get(id)?.visibleIndex ?? -1,
-  ),
-  focused: createSelector((state: State) => state.focused),
-  expanded: createSelector((state: State) => state.hovering || state.focused),
-  expandedOrOutOfFocus: createSelector(
-    (state: State) => state.hovering || state.focused || !state.isWindowFocused,
-  ),
-  prevFocusElement: createSelector((state: State) => state.prevFocusElement),
+  toasts: (state: State) => state.toasts,
+  isEmpty: (state: State) => state.toasts.length === 0,
+  toast: (state: State, id: string) => state.toastMetadata.get(id)?.value,
+  toastIndex: (state: State, id: string) => state.toastMetadata.get(id)?.domIndex ?? -1,
+  toastOffsetY: (state: State, id: string) => state.toastMetadata.get(id)?.offsetY ?? 0,
+  toastVisibleIndex: (state: State, id: string) => state.toastMetadata.get(id)?.visibleIndex ?? -1,
+  focused: (state: State) => state.focused,
+  expanded: (state: State) => state.hovering || state.focused,
+  expandedOrOutOfFocus: (state: State) => state.hovering || state.focused || !state.isWindowFocused,
+  prevFocusElement: (state: State) => state.prevFocusElement,
 };
 
 export class ToastStore extends ReactStore<State, {}, typeof selectors> {

--- a/packages/react/src/tooltip/store/TooltipStore.ts
+++ b/packages/react/src/tooltip/store/TooltipStore.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createSelector, ReactStore } from '@base-ui/utils/store';
+import { ReactStore } from '@base-ui/utils/store';
 import { NOOP } from '@base-ui/utils/empty';
 import { type TooltipRoot } from '../root/TooltipRoot';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
@@ -35,17 +35,16 @@ export type Context = PopupStoreContext<TooltipRoot.ChangeEventDetails> & {
 
 const selectors = {
   ...popupStoreSelectors,
-  disabled: createSelector((state: State<unknown>) => state.disabled),
-  instantType: createSelector((state: State<unknown>) => state.instantType),
-  isInstantPhase: createSelector((state: State<unknown>) => state.isInstantPhase),
-  trackCursorAxis: createSelector((state: State<unknown>) => state.trackCursorAxis),
-  disableHoverablePopup: createSelector((state: State<unknown>) => state.disableHoverablePopup),
-  lastOpenChangeReason: createSelector((state: State<unknown>) => state.openChangeReason),
-  closeOnClick: createSelector((state: State<unknown>) => state.closeOnClick),
-  closeDelay: createSelector((state: State<unknown>) => state.closeDelay),
-  adaptiveOrigin: createSelector(
-    (state: State<unknown>): AdaptiveOriginMiddleware | undefined => state.adaptiveOrigin,
-  ),
+  disabled: (state: State<unknown>) => state.disabled,
+  instantType: (state: State<unknown>) => state.instantType,
+  isInstantPhase: (state: State<unknown>) => state.isInstantPhase,
+  trackCursorAxis: (state: State<unknown>) => state.trackCursorAxis,
+  disableHoverablePopup: (state: State<unknown>) => state.disableHoverablePopup,
+  lastOpenChangeReason: (state: State<unknown>) => state.openChangeReason,
+  closeOnClick: (state: State<unknown>) => state.closeOnClick,
+  closeDelay: (state: State<unknown>) => state.closeDelay,
+  adaptiveOrigin: (state: State<unknown>): AdaptiveOriginMiddleware | undefined =>
+    state.adaptiveOrigin,
 };
 
 type Selectors = typeof selectors;

--- a/packages/react/src/utils/popups/store.ts
+++ b/packages/react/src/utils/popups/store.ts
@@ -1,4 +1,4 @@
-import { createSelector, type ReactStore } from '@base-ui/utils/store';
+import type { ReactStore } from '@base-ui/utils/store';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { FloatingRootContext } from '../../floating-ui-react';
 import { FloatingRootStore } from '../../floating-ui-react/components/FloatingRootStore';
@@ -142,16 +142,14 @@ export type PopupStoreContext<ChangeEventDetails> = {
 
 type S = PopupStoreState<unknown>;
 
-const activeTriggerIdSelector = createSelector(
-  (state: S) => state.triggerIdProp ?? state.activeTriggerId,
-);
+const activeTriggerIdSelector = (state: S) => state.triggerIdProp ?? state.activeTriggerId;
 
-const openSelector = createSelector((state: S) => state.openProp ?? state.open);
+const openSelector = (state: S) => state.openProp ?? state.open;
 
-const popupIdSelector = createSelector((state: S) => {
+const popupIdSelector = (state: S) => {
   const popupId = state.popupElement?.id ?? state.floatingId;
   return popupId || undefined;
-});
+};
 
 function triggerOwnsOpenPopup(state: S, triggerId: string | undefined) {
   return (
@@ -174,51 +172,42 @@ function triggerOwnsOpenPopupOrIsOnlyTrigger(state: S, triggerId: string | undef
 
 export const popupStoreSelectors = {
   open: openSelector,
-  mounted: createSelector((state: S) => state.mounted),
-  transitionStatus: createSelector((state: S) => state.transitionStatus),
-  floatingRootContext: createSelector((state: S) => state.floatingRootContext),
-  triggerCount: createSelector((state: S) => state.triggerCount),
-  preventUnmountingOnClose: createSelector((state: S) => state.preventUnmountingOnClose),
-  payload: createSelector((state: S) => state.payload),
+  mounted: (state: S) => state.mounted,
+  transitionStatus: (state: S) => state.transitionStatus,
+  floatingRootContext: (state: S) => state.floatingRootContext,
+  triggerCount: (state: S) => state.triggerCount,
+  preventUnmountingOnClose: (state: S) => state.preventUnmountingOnClose,
+  payload: (state: S) => state.payload,
 
   activeTriggerId: activeTriggerIdSelector,
-  activeTriggerElement: createSelector((state: S) =>
-    state.mounted ? state.activeTriggerElement : null,
-  ),
+  activeTriggerElement: (state: S) => (state.mounted ? state.activeTriggerElement : null),
   popupId: popupIdSelector,
   /**
    * Whether the trigger with the given ID was used to open the popup.
    */
-  isTriggerActive: createSelector(
-    (state: S, triggerId: string | undefined) =>
-      triggerId !== undefined && activeTriggerIdSelector(state) === triggerId,
-  ),
+  isTriggerActive: (state: S, triggerId: string | undefined) =>
+    triggerId !== undefined && activeTriggerIdSelector(state) === triggerId,
   /**
    * Whether the popup is open and was activated by a trigger with the given ID.
    */
-  isOpenedByTrigger: createSelector((state: S, triggerId: string | undefined) =>
+  isOpenedByTrigger: (state: S, triggerId: string | undefined) =>
     triggerOwnsOpenPopup(state, triggerId),
-  ),
   /**
    * Whether the popup is mounted and was activated by a trigger with the given ID.
    */
-  isMountedByTrigger: createSelector(
-    (state: S, triggerId: string | undefined) =>
-      triggerId !== undefined && activeTriggerIdSelector(state) === triggerId && state.mounted,
-  ),
-  triggerProps: createSelector((state: S, isActive: boolean) =>
+  isMountedByTrigger: (state: S, triggerId: string | undefined) =>
+    triggerId !== undefined && activeTriggerIdSelector(state) === triggerId && state.mounted,
+  triggerProps: (state: S, isActive: boolean) =>
     isActive ? state.activeTriggerProps : state.inactiveTriggerProps,
-  ),
   /**
    * Popup id for the trigger that currently owns the open popup.
    */
-  triggerPopupId: createSelector((state: S, triggerId: string | undefined) =>
+  triggerPopupId: (state: S, triggerId: string | undefined) =>
     triggerOwnsOpenPopupOrIsOnlyTrigger(state, triggerId) ? popupIdSelector(state) : undefined,
-  ),
-  popupProps: createSelector((state: S) => state.popupProps),
+  popupProps: (state: S) => state.popupProps,
 
-  popupElement: createSelector((state: S) => state.popupElement),
-  positionerElement: createSelector((state: S) => state.positionerElement),
+  popupElement: (state: S) => state.popupElement,
+  positionerElement: (state: S) => state.positionerElement,
 };
 
 export type PopupStoreSelectors = typeof popupStoreSelectors;


### PR DESCRIPTION
Remove redundant internal selector factories without changing the public store utility.

## Changes

- Use selector functions directly when no composition is needed.
- Keep Toast selector state and ID arguments explicit.
- Reduce @base-ui/react by 1,067 parsed bytes and 256 gzipped bytes.