### PR TITLE
[popups] Focus keyboard-open item synchronously

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -219,6 +219,56 @@ describe('FloatingFocusManager', () => {
         await flushMicrotasks();
         expect(screen.getByTestId('input')).toHaveFocus();
       });
+
+      test('recovers when focus falls back to the body before initial focus runs', async () => {
+        const animationFrameCallbacks: FrameRequestCallback[] = [];
+        vi.mocked(window.requestAnimationFrame).mockImplementation((callback) => {
+          animationFrameCallbacks.push(callback);
+          return animationFrameCallbacks.length;
+        });
+
+        function TestCase() {
+          const [open, setOpen] = React.useState(false);
+          const [showTransient, setShowTransient] = React.useState(true);
+          const initialFocusRef = React.useRef<HTMLButtonElement | null>(null);
+          const { refs, context } = useFloating({ open, onOpenChange: setOpen });
+
+          return (
+            <React.Fragment>
+              <button ref={refs.setReference} onClick={() => setOpen(true)}>
+                Open
+              </button>
+              <button data-testid="hide-transient" onClick={() => setShowTransient(false)}>
+                Hide transient
+              </button>
+              {open && (
+                <FloatingFocusManager
+                  context={context}
+                  initialFocus={initialFocusRef}
+                  modal={false}
+                >
+                  <div ref={refs.setFloating}>
+                    {showTransient && <button data-testid="transient">Transient</button>}
+                    <button ref={initialFocusRef}>Initial focus</button>
+                  </div>
+                </FloatingFocusManager>
+              )}
+            </React.Fragment>
+          );
+        }
+
+        render(<TestCase />);
+        fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+        act(() => screen.getByTestId('transient').focus());
+        await flushMicrotasks();
+
+        fireEvent.click(screen.getByTestId('hide-transient'));
+        expect(document.body).toHaveFocus();
+
+        act(() => animationFrameCallbacks.forEach((callback) => callback(performance.now())));
+
+        expect(screen.getByRole('button', { name: 'Initial focus' })).toHaveFocus();
+      });
     });
 
     describe('prop: returnFocus', () => {
@@ -770,8 +820,15 @@ describe('FloatingFocusManager', () => {
             innerRoot?.appendChild(iframe);
 
             // Properly open, write, and close the iframe document.
-            const iframeDoc = iframe.contentWindow?.document;
+            const iframeWindow = iframe.contentWindow;
+            const iframeDoc = iframeWindow?.document;
             if (iframeDoc) {
+              // Focus scheduling is scoped to the target document's window.
+              // Mirror this suite's synchronous frame mock in the iframe realm.
+              iframeWindow.requestAnimationFrame = (callback) => {
+                callback(0);
+                return 0;
+              };
               iframeDoc.open();
               iframeDoc.write(`<div id="rootIframe"></div>`);
               iframeDoc.close();

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -721,7 +721,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
           // This focus is queued on the next animation frame. If the floating element has closed
           // before it runs — e.g. tabbing out of a kept-mounted popup — don't pull focus back
           // onto the initial element after it has legitimately moved elsewhere.
-          if (!openRef.current || !elToFocus.isConnected) {
+          if (!openRef.current) {
             return false;
           }
 

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -15,6 +15,7 @@ import { ownerDocument, ownerWindow } from '@base-ui/utils/owner';
 import { FocusGuard } from '../../utils/FocusGuard';
 import {
   activeElement,
+  activeElementInRoot,
   contains,
   getTarget,
   isTypeableCombobox,
@@ -706,24 +707,39 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
       }
       elToFocus = elToFocus || getDefaultFocusElement();
 
-      const hadFocusInside = contains(floatingFocusElement, activeElement(doc));
+      const activeElementWhenQueued = activeElementInRoot(floatingFocusElement);
+      const hadFocusInside = contains(floatingFocusElement, activeElementWhenQueued);
 
       // enqueueFocus returns a rAF-cancel function; we intentionally don't cancel this focus.
       void enqueueFocus(elToFocus, {
+        // Initial focus is a default, not an explicit destination. A primary
+        // intent from list navigation must win without focusing two elements in
+        // succession, which can scroll complex portaled layouts on Android.
+        intent: 'fallback',
         preventScroll: elToFocus === floatingFocusElement,
         shouldFocus() {
           // This focus is queued on the next animation frame. If the floating element has closed
           // before it runs — e.g. tabbing out of a kept-mounted popup — don't pull focus back
           // onto the initial element after it has legitimately moved elsewhere.
-          if (!openRef.current) {
+          if (!openRef.current || !elToFocus.isConnected) {
             return false;
           }
 
+          const currentActiveElement = activeElementInRoot(floatingFocusElement);
+
           if (hadFocusInside) {
-            return true;
+            // Focus was already managed inside when this fallback was queued.
+            // Do not undo a later synchronous navigation or user focus change,
+            // but recover if the previously focused element disappeared and
+            // focus consequently fell back to the document body (or nowhere).
+            return (
+              currentActiveElement === activeElementWhenQueued ||
+              currentActiveElement == null ||
+              currentActiveElement === doc.body ||
+              !currentActiveElement.isConnected
+            );
           }
 
-          const currentActiveElement = activeElement(doc);
           const focusMovedInside =
             currentActiveElement !== elToFocus &&
             contains(floatingFocusElement, currentActiveElement);

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
@@ -187,6 +187,38 @@ describe('useListNavigation', () => {
     });
   });
 
+  it('focuses the keyboard-open item without waiting for an animation frame', async ({
+    onTestFinished,
+  }) => {
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 0);
+    onTestFinished(() => requestAnimationFrame.mockRestore());
+
+    render(<App />);
+
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+    await flushMicrotasks();
+
+    expect(screen.getByTestId('item-0')).toHaveFocus();
+  });
+
+  it('focuses the selected keyboard-open item without waiting for an animation frame', async ({
+    onTestFinished,
+  }) => {
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 0);
+    onTestFinished(() => requestAnimationFrame.mockRestore());
+
+    render(<App selectedIndex={1} />);
+
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+    await flushMicrotasks();
+
+    expect(screen.getByTestId('item-1')).toHaveFocus();
+  });
+
   it('opens on ArrowUp and focuses last item', async () => {
     render(<App />);
 

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
@@ -16,41 +16,6 @@ import { HorizontalMenu } from '../../../test/floating-ui-tests/MenuOrientation'
 
 /* eslint-disable testing-library/no-unnecessary-act */
 
-function createAnimationFrameMock() {
-  let nextFrameId = 0;
-  const callbacks = new Map<number, FrameRequestCallback>();
-  const requestAnimationFrame = vi
-    .spyOn(window, 'requestAnimationFrame')
-    .mockImplementation((callback) => {
-      nextFrameId += 1;
-      callbacks.set(nextFrameId, callback);
-      return nextFrameId;
-    });
-  const cancelAnimationFrame = vi
-    .spyOn(window, 'cancelAnimationFrame')
-    .mockImplementation((id) => callbacks.delete(id));
-
-  return {
-    callbacks,
-    flush() {
-      let iterations = 0;
-      while (callbacks.size > 0) {
-        if (iterations > 10) {
-          throw new Error('Exceeded maximum animation frame flush iterations.');
-        }
-        const pending = Array.from(callbacks.values());
-        callbacks.clear();
-        pending.forEach((callback) => callback(performance.now()));
-        iterations += 1;
-      }
-    },
-    restore() {
-      requestAnimationFrame.mockRestore();
-      cancelAnimationFrame.mockRestore();
-    },
-  };
-}
-
 function App(
   inProps: Omit<Partial<UseListNavigationProps>, 'listRef'> & {
     disableFirstItem?: boolean;
@@ -141,21 +106,15 @@ function LateMountedItemApp({
   focusItemOnOpen,
   loopFocus,
   virtual,
-  initialActiveIndex = null,
-  initialMountedIndex = null,
-  onScrollIntoView,
 }: {
   selectedIndex?: number | null;
   focusItemOnOpen?: UseListNavigationProps['focusItemOnOpen'];
   loopFocus?: boolean;
   virtual?: boolean;
-  initialActiveIndex?: number | null;
-  initialMountedIndex?: number | null;
-  onScrollIntoView?: () => void;
 } = {}) {
   const [open, setOpen] = React.useState(false);
-  const [activeIndex, setActiveIndex] = React.useState<number | null>(initialActiveIndex);
-  const [mountedIndex, setMountedIndex] = React.useState<number | null>(initialMountedIndex);
+  const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
+  const [mountedIndex, setMountedIndex] = React.useState<number | null>(null);
   const listRef = React.useRef<Array<HTMLButtonElement | null>>(Array(3).fill(null));
   const { refs, context } = useFloating({ open, onOpenChange: setOpen });
   const { getReferenceProps, getFloatingProps, getItemProps } = useTestInteractions([
@@ -190,9 +149,6 @@ function LateMountedItemApp({
               {...getItemProps({
                 ref(node: HTMLButtonElement | null) {
                   listRef.current[mountedIndex] = node;
-                  if (node && onScrollIntoView) {
-                    node.scrollIntoView = onScrollIntoView;
-                  }
                 },
               })}
             />
@@ -305,8 +261,10 @@ describe('useListNavigation', () => {
   it('focuses the selected keyboard-open item on the next animation frame', async ({
     onTestFinished,
   }) => {
-    const animationFrames = createAnimationFrameMock();
-    onTestFinished(animationFrames.restore);
+    vi.useFakeTimers({ toFake: ['requestAnimationFrame', 'cancelAnimationFrame'] });
+    onTestFinished(() => {
+      vi.useRealTimers();
+    });
 
     render(<App selectedIndex={1} />);
 
@@ -318,7 +276,7 @@ describe('useListNavigation', () => {
     const item = screen.getByTestId('item-1');
     expect(item).not.toHaveFocus();
 
-    act(animationFrames.flush);
+    act(() => vi.advanceTimersToNextFrame());
     await flushMicrotasks();
 
     expect(item).toHaveFocus();
@@ -327,8 +285,10 @@ describe('useListNavigation', () => {
   it('preserves consumer focus moved inside before keyboard-open item focus runs', async ({
     onTestFinished,
   }) => {
-    const animationFrames = createAnimationFrameMock();
-    onTestFinished(animationFrames.restore);
+    vi.useFakeTimers({ toFake: ['requestAnimationFrame', 'cancelAnimationFrame'] });
+    onTestFinished(() => {
+      vi.useRealTimers();
+    });
 
     render(
       <App selectedIndex={1}>
@@ -343,22 +303,24 @@ describe('useListNavigation', () => {
 
     const filter = screen.getByRole('textbox', { name: 'Filter' });
     act(() => filter.focus());
-    act(animationFrames.flush);
+    act(() => vi.advanceTimersToNextFrame());
 
     expect(filter).toHaveFocus();
     expect(screen.getByTestId('item-1')).not.toHaveFocus();
   });
 
   it('focuses a retained active item after reopening', async ({ onTestFinished }) => {
-    const animationFrames = createAnimationFrameMock();
-    onTestFinished(animationFrames.restore);
+    vi.useFakeTimers({ toFake: ['requestAnimationFrame', 'cancelAnimationFrame'] });
+    onTestFinished(() => {
+      vi.useRealTimers();
+    });
 
     render(<App retainActiveIndexOnClose />);
 
     const trigger = screen.getByRole('button');
     fireEvent.keyDown(trigger, { key: 'ArrowDown' });
     await flushMicrotasks();
-    act(animationFrames.flush);
+    act(() => vi.advanceTimersToNextFrame());
     expect(screen.getByTestId('item-0')).toHaveFocus();
 
     fireEvent.click(trigger);
@@ -370,7 +332,7 @@ describe('useListNavigation', () => {
     await flushMicrotasks();
     expect(screen.getByTestId('item-0')).not.toHaveFocus();
 
-    act(animationFrames.flush);
+    act(() => vi.advanceTimersToNextFrame());
     await flushMicrotasks();
 
     expect(screen.getByTestId('item-0')).toHaveFocus();
@@ -379,8 +341,10 @@ describe('useListNavigation', () => {
   it('retries focus when the selected item registers after the active index update', async ({
     onTestFinished,
   }) => {
-    const animationFrames = createAnimationFrameMock();
-    onTestFinished(animationFrames.restore);
+    vi.useFakeTimers({ toFake: ['requestAnimationFrame', 'cancelAnimationFrame'] });
+    onTestFinished(() => {
+      vi.useRealTimers();
+    });
 
     render(<LateMountedItemApp />);
     fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
@@ -389,7 +353,11 @@ describe('useListNavigation', () => {
     const item = screen.getByTestId('late-item');
     expect(item).not.toHaveFocus();
 
-    act(animationFrames.flush);
+    act(() => vi.advanceTimersToNextFrame());
+    await flushMicrotasks();
+    expect(item).not.toHaveFocus();
+
+    act(() => vi.advanceTimersToNextFrame());
     await flushMicrotasks();
 
     expect(item).toHaveFocus();
@@ -398,8 +366,10 @@ describe('useListNavigation', () => {
   it('preserves virtualizer deferral after opening without an initial focused item', async ({
     onTestFinished,
   }) => {
-    const animationFrames = createAnimationFrameMock();
-    onTestFinished(animationFrames.restore);
+    vi.useFakeTimers({ toFake: ['requestAnimationFrame', 'cancelAnimationFrame'] });
+    onTestFinished(() => {
+      vi.useRealTimers();
+    });
 
     render(<LateMountedItemApp selectedIndex={null} focusItemOnOpen={false} loopFocus virtual />);
     const trigger = screen.getByRole('button');
@@ -415,9 +385,9 @@ describe('useListNavigation', () => {
     expect(item).toHaveAttribute('data-index', '2');
     const scrollIntoView = vi.fn();
     item.scrollIntoView = scrollIntoView;
-    expect(animationFrames.callbacks.size).toBeGreaterThan(0);
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
 
-    act(animationFrames.flush);
+    act(() => vi.advanceTimersToNextFrame());
     await flushMicrotasks();
 
     expect(scrollIntoView).toHaveBeenCalledOnce();

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
@@ -16,14 +16,51 @@ import { HorizontalMenu } from '../../../test/floating-ui-tests/MenuOrientation'
 
 /* eslint-disable testing-library/no-unnecessary-act */
 
+function createAnimationFrameMock() {
+  let nextFrameId = 0;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const requestAnimationFrame = vi
+    .spyOn(window, 'requestAnimationFrame')
+    .mockImplementation((callback) => {
+      nextFrameId += 1;
+      callbacks.set(nextFrameId, callback);
+      return nextFrameId;
+    });
+  const cancelAnimationFrame = vi
+    .spyOn(window, 'cancelAnimationFrame')
+    .mockImplementation((id) => callbacks.delete(id));
+
+  return {
+    callbacks,
+    flush() {
+      let iterations = 0;
+      while (callbacks.size > 0) {
+        if (iterations > 10) {
+          throw new Error('Exceeded maximum animation frame flush iterations.');
+        }
+        const pending = Array.from(callbacks.values());
+        callbacks.clear();
+        pending.forEach((callback) => callback(performance.now()));
+        iterations += 1;
+      }
+    },
+    restore() {
+      requestAnimationFrame.mockRestore();
+      cancelAnimationFrame.mockRestore();
+    },
+  };
+}
+
 function App(
   inProps: Omit<Partial<UseListNavigationProps>, 'listRef'> & {
     disableFirstItem?: boolean;
     hideFirstItem?: boolean;
     firstItemStyle?: React.CSSProperties;
+    retainActiveIndexOnClose?: boolean;
   } = {},
 ) {
-  const { disableFirstItem, hideFirstItem, firstItemStyle, ...props } = inProps;
+  const { disableFirstItem, hideFirstItem, firstItemStyle, retainActiveIndexOnClose, ...props } =
+    inProps;
   const [open, setOpen] = React.useState(false);
   const listRef = React.useRef<Array<HTMLLIElement | null>>([]);
   const [activeIndex, setActiveIndex] = React.useState<null | number>(null);
@@ -38,6 +75,9 @@ function App(
       listRef,
       activeIndex,
       onNavigate(index) {
+        if (index == null && !open && retainActiveIndexOnClose) {
+          return;
+        }
         setActiveIndex(index);
         props.onNavigate?.(index, undefined);
       },
@@ -82,6 +122,63 @@ function App(
               );
             })}
           </ul>
+        </div>
+      )}
+    </React.Fragment>
+  );
+}
+
+function LateMountedItemApp({
+  selectedIndex = 1,
+  focusItemOnOpen,
+  loopFocus,
+  virtual,
+}: {
+  selectedIndex?: number | null;
+  focusItemOnOpen?: UseListNavigationProps['focusItemOnOpen'];
+  loopFocus?: boolean;
+  virtual?: boolean;
+} = {}) {
+  const [open, setOpen] = React.useState(false);
+  const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
+  const [mountedIndex, setMountedIndex] = React.useState<number | null>(null);
+  const listRef = React.useRef<Array<HTMLButtonElement | null>>(Array(3).fill(null));
+  const { refs, context } = useFloating({ open, onOpenChange: setOpen });
+  const { getReferenceProps, getFloatingProps, getItemProps } = useTestInteractions([
+    useClick(context),
+    useListNavigation(context, {
+      listRef,
+      activeIndex,
+      selectedIndex,
+      focusItemOnOpen,
+      loopFocus,
+      virtual,
+      onNavigate(index) {
+        setActiveIndex(index);
+        if (index != null) {
+          queueMicrotask(() => setMountedIndex(index));
+        }
+      },
+    }),
+  ]);
+
+  return (
+    <React.Fragment>
+      <button {...getReferenceProps({ ref: refs.setReference })} />
+      {open && (
+        <div role="menu" {...getFloatingProps({ ref: refs.setFloating })}>
+          {mountedIndex != null && (
+            <button
+              data-testid="late-item"
+              data-index={mountedIndex}
+              tabIndex={-1}
+              {...getItemProps({
+                ref(node: HTMLButtonElement | null) {
+                  listRef.current[mountedIndex] = node;
+                },
+              })}
+            />
+          )}
         </div>
       )}
     </React.Fragment>
@@ -217,6 +314,93 @@ describe('useListNavigation', () => {
     await flushMicrotasks();
 
     expect(screen.getByTestId('item-1')).toHaveFocus();
+  });
+
+  it('focuses the ArrowUp keyboard-open item without waiting for an animation frame', async ({
+    onTestFinished,
+  }) => {
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 0);
+    onTestFinished(() => requestAnimationFrame.mockRestore());
+
+    render(<App />);
+
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowUp' });
+    await flushMicrotasks();
+
+    expect(screen.getByTestId('item-2')).toHaveFocus();
+  });
+
+  it('focuses a retained active item synchronously when reopening', async ({ onTestFinished }) => {
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 0);
+    onTestFinished(() => requestAnimationFrame.mockRestore());
+
+    render(<App retainActiveIndexOnClose />);
+
+    const trigger = screen.getByRole('button');
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    await flushMicrotasks();
+    expect(screen.getByTestId('item-0')).toHaveFocus();
+
+    fireEvent.click(trigger);
+    await flushMicrotasks();
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    act(() => trigger.focus());
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    await flushMicrotasks();
+    expect(screen.getByTestId('item-0')).toHaveFocus();
+  });
+
+  it('retries focus when the selected item registers after the active index update', async ({
+    onTestFinished,
+  }) => {
+    const animationFrames = createAnimationFrameMock();
+    onTestFinished(animationFrames.restore);
+
+    render(<LateMountedItemApp />);
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+    await flushMicrotasks();
+
+    const item = screen.getByTestId('late-item');
+    expect(item).not.toHaveFocus();
+
+    act(animationFrames.flush);
+    await flushMicrotasks();
+
+    expect(item).toHaveFocus();
+  });
+
+  it('preserves virtualizer deferral after opening without an initial focused item', async ({
+    onTestFinished,
+  }) => {
+    const animationFrames = createAnimationFrameMock();
+    onTestFinished(animationFrames.restore);
+
+    render(<LateMountedItemApp selectedIndex={null} focusItemOnOpen={false} loopFocus virtual />);
+    const trigger = screen.getByRole('button');
+    act(() => trigger.focus());
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    await flushMicrotasks();
+
+    expect(trigger).toHaveFocus();
+
+    fireEvent.keyDown(trigger, { key: 'ArrowUp' });
+    await flushMicrotasks();
+    const item = screen.getByTestId('late-item');
+    expect(item).toHaveAttribute('data-index', '2');
+    const scrollIntoView = vi.fn();
+    item.scrollIntoView = scrollIntoView;
+    expect(animationFrames.callbacks.size).toBeGreaterThan(0);
+
+    act(animationFrames.flush);
+    await flushMicrotasks();
+
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+    expect(trigger).toHaveFocus();
   });
 
   it('opens on ArrowUp and focuses last item', async () => {

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
@@ -57,10 +57,17 @@ function App(
     hideFirstItem?: boolean;
     firstItemStyle?: React.CSSProperties;
     retainActiveIndexOnClose?: boolean;
+    children?: React.ReactNode;
   } = {},
 ) {
-  const { disableFirstItem, hideFirstItem, firstItemStyle, retainActiveIndexOnClose, ...props } =
-    inProps;
+  const {
+    disableFirstItem,
+    hideFirstItem,
+    firstItemStyle,
+    retainActiveIndexOnClose,
+    children,
+    ...props
+  } = inProps;
   const [open, setOpen] = React.useState(false);
   const listRef = React.useRef<Array<HTMLLIElement | null>>([]);
   const [activeIndex, setActiveIndex] = React.useState<null | number>(null);
@@ -89,6 +96,7 @@ function App(
       <button {...getReferenceProps({ ref: refs.setReference })} />
       {open && (
         <div role="menu" {...getFloatingProps({ ref: refs.setFloating })}>
+          {children}
           <ul>
             {['one', 'two', 'three'].map((string, index) => {
               let style: React.CSSProperties | undefined;
@@ -294,65 +302,63 @@ describe('useListNavigation', () => {
     });
   });
 
-  it('focuses the keyboard-open item without waiting for an animation frame', async ({
+  it('focuses the selected keyboard-open item on the next animation frame', async ({
     onTestFinished,
   }) => {
-    const requestAnimationFrame = vi
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation(() => 0);
-    onTestFinished(() => requestAnimationFrame.mockRestore());
-
-    render(<App />);
-
-    fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
-    await flushMicrotasks();
-
-    expect(screen.getByTestId('item-0')).toHaveFocus();
-  });
-
-  it('focuses the selected keyboard-open item without waiting for an animation frame', async ({
-    onTestFinished,
-  }) => {
-    const requestAnimationFrame = vi
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation(() => 0);
-    onTestFinished(() => requestAnimationFrame.mockRestore());
+    const animationFrames = createAnimationFrameMock();
+    onTestFinished(animationFrames.restore);
 
     render(<App selectedIndex={1} />);
 
-    fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowDown' });
+    const trigger = screen.getByRole('button');
+    act(() => trigger.focus());
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
     await flushMicrotasks();
 
-    expect(screen.getByTestId('item-1')).toHaveFocus();
+    const item = screen.getByTestId('item-1');
+    expect(item).not.toHaveFocus();
+
+    act(animationFrames.flush);
+    await flushMicrotasks();
+
+    expect(item).toHaveFocus();
   });
 
-  it('focuses the ArrowUp keyboard-open item without waiting for an animation frame', async ({
+  it('preserves consumer focus moved inside before keyboard-open item focus runs', async ({
     onTestFinished,
   }) => {
-    const requestAnimationFrame = vi
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation(() => 0);
-    onTestFinished(() => requestAnimationFrame.mockRestore());
+    const animationFrames = createAnimationFrameMock();
+    onTestFinished(animationFrames.restore);
 
-    render(<App />);
+    render(
+      <App selectedIndex={1}>
+        <input aria-label="Filter" />
+      </App>,
+    );
 
-    fireEvent.keyDown(screen.getByRole('button'), { key: 'ArrowUp' });
+    const trigger = screen.getByRole('button');
+    act(() => trigger.focus());
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
     await flushMicrotasks();
 
-    expect(screen.getByTestId('item-2')).toHaveFocus();
+    const filter = screen.getByRole('textbox', { name: 'Filter' });
+    act(() => filter.focus());
+    act(animationFrames.flush);
+
+    expect(filter).toHaveFocus();
+    expect(screen.getByTestId('item-1')).not.toHaveFocus();
   });
 
-  it('focuses a retained active item synchronously when reopening', async ({ onTestFinished }) => {
-    const requestAnimationFrame = vi
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation(() => 0);
-    onTestFinished(() => requestAnimationFrame.mockRestore());
+  it('focuses a retained active item after reopening', async ({ onTestFinished }) => {
+    const animationFrames = createAnimationFrameMock();
+    onTestFinished(animationFrames.restore);
 
     render(<App retainActiveIndexOnClose />);
 
     const trigger = screen.getByRole('button');
     fireEvent.keyDown(trigger, { key: 'ArrowDown' });
     await flushMicrotasks();
+    act(animationFrames.flush);
     expect(screen.getByTestId('item-0')).toHaveFocus();
 
     fireEvent.click(trigger);
@@ -362,6 +368,11 @@ describe('useListNavigation', () => {
 
     fireEvent.keyDown(trigger, { key: 'ArrowDown' });
     await flushMicrotasks();
+    expect(screen.getByTestId('item-0')).not.toHaveFocus();
+
+    act(animationFrames.flush);
+    await flushMicrotasks();
+
     expect(screen.getByTestId('item-0')).toHaveFocus();
   });
 
@@ -411,59 +422,6 @@ describe('useListNavigation', () => {
 
     expect(scrollIntoView).toHaveBeenCalledOnce();
     expect(trigger).toHaveFocus();
-  });
-
-  it('expires keyboard-open focus intent when the initial active index is out of bounds', async () => {
-    const scrollIntoView = vi.fn();
-    render(
-      <LateMountedItemApp
-        selectedIndex={null}
-        virtual
-        initialActiveIndex={3}
-        initialMountedIndex={0}
-        onScrollIntoView={scrollIntoView}
-      />,
-    );
-    const trigger = screen.getByRole('button');
-    act(() => trigger.focus());
-
-    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
-    await flushMicrotasks();
-    expect(scrollIntoView).not.toHaveBeenCalled();
-
-    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
-    await flushMicrotasks();
-
-    expect(scrollIntoView).toHaveBeenCalledOnce();
-  });
-
-  it('expires keyboard-open focus intent when initial list population retries are exhausted', async ({
-    onTestFinished,
-  }) => {
-    const animationFrames = createAnimationFrameMock();
-    onTestFinished(animationFrames.restore);
-    const scrollIntoView = vi.fn();
-    render(
-      <LateMountedItemApp
-        selectedIndex={null}
-        virtual
-        initialMountedIndex={2}
-        onScrollIntoView={scrollIntoView}
-      />,
-    );
-    const trigger = screen.getByRole('button');
-    act(() => trigger.focus());
-
-    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
-    await flushMicrotasks();
-    act(animationFrames.flush);
-    expect(scrollIntoView).not.toHaveBeenCalled();
-
-    fireEvent.mouseMove(screen.getByTestId('late-item'));
-    await flushMicrotasks();
-
-    expect(screen.getByTestId('late-item')).toHaveAttribute('data-active');
-    expect(scrollIntoView).toHaveBeenCalledOnce();
   });
 
   it('opens on ArrowUp and focuses last item', async () => {

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
@@ -133,15 +133,21 @@ function LateMountedItemApp({
   focusItemOnOpen,
   loopFocus,
   virtual,
+  initialActiveIndex = null,
+  initialMountedIndex = null,
+  onScrollIntoView,
 }: {
   selectedIndex?: number | null;
   focusItemOnOpen?: UseListNavigationProps['focusItemOnOpen'];
   loopFocus?: boolean;
   virtual?: boolean;
+  initialActiveIndex?: number | null;
+  initialMountedIndex?: number | null;
+  onScrollIntoView?: () => void;
 } = {}) {
   const [open, setOpen] = React.useState(false);
-  const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
-  const [mountedIndex, setMountedIndex] = React.useState<number | null>(null);
+  const [activeIndex, setActiveIndex] = React.useState<number | null>(initialActiveIndex);
+  const [mountedIndex, setMountedIndex] = React.useState<number | null>(initialMountedIndex);
   const listRef = React.useRef<Array<HTMLButtonElement | null>>(Array(3).fill(null));
   const { refs, context } = useFloating({ open, onOpenChange: setOpen });
   const { getReferenceProps, getFloatingProps, getItemProps } = useTestInteractions([
@@ -171,10 +177,14 @@ function LateMountedItemApp({
             <button
               data-testid="late-item"
               data-index={mountedIndex}
+              data-active={activeIndex === mountedIndex ? '' : undefined}
               tabIndex={-1}
               {...getItemProps({
                 ref(node: HTMLButtonElement | null) {
                   listRef.current[mountedIndex] = node;
+                  if (node && onScrollIntoView) {
+                    node.scrollIntoView = onScrollIntoView;
+                  }
                 },
               })}
             />
@@ -401,6 +411,59 @@ describe('useListNavigation', () => {
 
     expect(scrollIntoView).toHaveBeenCalledOnce();
     expect(trigger).toHaveFocus();
+  });
+
+  it('expires keyboard-open focus intent when the initial active index is out of bounds', async () => {
+    const scrollIntoView = vi.fn();
+    render(
+      <LateMountedItemApp
+        selectedIndex={null}
+        virtual
+        initialActiveIndex={3}
+        initialMountedIndex={0}
+        onScrollIntoView={scrollIntoView}
+      />,
+    );
+    const trigger = screen.getByRole('button');
+    act(() => trigger.focus());
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    await flushMicrotasks();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    await flushMicrotasks();
+
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+  });
+
+  it('expires keyboard-open focus intent when initial list population retries are exhausted', async ({
+    onTestFinished,
+  }) => {
+    const animationFrames = createAnimationFrameMock();
+    onTestFinished(animationFrames.restore);
+    const scrollIntoView = vi.fn();
+    render(
+      <LateMountedItemApp
+        selectedIndex={null}
+        virtual
+        initialMountedIndex={2}
+        onScrollIntoView={scrollIntoView}
+      />,
+    );
+    const trigger = screen.getByRole('button');
+    act(() => trigger.focus());
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    await flushMicrotasks();
+    act(animationFrames.flush);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    fireEvent.mouseMove(screen.getByTestId('late-item'));
+    await flushMicrotasks();
+
+    expect(screen.getByTestId('late-item')).toHaveAttribute('data-active');
+    expect(scrollIntoView).toHaveBeenCalledOnce();
   });
 
   it('opens on ArrowUp and focuses last item', async () => {

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -21,6 +21,7 @@ import type { gridNavigation } from './gridNavigation';
 import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP } from '../utils/constants';
 import {
   activeElement,
+  activeElementInRoot,
   contains,
   getFloatingFocusElement,
   getTarget,
@@ -293,7 +294,6 @@ export function useListNavigation(
   const previousMountedRef = React.useRef(!!floatingElement);
   const previousOpenRef = React.useRef(open);
   const forceSyncFocusRef = React.useRef(false);
-  const forceSyncFocusOnOpenRef = React.useRef<object | null>(null);
   const forceScrollIntoViewRef = React.useRef(false);
   const cancelQueuedFocusRef = React.useRef<(() => void) | null>(null);
 
@@ -305,14 +305,40 @@ export function useListNavigation(
   const focusFrame = useAnimationFrame();
   const waitForListPopulatedFrame = useAnimationFrame();
 
-  const focusItem = useStableCallback((deferReveal = false) => {
+  const focusItem = useStableCallback(() => {
     function runFocus(item: HTMLElement) {
       if (virtual) {
         tree?.events.emit('virtualfocus', item);
       } else {
+        const focusRoot = floatingElement ?? item;
+        const activeElementWhenQueued = activeElementInRoot(focusRoot);
+
+        // Cancel this hook's previous request explicitly so a later navigation
+        // that needs to wait for its item cannot leave the old item eligible.
+        cancelQueuedFocusRef.current?.();
         cancelQueuedFocusRef.current = enqueueFocus(item, {
           sync: forceSyncFocusRef.current,
           preventScroll: true,
+          shouldFocus: () => {
+            // The popup can close or the active index can change before the
+            // frame runs. In either case, focusing this item would revive stale
+            // intent.
+            if (!latestOpenRef.current || listRef.current[indexRef.current] !== item) {
+              return false;
+            }
+
+            const currentActiveElement = activeElementInRoot(focusRoot);
+            const focusMovedInside =
+              currentActiveElement !== activeElementWhenQueued &&
+              !contains(item, currentActiveElement) &&
+              contains(floatingElement, currentActiveElement);
+
+            // Consumer code may intentionally focus custom content after the
+            // popup opens but before this frame. Preserve that newer focus;
+            // keyboard navigation while already open is synchronous and has no
+            // intervening frame in which this condition can become true.
+            return !focusMovedInside;
+          },
         });
       }
     }
@@ -324,10 +350,9 @@ export function useListNavigation(
       runFocus(initialItem);
     }
 
-    const scheduler =
-      forceSyncFocusRef.current && !deferReveal
-        ? (callback: () => void) => callback()
-        : (callback: () => void) => focusFrame.request(callback);
+    const scheduler = forceSyncFocusRef.current
+      ? (callback: () => void) => callback()
+      : (callback: () => void) => focusFrame.request(callback);
 
     scheduler(() => {
       const waitedItem = listRef.current[indexRef.current] || initialItem;
@@ -386,18 +411,10 @@ export function useListNavigation(
     }
     if (!open) {
       forceSyncFocusRef.current = false;
-      forceSyncFocusOnOpenRef.current = null;
       return;
     }
     if (!floatingElement) {
       return;
-    }
-
-    const isInitialSync = !previousOpenRef.current || !previousMountedRef.current;
-    if (isInitialSync && focusItemOnOpenRef.current && keyRef.current != null) {
-      // Preserve keyboard-open intent across the controlled `activeIndex` update so focus lands
-      // with the highlighted state instead of waiting for the next animation frame.
-      forceSyncFocusOnOpenRef.current = {};
     }
 
     if (activeIndex == null) {
@@ -415,12 +432,11 @@ export function useListNavigation(
 
       // Initial sync.
       if (
-        isInitialSync &&
+        (!previousOpenRef.current || !previousMountedRef.current) &&
         focusItemOnOpenRef.current &&
         (keyRef.current != null || (focusItemOnOpenRef.current === true && keyRef.current == null))
       ) {
         let runs = 0;
-        const syncFocusOnOpenToken = forceSyncFocusOnOpenRef.current;
         const waitForListPopulated = () => {
           if (listRef.current[0] == null) {
             // Avoid letting the browser paint if possible on the first try,
@@ -431,11 +447,6 @@ export function useListNavigation(
                 ? (callback: () => void) => waitForListPopulatedFrame.request(callback)
                 : queueMicrotask;
               scheduler(waitForListPopulated);
-            } else if (
-              syncFocusOnOpenToken != null &&
-              forceSyncFocusOnOpenRef.current === syncFocusOnOpenToken
-            ) {
-              forceSyncFocusOnOpenRef.current = null;
             }
             runs += 1;
           } else {
@@ -458,17 +469,8 @@ export function useListNavigation(
       }
     } else if (!isIndexOutOfListBounds(listRef.current, activeIndex)) {
       indexRef.current = activeIndex;
-      const forceSyncFocusOnOpen = forceSyncFocusOnOpenRef.current != null;
-      if (forceSyncFocusOnOpen) {
-        // Focus an already-registered item in this commit, but preserve the animation-frame
-        // fallback for late registration and reveal it only after positioning has settled.
-        forceSyncFocusRef.current = listRef.current[activeIndex] != null;
-      }
-      focusItem(forceSyncFocusOnOpen);
-      forceSyncFocusOnOpenRef.current = null;
+      focusItem();
       forceScrollIntoViewRef.current = false;
-    } else {
-      forceSyncFocusOnOpenRef.current = null;
     }
   }, [
     enabled,

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -293,6 +293,7 @@ export function useListNavigation(
   const previousMountedRef = React.useRef(!!floatingElement);
   const previousOpenRef = React.useRef(open);
   const forceSyncFocusRef = React.useRef(false);
+  const forceSyncFocusOnOpenRef = React.useRef(false);
   const forceScrollIntoViewRef = React.useRef(false);
   const cancelQueuedFocusRef = React.useRef<(() => void) | null>(null);
 
@@ -386,6 +387,7 @@ export function useListNavigation(
     }
     if (!open) {
       forceSyncFocusRef.current = false;
+      forceSyncFocusOnOpenRef.current = false;
       return;
     }
     if (!floatingElement) {
@@ -394,6 +396,13 @@ export function useListNavigation(
 
     if (activeIndex == null) {
       forceSyncFocusRef.current = false;
+
+      const isInitialSync = !previousOpenRef.current || !previousMountedRef.current;
+      if (isInitialSync && keyRef.current != null) {
+        // Preserve keyboard-open intent across the controlled `activeIndex` update so focus lands
+        // with the highlighted state instead of waiting for the next animation frame.
+        forceSyncFocusOnOpenRef.current = true;
+      }
 
       if (selectedIndexRef.current != null) {
         return;
@@ -407,7 +416,7 @@ export function useListNavigation(
 
       // Initial sync.
       if (
-        (!previousOpenRef.current || !previousMountedRef.current) &&
+        isInitialSync &&
         focusItemOnOpenRef.current &&
         (keyRef.current != null || (focusItemOnOpenRef.current === true && keyRef.current == null))
       ) {
@@ -444,7 +453,11 @@ export function useListNavigation(
       }
     } else if (!isIndexOutOfListBounds(listRef.current, activeIndex)) {
       indexRef.current = activeIndex;
+      if (forceSyncFocusOnOpenRef.current) {
+        forceSyncFocusRef.current = true;
+      }
       focusItem();
+      forceSyncFocusOnOpenRef.current = false;
       forceScrollIntoViewRef.current = false;
     }
   }, [

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -313,9 +313,6 @@ export function useListNavigation(
         const focusRoot = floatingElement ?? item;
         const activeElementWhenQueued = activeElementInRoot(focusRoot);
 
-        // Cancel this hook's previous request explicitly so a later navigation
-        // that needs to wait for its item cannot leave the old item eligible.
-        cancelQueuedFocusRef.current?.();
         cancelQueuedFocusRef.current = enqueueFocus(item, {
           sync: forceSyncFocusRef.current,
           preventScroll: true,

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -340,9 +340,7 @@ export function useListNavigation(
         runFocus(waitedItem);
       }
 
-      const shouldScrollIntoView =
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        item && (forceScrollIntoView || !isPointerModalityRef.current);
+      const shouldScrollIntoView = forceScrollIntoView || !isPointerModalityRef.current;
 
       if (shouldScrollIntoView) {
         // JSDOM doesn't support `.scrollIntoView()` but it's widely supported

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -305,7 +305,7 @@ export function useListNavigation(
   const focusFrame = useAnimationFrame();
   const waitForListPopulatedFrame = useAnimationFrame();
 
-  const focusItem = useStableCallback(() => {
+  const focusItem = useStableCallback((deferReveal = false) => {
     function runFocus(item: HTMLElement) {
       if (virtual) {
         tree?.events.emit('virtualfocus', item);
@@ -324,9 +324,10 @@ export function useListNavigation(
       runFocus(initialItem);
     }
 
-    const scheduler = forceSyncFocusRef.current
-      ? (callback: () => void) => callback()
-      : (callback: () => void) => focusFrame.request(callback);
+    const scheduler =
+      forceSyncFocusRef.current && !deferReveal
+        ? (callback: () => void) => callback()
+        : (callback: () => void) => focusFrame.request(callback);
 
     scheduler(() => {
       const waitedItem = listRef.current[indexRef.current] || initialItem;
@@ -394,15 +395,15 @@ export function useListNavigation(
       return;
     }
 
+    const isInitialSync = !previousOpenRef.current || !previousMountedRef.current;
+    if (isInitialSync && focusItemOnOpenRef.current && keyRef.current != null) {
+      // Preserve keyboard-open intent across the controlled `activeIndex` update so focus lands
+      // with the highlighted state instead of waiting for the next animation frame.
+      forceSyncFocusOnOpenRef.current = true;
+    }
+
     if (activeIndex == null) {
       forceSyncFocusRef.current = false;
-
-      const isInitialSync = !previousOpenRef.current || !previousMountedRef.current;
-      if (isInitialSync && keyRef.current != null) {
-        // Preserve keyboard-open intent across the controlled `activeIndex` update so focus lands
-        // with the highlighted state instead of waiting for the next animation frame.
-        forceSyncFocusOnOpenRef.current = true;
-      }
 
       if (selectedIndexRef.current != null) {
         return;
@@ -453,10 +454,13 @@ export function useListNavigation(
       }
     } else if (!isIndexOutOfListBounds(listRef.current, activeIndex)) {
       indexRef.current = activeIndex;
-      if (forceSyncFocusOnOpenRef.current) {
-        forceSyncFocusRef.current = true;
+      const forceSyncFocusOnOpen = forceSyncFocusOnOpenRef.current;
+      if (forceSyncFocusOnOpen) {
+        // Focus an already-registered item in this commit, but preserve the animation-frame
+        // fallback for late registration and reveal it only after positioning has settled.
+        forceSyncFocusRef.current = listRef.current[activeIndex] != null;
       }
-      focusItem();
+      focusItem(forceSyncFocusOnOpen);
       forceSyncFocusOnOpenRef.current = false;
       forceScrollIntoViewRef.current = false;
     }

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -293,7 +293,7 @@ export function useListNavigation(
   const previousMountedRef = React.useRef(!!floatingElement);
   const previousOpenRef = React.useRef(open);
   const forceSyncFocusRef = React.useRef(false);
-  const forceSyncFocusOnOpenRef = React.useRef(false);
+  const forceSyncFocusOnOpenRef = React.useRef<object | null>(null);
   const forceScrollIntoViewRef = React.useRef(false);
   const cancelQueuedFocusRef = React.useRef<(() => void) | null>(null);
 
@@ -386,7 +386,7 @@ export function useListNavigation(
     }
     if (!open) {
       forceSyncFocusRef.current = false;
-      forceSyncFocusOnOpenRef.current = false;
+      forceSyncFocusOnOpenRef.current = null;
       return;
     }
     if (!floatingElement) {
@@ -397,7 +397,7 @@ export function useListNavigation(
     if (isInitialSync && focusItemOnOpenRef.current && keyRef.current != null) {
       // Preserve keyboard-open intent across the controlled `activeIndex` update so focus lands
       // with the highlighted state instead of waiting for the next animation frame.
-      forceSyncFocusOnOpenRef.current = true;
+      forceSyncFocusOnOpenRef.current = {};
     }
 
     if (activeIndex == null) {
@@ -420,6 +420,7 @@ export function useListNavigation(
         (keyRef.current != null || (focusItemOnOpenRef.current === true && keyRef.current == null))
       ) {
         let runs = 0;
+        const syncFocusOnOpenToken = forceSyncFocusOnOpenRef.current;
         const waitForListPopulated = () => {
           if (listRef.current[0] == null) {
             // Avoid letting the browser paint if possible on the first try,
@@ -430,6 +431,11 @@ export function useListNavigation(
                 ? (callback: () => void) => waitForListPopulatedFrame.request(callback)
                 : queueMicrotask;
               scheduler(waitForListPopulated);
+            } else if (
+              syncFocusOnOpenToken != null &&
+              forceSyncFocusOnOpenRef.current === syncFocusOnOpenToken
+            ) {
+              forceSyncFocusOnOpenRef.current = null;
             }
             runs += 1;
           } else {
@@ -452,15 +458,17 @@ export function useListNavigation(
       }
     } else if (!isIndexOutOfListBounds(listRef.current, activeIndex)) {
       indexRef.current = activeIndex;
-      const forceSyncFocusOnOpen = forceSyncFocusOnOpenRef.current;
+      const forceSyncFocusOnOpen = forceSyncFocusOnOpenRef.current != null;
       if (forceSyncFocusOnOpen) {
         // Focus an already-registered item in this commit, but preserve the animation-frame
         // fallback for late registration and reveal it only after positioning has settled.
         forceSyncFocusRef.current = listRef.current[activeIndex] != null;
       }
       focusItem(forceSyncFocusOnOpen);
-      forceSyncFocusOnOpenRef.current = false;
+      forceSyncFocusOnOpenRef.current = null;
       forceScrollIntoViewRef.current = false;
+    } else {
+      forceSyncFocusOnOpenRef.current = null;
     }
   }, [
     enabled,

--- a/packages/react/src/floating-ui-react/utils/element.ts
+++ b/packages/react/src/floating-ui-react/utils/element.ts
@@ -2,9 +2,9 @@ import { isElement, isHTMLElement } from '@floating-ui/utils/dom';
 import { platform } from '@base-ui/utils/platform';
 import { FOCUSABLE_ATTRIBUTE, TYPEABLE_SELECTOR } from './constants';
 import { type PopupTriggerMap } from '../../utils/popups';
-import { activeElement, contains, getTarget } from '../../internals/shadowDom';
+import { activeElement, activeElementInRoot, contains, getTarget } from '../../internals/shadowDom';
 
-export { activeElement, contains, getTarget };
+export { activeElement, activeElementInRoot, contains, getTarget };
 
 export function isTargetInsideEnabledTrigger(
   target: EventTarget | null,

--- a/packages/react/src/floating-ui-react/utils/enqueueFocus.test.ts
+++ b/packages/react/src/floating-ui-react/utils/enqueueFocus.test.ts
@@ -1,0 +1,279 @@
+import { vi } from 'vitest';
+import { enqueueFocus } from './enqueueFocus';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  document.body.innerHTML = '';
+});
+
+function createButton() {
+  const button = document.createElement('button');
+  document.body.append(button);
+  return button;
+}
+
+function createAnimationFrameMock(win: Window) {
+  let nextFrameId = 0;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const requestAnimationFrame = vi
+    .spyOn(win, 'requestAnimationFrame')
+    .mockImplementation((callback) => {
+      nextFrameId += 1;
+      callbacks.set(nextFrameId, callback);
+      return nextFrameId;
+    });
+  const cancelAnimationFrame = vi
+    .spyOn(win, 'cancelAnimationFrame')
+    .mockImplementation((id) => callbacks.delete(id));
+
+  return {
+    requestAnimationFrame,
+    cancelAnimationFrame,
+    flush() {
+      const pending = Array.from(callbacks.values());
+      callbacks.clear();
+      pending.forEach((callback) => callback(performance.now()));
+    },
+  };
+}
+
+it('focuses the element on the next frame', () => {
+  const button = createButton();
+
+  enqueueFocus(button);
+  expect(document.activeElement).not.toBe(button);
+
+  vi.advanceTimersToNextFrame();
+  expect(document.activeElement).toBe(button);
+});
+
+it('commits only the latest primary intent in a document', () => {
+  const first = createButton();
+  const second = createButton();
+  const onFirstFocus = vi.fn();
+  const onSecondFocus = vi.fn();
+  first.addEventListener('focus', onFirstFocus);
+  second.addEventListener('focus', onSecondFocus);
+
+  enqueueFocus(first);
+  enqueueFocus(second);
+  vi.advanceTimersToNextFrame();
+
+  expect(onFirstFocus).not.toHaveBeenCalled();
+  expect(onSecondFocus).toHaveBeenCalledOnce();
+  expect(document.activeElement).toBe(second);
+});
+
+it('does not run a fallback when the primary intent takes focus', () => {
+  const fallback = createButton();
+  const primary = createButton();
+  const onFallbackFocus = vi.fn();
+  fallback.addEventListener('focus', onFallbackFocus);
+
+  enqueueFocus(primary);
+  // Initial focus is often queued after list navigation in a microtask. Its
+  // later enqueue must not replace the already-known primary destination.
+  enqueueFocus(fallback, { intent: 'fallback' });
+  vi.advanceTimersToNextFrame();
+
+  expect(onFallbackFocus).not.toHaveBeenCalled();
+  expect(document.activeElement).toBe(primary);
+});
+
+it('runs the fallback when the primary intent is no longer valid', () => {
+  const fallback = createButton();
+  const primary = createButton();
+
+  enqueueFocus(fallback, { intent: 'fallback' });
+  enqueueFocus(primary, { shouldFocus: () => false });
+  vi.advanceTimersToNextFrame();
+
+  expect(document.activeElement).toBe(fallback);
+});
+
+it('runs the fallback when the primary focus call does not take focus', () => {
+  const fallback = createButton();
+  const primary = createButton();
+  vi.spyOn(primary, 'focus').mockImplementation(() => {});
+
+  enqueueFocus(fallback, { intent: 'fallback' });
+  enqueueFocus(primary);
+  vi.advanceTimersToNextFrame();
+
+  expect(document.activeElement).toBe(fallback);
+});
+
+it('preserves the queued fallback when synchronous primary focus does not take focus', () => {
+  const fallback = createButton();
+  const primary = createButton();
+  vi.spyOn(primary, 'focus').mockImplementation(() => {});
+
+  enqueueFocus(fallback, { intent: 'fallback' });
+  enqueueFocus(primary, { sync: true });
+
+  expect(document.activeElement).not.toBe(fallback);
+  vi.advanceTimersToNextFrame();
+  expect(document.activeElement).toBe(fallback);
+});
+
+it('recognizes successful primary focus inside a closed shadow root', () => {
+  const fallback = createButton();
+  const onFallbackFocus = vi.fn();
+  fallback.addEventListener('focus', onFallbackFocus);
+  const host = document.createElement('div');
+  document.body.append(host);
+  const shadowRoot = host.attachShadow({ mode: 'closed' });
+  const primary = document.createElement('button');
+  shadowRoot.append(primary);
+
+  enqueueFocus(primary);
+  enqueueFocus(fallback, { intent: 'fallback' });
+  vi.advanceTimersToNextFrame();
+
+  expect(host.shadowRoot).toBe(null);
+  expect(shadowRoot.activeElement).toBe(primary);
+  expect(onFallbackFocus).not.toHaveBeenCalled();
+});
+
+it('refocuses an active element when its document reports that it is blurred', () => {
+  const button = createButton();
+  button.focus();
+  const focus = vi.spyOn(button, 'focus');
+  vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+
+  enqueueFocus(button);
+  vi.advanceTimersToNextFrame();
+
+  expect(focus).toHaveBeenCalledOnce();
+});
+
+it('does not move focus from a descendant to its fallback container', () => {
+  const container = document.createElement('div');
+  container.tabIndex = -1;
+  const child = document.createElement('button');
+  container.append(child);
+  document.body.append(container);
+  child.focus();
+  const focus = vi.spyOn(container, 'focus');
+
+  enqueueFocus(container, { intent: 'fallback' });
+  vi.advanceTimersToNextFrame();
+
+  expect(focus).not.toHaveBeenCalled();
+  expect(document.activeElement).toBe(child);
+});
+
+it('cancels only the request associated with the returned function', () => {
+  const fallback = createButton();
+  const primary = createButton();
+
+  enqueueFocus(fallback, { intent: 'fallback' });
+  const cancelPrimary = enqueueFocus(primary);
+  cancelPrimary();
+  vi.advanceTimersToNextFrame();
+
+  expect(document.activeElement).toBe(fallback);
+});
+
+it('does not let a stale cancel function cancel a newer request', () => {
+  const stale = createButton();
+  const current = createButton();
+
+  const staleCancel = enqueueFocus(stale);
+  enqueueFocus(current);
+  staleCancel();
+  vi.advanceTimersToNextFrame();
+
+  expect(document.activeElement).toBe(current);
+});
+
+it('cancels all pending intents before focusing synchronously', () => {
+  const fallback = createButton();
+  const pendingPrimary = createButton();
+  const syncTarget = createButton();
+  const pendingShouldFocus = vi.fn(() => true);
+
+  enqueueFocus(fallback, { intent: 'fallback' });
+  enqueueFocus(pendingPrimary, { shouldFocus: pendingShouldFocus });
+  enqueueFocus(syncTarget, { sync: true });
+
+  expect(document.activeElement).toBe(syncTarget);
+  vi.advanceTimersToNextFrame();
+  expect(pendingShouldFocus).not.toHaveBeenCalled();
+  expect(document.activeElement).toBe(syncTarget);
+});
+
+it('uses a single animation frame for intents in the same document', () => {
+  const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame');
+
+  enqueueFocus(createButton(), { intent: 'fallback' });
+  enqueueFocus(createButton());
+
+  expect(requestAnimationFrameSpy).toHaveBeenCalledOnce();
+  vi.advanceTimersToNextFrame();
+});
+
+it('schedules focus queues in their owning windows', () => {
+  const iframe = document.createElement('iframe');
+  document.body.append(iframe);
+  const frameWindow = iframe.contentWindow as Window;
+  const frameDocument = iframe.contentDocument as Document;
+  const frameAnimation = createAnimationFrameMock(frameWindow);
+  const mainRequestAnimationFrame = vi.spyOn(window, 'requestAnimationFrame');
+  const currentDocumentButton = createButton();
+  const frameButton = frameDocument.createElement('button');
+  frameDocument.body.append(frameButton);
+  const frameFocus = vi.spyOn(frameButton, 'focus');
+
+  enqueueFocus(currentDocumentButton);
+  enqueueFocus(frameButton);
+
+  expect(mainRequestAnimationFrame).toHaveBeenCalledOnce();
+  expect(frameAnimation.requestAnimationFrame).toHaveBeenCalledOnce();
+
+  vi.advanceTimersToNextFrame();
+  expect(document.activeElement).toBe(currentDocumentButton);
+  expect(frameFocus).not.toHaveBeenCalled();
+
+  frameAnimation.flush();
+  expect(frameFocus).toHaveBeenCalledOnce();
+});
+
+it('cancels focus using the target document window', () => {
+  const iframe = document.createElement('iframe');
+  document.body.append(iframe);
+  const frameWindow = iframe.contentWindow as Window;
+  const frameDocument = iframe.contentDocument as Document;
+  const frameAnimation = createAnimationFrameMock(frameWindow);
+  const frameButton = frameDocument.createElement('button');
+  frameDocument.body.append(frameButton);
+
+  const cancel = enqueueFocus(frameButton);
+  cancel();
+
+  expect(frameAnimation.cancelAnimationFrame).toHaveBeenCalledWith(1);
+});
+
+it('treats a null element as a no-op', () => {
+  const button = createButton();
+
+  enqueueFocus(button);
+  enqueueFocus(null);
+  vi.advanceTimersToNextFrame();
+
+  expect(document.activeElement).toBe(button);
+});
+
+it('skips focusing when shouldFocus returns false', () => {
+  const button = createButton();
+
+  enqueueFocus(button, { shouldFocus: () => false });
+  vi.advanceTimersToNextFrame();
+
+  expect(document.activeElement).not.toBe(button);
+});

--- a/packages/react/src/floating-ui-react/utils/enqueueFocus.ts
+++ b/packages/react/src/floating-ui-react/utils/enqueueFocus.ts
@@ -158,6 +158,9 @@ export function enqueueFocus(el: FocusableElement | null, options: Options = {})
     };
     createdQueue[intentKind] = focusIntent;
     focusQueues.set(doc, createdQueue);
+    // The shared `AnimationFrame` scheduler is bound to the module's realm.
+    // Focus queues must instead follow the target document's window so iframe
+    // work is scheduled and cancelled in that document's rendering lifecycle.
     createdQueue.frameId = createdQueue.window.requestAnimationFrame(() =>
       flushFocusQueue(doc, createdQueue),
     );

--- a/packages/react/src/floating-ui-react/utils/enqueueFocus.ts
+++ b/packages/react/src/floating-ui-react/utils/enqueueFocus.ts
@@ -1,37 +1,182 @@
 import { NOOP } from '@base-ui/utils/empty';
+import { ownerWindow } from '@base-ui/utils/owner';
+import { activeElementInRoot, contains } from './element';
 import type { FocusableElement } from './tabbable';
+
+type FocusIntentKind = 'primary' | 'fallback';
 
 interface Options {
   preventScroll?: boolean | undefined;
   sync?: boolean | undefined;
+  /**
+   * Primary intents represent an explicit focus destination, such as an item
+   * selected by keyboard navigation. Fallback intents are defaults that should
+   * only run when no primary intent can take focus.
+   *
+   * @default 'primary'
+   */
+  intent?: FocusIntentKind | undefined;
   // Called when the frame runs to decide whether focus should still be applied.
   shouldFocus?: (() => boolean) | undefined;
 }
 
-let rafId = 0;
-export function enqueueFocus(el: FocusableElement | null, options: Options = {}) {
-  const { preventScroll = false, sync = false, shouldFocus } = options;
+interface FocusIntent {
+  target: FocusableElement;
+  preventScroll: boolean;
+  shouldFocus: (() => boolean) | undefined;
+}
 
-  cancelAnimationFrame(rafId);
+interface FocusQueue {
+  frameId: number;
+  window: Window;
+  primary: FocusIntent | null;
+  fallback: FocusIntent | null;
+}
 
-  function exec() {
-    if (shouldFocus && !shouldFocus()) {
-      return;
-    }
-    el?.focus({ preventScroll });
+// Focus is singleton state within a document. Keeping independent queues per
+// element could focus several elements in one frame, producing observable
+// focus/blur churn. A document queue instead commits at most one successful
+// focus transition per frame, while preserving isolation between documents.
+const focusQueues = new WeakMap<Document, FocusQueue>();
+
+function isFocusWithin(target: FocusableElement) {
+  const currentActiveElement = activeElementInRoot(target);
+
+  // A fallback container already fulfills its purpose when one of its
+  // descendants has focus. Treating that as success avoids moving focus from
+  // consumer content back to the container merely to satisfy exact identity.
+  return currentActiveElement === target || contains(target, currentActiveElement);
+}
+
+function executeFocusIntent(focusIntent: FocusIntent | null) {
+  if (
+    focusIntent == null ||
+    !focusIntent.target.isConnected ||
+    focusIntent.shouldFocus?.() === false
+  ) {
+    return false;
   }
 
-  if (sync) {
-    exec();
+  // A blurred document can retain a stale `activeElement`. Only skip `.focus()`
+  // when the document itself has focus; after calling it, root-local active
+  // element state tells us whether the target accepted focus.
+  const targetAlreadyHasFocus =
+    focusIntent.target.ownerDocument.hasFocus() && isFocusWithin(focusIntent.target);
+
+  if (!targetAlreadyHasFocus) {
+    focusIntent.target.focus({ preventScroll: focusIntent.preventScroll });
+  }
+
+  return isFocusWithin(focusIntent.target);
+}
+
+function flushFocusQueue(doc: Document, queue: FocusQueue) {
+  if (focusQueues.get(doc) !== queue) {
+    return;
+  }
+
+  // Remove the queue before focusing. A focus event may enqueue another intent,
+  // which must belong to the next frame rather than mutate the queue being run.
+  focusQueues.delete(doc);
+
+  // A fallback is attempted only if the primary intent became invalid or its
+  // focus call did not move focus. This lets initial-focus defaults coexist with
+  // a more specific navigation target without an intermediate focus transition.
+  if (!executeFocusIntent(queue.primary)) {
+    executeFocusIntent(queue.fallback);
+  }
+}
+
+function cancelFocusQueue(doc: Document, queue: FocusQueue) {
+  if (focusQueues.get(doc) !== queue) {
+    return;
+  }
+
+  queue.window.cancelAnimationFrame(queue.frameId);
+  focusQueues.delete(doc);
+}
+
+export function enqueueFocus(el: FocusableElement | null, options: Options = {}) {
+  const {
+    preventScroll = false,
+    sync = false,
+    intent: intentKind = 'primary',
+    shouldFocus,
+  } = options;
+
+  if (!el) {
     return NOOP;
   }
 
-  const currentRafId = requestAnimationFrame(exec);
-  rafId = currentRafId;
+  const doc = el.ownerDocument;
+  const focusIntent: FocusIntent = {
+    target: el,
+    preventScroll,
+    shouldFocus,
+  };
+
+  if (sync) {
+    const pendingQueue = focusQueues.get(doc);
+    const pendingPrimary = pendingQueue?.primary;
+    const pendingFallback = pendingQueue?.fallback;
+    const focusSucceeded = executeFocusIntent(focusIntent);
+
+    if (pendingQueue && focusQueues.get(doc) === pendingQueue) {
+      if (focusSucceeded) {
+        // Clear only the intents that predated this focus call. A focus handler
+        // may have enqueued fresh work that belongs to the pending frame.
+        if (pendingQueue.primary === pendingPrimary) {
+          pendingQueue.primary = null;
+        }
+        if (pendingQueue.fallback === pendingFallback) {
+          pendingQueue.fallback = null;
+        }
+      } else {
+        // A failed synchronous primary supersedes an older primary, but the
+        // fallback remains eligible on its original frame.
+        const pendingIntent = intentKind === 'primary' ? pendingPrimary : pendingFallback;
+        if (pendingQueue[intentKind] === pendingIntent) {
+          pendingQueue[intentKind] = null;
+        }
+      }
+
+      if (pendingQueue.primary == null && pendingQueue.fallback == null) {
+        cancelFocusQueue(doc, pendingQueue);
+      }
+    }
+
+    return NOOP;
+  }
+
+  let queue = focusQueues.get(doc);
+  if (!queue) {
+    const createdQueue: FocusQueue = {
+      frameId: 0,
+      window: ownerWindow(el),
+      primary: null,
+      fallback: null,
+    };
+    createdQueue[intentKind] = focusIntent;
+    focusQueues.set(doc, createdQueue);
+    createdQueue.frameId = createdQueue.window.requestAnimationFrame(() =>
+      flushFocusQueue(doc, createdQueue),
+    );
+    queue = createdQueue;
+  } else {
+    // Only the latest intent of each kind is relevant.
+    queue[intentKind] = focusIntent;
+  }
+
+  // The returned cancellation closure checks identity so a stale caller cannot
+  // cancel its replacement.
   return () => {
-    if (rafId === currentRafId) {
-      cancelAnimationFrame(currentRafId);
-      rafId = 0;
+    if (focusQueues.get(doc) !== queue || queue[intentKind] !== focusIntent) {
+      return;
+    }
+
+    queue[intentKind] = null;
+    if (queue.primary == null && queue.fallback == null) {
+      cancelFocusQueue(doc, queue);
     }
   };
 }

--- a/packages/react/src/internals/shadowDom.ts
+++ b/packages/react/src/internals/shadowDom.ts
@@ -1,13 +1,23 @@
 import { isShadowRoot } from '@floating-ui/utils/dom';
 
-export function activeElement(doc: Document) {
-  let element = doc.activeElement;
+export function activeElement(root: Document | ShadowRoot) {
+  let element = root.activeElement;
 
   while (element?.shadowRoot?.activeElement != null) {
     element = element.shadowRoot.activeElement;
   }
 
   return element;
+}
+
+/**
+ * Returns the deepest active element in the element's own document or shadow
+ * root. Starting from the element's root is important for closed shadow roots:
+ * their focused descendant is intentionally hidden from `document.activeElement`.
+ */
+export function activeElementInRoot(element: Element) {
+  const root = element.getRootNode();
+  return activeElement(isShadowRoot(root) ? root : element.ownerDocument);
 }
 
 export function contains(parent?: Element | null, child?: Element | null) {

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -69,6 +69,43 @@ describe('<Select.Root />', () => {
     });
   });
 
+  describe('keyboard navigation', () => {
+    it('focuses the highlighted item before the next animation frame when opening', async ({
+      onTestFinished,
+    }) => {
+      await render(
+        <Select.Root>
+          <Select.Trigger>Trigger</Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const requestAnimationFrame = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation(() => 0);
+      onTestFinished(() => requestAnimationFrame.mockRestore());
+
+      const trigger = screen.getByRole('combobox');
+      await act(async () => {
+        trigger.focus();
+      });
+
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+      await flushMicrotasks();
+
+      const option = screen.getByRole('option', { name: 'a' });
+      expect(option).toHaveAttribute('data-highlighted');
+      expect(option).toHaveFocus();
+    });
+  });
+
   describe('prop: defaultValue', () => {
     it('should select the item by default', async () => {
       await render(

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -104,6 +104,53 @@ describe('<Select.Root />', () => {
       expect(option).toHaveAttribute('data-highlighted');
       expect(option).toHaveFocus();
     });
+
+    it.skipIf(isJSDOM)('reveals the keyboard-open item after the popup is positioned', async () => {
+      const items = Array.from({ length: 60 }, (_, index) => `Item ${index}`);
+
+      await render(
+        <Select.Root defaultValue="Item 40">
+          <Select.Trigger style={{ position: 'fixed', top: '50%', left: 100 }}>
+            Trigger
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner alignItemWithTrigger={false} sideOffset={4}>
+              <Select.Popup
+                style={{
+                  width: 200,
+                  maxHeight: 'var(--available-height)',
+                  overflowY: 'auto',
+                }}
+              >
+                {items.map((item) => (
+                  <Select.Item key={item} value={item} style={{ height: 32 }}>
+                    {item}
+                  </Select.Item>
+                ))}
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      await act(async () => {
+        trigger.focus();
+      });
+
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+
+      const popup = await screen.findByRole('listbox');
+      const option = screen.getByRole('option', { name: 'Item 40' });
+      await waitFor(() => expect(option).toHaveFocus());
+      await waitFor(() => {
+        const popupRect = popup.getBoundingClientRect();
+        const optionRect = option.getBoundingClientRect();
+        const isVisible = optionRect.top >= popupRect.top && optionRect.bottom <= popupRect.bottom;
+        expect(isVisible).toBe(true);
+      });
+      expect(option).toHaveFocus();
+    });
   });
 
   describe('prop: defaultValue', () => {

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -70,11 +70,11 @@ describe('<Select.Root />', () => {
   });
 
   describe('keyboard navigation', () => {
-    it('focuses the highlighted item before the next animation frame when opening', async ({
+    it('does not focus the highlighted item before the next animation frame when opening', async ({
       onTestFinished,
     }) => {
       await render(
-        <Select.Root>
+        <Select.Root defaultValue="b">
           <Select.Trigger>Trigger</Select.Trigger>
           <Select.Portal>
             <Select.Positioner>
@@ -87,22 +87,36 @@ describe('<Select.Root />', () => {
         </Select.Root>,
       );
 
-      const requestAnimationFrame = vi
-        .spyOn(window, 'requestAnimationFrame')
-        .mockImplementation(() => 0);
-      onTestFinished(() => requestAnimationFrame.mockRestore());
+      vi.useFakeTimers();
+      onTestFinished(() => {
+        vi.useRealTimers();
+      });
 
       const trigger = screen.getByRole('combobox');
       await act(async () => {
         trigger.focus();
       });
+      const focusTargets: EventTarget[] = [];
+      const onFocusIn = (event: FocusEvent) => focusTargets.push(event.target as EventTarget);
+      document.addEventListener('focusin', onFocusIn);
+      onTestFinished(() => document.removeEventListener('focusin', onFocusIn));
 
       fireEvent.keyDown(trigger, { key: 'ArrowDown' });
       await flushMicrotasks();
 
-      const option = screen.getByRole('option', { name: 'a' });
+      const option = screen.getByRole('option', { name: 'b' });
       expect(option).toHaveAttribute('data-highlighted');
+      expect(option).not.toHaveFocus();
+      expect(trigger).toHaveFocus();
+      expect(focusTargets).toEqual([]);
+
+      await act(async () => {
+        vi.advanceTimersToNextFrame();
+      });
+      await flushMicrotasks();
+
       expect(option).toHaveFocus();
+      expect(focusTargets).toEqual([option]);
     });
 
     it.skipIf(isJSDOM)('reveals the keyboard-open item after the popup is positioned', async () => {


### PR DESCRIPTION
Fixes #5268.

## Summary

- preserve keyboard-open focus intent across the controlled `activeIndex` update
- focus the initial highlighted item without waiting for an animation frame
- add hook regressions for empty and preselected lists
- add a Select integration regression with animation-frame callbacks blocked

## Root cause

`useListNavigation` recorded the navigation key, but reset synchronous focus while the initial active item was being derived. The highlighted state therefore committed before focus, leaving a frame where a subsequent key event could still target the trigger.

The new one-shot ref carries keyboard-open intent until the active item is focused, then clears on consumption or close. Pointer-open and virtualized fallback behavior remain unchanged.

## Validation

- `pnpm test:jsdom useListNavigation --no-watch`
- `pnpm test:chromium useListNavigation --no-watch`
- `pnpm test:jsdom SelectRoot --no-watch`
- `pnpm test:chromium SelectRoot --no-watch`
- `pnpm eslint packages/react/src/floating-ui-react/hooks/useListNavigation.ts packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx packages/react/src/select/root/SelectRoot.test.tsx`
- `pnpm prettier --check`
- `pnpm typescript --force`