### PR TITLE
[combobox] Expand test coverage

### DIFF
--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -1283,6 +1283,7 @@ describe('<Autocomplete.Root />', () => {
               </Autocomplete.Portal>
             </Autocomplete.Root>
           </form>
+          {/* Claims the shared validation ref so Autocomplete must fall back to its input form. */}
           <Switch.Root aria-label="Unrelated switch" />
         </React.Fragment>,
       );

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -66,6 +66,106 @@ describe('<Autocomplete.Root />', () => {
     });
   });
 
+  describe('input inside popup composition', () => {
+    // Vitest's browser runner cannot wrap mount-time adapter updates in React act.
+    // Keep the subtree mounted there while preserving unmount/remount coverage in jsdom.
+    const keepPopupMounted = !isJSDOM;
+
+    it('commits a keyboard selection, restores trigger focus, and preserves it on reopen', async () => {
+      const { user } = await render(
+        <Autocomplete.Root items={['alpha', 'alpine', 'beta']} autoHighlight>
+          <Autocomplete.Trigger data-testid="trigger">
+            <Autocomplete.Value />
+          </Autocomplete.Trigger>
+          <Autocomplete.Portal keepMounted={keepPopupMounted}>
+            <Autocomplete.Positioner>
+              <Autocomplete.Popup aria-label="Commands">
+                <Autocomplete.Input data-testid="input" />
+                <Autocomplete.List>
+                  {(item: string) => (
+                    <Autocomplete.Item key={item} value={item}>
+                      {item}
+                    </Autocomplete.Item>
+                  )}
+                </Autocomplete.List>
+              </Autocomplete.Popup>
+            </Autocomplete.Positioner>
+          </Autocomplete.Portal>
+        </Autocomplete.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      await user.click(trigger);
+
+      const input = await screen.findByTestId('input');
+      await waitFor(() => expect(input).toHaveFocus());
+      await user.type(input, 'al');
+
+      const alpha = screen.getByRole('option', { name: 'alpha' });
+      await waitFor(() => expect(alpha).toHaveAttribute('data-highlighted'));
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBe(null));
+      expect(trigger).toHaveFocus();
+      expect(trigger).toHaveTextContent('alpha');
+
+      await user.click(trigger);
+
+      expect(await screen.findByTestId('input')).toHaveValue('alpha');
+      expect(screen.getByRole('option', { name: 'alpha' })).not.toBe(null);
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBe(null));
+    });
+
+    it('preserves the typed value when the popup is dismissed with Escape', async () => {
+      const onValueChange = vi.fn();
+      const { user } = await render(
+        <Autocomplete.Root items={['alpha', 'alpine', 'beta']} onValueChange={onValueChange}>
+          <Autocomplete.Trigger data-testid="trigger">
+            <Autocomplete.Value />
+          </Autocomplete.Trigger>
+          <Autocomplete.Portal keepMounted={keepPopupMounted}>
+            <Autocomplete.Positioner>
+              <Autocomplete.Popup aria-label="Commands">
+                <Autocomplete.Input data-testid="input" />
+                <Autocomplete.List>
+                  {(item: string) => (
+                    <Autocomplete.Item key={item} value={item}>
+                      {item}
+                    </Autocomplete.Item>
+                  )}
+                </Autocomplete.List>
+              </Autocomplete.Popup>
+            </Autocomplete.Positioner>
+          </Autocomplete.Portal>
+        </Autocomplete.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      await user.click(trigger);
+      const input = await screen.findByTestId('input');
+      await waitFor(() => expect(input).toHaveFocus());
+      await user.type(input, 'al');
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBe(null));
+      expect(trigger).toHaveFocus();
+      expect(trigger).toHaveTextContent('al');
+      expect(onValueChange.mock.lastCall?.[0]).toBe('al');
+
+      await user.click(trigger);
+
+      expect(await screen.findByTestId('input')).toHaveValue('al');
+      expect(screen.getByRole('option', { name: 'alpha' })).not.toBe(null);
+      expect(screen.getByRole('option', { name: 'alpine' })).not.toBe(null);
+      expect(screen.queryByRole('option', { name: 'beta' })).toBe(null);
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBe(null));
+    });
+  });
+
   it('should handle browser autofill', async () => {
     await render(
       <Field.Root name="auto">
@@ -767,6 +867,47 @@ describe('<Autocomplete.Root />', () => {
 
       await user.hover(screen.getByRole('option', { name: 'alpine' }));
       expect(input.value).toBe('alpha');
+    });
+
+    it('mode="both": external controlled updates replace the temporary inline value', async () => {
+      const items = ['apple', 'banana'];
+
+      function Test() {
+        const [value, setValue] = React.useState('');
+        return (
+          <div>
+            <button type="button" onClick={() => setValue('ba')}>
+              update value
+            </button>
+            <Autocomplete.Root mode="both" items={items} value={value} onValueChange={setValue}>
+              <Autocomplete.Input />
+              <Autocomplete.Portal>
+                <Autocomplete.Positioner>
+                  <Autocomplete.Popup>
+                    <Autocomplete.List>
+                      {(item) => (
+                        <Autocomplete.Item key={item} value={item}>
+                          {item}
+                        </Autocomplete.Item>
+                      )}
+                    </Autocomplete.List>
+                  </Autocomplete.Popup>
+                </Autocomplete.Positioner>
+              </Autocomplete.Portal>
+            </Autocomplete.Root>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+
+      await user.type(input, 'a');
+      await user.keyboard('{ArrowDown}');
+      expect(input.value).toBe('apple');
+
+      fireEvent.click(screen.getByText('update value'));
+      expect(input.value).toBe('ba');
     });
 
     it('mode="inline": static items with inline overlay', async () => {

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -113,7 +113,7 @@ describe('<Autocomplete.Root />', () => {
       await user.click(trigger);
 
       expect(await screen.findByTestId('input')).toHaveValue('alpha');
-      expect(screen.getByRole('option', { name: 'alpha' })).not.toBe(null);
+      expect(await screen.findByRole('option', { name: 'alpha' })).not.toBe(null);
 
       await user.keyboard('{Escape}');
       await waitFor(() => expect(screen.queryByRole('dialog')).toBe(null));

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -6,6 +6,7 @@ import { Autocomplete } from '@base-ui/react/autocomplete';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
 import { Input } from '@base-ui/react/input';
+import { Switch } from '@base-ui/react/switch';
 
 describe('<Autocomplete.Root />', () => {
   beforeEach(() => {
@@ -1152,6 +1153,28 @@ describe('<Autocomplete.Root />', () => {
     );
   });
 
+  describe('prop: value', () => {
+    it('treats a controlled null value as an empty query', async () => {
+      await render(
+        <Autocomplete.Root value={null as never} items={['apple']} defaultOpen>
+          <Autocomplete.Input />
+          <Autocomplete.Portal>
+            <Autocomplete.Positioner>
+              <Autocomplete.Popup>
+                <Autocomplete.List>
+                  <Autocomplete.Item value="apple">apple</Autocomplete.Item>
+                </Autocomplete.List>
+              </Autocomplete.Popup>
+            </Autocomplete.Positioner>
+          </Autocomplete.Portal>
+        </Autocomplete.Root>,
+      );
+
+      expect(screen.getByRole('combobox')).toHaveValue('');
+      expect(screen.getByRole('option', { name: 'apple' })).not.toBe(null);
+    });
+  });
+
   describe('prop: submitOnItemClick', () => {
     it('prevents submit on Enter when an item is highlighted by default (false)', async () => {
       let submitted = 0;
@@ -1233,6 +1256,40 @@ describe('<Autocomplete.Root />', () => {
       await user.click(alphaButton);
 
       expect(submitValue).toBe('alpha');
+      expect(submitCount).toBe(1);
+    });
+
+    it('uses the combobox input form when another unscoped control owns the validation ref', async () => {
+      let submitCount = 0;
+
+      const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+        event.preventDefault();
+        submitCount += 1;
+      };
+
+      const { user } = await render(
+        <React.Fragment>
+          <form onSubmit={handleSubmit}>
+            <Autocomplete.Root items={['alpha']} submitOnItemClick>
+              <Autocomplete.Input />
+              <Autocomplete.Portal>
+                <Autocomplete.Positioner>
+                  <Autocomplete.Popup>
+                    <Autocomplete.List>
+                      <Autocomplete.Item value="alpha">alpha</Autocomplete.Item>
+                    </Autocomplete.List>
+                  </Autocomplete.Popup>
+                </Autocomplete.Positioner>
+              </Autocomplete.Portal>
+            </Autocomplete.Root>
+          </form>
+          <Switch.Root aria-label="Unrelated switch" />
+        </React.Fragment>,
+      );
+
+      await user.type(screen.getByRole('combobox'), 'a');
+      await user.click(screen.getByRole('option', { name: 'alpha' }));
+
       expect(submitCount).toBe(1);
     });
 

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
@@ -62,7 +62,7 @@ export function AutocompleteRoot<ItemValue>(
   if (enableInline && inlineInputValue !== '') {
     resolvedInputValue = inlineInputValue;
   } else if (isControlled) {
-    resolvedInputValue = value ?? '';
+    resolvedInputValue = value;
   } else {
     resolvedInputValue = internalValue;
   }

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
@@ -62,7 +62,7 @@ export function AutocompleteRoot<ItemValue>(
   if (enableInline && inlineInputValue !== '') {
     resolvedInputValue = inlineInputValue;
   } else if (isControlled) {
-    resolvedInputValue = value;
+    resolvedInputValue = value ?? '';
   } else {
     resolvedInputValue = internalValue;
   }

--- a/packages/react/src/combobox/chip-remove/ComboboxChipRemove.test.tsx
+++ b/packages/react/src/combobox/chip-remove/ComboboxChipRemove.test.tsx
@@ -1,7 +1,7 @@
 import { expect, vi } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
-import { act, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 
 describe('<Combobox.ChipRemove />', () => {
   const { render } = createRenderer();
@@ -232,6 +232,54 @@ describe('<Combobox.ChipRemove />', () => {
       expect(screen.getByTestId('input')).toHaveFocus();
     });
 
+    it('keeps a popup input focused when removing a chip rendered outside the popup', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['apple', 'banana']} multiple defaultValue={['apple']}>
+          <Combobox.Chips>
+            <Combobox.Value>
+              {(value: string[]) =>
+                value.map((item) => (
+                  <Combobox.Chip key={item}>
+                    {item}
+                    <Combobox.ChipRemove data-testid={`remove-${item}`} />
+                  </Combobox.Chip>
+                ))
+              }
+            </Combobox.Value>
+          </Combobox.Chips>
+          <Combobox.Trigger>Open</Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.Input data-testid="input" />
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      const input = await screen.findByTestId('input');
+      await waitFor(() => expect(input).toHaveFocus());
+
+      await user.click(screen.getByTestId('remove-apple'));
+
+      expect(screen.queryByTestId('remove-apple')).toBe(null);
+      expect(screen.getByRole('dialog')).not.toBe(null);
+      expect(input).toHaveFocus();
+      expect(screen.getByRole('option', { name: 'apple' })).toHaveAttribute(
+        'aria-selected',
+        'false',
+      );
+    });
+
     it('should prevent event propagation', async () => {
       const handleChipClick = vi.fn();
       const handleRemoveClick = vi.fn();
@@ -254,6 +302,190 @@ describe('<Combobox.ChipRemove />', () => {
       // Remove click should happen but not propagate to chip
       expect(handleRemoveClick.mock.calls.length).toBe(1);
       expect(handleChipClick.mock.calls.length).toBe(0);
+    });
+
+    it('allows click and keyboard events to propagate when requested', async () => {
+      const handleChipClick = vi.fn();
+      const handleChipKeyDown = vi.fn();
+      const allowPropagation = (
+        _value: string[],
+        eventDetails: Combobox.Root.ChangeEventDetails,
+      ) => {
+        eventDetails.allowPropagation();
+      };
+      const { user } = await render(
+        <Combobox.Root multiple defaultValue={['apple']} onValueChange={allowPropagation}>
+          <Combobox.Input />
+          <Combobox.Chips>
+            <Combobox.Chip onClick={handleChipClick} onKeyDown={handleChipKeyDown}>
+              apple
+              <Combobox.ChipRemove data-testid="remove">×</Combobox.ChipRemove>
+            </Combobox.Chip>
+          </Combobox.Chips>
+        </Combobox.Root>,
+      );
+
+      const remove = screen.getByTestId('remove');
+      await user.click(remove);
+      expect(handleChipClick).toHaveBeenCalledTimes(1);
+
+      await act(async () => remove.focus());
+      await user.keyboard('{Enter}');
+      expect(handleChipKeyDown).toHaveBeenCalled();
+    });
+
+    it.each([{ disabled: true }, { readOnly: true }])(
+      'ignores click and keyboard activation on a non-native button: %o',
+      async (rootProps) => {
+        const handleValueChange = vi.fn();
+        await render(
+          <Combobox.Root
+            multiple
+            defaultValue={['apple']}
+            onValueChange={handleValueChange}
+            {...rootProps}
+          >
+            <Combobox.Chips>
+              <Combobox.Chip>
+                apple
+                <Combobox.ChipRemove data-testid="remove" nativeButton={false} render={<div />} />
+              </Combobox.Chip>
+            </Combobox.Chips>
+          </Combobox.Root>,
+        );
+
+        const remove = screen.getByTestId('remove');
+        await act(async () => {
+          remove.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+          remove.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+          );
+        });
+
+        expect(handleValueChange).not.toHaveBeenCalled();
+      },
+    );
+
+    it('removes a chip with Space but ignores unrelated keys', async () => {
+      const handleValueChange = vi.fn();
+      await render(
+        <Combobox.Root
+          multiple
+          defaultValue={['apple', 'banana']}
+          onValueChange={handleValueChange}
+        >
+          <Combobox.Chips>
+            <Combobox.Chip>
+              apple
+              <Combobox.ChipRemove data-testid="remove">×</Combobox.ChipRemove>
+            </Combobox.Chip>
+            <Combobox.Chip>banana</Combobox.Chip>
+          </Combobox.Chips>
+        </Combobox.Root>,
+      );
+
+      const remove = screen.getByTestId('remove');
+      remove.focus();
+      fireEvent.keyDown(remove, { key: 'ArrowDown' });
+      expect(handleValueChange).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(remove, { key: ' ' });
+      expect(handleValueChange).toHaveBeenCalledWith(['banana'], expect.anything());
+    });
+
+    it('keeps a different active item highlighted when removing a chip', async () => {
+      const { user } = await render(
+        <Combobox.Root multiple defaultOpen defaultValue={['apple', 'banana']}>
+          <Combobox.Input />
+          <Combobox.Chips>
+            <Combobox.Chip>
+              apple
+              <Combobox.ChipRemove data-testid="remove-apple">×</Combobox.ChipRemove>
+            </Combobox.Chip>
+            <Combobox.Chip>
+              banana
+              <Combobox.ChipRemove data-testid="remove-banana">×</Combobox.ChipRemove>
+            </Combobox.Chip>
+          </Combobox.Chips>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="apple">apple option</Combobox.Item>
+                  <Combobox.Item value="banana">banana option</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      await user.hover(screen.getByRole('option', { name: 'apple option' }));
+      fireEvent.click(screen.getByTestId('remove-banana'));
+
+      expect(screen.getByRole('option', { name: 'apple option' })).toHaveAttribute(
+        'data-highlighted',
+      );
+    });
+
+    it('removes a filtered-out chip without clearing the visible highlight', async () => {
+      const { user } = await render(
+        <Combobox.Root multiple defaultOpen defaultValue={['apple', 'banana']} items={['banana']}>
+          <Combobox.Input />
+          <Combobox.Chips>
+            <Combobox.Chip>
+              apple
+              <Combobox.ChipRemove data-testid="remove-apple">×</Combobox.ChipRemove>
+            </Combobox.Chip>
+            <Combobox.Chip>banana</Combobox.Chip>
+          </Combobox.Chips>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="banana">banana option</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      await user.hover(screen.getByRole('option', { name: 'banana option' }));
+      fireEvent.click(screen.getByTestId('remove-apple'));
+
+      expect(screen.getByRole('option', { name: 'banana option' })).toHaveAttribute(
+        'data-highlighted',
+      );
+    });
+
+    it('records pointer-origin removal when clearing the highlighted item', async () => {
+      const { user } = await render(
+        <Combobox.Root multiple defaultOpen defaultValue={['apple']}>
+          <Combobox.Chips>
+            <Combobox.Chip>
+              apple
+              <Combobox.ChipRemove data-testid="remove">×</Combobox.ChipRemove>
+            </Combobox.Chip>
+          </Combobox.Chips>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="apple">apple option</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      fireEvent.pointerMove(screen.getByRole('option', { name: 'apple option' }));
+      await user.click(screen.getByTestId('remove'));
+
+      expect(screen.getByRole('option', { name: 'apple option' })).not.toHaveAttribute(
+        'data-highlighted',
+      );
     });
 
     it('should handle keyboard activation', async () => {

--- a/packages/react/src/combobox/chip-remove/ComboboxChipRemove.tsx
+++ b/packages/react/src/combobox/chip-remove/ComboboxChipRemove.tsx
@@ -100,20 +100,12 @@ export const ComboboxChipRemove = React.forwardRef(function ComboboxChipRemove(
           event.preventDefault();
         },
         onClick(event) {
-          if (disabled || readOnly) {
-            return;
-          }
-
           const eventDetails = removeChip(event);
           if (!eventDetails.isPropagationAllowed) {
             event.stopPropagation();
           }
         },
         onKeyDown(event) {
-          if (disabled || readOnly) {
-            return;
-          }
-
           if (event.key === 'Enter' || event.key === ' ') {
             const eventDetails = removeChip(event);
             if (!eventDetails.isPropagationAllowed) {

--- a/packages/react/src/combobox/chip/ComboboxChip.test.tsx
+++ b/packages/react/src/combobox/chip/ComboboxChip.test.tsx
@@ -315,6 +315,98 @@ describe('<Combobox.Chip />', () => {
       expect(input).toHaveFocus();
     });
 
+    it('returns focus to the input for activation, vertical navigation, and text entry', async () => {
+      const { user } = await render(
+        <Combobox.Root multiple defaultValue={['apple']}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Chips>
+            <Combobox.Chip data-testid="chip">apple</Combobox.Chip>
+          </Combobox.Chips>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="banana">banana</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const chip = screen.getByTestId('chip');
+      const input = screen.getByTestId('input');
+
+      await act(async () => chip.focus());
+      await user.keyboard('{Enter}');
+      expect(input).toHaveFocus();
+
+      await act(async () => chip.focus());
+      await user.keyboard(' ');
+      expect(input).toHaveFocus();
+
+      await act(async () => chip.focus());
+      await user.keyboard('{ArrowDown}');
+      expect(input).toHaveFocus();
+      expect(screen.getByRole('listbox')).not.toBe(null);
+
+      await user.keyboard('{Escape}');
+      await act(async () => chip.focus());
+      await user.keyboard('{ArrowUp}');
+      expect(input).toHaveFocus();
+      expect(screen.getByRole('listbox')).not.toBe(null);
+
+      await user.keyboard('{Escape}');
+      await act(async () => chip.focus());
+      await user.keyboard('a');
+      expect(input).toHaveFocus();
+    });
+
+    it('leaves focus on a chip for modified printable keys', async () => {
+      const { user } = await render(
+        <Combobox.Root multiple defaultValue={['apple']}>
+          <Combobox.Input />
+          <Combobox.Chips>
+            <Combobox.Chip data-testid="chip">apple</Combobox.Chip>
+          </Combobox.Chips>
+        </Combobox.Root>,
+      );
+
+      const chip = screen.getByTestId('chip');
+
+      await act(async () => chip.focus());
+      await user.keyboard('{Control>}a{/Control}');
+      expect(chip).toHaveFocus();
+
+      await user.keyboard('{Meta>}a{/Meta}');
+      expect(chip).toHaveFocus();
+
+      await user.keyboard('{Alt>}a{/Alt}');
+      expect(chip).toHaveFocus();
+    });
+
+    it('handles Delete as a chip removal key', async () => {
+      const handleValueChange = vi.fn();
+      const { user } = await render(
+        <Combobox.Root
+          multiple
+          defaultValue={['apple', 'banana']}
+          onValueChange={handleValueChange}
+        >
+          <Combobox.Input />
+          <Combobox.Chips>
+            <Combobox.Chip data-testid="chip-apple">apple</Combobox.Chip>
+            <Combobox.Chip>banana</Combobox.Chip>
+          </Combobox.Chips>
+        </Combobox.Root>,
+      );
+
+      await act(async () => screen.getByTestId('chip-apple').focus());
+      await user.keyboard('{Delete}');
+
+      expect(handleValueChange).toHaveBeenCalledWith(['banana'], expect.anything());
+    });
+
     it('mirrors chip keyboard navigation in RTL mode', async () => {
       const { user } = await render(
         <DirectionProvider direction="rtl">

--- a/packages/react/src/combobox/chips/ComboboxChips.test.tsx
+++ b/packages/react/src/combobox/chips/ComboboxChips.test.tsx
@@ -1,6 +1,6 @@
 import { expect, vi } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
-import { fireEvent, screen } from '@mui/internal-test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 import { Field } from '@base-ui/react/field';
 
@@ -242,5 +242,69 @@ describe('<Combobox.Chips />', () => {
 
     expect(screen.getByTestId('input')).not.toHaveFocus();
     expect(screen.queryByRole('listbox')).toBe(null);
+  });
+
+  it('opens and focuses an input rendered inside the popup when the chips area is pressed', async () => {
+    const { user } = await render(
+      <Combobox.Root items={['apple', 'banana']} multiple defaultValue={['apple']}>
+        <Combobox.Chips data-testid="chips">
+          <Combobox.Chip>apple</Combobox.Chip>
+        </Combobox.Chips>
+        <Combobox.Trigger>Open</Combobox.Trigger>
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.Input data-testid="input" />
+              <Combobox.List>
+                {(item: string) => (
+                  <Combobox.Item key={item} value={item}>
+                    {item}
+                  </Combobox.Item>
+                )}
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    await user.click(screen.getByTestId('chips'));
+
+    expect(await screen.findByRole('dialog')).not.toBe(null);
+    await waitFor(() => expect(screen.getByTestId('input')).toHaveFocus());
+  });
+
+  it('clears the highlighted chip when the popup opens', async () => {
+    const { user } = await render(
+      <Combobox.Root multiple defaultValue={['apple']}>
+        <Combobox.Chips>
+          <Combobox.Chip data-testid="chip">apple</Combobox.Chip>
+          <Combobox.Input data-testid="input" />
+        </Combobox.Chips>
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                <Combobox.Item value="banana">banana</Combobox.Item>
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    const input = screen.getByTestId<HTMLInputElement>('input');
+    input.focus();
+    input.setSelectionRange(0, 0);
+    await user.keyboard('{ArrowLeft}');
+    expect(screen.getByTestId('chip')).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('listbox')).not.toBe(null);
+
+    input.focus();
+    input.setSelectionRange(0, 0);
+    await user.keyboard('{ArrowLeft}');
+    expect(screen.getByTestId('chip')).toHaveFocus();
   });
 });

--- a/packages/react/src/combobox/clear/ComboboxClear.test.tsx
+++ b/packages/react/src/combobox/clear/ComboboxClear.test.tsx
@@ -1,5 +1,6 @@
 import { expect } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
+import { Autocomplete } from '@base-ui/react/autocomplete';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 
@@ -29,6 +30,56 @@ describe('<Combobox.Clear />', () => {
     expect(screen.getByTestId('clear')).not.toBe(null);
   });
 
+  it('does not render without a value by default', async () => {
+    await render(
+      <Combobox.Root>
+        <Combobox.Input />
+        <Combobox.Clear data-testid="clear" />
+      </Combobox.Root>,
+    );
+
+    expect(screen.queryByTestId('clear')).toBe(null);
+  });
+
+  it('renders and clears the typed value in no-selection mode', async () => {
+    const { user } = await render(
+      <Autocomplete.Root defaultValue="apple">
+        <Autocomplete.Input />
+        <Autocomplete.Clear data-testid="clear" />
+      </Autocomplete.Root>,
+    );
+
+    const input = screen.getByRole<HTMLInputElement>('combobox');
+    expect(input.value).toBe('apple');
+
+    await user.click(screen.getByTestId('clear'));
+
+    expect(input.value).toBe('');
+    expect(input).toHaveFocus();
+  });
+
+  it('renders and clears chips in multiple mode', async () => {
+    const { user } = await render(
+      <Combobox.Root multiple defaultValue={['apple']}>
+        <Combobox.Chips>
+          <Combobox.Value>
+            {(value: string[]) =>
+              value.map((item) => <Combobox.Chip key={item}>{item}</Combobox.Chip>)
+            }
+          </Combobox.Value>
+          <Combobox.Input />
+        </Combobox.Chips>
+        <Combobox.Clear data-testid="clear" />
+      </Combobox.Root>,
+    );
+
+    expect(screen.getByText('apple')).not.toBe(null);
+
+    await user.click(screen.getByTestId('clear'));
+
+    expect(screen.queryByText('apple')).toBe(null);
+  });
+
   it('click clears selected value and focuses input', async () => {
     const { user } = await render(
       <Combobox.Root defaultValue="a">
@@ -51,6 +102,20 @@ describe('<Combobox.Clear />', () => {
 
     expect(screen.queryByTestId('clear')).toBe(null);
     expect(document.activeElement).toBe(input);
+  });
+
+  it('clears after pointer interaction marks keyboard navigation inactive', async () => {
+    const { user } = await render(
+      <Combobox.Root defaultValue="a">
+        <Combobox.Input data-testid="input" />
+        <Combobox.Clear data-testid="clear" />
+      </Combobox.Root>,
+    );
+
+    fireEvent.pointerMove(screen.getByTestId('input'));
+    await user.click(screen.getByTestId('clear'));
+
+    expect(screen.queryByTestId('clear')).toBe(null);
   });
 
   it('does not dismiss the popup on click (outsidePress is blocked)', async () => {
@@ -76,6 +141,40 @@ describe('<Combobox.Clear />', () => {
     await user.click(screen.getByTestId('clear'));
 
     expect(screen.getByRole('listbox')).not.toBe(null);
+  });
+
+  it('does not dismiss a popup input when the clear button is rendered outside it', async () => {
+    const { user } = await render(
+      <Combobox.Root items={['a', 'b']} defaultValue="a">
+        <Combobox.Trigger>
+          <Combobox.Value />
+        </Combobox.Trigger>
+        <Combobox.Clear data-testid="clear" />
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.Input data-testid="input" />
+              <Combobox.List>
+                {(item: string) => (
+                  <Combobox.Item key={item} value={item}>
+                    {item}
+                  </Combobox.Item>
+                )}
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    await waitFor(() => expect(screen.getByTestId('input')).toHaveFocus());
+
+    await user.click(screen.getByTestId('clear'));
+
+    expect(screen.getByRole('dialog')).not.toBe(null);
+    expect(screen.getByTestId('input')).toHaveFocus();
+    expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('aria-selected', 'false');
   });
 
   it('is disabled when root disabled and does nothing on click', async () => {
@@ -107,14 +206,16 @@ describe('<Combobox.Clear />', () => {
     expect(screen.getByTestId('clear')).not.toBe(null);
   });
 
-  it('exposes visible state to Combobox.Clear render props when rendered inside the popup', async () => {
+  it('clears selection without closing and restores popup input focus', async () => {
     const { user } = await render(
       <Combobox.Root defaultValue="a">
-        <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+        <Combobox.Trigger data-testid="trigger">
+          <Combobox.Value placeholder="None" />
+        </Combobox.Trigger>
         <Combobox.Portal>
           <Combobox.Positioner data-testid="positioner">
             <Combobox.Popup>
-              <Combobox.Input />
+              <Combobox.Input data-testid="input" />
               <Combobox.Clear
                 keepMounted
                 data-testid="clear"
@@ -145,6 +246,10 @@ describe('<Combobox.Clear />', () => {
       expect(clear).toHaveClass('hidden');
       expect(clear).not.toHaveAttribute('data-visible');
     });
+    expect(screen.getByRole('dialog')).not.toBe(null);
+    expect(screen.getByTestId('input')).toHaveFocus();
+    expect(screen.getByTestId('trigger')).toHaveTextContent('None');
+    expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('aria-selected', 'false');
   });
 
   describe.skipIf(isJSDOM)('animations', () => {

--- a/packages/react/src/combobox/collection/ComboboxCollection.test.tsx
+++ b/packages/react/src/combobox/collection/ComboboxCollection.test.tsx
@@ -32,4 +32,26 @@ describe('<Combobox.Collection />', () => {
     expect(screen.getByTestId('item-beta')).not.toBe(null);
     expect(screen.getByTestId('item-alpine')).not.toBe(null);
   });
+
+  it('renders nothing when a nested group does not provide items', async () => {
+    await render(
+      <Combobox.Root defaultOpen>
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                <Combobox.Group data-testid="group">
+                  <Combobox.Collection>
+                    {(item) => <span key={item}>{item}</span>}
+                  </Combobox.Collection>
+                </Combobox.Group>
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    expect(screen.getByTestId('group')).toBeEmptyDOMElement();
+  });
 });

--- a/packages/react/src/combobox/collection/ComboboxCollection.tsx
+++ b/packages/react/src/combobox/collection/ComboboxCollection.tsx
@@ -11,17 +11,13 @@ import { useGroupCollectionContext } from './GroupCollectionContext';
  *
  * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
  */
-export function ComboboxCollection(props: ComboboxCollection.Props): React.JSX.Element | null {
+export function ComboboxCollection(props: ComboboxCollection.Props): React.JSX.Element {
   const { children } = props;
 
   const { filteredItems } = useComboboxDerivedItemsContext();
   const groupContext = useGroupCollectionContext();
 
   const itemsToRender = groupContext ? groupContext.items : filteredItems;
-
-  if (!itemsToRender) {
-    return null;
-  }
 
   return <React.Fragment>{itemsToRender.map(children)}</React.Fragment>;
 }

--- a/packages/react/src/combobox/group/ComboboxGroupContext.test.tsx
+++ b/packages/react/src/combobox/group/ComboboxGroupContext.test.tsx
@@ -1,0 +1,24 @@
+import { expect, vi } from 'vitest';
+import { createRenderer } from '#test-utils';
+import { useComboboxGroupContext } from './ComboboxGroupContext';
+
+describe('ComboboxGroupContext', () => {
+  const { render } = createRenderer();
+
+  it('throws a descriptive error when used outside <Combobox.Group>', async () => {
+    function Consumer() {
+      useComboboxGroupContext();
+      return null;
+    }
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Consumer />)).rejects.toThrow(
+        'Base UI: ComboboxGroupContext is missing. ComboboxGroup parts must be placed within <Combobox.Group>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/react/src/combobox/input/ComboboxInput.android.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.android.test.tsx
@@ -1,0 +1,37 @@
+import { expect, vi } from 'vitest';
+import { Combobox } from '@base-ui/react/combobox';
+import { createRenderer } from '#test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
+
+vi.mock('@base-ui/utils/platform', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@base-ui/utils/platform')>();
+  return {
+    ...actual,
+    platform: {
+      ...actual.platform,
+      os: {
+        ...actual.platform.os,
+        android: true,
+      },
+    },
+  };
+});
+
+describe('<Combobox.Input /> on Android', () => {
+  const { render } = createRenderer();
+
+  it('propagates changes during Android composition', async () => {
+    const onInputValueChange = vi.fn();
+    await render(
+      <Combobox.Root onInputValueChange={onInputValueChange}>
+        <Combobox.Input />
+      </Combobox.Root>,
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: 'a' } });
+
+    expect(onInputValueChange).toHaveBeenCalledWith('a', expect.anything());
+  });
+});

--- a/packages/react/src/combobox/input/ComboboxInput.gecko.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.gecko.test.tsx
@@ -1,0 +1,42 @@
+import { expect, vi } from 'vitest';
+import { Combobox } from '@base-ui/react/combobox';
+import { DirectionProvider } from '@base-ui/react/direction-provider';
+import { createRenderer } from '#test-utils';
+import { screen } from '@mui/internal-test-utils';
+
+vi.mock('@base-ui/utils/platform', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@base-ui/utils/platform')>();
+  return {
+    ...actual,
+    platform: {
+      ...actual.platform,
+      engine: {
+        ...actual.platform.engine,
+        gecko: true,
+      },
+    },
+  };
+});
+
+describe('<Combobox.Input /> in Gecko RTL', () => {
+  const { render } = createRenderer();
+
+  it('uses Gecko RTL caret positions for Home and End', async () => {
+    const { user } = await render(
+      <DirectionProvider direction="rtl">
+        <Combobox.Root defaultInputValue="apple">
+          <Combobox.Input />
+        </Combobox.Root>
+      </DirectionProvider>,
+    );
+
+    const input = screen.getByRole<HTMLInputElement>('combobox');
+    input.focus();
+
+    await user.keyboard('{Home}');
+    expect(input.selectionStart).toBe(input.value.length);
+
+    await user.keyboard('{End}');
+    expect(input.selectionStart).toBe(0);
+  });
+});

--- a/packages/react/src/combobox/input/ComboboxInput.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.test.tsx
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
 import { REASONS } from '../../internals/reasons';
 
@@ -575,6 +575,299 @@ describe('<Combobox.Input />', () => {
       expect(input.value).toBe('abxxxycd');
       expect(input.selectionStart).toBe(6);
       expect(input.selectionEnd).toBe(6);
+    });
+
+    it('navigates an existing chip highlight when focus returns to the input', async () => {
+      const { user } = await render(
+        <Combobox.Root multiple defaultValue={['apple', 'banana', 'cherry']}>
+          <Combobox.Chips>
+            <Combobox.Chip data-testid="chip-apple">apple</Combobox.Chip>
+            <Combobox.Chip data-testid="chip-banana">banana</Combobox.Chip>
+            <Combobox.Chip data-testid="chip-cherry">cherry</Combobox.Chip>
+            <Combobox.Input data-testid="input" />
+          </Combobox.Chips>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId<HTMLInputElement>('input');
+      const apple = screen.getByTestId('chip-apple');
+      const banana = screen.getByTestId('chip-banana');
+      const cherry = screen.getByTestId('chip-cherry');
+
+      input.focus();
+      input.setSelectionRange(0, 0);
+      await user.keyboard('{ArrowLeft}');
+      expect(cherry).toHaveFocus();
+
+      input.focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(banana).toHaveFocus();
+
+      input.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(cherry).toHaveFocus();
+
+      input.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(input).toHaveFocus();
+
+      input.setSelectionRange(0, 0);
+      await user.keyboard('{ArrowLeft}');
+      input.focus();
+      await user.keyboard('{ArrowLeft}');
+      input.focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(apple).toHaveFocus();
+
+      input.focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(input).toHaveFocus();
+
+      input.setSelectionRange(0, 0);
+      await user.keyboard('{ArrowLeft}');
+      input.focus();
+      await user.keyboard('{Delete}');
+      expect(banana).toHaveFocus();
+
+      input.focus();
+      await user.keyboard('{Backspace}');
+      expect(banana).toHaveFocus();
+
+      input.focus();
+      await user.keyboard('x');
+      expect(input).toHaveValue('x');
+    });
+
+    it('keeps focus on the input when navigating toward chips but none are rendered', async () => {
+      const { user } = await render(
+        <Combobox.Root multiple defaultValue={['apple']}>
+          <Combobox.Chips>
+            <Combobox.Input />
+          </Combobox.Chips>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      input.focus();
+      input.setSelectionRange(0, 0);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(input).toHaveFocus();
+    });
+
+    it('treats a null selectionStart as the beginning of a custom input', async () => {
+      const { user } = await render(
+        <Combobox.Root multiple defaultValue={['apple']}>
+          <Combobox.Chips>
+            <Combobox.Chip data-testid="chip">apple</Combobox.Chip>
+            <Combobox.Input render={<input type="number" />} />
+          </Combobox.Chips>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      expect(input.selectionStart).toBe(null);
+      input.focus();
+      await user.keyboard('{ArrowLeft}');
+
+      expect(screen.getByTestId('chip')).toHaveFocus();
+    });
+
+    it('keeps the popup open after modified keyboard navigation', async () => {
+      const { user } = await render(
+        <Combobox.Root defaultOpen>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="apple">apple</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole('combobox');
+      input.focus();
+
+      await user.keyboard('{Control>}{ArrowDown}{/Control}');
+      expect(screen.getByRole('listbox')).not.toBe(null);
+    });
+
+    it('does not select an item for an IME keydown without a highlight', async () => {
+      const onValueChange = vi.fn();
+      await render(
+        <Combobox.Root defaultOpen onValueChange={onValueChange}>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="apple">apple</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole('combobox');
+      input.focus();
+      fireEvent.keyDown(input, { key: 'Enter', keyCode: 229, which: 229 });
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('does not restore an inline highlight after the highlighted slot is removed', async () => {
+      function Test() {
+        const [items, setItems] = React.useState(['apple']);
+        return (
+          <div>
+            <Combobox.Root inline open items={items}>
+              <Combobox.Input />
+              <Combobox.List>
+                {(item: string) => (
+                  <Combobox.Item key={item} value={item}>
+                    {item}
+                  </Combobox.Item>
+                )}
+              </Combobox.List>
+            </Combobox.Root>
+            <button type="button" onClick={() => setItems([])}>
+              remove items
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+      const input = screen.getByRole('combobox');
+      input.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(input).toHaveAttribute('aria-activedescendant');
+
+      await user.click(screen.getByRole('button', { name: 'remove items' }));
+      await user.click(input);
+
+      expect(input).not.toHaveAttribute('aria-activedescendant');
+    });
+
+    it('clears a closed multiple value on Escape and stops propagation', async () => {
+      const onValueChange = vi.fn();
+      const onOuterKeyDown = vi.fn();
+      const { user } = await render(
+        <div onKeyDown={onOuterKeyDown}>
+          <Combobox.Root multiple defaultValue={['apple']} onValueChange={onValueChange}>
+            <Combobox.Input />
+          </Combobox.Root>
+        </div>,
+      );
+
+      screen.getByRole('combobox').focus();
+      await user.keyboard('{Escape}');
+
+      expect(onValueChange).toHaveBeenCalledWith([], expect.anything());
+      expect(onOuterKeyDown).not.toHaveBeenCalled();
+    });
+
+    it('lets Escape propagate when a closed multiple value is already empty', async () => {
+      const onOuterKeyDown = vi.fn();
+      const { user } = await render(
+        <div onKeyDown={onOuterKeyDown}>
+          <Combobox.Root multiple defaultValue={[]}>
+            <Combobox.Input />
+          </Combobox.Root>
+        </div>,
+      );
+
+      screen.getByRole('combobox').focus();
+      await user.keyboard('{Escape}');
+
+      expect(onOuterKeyDown).toHaveBeenCalled();
+    });
+
+    it('lets Escape propagate from a closed inline combobox', async () => {
+      const onOuterKeyDown = vi.fn();
+      const { user } = await render(
+        <div onKeyDown={onOuterKeyDown}>
+          <Combobox.Root inline defaultValue="apple">
+            <Combobox.Input />
+          </Combobox.Root>
+        </div>,
+      );
+
+      screen.getByRole('combobox').focus();
+      await user.keyboard('{Escape}');
+
+      expect(onOuterKeyDown).toHaveBeenCalled();
+    });
+
+    it('closes on an empty composition update when input clicks do not open the popup', async () => {
+      await render(
+        <Combobox.Root
+          defaultOpen
+          defaultInputValue="x"
+          openOnInputClick={false}
+          filter={null}
+          items={['apple']}
+        >
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole('combobox');
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: '' } });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).toBe(null);
+      });
+    });
+
+    it('clears the highlight on an empty composition update while staying open', async () => {
+      const { user } = await render(
+        <Combobox.Root defaultOpen defaultInputValue="x" filter={null} items={['apple']}>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole('combobox');
+      input.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(input).toHaveAttribute('aria-activedescendant');
+
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: '' } });
+
+      expect(screen.getByRole('listbox')).not.toBe(null);
+      expect(input).not.toHaveAttribute('aria-activedescendant');
     });
 
     it('removes the last rendered chip when pressing Backspace in an empty input', async () => {

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -185,13 +185,6 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
     ) {
       event.preventDefault();
       nextIndex = renderedChipsCount > 0 ? renderedChipsCount - 1 : undefined;
-    } else if (
-      event.key === 'Backspace' &&
-      event.currentTarget.value === '' &&
-      selectedValue.length > 0
-    ) {
-      clearHighlight();
-      event.preventDefault();
     }
 
     return nextIndex;

--- a/packages/react/src/combobox/item-indicator/ComboboxItemIndicator.test.tsx
+++ b/packages/react/src/combobox/item-indicator/ComboboxItemIndicator.test.tsx
@@ -1,5 +1,6 @@
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
+import { screen } from '@mui/internal-test-utils';
 
 describe('<Combobox.ItemIndicator />', () => {
   const { render } = createRenderer();
@@ -14,4 +15,31 @@ describe('<Combobox.ItemIndicator />', () => {
       );
     },
   }));
+
+  it('updates a mounted indicator when its item becomes unselected', async () => {
+    const { user } = await render(
+      <Combobox.Root defaultOpen defaultValue="apple">
+        <Combobox.Input />
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                <Combobox.Item value="apple">
+                  apple
+                  <Combobox.ItemIndicator keepMounted data-testid="apple-indicator" />
+                </Combobox.Item>
+                <Combobox.Item value="banana">banana</Combobox.Item>
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    expect(screen.getByTestId('apple-indicator')).toHaveAttribute('data-selected');
+
+    await user.click(screen.getByRole('option', { name: 'banana' }));
+
+    expect(screen.getByTestId('apple-indicator')).not.toHaveAttribute('data-selected');
+  });
 });

--- a/packages/react/src/combobox/item/ComboboxItem.test.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.test.tsx
@@ -514,6 +514,25 @@ describe('<Combobox.Item />', () => {
 
       expect(screen.getByTestId('refresh-list-ref')).toHaveTextContent('||three|four|');
     });
+
+    it('uses an unregistered index for an item missing from the filtered values', async () => {
+      await render(
+        <Combobox.Root virtualized items={['one']} defaultOpen>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item>missing value</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByRole('option', { name: 'missing value' }).id).toMatch(/--1$/);
+    });
   });
 
   describe('virtualized with explicit index', () => {
@@ -655,6 +674,20 @@ describe('<Combobox.Item />', () => {
         expect(cherry).toHaveAttribute('data-highlighted');
       });
       expect(banana).not.toHaveAttribute('data-highlighted');
+    });
+
+    it('does not assign an id to an explicitly unregistered item', async () => {
+      await render(
+        <Combobox.Root defaultOpen>
+          <Combobox.List>
+            <Combobox.Item value="orphan" index={-1}>
+              orphan
+            </Combobox.Item>
+          </Combobox.List>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByRole('option', { name: 'orphan' })).not.toHaveAttribute('id');
     });
   });
 });

--- a/packages/react/src/combobox/item/ComboboxItem.test.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.test.tsx
@@ -515,10 +515,10 @@ describe('<Combobox.Item />', () => {
       expect(screen.getByTestId('refresh-list-ref')).toHaveTextContent('||three|four|');
     });
 
-    it('uses an unregistered index for an item missing from the filtered values', async () => {
-      await render(
+    it('does not register an item missing from the filtered values', async () => {
+      const { user } = await render(
         <Combobox.Root virtualized items={['one']} defaultOpen>
-          <Combobox.Input />
+          <Combobox.Input data-testid="input" />
           <Combobox.Portal>
             <Combobox.Positioner>
               <Combobox.Popup>
@@ -531,7 +531,14 @@ describe('<Combobox.Item />', () => {
         </Combobox.Root>,
       );
 
-      expect(screen.getByRole('option', { name: 'missing value' }).id).toMatch(/--1$/);
+      const input = screen.getByTestId('input');
+      const item = screen.getByRole('option', { name: 'missing value' });
+
+      await user.hover(item);
+
+      expect(input).not.toHaveAttribute('aria-activedescendant');
+      expect(item).not.toHaveAttribute('data-highlighted');
+      expect(item).not.toHaveAttribute('id');
     });
   });
 

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -62,7 +62,7 @@ function ComboboxItemInner(props: ComboboxItemInnerProps) {
   const isItemEqualToValue = useStore(store, selectors.isItemEqualToValue);
 
   const selectable = selectionMode !== 'none';
-  const index = indexProp ?? (virtualized ? (indexFromFilter ?? -1) : listItem.index);
+  const index = indexProp ?? indexFromFilter ?? listItem.index;
   const hasRegistered = listItem.index !== -1;
 
   const rootId = useStore(store, selectors.id);

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -63,7 +63,7 @@ function ComboboxItemInner(props: ComboboxItemInnerProps) {
 
   const selectable = selectionMode !== 'none';
   const index = indexProp ?? indexFromFilter ?? listItem.index;
-  const hasRegistered = listItem.index !== -1;
+  const hasRegistered = index !== -1;
 
   const rootId = useStore(store, selectors.id);
   const highlighted = useStore(store, selectors.isActive, index);

--- a/packages/react/src/combobox/item/ComboboxItemContext.test.tsx
+++ b/packages/react/src/combobox/item/ComboboxItemContext.test.tsx
@@ -1,0 +1,24 @@
+import { expect, vi } from 'vitest';
+import { createRenderer } from '#test-utils';
+import { useComboboxItemContext } from './ComboboxItemContext';
+
+describe('ComboboxItemContext', () => {
+  const { render } = createRenderer();
+
+  it('throws a descriptive error when used outside <Combobox.Item>', async () => {
+    function Consumer() {
+      useComboboxItemContext();
+      return null;
+    }
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Consumer />)).rejects.toThrow(
+        'Base UI: ComboboxItemContext is missing. ComboboxItem parts must be placed within <Combobox.Item>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/react/src/combobox/label/ComboboxLabel.test.tsx
+++ b/packages/react/src/combobox/label/ComboboxLabel.test.tsx
@@ -45,6 +45,7 @@ describe('<Combobox.Label />', () => {
         expect.stringContaining('<Combobox.Label> labels <Combobox.Trigger> only.'),
       );
     } finally {
+      errorSpy.mockRestore();
       Object.defineProperty(SafeReact, 'captureOwnerStack', {
         configurable: true,
         value: captureOwnerStack,
@@ -55,6 +56,13 @@ describe('<Combobox.Label />', () => {
   it.skipIf(!isJSDOM)('does not run the development warning in production', async () => {
     const nodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
+    const captureOwnerStack = SafeReact.captureOwnerStack;
+    const captureOwnerStackSpy = vi.fn();
+    Object.defineProperty(SafeReact, 'captureOwnerStack', {
+      configurable: true,
+      value: captureOwnerStackSpy,
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     try {
       await render(
@@ -63,7 +71,15 @@ describe('<Combobox.Label />', () => {
           <Combobox.Input />
         </Combobox.Root>,
       );
+
+      expect(captureOwnerStackSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
     } finally {
+      errorSpy.mockRestore();
+      Object.defineProperty(SafeReact, 'captureOwnerStack', {
+        configurable: true,
+        value: captureOwnerStack,
+      });
       process.env.NODE_ENV = nodeEnv;
     }
   });

--- a/packages/react/src/combobox/label/ComboboxLabel.test.tsx
+++ b/packages/react/src/combobox/label/ComboboxLabel.test.tsx
@@ -1,5 +1,7 @@
+import { expect, vi } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
-import { createRenderer, describeConformance } from '#test-utils';
+import { SafeReact } from '@base-ui/utils/safeReact';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Combobox.Label />', () => {
   const { render } = createRenderer();
@@ -22,4 +24,47 @@ describe('<Combobox.Label />', () => {
       );
     },
   }));
+
+  it('warns without relying on React.captureOwnerStack when labeling an external input', async () => {
+    const captureOwnerStack = SafeReact.captureOwnerStack;
+    Object.defineProperty(SafeReact, 'captureOwnerStack', {
+      configurable: true,
+      value: undefined,
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await render(
+        <Combobox.Root>
+          <Combobox.Label>Fruit</Combobox.Label>
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('<Combobox.Label> labels <Combobox.Trigger> only.'),
+      );
+    } finally {
+      Object.defineProperty(SafeReact, 'captureOwnerStack', {
+        configurable: true,
+        value: captureOwnerStack,
+      });
+    }
+  });
+
+  it.skipIf(!isJSDOM)('does not run the development warning in production', async () => {
+    const nodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      await render(
+        <Combobox.Root>
+          <Combobox.Label>Fruit</Combobox.Label>
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+    } finally {
+      process.env.NODE_ENV = nodeEnv;
+    }
+  });
 });

--- a/packages/react/src/combobox/list/ComboboxList.test.tsx
+++ b/packages/react/src/combobox/list/ComboboxList.test.tsx
@@ -1,7 +1,7 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
-import { screen } from '@mui/internal-test-utils';
+import { act, screen } from '@mui/internal-test-utils';
 
 describe('<Combobox.List />', () => {
   const { render } = createRenderer();
@@ -31,4 +31,83 @@ describe('<Combobox.List />', () => {
     const list = screen.getByRole('listbox');
     expect(list).toHaveAttribute('aria-multiselectable', 'true');
   });
+
+  it('does not prevent Enter when no item is highlighted', async () => {
+    await render(
+      <Combobox.Root defaultOpen>
+        <Combobox.Input />
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                <Combobox.Item value="a">a</Combobox.Item>
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    const list = screen.getByRole('listbox');
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    await act(async () => list.dispatchEvent(event));
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('selects the highlighted item with Enter', async () => {
+    const onValueChange = vi.fn();
+    const { user } = await render(
+      <Combobox.Root defaultOpen onValueChange={onValueChange}>
+        <Combobox.Input />
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                <Combobox.Item value="a">a</Combobox.Item>
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    await user.keyboard('{ArrowDown}');
+
+    const list = screen.getByRole('listbox');
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    await act(async () => list.dispatchEvent(event));
+
+    expect(onValueChange).toHaveBeenCalledWith('a', expect.anything());
+  });
+
+  it.each([{ disabled: true }, { readOnly: true }])(
+    'ignores Enter when interaction is disabled: %o',
+    async (rootProps) => {
+      const onValueChange = vi.fn();
+      await render(
+        <Combobox.Root defaultOpen onValueChange={onValueChange} {...rootProps}>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="a">a</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const list = screen.getByRole('listbox');
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+      });
+      await act(async () => list.dispatchEvent(event));
+
+      expect(onValueChange).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/react/src/combobox/popup/ComboboxPopup.test.tsx
+++ b/packages/react/src/combobox/popup/ComboboxPopup.test.tsx
@@ -1,7 +1,8 @@
 import { expect } from 'vitest';
+import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 
 describe('<Combobox.Popup />', () => {
   const { render } = createRenderer();
@@ -69,6 +70,84 @@ describe('<Combobox.Popup />', () => {
     const popup = await screen.findByTestId('popup');
     await waitFor(() => {
       expect(popup).toHaveAttribute('role', 'dialog');
+    });
+  });
+
+  it('focuses the popup instead of its input when opened by touch', async () => {
+    await render(
+      <Combobox.Root>
+        <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup data-testid="popup">
+              <Combobox.Input data-testid="input" />
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    fireEvent.pointerDown(trigger, { pointerType: 'touch' });
+    fireEvent.mouseDown(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('popup')).toHaveFocus();
+    });
+    expect(screen.getByTestId('input')).not.toHaveFocus();
+  });
+
+  it('honors initialFocus={false}', async () => {
+    await render(
+      <Combobox.Root>
+        <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup initialFocus={false}>
+              <Combobox.Input data-testid="input" />
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    await screen.findByTestId('input');
+    expect(trigger).toHaveFocus();
+  });
+
+  it('returns focus to an explicitly provided element when the popup closes', async () => {
+    function Test() {
+      const finalFocusRef = React.useRef<HTMLButtonElement | null>(null);
+      return (
+        <div>
+          <button ref={finalFocusRef} type="button">
+            final focus
+          </button>
+          <Combobox.Root defaultOpen>
+            <Combobox.Input />
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup finalFocus={finalFocusRef}>
+                  <Combobox.List>
+                    <Combobox.Item value="a">a</Combobox.Item>
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>
+        </div>
+      );
+    }
+
+    const { user } = await render(<Test />);
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'final focus' })).toHaveFocus();
     });
   });
 });

--- a/packages/react/src/combobox/portal/ComboboxPortalContext.test.tsx
+++ b/packages/react/src/combobox/portal/ComboboxPortalContext.test.tsx
@@ -1,0 +1,22 @@
+import { expect, vi } from 'vitest';
+import { createRenderer } from '#test-utils';
+import { useComboboxPortalContext } from './ComboboxPortalContext';
+
+describe('ComboboxPortalContext', () => {
+  const { render } = createRenderer();
+
+  it('throws a descriptive error when used outside <Combobox.Portal>', async () => {
+    function Consumer() {
+      useComboboxPortalContext();
+      return null;
+    }
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Consumer />)).rejects.toThrow('Base UI: <Combobox.Portal> is missing.');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/react/src/combobox/positioner/ComboboxPositionerContext.test.tsx
+++ b/packages/react/src/combobox/positioner/ComboboxPositionerContext.test.tsx
@@ -1,0 +1,24 @@
+import { expect, vi } from 'vitest';
+import { createRenderer } from '#test-utils';
+import { useComboboxPositionerContext } from './ComboboxPositionerContext';
+
+describe('ComboboxPositionerContext', () => {
+  const { render } = createRenderer();
+
+  it('throws a descriptive error when a required consumer is outside the positioner', async () => {
+    function Consumer() {
+      useComboboxPositionerContext();
+      return null;
+    }
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Consumer />)).rejects.toThrow(
+        'Base UI: <Combobox.Popup> and <Combobox.Arrow> must be used within the <Combobox.Positioner> component',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -94,7 +94,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     inputValue: inputValueProp,
     open: openProp,
     defaultOpen = false,
-    selectionMode = 'none',
+    selectionMode,
     onItemHighlighted: onItemHighlightedProp,
     name: nameProp,
     form,
@@ -231,6 +231,12 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     name: 'Combobox',
     state: 'open',
   });
+
+  // A controlled popup may ignore a close request. In that case, don't leave the list
+  // frozen on the query captured for an exit animation that never started.
+  if (open && closeQuery !== null) {
+    setCloseQuery(null);
+  }
 
   const isGrouped = isGroupedItems(items);
   const query = closeQuery ?? String(inputValue).trim();
@@ -617,7 +623,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
       // If reopening interrupts the close animation, handleUnmount won't run to clear the
       // frozen closeQuery and pending popup input.
-      if (nextOpen && multiple && inputInsidePopup && !inline && closeQuery !== null) {
+      if (nextOpen && inputInsidePopup && !inline && closeQuery !== null) {
         setQueryChangedAfterOpen(false);
         setCloseQuery(null);
 
@@ -694,29 +700,11 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
           createChangeEventDetails(eventDetails.reason, eventDetails.event),
         );
       }
-
-      if (
-        single &&
-        nextValue != null &&
-        eventDetails.reason !== REASONS.inputChange &&
-        queryChangedAfterOpen &&
-        !inline
-      ) {
-        setCloseQuery(query);
-      }
     },
   );
 
   const handleSelection = useStableCallback(
-    (event: MouseEvent | PointerEvent | KeyboardEvent, passedValue?: any) => {
-      let itemValue = passedValue;
-      if (itemValue === undefined) {
-        if (activeIndex === null) {
-          return;
-        }
-        itemValue = valuesRef.current[activeIndex];
-      }
-
+    (event: MouseEvent | PointerEvent | KeyboardEvent, itemValue: any) => {
       const targetEl = getTarget(event) as HTMLElement | null;
       const overrideEvent = selectionEventRef.current ?? event;
       selectionEventRef.current = null;
@@ -771,11 +759,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   );
 
   const requestSubmit = useStableCallback(() => {
-    if (!submitOnItemClick) {
-      return;
-    }
-
-    const formElement = validation.inputRef.current?.form ?? store.state.inputElement?.form;
+    const formElement = validation.inputRef.current?.form;
     if (formElement && typeof formElement.requestSubmit === 'function') {
       formElement.requestSubmit();
     }
@@ -1671,9 +1655,8 @@ export type AriaComboboxProps<
    * - `single`: Remembers the last selected value.
    * - `multiple`: Remember all selected values.
    * - `none`: Do not remember the selected value.
-   * @default 'none'
    */
-  selectionMode?: Mode | undefined;
+  selectionMode: Mode;
   /**
    * The selected value of the combobox. Use when controlled.
    */

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -759,7 +759,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
   );
 
   const requestSubmit = useStableCallback(() => {
-    const formElement = validation.inputRef.current?.form;
+    const formElement = validation.inputRef.current?.form ?? store.state.inputElement?.form;
     if (formElement && typeof formElement.requestSubmit === 'function') {
       formElement.requestSubmit();
     }

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -546,7 +546,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       if (eventDetails.reason === REASONS.inputChange) {
         // A controlled popup may ignore a close request. Resuming input proves the popup
         // is remaining open, so release the query captured for an exit animation.
-        if (closeQuery !== null) {
+        if (open && closeQuery !== null) {
           setCloseQuery(null);
         }
 
@@ -627,7 +627,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         setQueryChangedAfterOpen(false);
         setCloseQuery(null);
 
-        if (inputValue !== '') {
+        if (inputValue !== '' && eventDetails.reason !== REASONS.inputChange) {
           setInputValue('', createChangeEventDetails(REASONS.inputClear, eventDetails.event));
         }
       }

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -232,12 +232,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     state: 'open',
   });
 
-  // A controlled popup may ignore a close request. In that case, don't leave the list
-  // frozen on the query captured for an exit animation that never started.
-  if (open && closeQuery !== null) {
-    setCloseQuery(null);
-  }
-
   const isGrouped = isGroupedItems(items);
   const query = closeQuery ?? String(inputValue).trim();
 
@@ -550,6 +544,12 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       // If user is typing, ensure we don't auto-highlight on open due to a race
       // with the post-open effect that sets this flag.
       if (eventDetails.reason === REASONS.inputChange) {
+        // A controlled popup may ignore a close request. Resuming input proves the popup
+        // is remaining open, so release the query captured for an exit animation.
+        if (closeQuery !== null) {
+          setCloseQuery(null);
+        }
+
         const event = eventDetails.event as Event;
         const inputType = (event as InputEvent).inputType;
         // Treat composition commits as typed input; autofill may omit `inputType` or

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -18,6 +18,7 @@ import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
 import { Input } from '@base-ui/react/input';
 import { useStore } from '@base-ui/utils/store';
+import { useTimeout } from '@base-ui/utils/useTimeout';
 import { CompositeRoot } from '../../internals/composite/root/CompositeRoot';
 import { CompositeItem } from '../../internals/composite/item/CompositeItem';
 import { REASONS } from '../../internals/reasons';
@@ -6423,6 +6424,76 @@ describe('<Combobox.Root />', () => {
         expect(screen.getByRole('option', { name: 'Banana' })).not.toBe(null);
       });
     });
+
+    it.skipIf(isJSDOM)(
+      'keeps filtered content stable when a controlled close is deferred',
+      async ({ onTestFinished }) => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        onTestFinished(() => {
+          globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+        });
+
+        const style = `
+          @keyframes combobox-close-test {
+            to {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-popup[data-ending-style] {
+            animation: combobox-close-test 100ms linear;
+          }
+        `;
+
+        function Test() {
+          const [open, setOpen] = React.useState(true);
+          const closeTimeout = useTimeout();
+
+          return (
+            <React.Fragment>
+              {/* eslint-disable-next-line react/no-danger */}
+              <style dangerouslySetInnerHTML={{ __html: style }} />
+              <Combobox.Root
+                items={['Apple', 'Apricot', 'Banana']}
+                open={open}
+                onOpenChange={(nextOpen) => {
+                  if (!nextOpen) {
+                    closeTimeout.start(50, () => setOpen(false));
+                  }
+                }}
+              >
+                <Combobox.Input data-testid="input" />
+                <Combobox.Portal>
+                  <Combobox.Positioner>
+                    <Combobox.Popup data-testid="popup" className="animation-test-popup">
+                      <Combobox.List>
+                        {(item: string) => (
+                          <Combobox.Item key={item} value={item}>
+                            {item}
+                          </Combobox.Item>
+                        )}
+                      </Combobox.List>
+                    </Combobox.Popup>
+                  </Combobox.Positioner>
+                </Combobox.Portal>
+              </Combobox.Root>
+            </React.Fragment>
+          );
+        }
+
+        const { user } = await render(<Test />);
+        await user.type(screen.getByTestId('input'), 'ap');
+        await user.click(screen.getByRole('option', { name: 'Apple' }));
+
+        const popup = screen.getByTestId('popup');
+        await waitFor(() => expect(popup).toHaveAttribute('data-ending-style'));
+
+        expect(screen.getByTestId('input')).toHaveValue('Apple');
+        expect(screen.getByRole('option', { name: 'Apple' })).not.toBe(null);
+        expect(screen.getByRole('option', { name: 'Apricot' })).not.toBe(null);
+      },
+    );
   });
 
   describe('prop: onOpenChange', () => {

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -443,6 +443,7 @@ describe('<Combobox.Root />', () => {
                 <Combobox.Positioner>
                   <Combobox.Popup data-testid="popup" className="animation-test-popup">
                     <Combobox.Input data-testid="input" />
+                    <Combobox.Empty>No matches</Combobox.Empty>
                     <Combobox.List>
                       {(item: string) => (
                         <Combobox.Item key={item} value={item}>
@@ -470,6 +471,8 @@ describe('<Combobox.Root />', () => {
 
         await waitFor(() => expect(popup).not.toHaveAttribute('data-ending-style'));
         expect(input).toHaveValue('apb');
+        expect(screen.getByRole('status')).toHaveTextContent('No matches');
+        expect(screen.queryByRole('option')).toBe(null);
       },
     );
   });
@@ -6504,11 +6507,12 @@ describe('<Combobox.Root />', () => {
       });
     });
 
-    it('keeps filtering responsive after selection when popup input and open are controlled', async () => {
+    it('releases filtering when a controlled popup ignores a close request', async () => {
       const items = ['Apple', 'Apricot', 'Banana', 'Grape', 'Orange'];
+      const onOpenChange = vi.fn();
 
       const { user } = await render(
-        <Combobox.Root items={items} open>
+        <Combobox.Root items={items} open onOpenChange={onOpenChange}>
           <Combobox.Trigger>Open</Combobox.Trigger>
           <Combobox.Portal>
             <Combobox.Positioner>
@@ -6537,14 +6541,17 @@ describe('<Combobox.Root />', () => {
 
       await user.click(screen.getByRole('option', { name: 'Apple' }));
 
+      expect(onOpenChange.mock.lastCall?.[0]).toBe(false);
       expect(screen.getByRole('dialog')).not.toBe(null);
 
       await user.clear(input);
       await user.type(input, 'ba');
 
+      expect(input).toHaveValue('ba');
       await waitFor(() => {
         expect(screen.getByRole('option', { name: 'Banana' })).not.toBe(null);
       });
+      expect(screen.queryByRole('option', { name: 'Apple' })).toBe(null);
     });
 
     it.skipIf(isJSDOM)(

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/internal-test-utils';
 import { createRenderer, isJSDOM, popupConformanceTests } from '#test-utils';
 import { Combobox } from '@base-ui/react/combobox';
+import { Autocomplete } from '@base-ui/react/autocomplete';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Dialog } from '@base-ui/react/dialog';
 import { Field } from '@base-ui/react/field';
@@ -64,6 +65,12 @@ function SelectedIndexProbe() {
   return (
     <div data-testid="selected-index">{selectedIndex === null ? 'null' : `${selectedIndex}`}</div>
   );
+}
+
+function getHiddenControl() {
+  return screen
+    .getAllByRole<HTMLInputElement>('textbox', { hidden: true })
+    .find((element) => element.getAttribute('aria-hidden') === 'true')!;
 }
 
 function isElementOrAncestorInert(element: HTMLElement) {
@@ -198,6 +205,211 @@ describe('<Combobox.Root />', () => {
     await waitFor(() => {
       expect(trigger).toHaveFocus();
     });
+  });
+
+  describe('input inside popup composition', () => {
+    it('selects with the keyboard, restores focus, and resets the query on reopen', async () => {
+      const items = ['Apple', 'Banana', 'Cherry'];
+      const { user } = await render(
+        <Combobox.Root items={items}>
+          <Combobox.Trigger data-testid="trigger">
+            <Combobox.Value placeholder="Select a fruit" />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup aria-label="Fruits">
+                <Combobox.Input data-testid="input" />
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      await user.click(trigger);
+
+      const input = await screen.findByTestId('input');
+      await waitFor(() => expect(input).toHaveFocus());
+
+      await user.type(input, 'ban');
+      await user.keyboard('{ArrowDown}{Enter}');
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBe(null));
+      expect(trigger).toHaveFocus();
+      expect(trigger).toHaveTextContent('Banana');
+
+      await user.click(trigger);
+
+      const reopenedInput = await screen.findByTestId('input');
+      expect(reopenedInput).toHaveValue('');
+
+      const banana = screen.getByRole('option', { name: 'Banana' });
+      expect(banana).toHaveAttribute('aria-selected', 'true');
+      await waitFor(() => expect(banana).toHaveAttribute('data-highlighted'));
+    });
+
+    it('discards an uncommitted query on Escape and preserves the selection', async () => {
+      const onValueChange = vi.fn();
+      const { user } = await render(
+        <Combobox.Root
+          items={['Apple', 'Banana', 'Cherry']}
+          defaultValue="Apple"
+          onValueChange={onValueChange}
+        >
+          <Combobox.Trigger data-testid="trigger">
+            <Combobox.Value />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup aria-label="Fruits">
+                <Combobox.Input data-testid="input" />
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      await user.click(trigger);
+      await user.type(await screen.findByTestId('input'), 'ban');
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBe(null));
+      expect(trigger).toHaveFocus();
+      expect(trigger).toHaveTextContent('Apple');
+      expect(onValueChange).not.toHaveBeenCalled();
+
+      await user.click(trigger);
+
+      expect(await screen.findByTestId('input')).toHaveValue('');
+      expect(screen.getByRole('option', { name: 'Apple' })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+      expect(screen.getByRole('option', { name: 'Banana' })).not.toBe(null);
+    });
+
+    it('keeps filtering responsive when the selection close is canceled', async () => {
+      const { user } = await render(
+        <Combobox.Root
+          items={['Apple', 'Apricot', 'Banana']}
+          onOpenChange={(open, eventDetails) => {
+            if (!open) {
+              eventDetails.cancel();
+            }
+          }}
+        >
+          <Combobox.Trigger data-testid="trigger">
+            <Combobox.Value placeholder="Select a fruit" />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup aria-label="Fruits">
+                <Combobox.Input data-testid="input" />
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      await user.click(screen.getByTestId('trigger'));
+      const input = await screen.findByTestId('input');
+      await user.type(input, 'ap');
+      await user.click(screen.getByRole('option', { name: 'Apple' }));
+
+      expect(screen.getByRole('dialog')).not.toBe(null);
+      expect(screen.getByTestId('trigger')).toHaveTextContent('Apple');
+
+      await user.clear(input);
+      await user.type(input, 'ba');
+
+      expect(await screen.findByRole('option', { name: 'Banana' })).not.toBe(null);
+      expect(screen.queryByRole('option', { name: 'Apple' })).toBe(null);
+    });
+
+    it.skipIf(isJSDOM)(
+      'clears a single-select query when reopening during the close animation',
+      async ({ onTestFinished }) => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        onTestFinished(() => {
+          globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+        });
+
+        const style = `
+          @keyframes combobox-close-test {
+            to {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-popup[data-ending-style] {
+            animation: combobox-close-test 100ms linear;
+          }
+        `;
+
+        const { user } = await render(
+          <React.Fragment>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            <Combobox.Root items={['Apple', 'Banana']}>
+              <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup data-testid="popup" className="animation-test-popup">
+                    <Combobox.Input data-testid="input" />
+                    <Combobox.Empty>No matches</Combobox.Empty>
+                    <Combobox.List>
+                      {(item: string) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      )}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          </React.Fragment>,
+        );
+
+        const trigger = screen.getByTestId('trigger');
+        await user.click(trigger);
+        await user.type(await screen.findByTestId('input'), 'zz');
+        await user.keyboard('{Escape}');
+
+        const popup = screen.getByTestId('popup');
+        await waitFor(() => expect(popup).toHaveAttribute('data-ending-style'));
+
+        await user.click(trigger);
+
+        await waitFor(() => expect(popup).not.toHaveAttribute('data-ending-style'));
+        expect(screen.getByTestId('input')).toHaveValue('');
+        expect(screen.getByRole('option', { name: 'Apple' })).not.toBe(null);
+        expect(screen.getByRole('option', { name: 'Banana' })).not.toBe(null);
+      },
+    );
   });
 
   it('does not aria-hide the input group when the input is outside the popup', async () => {
@@ -4115,6 +4327,58 @@ describe('<Combobox.Root />', () => {
       expect(input).toHaveValue('');
     });
 
+    it('keeps the popup input focused through keyboard selection and restores the last selection', async () => {
+      const items = ['apple', 'apricot', 'banana'];
+      const { user } = await render(
+        <Combobox.Root multiple items={items}>
+          <Combobox.Trigger data-testid="trigger">
+            <Combobox.Value />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.Input data-testid="input" />
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      await user.click(trigger);
+
+      const input = await screen.findByTestId('input');
+      await user.type(input, 'ban');
+      await user.keyboard('{ArrowDown}{Enter}');
+
+      expect(screen.getByRole('dialog')).not.toBe(null);
+      expect(input).toHaveFocus();
+      expect(input).toHaveValue('');
+      expect(trigger).toHaveTextContent('banana');
+      expect(screen.getByRole('option', { name: 'banana' })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBe(null));
+      expect(trigger).toHaveFocus();
+
+      await user.click(trigger);
+
+      const selectedOption = await screen.findByRole('option', { name: 'banana' });
+      expect(screen.getByTestId('input')).toHaveValue('');
+      expect(selectedOption).toHaveAttribute('aria-selected', 'true');
+      await waitFor(() => expect(selectedOption).toHaveAttribute('data-highlighted'));
+    });
+
     it.skipIf(isJSDOM)(
       'keeps filtered popup content stable while closing with input inside popup',
       async ({ onTestFinished }) => {
@@ -4280,6 +4544,93 @@ describe('<Combobox.Root />', () => {
         expect(screen.getByTestId('input')).toHaveValue('');
         expect(screen.getByText('apple')).not.toBe(null);
         expect(screen.getByText('banana')).not.toBe(null);
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'does not emit another clear when controlled input is already empty on interrupted close',
+      async ({ onTestFinished }) => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        onTestFinished(() => {
+          globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+        });
+
+        const style = `
+          @keyframes combobox-close-test {
+            to {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-popup[data-ending-style] {
+            animation: combobox-close-test 100ms linear;
+          }
+        `;
+
+        const onInputValueChange = vi.fn();
+
+        function Test() {
+          const [inputValue, setInputValue] = React.useState('');
+          return (
+            <React.Fragment>
+              {/* eslint-disable-next-line react/no-danger */}
+              <style dangerouslySetInnerHTML={{ __html: style }} />
+              <Combobox.Root
+                multiple
+                items={['apple', 'banana']}
+                inputValue={inputValue}
+                onInputValueChange={(value) => {
+                  onInputValueChange(value);
+                  setInputValue(value);
+                }}
+                onOpenChange={(open) => {
+                  if (!open) {
+                    setInputValue('');
+                  }
+                }}
+              >
+                <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+                <Combobox.Portal>
+                  <Combobox.Positioner>
+                    <Combobox.Popup data-testid="popup" className="animation-test-popup">
+                      <Combobox.Input data-testid="input" />
+                      <Combobox.List>
+                        {(item: string) => (
+                          <Combobox.Item key={item} value={item}>
+                            {item}
+                          </Combobox.Item>
+                        )}
+                      </Combobox.List>
+                    </Combobox.Popup>
+                  </Combobox.Positioner>
+                </Combobox.Portal>
+              </Combobox.Root>
+            </React.Fragment>
+          );
+        }
+
+        const { user } = await render(<Test />);
+        const trigger = screen.getByTestId('trigger');
+        await user.click(trigger);
+        await user.type(await screen.findByTestId('input'), 'zz');
+        await user.keyboard('{Escape}');
+
+        const popup = screen.getByTestId('popup');
+        await waitFor(() => {
+          expect(popup).toHaveAttribute('data-ending-style');
+        });
+        expect(screen.getByTestId('input')).toHaveValue('');
+
+        const callsBeforeReopen = onInputValueChange.mock.calls.length;
+
+        await user.click(trigger);
+
+        await waitFor(() => {
+          expect(popup).not.toHaveAttribute('data-ending-style');
+        });
+        expect(screen.getByTestId('input')).toHaveValue('');
+        expect(onInputValueChange).toHaveBeenCalledTimes(callsBeforeReopen);
       },
     );
 
@@ -6021,6 +6372,49 @@ describe('<Combobox.Root />', () => {
       });
 
       await user.click(screen.getByRole('option', { name: 'Apple' }));
+
+      await user.clear(input);
+      await user.type(input, 'ba');
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Banana' })).not.toBe(null);
+      });
+    });
+
+    it('keeps filtering responsive after selection when popup input and open are controlled', async () => {
+      const items = ['Apple', 'Apricot', 'Banana', 'Grape', 'Orange'];
+
+      const { user } = await render(
+        <Combobox.Root items={items} open>
+          <Combobox.Trigger>Open</Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.Input data-testid="input" />
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+
+      await user.type(input, 'ap');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: 'Banana' })).toBe(null);
+      });
+
+      await user.click(screen.getByRole('option', { name: 'Apple' }));
+
+      expect(screen.getByRole('dialog')).not.toBe(null);
 
       await user.clear(input);
       await user.type(input, 'ba');
@@ -8940,6 +9334,394 @@ describe('<Combobox.Root />', () => {
 
       await waitFor(() => {
         expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+      });
+    });
+  });
+
+  describe('coverage edge cases', () => {
+    it('allows an attempted open to be canceled', async () => {
+      const onOpenChange = vi.fn((_open, details: Combobox.Root.ChangeEventDetails) => {
+        details.cancel();
+      });
+      const { user } = await render(
+        <Combobox.Root onOpenChange={onOpenChange}>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List />
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+
+      expect(onOpenChange).toHaveBeenCalledWith(true, expect.anything());
+      expect(screen.queryByRole('listbox')).toBe(null);
+    });
+
+    it('handles closing after a changed query is cleared', async () => {
+      const { user } = await render(
+        <Combobox.Root defaultOpen items={['apple']}>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'a');
+      await user.clear(input);
+      await user.keyboard('{Escape}');
+
+      expect(screen.queryByRole('listbox')).toBe(null);
+    });
+
+    it('clears a multiple inline query on close', async () => {
+      const { user } = await render(
+        <Combobox.Root multiple inline open items={['apple']}>
+          <Combobox.Input data-testid="inline-input" />
+          <Combobox.Trigger>Toggle</Combobox.Trigger>
+          <Combobox.List>
+            {(item: string) => (
+              <Combobox.Item key={item} value={item}>
+                {item}
+              </Combobox.Item>
+            )}
+          </Combobox.List>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('inline-input');
+      await user.type(input, 'a');
+      fireEvent.click(screen.getByText('Toggle'));
+
+      expect(input).toHaveValue('');
+    });
+
+    it('normalizes a controlled null value when selecting in multiple mode', async () => {
+      const onValueChange = vi.fn();
+      await render(
+        <Combobox.Root multiple value={null as never} defaultOpen onValueChange={onValueChange}>
+          <Combobox.Input />
+          <Combobox.List>
+            <Combobox.Item value="apple">apple</Combobox.Item>
+          </Combobox.List>
+        </Combobox.Root>,
+      );
+
+      fireEvent.click(screen.getByRole('option', { name: 'apple' }));
+
+      expect(onValueChange).toHaveBeenCalledWith(['apple'], expect.anything());
+    });
+
+    it('normalizes a controlled null value while closed in multiple mode', async () => {
+      await render(
+        <Combobox.Root multiple value={null as never} items={['apple']}>
+          <Combobox.Input />
+          <SelectedIndexProbe />
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('selected-index')).toHaveTextContent('null');
+    });
+
+    it('does not seed an initial highlight for an unmatched inline value', async () => {
+      await render(
+        <Combobox.Root inline open defaultValue="missing" items={['apple']}>
+          <Combobox.Input />
+          <SelectedIndexProbe />
+          <Combobox.List>
+            {(item: string) => (
+              <Combobox.Item key={item} value={item}>
+                {item}
+              </Combobox.Item>
+            )}
+          </Combobox.List>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('selected-index')).toHaveTextContent('null');
+    });
+
+    it('seeds the initial highlight for a matched inline value', async () => {
+      await render(
+        <Combobox.Root inline open defaultValue="apple" items={['apple']}>
+          <Combobox.Input />
+          <SelectedIndexProbe />
+          <Combobox.List>
+            {(item: string) => (
+              <Combobox.Item key={item} value={item}>
+                {item}
+              </Combobox.Item>
+            )}
+          </Combobox.List>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('selected-index')).toHaveTextContent('0');
+    });
+
+    it('restores the first highlight after an always-highlighted query becomes empty', async () => {
+      const { user } = await render(
+        <Autocomplete.Root defaultOpen autoHighlight="always" items={['apple']}>
+          <Autocomplete.Input />
+          <Autocomplete.List>
+            {(item: string) => (
+              <Autocomplete.Item key={item} value={item}>
+                {item}
+              </Autocomplete.Item>
+            )}
+          </Autocomplete.List>
+        </Autocomplete.Root>,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'z');
+      expect(screen.queryByRole('option')).toBe(null);
+
+      await user.clear(input);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'apple' })).toHaveAttribute('data-highlighted');
+      });
+    });
+
+    it('omits groups with no matching items', async () => {
+      const items = [
+        { value: 'fruit', items: ['apple'] },
+        { value: 'vegetables', items: ['broccoli'] },
+      ];
+      const { user } = await render(
+        <Combobox.Root defaultOpen items={items}>
+          <Combobox.Input />
+          <Combobox.List>
+            {(group) => (
+              <Combobox.Group key={group.value} items={group.items}>
+                <Combobox.GroupLabel>{group.value}</Combobox.GroupLabel>
+                <Combobox.Collection>
+                  {(item) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.Collection>
+              </Combobox.Group>
+            )}
+          </Combobox.List>
+        </Combobox.Root>,
+      );
+
+      await user.type(screen.getByRole('combobox'), 'app');
+
+      expect(screen.getByText('fruit')).not.toBe(null);
+      expect(screen.queryByText('vegetables')).toBe(null);
+    });
+
+    it('exposes an action that completes unmount cleanup', async () => {
+      const actionsRef = React.createRef<Combobox.Root.Actions>();
+      const onOpenChangeComplete = vi.fn();
+      await render(
+        <Combobox.Root
+          defaultOpen
+          actionsRef={actionsRef}
+          onOpenChangeComplete={onOpenChangeComplete}
+        >
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+
+      act(() => actionsRef.current?.unmount());
+
+      expect(onOpenChangeComplete).toHaveBeenCalledWith(false);
+    });
+
+    it('moves focus from the hidden control to an external input', async () => {
+      await render(
+        <Combobox.Root>
+          <Combobox.Input data-testid="visible-input" />
+        </Combobox.Root>,
+      );
+      const visibleInput = screen.getByTestId('visible-input');
+      const hiddenInput = getHiddenControl();
+
+      fireEvent.focus(hiddenInput);
+
+      expect(visibleInput).toHaveFocus();
+    });
+
+    it('falls back to the trigger when the hidden control is focused', async () => {
+      await render(
+        <Combobox.Root>
+          <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+        </Combobox.Root>,
+      );
+      const hiddenInput = getHiddenControl();
+
+      fireEvent.focus(hiddenInput);
+
+      expect(screen.getByTestId('trigger')).toHaveFocus();
+    });
+
+    it('falls back to the trigger after an external input unmounts', async () => {
+      function Test({ showInput }: { showInput: boolean }) {
+        return (
+          <Combobox.Root>
+            {showInput ? (
+              <Combobox.Input />
+            ) : (
+              <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+            )}
+          </Combobox.Root>
+        );
+      }
+
+      const { rerender } = await render(<Test showInput />);
+      await rerender(<Test showInput={false} />);
+
+      fireEvent.focus(getHiddenControl());
+
+      expect(screen.getByTestId('trigger')).toHaveFocus();
+    });
+
+    it('moves hidden-control focus to the trigger when the input is inside the popup', async () => {
+      await render(
+        <Combobox.Root defaultOpen>
+          <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.Input />
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      fireEvent.focus(getHiddenControl());
+
+      expect(screen.getByTestId('trigger')).toHaveFocus();
+    });
+
+    it('safely handles hidden-control focus without a visible control', async () => {
+      await render(<Combobox.Root />);
+      const hiddenInput = getHiddenControl();
+
+      fireEvent.focus(hiddenInput);
+
+      expect(document.body).toHaveFocus();
+    });
+
+    it('ignores scalar browser autofill in multiple mode', async () => {
+      const onValueChange = vi.fn();
+      await render(
+        <Combobox.Root multiple onValueChange={onValueChange}>
+          <Combobox.Input data-testid="visible-input" />
+        </Combobox.Root>,
+      );
+      const hiddenInput = getHiddenControl();
+
+      fireEvent.change(hiddenInput, { target: { value: 'apple' } });
+      await flushMicrotasks();
+
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('ignores unmatched browser autofill in single mode', async () => {
+      const onValueChange = vi.fn();
+      await render(
+        <Combobox.Root name="fruit" items={['apple']} onValueChange={onValueChange}>
+          <Combobox.Input />
+        </Combobox.Root>,
+      );
+      const hiddenInput = screen
+        .getAllByDisplayValue('')
+        .find((element) => element.getAttribute('name') === 'fruit')!;
+
+      fireEvent.change(hiddenInput, { target: { value: 'orange' } });
+      await flushMicrotasks();
+
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('does not request form submission when no form owns the autocomplete', async () => {
+      await render(
+        <Autocomplete.Root defaultOpen submitOnItemClick>
+          <Autocomplete.Input />
+          <Autocomplete.Portal>
+            <Autocomplete.Positioner>
+              <Autocomplete.Popup>
+                <Autocomplete.List>
+                  <Autocomplete.Item value="apple">apple</Autocomplete.Item>
+                </Autocomplete.List>
+              </Autocomplete.Popup>
+            </Autocomplete.Positioner>
+          </Autocomplete.Portal>
+        </Autocomplete.Root>,
+      );
+
+      fireEvent.click(screen.getByRole('option', { name: 'apple' }));
+      expect(screen.getByRole('combobox')).toHaveValue('apple');
+    });
+
+    it('does not request form submission when requestSubmit is unavailable', async () => {
+      await render(
+        <form aria-label="search">
+          <Autocomplete.Root defaultOpen submitOnItemClick>
+            <Autocomplete.Input />
+            <Autocomplete.Portal>
+              <Autocomplete.Positioner>
+                <Autocomplete.Popup>
+                  <Autocomplete.List>
+                    <Autocomplete.Item value="apple">apple</Autocomplete.Item>
+                  </Autocomplete.List>
+                </Autocomplete.Popup>
+              </Autocomplete.Positioner>
+            </Autocomplete.Portal>
+          </Autocomplete.Root>
+        </form>,
+      );
+      const form = screen.getByRole('form', { name: 'search' });
+      Object.defineProperty(form, 'requestSubmit', { configurable: true, value: undefined });
+
+      fireEvent.click(screen.getByRole('option', { name: 'apple' }));
+      expect(screen.getByRole('combobox')).toHaveValue('apple');
+    });
+
+    it('validates the autocomplete input when focus leaves its popup', async () => {
+      const validate = vi.fn();
+      const { user } = await render(
+        <Field.Root validationMode="onBlur" validate={validate}>
+          <Autocomplete.Root defaultOpen defaultValue="query">
+            <Autocomplete.Trigger>Open</Autocomplete.Trigger>
+            <Autocomplete.Portal>
+              <Autocomplete.Positioner>
+                <Autocomplete.Popup>
+                  <Autocomplete.Input />
+                </Autocomplete.Popup>
+              </Autocomplete.Positioner>
+            </Autocomplete.Portal>
+          </Autocomplete.Root>
+        </Field.Root>,
+      );
+
+      await user.click(document.body);
+
+      await waitFor(() => {
+        expect(validate).toHaveBeenCalledWith('query', expect.anything());
       });
     });
   });

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -411,6 +411,67 @@ describe('<Combobox.Root />', () => {
         expect(screen.getByRole('option', { name: 'Banana' })).not.toBe(null);
       },
     );
+
+    it.skipIf(isJSDOM)(
+      'preserves a typed query when input reopens single-select during the close animation',
+      async ({ onTestFinished }) => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        onTestFinished(() => {
+          globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+        });
+
+        const style = `
+          @keyframes combobox-close-test {
+            to {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-popup[data-ending-style] {
+            animation: combobox-close-test 100ms linear;
+          }
+        `;
+
+        const { user } = await render(
+          <React.Fragment>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            <Combobox.Root items={['Apple', 'Banana']}>
+              <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup data-testid="popup" className="animation-test-popup">
+                    <Combobox.Input data-testid="input" />
+                    <Combobox.List>
+                      {(item: string) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      )}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          </React.Fragment>,
+        );
+
+        await user.click(screen.getByTestId('trigger'));
+        const input = await screen.findByTestId('input');
+        await user.type(input, 'ap');
+        await user.keyboard('{Escape}');
+
+        const popup = screen.getByTestId('popup');
+        await waitFor(() => expect(popup).toHaveAttribute('data-ending-style'));
+
+        input.focus();
+        await user.type(input, 'b', { skipClick: true });
+
+        await waitFor(() => expect(popup).not.toHaveAttribute('data-ending-style'));
+        expect(input).toHaveValue('apb');
+      },
+    );
   });
 
   it('does not aria-hide the input group when the input is outside the popup', async () => {
@@ -4463,6 +4524,67 @@ describe('<Combobox.Root />', () => {
         const reopenedInput = await screen.findByTestId('input');
         expect(reopenedInput).toHaveValue('');
         expect(screen.getByText('apple')).not.toBe(null);
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'keeps filtered popup content stable when input changes during the close animation',
+      async ({ onTestFinished }) => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        onTestFinished(() => {
+          globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+        });
+
+        const style = `
+          @keyframes combobox-close-test {
+            to {
+              opacity: 0;
+            }
+          }
+
+          .animation-test-popup[data-ending-style] {
+            animation: combobox-close-test 100ms linear;
+          }
+        `;
+
+        const { user } = await render(
+          <React.Fragment>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            <Combobox.Root multiple items={['apple', 'apricot', 'banana']}>
+              <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup data-testid="popup" className="animation-test-popup">
+                    <Combobox.Input data-testid="input" />
+                    <Combobox.List>
+                      {(item: string) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      )}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          </React.Fragment>,
+        );
+
+        await user.click(screen.getByTestId('trigger'));
+        const input = await screen.findByTestId('input');
+        await user.type(input, 'ap');
+        await user.keyboard('{Escape}');
+
+        const popup = screen.getByTestId('popup');
+        await waitFor(() => expect(popup).toHaveAttribute('data-ending-style'));
+
+        await user.clear(input);
+
+        expect(screen.getByText('apple')).not.toBe(null);
+        expect(screen.getByText('apricot')).not.toBe(null);
+        expect(screen.queryByText('banana')).toBe(null);
       },
     );
 

--- a/packages/react/src/combobox/root/ComboboxRootContext.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRootContext.test.tsx
@@ -1,0 +1,46 @@
+import { expect, vi } from 'vitest';
+import { createRenderer } from '#test-utils';
+import {
+  useComboboxDerivedItemsContext,
+  useComboboxFloatingContext,
+  useComboboxRootContext,
+} from './ComboboxRootContext';
+
+describe('ComboboxRootContext', () => {
+  const { render } = createRenderer();
+
+  const cases = [
+    {
+      useContext: useComboboxRootContext,
+      message:
+        'Base UI: ComboboxRootContext is missing. Combobox parts must be placed within <Combobox.Root>.',
+    },
+    {
+      useContext: useComboboxFloatingContext,
+      message:
+        'Base UI: ComboboxFloatingContext is missing. Combobox parts must be placed within <Combobox.Root>.',
+    },
+    {
+      useContext: useComboboxDerivedItemsContext,
+      message:
+        'Base UI: ComboboxItemsContext is missing. Combobox parts must be placed within <Combobox.Root>.',
+    },
+  ];
+
+  cases.forEach(({ useContext, message }) => {
+    it(`throws when its provider is missing: ${message}`, async () => {
+      function Consumer() {
+        useContext();
+        return null;
+      }
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        await expect(render(<Consumer />)).rejects.toThrow(message);
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+  });
+});

--- a/packages/react/src/combobox/root/utils/index.test.ts
+++ b/packages/react/src/combobox/root/utils/index.test.ts
@@ -1,0 +1,54 @@
+import { expect } from 'vitest';
+import { getFilter } from '../../../internals/filter';
+import {
+  createCollatorItemFilter,
+  createSingleSelectionCollatorFilter,
+  getComboboxPopupId,
+} from './index';
+
+describe('Combobox root utilities', () => {
+  const filter = getFilter({ locale: 'en' });
+
+  describe('getComboboxPopupId', () => {
+    it('derives an id only when the root has an id', () => {
+      expect(getComboboxPopupId('fruit')).toBe('fruit-popup');
+      expect(getComboboxPopupId(null)).toBe(undefined);
+      expect(getComboboxPopupId(undefined)).toBe(undefined);
+    });
+  });
+
+  describe('createCollatorItemFilter', () => {
+    it('rejects nullish items and filters primitives and projected objects', () => {
+      const primitiveFilter = createCollatorItemFilter(filter);
+      const objectFilter = createCollatorItemFilter(filter, (item: { name: string }) => item.name);
+
+      expect(primitiveFilter(null, 'app')).toBe(false);
+      expect(primitiveFilter(undefined, 'app')).toBe(false);
+      expect(primitiveFilter('Apple', 'app')).toBe(true);
+      expect(objectFilter({ name: 'Banana' }, 'nan')).toBe(true);
+    });
+  });
+
+  describe('createSingleSelectionCollatorFilter', () => {
+    it('shows all items for an empty query and rejects nullish items', () => {
+      const itemFilter = createSingleSelectionCollatorFilter(filter);
+
+      expect(itemFilter(null, 'app')).toBe(false);
+      expect(itemFilter(undefined, 'app')).toBe(false);
+      expect(itemFilter('Apple', '')).toBe(true);
+    });
+
+    it('shows all items when the query exactly matches the selected label', () => {
+      const itemFilter = createSingleSelectionCollatorFilter(filter, undefined, 'Apple');
+
+      expect(itemFilter('Banana', 'apple')).toBe(true);
+    });
+
+    it('otherwise filters the current item', () => {
+      const itemFilter = createSingleSelectionCollatorFilter(filter, undefined, 'Apple');
+
+      expect(itemFilter('Banana', 'app')).toBe(false);
+      expect(itemFilter('Banana', 'nan')).toBe(true);
+    });
+  });
+});

--- a/packages/react/src/combobox/root/utils/useFilter.test.tsx
+++ b/packages/react/src/combobox/root/utils/useFilter.test.tsx
@@ -1,0 +1,41 @@
+import { expect } from 'vitest';
+import { createRenderer } from '#test-utils';
+import { screen } from '@mui/internal-test-utils';
+import { useComboboxFilter } from './useFilter';
+
+describe('useComboboxFilter', () => {
+  const { render } = createRenderer();
+
+  it('uses default options when called without arguments', async () => {
+    function TestFilter() {
+      const filter = useComboboxFilter();
+      return <span>{String(filter.contains('Apple', 'app'))}</span>;
+    }
+
+    await render(<TestFilter />);
+
+    expect(screen.getByText('true')).not.toBe(null);
+  });
+
+  it('filters selected and unselected items in single and multiple modes', async () => {
+    function TestFilter({ multiple }: { multiple: boolean }) {
+      const filter = useComboboxFilter({ locale: 'en', multiple, value: 'Apple' });
+      return (
+        <div>
+          <span data-testid="selected-match">{String(filter.contains('Banana', 'apple'))}</span>
+          <span data-testid="item-match">{String(filter.contains('Banana', 'nan'))}</span>
+        </div>
+      );
+    }
+
+    const { rerender } = await render(<TestFilter multiple={false} />);
+
+    expect(screen.getByTestId('selected-match')).toHaveTextContent('true');
+    expect(screen.getByTestId('item-match')).toHaveTextContent('true');
+
+    await rerender(<TestFilter multiple />);
+
+    expect(screen.getByTestId('selected-match')).toHaveTextContent('false');
+    expect(screen.getByTestId('item-match')).toHaveTextContent('true');
+  });
+});

--- a/packages/react/src/combobox/store.ts
+++ b/packages/react/src/combobox/store.ts
@@ -68,7 +68,7 @@ export type State = {
     type?: 'keyboard' | 'pointer' | 'none' | undefined;
   }) => void;
   forceMount: () => void;
-  handleSelection: (event: MouseEvent | PointerEvent | KeyboardEvent, passedValue?: any) => void;
+  handleSelection: (event: MouseEvent | PointerEvent | KeyboardEvent, itemValue: any) => void;
   requestSubmit: () => void;
 
   name: string | undefined;

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
@@ -1,10 +1,13 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
+import { Autocomplete } from '@base-ui/react/autocomplete';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
 import { REASONS } from '../../internals/reasons';
+import { useComboboxRootContext } from '../root/ComboboxRootContext';
 
 describe('<Combobox.Trigger />', () => {
   const { render } = createRenderer();
@@ -100,6 +103,24 @@ describe('<Combobox.Trigger />', () => {
       expect(screen.queryByRole('listbox')).toBe(null);
     });
 
+    it('ignores native keydown events on a disabled non-native trigger', async () => {
+      const onOpenChange = vi.fn();
+      await render(
+        <Combobox.Root onOpenChange={onOpenChange}>
+          <Combobox.Trigger disabled nativeButton={false} render={<div />} data-testid="trigger" />
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      await act(async () => {
+        trigger.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }),
+        );
+      });
+
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
     it('should prioritize local disabled over root disabled', async () => {
       await render(
         <Combobox.Root disabled={false}>
@@ -112,6 +133,85 @@ describe('<Combobox.Trigger />', () => {
       const trigger = screen.getByTestId('trigger');
       expect(trigger).toHaveAttribute('disabled');
     });
+  });
+
+  it.each([
+    {
+      name: 'single selection',
+      control: (
+        <Combobox.Root defaultValue="apple">
+          <Combobox.Trigger data-testid="trigger" />
+        </Combobox.Root>
+      ),
+      expectedValue: 'apple',
+    },
+    {
+      name: 'no selection',
+      control: (
+        <Autocomplete.Root defaultValue="query">
+          <Autocomplete.Trigger data-testid="trigger" />
+        </Autocomplete.Root>
+      ),
+      expectedValue: 'query',
+    },
+  ])('validates the $name value when blurred', async ({ control, expectedValue }) => {
+    const validate = vi.fn();
+    await render(
+      <Field.Root validationMode="onBlur" validate={validate}>
+        {control}
+      </Field.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    fireEvent.focus(trigger);
+    fireEvent.blur(trigger);
+
+    expect(validate).toHaveBeenCalledWith(expectedValue, expect.anything());
+  });
+
+  it('ignores a pending mouseup after the trigger unmounts', async () => {
+    const onOpenChange = vi.fn();
+
+    function Test({ showTrigger }: { showTrigger: boolean }) {
+      return (
+        <Combobox.Root onOpenChange={onOpenChange}>
+          {showTrigger && <Combobox.Trigger data-testid="trigger" />}
+        </Combobox.Root>
+      );
+    }
+
+    const { rerender } = await render(<Test showTrigger />);
+    fireEvent.mouseDown(screen.getByTestId('trigger'));
+    await rerender(<Test showTrigger={false} />);
+
+    fireEvent.mouseUp(document.body);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('does not select when closed typeahead matches a sparse label without a value', async () => {
+    const onValueChange = vi.fn();
+
+    function SparseRegistry() {
+      const store = useComboboxRootContext();
+      useIsoLayoutEffect(() => {
+        store.state.labelsRef.current[0] = 'apple';
+        delete store.state.valuesRef.current[0];
+      }, [store]);
+      return null;
+    }
+
+    const { user } = await render(
+      <Combobox.Root onValueChange={onValueChange}>
+        <SparseRegistry />
+        <Combobox.Trigger>Open</Combobox.Trigger>
+      </Combobox.Root>,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    trigger.focus();
+    await user.keyboard('a');
+
+    expect(onValueChange).not.toHaveBeenCalled();
   });
 
   describe('prop: readOnly', () => {
@@ -135,6 +235,32 @@ describe('<Combobox.Trigger />', () => {
       const trigger = screen.getByTestId('trigger');
       await user.click(trigger);
 
+      expect(screen.queryByRole('listbox')).toBe(null);
+    });
+
+    it.each(['ArrowDown', 'ArrowUp'])('does not open on %s when readOnly', async (key) => {
+      const onOpenChange = vi.fn();
+      const { user } = await render(
+        <Combobox.Root readOnly onOpenChange={onOpenChange}>
+          <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.Input />
+                <Combobox.List>
+                  <Combobox.Item value="a">a</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      trigger.focus();
+      await user.keyboard(`{${key}}`);
+
+      expect(onOpenChange).not.toHaveBeenCalled();
       expect(screen.queryByRole('listbox')).toBe(null);
     });
 

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
@@ -176,15 +176,26 @@ describe('<Combobox.Trigger />', () => {
       return (
         <Combobox.Root onOpenChange={onOpenChange}>
           {showTrigger && <Combobox.Trigger data-testid="trigger" />}
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.Input />
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
         </Combobox.Root>
       );
     }
 
     const { rerender } = await render(<Test showTrigger />);
     fireEvent.mouseDown(screen.getByTestId('trigger'));
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(true, expect.anything()));
+    onOpenChange.mockClear();
+
     await rerender(<Test showTrigger={false} />);
 
-    fireEvent.mouseUp(document.body);
+    fireEvent.mouseUp(document.body, { clientX: 100, clientY: 100 });
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -223,7 +223,8 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
           const doc = ownerDocument(event.currentTarget);
 
           function handleMouseUp(mouseEvent: MouseEvent) {
-            if (!triggerElement) {
+            const currentTriggerElement = store.state.triggerElement;
+            if (!currentTriggerElement) {
               return;
             }
 
@@ -232,14 +233,14 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
             const list = store.state.listElement;
 
             if (
-              contains(triggerElement, mouseUpTarget) ||
+              contains(currentTriggerElement, mouseUpTarget) ||
               contains(positioner, mouseUpTarget) ||
               contains(list, mouseUpTarget)
             ) {
               return;
             }
 
-            if (isMouseWithinBounds(mouseEvent, triggerElement)) {
+            if (isMouseWithinBounds(mouseEvent, currentTriggerElement)) {
               return;
             }
 
@@ -251,7 +252,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
           }
         },
         onKeyDown(event) {
-          if (disabled || readOnly) {
+          if (readOnly) {
             return;
           }
 

--- a/packages/react/src/combobox/utils/handleInputPress.test.ts
+++ b/packages/react/src/combobox/utils/handleInputPress.test.ts
@@ -1,0 +1,30 @@
+import { expect, vi } from 'vitest';
+import type * as React from 'react';
+import { handleInputPress } from './handleInputPress';
+import type { ComboboxStore } from '../store';
+
+describe('handleInputPress', () => {
+  it('handles an event whose target is not an Element', () => {
+    const focus = vi.fn();
+    const preventDefault = vi.fn();
+    const currentTarget = document.createElement('div');
+    const textNode = document.createTextNode('padding');
+    const nativeEvent = { target: textNode } as unknown as MouseEvent;
+    const event = {
+      currentTarget,
+      nativeEvent,
+      preventDefault,
+    } as unknown as React.MouseEvent<HTMLElement>;
+    const store = {
+      state: {
+        inputRef: { current: { focus } },
+        openOnInputClick: false,
+      },
+    } as unknown as ComboboxStore;
+
+    handleInputPress(event, store, false, false);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(focus).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react/src/combobox/utils/parts.test.ts
+++ b/packages/react/src/combobox/utils/parts.test.ts
@@ -1,0 +1,39 @@
+import { expect, vi } from 'vitest';
+import { clickHighlightedItem, getIndexAfterChipRemoval } from './parts';
+import type { ComboboxStore } from '../store';
+
+describe('Combobox part utilities', () => {
+  it('returns no index after removing the only chip', () => {
+    expect(getIndexAfterChipRemoval(0, 1)).toBe(undefined);
+  });
+
+  it('does nothing when the highlighted item is not rendered', () => {
+    const nativeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+    const store = {
+      state: {
+        listRef: { current: [] },
+        selectionEventRef: { current: null },
+      },
+    } as unknown as ComboboxStore;
+
+    clickHighlightedItem(store, 1, nativeEvent);
+
+    expect(store.state.selectionEventRef.current).toBe(null);
+  });
+
+  it('clicks the rendered highlighted item with the originating event', () => {
+    const click = vi.fn();
+    const nativeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+    const store = {
+      state: {
+        listRef: { current: [{ click }] },
+        selectionEventRef: { current: null },
+      },
+    } as unknown as ComboboxStore;
+
+    clickHighlightedItem(store, 0, nativeEvent);
+
+    expect(click).toHaveBeenCalledOnce();
+    expect(store.state.selectionEventRef.current).toBe(null);
+  });
+});

--- a/packages/react/src/combobox/utils/parts.test.ts
+++ b/packages/react/src/combobox/utils/parts.test.ts
@@ -24,16 +24,21 @@ describe('Combobox part utilities', () => {
   it('clicks the rendered highlighted item with the originating event', () => {
     const click = vi.fn();
     const nativeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+    let selectionEventAtClick: Event | null = null;
     const store = {
       state: {
         listRef: { current: [{ click }] },
         selectionEventRef: { current: null },
       },
     } as unknown as ComboboxStore;
+    click.mockImplementation(() => {
+      selectionEventAtClick = store.state.selectionEventRef.current;
+    });
 
     clickHighlightedItem(store, 0, nativeEvent);
 
     expect(click).toHaveBeenCalledOnce();
+    expect(selectionEventAtClick).toBe(nativeEvent);
     expect(store.state.selectionEventRef.current).toBe(null);
   });
 });

--- a/packages/react/src/combobox/utils/useInitialLiveRegionTextMutation.test.tsx
+++ b/packages/react/src/combobox/utils/useInitialLiveRegionTextMutation.test.tsx
@@ -25,13 +25,14 @@ describe('useInitialLiveRegionTextMutation', () => {
   });
 
   it('skips empty text nodes when finding the announcement text', async () => {
+    const text = document.createTextNode('Status');
+    const empty = document.createTextNode('');
+
     function Status() {
       const ref = useInitialLiveRegionTextMutation<HTMLDivElement>();
 
       useIsoLayoutEffect(() => {
-        const empty = document.createTextNode('');
-        const text = document.createTextNode('Status');
-        ref.current?.append(empty, text);
+        ref.current?.append(text, empty);
       }, [ref]);
 
       return <div ref={ref} data-testid="status" />;
@@ -39,7 +40,8 @@ describe('useInitialLiveRegionTextMutation', () => {
 
     await render(<Status />);
 
-    expect(screen.getByTestId('status').textContent).toContain('\u2060');
+    expect(text.data).toBe('Status\u2060');
+    expect(empty.data).toBe('');
   });
 
   it('does not overwrite text that changes before the reset', async () => {

--- a/packages/react/src/combobox/utils/useInitialLiveRegionTextMutation.test.tsx
+++ b/packages/react/src/combobox/utils/useInitialLiveRegionTextMutation.test.tsx
@@ -1,0 +1,63 @@
+import { expect } from 'vitest';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { createRenderer } from '#test-utils';
+import { screen } from '@mui/internal-test-utils';
+import {
+  INITIAL_LIVE_REGION_TEXT_MUTATION_RESET_DELAY,
+  useInitialLiveRegionTextMutation,
+} from './useInitialLiveRegionTextMutation';
+
+describe('useInitialLiveRegionTextMutation', () => {
+  const { render } = createRenderer();
+  const { render: renderWithFakeTimers, clock } = createRenderer({
+    clockOptions: { shouldAdvanceTime: true },
+  });
+
+  clock.withFakeTimers();
+
+  it('does nothing when its ref is not attached', async () => {
+    function Unattached() {
+      useInitialLiveRegionTextMutation();
+      return null;
+    }
+
+    await render(<Unattached />);
+  });
+
+  it('skips empty text nodes when finding the announcement text', async () => {
+    function Status() {
+      const ref = useInitialLiveRegionTextMutation<HTMLDivElement>();
+
+      useIsoLayoutEffect(() => {
+        const empty = document.createTextNode('');
+        const text = document.createTextNode('Status');
+        ref.current?.append(empty, text);
+      }, [ref]);
+
+      return <div ref={ref} data-testid="status" />;
+    }
+
+    await render(<Status />);
+
+    expect(screen.getByTestId('status').textContent).toContain('\u2060');
+  });
+
+  it('does not overwrite text that changes before the reset', async () => {
+    function Status() {
+      const ref = useInitialLiveRegionTextMutation<HTMLDivElement>();
+      return (
+        <div ref={ref} data-testid="status">
+          Status
+        </div>
+      );
+    }
+
+    await renderWithFakeTimers(<Status />);
+    const status = screen.getByTestId('status');
+    status.firstChild!.nodeValue = 'Updated';
+
+    clock.tick(INITIAL_LIVE_REGION_TEXT_MUTATION_RESET_DELAY);
+
+    expect(status).toHaveTextContent('Updated');
+  });
+});

--- a/packages/react/src/combobox/utils/useInitialLiveRegionTextMutation.test.tsx
+++ b/packages/react/src/combobox/utils/useInitialLiveRegionTextMutation.test.tsx
@@ -9,19 +9,16 @@ import {
 
 describe('useInitialLiveRegionTextMutation', () => {
   const { render } = createRenderer();
-  const { render: renderWithFakeTimers, clock } = createRenderer({
-    clockOptions: { shouldAdvanceTime: true },
-  });
-
-  clock.withFakeTimers();
 
   it('does nothing when its ref is not attached', async () => {
     function Unattached() {
       useInitialLiveRegionTextMutation();
-      return null;
+      return <div data-testid="status">Status</div>;
     }
 
     await render(<Unattached />);
+
+    expect(screen.getByTestId('status')).toHaveTextContent('Status');
   });
 
   it('skips empty text nodes when finding the announcement text', async () => {
@@ -44,22 +41,30 @@ describe('useInitialLiveRegionTextMutation', () => {
     expect(empty.data).toBe('');
   });
 
-  it('does not overwrite text that changes before the reset', async () => {
-    function Status() {
-      const ref = useInitialLiveRegionTextMutation<HTMLDivElement>();
-      return (
-        <div ref={ref} data-testid="status">
-          Status
-        </div>
-      );
-    }
+  describe('with fake timers', () => {
+    const { render: renderWithFakeTimers, clock } = createRenderer({
+      clockOptions: { shouldAdvanceTime: true },
+    });
 
-    await renderWithFakeTimers(<Status />);
-    const status = screen.getByTestId('status');
-    status.firstChild!.nodeValue = 'Updated';
+    clock.withFakeTimers();
 
-    clock.tick(INITIAL_LIVE_REGION_TEXT_MUTATION_RESET_DELAY);
+    it('does not overwrite text that changes before the reset', async () => {
+      function Status() {
+        const ref = useInitialLiveRegionTextMutation<HTMLDivElement>();
+        return (
+          <div ref={ref} data-testid="status">
+            Status
+          </div>
+        );
+      }
 
-    expect(status).toHaveTextContent('Updated');
+      await renderWithFakeTimers(<Status />);
+      const status = screen.getByTestId('status');
+      status.firstChild!.nodeValue = 'Updated';
+
+      clock.tick(INITIAL_LIVE_REGION_TEXT_MUTATION_RESET_DELAY);
+
+      expect(status).toHaveTextContent('Updated');
+    });
   });
 });

--- a/packages/react/src/combobox/utils/useInitialLiveRegionTextMutation.ts
+++ b/packages/react/src/combobox/utils/useInitialLiveRegionTextMutation.ts
@@ -42,7 +42,7 @@ export function useInitialLiveRegionTextMutation<T extends HTMLElement>() {
       return undefined;
     }
 
-    const originalValue = textNode.nodeValue ?? '';
+    const originalValue = textNode.data;
     const markedValue = `${originalValue}${LIVE_REGION_MARKER}`;
     textNode.nodeValue = markedValue;
 


### PR DESCRIPTION
Expands Combobox and Autocomplete test coverage to 100% across statements, branches, functions, and lines, including popup-input interactions in jsdom and Chromium.

- Fixes virtualized items missing from the filtered collection being assigned an invalid `-1` ID and registration, and releases stale filtering when a controlled or interrupted close leaves the popup open.
