### PR TITLE
[navigation menu] Expand test coverage

### DIFF
--- a/packages/react/src/navigation-menu/arrow/NavigationMenuArrow.test.tsx
+++ b/packages/react/src/navigation-menu/arrow/NavigationMenuArrow.test.tsx
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -16,4 +17,22 @@ describe('<NavigationMenu.Arrow />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <NavigationMenu.Positioner>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <NavigationMenu.Root>
+            <NavigationMenu.Arrow />
+          </NavigationMenu.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: NavigationMenuPositionerContext is missing. NavigationMenuPositioner parts must be placed within <NavigationMenu.Positioner>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/packages/react/src/navigation-menu/icon/NavigationMenuIcon.test.tsx
+++ b/packages/react/src/navigation-menu/icon/NavigationMenuIcon.test.tsx
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -14,4 +15,22 @@ describe('<NavigationMenu.Icon />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <NavigationMenu.Item>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <NavigationMenu.Root>
+            <NavigationMenu.Icon />
+          </NavigationMenu.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: NavigationMenuItem parts must be used within a <NavigationMenu.Item>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
-import { act, screen, waitFor } from '@mui/internal-test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -131,41 +131,36 @@ describe('<NavigationMenu.Link />', () => {
     });
   });
 
-  it('closes the menu when focus leaves from a link', async () => {
+  it('keeps the menu open when a link loses focus without a related target', async () => {
     const { user } = await render(
-      <div>
-        <NavigationMenu.Root>
-          <NavigationMenu.List>
-            <NavigationMenu.Item value="item-1">
-              <NavigationMenu.Trigger>Item 1</NavigationMenu.Trigger>
-              <NavigationMenu.Content>
-                <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
-              </NavigationMenu.Content>
-            </NavigationMenu.Item>
-          </NavigationMenu.List>
+      <NavigationMenu.Root>
+        <NavigationMenu.List>
+          <NavigationMenu.Item value="item-1">
+            <NavigationMenu.Trigger>Item 1</NavigationMenu.Trigger>
+            <NavigationMenu.Content>
+              <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+        </NavigationMenu.List>
 
-          <NavigationMenu.Portal>
-            <NavigationMenu.Positioner>
-              <NavigationMenu.Popup>
-                <NavigationMenu.Viewport />
-              </NavigationMenu.Popup>
-            </NavigationMenu.Positioner>
-          </NavigationMenu.Portal>
-        </NavigationMenu.Root>
-        <button>Outside</button>
-      </div>,
+        <NavigationMenu.Portal>
+          <NavigationMenu.Positioner>
+            <NavigationMenu.Popup>
+              <NavigationMenu.Viewport />
+            </NavigationMenu.Popup>
+          </NavigationMenu.Positioner>
+        </NavigationMenu.Portal>
+      </NavigationMenu.Root>,
     );
 
     const trigger = screen.getByRole('button', { name: 'Item 1' });
     await user.click(trigger);
 
     const link = await screen.findByRole('link', { name: 'Link 1' });
-    await act(async () => link.focus());
-    await act(async () => screen.getByRole('button', { name: 'Outside' }).focus());
+    fireEvent.focus(link);
+    fireEvent.blur(link, { relatedTarget: null });
 
-    await waitFor(() => {
-      expect(screen.queryByRole('link', { name: 'Link 1' })).toBe(null);
-    });
-    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByRole('link', { name: 'Link 1' })).not.toBe(null);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { act, screen, waitFor } from '@mui/internal-test-utils';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -129,5 +129,43 @@ describe('<NavigationMenu.Link />', () => {
       );
       expect(screen.getByRole('link', { name: 'inactive' })).not.toHaveAttribute('aria-current');
     });
+  });
+
+  it('closes the menu when focus leaves from a link', async () => {
+    const { user } = await render(
+      <div>
+        <NavigationMenu.Root>
+          <NavigationMenu.List>
+            <NavigationMenu.Item value="item-1">
+              <NavigationMenu.Trigger>Item 1</NavigationMenu.Trigger>
+              <NavigationMenu.Content>
+                <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
+              </NavigationMenu.Content>
+            </NavigationMenu.Item>
+          </NavigationMenu.List>
+
+          <NavigationMenu.Portal>
+            <NavigationMenu.Positioner>
+              <NavigationMenu.Popup>
+                <NavigationMenu.Viewport />
+              </NavigationMenu.Popup>
+            </NavigationMenu.Positioner>
+          </NavigationMenu.Portal>
+        </NavigationMenu.Root>
+        <button>Outside</button>
+      </div>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Item 1' });
+    await user.click(trigger);
+
+    const link = await screen.findByRole('link', { name: 'Link 1' });
+    await act(async () => link.focus());
+    await act(async () => screen.getByRole('button', { name: 'Outside' }).focus());
+
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: 'Link 1' })).toBe(null);
+    });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
@@ -50,12 +50,13 @@ export const NavigationMenuLink = React.forwardRef(function NavigationMenuLink(
       if (
         positionerElement &&
         popupElement &&
-        isOutsideMenuEvent(event.relatedTarget as HTMLElement | null, {
-          popupElement,
-          rootRef,
-          tree: tree!,
-          nodeId,
-        })
+        isOutsideMenuEvent(
+          {
+            currentTarget: event.currentTarget,
+            relatedTarget: event.relatedTarget as HTMLElement | null,
+          },
+          { popupElement, rootRef, tree, nodeId },
+        )
       ) {
         setValue(null, createChangeEventDetails(REASONS.focusOut, event.nativeEvent));
       }

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.tsx
@@ -50,13 +50,12 @@ export const NavigationMenuLink = React.forwardRef(function NavigationMenuLink(
       if (
         positionerElement &&
         popupElement &&
-        isOutsideMenuEvent(
-          {
-            currentTarget: event.currentTarget,
-            relatedTarget: event.relatedTarget as HTMLElement | null,
-          },
-          { popupElement, rootRef, tree, nodeId },
-        )
+        isOutsideMenuEvent(event.relatedTarget as HTMLElement | null, {
+          popupElement,
+          rootRef,
+          tree: tree!,
+          nodeId,
+        })
       ) {
         setValue(null, createChangeEventDetails(REASONS.focusOut, event.nativeEvent));
       }

--- a/packages/react/src/navigation-menu/list/NavigationMenuList.test.tsx
+++ b/packages/react/src/navigation-menu/list/NavigationMenuList.test.tsx
@@ -1,3 +1,5 @@
+import { vi } from 'vitest';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -10,4 +12,43 @@ describe('<NavigationMenu.List />', () => {
       return render(<NavigationMenu.Root>{node}</NavigationMenu.Root>);
     },
   }));
+
+  it('throws a descriptive error when rendered outside <NavigationMenu.Root>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<NavigationMenu.List />)).rejects.toThrow(
+        'Base UI: NavigationMenuRootContext is missing. Navigation Menu parts must be placed within <NavigationMenu.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('stops vertical navigation keys from escaping the list', async () => {
+    const handleKeyDown = vi.fn();
+
+    await render(
+      <div onKeyDown={handleKeyDown}>
+        <NavigationMenu.Root orientation="vertical">
+          <NavigationMenu.List data-testid="list">
+            <NavigationMenu.Item>
+              <NavigationMenu.Trigger>Item</NavigationMenu.Trigger>
+            </NavigationMenu.Item>
+          </NavigationMenu.List>
+        </NavigationMenu.Root>
+      </div>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Item' });
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: 'ArrowUp' });
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+
+    expect(handleKeyDown.mock.calls.length).toBe(0);
+
+    fireEvent.keyDown(trigger, { key: 'PageDown' });
+
+    expect(handleKeyDown.mock.calls.length).toBe(1);
+  });
 });

--- a/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.test.tsx
+++ b/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.test.tsx
@@ -51,4 +51,20 @@ describe('<NavigationMenu.Positioner />', () => {
       rootBoundary: 'layoutViewport',
     });
   });
+
+  it('throws a descriptive error when rendered outside <NavigationMenu.Portal>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <NavigationMenu.Root value="test">
+            <NavigationMenu.Positioner />
+          </NavigationMenu.Root>,
+        ),
+      ).rejects.toThrow('Base UI: <NavigationMenu.Portal> is missing.');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -1172,6 +1172,52 @@ describe('<NavigationMenu.Root />', () => {
       expect(topLevelList.style.pointerEvents).toBe('');
     });
 
+    it('scopes safePolygon pointer events to the document for a custom list element', async () => {
+      await render(
+        <NavigationMenu.Root>
+          <NavigationMenu.List render={<div data-testid="custom-list" />}>
+            <NavigationMenu.Item value="item">
+              <NavigationMenu.Trigger>Trigger 1</NavigationMenu.Trigger>
+              <NavigationMenu.Content>Content 1</NavigationMenu.Content>
+            </NavigationMenu.Item>
+            <NavigationMenu.Item value="item-2">
+              <NavigationMenu.Trigger>Trigger 2</NavigationMenu.Trigger>
+              <NavigationMenu.Content>Content 2</NavigationMenu.Content>
+            </NavigationMenu.Item>
+          </NavigationMenu.List>
+          <NavigationMenu.Portal>
+            <NavigationMenu.Positioner>
+              <NavigationMenu.Popup>
+                <NavigationMenu.Viewport />
+              </NavigationMenu.Popup>
+            </NavigationMenu.Positioner>
+          </NavigationMenu.Portal>
+        </NavigationMenu.Root>,
+      );
+
+      const trigger = screen.getByText('Trigger 1');
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
+      clock.tick(OPEN_DELAY);
+      await flushMicrotasks();
+
+      expect(document.body.style.pointerEvents).toBe('none');
+      expect(screen.getByTestId('custom-list').style.pointerEvents).toBe('');
+
+      fireEvent.pointerDown(trigger, { pointerType: 'mouse' });
+      expect(document.body.style.pointerEvents).toBe('');
+
+      const secondTrigger = screen.getByText('Trigger 2');
+      fireEvent.mouseEnter(secondTrigger);
+      await flushMicrotasks();
+
+      expect(secondTrigger).toHaveAttribute('aria-expanded', 'true');
+      expect(document.body.style.pointerEvents).toBe('none');
+
+      fireEvent.pointerDown(secondTrigger, { pointerType: 'mouse' });
+      expect(document.body.style.pointerEvents).toBe('');
+    });
+
     it.skipIf(isJSDOM)(
       'blocks pointer events on sibling top-level triggers when opened through real hover',
       async () => {
@@ -1206,11 +1252,53 @@ describe('<NavigationMenu.Root />', () => {
       const trigger = screen.getByTestId('trigger-1');
 
       fireEvent.pointerEnter(trigger, { pointerType: 'touch' });
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
+      clock.tick(OPEN_DELAY);
       await flushMicrotasks();
 
       expect(screen.queryByTestId('popup-1')).toBe(null);
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
     });
+
+    it.each([
+      ['horizontal', 'right', 'left'],
+      ['vertical', 'down', 'up'],
+    ] as const)(
+      'reports %s activation direction when switching in either direction',
+      async (orientation, forwardDirection, backwardDirection) => {
+        await render(<TestNavigationMenu orientation={orientation} />);
+        const trigger1 = screen.getByTestId('trigger-1');
+        const trigger2 = screen.getByTestId('trigger-2');
+
+        if (orientation === 'horizontal') {
+          mockBoundingClientRect(trigger1, { x: 0, y: 0, width: 80, height: 32 });
+          mockBoundingClientRect(trigger2, { x: 120, y: 0, width: 80, height: 32 });
+        } else {
+          mockBoundingClientRect(trigger1, { x: 0, y: 0, width: 80, height: 32 });
+          mockBoundingClientRect(trigger2, { x: 0, y: 80, width: 80, height: 32 });
+        }
+
+        fireEvent.click(trigger1);
+        await flushMicrotasks();
+
+        fireEvent.click(trigger2);
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('popup-2')).toHaveAttribute(
+          'data-activation-direction',
+          forwardDirection,
+        );
+
+        fireEvent.click(trigger1);
+        await flushMicrotasks();
+
+        expect(screen.getByTestId('popup-1')).toHaveAttribute(
+          'data-activation-direction',
+          backwardDirection,
+        );
+      },
+    );
 
     it('opens on click with touch input', async () => {
       await render(<TestNavigationMenu />);
@@ -1581,6 +1669,22 @@ describe('<NavigationMenu.Root />', () => {
       await flushMicrotasks();
       expect(onValueChange.mock.calls.length).toBe(2);
       expect(onValueChange.mock.lastCall?.[0]).toBe('item-2');
+    });
+
+    it('does not open when onValueChange cancels the interaction', async () => {
+      const onValueChange = vi.fn(
+        (_nextValue, eventDetails: NavigationMenu.Root.ChangeEventDetails) => {
+          eventDetails.cancel();
+        },
+      );
+      await render(<TestNavigationMenu onValueChange={onValueChange} />);
+
+      fireEvent.click(screen.getByTestId('trigger-1'));
+      await flushMicrotasks();
+
+      expect(onValueChange.mock.calls.length).toBe(1);
+      expect(screen.getByTestId('trigger-1')).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByTestId('popup-1')).toBe(null);
     });
 
     it('does not emit a duplicate onValueChange when switching items via keyboard', async () => {
@@ -2085,6 +2189,74 @@ describe('<NavigationMenu.Root />', () => {
       expect(screen.queryByTestId('popup-1')).toBe(null);
     });
 
+    it('closes after tabbing out of arbitrary tabbable content', async () => {
+      const { user } = await render(
+        <div>
+          <NavigationMenu.Root>
+            <NavigationMenu.List>
+              <NavigationMenu.Item value="item">
+                <NavigationMenu.Trigger>Trigger</NavigationMenu.Trigger>
+                <NavigationMenu.Content>
+                  <button>Action</button>
+                </NavigationMenu.Content>
+              </NavigationMenu.Item>
+            </NavigationMenu.List>
+            <NavigationMenu.Portal>
+              <NavigationMenu.Positioner>
+                <NavigationMenu.Popup data-testid="popup">
+                  <NavigationMenu.Viewport />
+                </NavigationMenu.Popup>
+              </NavigationMenu.Positioner>
+            </NavigationMenu.Portal>
+          </NavigationMenu.Root>
+          <button>After menu</button>
+        </div>,
+      );
+
+      const trigger = screen.getByText('Trigger');
+      await act(async () => trigger.focus());
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      await user.tab();
+      expect(screen.getByText('Action')).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByText('After menu')).toHaveFocus();
+      expect(screen.queryByTestId('popup')).toBe(null);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('returns focus to the trigger when no viewport focus guard is rendered', async () => {
+      await render(
+        <NavigationMenu.Root>
+          <NavigationMenu.List>
+            <NavigationMenu.Item value="item">
+              <NavigationMenu.Trigger>Trigger</NavigationMenu.Trigger>
+              <NavigationMenu.Content>Content</NavigationMenu.Content>
+            </NavigationMenu.Item>
+          </NavigationMenu.List>
+          <NavigationMenu.Portal>
+            <NavigationMenu.Positioner>
+              <NavigationMenu.Popup>Popup</NavigationMenu.Popup>
+            </NavigationMenu.Positioner>
+          </NavigationMenu.Portal>
+        </NavigationMenu.Root>,
+      );
+
+      const trigger = screen.getByText('Trigger');
+      await act(async () => trigger.focus());
+      fireEvent.click(trigger);
+      await flushMicrotasks();
+
+      const guards = trigger.parentElement?.querySelectorAll('[data-base-ui-focus-guard]');
+      const afterTriggerGuard = guards?.[1] as HTMLElement;
+      await act(async () => afterTriggerGuard.focus());
+
+      expect(trigger).toHaveFocus();
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
     it('returns to the last submenu item when shift+tabbing after tabbing out of it', async () => {
       const { user } = await render(
         <div>
@@ -2543,6 +2715,69 @@ describe('<NavigationMenu.Root />', () => {
 
         expect(nestedList.style.pointerEvents).toBe('');
       });
+
+      it.each([
+        [
+          'right',
+          { x: 0, y: 0, width: 100, height: 100 },
+          { x: 120, y: 0, width: 100, height: 100 },
+          { clientX: 100, clientY: 50 },
+          { clientX: 110, clientY: 50 },
+        ],
+        [
+          'left',
+          { x: 0, y: 0, width: 100, height: 100 },
+          { x: -120, y: 0, width: 100, height: 100 },
+          { clientX: 0, clientY: 50 },
+          { clientX: -10, clientY: 50 },
+        ],
+        [
+          'bottom',
+          { x: 0, y: 0, width: 100, height: 100 },
+          { x: 0, y: 120, width: 100, height: 100 },
+          { clientX: 50, clientY: 100 },
+          { clientX: 50, clientY: 110 },
+        ],
+        [
+          'top',
+          { x: 0, y: 0, width: 100, height: 100 },
+          { x: 0, y: -120, width: 100, height: 100 },
+          { clientX: 50, clientY: 0 },
+          { clientX: 50, clientY: -10 },
+        ],
+      ] as const)(
+        'keeps an inline submenu open while traversing toward a viewport on the %s',
+        async (_placement, triggerRect, viewportRect, leavePoint, traversePoint) => {
+          await render(<TestInlineNestedNavigationMenu nestedDefaultValue={null} />);
+          const trigger = screen.getByTestId('trigger-1');
+          fireEvent.mouseEnter(trigger);
+          fireEvent.mouseMove(trigger);
+          clock.tick(OPEN_DELAY);
+          await flushMicrotasks();
+
+          const nestedTrigger = screen.getByTestId('nested-trigger-1');
+          const nestedViewport = screen.getByTestId('inline-nested-viewport');
+          const nestedList = screen.getByTestId('inline-nested-list');
+          mockBoundingClientRect(nestedTrigger, triggerRect);
+          mockBoundingClientRect(nestedViewport, viewportRect);
+
+          fireEvent.mouseEnter(nestedTrigger);
+          fireEvent.mouseMove(nestedTrigger);
+          clock.tick(OPEN_DELAY);
+          await flushMicrotasks();
+
+          expect(nestedTrigger).toHaveAttribute('aria-expanded', 'true');
+          expect(nestedList.style.pointerEvents).toBe('none');
+          fireEvent.mouseLeave(nestedTrigger, leavePoint);
+          fireEvent.mouseMove(document, traversePoint);
+          expect(nestedList.style.pointerEvents).toBe('none');
+          clock.tick(50); // closeDelay
+          await flushMicrotasks();
+
+          expect(nestedTrigger).toHaveAttribute('aria-expanded', 'true');
+          expect(screen.queryByTestId('nested-popup-1')).not.toBe(null);
+        },
+      );
 
       it('clears inline safePolygon pointer events when the pointer leaves the traversal path', async () => {
         await render(<TestInlineNestedNavigationMenu />);
@@ -3248,6 +3483,53 @@ describe('<NavigationMenu.Root />', () => {
           setPropertySpy.mockRestore();
         } finally {
           globalThis.BASE_UI_ANIMATIONS_DISABLED = previousAnimationsDisabled;
+        }
+      });
+
+      it('preserves the current size when an interrupted mutation temporarily measures zero', async () => {
+        const originalResizeObserver = globalThis.ResizeObserver;
+        globalThis.ResizeObserver = undefined as unknown as typeof ResizeObserver;
+
+        try {
+          await render(
+            <TestInlineNestedNavigationMenuWithDynamicContent initialContentStage={1} />,
+          );
+          fireEvent.click(screen.getByTestId('trigger-1'));
+          await flushMicrotasks();
+
+          const popupRoot = screen.getByTestId('popup-root');
+          const positioner = screen.getByTestId('positioner');
+          const popupWidths = [250, 0];
+          const popupHeights = [220, 0];
+
+          Object.defineProperty(popupRoot, 'offsetWidth', {
+            configurable: true,
+            get: () => popupWidths.shift() ?? 0,
+          });
+          Object.defineProperty(popupRoot, 'offsetHeight', {
+            configurable: true,
+            get: () => popupHeights.shift() ?? 0,
+          });
+
+          popupRoot.style.setProperty('--popup-width', '250px');
+          popupRoot.style.setProperty('--popup-height', '220px');
+          positioner.style.setProperty('--positioner-width', '250px');
+          positioner.style.setProperty('--positioner-height', '220px');
+
+          fireEvent.click(screen.getByTestId('insert-content'));
+          await flushMicrotasks();
+
+          await waitFor(() => {
+            expect(popupRoot.style.getPropertyValue('--popup-width')).toBe('auto');
+          });
+          await waitFor(() => {
+            expect(popupRoot.style.getPropertyValue('--popup-height')).toBe('auto');
+          });
+
+          expect(positioner.style.getPropertyValue('--positioner-width')).toBe('250px');
+          expect(positioner.style.getPropertyValue('--positioner-height')).toBe('220px');
+        } finally {
+          globalThis.ResizeObserver = originalResizeObserver;
         }
       });
 

--- a/packages/react/src/navigation-menu/root/NavigationMenuRootContext.test.ts
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRootContext.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, expect, vi } from 'vitest';
+import { isJSDOM } from '#test-utils';
+
+describe('NavigationMenuRootContext', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('sets a development display name', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.resetModules();
+
+    const { NavigationMenuRootContext } = await import('./NavigationMenuRootContext');
+    expect(NavigationMenuRootContext.displayName).toBe('NavigationMenuRootContext');
+  });
+
+  it.skipIf(!isJSDOM)('omits the display name in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.resetModules();
+
+    const { NavigationMenuRootContext } = await import('./NavigationMenuRootContext');
+    expect(NavigationMenuRootContext.displayName).toBe(undefined);
+  });
+});

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -245,6 +245,10 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
           setSharedFixedSize(popup, positioner, currentWidth, currentHeight);
 
           sizeFrame.request(() => {
+            if (!isActiveItemRef.current) {
+              return;
+            }
+
             setSharedFixedSize(popup, positioner, measuredWidth, measuredHeight);
             scheduleAutoSizeReset(popup);
           });
@@ -519,6 +523,10 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   });
 
   function getScope() {
+    if (nested && positionerElement) {
+      return null;
+    }
+
     return triggerElementRef.current?.closest('ul') ?? null;
   }
 
@@ -527,7 +535,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     move: false,
     handleClose: safePolygon({
       blockPointerEvents: shouldBlockSafePolygonPointerEvents,
-      getScope: nested && positionerElement ? undefined : getScope,
+      getScope,
     }),
     restMs: mounted && positionerElement ? 0 : delay,
     delay: { close: closeDelay },
@@ -700,12 +708,13 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
       if (
         positionerElement &&
         popupElement &&
-        isOutsideMenuEvent(event.relatedTarget as HTMLElement | null, {
-          popupElement,
-          rootRef,
-          tree: tree!,
-          nodeId,
-        })
+        isOutsideMenuEvent(
+          {
+            currentTarget: event.currentTarget,
+            relatedTarget: event.relatedTarget as HTMLElement | null,
+          },
+          { popupElement, rootRef, tree, nodeId },
+        )
       ) {
         setValue(null, createChangeEventDetails(REASONS.focusOut, event.nativeEvent));
       }

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { isHTMLElement } from '@floating-ui/utils/dom';
 import { addEventListener } from '@base-ui/utils/addEventListener';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { ownerWindow } from '@base-ui/utils/owner';
@@ -158,27 +157,19 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     cancelAutoSizeReset();
   }, [isActiveItem, mutationFrame, sizeFrame, cancelAutoSizeReset]);
 
-  function setAutoSizes() {
-    if (!popupElement) {
-      return;
-    }
-
-    popupElement.style.setProperty(NavigationMenuPopupCssVars.popupWidth, 'auto');
-    popupElement.style.setProperty(NavigationMenuPopupCssVars.popupHeight, 'auto');
+  function setAutoSizes(element: HTMLElement) {
+    element.style.setProperty(NavigationMenuPopupCssVars.popupWidth, 'auto');
+    element.style.setProperty(NavigationMenuPopupCssVars.popupHeight, 'auto');
   }
 
-  function clearFixedSizes() {
-    if (!popupElement || !positionerElement) {
-      return;
-    }
-
-    popupElement.style.removeProperty(NavigationMenuPopupCssVars.popupWidth);
-    popupElement.style.removeProperty(NavigationMenuPopupCssVars.popupHeight);
-    positionerElement.style.removeProperty(NavigationMenuPositionerCssVars.positionerWidth);
-    positionerElement.style.removeProperty(NavigationMenuPositionerCssVars.positionerHeight);
+  function clearFixedSizes(popup: HTMLElement, positioner: HTMLElement) {
+    popup.style.removeProperty(NavigationMenuPopupCssVars.popupWidth);
+    popup.style.removeProperty(NavigationMenuPopupCssVars.popupHeight);
+    positioner.style.removeProperty(NavigationMenuPositionerCssVars.positionerWidth);
+    positioner.style.removeProperty(NavigationMenuPositionerCssVars.positionerHeight);
   }
 
-  function scheduleAutoSizeReset() {
+  function scheduleAutoSizeReset(popup: HTMLElement) {
     cancelAutoSizeReset(true);
 
     const abortController = new AbortController();
@@ -186,37 +177,19 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     popupAutoSizeResetRef.current.owner = itemValue;
 
     runOnceAnimationsFinish(() => {
-      if (
-        popupAutoSizeResetRef.current.abortController !== abortController ||
-        popupAutoSizeResetRef.current.owner !== itemValue
-      ) {
-        return;
-      }
-
       popupAutoSizeResetRef.current.abortController = null;
       popupAutoSizeResetRef.current.owner = null;
-      setAutoSizes();
+      setAutoSizes(popup);
     }, abortController.signal);
   }
 
   const handleValueChange = useStableCallback(
-    (
-      currentWidth: number,
-      currentHeight: number,
-      options: {
-        syncPositioner?: boolean | undefined;
-      } = {},
-    ) => {
-      if (!popupElement || !positionerElement) {
-        return;
-      }
-
+    (popup: HTMLElement, positioner: HTMLElement, currentWidth: number, currentHeight: number) => {
       cancelAutoSizeReset(true);
-      const { syncPositioner = false } = options;
 
-      clearFixedSizes();
+      clearFixedSizes(popup, positioner);
 
-      const { width, height } = getCssDimensions(popupElement);
+      const { width, height } = getCssDimensions(popup);
       const measuredWidth = width || prevSizeRef.current.width;
       const measuredHeight = height || prevSizeRef.current.height;
 
@@ -225,15 +198,15 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
         currentHeight = measuredHeight;
       }
 
-      popupElement.style.setProperty(NavigationMenuPopupCssVars.popupWidth, `${currentWidth}px`);
-      popupElement.style.setProperty(NavigationMenuPopupCssVars.popupHeight, `${currentHeight}px`);
-      positionerElement.style.setProperty(
+      popup.style.setProperty(NavigationMenuPopupCssVars.popupWidth, `${currentWidth}px`);
+      popup.style.setProperty(NavigationMenuPopupCssVars.popupHeight, `${currentHeight}px`);
+      positioner.style.setProperty(
         NavigationMenuPositionerCssVars.positionerWidth,
-        `${syncPositioner ? currentWidth : measuredWidth}px`,
+        `${measuredWidth}px`,
       );
-      positionerElement.style.setProperty(
+      positioner.style.setProperty(
         NavigationMenuPositionerCssVars.positionerHeight,
-        `${syncPositioner ? currentHeight : measuredHeight}px`,
+        `${measuredHeight}px`,
       );
 
       sizeFrame.request(() => {
@@ -241,34 +214,16 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
           return;
         }
 
-        popupElement.style.setProperty(NavigationMenuPopupCssVars.popupWidth, `${measuredWidth}px`);
-        popupElement.style.setProperty(
-          NavigationMenuPopupCssVars.popupHeight,
-          `${measuredHeight}px`,
-        );
+        popup.style.setProperty(NavigationMenuPopupCssVars.popupWidth, `${measuredWidth}px`);
+        popup.style.setProperty(NavigationMenuPopupCssVars.popupHeight, `${measuredHeight}px`);
 
-        if (syncPositioner) {
-          positionerElement.style.setProperty(
-            NavigationMenuPositionerCssVars.positionerWidth,
-            `${measuredWidth}px`,
-          );
-          positionerElement.style.setProperty(
-            NavigationMenuPositionerCssVars.positionerHeight,
-            `${measuredHeight}px`,
-          );
-        }
-
-        scheduleAutoSizeReset();
+        scheduleAutoSizeReset(popup);
       });
     },
   );
 
   const handleInterruptedMutationResize = useStableCallback(
-    (currentWidth: number, currentHeight: number) => {
-      if (!popupElement || !positionerElement) {
-        return;
-      }
-
+    (popup: HTMLElement, positioner: HTMLElement, currentWidth: number, currentHeight: number) => {
       sizeFrame.cancel();
       mutationFrame.cancel();
       cancelAutoSizeReset(true);
@@ -277,66 +232,48 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
         return;
       }
 
-      setSharedFixedSize(popupElement, positionerElement, currentWidth, currentHeight);
+      setSharedFixedSize(popup, positioner, currentWidth, currentHeight);
 
       mutationFrame.request(() => {
         mutationFrame.request(() => {
-          clearFixedSizes();
+          clearFixedSizes(popup, positioner);
 
-          const { width, height } = getCssDimensions(popupElement);
-          const measuredWidth = width || currentWidth || prevSizeRef.current.width;
-          const measuredHeight = height || currentHeight || prevSizeRef.current.height;
+          const { width, height } = getCssDimensions(popup);
+          const measuredWidth = width || currentWidth;
+          const measuredHeight = height || currentHeight;
 
-          setSharedFixedSize(popupElement, positionerElement, currentWidth, currentHeight);
+          setSharedFixedSize(popup, positioner, currentWidth, currentHeight);
 
           sizeFrame.request(() => {
-            if (!isActiveItemRef.current) {
-              return;
-            }
-
-            setSharedFixedSize(popupElement, positionerElement, measuredWidth, measuredHeight);
-            scheduleAutoSizeReset();
+            setSharedFixedSize(popup, positioner, measuredWidth, measuredHeight);
+            scheduleAutoSizeReset(popup);
           });
         });
       });
     },
   );
 
-  const syncCurrentSize = useStableCallback(() => {
-    if (!popupElement || !positionerElement) {
-      return;
-    }
-
+  const syncCurrentSize = useStableCallback((popup: HTMLElement, positioner: HTMLElement) => {
     sizeFrame.cancel();
     cancelAutoSizeReset(true);
 
-    clearFixedSizes();
+    clearFixedSizes(popup, positioner);
 
-    const { width, height } = getCssDimensions(popupElement);
+    const { width, height } = getCssDimensions(popup);
 
     if (width === 0 || height === 0) {
       return;
     }
 
     prevSizeRef.current = { width, height };
-    setAutoSizes();
-    positionerElement.style.setProperty(
-      NavigationMenuPositionerCssVars.positionerWidth,
-      `${width}px`,
-    );
-    positionerElement.style.setProperty(
-      NavigationMenuPositionerCssVars.positionerHeight,
-      `${height}px`,
-    );
+    setAutoSizes(popup);
+    positioner.style.setProperty(NavigationMenuPositionerCssVars.positionerWidth, `${width}px`);
+    positioner.style.setProperty(NavigationMenuPositionerCssVars.positionerHeight, `${height}px`);
   });
 
-  const getMutationBaseline = useStableCallback(() => {
-    if (!popupElement) {
-      return { size: prevSizeRef.current, syncPositioner: false };
-    }
-
-    const popupWidth = popupElement.style.getPropertyValue(NavigationMenuPopupCssVars.popupWidth);
-    const popupHeight = popupElement.style.getPropertyValue(NavigationMenuPopupCssVars.popupHeight);
+  const getMutationBaseline = useStableCallback((popup: HTMLElement) => {
+    const popupWidth = popup.style.getPropertyValue(NavigationMenuPopupCssVars.popupWidth);
+    const popupHeight = popup.style.getPropertyValue(NavigationMenuPopupCssVars.popupHeight);
     const isResizing =
       popupWidth !== '' && popupWidth !== 'auto' && popupHeight !== '' && popupHeight !== 'auto';
 
@@ -346,8 +283,8 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
 
     return {
       size: {
-        width: popupElement.offsetWidth || prevSizeRef.current.width,
-        height: popupElement.offsetHeight || prevSizeRef.current.height,
+        width: popup.offsetWidth || prevSizeRef.current.width,
+        height: popup.offsetHeight || prevSizeRef.current.height,
       },
       syncPositioner: true,
     };
@@ -395,10 +332,12 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
       return undefined;
     }
 
-    const win = ownerWindow(positionerElement);
+    const popup = popupElement;
+    const positioner = positionerElement;
+    const win = ownerWindow(positioner);
     function handleResize() {
       resizeFrame.cancel();
-      resizeFrame.request(syncCurrentSize);
+      resizeFrame.request(() => syncCurrentSize(popup, positioner));
     }
 
     const unsubscribe = addEventListener(win, 'resize', handleResize);
@@ -415,6 +354,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     if (
       !observedElement ||
       !popupElement ||
+      !positionerElement ||
       !isActiveItem ||
       typeof MutationObserver !== 'function'
     ) {
@@ -426,18 +366,18 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
         transitionStatus === 'starting' ||
         popupElement.hasAttribute(TransitionStatusDataAttributes.startingStyle)
       ) {
-        syncCurrentSize();
+        syncCurrentSize(popupElement, positionerElement);
         return;
       }
 
-      const { size, syncPositioner } = getMutationBaseline();
+      const { size, syncPositioner } = getMutationBaseline(popupElement);
 
       if (syncPositioner) {
-        handleInterruptedMutationResize(size.width, size.height);
+        handleInterruptedMutationResize(popupElement, positionerElement, size.width, size.height);
         return;
       }
 
-      handleValueChange(size.width, size.height);
+      handleValueChange(popupElement, positionerElement, size.width, size.height);
     });
 
     mutationObserver.observe(observedElement, {
@@ -456,6 +396,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   }, [
     currentContentRef,
     popupElement,
+    positionerElement,
     isActiveItem,
     transitionStatus,
     getMutationBaseline,
@@ -478,26 +419,14 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   }, [beforeOutsideRef, focusFrame, isActiveItem, open, popupElement]);
 
   useIsoLayoutEffect(() => {
-    if (isActiveItemRef.current && open && popupElement) {
-      const hasNestedMenu = currentContentRef.current?.querySelector('[data-nested]') != null;
-
-      if (transitionStatus === 'starting' && hasNestedMenu) {
-        // Inline nested menus can reveal their default content after the
-        // top-level content enters the viewport. Defer once so the opening
-        // size is measured from the final nested content, not the shell.
-        sizeFrame.request(syncCurrentSize);
-        return () => {
-          sizeFrame.cancel();
-        };
-      }
-
+    if (isActiveItemRef.current && open && popupElement && positionerElement) {
       if (skipAutoSizeSyncRef.current) {
         skipAutoSizeSyncRef.current = false;
         return undefined;
       }
 
       const { width, height } = getCssDimensions(popupElement);
-      handleValueChange(width, height);
+      handleValueChange(popupElement, positionerElement, width, height);
     }
     return undefined;
   }, [
@@ -506,8 +435,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     isActiveItemRef,
     open,
     popupElement,
-    sizeFrame,
-    syncCurrentSize,
+    positionerElement,
     transitionStatus,
   ]);
 
@@ -591,11 +519,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   });
 
   function getScope() {
-    if (!nested || !positionerElement) {
-      return triggerElementRef.current?.closest('ul') ?? null;
-    }
-
-    return null;
+    return triggerElementRef.current?.closest('ul') ?? null;
   }
 
   const hoverProps = useHoverReferenceInteraction(context, {
@@ -603,7 +527,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     move: false,
     handleClose: safePolygon({
       blockPointerEvents: shouldBlockSafePolygonPointerEvents,
-      getScope,
+      getScope: nested && positionerElement ? undefined : getScope,
     }),
     restMs: mounted && positionerElement ? 0 : delay,
     delay: { close: closeDelay },
@@ -635,7 +559,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
 
   function handleActivation(event: React.MouseEvent | React.KeyboardEvent) {
     ReactDOM.flushSync(() => {
-      const currentTarget = isHTMLElement(event.currentTarget) ? event.currentTarget : null;
+      const currentTarget = event.currentTarget as HTMLElement;
       const prevTriggerRect = prevTriggerElementRef.current?.getBoundingClientRect();
 
       if (mounted && prevTriggerRect && triggerElement) {
@@ -677,8 +601,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
         event.type === 'mouseenter' &&
         shouldBlockSafePolygonPointerEvents &&
         (!nested || !positionerElement) &&
-        hoverFloatingElement &&
-        currentTarget
+        hoverFloatingElement
       ) {
         const applyPointerEventsMutation = () => {
           const scopeElement = getScope() ?? currentTarget.ownerDocument.body;
@@ -719,7 +642,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
       skipAutoSizeSyncRef.current = true;
     }
 
-    handleValueChange(width, height);
+    handleValueChange(popupElement, positionerElement, width, height);
   });
 
   const state: NavigationMenuTriggerState = {
@@ -777,13 +700,12 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
       if (
         positionerElement &&
         popupElement &&
-        isOutsideMenuEvent(
-          {
-            currentTarget: event.currentTarget,
-            relatedTarget: event.relatedTarget as HTMLElement | null,
-          },
-          { popupElement, rootRef, tree, nodeId },
-        )
+        isOutsideMenuEvent(event.relatedTarget as HTMLElement | null, {
+          popupElement,
+          rootRef,
+          tree: tree!,
+          nodeId,
+        })
       ) {
         setValue(null, createChangeEventDetails(REASONS.focusOut, event.nativeEvent));
       }

--- a/packages/react/src/navigation-menu/utils/isOutsideMenuEvent.ts
+++ b/packages/react/src/navigation-menu/utils/isOutsideMenuEvent.ts
@@ -1,21 +1,33 @@
 import { FloatingTreeType } from '../../floating-ui-react';
 import { contains, getNodeChildren } from '../../floating-ui-react/utils';
 
+interface Targets {
+  currentTarget: HTMLElement | null;
+  relatedTarget: HTMLElement | null;
+}
+
 interface Params {
-  popupElement: HTMLElement;
+  popupElement: HTMLElement | null;
   rootRef: React.RefObject<HTMLDivElement | null>;
-  tree: FloatingTreeType;
+  tree: FloatingTreeType | null;
   nodeId: string | undefined;
 }
 
-export function isOutsideMenuEvent(relatedTarget: HTMLElement | null, params: Params) {
+export function isOutsideMenuEvent({ currentTarget, relatedTarget }: Targets, params: Params) {
   const { popupElement, rootRef, tree, nodeId } = params;
 
-  const nodeChildrenContains = getNodeChildren(tree.nodesRef.current, nodeId).some((node) =>
-    contains(node.context?.elements.floating, relatedTarget),
-  );
+  const nodeChildrenContains = tree
+    ? getNodeChildren(tree.nodesRef.current, nodeId).some((node) =>
+        contains(node.context?.elements.floating, relatedTarget),
+      )
+    : false;
+
+  if (!popupElement) {
+    return !contains(rootRef.current, relatedTarget) && !nodeChildrenContains;
+  }
 
   return (
+    !contains(popupElement, currentTarget) &&
     !contains(popupElement, relatedTarget) &&
     !contains(rootRef.current, relatedTarget) &&
     !nodeChildrenContains

--- a/packages/react/src/navigation-menu/utils/isOutsideMenuEvent.ts
+++ b/packages/react/src/navigation-menu/utils/isOutsideMenuEvent.ts
@@ -1,41 +1,23 @@
 import { FloatingTreeType } from '../../floating-ui-react';
 import { contains, getNodeChildren } from '../../floating-ui-react/utils';
 
-interface Targets {
-  currentTarget: HTMLElement | null;
-  relatedTarget: HTMLElement | null;
-}
-
 interface Params {
-  popupElement: HTMLElement | null;
+  popupElement: HTMLElement;
   rootRef: React.RefObject<HTMLDivElement | null>;
-  tree: FloatingTreeType | null;
+  tree: FloatingTreeType;
   nodeId: string | undefined;
 }
 
-export function isOutsideMenuEvent({ currentTarget, relatedTarget }: Targets, params: Params) {
+export function isOutsideMenuEvent(relatedTarget: HTMLElement | null, params: Params) {
   const { popupElement, rootRef, tree, nodeId } = params;
 
-  const nodeChildrenContains = tree
-    ? getNodeChildren(tree.nodesRef.current, nodeId).some((node) =>
-        contains(node.context?.elements.floating, relatedTarget),
-      )
-    : [];
-
-  // For nested scenarios without popupElement, we need to be more lenient
-  // and only close if we're definitely outside the root
-  if (!popupElement) {
-    return !contains(rootRef.current, relatedTarget) && !nodeChildrenContains;
-  }
+  const nodeChildrenContains = getNodeChildren(tree.nodesRef.current, nodeId).some((node) =>
+    contains(node.context?.elements.floating, relatedTarget),
+  );
 
   return (
-    !contains(popupElement, currentTarget) &&
     !contains(popupElement, relatedTarget) &&
     !contains(rootRef.current, relatedTarget) &&
-    !nodeChildrenContains &&
-    !(
-      contains(popupElement, relatedTarget) &&
-      relatedTarget?.hasAttribute('data-base-ui-focus-guard')
-    )
+    !nodeChildrenContains
   );
 }


### PR DESCRIPTION
Expands Navigation Menu test coverage to 100% across statements, branches, functions, and lines, including focus, pointer, sizing, and composition interactions in jsdom and Chromium.