### PR TITLE
[popups] Scope queued focus cancellation to its target element

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.test.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { flushMicrotasks } from '@mui/internal-test-utils';
 import { isJSDOM, useTestInteractions } from '#test-utils';
-import { useClick, useDismiss, useFloating, useListNavigation } from '../index';
+import { FloatingFocusManager, useClick, useDismiss, useFloating, useListNavigation } from '../index';
 import { gridNavigation } from './gridNavigation';
 import type { UseListNavigationProps } from '../types';
 import { Main as ComplexGrid } from '../../../test/floating-ui-tests/ComplexGrid';
@@ -1524,5 +1524,105 @@ describe('useListNavigation', () => {
     await waitFor(() => {
       expect(screen.getByTestId('item-1')).toHaveFocus();
     });
+  });
+});
+
+describe('queued focus', () => {
+  function ManagedApp() {
+    const [open, setOpen] = React.useState(false);
+    const listRef = React.useRef<Array<HTMLLIElement | null>>([]);
+    const [activeIndex, setActiveIndex] = React.useState<null | number>(null);
+    const { refs, context } = useFloating({
+      open,
+      onOpenChange: setOpen,
+    });
+    const { getReferenceProps, getFloatingProps, getItemProps } = useTestInteractions([
+      useClick(context),
+      useListNavigation(context, {
+        listRef,
+        activeIndex,
+        onNavigate: setActiveIndex,
+      }),
+    ]);
+
+    return (
+      <React.Fragment>
+        <button data-testid="reference" {...getReferenceProps({ ref: refs.setReference })} />
+        <button data-testid="nav-1" onClick={() => setActiveIndex(1)} />
+        <button data-testid="nav-2" onClick={() => setActiveIndex(2)} />
+        {open && (
+          <FloatingFocusManager context={context}>
+            <div role="menu" {...getFloatingProps({ ref: refs.setFloating })}>
+              <button data-testid="close" type="button" />
+              <ul>
+                {['one', 'two', 'three'].map((string, index) => (
+                  <li
+                    data-testid={`item-${index}`}
+                    key={string}
+                    tabIndex={-1}
+                    {...getItemProps({
+                      ref(node: HTMLLIElement) {
+                        listRef.current[index] = node;
+                      },
+                    })}
+                  >
+                    {string}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </FloatingFocusManager>
+        )}
+      </React.Fragment>
+    );
+  }
+
+  it('keyboard open focuses the active item when the focus manager initial focus targets another tabbable', async () => {
+    vi.useFakeTimers();
+    try {
+      render(<ManagedApp />);
+
+      fireEvent.keyDown(screen.getByTestId('reference'), { key: 'ArrowDown' });
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      // Let the focus manager's queued initial focus land before the frame runs.
+      await act(async () => {});
+      await act(async () => {
+        vi.advanceTimersToNextFrame();
+      });
+
+      expect(screen.getByTestId('item-0')).toHaveFocus();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('consecutive queued focus requests before the frame runs skip intermediate items', async () => {
+    vi.useFakeTimers();
+    try {
+      render(<ManagedApp />);
+
+      let intermediateFocusCount = 0;
+      const onIntermediateFocus = () => {
+        intermediateFocusCount += 1;
+      };
+
+      // Open with a click so focus requests stay queued instead of running
+      // synchronously as they do once an item holds focus.
+      fireEvent.click(screen.getByTestId('reference'));
+      await act(async () => {});
+      screen.getByTestId('item-0').addEventListener('focus', onIntermediateFocus);
+      screen.getByTestId('item-1').addEventListener('focus', onIntermediateFocus);
+
+      fireEvent.click(screen.getByTestId('nav-1'));
+      fireEvent.click(screen.getByTestId('nav-2'));
+      await act(async () => {
+        vi.advanceTimersToNextFrame();
+      });
+
+      expect(intermediateFocusCount).toBe(0);
+      expect(screen.getByTestId('item-2')).toHaveFocus();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
+++ b/packages/react/src/floating-ui-react/hooks/useListNavigation.ts
@@ -309,6 +309,9 @@ export function useListNavigation(
       if (virtual) {
         tree?.events.emit('virtualfocus', item);
       } else {
+        // Queued focus is only cancelled per element, so retire this hook's
+        // own previous request before queueing focus for another item.
+        cancelQueuedFocusRef.current?.();
         cancelQueuedFocusRef.current = enqueueFocus(item, {
           sync: forceSyncFocusRef.current,
           preventScroll: true,

--- a/packages/react/src/floating-ui-react/utils/enqueueFocus.test.ts
+++ b/packages/react/src/floating-ui-react/utils/enqueueFocus.test.ts
@@ -1,0 +1,118 @@
+import { vi } from 'vitest';
+import { enqueueFocus } from './enqueueFocus';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.innerHTML = '';
+});
+
+function createButton() {
+  const button = document.createElement('button');
+  document.body.append(button);
+  return button;
+}
+
+it('focuses the element on the next frame', () => {
+  const button = createButton();
+
+  enqueueFocus(button);
+  expect(document.activeElement).not.toBe(button);
+
+  vi.advanceTimersToNextFrame();
+  expect(document.activeElement).toBe(button);
+});
+
+it('does not cancel focus queued for a different element', () => {
+  const first = createButton();
+  const second = createButton();
+  const received: HTMLElement[] = [];
+  first.addEventListener('focus', () => received.push(first));
+  second.addEventListener('focus', () => received.push(second));
+
+  enqueueFocus(first);
+  enqueueFocus(second);
+  vi.advanceTimersToNextFrame();
+
+  expect(received).toEqual([first, second]);
+  expect(document.activeElement).toBe(second);
+});
+
+it('keeps only the last queued focus for the same element', () => {
+  const button = createButton();
+  const staleShouldFocus = vi.fn(() => true);
+
+  enqueueFocus(button, { shouldFocus: staleShouldFocus });
+  enqueueFocus(button);
+  vi.advanceTimersToNextFrame();
+
+  expect(staleShouldFocus).not.toHaveBeenCalled();
+  expect(document.activeElement).toBe(button);
+});
+
+it('the returned function cancels only its own queued focus', () => {
+  const first = createButton();
+  const second = createButton();
+  let firstFocused = false;
+  first.addEventListener('focus', () => {
+    firstFocused = true;
+  });
+
+  const cancelFirst = enqueueFocus(first);
+  enqueueFocus(second);
+  cancelFirst();
+  vi.advanceTimersToNextFrame();
+
+  expect(firstFocused).toBe(false);
+  expect(document.activeElement).toBe(second);
+});
+
+it('a stale cancel function does not cancel a newer request for the element', () => {
+  const button = createButton();
+  const liveShouldFocus = vi.fn(() => true);
+  const finalShouldFocus = vi.fn(() => true);
+
+  const staleCancel = enqueueFocus(button);
+  enqueueFocus(button, { shouldFocus: liveShouldFocus });
+  staleCancel();
+  enqueueFocus(button, { shouldFocus: finalShouldFocus });
+  vi.advanceTimersToNextFrame();
+
+  expect(liveShouldFocus).not.toHaveBeenCalled();
+  expect(finalShouldFocus).toHaveBeenCalledTimes(1);
+  expect(document.activeElement).toBe(button);
+});
+
+it('sync focus cancels the pending queued focus for the element', () => {
+  const button = createButton();
+  const staleShouldFocus = vi.fn(() => true);
+
+  enqueueFocus(button, { shouldFocus: staleShouldFocus });
+  enqueueFocus(button, { sync: true });
+  expect(document.activeElement).toBe(button);
+
+  vi.advanceTimersToNextFrame();
+  expect(staleShouldFocus).not.toHaveBeenCalled();
+});
+
+it('a null element is a no-op and leaves queued focus for other elements alone', () => {
+  const button = createButton();
+
+  enqueueFocus(button);
+  enqueueFocus(null);
+  vi.advanceTimersToNextFrame();
+
+  expect(document.activeElement).toBe(button);
+});
+
+it('skips focusing when shouldFocus returns false', () => {
+  const button = createButton();
+
+  enqueueFocus(button, { shouldFocus: () => false });
+  vi.advanceTimersToNextFrame();
+
+  expect(document.activeElement).not.toBe(button);
+});

--- a/packages/react/src/floating-ui-react/utils/enqueueFocus.ts
+++ b/packages/react/src/floating-ui-react/utils/enqueueFocus.ts
@@ -8,17 +8,32 @@ interface Options {
   shouldFocus?: (() => boolean) | undefined;
 }
 
-let rafId = 0;
+// Pending focus frames are keyed per element so concurrent callers targeting
+// different elements can't cancel each other's queued focus.
+const rafIds = new WeakMap<FocusableElement, number>();
+
 export function enqueueFocus(el: FocusableElement | null, options: Options = {}) {
   const { preventScroll = false, sync = false, shouldFocus } = options;
 
-  cancelAnimationFrame(rafId);
+  if (!el) {
+    return NOOP;
+  }
+
+  // `exec` is a hoisted function declaration, so the null-guard narrowing
+  // of `el` is not preserved inside it.
+  const target = el;
+  const pendingRafId = rafIds.get(target);
+  if (pendingRafId !== undefined) {
+    cancelAnimationFrame(pendingRafId);
+    rafIds.delete(target);
+  }
 
   function exec() {
+    rafIds.delete(target);
     if (shouldFocus && !shouldFocus()) {
       return;
     }
-    el?.focus({ preventScroll });
+    target.focus({ preventScroll });
   }
 
   if (sync) {
@@ -27,11 +42,11 @@ export function enqueueFocus(el: FocusableElement | null, options: Options = {})
   }
 
   const currentRafId = requestAnimationFrame(exec);
-  rafId = currentRafId;
+  rafIds.set(target, currentRafId);
   return () => {
-    if (rafId === currentRafId) {
+    if (rafIds.get(target) === currentRafId) {
       cancelAnimationFrame(currentRafId);
-      rafId = 0;
+      rafIds.delete(target);
     }
   };
 }


### PR DESCRIPTION
Fixes #5268

## Summary

`enqueueFocus` keeps a single module-level rAF handle and unconditionally cancels it on entry, so concurrent callers cancel each other's queued focus regardless of target. On keyboard-open of a roving-focus popup, `FloatingFocusManager`'s initial-focus call cancels the option focus queued by `useListNavigation` — the manager's `shouldFocus` guard is designed to yield when focus has already moved inside the popup, but the module-level cancel kills the very frame that would move it, so the guard never gets the chance.

Pending frames are now keyed per element (`WeakMap<FocusableElement, number>`), so a caller only replaces its own target's pending focus. With that in place, the initial-focus guard observes the item focus and yields as designed. When the manager's initial-focus fallback resolves to a different element than the active item (any tabbable rendered before the items), the old code left focus permanently on that element and list navigation dead — the new hook-level test pins that case. `useListNavigation` retires its own previous queued request before queueing focus for another item, preserving the previous last-wins behavior for consecutive queued requests. A `null` target is now a no-op instead of cancelling an unrelated caller's pending focus.

The existing TODO in `useListNavigation.test.tsx` ("the animation frame callback from `enqueueFocus` sometimes kicking in after the click … causes flakeyness") describes the same mechanism.

## Behavior notes

- Two same-frame enqueues for different elements now both fire in order (last scheduled wins, before paint); previously the earlier one was silently cancelled. Final focus is unchanged in every reachable call-site ordering.
- Migrating this file to the shared `AnimationFrame` scheduler was evaluated and deliberately left out: it changes timing under JSDOM's rAF stub and breaks four JSDOM-only `FloatingFocusManager` tests. #1901 also left this file's raw rAF in place.

## Tests

- `enqueueFocus.test.ts` (new): the cancellation semantics unit-tested with faked frames — JSDOM's real `cancelAnimationFrame` doesn't cancel, so the suite runs on `vi.useFakeTimers()`. Two cases fail on `main` (cross-element cancel, `null` side effect); the rest pin the preserved behavior (same-element replacement, cancel-function guard, `sync`, `shouldFocus`), each verified to fail against a mutated implementation.
- `useListNavigation.test.tsx`: keyboard-open focuses the active item when the manager's initial focus targets another tabbable (fails on `main`); consecutive queued requests skip intermediate items.
- Full jsdom suites pass (floating-ui-react, Select, Menu, Combobox — 2,113 tests) and the same suites pass in the Chromium environment, where real rAF cancellation is exercised.
