### PR TITLE
[tooltip] Expand test coverage

### DIFF
--- a/packages/react/src/tooltip/arrow/TooltipArrow.test.tsx
+++ b/packages/react/src/tooltip/arrow/TooltipArrow.test.tsx
@@ -1,5 +1,7 @@
+import { expect } from 'vitest';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { createRenderer, describeConformance } from '#test-utils';
+import { screen } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Tooltip.Arrow />', () => {
   const { render } = createRenderer();
@@ -18,4 +20,49 @@ describe('<Tooltip.Arrow />', () => {
       );
     },
   }));
+
+  function ArrowTooltip({
+    arrowPadding,
+    triggerWidth = 20,
+  }: {
+    arrowPadding?: number;
+    triggerWidth?: number;
+  }) {
+    return (
+      <div style={{ position: 'fixed', top: 0, left: 0 }}>
+        <Tooltip.Root open>
+          <Tooltip.Trigger style={{ width: triggerWidth, height: 20 }}>T</Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Positioner side="bottom" arrowPadding={arrowPadding}>
+              <Tooltip.Popup style={{ width: 200, height: 40 }}>
+                <Tooltip.Arrow data-testid="arrow" style={{ width: 10, height: 10 }} />
+              </Tooltip.Popup>
+            </Tooltip.Positioner>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </div>
+    );
+  }
+
+  it('is hidden from assistive technology and mirrors the resolved side', async () => {
+    await render(<ArrowTooltip />);
+
+    const arrow = screen.getByTestId('arrow');
+
+    expect(arrow).toHaveAttribute('aria-hidden', 'true');
+    expect(arrow).toHaveAttribute('data-side', 'bottom');
+    expect(arrow).toHaveAttribute('data-open');
+  });
+
+  it.skipIf(isJSDOM)('is marked uncentered when it cannot point at the anchor', async () => {
+    await render(<ArrowTooltip arrowPadding={40} />);
+
+    expect(screen.getByTestId('arrow')).toHaveAttribute('data-uncentered');
+  });
+
+  it.skipIf(isJSDOM)('is not marked uncentered when it can point at the anchor', async () => {
+    await render(<ArrowTooltip arrowPadding={0} triggerWidth={200} />);
+
+    expect(screen.getByTestId('arrow')).not.toHaveAttribute('data-uncentered');
+  });
 });

--- a/packages/react/src/tooltip/popup/TooltipPopup.test.tsx
+++ b/packages/react/src/tooltip/popup/TooltipPopup.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
@@ -31,5 +31,25 @@ describe('<Tooltip.Popup />', () => {
     );
 
     expect(screen.getByText('Content')).not.toBe(null);
+  });
+
+  it('throws a descriptive error when rendered outside <Tooltip.Positioner>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Tooltip.Root open>
+            <Tooltip.Portal>
+              <Tooltip.Popup />
+            </Tooltip.Portal>
+          </Tooltip.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: TooltipPositionerContext is missing. TooltipPositioner parts must be placed within <Tooltip.Positioner>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/packages/react/src/tooltip/portal/TooltipPortal.test.tsx
+++ b/packages/react/src/tooltip/portal/TooltipPortal.test.tsx
@@ -1,5 +1,7 @@
+import { expect } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
+import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Tooltip.Portal />', () => {
@@ -11,4 +13,31 @@ describe('<Tooltip.Portal />', () => {
       return render(<Tooltip.Root open>{node}</Tooltip.Root>);
     },
   }));
+
+  describe('prop: keepMounted', () => {
+    function ClosedTooltip({ keepMounted }: { keepMounted?: boolean }) {
+      return (
+        <Tooltip.Root>
+          <Tooltip.Trigger>Trigger</Tooltip.Trigger>
+          <Tooltip.Portal keepMounted={keepMounted}>
+            <Tooltip.Positioner>
+              <Tooltip.Popup data-testid="popup">Content</Tooltip.Popup>
+            </Tooltip.Positioner>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      );
+    }
+
+    it('renders the closed popup as hidden instead of unmounting it', async () => {
+      await render(<ClosedTooltip keepMounted />);
+
+      expect(screen.getByTestId('popup')).toBeInaccessible();
+    });
+
+    it('unmounts the closed popup by default', async () => {
+      await render(<ClosedTooltip />);
+
+      expect(screen.queryByTestId('popup')).toBe(null);
+    });
+  });
 });

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { screen, waitFor } from '@mui/internal-test-utils';
@@ -24,6 +24,34 @@ describe('<Tooltip.Positioner />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <Tooltip.Root>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Tooltip.Positioner />)).rejects.toThrow(
+        'Base UI: TooltipRootContext is missing. Tooltip parts must be placed within <Tooltip.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('throws a descriptive error when rendered outside <Tooltip.Portal>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Tooltip.Root open>
+            <Tooltip.Positioner />
+          </Tooltip.Root>,
+        ),
+      ).rejects.toThrow('Base UI: <Tooltip.Portal> is missing.');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   const baselineX = 10;
   const baselineY = 36;

--- a/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
+++ b/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
@@ -180,4 +180,76 @@ describe('<Tooltip.Provider />', () => {
       expect(screen.queryByText('Content')).toBe(null);
     });
   });
+
+  describe('prop: timeout', () => {
+    clock.withFakeTimers();
+
+    function TwoTooltips({ timeout }: { timeout: number }) {
+      return (
+        <Tooltip.Provider delay={100} timeout={timeout}>
+          {['One', 'Two'].map((name) => (
+            <Tooltip.Root key={name}>
+              <Tooltip.Trigger>{name}</Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Positioner>
+                  <Tooltip.Popup>{`Content ${name}`}</Tooltip.Popup>
+                </Tooltip.Positioner>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          ))}
+        </Tooltip.Provider>
+      );
+    }
+
+    it('opens an adjacent tooltip instantly while the group is active', async () => {
+      await render(<TwoTooltips timeout={400} />);
+
+      const first = screen.getByRole('button', { name: 'One' });
+      const second = screen.getByRole('button', { name: 'Two' });
+
+      fireEvent.mouseEnter(first);
+      fireEvent.mouseMove(first);
+      clock.tick(100);
+      await flushMicrotasks();
+
+      expect(screen.queryByText('Content One')).not.toBe(null);
+
+      fireEvent.mouseLeave(first);
+      fireEvent.mouseEnter(second);
+      fireEvent.mouseMove(second);
+      await flushMicrotasks();
+
+      expect(screen.queryByText('Content Two')).not.toBe(null);
+      expect(screen.queryByText('Content One')).toBe(null);
+    });
+
+    it('requires the full delay again once the timeout elapses', async () => {
+      await render(<TwoTooltips timeout={400} />);
+
+      const first = screen.getByRole('button', { name: 'One' });
+      const second = screen.getByRole('button', { name: 'Two' });
+
+      fireEvent.mouseEnter(first);
+      fireEvent.mouseMove(first);
+      clock.tick(100);
+      await flushMicrotasks();
+
+      expect(screen.queryByText('Content One')).not.toBe(null);
+
+      fireEvent.mouseLeave(first);
+      clock.tick(400);
+      await flushMicrotasks();
+
+      fireEvent.mouseEnter(second);
+      fireEvent.mouseMove(second);
+      await flushMicrotasks();
+
+      expect(screen.queryByText('Content Two')).toBe(null);
+
+      clock.tick(100);
+      await flushMicrotasks();
+
+      expect(screen.queryByText('Content Two')).not.toBe(null);
+    });
+  });
 });

--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -2512,6 +2512,55 @@ describe('nested tooltips', () => {
     }
   });
 
+  it.each([
+    {
+      name: 'starts with a ShadowRoot',
+      getPath(innerTrigger: HTMLElement, outerTrigger: HTMLElement) {
+        const shadowRoot = document.createElement('div').attachShadow({ mode: 'open' });
+        return [shadowRoot, innerTrigger, outerTrigger, document.body, document, window];
+      },
+    },
+    {
+      name: 'is empty',
+      getPath() {
+        return [];
+      },
+    },
+  ])('handles a composed path that $name', async ({ getPath }) => {
+    await render(
+      <Tooltip.Root>
+        <Tooltip.Trigger data-testid="outer-trigger" render={<span />}>
+          Outer
+          <Tooltip.Root>
+            <Tooltip.Trigger data-testid="inner-trigger">Inner</Tooltip.Trigger>
+          </Tooltip.Root>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Positioner>
+            <Tooltip.Popup data-testid="outer-popup">Outer tooltip</Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>,
+    );
+
+    const outerTrigger = screen.getByTestId('outer-trigger');
+    const innerTrigger = screen.getByTestId('inner-trigger');
+
+    fireEvent.pointerEnter(outerTrigger, { pointerType: 'mouse' });
+    fireEvent.mouseEnter(outerTrigger);
+
+    const mouseOverEvent = new MouseEvent('mouseover', { bubbles: true, composed: true });
+    Object.defineProperty(mouseOverEvent, 'composedPath', {
+      value: () => getPath(innerTrigger, outerTrigger),
+    });
+    innerTrigger.dispatchEvent(mouseOverEvent);
+
+    clock.tick(OPEN_DELAY);
+    await flushMicrotasks();
+
+    expect(screen.queryByTestId('outer-popup')).toBe(null);
+  });
+
   it('should open the outer tooltip when hovering over the non-nested area', async () => {
     await render(
       <Tooltip.Root>

--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -376,6 +376,39 @@ describe('<Tooltip.Root />', () => {
           expect(screen.queryByTestId('positioner')).toBe(null);
         });
       });
+
+      it('closes the tooltip when the `close` method is called', async () => {
+        const onOpenChange = vi.fn();
+        const actionsRef = {
+          current: {
+            unmount: vi.fn(),
+            close: vi.fn(),
+          },
+        };
+
+        const { user } = await render(
+          <TestTooltip rootProps={{ actionsRef, onOpenChange }} triggerProps={{ delay: 0 }} />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+        await user.hover(trigger);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('popup')).not.toBe(null);
+        });
+
+        await act(async () => actionsRef.current.close());
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('positioner')).toBe(null);
+        });
+
+        expect(trigger).not.toHaveAttribute('data-popup-open');
+        expect(onOpenChange).toHaveBeenLastCalledWith(
+          false,
+          expect.objectContaining({ reason: REASONS.imperativeAction }),
+        );
+      });
     });
 
     describe.skipIf(isJSDOM)('prop: onOpenChangeComplete', () => {
@@ -754,6 +787,35 @@ describe('<Tooltip.Root />', () => {
 
         expect(screen.queryByText('Content')).toBe(null);
       });
+
+      it('marks the trigger as disabled when the root is disabled', async () => {
+        await render(<TestTooltip rootProps={{ disabled: true }} />);
+
+        expect(screen.getByRole('button', { name: 'Toggle' })).toHaveAttribute(
+          'data-trigger-disabled',
+        );
+      });
+
+      it('keeps the tooltip disabled when the root is disabled and the trigger opts back in', async () => {
+        await render(
+          <TestTooltip
+            rootProps={{ disabled: true }}
+            triggerProps={{ disabled: false, delay: 0 }}
+          />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        expect(trigger).not.toHaveAttribute('data-trigger-disabled');
+
+        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        await flushMicrotasks();
+
+        expect(screen.queryByText('Content')).toBe(null);
+      });
     });
 
     describe('prop: disableHoverablePopup', () => {
@@ -787,6 +849,68 @@ describe('<Tooltip.Root />', () => {
         await flushMicrotasks();
 
         expect(screen.getByTestId('positioner').style.pointerEvents).toBe('');
+      });
+    });
+
+    describe('prop: trackCursorAxis', () => {
+      it('makes the positioner inert when tracking both axes', async () => {
+        await render(
+          <TestTooltip rootProps={{ trackCursorAxis: 'both' }} triggerProps={{ delay: 0 }} />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('positioner').style.pointerEvents).toBe('none');
+      });
+
+      it('keeps the positioner hoverable when tracking a single axis', async () => {
+        await render(
+          <TestTooltip rootProps={{ trackCursorAxis: 'x' }} triggerProps={{ delay: 0 }} />,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('positioner').style.pointerEvents).toBe('');
+      });
+    });
+
+    describe.skipIf(isJSDOM)('instant animations', () => {
+      it('marks the popup as instant when opened by focus, but not when opened by hover', async () => {
+        await render(<TestTooltip triggerProps={{ delay: 0, closeDelay: 0 }} />);
+
+        const trigger = screen.getByRole('button', { name: 'Toggle' });
+
+        await act(async () => trigger.focus());
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('popup')).toHaveAttribute('data-instant', 'focus');
+
+        await act(async () => trigger.blur());
+        await waitFor(() => {
+          expect(screen.queryByTestId('popup')).toBe(null);
+        });
+
+        fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('popup')).not.toBe(null);
+        });
+
+        expect(screen.getByTestId('popup')).not.toHaveAttribute('data-instant');
       });
     });
 
@@ -847,6 +971,28 @@ describe('<Tooltip.Root />', () => {
 
     describe('dismissal', () => {
       clock.withFakeTimers();
+
+      it('should close when Escape is pressed', async () => {
+        const onOpenChange = vi.fn();
+        await render(
+          <TestTooltip
+            rootProps={{ defaultOpen: true, onOpenChange }}
+            triggerProps={{ delay: 0 }}
+          />,
+        );
+
+        expect(screen.getByText('Content')).not.toBe(null);
+
+        fireEvent.keyDown(document.body, { key: 'Escape' });
+
+        await flushMicrotasks();
+
+        expect(screen.queryByText('Content')).toBe(null);
+        expect(onOpenChange).toHaveBeenCalledWith(
+          false,
+          expect.objectContaining({ reason: REASONS.escapeKey }),
+        );
+      });
 
       it('should not open when the trigger was clicked before delay duration', async () => {
         await render(<TestTooltip />);
@@ -1224,6 +1370,77 @@ describe('<Tooltip.Root />', () => {
     },
   );
 
+  describe.skipIf(isJSDOM)('hoverable popup', () => {
+    function HoverableTooltip({ disableHoverablePopup }: { disableHoverablePopup?: boolean }) {
+      return (
+        <div style={{ paddingTop: 100, paddingLeft: 100 }}>
+          <Tooltip.Root disableHoverablePopup={disableHoverablePopup}>
+            <Tooltip.Trigger delay={0} closeDelay={0} style={{ width: 120, height: 40 }}>
+              Trigger
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Positioner data-testid="positioner" side="bottom" sideOffset={0}>
+                <Tooltip.Popup data-testid="popup" style={{ width: 120, height: 40 }}>
+                  Content
+                </Tooltip.Popup>
+              </Tooltip.Positioner>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+          <button type="button">Outside</button>
+        </div>
+      );
+    }
+
+    async function openByHover() {
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
+
+      const popup = await screen.findByTestId('popup');
+      return { trigger, popup };
+    }
+
+    function center(element: Element) {
+      const rect = element.getBoundingClientRect();
+      return { clientX: rect.left + rect.width / 2, clientY: rect.top + rect.height / 2 };
+    }
+
+    it('survives the trip from the trigger to the popup, then closes after leaving it', async () => {
+      await render(<HoverableTooltip />);
+
+      const { trigger, popup } = await openByHover();
+
+      fireEvent.mouseLeave(trigger, center(popup));
+      fireEvent.mouseEnter(popup);
+      await flushMicrotasks();
+
+      expect(screen.queryByTestId('popup')).not.toBe(null);
+
+      fireEvent.mouseLeave(popup, {
+        relatedTarget: document.body,
+        ...center(screen.getByRole('button', { name: 'Outside' })),
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('popup')).toBe(null);
+      });
+    });
+
+    it('closes on that same trip when `disableHoverablePopup` is set', async () => {
+      await render(<HoverableTooltip disableHoverablePopup />);
+
+      const { trigger, popup } = await openByHover();
+
+      fireEvent.mouseLeave(trigger, center(popup));
+      fireEvent.mouseEnter(popup);
+      await flushMicrotasks();
+
+      expect(screen.queryByTestId('popup')).toBe(null);
+    });
+  });
+
   it('keeps the tooltip open when moving across spaced triggers without a closeDelay', async () => {
     const testTooltip = Tooltip.createHandle();
     const { user } = await render(
@@ -1576,6 +1793,78 @@ describe('nested tooltips', () => {
     await flushMicrotasks();
 
     expect(screen.getByTestId('outer-popup')).not.toBe(null);
+  });
+
+  it('should not re-announce an open outer tooltip when the pending reopen fires', async () => {
+    const delay = 100;
+    const onOpenChange = vi.fn();
+
+    function App() {
+      const [open, setOpen] = React.useState(false);
+
+      return (
+        <div>
+          <button data-testid="open-outer" onClick={() => setOpen(true)} type="button" />
+          <Tooltip.Provider delay={delay}>
+            <Tooltip.Root
+              open={open}
+              onOpenChange={(nextOpen, eventDetails) => {
+                onOpenChange(nextOpen, eventDetails);
+                setOpen(nextOpen);
+              }}
+            >
+              <Tooltip.Trigger data-testid="outer-trigger" render={<span />}>
+                <span data-testid="outer-area">Outer</span>
+                <Tooltip.Root>
+                  <Tooltip.Trigger data-testid="inner-trigger" delay={delay * 10}>
+                    Inner
+                  </Tooltip.Trigger>
+                  <Tooltip.Portal>
+                    <Tooltip.Positioner>
+                      <Tooltip.Popup data-testid="inner-popup">Inner tooltip</Tooltip.Popup>
+                    </Tooltip.Positioner>
+                  </Tooltip.Portal>
+                </Tooltip.Root>
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Positioner>
+                  <Tooltip.Popup data-testid="outer-popup">Outer tooltip</Tooltip.Popup>
+                </Tooltip.Positioner>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+        </div>
+      );
+    }
+
+    await render(<App />);
+
+    const outerTrigger = screen.getByTestId('outer-trigger');
+    const innerTrigger = screen.getByTestId('inner-trigger');
+    const outerArea = screen.getByTestId('outer-area');
+
+    fireEvent.pointerEnter(outerTrigger, { pointerType: 'mouse', clientX: 10, clientY: 10 });
+    fireEvent.mouseEnter(outerTrigger);
+    fireEvent.pointerEnter(innerTrigger, { pointerType: 'mouse', clientX: 50, clientY: 10 });
+    fireEvent.mouseEnter(innerTrigger);
+    fireEvent.mouseOver(innerTrigger);
+    fireEvent.mouseMove(innerTrigger, { clientX: 50, clientY: 10 });
+
+    // Move back to the parent area so the local reopen is scheduled but not yet due.
+    fireEvent.mouseOut(innerTrigger, { relatedTarget: outerArea });
+    fireEvent.mouseOver(outerArea);
+
+    // The tooltip is opened from the outside before the pending reopen fires.
+    fireEvent.click(screen.getByTestId('open-outer'));
+    await flushMicrotasks();
+
+    expect(screen.getByTestId('outer-popup')).not.toBe(null);
+
+    clock.tick(delay);
+    await flushMicrotasks();
+
+    expect(screen.getByTestId('outer-popup')).not.toBe(null);
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it('should support nested triggers inside a detached parent trigger', async () => {

--- a/packages/react/src/tooltip/store/TooltipStore.ts
+++ b/packages/react/src/tooltip/store/TooltipStore.ts
@@ -69,9 +69,9 @@ export class TooltipStore<Payload> extends ReactStore<
   Selectors
 > {
   constructor(
-    initialState?: Partial<State<Payload>>,
-    floatingId?: string | undefined,
-    nested = false,
+    initialState: Partial<State<Payload>>,
+    floatingId: string | undefined,
+    nested: boolean,
   ) {
     const triggerElements = new PopupTriggerMap();
     super(

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.test.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { Toolbar } from '@base-ui/react/toolbar';
@@ -14,6 +14,18 @@ describe('<Tooltip.Trigger />', () => {
       return render(<Tooltip.Root>{node}</Tooltip.Root>);
     },
   }));
+
+  it('throws a descriptive error when rendered without a root or a handle', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Tooltip.Trigger>Trigger</Tooltip.Trigger>)).rejects.toThrow(
+        'Base UI: <Tooltip.Trigger> must be either used within a <Tooltip.Root> component or provided with a handle.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   it('removes `data-popup-open` as soon as `open` becomes false', async () => {
     function TooltipWithPreventedUnmount() {

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -18,34 +18,16 @@ import {
   useFocus,
   useHoverReferenceInteraction,
 } from '../../floating-ui-react';
-import { contains } from '../../floating-ui-react/utils/element';
+import { contains, getTarget } from '../../floating-ui-react/utils/element';
 import { isMouseLikePointerType } from '../../floating-ui-react/utils/event';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 import { useHoverInteractionSharedState } from '../../floating-ui-react/hooks/useHoverInteractionSharedState';
+import { getDelay } from '../../floating-ui-react/hooks/useHoverShared';
 
 import { OPEN_DELAY } from '../utils/constants';
 
 const TOOLTIP_TRIGGER_IDENTIFIER = 'data-base-ui-tooltip-trigger';
-
-function getTargetElement(event: Event): Element | null {
-  if ('composedPath' in event) {
-    const path = event.composedPath();
-    for (let i = 0; i < path.length; i += 1) {
-      const element = path[i];
-      if (isElement(element)) {
-        return element;
-      }
-    }
-  }
-
-  const target = event.target;
-  if (isElement(target)) {
-    return target;
-  }
-
-  return null;
-}
 
 function closestEnabledTooltipTrigger(element: Element | null): Element | null {
   let current = element;
@@ -139,20 +121,13 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
     if (!hasProvider) {
       return delayWithDefault;
     }
-    const groupOpenValue = typeof delayRef.current === 'object' ? delayRef.current.open : undefined;
-    return groupOpenValue === 0 ? 0 : (delay ?? providerDelay ?? OPEN_DELAY);
+    return getDelay(delayRef.current, 'open') === 0 ? 0 : (delay ?? providerDelay ?? OPEN_DELAY);
   }
 
   function isEnabledNestedTriggerTarget(target: Element | null) {
     const triggerEl = triggerElementRef.current;
-    if (!triggerEl || !target) {
-      return false;
-    }
-
     const nearestTrigger = closestEnabledTooltipTrigger(target);
-    return (
-      nearestTrigger !== null && nearestTrigger !== triggerEl && contains(triggerEl, nearestTrigger)
-    );
+    return nearestTrigger !== triggerEl && contains(triggerEl, nearestTrigger);
   }
 
   function detectNestedTriggerHover(target: Element | null) {
@@ -176,9 +151,7 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
     restMs: getOpenDelay,
     delay() {
       if (closeDelay == null && hasProvider) {
-        return {
-          close: typeof delayRef.current === 'object' ? delayRef.current.close : undefined,
-        };
+        return { close: getDelay(delayRef.current, 'close') };
       }
       return { close: closeDelayWithDefault };
     },
@@ -194,7 +167,7 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
 
   const handleNestedTriggerHover = (event: MouseEvent) => {
     const wasNestedTriggerHovered = isNestedTriggerHoveredRef.current;
-    const target = getTargetElement(event);
+    const target = getTarget(event) as Element | null;
     const nestedTriggerHovered = detectNestedTriggerHover(target);
     const triggerEl = triggerElementRef.current as HTMLElement | null;
     const targetInsideTrigger = triggerEl && target && contains(triggerEl, target);
@@ -257,7 +230,7 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
           handleNestedTriggerHover(event.nativeEvent);
         },
         onFocus(event: React.FocusEvent) {
-          if (isEnabledNestedTriggerTarget(getTargetElement(event.nativeEvent))) {
+          if (isEnabledNestedTriggerTarget(getTarget(event.nativeEvent) as Element | null)) {
             (event as BaseUIEvent<React.FocusEvent<Element>>).preventBaseUIHandler();
           }
         },

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -18,7 +18,7 @@ import {
   useFocus,
   useHoverReferenceInteraction,
 } from '../../floating-ui-react';
-import { contains, getTarget } from '../../floating-ui-react/utils/element';
+import { contains } from '../../floating-ui-react/utils/element';
 import { isMouseLikePointerType } from '../../floating-ui-react/utils/event';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
@@ -28,6 +28,25 @@ import { getDelay } from '../../floating-ui-react/hooks/useHoverShared';
 import { OPEN_DELAY } from '../utils/constants';
 
 const TOOLTIP_TRIGGER_IDENTIFIER = 'data-base-ui-tooltip-trigger';
+
+function getTargetElement(event: Event): Element | null {
+  if ('composedPath' in event) {
+    const path = event.composedPath();
+    for (let i = 0; i < path.length; i += 1) {
+      const element = path[i];
+      if (isElement(element)) {
+        return element;
+      }
+    }
+  }
+
+  const target = event.target;
+  if (isElement(target)) {
+    return target;
+  }
+
+  return null;
+}
 
 function closestEnabledTooltipTrigger(element: Element | null): Element | null {
   let current = element;
@@ -126,8 +145,14 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
 
   function isEnabledNestedTriggerTarget(target: Element | null) {
     const triggerEl = triggerElementRef.current;
+    if (!triggerEl || !target) {
+      return false;
+    }
+
     const nearestTrigger = closestEnabledTooltipTrigger(target);
-    return nearestTrigger !== triggerEl && contains(triggerEl, nearestTrigger);
+    return (
+      nearestTrigger !== null && nearestTrigger !== triggerEl && contains(triggerEl, nearestTrigger)
+    );
   }
 
   function detectNestedTriggerHover(target: Element | null) {
@@ -167,7 +192,7 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
 
   const handleNestedTriggerHover = (event: MouseEvent) => {
     const wasNestedTriggerHovered = isNestedTriggerHoveredRef.current;
-    const target = getTarget(event) as Element | null;
+    const target = getTargetElement(event);
     const nestedTriggerHovered = detectNestedTriggerHover(target);
     const triggerEl = triggerElementRef.current as HTMLElement | null;
     const targetInsideTrigger = triggerEl && target && contains(triggerEl, target);
@@ -230,7 +255,7 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
           handleNestedTriggerHover(event.nativeEvent);
         },
         onFocus(event: React.FocusEvent) {
-          if (isEnabledNestedTriggerTarget(getTarget(event.nativeEvent) as Element | null)) {
+          if (isEnabledNestedTriggerTarget(getTargetElement(event.nativeEvent))) {
             (event as BaseUIEvent<React.FocusEvent<Element>>).preventBaseUIHandler();
           }
         },

--- a/packages/react/src/tooltip/viewport/TooltipViewport.test.tsx
+++ b/packages/react/src/tooltip/viewport/TooltipViewport.test.tsx
@@ -44,6 +44,31 @@ describe('<Tooltip.Viewport />', () => {
     expect(currentContainer!.textContent).toBe('Content');
   });
 
+  it.skipIf(isJSDOM)('should mirror the instant animation type of the tooltip', async () => {
+    await render(
+      <Tooltip.Root>
+        <Tooltip.Trigger delay={0} closeDelay={0}>
+          Trigger
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Positioner>
+            <Tooltip.Popup>
+              <Tooltip.Viewport data-testid="viewport">Content</Tooltip.Viewport>
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+    await act(async () => trigger.focus());
+
+    await waitFor(() => {
+      expect(screen.getByTestId('viewport')).toHaveAttribute('data-instant', 'focus');
+    });
+  });
+
   it('should remount the `current` container when the active trigger changes', async () => {
     ignoreActWarnings();
     await render(


### PR DESCRIPTION
Expands Tooltip test coverage to 100% across statements, branches, functions, and lines on merged jsdom and Chromium results, and removes the unreachable code the sweep uncovered.