### PR TITLE
[number field] Expand test coverage

### DIFF
--- a/packages/react/src/number-field/increment/NumberFieldIncrement.test.tsx
+++ b/packages/react/src/number-field/increment/NumberFieldIncrement.test.tsx
@@ -617,6 +617,63 @@ describe('<NumberField.Increment />', () => {
     expect(input).toHaveValue('101');
   });
 
+  it('ignores non-primary pointer buttons', async () => {
+    const onValueChange = vi.fn();
+
+    // Controlled and pinned to 0, so the typed text stays out of sync with the stored value and
+    // any dirty-text sync from the press would be reported.
+    await render(
+      <NumberField.Root value={0} onValueChange={onValueChange}>
+        <NumberField.Increment />
+        <NumberField.Input />
+      </NumberField.Root>,
+    );
+
+    const input = screen.getByRole('textbox');
+
+    await act(() => input.focus());
+
+    fireEvent.change(input, { target: { value: '100' } });
+    onValueChange.mockClear();
+
+    fireEvent.pointerDown(screen.getByRole('button'), { button: 1 });
+
+    // A middle/right press must not even sync the dirty text, let alone start a hold.
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(input).toHaveValue('100');
+  });
+
+  it('does not step or commit when the dirty-input sync is canceled', async () => {
+    const onValueChange = vi.fn((_value, details) => details.cancel());
+    const onValueCommitted = vi.fn();
+
+    await render(
+      <NumberField.Root
+        defaultValue={0}
+        onValueChange={onValueChange}
+        onValueCommitted={onValueCommitted}
+      >
+        <NumberField.Increment />
+        <NumberField.Input />
+      </NumberField.Root>,
+    );
+
+    const input = screen.getByRole('textbox');
+
+    await act(() => input.focus());
+
+    fireEvent.change(input, { target: { value: '100' } });
+    // A keyboard/AT activation reaches `onClick` without a preceding `pointerdown`.
+    fireEvent.click(screen.getByRole('button'));
+
+    // Both the dirty-text sync and the step that follows it were vetoed: the step still runs
+    // (from the unchanged stored 0, not the typed 100), the typed text is left alone, and
+    // nothing is committed.
+    expect(onValueChange.mock.calls.map((call) => call[0])).toEqual([100, 100, 1]);
+    expect(input).toHaveValue('100');
+    expect(onValueCommitted).not.toHaveBeenCalled();
+  });
+
   it('treats pen pointer as touch-like', async () => {
     await render(
       <NumberField.Root defaultValue={0}>

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -2,6 +2,8 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { act, screen, fireEvent } from '@mui/internal-test-utils';
 import { NumberField } from '@base-ui/react/number-field';
+import { Field } from '@base-ui/react/field';
+import { SafeReact } from '@base-ui/utils/safeReact';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<NumberField.Input />', () => {
@@ -28,6 +30,18 @@ describe('<NumberField.Input />', () => {
       return render(<NumberField.Root>{node}</NumberField.Root>);
     },
   }));
+
+  it('throws a descriptive error when rendered outside <NumberField.Root>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<NumberField.Input />)).rejects.toThrow(
+        'Base UI: NumberFieldRootContext is missing. NumberField parts must be placed within <NumberField.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   it('has textbox role', async () => {
     await render(
@@ -1404,5 +1418,163 @@ describe('<NumberField.Input />', () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it('warns without an owner stack when React cannot provide one', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ownerStackSpy = vi.spyOn(SafeReact, 'captureOwnerStack').mockReturnValue(null);
+
+    try {
+      await render(
+        <NumberField.Root defaultValue={12}>
+          <NumberField.Input />
+        </NumberField.Root>,
+      );
+
+      const input = screen.getByRole('textbox');
+      await act(async () => input.focus());
+
+      pasteWithError(input, new DOMException('Blocked', 'SecurityError'));
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toBe(
+        'Base UI: <NumberField.Input> could not read clipboard text during paste handling. ',
+      );
+    } finally {
+      ownerStackSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('leaves the value untouched when a paste event carries no clipboard data', async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      <NumberField.Root defaultValue={12} onValueChange={onValueChange}>
+        <NumberField.Input />
+      </NumberField.Root>,
+    );
+
+    const input = screen.getByRole('textbox');
+    await act(async () => input.focus());
+
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(pasteEvent, 'clipboardData', { value: null });
+    fireEvent(input, pasteEvent);
+
+    expect(input).toHaveValue('12');
+    expect(onValueChange.mock.lastCall?.[0]).toBe(12);
+  });
+
+  describe('single sign character', () => {
+    async function renderSigned() {
+      await render(
+        <NumberField.Root min={-10} max={10} defaultValue={-5}>
+          <NumberField.Input />
+        </NumberField.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('textbox');
+      await act(async () => input.focus());
+      expect(input).toHaveValue('-5');
+
+      return {
+        input,
+        pressMinus() {
+          return input.dispatchEvent(
+            new window.KeyboardEvent('keydown', { key: '-', bubbles: true, cancelable: true }),
+          );
+        },
+      };
+    }
+
+    it('blocks a second minus sign when the existing one is not selected', async () => {
+      const { input, pressMinus } = await renderSigned();
+      input.setSelectionRange(2, 2);
+      expect(pressMinus()).toBe(false);
+    });
+
+    it('allows a minus sign that replaces the selected existing sign', async () => {
+      const { input, pressMinus } = await renderSigned();
+      input.setSelectionRange(0, 1);
+      expect(pressMinus()).toBe(true);
+    });
+
+    it('allows a minus sign when the whole value is selected', async () => {
+      const { input, pressMinus } = await renderSigned();
+      input.setSelectionRange(0, input.value.length);
+      expect(pressMinus()).toBe(true);
+    });
+  });
+
+  describe('consumer-prevented defaults', () => {
+    it('does not mark the field focused when the focus default is prevented', async () => {
+      await render(
+        <Field.Root data-testid="field">
+          <NumberField.Root defaultValue={1234}>
+            <NumberField.Input onFocus={(event) => event.preventDefault()} />
+          </NumberField.Root>
+        </Field.Root>,
+      );
+
+      await act(async () => screen.getByRole('textbox').focus());
+
+      expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+    });
+
+    it('does not reformat, touch, or commit on blur when the blur default is prevented', async () => {
+      const onValueCommitted = vi.fn();
+
+      await render(
+        <Field.Root data-testid="field">
+          <NumberField.Root onValueCommitted={onValueCommitted}>
+            <NumberField.Input onBlur={(event) => event.preventDefault()} />
+          </NumberField.Root>
+        </Field.Root>,
+      );
+
+      const input = screen.getByRole('textbox');
+      await act(async () => input.focus());
+      fireEvent.change(input, { target: { value: '5.10' } });
+      fireEvent.blur(input);
+
+      expect(input).toHaveValue('5.10');
+      expect(screen.getByTestId('field')).not.toHaveAttribute('data-touched');
+      expect(onValueCommitted).not.toHaveBeenCalled();
+    });
+
+    it('ignores a change whose native default was already prevented', async () => {
+      const onValueChange = vi.fn();
+
+      await render(
+        <NumberField.Root defaultValue={5} onValueChange={onValueChange}>
+          <NumberField.Input onChange={(event) => event.preventDefault()} />
+        </NumberField.Root>,
+      );
+
+      const input = screen.getByRole('textbox');
+      await act(async () => input.focus());
+      fireEvent.change(input, { target: { value: '9' }, cancelable: true });
+
+      expect(input).toHaveValue('5');
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('does not step when the keydown default is prevented', async () => {
+      const onValueChange = vi.fn();
+
+      await render(
+        <NumberField.Root defaultValue={5} onValueChange={onValueChange}>
+          <NumberField.Input onKeyDown={(event) => event.preventDefault()} />
+        </NumberField.Root>,
+      );
+
+      const input = screen.getByRole('textbox');
+      await act(async () => input.focus());
+      fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+      expect(input).toHaveValue('5');
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -5,6 +5,7 @@ import { NumberField } from '@base-ui/react/number-field';
 import { Field } from '@base-ui/react/field';
 import { SafeReact } from '@base-ui/utils/safeReact';
 import { createRenderer, describeConformance } from '#test-utils';
+import { REASONS } from '../../internals/reasons';
 
 describe('<NumberField.Input />', () => {
   const { render } = createRenderer();
@@ -1453,7 +1454,7 @@ describe('<NumberField.Input />', () => {
     },
   );
 
-  it('leaves the value untouched when a paste event carries no clipboard data', async () => {
+  it('reports an unchanged value once when a paste event carries no clipboard data', async () => {
     const onValueChange = vi.fn();
 
     await render(
@@ -1469,8 +1470,13 @@ describe('<NumberField.Input />', () => {
     Object.defineProperty(pasteEvent, 'clipboardData', { value: null });
     fireEvent(input, pasteEvent);
 
+    // Missing clipboard text splices an empty string in, so the text is unchanged. The paste
+    // still marks the input dirty, and direct-entry reasons report even when the number is
+    // unchanged, so exactly one `input-paste` change is emitted with the current value.
     expect(input).toHaveValue('12');
-    expect(onValueChange.mock.lastCall?.[0]).toBe(12);
+    expect(onValueChange.mock.calls.length).toBe(1);
+    expect(onValueChange.mock.calls[0][0]).toBe(12);
+    expect(onValueChange.mock.calls[0][1].reason).toBe(REASONS.inputPaste);
   });
 
   describe('single sign character', () => {

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -1420,31 +1420,38 @@ describe('<NumberField.Input />', () => {
     }
   });
 
-  it('warns without an owner stack when React cannot provide one', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const ownerStackSpy = vi.spyOn(SafeReact, 'captureOwnerStack').mockReturnValue(null);
+  // React below 19.1 has no `captureOwnerStack`, so the test above already warns without a
+  // stack. `warn` dedupes by message, which would swallow the identical warning here.
+  const hasCaptureOwnerStack = typeof SafeReact.captureOwnerStack === 'function';
 
-    try {
-      await render(
-        <NumberField.Root defaultValue={12}>
-          <NumberField.Input />
-        </NumberField.Root>,
-      );
+  it.skipIf(!hasCaptureOwnerStack)(
+    'warns without an owner stack when React cannot provide one',
+    async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const ownerStackSpy = vi.spyOn(SafeReact, 'captureOwnerStack').mockReturnValue(null);
 
-      const input = screen.getByRole('textbox');
-      await act(async () => input.focus());
+      try {
+        await render(
+          <NumberField.Root defaultValue={12}>
+            <NumberField.Input />
+          </NumberField.Root>,
+        );
 
-      pasteWithError(input, new DOMException('Blocked', 'SecurityError'));
+        const input = screen.getByRole('textbox');
+        await act(async () => input.focus());
 
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy.mock.calls[0]?.[0]).toBe(
-        'Base UI: <NumberField.Input> could not read clipboard text during paste handling. ',
-      );
-    } finally {
-      ownerStackSpy.mockRestore();
-      warnSpy.mockRestore();
-    }
-  });
+        pasteWithError(input, new DOMException('Blocked', 'SecurityError'));
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0]?.[0]).toBe(
+          'Base UI: <NumberField.Input> could not read clipboard text during paste handling. ',
+        );
+      } finally {
+        ownerStackSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    },
+  );
 
   it('leaves the value untouched when a paste event carries no clipboard data', async () => {
     const onValueChange = vi.fn();

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -218,7 +218,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
           blockRevalidationRef.current = false;
           return;
         }
-        committedValue = lastChangedValueRef.current ?? committed;
+        committedValue = lastChangedValueRef.current;
         // If validation normalized back to the current value, `useValueChanged` won't fire to
         // reset the flag, so reset it here or the next external change won't revalidate.
         if (committedValue === value) {
@@ -360,12 +360,17 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
         return;
       }
 
-      const willSetHome = event.key === 'Home' && min != null;
-      const willSetEnd = event.key === 'End' && max != null;
+      // Home/End jump to the corresponding bound, but only when that bound is defined.
+      let boundaryValue: number | null = null;
+      if (event.key === 'Home' && min != null) {
+        boundaryValue = min;
+      } else if (event.key === 'End' && max != null) {
+        boundaryValue = max;
+      }
 
       // Let the browser handle multi-character keys we don't act on (PageUp, Insert, F-keys,
       // Home/End without min/max); invalid single characters are still blocked below.
-      if (event.key.length > 1 && !isStepKey && !willSetHome && !willSetEnd) {
+      if (event.key.length > 1 && !isStepKey && boundaryValue === null) {
         return;
       }
 
@@ -386,7 +391,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       const commitDetails = createGenericEventDetails(REASONS.keyboard, nativeEvent);
 
       let changed = false;
-      if (isStepKey || willSetHome || willSetEnd) {
+      if (isStepKey || boundaryValue !== null) {
         allowInputSyncRef.current = true;
       }
       if (isStepKey) {
@@ -403,15 +408,14 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
           event: nativeEvent,
           reason: REASONS.keyboard,
         });
-      } else if (willSetHome || willSetEnd) {
-        changed = setValue(
-          (willSetHome ? min : max) ?? null,
-          createChangeEventDetails(REASONS.keyboard, nativeEvent),
-        );
+      } else if (boundaryValue !== null) {
+        changed = setValue(boundaryValue, createChangeEventDetails(REASONS.keyboard, nativeEvent));
       }
 
+      // `changed` is only true when `setValue` applied the change, which records the stored
+      // (clamped/snapped) value, so commit that rather than the pre-validation input.
       if (changed) {
-        onValueCommitted(lastChangedValueRef.current ?? valueRef.current, commitDetails);
+        onValueCommitted(lastChangedValueRef.current, commitDetails);
       }
     },
     onPaste(event) {
@@ -424,6 +428,7 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       try {
         pastedData = event.clipboardData?.getData('text/plain') ?? '';
       } catch {
+        /* istanbul ignore else -- `process.env.NODE_ENV` is a build-time constant under test */
         if (process.env.NODE_ENV !== 'production') {
           const ownerStackMessage = SafeReact.captureOwnerStack?.() || '';
           warn(
@@ -440,9 +445,12 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
 
       // Insert the pasted text at the caret/selection instead of replacing the entire value,
       // matching native input behavior (e.g. pasting "5" into "123|" yields "1235").
+      // The component renders `type="text"`, which always reports a selection range. Overriding
+      // `type` with a selection-less one (`email`, `number`) is unsupported either way: the caret
+      // restore above throws on those, so there is no working behavior to preserve here.
       const input = event.currentTarget;
-      const selectionStart = input.selectionStart ?? inputValue.length;
-      const selectionEnd = input.selectionEnd ?? inputValue.length;
+      const selectionStart = input.selectionStart!;
+      const selectionEnd = input.selectionEnd!;
       const nextText =
         inputValue.slice(0, selectionStart) + pastedData + inputValue.slice(selectionEnd);
 

--- a/packages/react/src/number-field/root/NumberFieldRoot.iOS.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.iOS.test.tsx
@@ -1,0 +1,53 @@
+import { expect, vi } from 'vitest';
+import { screen } from '@mui/internal-test-utils';
+import { NumberField } from '@base-ui/react/number-field';
+import { createRenderer } from '#test-utils';
+
+vi.mock('@base-ui/utils/platform', async () => {
+  const actual =
+    await vi.importActual<typeof import('@base-ui/utils/platform')>('@base-ui/utils/platform');
+
+  return {
+    ...actual,
+    platform: {
+      ...actual.platform,
+      os: { ...actual.platform.os, ios: true, apple: true },
+    },
+  };
+});
+
+describe('<NumberField.Root /> iOS', () => {
+  const { render } = createRenderer();
+
+  // The iOS numeric software keyboard has no decimal key, and no minus key at all, so the input
+  // mode is widened just enough to keep every valid character typeable.
+  it('uses the decimal keyboard when negative values are impossible', async () => {
+    await render(
+      <NumberField.Root min={0}>
+        <NumberField.Input />
+      </NumberField.Root>,
+    );
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('inputmode', 'decimal');
+  });
+
+  it('uses the text keyboard when negative values are allowed', async () => {
+    await render(
+      <NumberField.Root min={-5}>
+        <NumberField.Input />
+      </NumberField.Root>,
+    );
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('inputmode', 'text');
+  });
+
+  it('uses the text keyboard when no minimum is set', async () => {
+    await render(
+      <NumberField.Root>
+        <NumberField.Input />
+      </NumberField.Root>,
+    );
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('inputmode', 'text');
+  });
+});

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -1429,6 +1429,28 @@ describe('<NumberField />', () => {
       expect(onValueCommitted.mock.calls.length).toBe(2);
     });
 
+    it('does not commit when a wheel step is a no-op at the boundary', async () => {
+      const onValueChange = vi.fn();
+      const onValueCommitted = vi.fn();
+      await render(
+        <NumberField
+          defaultValue={5}
+          max={5}
+          allowWheelScrub
+          onValueChange={onValueChange}
+          onValueCommitted={onValueCommitted}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+      await act(async () => input.focus());
+
+      fireEvent.wheel(input, { deltaY: -1 });
+
+      expect(onValueChange).not.toHaveBeenCalled();
+      expect(onValueCommitted).not.toHaveBeenCalled();
+      expect(input).toHaveValue('5');
+    });
+
     it('syncs the visible input value when using the mouse wheel after pasting', async () => {
       const onValueChange = vi.fn();
 
@@ -2272,6 +2294,61 @@ describe('<NumberField />', () => {
       await render(<NumberField />);
       const input = screen.getByRole('textbox');
       expect(input).toHaveAttribute('inputmode', 'numeric');
+    });
+  });
+
+  describe('hidden input', () => {
+    function getHiddenInput() {
+      const hiddenInput = document.querySelector<HTMLInputElement>(
+        'input[aria-hidden][type=number]',
+      );
+      if (!hiddenInput) {
+        throw new Error('Expected a hidden number input.');
+      }
+      return hiddenInput;
+    }
+
+    it('forwards focus to the visible input', async () => {
+      await render(<NumberField defaultValue={5} />);
+
+      await act(async () => getHiddenInput().focus());
+
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
+
+    it('clears the value when autofill empties the hidden input', async () => {
+      const onValueChange = vi.fn();
+      await render(<NumberField defaultValue={5} onValueChange={onValueChange} />);
+
+      fireEvent.change(getHiddenInput(), { target: { value: '' } });
+
+      expect(screen.getByRole('textbox')).toHaveValue('');
+      expect(onValueChange.mock.lastCall?.[0]).toBe(null);
+    });
+
+    it('applies an autofilled value to the visible input', async () => {
+      const onValueChange = vi.fn();
+      await render(<NumberField onValueChange={onValueChange} />);
+
+      fireEvent.change(getHiddenInput(), { target: { value: '7' } });
+
+      expect(screen.getByRole('textbox')).toHaveValue('7');
+      expect(onValueChange.mock.lastCall?.[0]).toBe(7);
+    });
+
+    it('validates the autofilled value even when the change is canceled', async () => {
+      const validate = vi.fn((_value: unknown) => null);
+
+      await render(
+        <Field.Root validate={validate} validationMode="onChange">
+          <NumberField onValueChange={(_value, details) => details.cancel()} />
+        </Field.Root>,
+      );
+
+      fireEvent.change(getHiddenInput(), { target: { value: '7' } });
+
+      expect(screen.getByRole('textbox')).toHaveValue('');
+      expect(validate.mock.lastCall?.[0]).toBe(7);
     });
   });
 

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -155,9 +155,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
     const decimal =
       parts.find((part) => part.type === 'decimal')?.value ??
       getNumberLocaleDetails(locale, format).decimal;
-    if (decimal) {
-      keys.add(decimal);
-    }
+    keys.add(decimal);
 
     // Allow every non-digit character the formatter renders — separators, currency symbols, units
     // (e.g. `km/h`, `°C`), exponent separators, and locale literals — decomposed per character
@@ -374,7 +372,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
         });
         if (changed) {
           onValueCommitted(
-            lastChangedValueRef.current ?? valueRef.current,
+            lastChangedValueRef.current,
             createGenericEventDetails(REASONS.wheel, event),
           );
         }

--- a/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.test.tsx
+++ b/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.test.tsx
@@ -43,6 +43,24 @@ describe.skipIf(isWebKit)('<NumberField.ScrubAreaCursor />', () => {
     expect(screen.queryByRole('presentation')).not.toBe(null);
   });
 
+  it('throws a descriptive error when rendered outside <NumberField.ScrubArea>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <NumberField.Root>
+            <NumberField.ScrubAreaCursor />
+          </NumberField.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: NumberFieldScrubAreaContext is missing. NumberFieldScrubArea parts must be placed within <NumberField.ScrubArea>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it('renders when using mouse input', async () => {
     const originalRequestPointerLock = Element.prototype.requestPointerLock;
 

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.gecko.test.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.gecko.test.tsx
@@ -1,0 +1,73 @@
+import { expect, vi } from 'vitest';
+import { screen, act } from '@mui/internal-test-utils';
+import { NumberField } from '@base-ui/react/number-field';
+import { createRenderer, isJSDOM } from '#test-utils';
+import { platform } from '@base-ui/utils/platform';
+
+vi.mock('@base-ui/utils/platform', async () => {
+  const actual =
+    await vi.importActual<typeof import('@base-ui/utils/platform')>('@base-ui/utils/platform');
+
+  return {
+    ...actual,
+    platform: {
+      ...actual.platform,
+      engine: { ...actual.platform.engine, gecko: true },
+    },
+  };
+});
+
+// Scrubbing relies on real pointer movement, which only the Chromium/Firefox runners provide.
+describe.skipIf(isJSDOM || platform.engine.webkit)('<NumberField.ScrubArea /> on Gecko', () => {
+  const { render, clock } = createRenderer();
+
+  clock.withFakeTimers();
+
+  it('delays releasing the pointer lock so soft clicks are not swallowed', async () => {
+    const onValueCommitted = vi.fn();
+
+    await render(
+      <NumberField.Root defaultValue={0} data-testid="root" onValueCommitted={onValueCommitted}>
+        <NumberField.Input />
+        <NumberField.ScrubArea data-testid="scrub-area">
+          <NumberField.ScrubAreaCursor />
+        </NumberField.ScrubArea>
+      </NumberField.Root>,
+    );
+
+    const scrubArea = screen.getByTestId('scrub-area');
+    const root = screen.getByTestId('root');
+    const box = scrubArea.getBoundingClientRect();
+
+    await act(async () => {
+      scrubArea.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: box.left + box.width / 2,
+          clientY: box.top + box.height / 2,
+        }),
+      );
+      scrubArea.dispatchEvent(
+        new PointerEvent('pointermove', { bubbles: true, movementX: 10, movementY: 0 }),
+      );
+    });
+
+    expect(screen.getByRole('textbox')).toHaveValue('10');
+
+    await act(async () => {
+      window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    });
+
+    // Firefox needs the pointer lock to outlive the release, so the scrub is still open here.
+    expect(onValueCommitted).not.toHaveBeenCalled();
+    expect(root).toHaveAttribute('data-scrubbing');
+
+    await act(async () => {
+      clock.tick(20);
+    });
+
+    expect(onValueCommitted.mock.calls.length).toBe(1);
+    expect(onValueCommitted.mock.lastCall?.[0]).toBe(10);
+    expect(root).not.toHaveAttribute('data-scrubbing');
+  });
+});

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.test.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.test.tsx
@@ -1,5 +1,6 @@
 import { expect, vi } from 'vitest';
-import { screen, act, fireEvent } from '@mui/internal-test-utils';
+import * as React from 'react';
+import { screen, act, fireEvent, reactMajor } from '@mui/internal-test-utils';
 import { NumberField } from '@base-ui/react/number-field';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { platform } from '@base-ui/utils/platform';
@@ -73,6 +74,78 @@ describe('<NumberField.ScrubArea />', () => {
       </NumberField.Root>,
     );
     expect(screen.queryByRole('presentation')).not.toBe(null);
+  });
+
+  describe('touch input', () => {
+    function createTouch(target: EventTarget) {
+      if (typeof Touch === 'function') {
+        return new Touch({ identifier: 1, target, clientX: 0, clientY: 0 });
+      }
+      return { clientX: 0, clientY: 0 };
+    }
+
+    async function renderScrubArea() {
+      await render(
+        <NumberField.Root defaultValue={0}>
+          <NumberField.Input />
+          <NumberField.ScrubArea data-testid="scrub-area" />
+        </NumberField.Root>,
+      );
+      return { scrubArea: screen.getByTestId('scrub-area') };
+    }
+
+    it('blocks scrolling for a single-touch scrub', async () => {
+      const { scrubArea } = await renderScrubArea();
+      const notCanceled = fireEvent.touchStart(scrubArea, {
+        touches: [createTouch(scrubArea)],
+      });
+      expect(notCanceled).toBe(false);
+    });
+
+    it('leaves multi-touch gestures such as pinch-zoom to the browser', async () => {
+      const { scrubArea } = await renderScrubArea();
+      const notCanceled = fireEvent.touchStart(scrubArea, {
+        touches: [createTouch(scrubArea), createTouch(scrubArea)],
+      });
+      expect(notCanceled).toBe(true);
+    });
+  });
+
+  describe('pointerdown guards', () => {
+    async function renderScrubArea(props?: NumberField.Root.Props) {
+      await render(
+        <NumberField.Root defaultValue={0} data-testid="root" {...props}>
+          <NumberField.Input />
+          <NumberField.ScrubArea data-testid="scrub-area">
+            <NumberField.ScrubAreaCursor />
+          </NumberField.ScrubArea>
+        </NumberField.Root>,
+      );
+      return {
+        scrubArea: screen.getByTestId('scrub-area'),
+        root: screen.getByTestId('root'),
+      };
+    }
+
+    it('ignores non-primary pointer buttons', async () => {
+      const { scrubArea, root } = await renderScrubArea();
+
+      await act(async () => {
+        scrubArea.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 1 }));
+      });
+
+      expect(root).not.toHaveAttribute('data-scrubbing');
+    });
+
+    it('does not start scrubbing when the field is read-only', async () => {
+      const { scrubArea, root } = await renderScrubArea({ readOnly: true });
+
+      await act(async () => {
+        scrubArea.dispatchEvent(createPointerDownEvent(scrubArea));
+      });
+
+      expect(root).not.toHaveAttribute('data-scrubbing');
+    });
   });
 
   // Only run the following tests in Chromium/Firefox.
@@ -279,7 +352,110 @@ describe('<NumberField.ScrubArea />', () => {
     expect(committed).toBe(lastChange);
   });
 
+  // Gecko defers the pointer lock release by 20ms, so the scrub is still live right after
+  // `pointerup` there; that path is covered by `NumberFieldScrubArea.gecko.test.tsx`.
+  it.skipIf(platform.engine.gecko)(
+    'ignores pointer movement once the scrub has ended',
+    async () => {
+      await render(
+        <NumberField.Root defaultValue={0}>
+          <NumberField.Input />
+          <NumberField.ScrubArea data-testid="scrub-area">
+            <NumberField.ScrubAreaCursor />
+          </NumberField.ScrubArea>
+        </NumberField.Root>,
+      );
+
+      const scrubArea = screen.getByTestId('scrub-area');
+      const input = screen.getByRole('textbox');
+
+      await act(async () => {
+        scrubArea.dispatchEvent(createPointerDownEvent(scrubArea));
+        scrubArea.dispatchEvent(createPointerMoveEvent({ movementX: 10 }));
+      });
+
+      expect(input).toHaveValue('10');
+
+      await act(async () => {
+        window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+        window.dispatchEvent(createPointerMoveEvent({ movementX: 10 }));
+      });
+
+      expect(input).toHaveValue('10');
+    },
+  );
+
+  describe.skipIf(reactMajor < 19)('React.Activity', () => {
+    it('does not resume scrubbing when a hidden scrub area is revealed again', async () => {
+      const Activity = (
+        React as typeof React & {
+          Activity: React.ComponentType<{ mode: 'visible' | 'hidden'; children: React.ReactNode }>;
+        }
+      ).Activity;
+
+      function App(props: { visible: boolean }) {
+        return (
+          <Activity mode={props.visible ? 'visible' : 'hidden'}>
+            <NumberField.Root defaultValue={0}>
+              <NumberField.Input />
+              <NumberField.ScrubArea data-testid="scrub-area">
+                <NumberField.ScrubAreaCursor />
+              </NumberField.ScrubArea>
+            </NumberField.Root>
+          </Activity>
+        );
+      }
+
+      const { setProps } = await render(<App visible />);
+
+      const scrubArea = screen.getByTestId('scrub-area');
+      const input = screen.getByRole('textbox');
+
+      await act(async () => {
+        scrubArea.dispatchEvent(createPointerDownEvent(scrubArea));
+        scrubArea.dispatchEvent(createPointerMoveEvent({ movementX: 10 }));
+      });
+
+      expect(input).toHaveValue('10');
+
+      // Hiding tears the effects down mid-scrub without unmounting; revealing re-runs them.
+      await act(async () => setProps({ visible: false }));
+      await act(async () => setProps({ visible: true }));
+
+      // No pointer is down anymore, so a bare mouse move must not change the value.
+      await act(async () => {
+        window.dispatchEvent(createPointerMoveEvent({ movementX: 10 }));
+      });
+
+      expect(screen.getByRole('textbox')).toHaveValue('10');
+    });
+  });
+
   describe('prop: pixelSensitivity', () => {
+    it('does not change the value for a zero-distance move when sensitivity is 0', async () => {
+      const onValueChange = vi.fn();
+
+      await render(
+        // `snapOnStep` makes a zero-amount step observable: it would snap 3.5 down to 3.
+        <NumberField.Root defaultValue={3.5} step={1} snapOnStep onValueChange={onValueChange}>
+          <NumberField.Input />
+          <NumberField.ScrubArea data-testid="scrub-area" pixelSensitivity={0}>
+            <NumberField.ScrubAreaCursor />
+          </NumberField.ScrubArea>
+        </NumberField.Root>,
+      );
+
+      const scrubArea = screen.getByTestId('scrub-area');
+
+      await act(async () => {
+        scrubArea.dispatchEvent(createPointerDownEvent(scrubArea));
+        scrubArea.dispatchEvent(createPointerMoveEvent({ movementX: 0 }));
+      });
+
+      expect(screen.getByRole('textbox')).toHaveValue('3.5');
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
     it('should only increment if the pointer movement was greater than or equal to the value', async () => {
       await render(
         <NumberField.Root defaultValue={0}>
@@ -347,7 +523,90 @@ describe('<NumberField.ScrubArea />', () => {
     });
   });
 
+  describe('prop: teleportDistance', () => {
+    it('wraps the virtual cursor around the allowed bounds', async () => {
+      // Headless Chromium denies pointer lock, which unmounts the virtual cursor mid-test.
+      const pointerLock = vi
+        .spyOn(document.body, 'requestPointerLock')
+        .mockImplementation(() => Promise.resolve());
+
+      try {
+        await render(
+          <NumberField.Root defaultValue={0}>
+            <NumberField.Input />
+            {/* Pin the scrub area so the bounds don't shift as the value (and input width) grows. */}
+            <NumberField.ScrubArea
+              data-testid="scrub-area"
+              teleportDistance={100}
+              style={{ position: 'fixed', left: 100, top: 100, width: 20, height: 20 }}
+            >
+              <NumberField.ScrubAreaCursor data-testid="cursor" />
+            </NumberField.ScrubArea>
+          </NumberField.Root>,
+        );
+
+        const scrubArea = screen.getByTestId('scrub-area');
+
+        await act(async () => {
+          scrubArea.dispatchEvent(createPointerDownEvent(scrubArea));
+        });
+
+        const cursor = screen.getByTestId('cursor');
+        // The bare cursor has no size, so its wrap coordinates are the bounds themselves.
+        expect(cursor.offsetWidth).toBe(0);
+
+        // Past the right bound (120 + 100 / 2): the cursor reappears at the left one.
+        await act(async () => {
+          scrubArea.dispatchEvent(createPointerMoveEvent({ movementX: 5000 }));
+        });
+        expect(cursor.style.transform).toContain('translate3d(50px,');
+
+        // And symmetrically past the left bound (100 - 100 / 2).
+        await act(async () => {
+          scrubArea.dispatchEvent(createPointerMoveEvent({ movementX: -5000 }));
+        });
+        expect(cursor.style.transform).toContain('translate3d(170px,');
+      } finally {
+        pointerLock.mockRestore();
+      }
+    });
+  });
+
   describe('prop: direction', () => {
+    it('scrubs on vertical movement when direction is vertical', async () => {
+      await render(
+        <NumberField.Root defaultValue={0}>
+          <NumberField.Input />
+          <NumberField.ScrubArea data-testid="scrub-area" direction="vertical">
+            <NumberField.ScrubAreaCursor />
+          </NumberField.ScrubArea>
+        </NumberField.Root>,
+      );
+
+      const scrubArea = screen.getByTestId('scrub-area');
+      const input = screen.getByRole('textbox');
+
+      await act(async () => {
+        scrubArea.dispatchEvent(createPointerDownEvent(scrubArea));
+        scrubArea.dispatchEvent(createPointerMoveEvent({ movementX: 10 }));
+      });
+
+      expect(input).toHaveValue('0');
+
+      // Upward movement (negative Y) increases the value.
+      await act(async () => {
+        scrubArea.dispatchEvent(createPointerMoveEvent({ movementY: -10 }));
+      });
+
+      expect(input).toHaveValue('10');
+
+      await act(async () => {
+        scrubArea.dispatchEvent(createPointerMoveEvent({ movementY: 4 }));
+      });
+
+      expect(input).toHaveValue('6');
+    });
+
     it('should only scrub if the pointer moved in the given direction', async () => {
       await render(
         <NumberField.Root defaultValue={0}>

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
@@ -71,14 +71,11 @@ export const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubAr
   const [isPointerLockDenied, setIsPointerLockDenied] = React.useState(false);
   const [isScrubbing, setIsScrubbing] = React.useState(false);
 
-  function updateCursorTransform(x: number, y: number) {
-    const virtualCursor = scrubAreaCursorRef.current;
-    if (virtualCursor) {
-      // Invert the visual viewport scale so the cursor matches the OS cursor, which doesn't
-      // scale with the content on pinch-zoom.
-      const scale = ownerWindow(virtualCursor).visualViewport?.scale ?? 1;
-      virtualCursor.style.transform = `translate3d(${x}px,${y}px,0) scale(${1 / scale})`;
-    }
+  function updateCursorTransform(virtualCursor: HTMLSpanElement, x: number, y: number) {
+    // Invert the visual viewport scale so the cursor matches the OS cursor, which doesn't
+    // scale with the content on pinch-zoom.
+    const scale = ownerWindow(virtualCursor).visualViewport?.scale ?? 1;
+    virtualCursor.style.transform = `translate3d(${x}px,${y}px,0) scale(${1 / scale})`;
   }
 
   const onScrub = useStableCallback(({ movementX, movementY }: PointerEvent) => {
@@ -121,7 +118,7 @@ export const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubAr
 
     virtualCursorCoords.current = newCoords;
 
-    updateCursorTransform(newCoords.x, newCoords.y);
+    updateCursorTransform(virtualCursor, newCoords.x, newCoords.y);
   });
 
   const onScrubbingChange = useStableCallback(
@@ -143,7 +140,7 @@ export const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubAr
 
       virtualCursorCoords.current = initialCoords;
 
-      updateCursorTransform(initialCoords.x, initialCoords.y);
+      updateCursorTransform(virtualCursor, initialCoords.x, initialCoords.y);
     },
   );
 
@@ -198,6 +195,9 @@ export const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubAr
       }
 
       function handleScrubPointerMove(event: PointerEvent) {
+        // The effects below can tear down and re-run without unmounting (`<Activity>`), which
+        // clears the ref while `isScrubbing` stays `true` and re-attaches this listener. The ref
+        // is the source of truth for whether a pointer is actually down.
         if (!isScrubbingRef.current) {
           return;
         }

--- a/packages/react/src/number-field/utils/constants.ts
+++ b/packages/react/src/number-field/utils/constants.ts
@@ -1,3 +1,2 @@
 export const CHANGE_VALUE_TICK_DELAY = 60;
 export const START_AUTO_CHANGE_DELAY = 400;
-export const SCROLLING_POINTER_MOVE_DISTANCE = 8;

--- a/packages/react/src/number-field/utils/getViewportRect.test.ts
+++ b/packages/react/src/number-field/utils/getViewportRect.test.ts
@@ -1,0 +1,77 @@
+import { expect, vi } from 'vitest';
+import { isJSDOM } from '#test-utils';
+import { getViewportRect } from './getViewportRect';
+
+describe('getViewportRect', () => {
+  let element: HTMLElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    element.style.cssText = 'position:fixed;left:100px;top:100px;width:20px;height:20px';
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('pads the element rect by half the teleport distance', () => {
+    const rect = element.getBoundingClientRect();
+
+    expect(getViewportRect(100, element)).toEqual({
+      left: rect.left - 50,
+      top: rect.top - 50,
+      right: rect.right + 50,
+      bottom: rect.bottom + 50,
+    });
+  });
+
+  it('collapses to the element rect for a zero teleport distance', () => {
+    const rect = element.getBoundingClientRect();
+
+    expect(getViewportRect(0, element)).toEqual({
+      left: rect.left,
+      top: rect.top,
+      right: rect.right,
+      bottom: rect.bottom,
+    });
+  });
+
+  it.skipIf(isJSDOM)('uses the visual viewport when no teleport distance is set', () => {
+    const visualViewport = window.visualViewport;
+    if (!visualViewport) {
+      throw new Error('Expected visualViewport in a browser test.');
+    }
+
+    // A pinch-zoomed viewport: offset from the layout viewport and smaller than it, so the
+    // result can't coincide with the document element's bounds.
+    const spies = [
+      vi.spyOn(visualViewport, 'offsetLeft', 'get').mockReturnValue(7),
+      vi.spyOn(visualViewport, 'offsetTop', 'get').mockReturnValue(11),
+      vi.spyOn(visualViewport, 'width', 'get').mockReturnValue(300),
+      vi.spyOn(visualViewport, 'height', 'get').mockReturnValue(400),
+    ];
+
+    try {
+      expect(getViewportRect(undefined, element)).toEqual({
+        left: 7,
+        top: 11,
+        right: 307,
+        bottom: 411,
+      });
+    } finally {
+      spies.forEach((spy) => spy.mockRestore());
+    }
+  });
+
+  it.skipIf(!isJSDOM)('falls back to the document element without a visual viewport', () => {
+    expect(window.visualViewport).toBe(undefined);
+
+    expect(getViewportRect(undefined, element)).toEqual({
+      left: 0,
+      top: 0,
+      right: document.documentElement.clientWidth,
+      bottom: document.documentElement.clientHeight,
+    });
+  });
+});

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -88,17 +88,20 @@ export function getNumberLocaleDetails(
   });
 
   // The formatting options may omit the decimal separator (e.g. integer formats), so resolve it
-  // from the plain locale formatter. This overrides any options-derived decimal too, which is
-  // safe because the separator is locale-determined and identical across format styles.
+  // from the plain locale formatter, which renders one for every locale and numbering system. This
+  // overrides any options-derived decimal too, which is safe because the separator is
+  // locale-determined and identical across format styles. The ASCII seed is a formality to keep
+  // the separator non-optional for callers; it is always replaced below.
+  let decimal = '.';
   getFormatter(locale)
     .formatToParts(0.1)
     .forEach((part) => {
       if (part.type === 'decimal') {
-        result[part.type] = part.value;
+        decimal = part.value;
       }
     });
 
-  return result;
+  return { ...result, decimal };
 }
 
 export function parseNumber(
@@ -106,12 +109,8 @@ export function parseNumber(
   locale?: Intl.LocalesArgument,
   options?: Intl.NumberFormatOptions,
 ) {
-  if (formattedNumber == null) {
-    return null;
-  }
-
   // Normalize control characters and whitespace; remove bidi/format controls
-  let input = String(formattedNumber).replace(FORMAT_CONTROL_GLOBAL_RE, '').trim();
+  let input = formattedNumber.replace(FORMAT_CONTROL_GLOBAL_RE, '').trim();
 
   // Normalize unicode minus/plus to ASCII, handle leading/trailing signs
   input = input.replace(ANY_MINUS_RE, '-').replace(ANY_PLUS_RE, '+');
@@ -169,7 +168,7 @@ export function parseNumber(
 
   const replacements: Array<[RegExp | null, string | ((m: string) => string)]> = [
     [groupRegex, ''],
-    [decimal ? new RegExp(escapeRegExp(decimal), 'g') : null, '.'],
+    [new RegExp(escapeRegExp(decimal), 'g'), '.'],
     // Fullwidth/Arabic punctuation
     [/[．٫]/g, '.'], // FULLWIDTH_DECIMAL, ARABIC DECIMAL SEPARATOR (U+066B)
     [/[，٬]/g, ''], // FULLWIDTH_GROUP, ARABIC THOUSANDS SEPARATOR (U+066C)

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -73,6 +73,20 @@ describe('NumberField validate', () => {
       expect(removeFloatingPointErrors(1000000.1 + 0.2)).not.toBe(1000000.3);
     });
 
+    it('returns non-finite values untouched', () => {
+      expect(removeFloatingPointErrors(Infinity)).toBe(Infinity);
+      expect(removeFloatingPointErrors(-Infinity)).toBe(-Infinity);
+      expect(removeFloatingPointErrors(NaN)).toBeNaN();
+    });
+
+    it('rounds compact notation against its standard equivalent', () => {
+      // `compact` would format 1234.567 as "1.2K", which cannot round-trip back to a number, so
+      // the rounding is resolved with standard notation instead.
+      expect(
+        removeFloatingPointErrors(1234.567, { notation: 'compact', maximumFractionDigits: 1 }),
+      ).toBe(1234.6);
+    });
+
     it('returns 0.3 for 0.2 + 0.1 with maximumFractionDigits', () => {
       expect(removeFloatingPointErrors(0.2 + 0.1, { maximumFractionDigits: 1 })).toBe(0.3);
     });
@@ -725,6 +739,23 @@ describe('NumberField validate', () => {
         }),
       ).toBe(-0.2);
     });
+  });
+
+  it('keeps rounded out-of-range values when clamping is disabled', () => {
+    // `allowOutOfRange` text entry rounds to the format's precision but must stay outside the
+    // range so native overflow validation can report it.
+    expect(
+      toValidatedNumber(12.349, {
+        ...defaultOptions,
+        step: undefined,
+        snapOnStep: false,
+        format: { maximumFractionDigits: 2 },
+        minWithDefault: 0,
+        minWithZeroDefault: 0,
+        maxWithDefault: 10,
+        clamp: false,
+      }),
+    ).toBe(12.35);
   });
 
   it('clamps to a non-step-aligned max after snapping so the boundary is reachable', () => {


### PR DESCRIPTION
Expands Number Field test coverage to 100% across statements, branches, functions, and lines on merged jsdom and Chromium results, and removes the dead code the sweep uncovered.

## Changes

- Added behavior tests for consumer-prevented focus, blur, change, and keydown defaults, single sign-character replacement, hidden-input focus and autofill, vertical scrubbing, virtual cursor wrapping, multi-touch pinch, non-primary pointer buttons, the iOS input mode, the Gecko pointer lock delay, and the missing-context errors.
- Restored the scrub area's `isScrubbingRef` guard on pointer move. Effects can tear down and re-run without unmounting under `<Activity>`, which clears the ref while `isScrubbing` stays true and re-attaches the listener, so a bare mouse move changed the value.
- Made `getNumberLocaleDetails` always return a decimal separator, which drops the optional-decimal branches in `parseNumber` and `NumberField.Root`.
- Replaced the `willSetHome`/`willSetEnd` pair in `NumberField.Input` with a single boundary value, removing an unreachable `?? null`.
- Removed the commit fallbacks in the blur, keyboard, and wheel paths. `setValue` always records the stored value before those run, so the fallback could never fire.
- Removed the null guard in `parseNumber`, the redundant cursor null check in `NumberField.ScrubArea`, and the unused `SCROLLING_POINTER_MOVE_DISTANCE` constant.
