### PR TITLE
[drawer] Defer swipe pointer capture until the drag threshold

### DIFF
--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -267,6 +267,46 @@ describe('<Drawer.SwipeArea />', () => {
     expect(swipeArea).toHaveAttribute('data-open', '');
   });
 
+  it('captures the pointer immediately on pointer down', async () => {
+    await render(
+      <Drawer.Root>
+        <Drawer.SwipeArea data-testid="swipe-area" />
+      </Drawer.Root>,
+    );
+
+    const swipeArea = screen.getByTestId('swipe-area');
+    const setPointerCapture = vi.fn();
+    Object.defineProperty(swipeArea, 'setPointerCapture', {
+      configurable: true,
+      value: setPointerCapture,
+    });
+    Object.defineProperty(swipeArea, 'releasePointerCapture', {
+      configurable: true,
+      value: () => {},
+    });
+
+    // The swipe area is a thin strip the pointer exits within a few pixels, so it must
+    // capture eagerly to keep receiving move events (unlike drag surfaces, which defer
+    // capture until the drag threshold to preserve clicks on interactive children).
+    fireEvent.pointerDown(swipeArea, {
+      button: 0,
+      buttons: 1,
+      pointerId: 1,
+      clientX: 10,
+      clientY: 120,
+      pointerType: 'mouse',
+    });
+
+    expect(setPointerCapture).toHaveBeenCalledTimes(1);
+
+    fireEvent.pointerUp(swipeArea, {
+      pointerId: 1,
+      clientX: 10,
+      clientY: 120,
+      pointerType: 'mouse',
+    });
+  });
+
   it('does not open when the swipe direction never locks to the open direction', async () => {
     const handleOpenChange = vi.fn();
 

--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -3272,6 +3272,92 @@ describe('<Drawer.Viewport />', () => {
     expect(handleOpenChange).toHaveBeenCalledWith(false, expect.anything());
   });
 
+  it('defers pointer capture until movement passes the drag threshold', async () => {
+    await render(
+      <Drawer.Root open>
+        <Drawer.Portal>
+          <Drawer.Viewport data-testid="viewport">
+            <Drawer.Popup data-testid="popup">Drawer</Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>,
+    );
+
+    const viewport = screen.getByTestId('viewport');
+    const popup = screen.getByTestId('popup');
+
+    const setPointerCapture = vi.fn();
+    Object.defineProperty(popup, 'setPointerCapture', {
+      configurable: true,
+      value: setPointerCapture,
+    });
+    Object.defineProperty(popup, 'releasePointerCapture', {
+      configurable: true,
+      value: () => {},
+    });
+
+    const originalElementFromPoint = document.elementFromPoint;
+    document.elementFromPoint = () => popup;
+
+    try {
+      fireEvent.pointerDown(viewport, {
+        button: 0,
+        buttons: 1,
+        pointerId: 1,
+        clientX: 0,
+        clientY: 0,
+        pointerType: 'mouse',
+      });
+
+      await flushMicrotasks();
+
+      // A plain press must not capture the pointer: capture would retarget the eventual
+      // `click` to the popup and block activation of non-native interactive children.
+      expect(setPointerCapture).not.toHaveBeenCalled();
+
+      fireEvent.pointerMove(viewport, {
+        buttons: 1,
+        pointerId: 1,
+        clientX: 0,
+        clientY: 2,
+        pointerType: 'mouse',
+      });
+      fireEvent.pointerMove(viewport, {
+        buttons: 1,
+        pointerId: 1,
+        clientX: 0,
+        clientY: 4,
+        pointerType: 'mouse',
+      });
+
+      await flushMicrotasks();
+
+      // Sub-threshold jitter during a click must not capture either.
+      expect(setPointerCapture).not.toHaveBeenCalled();
+
+      fireEvent.pointerMove(viewport, {
+        buttons: 1,
+        pointerId: 1,
+        clientX: 0,
+        clientY: 12,
+        pointerType: 'mouse',
+      });
+
+      await flushMicrotasks();
+
+      expect(setPointerCapture).toHaveBeenCalledTimes(1);
+
+      fireEvent.pointerUp(viewport, {
+        pointerId: 1,
+        clientX: 0,
+        clientY: 12,
+        pointerType: 'mouse',
+      });
+    } finally {
+      document.elementFromPoint = originalElementFromPoint;
+    }
+  });
+
   it('ends swipe drag when the primary mouse button is released mid-gesture', async () => {
     await render(
       <Drawer.Root open>

--- a/packages/react/src/utils/useSwipeDismiss.ts
+++ b/packages/react/src/utils/useSwipeDismiss.ts
@@ -30,6 +30,7 @@ type SwipeProgressDetailsInternal = {
 const DEFAULT_SWIPE_THRESHOLD = 40;
 const REVERSE_CANCEL_THRESHOLD = 10;
 const MIN_DRAG_THRESHOLD = 1;
+const POINTER_CAPTURE_THRESHOLD = 5;
 const MIN_VELOCITY_DURATION_MS = 50;
 const MIN_RELEASE_VELOCITY_DURATION_MS = 16;
 const MAX_RELEASE_VELOCITY_AGE_MS = 80;
@@ -185,6 +186,7 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
   const lastProgressDetailsRef = React.useRef<SwipeProgressDetailsInternal | null>(null);
   const isSwipingRef = React.useRef(false);
   const dragStyleSnapshotRef = React.useRef<[string, string] | null>(null);
+  const pendingPointerCaptureIdRef = React.useRef<number | null>(null);
 
   const setSwiping = useStableCallback((nextSwiping: boolean) => {
     if (isSwipingRef.current === nextSwiping) {
@@ -322,6 +324,7 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
     lastDragSampleRef.current = null;
     lastDragVelocityRef.current = { x: 0, y: 0 };
     lastProgressDetailsRef.current = null;
+    pendingPointerCaptureIdRef.current = null;
     syncDragStyles(false);
   }, [setSwiping, swipeThresholdDefault, syncDragStyles, updateSwipeProgress]);
 
@@ -428,7 +431,18 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
       recordDragSample({ x: transform.x, y: transform.y }, swipeStartTimeRef.current);
 
       if (!('touches' in event)) {
-        safelyChangePointerCapture(element, event.pointerId, 'setPointerCapture');
+        if (trackDrag) {
+          // Capturing the pointer here would make the browser retarget the eventual `click`
+          // to this element, so taps on non-native interactive children (e.g. a span with
+          // `role="radio"`) would never activate them. Defer capture until the pointer has
+          // actually moved far enough to signal a drag.
+          pendingPointerCaptureIdRef.current = event.pointerId;
+        } else {
+          // `trackDrag: false` surfaces (the swipe area) are thin strips the pointer exits
+          // within a few pixels, before deferred capture could engage; without immediate
+          // capture their move/up events would be lost mid-gesture.
+          safelyChangePointerCapture(element, event.pointerId, 'setPointerCapture');
+        }
       }
     }
 
@@ -471,6 +485,7 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
     sawPrimaryButtonsOnMoveRef.current = false;
     syncDragStyles(false);
 
+    pendingPointerCaptureIdRef.current = null;
     const element = elementRef.current;
     if (element) {
       safelyChangePointerCapture(element, event.pointerId, 'releasePointerCapture');
@@ -645,6 +660,22 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
     const cancelDeltaY = clientY - swipeCancelBaselineRef.current.y;
     const cancelDeltaX = clientX - swipeCancelBaselineRef.current.x;
 
+    if (
+      !('touches' in event) &&
+      pendingPointerCaptureIdRef.current !== null &&
+      deltaX * deltaX + deltaY * deltaY >= POINTER_CAPTURE_THRESHOLD * POINTER_CAPTURE_THRESHOLD
+    ) {
+      const element = elementRef.current;
+      if (element) {
+        safelyChangePointerCapture(
+          element,
+          pendingPointerCaptureIdRef.current,
+          'setPointerCapture',
+        );
+      }
+      pendingPointerCaptureIdRef.current = null;
+    }
+
     let lockedDirection = lockedDirectionRef.current;
     if (lockedDirection === null && hasHorizontal && hasVertical) {
       const movementDistance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
@@ -789,6 +820,7 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
     lockedDirectionRef.current = null;
     resetPendingSwipeState();
     sawPrimaryButtonsOnMoveRef.current = false;
+    pendingPointerCaptureIdRef.current = null;
 
     const element = elementRef.current;
     if (element) {


### PR DESCRIPTION
Closes #5286

Starting a swipe called `setPointerCapture` on `pointerdown`. Capturing at that point makes the browser retarget the eventual `click` to the popup, so pressing a non-native interactive element inside the drawer with a mouse or pen — such as Radio's `<span role="radio">` when it isn't wrapped in a `label`, isn't covered by the ignore selector, and sits outside `Drawer.Content` — never activated it. Touch was unaffected because touch swipes never capture the pointer.

Capture is now deferred until the pointer travels 5px, distinguishing a drag from a click. The drag transform already tracks from the first move regardless of capture, so gesture behavior and responsiveness are unchanged; plain clicks simply survive. This also removes any need to grow the ignore selector with ARIA roles for custom widgets.

`Drawer.SwipeArea` (`trackDrag: false`) keeps capturing eagerly: it is a thin strip the pointer exits within a few pixels, so deferred capture would lose move events mid-gesture, and it has no interactive children to protect.
