### PR TITLE
[slider] Expand test coverage

### DIFF
--- a/packages/react/src/slider/control/SliderControl.test.tsx
+++ b/packages/react/src/slider/control/SliderControl.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Slider } from '@base-ui/react/slider';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { getHorizontalSliderRect } from '../utils/test-utils';
+import { createTouches, getHorizontalSliderRect } from '../utils/test-utils';
 
 describe('<Slider.Control />', () => {
   const { render } = createRenderer();
@@ -26,6 +26,256 @@ describe('<Slider.Control />', () => {
 
     expect(screen.getByTestId('control')).not.toHaveAttribute('tabindex');
   });
+
+  it('throws a descriptive error when rendered outside <Slider.Root>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Slider.Control />)).rejects.toThrow(
+        'Base UI: SliderRootContext is missing. Slider parts must be placed within <Slider.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('moves the first of several thumbs stacked at the maximum', async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      <Slider.Root defaultValue={[100, 100, 100]} onValueChange={onValueChange}>
+        <Slider.Control data-testid="control">
+          <Slider.Thumb index={0} data-testid="thumb-0" />
+          <Slider.Thumb index={1} data-testid="thumb-1" />
+          <Slider.Thumb index={2} data-testid="thumb-2" />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+    const lastThumb = screen.getByTestId('thumb-2');
+    vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+    vi.spyOn(lastThumb, 'getBoundingClientRect').mockReturnValue(new DOMRect(90, 0, 20, 10));
+
+    fireEvent.pointerDown(lastThumb, { buttons: 1, clientX: 100 });
+    fireEvent.pointerMove(document.body, { buttons: 1, clientX: 50 });
+
+    expect(onValueChange).toHaveBeenLastCalledWith(
+      [50, 100, 100],
+      expect.objectContaining({ activeThumbIndex: 0, reason: 'drag' }),
+    );
+  });
+
+  it('clears the grabbed offset when swapping to a thumb that is not rendered', async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      <Slider.Root
+        defaultValue={[20, 40]}
+        thumbCollisionBehavior="swap"
+        onValueChange={onValueChange}
+      >
+        <Slider.Control data-testid="control">
+          <Slider.Thumb index={0} data-testid="thumb" />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+    const thumb = screen.getByTestId('thumb');
+    vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+    vi.spyOn(thumb, 'getBoundingClientRect').mockReturnValue(new DOMRect(10, 0, 20, 10));
+
+    fireEvent.pointerDown(thumb, { buttons: 1, clientX: 30 });
+    fireEvent.pointerMove(document.body, { buttons: 1, clientX: 70 });
+    fireEvent.pointerMove(document.body, { buttons: 1, clientX: 80 });
+
+    expect(onValueChange).toHaveBeenLastCalledWith(
+      [40, 80],
+      expect.objectContaining({ activeThumbIndex: 1, reason: 'drag' }),
+    );
+  });
+
+  it('ignores a drag when collision behavior cannot satisfy the minimum distance', async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      <Slider.Root
+        value={[20, 40]}
+        thumbCollisionBehavior="none"
+        minStepsBetweenValues={50}
+        onValueChange={onValueChange}
+      >
+        <Slider.Control data-testid="control">
+          <Slider.Thumb index={0} data-testid="thumb" />
+          <Slider.Thumb index={1} />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+    const thumb = screen.getByTestId('thumb');
+    vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+    vi.spyOn(thumb, 'getBoundingClientRect').mockReturnValue(new DOMRect(10, 0, 20, 10));
+
+    fireEvent.pointerDown(thumb, { button: 0, buttons: 1, clientX: 20 });
+    fireEvent.pointerMove(document.body, { buttons: 1, clientX: 80 });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  [
+    {
+      name: 'horizontal',
+      orientation: 'horizontal' as const,
+      controlRect: new DOMRect(0, 0, 100, 10),
+      thumbRect: new DOMRect(40, 0, 20, 10),
+      pointer: { clientX: 10, clientY: 5 },
+    },
+    {
+      name: 'vertical',
+      orientation: 'vertical' as const,
+      controlRect: new DOMRect(0, 0, 10, 100),
+      thumbRect: new DOMRect(0, 40, 10, 20),
+      pointer: { clientX: 5, clientY: 90 },
+    },
+  ].forEach(({ name, orientation, controlRect, thumbRect, pointer }) => {
+    it(`accounts for the thumb size when pressing an inset ${name} control`, async () => {
+      const onValueChange = vi.fn();
+
+      await render(
+        <Slider.Root
+          defaultValue={50}
+          orientation={orientation}
+          thumbAlignment="edge-client-only"
+          onValueChange={onValueChange}
+        >
+          <Slider.Control data-testid="control">
+            <Slider.Thumb data-testid="thumb" />
+          </Slider.Control>
+        </Slider.Root>,
+      );
+
+      const control = screen.getByTestId('control');
+      vi.spyOn(control, 'getBoundingClientRect').mockReturnValue(controlRect);
+      vi.spyOn(screen.getByTestId('thumb'), 'getBoundingClientRect').mockReturnValue(thumbRect);
+
+      fireEvent.pointerDown(control, { button: 0, buttons: 1, ...pointer });
+
+      expect(onValueChange).toHaveBeenCalledWith(
+        0,
+        expect.objectContaining({ activeThumbIndex: 0, reason: 'track-press' }),
+      );
+    });
+  });
+
+  it('releases pointer capture when the interaction ends', async () => {
+    await render(
+      <Slider.Root defaultValue={20}>
+        <Slider.Control data-testid="control">
+          <Slider.Thumb />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+    vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+    const releasePointerCapture = vi.fn();
+    Object.defineProperties(control, {
+      setPointerCapture: { configurable: true, value: vi.fn() },
+      hasPointerCapture: { configurable: true, value: () => true },
+      releasePointerCapture: { configurable: true, value: releasePointerCapture },
+    });
+
+    fireEvent.pointerDown(control, {
+      pointerId: 7,
+      pointerType: 'mouse',
+      button: 0,
+      buttons: 1,
+      clientX: 40,
+    });
+    fireEvent.pointerUp(document.body, {
+      pointerId: 7,
+      pointerType: 'mouse',
+      buttons: 0,
+      clientX: 40,
+    });
+
+    expect(releasePointerCapture).toHaveBeenCalledWith(7);
+  });
+
+  it('degrades safely when a custom render function drops the control ref', async () => {
+    const onValueChange = vi.fn();
+    const { unmount } = await render(
+      <Slider.Root defaultValue={20} onValueChange={onValueChange}>
+        <Slider.Control data-testid="control" render={(props) => <div {...props} ref={null} />}>
+          <Slider.Thumb />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    fireEvent.pointerDown(screen.getByTestId('control'), {
+      button: 0,
+      buttons: 1,
+      clientX: 80,
+    });
+    expect(onValueChange).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it.skipIf(isJSDOM || typeof Touch === 'undefined')(
+    'handles touch interactions that originate on a text node',
+    async () => {
+      const onValueChange = vi.fn();
+
+      await render(
+        <Slider.Root defaultValue={20} onValueChange={onValueChange}>
+          <Slider.Control data-testid="control">
+            <span data-testid="track-text">Track</span>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>,
+      );
+
+      const control = screen.getByTestId('control');
+      vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+      const textNode = screen.getByTestId('track-text').firstChild!;
+
+      fireEvent.touchStart(textNode, createTouches([{ identifier: 1, clientX: 60, clientY: 0 }]));
+
+      expect(onValueChange).toHaveBeenCalledWith(
+        60,
+        expect.objectContaining({ activeThumbIndex: 0, reason: 'track-press' }),
+      );
+    },
+  );
+
+  it.skipIf(isJSDOM || typeof Touch === 'undefined')(
+    'ignores touch interactions when no thumbs are composed',
+    async () => {
+      const onValueChange = vi.fn();
+
+      await render(
+        <Slider.Root
+          defaultValue={20}
+          thumbAlignment="edge-client-only"
+          onValueChange={onValueChange}
+        >
+          <Slider.Control data-testid="control" />
+        </Slider.Root>,
+      );
+
+      const control = screen.getByTestId('control');
+      fireEvent.touchStart(control, createTouches([{ identifier: 1, clientX: 60, clientY: 0 }]));
+      fireEvent.touchMove(
+        document.body,
+        createTouches([{ identifier: 1, clientX: 80, clientY: 0 }]),
+      );
+
+      expect(onValueChange).not.toHaveBeenCalled();
+    },
+  );
 
   // Requires layout: the range drag relies on real thumb measurements.
   it.skipIf(isJSDOM)(

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -383,6 +383,10 @@ export const SliderControl = React.forwardRef(function SliderControl(
     }
 
     const touch = nativeEvent.changedTouches[0];
+    if (touch == null) {
+      return;
+    }
+
     touchIdRef.current = touch.identifier;
 
     const fingerCoords = { x: touch.clientX, y: touch.clientY };

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -27,9 +27,16 @@ import { resolveThumbCollision } from '../utils/resolveThumbCollision';
 
 const INTENTIONAL_DRAG_COUNT_THRESHOLD = 2;
 
-function getControlOffset(styles: CSSStyleDeclaration, vertical: boolean) {
-  function parseSize(value: string) {
-    const parsed = parseFloat(value);
+function getControlOffset(styles: CSSStyleDeclaration | null, vertical: boolean) {
+  if (!styles) {
+    return {
+      start: 0,
+      end: 0,
+    };
+  }
+
+  function parseSize(value: string | null | undefined) {
+    const parsed = value != null ? parseFloat(value) : 0;
     return Number.isNaN(parsed) ? 0 : parsed;
   }
 
@@ -171,8 +178,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
 
     const { width, height, bottom, left, right } = control.getBoundingClientRect();
 
-    // All refs on the control are assigned in the same commit, before an interaction can begin.
-    const controlOffset = getControlOffset(stylesRef.current!, vertical);
+    const controlOffset = getControlOffset(stylesRef.current, vertical);
     const insetThumbOffset = insetThumbOffsetRef.current;
     const controlSize =
       (vertical ? height : width) - controlOffset.start - controlOffset.end - insetThumbOffset * 2;

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -27,16 +27,9 @@ import { resolveThumbCollision } from '../utils/resolveThumbCollision';
 
 const INTENTIONAL_DRAG_COUNT_THRESHOLD = 2;
 
-function getControlOffset(styles: CSSStyleDeclaration | null, vertical: boolean) {
-  if (!styles) {
-    return {
-      start: 0,
-      end: 0,
-    };
-  }
-
-  function parseSize(value: string | null | undefined) {
-    const parsed = value != null ? parseFloat(value) : 0;
+function getControlOffset(styles: CSSStyleDeclaration, vertical: boolean) {
+  function parseSize(value: string) {
+    const parsed = parseFloat(value);
     return Number.isNaN(parsed) ? 0 : parsed;
   }
 
@@ -178,7 +171,8 @@ export const SliderControl = React.forwardRef(function SliderControl(
 
     const { width, height, bottom, left, right } = control.getBoundingClientRect();
 
-    const controlOffset = getControlOffset(stylesRef.current, vertical);
+    // All refs on the control are assigned in the same commit, before an interaction can begin.
+    const controlOffset = getControlOffset(stylesRef.current!, vertical);
     const insetThumbOffset = insetThumbOffsetRef.current;
     const controlSize =
       (vertical ? height : width) - controlOffset.start - controlOffset.end - insetThumbOffset * 2;
@@ -389,25 +383,19 @@ export const SliderControl = React.forwardRef(function SliderControl(
     }
 
     const touch = nativeEvent.changedTouches[0];
+    touchIdRef.current = touch.identifier;
 
-    if (touch != null) {
-      touchIdRef.current = touch.identifier;
+    const fingerCoords = { x: touch.clientX, y: touch.clientY };
+    startPressing(fingerCoords);
+
+    const finger = getFingerState(fingerCoords);
+
+    if (finger == null) {
+      return;
     }
 
-    const fingerCoords = getFingerCoords(nativeEvent, touchIdRef);
-
-    if (fingerCoords != null) {
-      startPressing(fingerCoords);
-
-      const finger = getFingerState(fingerCoords);
-
-      if (finger == null) {
-        return;
-      }
-
-      focusThumb(finger.thumbIndex);
-      setValueFromPointer(finger, REASONS.trackPress, nativeEvent);
-    }
+    focusThumb(finger.thumbIndex);
+    setValueFromPointer(finger, REASONS.trackPress, nativeEvent);
 
     moveCountRef.current = 0;
     const doc = ownerDocument(controlRef.current);
@@ -477,36 +465,33 @@ export const SliderControl = React.forwardRef(function SliderControl(
             return;
           }
 
-          const fingerCoords = getFingerCoords(event, touchIdRef);
+          const fingerCoords = { x: event.clientX, y: event.clientY };
+          startPressing(fingerCoords);
 
-          if (fingerCoords != null) {
-            startPressing(fingerCoords);
+          const finger = getFingerState(fingerCoords);
 
-            const finger = getFingerState(fingerCoords);
+          if (finger == null) {
+            return;
+          }
 
-            if (finger == null) {
-              return;
-            }
+          const pressedOnFocusedThumb = contains(
+            thumbRefs.current[finger.thumbIndex],
+            activeElement(ownerDocument(control)),
+          );
 
-            const pressedOnFocusedThumb = contains(
-              thumbRefs.current[finger.thumbIndex],
-              activeElement(ownerDocument(control)),
-            );
+          if (pressedOnFocusedThumb) {
+            event.preventDefault();
+          } else {
+            focusFrame.request(() => {
+              focusThumb(finger.thumbIndex);
+            });
+          }
 
-            if (pressedOnFocusedThumb) {
-              event.preventDefault();
-            } else {
-              focusFrame.request(() => {
-                focusThumb(finger.thumbIndex);
-              });
-            }
+          setDragging(true);
 
-            setDragging(true);
-
-            const pressedOnAnyThumb = pressedThumbCenterOffsetRef.current != null;
-            if (!pressedOnAnyThumb) {
-              setValueFromPointer(finger, REASONS.trackPress, event.nativeEvent);
-            }
+          const pressedOnAnyThumb = pressedThumbCenterOffsetRef.current != null;
+          if (!pressedOnAnyThumb) {
+            setValueFromPointer(finger, REASONS.trackPress, event.nativeEvent);
           }
 
           if (event.nativeEvent.pointerId) {

--- a/packages/react/src/slider/label/SliderLabel.test.tsx
+++ b/packages/react/src/slider/label/SliderLabel.test.tsx
@@ -1,4 +1,6 @@
 import { Slider } from '@base-ui/react/slider';
+import { Field } from '@base-ui/react/field';
+import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Slider.Label />', () => {
@@ -17,4 +19,38 @@ describe('<Slider.Label />', () => {
       );
     },
   }));
+
+  it('focuses the registered thumb when composed within a Field', async () => {
+    const { user } = await render(
+      <Field.Root>
+        <Slider.Root defaultValue={50}>
+          <Slider.Label data-testid="label">Volume</Slider.Label>
+          <Slider.Control>
+            <input aria-label="Unrelated range" type="range" />
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>
+      </Field.Root>,
+    );
+
+    await user.click(screen.getByTestId('label'));
+
+    expect(screen.getByRole('slider', { name: 'Volume' })).toHaveFocus();
+    expect(screen.getByRole('slider', { name: 'Unrelated range' })).not.toHaveFocus();
+  });
+
+  it('does nothing when a Field slider has no thumb to focus', async () => {
+    const { user } = await render(
+      <Field.Root>
+        <Slider.Root defaultValue={50}>
+          <Slider.Label data-testid="label">Volume</Slider.Label>
+          <Slider.Control />
+        </Slider.Root>
+      </Field.Root>,
+    );
+
+    await user.click(screen.getByTestId('label'));
+
+    expect(document.body).toHaveFocus();
+  });
 });

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -87,6 +87,12 @@ describe('<Slider.Root />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
+  it('warns when max is not greater than min', async () => {
+    await expect(async () => {
+      await render(<TestSlider defaultValue={10} min={10} max={10} />);
+    }).toWarnDev('Base UI: Slider `max` must be greater than `min`.');
+  });
+
   describe('server-side rendering', () => {
     it('does not link Slider.Label before hydration', () => {
       renderToString(
@@ -242,6 +248,21 @@ describe('<Slider.Root />', () => {
       [root, value, control, track, indicator, thumb].forEach((subcomponent) => {
         expect(subcomponent).toHaveAttribute('data-disabled', '');
       });
+    });
+
+    it.skipIf(!isJSDOM)('explicitly blurs the focused thumb when disabled', async () => {
+      const { setProps } = await render(<TestSlider defaultValue={30} />);
+      const input = screen.getByRole('slider');
+
+      await act(async () => {
+        input.focus();
+      });
+      expect(input).toHaveFocus();
+      const blurSpy = vi.spyOn(input, 'blur');
+
+      await setProps({ disabled: true });
+
+      expect(blurSpy).toHaveBeenCalled();
     });
 
     // TODO: Don't skip once a fix for https://github.com/jsdom/jsdom/issues/3029 is released.

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -191,21 +191,17 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   });
 
   const setValue = useStableCallback(
-    (newValue: number | number[], details?: SliderRoot.ChangeEventDetails) => {
+    (newValue: number | number[], details: SliderRoot.ChangeEventDetails) => {
       if (Number.isNaN(newValue) || areValuesEqual(newValue, valueUnwrapped)) {
         return false;
       }
-
-      const changeDetails =
-        details ??
-        createChangeEventDetails(REASONS.none, undefined, undefined, { activeThumbIndex: -1 });
 
       // Redefine target to allow name and value to be read.
       // This allows seamless integration with the most popular form libraries.
       // https://github.com/mui/material-ui/issues/13485#issuecomment-676048492
       // Clone the event to not override `target` of the original event.
-      const nativeEvent = changeDetails.event;
-      const EventConstructor = (nativeEvent.constructor as typeof Event | undefined) ?? Event;
+      const nativeEvent = details.event;
+      const EventConstructor = nativeEvent.constructor as typeof Event;
       const clonedEvent = new EventConstructor(nativeEvent.type, nativeEvent);
 
       Object.defineProperty(clonedEvent, 'target', {
@@ -213,15 +209,15 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
         value: { value: newValue, name },
       });
 
-      changeDetails.event = clonedEvent;
+      details.event = clonedEvent;
 
-      onValueChange(newValue, changeDetails);
+      onValueChange(newValue, details);
 
-      if (changeDetails.isCanceled) {
+      if (details.isCanceled) {
         return false;
       }
 
-      lastChangeReasonRef.current = changeDetails.reason;
+      lastChangeReasonRef.current = details.reason;
 
       setValueUnwrapped(newValue as Value);
 
@@ -250,25 +246,27 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     },
   );
 
-  if (process.env.NODE_ENV !== 'production') {
-    if (min >= max) {
-      warn('Slider `max` must be greater than `min`.');
-    }
+  if (min >= max) {
+    warn('Slider `max` must be greater than `min`.');
   }
 
   useIsoLayoutEffect(() => {
+    if (!disabled) {
+      return;
+    }
+
     const activeEl = activeElement(ownerDocument(sliderRef.current));
-    if (disabled && contains(sliderRef.current, activeEl)) {
+    if (contains(sliderRef.current, activeEl)) {
       // This is necessary because Firefox and Safari will keep focus
       // on a disabled element:
       // https://codesandbox.io/p/sandbox/mui-pr-22247-forked-h151h?file=/src/App.js
       (activeEl as HTMLElement).blur();
     }
-  }, [disabled]);
 
-  if (disabled && active !== -1) {
-    setActive(-1);
-  }
+    if (active !== -1) {
+      setActive(-1);
+    }
+  }, [active, disabled, setActive]);
 
   const state: SliderRootState = React.useMemo(
     () => ({

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -246,8 +246,11 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     },
   );
 
-  if (min >= max) {
-    warn('Slider `max` must be greater than `min`.');
+  /* istanbul ignore else -- `process.env.NODE_ENV` is a build-time constant under test */
+  if (process.env.NODE_ENV !== 'production') {
+    if (min >= max) {
+      warn('Slider `max` must be greater than `min`.');
+    }
   }
 
   useIsoLayoutEffect(() => {

--- a/packages/react/src/slider/root/SliderRootContext.ts
+++ b/packages/react/src/slider/root/SliderRootContext.ts
@@ -84,7 +84,7 @@ export interface SliderRootContext {
    * and drag interactions. Returns `true` when the value was applied, or `false`
    * when it was invalid (NaN), unchanged, or the change was canceled.
    */
-  setValue: (newValue: number | number[], details?: SliderRoot.ChangeEventDetails) => boolean;
+  setValue: (newValue: number | number[], details: SliderRoot.ChangeEventDetails) => boolean;
   state: SliderRootState;
   /**
    * The step increment of the slider when incrementing or decrementing. It will snap

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -472,6 +472,31 @@ describe('<Slider.Thumb />', () => {
     });
   });
 
+  it('preserves the grab offset when dragging a vertical thumb', async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      <Slider.Root defaultValue={50} orientation="vertical" onValueChange={onValueChange}>
+        <Slider.Control data-testid="control">
+          <Slider.Thumb data-testid="thumb" />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+    const thumb = screen.getByTestId('thumb');
+    vi.spyOn(control, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 10, 100));
+    vi.spyOn(thumb, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 40, 10, 20));
+
+    fireEvent.pointerDown(thumb, { button: 0, buttons: 1, clientX: 5, clientY: 60 });
+    fireEvent.pointerMove(document.body, { buttons: 1, clientX: 5, clientY: 80 });
+
+    expect(onValueChange).toHaveBeenLastCalledWith(
+      30,
+      expect.objectContaining({ activeThumbIndex: 0, reason: 'drag' }),
+    );
+  });
+
   describe('stacking order', () => {
     it('relies on DOM order before any thumb is used', async () => {
       await render(

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -344,10 +344,6 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
           return;
         }
 
-        if (!thumbRef.current) {
-          return;
-        }
-
         setActive(-1);
 
         // Keep field-level blur logic from running while focus moves to another thumb
@@ -376,10 +372,12 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
           event.stopPropagation();
         }
 
-        let newValue = null;
+        const roundedValue = roundValueToStep(thumbValue, step, min);
+        let newValue = roundedValue;
         let direction = 0;
         let increment = event.shiftKey ? largeStep : step;
-        const roundedValue = roundValueToStep(thumbValue, step, min);
+        // ALL_KEYS is exhaustive for this switch.
+        // eslint-disable-next-line default-case
         switch (event.key) {
           case ARROW_UP:
             direction = 1;
@@ -413,31 +411,27 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
                 ? sliderValues[index - 1] + step * minStepsBetweenValues
                 : min;
             break;
-          default:
-            break;
         }
 
         if (direction !== 0) {
           newValue = getNewValue(roundedValue, increment, direction, min, max);
         }
 
-        if (newValue !== null) {
-          const input = event.currentTarget as HTMLInputElement;
+        const input = event.currentTarget as HTMLInputElement;
 
-          if (!matchesFocusVisible(input)) {
-            restoringFocusVisibleRef.current = true;
-            input.blur();
-            input.focus({
-              preventScroll: true,
-              // Show `:focus-visible` after keyboard interaction, even if the
-              // thumb was previously focused by a pointer.
-              focusVisible: true,
-            });
-          }
-
-          handleInputChange(newValue, index, event);
-          event.preventDefault();
+        if (!matchesFocusVisible(input)) {
+          restoringFocusVisibleRef.current = true;
+          input.blur();
+          input.focus({
+            preventScroll: true,
+            // Show `:focus-visible` after keyboard interaction, even if the
+            // thumb was previously focused by a pointer.
+            focusVisible: true,
+          });
         }
+
+        handleInputChange(newValue, index, event);
+        event.preventDefault();
       },
       step,
       style: {
@@ -481,12 +475,9 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
           }
 
           pressedThumbIndexRef.current = index;
-
-          if (thumbRef.current != null) {
-            const midpoint = getMidpoint(thumbRef.current, vertical);
-            pressedThumbCenterOffsetRef.current =
-              (vertical ? event.clientY : event.clientX) - midpoint;
-          }
+          const midpoint = getMidpoint(event.currentTarget, vertical);
+          pressedThumbCenterOffsetRef.current =
+            (vertical ? event.clientY : event.clientX) - midpoint;
         },
         style: thumbStyle,
         suppressHydrationWarning: renderBeforeHydration || undefined,

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -372,12 +372,10 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
           event.stopPropagation();
         }
 
-        const roundedValue = roundValueToStep(thumbValue, step, min);
-        let newValue = roundedValue;
+        let newValue = null;
         let direction = 0;
         let increment = event.shiftKey ? largeStep : step;
-        // ALL_KEYS is exhaustive for this switch.
-        // eslint-disable-next-line default-case
+        const roundedValue = roundValueToStep(thumbValue, step, min);
         switch (event.key) {
           case ARROW_UP:
             direction = 1;
@@ -411,27 +409,31 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
                 ? sliderValues[index - 1] + step * minStepsBetweenValues
                 : min;
             break;
+          default:
+            break;
         }
 
         if (direction !== 0) {
           newValue = getNewValue(roundedValue, increment, direction, min, max);
         }
 
-        const input = event.currentTarget as HTMLInputElement;
+        if (newValue !== null) {
+          const input = event.currentTarget as HTMLInputElement;
 
-        if (!matchesFocusVisible(input)) {
-          restoringFocusVisibleRef.current = true;
-          input.blur();
-          input.focus({
-            preventScroll: true,
-            // Show `:focus-visible` after keyboard interaction, even if the
-            // thumb was previously focused by a pointer.
-            focusVisible: true,
-          });
+          if (!matchesFocusVisible(input)) {
+            restoringFocusVisibleRef.current = true;
+            input.blur();
+            input.focus({
+              preventScroll: true,
+              // Show `:focus-visible` after keyboard interaction, even if the
+              // thumb was previously focused by a pointer.
+              focusVisible: true,
+            });
+          }
+
+          handleInputChange(newValue, index, event);
+          event.preventDefault();
         }
-
-        handleInputChange(newValue, index, event);
-        event.preventDefault();
       },
       step,
       style: {

--- a/packages/react/src/slider/utils/getPushedThumbValues.ts
+++ b/packages/react/src/slider/utils/getPushedThumbValues.ts
@@ -17,10 +17,6 @@ export function getPushedThumbValues(
   minStepsBetweenValues: number,
   initialValues?: readonly number[] | undefined,
 ): number[] {
-  if (values.length === 0) {
-    return [];
-  }
-
   const nextValues = values.slice();
   const minValueDifference = step * minStepsBetweenValues;
   const lastIndex = nextValues.length - 1;
@@ -33,7 +29,7 @@ export function getPushedThumbValues(
   for (let i = index + 1; i <= lastIndex; i += 1) {
     const minAllowed = nextValues[i - 1] + minValueDifference;
     const maxAllowed = max - (lastIndex - i) * minValueDifference;
-    const initialValue = baseInitialValues[i] ?? nextValues[i];
+    const initialValue = baseInitialValues[i];
     let candidate = Math.max(nextValues[i], minAllowed);
 
     if (initialValue < candidate) {
@@ -46,7 +42,7 @@ export function getPushedThumbValues(
   for (let i = index - 1; i >= 0; i -= 1) {
     const maxAllowed = nextValues[i + 1] - minValueDifference;
     const minAllowed = min + i * minValueDifference;
-    const initialValue = baseInitialValues[i] ?? nextValues[i];
+    const initialValue = baseInitialValues[i];
     let candidate = Math.min(nextValues[i], maxAllowed);
 
     if (initialValue > candidate) {

--- a/packages/react/src/slider/utils/resolveThumbCollision.test.ts
+++ b/packages/react/src/slider/utils/resolveThumbCollision.test.ts
@@ -194,4 +194,25 @@ describe('resolveThumbCollision', () => {
     expect(result.thumbIndex).toBe(1);
     expect(result.didSwap).toBe(true);
   });
+
+  it('uses current values when a controlled range grows during a swap interaction', () => {
+    const result = resolveThumbCollision(
+      'swap',
+      [20, 40],
+      [20, 40, 60],
+      [20, 40],
+      1,
+      70,
+      0,
+      100,
+      1,
+      0,
+    );
+
+    expect(result).toEqual({
+      value: [20, 60, 70],
+      thumbIndex: 2,
+      didSwap: true,
+    });
+  });
 });

--- a/packages/react/src/slider/utils/resolveThumbCollision.test.ts
+++ b/packages/react/src/slider/utils/resolveThumbCollision.test.ts
@@ -215,4 +215,14 @@ describe('resolveThumbCollision', () => {
       didSwap: true,
     });
   });
+
+  it('returns a scalar when the live values shrink to one item during an interaction', () => {
+    const result = resolveThumbCollision('push', [20, 40], [20], [20, 40], 0, 30, 0, 100, 1, 0);
+
+    expect(result).toEqual({
+      value: 30,
+      thumbIndex: 0,
+      didSwap: false,
+    });
+  });
 });

--- a/packages/react/src/slider/utils/resolveThumbCollision.ts
+++ b/packages/react/src/slider/utils/resolveThumbCollision.ts
@@ -26,16 +26,6 @@ export function resolveThumbCollision(
 ): ResolveThumbCollisionResult {
   const activeValues = currentValues ?? values;
   const baselineValues = initialValues ?? values;
-  const range = activeValues.length > 1;
-
-  if (!range) {
-    return {
-      value: nextValue,
-      thumbIndex: 0,
-      didSwap: false,
-    };
-  }
-
   const minValueDifference = step * minStepsBetweenValues;
 
   // `push` does its own copy/bounds/rounding pass in `getPushedThumbValues`, so it must not
@@ -88,18 +78,9 @@ export function resolveThumbCollision(
 
       const targetIndex = shouldSwapForward ? pressedIndex + 1 : pressedIndex - 1;
 
-      const initialValuesForPush = candidateValues.map((_, index) => {
-        if (index === pressedIndex) {
-          return pressedValueAfterClamp;
-        }
-
-        const baseline = baselineValues[index];
-        if (baseline != null) {
-          return baseline;
-        }
-
-        return activeValues[index];
-      });
+      // Keep live entries added during the interaction while restoring the original baseline.
+      const initialValuesForPush = Object.assign(activeValues.slice(), baselineValues);
+      initialValuesForPush[pressedIndex] = pressedValueAfterClamp;
 
       let nextValueForTarget = nextValue;
       if (shouldSwapForward) {
@@ -121,22 +102,20 @@ export function resolveThumbCollision(
 
       const neighborIndex = shouldSwapForward ? targetIndex - 1 : targetIndex + 1;
 
-      if (neighborIndex >= 0 && neighborIndex < adjustedValues.length) {
-        const previousValue = adjustedValues[neighborIndex - 1];
-        const nextValueAfter = adjustedValues[neighborIndex + 1];
+      const previousValue = adjustedValues[neighborIndex - 1];
+      const nextValueAfter = adjustedValues[neighborIndex + 1];
 
-        let neighborLowerBound = previousValue != null ? previousValue + minValueDifference : min;
-        neighborLowerBound = Math.max(neighborLowerBound, min + neighborIndex * minValueDifference);
+      let neighborLowerBound = previousValue != null ? previousValue + minValueDifference : min;
+      neighborLowerBound = Math.max(neighborLowerBound, min + neighborIndex * minValueDifference);
 
-        let neighborUpperBound = nextValueAfter != null ? nextValueAfter - minValueDifference : max;
-        neighborUpperBound = Math.min(
-          neighborUpperBound,
-          max - (adjustedValues.length - 1 - neighborIndex) * minValueDifference,
-        );
+      let neighborUpperBound = nextValueAfter != null ? nextValueAfter - minValueDifference : max;
+      neighborUpperBound = Math.min(
+        neighborUpperBound,
+        max - (adjustedValues.length - 1 - neighborIndex) * minValueDifference,
+      );
 
-        const restoredValue = clamp(pressedValueAfterClamp, neighborLowerBound, neighborUpperBound);
-        adjustedValues[neighborIndex] = Number(restoredValue.toFixed(12));
-      }
+      const restoredValue = clamp(pressedValueAfterClamp, neighborLowerBound, neighborUpperBound);
+      adjustedValues[neighborIndex] = Number(restoredValue.toFixed(12));
 
       return {
         value: adjustedValues,

--- a/packages/react/src/slider/utils/resolveThumbCollision.ts
+++ b/packages/react/src/slider/utils/resolveThumbCollision.ts
@@ -26,6 +26,16 @@ export function resolveThumbCollision(
 ): ResolveThumbCollisionResult {
   const activeValues = currentValues ?? values;
   const baselineValues = initialValues ?? values;
+  const range = activeValues.length > 1;
+
+  if (!range) {
+    return {
+      value: nextValue,
+      thumbIndex: 0,
+      didSwap: false,
+    };
+  }
+
   const minValueDifference = step * minStepsBetweenValues;
 
   // `push` does its own copy/bounds/rounding pass in `getPushedThumbValues`, so it must not
@@ -78,9 +88,18 @@ export function resolveThumbCollision(
 
       const targetIndex = shouldSwapForward ? pressedIndex + 1 : pressedIndex - 1;
 
-      // Keep live entries added during the interaction while restoring the original baseline.
-      const initialValuesForPush = Object.assign(activeValues.slice(), baselineValues);
-      initialValuesForPush[pressedIndex] = pressedValueAfterClamp;
+      const initialValuesForPush = candidateValues.map((_, index) => {
+        if (index === pressedIndex) {
+          return pressedValueAfterClamp;
+        }
+
+        const baseline = baselineValues[index];
+        if (baseline != null) {
+          return baseline;
+        }
+
+        return activeValues[index];
+      });
 
       let nextValueForTarget = nextValue;
       if (shouldSwapForward) {

--- a/packages/react/src/slider/utils/roundValueToStep.test.ts
+++ b/packages/react/src/slider/utils/roundValueToStep.test.ts
@@ -5,4 +5,8 @@ describe('roundValueToStep', () => {
   it('preserves precision from the step origin', () => {
     expect(roundValueToStep(0.35, 0.1, 0.25)).toBe(0.35);
   });
+
+  it('preserves decimal precision for steps greater than one', () => {
+    expect(roundValueToStep(13.2, 1.5, 10.2)).toBe(13.2);
+  });
 });

--- a/packages/react/src/slider/utils/test-utils.ts
+++ b/packages/react/src/slider/utils/test-utils.ts
@@ -14,15 +14,5 @@ export function createTouches(touches: Touches) {
 }
 
 export function getHorizontalSliderRect(width = 100) {
-  return {
-    width,
-    height: 10,
-    bottom: 10,
-    left: 0,
-    x: 0,
-    y: 0,
-    top: 0,
-    right: width,
-    toJSON() {},
-  };
+  return new DOMRect(0, 0, width, 10);
 }

--- a/packages/react/src/slider/value/SliderValue.tsx
+++ b/packages/react/src/slider/value/SliderValue.tsx
@@ -28,14 +28,10 @@ export const SliderValue = React.forwardRef(function SliderValue(
 
   const { thumbMap, state, values, format, locale } = useSliderRootContext();
 
-  let htmlFor = '';
-  for (const thumbMetadata of thumbMap.values()) {
-    if (thumbMetadata.inputId) {
-      htmlFor += `${thumbMetadata.inputId} `;
-    }
-  }
-
-  const outputFor = htmlFor.trim() || undefined;
+  const outputFor =
+    Array.from(thumbMap.values(), ({ inputId }) => inputId)
+      .join(' ')
+      .trim() || undefined;
 
   const formattedValues = React.useMemo(
     () => values.map((v) => formatNumber(v, locale, format)),


### PR DESCRIPTION
Expands Slider test coverage to 100% across statements, branches, functions, and lines on merged jsdom and Chromium results, and removes the redundant code the sweep uncovered.

## Changes

- Added behavior tests for stacked and dynamically changing ranges, pointer and touch dragging, inset controls, Field labels, disabled focus, and decimal steps.
- Fixed disabled sliders clearing active state before the focused thumb could be blurred.
- Kept collision resolution tied to the current range shape when controlled values change during a drag.
- Removed unreachable fallbacks and redundant checks from pointer, keyboard, collision, and value association paths.