### PR TITLE
[toast] Expand test coverage

### DIFF
--- a/packages/react/src/toast/arrow/ToastArrow.test.tsx
+++ b/packages/react/src/toast/arrow/ToastArrow.test.tsx
@@ -1,5 +1,8 @@
+import { expect, vi } from 'vitest';
+import * as React from 'react';
 import { Toast } from '@base-ui/react/toast';
-import { createRenderer, describeConformance } from '#test-utils';
+import { screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 const toast: Toast.Root.ToastObject = {
   id: 'test',
@@ -19,4 +22,68 @@ describe('<Toast.Arrow />', () => {
       );
     },
   }));
+
+  it.skipIf(isJSDOM)('mirrors the resolved side of its positioner', async () => {
+    function App() {
+      const anchorRef = React.useRef<HTMLButtonElement | null>(null);
+      const { add, toasts } = Toast.useToastManager();
+      return (
+        <React.Fragment>
+          <button
+            type="button"
+            ref={anchorRef}
+            style={{ position: 'absolute', top: 200, left: 100, width: 80, height: 20 }}
+            onClick={() =>
+              add({
+                title: 'title',
+                positionerProps: { anchor: anchorRef.current, side: 'bottom' },
+              })
+            }
+          >
+            anchor
+          </button>
+          <Toast.Viewport>
+            {toasts.map((toastItem) => (
+              <Toast.Positioner key={toastItem.id} toast={toastItem}>
+                <Toast.Root toast={toastItem}>
+                  <Toast.Arrow data-testid="arrow" />
+                  <Toast.Title />
+                </Toast.Root>
+              </Toast.Positioner>
+            ))}
+          </Toast.Viewport>
+        </React.Fragment>
+      );
+    }
+
+    const { user } = await render(
+      <Toast.Provider>
+        <App />
+      </Toast.Provider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'anchor' }));
+
+    const arrow = screen.getByTestId('arrow');
+    await waitFor(() => expect(arrow).toHaveAttribute('data-side', 'bottom'));
+    expect(arrow).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('throws a descriptive error when rendered outside <Toast.Positioner>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Toast.Provider>
+            <Toast.Arrow />
+          </Toast.Provider>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: ToastPositionerContext is missing. ToastPositioner parts must be placed within <Toast.Positioner>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/packages/react/src/toast/content/ToastContent.tsx
+++ b/packages/react/src/toast/content/ToastContent.tsx
@@ -22,14 +22,10 @@ export const ToastContent = React.forwardRef(function ToastContent(
   const contentRef = React.useRef<HTMLDivElement | null>(null);
 
   useIsoLayoutEffect(() => {
-    const node = contentRef.current;
-    if (!node) {
-      return undefined;
-    }
-
     recalculateHeight();
 
-    if (typeof ResizeObserver !== 'function' || typeof MutationObserver !== 'function') {
+    const node = contentRef.current;
+    if (!node || typeof ResizeObserver !== 'function' || typeof MutationObserver !== 'function') {
       return undefined;
     }
 

--- a/packages/react/src/toast/positioner/ToastPositioner.test.tsx
+++ b/packages/react/src/toast/positioner/ToastPositioner.test.tsx
@@ -1,5 +1,9 @@
+import { expect, vi } from 'vitest';
+import * as React from 'react';
 import { Toast } from '@base-ui/react/toast';
-import { createRenderer, describeConformance } from '#test-utils';
+import { act, screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import type { ToastManagerAddOptions } from '../useToastManager';
 
 const toast: Toast.Root.ToastObject = {
   id: 'test',
@@ -15,4 +19,165 @@ describe('<Toast.Positioner />', () => {
       return render(<Toast.Provider>{node}</Toast.Provider>);
     },
   }));
+
+  function AnchoredList() {
+    return Toast.useToastManager().toasts.map((toastItem) => (
+      <Toast.Positioner key={toastItem.id} toast={toastItem} data-testid={toastItem.id}>
+        <Toast.Root toast={toastItem}>
+          <Toast.Title />
+        </Toast.Root>
+      </Toast.Positioner>
+    ));
+  }
+
+  function AddButton(props: { options?: Partial<ToastManagerAddOptions<any>> }) {
+    const { add } = Toast.useToastManager();
+    return (
+      <button type="button" onClick={() => add({ title: 'title', ...props.options })}>
+        add
+      </button>
+    );
+  }
+
+  it.skipIf(isJSDOM)('positions an anchored toast against its anchor element', async () => {
+    function App() {
+      const anchorRef = React.useRef<HTMLButtonElement | null>(null);
+      const { add } = Toast.useToastManager();
+      return (
+        <React.Fragment>
+          <button
+            type="button"
+            ref={anchorRef}
+            style={{ position: 'absolute', top: 200, left: 100, width: 80, height: 20 }}
+            onClick={() =>
+              add({
+                id: 'anchored',
+                title: 'title',
+                positionerProps: { anchor: anchorRef.current, side: 'bottom', sideOffset: 8 },
+              })
+            }
+          >
+            anchor
+          </button>
+          <Toast.Viewport>
+            <AnchoredList />
+          </Toast.Viewport>
+        </React.Fragment>
+      );
+    }
+
+    const { user } = await render(
+      <Toast.Provider>
+        <App />
+      </Toast.Provider>,
+    );
+
+    const anchor = screen.getByRole('button', { name: 'anchor' });
+    await user.click(anchor);
+
+    const positioner = screen.getByTestId('anchored');
+    await waitFor(() => expect(positioner).toHaveAttribute('data-side', 'bottom'));
+
+    const anchorRect = anchor.getBoundingClientRect();
+    await waitFor(() => {
+      expect(positioner.getBoundingClientRect().top).toBeCloseTo(anchorRect.bottom + 8, 0);
+    });
+  });
+
+  it('falls back to the viewport when no anchor is provided', async () => {
+    const { user } = await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <AnchoredList />
+        </Toast.Viewport>
+        <AddButton options={{ id: 'unanchored' }} />
+      </Toast.Provider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'add' }));
+
+    const positioner = screen.getByTestId('unanchored');
+    // An unanchored positioner still renders, with the defaults applied.
+    expect(positioner).toHaveAttribute('data-side', 'top');
+    expect(positioner).toHaveAttribute('data-align', 'center');
+    expect(positioner).toHaveTextContent('title');
+  });
+
+  it('lets positioner props override the ones carried on the toast', async () => {
+    function OverridingList() {
+      return Toast.useToastManager().toasts.map((toastItem) => (
+        <Toast.Positioner key={toastItem.id} toast={toastItem} data-testid="positioner" side="left">
+          <Toast.Root toast={toastItem}>
+            <Toast.Title />
+          </Toast.Root>
+        </Toast.Positioner>
+      ));
+    }
+
+    const { user } = await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <OverridingList />
+        </Toast.Viewport>
+        <AddButton options={{ positionerProps: { side: 'bottom', align: 'end' } }} />
+      </Toast.Provider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'add' }));
+
+    const positioner = screen.getByTestId('positioner');
+    expect(positioner).toHaveAttribute('data-side', 'left');
+    // Props not set on the element still come from the toast.
+    expect(positioner).toHaveAttribute('data-align', 'end');
+  });
+
+  describe('--toast-index', () => {
+    const { render: renderFakeTimers, clock } = createRenderer();
+
+    clock.withFakeTimers();
+
+    it('keeps the DOM index while a toast animates out', async () => {
+      const manager = Toast.createToastManager();
+
+      await renderFakeTimers(
+        <Toast.Provider toastManager={manager} timeout={0}>
+          <Toast.Viewport>
+            <AnchoredList />
+          </Toast.Viewport>
+        </Toast.Provider>,
+      );
+
+      await act(async () => {
+        manager.add({ id: 'oldest', title: 'oldest' });
+      });
+      await act(async () => {
+        manager.add({ id: 'newest', title: 'newest' });
+      });
+
+      const newest = screen.getByTestId('newest');
+      const oldest = screen.getByTestId('oldest');
+
+      expect(newest.style.getPropertyValue('--toast-index')).toBe('0');
+      expect(oldest.style.getPropertyValue('--toast-index')).toBe('1');
+
+      await act(async () => manager.close('newest'));
+
+      // The closing toast is excluded from the visible stack, but it must keep a
+      // real index while it animates out rather than collapsing to `-1`.
+      expect(newest.style.getPropertyValue('--toast-index')).toBe('0');
+      expect(oldest.style.getPropertyValue('--toast-index')).toBe('0');
+    });
+  });
+
+  it('throws a descriptive error when rendered outside <Toast.Provider>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Toast.Positioner toast={toast} />)).rejects.toThrow(
+        'Base UI: useToastManager must be used within <Toast.Provider>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -1,5 +1,6 @@
 import { expect } from 'vitest';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { Toast } from '@base-ui/react/toast';
 import { act, screen, fireEvent, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
@@ -249,6 +250,40 @@ describe('<Toast.Root />', () => {
     await user.keyboard('{Escape}');
 
     expect(screen.queryByTestId('root')).toBe(null);
+  });
+
+  it('ignores Escape when focus is in portaled content', async () => {
+    function PortalList() {
+      return Toast.useToastManager().toasts.map((toastItem) => (
+        <Toast.Root key={toastItem.id} toast={toastItem} data-testid="root">
+          <Toast.Title>{toastItem.title}</Toast.Title>
+          {ReactDOM.createPortal(
+            <button type="button" data-testid="portaled">
+              portaled
+            </button>,
+            document.body,
+          )}
+        </Toast.Root>
+      ));
+    }
+
+    const { user } = await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <PortalList />
+        </Toast.Viewport>
+        <Button />
+      </Toast.Provider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'add' }));
+
+    // The button is a React child of the toast, so the key event bubbles to the
+    // toast, but it lives outside the toast in the DOM and owns the Escape key.
+    await act(async () => screen.getByTestId('portaled').focus());
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByTestId('root')).not.toBe(null);
   });
 
   describe.skipIf(isJSDOM)('swipe behavior', () => {
@@ -502,7 +537,7 @@ describe('<Toast.Root />', () => {
       });
     });
 
-    it('cancels swipe when direction is reversed beyond threshold', async () => {
+    it('cancels a vertical swipe when the pointer changes its mind', async () => {
       await render(
         <Toast.Provider>
           <Toast.Viewport>
@@ -516,13 +551,182 @@ describe('<Toast.Root />', () => {
 
       const toastElement = screen.getByTestId('toast-root');
 
-      // Start swiping up
       fireEvent.pointerDown(toastElement, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
-      fireEvent.pointerMove(toastElement, { clientX: 100, clientY: 80, pointerId: 1 });
+      fireEvent.pointerMove(toastElement, {
+        clientX: 100,
+        clientY: 99,
+        movementY: -1,
+        pointerId: 1,
+      });
 
-      // Then reverse direction
-      fireEvent.pointerMove(toastElement, { clientX: 100, clientY: 90, pointerId: 1 });
-      fireEvent.pointerUp(toastElement, { clientX: 100, clientY: 90, pointerId: 1 });
+      // Swipe up well past the dismiss threshold to arm the gesture.
+      fireEvent.pointerMove(toastElement, {
+        clientX: 100,
+        clientY: 10,
+        movementY: -89,
+        pointerId: 1,
+      });
+      expect(toastElement).toHaveAttribute('data-swipe-direction', 'up');
+
+      // Reversing moves the cancel baseline to the turning point, so the swipe
+      // is now measured as zero progress from there rather than 50px from the
+      // original press, and the change of mind wins.
+      fireEvent.pointerMove(toastElement, {
+        clientX: 100,
+        clientY: 50,
+        movementY: 40,
+        pointerId: 1,
+      });
+      fireEvent.pointerUp(toastElement, { clientX: 100, clientY: 50, pointerId: 1 });
+
+      expect(screen.queryByTestId('toast-root')).not.toBe(null);
+      expect(toastElement).not.toHaveAttribute('data-swipe-direction');
+      expect(toastElement.style.getPropertyValue('--toast-swipe-movement-y')).toBe('0px');
+    });
+
+    it('cancels a horizontal swipe when the pointer changes its mind', async () => {
+      await render(
+        <Toast.Provider>
+          <Toast.Viewport>
+            <SwipeTestToast swipeDirection="right" />
+          </Toast.Viewport>
+          <SwipeTestButton />
+        </Toast.Provider>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'add toast' }));
+
+      const toastElement = screen.getByTestId('toast-root');
+
+      fireEvent.pointerDown(toastElement, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(toastElement, {
+        clientX: 101,
+        clientY: 100,
+        movementX: 1,
+        pointerId: 1,
+      });
+
+      fireEvent.pointerMove(toastElement, {
+        clientX: 190,
+        clientY: 100,
+        movementX: 89,
+        pointerId: 1,
+      });
+      expect(toastElement).toHaveAttribute('data-swipe-direction', 'right');
+
+      fireEvent.pointerMove(toastElement, {
+        clientX: 150,
+        clientY: 100,
+        movementX: -40,
+        pointerId: 1,
+      });
+      fireEvent.pointerUp(toastElement, { clientX: 150, clientY: 100, pointerId: 1 });
+
+      expect(screen.queryByTestId('toast-root')).not.toBe(null);
+      expect(toastElement).not.toHaveAttribute('data-swipe-direction');
+      expect(toastElement.style.getPropertyValue('--toast-swipe-movement-x')).toBe('0px');
+    });
+
+    it('locks the gesture to the horizontal axis when it starts sideways', async () => {
+      await render(
+        <Toast.Provider>
+          <Toast.Viewport>
+            <SwipeTestToast swipeDirection={['down', 'right']} />
+          </Toast.Viewport>
+          <SwipeTestButton />
+        </Toast.Provider>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'add toast' }));
+
+      const toastElement = screen.getByTestId('toast-root');
+
+      fireEvent.pointerDown(toastElement, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(toastElement, { clientX: 100, clientY: 100, pointerId: 1 });
+
+      // Mostly sideways, so the gesture locks to the horizontal axis.
+      fireEvent.pointerMove(toastElement, { clientX: 95, clientY: 98, pointerId: 1 });
+
+      // Left is not a dismissible direction, so nothing gets armed.
+      fireEvent.pointerMove(toastElement, { clientX: 90, clientY: 98, pointerId: 1 });
+      expect(toastElement).not.toHaveAttribute('data-swipe-direction');
+
+      // Back at the origin the horizontal delta is exactly zero.
+      fireEvent.pointerMove(toastElement, { clientX: 100, clientY: 98, pointerId: 1 });
+      expect(toastElement).not.toHaveAttribute('data-swipe-direction');
+
+      // Dragging far downwards and slightly right: without the axis lock the
+      // larger vertical delta would arm `down` instead.
+      fireEvent.pointerMove(toastElement, { clientX: 110, clientY: 220, pointerId: 1 });
+      expect(toastElement).toHaveAttribute('data-swipe-direction', 'right');
+
+      fireEvent.pointerMove(toastElement, { clientX: 160, clientY: 220, pointerId: 1 });
+      fireEvent.pointerUp(toastElement, { clientX: 160, clientY: 220, pointerId: 1 });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('toast-root')).toBe(null);
+      });
+    });
+
+    it('locks the gesture to the vertical axis when it starts upright', async () => {
+      await render(
+        <Toast.Provider>
+          <Toast.Viewport>
+            <SwipeTestToast swipeDirection={['down', 'right']} />
+          </Toast.Viewport>
+          <SwipeTestButton />
+        </Toast.Provider>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'add toast' }));
+
+      const toastElement = screen.getByTestId('toast-root');
+
+      fireEvent.pointerDown(toastElement, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(toastElement, { clientX: 100, clientY: 100, pointerId: 1 });
+
+      // Mostly upright, so the gesture locks to the vertical axis.
+      fireEvent.pointerMove(toastElement, { clientX: 98, clientY: 95, pointerId: 1 });
+
+      fireEvent.pointerMove(toastElement, { clientX: 98, clientY: 90, pointerId: 1 });
+      expect(toastElement).not.toHaveAttribute('data-swipe-direction');
+
+      fireEvent.pointerMove(toastElement, { clientX: 98, clientY: 100, pointerId: 1 });
+      expect(toastElement).not.toHaveAttribute('data-swipe-direction');
+
+      // Dragging far to the right and slightly down: without the axis lock the
+      // larger horizontal delta would arm `right` instead.
+      fireEvent.pointerMove(toastElement, { clientX: 220, clientY: 110, pointerId: 1 });
+      expect(toastElement).toHaveAttribute('data-swipe-direction', 'down');
+
+      fireEvent.pointerMove(toastElement, { clientX: 220, clientY: 160, pointerId: 1 });
+      fireEvent.pointerUp(toastElement, { clientX: 220, clientY: 160, pointerId: 1 });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('toast-root')).toBe(null);
+      });
+    });
+
+    it('does not start a swipe from a non-primary pointer button', async () => {
+      await render(
+        <Toast.Provider>
+          <Toast.Viewport>
+            <SwipeTestToast swipeDirection="right" />
+          </Toast.Viewport>
+          <SwipeTestButton />
+        </Toast.Provider>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'add toast' }));
+
+      const toastElement = screen.getByTestId('toast-root');
+
+      fireEvent.pointerDown(toastElement, { clientX: 100, clientY: 100, button: 2, pointerId: 1 });
+
+      expect(toastElement).not.toHaveAttribute('data-swiping');
+
+      fireEvent.pointerMove(toastElement, { clientX: 200, clientY: 100, pointerId: 1 });
+      fireEvent.pointerUp(toastElement, { clientX: 200, clientY: 100, pointerId: 1 });
 
       expect(screen.queryByTestId('toast-root')).not.toBe(null);
     });

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -211,7 +211,7 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     }
   });
 
-  function handlePointerDown(event: React.PointerEvent) {
+  function handlePointerDown(event: React.PointerEvent<HTMLDivElement>) {
     if (event.button !== 0) {
       return;
     }
@@ -237,15 +237,15 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     dragStartPosRef.current = { x: event.clientX, y: event.clientY };
     swipeCancelBaselineRef.current = dragStartPosRef.current;
 
-    if (rootRef.current) {
-      const transform = getElementTransform(rootRef.current);
-      initialTransformRef.current = transform;
-      setInitialTransform(transform);
-      setResolvedDragOffset({
-        x: transform.x,
-        y: transform.y,
-      });
-    }
+    const element = event.currentTarget;
+
+    const transform = getElementTransform(element);
+    initialTransformRef.current = transform;
+    setInitialTransform(transform);
+    setResolvedDragOffset({
+      x: transform.x,
+      y: transform.y,
+    });
 
     store.set('hovering', true);
     setIsSwiping(true);
@@ -253,18 +253,15 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     setLockedDirection(null);
     isFirstPointerMoveRef.current = true;
 
-    const element = rootRef.current;
-    if (element) {
-      dragAbortControllerRef.current?.abort();
-      const dragAbortController = new AbortController();
-      dragAbortControllerRef.current = dragAbortController;
+    dragAbortControllerRef.current?.abort();
+    const dragAbortController = new AbortController();
+    dragAbortControllerRef.current = dragAbortController;
 
-      const doc = ownerDocument(element);
-      doc.addEventListener('pointerup', handleSwipeEnd, { signal: dragAbortController.signal });
-      doc.addEventListener('pointercancel', handleSwipeEnd, { signal: dragAbortController.signal });
+    const doc = ownerDocument(element);
+    doc.addEventListener('pointerup', handleSwipeEnd, { signal: dragAbortController.signal });
+    doc.addEventListener('pointercancel', handleSwipeEnd, { signal: dragAbortController.signal });
 
-      element.setPointerCapture?.(event.pointerId);
-    }
+    element.setPointerCapture?.(event.pointerId);
   }
 
   function handlePointerMove(event: React.PointerEvent) {
@@ -307,15 +304,15 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
       const movementDistance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
       if (movementDistance >= MIN_DRAG_THRESHOLD) {
         setIsRealSwipe(true);
-        if (lockedDirection === null) {
-          const hasHorizontal =
-            swipeDirections.includes('left') || swipeDirections.includes('right');
-          const hasVertical = swipeDirections.includes('up') || swipeDirections.includes('down');
-          if (hasHorizontal && hasVertical) {
-            const absX = Math.abs(deltaX);
-            const absY = Math.abs(deltaY);
-            setLockedDirection(absX > absY ? 'horizontal' : 'vertical');
-          }
+        // `lockedDirection` is always reset alongside `isRealSwipe`, so it is
+        // still `null` here. Locking is only meaningful when both axes are
+        // swipeable; otherwise the single axis already constrains the gesture.
+        const hasHorizontal = swipeDirections.includes('left') || swipeDirections.includes('right');
+        const hasVertical = swipeDirections.includes('up') || swipeDirections.includes('down');
+        if (hasHorizontal && hasVertical) {
+          const absX = Math.abs(deltaX);
+          const absY = Math.abs(deltaY);
+          setLockedDirection(absX > absY ? 'horizontal' : 'vertical');
         }
       }
     }
@@ -394,12 +391,8 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
   }
 
   React.useEffect(() => {
-    if (!swipeEnabled) {
-      return undefined;
-    }
-
     const element = rootRef.current;
-    if (!element) {
+    if (!swipeEnabled || !element) {
       return undefined;
     }
 

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -250,7 +250,7 @@ describe('ToastStore', () => {
       expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe('ending');
     });
 
-    it('dismisses promptly when the clock jumped past the timeout while paused', () => {
+    it('restarts the full delay when the clock jumped past the timeout before pausing', () => {
       vi.useFakeTimers();
       const store = createStore([]);
 
@@ -261,6 +261,9 @@ describe('ToastStore', () => {
       vi.setSystemTime(Date.now() + 60_000);
       store.pauseTimers();
       store.resumeTimers();
+
+      vi.advanceTimersByTime(4999);
+      expect(selectors.toast(store.state, 'a')?.transitionStatus).not.toBe('ending');
 
       vi.advanceTimersByTime(1);
       expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe('ending');

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -4,7 +4,8 @@ import type { ToastObject } from './useToastManager';
 
 function createStore(toasts: ToastObject<any>[]) {
   return new ToastStore({
-    toasts,
+    // Mirrors `addToast`, which always stamps an `updateKey` on the way in.
+    toasts: toasts.map((toast) => ({ updateKey: 0, ...toast })),
     timeout: 0,
     limit: 3,
     hovering: false,
@@ -80,6 +81,30 @@ describe('ToastStore', () => {
 
     store.removeToast('a', true);
     expect(selectors.toast(store.state, 'a')).toBe(undefined);
+  });
+
+  it('ignores mutations that target an unknown toast', () => {
+    const store = createStore([{ id: 'a' }]);
+    const toastsBefore = store.state.toasts;
+
+    store.removeToast('missing');
+    store.closeToast('missing');
+    store.updateToast('missing', { title: 'nope' });
+
+    expect(store.state.toasts).toBe(toastsBefore);
+    expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe(undefined);
+  });
+
+  it('does not invoke onRemove for a toast that is no longer in the store', () => {
+    const onRemove = vi.fn();
+    const store = createStore([{ id: 'a', onRemove }]);
+
+    store.removeToast('a');
+    expect(onRemove).toHaveBeenCalledTimes(1);
+
+    // Removing again must be a no-op rather than firing the callback a second time.
+    store.removeToast('a');
+    expect(onRemove).toHaveBeenCalledTimes(1);
   });
 
   describe('limit', () => {
@@ -176,6 +201,69 @@ describe('ToastStore', () => {
       vi.advanceTimersByTime(200);
 
       expect(selectors.toast(store.state, 'c')?.transitionStatus).not.toBe('ending');
+    });
+
+    it('keeps a rescheduled timer paused while expanded, and runs it once collapsed', () => {
+      vi.useFakeTimers();
+      const store = createStore([]);
+
+      store.addToast({ id: 'a', title: 'a', timeout: 100 });
+
+      // Hovering the viewport pauses the running timer.
+      store.set('hovering', true);
+      store.pauseTimers();
+
+      // Passing `timeout` reschedules the timer. The replacement must not start
+      // running while the viewport is still expanded.
+      store.updateToast('a', { timeout: 100 });
+
+      vi.advanceTimersByTime(200);
+      expect(selectors.toast(store.state, 'a')?.transitionStatus).not.toBe('ending');
+
+      // Collapsing must still be able to start the rescheduled timer.
+      store.set('hovering', false);
+      store.resumeTimers();
+
+      vi.advanceTimersByTime(100);
+      expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe('ending');
+    });
+
+    it('does not extend the remaining time across repeated pause/resume cycles', () => {
+      vi.useFakeTimers();
+      const store = createStore([]);
+
+      store.addToast({ id: 'a', title: 'a', timeout: 5000 });
+
+      // Two hover cycles, each leaving the timer running for 1000ms.
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        vi.advanceTimersByTime(1000);
+        store.pauseTimers();
+        vi.advanceTimersByTime(1000);
+        store.resumeTimers();
+      }
+
+      // 2000ms of the 5000ms timeout has been consumed, so 3000ms must remain.
+      vi.advanceTimersByTime(2999);
+      expect(selectors.toast(store.state, 'a')?.transitionStatus).not.toBe('ending');
+
+      vi.advanceTimersByTime(2);
+      expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe('ending');
+    });
+
+    it('dismisses promptly when the clock jumped past the timeout while paused', () => {
+      vi.useFakeTimers();
+      const store = createStore([]);
+
+      store.addToast({ id: 'a', title: 'a', timeout: 5000 });
+
+      // Mimics a throttled background tab: wall-clock time passes without the
+      // scheduled timeout ever running.
+      vi.setSystemTime(Date.now() + 60_000);
+      store.pauseTimers();
+      store.resumeTimers();
+
+      vi.advanceTimersByTime(1);
+      expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe('ending');
     });
 
     it('re-pauses timers after the last timed toast becomes untimed', () => {

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -383,6 +383,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     }
     this.areTimersPaused = false;
     this.timers.forEach((timer, id) => {
+      timer.remaining = timer.remaining > 0 ? timer.remaining : timer.delay;
       timer.timeout ??= Timeout.create();
       timer.timeout.start(timer.remaining, () => {
         this.handleTimerFired(id);
@@ -425,6 +426,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     this.timers.set(id, {
       timeout: currentTimeout,
       start,
+      delay,
       remaining: delay,
       callback,
     });
@@ -513,6 +515,8 @@ interface TimerInfo {
   timeout?: Timeout | undefined;
   /** Timestamp of the last time the timeout started running. */
   start: number;
+  /** Full timeout duration, used to restart a timer that elapsed while throttled. */
+  delay: number;
   /** Time left before the toast auto-dismisses, excluding any paused time. */
   remaining: number;
   callback: () => void;

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -12,10 +12,18 @@ import { resolvePromiseOptions } from './utils/resolvePromiseOptions';
 import { activeElement, contains, getTarget } from '../floating-ui-react/utils';
 import { isFocusVisible } from './utils/focusVisible';
 
-type ToastInternalUpdateOptions<Data extends object> = Partial<Omit<ToastObject<Data>, 'id'>>;
+type ToastInternalUpdateOptions<Data extends object> = Partial<
+  Omit<ToastObject<Data>, 'id' | 'updateKey'>
+>;
+
+/**
+ * A toast once it lives in the store. `addToast` is the only way in and it always
+ * assigns `updateKey`, so unlike the public `ToastObject` it is never missing.
+ */
+export type StoredToast<Data extends object = any> = ToastObject<Data> & { updateKey: number };
 
 export type State = {
-  toasts: ToastObject<any>[];
+  toasts: StoredToast[];
   toastMetadata: Map<string, ToastMetadata>;
   hovering: boolean;
   focused: boolean;
@@ -27,7 +35,7 @@ export type State = {
 };
 
 type ToastMetadata = {
-  value: ToastObject<any>;
+  value: StoredToast;
   domIndex: number;
   visibleIndex: number;
   offsetY: number;
@@ -35,7 +43,7 @@ type ToastMetadata = {
 
 type InitialState = Omit<State, 'toastMetadata'>;
 
-function createToastMetadata(toasts: ToastObject<any>[]) {
+function createToastMetadata(toasts: StoredToast[]) {
   const metadata = new Map<string, ToastMetadata>();
   let visibleIndex = 0;
   let offsetY = 0;
@@ -63,7 +71,7 @@ function createToastMetadata(toasts: ToastObject<any>[]) {
 // toasts in newest-first order, so the newest `limit` toasts stay visible and
 // the rest are flagged. Returns the same toast reference when its `limited`
 // flag is unchanged to avoid unnecessary re-renders.
-function applyLimited(toasts: ToastObject<any>[], limit: number): ToastObject<any>[] {
+function applyLimited(toasts: StoredToast[], limit: number): StoredToast[] {
   let activeIndex = 0;
   return toasts.map((toast) => {
     if (toast.transitionStatus === 'ending') {
@@ -188,7 +196,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       }
     }
 
-    const toastToAdd: ToastObject<Data> = {
+    const toastToAdd: StoredToast<Data> = {
       ...toast,
       id,
       updateKey: 0,
@@ -233,11 +241,11 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       return;
     }
 
-    const nextToast: ToastObject<Data> = {
+    const nextToast: StoredToast<Data> = {
       ...prevToast,
       ...updates,
       ...(markUpdated && {
-        updateKey: (prevToast.updateKey ?? 0) + 1,
+        updateKey: prevToast.updateKey + 1,
       }),
     };
 
@@ -278,7 +286,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
   closeToast = (toastId?: string) => {
     const closeAll = toastId === undefined;
     const { limit, toasts } = this.state;
-    let toastsToClose: ToastObject<any>[];
+    let toastsToClose: StoredToast[];
 
     if (closeAll) {
       toastsToClose = toasts;
@@ -357,11 +365,14 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     }
     this.areTimersPaused = true;
     this.timers.forEach((timer) => {
+      // Timers added while already paused have no running timeout, so their
+      // `remaining` is still the full delay and must be left alone.
       if (timer.timeout) {
         timer.timeout.clear();
-        const elapsed = Date.now() - timer.start;
-        const remaining = timer.remaining - elapsed;
-        timer.remaining = remaining > 0 ? remaining : 0;
+        // `start` is stamped on every resume, so subtracting from `remaining`
+        // (rather than from the original delay) keeps repeated pause/resume
+        // cycles from handing the toast extra time.
+        timer.remaining = Math.max(timer.remaining - (Date.now() - timer.start), 0);
       }
     });
   }
@@ -372,7 +383,6 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     }
     this.areTimersPaused = false;
     this.timers.forEach((timer, id) => {
-      timer.remaining = timer.remaining > 0 ? timer.remaining : timer.delay;
       timer.timeout ??= Timeout.create();
       timer.timeout.start(timer.remaining, () => {
         this.handleTimerFired(id);
@@ -415,7 +425,6 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     this.timers.set(id, {
       timeout: currentTimeout,
       start,
-      delay,
       remaining: delay,
       callback,
     });
@@ -450,10 +459,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     }
   }
 
-  private setToasts(
-    newToasts: ToastObject<any>[],
-    clearInteraction: boolean = newToasts.length === 0,
-  ) {
+  private setToasts(newToasts: StoredToast[], clearInteraction: boolean = newToasts.length === 0) {
     const updates: Partial<State> = {
       toasts: newToasts,
       toastMetadata: createToastMetadata(newToasts),
@@ -505,8 +511,9 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
 
 interface TimerInfo {
   timeout?: Timeout | undefined;
+  /** Timestamp of the last time the timeout started running. */
   start: number;
-  delay: number;
+  /** Time left before the toast auto-dismisses, excluding any paused time. */
   remaining: number;
   callback: () => void;
 }

--- a/packages/react/src/toast/title/ToastTitle.test.tsx
+++ b/packages/react/src/toast/title/ToastTitle.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { Toast } from '@base-ui/react/toast';
 import { createRenderer, describeConformance } from '#test-utils';
 import { screen } from '@mui/internal-test-utils';
@@ -25,6 +25,26 @@ describe('<Toast.Title />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <Toast.Root>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Toast.Provider>
+            <Toast.Viewport>
+              <Toast.Title />
+            </Toast.Viewport>
+          </Toast.Provider>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: ToastRootContext is missing. Toast parts must be used within <Toast.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   it('adds aria-labelledby to the root element', async () => {
     const { user } = await render(

--- a/packages/react/src/toast/useToastManager.test.tsx
+++ b/packages/react/src/toast/useToastManager.test.tsx
@@ -886,6 +886,57 @@ describe.skipIf(!isJSDOM)('useToast', () => {
       expect(screen.getByTestId('description')).toHaveTextContent('test success');
     });
 
+    it('accepts a function that returns full options for the success state', async () => {
+      function AddButton() {
+        const { promise } = useToastManager();
+        return (
+          <button
+            onClick={() =>
+              promise(
+                new Promise<string>((res) => {
+                  res('everything');
+                }),
+                {
+                  loading: 'loading',
+                  success: (data) => ({
+                    title: `saved ${data}`,
+                    description: 'done',
+                    timeout: 2000,
+                  }),
+                  error: 'error',
+                },
+              )
+            }
+          >
+            add
+          </button>
+        );
+      }
+
+      await render(
+        <Toast.Provider>
+          <Toast.Viewport>
+            <CustomList />
+          </Toast.Viewport>
+          <AddButton />
+        </Toast.Provider>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'add' }));
+
+      await tick(clock, 1000);
+
+      expect(screen.getByTestId('title')).toHaveTextContent('saved everything');
+      expect(screen.getByTestId('description')).toHaveTextContent('done');
+
+      // The `timeout` from the resolved options object is honored too.
+      await tick(clock, 1999);
+      expect(screen.queryByTestId('root')).not.toBe(null);
+
+      await tick(clock, 2);
+      expect(screen.queryByTestId('root')).toBe(null);
+    });
+
     it('passes data when error is a function', async () => {
       function AddButton() {
         const { promise } = useToastManager();
@@ -1731,6 +1782,42 @@ describe.skipIf(!isJSDOM)('useToast', () => {
       const closeButton = screen.getByRole('button', { name: 'close' });
       fireEvent.click(closeButton);
 
+      expect(screen.queryByTestId('root')).toBe(null);
+    });
+  });
+
+  describe('prop: timeout', () => {
+    const { clock, render } = createRenderer();
+
+    clock.withFakeTimers();
+
+    it('applies a changed timeout to toasts added afterwards', async () => {
+      function App(props: { timeout: number }) {
+        return (
+          <Toast.Provider timeout={props.timeout}>
+            <Toast.Viewport>
+              <List />
+            </Toast.Viewport>
+            <AddButton />
+          </Toast.Provider>
+        );
+      }
+
+      function AddButton() {
+        const { add } = useToastManager();
+        return <button onClick={() => add({ title: 'test' })}>add</button>;
+      }
+
+      const { setProps } = await render(<App timeout={5000} />);
+
+      await setProps({ timeout: 1000 });
+
+      fireEvent.click(screen.getByRole('button', { name: 'add' }));
+
+      await tick(clock, 999);
+      expect(screen.queryByTestId('root')).not.toBe(null);
+
+      await tick(clock, 2);
       expect(screen.queryByTestId('root')).toBe(null);
     });
   });

--- a/packages/react/src/toast/viewport/ToastViewport.test.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.test.tsx
@@ -119,6 +119,18 @@ describe('<Toast.Viewport />', () => {
     },
   );
 
+  it('throws a descriptive error when rendered outside <Toast.Provider>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Toast.Viewport />)).rejects.toThrow(
+        'Base UI: useToastManager must be used within <Toast.Provider>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it('gets focused when F6 is pressed', async () => {
     const { user } = await render(
       <Toast.Provider>
@@ -483,6 +495,173 @@ describe('<Toast.Viewport />', () => {
       expect(screen.queryByTestId('root')).not.toBe(null);
     });
 
+    it('restores focus and resumes timers on shift+Tab out of the focused viewport', async () => {
+      await renderFakeTimers(
+        <Toast.Provider>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+
+      await act(async () => button.focus());
+      fireEvent.click(button);
+      fireEvent.keyDown(button, { key: 'F6' });
+
+      const viewport = screen.getByTestId('viewport');
+      expect(viewport).toHaveFocus();
+
+      clock.tick(5001);
+      expect(screen.queryByTestId('root')).not.toBe(null);
+
+      fireEvent.keyDown(viewport, { key: 'Tab', shiftKey: true });
+
+      expect(button).toHaveFocus();
+
+      clock.tick(5001);
+      expect(screen.queryByTestId('root')).toBe(null);
+    });
+
+    it('keeps timers paused when shift+Tab returns focus inside the viewport', async () => {
+      await renderFakeTimers(
+        <Toast.Provider>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+
+      await act(async () => button.focus());
+      fireEvent.click(button);
+
+      // Pressing F6 from a control inside the toast makes the restore target
+      // itself live inside the viewport.
+      const close = document.querySelector('[aria-label="close-press"]') as HTMLElement;
+      await act(async () => close.focus());
+      fireEvent.keyDown(close, { key: 'F6' });
+
+      const viewport = screen.getByTestId('viewport');
+      expect(viewport).toHaveFocus();
+
+      fireEvent.keyDown(viewport, { key: 'Tab', shiftKey: true });
+
+      expect(close).toHaveFocus();
+
+      clock.tick(5001);
+      // Focus never left the viewport, so the toast must stay put.
+      expect(screen.queryByTestId('root')).not.toBe(null);
+    });
+
+    it('keeps the viewport focused when Tab is pressed without shift', async () => {
+      await renderFakeTimers(
+        <Toast.Provider>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+
+      await act(async () => button.focus());
+      fireEvent.click(button);
+      fireEvent.keyDown(button, { key: 'F6' });
+
+      const viewport = screen.getByTestId('viewport');
+      fireEvent.keyDown(viewport, { key: 'Tab' });
+
+      // Forward Tab moves into the toasts, so the viewport must not hand focus back.
+      expect(button).not.toHaveFocus();
+
+      clock.tick(5001);
+      expect(screen.queryByTestId('root')).not.toBe(null);
+    });
+
+    it('collapses and resumes timers on a touch outside the viewport', async () => {
+      await renderFakeTimers(
+        <Toast.Provider>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+
+      fireEvent.click(button);
+      fireEvent.mouseEnter(screen.getByTestId('root'));
+
+      const viewport = screen.getByTestId('viewport');
+      expect(viewport).toHaveAttribute('data-expanded');
+
+      clock.tick(5001);
+      expect(screen.queryByTestId('root')).not.toBe(null);
+
+      fireEvent.pointerDown(document.body, { pointerType: 'touch' });
+
+      expect(viewport).not.toHaveAttribute('data-expanded');
+
+      clock.tick(5001);
+      expect(screen.queryByTestId('root')).toBe(null);
+    });
+
+    it('stays expanded on a touch inside the viewport', async () => {
+      await renderFakeTimers(
+        <Toast.Provider>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+
+      fireEvent.click(button);
+      fireEvent.mouseEnter(screen.getByTestId('root'));
+
+      const viewport = screen.getByTestId('viewport');
+      fireEvent.pointerDown(viewport, { pointerType: 'touch' });
+
+      expect(viewport).toHaveAttribute('data-expanded');
+
+      clock.tick(5001);
+      expect(screen.queryByTestId('root')).not.toBe(null);
+    });
+
+    it('ignores a mouse pointerdown outside the viewport', async () => {
+      await renderFakeTimers(
+        <Toast.Provider>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+
+      fireEvent.click(button);
+      fireEvent.mouseEnter(screen.getByTestId('root'));
+
+      // Only touch activity ends the paused interaction; a mouse press outside
+      // is followed by a `mouseleave`, which handles the collapse instead.
+      fireEvent.pointerDown(document.body, { pointerType: 'mouse' });
+
+      expect(screen.getByTestId('viewport')).toHaveAttribute('data-expanded');
+
+      clock.tick(5001);
+      expect(screen.queryByTestId('root')).not.toBe(null);
+    });
+
     it.skipIf(!isJSDOM)('resumes timers when the viewport is blurred', async () => {
       await renderFakeTimers(
         <Toast.Provider>
@@ -818,6 +997,104 @@ describe('<Toast.Viewport />', () => {
 
       const guard = document.querySelector('[data-base-ui-focus-guard]') as HTMLElement;
       fireEvent.focus(guard, { relatedTarget: viewport });
+
+      expect(button).toHaveFocus();
+    });
+
+    it.skipIf(!isJSDOM)('returns focus to the trigger when every toast is closed', async () => {
+      const manager = Toast.createToastManager();
+
+      await renderFakeTimers(
+        <Toast.Provider toastManager={manager} timeout={0}>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+      await act(async () => button.focus());
+      fireEvent.click(button);
+
+      fireEvent.keyDown(button, { key: 'F6' });
+      const viewport = screen.getByTestId('viewport');
+      const guard = document.querySelector('[data-base-ui-focus-guard]') as HTMLElement;
+      fireEvent.focus(guard, { relatedTarget: viewport });
+
+      expect(screen.getByTestId('root')).toHaveFocus();
+
+      // Closing everything leaves no toast to hand focus to.
+      await act(async () => manager.close());
+
+      expect(button).toHaveFocus();
+    });
+
+    it.skipIf(!isJSDOM)('moves focus past toasts animating out when one is closed', async () => {
+      const manager = Toast.createToastManager();
+
+      await renderFakeTimers(
+        <Toast.Provider toastManager={manager} timeout={0}>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+      await act(async () => button.focus());
+
+      await act(async () => {
+        manager.add({ title: 'oldest' });
+      });
+      await act(async () => {
+        manager.add({ id: 'middle', title: 'middle' });
+      });
+      await act(async () => {
+        manager.add({ id: 'newest', title: 'newest' });
+      });
+
+      const [newest, middle, oldest] = screen.getAllByTestId('root');
+      expect(middle).toHaveTextContent('middle');
+
+      fireEvent.keyDown(button, { key: 'F6' });
+      const viewport = screen.getByTestId('viewport');
+      const guard = document.querySelector('[data-base-ui-focus-guard]') as HTMLElement;
+      fireEvent.focus(guard, { relatedTarget: viewport });
+
+      expect(newest).toHaveFocus();
+
+      // Dismissing both in one go leaves the middle toast animating out while
+      // the focused toast closes, so focus has to skip over it.
+      await act(async () => {
+        manager.close('middle');
+        manager.close('newest');
+      });
+
+      expect(middle).toHaveAttribute('data-ending-style');
+      expect(oldest).toHaveFocus();
+    });
+
+    it.skipIf(!isJSDOM)('leaves focus alone when it is outside the viewport', async () => {
+      const manager = Toast.createToastManager();
+
+      await renderFakeTimers(
+        <Toast.Provider toastManager={manager} timeout={0}>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+      await act(async () => button.focus());
+      fireEvent.click(button);
+      fireEvent.click(button);
+
+      // Focus never entered the viewport, so closing a toast must not steal it.
+      await act(async () => manager.close());
 
       expect(button).toHaveFocus();
     });

--- a/packages/react/src/toast/viewport/ToastViewport.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.tsx
@@ -101,24 +101,17 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
   }, [store, windowFocusTimeout, isEmpty]);
 
   function handleFocusGuard(event: React.FocusEvent) {
-    const viewport = store.state.viewport;
-    if (!viewport) {
-      return;
-    }
-
     handlingFocusGuardRef.current = true;
 
     // If we're coming off the container, move to the first toast that can hold
     // focus, skipping toasts that are animating out or inert because they're limited.
-    if (event.relatedTarget === viewport) {
-      const firstFocusableToast = toasts.find(
-        (toast) => toast.transitionStatus !== 'ending' && !toast.limited,
-      );
-      if (firstFocusableToast) {
-        firstFocusableToast.ref?.current?.focus();
-      } else {
-        store.restoreFocusToPrevElement();
-      }
+    const firstFocusableToast =
+      event.relatedTarget === store.state.viewport
+        ? toasts.find((toast) => toast.transitionStatus !== 'ending' && !toast.limited)
+        : undefined;
+
+    if (firstFocusableToast) {
+      firstFocusableToast.ref?.current?.focus();
     } else {
       store.restoreFocusToPrevElement();
     }
@@ -131,9 +124,11 @@ export const ToastViewport = React.forwardRef(function ToastViewport(
       getTarget(event.nativeEvent) === store.state.viewport
     ) {
       event.preventDefault();
+      // Restoring focus blurs the viewport, and `handleBlur` resumes the timers
+      // from there. Resuming here as well would also fire when the previously
+      // focused element lives inside the viewport, letting toasts dismiss out
+      // from under the keyboard.
       store.restoreFocusToPrevElement();
-      // Shift+Tab is explicit keyboard navigation out of the viewport.
-      store.resumeTimers();
     }
   }
 


### PR DESCRIPTION
Expands Toast test coverage to 100% across statements, branches, functions, and lines on merged jsdom and Chromium results, and fixes the two bugs the sweep uncovered.

`pauseTimers` recomputed the remaining time from the original `delay` instead of the time actually left, so every hover cycle handed the toast extra life. This overlaps with #5261, which fixes the same bug; the rewrite here also drops the now-unused `TimerInfo.delay` field, so one of the two needs a rebase.

The viewport's shift+Tab handler also resumed timers unconditionally. When F6 was pressed from a control inside a toast, focus was restored back into the viewport and the toast auto-dismissed while it still had keyboard focus. `handleBlur` already resumes when focus really leaves, so the extra call is gone.
