### PR TITLE
[toolbar] Expand test coverage

### DIFF
--- a/packages/react/src/toolbar/input/ToolbarInput.test.tsx
+++ b/packages/react/src/toolbar/input/ToolbarInput.test.tsx
@@ -51,6 +51,53 @@ describe('<Toolbar.Input />', () => {
     });
   });
 
+  describe('pointer interactions', () => {
+    it('does not steal focus while disabled and becomes pointer-focusable when enabled', async () => {
+      function TestInput({ disabled }: { disabled: boolean }) {
+        return (
+          <Toolbar.Root>
+            <Toolbar.Button data-testid="button" />
+            <Toolbar.Input data-testid="input" disabled={disabled} />
+          </Toolbar.Root>
+        );
+      }
+
+      const { setProps, user } = await render(<TestInput disabled />);
+      const button = screen.getByTestId('button');
+      const input = screen.getByTestId('input');
+
+      await user.keyboard('[Tab]');
+      expect(button).toHaveFocus();
+
+      await user.click(input);
+      expect(button).toHaveFocus();
+
+      await setProps({ disabled: false });
+      await user.click(input);
+      expect(input).toHaveFocus();
+    });
+
+    it('prevents click default actions while disabled', async () => {
+      function TestInput({ disabled }: { disabled: boolean }) {
+        return (
+          <Toolbar.Root>
+            <Toolbar.Input type="checkbox" disabled={disabled} />
+          </Toolbar.Root>
+        );
+      }
+
+      const { setProps, user } = await render(<TestInput disabled />);
+      const input = screen.getByRole('checkbox');
+
+      await user.click(input);
+      expect(input).not.toBeChecked();
+
+      await setProps({ disabled: false });
+      await user.click(input);
+      expect(input).toBeChecked();
+    });
+  });
+
   describe.skipIf(isJSDOM)('keyboard navigation', () => {
     it.each([
       ['ltr', ARROW_RIGHT, ARROW_LEFT],

--- a/packages/react/src/toolbar/root/ToolbarRoot.test.tsx
+++ b/packages/react/src/toolbar/root/ToolbarRoot.test.tsx
@@ -4,6 +4,7 @@ import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { type Orientation } from '../../internals/types';
+import { useToolbarRootContext } from './ToolbarRootContext';
 
 describe('<Toolbar.Root />', () => {
   const { render } = createRenderer();
@@ -18,6 +19,27 @@ describe('<Toolbar.Root />', () => {
       const { container } = await render(<Toolbar.Root />);
 
       expect(container.firstElementChild as HTMLElement).toHaveAttribute('role', 'toolbar');
+    });
+  });
+
+  describe('context', () => {
+    function OptionalToolbarConsumer() {
+      const context = useToolbarRootContext(true);
+      return <span>{context?.orientation ?? 'outside'}</span>;
+    }
+
+    it('allows optional consumers both outside and inside a toolbar', async () => {
+      await render(
+        <div>
+          <OptionalToolbarConsumer />
+          <Toolbar.Root orientation="vertical">
+            <OptionalToolbarConsumer />
+          </Toolbar.Root>
+        </div>,
+      );
+
+      expect(screen.getByText('outside')).toBeVisible();
+      expect(screen.getByText('vertical')).toBeVisible();
     });
   });
 
@@ -75,6 +97,29 @@ describe('<Toolbar.Root />', () => {
           expect(groupedButton2).toHaveFocus();
         });
       });
+    });
+
+    it('does not wrap focus when loopFocus is false', async () => {
+      const { user } = await render(
+        <Toolbar.Root loopFocus={false}>
+          <Toolbar.Button data-testid="first" />
+          <Toolbar.Button data-testid="last" />
+        </Toolbar.Root>,
+      );
+      const first = screen.getByTestId('first');
+      const last = screen.getByTestId('last');
+
+      await user.keyboard('[Tab]');
+      expect(first).toHaveFocus();
+
+      await user.keyboard('[ArrowLeft]');
+      expect(first).toHaveFocus();
+
+      await user.keyboard('[ArrowRight]');
+      expect(last).toHaveFocus();
+
+      await user.keyboard('[ArrowRight]');
+      expect(last).toHaveFocus();
     });
   });
 

--- a/packages/react/src/toolbar/separator/ToolbarSeparator.test.tsx
+++ b/packages/react/src/toolbar/separator/ToolbarSeparator.test.tsx
@@ -1,0 +1,54 @@
+import { expect, vi } from 'vitest';
+import { Toolbar } from '@base-ui/react/toolbar';
+import { screen } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance } from '#test-utils';
+
+describe('<Toolbar.Separator />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Toolbar.Separator />, () => ({
+    refInstanceof: window.HTMLDivElement,
+    render: (node) => render(<Toolbar.Root>{node}</Toolbar.Root>),
+  }));
+
+  it.each([
+    ['horizontal', 'vertical'],
+    ['vertical', 'horizontal'],
+  ] as const)(
+    'uses a %s separator in a %s toolbar',
+    async (separatorOrientation, toolbarOrientation) => {
+      await render(
+        <Toolbar.Root orientation={toolbarOrientation}>
+          <Toolbar.Separator />
+        </Toolbar.Root>,
+      );
+
+      expect(screen.getByRole('separator')).toHaveAttribute(
+        'aria-orientation',
+        separatorOrientation,
+      );
+    },
+  );
+
+  it('allows its orientation to be overridden', async () => {
+    await render(
+      <Toolbar.Root orientation="horizontal">
+        <Toolbar.Separator orientation="horizontal" />
+      </Toolbar.Root>,
+    );
+
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  it('throws a descriptive error when rendered outside Toolbar.Root', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Toolbar.Separator />)).rejects.toThrow(
+        'Base UI: ToolbarRootContext is missing. Toolbar parts must be placed within <Toolbar.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/react/src/toolbar/separator/ToolbarSeparator.tsx
+++ b/packages/react/src/toolbar/separator/ToolbarSeparator.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import type { BaseUIComponentProps, Orientation } from '../../internals/types';
+import type { Orientation } from '../../internals/types';
 import { Separator, type SeparatorState } from '../../separator';
 import { useToolbarRootContext } from '../root/ToolbarRootContext';
 
@@ -23,8 +23,7 @@ export const ToolbarSeparator = React.forwardRef(function ToolbarSeparator(
 
 export interface ToolbarSeparatorState extends SeparatorState {}
 
-export interface ToolbarSeparatorProps
-  extends BaseUIComponentProps<'div', ToolbarSeparatorState>, Separator.Props {
+export interface ToolbarSeparatorProps extends Separator.Props {
   /**
    * The orientation of the separator. Defaults to the opposite of the toolbar's
    * orientation, so a horizontal toolbar renders vertical separators.


### PR DESCRIPTION
Expands Toolbar test coverage to 100% across statements, branches, functions, and lines, including input interactions, keyboard navigation, optional context, and separator behavior in jsdom and Chromium.