### PR TITLE
[all components] Keep unpositioned popups at the viewport origin

### DIFF
--- a/docs/src/app/(private)/experiments/drawer/select-in-drawer.tsx
+++ b/docs/src/app/(private)/experiments/drawer/select-in-drawer.tsx
@@ -1,0 +1,66 @@
+'use client';
+import * as React from 'react';
+import { Drawer } from '@base-ui/react/drawer';
+import { Select } from '@base-ui/react/select';
+import drawerStyles from './drawer-controlled-opening.module.css';
+import selectStyles from '../long-select.module.css';
+
+const fonts = ['Sans-serif', 'Serif', 'Monospace', 'Cursive', 'Fantasy', 'System UI'];
+
+function FontSelect() {
+  return (
+    <Select.Root defaultValue="Sans-serif">
+      <Select.Trigger
+        className={selectStyles.Select}
+        data-testid="select-trigger"
+        style={{ width: '100%' }}
+      >
+        <Select.Value />
+        <Select.Icon className={selectStyles.SelectIcon}>▼</Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Positioner
+          className={selectStyles.Positioner}
+          sideOffset={8}
+          data-testid="select-positioner"
+        >
+          <Select.Popup className={selectStyles.Popup} data-testid="select-popup">
+            <Select.List className={selectStyles.List}>
+              {fonts.map((font) => (
+                <Select.Item key={font} className={selectStyles.Item} value={font}>
+                  <Select.ItemText className={selectStyles.ItemText}>{font}</Select.ItemText>
+                </Select.Item>
+              ))}
+            </Select.List>
+          </Select.Popup>
+        </Select.Positioner>
+      </Select.Portal>
+    </Select.Root>
+  );
+}
+
+export default function SelectInDrawer() {
+  return (
+    <Drawer.Root>
+      <Drawer.Trigger className={drawerStyles.Button} data-testid="drawer-trigger">
+        Open bottom drawer
+      </Drawer.Trigger>
+      <Drawer.Portal>
+        <Drawer.Backdrop className={drawerStyles.Backdrop} />
+        <Drawer.Viewport className={drawerStyles.Viewport}>
+          <Drawer.Popup className={drawerStyles.Popup}>
+            <div className={drawerStyles.Handle} />
+            <Drawer.Content className={drawerStyles.Content}>
+              <Drawer.Title className={drawerStyles.Title}>Font settings</Drawer.Title>
+              <Drawer.Description className={drawerStyles.Description}>
+                Pick a font from the select below.
+              </Drawer.Description>
+              <FontSelect />
+              <div style={{ height: '4rem' }} />
+            </Drawer.Content>
+          </Drawer.Popup>
+        </Drawer.Viewport>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+}

--- a/packages/react/src/select/positioner/SelectPositioner.test.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.test.tsx
@@ -1,7 +1,7 @@
 import { expect } from 'vitest';
 import * as React from 'react';
 import { Select } from '@base-ui/react/select';
-import { screen } from '@mui/internal-test-utils';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 const Trigger = React.forwardRef(function Trigger(
@@ -279,6 +279,42 @@ describe('<Select.Positioner />', () => {
 
       // correctly flips the side in the browser
       expect(side).toBe('inline-end');
+    });
+  });
+
+  describe.skipIf(isJSDOM)('kept-mounted positioner', () => {
+    it('does not retain stale coordinates while closed', async () => {
+      const { user } = await render(
+        <Select.Root defaultOpen>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <Select.Portal>
+            <Select.Positioner data-testid="positioner" alignItemWithTrigger={false}>
+              <Select.Popup style={popupStyle}>Popup</Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      const positioner = screen.getByTestId('positioner');
+      expect(positioner.style.transform).not.toBe('');
+
+      await user.keyboard('{Escape}');
+
+      // The portal can remount around the close, so re-query the kept-mounted node.
+      await waitFor(() => {
+        expect(screen.getByTestId('positioner').hidden).toBe(true);
+      });
+
+      // Rendering the full-size popup at coordinates computed for the hidden (zero-size)
+      // positioner can overflow the layout viewport on the next open, making mobile Chrome
+      // zoom the page out. The positioner must sit at the viewport origin until positioned.
+      const closedPositioner = screen.getByTestId('positioner');
+      await waitFor(() => {
+        expect(closedPositioner.style.position).toBe('fixed');
+      });
+      expect(closedPositioner.style.transform).toBe('');
+      expect(closedPositioner.style.top).toBe('0px');
+      expect(closedPositioner.style.left).toBe('0px');
     });
   });
 });

--- a/packages/react/src/utils/useAnchorPositioning.ts
+++ b/packages/react/src/utils/useAnchorPositioning.ts
@@ -474,9 +474,18 @@ export function useAnchorPositioningWithHook(
   const resolvedPosition: 'absolute' | 'fixed' = isPositioned ? positionMethod : 'fixed';
 
   const floatingStyles = React.useMemo<React.CSSProperties>(() => {
-    const base: React.CSSProperties & Record<string, unknown> = adaptiveOrigin
-      ? { position: resolvedPosition, [sideX]: x, [sideY]: y }
-      : { position: resolvedPosition, ...originalFloatingStyles };
+    let base: React.CSSProperties & Record<string, unknown>;
+    if (!isPositioned) {
+      // Until a position for the current open is computed, ignore any coordinates retained from a
+      // previous open (or from a pass that measured the hidden popup as 0x0). Rendering the
+      // full-size popup at such stale coordinates can overflow the layout viewport, which makes
+      // mobile Chrome zoom the page out and reflow everything the popup is anchored to.
+      base = { position: resolvedPosition, top: 0, left: 0 };
+    } else if (adaptiveOrigin) {
+      base = { position: resolvedPosition, [sideX]: x, [sideY]: y };
+    } else {
+      base = { ...originalFloatingStyles, position: resolvedPosition };
+    }
 
     // Seed the available size vars so consumer `max-height: min(x, var(--available-height))` rules
     // resolve to a valid length on the first positioning pass, before `size()` writes the real


### PR DESCRIPTION
Fixes the mobile Chrome bug reported for Select inside a sheet/drawer: the first open works, but reopening leaves the popup mispositioned (or the whole page zoomed out and "stuck"). Reproduces in Chrome mobile emulation and on Android; also reported against shadcn's Base UI-based components.

## Root cause

`Select.Positioner` is always kept mounted. While closed, the positioner can retain (or newly receive) coordinates computed while the popup measured **0×0** — with `align="center"` the resulting x is the anchor's center. On reopen, the full-size popup is laid out at those stale coordinates for at least one frame before the fresh positioning pass lands. `opacity: 0` hides that frame visually, but the element still participates in layout.

The `!isPositioned` fallback in `useAnchorPositioning` was meant to guard exactly this ("Default to `fixed` when not positioned … ensures the popup is inside the viewport initially"), but it was overridden:

```js
{ position: resolvedPosition, ...originalFloatingStyles }
```

`originalFloatingStyles` re-applies `position: absolute` plus the stale transform, so the guard never took effect.

On desktop this is a harmless invisible frame. On mobile Chrome, the popup overflowing the layout viewport triggers scale-to-fit viewport expansion — and when the anchor's width follows the viewport (a full-width trigger inside a `100vw` bottom sheet), it ratchets: viewport ↑ → sheet ↑ → `--anchor-width` ↑ → popup ↑ → more overflow. Measured `window.innerWidth` exploding 412 → **1648px** (Chrome's minimum-scale 0.25 clamp) inside a Radix-based sheet, and 412 → 718px in a pure Base UI Drawer, with the popup rendered ~230px away from its trigger. Touch-only because `openMethod === 'touch'` disables `alignItemWithTrigger`, taking the `position: absolute` path.

## Fix

While `!isPositioned`, render `position: fixed; top: 0; left: 0` and ignore retained coordinates, as the fallback originally intended. After the fix, both repros keep `innerWidth` stable at 412px and the popup lands on the anchor on every open.

## Testing

- New Chromium regression test in `SelectPositioner.test.tsx` asserting the kept-mounted positioner holds no stale coordinates while closed (fails without the fix: `position` stays `absolute` with the old transform).
- New experiment `experiments/drawer/select-in-drawer` for manual verification in Chrome mobile emulation (open the drawer, open the select, select an item, reopen).
- Verified with Playwright touch emulation (Pixel 7) against the docs app: pure Base UI Drawer (2nd open) and a Radix modal bottom sheet (1st open, trigger force-mounted by the sheet's autofocus) both no longer expand the viewport.
- `Select`/`Popover`/`Menu` jsdom + Chromium suites pass; no new TypeScript or lint errors.

App-level workaround for affected users until released: `<meta name="viewport" ... minimum-scale=1>` (Next.js: `export const viewport = { minimumScale: 1 }`).

Note: in Radix/vaul sheets there is a second, independent integration issue — Radix modal layers set `pointer-events: none` on `<body>`, which Base UI popups portaled to `<body>` inherit, making items untappable (shadcn-ui/ui#8814, shadcn-ui/ui#9130). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)