### PR TITLE
[composite] Publish an atomic item registry

### DIFF
--- a/packages/react/src/combobox/item/ComboboxItem.test.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.test.tsx
@@ -3,6 +3,7 @@ import { expect, vi } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { useComboboxRootContext } from '../root/ComboboxRootContext';
 
 describe('<Combobox.Item />', () => {
   const { render } = createRenderer();
@@ -455,6 +456,103 @@ describe('<Combobox.Item />', () => {
       await user.click(screen.getByRole('option', { name: 'five' }));
 
       await waitFor(() => expect(input).toHaveValue('five'));
+      expect(screen.queryByRole('listbox')).toBe(null);
+    });
+
+    it('registers a rendered window at its filtered indexes', async () => {
+      function ListRefProbe() {
+        const store = useComboboxRootContext();
+        const [snapshot, setSnapshot] = React.useState('');
+
+        return (
+          <button
+            type="button"
+            data-testid="refresh-list-ref"
+            onClick={() => {
+              const list = store.state.listRef.current;
+              setSnapshot(
+                Array.from(
+                  { length: list.length },
+                  (_, index) => list[index]?.textContent ?? '',
+                ).join('|'),
+              );
+            }}
+          >
+            {snapshot}
+          </button>
+        );
+      }
+
+      function WindowedItems() {
+        const items = Combobox.useFilteredItems<string>();
+        return items.slice(2, 4).map((item) => (
+          <Combobox.Item key={item} value={item}>
+            {item}
+          </Combobox.Item>
+        ));
+      }
+
+      const { user } = await render(
+        <Combobox.Root virtualized items={['one', 'two', 'three', 'four', 'five']}>
+          <Combobox.Input data-testid="input" />
+          <ListRefProbe />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <WindowedItems />
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      await user.click(screen.getByTestId('input'));
+      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+      fireEvent.click(screen.getByTestId('refresh-list-ref'));
+
+      expect(screen.getByTestId('refresh-list-ref')).toHaveTextContent('||three|four|');
+    });
+  });
+
+  describe('virtualized with explicit index', () => {
+    function VirtualizedItems() {
+      const items = Combobox.useFilteredItems<string>();
+      return items.map((item, index) => (
+        <Combobox.Item key={item} value={item} index={index}>
+          {item}
+        </Combobox.Item>
+      ));
+    }
+
+    it('selects the highlighted filtered item with the keyboard after filtering', async () => {
+      const { user } = await render(
+        <Combobox.Root virtualized items={['one', 'two', 'three']}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <VirtualizedItems />
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+
+      await user.type(input, 't');
+      await waitFor(() => expect(screen.queryByRole('option', { name: 'one' })).toBe(null));
+
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => expect(input).toHaveValue('two'));
       expect(screen.queryByRole('listbox')).toBe(null);
     });
   });

--- a/packages/react/src/combobox/item/ComboboxItem.test.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.test.tsx
@@ -516,4 +516,47 @@ describe('<Combobox.Item />', () => {
       expect(renderSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('prop: index', () => {
+    // Regression test for https://github.com/mui/base-ui/issues/4657 — explicitly
+    // indexed items in a non-virtualized list previously skipped CompositeList
+    // registration, so hover could not resolve the item in `listRef` and
+    // `data-highlighted` stayed on the previous item.
+    it('updates the highlight on hover in a non-virtualized list', async () => {
+      const items = ['apple', 'banana', 'cherry'];
+      const { user } = await render(
+        <Combobox.Root items={items} defaultOpen autoHighlight>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {items.map((item, index) => (
+                    <Combobox.Item key={item} value={item} index={index}>
+                      {item}
+                    </Combobox.Item>
+                  ))}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
+
+      const banana = screen.getByRole('option', { name: 'banana' });
+      await user.hover(banana);
+      await waitFor(() => {
+        expect(banana).toHaveAttribute('data-highlighted');
+      });
+
+      const cherry = screen.getByRole('option', { name: 'cherry' });
+      await user.hover(cherry);
+      await waitFor(() => {
+        expect(cherry).toHaveAttribute('data-highlighted');
+      });
+      expect(banana).not.toHaveAttribute('data-highlighted');
+    });
+  });
 });

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -48,6 +48,7 @@ function ComboboxItemInner(props: ComboboxItemInnerProps) {
 
   const textRef = React.useRef<HTMLElement | null>(null);
   const listItem = useCompositeListItem({
+    guess: true,
     index: indexProp,
     textRef,
   });

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -8,10 +8,7 @@ import {
   useComboboxHasItemsContext,
   useComboboxDerivedItemsContext,
 } from '../root/ComboboxRootContext';
-import {
-  useCompositeListItem,
-  IndexGuessBehavior,
-} from '../../internals/composite/list/useCompositeListItem';
+import { useCompositeListItem } from '../../internals/composite/list/useCompositeListItem';
 import type { BaseUIComponentProps, HTMLProps, NonNativeButtonProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { ComboboxItemContext } from './ComboboxItemContext';
@@ -53,7 +50,6 @@ function ComboboxItemInner(props: ComboboxItemInnerProps) {
   const listItem = useCompositeListItem({
     index: indexProp,
     textRef,
-    indexGuessBehavior: IndexGuessBehavior.GuessFromOrder,
   });
 
   const store = useComboboxRootContext();

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
@@ -875,6 +875,66 @@ describe('<Combobox.Trigger />', () => {
         expect(trigger).toHaveTextContent('apricot');
       });
     });
+
+    it('only matches mounted indexed item labels when typing on the focused trigger', async () => {
+      function TestComponent() {
+        const [showBanana, setShowBanana] = React.useState(true);
+
+        return (
+          <Combobox.Root>
+            <Combobox.Trigger data-testid="trigger">
+              <Combobox.Value />
+            </Combobox.Trigger>
+            <button type="button" onClick={() => setShowBanana(false)}>
+              Remove banana
+            </button>
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <Combobox.List>
+                    <Combobox.Item value="apple" index={0}>
+                      Apple
+                    </Combobox.Item>
+                    {showBanana && (
+                      <Combobox.Item value="banana" index={1}>
+                        Banana
+                      </Combobox.Item>
+                    )}
+                    <Combobox.Item value="blueberry" index={2}>
+                      Blueberry
+                    </Combobox.Item>
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>
+        );
+      }
+
+      const { user } = await render(<TestComponent />);
+      const trigger = screen.getByTestId('trigger');
+
+      await user.click(trigger);
+      await screen.findByRole('listbox');
+
+      await user.click(screen.getByRole('button', { name: 'Remove banana' }));
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: 'Banana' })).toBe(null);
+      });
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).toBe(null);
+      });
+
+      await act(async () => {
+        trigger.focus();
+      });
+      await user.keyboard('b');
+
+      await waitFor(() => {
+        expect(trigger).toHaveTextContent('blueberry');
+      });
+    });
   });
 
   describe('data state attributes', () => {

--- a/packages/react/src/internals/composite/index.ts
+++ b/packages/react/src/internals/composite/index.ts
@@ -6,7 +6,6 @@ export type { CompositeListContextValue } from './list/CompositeListContext';
 export { CompositeRoot } from './root/CompositeRoot';
 export { useCompositeListItem } from './list/useCompositeListItem';
 export type { UseCompositeListItemParameters } from './list/useCompositeListItem';
-export { IndexGuessBehavior } from './list/useCompositeListItem';
 export { useCompositeRoot } from './root/useCompositeRoot';
 export type { UseCompositeRootParameters } from './root/useCompositeRoot';
 export { gridNavigation } from './root/gridNavigation';

--- a/packages/react/src/internals/composite/item/CompositeItem.tsx
+++ b/packages/react/src/internals/composite/item/CompositeItem.tsx
@@ -29,6 +29,7 @@ export function CompositeItem<Metadata, State extends Record<string, any>>(
 
   return useRenderElement(tag, componentProps, {
     state,
+    // The composite ref attaches first so an outer item wins when nested items share a DOM node.
     ref: [compositeRef, ...refs],
     props: [compositeProps, ...props, elementProps],
     stateAttributesMapping,

--- a/packages/react/src/internals/composite/item/CompositeItem.tsx
+++ b/packages/react/src/internals/composite/item/CompositeItem.tsx
@@ -29,7 +29,7 @@ export function CompositeItem<Metadata, State extends Record<string, any>>(
 
   return useRenderElement(tag, componentProps, {
     state,
-    ref: [...refs, compositeRef],
+    ref: [compositeRef, ...refs],
     props: [compositeProps, ...props, elementProps],
     stateAttributesMapping,
   });

--- a/packages/react/src/internals/composite/item/useCompositeItem.ts
+++ b/packages/react/src/internals/composite/item/useCompositeItem.ts
@@ -10,7 +10,7 @@ import { HTMLProps } from '../../types';
 
 export interface UseCompositeItemParameters<Metadata> extends Pick<
   UseCompositeListItemParameters<Metadata>,
-  'metadata' | 'indexGuessBehavior'
+  'metadata'
 > {}
 
 export function useCompositeItem<Metadata>(params: UseCompositeItemParameters<Metadata> = {}) {

--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -1,7 +1,7 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { act, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';
 import { CompositeList } from './CompositeList';
 import { useCompositeListItem } from './useCompositeListItem';
@@ -130,8 +130,8 @@ describe('<CompositeList />', () => {
         </CompositeList>,
       );
 
-      const map = onMapChange.mock.lastCall?.[0] as Map<Element, { index?: number } | null>;
-      expect(Array.from(map.values(), (metadata) => metadata?.index)).toEqual([0, 1, 2]);
+      const map = onMapChange.mock.lastCall?.[0] as Map<Element, { index: number }>;
+      expect(Array.from(map.values(), (metadata) => metadata.index)).toEqual([0, 1, 2]);
       expect(elementsRef.current).toEqual([
         screen.getByTestId('zero'),
         screen.getByTestId('one'),
@@ -181,7 +181,7 @@ describe('<CompositeList />', () => {
             <GuessedItem label="baseline automatic" />
           </CompositeList>
           <CompositeList elementsRef={elementsRef}>
-            <GuessedItem label="explicit" index={100} />
+            <GuessedItem label="explicit" index={1} />
             <GuessedItem label="automatic" />
           </CompositeList>
         </React.Fragment>,
@@ -193,7 +193,7 @@ describe('<CompositeList />', () => {
         screen.getByTestId('baseline automatic').dataset.initialIndex,
       );
       expect(elementsRef.current[0]).toBe(screen.getByTestId('automatic'));
-      expect(elementsRef.current[100]).toBe(screen.getByTestId('explicit'));
+      expect(elementsRef.current[1]).toBe(screen.getByTestId('explicit'));
     });
 
     it('populates a replacement element registry when the items are unchanged', async () => {
@@ -557,7 +557,7 @@ describe('<CompositeList />', () => {
       expect(screen.getByTestId('a')).toHaveAttribute('data-index', '1');
     });
 
-    it('keeps an item registered when it renders no element', async () => {
+    it('updates the registry when a mounted item stops rendering an element', async () => {
       const elementsRef = {
         current: [] as Array<HTMLElement | null>,
       };
@@ -901,24 +901,20 @@ describe('<CompositeList />', () => {
       const labelsRef = {
         current: [] as Array<string | null>,
       };
-      const onMapChange = vi.fn();
-
       function App(props: { label: string }) {
         return (
-          <CompositeList elementsRef={elementsRef} labelsRef={labelsRef} onMapChange={onMapChange}>
+          <CompositeList elementsRef={elementsRef} labelsRef={labelsRef}>
             <LabelledItem testId="item" label={props.label} />
           </CompositeList>
         );
       }
 
-      const { setProps } = await render(<App label="before" />, { strict: false });
+      const { setProps } = await render(<App label="before" />);
       expect(labelsRef.current).toEqual(['before']);
-      onMapChange.mockClear();
 
       await setProps({ label: 'after' });
 
       expect(labelsRef.current).toEqual(['after']);
-      expect(onMapChange).toHaveBeenCalledOnce();
     });
   });
 
@@ -945,6 +941,120 @@ describe('<CompositeList />', () => {
       const map = onMapChange.mock.lastCall?.[0] as Map<Element, { kind: string; index: number }>;
       expect(map.get(screen.getByTestId('first'))).toEqual({ kind: 'alpha', index: 0 });
       expect(map.get(screen.getByTestId('second'))).toEqual({ kind: 'beta', index: 1 });
+    });
+  });
+
+  describe('Suspense integration', () => {
+    it('does not publish an empty registry when an outer boundary repeatedly suspends', async () => {
+      function createSuspender() {
+        let pending = true;
+        let resolvePromise = () => {};
+        const promise = new Promise<void>((resolve) => {
+          resolvePromise = resolve;
+        });
+
+        return {
+          read() {
+            if (pending) {
+              throw promise;
+            }
+          },
+          resolve() {
+            pending = false;
+            resolvePromise();
+          },
+        };
+      }
+
+      const suspenders = [createSuspender(), createSuspender()];
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const labelsRef = {
+        current: [] as Array<string | null>,
+      };
+      const snapshots: Array<{
+        elements: Array<HTMLElement | null>;
+        labels: Array<string | null>;
+        mapElements: Element[];
+      }> = [];
+
+      function Item(props: { attempt?: number; label: string }) {
+        const { ref, index } = useCompositeListItem({ guess: true, label: props.label });
+        if (props.attempt != null && props.attempt >= 0) {
+          suspenders[props.attempt].read();
+        }
+        return (
+          <div ref={ref} data-testid={props.label} data-index={index}>
+            {props.label}
+          </div>
+        );
+      }
+
+      function App() {
+        const [attempt, setAttempt] = React.useState(-1);
+        return (
+          <React.Fragment>
+            <button type="button" onClick={() => setAttempt((value) => value + 1)}>
+              Suspend
+            </button>
+            <React.Suspense fallback={<div>Loading</div>}>
+              <CompositeList
+                elementsRef={elementsRef}
+                labelsRef={labelsRef}
+                onMapChange={(map) => {
+                  snapshots.push({
+                    elements: [...elementsRef.current],
+                    labels: [...labelsRef.current],
+                    mapElements: Array.from(map.keys()),
+                  });
+                }}
+              >
+                <Item label="a" />
+                <Item label="b" attempt={attempt} />
+                <Item label="c" />
+              </CompositeList>
+            </React.Suspense>
+          </React.Fragment>
+        );
+      }
+
+      await render(<App />);
+
+      async function suspendAndResolve(attempt: number) {
+        await act(async () => {
+          screen.getByRole('button', { name: 'Suspend' }).click();
+        });
+        await screen.findByText('Loading');
+
+        await act(async () => {
+          suspenders[attempt].resolve();
+          await Promise.resolve();
+        });
+        await waitFor(() => {
+          expect(screen.queryByText('Loading')).toBe(null);
+        });
+
+        expect(elementsRef.current).toEqual([
+          screen.getByTestId('a'),
+          screen.getByTestId('b'),
+          screen.getByTestId('c'),
+        ]);
+        expect(labelsRef.current).toEqual(['a', 'b', 'c']);
+        expect(screen.getByTestId('a')).toHaveAttribute('data-index', '0');
+        expect(screen.getByTestId('b')).toHaveAttribute('data-index', '1');
+        expect(screen.getByTestId('c')).toHaveAttribute('data-index', '2');
+      }
+
+      await suspendAndResolve(0);
+      await suspendAndResolve(1);
+
+      expect(snapshots.length).toBeGreaterThan(0);
+      snapshots.forEach((snapshot) => {
+        expect(snapshot.mapElements).toHaveLength(3);
+        expect(snapshot.elements).toEqual(snapshot.mapElements);
+        expect(snapshot.labels).toEqual(['a', 'b', 'c']);
+      });
     });
   });
 
@@ -989,9 +1099,9 @@ describe('<CompositeList />', () => {
 
       const { unmount } = await render(<OrphanItem />);
 
-      // The default context no-ops keep a stray item inert rather than throwing. Its index is
-      // whatever the guess produced, since there is no list to correct it, so it isn't asserted.
+      // The default context no-ops keep a stray item inert rather than throwing.
       expect(screen.getByTestId('orphan')).toBeInTheDocument();
+      expect(screen.getByTestId('orphan')).toHaveAttribute('data-index', '-1');
       expect(() => unmount()).not.toThrow();
     });
   });

--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -1,5 +1,6 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';
 import { CompositeList } from './CompositeList';
@@ -9,8 +10,8 @@ describe('<CompositeList />', () => {
   const { render } = createRenderer();
 
   describe('prop: elementsRef', () => {
-    function Item(props: { label?: string }) {
-      const { ref, index } = useCompositeListItem();
+    function Item(props: { label?: string; index?: number }) {
+      const { ref, index } = useCompositeListItem({ index: props.index });
       return (
         <div ref={ref} data-testid={props.label} data-index={props.label ? index : undefined}>
           {props.label}
@@ -39,6 +40,543 @@ describe('<CompositeList />', () => {
       unmount();
       expect(elementsRef.current).toHaveLength(0);
       expect(labelsRef.current).toHaveLength(0);
+    });
+
+    it('only publishes maps that are aligned with the element registry', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const snapshots: Array<{
+        elements: Array<HTMLElement | null>;
+        mapElements: Element[];
+      }> = [];
+
+      await render(
+        <CompositeList
+          elementsRef={elementsRef}
+          onMapChange={(map) => {
+            snapshots.push({
+              elements: [...elementsRef.current],
+              mapElements: Array.from(map.keys()),
+            });
+          }}
+        >
+          <Item label="a" />
+          <Item label="b" />
+          <Item label="c" />
+        </CompositeList>,
+      );
+
+      expect(snapshots.length).toBeGreaterThan(0);
+      snapshots.forEach((snapshot) => {
+        expect(snapshot.elements).toEqual(snapshot.mapElements);
+      });
+    });
+
+    it('registers explicitly indexed items in their index-addressed slots', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const onMapChange = vi.fn();
+
+      await render(
+        <CompositeList elementsRef={elementsRef} onMapChange={onMapChange}>
+          <Item label="two" index={2} />
+          <Item label="zero" index={0} />
+        </CompositeList>,
+      );
+
+      const map = onMapChange.mock.lastCall?.[0] as Map<Element, { index?: number } | null>;
+      expect(Array.from(map.values(), (metadata) => metadata?.index)).toEqual([0, 2]);
+      expect(elementsRef.current).toHaveLength(3);
+      expect(elementsRef.current[0]).toBe(screen.getByTestId('zero'));
+      expect(Object.hasOwn(elementsRef.current, 1)).toBe(false);
+      expect(elementsRef.current[2]).toBe(screen.getByTestId('two'));
+    });
+
+    it('reserves explicit slots when assigning automatic indexes', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      await render(
+        <CompositeList elementsRef={elementsRef}>
+          <Item label="automatic one" />
+          <Item label="explicit zero" index={0} />
+          <Item label="automatic two" />
+        </CompositeList>,
+      );
+
+      expect(elementsRef.current).toEqual([
+        screen.getByTestId('explicit zero'),
+        screen.getByTestId('automatic one'),
+        screen.getByTestId('automatic two'),
+      ]);
+      expect(screen.getByTestId('automatic one')).toHaveAttribute('data-index', '1');
+      expect(screen.getByTestId('automatic two')).toHaveAttribute('data-index', '2');
+    });
+
+    it('does not consume an index guess for an explicitly indexed item', async () => {
+      const baselineElementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      function GuessedItem(props: { label: string; index?: number }) {
+        const { ref, index } = useCompositeListItem({ index: props.index });
+        const initialIndex = React.useRef(index).current;
+        return <div ref={ref} data-testid={props.label} data-initial-index={initialIndex} />;
+      }
+
+      await render(
+        <React.Fragment>
+          <CompositeList elementsRef={baselineElementsRef}>
+            <GuessedItem label="baseline automatic" />
+          </CompositeList>
+          <CompositeList elementsRef={elementsRef}>
+            <GuessedItem label="explicit" index={100} />
+            <GuessedItem label="automatic" />
+          </CompositeList>
+        </React.Fragment>,
+      );
+
+      // React 18 Strict Mode consumes a guess during its discarded render. Compare against
+      // the same runtime's baseline to isolate whether the explicit item consumed another.
+      expect(screen.getByTestId('automatic').dataset.initialIndex).toBe(
+        screen.getByTestId('baseline automatic').dataset.initialIndex,
+      );
+      expect(elementsRef.current[0]).toBe(screen.getByTestId('automatic'));
+      expect(elementsRef.current[100]).toBe(screen.getByTestId('explicit'));
+    });
+
+    it('populates a replacement element registry when the items are unchanged', async () => {
+      const firstElementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const secondElementsRef = {
+        current: [null, null] as Array<HTMLElement | null>,
+      };
+
+      function App() {
+        const [useSecondRef, setUseSecondRef] = React.useState(false);
+        return (
+          <CompositeList elementsRef={useSecondRef ? secondElementsRef : firstElementsRef}>
+            <button type="button" onClick={() => setUseSecondRef(true)}>
+              Replace ref
+            </button>
+            <Item label="item" />
+          </CompositeList>
+        );
+      }
+
+      const { user } = await render(<App />);
+      expect(firstElementsRef.current).toEqual([screen.getByTestId('item')]);
+
+      await user.click(screen.getByRole('button', { name: 'Replace ref' }));
+      expect(secondElementsRef.current).toEqual([screen.getByTestId('item')]);
+    });
+
+    it('registers a replacement render target', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      function SwitchingItem() {
+        const [useButton, setUseButton] = React.useState(false);
+        const { ref } = useCompositeListItem();
+
+        return (
+          <React.Fragment>
+            <button type="button" onClick={() => setUseButton(true)}>
+              Replace target
+            </button>
+            {useButton ? (
+              <button ref={ref} data-testid="item" type="button">
+                item
+              </button>
+            ) : (
+              <div ref={ref} data-testid="item">
+                item
+              </div>
+            )}
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(
+        <CompositeList elementsRef={elementsRef}>
+          <SwitchingItem />
+        </CompositeList>,
+      );
+      const initialItem = screen.getByTestId('item');
+
+      await user.click(screen.getByRole('button', { name: 'Replace target' }));
+
+      const replacementItem = screen.getByTestId('item');
+      expect(replacementItem).not.toBe(initialItem);
+      expect(initialItem.isConnected).toBe(false);
+      expect(elementsRef.current).toEqual([replacementItem]);
+    });
+
+    it('does not register negative explicit indexes', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      await render(
+        <CompositeList elementsRef={elementsRef}>
+          <Item label="item" index={-1} />
+        </CompositeList>,
+      );
+
+      expect(elementsRef.current).toHaveLength(0);
+      expect(Object.hasOwn(elementsRef.current, '-1')).toBe(false);
+    });
+
+    it('updates refs when an item mounts from a nested state update', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      function DeepSection() {
+        const [showItem, setShowItem] = React.useState(false);
+        return (
+          <React.Fragment>
+            <button type="button" onClick={() => setShowItem(true)}>
+              Add item
+            </button>
+            {showItem && <Item label="nested" />}
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(
+        <CompositeList elementsRef={elementsRef}>
+          <Item label="first" />
+          <DeepSection />
+          <Item label="last" />
+        </CompositeList>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Add item' }));
+
+      expect(elementsRef.current).toEqual([
+        screen.getByTestId('first'),
+        screen.getByTestId('nested'),
+        screen.getByTestId('last'),
+      ]);
+    });
+
+    it('updates refs when an item unmounts from a nested state update', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const onMapChange = vi.fn();
+
+      function DeepSection() {
+        const [showItem, setShowItem] = React.useState(true);
+        return (
+          <React.Fragment>
+            <button type="button" onClick={() => setShowItem(false)}>
+              Remove item
+            </button>
+            {showItem && <Item label="nested" />}
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(
+        <CompositeList elementsRef={elementsRef} onMapChange={onMapChange}>
+          <Item label="first" />
+          <DeepSection />
+          <Item label="last" />
+        </CompositeList>,
+      );
+
+      expect(elementsRef.current).toHaveLength(3);
+
+      await user.click(screen.getByRole('button', { name: 'Remove item' }));
+
+      expect(elementsRef.current).toEqual([
+        screen.getByTestId('first'),
+        screen.getByTestId('last'),
+      ]);
+      const map = onMapChange.mock.lastCall?.[0] as Map<Element, unknown>;
+      expect(Array.from(map.keys())).toEqual([
+        screen.getByTestId('first'),
+        screen.getByTestId('last'),
+      ]);
+      expect(screen.getByTestId('last')).toHaveAttribute('data-index', '1');
+    });
+
+    it('assigns correct guessed indexes during the first render', async () => {
+      const renderCounts: Record<string, number> = { a: 0, b: 0, c: 0 };
+      const initialIndexes: Record<string, number> = {};
+
+      function GuessedItem(props: { label: string }) {
+        const { ref, index } = useCompositeListItem();
+        renderCounts[props.label] += 1;
+        if (!(props.label in initialIndexes)) {
+          initialIndexes[props.label] = index;
+        }
+        return <div ref={ref} data-testid={props.label} data-index={index} />;
+      }
+
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      await render(
+        <CompositeList elementsRef={elementsRef}>
+          <GuessedItem label="a" />
+          <GuessedItem label="b" />
+          <GuessedItem label="c" />
+        </CompositeList>,
+        // The guess exists to avoid the corrective re-render in production behavior;
+        // Strict Mode's double-render would obscure the count.
+        { strict: false },
+      );
+
+      expect(initialIndexes).toEqual({ a: 0, b: 1, c: 2 });
+      expect(renderCounts).toEqual({ a: 1, b: 1, c: 1 });
+      expect(elementsRef.current).toEqual([
+        screen.getByTestId('a'),
+        screen.getByTestId('b'),
+        screen.getByTestId('c'),
+      ]);
+    });
+
+    it('re-registers an explicitly indexed item when its index changes', async () => {
+      const refCalls: Array<HTMLElement | null> = [];
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      function TrackedItem(props: { index: number }) {
+        const { ref, index } = useCompositeListItem({ index: props.index });
+        const trackingRef = React.useCallback(
+          (node: HTMLElement | null) => {
+            refCalls.push(node);
+            ref(node);
+          },
+          [ref],
+        );
+        return <div ref={trackingRef} data-testid="tracked" data-index={index} />;
+      }
+
+      function App(props: { index: number }) {
+        return (
+          <CompositeList elementsRef={elementsRef}>
+            <TrackedItem index={props.index} />
+          </CompositeList>
+        );
+      }
+
+      const { setProps } = await render(<App index={0} />, { strict: false });
+      const tracked = screen.getByTestId('tracked');
+      expect(refCalls).toEqual([tracked]);
+      expect(elementsRef.current[0]).toBe(tracked);
+
+      // Moving a controlled item re-registers it at the new slot. The ref identity depends on
+      // the registration data, so the element's refs cycle once: registration ownership for a
+      // shared node is decided by ref attachment order, which an effect-based republish would
+      // escape.
+      await setProps({ index: 2 });
+
+      expect(refCalls).toEqual([tracked, null, tracked]);
+      expect(screen.getByTestId('tracked')).toHaveAttribute('data-index', '2');
+      expect(Object.hasOwn(elementsRef.current, 0)).toBe(false);
+      expect(elementsRef.current[2]).toBe(tracked);
+    });
+
+    it('does not detach item refs when an index shifts', async () => {
+      const refCalls: Array<HTMLElement | null> = [];
+
+      function TrackedItem() {
+        const { ref, index } = useCompositeListItem();
+        const trackingRef = React.useCallback(
+          (node: HTMLElement | null) => {
+            refCalls.push(node);
+            ref(node);
+          },
+          [ref],
+        );
+        return <div ref={trackingRef} data-testid="tracked" data-index={index} />;
+      }
+
+      function App(props: { items: string[] }) {
+        const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
+        return (
+          <CompositeList elementsRef={elementsRef}>
+            {props.items.map((item) =>
+              item === 'tracked' ? <TrackedItem key={item} /> : <Item key={item} label={item} />,
+            )}
+          </CompositeList>
+        );
+      }
+
+      // Strict Mode replays initial refs; production behavior is what the
+      // stability contract targets.
+      const { setProps } = await render(<App items={['tracked']} />, { strict: false });
+      const tracked = screen.getByTestId('tracked');
+      expect(refCalls).toEqual([tracked]);
+
+      await setProps({ items: ['before', 'tracked'] });
+      await waitFor(() => {
+        expect(screen.getByTestId('tracked')).toHaveAttribute('data-index', '1');
+      });
+      expect(refCalls).toEqual([tracked]);
+    });
+
+    it('excludes items detached outside React from the registry', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const onMapChange = vi.fn();
+
+      function App(props: { extra: boolean }) {
+        return (
+          <CompositeList elementsRef={elementsRef} onMapChange={onMapChange}>
+            <div>
+              <Item label="a" />
+              <Item label="b" />
+              <Item label="c" />
+            </div>
+            {props.extra && <Item label="d" />}
+          </CompositeList>
+        );
+      }
+
+      const { setProps } = await render(<App extra={false} />, { strict: false });
+
+      // Detaching a registered item outside React never fires its ref callback, so it
+      // stays registered while disconnected. `compareDocumentPosition` is meaningless
+      // for it, and leaving it in would scramble the order of every other item.
+      const detached = screen.getByTestId('b');
+      detached.remove();
+
+      await setProps({ extra: true });
+
+      expect(elementsRef.current).toEqual([
+        screen.getByTestId('a'),
+        screen.getByTestId('c'),
+        screen.getByTestId('d'),
+      ]);
+      const map = onMapChange.mock.lastCall?.[0] as Map<Element, unknown>;
+      expect(Array.from(map.keys())).toEqual([
+        screen.getByTestId('a'),
+        screen.getByTestId('c'),
+        screen.getByTestId('d'),
+      ]);
+    });
+
+    it('skips detached items while verifying order after a move', async () => {
+      function App() {
+        const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
+        return (
+          <CompositeList elementsRef={elementsRef}>
+            <div data-testid="list">
+              <Item label="a" />
+              <Item label="b" />
+              <Item label="c" />
+            </div>
+          </CompositeList>
+        );
+      }
+
+      await render(<App />, { strict: false });
+
+      const list = screen.getByTestId('list');
+      const a = screen.getByTestId('a');
+      const c = screen.getByTestId('c');
+
+      // One batch that both detaches a registered item and moves another. The move makes the
+      // observer verify order, and the verification walks the detached item, which no longer
+      // has a meaningful document position.
+      screen.getByTestId('b').remove();
+      list.insertBefore(c, a);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('c')).toHaveAttribute('data-index', '0');
+      });
+      expect(screen.getByTestId('a')).toHaveAttribute('data-index', '1');
+    });
+
+    it('keeps an item registered when it renders no element', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      function VanishingItem() {
+        // Starts with no element at all, so the item registers nothing until it renders one.
+        const [hidden, setHidden] = React.useState(true);
+        const { ref, index } = useCompositeListItem({ label: hidden ? 'hidden' : 'shown' });
+        return (
+          <React.Fragment>
+            <button type="button" onClick={() => setHidden((value) => !value)}>
+              Toggle element
+            </button>
+            {!hidden && (
+              <div ref={ref} data-testid="vanishing" data-index={index}>
+                vanishing
+              </div>
+            )}
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(
+        <CompositeList elementsRef={elementsRef}>
+          <VanishingItem />
+          <Item label="tail" />
+        </CompositeList>,
+      );
+
+      expect(elementsRef.current).toEqual([screen.getByTestId('tail')]);
+
+      await user.click(screen.getByRole('button', { name: 'Toggle element' }));
+      expect(elementsRef.current).toHaveLength(2);
+
+      // The item stays mounted and subscribed while its element detaches, so the next
+      // publication reaches a subscriber whose node is gone.
+      await user.click(screen.getByRole('button', { name: 'Toggle element' }));
+
+      expect(elementsRef.current).toEqual([screen.getByTestId('tail')]);
+      expect(screen.getByTestId('tail')).toHaveAttribute('data-index', '0');
+    });
+
+    it('updates indexes when a leaf item moves outside React', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      await render(
+        <CompositeList elementsRef={elementsRef}>
+          <div data-testid="container">
+            <Item label="a" />
+            <Item label="b" />
+            <Item label="c" />
+          </div>
+        </CompositeList>,
+      );
+
+      expect(screen.getByTestId('a')).toHaveAttribute('data-index', '0');
+
+      const container = screen.getByTestId('container');
+      container.appendChild(screen.getByTestId('a'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('a')).toHaveAttribute('data-index', '2');
+      });
+      expect(screen.getByTestId('b')).toHaveAttribute('data-index', '0');
+      expect(screen.getByTestId('c')).toHaveAttribute('data-index', '1');
+      expect(elementsRef.current).toEqual([
+        screen.getByTestId('b'),
+        screen.getByTestId('c'),
+        screen.getByTestId('a'),
+      ]);
     });
 
     it('updates indexes when keyed groups reorder', async () => {
@@ -72,6 +610,28 @@ describe('<CompositeList />', () => {
       expect(screen.getByTestId('b')).toHaveAttribute('data-index', '1');
 
       await user.click(screen.getByRole('button', { name: 'Reorder' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('b')).toHaveAttribute('data-index', '0');
+      });
+      expect(screen.getByTestId('a')).toHaveAttribute('data-index', '1');
+    });
+
+    it('observes reorders after the list grows from one item', async () => {
+      function App(props: { items: string[] }) {
+        const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
+        return (
+          <CompositeList elementsRef={elementsRef}>
+            {props.items.map((item) => (
+              <Item key={item} label={item} />
+            ))}
+          </CompositeList>
+        );
+      }
+
+      const { setProps } = await render(<App items={['a']} />, { strict: false });
+      await setProps({ items: ['a', 'b'] });
+      await setProps({ items: ['b', 'a'] });
 
       await waitFor(() => {
         expect(screen.getByTestId('b')).toHaveAttribute('data-index', '0');
@@ -156,6 +716,149 @@ describe('<CompositeList />', () => {
         expect(screen.queryByTestId('badge')).toBe(null);
       });
       expect(onMapChange).not.toHaveBeenCalled();
+    });
+
+    it('registers items that sit across a shadow boundary', async () => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const shadowContainer = document.createElement('div');
+      host.attachShadow({ mode: 'open' }).appendChild(shadowContainer);
+
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      try {
+        // No ancestor can `contain` both items, so the pair has no common root to observe.
+        // Registration still has to hold.
+        const { unmount } = await render(
+          <CompositeList elementsRef={elementsRef}>
+            <Item label="light" />
+            {ReactDOM.createPortal(<Item label="shadow" />, shadowContainer)}
+          </CompositeList>,
+          { strict: false },
+        );
+
+        const shadowItem = shadowContainer.querySelector('[data-testid="shadow"]');
+        expect(shadowItem).not.toBe(null);
+        expect(elementsRef.current).toHaveLength(2);
+        expect(elementsRef.current).toContain(screen.getByTestId('light'));
+        expect(elementsRef.current).toContain(shadowItem);
+
+        unmount();
+        expect(elementsRef.current).toHaveLength(0);
+      } finally {
+        host.remove();
+      }
+    });
+  });
+
+  describe('prop: labelsRef', () => {
+    function LabelledItem(props: {
+      testId: string;
+      label?: string | null;
+      text?: string;
+      useTextRef?: boolean;
+    }) {
+      const textRef = React.useRef<HTMLElement | null>(null);
+      const { ref } = useCompositeListItem({
+        label: props.label,
+        textRef: props.useTextRef ? textRef : undefined,
+      });
+      return (
+        <div ref={ref} data-testid={props.testId}>
+          <span ref={props.useTextRef ? textRef : undefined}>{props.text}</span>
+          {props.useTextRef ? '-ignored' : ''}
+        </div>
+      );
+    }
+
+    it('resolves each label source', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const labelsRef = {
+        current: [] as Array<string | null>,
+      };
+
+      await render(
+        <CompositeList elementsRef={elementsRef} labelsRef={labelsRef}>
+          <LabelledItem testId="explicit" label="explicit label" text="ignored" />
+          {/* An explicit `null` means "no label", and must not fall back to the text. */}
+          <LabelledItem testId="null-label" label={null} text="not a label" />
+          <LabelledItem testId="text-ref" useTextRef text="from text ref" />
+          <LabelledItem testId="element-text" text="from element" />
+        </CompositeList>,
+      );
+
+      expect(labelsRef.current).toEqual(['explicit label', null, 'from text ref', 'from element']);
+    });
+
+    it('drops label slots for items that unmount', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const labelsRef = {
+        current: [] as Array<string | null>,
+      };
+
+      function App(props: { items: string[] }) {
+        return (
+          <CompositeList elementsRef={elementsRef} labelsRef={labelsRef}>
+            {props.items.map((item) => (
+              <LabelledItem key={item} testId={item} label={item} />
+            ))}
+          </CompositeList>
+        );
+      }
+
+      const { setProps } = await render(<App items={['a', 'b', 'c']} />);
+      expect(labelsRef.current).toEqual(['a', 'b', 'c']);
+
+      await setProps({ items: ['a'] });
+      expect(labelsRef.current).toEqual(['a']);
+    });
+  });
+
+  describe('prop: onMapChange', () => {
+    it('publishes item metadata alongside the index', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const onMapChange = vi.fn();
+
+      function MetadataItem(props: { testId: string; kind: string }) {
+        const metadata = React.useMemo(() => ({ kind: props.kind }), [props.kind]);
+        const { ref } = useCompositeListItem({ metadata });
+        return <div ref={ref} data-testid={props.testId} />;
+      }
+
+      await render(
+        <CompositeList elementsRef={elementsRef} onMapChange={onMapChange}>
+          <MetadataItem testId="first" kind="alpha" />
+          <MetadataItem testId="second" kind="beta" />
+        </CompositeList>,
+      );
+
+      const map = onMapChange.mock.lastCall?.[0] as Map<Element, { kind: string; index: number }>;
+      expect(map.get(screen.getByTestId('first'))).toEqual({ kind: 'alpha', index: 0 });
+      expect(map.get(screen.getByTestId('second'))).toEqual({ kind: 'beta', index: 1 });
+    });
+  });
+
+  describe('without a parent list', () => {
+    it('renders an item that is not wrapped in a list', async () => {
+      function OrphanItem() {
+        const { ref, index } = useCompositeListItem();
+        return <div ref={ref} data-testid="orphan" data-index={index} />;
+      }
+
+      const { unmount } = await render(<OrphanItem />);
+
+      // The default context no-ops keep a stray item inert rather than throwing. Its index is
+      // whatever the guess produced, since there is no list to correct it, so it isn't asserted.
+      expect(screen.getByTestId('orphan')).toBeInTheDocument();
+      expect(() => unmount()).not.toThrow();
     });
   });
 });

--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -86,23 +86,31 @@ describe('<CompositeList />', () => {
         mapElements: Element[];
       }> = [];
 
-      await render(
-        <CompositeList
-          elementsRef={elementsRef}
-          onMapChange={(map) => {
-            snapshots.push({
-              elements: [...elementsRef.current],
-              mapElements: Array.from(map.keys()),
-            });
-          }}
-        >
-          <Item label="a" />
-          <Item label="b" />
-          <Item label="c" />
-        </CompositeList>,
-      );
+      function App(props: { items: string[] }) {
+        return (
+          <CompositeList
+            elementsRef={elementsRef}
+            onMapChange={(map) => {
+              snapshots.push({
+                elements: [...elementsRef.current],
+                mapElements: Array.from(map.keys()),
+              });
+            }}
+          >
+            {props.items.map((item) => (
+              <Item key={item} label={item} />
+            ))}
+          </CompositeList>
+        );
+      }
 
-      expect(snapshots.length).toBeGreaterThan(0);
+      const { setProps } = await render(<App items={['a', 'b', 'c']} />, { strict: false });
+
+      expect(snapshots).toHaveLength(1);
+
+      await setProps({ items: ['a', 'b', 'c', 'd'] });
+
+      expect(snapshots).toHaveLength(2);
       snapshots.forEach((snapshot) => {
         expect(snapshot.elements).toEqual(snapshot.mapElements);
       });
@@ -118,15 +126,17 @@ describe('<CompositeList />', () => {
         <CompositeList elementsRef={elementsRef} onMapChange={onMapChange}>
           <Item label="two" index={2} />
           <Item label="zero" index={0} />
+          <Item label="one" index={1} />
         </CompositeList>,
       );
 
       const map = onMapChange.mock.lastCall?.[0] as Map<Element, { index?: number } | null>;
-      expect(Array.from(map.values(), (metadata) => metadata?.index)).toEqual([0, 2]);
-      expect(elementsRef.current).toHaveLength(3);
-      expect(elementsRef.current[0]).toBe(screen.getByTestId('zero'));
-      expect(Object.hasOwn(elementsRef.current, 1)).toBe(false);
-      expect(elementsRef.current[2]).toBe(screen.getByTestId('two'));
+      expect(Array.from(map.values(), (metadata) => metadata?.index)).toEqual([0, 1, 2]);
+      expect(elementsRef.current).toEqual([
+        screen.getByTestId('zero'),
+        screen.getByTestId('one'),
+        screen.getByTestId('two'),
+      ]);
     });
 
     it('reserves explicit slots when assigning automatic indexes', async () => {
@@ -383,14 +393,14 @@ describe('<CompositeList />', () => {
       ]);
     });
 
-    it('re-registers an explicitly indexed item when its index changes', async () => {
+    it('re-registers an item when its explicit index changes or is removed', async () => {
       const refCalls: Array<HTMLElement | null> = [];
       const elementsRef = {
         current: [] as Array<HTMLElement | null>,
       };
 
-      function TrackedItem(props: { index: number }) {
-        const { ref, index } = useCompositeListItem({ index: props.index });
+      function TrackedItem(props: { index?: number }) {
+        const { ref, index } = useCompositeListItem({ guess: true, index: props.index });
         const trackingRef = React.useCallback(
           (node: HTMLElement | null) => {
             refCalls.push(node);
@@ -401,7 +411,7 @@ describe('<CompositeList />', () => {
         return <div ref={trackingRef} data-testid="tracked" data-index={index} />;
       }
 
-      function App(props: { index: number }) {
+      function App(props: { index?: number }) {
         return (
           <CompositeList elementsRef={elementsRef}>
             <TrackedItem index={props.index} />
@@ -424,6 +434,14 @@ describe('<CompositeList />', () => {
       expect(screen.getByTestId('tracked')).toHaveAttribute('data-index', '2');
       expect(Object.hasOwn(elementsRef.current, 0)).toBe(false);
       expect(elementsRef.current[2]).toBe(tracked);
+
+      await setProps({ index: undefined });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('tracked')).toHaveAttribute('data-index', '0');
+      });
+      expect(refCalls).toEqual([tracked, null, tracked, null, tracked]);
+      expect(elementsRef.current).toEqual([tracked]);
     });
 
     it('does not detach item refs when an index shifts', async () => {
@@ -875,6 +893,33 @@ describe('<CompositeList />', () => {
       await setProps({ items: ['a'] });
       expect(labelsRef.current).toEqual(['a']);
     });
+
+    it('updates the label of a mounted item', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const labelsRef = {
+        current: [] as Array<string | null>,
+      };
+      const onMapChange = vi.fn();
+
+      function App(props: { label: string }) {
+        return (
+          <CompositeList elementsRef={elementsRef} labelsRef={labelsRef} onMapChange={onMapChange}>
+            <LabelledItem testId="item" label={props.label} />
+          </CompositeList>
+        );
+      }
+
+      const { setProps } = await render(<App label="before" />, { strict: false });
+      expect(labelsRef.current).toEqual(['before']);
+      onMapChange.mockClear();
+
+      await setProps({ label: 'after' });
+
+      expect(labelsRef.current).toEqual(['after']);
+      expect(onMapChange).toHaveBeenCalledOnce();
+    });
   });
 
   describe('prop: onMapChange', () => {
@@ -909,7 +954,7 @@ describe('<CompositeList />', () => {
       return <div ref={ref} data-testid={props.label} data-index={index} />;
     }
 
-    it('hydrates a server-rendered list without a mismatch under Strict Mode', async () => {
+    it('hydrates a server-rendered list without a mismatch under Strict Mode', () => {
       const elementsRef = {
         current: [] as Array<HTMLElement | null>,
       };
@@ -923,15 +968,11 @@ describe('<CompositeList />', () => {
         );
       }
 
-      const { hydrate } = await renderToString(
-        <React.StrictMode>
-          <App />
-        </React.StrictMode>,
-      );
+      const { hydrate } = renderToString(<App />);
       expect(screen.getByTestId('a')).toHaveAttribute('data-index', '-1');
       expect(screen.getByTestId('b')).toHaveAttribute('data-index', '-1');
 
-      await hydrate();
+      hydrate();
 
       expect(screen.getByTestId('a')).toHaveAttribute('data-index', '0');
       expect(screen.getByTestId('b')).toHaveAttribute('data-index', '1');

--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -579,6 +579,28 @@ describe('<CompositeList />', () => {
       ]);
     });
 
+    it('observes each shared mutation root once', async () => {
+      const observe = vi.spyOn(MutationObserver.prototype, 'observe');
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      await render(
+        <CompositeList elementsRef={elementsRef}>
+          <div data-testid="list">
+            <Item label="a" />
+            <Item label="b" />
+            <Item label="c" />
+          </div>
+        </CompositeList>,
+        { strict: false },
+      );
+
+      const observedRoots = observe.mock.calls.map(([root]) => root);
+      observe.mockRestore();
+      expect(observedRoots).toEqual([screen.getByTestId('list')]);
+    });
+
     it('updates indexes when keyed groups reorder', async () => {
       function App() {
         const [reordered, setReordered] = React.useState(false);

--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -7,7 +7,7 @@ import { CompositeList } from './CompositeList';
 import { useCompositeListItem } from './useCompositeListItem';
 
 describe('<CompositeList />', () => {
-  const { render } = createRenderer();
+  const { render, renderToString } = createRenderer();
 
   describe('prop: elementsRef', () => {
     function Item(props: { label?: string; index?: number }) {
@@ -125,7 +125,7 @@ describe('<CompositeList />', () => {
       };
 
       function GuessedItem(props: { label: string; index?: number }) {
-        const { ref, index } = useCompositeListItem({ index: props.index });
+        const { ref, index } = useCompositeListItem({ guess: true, index: props.index });
         const initialIndex = React.useRef(index).current;
         return <div ref={ref} data-testid={props.label} data-initial-index={initialIndex} />;
       }
@@ -316,7 +316,7 @@ describe('<CompositeList />', () => {
       const initialIndexes: Record<string, number> = {};
 
       function GuessedItem(props: { label: string }) {
-        const { ref, index } = useCompositeListItem();
+        const { ref, index } = useCompositeListItem({ guess: true });
         renderCounts[props.label] += 1;
         if (!(props.label in initialIndexes)) {
           initialIndexes[props.label] = index;
@@ -843,6 +843,42 @@ describe('<CompositeList />', () => {
       const map = onMapChange.mock.lastCall?.[0] as Map<Element, { kind: string; index: number }>;
       expect(map.get(screen.getByTestId('first'))).toEqual({ kind: 'alpha', index: 0 });
       expect(map.get(screen.getByTestId('second'))).toEqual({ kind: 'beta', index: 1 });
+    });
+  });
+
+  describe('server-side rendering', () => {
+    function Item(props: { label: string }) {
+      const { ref, index } = useCompositeListItem();
+      return <div ref={ref} data-testid={props.label} data-index={index} />;
+    }
+
+    it('hydrates a server-rendered list without a mismatch under Strict Mode', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      function App() {
+        return (
+          <CompositeList elementsRef={elementsRef}>
+            <Item label="a" />
+            <Item label="b" />
+          </CompositeList>
+        );
+      }
+
+      const { hydrate } = await renderToString(
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>,
+      );
+      expect(screen.getByTestId('a')).toHaveAttribute('data-index', '-1');
+      expect(screen.getByTestId('b')).toHaveAttribute('data-index', '-1');
+
+      await hydrate();
+
+      expect(screen.getByTestId('a')).toHaveAttribute('data-index', '0');
+      expect(screen.getByTestId('b')).toHaveAttribute('data-index', '1');
+      expect(elementsRef.current).toEqual([screen.getByTestId('a'), screen.getByTestId('b')]);
     });
   });
 

--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -42,6 +42,41 @@ describe('<CompositeList />', () => {
       expect(labelsRef.current).toHaveLength(0);
     });
 
+    it('keeps refs populated for items whose guessed index is already correct', async () => {
+      function GuessedItem(props: { label: string }) {
+        const { ref } = useCompositeListItem({ guess: true, label: props.label });
+        return (
+          <div ref={ref} data-testid={props.label}>
+            {props.label}
+          </div>
+        );
+      }
+
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+      const labelsRef = {
+        current: [] as Array<string | null>,
+      };
+
+      await render(
+        <CompositeList elementsRef={elementsRef} labelsRef={labelsRef}>
+          <GuessedItem label="a" />
+          <GuessedItem label="b" />
+          <GuessedItem label="c" />
+        </CompositeList>,
+      );
+
+      // A React 18 Strict Mode effect replay empties the arrays without reattaching refs
+      // when every guessed index is already correct. The list must repopulate them itself.
+      await waitFor(() => {
+        expect(elementsRef.current[0]).toBe(screen.getByTestId('a'));
+      });
+      expect(elementsRef.current[1]).toBe(screen.getByTestId('b'));
+      expect(elementsRef.current[2]).toBe(screen.getByTestId('c'));
+      expect(labelsRef.current).toEqual(['a', 'b', 'c']);
+    });
+
     it('only publishes maps that are aligned with the element registry', async () => {
       const elementsRef = {
         current: [] as Array<HTMLElement | null>,

--- a/packages/react/src/internals/composite/list/CompositeList.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.tsx
@@ -7,7 +7,7 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { CompositeListContext, type CompositeListRegistration } from './CompositeListContext';
 
 export type CompositeMetadata<CustomMetadata> = {
-  index?: number | null | undefined;
+  index: number;
 } & CustomMetadata;
 
 interface CompositeListItem<Metadata> {
@@ -59,7 +59,7 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
   });
 
   const syncRefs = useStableCallback((items: readonly CompositeListItem<Metadata>[]) => {
-    const nextMap = new Map<Element, CompositeMetadata<Metadata> | null>();
+    const nextMap = new Map<Element, CompositeMetadata<Metadata>>();
 
     elementsRef.current.length = 0;
     if (labelsRef) {
@@ -89,6 +89,7 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
 
   function observe(sortedNodes: HTMLElement[]) {
     mutationObserverRef.current?.disconnect();
+    mutationObserverRef.current = null;
 
     // A single item can't reorder.
     if (typeof MutationObserver !== 'function' || sortedNodes.length < 2) {
@@ -246,7 +247,9 @@ function getCompositeListSnapshot<Metadata>(
     nextAutomaticIndex += 1;
   });
 
-  items.sort((a, b) => a.index - b.index);
+  if (reservedIndices.size > 0) {
+    items.sort((a, b) => a.index - b.index);
+  }
 
   return [items, automaticItems.map((item) => item.element)] as const;
 }
@@ -296,7 +299,7 @@ export interface CompositeListProps<Metadata> {
    * `useTypeahead`'s `listRef` prop.
    */
   labelsRef?: React.RefObject<Array<string | null>> | undefined;
-  onMapChange?: ((newMap: Map<Element, CompositeMetadata<Metadata> | null>) => void) | undefined;
+  onMapChange?: ((newMap: Map<Element, CompositeMetadata<Metadata>>) => void) | undefined;
 }
 
 export namespace CompositeList {

--- a/packages/react/src/internals/composite/list/CompositeList.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.tsx
@@ -4,11 +4,17 @@ import * as React from 'react';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { CompositeListContext } from './CompositeListContext';
+import { CompositeListContext, type CompositeListRegistration } from './CompositeListContext';
 
 export type CompositeMetadata<CustomMetadata> = {
   index?: number | null | undefined;
 } & CustomMetadata;
+
+interface CompositeListItem<Metadata> {
+  index: number;
+  element: HTMLElement;
+  metadata: Metadata | null;
+}
 
 /**
  * Provides context for a list of items in a composite component.
@@ -19,70 +25,75 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
 
   const onMapChange = useStableCallback(onMapChangeProp);
 
-  const nextIndexRef = React.useRef(0);
+  const [, setMapTick] = React.useState(false);
+
   const listeners = useRefWithInit(createListeners).current;
-
-  // We use a stable `map` to avoid O(n^2) re-allocation costs for large lists.
-  // `mapTick` is our re-render trigger mechanism. We also need to update the
-  // elements and label refs, but there's a lot of async work going on and sometimes
-  // the effect that handles `onMapChange` gets called after those refs have been
-  // filled, and we don't want to lose those values by setting their lengths to `0`.
-  // We also need to have them at the proper length because floating-ui uses that
-  // information for list navigation.
-
   const map = useRefWithInit(createMap<Metadata>).current;
-  // `mapTick` uses a counter rather than objects for low precision-loss risk and better memory efficiency
-  const [mapTick, setMapTick] = React.useState(0);
-  const lastTickRef = React.useRef(mapTick);
+  const nextIndexRef = React.useRef(0);
+  const isDirtyRef = React.useRef(true);
+  const itemsRef = React.useRef<readonly CompositeListItem<Metadata>[]>([]);
+  const mutationObserverRef = React.useRef<MutationObserver | null>(null);
 
-  const register = useStableCallback((node: Element, metadata: Metadata) => {
-    map.set(node, metadata ?? null);
-    lastTickRef.current += 1;
-    setMapTick(lastTickRef.current);
-  });
+  // Item effects can run without their parent rendering. Schedule one synchronous
+  // parent update for the whole commit so refs are rebuilt before paint and while
+  // the originating React event is still inside `act()` in tests.
+  function scheduleMapUpdate() {
+    if (isDirtyRef.current) {
+      return;
+    }
+
+    isDirtyRef.current = true;
+    setMapTick((tick) => !tick);
+  }
+
+  const register = useStableCallback(
+    (node: Element, registration: CompositeListRegistration<Metadata>) => {
+      map.set(node, registration);
+      scheduleMapUpdate();
+    },
+  );
 
   const unregister = useStableCallback((node: Element) => {
     map.delete(node);
-    lastTickRef.current += 1;
-    setMapTick(lastTickRef.current);
+    scheduleMapUpdate();
   });
 
-  const sortedMap = React.useMemo(() => {
-    // `mapTick` is the `useMemo` trigger as `map` is stable.
-    disableEslintWarning(mapTick);
+  const syncRefs = useStableCallback((items: readonly CompositeListItem<Metadata>[]) => {
+    const nextMap = new Map<Element, CompositeMetadata<Metadata> | null>();
 
-    const newMap = new Map<Element, CompositeMetadata<Metadata>>();
-    // Filter out disconnected elements before sorting to avoid inconsistent
-    // compareDocumentPosition results when elements are detached from the DOM.
-    const sortedNodes = Array.from(map.keys())
-      .filter((node) => node.isConnected)
-      .sort(sortByDocumentPosition);
-
-    sortedNodes.forEach((node, index) => {
-      const metadata = map.get(node) ?? ({} as CompositeMetadata<Metadata>);
-      newMap.set(node, { ...metadata, index });
-    });
-
-    return newMap;
-  }, [map, mapTick]);
-
-  useIsoLayoutEffect(() => {
-    // A single item can't reorder.
-    if (typeof MutationObserver !== 'function' || sortedMap.size < 2) {
-      return undefined;
+    elementsRef.current.length = 0;
+    if (labelsRef) {
+      labelsRef.current.length = 0;
     }
 
-    // `sortedMap` is populated in sorted order, so its keys are the last known
-    // document order of the items.
-    const sortedNodes = Array.from(sortedMap.keys());
+    items.forEach((item) => {
+      nextMap.set(item.element, {
+        ...(item.metadata ?? ({} as Metadata)),
+        index: item.index,
+      });
 
-    // Rather than observing the whole composite container, observe the smallest
-    // direct-child lists whose order can affect registered item order. For flat
-    // lists this is the item parent; for grouped lists this includes the group
-    // wrapper boundary between adjacent items.
-    const roots = getAdjacentNodeRoots(sortedNodes);
-    if (roots.size === 0) {
-      return undefined;
+      elementsRef.current[item.index] = item.element;
+
+      if (labelsRef) {
+        const registration = map.get(item.element)!;
+        labelsRef.current[item.index] =
+          registration.label !== undefined
+            ? registration.label
+            : (registration.textRef?.current?.textContent ?? item.element.textContent);
+      }
+    });
+
+    nextIndexRef.current = elementsRef.current.length;
+
+    return nextMap;
+  });
+
+  function observe(sortedNodes: HTMLElement[]) {
+    mutationObserverRef.current?.disconnect();
+
+    // A single item can't reorder.
+    if (typeof MutationObserver !== 'function' || sortedNodes.length < 2) {
+      return;
     }
 
     const mutationObserver = new MutationObserver((entries) => {
@@ -105,8 +116,7 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
 
         if (previousConnectedNode && sortByDocumentPosition(previousConnectedNode, node) > 0) {
           mutationObserver.disconnect();
-          lastTickRef.current += 1;
-          setMapTick(lastTickRef.current);
+          scheduleMapUpdate();
           return;
         }
 
@@ -114,43 +124,58 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
       }
     });
 
-    roots.forEach((root) => {
-      mutationObserver.observe(root, { childList: true });
-    });
+    mutationObserverRef.current = mutationObserver;
 
-    return () => {
-      mutationObserver.disconnect();
-    };
-  }, [sortedMap]);
+    // A reorder that changes item indexes must invert at least one adjacent pair
+    // from the previous sorted order. Observing each pair's common parent catches
+    // both direct item moves and ancestor wrapper moves at the boundary.
+    for (let i = 1; i < sortedNodes.length; i += 1) {
+      const root = getCommonAncestor(sortedNodes[i - 1], sortedNodes[i]);
+      if (root) {
+        mutationObserver.observe(root, { childList: true });
+      }
+    }
+  }
+
+  const flush = useStableCallback(() => {
+    const [items, automaticNodes] = getCompositeListSnapshot(map);
+    const nextMap = syncRefs(items);
+
+    observe(automaticNodes);
+    itemsRef.current = items;
+    isDirtyRef.current = false;
+
+    listeners.forEach((listener) => listener(nextMap));
+    onMapChange(nextMap);
+  });
 
   useIsoLayoutEffect(() => {
-    const shouldUpdateLengths = lastTickRef.current === mapTick;
-    if (shouldUpdateLengths) {
-      if (elementsRef.current.length !== sortedMap.size) {
-        elementsRef.current.length = sortedMap.size;
-      }
-      if (labelsRef && labelsRef.current.length !== sortedMap.size) {
-        labelsRef.current.length = sortedMap.size;
-      }
-      nextIndexRef.current = sortedMap.size;
+    if (!isDirtyRef.current) {
+      syncRefs(itemsRef.current);
     }
 
-    onMapChange(sortedMap);
-  }, [onMapChange, sortedMap, elementsRef, labelsRef, mapTick]);
-
-  useIsoLayoutEffect(() => {
     return () => {
       elementsRef.current = [];
-    };
-  }, [elementsRef]);
-
-  useIsoLayoutEffect(() => {
-    return () => {
       if (labelsRef) {
         labelsRef.current = [];
       }
     };
-  }, [labelsRef]);
+  }, [elementsRef, labelsRef, syncRefs]);
+
+  useIsoLayoutEffect(() => {
+    if (isDirtyRef.current) {
+      flush();
+    }
+  });
+
+  useIsoLayoutEffect(() => {
+    return () => {
+      mutationObserverRef.current?.disconnect();
+      // React 18 Strict Mode replays effects without replaying callback refs.
+      // Mark the retained map dirty so the replay rebuilds refs and observation.
+      isDirtyRef.current = true;
+    };
+  }, []);
 
   const subscribeMapChange = useStableCallback((fn) => {
     listeners.add(fn);
@@ -159,13 +184,9 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     };
   });
 
-  useIsoLayoutEffect(() => {
-    listeners.forEach((l) => l(sortedMap));
-  }, [listeners, sortedMap]);
-
   const contextValue = React.useMemo(
-    () => ({ register, unregister, subscribeMapChange, elementsRef, labelsRef, nextIndexRef }),
-    [register, unregister, subscribeMapChange, elementsRef, labelsRef, nextIndexRef],
+    () => ({ register, unregister, subscribeMapChange, nextIndexRef }),
+    [register, unregister, subscribeMapChange, nextIndexRef],
   );
 
   return (
@@ -174,28 +195,56 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
 }
 
 function createMap<Metadata>() {
-  return new Map<Element, CompositeMetadata<Metadata> | null>();
+  return new Map<Element, CompositeListRegistration<Metadata>>();
 }
 
 function createListeners() {
   return new Set<Function>();
 }
 
-function getAdjacentNodeRoots(nodes: Element[]) {
-  const roots = new Set<Element>();
+function getCompositeListSnapshot<Metadata>(
+  map: Map<Element, CompositeListRegistration<Metadata>>,
+) {
+  const reservedIndices = new Set<number>();
+  const items: CompositeListItem<Metadata>[] = [];
+  const automaticItems: CompositeListItem<Metadata>[] = [];
 
-  // A reorder that changes item indexes must invert at least one adjacent pair
-  // from the previous sorted order. Observing each pair's common parent catches
-  // both direct item moves and ancestor wrapper moves at the boundary.
-  for (let i = 1; i < nodes.length; i += 1) {
-    const ancestor = getCommonAncestor(nodes[i - 1], nodes[i]);
-
-    if (ancestor) {
-      roots.add(ancestor);
+  map.forEach((registration, node) => {
+    if (!node.isConnected) {
+      return;
     }
-  }
 
-  return roots;
+    const index = registration.index;
+    const item = {
+      index: index ?? -1,
+      element: node as HTMLElement,
+      metadata: registration.metadata,
+    };
+
+    if (index === null) {
+      automaticItems.push(item);
+    } else if (index >= 0) {
+      reservedIndices.add(index);
+      items.push(item);
+    }
+  });
+
+  let nextAutomaticIndex = 0;
+  automaticItems.sort((a, b) => sortByDocumentPosition(a.element, b.element));
+
+  automaticItems.forEach((item) => {
+    while (reservedIndices.has(nextAutomaticIndex)) {
+      nextAutomaticIndex += 1;
+    }
+
+    item.index = nextAutomaticIndex;
+    items.push(item);
+    nextAutomaticIndex += 1;
+  });
+
+  items.sort((a, b) => a.index - b.index);
+
+  return [items, automaticItems.map((item) => item.element)] as const;
 }
 
 function getCommonAncestor(firstNode: Element, lastNode: Element) {
@@ -211,27 +260,11 @@ function getCommonAncestor(firstNode: Element, lastNode: Element) {
 }
 
 function hasMovedNode(entries: MutationRecord[]) {
-  const removed = new Set<Node>();
-
-  // The records are chronological: an addition following a removal is a move,
-  // while a removal following an addition is a net removal.
   for (const entry of entries) {
-    for (let i = 0; i < entry.addedNodes.length; i += 1) {
-      if (removed.has(entry.addedNodes[i])) {
+    for (let i = 0; i < entry.removedNodes.length; i += 1) {
+      if (entry.removedNodes[i].isConnected) {
         return true;
       }
-    }
-
-    for (let i = 0; i < entry.removedNodes.length; i += 1) {
-      removed.add(entry.removedNodes[i]);
-    }
-  }
-
-  // A removed node that is still connected was reparented into a container
-  // this observer doesn't watch.
-  for (const node of removed) {
-    if (node.isConnected) {
-      return true;
     }
   }
 
@@ -239,23 +272,10 @@ function hasMovedNode(entries: MutationRecord[]) {
 }
 
 function sortByDocumentPosition(a: Element, b: Element) {
-  const position = a.compareDocumentPosition(b);
-
-  if (
-    position & Node.DOCUMENT_POSITION_FOLLOWING ||
-    position & Node.DOCUMENT_POSITION_CONTAINED_BY
-  ) {
-    return -1;
-  }
-
-  if (position & Node.DOCUMENT_POSITION_PRECEDING || position & Node.DOCUMENT_POSITION_CONTAINS) {
-    return 1;
-  }
-
-  return 0;
+  // `DOCUMENT_POSITION_CONTAINED_BY` is always reported alongside `FOLLOWING`, and `CONTAINS`
+  // alongside `PRECEDING`, so testing `FOLLOWING` alone orders siblings and nested items alike.
+  return a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
 }
-
-function disableEslintWarning(_: any) {}
 
 export interface CompositeListState {}
 
@@ -263,6 +283,7 @@ export interface CompositeListProps<Metadata> {
   children: React.ReactNode;
   /**
    * A ref to the list of HTML elements, ordered by their index.
+   * Explicit indexes can leave empty slots in the array.
    * `useListNavigation`'s `listRef` prop.
    */
   elementsRef: React.RefObject<Array<HTMLElement | null>>;

--- a/packages/react/src/internals/composite/list/CompositeList.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.tsx
@@ -13,7 +13,7 @@ export type CompositeMetadata<CustomMetadata> = {
 interface CompositeListItem<Metadata> {
   index: number;
   element: HTMLElement;
-  metadata: Metadata | null;
+  registration: CompositeListRegistration<Metadata>;
 }
 
 /**
@@ -37,14 +37,14 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
   // Item effects can run without their parent rendering. Schedule one synchronous
   // parent update for the whole commit so refs are rebuilt before paint and while
   // the originating React event is still inside `act()` in tests.
-  function scheduleMapUpdate() {
+  const scheduleMapUpdate = useStableCallback(() => {
     if (isDirtyRef.current) {
       return;
     }
 
     isDirtyRef.current = true;
     setMapTick((tick) => !tick);
-  }
+  });
 
   const register = useStableCallback(
     (node: Element, registration: CompositeListRegistration<Metadata>) => {
@@ -68,18 +68,17 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
 
     items.forEach((item) => {
       nextMap.set(item.element, {
-        ...(item.metadata ?? ({} as Metadata)),
+        ...(item.registration.metadata ?? ({} as Metadata)),
         index: item.index,
       });
 
       elementsRef.current[item.index] = item.element;
 
       if (labelsRef) {
-        const registration = map.get(item.element)!;
         labelsRef.current[item.index] =
-          registration.label !== undefined
-            ? registration.label
-            : (registration.textRef?.current?.textContent ?? item.element.textContent);
+          item.registration.label !== undefined
+            ? item.registration.label
+            : (item.registration.textRef?.current?.textContent ?? item.element.textContent);
       }
     });
 
@@ -153,6 +152,8 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
   });
 
   useIsoLayoutEffect(() => {
+    // Re-copy the last committed snapshot when the ref objects change or Strict Mode replays
+    // effects without reattaching callback refs.
     if (!isDirtyRef.current) {
       syncRefs(itemsRef.current);
     }
@@ -221,7 +222,7 @@ function getCompositeListSnapshot<Metadata>(
     const item = {
       index: index ?? -1,
       element: node as HTMLElement,
-      metadata: registration.metadata,
+      registration,
     };
 
     if (index === null) {

--- a/packages/react/src/internals/composite/list/CompositeList.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.tsx
@@ -129,12 +129,15 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
     // A reorder that changes item indexes must invert at least one adjacent pair
     // from the previous sorted order. Observing each pair's common parent catches
     // both direct item moves and ancestor wrapper moves at the boundary.
+    const roots = new Set<Element>();
     for (let i = 1; i < sortedNodes.length; i += 1) {
       const root = getCommonAncestor(sortedNodes[i - 1], sortedNodes[i]);
       if (root) {
-        mutationObserver.observe(root, { childList: true });
+        roots.add(root);
       }
     }
+
+    roots.forEach((root) => mutationObserver.observe(root, { childList: true }));
   }
 
   const flush = useStableCallback(() => {

--- a/packages/react/src/internals/composite/list/CompositeListContext.ts
+++ b/packages/react/src/internals/composite/list/CompositeListContext.ts
@@ -11,7 +11,7 @@ export interface CompositeListRegistration<Metadata> {
 export interface CompositeListContextValue<Metadata> {
   register: (node: Element, registration: CompositeListRegistration<Metadata>) => void;
   unregister: (node: Element) => void;
-  subscribeMapChange: (fn: (map: Map<Element, Metadata | null>) => void) => () => void;
+  subscribeMapChange: (fn: (map: Map<Element, Metadata>) => void) => () => void;
   nextIndexRef: React.RefObject<number>;
 }
 

--- a/packages/react/src/internals/composite/list/CompositeListContext.ts
+++ b/packages/react/src/internals/composite/list/CompositeListContext.ts
@@ -1,22 +1,24 @@
 'use client';
 import * as React from 'react';
 
+export interface CompositeListRegistration<Metadata> {
+  metadata: Metadata | null;
+  index: number | null;
+  label: string | null | undefined;
+  textRef: React.RefObject<HTMLElement | null> | undefined;
+}
+
 export interface CompositeListContextValue<Metadata> {
-  register: (node: Element, metadata: Metadata) => void;
+  register: (node: Element, registration: CompositeListRegistration<Metadata>) => void;
   unregister: (node: Element) => void;
   subscribeMapChange: (fn: (map: Map<Element, Metadata | null>) => void) => () => void;
-  elementsRef: React.RefObject<Array<HTMLElement | null>>;
-  labelsRef?: React.RefObject<Array<string | null>> | undefined;
   nextIndexRef: React.RefObject<number>;
 }
 
 export const CompositeListContext = React.createContext<CompositeListContextValue<any>>({
   register: () => {},
   unregister: () => {},
-  subscribeMapChange: () => {
-    return () => {};
-  },
-  elementsRef: { current: [] },
+  subscribeMapChange: () => () => {},
   nextIndexRef: { current: 0 },
 });
 

--- a/packages/react/src/internals/composite/list/useCompositeListItem.ts
+++ b/packages/react/src/internals/composite/list/useCompositeListItem.ts
@@ -12,7 +12,12 @@ export interface UseCompositeListItemParameters<Metadata> {
   guess?: boolean | undefined;
   index?: number | undefined;
   label?: string | null | undefined;
+  /**
+   * Metadata published with the item. Keep object values referentially stable to avoid
+   * unnecessarily detaching and reattaching the callback ref.
+   */
   metadata?: Metadata | undefined;
+  /** Keep the ref object stable to avoid unnecessarily reattaching the item. */
   textRef?: React.RefObject<HTMLElement | null> | undefined;
 }
 
@@ -31,7 +36,7 @@ export function useCompositeListItem<Metadata>(
 
   const { register, unregister, subscribeMapChange, nextIndexRef } = useCompositeListContext();
 
-  // Guess the index from the registration order. This avoids a re-render after mount for
+  // Guess the index from the render order. This avoids a re-render after mount for
   // flat lists rendered in DOM order; when the guess is wrong (grouped or out-of-order
   // rendering), the commit flush corrects it before paint.
   const indexRef = React.useRef(-1);

--- a/packages/react/src/internals/composite/list/useCompositeListItem.ts
+++ b/packages/react/src/internals/composite/list/useCompositeListItem.ts
@@ -8,10 +8,6 @@ export interface UseCompositeListItemParameters<Metadata> {
   label?: string | null | undefined;
   metadata?: Metadata | undefined;
   textRef?: React.RefObject<HTMLElement | null> | undefined;
-  /** Enables guessing the indexes. This avoids a re-render after mount, which is useful for
-   * large lists. This should be used for lists that are likely flat and vertical, other cases
-   * might trigger a re-render anyway. */
-  indexGuessBehavior?: IndexGuessBehavior | undefined;
 }
 
 interface UseCompositeListItemReturnValue {
@@ -19,74 +15,60 @@ interface UseCompositeListItemReturnValue {
   index: number;
 }
 
-const GUESS_FROM_ORDER = 1;
-
-export const IndexGuessBehavior = {
-  None: 0,
-  GuessFromOrder: GUESS_FROM_ORDER,
-} as const;
-export type IndexGuessBehavior = (typeof IndexGuessBehavior)[keyof typeof IndexGuessBehavior];
-
 /**
  * Used to register a list item and its index (DOM position) in the `CompositeList`.
  */
 export function useCompositeListItem<Metadata>(
   params: UseCompositeListItemParameters<Metadata> = {},
 ): UseCompositeListItemReturnValue {
-  const { label, metadata, textRef, indexGuessBehavior, index: externalIndex } = params;
+  const { label, metadata, textRef, index: externalIndex } = params;
 
-  const { register, unregister, subscribeMapChange, elementsRef, labelsRef, nextIndexRef } =
-    useCompositeListContext();
+  const { register, unregister, subscribeMapChange, nextIndexRef } = useCompositeListContext();
 
+  // Guess the index from the registration order. This avoids a re-render after mount for
+  // flat lists rendered in DOM order; when the guess is wrong (grouped or out-of-order
+  // rendering), the commit flush corrects it before paint.
   const indexRef = React.useRef(-1);
-  const [index, setIndex] = React.useState<number>(
-    externalIndex ??
-      (indexGuessBehavior === GUESS_FROM_ORDER
-        ? () => {
-            if (indexRef.current === -1) {
-              const newIndex = nextIndexRef.current;
-              nextIndexRef.current += 1;
-              indexRef.current = newIndex;
-            }
-            return indexRef.current;
+  const [internalIndex, setInternalIndex] = React.useState<number>(
+    externalIndex == null
+      ? () => {
+          if (indexRef.current === -1) {
+            const newIndex = nextIndexRef.current;
+            nextIndexRef.current += 1;
+            indexRef.current = newIndex;
           }
-        : -1),
+          return indexRef.current;
+        }
+      : -1,
   );
+  const index = externalIndex ?? internalIndex;
 
   const componentRef = React.useRef<Element | null>(null);
 
+  // Deliberately identity-sensitive: nested items sharing one DOM node rely on ref attachment
+  // order to decide which registration wins, and republishing from an effect instead would let
+  // an inner item's later update silently take ownership from the outer one.
   const ref = React.useCallback(
     (node: HTMLElement | null) => {
+      const previousNode = componentRef.current;
+
+      if (previousNode) {
+        unregister(previousNode);
+      }
+
       componentRef.current = node;
 
-      if (index !== -1 && node !== null) {
-        elementsRef.current[index] = node;
-
-        if (labelsRef) {
-          const isLabelDefined = label !== undefined;
-          labelsRef.current[index] = isLabelDefined
-            ? label
-            : (textRef?.current?.textContent ?? node.textContent);
-        }
+      if (node) {
+        register(node, {
+          metadata: metadata ?? null,
+          index: externalIndex ?? null,
+          label,
+          textRef,
+        });
       }
     },
-    [index, elementsRef, labelsRef, label, textRef],
+    [externalIndex, register, unregister, metadata, label, textRef],
   );
-
-  useIsoLayoutEffect(() => {
-    if (externalIndex != null) {
-      return undefined;
-    }
-
-    const node = componentRef.current;
-    if (node) {
-      register(node, metadata);
-      return () => {
-        unregister(node);
-      };
-    }
-    return undefined;
-  }, [externalIndex, register, unregister, metadata]);
 
   useIsoLayoutEffect(() => {
     if (externalIndex != null) {
@@ -97,10 +79,10 @@ export function useCompositeListItem<Metadata>(
       const i = componentRef.current ? map.get(componentRef.current)?.index : null;
 
       if (i != null) {
-        setIndex(i);
+        setInternalIndex(i);
       }
     });
-  }, [externalIndex, subscribeMapChange, setIndex]);
+  }, [externalIndex, subscribeMapChange]);
 
   return { ref, index };
 }

--- a/packages/react/src/internals/composite/list/useCompositeListItem.ts
+++ b/packages/react/src/internals/composite/list/useCompositeListItem.ts
@@ -4,6 +4,12 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useCompositeListContext } from './CompositeListContext';
 
 export interface UseCompositeListItemParameters<Metadata> {
+  /**
+   * Whether to guess the initial index from render order, avoiding a re-render after mount for
+   * flat lists.
+   * @default false
+   */
+  guess?: boolean | undefined;
   index?: number | undefined;
   label?: string | null | undefined;
   metadata?: Metadata | undefined;
@@ -21,7 +27,7 @@ interface UseCompositeListItemReturnValue {
 export function useCompositeListItem<Metadata>(
   params: UseCompositeListItemParameters<Metadata> = {},
 ): UseCompositeListItemReturnValue {
-  const { label, metadata, textRef, index: externalIndex } = params;
+  const { guess, label, metadata, textRef, index: externalIndex } = params;
 
   const { register, unregister, subscribeMapChange, nextIndexRef } = useCompositeListContext();
 
@@ -30,7 +36,7 @@ export function useCompositeListItem<Metadata>(
   // rendering), the commit flush corrects it before paint.
   const indexRef = React.useRef(-1);
   const [internalIndex, setInternalIndex] = React.useState<number>(
-    externalIndex == null
+    externalIndex == null && guess
       ? () => {
           if (indexRef.current === -1) {
             const newIndex = nextIndexRef.current;

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -1156,13 +1156,13 @@ const NestedItem = React.forwardRef(function NestedItem(
 
 function NestedItemsRoot() {
   const [itemMap, setItemMap] = React.useState(
-    () => new Map<Node, CompositeMetadata<NestedItemMetadata> | null>(),
+    () => new Map<Node, CompositeMetadata<NestedItemMetadata>>(),
   );
   const disabledIndices = React.useMemo(() => {
     const output: number[] = [];
 
     itemMap.forEach((metadata) => {
-      if (metadata?.index != null && metadata.disabled && !metadata.focusableWhenDisabled) {
+      if (metadata.disabled && !metadata.focusableWhenDisabled) {
         output.push(metadata.index);
       }
     });

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -12,6 +12,7 @@ import { isJSDOM } from '#test-utils';
 import { DirectionProvider } from '../../../direction-provider';
 import { CompositeItem } from '../item/CompositeItem';
 import { type CompositeMetadata } from '../list/CompositeList';
+import { useCompositeListItem } from '../list/useCompositeListItem';
 import { CompositeRoot } from './CompositeRoot';
 import { gridNavigation } from './gridNavigation';
 
@@ -20,6 +21,17 @@ const threeColsGrid = gridNavigation({ cols: 3 });
 describe('Composite', () => {
   const { render } = createRenderer();
   const gridItems = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
+  function IndexedItem(props: { index: number; active?: boolean; testId: string }) {
+    const { ref } = useCompositeListItem({ index: props.index });
+    return (
+      <div
+        ref={ref}
+        data-testid={props.testId}
+        data-composite-item-active={props.active ? '' : undefined}
+      />
+    );
+  }
 
   function TestGridItems() {
     return (
@@ -133,6 +145,21 @@ describe('Composite', () => {
 
       expect(item1).toHaveAttribute('tabindex', '0');
       expect(item1).toHaveFocus();
+    });
+
+    it('uses an active item explicit index as the initial highlighted index', async () => {
+      const onHighlightedIndexChange = vi.fn();
+
+      await render(
+        <CompositeRoot highlightedIndex={0} onHighlightedIndexChange={onHighlightedIndexChange}>
+          <IndexedItem testId="two" index={2} active />
+          <IndexedItem testId="zero" index={0} />
+          <IndexedItem testId="one" index={1} />
+        </CompositeRoot>,
+        { strict: false },
+      );
+
+      expect(onHighlightedIndexChange).toHaveBeenCalledWith(2);
     });
 
     it('keeps native input behavior when the native target differs from the synthetic target', async () => {

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -11,6 +11,7 @@ import {
 import { isJSDOM } from '#test-utils';
 import { DirectionProvider } from '../../../direction-provider';
 import { CompositeItem } from '../item/CompositeItem';
+import { type CompositeMetadata } from '../list/CompositeList';
 import { CompositeRoot } from './CompositeRoot';
 import { gridNavigation } from './gridNavigation';
 
@@ -1099,5 +1100,137 @@ describe('Composite', () => {
       await flushMicrotasks();
       expect(item3).toHaveFocus();
     });
+  });
+});
+
+interface NestedItemMetadata {
+  disabled: boolean;
+  focusableWhenDisabled: boolean;
+}
+
+const FOCUSABLE_DISABLED: NestedItemMetadata = {
+  disabled: true,
+  focusableWhenDisabled: true,
+};
+
+const UNFOCUSABLE_DISABLED: NestedItemMetadata = {
+  disabled: true,
+  focusableWhenDisabled: false,
+};
+
+const NestedItem = React.forwardRef(function NestedItem(
+  props: React.ComponentPropsWithoutRef<'button'>,
+  forwardedRef: React.ForwardedRef<HTMLButtonElement>,
+) {
+  return (
+    <CompositeItem tag="button" metadata={UNFOCUSABLE_DISABLED} refs={[forwardedRef]} {...props} />
+  );
+});
+
+function NestedItemsRoot() {
+  const [itemMap, setItemMap] = React.useState(
+    () => new Map<Node, CompositeMetadata<NestedItemMetadata> | null>(),
+  );
+  const disabledIndices = React.useMemo(() => {
+    const output: number[] = [];
+
+    itemMap.forEach((metadata) => {
+      if (metadata?.index != null && metadata.disabled && !metadata.focusableWhenDisabled) {
+        output.push(metadata.index);
+      }
+    });
+
+    return output;
+  }, [itemMap]);
+
+  return (
+    <CompositeRoot
+      orientation="horizontal"
+      disabledIndices={disabledIndices}
+      onMapChange={setItemMap}
+    >
+      <CompositeItem tag="button" metadata={FOCUSABLE_DISABLED} data-testid="first" />
+      <CompositeItem
+        tag="button"
+        render={<NestedItem data-testid="second" />}
+        metadata={FOCUSABLE_DISABLED}
+      />
+      <CompositeItem
+        tag="button"
+        render={<NestedItem data-testid="third" />}
+        metadata={FOCUSABLE_DISABLED}
+      />
+    </CompositeRoot>
+  );
+}
+
+const DynamicNestedItem = React.forwardRef(function DynamicNestedItem(
+  props: React.ComponentPropsWithoutRef<'button'> & { revision: number },
+  forwardedRef: React.ForwardedRef<HTMLButtonElement>,
+) {
+  const { revision, ...other } = props;
+  // Only the inner registration data changes; the outer item's stays put.
+  const metadata = React.useMemo(() => ({ ...UNFOCUSABLE_DISABLED, revision }), [revision]);
+
+  return <CompositeItem tag="button" metadata={metadata} refs={[forwardedRef]} {...other} />;
+});
+
+function DynamicNestedRoot(props: { onMapChange: (map: Map<Node, any>) => void }) {
+  const [revision, setRevision] = React.useState(0);
+
+  return (
+    <React.Fragment>
+      <button type="button" onClick={() => setRevision((value) => value + 1)}>
+        Update inner
+      </button>
+      <CompositeRoot orientation="horizontal" onMapChange={props.onMapChange}>
+        <CompositeItem
+          tag="button"
+          render={<DynamicNestedItem data-testid="shared" revision={revision} />}
+          metadata={FOCUSABLE_DISABLED}
+        />
+      </CompositeRoot>
+    </React.Fragment>
+  );
+}
+
+describe.each([false, true])('nested Composite items (strict: %s)', (strict) => {
+  const { render } = createRenderer({ strict });
+
+  it('keeps outer metadata and focus navigation when items share a DOM node', async () => {
+    const { user } = await render(<NestedItemsRoot />);
+    const first = screen.getByTestId('first');
+    const second = screen.getByTestId('second');
+    const third = screen.getByTestId('third');
+
+    await user.tab();
+    expect(first).toHaveFocus();
+
+    await user.keyboard('{ArrowRight}');
+    await waitFor(() => {
+      expect(second).toHaveFocus();
+    });
+
+    await user.keyboard('{ArrowRight}');
+    await waitFor(() => {
+      expect(third).toHaveFocus();
+    });
+  });
+
+  it('keeps the outer registration when only the inner item updates', async () => {
+    const onMapChange = vi.fn();
+    const { user } = await render(<DynamicNestedRoot onMapChange={onMapChange} />);
+    const shared = screen.getByTestId('shared');
+    const publishedMetadata = () =>
+      (onMapChange.mock.lastCall?.[0] as Map<Node, NestedItemMetadata>)?.get(shared);
+
+    // Both items register the same node; the outer ref attaches last and owns the entry.
+    expect(publishedMetadata()).toMatchObject({ focusableWhenDisabled: true });
+
+    // Updating only the inner item must not hand it ownership. Registration precedence comes
+    // from ref attachment order, so the inner item cannot republish on its own.
+    await user.click(screen.getByRole('button', { name: 'Update inner' }));
+
+    expect(publishedMetadata()).toMatchObject({ focusableWhenDisabled: true });
   });
 });

--- a/packages/react/src/internals/composite/root/CompositeRoot.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.tsx
@@ -123,7 +123,7 @@ export interface CompositeRootProps<Metadata, State extends Record<string, any>>
   highlightedIndex?: number | undefined;
   onHighlightedIndexChange?: ((index: number) => void) | undefined;
   enableHomeAndEndKeys?: boolean | undefined;
-  onMapChange?: ((newMap: Map<Node, CompositeMetadata<Metadata> | null>) => void) | undefined;
+  onMapChange?: ((newMap: Map<Node, CompositeMetadata<Metadata>>) => void) | undefined;
   onKeyDown?: ((event: BaseUIEvent<React.KeyboardEvent>) => void) | undefined;
   stopEventPropagation?: boolean | undefined;
   rootRef?: React.RefObject<HTMLElement | null> | undefined;

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -116,8 +116,10 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
       sortedElements.find((compositeElement) =>
         compositeElement?.hasAttribute(ACTIVE_COMPOSITE_ITEM),
       ) ?? null;
-    // Set the default highlighted index of an arbitrary composite item.
-    const activeIndex = activeItem ? sortedElements.indexOf(activeItem) : -1;
+    // Set the default highlighted index of an arbitrary composite item. The map value carries
+    // the item's own index, which is not its position among the keys once a list mixes explicit
+    // and automatic indexes and leaves gaps.
+    const activeIndex = activeItem ? (map.get(activeItem)?.index ?? -1) : -1;
 
     if (activeIndex !== -1) {
       onHighlightedIndexChange(activeIndex);

--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
@@ -39,7 +39,7 @@ export const MenuCheckboxItem = React.forwardRef(function MenuCheckboxItem(
     ...elementProps
   } = componentProps;
 
-  const listItem = useCompositeListItem({ label });
+  const listItem = useCompositeListItem({ guess: true, label });
   const menuPositionerContext = useMenuPositionerContext(true);
   const id = useBaseUiId(idProp);
 

--- a/packages/react/src/menu/item/MenuItem.tsx
+++ b/packages/react/src/menu/item/MenuItem.tsx
@@ -30,7 +30,7 @@ export const MenuItem = React.forwardRef(function MenuItem(
     ...elementProps
   } = componentProps;
 
-  const listItem = useCompositeListItem({ label });
+  const listItem = useCompositeListItem({ guess: true, label });
   const menuPositionerContext = useMenuPositionerContext(true);
   const id = useBaseUiId(idProp);
 

--- a/packages/react/src/menu/link-item/MenuLinkItem.tsx
+++ b/packages/react/src/menu/link-item/MenuLinkItem.tsx
@@ -32,7 +32,7 @@ export const MenuLinkItem = React.forwardRef(function MenuLinkItem(
 
   const linkRef = React.useRef<HTMLAnchorElement | null>(null);
 
-  const listItem = useCompositeListItem({ label });
+  const listItem = useCompositeListItem({ guess: true, label });
   const menuPositionerContext = useMenuPositionerContext(true);
   const nodeId = menuPositionerContext?.context.nodeId;
 

--- a/packages/react/src/menu/radio-item/MenuRadioItem.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.tsx
@@ -36,7 +36,7 @@ export const MenuRadioItem = React.forwardRef(function MenuRadioItem(
     ...elementProps
   } = componentProps;
 
-  const listItem = useCompositeListItem({ label });
+  const listItem = useCompositeListItem({ guess: true, label });
   const menuPositionerContext = useMenuPositionerContext(true);
   const id = useBaseUiId(idProp);
 

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -84,6 +84,56 @@ describe('<Menu.Root />', () => {
         });
       });
 
+      it.skipIf(isJSDOM)('navigates across grouped items with arrow keys and text', async () => {
+        const { user } = await render(
+          <TestMenu
+            popupProps={{
+              children: (
+                <React.Fragment>
+                  <Menu.Group>
+                    <Menu.Item>Apple</Menu.Item>
+                    <Menu.Item>Banana</Menu.Item>
+                  </Menu.Group>
+                  <Menu.Group>
+                    <Menu.Item>Cherry</Menu.Item>
+                  </Menu.Group>
+                </React.Fragment>
+              ),
+            }}
+          />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+        await act(async () => {
+          trigger.focus();
+        });
+        await user.keyboard('[Enter]');
+
+        const apple = screen.getByRole('menuitem', { name: 'Apple' });
+        const banana = screen.getByRole('menuitem', { name: 'Banana' });
+        const cherry = screen.getByRole('menuitem', { name: 'Cherry' });
+
+        await waitFor(() => {
+          expect(apple).toHaveFocus();
+        });
+        await user.keyboard('{ArrowDown}');
+        await waitFor(() => {
+          expect(banana).toHaveFocus();
+        });
+        await user.keyboard('{ArrowDown}');
+        await waitFor(() => {
+          expect(cherry).toHaveFocus();
+        });
+
+        await act(async () => {
+          apple.focus();
+        });
+        await user.keyboard('c');
+        await waitFor(() => {
+          expect(cherry).toHaveFocus();
+        });
+      });
+
       it('closes with a `detail === 0` click event on keyboard item activation', async () => {
         const openChangeSpy = vi.fn();
 

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -41,7 +41,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
     ...elementProps
   } = componentProps;
 
-  const listItem = useCompositeListItem({ label });
+  const listItem = useCompositeListItem({ guess: true, label });
   const menuPositionerContext = useMenuPositionerContext();
 
   const { store } = useMenuRootContext();

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -62,7 +62,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
     value,
   } = useOTPFieldRootContext();
 
-  const { ref: listItemRef, index } = useCompositeListItem();
+  const { ref: listItemRef, index } = useCompositeListItem({ guess: true });
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const direction = useDirection();
 

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -3,10 +3,7 @@ import * as React from 'react';
 import { SafeReact } from '@base-ui/utils/safeReact';
 import { warn } from '@base-ui/utils/warn';
 import { stopEvent } from '../../floating-ui-react/utils';
-import {
-  IndexGuessBehavior,
-  useCompositeListItem,
-} from '../../internals/composite/list/useCompositeListItem';
+import { useCompositeListItem } from '../../internals/composite/list/useCompositeListItem';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useDirection } from '../../internals/direction-context/DirectionContext';
 import { useRenderElement } from '../../internals/useRenderElement';
@@ -65,9 +62,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
     value,
   } = useOTPFieldRootContext();
 
-  const { ref: listItemRef, index } = useCompositeListItem({
-    indexGuessBehavior: IndexGuessBehavior.GuessFromOrder,
-  });
+  const { ref: listItemRef, index } = useCompositeListItem();
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const direction = useDirection();
 

--- a/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
@@ -1320,6 +1320,27 @@ describe('<OTPField.Root />', () => {
     });
 
     describe('server-side rendering', () => {
+      it('renders visible inputs with unique IDs', () => {
+        renderToString(
+          <OTPFieldBase.Root data-testid="root" id="verification-code" length={OTP_LENGTH}>
+            {Array.from({ length: OTP_LENGTH }, (_, index) => (
+              <OTPFieldBase.Input key={index} />
+            ))}
+          </OTPFieldBase.Root>,
+        );
+
+        const inputs = screen.getByTestId('root').querySelectorAll('input');
+
+        expect(Array.from(inputs, (input) => input.id)).toEqual([
+          'verification-code',
+          'verification-code-2',
+          'verification-code-3',
+          'verification-code-4',
+          'verification-code-5',
+          'verification-code-6',
+        ]);
+      });
+
       it('renders a hidden validation input with the provided length', () => {
         renderToString(
           <OTPFieldBase.Root name="otp" required length={OTP_LENGTH}>

--- a/packages/react/src/select/item/SelectItem.test.tsx
+++ b/packages/react/src/select/item/SelectItem.test.tsx
@@ -234,6 +234,62 @@ describe('<Select.Item />', () => {
     });
   });
 
+  it('should highlight a hovered item and commit it with a mouse click', async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      <Select.Root onValueChange={onValueChange}>
+        <Select.Trigger data-testid="trigger">
+          <Select.Value data-testid="value" />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="one">one</Select.Item>
+              <Select.Item value="two">two</Select.Item>
+              <Select.Item value="three">three</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+
+    fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+    fireEvent.mouseDown(trigger);
+    fireEvent.pointerUp(trigger, { pointerType: 'mouse' });
+    fireEvent.mouseUp(trigger);
+    fireEvent.click(trigger);
+    await flushMicrotasks();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('listbox')).not.toBe(null);
+    });
+
+    const option = screen.getByRole('option', { name: 'two' });
+
+    fireEvent.pointerEnter(option, { pointerType: 'mouse' });
+    fireEvent.mouseMove(option);
+
+    await waitFor(() => {
+      expect(option).toHaveAttribute('data-highlighted');
+    });
+
+    fireEvent.pointerDown(option, { pointerType: 'mouse' });
+    fireEvent.mouseDown(option);
+    fireEvent.pointerUp(option, { pointerType: 'mouse' });
+    fireEvent.mouseUp(option);
+    fireEvent.click(option);
+    await flushMicrotasks();
+
+    expect(onValueChange).toHaveBeenCalledOnce();
+    expect(onValueChange).toHaveBeenCalledWith('two', expect.anything());
+    await waitFor(() => {
+      expect(screen.getByTestId('value').textContent).toBe('two');
+    });
+  });
+
   it('should ignore an unhighlighted item with a generic virtual click', async () => {
     await render(
       <Select.Root defaultOpen highlightItemOnHover={false}>

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -3,10 +3,7 @@ import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStore } from '@base-ui/utils/store';
 import { useSelectRootContext } from '../root/SelectRootContext';
-import {
-  useCompositeListItem,
-  IndexGuessBehavior,
-} from '../../internals/composite/list/useCompositeListItem';
+import { useCompositeListItem } from '../../internals/composite/list/useCompositeListItem';
 import type {
   BaseUIComponentProps,
   BaseUIEvent,
@@ -48,7 +45,6 @@ export const SelectItem = React.memo(
     const listItem = useCompositeListItem({
       label,
       textRef,
-      indexGuessBehavior: IndexGuessBehavior.GuessFromOrder,
     });
 
     const {

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -43,6 +43,7 @@ export const SelectItem = React.memo(
 
     const textRef = React.useRef<HTMLElement | null>(null);
     const listItem = useCompositeListItem({
+      guess: true,
       label,
       textRef,
     });

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -141,7 +141,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   const [lastUsedThumbIndex, setLastUsedThumbIndex] = React.useState(-1);
   const [dragging, setDragging] = React.useState(false);
   const [thumbMap, setThumbMap] = React.useState(
-    () => new Map<Node, CompositeMetadata<ThumbMetadata> | null>(),
+    () => new Map<Node, CompositeMetadata<ThumbMetadata>>(),
   );
   const [indicatorPosition, setIndicatorPosition] = React.useState<(number | undefined)[]>([
     undefined,

--- a/packages/react/src/slider/root/SliderRootContext.ts
+++ b/packages/react/src/slider/root/SliderRootContext.ts
@@ -93,7 +93,7 @@ export interface SliderRootContext {
    */
   step: number;
   thumbCollisionBehavior: 'push' | 'swap' | 'none';
-  thumbMap: Map<Node, CompositeMetadata<ThumbMetadata> | null>;
+  thumbMap: Map<Node, CompositeMetadata<ThumbMetadata>>;
   thumbRefs: React.RefObject<(HTMLElement | null)[]>;
   /**
    * The value(s) of the slider

--- a/packages/react/src/slider/value/SliderValue.test.tsx
+++ b/packages/react/src/slider/value/SliderValue.test.tsx
@@ -37,6 +37,24 @@ describe('<Slider.Value />', () => {
     expect(sliderValue).toHaveTextContent('40 – 65');
   });
 
+  it('associates the output with every thumb input', async () => {
+    await render(
+      <Slider.Root defaultValue={[40, 65]}>
+        <Slider.Value data-testid="output" />
+        <Slider.Control>
+          <Slider.Thumb index={0} />
+          <Slider.Thumb index={1} />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    const thumbIds = screen.getAllByRole('slider').map((thumb) => thumb.id);
+
+    expect(thumbIds).not.toContain('');
+    expect(new Set(thumbIds).size).toBe(thumbIds.length);
+    expect(screen.getByTestId('output')).toHaveAttribute('for', thumbIds.join(' '));
+  });
+
   it('renders all thumb values', async () => {
     await render(
       <Slider.Root defaultValue={[40, 60, 80, 95]}>

--- a/packages/react/src/slider/value/SliderValue.tsx
+++ b/packages/react/src/slider/value/SliderValue.tsx
@@ -30,7 +30,7 @@ export const SliderValue = React.forwardRef(function SliderValue(
 
   let htmlFor = '';
   for (const thumbMetadata of thumbMap.values()) {
-    if (thumbMetadata?.inputId) {
+    if (thumbMetadata.inputId) {
       htmlFor += `${thumbMetadata.inputId} `;
     }
   }

--- a/packages/react/src/tabs/root/TabsRoot.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.tsx
@@ -57,7 +57,7 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
   const isControlled = valueProp !== undefined;
 
   const [tabMap, setTabMap] = React.useState(
-    () => new Map<Node, CompositeMetadata<TabsTab.Metadata> | null>(),
+    () => new Map<Node, CompositeMetadata<TabsTab.Metadata>>(),
   );
   const lastKnownTabElementRef = React.useRef<Node | undefined>(undefined);
 
@@ -174,8 +174,8 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
   const getTabIdByPanelValue = React.useCallback(
     (tabPanelValue: TabsTab.Value) => {
       for (const tabMetadata of tabMap.values()) {
-        if (tabPanelValue === tabMetadata?.value) {
-          return tabMetadata?.id;
+        if (tabPanelValue === tabMetadata.value) {
+          return tabMetadata.id;
         }
       }
       return undefined;
@@ -210,7 +210,7 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
 
   const selectedTabMetadata = React.useMemo(() => {
     for (const tabMetadata of tabMap.values()) {
-      if (tabMetadata != null && tabMetadata.value === value) {
+      if (tabMetadata.value === value) {
         return tabMetadata;
       }
     }
@@ -221,7 +221,7 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
   // Used as a fallback when the current selection is disabled or missing.
   const firstEnabledTabValue = React.useMemo(() => {
     for (const tabMetadata of tabMap.values()) {
-      if (tabMetadata != null && !tabMetadata.disabled) {
+      if (!tabMetadata.disabled) {
         return tabMetadata.value;
       }
     }
@@ -359,7 +359,7 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
 });
 
 function findTabElement(
-  tabMap: Map<Node, CompositeMetadata<TabsTab.Metadata> | null>,
+  tabMap: Map<Node, CompositeMetadata<TabsTab.Metadata>>,
   value: TabsTab.Value | undefined,
 ): HTMLElement | null {
   if (value === undefined) {
@@ -367,7 +367,7 @@ function findTabElement(
   }
 
   for (const [tabElement, tabMetadata] of tabMap.entries()) {
-    if (tabMetadata != null && value === (tabMetadata.value ?? tabMetadata.index)) {
+    if (value === (tabMetadata.value ?? tabMetadata.index)) {
       return tabElement as HTMLElement;
     }
   }
@@ -379,7 +379,7 @@ function computeActivationDirection(
   oldValue: TabsTab.Value | null,
   newValue: TabsTab.Value | null,
   orientation: 'horizontal' | 'vertical',
-  tabMap: Map<Node, CompositeMetadata<TabsTab.Metadata> | null>,
+  tabMap: Map<Node, CompositeMetadata<TabsTab.Metadata>>,
 ): TabsTab.ActivationDirection {
   if (oldValue == null || newValue == null) {
     return 'none';

--- a/packages/react/src/tabs/root/TabsRootContext.ts
+++ b/packages/react/src/tabs/root/TabsRootContext.ts
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import type { CompositeMetadata } from '../../internals/composite/list/CompositeList';
 import type { TabsTab } from '../tab/TabsTab';
 import type { TabsRoot } from './TabsRoot';
 
@@ -29,9 +30,7 @@ export interface TabsRootContext {
    */
   getTabPanelIdByValue: (tabValue: TabsTab.Value) => string | undefined;
   registerMountedTabPanel: (panelValue: TabsTab.Value | number, panelId: string) => () => void;
-  setTabMap: (
-    map: Map<Node, (TabsTab.Metadata & { index?: number | null | undefined }) | null>,
-  ) => void;
+  setTabMap: (map: Map<Node, CompositeMetadata<TabsTab.Metadata>>) => void;
   /**
    * The position of the active tab relative to the previously active tab.
    */

--- a/packages/react/src/toolbar/root/ToolbarRoot.tsx
+++ b/packages/react/src/toolbar/root/ToolbarRoot.tsx
@@ -30,7 +30,7 @@ export const ToolbarRoot = React.forwardRef(function ToolbarRoot(
   } = componentProps;
 
   const [itemMap, setItemMap] = React.useState(
-    () => new Map<Node, CompositeMetadata<ToolbarRoot.ItemMetadata> | null>(),
+    () => new Map<Node, CompositeMetadata<ToolbarRoot.ItemMetadata>>(),
   );
 
   const disabledIndices = React.useMemo(() => {
@@ -38,11 +38,7 @@ export const ToolbarRoot = React.forwardRef(function ToolbarRoot(
     for (const itemMetadata of itemMap.values()) {
       // Only items that are disabled and not focusable when disabled
       // are removed from roving focus.
-      if (
-        itemMetadata?.index != null &&
-        itemMetadata.disabled &&
-        !itemMetadata.focusableWhenDisabled
-      ) {
+      if (itemMetadata.disabled && !itemMetadata.focusableWhenDisabled) {
         output.push(itemMetadata.index);
       }
     }

--- a/test/performance/tests/combobox.bench.tsx
+++ b/test/performance/tests/combobox.bench.tsx
@@ -63,6 +63,16 @@ function LargeCombobox() {
   );
 }
 
+// Initial mount with the popup open: measures the open/registration cost of a large list in
+// isolation, without any keystroke work.
+benchmark(
+  'Combobox open — 500 items',
+  () => <LargeCombobox />,
+  async ({ waitForElementTiming }) => {
+    await waitForElementTiming('combobox-open');
+  },
+);
+
 // Typing a common prefix keeps every item in the filtered set, so all 500 stay mounted across
 // keystrokes. This isolates the per-keystroke re-render cost of the already-rendered items
 // (no mount/unmount churn): the exact work the derived-items-context split removes.


### PR DESCRIPTION
Fixes #4657
Fixes #4698

Supersedes #5148 and #5207. The `onItemsCommit` callback that #5227 needs will land with that fix rather than ahead of it.

## Problem

`CompositeList` committed the map, elements, labels, and indexes through separate paths: the map was built in a render memo, elements and labels were written by each item's ref callback, and the array lengths were trimmed in a later parent effect. Consumers reading `elementsRef` during `onMapChange` could see a registry that didn't match the map.

Items with an explicit `index` skipped registration entirely, so non-virtualized lists couldn't resolve them in `listRef` for pointer navigation (#4657), and the length trim wiped their slots. In StrictMode the cleanup emptied the arrays without the ref callbacks re-running to refill them (#4698).

## Changes

Registration moves to the item ref callback, and one flush per commit publishes a settled, index-addressed snapshot, so elements, labels, map, and indexes are always aligned. Explicit and automatic indexes coexist: explicit slots are reserved and automatic indexes fill the gaps.

Index guessing is opt-in per consumer, and `IndexGuessBehavior` is removed. Combobox, Menu, and Select opt in for list performance; other composites retain master's initial `-1` behavior until the commit flush. A correct guess skips the corrective re-render, while a wrong guess costs exactly what non-guessing already paid because the flush corrects it before paint.

`packages/react/src/internals/composite/list` now has 100% statement, branch, function, and line coverage. Unreachable registration and document-order branches were removed, while tests now cover detached, shadow-root, and temporarily elementless items.

> [!WARNING]
> **Breaking change (`internals`):** The internal `IndexGuessBehavior` export and `indexGuessBehavior` option are replaced by `guess`.

> [!NOTE]
> GPT-5.6 may flag “Sparse explicit indexes create dead keyboard stops” in reviews. This is intentionally ignored because master is already broken for sparse explicit indexes and the scenario is unrealistic.

> [!NOTE]
> Direct ShadowRoot-child and cross-wrapper DOM reorders remain unsupported, matching master. Wait for real usage before expanding mutation observation to those cases.

## Measurements

Production build, Chromium, 20 iterations per benchmark. Master and this branch were built and benchmarked alternately, 6 samples each; mean ± SD across samples, with Welch's t-test.

| Benchmark | master | this PR | Δ | Renders |
| --- | ---: | ---: | ---: | ---: |
| Slider mount (300 instances) | 30.94 ± 1.62 ms | 19.28 ± 0.93 ms | **−37.7%** | 3 → 2 |
| Combobox type, narrows to ~11 | 9.49 ± 0.39 ms | 9.03 ± 0.59 ms | −4.8% (ns) | 17 → 15 |
| Combobox open (500 items) | 6.56 ± 0.31 ms | 6.33 ± 0.45 ms | −3.6% (ns) | 4 |
| Combobox type, 500 stay mounted | 7.86 ± 1.21 ms | 6.43 ± 0.42 ms | **−18.2%** | 11 |
| Menu open (500 items) | 17.18 ± 1.10 ms | 16.21 ± 1.35 ms | −5.6% (ns) | 12 |
| Select open (500 options) | 10.02 ± 0.56 ms | 9.37 ± 0.88 ms | −6.5% (ns) | 14 |
| Menu mount (300 instances) | 22.14 ± 2.23 ms | 22.39 ± 2.50 ms | +1.1% (ns) | 2 |
| Select mount (200 instances) | 23.67 ± 2.87 ms | 23.33 ± 3.33 ms | −1.4% (ns) | 3 |

Only Slider mount and `Combobox type, 500 stay mounted` are statistically significant; Slider and narrowing Combobox also deterministically drop from 3 → 2 and 17 → 15 renders. Menu opts into `guess` like Select to avoid a corrective popup-mount render without changing initial server markup; the pre-paint flush still corrects grouped or out-of-order guesses.
