### PR TITLE
[drawer] Fix cross-axis scroll blocked on iOS below the touchmove slop

### DIFF
--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -2090,6 +2090,162 @@ describe('<Drawer.Viewport />', () => {
     }
   });
 
+  it('does not prevent a sub-slop first touchmove over cross-axis scrollable content', async () => {
+    await render(
+      <Drawer.Root open swipeDirection="right">
+        <Drawer.Portal>
+          <Drawer.Backdrop data-testid="backdrop" />
+          <Drawer.Viewport>
+            <Drawer.Popup>
+              <div data-testid="scroll" style={{ overflowY: 'auto', maxHeight: 40 }}>
+                <div style={{ height: 120 }}>Scrollable content</div>
+              </div>
+            </Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>,
+    );
+
+    const scroll = screen.getByTestId('scroll');
+    Object.defineProperty(scroll, 'scrollHeight', { value: 120, configurable: true });
+    Object.defineProperty(scroll, 'clientHeight', { value: 40, configurable: true });
+
+    const originalElementFromPoint = document.elementFromPoint;
+    document.elementFromPoint = () => scroll;
+
+    try {
+      fireEvent.touchStart(scroll, {
+        touches: [createTouch(scroll, { clientX: 100, clientY: 100 })],
+      });
+
+      // Below the axis-attribution slop the gesture cannot be claimed yet: preventing the first
+      // cancelable touchmove on iOS cancels native scrolling for the entire gesture.
+      const firstMoveDispatched = fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 100, clientY: 97 })],
+      });
+      expect(firstMoveDispatched).toBe(true);
+
+      // Past the slop on the cross axis, native vertical scrolling stays preserved.
+      const secondMoveDispatched = fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 100, clientY: 60 })],
+      });
+      expect(secondMoveDispatched).toBe(true);
+
+      fireEvent.touchEnd(scroll, {
+        changedTouches: [createTouch(scroll, { clientX: 100, clientY: 60 })],
+      });
+
+      await flushMicrotasks();
+    } finally {
+      document.elementFromPoint = originalElementFromPoint;
+    }
+  });
+
+  it('claims the gesture once the drawer axis passes the slop over cross-axis scrollable content', async () => {
+    await render(
+      <Drawer.Root open swipeDirection="right">
+        <Drawer.Portal>
+          <Drawer.Backdrop data-testid="backdrop" />
+          <Drawer.Viewport>
+            <Drawer.Popup>
+              <div data-testid="scroll" style={{ overflowY: 'auto', maxHeight: 40 }}>
+                <div style={{ height: 120 }}>Scrollable content</div>
+              </div>
+            </Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>,
+    );
+
+    const scroll = screen.getByTestId('scroll');
+    Object.defineProperty(scroll, 'scrollHeight', { value: 120, configurable: true });
+    Object.defineProperty(scroll, 'clientHeight', { value: 40, configurable: true });
+
+    const originalElementFromPoint = document.elementFromPoint;
+    document.elementFromPoint = () => scroll;
+
+    try {
+      fireEvent.touchStart(scroll, {
+        touches: [createTouch(scroll, { clientX: 100, clientY: 100 })],
+      });
+
+      const ambiguousMoveDispatched = fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 103, clientY: 101 })],
+      });
+      expect(ambiguousMoveDispatched).toBe(true);
+
+      const drawerAxisMoveDispatched = fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 112, clientY: 101 })],
+      });
+      expect(drawerAxisMoveDispatched).toBe(false);
+
+      fireEvent.touchEnd(scroll, {
+        changedTouches: [createTouch(scroll, { clientX: 112, clientY: 101 })],
+      });
+
+      await flushMicrotasks();
+    } finally {
+      document.elementFromPoint = originalElementFromPoint;
+    }
+  });
+
+  it('yields the gesture when the browser commits to a native cross-axis scroll', async () => {
+    await render(
+      <Drawer.Root open swipeDirection="right">
+        <Drawer.Portal>
+          <Drawer.Backdrop data-testid="backdrop" />
+          <Drawer.Viewport>
+            <Drawer.Popup>
+              <div data-testid="scroll" style={{ overflowY: 'auto', maxHeight: 40 }}>
+                <div style={{ height: 120 }}>Scrollable content</div>
+              </div>
+            </Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>,
+    );
+
+    const scroll = screen.getByTestId('scroll');
+    Object.defineProperty(scroll, 'scrollHeight', { value: 120, configurable: true });
+    Object.defineProperty(scroll, 'clientHeight', { value: 40, configurable: true });
+
+    const originalElementFromPoint = document.elementFromPoint;
+    document.elementFromPoint = () => scroll;
+
+    try {
+      fireEvent.touchStart(scroll, {
+        touches: [createTouch(scroll, { clientX: 100, clientY: 100 })],
+      });
+
+      fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 100, clientY: 97 })],
+      });
+
+      // A non-cancelable touchmove (still below the slop) means the browser committed the
+      // gesture to a native scroll.
+      const nonCancelableMove = new Event('touchmove', { bubbles: true, cancelable: false });
+      Object.defineProperty(nonCancelableMove, 'touches', {
+        value: [createTouch(scroll, { clientX: 100, clientY: 96 })],
+        configurable: true,
+      });
+      scroll.dispatchEvent(nonCancelableMove);
+
+      // Even a decisive drawer-axis move afterwards must not be claimed.
+      const drawerAxisMoveDispatched = fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 140, clientY: 96 })],
+      });
+      expect(drawerAxisMoveDispatched).toBe(true);
+
+      fireEvent.touchEnd(scroll, {
+        changedTouches: [createTouch(scroll, { clientX: 140, clientY: 96 })],
+      });
+
+      await flushMicrotasks();
+    } finally {
+      document.elementFromPoint = originalElementFromPoint;
+    }
+  });
+
   it('does not lock vertical swipe after minor cross-axis jitter in down drawers', async () => {
     await render(
       <Drawer.Root open swipeDirection="down">

--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -2246,6 +2246,131 @@ describe('<Drawer.Viewport />', () => {
     }
   });
 
+  it('keeps tracking the finger when a claimed drag returns inside the slop', async () => {
+    await render(
+      <Drawer.Root open swipeDirection="right">
+        <Drawer.Portal>
+          <Drawer.Backdrop data-testid="backdrop" />
+          <Drawer.Viewport>
+            <Drawer.Popup data-testid="popup">
+              <div data-testid="scroll" style={{ overflowY: 'auto', maxHeight: 40 }}>
+                <div style={{ height: 120 }}>Scrollable content</div>
+              </div>
+            </Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>,
+    );
+
+    const scroll = screen.getByTestId('scroll');
+    const popup = screen.getByTestId('popup');
+    Object.defineProperty(scroll, 'scrollHeight', { value: 120, configurable: true });
+    Object.defineProperty(scroll, 'clientHeight', { value: 40, configurable: true });
+
+    const originalElementFromPoint = document.elementFromPoint;
+    document.elementFromPoint = () => scroll;
+
+    try {
+      fireEvent.touchStart(scroll, {
+        touches: [createTouch(scroll, { clientX: 100, clientY: 100 })],
+      });
+
+      fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 120, clientY: 100 })],
+      });
+      fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 150, clientY: 100 })],
+      });
+
+      expect(popup.style.getPropertyValue('--drawer-swipe-movement-x')).toBe('30px');
+
+      // The slop is measured from the touch origin, so a claimed drag that travels back inside it
+      // must not be re-arbitrated: the popup has to keep following the finger.
+      const inSlopMoveDispatched = fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 103, clientY: 100 })],
+      });
+      expect(inSlopMoveDispatched).toBe(false);
+      expect(
+        Number.parseFloat(popup.style.getPropertyValue('--drawer-swipe-movement-x')),
+      ).toBeLessThan(0);
+
+      fireEvent.touchEnd(scroll, {
+        changedTouches: [createTouch(scroll, { clientX: 103, clientY: 100 })],
+      });
+
+      await flushMicrotasks();
+    } finally {
+      document.elementFromPoint = originalElementFromPoint;
+    }
+  });
+
+  it('keeps driving a claimed drag through a non-cancelable touchmove', async () => {
+    await render(
+      <Drawer.Root open swipeDirection="right">
+        <Drawer.Portal>
+          <Drawer.Backdrop data-testid="backdrop" />
+          <Drawer.Viewport>
+            <Drawer.Popup data-testid="popup">
+              <div data-testid="scroll" style={{ overflowY: 'auto', maxHeight: 40 }}>
+                <div style={{ height: 120 }}>Scrollable content</div>
+              </div>
+            </Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>,
+    );
+
+    const scroll = screen.getByTestId('scroll');
+    const popup = screen.getByTestId('popup');
+    Object.defineProperty(scroll, 'scrollHeight', { value: 120, configurable: true });
+    Object.defineProperty(scroll, 'clientHeight', { value: 40, configurable: true });
+
+    const originalElementFromPoint = document.elementFromPoint;
+    document.elementFromPoint = () => scroll;
+
+    try {
+      fireEvent.touchStart(scroll, {
+        touches: [createTouch(scroll, { clientX: 100, clientY: 100 })],
+      });
+
+      fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 150, clientY: 100 })],
+      });
+      fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 200, clientY: 100 })],
+      });
+
+      expect(popup.style.getPropertyValue('--drawer-swipe-movement-x')).toBe('50px');
+
+      // Once the drawer axis owns the gesture, a non-cancelable move no longer means the browser
+      // took it for a native scroll, so the drag must not be abandoned.
+      const nonCancelableMove = new Event('touchmove', { bubbles: true, cancelable: false });
+      Object.defineProperty(nonCancelableMove, 'touches', {
+        value: [createTouch(scroll, { clientX: 250, clientY: 100 })],
+        configurable: true,
+      });
+      await act(async () => {
+        scroll.dispatchEvent(nonCancelableMove);
+      });
+
+      expect(popup.style.getPropertyValue('--drawer-swipe-movement-x')).toBe('100px');
+
+      const laterMoveDispatched = fireEvent.touchMove(scroll, {
+        touches: [createTouch(scroll, { clientX: 300, clientY: 100 })],
+      });
+      expect(laterMoveDispatched).toBe(false);
+      expect(popup.style.getPropertyValue('--drawer-swipe-movement-x')).toBe('150px');
+
+      fireEvent.touchEnd(scroll, {
+        changedTouches: [createTouch(scroll, { clientX: 300, clientY: 100 })],
+      });
+
+      await flushMicrotasks();
+    } finally {
+      document.elementFromPoint = originalElementFromPoint;
+    }
+  });
+
   it('does not lock vertical swipe after minor cross-axis jitter in down drawers', async () => {
     await render(
       <Drawer.Root open swipeDirection="down">

--- a/packages/react/src/drawer/viewport/DrawerViewport.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.tsx
@@ -50,6 +50,8 @@ const MIN_SWIPE_RELEASE_DURATION_MS = 80;
 const MAX_SWIPE_RELEASE_DURATION_MS = 360;
 const MIN_SWIPE_RELEASE_SCALAR = 0.1;
 const MAX_SWIPE_RELEASE_SCALAR = 1;
+const AXIS_LOCK_SLOP = 6;
+const AXIS_LOCK_BIAS = 2;
 const DRAWER_CONTENT_SELECTOR = `[${DRAWER_CONTENT_ATTRIBUTE}]`;
 
 interface TouchScrollState {
@@ -739,7 +741,7 @@ export const DrawerViewport = React.forwardRef(function DrawerViewport(
         return;
       }
 
-      if (preserveNativeCrossAxisScrollOnMove(touchState, touch, isVerticalScrollAxis)) {
+      if (preserveNativeCrossAxisScrollOnMove(touchState, event, touch, isVerticalScrollAxis)) {
         return;
       }
 
@@ -1174,6 +1176,7 @@ function updateTouchScrollPosition(touchState: TouchScrollState, touch: Touch): 
 
 function preserveNativeCrossAxisScrollOnMove(
   touchState: TouchScrollState,
+  event: TouchEvent,
   touch: Touch,
   isVerticalScrollAxis: boolean,
 ): boolean {
@@ -1185,6 +1188,13 @@ function preserveNativeCrossAxisScrollOnMove(
     return false;
   }
 
+  // A non-cancelable touchmove means the browser has already committed the gesture to a native
+  // scroll; claiming it for the swipe would drag the popup alongside the scrolling content.
+  if (!event.cancelable) {
+    touchState.preserveNativeCrossAxisScroll = true;
+    return true;
+  }
+
   const drawerAxisGestureDelta = isVerticalScrollAxis
     ? touch.clientY - touchState.startY
     : touch.clientX - touchState.startX;
@@ -1194,11 +1204,22 @@ function preserveNativeCrossAxisScrollOnMove(
   const absDrawerAxisGestureDelta = Math.abs(drawerAxisGestureDelta);
   const absCrossAxisGestureDelta = Math.abs(crossAxisGestureDelta);
 
-  if (absCrossAxisGestureDelta < 6 || absCrossAxisGestureDelta <= absDrawerAxisGestureDelta + 2) {
+  if (
+    absCrossAxisGestureDelta >= AXIS_LOCK_SLOP &&
+    absCrossAxisGestureDelta > absDrawerAxisGestureDelta + AXIS_LOCK_BIAS
+  ) {
+    touchState.preserveNativeCrossAxisScroll = true;
+    return true;
+  }
+
+  if (absDrawerAxisGestureDelta >= AXIS_LOCK_SLOP) {
     return false;
   }
 
-  touchState.preserveNativeCrossAxisScroll = true;
+  // Neither axis has traveled past the slop yet, so the gesture cannot be attributed. Leave the
+  // event alone: on iOS, `preventDefault()` on the first cancelable touchmove cancels native
+  // scrolling for the entire gesture, which would lock a cross-axis scroll that only passes the
+  // slop on a later move.
   return true;
 }
 

--- a/packages/react/src/drawer/viewport/DrawerViewport.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.tsx
@@ -63,6 +63,7 @@ interface TouchScrollState {
   hasCrossAxisScrollableContent: boolean;
   allowSwipe: boolean | null;
   preserveNativeCrossAxisScroll: boolean;
+  drawerAxisAttributed: boolean;
 }
 
 /**
@@ -741,7 +742,7 @@ export const DrawerViewport = React.forwardRef(function DrawerViewport(
         return;
       }
 
-      if (preserveNativeCrossAxisScrollOnMove(touchState, event, touch, isVerticalScrollAxis)) {
+      if (shouldYieldTouchMove(touchState, event, touch, isVerticalScrollAxis)) {
         return;
       }
 
@@ -1033,6 +1034,7 @@ export const DrawerViewport = React.forwardRef(function DrawerViewport(
             hasCrossAxisScrollableContent,
             allowSwipe,
             preserveNativeCrossAxisScroll: false,
+            drawerAxisAttributed: false,
           };
 
           swipeTouchProps.onTouchStart?.(event);
@@ -1174,7 +1176,12 @@ function updateTouchScrollPosition(touchState: TouchScrollState, touch: Touch): 
   touchState.lastY = touch.clientY;
 }
 
-function preserveNativeCrossAxisScrollOnMove(
+/**
+ * Arbitrates a touchmove between the drawer swipe and a native cross-axis scroll.
+ * Returns `true` when the move must be left alone — either because the cross axis already won the
+ * gesture, or because neither axis has passed the slop yet and the gesture cannot be attributed.
+ */
+function shouldYieldTouchMove(
   touchState: TouchScrollState,
   event: TouchEvent,
   touch: Touch,
@@ -1184,7 +1191,14 @@ function preserveNativeCrossAxisScrollOnMove(
     return true;
   }
 
-  if (touchState.allowSwipe === true || !touchState.hasCrossAxisScrollableContent) {
+  // Attribution happens once per gesture. Re-arbitrating after the drawer axis has won would let
+  // the pre-attribution branches below fire mid-drag (the slop is measured from the touch origin,
+  // which is never re-baselined), freezing the popup and dropping `preventDefault()`.
+  if (
+    touchState.drawerAxisAttributed ||
+    touchState.allowSwipe === true ||
+    !touchState.hasCrossAxisScrollableContent
+  ) {
     return false;
   }
 
@@ -1213,6 +1227,7 @@ function preserveNativeCrossAxisScrollOnMove(
   }
 
   if (absDrawerAxisGestureDelta >= AXIS_LOCK_SLOP) {
+    touchState.drawerAxisAttributed = true;
     return false;
   }
 


### PR DESCRIPTION
Closes https://github.com/mui/base-ui/issues/5255

Vertical scrolling inside a left/right drawer intermittently failed on iOS. `DrawerViewport`'s touchmove handler treated any gesture below the 6px cross-axis threshold as a drawer swipe and called `preventDefault()`. On iOS, preventing the first cancelable `touchmove` cancels native scrolling for the entire gesture, so a drag whose first move landed under the threshold could never scroll, no matter how far it traveled afterwards.

Gestures that haven't traveled past the slop on either axis are now left alone — neither prevented nor claimed for the swipe — until one axis wins. A non-cancelable move (the browser already committed to a native scroll) now also yields the gesture instead of dragging the popup alongside the scrolling content. The trade-off is inherent to iOS: the swipe can only be claimed once the drawer axis passes the slop, so it starts ~6px later over cross-axis scrollable content.

Manually verified on the iOS Simulator with the `drawer/cross-axis-scroll` experiment.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
