### PR TITLE
[tabs] Expand test coverage

### DIFF
--- a/packages/react/src/tabs/enumSync.test.tsx
+++ b/packages/react/src/tabs/enumSync.test.tsx
@@ -6,6 +6,9 @@ import { createRenderer } from '#test-utils';
 import { tabsStateAttributesMapping } from './root/stateAttributesMapping';
 import { TabsRootDataAttributes } from './root/TabsRootDataAttributes';
 import { TabsPanelDataAttributes } from './panel/TabsPanelDataAttributes';
+import { TabsListDataAttributes } from './list/TabsListDataAttributes';
+import { TabsTabDataAttributes } from './tab/TabsTabDataAttributes';
+import { TabsIndicatorDataAttributes } from './indicator/TabsIndicatorDataAttributes';
 import { TabsIndicatorCssVars } from './indicator/TabsIndicatorCssVars';
 
 // The parts inline these enums' values instead of referencing the members, so
@@ -31,6 +34,46 @@ describe('Tabs enum sync', () => {
     );
 
     expect(screen.getByTestId('panel')).toHaveAttribute(TabsPanelDataAttributes.index);
+  });
+
+  it('names the tab attributes per TabsTabDataAttributes', async () => {
+    await render(
+      <Tabs.Root defaultValue={0} orientation="vertical">
+        <Tabs.List>
+          <Tabs.Tab value={0} data-testid="active-tab" />
+          <Tabs.Tab value={1} disabled data-testid="disabled-tab" />
+        </Tabs.List>
+      </Tabs.Root>,
+    );
+
+    const activeTab = screen.getByTestId('active-tab');
+    expect(activeTab).toHaveAttribute(TabsTabDataAttributes.orientation, 'vertical');
+    expect(activeTab).toHaveAttribute(TabsTabDataAttributes.activationDirection, 'none');
+    expect(activeTab).toHaveAttribute(TabsTabDataAttributes.active);
+    expect(activeTab).not.toHaveAttribute(TabsTabDataAttributes.disabled);
+
+    const disabledTab = screen.getByTestId('disabled-tab');
+    expect(disabledTab).toHaveAttribute(TabsTabDataAttributes.disabled);
+    expect(disabledTab).not.toHaveAttribute(TabsTabDataAttributes.active);
+  });
+
+  it('names the list and indicator attributes per their data attribute enums', async () => {
+    await render(
+      <Tabs.Root defaultValue={0} orientation="vertical">
+        <Tabs.List data-testid="list">
+          <Tabs.Tab value={0} />
+          <Tabs.Indicator data-testid="indicator" />
+        </Tabs.List>
+      </Tabs.Root>,
+    );
+
+    const list = screen.getByTestId('list');
+    expect(list).toHaveAttribute(TabsListDataAttributes.orientation, 'vertical');
+    expect(list).toHaveAttribute(TabsListDataAttributes.activationDirection, 'none');
+
+    const indicator = screen.getByTestId('indicator');
+    expect(indicator).toHaveAttribute(TabsIndicatorDataAttributes.orientation, 'vertical');
+    expect(indicator).toHaveAttribute(TabsIndicatorDataAttributes.activationDirection, 'none');
   });
 
   it('names the indicator CSS variables per TabsIndicatorCssVars', async () => {

--- a/packages/react/src/tabs/indicator/TabsIndicator.test.tsx
+++ b/packages/react/src/tabs/indicator/TabsIndicator.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, expect, vi } from 'vitest';
 import * as React from 'react';
 import { Tabs } from '@base-ui/react/tabs';
 import { CSPProvider } from '@base-ui/react/csp-provider';
-import { waitFor, screen } from '@mui/internal-test-utils';
+import { act, waitFor, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { getCssDimensions } from '../../utils/getCssDimensions';
 import { script as generatedPrehydrationScript } from './prehydrationScript.min';
@@ -272,6 +272,106 @@ describe('<Tabs.Indicator />', () => {
       await waitFor(() => {
         assertBubblePositionVariables(bubble, tabList, activeTab);
       });
+    });
+
+    it('keeps observing a tab whose rendered element type changes', async () => {
+      function TestTabs({ asAnchor }: { asAnchor: boolean }) {
+        return (
+          <Tabs.Root value={2}>
+            <Tabs.List
+              data-testid="tab-list"
+              style={{ width: '300px', display: 'flex', overflow: 'hidden' }}
+            >
+              <Tabs.Tab
+                data-testid="first-tab"
+                value={1}
+                nativeButton={!asAnchor}
+                render={asAnchor ? <a href="#one" /> : undefined}
+                style={{ width: '100px', flexShrink: 0 }}
+              >
+                One
+              </Tabs.Tab>
+              <Tabs.Tab value={2} style={{ width: '100px', flexShrink: 0 }}>
+                Two
+              </Tabs.Tab>
+              <Tabs.Indicator data-testid="bubble" />
+            </Tabs.List>
+          </Tabs.Root>
+        );
+      }
+
+      const { setProps } = await render(<TestTabs asAnchor={false} />);
+
+      const bubble = screen.getByTestId('bubble');
+      const tabList = screen.getByTestId('tab-list');
+      const activeTab = screen.getAllByRole('tab')[1];
+
+      await waitFor(() => {
+        assertBubblePositionVariables(bubble, tabList, activeTab);
+      });
+
+      await setProps({ asAnchor: true });
+
+      const swappedTab = screen.getByTestId('first-tab');
+      expect(swappedTab.tagName).toBe('A');
+
+      // Drain the resize entries the swap itself produces (the replaced element
+      // collapses to 0x0), so the assertion below can only be satisfied by the
+      // observer having followed the tab to its new element.
+      await act(async () => {
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => resolve());
+          });
+        });
+      });
+
+      swappedTab.setAttribute('style', 'width: 160px; flex-shrink: 0;');
+
+      await waitFor(() => {
+        assertBubblePositionVariables(bubble, tabList, activeTab);
+      });
+    });
+
+    it('falls back to offset positions when the tab list is scaled to zero', async () => {
+      await render(
+        <div style={{ transform: 'scale(0)' }}>
+          <Tabs.Root value={2}>
+            <Tabs.List
+              data-testid="tab-list"
+              style={{
+                position: 'relative',
+                width: '300px',
+                display: 'flex',
+                overflow: 'hidden',
+              }}
+            >
+              <Tabs.Tab value={1} style={{ width: '100px', flexShrink: 0 }}>
+                One
+              </Tabs.Tab>
+              <Tabs.Tab value={2} style={{ width: '100px', flexShrink: 0 }}>
+                Two
+              </Tabs.Tab>
+              <Tabs.Indicator data-testid="bubble" />
+            </Tabs.List>
+          </Tabs.Root>
+        </div>,
+      );
+
+      const bubble = screen.getByTestId('bubble');
+      const activeTab = screen.getAllByRole('tab')[1];
+
+      // The collapsed bounding rects can't be divided by, so the indicator uses
+      // the untransformed offsets instead of producing `NaN` positions.
+      await waitFor(() => {
+        const bubbleComputedStyle = window.getComputedStyle(bubble);
+        assertSize(bubbleComputedStyle.getPropertyValue('--active-tab-left'), activeTab.offsetLeft);
+      });
+
+      const bubbleComputedStyle = window.getComputedStyle(bubble);
+      assertSize(bubbleComputedStyle.getPropertyValue('--active-tab-top'), activeTab.offsetTop);
+      assertSize(bubbleComputedStyle.getPropertyValue('--active-tab-width'), 100);
+      expect(bubble).not.toHaveAttribute('hidden');
     });
 
     it('updates position when a new tab is inserted and then resized', async () => {

--- a/packages/react/src/tabs/panel/TabsPanel.test.tsx
+++ b/packages/react/src/tabs/panel/TabsPanel.test.tsx
@@ -12,6 +12,55 @@ describe('<Tabs.Panel />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
+  it('throws a descriptive error when rendered outside <Tabs.Root>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Tabs.Panel value="1" keepMounted />)).rejects.toThrow(
+        'Base UI: TabsRootContext is missing. Tabs parts must be placed within <Tabs.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  describe('panels sharing a value', () => {
+    it('keeps the surviving registration when a shadowed panel unmounts', async () => {
+      function App() {
+        const [shadowedMounted, setShadowedMounted] = React.useState(true);
+
+        return (
+          <React.Fragment>
+            <button type="button" onClick={() => setShadowedMounted(false)}>
+              unmount shadowed
+            </button>
+            <Tabs.Root value="a">
+              <Tabs.List>
+                <Tabs.Tab value="a">A</Tabs.Tab>
+                <Tabs.Tab value="b">B</Tabs.Tab>
+              </Tabs.List>
+              {shadowedMounted && <Tabs.Panel value="b" keepMounted data-testid="shadowed" />}
+              <Tabs.Panel value="b" keepMounted data-testid="owner" />
+            </Tabs.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      const tabB = screen.getAllByRole('tab')[1];
+      const owner = screen.getByTestId('owner');
+
+      // The last panel to register owns the value.
+      expect(tabB).toHaveAttribute('aria-controls', owner.id);
+
+      await user.click(screen.getByRole('button', { name: 'unmount shadowed' }));
+
+      expect(screen.queryByTestId('shadowed')).toBe(null);
+      expect(tabB).toHaveAttribute('aria-controls', owner.id);
+    });
+  });
+
   describe('Suspense integration', () => {
     it.skipIf(reactMajor < 19)(
       'renders a panel that suspends when opened with the boundary outside the root',

--- a/packages/react/src/tabs/panel/TabsPanel.tsx
+++ b/packages/react/src/tabs/panel/TabsPanel.tsx
@@ -89,11 +89,10 @@ export const TabsPanel = React.forwardRef(function TabsPanel(
   });
 
   useIsoLayoutEffect(() => {
-    if (hidden && !keepMounted) {
-      return undefined;
-    }
-
-    if (id == null) {
+    // On React 17 `useId` resolves in a passive effect, so `id` is still
+    // undefined during this layout effect on the first commit. Skip the
+    // registration until the effect re-runs with the resolved id.
+    if (id == null || (hidden && !keepMounted)) {
       return undefined;
     }
 

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -1,6 +1,6 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
-import { act, flushMicrotasks, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { act, flushMicrotasks, fireEvent, screen, waitFor, within } from '@mui/internal-test-utils';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
 import { Popover } from '@base-ui/react/popover';
 import { Dialog } from '@base-ui/react/dialog';
@@ -1053,6 +1053,33 @@ describe('<Tabs.Root />', () => {
       expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
     });
 
+    it('does not emit a second change when the fallback resolves to the current value', async () => {
+      const handleValueChange = vi.fn();
+
+      // Tabs can transiently share a value while a dynamic list is reordered.
+      // Duplicate values are not a supported configuration and this test makes
+      // no claim about the resulting DOM state; it only pins that the automatic
+      // fallback settles instead of re-emitting.
+      //
+      // The implicit default (`0`) matches no tab, so the root falls back to the
+      // first enabled tab. The disabled tab shares that value, so the selection
+      // still looks disabled on the next pass and must not be re-committed.
+      await render(
+        <Tabs.Root onValueChange={handleValueChange}>
+          <Tabs.List>
+            <Tabs.Tab value="a" disabled>
+              Stale duplicate
+            </Tabs.Tab>
+            <Tabs.Tab value="a">A</Tabs.Tab>
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      expect(handleValueChange).toHaveBeenCalledTimes(1);
+      expect(handleValueChange.mock.calls[0][0]).toBe('a');
+      expect(handleValueChange.mock.calls[0][1].reason).toBe('initial');
+    });
+
     it('does not call onValueChange when a controlled selected tab becomes disabled', async () => {
       const handleChange = vi.fn();
 
@@ -2075,6 +2102,33 @@ describe('<Tabs.Root />', () => {
       expect(screen.getByTestId('root')).toHaveAttribute('data-activation-direction', 'none');
     });
 
+    it('resets `data-activation-direction` when the selection is cleared and restored', async () => {
+      const { setProps } = await render(
+        <Tabs.Root data-testid="root" value={0}>
+          <Tabs.List>
+            <Tabs.Tab value={0} />
+            <Tabs.Tab value={1} />
+            <Tabs.Indicator data-testid="indicator" />
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      const root = screen.getByTestId('root');
+
+      await setProps({ value: 1 });
+      expect(root).toHaveAttribute('data-activation-direction', 'right');
+
+      // Clearing the selection is not a directional transition.
+      await setProps({ value: null });
+      expect(root).toHaveAttribute('data-activation-direction', 'none');
+      expect(screen.queryByTestId('indicator')).toBe(null);
+
+      // Neither is selecting a tab again from a cleared state.
+      await setProps({ value: 0 });
+      expect(root).toHaveAttribute('data-activation-direction', 'none');
+      expect(screen.getByTestId('indicator')).not.toBe(null);
+    });
+
     it('should update `data-activation-direction` on programmatic change after a canceled click', async () => {
       const { user, setProps } = await render(
         <Tabs.Root
@@ -2230,6 +2284,63 @@ describe('<Tabs.Root />', () => {
         expect.objectContaining({ tabActivationDirection: 'right' }),
       );
       expect(root).toHaveAttribute('data-activation-direction', 'right');
+    });
+  });
+
+  describe('nested tabs', () => {
+    it('keeps a nested root independent from the one hosting its panel', async () => {
+      const { user } = await render(
+        <Tabs.Root defaultValue="outer-1">
+          <Tabs.List data-testid="outer-list">
+            <Tabs.Tab value="outer-1">Outer 1</Tabs.Tab>
+            <Tabs.Tab value="outer-2">Outer 2</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value="outer-1" data-testid="outer-panel-1">
+            <Tabs.Root defaultValue="inner-1">
+              <Tabs.List data-testid="inner-list">
+                <Tabs.Tab value="inner-1">Inner 1</Tabs.Tab>
+                <Tabs.Tab value="inner-2">Inner 2</Tabs.Tab>
+              </Tabs.List>
+              <Tabs.Panel value="inner-1">Inner panel 1</Tabs.Panel>
+              <Tabs.Panel value="inner-2">Inner panel 2</Tabs.Panel>
+            </Tabs.Root>
+          </Tabs.Panel>
+          <Tabs.Panel value="outer-2">Outer panel 2</Tabs.Panel>
+        </Tabs.Root>,
+      );
+
+      const [outerTab1, outerTab2] = within(screen.getByTestId('outer-list')).getAllByRole('tab');
+      const [innerTab1, innerTab2] = within(screen.getByTestId('inner-list')).getAllByRole('tab');
+
+      const outerPanel1 = screen.getByTestId('outer-panel-1');
+      const innerPanel1 = screen.getByText('Inner panel 1');
+
+      // Each root wires its own tabs and panels together.
+      expect(outerTab1).toHaveAttribute('aria-controls', outerPanel1.id);
+      expect(innerTab1).toHaveAttribute('aria-controls', innerPanel1.id);
+      expect(innerPanel1).toHaveAttribute('aria-labelledby', innerTab1.id);
+
+      // Arrow keys within the nested list stay within the nested list.
+      await act(async () => {
+        innerTab1.focus();
+      });
+      await user.keyboard('{ArrowRight}');
+
+      expect(innerTab2).toHaveFocus();
+      expect(innerTab2).toHaveAttribute('aria-selected', 'false');
+
+      await user.keyboard('{Enter}');
+
+      expect(innerTab2).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByText('Inner panel 2')).not.toHaveAttribute('hidden');
+      expect(outerTab1).toHaveAttribute('aria-selected', 'true');
+      expect(outerTab2).toHaveAttribute('aria-selected', 'false');
+
+      // Selecting an outer tab unmounts the nested root along with its panel.
+      await user.click(outerTab2);
+
+      expect(screen.queryByTestId('inner-list')).toBe(null);
+      expect(screen.getByText('Outer panel 2')).not.toHaveAttribute('hidden');
     });
   });
 

--- a/packages/react/src/tabs/root/TabsRoot.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.tsx
@@ -44,7 +44,7 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
 
   const tabPanelRefs = React.useRef<(HTMLElement | null)[]>([]);
   const [mountedTabPanels, setMountedTabPanels] = React.useState(
-    () => new Map<TabsTab.Value | number, string>(),
+    () => new Map<TabsTab.Value, string>(),
   );
 
   const [value, setValue] = useControlled({
@@ -63,8 +63,7 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
 
   // Used for activation direction detection via tab element positions.
   const getTabElementBySelectedValue = React.useCallback(
-    (selectedValue: TabsTab.Value | undefined): HTMLElement | null =>
-      findTabElement(tabMap, selectedValue),
+    (selectedValue: TabsTab.Value): HTMLElement | null => findTabElement(tabMap, selectedValue),
     [tabMap],
   );
 
@@ -137,12 +136,8 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
   );
 
   const registerMountedTabPanel = useStableCallback(
-    (panelValue: TabsTab.Value | number, panelId: string) => {
+    (panelValue: TabsTab.Value, panelId: string) => {
       setMountedTabPanels((prev) => {
-        if (prev.get(panelValue) === panelId) {
-          return prev;
-        }
-
         const next = new Map(prev);
         next.set(panelValue, panelId);
         return next;
@@ -150,6 +145,8 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
 
       return () => {
         setMountedTabPanels((prev) => {
+          // Another panel with the same value took ownership in the meantime;
+          // leave its registration in place.
           if (prev.get(panelValue) !== panelId) {
             return prev;
           }
@@ -253,15 +250,9 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
       setValue(fallbackValue);
       // Automatic fallbacks are not directional transitions; reset the direction
       // alongside the value so the batched commit keeps both in sync.
-      setActivationDirectionState((prev) => {
-        if (prev.previousValue === fallbackValue && prev.tabActivationDirection === 'none') {
-          return prev;
-        }
-
-        return {
-          previousValue: fallbackValue,
-          tabActivationDirection: 'none',
-        };
+      setActivationDirectionState({
+        previousValue: fallbackValue,
+        tabActivationDirection: 'none',
       });
       notifyAutomaticValueChange(fallbackValue, fallbackReason);
       // Mark the initial notification as delivered only after the consumer
@@ -360,14 +351,10 @@ export const TabsRoot = React.forwardRef(function TabsRoot(
 
 function findTabElement(
   tabMap: Map<Node, CompositeMetadata<TabsTab.Metadata>>,
-  value: TabsTab.Value | undefined,
+  value: TabsTab.Value,
 ): HTMLElement | null {
-  if (value === undefined) {
-    return null;
-  }
-
   for (const [tabElement, tabMetadata] of tabMap.entries()) {
-    if (value === (tabMetadata.value ?? tabMetadata.index)) {
+    if (value === tabMetadata.value) {
       return tabElement as HTMLElement;
     }
   }

--- a/packages/react/src/tabs/root/TabsRootContext.ts
+++ b/packages/react/src/tabs/root/TabsRootContext.ts
@@ -20,7 +20,7 @@ export interface TabsRootContext {
   /**
    * Gets the element of the Tab with the given value.
    */
-  getTabElementBySelectedValue: (selectedValue: TabsTab.Value | undefined) => HTMLElement | null;
+  getTabElementBySelectedValue: (selectedValue: TabsTab.Value) => HTMLElement | null;
   /**
    * Gets the `id` attribute of the Tab that corresponds to the given TabPanel value.
    */
@@ -29,7 +29,7 @@ export interface TabsRootContext {
    * Gets the `id` attribute of the TabPanel that corresponds to the given Tab value.
    */
   getTabPanelIdByValue: (tabValue: TabsTab.Value) => string | undefined;
-  registerMountedTabPanel: (panelValue: TabsTab.Value | number, panelId: string) => () => void;
+  registerMountedTabPanel: (panelValue: TabsTab.Value, panelId: string) => () => void;
   setTabMap: (map: Map<Node, CompositeMetadata<TabsTab.Metadata>>) => void;
   /**
    * The position of the active tab relative to the previously active tab.

--- a/packages/react/src/tabs/tab/TabsTab.test.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.test.tsx
@@ -1,6 +1,6 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
-import { act, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import { Tabs } from '@base-ui/react/tabs';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -131,6 +131,23 @@ describe('<Tabs.Tab />', () => {
       await user.pointer({ keys: '[MouseRight]', target: secondTab });
 
       expect(handleValueChange).not.toHaveBeenCalled();
+
+      await act(async () => {
+        firstTab.focus();
+      });
+      await user.keyboard('{ArrowRight}');
+
+      expect(handleValueChange).toHaveBeenCalledTimes(1);
+      expect(secondTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('activates on focus again once a secondary-button press is cancelled', async () => {
+      const handleValueChange = vi.fn();
+      const { user } = await render(<TwoTabs onValueChange={handleValueChange} />);
+
+      const [firstTab, secondTab] = screen.getAllByRole('tab');
+      fireEvent.pointerDown(secondTab, { button: 2 });
+      fireEvent.pointerCancel(secondTab);
 
       await act(async () => {
         firstTab.focus();

--- a/packages/react/src/tabs/tab/TabsTab.test.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.test.tsx
@@ -1,6 +1,6 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
-import { screen } from '@mui/internal-test-utils';
+import { act, screen } from '@mui/internal-test-utils';
 import { Tabs } from '@base-ui/react/tabs';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
@@ -43,6 +43,132 @@ describe('<Tabs.Tab />', () => {
 
       expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
       expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  it('throws a descriptive error when rendered outside <Tabs.List>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <Tabs.Root>
+            <Tabs.Tab value="1" />
+          </Tabs.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: TabsListContext is missing. TabsList parts must be placed within <Tabs.List>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  describe('pointer interaction', () => {
+    function TwoTabs(props: {
+      onValueChange?: Tabs.Root.Props['onValueChange'];
+      disabledSecond?: boolean;
+    }) {
+      return (
+        <Tabs.Root defaultValue={0} onValueChange={props.onValueChange}>
+          <Tabs.List activateOnFocus>
+            <Tabs.Tab value={0}>One</Tabs.Tab>
+            <Tabs.Tab value={1} disabled={props.disabledSecond}>
+              Two
+            </Tabs.Tab>
+          </Tabs.List>
+        </Tabs.Root>
+      );
+    }
+
+    it('does not re-commit the value when the active tab is pressed', async () => {
+      const handleValueChange = vi.fn();
+      const { user } = await render(<TwoTabs onValueChange={handleValueChange} />);
+
+      const [firstTab] = screen.getAllByRole('tab');
+      await user.pointer({ keys: '[MouseLeft]', target: firstTab });
+
+      expect(handleValueChange).not.toHaveBeenCalled();
+      expect(firstTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('does not activate a disabled tab that is pressed and focused', async () => {
+      const handleValueChange = vi.fn();
+      const { user } = await render(<TwoTabs onValueChange={handleValueChange} disabledSecond />);
+
+      const [firstTab, secondTab] = screen.getAllByRole('tab');
+      await user.pointer({ keys: '[MouseLeft]', target: secondTab });
+      // Disabled tabs stay focusable, and `activateOnFocus` must not select them.
+      await act(async () => {
+        secondTab.focus();
+      });
+
+      expect(secondTab).toHaveFocus();
+      expect(handleValueChange).not.toHaveBeenCalled();
+      expect(firstTab).toHaveAttribute('aria-selected', 'true');
+      expect(secondTab).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('does not activate a tab focused by a held secondary-button press', async () => {
+      const handleValueChange = vi.fn();
+      const { user } = await render(<TwoTabs onValueChange={handleValueChange} />);
+
+      const [, secondTab] = screen.getAllByRole('tab');
+      await user.pointer({ keys: '[MouseRight>]', target: secondTab });
+      await act(async () => {
+        secondTab.focus();
+      });
+
+      expect(handleValueChange).not.toHaveBeenCalled();
+      expect(secondTab).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('activates on focus again once a secondary-button press has ended', async () => {
+      const handleValueChange = vi.fn();
+      const { user } = await render(<TwoTabs onValueChange={handleValueChange} />);
+
+      const [firstTab, secondTab] = screen.getAllByRole('tab');
+      await user.pointer({ keys: '[MouseRight]', target: secondTab });
+
+      expect(handleValueChange).not.toHaveBeenCalled();
+
+      await act(async () => {
+        firstTab.focus();
+      });
+      await user.keyboard('{ArrowRight}');
+
+      expect(handleValueChange).toHaveBeenCalledTimes(1);
+      expect(secondTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('keyboard activation', () => {
+    it.each([
+      ['Enter', '{Enter}'],
+      ['Space', ' '],
+    ])('activates the focused tab with %s when `activateOnFocus` is false', async (_label, key) => {
+      const { user } = await render(
+        <Tabs.Root defaultValue={0}>
+          <Tabs.List>
+            <Tabs.Tab value={0}>One</Tabs.Tab>
+            <Tabs.Tab value={1}>Two</Tabs.Tab>
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      const [firstTab, secondTab] = screen.getAllByRole('tab');
+      await act(async () => {
+        firstTab.focus();
+      });
+      await user.keyboard('{ArrowRight}');
+
+      expect(secondTab).toHaveFocus();
+      expect(secondTab).toHaveAttribute('aria-selected', 'false');
+
+      await user.keyboard(key);
+
+      expect(secondTab).toHaveAttribute('aria-selected', 'true');
+      expect(firstTab).toHaveAttribute('aria-selected', 'false');
     });
   });
 

--- a/packages/react/src/tabs/tab/TabsTab.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useBaseUiId } from '../../internals/useBaseUiId';
 import { useRenderElement } from '../../internals/useRenderElement';
 import type { BaseUIComponentProps, NativeButtonProps } from '../../internals/types';
@@ -68,16 +69,14 @@ export const TabsTab = React.forwardRef(function TabsTab(
   const active = value === activeTabValue;
 
   const isNavigatingRef = React.useRef(false);
-  const tabElementRef = React.useRef<HTMLElement | null>(null);
+  const unobserveTabElementRef = React.useRef<(() => void) | null>(null);
 
-  useIsoLayoutEffect(() => {
-    const tabElement = tabElementRef.current;
-    if (!tabElement) {
-      return undefined;
-    }
-
-    return registerTabResizeObserverElement(tabElement);
-  }, [registerTabResizeObserverElement]);
+  // Registered from the ref callback rather than an effect so the observer
+  // follows the rendered element when the `render` prop swaps the host element.
+  const observeTabElement = useStableCallback((element: HTMLElement | null) => {
+    unobserveTabElementRef.current?.();
+    unobserveTabElementRef.current = element ? registerTabResizeObserverElement(element) : null;
+  });
 
   // Keep the highlighted item in sync with the currently active tab
   // when the value prop changes externally (controlled mode)
@@ -146,7 +145,7 @@ export const TabsTab = React.forwardRef(function TabsTab(
     if (
       activateOnFocus &&
       (!isPressingRef.current || // keyboard or touch focus
-        (isPressingRef.current && isMainButtonRef.current)) // mouse focus
+        isMainButtonRef.current) // main mouse button focus
     ) {
       activate(event);
     }
@@ -158,18 +157,20 @@ export const TabsTab = React.forwardRef(function TabsTab(
     }
 
     isPressingRef.current = true;
+    // Secondary presses (context menu, middle click) may focus the tab, but
+    // must not activate it with `activateOnFocus`.
+    isMainButtonRef.current = event.button === 0;
 
-    function handlePointerUp() {
-      isPressingRef.current = false;
-      isMainButtonRef.current = false;
-    }
-
-    if (!event.button) {
-      isMainButtonRef.current = true;
-
-      const doc = ownerDocument(event.currentTarget);
-      doc.addEventListener('pointerup', handlePointerUp, { once: true });
-    }
+    // Registered for every button so a secondary press doesn't leave the tab
+    // stuck in the pressing state, which would suppress later focus activation.
+    ownerDocument(event.currentTarget).addEventListener(
+      'pointerup',
+      () => {
+        isPressingRef.current = false;
+        isMainButtonRef.current = false;
+      },
+      { once: true },
+    );
   }
 
   const state: TabsTabState = {
@@ -181,7 +182,7 @@ export const TabsTab = React.forwardRef(function TabsTab(
 
   const element = useRenderElement('button', componentProps, {
     state,
-    ref: [forwardedRef, buttonRef, compositeRef, tabElementRef],
+    ref: [forwardedRef, buttonRef, compositeRef, observeTabElement],
     props: [
       compositeProps,
       {

--- a/packages/react/src/tabs/tab/TabsTab.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.tsx
@@ -163,14 +163,17 @@ export const TabsTab = React.forwardRef(function TabsTab(
 
     // Registered for every button so a secondary press doesn't leave the tab
     // stuck in the pressing state, which would suppress later focus activation.
-    ownerDocument(event.currentTarget).addEventListener(
-      'pointerup',
-      () => {
-        isPressingRef.current = false;
-        isMainButtonRef.current = false;
-      },
-      { once: true },
-    );
+    const doc = ownerDocument(event.currentTarget);
+
+    function handlePointerEnd() {
+      isPressingRef.current = false;
+      isMainButtonRef.current = false;
+      doc.removeEventListener('pointerup', handlePointerEnd);
+      doc.removeEventListener('pointercancel', handlePointerEnd);
+    }
+
+    doc.addEventListener('pointerup', handlePointerEnd);
+    doc.addEventListener('pointercancel', handlePointerEnd);
   }
 
   const state: TabsTabState = {


### PR DESCRIPTION
Expands Tabs test coverage to 100% across statements, branches, functions, and lines in jsdom and Chromium, and removes the dead code found along the way.

## Changes

- Fixed the tab resize observer not following a tab when the `render` prop swaps the underlying element, which left the indicator stale when that tab later resized.
- Fixed a secondary-button press leaving the tab stuck in the pressing state, so `activateOnFocus` no longer selected it on a later keyboard focus.
- Removed dead code in `Tabs.Root`: the index fallback in the tab element lookup, an unreachable panel registration guard, and a state bail that never saved a commit.
