### PR TITLE
[drawer] Fix snap point jump when pinned pointer moves leave the drag offset unchanged

### DIFF
--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -1640,6 +1640,97 @@ describe('<Drawer.Viewport />', () => {
     expect(backdrop).not.toHaveAttribute('data-swiping');
   });
 
+  it('keeps damped snap-point styles when a duplicate-coordinate pointermove arrives', async () => {
+    await render(
+      <Drawer.Root open snapPoints={['100px', 1]}>
+        <Drawer.Portal>
+          <Drawer.Backdrop />
+          <Drawer.Viewport data-testid="viewport">
+            <Drawer.Popup data-testid="popup">Drawer</Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>,
+    );
+
+    const viewport = screen.getByTestId('viewport');
+    const popup = screen.getByTestId('popup');
+
+    const originalElementFromPoint = document.elementFromPoint;
+    document.elementFromPoint = () => popup;
+
+    try {
+      fireEvent.pointerDown(viewport, {
+        button: 0,
+        buttons: 1,
+        pointerId: 1,
+        clientX: 0,
+        clientY: 100,
+        pointerType: 'mouse',
+      });
+
+      await flushMicrotasks();
+
+      // The first move only re-anchors the drag origin.
+      fireEvent.pointerMove(viewport, {
+        pointerId: 1,
+        buttons: 1,
+        clientX: 0,
+        clientY: 100,
+        pointerType: 'mouse',
+      });
+
+      // Drag upward past the fully-open edge; the snap-point progress handler replaces the raw
+      // frozen transform with square-root-damped movement on every processed move.
+      fireEvent.pointerMove(viewport, {
+        pointerId: 1,
+        buttons: 1,
+        clientX: 0,
+        clientY: 0,
+        pointerType: 'mouse',
+      });
+
+      await flushMicrotasks();
+
+      expect(popup.style.transform).toBe('');
+      const dampedMovementY = popup.style.getPropertyValue('--drawer-swipe-movement-y');
+      expect(dampedMovementY).toBe('-10px');
+
+      // A cursor pinned at a screen edge during an off-screen drag produces
+      // duplicate-coordinate moves. They must not reinstate the raw frozen transform, which
+      // would jump the popup to the undamped position.
+      fireEvent.pointerMove(viewport, {
+        pointerId: 1,
+        buttons: 1,
+        clientX: 0,
+        clientY: 0,
+        pointerType: 'mouse',
+      });
+
+      await flushMicrotasks();
+
+      expect(popup.style.transform).toBe('');
+      expect(popup.style.getPropertyValue('--drawer-swipe-movement-y')).toBe(dampedMovementY);
+
+      // Only vertical directions are enabled, so horizontal jitter while the vertical
+      // position is pinned leaves the drag offset unchanged. Such moves must not reinstate
+      // the raw frozen transform either.
+      fireEvent.pointerMove(viewport, {
+        pointerId: 1,
+        buttons: 1,
+        clientX: 5,
+        clientY: 0,
+        pointerType: 'mouse',
+      });
+
+      await flushMicrotasks();
+
+      expect(popup.style.transform).toBe('');
+      expect(popup.style.getPropertyValue('--drawer-swipe-movement-y')).toBe(dampedMovementY);
+    } finally {
+      document.elementFromPoint = originalElementFromPoint;
+    }
+  });
+
   it('does not start an opposite-direction swipe from scroll right edge for right drawers', async () => {
     await render(
       <Drawer.Root open swipeDirection="right">

--- a/packages/react/src/utils/useSwipeDismiss.ts
+++ b/packages/react/src/utils/useSwipeDismiss.ts
@@ -727,8 +727,20 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
       }
     }
 
+    // Only rewrite drag styles when the drag offset actually changed. `syncDragStyles` writes the
+    // raw (undamped) frozen transform and movement vars, relying on the consumer's `onProgress`
+    // to overwrite them with damped styles — but `updateSwipeProgress` dedupes unchanged
+    // deltas and skips `onProgress`. A move that doesn't change the offset (e.g. the cursor
+    // pinned at a screen edge during an off-screen drag, jittering only on the ignored axis)
+    // would otherwise reinstate the raw styles with no correction, jumping the element to the
+    // undamped position.
+    const previousOffset = dragOffsetRef.current;
+    const offsetChanged = newOffsetX !== previousOffset.x || newOffsetY !== previousOffset.y;
+
     dragOffsetRef.current = { x: newOffsetX, y: newOffsetY };
-    syncDragStyles(true);
+    if (offsetChanged) {
+      syncDragStyles(true);
+    }
     recordDragSample({ x: newOffsetX, y: newOffsetY }, getValidTimeStamp(event.timeStamp));
     const dragDeltaX = newOffsetX - initialTransformRef.current.x;
     const dragDeltaY = newOffsetY - initialTransformRef.current.y;


### PR DESCRIPTION
When a snap-point drawer is over-dragged past the fully-open edge and the cursor pins at the screen edge (an off-screen mouse drag), pointer moves keep arriving that don't change the drag offset — exact duplicates, or jitter on the horizontal axis that vertical-only drawers ignore. `handleMoveCore` rewrote the raw (undamped) frozen transform and movement vars via `syncDragStyles` on every move, relying on the drawer's `onProgress` to overwrite them with the square-root-damped styles — but `updateSwipeProgress` dedupes unchanged deltas and skips `onProgress` for exactly those moves. The raw styles then stuck, randomly jumping the popup to the undamped position and revealing the page below its bottom edge.

The fix gates `syncDragStyles` on the drag offset actually changing: a move that doesn't change the offset has nothing new to write, so the damped styles from the last processed move stay in place. Velocity sampling still runs on every move so release velocity decays correctly while the pointer is pinned.

https://deploy-preview-5308--base-ui.netlify.app/react/components/drawer#snap-points - drag the drawer with a pointer way offscreen at the top. On 1.6.0/master it jumps/glitches, now it does not.