### PR TITLE
[docs][menu] Use align="start" in demos

### DIFF
--- a/docs/src/app/(docs)/react/components/menu/demos/checkbox-items/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/checkbox-items/css-modules/index.tsx
@@ -14,7 +14,7 @@ export default function ExampleMenu() {
         Workspace <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className={styles.Positioner} sideOffset={8}>
+        <Menu.Positioner className={styles.Positioner} sideOffset={8} align="start">
           <Menu.Popup className={styles.Popup}>
             <Menu.CheckboxItem
               checked={showMinimap}

--- a/docs/src/app/(docs)/react/components/menu/demos/checkbox-items/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/checkbox-items/tailwind/index.tsx
@@ -13,7 +13,7 @@ export default function ExampleMenu() {
         Workspace <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className="outline-hidden" sideOffset={8}>
+        <Menu.Positioner className="outline-hidden" sideOffset={8} align="start">
           <Menu.Popup className="relative origin-[var(--transform-origin)] border border-neutral-950 bg-white py-1 text-neutral-950 shadow-[0.25rem_0.25rem_0] shadow-black/12 outline-hidden transition-[scale,opacity] duration-100 ease-out data-ending-style:scale-[0.98] data-ending-style:opacity-0 data-starting-style:scale-[0.98] data-starting-style:opacity-0 dark:border-white dark:bg-neutral-950 dark:text-white dark:shadow-none">
             <Menu.CheckboxItem
               checked={showMinimap}

--- a/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-controlled/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-controlled/css-modules/index.tsx
@@ -85,7 +85,7 @@ export default function MenuDetachedTriggersControlledDemo() {
       >
         {({ payload }) => (
           <Menu.Portal>
-            <Menu.Positioner className={styles.Positioner} sideOffset={8}>
+            <Menu.Positioner className={styles.Positioner} sideOffset={8} align="start">
               <Menu.Popup className={styles.Popup}>
                 {payload &&
                   itemGroups[payload].map((item, index) => (

--- a/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-controlled/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-controlled/tailwind/index.tsx
@@ -87,7 +87,7 @@ export default function MenuDetachedTriggersControlledDemo() {
       >
         {({ payload }) => (
           <Menu.Portal>
-            <Menu.Positioner sideOffset={8} className="outline-hidden">
+            <Menu.Positioner sideOffset={8} align="start" className="outline-hidden">
               <Menu.Popup className={popupClass}>
                 {payload &&
                   MENUS[payload].map((item, index) => (

--- a/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-full/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-full/css-modules/index.tsx
@@ -55,6 +55,7 @@ export default function MenuDetachedTriggersFullDemo() {
           <Menu.Portal>
             <Menu.Positioner
               sideOffset={8}
+              align="start"
               className={`${styles.Positioner} ${transitionStyles.Positioner}`}
             >
               <Menu.Popup className={`${styles.Popup} ${transitionStyles.Popup}`}>

--- a/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-full/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-full/tailwind/index.tsx
@@ -53,6 +53,7 @@ export default function MenuDetachedTriggersFullDemo() {
           <Menu.Portal>
             <Menu.Positioner
               sideOffset={8}
+              align="start"
               className={`
                 outline-none
                 h-[var(--positioner-height)] w-[var(--positioner-width)] max-w-[var(--available-width)]

--- a/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-simple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-simple/css-modules/index.tsx
@@ -14,7 +14,7 @@ export default function MenuDetachedTriggersSimpleDemo() {
 
       <Menu.Root handle={demoMenu}>
         <Menu.Portal>
-          <Menu.Positioner sideOffset={8} className={styles.Positioner}>
+          <Menu.Positioner sideOffset={8} align="start" className={styles.Positioner}>
             <Menu.Popup className={styles.Popup}>
               <Menu.Item className={styles.Item}>Rename</Menu.Item>
               <Menu.Item className={styles.Item}>Duplicate</Menu.Item>

--- a/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-simple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/detached-triggers-simple/tailwind/index.tsx
@@ -17,7 +17,7 @@ export default function MenuDetachedTriggersSimpleDemo() {
 
       <Menu.Root handle={demoMenu}>
         <Menu.Portal>
-          <Menu.Positioner sideOffset={8} className="outline-hidden">
+          <Menu.Positioner sideOffset={8} align="start" className="outline-hidden">
             <Menu.Popup className={popupClass}>
               <Menu.Item className={itemClass}>Rename</Menu.Item>
               <Menu.Item className={itemClass}>Duplicate</Menu.Item>

--- a/docs/src/app/(docs)/react/components/menu/demos/group-labels/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/group-labels/css-modules/index.tsx
@@ -15,7 +15,7 @@ export default function ExampleMenu() {
         View <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className={styles.Positioner} sideOffset={8}>
+        <Menu.Positioner className={styles.Positioner} sideOffset={8} align="start">
           <Menu.Popup className={styles.Popup}>
             <Menu.RadioGroup value={value} onValueChange={setValue}>
               <Menu.GroupLabel className={styles.GroupLabel}>Sort</Menu.GroupLabel>

--- a/docs/src/app/(docs)/react/components/menu/demos/group-labels/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/group-labels/tailwind/index.tsx
@@ -14,7 +14,7 @@ export default function ExampleMenu() {
         View <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className="outline-hidden" sideOffset={8}>
+        <Menu.Positioner className="outline-hidden" sideOffset={8} align="start">
           <Menu.Popup className="relative origin-[var(--transform-origin)] border border-neutral-950 bg-white py-1 text-neutral-950 shadow-[0.25rem_0.25rem_0] shadow-black/12 outline-hidden transition-[scale,opacity] duration-100 ease-out data-ending-style:scale-[0.98] data-ending-style:opacity-0 data-starting-style:scale-[0.98] data-starting-style:opacity-0 dark:border-white dark:bg-neutral-950 dark:text-white dark:shadow-none">
             <Menu.RadioGroup value={value} onValueChange={setValue}>
               <Menu.GroupLabel className="py-2 pr-8 pl-[2.125rem] text-sm leading-4 text-neutral-500 select-none dark:text-neutral-400">

--- a/docs/src/app/(docs)/react/components/menu/demos/hero/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/hero/css-modules/index.tsx
@@ -9,7 +9,7 @@ export default function ExampleMenu() {
         Song <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className={styles.Positioner} sideOffset={8}>
+        <Menu.Positioner className={styles.Positioner} sideOffset={8} align="start">
           <Menu.Popup className={styles.Popup}>
             <Menu.Item className={styles.Item}>Add to Library</Menu.Item>
             <Menu.Item className={styles.Item}>Add to Playlist</Menu.Item>

--- a/docs/src/app/(docs)/react/components/menu/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/hero/tailwind/index.tsx
@@ -8,7 +8,7 @@ export default function ExampleMenu() {
         Song <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className="outline-hidden" sideOffset={8}>
+        <Menu.Positioner className="outline-hidden" sideOffset={8} align="start">
           <Menu.Popup className="relative origin-[var(--transform-origin)] border border-neutral-950 bg-white py-1 text-neutral-950 shadow-[0.25rem_0.25rem_0] shadow-black/12 outline-hidden transition-[scale,opacity] duration-100 ease-out data-ending-style:scale-[0.98] data-ending-style:opacity-0 data-starting-style:scale-[0.98] data-starting-style:opacity-0 dark:border-white dark:bg-neutral-950 dark:text-white dark:shadow-none">
             <Menu.Item className={itemClass}>Add to Library</Menu.Item>
             <Menu.Item className={itemClass}>Add to Playlist</Menu.Item>

--- a/docs/src/app/(docs)/react/components/menu/demos/open-on-hover/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/open-on-hover/css-modules/index.tsx
@@ -9,7 +9,7 @@ export default function ExampleMenu() {
         Add to playlist <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className={styles.Positioner} sideOffset={8}>
+        <Menu.Positioner className={styles.Positioner} sideOffset={8} align="start">
           <Menu.Popup className={styles.Popup}>
             <Menu.Item className={styles.Item}>Get Up!</Menu.Item>
             <Menu.Item className={styles.Item}>Inside Out</Menu.Item>

--- a/docs/src/app/(docs)/react/components/menu/demos/open-on-hover/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/open-on-hover/tailwind/index.tsx
@@ -11,7 +11,7 @@ export default function ExampleMenu() {
         Add to playlist <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className="outline-hidden" sideOffset={8}>
+        <Menu.Positioner className="outline-hidden" sideOffset={8} align="start">
           <Menu.Popup className="relative origin-[var(--transform-origin)] border border-neutral-950 bg-white py-1 text-neutral-950 shadow-[0.25rem_0.25rem_0] shadow-black/12 outline-hidden transition-[scale,opacity] duration-100 ease-out data-ending-style:scale-[0.98] data-ending-style:opacity-0 data-starting-style:scale-[0.98] data-starting-style:opacity-0 dark:border-white dark:bg-neutral-950 dark:text-white dark:shadow-none">
             <Menu.Item className={itemClass}>Get Up!</Menu.Item>
             <Menu.Item className={itemClass}>Inside Out</Menu.Item>

--- a/docs/src/app/(docs)/react/components/menu/demos/radio-items/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/radio-items/css-modules/index.tsx
@@ -11,7 +11,7 @@ export default function ExampleMenu() {
         Sort <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className={styles.Positioner} sideOffset={8}>
+        <Menu.Positioner className={styles.Positioner} sideOffset={8} align="start">
           <Menu.Popup className={styles.Popup}>
             <Menu.RadioGroup value={value} onValueChange={setValue}>
               <Menu.RadioItem className={styles.RadioItem} value="date">

--- a/docs/src/app/(docs)/react/components/menu/demos/radio-items/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/radio-items/tailwind/index.tsx
@@ -10,7 +10,7 @@ export default function ExampleMenu() {
         Sort <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className="outline-hidden" sideOffset={8}>
+        <Menu.Positioner className="outline-hidden" sideOffset={8} align="start">
           <Menu.Popup className="relative origin-[var(--transform-origin)] border border-neutral-950 bg-white py-1 text-neutral-950 shadow-[0.25rem_0.25rem_0] shadow-black/12 outline-hidden transition-[scale,opacity] duration-100 ease-out data-ending-style:scale-[0.98] data-ending-style:opacity-0 data-starting-style:scale-[0.98] data-starting-style:opacity-0 dark:border-white dark:bg-neutral-950 dark:text-white dark:shadow-none">
             <Menu.RadioGroup value={value} onValueChange={setValue}>
               <Menu.RadioItem value="date" className={radioItemClass}>

--- a/docs/src/app/(docs)/react/components/menu/demos/submenu/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/submenu/css-modules/index.tsx
@@ -10,7 +10,7 @@ export default function ExampleMenu() {
         Song <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className={styles.Positioner} sideOffset={8}>
+        <Menu.Positioner className={styles.Positioner} sideOffset={8} align="start">
           <Menu.Popup className={styles.Popup}>
             <Menu.Item className={styles.Item}>Add to Library</Menu.Item>
 

--- a/docs/src/app/(docs)/react/components/menu/demos/submenu/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/menu/demos/submenu/tailwind/index.tsx
@@ -9,7 +9,7 @@ export default function ExampleMenu() {
         Song <CaretDownIcon />
       </Menu.Trigger>
       <Menu.Portal>
-        <Menu.Positioner className="outline-hidden" sideOffset={8}>
+        <Menu.Positioner className="outline-hidden" sideOffset={8} align="start">
           <Menu.Popup className={popupClass}>
             <Menu.Item className={itemClass}>Add to Library</Menu.Item>
 


### PR DESCRIPTION
## What changed

Adds `align="start"` to `Menu.Positioner` in all standalone menu demos, except the [arrow](https://deploy-preview-5262--base-ui.netlify.app/react/components/menu#arrow) one.

## Why

With the default `align="center"`, the popup's appear animation (`scale(0.98)` from `var(--transform-origin)`) blooms out symmetrically from behind the trigger with neither popup edge anchored to it, which looks off — most visibly in `detached-triggers-simple`, where the trigger is a small icon button. Start alignment matches menu conventions and makes the animation grow out from the trigger's corner.

## Notes for review

- Demos that already set an explicit `align` (e.g. `context-menu/with-menu`, `autocomplete/async`/`grid`, `combobox/input-inside-popup`) are untouched.
- Other popup demos were audited and intentionally left alone: popover/preview-card/tooltip/navigation-menu demos render an `Arrow` (centering is intentional), combobox/autocomplete popups match the anchor width (`--anchor-width`) so `align` has no visual effect, and context menu/menubar/nested submenus already default to `start` via `MenuPositioner`.

|before|after|
|---|---|
|<img width="160" alt="image" src="https://github.com/user-attachments/assets/a986cb41-7242-4557-878e-6f1b550d106f" />|<img width="160" alt="image" src="https://github.com/user-attachments/assets/f3113b6c-dd97-492d-a3f3-0a79f43520d2" />|