### PR TITLE
[form][field][fieldset] Expand test coverage

### DIFF
--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -181,7 +181,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
   const registerFieldInput = validation.registerInput;
   const registeredInputValue = groupContext ? value : undefined;
   const registerInput = React.useCallback(
-    (element: HTMLInputElement | null) =>
+    (element: HTMLInputElement) =>
       registerFieldInput(element, { controlRef, value: registeredInputValue }),
     [registerFieldInput, registeredInputValue],
   );

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -1,6 +1,7 @@
 import { expect, vi } from 'vitest';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
+import { Form } from '@base-ui/react/form';
 import { describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Field.Control />', () => {
@@ -54,6 +55,31 @@ describe('<Field.Control />', () => {
 
     expect(validate).toHaveBeenCalledTimes(1);
     expect(validate.mock.lastCall?.[0]).toBe('a');
+  });
+
+  it('does not clear errors or validate when change is prevented', async () => {
+    const validate = vi.fn();
+    const handleValueChange = vi.fn();
+
+    await render(
+      <Form errors={{ message: 'Server error' }}>
+        <Field.Root name="message" validationMode="onChange" validate={validate}>
+          <Field.Control onValueChange={handleValueChange} />
+          <Field.Error />
+        </Field.Root>
+      </Form>,
+    );
+
+    const control = screen.getByRole<HTMLInputElement>('textbox');
+    control.addEventListener('input', (event) => event.preventDefault(), {
+      capture: true,
+      once: true,
+    });
+    fireEvent.input(control, { cancelable: true, target: { value: 'a' } });
+
+    expect(handleValueChange).toHaveBeenCalledTimes(1);
+    expect(validate).not.toHaveBeenCalled();
+    expect(screen.getByText('Server error')).toBeInTheDocument();
   });
 
   it('shows a required error when a prefilled value is cleared', async () => {

--- a/packages/react/src/field/description/FieldDescription.test.tsx
+++ b/packages/react/src/field/description/FieldDescription.test.tsx
@@ -40,6 +40,17 @@ describe('<Field.Description />', () => {
     );
   });
 
+  it('does not register an empty description id', () => {
+    render(
+      <Field.Root>
+        <Field.Control aria-describedby="external-description" />
+        <Field.Description id="">Message</Field.Description>
+      </Field.Root>,
+    );
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-describedby', 'external-description');
+  });
+
   it('reflects the disabled state from Field.Item', async () => {
     await render(
       <Field.Root>

--- a/packages/react/src/field/error/FieldError.test.tsx
+++ b/packages/react/src/field/error/FieldError.test.tsx
@@ -211,6 +211,40 @@ describe('<Field.Error />', () => {
       expect(screen.getByTestId('default-error')).toHaveTextContent('Username is reserved');
     });
 
+    it('renders client validation error arrays as a list', async () => {
+      await render(
+        <Form>
+          <Field.Root validate={() => ['First error', 'Second error']}>
+            <Field.Control />
+            <Field.Error data-testid="default-error" />
+          </Field.Root>
+          <button type="submit">submit</button>
+        </Form>,
+      );
+
+      fireEvent.click(screen.getByText('submit'));
+
+      const list = screen.getByTestId('default-error').querySelector('ul');
+      expect(list).not.toBe(null);
+      expect(list?.querySelectorAll('li')).toHaveLength(2);
+      expect(screen.getByText('First error')).not.toBe(null);
+      expect(screen.getByText('Second error')).not.toBe(null);
+    });
+
+    it('does not register an empty error id', async () => {
+      await render(
+        <Field.Root invalid>
+          <Field.Control aria-describedby="external-description" />
+          <Field.Error id="">Message</Field.Error>
+        </Field.Root>,
+      );
+
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-describedby',
+        'external-description',
+      );
+    });
+
     it('ignores empty Form error arrays', async () => {
       await render(
         <Form errors={{ username: [] }}>

--- a/packages/react/src/field/error/FieldError.tsx
+++ b/packages/react/src/field/error/FieldError.tsx
@@ -78,7 +78,7 @@ export const FieldError = React.forwardRef(function FieldError(
     error = validityData.errors;
   }
 
-  let errorMessage: React.ReactNode = error ?? '';
+  let errorMessage: React.ReactNode = error;
   if (Array.isArray(error)) {
     errorMessage =
       error.length > 1 ? (
@@ -88,7 +88,7 @@ export const FieldError = React.forwardRef(function FieldError(
           ))}
         </ul>
       ) : (
-        (error[0] ?? '')
+        error[0]
       );
   }
 

--- a/packages/react/src/field/item/FieldItem.test.tsx
+++ b/packages/react/src/field/item/FieldItem.test.tsx
@@ -81,4 +81,31 @@ describe('<Field.Item />', () => {
       expect(onValueChange.mock.calls.length).toBe(1);
     });
   });
+
+  it('associates a Field.Item label with a parent checkbox', async () => {
+    const { user } = await render(
+      <Field.Root>
+        <CheckboxGroup allValues={['a', 'b']}>
+          <Field.Item>
+            <Field.Label>
+              <Checkbox.Root parent data-testid="parent" />
+              Toggle all
+            </Field.Label>
+          </Field.Item>
+          <Checkbox.Root value="a" data-testid="a" />
+          <Checkbox.Root value="b" data-testid="b" />
+        </CheckboxGroup>
+      </Field.Root>,
+    );
+
+    const label = screen.getByText('Toggle all').closest('label') as HTMLLabelElement;
+    const parent = screen.getByTestId('parent');
+
+    expect(label).toHaveAttribute('for');
+    expect(label.control).toHaveAttribute('type', 'checkbox');
+    await user.click(screen.getByText('Toggle all'));
+    expect(parent).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('a')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('b')).toHaveAttribute('aria-checked', 'true');
+  });
 });

--- a/packages/react/src/field/item/FieldItem.tsx
+++ b/packages/react/src/field/item/FieldItem.tsx
@@ -7,7 +7,6 @@ import type { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { FieldItemContext } from './FieldItemContext';
 import { LabelableProvider } from '../../internals/labelable-provider';
-import { useCheckboxGroupContext } from '../../checkbox-group/CheckboxGroupContext';
 
 /**
  * Groups individual items in a checkbox group or radio group with a label and description.
@@ -32,10 +31,6 @@ export const FieldItem = React.forwardRef(function FieldItem(
   const disabled = rootDisabled || disabledProp;
   const state: FieldItemState = { ...fieldState, disabled };
 
-  const checkboxGroupContext = useCheckboxGroupContext();
-  const hasParentCheckbox = checkboxGroupContext?.allValues !== undefined;
-  const controlId = hasParentCheckbox ? checkboxGroupContext?.parent.id : undefined;
-
   const fieldItemContext: FieldItemContext = React.useMemo(() => ({ disabled }), [disabled]);
 
   const element = useRenderElement('div', componentProps, {
@@ -46,7 +41,7 @@ export const FieldItem = React.forwardRef(function FieldItem(
   });
 
   return (
-    <LabelableProvider controlId={controlId}>
+    <LabelableProvider>
       <FieldItemContext.Provider value={fieldItemContext}>{element}</FieldItemContext.Provider>
     </LabelableProvider>
   );

--- a/packages/react/src/field/label/FieldLabel.test.tsx
+++ b/packages/react/src/field/label/FieldLabel.test.tsx
@@ -1,4 +1,5 @@
 import { expect } from 'vitest';
+import * as React from 'react';
 import { Field } from '@base-ui/react/field';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
@@ -74,30 +75,53 @@ describe('<Field.Label />', () => {
       errorSpy.mockRestore();
     });
 
+    it('does not warn when the render function returns no element', async () => {
+      const errorSpy = vi
+        .spyOn(console, 'error')
+        .mockName('console.error')
+        .mockImplementation(() => {});
+
+      const EmptyLabel = React.forwardRef(function EmptyLabel() {
+        return null;
+      });
+
+      await render(
+        <Field.Root>
+          <Field.Label render={<EmptyLabel />}>Label</Field.Label>
+        </Field.Root>,
+      );
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
     it('errors if nativeLabel=true but ref is not a label', async () => {
       const errorSpy = vi
         .spyOn(console, 'error')
         .mockName('console.error')
         .mockImplementation(() => {});
 
-      await render(
-        <Field.Root>
-          <Field.Control />
-          <Field.Label nativeLabel render={<div />}>
-            Label
-          </Field.Label>
-        </Field.Root>,
-      );
+      try {
+        await render(
+          <Field.Root>
+            <Field.Control />
+            <Field.Label nativeLabel render={<div />}>
+              Label
+            </Field.Label>
+          </Field.Root>,
+        );
 
-      expect(errorSpy).toHaveBeenCalledTimes(1);
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'Base UI: <Field.Label> expected a <label> element because the `nativeLabel` prop is true. ' +
-            'Rendering a non-<label> disables native label association, so `htmlFor` will not ' +
-            'work. Use a real <label> in the `render` prop, or set `nativeLabel` to `false`.',
-        ),
-      );
-      errorSpy.mockRestore();
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Base UI: <Field.Label> expected a <label> element because the `nativeLabel` prop is true. ' +
+              'Rendering a non-<label> disables native label association, so `htmlFor` will not ' +
+              'work. Use a real <label> in the `render` prop, or set `nativeLabel` to `false`.',
+          ),
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
 
     it('errors if nativeLabel=false but ref is a label', async () => {
@@ -106,23 +130,26 @@ describe('<Field.Label />', () => {
         .mockName('console.error')
         .mockImplementation(() => {});
 
-      await render(
-        <Field.Root>
-          <Field.Control />
-          <Field.Label nativeLabel={false}>Label</Field.Label>
-        </Field.Root>,
-      );
+      try {
+        await render(
+          <Field.Root>
+            <Field.Control />
+            <Field.Label nativeLabel={false}>Label</Field.Label>
+          </Field.Root>,
+        );
 
-      expect(errorSpy).toHaveBeenCalledTimes(1);
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'Base UI: <Field.Label> expected a non-<label> element because the `nativeLabel` prop is false. ' +
-            'Rendering a <label> assumes native label behavior while Base UI treats it as ' +
-            'non-native, which can cause unexpected pointer behavior. Use a non-<label> in the ' +
-            '`render` prop, or set `nativeLabel` to `true`.',
-        ),
-      );
-      errorSpy.mockRestore();
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Base UI: <Field.Label> expected a non-<label> element because the `nativeLabel` prop is false. ' +
+              'Rendering a <label> assumes native label behavior while Base UI treats it as ' +
+              'non-native, which can cause unexpected pointer behavior. Use a non-<label> in the ' +
+              '`render` prop, or set `nativeLabel` to `true`.',
+          ),
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/react/src/field/root/FieldRoot.react17.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.react17.test.tsx
@@ -1,0 +1,78 @@
+import { expect, vi } from 'vitest';
+import * as React from 'react';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { Field } from '@base-ui/react/field';
+import { screen } from '@mui/internal-test-utils';
+import { createRenderer } from '#test-utils';
+
+vi.mock('@base-ui/utils/safeReact', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@base-ui/utils/safeReact')>();
+
+  return {
+    SafeReact: {
+      ...original.SafeReact,
+      captureOwnerStack: undefined,
+      useId: undefined,
+    },
+  };
+});
+
+describe('<Field.Root /> with the React 17 id fallback', () => {
+  const { render } = createRenderer();
+
+  it('allows mount-time imperative validation before the fallback id is assigned', async () => {
+    function TestCase() {
+      const actionsRef = React.useRef<Field.Root.Actions>(null);
+
+      useIsoLayoutEffect(() => {
+        actionsRef.current?.validate();
+      }, []);
+
+      return (
+        <Field.Root actionsRef={actionsRef} validate={() => 'Mount-time error'}>
+          <Field.Error />
+        </Field.Root>
+      );
+    }
+
+    await render(<TestCase />);
+
+    expect(await screen.findByText('Mount-time error')).toBeVisible();
+  });
+
+  it('reports label mismatches without the owner-stack API', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await render(
+        <Field.Root>
+          <Field.Label render={<div />}>Label</Field.Label>
+        </Field.Root>,
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('<Field.Label> expected a <label> element'),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('reports non-native label mismatches without the owner-stack API', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await render(
+        <Field.Root>
+          <Field.Label nativeLabel={false}>Label</Field.Label>
+        </Field.Root>,
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('<Field.Label> expected a non-<label> element'),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -1651,6 +1651,18 @@ describe('<Field.Root />', () => {
       expect(control).toHaveAttribute('aria-invalid', 'true');
       expect(screen.getByTestId('error')).not.toBe(null);
     });
+
+    it('does not update controlled dirty state from user input', async () => {
+      await render(
+        <Field.Root data-testid="root" dirty={false}>
+          <Field.Control />
+        </Field.Root>,
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'changed' } });
+
+      expect(screen.getByTestId('root')).not.toHaveAttribute('data-dirty');
+    });
   });
 
   describe('prop: touched', () => {
@@ -1667,6 +1679,19 @@ describe('<Field.Root />', () => {
       ['root', 'control', 'label', 'description'].forEach((part) => {
         expect(screen.getByTestId(part)).toHaveAttribute('data-touched');
       });
+    });
+
+    it('does not update controlled touched state on blur', async () => {
+      await render(
+        <Field.Root data-testid="root" touched={false}>
+          <Field.Control />
+        </Field.Root>,
+      );
+
+      fireEvent.focus(screen.getByRole('textbox'));
+      fireEvent.blur(screen.getByRole('textbox'));
+
+      expect(screen.getByTestId('root')).not.toHaveAttribute('data-touched');
     });
   });
 
@@ -1694,6 +1719,28 @@ describe('<Field.Root />', () => {
       await user.click(screen.getByText('validate'));
 
       expect(screen.queryByTestId('error')).not.toBe(null);
+    });
+
+    it('validates a logical field without a mounted control', async () => {
+      function App() {
+        const actionsRef = React.useRef<Field.Root.Actions>(null);
+        return (
+          <div>
+            <Field.Root actionsRef={actionsRef} validate={() => 'Logical field error'}>
+              <Field.Error />
+            </Field.Root>
+            <button type="button" onClick={() => actionsRef.current?.validate()}>
+              validate
+            </button>
+          </div>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      await user.click(screen.getByRole('button', { name: 'validate' }));
+
+      expect(screen.getByText('Logical field error')).toBeVisible();
     });
 
     it('validates the current control value when the `validate` method is called', async () => {

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -99,10 +99,7 @@ export function useFieldValidation(
   // projection can use the same live controls. This also ensures a `required` checkbox can't be
   // satisfied by another input in the group, matching native per-checkbox behavior.
   const registerInput = React.useCallback(
-    (element: HTMLInputElement | null, registration: RegisteredInput) => {
-      if (!element) {
-        return undefined;
-      }
+    (element: HTMLInputElement, registration: RegisteredInput) => {
       registeredInputs.set(element, registration);
       return () => {
         registeredInputs.delete(element);
@@ -370,10 +367,7 @@ export interface UseFieldValidationReturnValue {
   getValidationProps: (disabled: boolean, props?: HTMLProps) => HTMLProps;
   inputRef: React.RefObject<HTMLInputElement | null>;
   registeredInputs: RegisteredInputs;
-  registerInput: (
-    element: HTMLInputElement | null,
-    registration: RegisteredInput,
-  ) => void | (() => void);
+  registerInput: (element: HTMLInputElement, registration: RegisteredInput) => void | (() => void);
   getInputControl: () => HTMLElement | null;
   commit: (value: unknown) => Promise<void>;
   change: (value: unknown) => void;

--- a/packages/react/src/fieldset/legend/FieldsetLegend.test.tsx
+++ b/packages/react/src/fieldset/legend/FieldsetLegend.test.tsx
@@ -1,5 +1,6 @@
 import { expect, vi } from 'vitest';
-import { createRenderer, screen, waitFor } from '@mui/internal-test-utils';
+import * as React from 'react';
+import { createRenderer, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Fieldset } from '@base-ui/react/fieldset';
 import { describeConformance, isJSDOM } from '#test-utils';
 
@@ -34,6 +35,35 @@ describe('<Fieldset.Legend />', () => {
     );
 
     expect(screen.getByRole('group')).toHaveAttribute('aria-labelledby', 'legend-id');
+  });
+
+  it('updates and clears the legend association', async () => {
+    function App() {
+      const [legendId, setLegendId] = React.useState('legend-a');
+      const [showLegend, setShowLegend] = React.useState(true);
+
+      return (
+        <React.Fragment>
+          <Fieldset.Root>
+            {showLegend ? <Fieldset.Legend id={legendId}>Legend</Fieldset.Legend> : null}
+          </Fieldset.Root>
+          <button type="button" onClick={() => setLegendId('legend-b')}>
+            Change id
+          </button>
+          <button type="button" onClick={() => setShowLegend(false)}>
+            Remove legend
+          </button>
+        </React.Fragment>
+      );
+    }
+
+    render(<App />);
+
+    expect(screen.getByRole('group')).toHaveAttribute('aria-labelledby', 'legend-a');
+    fireEvent.click(screen.getByRole('button', { name: 'Change id' }));
+    expect(screen.getByRole('group')).toHaveAttribute('aria-labelledby', 'legend-b');
+    fireEvent.click(screen.getByRole('button', { name: 'Remove legend' }));
+    expect(screen.getByRole('group')).not.toHaveAttribute('aria-labelledby');
   });
 
   it('throws a descriptive error when rendered outside <Fieldset.Root>', () => {

--- a/packages/react/src/fieldset/legend/FieldsetLegend.tsx
+++ b/packages/react/src/fieldset/legend/FieldsetLegend.tsx
@@ -1,10 +1,9 @@
 'use client';
 import * as React from 'react';
-import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { useBaseUiId } from '../../internals/useBaseUiId';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useFieldsetRootContext } from '../root/FieldsetRootContext';
 import type { BaseUIComponentProps } from '../../internals/types';
+import { useRegisteredLabelId } from '../../utils/useRegisteredLabelId';
 
 /**
  * An accessible label that is automatically associated with the fieldset.
@@ -20,14 +19,7 @@ export const FieldsetLegend = React.forwardRef(function FieldsetLegend(
 
   const { disabled, setLegendId } = useFieldsetRootContext();
 
-  const id = useBaseUiId(idProp);
-
-  useIsoLayoutEffect(() => {
-    setLegendId(id);
-    return () => {
-      setLegendId(undefined);
-    };
-  }, [setLegendId, id]);
+  const id = useRegisteredLabelId(idProp, setLegendId);
 
   const state: FieldsetLegendState = {
     disabled,

--- a/packages/react/src/fieldset/root/FieldsetRoot.test.tsx
+++ b/packages/react/src/fieldset/root/FieldsetRoot.test.tsx
@@ -1,5 +1,6 @@
 import { expect } from 'vitest';
-import { createRenderer, screen } from '@mui/internal-test-utils';
+import * as React from 'react';
+import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { Checkbox } from '@base-ui/react/checkbox';
 import { CheckboxGroup } from '@base-ui/react/checkbox-group';
 import { Field } from '@base-ui/react/field';
@@ -40,6 +41,46 @@ describe('<Fieldset.Root />', () => {
     );
 
     expect(screen.getByTestId('control')).toHaveAttribute('disabled');
+  });
+
+  it('updates nested disabled precedence in both directions', async () => {
+    function App() {
+      const [outerDisabled, setOuterDisabled] = React.useState(false);
+      const [innerDisabled, setInnerDisabled] = React.useState(true);
+
+      return (
+        <React.Fragment>
+          <Fieldset.Root disabled={outerDisabled}>
+            <Fieldset.Root disabled={innerDisabled}>
+              <Field.Root data-testid="root">
+                <Field.Control data-testid="control" />
+              </Field.Root>
+            </Fieldset.Root>
+          </Fieldset.Root>
+          <button type="button" onClick={() => setOuterDisabled(true)}>
+            Disable outer
+          </button>
+          <button type="button" onClick={() => setInnerDisabled(false)}>
+            Enable inner
+          </button>
+          <button type="button" onClick={() => setOuterDisabled(false)}>
+            Enable outer
+          </button>
+        </React.Fragment>
+      );
+    }
+
+    await render(<App />);
+
+    expect(screen.getByTestId('control')).toBeDisabled();
+    expect(screen.getByTestId('root')).toHaveAttribute('data-disabled');
+    fireEvent.click(screen.getByRole('button', { name: 'Disable outer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Enable inner' }));
+    expect(screen.getByTestId('control')).toBeDisabled();
+    expect(screen.getByTestId('root')).toHaveAttribute('data-disabled');
+    fireEvent.click(screen.getByRole('button', { name: 'Enable outer' }));
+    expect(screen.getByTestId('control')).not.toBeDisabled();
+    expect(screen.getByTestId('root')).not.toHaveAttribute('data-disabled');
   });
 
   it('passes disabled to rendered Base UI roots', async () => {

--- a/packages/react/src/form/Form.test.tsx
+++ b/packages/react/src/form/Form.test.tsx
@@ -273,6 +273,9 @@ describe('<Form />', () => {
           <button type="button" onClick={() => setDisabled(true)}>
             Disable
           </button>
+          <button type="button" onClick={() => setDisabled(false)}>
+            Enable
+          </button>
           <button type="submit">Submit</button>
         </Form>
       );
@@ -296,6 +299,13 @@ describe('<Form />', () => {
 
     expect(handleSubmit).toHaveBeenCalledTimes(1);
     expect(handleSubmit.mock.lastCall?.[0]).toEqual({});
+
+    await user.click(screen.getByRole('button', { name: 'Enable' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('control')).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByTestId('error')).toBeInTheDocument();
   });
 
   it('clears invalid attributes when a field control becomes disabled', async () => {

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -87,7 +87,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
 
   const registerFieldInput = validation?.registerInput;
   const registerInput = React.useCallback(
-    (element: HTMLInputElement | null) =>
+    (element: HTMLInputElement) =>
       registerFieldInput?.(element, { controlRef: radioRef, value: undefined }),
     [registerFieldInput],
   );


### PR DESCRIPTION
Expands Form, Field, and Fieldset test coverage to 100% across statements, branches, functions, and lines on merged jsdom and Chromium results, and removes the redundant logic the sweep uncovered.

## Changes

- Added behavior tests for canceled changes, controlled dirty and touched state, label and description association, error rendering, nested disabled precedence, logical-field validation, and React 17 fallback paths.
- Reused the shared label registration helper for `Fieldset.Legend`.
- Removed redundant `Field.Item` parent-checkbox control id plumbing, `Field.Error` empty fallbacks, and unreachable nullable hidden-input registration paths.