### PR TITLE
[form][field] Ignore controls in disabled native fieldsets

### DIFF
--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -1180,6 +1180,36 @@ describe('<CheckboxGroup />', () => {
       expect(validate.mock.lastCall?.[1].fruits).toEqual(['apple']);
       expect(handleSubmit.mock.lastCall?.[0].fruits).toEqual(['apple']);
     });
+
+    it.skipIf(isJSDOM)(
+      'omits a group disabled by a native fieldset from validation and submission',
+      () => {
+        const handleSubmit = vi.fn();
+        const validate = vi.fn(() => 'invalid');
+
+        render(
+          <Form onFormSubmit={handleSubmit} data-testid="form">
+            <fieldset disabled>
+              <Field.Root name="fruits" validate={validate}>
+                <CheckboxGroup defaultValue={['apple']}>
+                  <Checkbox.Root value="apple" />
+                  <Checkbox.Root value="banana" />
+                </CheckboxGroup>
+              </Field.Root>
+            </fieldset>
+            <button type="submit">Submit</button>
+          </Form>,
+        );
+
+        const form = screen.getByTestId('form') as HTMLFormElement;
+        expect(new FormData(form).getAll('fruits')).toEqual([]);
+
+        fireEvent.click(screen.getByText('Submit'));
+
+        expect(validate).not.toHaveBeenCalled();
+        expect(handleSubmit.mock.lastCall?.[0]).toEqual({});
+      },
+    );
   });
 
   describe.skipIf(isJSDOM)('Form', () => {

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -565,6 +565,93 @@ describe('<Checkbox.Root />', () => {
   });
 
   describe('Form', () => {
+    it.skipIf(isJSDOM)(
+      'omits a field disabled by a native fieldset from validation and submission',
+      async () => {
+        const handleSubmit = vi.fn();
+        const validate = vi.fn(() => 'invalid');
+
+        function App() {
+          const [disabled, setDisabled] = React.useState(true);
+
+          return (
+            <Form onFormSubmit={handleSubmit} data-testid="form">
+              <fieldset disabled={disabled}>
+                <Field.Root name="terms" validate={validate}>
+                  <Checkbox.Root defaultChecked required />
+                </Field.Root>
+              </fieldset>
+              <Field.Root name="enabled">
+                <Field.Control defaultValue="sent" />
+              </Field.Root>
+              <button type="button" onClick={() => setDisabled((value) => !value)}>
+                {disabled ? 'Enable' : 'Disable'}
+              </button>
+              <button type="submit">Submit</button>
+            </Form>
+          );
+        }
+
+        const { user } = await render(<App />);
+
+        const form = screen.getByTestId('form') as HTMLFormElement;
+        expect(new FormData(form).has('terms')).toBe(false);
+
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        expect(validate).not.toHaveBeenCalled();
+        expect(handleSubmit).toHaveBeenCalledTimes(1);
+        expect(handleSubmit.mock.lastCall?.[0]).toEqual({ enabled: 'sent' });
+
+        await user.click(screen.getByRole('button', { name: 'Enable' }));
+        expect(new FormData(form).get('terms')).toBe('on');
+
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        expect(validate).toHaveBeenCalledTimes(1);
+        expect(handleSubmit).toHaveBeenCalledTimes(1);
+        expect(screen.getByRole('checkbox')).toHaveFocus();
+
+        await user.click(screen.getByRole('button', { name: 'Disable' }));
+        expect(new FormData(form).has('terms')).toBe(false);
+
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        expect(validate).toHaveBeenCalledTimes(1);
+        expect(handleSubmit).toHaveBeenCalledTimes(2);
+        expect(handleSubmit.mock.lastCall?.[0]).toEqual({ enabled: 'sent' });
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'includes a field inside the first legend of a disabled native fieldset',
+      async () => {
+        const handleSubmit = vi.fn();
+        const validate = vi.fn(() => null);
+
+        const { user } = await render(
+          <Form onFormSubmit={handleSubmit} data-testid="form">
+            <fieldset disabled>
+              <legend>
+                <Field.Root name="terms" validate={validate}>
+                  <Checkbox.Root defaultChecked />
+                </Field.Root>
+              </legend>
+            </fieldset>
+            <button type="submit">Submit</button>
+          </Form>,
+        );
+
+        const form = screen.getByTestId('form') as HTMLFormElement;
+        expect(new FormData(form).get('terms')).toBe('on');
+
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        expect(validate).toHaveBeenCalledTimes(1);
+        expect(handleSubmit.mock.lastCall?.[0]).toEqual({ terms: true });
+      },
+    );
+
     it('triggers native HTML validation on submit', async () => {
       const { user } = await render(
         <Form>

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -135,6 +135,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
   const [validateFieldControl, registerFieldControl] = useFieldControlRegistration({
     commit: validation.commit,
     invalid,
+    isDisabled: validation.isDisabled,
     markedDirtyRef,
     name,
     setRegisteredFieldName,

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -113,7 +113,28 @@ export function useFieldValidation(
     return (element && registeredInputs.get(element)?.controlRef.current) || null;
   });
 
+  // Composite controls register a visible element for focus while their hidden native input owns
+  // form semantics. Read effective disabledness from that input, including ancestor fieldsets. A
+  // group remains active as long as at least one of its mounted native inputs is enabled.
+  const isDisabled = useStableCallback(() => {
+    if (registeredInputs.size === 0) {
+      return inputRef.current?.matches(':disabled') ?? false;
+    }
+
+    for (const input of registeredInputs.keys()) {
+      if (!input.matches(':disabled')) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+
   const commit = useStableCallback(async (value: unknown, revalidate = false) => {
+    if (isDisabled()) {
+      return;
+    }
+
     validationCommitIdRef.current += 1;
     const validationCommitId = validationCommitIdRef.current;
 
@@ -249,7 +270,7 @@ export function useFieldValidation(
       // - validating on change, or
       // - native constraint validations passed, custom validity check is next
       const formValues = Array.from(formRef.current.fields.values()).reduce((acc, field) => {
-        if (field.name) {
+        if (field.name && !field.isDisabled()) {
           acc[field.name] = field.getValue();
         }
         return acc;
@@ -341,10 +362,19 @@ export function useFieldValidation(
       registeredInputs,
       registerInput,
       getInputControl,
+      isDisabled,
       commit,
       change,
     }),
-    [getValidationProps, registeredInputs, registerInput, getInputControl, commit, change],
+    [
+      getValidationProps,
+      registeredInputs,
+      registerInput,
+      getInputControl,
+      isDisabled,
+      commit,
+      change,
+    ],
   );
 }
 
@@ -369,6 +399,7 @@ export interface UseFieldValidationReturnValue {
   registeredInputs: RegisteredInputs;
   registerInput: (element: HTMLInputElement, registration: RegisteredInput) => void | (() => void);
   getInputControl: () => HTMLElement | null;
+  isDisabled: () => boolean;
   commit: (value: unknown) => Promise<void>;
   change: (value: unknown) => void;
 }

--- a/packages/react/src/form/Form.tsx
+++ b/packages/react/src/form/Form.tsx
@@ -42,8 +42,9 @@ export const Form = React.forwardRef(function Form<
 
   const focusFirstInvalid = useStableCallback(() => {
     // A field can be invalid without a focusable control (for example a checkbox group whose
-    // custom validation failed while every checkbox is unmounted, disabled, or reassociated).
-    // Keep submission blocked, but move focus to the first invalid field that has a usable control.
+    // custom validation failed before every checkbox was unmounted or reassociated). Disabled
+    // fields do not participate; keep other invalid fields blocking submission and focus the first
+    // one with a usable control.
     // Registration order can diverge from DOM order (keyed fields reordered without
     // remounting, portals), so pick the first control by document position. For controls
     // in disconnected trees (e.g. separate shadow roots), where document position is
@@ -51,7 +52,7 @@ export const Form = React.forwardRef(function Form<
     let hasInvalid = false;
     let firstControl: HTMLElement | null = null;
     for (const field of formRef.current.fields.values()) {
-      if (field.validityData.state.valid !== false) {
+      if (field.isDisabled() || field.validityData.state.valid !== false) {
         continue;
       }
       hasInvalid = true;
@@ -129,7 +130,7 @@ export const Form = React.forwardRef(function Form<
 
             const formValues = {} as FormValues;
             formRef.current.fields.forEach((field) => {
-              if (field.name) {
+              if (field.name && !field.isDisabled()) {
                 (formValues as Record<string, any>)[field.name] = field.getValue();
               }
             });

--- a/packages/react/src/internals/field-register-control/useFieldControlRegistration.ts
+++ b/packages/react/src/internals/field-register-control/useFieldControlRegistration.ts
@@ -18,6 +18,7 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
   const {
     commit,
     invalid,
+    isDisabled,
     markedDirtyRef,
     name,
     setRegisteredFieldName,
@@ -49,6 +50,10 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
   }
 
   const validate = useStableCallback(() => {
+    if (isDisabled()) {
+      return;
+    }
+
     const registration = registrationRef.current;
     markedDirtyRef.current = true;
 
@@ -70,6 +75,7 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
       getValue: getValueForForm,
       name: name ?? registration.name,
       controlRef: registration.controlRef,
+      isDisabled,
       validityData: getCombinedFieldValidityData(validityData, invalid),
       validate,
     });
@@ -106,10 +112,20 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
       getValue: getValueForForm,
       name: name ?? registration.name,
       controlRef: registration.controlRef,
+      isDisabled,
       validityData: getCombinedFieldValidityData(validityData, invalid),
       validate,
     });
-  }, [formRef, getValueForForm, invalid, name, setRegisteredFieldName, validate, validityData]);
+  }, [
+    formRef,
+    getValueForForm,
+    invalid,
+    isDisabled,
+    name,
+    setRegisteredFieldName,
+    validate,
+    validityData,
+  ]);
 
   useIsoLayoutEffect(() => {
     const fields = formRef.current.fields;
@@ -159,6 +175,7 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
 export interface UseFieldControlRegistrationParameters {
   commit: (value: unknown) => void;
   invalid: boolean;
+  isDisabled: () => boolean;
   markedDirtyRef: React.RefObject<boolean>;
   name: string | undefined;
   setRegisteredFieldName: (name: string | undefined) => void;

--- a/packages/react/src/internals/field-root-context/FieldRootContext.ts
+++ b/packages/react/src/internals/field-root-context/FieldRootContext.ts
@@ -55,6 +55,7 @@ export const DEFAULT_FIELD_ROOT_CONTEXT: FieldRootContext = {
     registeredInputs: new Map(),
     registerInput: NOOP,
     getInputControl: () => null,
+    isDisabled: () => false,
     commit: async () => {},
     change: NOOP,
   },

--- a/packages/react/src/internals/form-context/FormContext.ts
+++ b/packages/react/src/internals/form-context/FormContext.ts
@@ -22,6 +22,8 @@ export interface FormContext {
         validate: () => void;
         validityData: FieldValidityData;
         controlRef: React.RefObject<HTMLElement | null>;
+        /** Whether the field's native form control is effectively disabled at read time. */
+        isDisabled: () => boolean;
         getValue: () => unknown;
       }
     >;

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1591,11 +1591,12 @@ describe('<RadioGroup />', () => {
       'excludes a radio disabled through an ancestor <fieldset disabled> to match native form data',
       async () => {
         const handleSubmit = vi.fn();
+        const validate = vi.fn(() => 'invalid');
 
         await renderFakeTimers(
           <Form onFormSubmit={handleSubmit} data-testid="form">
             <fieldset disabled>
-              <Field.Root name="choice">
+              <Field.Root name="choice" validate={validate}>
                 <RadioGroup defaultValue="a">
                   <Radio.Root value="a" data-testid="item-a" />
                   <Radio.Root value="b" data-testid="item-b" />
@@ -1613,7 +1614,8 @@ describe('<RadioGroup />', () => {
 
         fireEvent.click(screen.getByText('Submit'));
 
-        expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: null });
+        expect(validate).not.toHaveBeenCalled();
+        expect(handleSubmit.mock.calls[0][0]).toEqual({});
       },
     );
 

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -526,6 +526,64 @@ describe('<Switch.Root />', () => {
 
   describe('Form', () => {
     it.skipIf(isJSDOM)(
+      'omits a field disabled by a native fieldset from validation and submission',
+      async () => {
+        const handleSubmit = vi.fn();
+        const validate = vi.fn(() => 'invalid');
+
+        function App() {
+          const [disabled, setDisabled] = React.useState(true);
+
+          return (
+            <Form onFormSubmit={handleSubmit} data-testid="form">
+              <fieldset disabled={disabled}>
+                <Field.Root name="notifications" validate={validate}>
+                  <Switch.Root defaultChecked required />
+                </Field.Root>
+              </fieldset>
+              <Field.Root name="enabled">
+                <Field.Control defaultValue="sent" />
+              </Field.Root>
+              <button type="button" onClick={() => setDisabled((value) => !value)}>
+                {disabled ? 'Enable' : 'Disable'}
+              </button>
+              <button type="submit">Submit</button>
+            </Form>
+          );
+        }
+
+        const { user } = await render(<App />);
+
+        const form = screen.getByTestId('form') as HTMLFormElement;
+        expect(new FormData(form).has('notifications')).toBe(false);
+
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        expect(validate).not.toHaveBeenCalled();
+        expect(handleSubmit).toHaveBeenCalledTimes(1);
+        expect(handleSubmit.mock.lastCall?.[0]).toEqual({ enabled: 'sent' });
+
+        await user.click(screen.getByRole('button', { name: 'Enable' }));
+        expect(new FormData(form).get('notifications')).toBe('on');
+
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        expect(validate).toHaveBeenCalledTimes(1);
+        expect(handleSubmit).toHaveBeenCalledTimes(1);
+        expect(screen.getByRole('switch')).toHaveFocus();
+
+        await user.click(screen.getByRole('button', { name: 'Disable' }));
+        expect(new FormData(form).has('notifications')).toBe(false);
+
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        expect(validate).toHaveBeenCalledTimes(1);
+        expect(handleSubmit).toHaveBeenCalledTimes(2);
+        expect(handleSubmit.mock.lastCall?.[0]).toEqual({ enabled: 'sent' });
+      },
+    );
+
+    it.skipIf(isJSDOM)(
       'preserves Field validation props through canceled changes, submit, and reset',
       async () => {
         let cancelChanges = true;


### PR DESCRIPTION
Native disabled fieldsets were not reflected in Base UI's field registry for composite controls whose visible element differs from the hidden native input. This could run validation, block submission, and include a value in `onFormSubmit` even though the browser omitted the control.

## Changes

- Read effective disabled state from registered native inputs while preserving visible control refs.
- Skip disabled fields during validation, invalid focus, and Form value collection.
- Add Chromium regression coverage for Checkbox and Switch, including grouped and Radio behavior.