### PR TITLE
[menu] Expand test coverage

### DIFF
--- a/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
+++ b/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
@@ -99,6 +99,10 @@ describe('<ContextMenu.Root />', () => {
     });
 
     it('does not activate a submenu trigger when releasing the context menu pointer over it', async () => {
+      if (reactMajor <= 18) {
+        ignoreActWarnings();
+      }
+
       const submenuOnOpenChange = vi.fn();
 
       await render(

--- a/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
+++ b/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
@@ -98,6 +98,52 @@ describe('<ContextMenu.Root />', () => {
       expect(rootOnOpenChange.mock.lastCall?.[1].reason).toBe(REASONS.itemPress);
     });
 
+    it('does not activate a submenu trigger when releasing the context menu pointer over it', async () => {
+      const submenuOnOpenChange = vi.fn();
+
+      await render(
+        <ContextMenu.Root>
+          <ContextMenu.Trigger data-testid="context-trigger">Surface</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner>
+              <ContextMenu.Popup data-testid="context-root-popup">
+                <ContextMenu.SubmenuRoot onOpenChange={submenuOnOpenChange}>
+                  <ContextMenu.SubmenuTrigger
+                    data-testid="context-submenu-trigger"
+                    openOnHover={false}
+                  >
+                    More options
+                  </ContextMenu.SubmenuTrigger>
+                  <ContextMenu.Portal>
+                    <ContextMenu.Positioner>
+                      <ContextMenu.Popup data-testid="context-submenu-popup">
+                        <ContextMenu.Item>Deep action</ContextMenu.Item>
+                      </ContextMenu.Popup>
+                    </ContextMenu.Positioner>
+                  </ContextMenu.Portal>
+                </ContextMenu.SubmenuRoot>
+              </ContextMenu.Popup>
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('context-trigger');
+      fireEvent.contextMenu(trigger, { clientX: 20, clientY: 20, button: 2 });
+      await screen.findByTestId('context-root-popup');
+
+      fireEvent.pointerMove(document.body, { clientX: 24, clientY: 24 });
+      fireEvent.mouseUp(screen.getByTestId('context-submenu-trigger'), {
+        button: 2,
+        clientX: 24,
+        clientY: 24,
+      });
+      await flushMicrotasks();
+
+      expect(screen.queryByTestId('context-submenu-popup')).toBe(null);
+      expect(submenuOnOpenChange).not.toHaveBeenCalled();
+    });
+
     it('ignores mouseup directly under the cursor when the context menu spawns there', async () => {
       if (reactMajor <= 18) {
         ignoreActWarnings();

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
@@ -25,9 +25,15 @@ describe('<ContextMenu.Trigger />', () => {
   }));
 
   it('throws when rendered outside ContextMenu.Root', async () => {
-    await expect(render(<ContextMenu.Trigger />)).rejects.toThrow(
-      'Base UI: ContextMenuRootContext is missing. ContextMenu parts must be placed within <ContextMenu.Root>.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<ContextMenu.Trigger />)).rejects.toThrow(
+        'Base UI: ContextMenuRootContext is missing. ContextMenu parts must be placed within <ContextMenu.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('should open menu on right click (context menu event)', async () => {
@@ -287,7 +293,7 @@ describe('<ContextMenu.Trigger />', () => {
     });
   });
 
-  it('blocks native context menus on both internal and external backdrops only', async () => {
+  it('blocks native context menus on both internal and external backdrops', async () => {
     await render(
       <ContextMenu.Root defaultOpen>
         <ContextMenu.Trigger>Right click me</ContextMenu.Trigger>
@@ -317,6 +323,47 @@ describe('<ContextMenu.Trigger />', () => {
     expect(internalEvent.defaultPrevented).toBe(true);
     expect(externalEvent.defaultPrevented).toBe(true);
     expect(outsideEvent.defaultPrevented).toBe(false);
+  });
+
+  it('blocks native context menus in a portal mounted inside the trigger DOM subtree', async () => {
+    const portalContainerRef = React.createRef<HTMLDivElement>();
+
+    await render(
+      <ContextMenu.Root defaultOpen>
+        <ContextMenu.Trigger>
+          Right click me
+          <div ref={portalContainerRef} />
+        </ContextMenu.Trigger>
+        <ContextMenu.Portal container={portalContainerRef}>
+          <ContextMenu.Positioner>
+            <ContextMenu.Popup data-testid="popup" />
+          </ContextMenu.Positioner>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    screen.getByTestId('popup').dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('blocks the native context menu when onContextMenu skips the Base UI handler', async () => {
+    await render(
+      <ContextMenu.Root>
+        <ContextMenu.Trigger
+          data-testid="trigger"
+          onContextMenu={(event) => event.preventBaseUIHandler()}
+        >
+          Right click me
+        </ContextMenu.Trigger>
+      </ContextMenu.Root>,
+    );
+
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    screen.getByTestId('trigger').dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
   });
 
   describe.skipIf(isJSDOM)('long press', () => {

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
@@ -2,6 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { ContextMenu } from '@base-ui/react/context-menu';
+import { Timeout } from '@base-ui/utils/useTimeout';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<ContextMenu.Trigger />', () => {
@@ -491,6 +492,42 @@ describe('<ContextMenu.Trigger />', () => {
 
       expect(onOpenChange).not.toHaveBeenCalled();
       expect(screen.queryByRole('menu')).toBe(null);
+    });
+
+    it('ignores a queued long press callback after the touch ends', async () => {
+      const onOpenChange = vi.fn();
+      let runPendingLongPress: (() => void) | undefined;
+      const timeoutStartSpy = vi
+        .spyOn(Timeout.prototype, 'start')
+        .mockImplementation((_delay, callback) => {
+          runPendingLongPress = callback as () => void;
+        });
+
+      try {
+        await render(
+          <ContextMenu.Root onOpenChange={onOpenChange}>
+            <ContextMenu.Trigger data-testid="trigger">Long press me</ContextMenu.Trigger>
+            <ContextMenu.Portal>
+              <ContextMenu.Positioner>
+                <ContextMenu.Popup />
+              </ContextMenu.Positioner>
+            </ContextMenu.Portal>
+          </ContextMenu.Root>,
+        );
+
+        const trigger = screen.getByTestId('trigger');
+        fireEvent.touchStart(trigger, {
+          touches: [new Touch({ identifier: 0, target: trigger, clientX: 100, clientY: 100 })],
+        });
+        fireEvent.touchEnd(trigger);
+
+        runPendingLongPress?.();
+
+        expect(onOpenChange).not.toHaveBeenCalled();
+        expect(screen.queryByRole('menu')).toBe(null);
+      } finally {
+        timeoutStartSpy.mockRestore();
+      }
     });
 
     it('ignores multi-touch gestures', async () => {

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
@@ -1,9 +1,14 @@
 import { expect, vi } from 'vitest';
-import { fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
+import * as React from 'react';
+import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { ContextMenu } from '@base-ui/react/context-menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<ContextMenu.Trigger />', () => {
+  beforeEach(() => {
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+  });
+
   const { render, clock } = createRenderer({
     clockOptions: {
       shouldAdvanceTime: true,
@@ -18,6 +23,12 @@ describe('<ContextMenu.Trigger />', () => {
       return render(<ContextMenu.Root>{node}</ContextMenu.Root>);
     },
   }));
+
+  it('throws when rendered outside ContextMenu.Root', async () => {
+    await expect(render(<ContextMenu.Trigger />)).rejects.toThrow(
+      'Base UI: ContextMenuRootContext is missing. ContextMenu parts must be placed within <ContextMenu.Root>.',
+    );
+  });
 
   it('should open menu on right click (context menu event)', async () => {
     await render(
@@ -134,6 +145,95 @@ describe('<ContextMenu.Trigger />', () => {
     expect(onOpenChange.mock.lastCall?.[0]).toBe(false);
   });
 
+  it('keeps the menu open when the context-menu gesture ends inside its positioner', async () => {
+    const onOpenChange = vi.fn();
+
+    await render(
+      <ContextMenu.Root onOpenChange={onOpenChange}>
+        <ContextMenu.Trigger data-testid="trigger">Right click me</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Positioner data-testid="positioner">
+            <ContextMenu.Popup />
+          </ContextMenu.Positioner>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    fireEvent.contextMenu(screen.getByTestId('trigger'));
+    clock.tick(501);
+    fireEvent.mouseUp(screen.getByTestId('positioner'));
+
+    expect(onOpenChange.mock.calls).toHaveLength(1);
+    expect(screen.queryByRole('menu')).not.toBe(null);
+  });
+
+  it('keeps the root menu open when the context-menu gesture ends in a portaled submenu', async () => {
+    const onOpenChange = vi.fn();
+
+    await render(
+      <ContextMenu.Root onOpenChange={onOpenChange}>
+        <ContextMenu.Trigger data-testid="trigger">Right click me</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Positioner>
+            <ContextMenu.Popup>
+              <ContextMenu.SubmenuRoot defaultOpen>
+                <ContextMenu.SubmenuTrigger>More</ContextMenu.SubmenuTrigger>
+                <ContextMenu.Portal>
+                  <ContextMenu.Positioner>
+                    <ContextMenu.Popup data-testid="submenu-popup" />
+                  </ContextMenu.Positioner>
+                </ContextMenu.Portal>
+              </ContextMenu.SubmenuRoot>
+            </ContextMenu.Popup>
+          </ContextMenu.Positioner>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    fireEvent.contextMenu(screen.getByTestId('trigger'));
+    clock.tick(501);
+    fireEvent.mouseUp(screen.getByTestId('submenu-popup'));
+
+    expect(onOpenChange.mock.calls).toHaveLength(1);
+    expect(screen.queryByTestId('submenu-popup')).not.toBe(null);
+  });
+
+  it('aborts the pending document mouseup listener when the trigger unmounts', async () => {
+    const onOpenChange = vi.fn();
+    let hideTrigger = () => {};
+
+    function Test() {
+      const [showTrigger, setShowTrigger] = React.useState(true);
+      hideTrigger = () => setShowTrigger(false);
+
+      return (
+        <ContextMenu.Root onOpenChange={onOpenChange}>
+          {showTrigger && (
+            <ContextMenu.Trigger data-testid="trigger">Right click me</ContextMenu.Trigger>
+          )}
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner>
+              <ContextMenu.Popup />
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>
+      );
+    }
+
+    await render(<Test />);
+    fireEvent.contextMenu(screen.getByTestId('trigger'));
+
+    await act(async () => {
+      hideTrigger();
+    });
+
+    clock.tick(501);
+    fireEvent.mouseUp(document.body);
+
+    expect(onOpenChange.mock.calls).toHaveLength(1);
+    expect(screen.queryByRole('menu')).not.toBe(null);
+  });
+
   describe('prop: disabled', () => {
     it('does not open on right-click when disabled', async () => {
       const onOpenChange = vi.fn();
@@ -185,6 +285,38 @@ describe('<ContextMenu.Trigger />', () => {
 
       expect(defaultPrevented).toBe(false);
     });
+  });
+
+  it('blocks native context menus on both internal and external backdrops only', async () => {
+    await render(
+      <ContextMenu.Root defaultOpen>
+        <ContextMenu.Trigger>Right click me</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Backdrop data-testid="backdrop" />
+          <ContextMenu.Positioner>
+            <ContextMenu.Popup />
+          </ContextMenu.Positioner>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    await flushMicrotasks();
+
+    const internalBackdrop = document.querySelector(
+      '[data-base-ui-portal] > [data-base-ui-inert][role="presentation"]',
+    )!;
+    const externalBackdrop = screen.getByTestId('backdrop');
+    const internalEvent = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    const externalEvent = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    const outsideEvent = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+
+    internalBackdrop.dispatchEvent(internalEvent);
+    externalBackdrop.dispatchEvent(externalEvent);
+    document.body.dispatchEvent(outsideEvent);
+
+    expect(internalEvent.defaultPrevented).toBe(true);
+    expect(externalEvent.defaultPrevented).toBe(true);
+    expect(outsideEvent.defaultPrevented).toBe(false);
   });
 
   describe.skipIf(isJSDOM)('long press', () => {
@@ -262,6 +394,109 @@ describe('<ContextMenu.Trigger />', () => {
 
       expect(screen.queryByRole('menu')).toBe(null);
       expect(onOpenChange.mock.calls.length).toBe(0);
+    });
+
+    it('keeps a pending long press when touch movement stays within the threshold', async () => {
+      await render(
+        <ContextMenu.Root>
+          <ContextMenu.Trigger data-testid="trigger">Long press me</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner>
+              <ContextMenu.Popup />
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.touchStart(trigger, {
+        touches: [new Touch({ identifier: 0, target: trigger, clientX: 100, clientY: 100 })],
+      });
+      fireEvent.touchMove(trigger, {
+        touches: [new Touch({ identifier: 0, target: trigger, clientX: 105, clientY: 105 })],
+      });
+
+      clock.tick(500);
+
+      expect(screen.queryByRole('menu')).not.toBe(null);
+    });
+
+    it('cancels a pending long press when the touch ends', async () => {
+      const onOpenChange = vi.fn();
+
+      await render(
+        <ContextMenu.Root onOpenChange={onOpenChange}>
+          <ContextMenu.Trigger data-testid="trigger">Long press me</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner>
+              <ContextMenu.Popup />
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.touchStart(trigger, {
+        touches: [new Touch({ identifier: 0, target: trigger, clientX: 100, clientY: 100 })],
+      });
+      fireEvent.touchEnd(trigger);
+      clock.tick(500);
+
+      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(screen.queryByRole('menu')).toBe(null);
+    });
+
+    it('ignores multi-touch gestures', async () => {
+      const onOpenChange = vi.fn();
+
+      await render(
+        <ContextMenu.Root onOpenChange={onOpenChange}>
+          <ContextMenu.Trigger data-testid="trigger">Long press me</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner>
+              <ContextMenu.Popup />
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      const touches = [
+        new Touch({ identifier: 0, target: trigger, clientX: 100, clientY: 100 }),
+        new Touch({ identifier: 1, target: trigger, clientX: 120, clientY: 100 }),
+      ];
+      fireEvent.touchStart(trigger, { touches });
+      fireEvent.touchMove(trigger, { touches });
+      clock.tick(500);
+
+      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(screen.queryByRole('menu')).toBe(null);
+    });
+
+    it('delays outside-press dismissal after opening from a long press', async () => {
+      await render(
+        <ContextMenu.Root>
+          <ContextMenu.Trigger data-testid="trigger">Long press me</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner>
+              <ContextMenu.Popup />
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.touchStart(trigger, {
+        touches: [new Touch({ identifier: 0, target: trigger, clientX: 100, clientY: 100 })],
+      });
+      clock.tick(500);
+
+      fireEvent.mouseDown(document.body);
+      expect(screen.queryByRole('menu')).not.toBe(null);
+
+      clock.tick(500);
+      fireEvent.mouseDown(document.body);
+      expect(screen.queryByRole('menu')).toBe(null);
     });
 
     it('does not open on long press when disabled', async () => {

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
@@ -2,7 +2,6 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { ContextMenu } from '@base-ui/react/context-menu';
-import { Timeout } from '@base-ui/utils/useTimeout';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<ContextMenu.Trigger />', () => {
@@ -494,43 +493,7 @@ describe('<ContextMenu.Trigger />', () => {
       expect(screen.queryByRole('menu')).toBe(null);
     });
 
-    it('ignores a queued long press callback after the touch ends', async () => {
-      const onOpenChange = vi.fn();
-      let runPendingLongPress: (() => void) | undefined;
-      const timeoutStartSpy = vi
-        .spyOn(Timeout.prototype, 'start')
-        .mockImplementation((_delay, callback) => {
-          runPendingLongPress = callback as () => void;
-        });
-
-      try {
-        await render(
-          <ContextMenu.Root onOpenChange={onOpenChange}>
-            <ContextMenu.Trigger data-testid="trigger">Long press me</ContextMenu.Trigger>
-            <ContextMenu.Portal>
-              <ContextMenu.Positioner>
-                <ContextMenu.Popup />
-              </ContextMenu.Positioner>
-            </ContextMenu.Portal>
-          </ContextMenu.Root>,
-        );
-
-        const trigger = screen.getByTestId('trigger');
-        fireEvent.touchStart(trigger, {
-          touches: [new Touch({ identifier: 0, target: trigger, clientX: 100, clientY: 100 })],
-        });
-        fireEvent.touchEnd(trigger);
-
-        runPendingLongPress?.();
-
-        expect(onOpenChange).not.toHaveBeenCalled();
-        expect(screen.queryByRole('menu')).toBe(null);
-      } finally {
-        timeoutStartSpy.mockRestore();
-      }
-    });
-
-    it('ignores multi-touch gestures', async () => {
+    it('cancels a pending long press when the gesture becomes multi-touch', async () => {
       const onOpenChange = vi.fn();
 
       await render(
@@ -545,12 +508,23 @@ describe('<ContextMenu.Trigger />', () => {
       );
 
       const trigger = screen.getByTestId('trigger');
+      const firstTouch = new Touch({ identifier: 0, target: trigger, clientX: 100, clientY: 100 });
       const touches = [
-        new Touch({ identifier: 0, target: trigger, clientX: 100, clientY: 100 }),
+        firstTouch,
         new Touch({ identifier: 1, target: trigger, clientX: 120, clientY: 100 }),
       ];
-      fireEvent.touchStart(trigger, { touches });
+
+      fireEvent.touchStart(trigger, { touches: [firstTouch] });
       fireEvent.touchMove(trigger, { touches });
+      fireEvent.touchMove(trigger, { touches: [firstTouch] });
+      clock.tick(500);
+
+      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(screen.queryByRole('menu')).toBe(null);
+
+      fireEvent.touchEnd(trigger);
+      fireEvent.touchStart(trigger, { touches: [firstTouch] });
+      fireEvent.touchStart(trigger, { touches });
       clock.tick(500);
 
       expect(onOpenChange).not.toHaveBeenCalled();

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
@@ -126,15 +126,10 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
     if (event.touches.length === 1) {
       event.stopPropagation();
       const touch = event.touches[0];
-      touchPositionRef.current = { x: touch.clientX, y: touch.clientY };
+      const touchPosition = { x: touch.clientX, y: touch.clientY };
+      touchPositionRef.current = touchPosition;
       longPressTimeout.start(LONG_PRESS_DELAY, () => {
-        if (touchPositionRef.current) {
-          handleLongPress(
-            touchPositionRef.current.x,
-            touchPositionRef.current.y,
-            event.nativeEvent,
-          );
-        }
+        handleLongPress(touchPosition.x, touchPosition.y, event.nativeEvent);
       });
     }
   }
@@ -175,7 +170,6 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
       const target = getTarget(event);
       const targetElement = target as HTMLElement | null;
       if (
-        contains(triggerRef.current, targetElement) ||
         contains(internalBackdropRef.current, targetElement) ||
         contains(backdropRef.current, targetElement)
       ) {

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
@@ -170,6 +170,7 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
       const target = getTarget(event);
       const targetElement = target as HTMLElement | null;
       if (
+        contains(triggerRef.current, targetElement) ||
         contains(internalBackdropRef.current, targetElement) ||
         contains(backdropRef.current, targetElement)
       ) {

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
@@ -118,26 +118,38 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
     );
   }
 
+  function cancelLongPress() {
+    longPressTimeout.clear();
+    touchPositionRef.current = null;
+  }
+
   function handleTouchStart(event: React.TouchEvent) {
     if (disabled) {
+      cancelLongPress();
       return;
     }
     allowMouseUpTriggerRef.current = false;
-    if (event.touches.length === 1) {
-      event.stopPropagation();
-      const touch = event.touches[0];
-      const touchPosition = { x: touch.clientX, y: touch.clientY };
-      touchPositionRef.current = touchPosition;
-      longPressTimeout.start(LONG_PRESS_DELAY, () => {
-        if (touchPositionRef.current === touchPosition) {
-          handleLongPress(touchPosition.x, touchPosition.y, event.nativeEvent);
-        }
-      });
+    if (event.touches.length !== 1) {
+      cancelLongPress();
+      return;
     }
+
+    event.stopPropagation();
+    const touch = event.touches[0];
+    const touchPosition = { x: touch.clientX, y: touch.clientY };
+    touchPositionRef.current = touchPosition;
+    longPressTimeout.start(LONG_PRESS_DELAY, () => {
+      handleLongPress(touchPosition.x, touchPosition.y, event.nativeEvent);
+    });
   }
 
   function handleTouchMove(event: React.TouchEvent) {
-    if (longPressTimeout.isStarted() && touchPositionRef.current && event.touches.length === 1) {
+    if (event.touches.length !== 1) {
+      cancelLongPress();
+      return;
+    }
+
+    if (longPressTimeout.isStarted() && touchPositionRef.current) {
       const touch = event.touches[0];
       const moveThreshold = 10;
 
@@ -145,14 +157,9 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
       const deltaY = Math.abs(touch.clientY - touchPositionRef.current.y);
 
       if (deltaX > moveThreshold || deltaY > moveThreshold) {
-        longPressTimeout.clear();
+        cancelLongPress();
       }
     }
-  }
-
-  function handleTouchEnd() {
-    longPressTimeout.clear();
-    touchPositionRef.current = null;
   }
 
   React.useEffect(
@@ -196,8 +203,8 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
         onContextMenu: handleContextMenu,
         onTouchStart: handleTouchStart,
         onTouchMove: handleTouchMove,
-        onTouchEnd: handleTouchEnd,
-        onTouchCancel: handleTouchEnd,
+        onTouchEnd: cancelLongPress,
+        onTouchCancel: cancelLongPress,
         style: {
           WebkitTouchCallout: 'none',
         },

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
@@ -129,7 +129,9 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
       const touchPosition = { x: touch.clientX, y: touch.clientY };
       touchPositionRef.current = touchPosition;
       longPressTimeout.start(LONG_PRESS_DELAY, () => {
-        handleLongPress(touchPosition.x, touchPosition.y, event.nativeEvent);
+        if (touchPositionRef.current === touchPosition) {
+          handleLongPress(touchPosition.x, touchPosition.y, event.nativeEvent);
+        }
       });
     }
   }

--- a/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.test.tsx
+++ b/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.test.tsx
@@ -28,6 +28,12 @@ describe('<Menu.CheckboxItemIndicator />', () => {
     },
   }));
 
+  it('throws when rendered outside Menu.CheckboxItem', async () => {
+    await expect(render(<Menu.CheckboxItemIndicator />)).rejects.toThrow(
+      'Base UI: MenuCheckboxItemContext is missing. MenuCheckboxItem parts must be placed within <Menu.CheckboxItem>.',
+    );
+  });
+
   it.skipIf(isJSDOM)(
     'should remove the indicator when there is no exit animation defined',
     async () => {

--- a/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.test.tsx
+++ b/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
@@ -29,9 +29,15 @@ describe('<Menu.CheckboxItemIndicator />', () => {
   }));
 
   it('throws when rendered outside Menu.CheckboxItem', async () => {
-    await expect(render(<Menu.CheckboxItemIndicator />)).rejects.toThrow(
-      'Base UI: MenuCheckboxItemContext is missing. MenuCheckboxItem parts must be placed within <Menu.CheckboxItem>.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Menu.CheckboxItemIndicator />)).rejects.toThrow(
+        'Base UI: MenuCheckboxItemContext is missing. MenuCheckboxItem parts must be placed within <Menu.CheckboxItem>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it.skipIf(isJSDOM)(

--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useControlled } from '@base-ui/utils/useControlled';
+import { NOOP } from '@base-ui/utils/empty';
 import { MenuCheckboxItemContext } from './MenuCheckboxItemContext';
 import { REGULAR_ITEM, useMenuItem } from '../item/useMenuItem';
 import { useCompositeListItem } from '../../internals/composite/list/useCompositeListItem';
@@ -76,7 +77,7 @@ export const MenuCheckboxItem = React.forwardRef(function MenuCheckboxItem(
 
   function handleClick(event: React.MouseEvent) {
     const details = createChangeEventDetails(REASONS.itemPress, event.nativeEvent, undefined, {
-      preventUnmountOnClose() {},
+      preventUnmountOnClose: NOOP,
     });
 
     onCheckedChange?.(!checked, details);

--- a/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
+++ b/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, expect } from 'vitest';
+import { afterEach, expect, vi } from 'vitest';
 import { act, screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';
@@ -28,9 +28,15 @@ describe('<Menu.GroupLabel />', () => {
   }));
 
   it('throws when rendered outside Menu.Group or Menu.RadioGroup', async () => {
-    await expect(render(<Menu.GroupLabel />)).rejects.toThrow(
-      'Base UI: MenuGroupContext is missing. Menu group parts must be used within <Menu.Group> or <Menu.RadioGroup>.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Menu.GroupLabel />)).rejects.toThrow(
+        'Base UI: MenuGroupContext is missing. Menu group parts must be used within <Menu.Group> or <Menu.RadioGroup>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   describe('a11y attributes', () => {

--- a/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
+++ b/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
@@ -1,5 +1,5 @@
-import { expect } from 'vitest';
-import { screen } from '@mui/internal-test-utils';
+import { afterEach, expect } from 'vitest';
+import { act, screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';
 import { MenuGroupContext } from '../group/MenuGroupContext';
@@ -9,6 +9,15 @@ const testContext: MenuGroupContext = () => {};
 describe('<Menu.GroupLabel />', () => {
   const { render } = createRenderer();
 
+  afterEach(async () => {
+    await act(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        }),
+    );
+  });
+
   describeConformance(<Menu.GroupLabel />, () => ({
     render: (node) => {
       return render(
@@ -17,6 +26,12 @@ describe('<Menu.GroupLabel />', () => {
     },
     refInstanceof: window.HTMLDivElement,
   }));
+
+  it('throws when rendered outside Menu.Group or Menu.RadioGroup', async () => {
+    await expect(render(<Menu.GroupLabel />)).rejects.toThrow(
+      'Base UI: MenuGroupContext is missing. Menu group parts must be used within <Menu.Group> or <Menu.RadioGroup>.',
+    );
+  });
 
   describe('a11y attributes', () => {
     it('should have the role `presentation`', async () => {

--- a/packages/react/src/menu/item/MenuItem.test.tsx
+++ b/packages/react/src/menu/item/MenuItem.test.tsx
@@ -21,6 +21,12 @@ describe('<Menu.Item />', () => {
     },
   }));
 
+  it('throws when rendered outside Menu.Root', async () => {
+    await expect(render(<Menu.Item />)).rejects.toThrow(
+      'Base UI: MenuRootContext is missing. Menu parts must be placed within <Menu.Root>.',
+    );
+  });
+
   it('calls the onClick handler when clicked', async () => {
     const onClick = vi.fn();
     const { user } = await render(

--- a/packages/react/src/menu/item/MenuItem.test.tsx
+++ b/packages/react/src/menu/item/MenuItem.test.tsx
@@ -22,9 +22,15 @@ describe('<Menu.Item />', () => {
   }));
 
   it('throws when rendered outside Menu.Root', async () => {
-    await expect(render(<Menu.Item />)).rejects.toThrow(
-      'Base UI: MenuRootContext is missing. Menu parts must be placed within <Menu.Root>.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Menu.Item />)).rejects.toThrow(
+        'Base UI: MenuRootContext is missing. Menu parts must be placed within <Menu.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('calls the onClick handler when clicked', async () => {

--- a/packages/react/src/menu/item/useMenuItem.ts
+++ b/packages/react/src/menu/item/useMenuItem.ts
@@ -14,7 +14,7 @@ export const REGULAR_ITEM = {
 export function useMenuItem(params: UseMenuItemParameters): UseMenuItemReturnValue {
   const {
     closeOnClick,
-    disabled: disabledProp = false,
+    disabled: disabledProp,
     highlighted,
     id,
     store,

--- a/packages/react/src/menu/item/useMenuItemCommonProps.ts
+++ b/packages/react/src/menu/item/useMenuItemCommonProps.ts
@@ -38,10 +38,9 @@ export interface UseMenuItemCommonPropsParameters {
    */
   itemRef: React.RefObject<HTMLElement | null>;
   /**
-   * Optional metadata for checking item type before triggering click.
-   * If provided, click will only be triggered for 'regular-item' type.
+   * Metadata for checking item type before triggering click.
    */
-  itemMetadata?: UseMenuItemMetadata | undefined;
+  itemMetadata: UseMenuItemMetadata;
 }
 
 /**
@@ -111,7 +110,7 @@ export function useMenuItemCommonProps(params: UseMenuItemCommonPropsParameters)
         ) {
           // This fires whenever the user clicks on the trigger, moves the cursor, and releases it over the item.
           // We trigger the click and override the `closeOnClick` preference to always close the menu.
-          if (!itemMetadata || itemMetadata.type === 'regular-item') {
+          if (itemMetadata.type === 'regular-item') {
             // `detail: 1` marks this as a mouse-gesture click so MenuRoot doesn't
             // treat it as a keyboard activation (`detail === 0` → `data-instant`).
             dispatchClickWithModifiers(itemRef.current, event, { detail: 1 });

--- a/packages/react/src/menu/link-item/MenuLinkItem.tsx
+++ b/packages/react/src/menu/link-item/MenuLinkItem.tsx
@@ -7,6 +7,7 @@ import type { BaseUIComponentProps, HTMLProps } from '../../internals/types';
 import { useCompositeListItem } from '../../internals/composite/list/useCompositeListItem';
 import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 import { useMenuItemCommonProps } from '../item/useMenuItemCommonProps';
+import { REGULAR_ITEM } from '../item/useMenuItem';
 import { useButton } from '../../internals/use-button';
 import { mergeProps } from '../../merge-props';
 
@@ -56,6 +57,7 @@ export const MenuLinkItem = React.forwardRef(function MenuLinkItem(
     store,
     typingRef,
     itemRef: linkRef,
+    itemMetadata: REGULAR_ITEM,
   });
 
   function getItemProps(externalProps?: HTMLProps): HTMLProps {

--- a/packages/react/src/menu/popup/MenuPopup.test.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.test.tsx
@@ -1,8 +1,9 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';
-import { act, waitFor, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, waitFor, screen } from '@mui/internal-test-utils';
+import { ToolbarRootContext } from '../../toolbar/root/ToolbarRootContext';
 
 describe('<Menu.Popup />', () => {
   const { render } = createRenderer();
@@ -19,6 +20,47 @@ describe('<Menu.Popup />', () => {
     },
     refInstanceof: window.HTMLDivElement,
   }));
+
+  it('throws when rendered outside Menu.Positioner', async () => {
+    await expect(
+      render(
+        <Menu.Root open>
+          <Menu.Popup />
+        </Menu.Root>,
+      ),
+    ).rejects.toThrow(
+      'Base UI: MenuPositionerContext is missing. MenuPositioner parts must be placed within <Menu.Positioner>.',
+    );
+  });
+
+  it('stops toolbar navigation keys without blocking ordinary key events', async () => {
+    const onParentKeyDown = vi.fn();
+
+    await render(
+      <ToolbarRootContext.Provider value={{ disabled: false, orientation: 'horizontal' }}>
+        <div onKeyDown={onParentKeyDown}>
+          <Menu.Root>
+            <Menu.Portal keepMounted>
+              <Menu.Positioner>
+                <Menu.Popup data-testid="popup" />
+              </Menu.Positioner>
+            </Menu.Portal>
+          </Menu.Root>
+        </div>
+      </ToolbarRootContext.Provider>,
+    );
+
+    const popup = screen.getByTestId('popup');
+    fireEvent(
+      popup,
+      new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'ArrowRight' }),
+    );
+    expect(onParentKeyDown).not.toHaveBeenCalled();
+
+    fireEvent(popup, new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'F1' }));
+    expect(onParentKeyDown).toHaveBeenCalled();
+    expect(onParentKeyDown.mock.calls.every(([event]) => event.key === 'F1')).toBe(true);
+  });
 
   describe('prop: finalFocus', () => {
     it('should focus the trigger by default when closed', async () => {

--- a/packages/react/src/menu/popup/MenuPopup.test.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.test.tsx
@@ -22,15 +22,21 @@ describe('<Menu.Popup />', () => {
   }));
 
   it('throws when rendered outside Menu.Positioner', async () => {
-    await expect(
-      render(
-        <Menu.Root open>
-          <Menu.Popup />
-        </Menu.Root>,
-      ),
-    ).rejects.toThrow(
-      'Base UI: MenuPositionerContext is missing. MenuPositioner parts must be placed within <Menu.Positioner>.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Menu.Root open>
+            <Menu.Popup />
+          </Menu.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: MenuPositionerContext is missing. MenuPositioner parts must be placed within <Menu.Positioner>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('stops toolbar navigation keys without blocking ordinary key events', async () => {

--- a/packages/react/src/menu/positioner/MenuPositioner.test.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, expect, vi } from 'vitest';
 import * as React from 'react';
 import userEvent from '@testing-library/user-event';
-import { flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
+import { act, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { ContextMenu } from '@base-ui/react/context-menu';
 import { Menu } from '@base-ui/react/menu';
 import { Menubar } from '@base-ui/react/menubar';
@@ -35,6 +35,16 @@ describe('<Menu.Positioner />', () => {
 
   beforeEach(() => {
     useAnchorPositioningSpy.mockClear();
+  });
+
+  it('throws when rendered outside Menu.Portal', async () => {
+    await expect(
+      render(
+        <Menu.Root open>
+          <Menu.Positioner />
+        </Menu.Root>,
+      ),
+    ).rejects.toThrow('Base UI: <Menu.Portal> is missing.');
   });
 
   describeConformance(<Menu.Positioner />, () => ({
@@ -83,6 +93,25 @@ describe('<Menu.Positioner />', () => {
       });
     });
 
+    it('preserves explicit context-menu placement and offsets', async () => {
+      await render(
+        <ContextMenu.Root open>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner side="right" align="center" sideOffset={11} alignOffset={13}>
+              <ContextMenu.Popup>Popup</ContextMenu.Popup>
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      expect(useAnchorPositioningSpy.mock.lastCall?.[0]).toMatchObject({
+        side: 'right',
+        align: 'center',
+        sideOffset: 11,
+        alignOffset: 13,
+      });
+    });
+
     it('uses the visual viewport for a context menu submenu', async () => {
       await render(
         <ContextMenu.Root open>
@@ -99,6 +128,48 @@ describe('<Menu.Positioner />', () => {
       expect(useAnchorPositioningSpy).toHaveBeenCalled();
       expect(useAnchorPositioningSpy.mock.lastCall?.[0].shift).toBe(undefined);
     });
+  });
+
+  it('closes an open submenu with a sibling reason when its controlled parent closes', async () => {
+    const onSubmenuOpenChange = vi.fn();
+    let closeParent = () => {};
+
+    function Test() {
+      const [open, setOpen] = React.useState(true);
+      closeParent = () => setOpen(false);
+
+      return (
+        <Menu.Root open={open}>
+          <Menu.Trigger>Open</Menu.Trigger>
+          <Menu.Portal keepMounted>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.SubmenuRoot defaultOpen onOpenChange={onSubmenuOpenChange}>
+                  <Menu.SubmenuTrigger>More</Menu.SubmenuTrigger>
+                  <Menu.Portal>
+                    <Menu.Positioner>
+                      <Menu.Popup data-testid="submenu-popup" />
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.SubmenuRoot>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
+      );
+    }
+
+    await render(<Test />);
+    expect(screen.queryByTestId('submenu-popup')).not.toBe(null);
+
+    await act(async () => {
+      closeParent();
+    });
+
+    await waitFor(() => {
+      expect(onSubmenuOpenChange.mock.lastCall?.[0]).toBe(false);
+    });
+    expect(onSubmenuOpenChange.mock.lastCall?.[1].reason).toBe('sibling-open');
   });
 
   describe.skipIf(isJSDOM)('prop: anchor', () => {

--- a/packages/react/src/menu/positioner/MenuPositioner.test.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.test.tsx
@@ -38,13 +38,19 @@ describe('<Menu.Positioner />', () => {
   });
 
   it('throws when rendered outside Menu.Portal', async () => {
-    await expect(
-      render(
-        <Menu.Root open>
-          <Menu.Positioner />
-        </Menu.Root>,
-      ),
-    ).rejects.toThrow('Base UI: <Menu.Portal> is missing.');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Menu.Root open>
+            <Menu.Positioner />
+          </Menu.Root>,
+        ),
+      ).rejects.toThrow('Base UI: <Menu.Portal> is missing.');
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   describeConformance(<Menu.Positioner />, () => ({

--- a/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.test.tsx
+++ b/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.test.tsx
@@ -26,6 +26,12 @@ describe('<Menu.RadioItemIndicator />', () => {
     },
   }));
 
+  it('throws when rendered outside Menu.RadioItem', async () => {
+    await expect(render(<Menu.RadioItemIndicator />)).rejects.toThrow(
+      'Base UI: MenuRadioItemContext is missing. MenuRadioItem parts must be placed within <Menu.RadioItem>.',
+    );
+  });
+
   it.skipIf(isJSDOM)(
     'should remove the indicator when there is no exit animation defined',
     async () => {

--- a/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.test.tsx
+++ b/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
@@ -27,9 +27,15 @@ describe('<Menu.RadioItemIndicator />', () => {
   }));
 
   it('throws when rendered outside Menu.RadioItem', async () => {
-    await expect(render(<Menu.RadioItemIndicator />)).rejects.toThrow(
-      'Base UI: MenuRadioItemContext is missing. MenuRadioItem parts must be placed within <Menu.RadioItem>.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Menu.RadioItemIndicator />)).rejects.toThrow(
+        'Base UI: MenuRadioItemContext is missing. MenuRadioItem parts must be placed within <Menu.RadioItem>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it.skipIf(isJSDOM)(

--- a/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
@@ -33,6 +33,18 @@ describe('<Menu.RadioItem />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
+  it('throws when rendered outside Menu.RadioGroup', async () => {
+    await expect(
+      render(
+        <Menu.Root open>
+          <Menu.RadioItem value="one" />
+        </Menu.Root>,
+      ),
+    ).rejects.toThrow(
+      'Base UI: MenuRadioGroupContext is missing. MenuRadioGroup parts must be placed within <Menu.RadioGroup>.',
+    );
+  });
+
   it('perf: does not rerender menu items unnecessarily', async ({ skip }) => {
     if (isJSDOM) {
       skip();

--- a/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
@@ -34,15 +34,21 @@ describe('<Menu.RadioItem />', () => {
   }));
 
   it('throws when rendered outside Menu.RadioGroup', async () => {
-    await expect(
-      render(
-        <Menu.Root open>
-          <Menu.RadioItem value="one" />
-        </Menu.Root>,
-      ),
-    ).rejects.toThrow(
-      'Base UI: MenuRadioGroupContext is missing. MenuRadioGroup parts must be placed within <Menu.RadioGroup>.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Menu.Root open>
+            <Menu.RadioItem value="one" />
+          </Menu.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: MenuRadioGroupContext is missing. MenuRadioGroup parts must be placed within <Menu.RadioGroup>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('perf: does not rerender menu items unnecessarily', async ({ skip }) => {

--- a/packages/react/src/menu/radio-item/MenuRadioItem.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { NOOP } from '@base-ui/utils/empty';
 import { useMenuRootContext } from '../root/MenuRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useBaseUiId } from '../../internals/useBaseUiId';
@@ -75,7 +76,7 @@ export const MenuRadioItem = React.forwardRef(function MenuRadioItem(
 
   function handleClick(event: React.MouseEvent) {
     const details = createChangeEventDetails(REASONS.itemPress, event.nativeEvent, undefined, {
-      preventUnmountOnClose() {},
+      preventUnmountOnClose: NOOP,
     });
 
     setSelectedValue(value, details);

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -43,6 +43,54 @@ describe('<Menu.Root />', () => {
     expectedPopupRole: 'menu',
   });
 
+  function NestedMenuWithModalProp() {
+    const SubmenuRootWithModal = Menu.SubmenuRoot as React.ComponentType<
+      React.ComponentProps<typeof Menu.SubmenuRoot> & { modal: boolean }
+    >;
+
+    return (
+      <Menu.Root open>
+        <Menu.Portal>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <SubmenuRootWithModal defaultOpen modal={false}>
+                <Menu.SubmenuTrigger>More</Menu.SubmenuTrigger>
+                <Menu.Portal>
+                  <Menu.Positioner>
+                    <Menu.Popup />
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </SubmenuRootWithModal>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
+    );
+  }
+
+  it('warns that nested menus ignore the modal prop', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await render(<NestedMenuWithModalProp />);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Base UI: The `modal` prop is not supported on nested menus. It will be ignored.',
+    );
+  });
+
+  it.skipIf(!isJSDOM)('does not emit the nested modal warning in production', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      await render(<NestedMenuWithModalProp />);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
   // All these tests run for contained and detached triggers.
   // The rendered menu has the same structure in most cases.
   describe.for([

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -72,7 +72,7 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
 
   const contextMenuContext = useContextMenuRootContext(true);
   const parentMenuRootContext = useMenuRootContext(true);
-  const menubarContext = useMenubarContext();
+  const menubarContext = useMenubarContext(true);
   const isSubmenu = useMenuSubmenuRootContext();
 
   const parentFromContext: MenuParent = React.useMemo(() => {

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -72,7 +72,7 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
 
   const contextMenuContext = useContextMenuRootContext(true);
   const parentMenuRootContext = useMenuRootContext(true);
-  const menubarContext = useMenubarContext(true);
+  const menubarContext = useMenubarContext();
   const isSubmenu = useMenuSubmenuRootContext();
 
   const parentFromContext: MenuParent = React.useMemo(() => {
@@ -164,7 +164,7 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
 
   useImplicitActiveTrigger(store);
   const { forceUnmount } = useOpenStateTransitions(open, store, () => {
-    store.update({ allowMouseEnter: false, stickIfOpen: true });
+    store.set('allowMouseEnter', false);
   });
 
   useIsoLayoutEffect(() => {
@@ -296,7 +296,7 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
         open: nextOpen,
         openChangeReason: reason,
       };
-      openEventRef.current = eventDetails.event ?? null;
+      openEventRef.current = eventDetails.event;
 
       setPopupOpenState(
         updatedState,

--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -26,7 +26,6 @@ export type State<Payload> = PopupStoreState<Payload> & {
   rootId: string | undefined;
   activeIndex: number | null;
   hoverEnabled: boolean;
-  stickIfOpen: boolean;
   instantType: 'dismiss' | 'click' | 'group' | 'trigger-change' | undefined;
   openChangeReason: MenuRoot.ChangeEventReason | null;
   floatingTreeRoot: FloatingTreeStore;
@@ -65,7 +64,6 @@ const selectors = {
 
   allowMouseEnter: createSelector((state: State<unknown>) => state.allowMouseEnter),
   highlightItemOnHover: createSelector((state: State<unknown>) => state.highlightItemOnHover),
-  stickIfOpen: createSelector((state: State<unknown>) => state.stickIfOpen),
   parent: createSelector((state: State<unknown>) => state.parent),
   rootId: createSelector((state: State<unknown>): string | undefined => {
     if (state.parent.type === 'menu') {
@@ -211,7 +209,6 @@ function createInitialState<Payload>(): State<Payload> {
     openMethod: null,
     allowMouseEnter: false,
     highlightItemOnHover: true,
-    stickIfOpen: true,
     parent: {
       type: undefined,
     },

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
@@ -1,13 +1,29 @@
-import { vi, expect } from 'vitest';
-import { fireEvent, waitFor, screen } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance } from '#test-utils';
+import { afterEach, beforeEach, vi, expect } from 'vitest';
+import { act, fireEvent, waitFor, screen } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Menu } from '@base-ui/react/menu';
+import { SafeReact } from '@base-ui/utils/safeReact';
 
 type TextDirection = 'ltr' | 'rtl';
 
 describe('<Menu.SubmenuTrigger />', () => {
   const { render } = createRenderer();
+
+  beforeEach(() => {
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+  });
+
+  async function waitForAnimationFrame() {
+    await act(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        }),
+    );
+  }
+
+  afterEach(waitForAnimationFrame);
 
   describeConformance(<Menu.SubmenuTrigger />, () => ({
     refInstanceof: window.HTMLDivElement,
@@ -26,6 +42,12 @@ describe('<Menu.SubmenuTrigger />', () => {
       );
     },
   }));
+
+  it('throws when rendered outside Menu.SubmenuRoot', async () => {
+    await expect(render(<Menu.SubmenuTrigger />)).rejects.toThrow(
+      'Base UI: <Menu.SubmenuTrigger> must be placed in <Menu.SubmenuRoot>.',
+    );
+  });
 
   function TestComponent({ direction = 'ltr' }: { direction: TextDirection }) {
     return (
@@ -209,6 +231,7 @@ describe('<Menu.SubmenuTrigger />', () => {
         .spyOn(console, 'warn')
         .mockName('console.warn')
         .mockImplementation(() => {});
+      vi.spyOn(SafeReact, 'captureOwnerStack').mockReturnValue(undefined as never);
 
       await render(
         <Menu.Root open>
@@ -237,6 +260,38 @@ describe('<Menu.SubmenuTrigger />', () => {
           'Base UI: A disabled element was detected on <Menu.SubmenuTrigger>. To properly disable the trigger, use the `disabled` prop on the component instead of setting it on the rendered element.',
         ),
       );
+      expect(warnSpy.mock.lastCall?.[0]).not.toContain('undefined');
+    });
+
+    it.skipIf(!isJSDOM)('does not inspect rendered disabled elements in production', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+
+      try {
+        await render(
+          <Menu.Root open>
+            <Menu.Portal>
+              <Menu.Positioner>
+                <Menu.Popup>
+                  <Menu.SubmenuRoot>
+                    <Menu.SubmenuTrigger
+                      nativeButton
+                      render={<button type="button" disabled={true} />}
+                    >
+                      Open submenu
+                    </Menu.SubmenuTrigger>
+                  </Menu.SubmenuRoot>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
+          </Menu.Root>,
+        );
+
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
     });
   });
 });

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
@@ -3,7 +3,6 @@ import { act, fireEvent, waitFor, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Menu } from '@base-ui/react/menu';
-import { SafeReact } from '@base-ui/utils/safeReact';
 
 type TextDirection = 'ltr' | 'rtl';
 
@@ -44,9 +43,15 @@ describe('<Menu.SubmenuTrigger />', () => {
   }));
 
   it('throws when rendered outside Menu.SubmenuRoot', async () => {
-    await expect(render(<Menu.SubmenuTrigger />)).rejects.toThrow(
-      'Base UI: <Menu.SubmenuTrigger> must be placed in <Menu.SubmenuRoot>.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Menu.SubmenuTrigger />)).rejects.toThrow(
+        'Base UI: <Menu.SubmenuTrigger> must be placed in <Menu.SubmenuRoot>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   function TestComponent({ direction = 'ltr' }: { direction: TextDirection }) {
@@ -231,8 +236,6 @@ describe('<Menu.SubmenuTrigger />', () => {
         .spyOn(console, 'warn')
         .mockName('console.warn')
         .mockImplementation(() => {});
-      vi.spyOn(SafeReact, 'captureOwnerStack').mockReturnValue(undefined as never);
-
       await render(
         <Menu.Root open>
           <Menu.Trigger>Open menu</Menu.Trigger>

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
@@ -3,8 +3,10 @@ import { act, fireEvent, waitFor, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Menu } from '@base-ui/react/menu';
+import { SafeReact } from '@base-ui/utils/safeReact';
 
 type TextDirection = 'ltr' | 'rtl';
+const hasCaptureOwnerStack = typeof SafeReact.captureOwnerStack === 'function';
 
 describe('<Menu.SubmenuTrigger />', () => {
   const { render } = createRenderer();
@@ -265,6 +267,43 @@ describe('<Menu.SubmenuTrigger />', () => {
       );
       expect(warnSpy.mock.lastCall?.[0]).not.toContain('undefined');
     });
+
+    it.skipIf(!hasCaptureOwnerStack)(
+      'warns without an owner stack when React cannot provide one',
+      async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const ownerStackSpy = vi.spyOn(SafeReact, 'captureOwnerStack').mockReturnValue(null);
+
+        try {
+          await render(
+            <Menu.Root open>
+              <Menu.Portal>
+                <Menu.Positioner>
+                  <Menu.Popup>
+                    <Menu.SubmenuRoot>
+                      <Menu.SubmenuTrigger
+                        nativeButton
+                        render={<button type="button" disabled={true} />}
+                      >
+                        Open submenu
+                      </Menu.SubmenuTrigger>
+                    </Menu.SubmenuRoot>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>,
+          );
+
+          expect(warnSpy).toHaveBeenCalledTimes(1);
+          expect(warnSpy).toHaveBeenCalledWith(
+            'Base UI: A disabled element was detected on <Menu.SubmenuTrigger>. To properly disable the trigger, use the `disabled` prop on the component instead of setting it on the rendered element.',
+          );
+        } finally {
+          ownerStackSpy.mockRestore();
+          warnSpy.mockRestore();
+        }
+      },
+    );
 
     it.skipIf(!isJSDOM)('does not inspect rendered disabled elements in production', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -41,6 +41,11 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
     ...elementProps
   } = componentProps;
 
+  const submenuRootContext = useMenuSubmenuRootContext();
+  if (!submenuRootContext?.parentMenu) {
+    throw new Error('Base UI: <Menu.SubmenuTrigger> must be placed in <Menu.SubmenuRoot>.');
+  }
+
   const listItem = useCompositeListItem({ guess: true, label });
   const menuPositionerContext = useMenuPositionerContext();
 
@@ -78,11 +83,6 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
     },
     [store],
   );
-
-  const submenuRootContext = useMenuSubmenuRootContext();
-  if (!submenuRootContext?.parentMenu) {
-    throw new Error('Base UI: <Menu.SubmenuTrigger> must be placed in <Menu.SubmenuRoot>.');
-  }
 
   store.useSyncedValue('closeDelay', closeDelay);
 

--- a/packages/react/src/menu/trigger/MenuTrigger.test.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';
@@ -21,9 +21,15 @@ describe('<Menu.Trigger />', () => {
   }));
 
   it('throws without Menu.Root or a handle', async () => {
-    await expect(render(<Menu.Trigger />)).rejects.toThrow(
-      'Base UI: <Menu.Trigger> must be either used within a <Menu.Root> component or provided with a handle.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Menu.Trigger />)).rejects.toThrow(
+        'Base UI: <Menu.Trigger> must be either used within a <Menu.Root> component or provided with a handle.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   describe('prop: disabled', () => {

--- a/packages/react/src/menu/trigger/MenuTrigger.test.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';
 import { Popover } from '@base-ui/react/popover';
-import { describeConformance, createRenderer } from '#test-utils';
+import { describeConformance, createRenderer, isJSDOM } from '#test-utils';
 import { PATIENT_CLICK_THRESHOLD } from '../../internals/constants';
 
 describe('<Menu.Trigger />', () => {
@@ -19,6 +19,12 @@ describe('<Menu.Trigger />', () => {
       return render(<Menu.Root open>{node}</Menu.Root>);
     },
   }));
+
+  it('throws without Menu.Root or a handle', async () => {
+    await expect(render(<Menu.Trigger />)).rejects.toThrow(
+      'Base UI: <Menu.Trigger> must be either used within a <Menu.Root> component or provided with a handle.',
+    );
+  });
 
   describe('prop: disabled', () => {
     it('should render a disabled button', async () => {
@@ -383,6 +389,36 @@ describe('<Menu.Trigger />', () => {
       expect(screen.getByText('Content')).not.toBe(null);
     });
   });
+
+  it.skipIf(isJSDOM)(
+    'keeps a hover-opened menu open when mouseup lands outside the trigger DOM but within its bounds',
+    async () => {
+      const { user } = await render(
+        <Menu.Root>
+          <Menu.Trigger openOnHover delay={0} style={{ width: 120, height: 40, display: 'block' }}>
+            Open
+          </Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup />
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Open' });
+      await user.hover(trigger);
+      expect(screen.queryByRole('menu')).not.toBe(null);
+
+      const rect = trigger.getBoundingClientRect();
+      fireEvent.mouseUp(document.body, {
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+      });
+
+      expect(screen.queryByRole('menu')).not.toBe(null);
+    },
+  );
 
   describe('preventBaseUIHandler', () => {
     it('prevents opening the menu with a mouse when `preventBaseUIHandler` is called in onMouseDown', async () => {

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -32,7 +32,6 @@ import { useBaseUiId } from '../../internals/useBaseUiId';
 import { REASONS } from '../../internals/reasons';
 import { useMixedToggleClickHandler } from '../../utils/useMixedToggleClickHandler';
 import { MenuHandle } from '../store/MenuHandle';
-import { useContextMenuRootContext } from '../../context-menu/root/ContextMenuRootContext';
 import { useMenubarContext } from '../../menubar/MenubarContext';
 import { MenuParent } from '../root/MenuRoot';
 import { PATIENT_CLICK_THRESHOLD } from '../../internals/constants';
@@ -168,7 +167,6 @@ export const MenuTrigger = fastComponentRef(function MenuTrigger(
     enabled:
       openOnHover &&
       !disabled &&
-      parent.type !== 'context-menu' &&
       (!isInMenubar || (parentMenubarHasSubmenuOpen && !isMountedByThisTrigger)),
     handleClose: safePolygon({ blockPointerEvents: !isInMenubar }),
     mouseOnly: true,
@@ -187,7 +185,7 @@ export const MenuTrigger = fastComponentRef(function MenuTrigger(
   const stickIfOpen = useStickIfOpen(isOpenedByThisTrigger, store.select('lastOpenChangeReason'));
 
   const click = useClick(floatingRootContext, {
-    enabled: !disabled && parent.type !== 'context-menu',
+    enabled: !disabled,
     event: isOpenedByThisTrigger && isInMenubar ? 'click' : 'mousedown',
     toggle: true,
     ignoreMouse: false,
@@ -378,9 +376,7 @@ function useStickIfOpen(open: boolean, openReason: string | null) {
 }
 
 function useMenuParent() {
-  const contextMenuContext = useContextMenuRootContext(true);
-  const parentContext = useMenuRootContext(true);
-  const menubarContext = useMenubarContext(true);
+  const menubarContext = useMenubarContext();
 
   const parent: MenuParent = React.useMemo(() => {
     if (menubarContext) {
@@ -390,20 +386,10 @@ function useMenuParent() {
       };
     }
 
-    // Ensure this is not a Menu nested inside ContextMenu.Trigger.
-    // ContextMenu parentContext is always undefined as ContextMenu.Root is instantiated with
-    // <MenuRootContext.Provider value={undefined}>
-    if (contextMenuContext && !parentContext) {
-      return {
-        type: 'context-menu',
-        context: contextMenuContext,
-      };
-    }
-
     return {
       type: undefined,
     };
-  }, [contextMenuContext, parentContext, menubarContext]);
+  }, [menubarContext]);
 
   return parent;
 }

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -376,7 +376,7 @@ function useStickIfOpen(open: boolean, openReason: string | null) {
 }
 
 function useMenuParent() {
-  const menubarContext = useMenubarContext();
+  const menubarContext = useMenubarContext(true);
 
   const parent: MenuParent = React.useMemo(() => {
     if (menubarContext) {

--- a/packages/react/src/menu/utils/findRootOwnerId.ts
+++ b/packages/react/src/menu/utils/findRootOwnerId.ts
@@ -2,7 +2,7 @@ import { getParentNode, isHTMLElement, isLastTraversableNode } from '@floating-u
 
 export function findRootOwnerId(node: Node): string | undefined {
   if (isHTMLElement(node) && node.hasAttribute('data-rootownerid')) {
-    return node.getAttribute('data-rootownerid') ?? undefined;
+    return node.getAttribute('data-rootownerid')!;
   }
 
   if (isLastTraversableNode(node)) {

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -20,6 +20,70 @@ describe('<Menubar />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
+  it('ignores a delayed touch click immediately after focus opens another menu', async () => {
+    const { user } = await render(<ContainedTriggerMenubar />);
+
+    await user.click(screen.getByTestId('file-trigger'));
+    await screen.findByTestId('file-menu');
+
+    const editTrigger = screen.getByTestId('edit-trigger');
+    await act(async () => {
+      editTrigger.focus();
+    });
+    await screen.findByTestId('edit-menu');
+
+    fireEvent(
+      editTrigger,
+      new PointerEvent('click', { bubbles: true, cancelable: true, pointerType: 'touch' }),
+    );
+    expect(screen.queryByTestId('edit-menu')).not.toBe(null);
+
+    await wait(310);
+    fireEvent(
+      editTrigger,
+      new PointerEvent('click', { bubbles: true, cancelable: true, pointerType: 'touch' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('edit-menu')).toBe(null);
+    });
+  });
+
+  it('keeps focus on an outside target when a triggerless menubar menu closes', async () => {
+    function TestComponent() {
+      const [open, setOpen] = React.useState(true);
+
+      return (
+        <React.Fragment>
+          <button data-testid="outside" type="button">
+            Outside
+          </button>
+          <Menubar>
+            <Menu.Root open={open} onOpenChange={setOpen}>
+              <Menu.Portal keepMounted>
+                <Menu.Positioner>
+                  <Menu.Popup data-testid="triggerless-menu">
+                    <Menu.Item>Item</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
+          </Menubar>
+        </React.Fragment>
+      );
+    }
+
+    const { user } = await render(<TestComponent />);
+    const outside = screen.getByTestId('outside');
+
+    await user.click(outside);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('triggerless-menu')).not.toHaveAttribute('data-open');
+    });
+    expect(outside).toHaveFocus();
+  });
+
   // All these tests run for contained, detached and multiple contained triggers.
   // The rendered menubar has the same structure in most cases.
   describe.for([

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -5,6 +5,7 @@ import { createRenderer, describeConformance, isJSDOM, wait } from '#test-utils'
 import { Menubar } from '@base-ui/react/menubar';
 import { Menu } from '@base-ui/react/menu';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
+import { useMenubarContext } from './MenubarContext';
 
 describe('<Menubar />', () => {
   beforeEach(() => {
@@ -19,6 +20,23 @@ describe('<Menubar />', () => {
     },
     refInstanceof: window.HTMLDivElement,
   }));
+
+  it('throws when the menubar context is missing', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    function ContextConsumer() {
+      useMenubarContext();
+      return null;
+    }
+
+    try {
+      await expect(render(<ContextConsumer />)).rejects.toThrow(
+        'Base UI: MenubarContext is missing. Menubar parts must be placed within <Menubar>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   it('ignores a delayed touch click immediately after focus opens another menu', async () => {
     const { user } = await render(<ContainedTriggerMenubar />);

--- a/packages/react/src/menubar/Menubar.tsx
+++ b/packages/react/src/menubar/Menubar.tsx
@@ -97,7 +97,7 @@ export const Menubar = React.forwardRef(function Menubar(
 function MenubarContent(props: React.PropsWithChildren<{}>) {
   const nodeId = useFloatingNodeId();
   const { events: menuEvents } = useFloatingTree()!;
-  const rootContext = useMenubarContext();
+  const rootContext = useMenubarContext()!;
 
   React.useEffect(() => {
     function onSubmenuOpenChange(details: MenuOpenEventDetails) {

--- a/packages/react/src/menubar/Menubar.tsx
+++ b/packages/react/src/menubar/Menubar.tsx
@@ -97,7 +97,7 @@ export const Menubar = React.forwardRef(function Menubar(
 function MenubarContent(props: React.PropsWithChildren<{}>) {
   const nodeId = useFloatingNodeId();
   const { events: menuEvents } = useFloatingTree()!;
-  const rootContext = useMenubarContext()!;
+  const rootContext = useMenubarContext();
 
   React.useEffect(() => {
     function onSubmenuOpenChange(details: MenuOpenEventDetails) {

--- a/packages/react/src/menubar/MenubarContext.ts
+++ b/packages/react/src/menubar/MenubarContext.ts
@@ -16,6 +16,15 @@ export interface MenubarContext {
 
 export const MenubarContext = React.createContext<MenubarContext | null>(null);
 
-export function useMenubarContext() {
-  return React.useContext(MenubarContext);
+export function useMenubarContext(optional?: false): MenubarContext;
+export function useMenubarContext(optional: true): MenubarContext | null;
+export function useMenubarContext(optional?: boolean) {
+  const context = React.useContext(MenubarContext);
+  if (context === null && !optional) {
+    throw new Error(
+      'Base UI: MenubarContext is missing. Menubar parts must be placed within <Menubar>.',
+    );
+  }
+
+  return context;
 }

--- a/packages/react/src/menubar/MenubarContext.ts
+++ b/packages/react/src/menubar/MenubarContext.ts
@@ -16,15 +16,6 @@ export interface MenubarContext {
 
 export const MenubarContext = React.createContext<MenubarContext | null>(null);
 
-export function useMenubarContext(optional?: false): MenubarContext;
-export function useMenubarContext(optional: true): MenubarContext | null;
-export function useMenubarContext(optional?: boolean) {
-  const context = React.useContext(MenubarContext);
-  if (context === null && !optional) {
-    throw new Error(
-      'Base UI: MenubarContext is missing. Menubar parts must be placed within <Menubar>.',
-    );
-  }
-
-  return context;
+export function useMenubarContext() {
+  return React.useContext(MenubarContext);
 }

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -260,10 +260,18 @@ describe('e2e', () => {
         async () => {
           await renderFixture('menu/LinkItemNavigation');
 
-          await page.keyboard.press('Tab');
+          const trigger = page.getByTestId('menu-trigger');
+          await trigger.focus();
           await page.keyboard.press('Enter');
+
+          const linkOne = page.getByTestId('link-one');
+          await expect(linkOne).toBeFocused();
+
           // first item (page one) is initially highlighted
           await page.keyboard.press('ArrowDown');
+
+          const linkTwo = page.getByTestId('link-two');
+          await expect(linkTwo).toBeFocused();
           await page.keyboard.press('Enter');
 
           await expect(page).toHaveURL(/\/e2e-fixtures\/menu\/PageTwo/);


### PR DESCRIPTION
Expands Menu, Context Menu, and Menubar test coverage to 100% across statements, branches, functions, and lines, including pointer, touch, submenu, and focus interactions in jsdom and Chromium.