### PR TITLE
[popover] Expand test coverage

### DIFF
--- a/packages/react/src/popover/close/PopoverClose.test.tsx
+++ b/packages/react/src/popover/close/PopoverClose.test.tsx
@@ -1,7 +1,8 @@
 import { expect, vi } from 'vitest';
+import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 import { REASONS } from '../../internals/reasons';
 
@@ -111,6 +112,73 @@ describe('<Popover.Close />', () => {
     expect(handleOpenChange.mock.calls[0][0]).toBe(false);
     expect(handleOpenChange.mock.calls[0][1].reason).toBe(REASONS.closePress);
     expect(handleOpenChange.mock.calls[0][1].trigger?.id).toBe('trigger-1');
+  });
+
+  // `triggerId` can point at a trigger that isn't mounted (for example while a controlled id is
+  // being handed over), but the popup is still anchored to the element it opened against, so the
+  // close event has to report that element rather than nothing.
+  it('falls back to the active trigger element when the active trigger id is unregistered', async () => {
+    const handleOpenChange = vi.fn();
+    let repoint: () => void = () => {};
+
+    function App() {
+      const [triggerId, setTriggerId] = React.useState<string | null>('trigger-1');
+      repoint = () => setTriggerId('unregistered');
+
+      return (
+        <Popover.Root open triggerId={triggerId} onOpenChange={handleOpenChange}>
+          <Popover.Trigger id="trigger-1">Trigger</Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup>
+                Content
+                <Popover.Close data-testid="close" />
+              </Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>
+      );
+    }
+
+    await render(<App />);
+
+    await act(async () => {
+      repoint();
+    });
+
+    fireEvent.click(screen.getByTestId('close'));
+
+    expect(handleOpenChange).toHaveBeenCalledTimes(1);
+    expect(handleOpenChange.mock.calls[0][1].reason).toBe(REASONS.closePress);
+    expect(handleOpenChange.mock.calls[0][1].trigger).toBe(
+      screen.getByRole('button', {
+        name: 'Trigger',
+      }),
+    );
+  });
+
+  it('reports no trigger when the active trigger id has no mounted trigger', async () => {
+    const handleOpenChange = vi.fn();
+
+    await render(
+      <Popover.Root defaultOpen defaultTriggerId="never-mounted" onOpenChange={handleOpenChange}>
+        <Popover.Portal>
+          <Popover.Positioner>
+            <Popover.Popup>
+              Content
+              <Popover.Close data-testid="close" />
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>,
+    );
+
+    fireEvent.click(screen.getByTestId('close'));
+
+    expect(screen.queryByText('Content')).toBe(null);
+    expect(handleOpenChange).toHaveBeenCalledTimes(1);
+    expect(handleOpenChange.mock.calls[0][1].reason).toBe(REASONS.closePress);
+    expect(handleOpenChange.mock.calls[0][1].trigger).toBe(undefined);
   });
 
   it('enables modal focus management when `modal=true` and close is rendered', async () => {

--- a/packages/react/src/popover/enumSync.test.tsx
+++ b/packages/react/src/popover/enumSync.test.tsx
@@ -1,0 +1,311 @@
+import * as React from 'react';
+import { expect } from 'vitest';
+import { Popover } from '@base-ui/react/popover';
+import { screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, isJSDOM } from '#test-utils';
+import { PopoverArrowDataAttributes } from './arrow/PopoverArrowDataAttributes';
+import { PopoverBackdropDataAttributes } from './backdrop/PopoverBackdropDataAttributes';
+import { PopoverPopupCssVars } from './popup/PopoverPopupCssVars';
+import { PopoverPopupDataAttributes } from './popup/PopoverPopupDataAttributes';
+import { PopoverPositionerCssVars } from './positioner/PopoverPositionerCssVars';
+import { PopoverPositionerDataAttributes } from './positioner/PopoverPositionerDataAttributes';
+import { PopoverTriggerDataAttributes } from './trigger/PopoverTriggerDataAttributes';
+import { PopoverViewportCssVars } from './viewport/PopoverViewportCssVars';
+import { PopoverViewportDataAttributes } from './viewport/PopoverViewportDataAttributes';
+import { popupStateMapping } from '../utils/popupStateMapping';
+import { transitionStatusMapping } from '../internals/stateAttributesMapping';
+import { popupViewportStateMapping } from '../utils/usePopupViewport';
+
+// The parts emit these attribute names as inlined string literals so the enums below stay
+// tree-shakeable (they exist for types and docs only). Nothing else links the literals to the
+// enums, so re-link every member of every enum in this module here: renaming only one side fails
+// CI.
+describe('Popover enum sync', () => {
+  const { render } = createRenderer();
+
+  async function renderPopover() {
+    return render(
+      <Popover.Root>
+        <Popover.Trigger>Toggle</Popover.Trigger>
+        <Popover.Backdrop data-testid="backdrop" />
+        <Popover.Portal keepMounted>
+          <Popover.Positioner data-testid="positioner">
+            <Popover.Popup data-testid="popup">
+              <Popover.Arrow data-testid="arrow" />
+              <Popover.Viewport data-testid="viewport">Content</Popover.Viewport>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>,
+    );
+  }
+
+  it('names the open/closed attributes on every part per its data attributes enum', async () => {
+    const { user } = await renderPopover();
+
+    expect(screen.getByTestId('positioner')).toHaveAttribute(
+      PopoverPositionerDataAttributes.closed,
+    );
+    expect(screen.getByTestId('popup')).toHaveAttribute(PopoverPopupDataAttributes.closed);
+    expect(screen.getByTestId('backdrop')).toHaveAttribute(PopoverBackdropDataAttributes.closed);
+
+    await user.click(screen.getByRole('button', { name: 'Toggle' }));
+
+    expect(screen.getByTestId('positioner')).toHaveAttribute(PopoverPositionerDataAttributes.open);
+    expect(screen.getByTestId('popup')).toHaveAttribute(PopoverPopupDataAttributes.open);
+    expect(screen.getByTestId('backdrop')).toHaveAttribute(PopoverBackdropDataAttributes.open);
+    expect(screen.getByTestId('arrow')).toHaveAttribute(PopoverArrowDataAttributes.open);
+  });
+
+  it('names the trigger attributes per PopoverTriggerDataAttributes', async () => {
+    const { user } = await renderPopover();
+
+    const trigger = screen.getByRole('button', { name: 'Toggle' });
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute(PopoverTriggerDataAttributes.popupOpen);
+    expect(trigger).toHaveAttribute(PopoverTriggerDataAttributes.pressed);
+  });
+
+  it('names the side/align attributes per each part data attributes enum', async () => {
+    const { user } = await renderPopover();
+
+    await user.click(screen.getByRole('button', { name: 'Toggle' }));
+
+    for (const [testId, attributes] of [
+      ['positioner', PopoverPositionerDataAttributes],
+      ['popup', PopoverPopupDataAttributes],
+      ['arrow', PopoverArrowDataAttributes],
+    ] as const) {
+      expect(screen.getByTestId(testId)).toHaveAttribute(attributes.side);
+      expect(screen.getByTestId(testId)).toHaveAttribute(attributes.align);
+    }
+  });
+
+  it('names the instant attribute per the popup and viewport data attributes enums', async () => {
+    const { user } = await renderPopover();
+
+    await user.click(screen.getByRole('button', { name: 'Toggle' }));
+    await user.keyboard('[Escape]');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('popup')).toHaveAttribute(
+        PopoverPopupDataAttributes.instant,
+        'dismiss',
+      );
+    });
+
+    expect(screen.getByTestId('viewport')).toHaveAttribute(
+      PopoverViewportDataAttributes.instant,
+      'dismiss',
+    );
+  });
+
+  it('names the viewport `current` attribute per PopoverViewportDataAttributes', async () => {
+    const { user } = await renderPopover();
+
+    await user.click(screen.getByRole('button', { name: 'Toggle' }));
+
+    expect(
+      screen.getByTestId('viewport').querySelector(`[${PopoverViewportDataAttributes.current}]`),
+    ).not.toBe(null);
+  });
+
+  // Covers the members the DOM assertions above can't reach without contriving a transition or a
+  // collision, so that every member of every enum in this module is linked to something real.
+  it('names the attributes emitted by the shared popup state mappings', () => {
+    const openAttribute = Object.keys(popupStateMapping.open(true)!)[0];
+    const closedAttribute = Object.keys(popupStateMapping.open(false)!)[0];
+
+    for (const attributes of [
+      PopoverPopupDataAttributes,
+      PopoverPositionerDataAttributes,
+      PopoverBackdropDataAttributes,
+      PopoverArrowDataAttributes,
+    ]) {
+      expect(attributes.open).toBe(openAttribute);
+      expect(attributes.closed).toBe(closedAttribute);
+    }
+
+    const startingAttribute = Object.keys(transitionStatusMapping.transitionStatus('starting')!)[0];
+    const endingAttribute = Object.keys(transitionStatusMapping.transitionStatus('ending')!)[0];
+
+    for (const attributes of [PopoverPopupDataAttributes, PopoverBackdropDataAttributes]) {
+      expect(attributes.startingStyle).toBe(startingAttribute);
+      expect(attributes.endingStyle).toBe(endingAttribute);
+    }
+
+    expect(PopoverPositionerDataAttributes.anchorHidden).toBe(
+      Object.keys(popupStateMapping.anchorHidden(true)!)[0],
+    );
+    expect(PopoverViewportDataAttributes.activationDirection).toBe(
+      Object.keys(popupViewportStateMapping.activationDirection!('left down')!)[0],
+    );
+  });
+
+  // The arrow only reports itself as uncentered once a collision shifts the popup away from the
+  // anchor's center, which needs real layout.
+  it.skipIf(isJSDOM)('names the uncentered attribute per PopoverArrowDataAttributes', async () => {
+    const { user } = await render(
+      <Popover.Root>
+        <Popover.Trigger style={{ position: 'fixed', top: 8, left: 0, width: 20, height: 20 }}>
+          Toggle
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Positioner side="bottom" align="center" arrowPadding={8}>
+            <Popover.Popup style={{ width: 300, height: 40 }}>
+              <Popover.Arrow data-testid="arrow" style={{ width: 10, height: 10 }} />
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Toggle' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('arrow')).toHaveAttribute(PopoverArrowDataAttributes.uncentered);
+    });
+  });
+
+  it.skipIf(isJSDOM)(
+    'names the positioner CSS variables per PopoverPositionerCssVars',
+    async () => {
+      const { user } = await renderPopover();
+
+      await user.click(screen.getByRole('button', { name: 'Toggle' }));
+
+      const positioner = screen.getByTestId('positioner');
+
+      // A single positioning pass writes all of them, so waiting for one is enough.
+      await waitFor(() => {
+        expect(positioner.style.getPropertyValue(PopoverPositionerCssVars.availableWidth)).not.toBe(
+          '',
+        );
+      });
+
+      expect(positioner.style.getPropertyValue(PopoverPositionerCssVars.availableHeight)).not.toBe(
+        '',
+      );
+      expect(positioner.style.getPropertyValue(PopoverPositionerCssVars.anchorWidth)).not.toBe('');
+      expect(positioner.style.getPropertyValue(PopoverPositionerCssVars.anchorHeight)).not.toBe('');
+      expect(positioner.style.getPropertyValue(PopoverPositionerCssVars.transformOrigin)).not.toBe(
+        '',
+      );
+    },
+  );
+
+  // Only `Popover.Viewport` pulls in the auto-resize pass that writes these, so they exist on the
+  // popup and positioner just by rendering one.
+  it.skipIf(isJSDOM)('names the size CSS variables written by the viewport', async () => {
+    const { user } = await renderPopover();
+
+    await user.click(screen.getByRole('button', { name: 'Toggle' }));
+
+    const positioner = screen.getByTestId('positioner');
+    const popup = screen.getByTestId('popup');
+
+    await waitFor(() => {
+      expect(positioner.style.getPropertyValue(PopoverPositionerCssVars.positionerWidth)).not.toBe(
+        '',
+      );
+    });
+    await waitFor(() => {
+      expect(positioner.style.getPropertyValue(PopoverPositionerCssVars.positionerHeight)).not.toBe(
+        '',
+      );
+    });
+    await waitFor(() => {
+      expect(popup.style.getPropertyValue(PopoverPopupCssVars.popupWidth)).not.toBe('');
+    });
+    await waitFor(() => {
+      expect(popup.style.getPropertyValue(PopoverPopupCssVars.popupHeight)).not.toBe('');
+    });
+  });
+
+  describe.skipIf(isJSDOM)('mid-transition viewport', () => {
+    beforeEach(() => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+    });
+
+    afterEach(() => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+    });
+
+    // The `previous` container and its size variables only exist while the viewport morphs
+    // between two triggers' contents, which requires a running exit animation.
+    it('names the `previous` attribute and CSS variables per their enums', async () => {
+      const { user } = await render(
+        <div>
+          <style>
+            {`
+              [data-transitioning] [data-previous] {
+                animation: fade-out 0.3s ease-out forwards;
+              }
+              [data-transitioning] [data-current] {
+                animation: fade-in 0.3s ease-out forwards;
+              }
+              @keyframes fade-out {
+                from { opacity: 1; }
+                to { opacity: 0; }
+              }
+              @keyframes fade-in {
+                from { opacity: 0; }
+                to { opacity: 1; }
+              }
+            `}
+          </style>
+          <Popover.Root>
+            {({ payload }) => (
+              <React.Fragment>
+                <Popover.Trigger
+                  payload="One"
+                  style={{ position: 'absolute', top: 10, left: 10, width: 100, height: 50 }}
+                >
+                  One
+                </Popover.Trigger>
+                <Popover.Trigger
+                  payload="Two"
+                  style={{ position: 'absolute', top: 100, left: 200, width: 100, height: 50 }}
+                >
+                  Two
+                </Popover.Trigger>
+                <Popover.Portal>
+                  <Popover.Positioner>
+                    <Popover.Popup>
+                      <Popover.Viewport data-testid="viewport">
+                        <div data-testid="content" style={{ width: 100, height: 40 }}>
+                          {payload as string}
+                        </div>
+                      </Popover.Viewport>
+                    </Popover.Popup>
+                  </Popover.Positioner>
+                </Popover.Portal>
+              </React.Fragment>
+            )}
+          </Popover.Root>
+        </div>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'One' }));
+      await waitFor(() => {
+        expect(screen.getByTestId('content')).toBeVisible();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Two' }));
+
+      const viewport = screen.getByTestId('viewport');
+      let previous: HTMLElement | null = null;
+      await waitFor(() => {
+        previous = viewport.querySelector<HTMLElement>(
+          `[${PopoverViewportDataAttributes.previous}]`,
+        );
+        expect(previous).not.toBe(null);
+      });
+
+      expect(viewport).toHaveAttribute(PopoverViewportDataAttributes.transitioning);
+      expect(previous!.style.getPropertyValue(PopoverViewportCssVars.popupWidth)).not.toBe('');
+      expect(previous!.style.getPropertyValue(PopoverViewportCssVars.popupHeight)).not.toBe('');
+    });
+  });
+});

--- a/packages/react/src/popover/popup/PopoverPopup.test.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.test.tsx
@@ -1,6 +1,7 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
+import { Toolbar } from '@base-ui/react/toolbar';
 import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM, waitSingleFrame } from '#test-utils';
 
@@ -20,6 +21,38 @@ describe('<Popover.Popup />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <Popover.Root>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Popover.Popup />)).rejects.toThrow(
+        'Base UI: PopoverRootContext is missing. Popover parts must be placed within <Popover.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('throws a descriptive error when rendered outside <Popover.Positioner>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Popover.Root open>
+            <Popover.Portal>
+              <Popover.Popup />
+            </Popover.Portal>
+          </Popover.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: PopoverPositionerContext is missing. PopoverPositioner parts must be placed within <Popover.Positioner>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   it('should render the children', async () => {
     await render(
@@ -618,6 +651,82 @@ describe('<Popover.Popup />', () => {
       await waitFor(() => {
         expect(trigger).toHaveFocus();
       });
+    });
+  });
+
+  describe('inside a toolbar', () => {
+    function ToolbarPopover({ children }: { children: React.ReactNode }) {
+      return (
+        <Toolbar.Root>
+          <Toolbar.Button>First</Toolbar.Button>
+          <Popover.Root>
+            <Toolbar.Button render={<Popover.Trigger />}>Open</Toolbar.Button>
+            <Popover.Portal>
+              <Popover.Positioner>
+                <Popover.Popup>{children}</Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          </Popover.Root>
+          <Toolbar.Button>Last</Toolbar.Button>
+        </Toolbar.Root>
+      );
+    }
+
+    // The popup is portaled but still bubbles React events up to `Toolbar.Root`, whose composite
+    // handler would move the roving highlight and pull focus out of the open popup.
+    it('does not relay composite keys from the popup to the toolbar', async () => {
+      const { user } = await render(
+        <ToolbarPopover>
+          <button type="button">Inside</button>
+        </ToolbarPopover>,
+      );
+
+      // The toolbar itself still navigates with the same key, so a passing assertion below can't
+      // come from an inert toolbar.
+      await user.keyboard('[Tab]');
+      expect(screen.getByRole('button', { name: 'First' })).toHaveFocus();
+      await user.keyboard('[ArrowRight]');
+      const trigger = screen.getByRole('button', { name: 'Open' });
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
+      });
+
+      await user.keyboard('[Enter]');
+      const insideButton = screen.getByRole('button', { name: 'Inside' });
+      await waitFor(() => {
+        expect(insideButton).toHaveFocus();
+      });
+
+      await user.keyboard('[ArrowRight]');
+      await flushMicrotasks();
+
+      expect(insideButton).toHaveFocus();
+      expect(screen.getByRole('button', { name: 'Last' })).not.toHaveFocus();
+    });
+
+    // Shielding the toolbar must not disable the keys inside the popup: only propagation is
+    // stopped, so native caret movement in popup content keeps working.
+    it('keeps composite keys working inside the popup content', async () => {
+      const { user } = await render(
+        <ToolbarPopover>
+          <input defaultValue="ab" />
+        </ToolbarPopover>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Open' }));
+
+      const input = screen.getByRole('textbox') as HTMLInputElement;
+      await waitFor(() => {
+        expect(input).toHaveFocus();
+      });
+
+      await act(async () => {
+        input.setSelectionRange(0, 0);
+      });
+      await user.keyboard('[ArrowRight]');
+
+      expect(input.selectionStart).toBe(1);
+      expect(screen.getByRole('button', { name: 'Last' })).not.toHaveFocus();
     });
   });
 });

--- a/packages/react/src/popover/popup/PopoverPopupDataAttributes.ts
+++ b/packages/react/src/popover/popup/PopoverPopupDataAttributes.ts
@@ -21,12 +21,12 @@ export enum PopoverPopupDataAttributes {
    * Indicates which side the popup is positioned relative to the trigger.
    * @type {'top' | 'bottom' | 'left' | 'right' | 'inline-end' | 'inline-start'}
    */
-  side = 'data-side',
+  side = CommonPopupDataAttributes.side,
   /**
    * Indicates how the popup is aligned relative to specified side.
    * @type {'start' | 'center' | 'end'}
    */
-  align = 'data-align',
+  align = CommonPopupDataAttributes.align,
   /**
    * Present if animations should be instant.
    * @type {'click' | 'dismiss' | 'focus' | 'trigger-change'}

--- a/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Popover } from '@base-ui/react/popover';
@@ -27,6 +27,22 @@ describe('<Popover.Positioner />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <Popover.Portal>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Popover.Root open>
+            <Popover.Positioner />
+          </Popover.Root>,
+        ),
+      ).rejects.toThrow('Base UI: <Popover.Portal> is missing.');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   const baselineX = 10;
   const baselineY = 36;

--- a/packages/react/src/popover/root/PopoverRoot.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.tsx
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { useDismiss, FloatingTree } from '../../floating-ui-react';
 import { PopoverRootContext, usePopoverRootContext } from './PopoverRootContext';
 import { PopoverStore, type State as PopoverStoreState } from '../store/PopoverStore';
@@ -238,11 +237,13 @@ function PopoverInteractions({
     },
   });
 
+  // `useDismiss` is not given an `enabled` option, so it always returns both prop bags. Restore
+  // the `EMPTY_OBJECT` fallbacks if that ever changes: the store fields are non-optional.
   // `dismiss.trigger` is always the same object as `dismiss.reference`.
-  const triggerProps = dismiss.reference ?? EMPTY_OBJECT;
+  const triggerProps = dismiss.reference!;
   // PopoverPopup already spreads `FOCUSABLE_POPUP_PROPS` directly, so the popup
   // props only need to carry the dismiss handlers.
-  const popupProps = dismiss.floating ?? EMPTY_OBJECT;
+  const popupProps = dismiss.floating!;
 
   usePopupInteractionProps(store, {
     activeTriggerProps: triggerProps,

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -82,9 +82,9 @@ export class PopoverStore<Payload> extends ReactStore<
   Selectors
 > {
   constructor(
-    initialState?: Partial<State<Payload>>,
-    floatingId?: string | undefined,
-    nested = false,
+    initialState: Partial<State<Payload>>,
+    floatingId: string | undefined,
+    nested: boolean,
   ) {
     const triggerElements = new PopupTriggerMap();
     super(

--- a/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
@@ -1,4 +1,5 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
+import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import {
@@ -22,6 +23,18 @@ describe('<Popover.Trigger />', () => {
       return render(<Popover.Root open>{node}</Popover.Root>);
     },
   }));
+
+  it('throws a descriptive error when rendered without a root or a handle', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Popover.Trigger>Toggle</Popover.Trigger>)).rejects.toThrow(
+        'Base UI: <Popover.Trigger> must be either used within a <Popover.Root> component or provided with a handle.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   describe('prop: disabled', () => {
     it('disables the popover', async () => {
@@ -91,6 +104,85 @@ describe('<Popover.Trigger />', () => {
 
       expect(screen.queryByText('Content')).toBe(null);
       expect(trigger).not.toHaveAttribute('data-popup-open');
+    });
+  });
+
+  describe('openOnHover opened by touch', () => {
+    function MultiTriggerPopover() {
+      return (
+        <Popover.Root>
+          {({ payload }) => (
+            <React.Fragment>
+              <Popover.Trigger payload="One" openOnHover delay={0} closeDelay={0}>
+                One
+              </Popover.Trigger>
+              <Popover.Trigger payload="Two" openOnHover delay={0} closeDelay={0}>
+                Two
+              </Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Positioner>
+                  <Popover.Popup>
+                    <span data-testid="content">{payload as string}</span>
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </React.Fragment>
+          )}
+        </Popover.Root>
+      );
+    }
+
+    function pressTrigger(trigger: HTMLElement, pointerType: 'mouse' | 'touch') {
+      fireEvent.pointerDown(trigger, { pointerType });
+      fireEvent.mouseDown(trigger);
+      fireEvent.click(trigger, { detail: 1 });
+    }
+
+    function hoverTrigger(trigger: HTMLElement) {
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
+    }
+
+    // A touch tap leaves the pointer parked wherever the cursor happens to be, so hover must stay
+    // disarmed until the popover is reopened by some other means. Otherwise a stray hover over a
+    // sibling trigger silently swaps the content the user just tapped for.
+    it('keeps ownership on the tapped trigger when a sibling trigger is hovered', async () => {
+      await render(<MultiTriggerPopover />);
+
+      const one = screen.getByRole('button', { name: 'One' });
+      const two = screen.getByRole('button', { name: 'Two' });
+
+      pressTrigger(one, 'touch');
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('content')).toHaveTextContent('One');
+
+      hoverTrigger(two);
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('content')).toHaveTextContent('One');
+      expect(two).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    // The same hover must still take over when the popover was opened with a mouse, so the guard
+    // above can't be a blanket disable.
+    it('hands ownership to a hovered sibling trigger when opened by mouse', async () => {
+      await render(<MultiTriggerPopover />);
+
+      const one = screen.getByRole('button', { name: 'One' });
+      const two = screen.getByRole('button', { name: 'Two' });
+
+      pressTrigger(one, 'mouse');
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('content')).toHaveTextContent('One');
+
+      hoverTrigger(two);
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('content')).toHaveTextContent('Two');
+      expect(two).toHaveAttribute('aria-expanded', 'true');
     });
   });
 


### PR DESCRIPTION
Expands Popover test coverage to 100% across statements, branches, functions, and lines, including toolbar composition and touch-opened hover behavior in jsdom and Chromium.