### PR TITLE
[dialog] Expand test coverage

### DIFF
--- a/packages/react/src/dialog/close/DialogClose.test.tsx
+++ b/packages/react/src/dialog/close/DialogClose.test.tsx
@@ -1,6 +1,6 @@
 import { expect, vi } from 'vitest';
 import { Dialog } from '@base-ui/react/dialog';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Dialog.Close />', () => {
@@ -113,5 +113,44 @@ describe('<Dialog.Close />', () => {
 
     expect(handleOpenChange.mock.calls.length).toBe(2);
     expect(handleOpenChange.mock.calls[1][0]).toBe(false);
+  });
+
+  it('does not close the dialog when the Base UI click handler is prevented', async () => {
+    const handleOpenChange = vi.fn();
+
+    const { user } = await render(
+      <Dialog.Root defaultOpen modal={false} onOpenChange={handleOpenChange}>
+        <Dialog.Portal>
+          <Dialog.Popup>
+            <Dialog.Close onClick={(event) => event.preventBaseUIHandler()}>Close</Dialog.Close>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(screen.getByRole('dialog')).not.toBe(null);
+    expect(handleOpenChange.mock.calls.length).toBe(0);
+  });
+
+  it('does not request another close when clicked after the dialog has closed', async () => {
+    const handleOpenChange = vi.fn();
+    const handleClick = vi.fn();
+
+    await render(
+      <Dialog.Root open={false} modal={false} onOpenChange={handleOpenChange}>
+        <Dialog.Portal keepMounted>
+          <Dialog.Popup>
+            <Dialog.Close onClick={handleClick}>Close</Dialog.Close>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close', hidden: true }));
+
+    expect(handleClick.mock.calls.length).toBe(1);
+    expect(handleOpenChange.mock.calls.length).toBe(0);
   });
 });

--- a/packages/react/src/dialog/portal/DialogPortal.test.tsx
+++ b/packages/react/src/dialog/portal/DialogPortal.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Dialog } from '@base-ui/react/dialog';
 import { createRenderer, describeConformance } from '#test-utils';
@@ -13,6 +13,22 @@ describe('<Dialog.Portal />', () => {
       return render(<Dialog.Root open>{node}</Dialog.Root>);
     },
   }));
+
+  it('throws a descriptive error when a portaled part is rendered without <Dialog.Portal>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Dialog.Root open>
+            <Dialog.Viewport />
+          </Dialog.Root>,
+        ),
+      ).rejects.toThrow('Base UI: <Dialog.Portal> is missing.');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   describe('Suspense integration', () => {
     // Issue #3695

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -60,6 +60,25 @@ describe('<Dialog.Root />', () => {
       expect(screen.getByTestId('payload').textContent).toBe('1');
     });
 
+    it.skipIf(!isJSDOM)('does not warn for a detached payload open in production', () => {
+      const originalEnvironment = process.env.NODE_ENV;
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      process.env.NODE_ENV = 'production';
+
+      try {
+        const handle = Dialog.createHandle<number>();
+
+        handle.openWithPayload(8);
+
+        expect(handle.isOpen).toBe(false);
+        expect(consoleWarn.mock.calls.length).toBe(0);
+      } finally {
+        process.env.NODE_ENV = originalEnvironment;
+        consoleWarn.mockRestore();
+      }
+    });
+
     it('ignores imperative handle calls made after the root is detached', async () => {
       const handle = Dialog.createHandle<number>();
 

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -128,6 +128,61 @@ describe('<Dialog.Root />', () => {
       );
     });
 
+    it('keeps accessible names and descriptions in sync when label parts change', async () => {
+      function DynamicLabels() {
+        const [phase, setPhase] = React.useState(0);
+
+        return (
+          <React.Fragment>
+            {phase < 2 && <Dialog.Title key={`title-${phase}`}>Title {phase + 1}</Dialog.Title>}
+            {phase < 2 && (
+              <Dialog.Description key={`description-${phase}`}>
+                Description {phase + 1}
+              </Dialog.Description>
+            )}
+            <button onClick={() => setPhase((value) => value + 1)}>Change labels</button>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(
+        <TestDialog
+          rootProps={{ modal: false, open: true }}
+          popupProps={{ children: <DynamicLabels /> }}
+        />,
+      );
+
+      const popup = screen.getByRole('dialog');
+      const firstTitleId = screen.getByText('Title 1').getAttribute('id');
+      const firstDescriptionId = screen.getByText('Description 1').getAttribute('id');
+
+      expect(popup.getAttribute('aria-labelledby')).toBe(firstTitleId);
+      expect(popup.getAttribute('aria-describedby')).toBe(firstDescriptionId);
+
+      await user.click(screen.getByRole('button', { name: 'Change labels' }));
+
+      const secondTitleId = screen.getByText('Title 2').getAttribute('id');
+      const secondDescriptionId = screen.getByText('Description 2').getAttribute('id');
+
+      await waitFor(() => {
+        expect(popup.getAttribute('aria-labelledby')).toBe(secondTitleId);
+      });
+      await waitFor(() => {
+        expect(popup.getAttribute('aria-describedby')).toBe(secondDescriptionId);
+      });
+      expect(secondTitleId).not.toBe(firstTitleId);
+      expect(secondDescriptionId).not.toBe(firstDescriptionId);
+
+      await user.click(screen.getByRole('button', { name: 'Change labels' }));
+
+      await waitFor(() => {
+        expect(popup).not.toHaveAttribute('aria-labelledby');
+      });
+      await waitFor(() => {
+        expect(popup).not.toHaveAttribute('aria-describedby');
+      });
+    });
+
     describe('prop: onOpenChange', () => {
       it('calls onOpenChange with the new open state', async () => {
         const handleOpenChange = vi.fn();
@@ -169,6 +224,34 @@ describe('<Dialog.Root />', () => {
 
         expect(handleOpenChange.mock.calls.length).toBe(2);
         expect(handleOpenChange.mock.calls[1][1].reason).toBe(REASONS.closePress);
+      });
+
+      it('reports no trigger when closing with an initial trigger id that is not mounted', async () => {
+        const handleOpenChange = vi.fn();
+        const actionsRef = React.createRef<Dialog.Root.Actions>();
+
+        await render(
+          <Dialog.Root
+            actionsRef={actionsRef}
+            defaultOpen
+            defaultTriggerId="missing-trigger"
+            modal={false}
+            onOpenChange={handleOpenChange}
+          >
+            <Dialog.Portal>
+              <Dialog.Popup>Dialog</Dialog.Popup>
+            </Dialog.Portal>
+          </Dialog.Root>,
+        );
+
+        await act(async () => {
+          actionsRef.current?.close();
+        });
+
+        expect(handleOpenChange.mock.calls.length).toBe(1);
+        expect(handleOpenChange.mock.calls[0][0]).toBe(false);
+        expect(handleOpenChange.mock.calls[0][1].reason).toBe(REASONS.imperativeAction);
+        expect(handleOpenChange.mock.calls[0][1].trigger).toBe(undefined);
       });
 
       it('calls onOpenChange with the reason for change when pressed Esc while the dialog is open', async () => {
@@ -1341,9 +1424,39 @@ describe('<Dialog.Root />', () => {
     });
   });
 
+  it('does not close on a right-button outside press', async () => {
+    const handleOpenChange = vi.fn();
+
+    await render(
+      <div>
+        <button data-testid="outside">Outside</button>
+        <Dialog.Root defaultOpen modal="trap-focus" onOpenChange={handleOpenChange}>
+          <Dialog.Portal>
+            <Dialog.Popup>Dialog</Dialog.Popup>
+          </Dialog.Portal>
+        </Dialog.Root>
+      </div>,
+    );
+
+    fireEvent.pointerDown(screen.getByTestId('outside'), {
+      bubbles: true,
+      button: 2,
+      pointerType: 'mouse',
+    });
+
+    await flushMicrotasks();
+
+    expect(screen.getByRole('dialog')).not.toBe(null);
+    expect(handleOpenChange.mock.calls.length).toBe(0);
+  });
+
   describe.skipIf(isJSDOM)('touch outside press', () => {
-    function createTouch(target: EventTarget, point: { clientX: number; clientY: number }) {
-      return new Touch({ identifier: 1, target, ...point });
+    function createTouch(
+      target: EventTarget,
+      point: { clientX: number; clientY: number },
+      identifier = 1,
+    ) {
+      return new Touch({ identifier, target, ...point });
     }
 
     // Simulates a finger tapping outside the dialog: a `touchstart`, a small
@@ -1484,6 +1597,77 @@ describe('<Dialog.Root />', () => {
 
       expect(screen.queryByRole('dialog')).not.toBe(null);
       expect(handleOpenChange.mock.calls.length).toBe(0);
+    });
+
+    it('does not close when multiple touches move past the drag dismissal threshold', async () => {
+      const handleOpenChange = vi.fn();
+
+      await render(
+        <div>
+          <button data-testid="outside">Outside</button>
+          <Dialog.Root defaultOpen modal={false} onOpenChange={handleOpenChange}>
+            <Dialog.Portal>
+              <Dialog.Popup>Dialog</Dialog.Popup>
+            </Dialog.Portal>
+          </Dialog.Root>
+        </div>,
+      );
+
+      const outside = screen.getByTestId('outside');
+      const touch1Start = createTouch(outside, { clientX: 50, clientY: 50 });
+      const touch2Start = createTouch(outside, { clientX: 70, clientY: 70 }, 2);
+      const touch1Move = createTouch(outside, { clientX: 50, clientY: 70 });
+      const touch2Move = createTouch(outside, { clientX: 70, clientY: 90 }, 2);
+
+      fireEvent.touchStart(outside, {
+        bubbles: true,
+        touches: [touch1Start, touch2Start],
+      });
+
+      fireEvent.touchMove(outside, {
+        bubbles: true,
+        touches: [touch1Move, touch2Move],
+      });
+
+      await flushMicrotasks();
+
+      expect(screen.queryByRole('dialog')).not.toBe(null);
+      expect(handleOpenChange.mock.calls.length).toBe(0);
+    });
+
+    it('closes as soon as a single touch moves past the drag dismissal threshold', async () => {
+      const handleOpenChange = vi.fn();
+
+      await render(
+        <div>
+          <button data-testid="outside">Outside</button>
+          <Dialog.Root defaultOpen modal={false} onOpenChange={handleOpenChange}>
+            <Dialog.Portal>
+              <Dialog.Popup>Dialog</Dialog.Popup>
+            </Dialog.Portal>
+          </Dialog.Root>
+        </div>,
+      );
+
+      const outside = screen.getByTestId('outside');
+      const touchStart = createTouch(outside, { clientX: 50, clientY: 50 });
+      const touchMove = createTouch(outside, { clientX: 50, clientY: 70 });
+
+      fireEvent.touchStart(outside, {
+        bubbles: true,
+        touches: [touchStart],
+      });
+
+      fireEvent.touchMove(outside, {
+        bubbles: true,
+        touches: [touchMove],
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).toBe(null);
+      });
+      expect(handleOpenChange.mock.calls.length).toBe(1);
+      expect(handleOpenChange.mock.calls[0][1].reason).toBe(REASONS.outsidePress);
     });
   });
 

--- a/packages/react/src/dialog/root/useDialogRoot.ts
+++ b/packages/react/src/dialog/root/useDialogRoot.ts
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import { useScrollLock } from '@base-ui/utils/useScrollLock';
-import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { useDismiss } from '../../floating-ui-react';
 import { contains, getTarget } from '../../floating-ui-react/utils';
 import { DialogStore } from '../store/DialogStore';
@@ -111,16 +110,14 @@ export function DialogInteractions({
     };
   }, [isDrawer, open, ownNestedOpenDialogs, ownNestedOpenDrawers, parentContext]);
 
-  // `dismiss.trigger` is always the same object as `dismiss.reference`.
-  const triggerProps = dismiss.reference ?? EMPTY_OBJECT;
-  // Consumers (DialogPopup/DrawerPopup) already spread `FOCUSABLE_POPUP_PROPS`
-  // directly, so the popup props only need to carry the dismiss handlers.
-  const popupProps = dismiss.floating ?? EMPTY_OBJECT;
-
   usePopupInteractionProps(store, {
-    activeTriggerProps: triggerProps,
-    inactiveTriggerProps: triggerProps,
-    popupProps,
+    // `enabled` is not passed to `useDismiss`, so its props are always defined,
+    // and `trigger` is the same object as `reference`.
+    activeTriggerProps: dismiss.reference!,
+    inactiveTriggerProps: dismiss.trigger!,
+    // DialogPopup and DrawerPopup spread `FOCUSABLE_POPUP_PROPS` directly, so
+    // this only needs to carry the dismiss handlers.
+    popupProps: dismiss.floating!,
     nestedOpenDialogCount: ownNestedOpenDialogs,
     nestedOpenDrawerCount: ownNestedOpenDrawers,
   });

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -62,9 +62,9 @@ export class DialogStore<Payload> extends ReactStore<
   typeof selectors
 > {
   constructor(
-    initialState?: Partial<State<Payload>>,
-    floatingId?: string | undefined,
-    nested = false,
+    initialState: Partial<State<Payload>> | undefined,
+    floatingId: string | undefined,
+    nested: boolean,
   ) {
     const triggerElements = new PopupTriggerMap();
     const state = createInitialState<Payload>(initialState, triggerElements, floatingId, nested);

--- a/packages/react/src/dialog/trigger/DialogTrigger.test.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { Dialog } from '@base-ui/react/dialog';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
@@ -18,6 +18,18 @@ describe('<Dialog.Trigger />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error without a root or handle', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Dialog.Trigger />)).rejects.toThrow(
+        'Base UI: <Dialog.Trigger> must be used within <Dialog.Root> or provided with a handle.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   describe('prop: disabled', () => {
     it('disables the dialog', async () => {


### PR DESCRIPTION
Expands Dialog and Alert Dialog test coverage to 100% across statements, branches, functions, and lines, including dismissal, accessibility, and detached-trigger interactions in jsdom and Chromium.