### PR TITLE
[docs] Add Chord to community libraries

### DIFF
--- a/docs/src/app/(docs)/react/overview/community/page.mdx
+++ b/docs/src/app/(docs)/react/overview/community/page.mdx
@@ -24,7 +24,7 @@ Here's a non-exhaustive list of open-source styled libraries built with Base UI
 - [ReUI](https://reui.io): a large collection of components and templates built on shadcn/ui.
 - [Fig UI](https://figui.dev): a Figma UI3 style component library for use in Figma plugins.
 - [Selia](https://selia.earth): a collection of components designed for visual cohesion.
-- [Chord](https://chord.so): an opinionated collection of copy-paste components built with Tailwind CSS.
+- [Chord](https://chord.so): opinionated, copy-and-paste components composed from Base UI primitives.
 
 ## Unofficial ports
 

--- a/docs/src/app/(docs)/react/overview/community/page.mdx
+++ b/docs/src/app/(docs)/react/overview/community/page.mdx
@@ -24,6 +24,7 @@ Here's a non-exhaustive list of open-source styled libraries built with Base UI
 - [ReUI](https://reui.io): a large collection of components and templates built on shadcn/ui.
 - [Fig UI](https://figui.dev): a Figma UI3 style component library for use in Figma plugins.
 - [Selia](https://selia.earth): a collection of components designed for visual cohesion.
+- [Chord](https://chord.so): an opinionated collection of copy-paste components built with Tailwind CSS.
 
 ## Unofficial ports
 


### PR DESCRIPTION
Adds [Chord](https://chord.so) to the styled libraries section. Chord is an open-source collection of copy-paste React components built directly on Base UI and Tailwind CSS.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).