### PR TITLE
[docs] Fix code block focus outline

### DIFF
--- a/docs/src/components/CodeBlock/CodeBlock.css
+++ b/docs/src/components/CodeBlock/CodeBlock.css
@@ -90,6 +90,11 @@
     }
   }
 
+  .CodeBlockRoot > .CodeBlockPreContainer:first-child .CodeBlockViewport {
+    border-top-left-radius: calc(var(--radius-12) - 1px);
+    border-top-right-radius: calc(var(--radius-12) - 1px);
+  }
+
   .CodeBlockPreInline {
     font-size: 0.8125rem; /* 13px */
     line-height: 1.25rem; /* 20px */


### PR DESCRIPTION
## Summary

- round the top corners of standalone code block viewports
- preserve the square internal top edge when a code block has a title panel

## Problem

`CodeBlockViewport` only had bottom border radii because titled code blocks render a panel above the viewport. Standalone code blocks, such as detailed types in API reference accordions, use the same viewport without a panel, leaving the top corners of the keyboard focus outline square inside a rounded container.

The new selector applies the matching inner top radius only when the viewport container is the first child of `CodeBlockRoot`.

|before|after|
|---|---|
|![The focus outline has square top corners](https://raw.githubusercontent.com/aarongarciah/base-ui/33b3d474cfea338b6f93c52b98ce21a35be34499/screenshots/5282/before.png)|![The focus outline follows the code block's rounded corners](https://raw.githubusercontent.com/aarongarciah/base-ui/33b3d474cfea338b6f93c52b98ce21a35be34499/screenshots/5282/after.png)|

Preview: https://deploy-preview-5282--base-ui.netlify.app/react/components/accordion#AccordionRoot-render

Make the viewport smaller so the code block is scrollable and then tab to it.
