### PR TITLE
[select] Expand test coverage

### DIFF
--- a/packages/react/src/select/group-label/SelectGroupLabel.test.tsx
+++ b/packages/react/src/select/group-label/SelectGroupLabel.test.tsx
@@ -1,3 +1,4 @@
+import { expect, vi } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -14,4 +15,22 @@ describe('<Select.GroupLabel />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <Select.Group>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Select.Root open>
+            <Select.GroupLabel />
+          </Select.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: SelectGroupContext is missing. SelectGroup parts must be placed within <Select.Group>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/packages/react/src/select/item-indicator/SelectItemIndicator.test.tsx
+++ b/packages/react/src/select/item-indicator/SelectItemIndicator.test.tsx
@@ -1,4 +1,6 @@
+import { expect } from 'vitest';
 import { Select } from '@base-ui/react/select';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Select.ItemIndicator />', () => {
@@ -19,4 +21,40 @@ describe('<Select.ItemIndicator />', () => {
       );
     },
   }));
+
+  it('settles out of its transition state after the item is deselected', async () => {
+    const { user } = await render(
+      <Select.Root multiple defaultOpen defaultValue={['a']}>
+        <Select.Trigger>
+          <Select.Value />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="a">
+                a
+                <Select.ItemIndicator keepMounted data-testid="indicator" />
+              </Select.Item>
+              <Select.Item value="b">b</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const indicator = screen.getByTestId('indicator');
+    expect(indicator).toHaveAttribute('data-selected');
+
+    await user.click(screen.getByRole('option', { name: 'a' }));
+
+    await waitFor(() => {
+      expect(indicator).not.toHaveAttribute('data-selected');
+    });
+
+    // A kept-mounted indicator must not be left advertising an exit transition once the
+    // deselection has finished, or `[data-ending-style]` CSS would stick permanently.
+    await waitFor(() => {
+      expect(indicator).not.toHaveAttribute('data-ending-style');
+    });
+  });
 });

--- a/packages/react/src/select/item-text/SelectItemText.test.tsx
+++ b/packages/react/src/select/item-text/SelectItemText.test.tsx
@@ -1,3 +1,4 @@
+import { expect, vi } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -16,4 +17,24 @@ describe('<Select.ItemText />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <Select.Item>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Select.Root open>
+            <Select.Positioner>
+              <Select.ItemText />
+            </Select.Positioner>
+          </Select.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: SelectItemContext is missing. SelectItem parts must be placed within <Select.Item>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/packages/react/src/select/item-text/SelectItemText.tsx
+++ b/packages/react/src/select/item-text/SelectItemText.tsx
@@ -16,14 +16,14 @@ export const SelectItemText = React.memo(
     componentProps: SelectItemText.Props,
     forwardedRef: React.ForwardedRef<HTMLDivElement>,
   ) {
-    const { index, textRef, selectedByFocus, hasRegistered } = useSelectItemContext();
+    const { index, textRef, selectedByFocus } = useSelectItemContext();
     const { firstItemTextRef, selectedItemTextRef } = useSelectRootContext();
 
     const { render, className, style, ...elementProps } = componentProps;
 
     const localRef = React.useCallback(
       (node: HTMLElement | null) => {
-        if (!node || !hasRegistered) {
+        if (!node) {
           return;
         }
 
@@ -34,7 +34,7 @@ export const SelectItemText = React.memo(
           selectedItemTextRef.current = node;
         }
       },
-      [firstItemTextRef, selectedItemTextRef, index, selectedByFocus, hasRegistered],
+      [firstItemTextRef, selectedItemTextRef, index, selectedByFocus],
     );
 
     const element = useRenderElement('div', componentProps, {

--- a/packages/react/src/select/item/SelectItem.test.tsx
+++ b/packages/react/src/select/item/SelectItem.test.tsx
@@ -1,4 +1,5 @@
 import { expect, vi } from 'vitest';
+import * as React from 'react';
 import { Select } from '@base-ui/react/select';
 import {
   act,
@@ -20,6 +21,101 @@ describe('<Select.Item />', () => {
       return render(<Select.Root open>{node}</Select.Root>);
     },
   }));
+
+  it('treats a null value as an empty selection in multiple mode', async () => {
+    const handleValueChange = vi.fn();
+
+    // A controlled multiple select can legitimately be handed `null` (for example while its
+    // value is still loading) instead of an array.
+    const { user } = await render(
+      <Select.Root multiple value={null} onValueChange={handleValueChange}>
+        <Select.Trigger data-testid="trigger">
+          <Select.Value />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="one">one</Select.Item>
+              <Select.Item value="two">two</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    await user.click(screen.getByTestId('trigger'));
+
+    const option = await screen.findByRole('option', { name: 'one' });
+    expect(option).toHaveAttribute('aria-selected', 'false');
+
+    await user.click(option);
+
+    expect(handleValueChange).toHaveBeenCalledWith(['one'], expect.anything());
+  });
+
+  it('keeps the selection while grouped items are reordered and inserted', async () => {
+    // `useCompositeListItem({ guess: true })` guesses each index from render order and lets the
+    // commit flush correct it. Grouping, reordering and late insertion all invalidate the guess,
+    // so this pins that a corrected index still resolves back to the right item.
+    function App() {
+      const [items, setItems] = React.useState(['b', 'c']);
+      const [reversed, setReversed] = React.useState(false);
+      const ordered = reversed ? [...items].reverse() : items;
+
+      return (
+        <div>
+          <Select.Root open defaultValue="b">
+            <Select.Trigger>
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup>
+                  <Select.Group>
+                    <Select.GroupLabel>Group one</Select.GroupLabel>
+                    {ordered.map((itemValue) => (
+                      <Select.Item key={itemValue} value={itemValue}>
+                        <Select.ItemText>{itemValue}</Select.ItemText>
+                      </Select.Item>
+                    ))}
+                  </Select.Group>
+                  <Select.Group>
+                    <Select.GroupLabel>Group two</Select.GroupLabel>
+                    <Select.Item value="z">
+                      <Select.ItemText>z</Select.ItemText>
+                    </Select.Item>
+                  </Select.Group>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+          <button data-testid="prepend" onClick={() => setItems((prev) => ['a', ...prev])}>
+            Prepend
+          </button>
+          <button data-testid="reverse" onClick={() => setReversed((prev) => !prev)}>
+            Reverse
+          </button>
+        </div>
+      );
+    }
+
+    const { user } = await render(<App />);
+
+    await user.click(screen.getByTestId('prepend'));
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'a' })).not.toBe(null);
+    });
+
+    await user.click(screen.getByTestId('reverse'));
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'b' })).toHaveAttribute('data-selected');
+    });
+
+    await user.click(screen.getByTestId('reverse'));
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'b' })).toHaveAttribute('data-selected');
+    });
+  });
 
   it('should select the item and close popup when clicked', async () => {
     ignoreActWarnings();
@@ -524,6 +620,136 @@ describe('<Select.Item />', () => {
 
       await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('one'));
       expect(handleClick).toHaveBeenCalledOnce();
+    });
+
+    it('does not fire click handlers on a disabled item during drag-to-select', async () => {
+      ignoreActWarnings();
+      const handleClick = vi.fn();
+
+      await renderFakeTimers(
+        <Select.Root>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" placeholder="Select font" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="one" disabled onClick={handleClick}>
+                  one
+                </Select.Item>
+                <Select.Item value="two">two</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.mouseDown(trigger);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+
+      const option = screen.getByRole('option', { name: 'one' });
+      fireEvent.pointerEnter(option, { pointerType: 'mouse' });
+      for (let i = 0; i < 4; i += 1) {
+        fireEvent.pointerMove(option, { pointerType: 'mouse', buttons: 1, movementY: 2 });
+      }
+
+      await act(async () => {
+        await clock.tickAsync(100);
+      });
+      fireEvent.mouseUp(option);
+
+      await flushMicrotasks();
+
+      // Releasing over a disabled item must not synthesize a click on it at all.
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it('should not select a disabled item via drag-to-select', async () => {
+      ignoreActWarnings();
+      const handleValueChange = vi.fn();
+
+      await renderFakeTimers(
+        <Select.Root onValueChange={handleValueChange}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" placeholder="Select font" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="one" disabled>
+                  one
+                </Select.Item>
+                <Select.Item value="two">two</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.mouseDown(trigger);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+
+      const option = screen.getByRole('option', { name: 'one' });
+      fireEvent.pointerEnter(option, { pointerType: 'mouse' });
+      for (let i = 0; i < 4; i += 1) {
+        fireEvent.pointerMove(option, {
+          pointerType: 'mouse',
+          buttons: 1,
+          movementY: 2,
+        });
+      }
+
+      await act(async () => {
+        await clock.tickAsync(100);
+      });
+      fireEvent.mouseUp(option);
+
+      await flushMicrotasks();
+
+      expect(handleValueChange).not.toHaveBeenCalled();
+      expect(screen.getByTestId('value').textContent).toBe('Select font');
+    });
+
+    it('should not select on mouseup that follows a touch interaction', async () => {
+      ignoreActWarnings();
+      const handleValueChange = vi.fn();
+
+      await renderFakeTimers(
+        <Select.Root onValueChange={handleValueChange}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" placeholder="Select font" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="one">one</Select.Item>
+                <Select.Item value="two">two</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      fireEvent.mouseDown(trigger);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
+
+      const option = screen.getByRole('option', { name: 'one' });
+      // A touch drag over the item: the synthesized mouseup must not commit a selection,
+      // otherwise scrolling the popup with a finger would pick whatever is released over.
+      fireEvent.pointerEnter(option, { pointerType: 'touch' });
+
+      await act(async () => {
+        await clock.tickAsync(500);
+      });
+      fireEvent.mouseUp(option);
+
+      await flushMicrotasks();
+
+      expect(handleValueChange).not.toHaveBeenCalled();
+      expect(screen.getByTestId('value').textContent).toBe('Select font');
     });
 
     it('should accumulate drag-to-select movement across items', async () => {

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -69,28 +69,19 @@ export const SelectItem = React.memo(
     const isItemEqualToValue = useStore(store, selectors.isItemEqualToValue);
 
     const index = listItem.index;
-    const hasRegistered = index !== -1;
 
     const itemRef = React.useRef<HTMLDivElement | null>(null);
 
     useIsoLayoutEffect(() => {
-      if (!hasRegistered) {
-        return undefined;
-      }
-
       const values = valuesRef.current;
       values[index] = itemValue;
 
       return () => {
         delete values[index];
       };
-    }, [hasRegistered, index, itemValue, valuesRef]);
+    }, [index, itemValue, valuesRef]);
 
     useIsoLayoutEffect(() => {
-      if (!hasRegistered) {
-        return;
-      }
-
       const selectedValue = store.state.value;
 
       let selectedCandidate = selectedValue;
@@ -112,7 +103,7 @@ export const SelectItem = React.memo(
           selectedItemTextRef.current = textRef.current;
         }
       }
-    }, [hasRegistered, index, multiple, isItemEqualToValue, store, itemValue, selectedItemTextRef]);
+    }, [index, multiple, isItemEqualToValue, store, itemValue, selectedItemTextRef]);
 
     const pointerTypeRef = React.useRef<'mouse' | 'touch' | 'pen'>('mouse');
     const allowMouseSelectionRef = React.useRef(false);
@@ -246,9 +237,8 @@ export const SelectItem = React.memo(
         index,
         textRef,
         selectedByFocus,
-        hasRegistered,
       }),
-      [selected, index, textRef, selectedByFocus, hasRegistered],
+      [selected, index, textRef, selectedByFocus],
     );
 
     return <SelectItemContext.Provider value={contextValue}>{element}</SelectItemContext.Provider>;

--- a/packages/react/src/select/item/SelectItemContext.ts
+++ b/packages/react/src/select/item/SelectItemContext.ts
@@ -6,7 +6,6 @@ export interface SelectItemContext {
   index: number;
   textRef: React.RefObject<HTMLElement | null>;
   selectedByFocus: boolean;
-  hasRegistered: boolean;
 }
 
 export const SelectItemContext = React.createContext<SelectItemContext | undefined>(undefined);

--- a/packages/react/src/select/popup/SelectPopup.test.tsx
+++ b/packages/react/src/select/popup/SelectPopup.test.tsx
@@ -1,8 +1,9 @@
 import { expect } from 'vitest';
 import * as React from 'react';
 import { Select } from '@base-ui/react/select';
+import { Toolbar } from '@base-ui/react/toolbar';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
-import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, ignoreActWarnings, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Select.Popup />', () => {
@@ -20,6 +21,71 @@ describe('<Select.Popup />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <Select.Positioner>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Select.Root open>
+            <Select.Popup />
+          </Select.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: SelectPositionerContext is missing. SelectPositioner parts must be placed within <Select.Positioner>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('keeps arrow keys inside the popup when the trigger lives in a toolbar', async () => {
+    // Clicking the trigger starts its deferred `forceMount` timer, which settles after the
+    // assertions below.
+    ignoreActWarnings();
+    const onToolbarKeyDown = vi.fn();
+    const { user } = await render(
+      <Toolbar.Root onKeyDown={onToolbarKeyDown}>
+        <Select.Root defaultValue="a">
+          <Toolbar.Button render={<Select.Trigger data-testid="trigger" />}>
+            <Select.Value />
+          </Toolbar.Button>
+          {/* Rendered inline rather than portaled, so the popup sits inside the toolbar's own
+              DOM subtree and its composite key handling actually sees these events. */}
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="a">a</Select.Item>
+              <Select.Item value="b">b</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Root>
+        <Toolbar.Button data-testid="next">Next</Toolbar.Button>
+      </Toolbar.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    await act(async () => {
+      trigger.focus();
+    });
+
+    // Opening with the keyboard moves focus onto the selected item inside the popup.
+    await user.keyboard('{Enter}');
+    await screen.findByRole('listbox');
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'a' })).toHaveFocus();
+    });
+
+    // Enter isn't a composite key, so opening legitimately reaches the toolbar.
+    onToolbarKeyDown.mockClear();
+
+    // A horizontal toolbar navigates with ArrowRight. While the select popup owns focus that key
+    // belongs to the popup, so it must not bubble out and move focus off the toolbar button.
+    await user.keyboard('{ArrowRight}');
+
+    expect(onToolbarKeyDown).not.toHaveBeenCalled();
+    expect(screen.getByTestId('next')).not.toHaveFocus();
+  });
 
   it('has aria attributes when no Select.List is present', async () => {
     const { user } = await render(
@@ -966,6 +1032,645 @@ describe('<Select.Popup />', () => {
       }
     },
   );
+
+  it('does not resize the positioner when the list scrolls before the popup is placed', async () => {
+    await render(
+      <Select.Root defaultValue="a">
+        <Select.Trigger data-testid="trigger">
+          <Select.Value />
+        </Select.Trigger>
+        <Select.Positioner data-testid="positioner">
+          <Select.Popup>
+            <Select.ScrollUpArrow keepMounted data-testid="up-arrow" />
+            <Select.List
+              data-testid="list"
+              ref={(node) => {
+                if (!node) {
+                  return;
+                }
+
+                Object.defineProperty(node, 'scrollTop', { value: 100, configurable: true });
+                Object.defineProperty(node, 'scrollHeight', { value: 400, configurable: true });
+                Object.defineProperty(node, 'clientHeight', { value: 200, configurable: true });
+              }}
+            >
+              <Select.Item value="a">a</Select.Item>
+              <Select.Item value="b">b</Select.Item>
+            </Select.List>
+          </Select.Popup>
+        </Select.Positioner>
+      </Select.Root>,
+    );
+
+    const positioner = screen.getByTestId('positioner');
+    const geometryBefore = {
+      height: positioner.style.height,
+      top: positioner.style.top,
+      bottom: positioner.style.bottom,
+    };
+
+    // A closed popup has never been measured, so a stray scroll must neither rewrite the
+    // positioner geometry nor light up the scroll arrows.
+    fireEvent.scroll(screen.getByTestId('list'));
+
+    expect({
+      height: positioner.style.height,
+      top: positioner.style.top,
+      bottom: positioner.style.bottom,
+    }).toEqual(geometryBefore);
+    expect(screen.getByTestId('up-arrow')).not.toHaveAttribute('data-visible');
+  });
+
+  describe.skipIf(isJSDOM)('aligned popup scroll resizing', () => {
+    const docEl = document.documentElement;
+    const restores: Array<() => void> = [];
+
+    function stubProperty(target: object, property: string, value: unknown) {
+      const descriptor = Object.getOwnPropertyDescriptor(target, property);
+      Object.defineProperty(target, property, { value, configurable: true });
+      restores.push(() => {
+        if (descriptor) {
+          Object.defineProperty(target, property, descriptor);
+        } else {
+          delete (target as Record<string, unknown>)[property];
+        }
+      });
+    }
+
+    function stubRect(node: HTMLElement, left: number, top: number, width: number, height: number) {
+      stubProperty(node, 'getBoundingClientRect', () => ({
+        x: left,
+        y: top,
+        left,
+        top,
+        width,
+        height,
+        right: left + width,
+        bottom: top + height,
+        toJSON: () => ({}),
+      }));
+      // Floating UI derives the element scale by comparing the rect against the offset box, so
+      // both have to agree or the stubbed geometry reads back as if the page were zoomed.
+      stubProperty(node, 'offsetWidth', width);
+      stubProperty(node, 'offsetHeight', height);
+    }
+
+    afterEach(() => {
+      while (restores.length > 0) {
+        restores.pop()!();
+      }
+    });
+
+    /**
+     * Renders an item-aligned select whose viewport and element geometry are fully stubbed, so
+     * the height-on-scroll behavior is reproducible instead of depending on the runner's window.
+     */
+    async function renderAligned(options: {
+      viewportHeight: number;
+      triggerTop: number;
+      positionerHeight: number;
+      listScrollHeight: number;
+      listClientHeight: number;
+      /** Vertical distance from the positioner top to the selected item's text. */
+      selectedTextTop?: number;
+      popupMaxHeight?: string;
+      /** Use uncontrolled open state so the component can close itself. */
+      uncontrolledOpen?: boolean;
+    }) {
+      const {
+        viewportHeight,
+        triggerTop,
+        positionerHeight,
+        listScrollHeight,
+        listClientHeight,
+        selectedTextTop,
+        popupMaxHeight = 'none',
+        uncontrolledOpen = false,
+      } = options;
+
+      stubProperty(docEl, 'clientHeight', viewportHeight);
+      stubProperty(docEl, 'clientWidth', 400);
+
+      let listScrollTop = 0;
+
+      await render(
+        <Select.Root
+          open={uncontrolledOpen ? undefined : true}
+          defaultOpen={uncontrolledOpen}
+          defaultValue="selected"
+        >
+          <Select.Trigger
+            data-testid="trigger"
+            ref={(node) => {
+              if (node) {
+                stubRect(node, 10, triggerTop, 80, 30);
+              }
+            }}
+          >
+            <Select.Value
+              data-testid="value"
+              ref={(node) => {
+                if (node) {
+                  stubRect(node, 10, triggerTop, 60, 30);
+                }
+              }}
+            />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner
+              data-testid="positioner"
+              ref={(node) => {
+                if (node) {
+                  stubRect(node, 10, 0, 108, positionerHeight);
+                }
+              }}
+            >
+              <Select.Popup data-testid="popup" style={{ maxHeight: popupMaxHeight }}>
+                <Select.List
+                  data-testid="list"
+                  ref={(node) => {
+                    if (!node) {
+                      return;
+                    }
+
+                    Object.defineProperty(node, 'scrollTop', {
+                      configurable: true,
+                      get: () => listScrollTop,
+                      set: (value: number) => {
+                        listScrollTop = value;
+                      },
+                    });
+                    stubProperty(node, 'scrollHeight', listScrollHeight);
+                    stubProperty(node, 'clientHeight', listClientHeight);
+                  }}
+                >
+                  <Select.Item value="selected">
+                    <Select.ItemText
+                      data-testid="selected-text"
+                      ref={(node) => {
+                        if (node && selectedTextTop != null) {
+                          stubRect(node, 10, selectedTextTop, 80, 30);
+                        }
+                      }}
+                    >
+                      Selected
+                    </Select.ItemText>
+                  </Select.Item>
+                  <Select.Item value="other">
+                    <Select.ItemText>Other</Select.ItemText>
+                  </Select.Item>
+                </Select.List>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const positioner = screen.getByTestId('positioner');
+      const list = screen.getByTestId('list');
+
+      await waitFor(() => {
+        expect(positioner).toHaveAttribute('data-side', 'none');
+      });
+
+      return {
+        positioner,
+        list,
+        getListScrollTop: () => listScrollTop,
+        setListScrollTop: (value: number) => {
+          listScrollTop = value;
+        },
+      };
+    }
+
+    it('anchors the popup to the viewport bottom when the selection sits near the list top', async () => {
+      const { positioner } = await renderAligned({
+        viewportHeight: 720,
+        triggerTop: 300,
+        positionerHeight: 200,
+        listScrollHeight: 400,
+        listClientHeight: 200,
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.bottom).toBe('0px');
+      });
+      expect(positioner.style.top).toBe('');
+    });
+
+    it('grows a bottom-anchored popup as the list is scrolled and re-pins it to the top', async () => {
+      const { positioner, list, getListScrollTop, setListScrollTop } = await renderAligned({
+        viewportHeight: 720,
+        triggerTop: 300,
+        positionerHeight: 200,
+        listScrollHeight: 400,
+        listClientHeight: 200,
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.bottom).toBe('0px');
+      });
+
+      setListScrollTop(100);
+      fireEvent.scroll(list);
+
+      // The scrolled distance is converted into extra popup height, and the list snaps back so
+      // the newly revealed rows appear by growing rather than by scrolling.
+      await waitFor(() => {
+        expect(positioner.style.height).toBe('300px');
+      });
+      expect(getListScrollTop()).toBe(0);
+    });
+
+    it('consumes a sub-pixel overscroll into the popup height', async () => {
+      const { positioner, list, getListScrollTop, setListScrollTop } = await renderAligned({
+        viewportHeight: 720,
+        triggerTop: 300,
+        positionerHeight: 200,
+        listScrollHeight: 400,
+        listClientHeight: 200,
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.bottom).toBe('0px');
+      });
+
+      setListScrollTop(0.5);
+      fireEvent.scroll(list);
+
+      await waitFor(() => {
+        expect(positioner.style.height).toBe('200.5px');
+      });
+      expect(getListScrollTop()).toBe(0);
+    });
+
+    it('leaves the popup height alone when the list is already at the anchored edge', async () => {
+      const { positioner, list, setListScrollTop } = await renderAligned({
+        viewportHeight: 720,
+        triggerTop: 300,
+        positionerHeight: 200,
+        listScrollHeight: 400,
+        listClientHeight: 200,
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.bottom).toBe('0px');
+      });
+
+      const heightBefore = positioner.style.height;
+
+      setListScrollTop(0);
+      fireEvent.scroll(list);
+
+      await waitFor(() => {
+        expect(positioner.style.height).toBe(heightBefore);
+      });
+    });
+
+    it('grows a top-anchored popup upward and keeps the list pinned to the bottom', async () => {
+      const { positioner, list, getListScrollTop, setListScrollTop } = await renderAligned({
+        viewportHeight: 400,
+        triggerTop: 200,
+        positionerHeight: 200,
+        listScrollHeight: 400,
+        listClientHeight: 300,
+        selectedTextTop: 300,
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.top).toBe('0px');
+      });
+      expect(positioner.style.bottom).toBe('');
+
+      setListScrollTop(0);
+      fireEvent.scroll(list);
+
+      await waitFor(() => {
+        expect(positioner.style.height).toBe('300px');
+      });
+      expect(getListScrollTop()).toBe(100);
+    });
+
+    it('stops growing a top-anchored popup once it fills the available height', async () => {
+      const { positioner, list, setListScrollTop } = await renderAligned({
+        viewportHeight: 400,
+        triggerTop: 200,
+        positionerHeight: 300,
+        listScrollHeight: 400,
+        listClientHeight: 300,
+        selectedTextTop: 300,
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.top).toBe('0px');
+      });
+
+      setListScrollTop(0);
+      fireEvent.scroll(list);
+
+      // 300px of popup plus 100px of remaining scroll saturates the 380px of available height,
+      // so it clamps instead of overshooting the viewport.
+      await waitFor(() => {
+        expect(positioner.style.height).toBe('380px');
+      });
+
+      // Once saturated, further scrolling must not keep resizing.
+      setListScrollTop(50);
+      fireEvent.scroll(list);
+
+      await waitFor(() => {
+        expect(positioner.style.height).toBe('380px');
+      });
+    });
+
+    it('pins a top-anchored popup that already fills the viewport to the end of the list', async () => {
+      const { positioner, list, getListScrollTop, setListScrollTop } = await renderAligned({
+        viewportHeight: 400,
+        triggerTop: 200,
+        positionerHeight: 380,
+        listScrollHeight: 400,
+        listClientHeight: 300,
+        selectedTextTop: 300,
+      });
+
+      // A popup at least as tall as the usable viewport is flush with its top edge.
+      await waitFor(() => {
+        expect(positioner.style.top).toBe('0px');
+      });
+
+      const heightBefore = positioner.style.height;
+
+      setListScrollTop(100);
+      fireEvent.scroll(list);
+
+      await waitFor(() => {
+        expect(getListScrollTop()).toBe(100);
+      });
+      expect(positioner.style.height).toBe(heightBefore);
+
+      // Having reached its maximum, the popup stops taking over scrolling entirely: a later
+      // sub-pixel scroll is left to the list instead of being snapped back to the edge.
+      setListScrollTop(99.5);
+      fireEvent.scroll(list);
+
+      await waitFor(() => {
+        expect(positioner.style.height).toBe(heightBefore);
+      });
+      expect(getListScrollTop()).toBe(99.5);
+    });
+
+    it('stops resizing once a max-height constrained popup is fully grown', async () => {
+      const { positioner, list, setListScrollTop } = await renderAligned({
+        viewportHeight: 720,
+        triggerTop: 300,
+        positionerHeight: 200,
+        listScrollHeight: 400,
+        listClientHeight: 200,
+        popupMaxHeight: '100px',
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.bottom).toBe('0px');
+      });
+
+      const heightBefore = positioner.style.height;
+
+      setListScrollTop(100);
+      fireEvent.scroll(list);
+
+      await waitFor(() => {
+        expect(positioner.style.height).toBe(heightBefore);
+      });
+    });
+
+    it('treats a zero max-height as unconstrained rather than collapsing the popup', async () => {
+      const { positioner, list, setListScrollTop } = await renderAligned({
+        viewportHeight: 720,
+        triggerTop: 300,
+        positionerHeight: 200,
+        listScrollHeight: 400,
+        listClientHeight: 200,
+        popupMaxHeight: '0px',
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.bottom).toBe('0px');
+      });
+
+      setListScrollTop(100);
+      fireEvent.scroll(list);
+
+      // `max-height: 0` is treated as unset, matching the margin/min-height fallbacks, so the
+      // popup still grows by the scrolled distance instead of clamping to nothing.
+      await waitFor(() => {
+        expect(positioner.style.height).toBe('300px');
+      });
+    });
+
+    it('centers the transform origin when the positioner has no measurable height', async () => {
+      const { positioner } = await renderAligned({
+        viewportHeight: 720,
+        triggerTop: 300,
+        positionerHeight: 0,
+        listScrollHeight: 400,
+        listClientHeight: 200,
+        selectedTextTop: 100,
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.bottom).toBe('0px');
+      });
+
+      expect(screen.getByTestId('popup').style.getPropertyValue('--transform-origin')).toBe(
+        '50% 50%',
+      );
+    });
+
+    it('never applies a non-positive height when the viewport collapses below the margins', async () => {
+      const { positioner, list, setListScrollTop } = await renderAligned({
+        viewportHeight: 720,
+        triggerTop: 300,
+        positionerHeight: 200,
+        listScrollHeight: 400,
+        listClientHeight: 200,
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.bottom).toBe('0px');
+      });
+
+      const heightBefore = positioner.style.height;
+
+      // The viewport shrinks to less than the popup's own margins after placement.
+      stubProperty(docEl, 'clientHeight', 20);
+
+      setListScrollTop(100);
+      fireEvent.scroll(list);
+
+      await waitFor(() => {
+        expect(positioner.style.height).toBe(heightBefore);
+      });
+    });
+
+    it('ignores a pinch-zoomed visual viewport outside WebKit', async () => {
+      const { visualViewport } = window;
+      if (visualViewport) {
+        stubProperty(visualViewport, 'scale', 1.5);
+      }
+
+      const { positioner } = await renderAligned({
+        viewportHeight: 720,
+        triggerTop: 300,
+        positionerHeight: 200,
+        listScrollHeight: 400,
+        listClientHeight: 200,
+      });
+
+      // Only WebKit mispositions pinch-zoomed popups, so other engines keep item alignment.
+      await waitFor(() => {
+        expect(positioner).toHaveAttribute('data-side', 'none');
+      });
+    });
+
+    it('ignores scroll events bubbling to the popup while a Select.List owns scrolling', async () => {
+      const { positioner, list, setListScrollTop } = await renderAligned({
+        viewportHeight: 720,
+        triggerTop: 300,
+        positionerHeight: 200,
+        listScrollHeight: 400,
+        listClientHeight: 200,
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.bottom).toBe('0px');
+      });
+
+      const heightBefore = positioner.style.height;
+
+      // Give the popup its own (different) scroll geometry so handling it would be detectable.
+      const popup = screen.getByTestId('popup');
+      Object.defineProperty(popup, 'scrollTop', { value: 50, configurable: true });
+      Object.defineProperty(popup, 'scrollHeight', { value: 400, configurable: true });
+      Object.defineProperty(popup, 'clientHeight', { value: 200, configurable: true });
+
+      setListScrollTop(100);
+      // The list, not the popup, is the scroll container here. Handling the bubbled event on the
+      // popup as well would resize using the wrong element's offsets.
+      fireEvent.scroll(popup);
+
+      await waitFor(() => {
+        expect(positioner.style.height).toBe(heightBefore);
+      });
+
+      fireEvent.scroll(list);
+
+      await waitFor(() => {
+        expect(positioner.style.height).toBe('300px');
+      });
+    });
+
+    it('grows the popup when it is itself the scroll container', async () => {
+      stubProperty(docEl, 'clientHeight', 720);
+      stubProperty(docEl, 'clientWidth', 400);
+
+      let popupScrollTop = 0;
+
+      await render(
+        <Select.Root open defaultValue="selected">
+          <Select.Trigger
+            data-testid="trigger"
+            ref={(node) => {
+              if (node) {
+                stubRect(node, 10, 300, 80, 30);
+              }
+            }}
+          >
+            <Select.Value
+              ref={(node) => {
+                if (node) {
+                  stubRect(node, 10, 300, 60, 30);
+                }
+              }}
+            />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner
+              data-testid="positioner"
+              ref={(node) => {
+                if (node) {
+                  stubRect(node, 10, 0, 108, 200);
+                }
+              }}
+            >
+              <Select.Popup
+                data-testid="popup"
+                style={{ maxHeight: 'none' }}
+                ref={(node) => {
+                  if (!node) {
+                    return;
+                  }
+
+                  Object.defineProperty(node, 'scrollTop', {
+                    configurable: true,
+                    get: () => popupScrollTop,
+                    set: (value: number) => {
+                      popupScrollTop = value;
+                    },
+                  });
+                  stubProperty(node, 'scrollHeight', 400);
+                  stubProperty(node, 'clientHeight', 200);
+                }}
+              >
+                <Select.Item value="selected">
+                  <Select.ItemText>Selected</Select.ItemText>
+                </Select.Item>
+                <Select.Item value="other">
+                  <Select.ItemText>Other</Select.ItemText>
+                </Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const positioner = screen.getByTestId('positioner');
+      const popup = screen.getByTestId('popup');
+
+      await waitFor(() => {
+        expect(positioner.style.bottom).toBe('0px');
+      });
+
+      popupScrollTop = 100;
+      fireEvent.scroll(popup);
+
+      await waitFor(() => {
+        expect(positioner.style.height).toBe('300px');
+      });
+      expect(popupScrollTop).toBe(0);
+    });
+
+    it('closes the aligned popup when the window is resized', async () => {
+      const { positioner } = await renderAligned({
+        viewportHeight: 720,
+        triggerTop: 300,
+        positionerHeight: 200,
+        listScrollHeight: 400,
+        listClientHeight: 200,
+        uncontrolledOpen: true,
+      });
+
+      await waitFor(() => {
+        expect(positioner.style.bottom).toBe('0px');
+      });
+
+      // The aligned geometry is measured once, so a resize invalidates it entirely.
+      fireEvent(window, new UIEvent('resize'));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).toBe(null);
+      });
+    });
+  });
 
   describe('prop: finalFocus', () => {
     it('should focus the trigger by default when closed', async () => {

--- a/packages/react/src/select/popup/SelectPopup.tsx
+++ b/packages/react/src/select/popup/SelectPopup.tsx
@@ -12,7 +12,7 @@ import type { InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import { FloatingFocusManager, platform as floatingPlatform } from '../../floating-ui-react';
 import type { ClientRectObject } from '../../floating-ui-react';
 import type { BaseUIComponentProps, HTMLProps } from '../../internals/types';
-import { useSelectFloatingContext, useSelectRootContext } from '../root/SelectRootContext';
+import { useSelectRootContext } from '../root/SelectRootContext';
 import { popupStateMapping } from '../../utils/popupStateMapping';
 import type { Side, Align } from '../../utils/useAnchorPositioning';
 import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
@@ -64,6 +64,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     scrollHandlerRef,
     listRef,
     highlightItemOnHover,
+    floatingContext: floatingRootContext,
   } = useSelectRootContext();
   const {
     side,
@@ -73,7 +74,6 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     setControlledAlignItemWithTrigger,
   } = useSelectPositionerContext();
   const insideToolbar = useToolbarRootContext(true) != null;
-  const floatingRootContext = useSelectFloatingContext();
   const direction = useDirection();
 
   const { nonce, disableStyleElements } = useCSPContext();
@@ -107,7 +107,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
       !alignItemWithTriggerActive ||
       (!isTopPositioned && !isBottomPositioned)
     ) {
-      handleScrollArrowVisibility();
+      handleScrollArrowVisibility(scroller);
       return;
     }
 
@@ -151,7 +151,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
       if (maxAvailableHeight - (currentHeight + heightDelta) <= SCROLL_EDGE_TOLERANCE_PX) {
         reachedMaxHeightRef.current = true;
       }
-      handleScrollArrowVisibility();
+      handleScrollArrowVisibility(scroller);
       return;
     }
 
@@ -182,7 +182,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
       reachedMaxHeightRef.current = true;
     }
 
-    handleScrollArrowVisibility();
+    handleScrollArrowVisibility(scroller);
   });
 
   React.useImperativeHandle(scrollHandlerRef, () => handleScroll, [handleScroll]);
@@ -257,7 +257,9 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     popupElement.style.removeProperty('--transform-origin');
 
     if (!alignItemWithTriggerActive) {
-      scrollArrowFrame.request(handleScrollArrowVisibility);
+      // The wrapper supplies the scroller: the list owns scrolling once it has mounted, and
+      // this effect re-runs (cancelling the stale frame) when that happens.
+      scrollArrowFrame.request(() => handleScrollArrowVisibility(listElement || popupElement));
       return;
     }
 
@@ -399,7 +401,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
         reachedMaxHeightRef.current = true;
       }
 
-      handleScrollArrowVisibility();
+      handleScrollArrowVisibility(scroller);
 
       if (
         highlightItemOnHover &&

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -4,7 +4,7 @@ import { inertValue } from '@base-ui/utils/inertValue';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useStore } from '@base-ui/utils/store';
-import { useSelectRootContext, useSelectFloatingContext } from '../root/SelectRootContext';
+import { useSelectRootContext } from '../root/SelectRootContext';
 import { CompositeList } from '../../internals/composite/list/CompositeList';
 import type { BaseUIComponentProps } from '../../internals/types';
 import {
@@ -68,8 +68,8 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
     initialValueRef,
     popupRef,
     setValue,
+    floatingContext: floatingRootContext,
   } = useSelectRootContext();
-  const floatingRootContext = useSelectFloatingContext();
 
   const open = useStore(store, selectors.open);
   const mounted = useStore(store, selectors.mounted);

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -680,6 +680,94 @@ describe('<Select.Root />', () => {
     });
   });
 
+  it('ignores browser autofill in multiple mode', async () => {
+    const handleValueChange = vi.fn();
+
+    await render(
+      <Select.Root multiple name="select" onValueChange={handleValueChange}>
+        <Select.Trigger data-testid="trigger">
+          <Select.Value />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="a">a</Select.Item>
+              <Select.Item value="b">b</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const selectInput = screen.getByRole('textbox', { hidden: true });
+
+    // Autofill only ever writes a single scalar, which can't be meaningfully applied to a
+    // multi-selection, so it must be dropped rather than collapsing the value to one item.
+    fireEvent.change(selectInput, { target: { value: 'b' } });
+    await flushMicrotasks();
+
+    expect(handleValueChange).not.toHaveBeenCalled();
+  });
+
+  it('leaves the value untouched when autofill matches no item', async () => {
+    const handleValueChange = vi.fn();
+
+    await render(
+      <Select.Root name="select" defaultValue="a" onValueChange={handleValueChange}>
+        <Select.Trigger data-testid="trigger">
+          <Select.Value />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="a">a</Select.Item>
+              <Select.Item value="b">b</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    const selectInput = screen.getByRole('textbox', { hidden: true });
+
+    fireEvent.change(selectInput, { target: { value: 'not-an-option' } });
+    await flushMicrotasks();
+
+    expect(handleValueChange).not.toHaveBeenCalled();
+    expect(trigger).toHaveTextContent('a');
+  });
+
+  it('redirects focus to the trigger when the hidden input is focused', async () => {
+    await render(
+      <Select.Root name="select">
+        <Select.Trigger data-testid="trigger">
+          <Select.Value />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="a">a</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    const selectInput = screen.getByRole('textbox', { hidden: true });
+
+    // Browsers can focus the visually hidden input (for example when validation reports an
+    // error on it); focus has to land on the visible control instead.
+    await act(async () => {
+      selectInput.focus();
+    });
+
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
+
   it('should pass autoComplete to the hidden input', async () => {
     await render(
       <Select.Root name="country" autoComplete="country">
@@ -4965,6 +5053,52 @@ describe('<Select.Root />', () => {
       expect(optionB).toHaveAttribute('data-selected', '');
 
       expect(screen.getByRole('listbox')).not.toBe(null);
+    });
+
+    it('keeps the selection when items are added and none of the selected ones are removed', async () => {
+      const handleValueChange = vi.fn();
+
+      function App() {
+        const [items, setItems] = React.useState(['a', 'b']);
+
+        return (
+          <div>
+            <Select.Root multiple open defaultValue={['a']} onValueChange={handleValueChange}>
+              <Select.Trigger data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    {items.map((item) => (
+                      <Select.Item key={item} value={item}>
+                        {item}
+                      </Select.Item>
+                    ))}
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+            <button data-testid="add" onClick={() => setItems((prev) => [...prev, 'c'])}>
+              Add C
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      expect(await screen.findByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
+
+      await user.click(screen.getByTestId('add'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'c' })).not.toBe(null);
+      });
+
+      // Growing the list must not rewrite a still-valid selection.
+      expect(handleValueChange).not.toHaveBeenCalled();
+      expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-selected', '');
     });
 
     it('should deselect items when clicked again in multiple mode', async () => {

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -19,7 +19,7 @@ import {
   useListNavigation,
   useTypeahead,
 } from '../../floating-ui-react';
-import { SelectRootContext, SelectFloatingContext } from './SelectRootContext';
+import { SelectRootContext } from './SelectRootContext';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
 import { useRegisterFieldControl } from '../../internals/field-register-control/useRegisterFieldControl';
 import { useLabelableId } from '../../internals/labelable-provider/useLabelableId';
@@ -315,12 +315,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     },
   );
 
-  const handleScrollArrowVisibility = useStableCallback(() => {
-    const scroller = store.state.listElement || popupRef.current;
-    if (!scroller) {
-      return;
-    }
-
+  const handleScrollArrowVisibility = useStableCallback((scroller: HTMLElement) => {
     const maxScrollTop = getMaxScrollOffset(scroller.scrollHeight, scroller.clientHeight);
     const scrollTop = normalizeScrollOffset(scroller.scrollTop, maxScrollTop);
     const shouldShowUp = scrollTop > 0;
@@ -386,28 +381,24 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     },
   });
 
-  const mergedTriggerProps = React.useMemo(() => {
-    const triggerInteractionProps = mergeProps(
+  // `Select.Trigger` applies the id itself from the store, so it's deliberately not merged here.
+  const mergedTriggerProps = React.useMemo(
+    () =>
+      mergeProps(
+        typeahead.reference,
+        listNavigation.reference,
+        dismiss.reference,
+        click.reference,
+        interactionTypeProps,
+      ),
+    [
+      click.reference,
       typeahead.reference,
       listNavigation.reference,
       dismiss.reference,
-      click.reference,
       interactionTypeProps,
-    );
-
-    if (generatedId) {
-      triggerInteractionProps.id = generatedId;
-    }
-
-    return triggerInteractionProps;
-  }, [
-    click.reference,
-    typeahead.reference,
-    listNavigation.reference,
-    dismiss.reference,
-    interactionTypeProps,
-    generatedId,
-  ]);
+    ],
+  );
 
   const popupProps = React.useMemo(
     () =>
@@ -450,6 +441,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   const contextValue: SelectRootContext = React.useMemo(
     () => ({
       store,
+      floatingContext,
       required,
       disabled,
       readOnly,
@@ -477,6 +469,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     }),
     [
       store,
+      floatingContext,
       required,
       disabled,
       readOnly,
@@ -517,78 +510,75 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
 
   return (
     <SelectRootContext.Provider value={contextValue}>
-      <SelectFloatingContext.Provider value={floatingContext}>
-        {children}
-        <input
-          {...validation.getValidationProps(disabled, {
-            onFocus() {
-              // Move focus to the trigger element when the hidden input is focused.
-              store.state.triggerElement?.focus({
-                // Supported in Chrome from 144 (January 2026)
-                focusVisible: true,
-              });
-            },
-            // Handle browser autofill.
-            onChange(event: React.ChangeEvent<HTMLInputElement>) {
-              // Workaround for https://github.com/react/react/issues/9023
-              if (event.nativeEvent.defaultPrevented || disabled || readOnly) {
+      {children}
+      <input
+        {...validation.getValidationProps(disabled, {
+          onFocus() {
+            // Move focus to the trigger element when the hidden input is focused.
+            store.state.triggerElement?.focus({
+              // Supported in Chrome from 144 (January 2026)
+              focusVisible: true,
+            });
+          },
+          // Handle browser autofill.
+          onChange(event: React.ChangeEvent<HTMLInputElement>) {
+            // Workaround for https://github.com/react/react/issues/9023
+            if (event.nativeEvent.defaultPrevented || disabled || readOnly) {
+              return;
+            }
+
+            const nextValue = event.currentTarget.value;
+            const details = createChangeEventDetails(REASONS.none, event.nativeEvent);
+
+            function handleChange() {
+              if (multiple) {
+                // Browser autofill only writes a single scalar value.
                 return;
               }
 
-              const nextValue = event.currentTarget.value;
-              const details = createChangeEventDetails(REASONS.none, event.nativeEvent);
+              // Preserve the original serialized matching, then fall back to rendered text,
+              // which browsers can autofill for primitive values like `value="US">United States`.
+              const nextValueLower = nextValue.toLowerCase();
+              let matchingIndex = valuesRef.current.findIndex(
+                (candidate) =>
+                  stringifyAsValue(candidate, itemToStringValue).toLowerCase() === nextValueLower ||
+                  stringifyAsLabel(candidate, itemToStringLabel).toLowerCase() === nextValueLower,
+              );
 
-              function handleChange() {
-                if (multiple) {
-                  // Browser autofill only writes a single scalar value.
-                  return;
-                }
-
-                // Preserve the original serialized matching, then fall back to rendered text,
-                // which browsers can autofill for primitive values like `value="US">United States`.
-                const nextValueLower = nextValue.toLowerCase();
-                let matchingIndex = valuesRef.current.findIndex(
-                  (candidate) =>
-                    stringifyAsValue(candidate, itemToStringValue).toLowerCase() ===
-                      nextValueLower ||
-                    stringifyAsLabel(candidate, itemToStringLabel).toLowerCase() === nextValueLower,
-                );
-
-                if (matchingIndex === -1) {
-                  matchingIndex = valuesRef.current.findIndex((_, index) => {
-                    const renderedLabel = labelsRef.current[index];
-                    return renderedLabel != null && renderedLabel.toLowerCase() === nextValueLower;
-                  });
-                }
-
-                const matchingValue = valuesRef.current[matchingIndex];
-                if (matchingValue != null) {
-                  // `setValue` may be canceled by `onValueChange`; rely on `useValueChanged` to
-                  // mark the field dirty and run validation only when the value actually changes.
-                  setValue(matchingValue, details);
-                }
+              if (matchingIndex === -1) {
+                matchingIndex = valuesRef.current.findIndex((_, index) => {
+                  const renderedLabel = labelsRef.current[index];
+                  return renderedLabel != null && renderedLabel.toLowerCase() === nextValueLower;
+                });
               }
 
-              store.set('forceMount', true);
-              queueMicrotask(handleChange);
-            },
-          })}
-          id={generatedId && hiddenInputName == null ? `${generatedId}-hidden-input` : undefined}
-          form={form}
-          name={hiddenInputName}
-          autoComplete={autoComplete}
-          value={serializedValue}
-          disabled={disabled}
-          required={required && !(multiple && hasSelectedValue)}
-          readOnly={readOnly}
-          ref={ref}
-          style={name ? visuallyHiddenInput : visuallyHidden}
-          tabIndex={-1}
-          aria-hidden
-          suppressHydrationWarning
-        />
-        {hiddenInputs}
-      </SelectFloatingContext.Provider>
+              const matchingValue = valuesRef.current[matchingIndex];
+              if (matchingValue != null) {
+                // `setValue` may be canceled by `onValueChange`; rely on `useValueChanged` to
+                // mark the field dirty and run validation only when the value actually changes.
+                setValue(matchingValue, details);
+              }
+            }
+
+            store.set('forceMount', true);
+            queueMicrotask(handleChange);
+          },
+        })}
+        id={generatedId && hiddenInputName == null ? `${generatedId}-hidden-input` : undefined}
+        form={form}
+        name={hiddenInputName}
+        autoComplete={autoComplete}
+        value={serializedValue}
+        disabled={disabled}
+        required={required && !(multiple && hasSelectedValue)}
+        readOnly={readOnly}
+        ref={ref}
+        style={name ? visuallyHiddenInput : visuallyHidden}
+        tabIndex={-1}
+        aria-hidden
+        suppressHydrationWarning
+      />
+      {hiddenInputs}
     </SelectRootContext.Provider>
   );
 }

--- a/packages/react/src/select/root/SelectRootContext.ts
+++ b/packages/react/src/select/root/SelectRootContext.ts
@@ -8,6 +8,7 @@ import type { SelectRoot } from './SelectRoot';
 
 export interface SelectRootContext {
   store: SelectStore;
+  floatingContext: FloatingRootContext;
   disabled: boolean;
   readOnly: boolean;
   required: boolean;
@@ -18,7 +19,7 @@ export interface SelectRootContext {
   listRef: React.RefObject<Array<HTMLElement | null>>;
   popupRef: React.RefObject<HTMLDivElement | null>;
   scrollHandlerRef: React.RefObject<((el: HTMLDivElement) => void) | null>;
-  handleScrollArrowVisibility: () => void;
+  handleScrollArrowVisibility: (scroller: HTMLElement) => void;
   scrollArrowsMountedCountRef: React.RefObject<number>;
   itemProps: HTMLProps;
   valueRef: React.RefObject<HTMLSpanElement | null>;
@@ -39,23 +40,12 @@ export interface SelectRootContext {
 }
 
 export const SelectRootContext = React.createContext<SelectRootContext | null>(null);
-export const SelectFloatingContext = React.createContext<FloatingRootContext | null>(null);
 
 export function useSelectRootContext() {
   const context = React.useContext(SelectRootContext);
   if (context === null) {
     throw new Error(
       'Base UI: SelectRootContext is missing. Select parts must be placed within <Select.Root>.',
-    );
-  }
-  return context;
-}
-
-export function useSelectFloatingContext() {
-  const context = React.useContext(SelectFloatingContext);
-  if (context === null) {
-    throw new Error(
-      'Base UI: SelectFloatingContext is missing. Select parts must be placed within <Select.Root>.',
     );
   }
   return context;

--- a/packages/react/src/select/scroll-arrow/SelectScrollArrow.test.tsx
+++ b/packages/react/src/select/scroll-arrow/SelectScrollArrow.test.tsx
@@ -1,0 +1,441 @@
+import { expect, vi } from 'vitest';
+import { Select } from '@base-ui/react/select';
+import { act, fireEvent, screen } from '@mui/internal-test-utils';
+import { createRenderer } from '#test-utils';
+
+/**
+ * Installs a mutable `scrollTop` plus fixed `scrollHeight`/`clientHeight` on a scroller so the
+ * hover auto-scroll can be exercised in both environments (jsdom reports zeroed geometry, and
+ * Chromium won't lay out enough content to overflow at these sizes).
+ */
+function stubScroller(
+  node: HTMLElement | null,
+  geometry: { scrollHeight: number; clientHeight: number },
+  readScrollTop: () => number,
+  onScrollTopChange: (value: number) => void,
+) {
+  if (!node) {
+    return;
+  }
+
+  Object.defineProperty(node, 'scrollTop', {
+    configurable: true,
+    get: readScrollTop,
+    set: onScrollTopChange,
+  });
+  Object.defineProperty(node, 'scrollHeight', {
+    value: geometry.scrollHeight,
+    configurable: true,
+  });
+  Object.defineProperty(node, 'clientHeight', {
+    value: geometry.clientHeight,
+    configurable: true,
+  });
+}
+
+function stubItem(node: HTMLElement | null, offsetTop: number, offsetHeight: number) {
+  if (!node) {
+    return;
+  }
+
+  Object.defineProperty(node, 'offsetTop', { value: offsetTop, configurable: true });
+  Object.defineProperty(node, 'offsetHeight', { value: offsetHeight, configurable: true });
+}
+
+describe('<Select.ScrollArrow />', () => {
+  const { render } = createRenderer();
+
+  /**
+   * Renders a scrollable select whose list geometry is fully stubbed, and returns a live view of
+   * the scroll offset the component writes back.
+   */
+  async function renderScrollableSelect(options: {
+    initialScrollTop: number;
+    scrollHeight?: number;
+    clientHeight?: number;
+    itemOffsets?: number[];
+    itemHeight?: number;
+  }) {
+    const {
+      initialScrollTop,
+      scrollHeight = 400,
+      clientHeight = 200,
+      itemOffsets = [0, 40, 80, 120, 160, 200, 240, 280, 320, 360],
+      itemHeight = 40,
+    } = options;
+
+    let scrollTop = initialScrollTop;
+    let scrollWrites = 0;
+
+    await render(
+      <Select.Root open>
+        <Select.Trigger>Open</Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner alignItemWithTrigger={false}>
+            <Select.Popup>
+              <Select.ScrollUpArrow keepMounted />
+              <Select.List
+                ref={(node) =>
+                  stubScroller(
+                    node,
+                    { scrollHeight, clientHeight },
+                    () => scrollTop,
+                    (value) => {
+                      scrollWrites += 1;
+                      scrollTop = value;
+                    },
+                  )
+                }
+              >
+                {itemOffsets.map((offsetTop, index) => (
+                  <Select.Item
+                    key={index}
+                    value={`item-${index}`}
+                    ref={(node) => stubItem(node, offsetTop, itemHeight)}
+                  >
+                    Item {index}
+                  </Select.Item>
+                ))}
+              </Select.List>
+              <Select.ScrollDownArrow keepMounted />
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const downArrow = screen.getByText('▼');
+    const upArrow = screen.getByText('▲');
+    Object.defineProperty(downArrow, 'offsetHeight', { value: 0, configurable: true });
+    Object.defineProperty(upArrow, 'offsetHeight', { value: 0, configurable: true });
+
+    return {
+      downArrow,
+      upArrow,
+      getScrollTop: () => scrollTop,
+      getScrollWrites: () => scrollWrites,
+    };
+  }
+
+  it('does not start auto-scrolling for a mouse move that did not move the pointer', async () => {
+    vi.useFakeTimers();
+    try {
+      const { downArrow, getScrollTop } = await renderScrollableSelect({ initialScrollTop: 0 });
+
+      // Browsers dispatch a zero-movement `mousemove` when content scrolls beneath a stationary
+      // cursor; that must not kick off the hover scroll.
+      fireEvent.mouseMove(downArrow, { movementX: 0, movementY: 0 });
+
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+
+      expect(getScrollTop()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not let continuous pointer movement postpone the scheduled scroll', async () => {
+    vi.useFakeTimers();
+    try {
+      const { downArrow, getScrollTop } = await renderScrollableSelect({ initialScrollTop: 0 });
+
+      fireEvent.mouseMove(downArrow, { movementX: 0, movementY: 1 });
+
+      act(() => {
+        vi.advanceTimersByTime(30);
+      });
+
+      // A second move arrives before the first scroll fires. Restarting the timer here would
+      // mean a user who keeps jiggling the pointer never scrolls at all.
+      fireEvent.mouseMove(downArrow, { movementX: 1, movementY: 1 });
+
+      act(() => {
+        vi.advanceTimersByTime(15);
+      });
+
+      expect(getScrollTop()).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops auto-scrolling once the pointer leaves the arrow', async () => {
+    vi.useFakeTimers();
+    try {
+      const { downArrow, getScrollTop } = await renderScrollableSelect({ initialScrollTop: 0 });
+
+      fireEvent.mouseMove(downArrow, { movementX: 0, movementY: 1 });
+
+      act(() => {
+        vi.advanceTimersByTime(40);
+      });
+
+      const scrollTopAfterFirstStep = getScrollTop();
+      expect(scrollTopAfterFirstStep).toBeGreaterThan(0);
+
+      fireEvent.mouseLeave(downArrow);
+
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+
+      expect(getScrollTop()).toBe(scrollTopAfterFirstStep);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('snaps a sub-pixel offset to the exact top edge and then stops scrolling', async () => {
+    vi.useFakeTimers();
+    try {
+      // Within `SCROLL_EDGE_TOLERANCE_PX` of the top, so the offset normalizes to exactly 0.
+      const { upArrow, getScrollTop, getScrollWrites } = await renderScrollableSelect({
+        initialScrollTop: 0.4,
+      });
+
+      fireEvent.mouseMove(upArrow, { movementX: 0, movementY: -1 });
+
+      act(() => {
+        vi.advanceTimersByTime(40);
+      });
+
+      expect(getScrollTop()).toBe(0);
+
+      const writesAtEdge = getScrollWrites();
+
+      // Reaching the edge must cancel the loop rather than spin on no-op scroll writes every
+      // 40ms for as long as the pointer rests on the arrow.
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+
+      expect(getScrollTop()).toBe(0);
+      expect(getScrollWrites()).toBe(writesAtEdge);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('scrolls the popup itself when no Select.List is rendered', async () => {
+    vi.useFakeTimers();
+    try {
+      let scrollTop = 0;
+
+      await render(
+        <Select.Root open>
+          <Select.Trigger>Open</Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger={false}>
+              <Select.Popup
+                ref={(node) =>
+                  stubScroller(
+                    node,
+                    { scrollHeight: 400, clientHeight: 200 },
+                    () => scrollTop,
+                    (value) => {
+                      scrollTop = value;
+                    },
+                  )
+                }
+              >
+                <Select.ScrollUpArrow keepMounted />
+                {[0, 40, 80, 120, 160, 200, 240, 280, 320, 360].map((offsetTop, index) => (
+                  <Select.Item
+                    key={index}
+                    value={`item-${index}`}
+                    ref={(node) => stubItem(node, offsetTop, 40)}
+                  >
+                    Item {index}
+                  </Select.Item>
+                ))}
+                <Select.ScrollDownArrow keepMounted />
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const arrow = screen.getByText('▼');
+      Object.defineProperty(arrow, 'offsetHeight', { value: 0, configurable: true });
+
+      fireEvent.mouseMove(arrow, { movementX: 0, movementY: 1 });
+
+      act(() => {
+        vi.advanceTimersByTime(40);
+      });
+
+      expect(scrollTop).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reflects scrollability on the arrows when the popup has no registered items', async () => {
+    vi.useFakeTimers();
+    try {
+      let scrollTop = 100;
+
+      await render(
+        <Select.Root open>
+          <Select.Trigger>Open</Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger={false}>
+              <Select.Popup
+                ref={(node) =>
+                  stubScroller(
+                    node,
+                    { scrollHeight: 400, clientHeight: 200 },
+                    () => scrollTop,
+                    (value) => {
+                      scrollTop = value;
+                    },
+                  )
+                }
+              >
+                <Select.ScrollUpArrow keepMounted data-testid="up" />
+                <Select.ScrollDownArrow keepMounted data-testid="down" />
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const down = screen.getByTestId('down');
+      Object.defineProperty(down, 'offsetHeight', { value: 0, configurable: true });
+
+      fireEvent.mouseMove(down, { movementX: 0, movementY: 1 });
+
+      act(() => {
+        vi.advanceTimersByTime(40);
+      });
+
+      // Mid-scroller with nothing to step through: the down arrow still reports that more
+      // content lies below rather than silently disappearing.
+      expect(down).toHaveAttribute('data-visible');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reflects scrollability on the up arrow when the popup has no registered items', async () => {
+    vi.useFakeTimers();
+    try {
+      let scrollTop = 100;
+
+      await render(
+        <Select.Root open>
+          <Select.Trigger>Open</Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger={false}>
+              <Select.Popup
+                ref={(node) =>
+                  stubScroller(
+                    node,
+                    { scrollHeight: 400, clientHeight: 200 },
+                    () => scrollTop,
+                    (value) => {
+                      scrollTop = value;
+                    },
+                  )
+                }
+              >
+                <Select.ScrollUpArrow keepMounted data-testid="up" />
+                <Select.ScrollDownArrow keepMounted data-testid="down" />
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const up = screen.getByTestId('up');
+      Object.defineProperty(up, 'offsetHeight', { value: 0, configurable: true });
+
+      fireEvent.mouseMove(up, { movementX: 0, movementY: -1 });
+
+      act(() => {
+        vi.advanceTimersByTime(40);
+      });
+
+      expect(up).toHaveAttribute('data-visible');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('hides the arrow when an item-less popup is already scrolled to its edge', async () => {
+    vi.useFakeTimers();
+    try {
+      let scrollTop = 200;
+
+      await render(
+        <Select.Root open>
+          <Select.Trigger>Open</Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger={false}>
+              <Select.Popup
+                ref={(node) =>
+                  stubScroller(
+                    node,
+                    { scrollHeight: 400, clientHeight: 200 },
+                    () => scrollTop,
+                    (value) => {
+                      scrollTop = value;
+                    },
+                  )
+                }
+              >
+                <Select.ScrollUpArrow keepMounted data-testid="up" />
+                <Select.ScrollDownArrow keepMounted data-testid="down" />
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const down = screen.getByTestId('down');
+      Object.defineProperty(down, 'offsetHeight', { value: 0, configurable: true });
+
+      fireEvent.mouseMove(down, { movementX: 0, movementY: 1 });
+
+      act(() => {
+        vi.advanceTimersByTime(40);
+      });
+
+      expect(down).not.toHaveAttribute('data-visible');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores pointer interaction when the arrow has no scrollable popup', async () => {
+    vi.useFakeTimers();
+    try {
+      await render(
+        <Select.Root open>
+          <Select.Trigger>Open</Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger={false}>
+              <Select.ScrollDownArrow keepMounted data-testid="down" />
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const down = screen.getByTestId('down');
+
+      fireEvent.mouseMove(down, { movementX: 0, movementY: 1 });
+
+      // Without a popup there is nothing to scroll; the loop must bail out instead of
+      // dereferencing a missing scroller.
+      expect(() => {
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+      }).not.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/react/src/select/scroll-arrow/SelectScrollArrow.tsx
+++ b/packages/react/src/select/scroll-arrow/SelectScrollArrow.tsx
@@ -96,7 +96,7 @@ export const SelectScrollArrow = React.forwardRef(function SelectScrollArrow(
         }
 
         store.set('activeIndex', null);
-        handleScrollArrowVisibility();
+        handleScrollArrowVisibility(scroller);
 
         const maxScrollTop = getMaxScrollOffset(scroller.scrollHeight, scroller.clientHeight);
         const scrollTop = normalizeScrollOffset(scroller.scrollTop, maxScrollTop);
@@ -105,11 +105,6 @@ export const SelectScrollArrow = React.forwardRef(function SelectScrollArrow(
 
         if (scrollTop !== scroller.scrollTop) {
           scroller.scrollTop = scrollTop;
-        }
-
-        // Fallback when there are no items registered yet.
-        if (items.length === 0) {
-          store.set(isUp ? 'scrollUpArrowVisible' : 'scrollDownArrowVisible', !isScrolledToEdge);
         }
 
         if (isScrolledToEdge) {

--- a/packages/react/src/select/scroll-down-arrow/SelectScrollDownArrow.test.tsx
+++ b/packages/react/src/select/scroll-down-arrow/SelectScrollDownArrow.test.tsx
@@ -190,4 +190,91 @@ describe('<Select.ScrollDownArrow />', () => {
       vi.useRealTimers();
     }
   });
+
+  it('scrolls to the bottom when trailing content extends past the last item', async () => {
+    let scrollTop = 390;
+
+    vi.useFakeTimers();
+    try {
+      await render(
+        <Select.Root open>
+          <Select.Trigger>Open</Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger={false}>
+              <Select.Popup>
+                <Select.ScrollUpArrow keepMounted />
+                <Select.List
+                  ref={(node) => {
+                    if (!node) {
+                      return;
+                    }
+
+                    Object.defineProperty(node, 'scrollTop', {
+                      configurable: true,
+                      get: () => scrollTop,
+                      set: (value: number) => {
+                        scrollTop = value;
+                      },
+                    });
+                    // 200px of trailing content (padding, a footer) below the last item.
+                    Object.defineProperty(node, 'scrollHeight', {
+                      value: 600,
+                      configurable: true,
+                    });
+                    Object.defineProperty(node, 'clientHeight', {
+                      value: 200,
+                      configurable: true,
+                    });
+                  }}
+                >
+                  {[0, 40, 80, 120, 160, 200, 240, 280, 320, 360].map((offsetTop, index) => (
+                    <Select.Item
+                      key={index}
+                      value={`item-${index}`}
+                      ref={(node) => {
+                        if (!node) {
+                          return;
+                        }
+
+                        Object.defineProperty(node, 'offsetTop', {
+                          value: offsetTop,
+                          configurable: true,
+                        });
+                        Object.defineProperty(node, 'offsetHeight', {
+                          value: 40,
+                          configurable: true,
+                        });
+                      }}
+                    >
+                      Item {index}
+                    </Select.Item>
+                  ))}
+                </Select.List>
+                <Select.ScrollDownArrow keepMounted />
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const arrow = screen.getByText('▼');
+      Object.defineProperty(arrow, 'offsetHeight', {
+        value: 0,
+        configurable: true,
+      });
+
+      fireEvent.mouseMove(arrow, {
+        movementX: 0,
+        movementY: 1,
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(40);
+      });
+
+      expect(scrollTop).toBe(400);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/react/src/select/scroll-up-arrow/SelectScrollUpArrow.test.tsx
+++ b/packages/react/src/select/scroll-up-arrow/SelectScrollUpArrow.test.tsx
@@ -102,4 +102,92 @@ describe('<Select.ScrollUpArrow />', () => {
       vi.useRealTimers();
     }
   });
+
+  it('scrolls to the very top when no earlier item remains to land on', async () => {
+    let scrollTop = 100;
+
+    vi.useFakeTimers();
+    try {
+      await render(
+        <Select.Root open>
+          <Select.Trigger>Open</Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger={false}>
+              <Select.Popup>
+                <Select.ScrollUpArrow keepMounted />
+                <Select.List
+                  ref={(node) => {
+                    if (!node) {
+                      return;
+                    }
+
+                    Object.defineProperty(node, 'scrollTop', {
+                      configurable: true,
+                      get: () => scrollTop,
+                      set: (value: number) => {
+                        scrollTop = value;
+                      },
+                    });
+                    Object.defineProperty(node, 'scrollHeight', {
+                      value: 600,
+                      configurable: true,
+                    });
+                    Object.defineProperty(node, 'clientHeight', {
+                      value: 200,
+                      configurable: true,
+                    });
+                  }}
+                >
+                  {/* Every item sits below the current viewport top, as it would with a tall
+                      group label or padding above the first item. */}
+                  {[300, 340, 380].map((offsetTop, index) => (
+                    <Select.Item
+                      key={index}
+                      value={`item-${index}`}
+                      ref={(node) => {
+                        if (!node) {
+                          return;
+                        }
+
+                        Object.defineProperty(node, 'offsetTop', {
+                          value: offsetTop,
+                          configurable: true,
+                        });
+                        Object.defineProperty(node, 'offsetHeight', {
+                          value: 40,
+                          configurable: true,
+                        });
+                      }}
+                    >
+                      Item {index}
+                    </Select.Item>
+                  ))}
+                </Select.List>
+                <Select.ScrollDownArrow keepMounted />
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const arrow = screen.getByText('▲');
+      Object.defineProperty(arrow, 'offsetHeight', {
+        value: 0,
+        configurable: true,
+      });
+
+      fireEvent.mouseMove(arrow, {
+        movementX: 0,
+        movementY: -1,
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(40);
+      });
+
+      expect(scrollTop).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/react/src/select/trigger/SelectTrigger.test.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.test.tsx
@@ -1,7 +1,7 @@
 import { expect, vi } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { fireEvent, ignoreActWarnings, screen, waitFor } from '@mui/internal-test-utils';
 
 describe('<Select.Trigger />', () => {
   const { render } = createRenderer();
@@ -13,6 +13,93 @@ describe('<Select.Trigger />', () => {
       return render(<Select.Root open>{node}</Select.Root>);
     },
   }));
+
+  it('throws a descriptive error when rendered outside <Select.Root>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Select.Trigger />)).rejects.toThrow(
+        'Base UI: SelectRootContext is missing. Select parts must be placed within <Select.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it.skipIf(isJSDOM)(
+    'closes an aligned popup when focus lands on the trigger so it is not obscured',
+    async () => {
+      // Focusing the trigger starts its deferred `forceMount` timer, which settles after the
+      // assertions below.
+      ignoreActWarnings();
+      const onOpenChange = vi.fn();
+
+      await render(
+        <div style={{ paddingTop: 200, minHeight: 600 }}>
+          <Select.Root defaultOpen defaultValue="a" onOpenChange={onOpenChange}>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner data-testid="positioner" alignItemWithTrigger>
+                <Select.Popup>
+                  <Select.Item value="a">a</Select.Item>
+                  <Select.Item value="b">b</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        </div>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+
+      // `data-side="none"` proves the popup is still item-aligned over the trigger.
+      await waitFor(() => {
+        expect(screen.getByTestId('positioner')).toHaveAttribute('data-side', 'none');
+      });
+
+      fireEvent.focus(trigger);
+
+      await waitFor(() => {
+        expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      });
+
+      expect(onOpenChange).toHaveBeenCalledWith(false, expect.objectContaining({ reason: 'none' }));
+    },
+  );
+
+  it('keeps a non-aligned popup open when focus lands on the trigger', async () => {
+    // Focusing the trigger starts its deferred `forceMount` timer, which settles after the
+    // assertions below.
+    ignoreActWarnings();
+    const onOpenChange = vi.fn();
+
+    await render(
+      <Select.Root defaultOpen onOpenChange={onOpenChange}>
+        <Select.Trigger data-testid="trigger">
+          <Select.Value />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner alignItemWithTrigger={false}>
+            <Select.Popup>
+              <Select.Item value="a">a</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+
+    fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
 
   describe('disabled state', () => {
     it('cannot be focused when disabled', async () => {


### PR DESCRIPTION
Expands Select test coverage to 100% across statements, branches, functions, and lines on merged jsdom and Chromium results, and drops the dead code that the sweep turned up.

## Changes

- Added behavior tests for aligned-popup scroll resizing, hover scroll arrows, browser autofill, toolbar key handling, and the missing-context errors.
- Removed the `hasRegistered` flag from `Select.Item`. `useCompositeListItem({ guess: true })` always seeds a non-negative index, so it was never `false`.
- Merged `SelectFloatingContext` into `SelectRootContext`. Both providers were always rendered together, so the separate hook's error could never fire.
- Removed the scroll arrow visibility fallback in `Select.ScrollArrow`, which recomputed exactly what `handleScrollArrowVisibility` had already written a few lines above.
- Removed the trigger id merge in `Select.Root`, since `Select.Trigger` already applies the same id from the store.
- Passed the scroller into `handleScrollArrowVisibility` instead of re-deriving it from the store, which also drops an unreachable null guard.
