### PR TITLE
[docs] Remove Fig UI from community page

### DIFF
--- a/docs/src/app/(docs)/react/overview/community/page.mdx
+++ b/docs/src/app/(docs)/react/overview/community/page.mdx
@@ -22,7 +22,6 @@ Here's a non-exhaustive list of open-source styled libraries built with Base UI
 - [Lumi UI](https://www.lumiui.dev): composable React components.
 - [Olyx UI](https://www.olyxui.com): composable components styled with native CSS and HCT color system.
 - [ReUI](https://reui.io): a large collection of components and templates built on shadcn/ui.
-- [Fig UI](https://figui.dev): a Figma UI3 style component library for use in Figma plugins.
 - [Selia](https://selia.earth): a collection of components designed for visual cohesion.
 
 ## Unofficial ports


### PR DESCRIPTION
## Summary

- remove Fig UI from the styled libraries list
- keep the list aligned with its stated open-source requirement

Fig UI's public repository currently has no software license, so its source cannot be freely used, modified, or redistributed under the usual definition of open source. It can be added back once the project adopts an open-source license.

## Impact

The community page no longer presents an unlicensed, source-available project as an open-source styled library.