### PR TITLE
fix(Slider): update aria-valuenow before blur/focus cycle to fix VoiceOver stale value

### DIFF
--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -420,6 +420,11 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
         if (newValue !== null) {
           const input = event.currentTarget as HTMLInputElement;
 
+          // Update aria-valuenow before the blur/focus cycle so that VoiceOver
+          // reads the new value at the blur event rather than the stale one.
+          // See: https://github.com/mui/base-ui/issues/5296
+          handleInputChange(newValue, index, event);
+
           if (!matchesFocusVisible(input)) {
             restoringFocusVisibleRef.current = true;
             input.blur();
@@ -431,7 +436,6 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
             });
           }
 
-          handleInputChange(newValue, index, event);
           event.preventDefault();
         }
       },


### PR DESCRIPTION
## Summary

Fixes #5296

When a VoiceOver user navigates to the Slider using VO cursor (Control+Option+Arrow) instead of Tab, `:focus-visible` is not set on the hidden range input. On the first keypress to change the value, the `blur()` → `focus()` cycle fires **before** `handleInputChange`, causing VoiceOver to read `aria-valuenow` at blur time — which is still the old value.

## Root cause

```ts
// Before (buggy): blur fires before value update
if (!matchesFocusVisible(input)) {
  input.blur();   // ← VoiceOver reads stale aria-valuenow here
  input.focus(…);
}
handleInputChange(newValue, index, event); // ← value updated too late
```

## Fix

Move `handleInputChange` before the blur/focus cycle so `aria-valuenow` already reflects the new value when VoiceOver reads it at the `blur` event:

```ts
// After (fixed): value updated before blur
handleInputChange(newValue, index, event); // ← aria-valuenow updated first

if (!matchesFocusVisible(input)) {
  input.blur();   // ← VoiceOver now reads the correct value
  input.focus(…);
}
```

## Reproduction steps

1. Open the Slider demo with VoiceOver enabled
2. Navigate to the slider using **Control+Option+Right/Left** (VO cursor — not Tab)
3. Enter interaction mode: **Control+Option+Shift+Down**
4. Change value: **Control+Option+Right/Left**

**Before:** VoiceOver announces the previous value (off by one)
**After:** VoiceOver announces the correct new value