### PR TITLE
[popups] Mount the popup subtree synchronously on open in React 17

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
@@ -2,7 +2,7 @@ import { expect } from 'vitest';
 import * as React from 'react';
 import { fireEvent, flushMicrotasks, render, screen } from '@mui/internal-test-utils';
 import { isJSDOM } from '#test-utils';
-import { FloatingPortal, useFloating } from '../index';
+import { FloatingFocusManager, FloatingPortal, useFloating } from '../index';
 import { FloatingPortalLite } from '../../utils/FloatingPortalLite';
 import type { UseFloatingPortalNodeProps } from './FloatingPortal';
 
@@ -136,6 +136,25 @@ describe.skipIf(!isJSDOM)('FloatingPortal', () => {
     expect(portal).not.toBeNull();
     expect(portal).toHaveClass('closed');
     expect(portal).toHaveAttribute('data-base-ui-portal');
+  });
+
+  test('uses the rendered portal ID for the aria-owns relationship', async () => {
+    function Test() {
+      const { context, refs } = useFloating({ open: true });
+
+      return (
+        <FloatingPortal id="custom-portal">
+          <FloatingFocusManager context={context} modal={false}>
+            <div ref={refs.setFloating} />
+          </FloatingFocusManager>
+        </FloatingPortal>
+      );
+    }
+
+    render(<Test />);
+    await flushMicrotasks();
+
+    expect(document.querySelector('[aria-owns]')).toHaveAttribute('aria-owns', 'custom-portal');
   });
 
   test('FloatingPortalLite forwards HTML props to the portal element', async () => {

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -148,7 +148,9 @@ export function useFloatingPortalNode(
 
   return {
     portalNode,
-    portalNodeId: uniqueId,
+    // `id` and `render` props can override or remove the generated ID. Use the exact
+    // rendered value so `aria-owns` never points at an ID absent from the DOM.
+    portalNodeId: (portalElement as React.ReactElement<{ id?: string | undefined }>).props.id,
     portalSubtree,
   };
 }

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -64,6 +64,11 @@ export interface UseFloatingPortalNodeProps {
 
 export interface UseFloatingPortalNodeResult {
   portalNode: HTMLElement | null;
+  /**
+   * The `id` attribute of the portal node. On React 17 it is `undefined` until the `useId`
+   * polyfill assigns it in an effect after the node has been created.
+   */
+  portalNodeId: string | undefined;
   portalSubtree: React.ReactPortal | null;
 }
 
@@ -102,11 +107,6 @@ export function useFloatingPortalNode(
       return;
     }
 
-    // React 17 does not use React.useId().
-    if (uniqueId == null) {
-      return;
-    }
-
     const resolvedContainer =
       (containerProp && (isNode(containerProp) ? containerProp : containerProp.current)) ??
       parentPortalNode ??
@@ -126,7 +126,7 @@ export function useFloatingPortalNode(
       setPortalNode(null);
       setContainerElement(resolvedContainer);
     }
-  }, [containerProp, parentPortalNode, uniqueId]);
+  }, [containerProp, parentPortalNode]);
 
   const portalElement = useRenderElement('div', componentProps, {
     ref: [ref, setPortalNodeRef],
@@ -148,6 +148,7 @@ export function useFloatingPortalNode(
 
   return {
     portalNode,
+    portalNodeId: uniqueId,
     portalSubtree,
   };
 }
@@ -167,7 +168,7 @@ export const FloatingPortal = React.forwardRef(function FloatingPortal(
 ) {
   const { render, className, style, children, container, ...elementProps } = componentProps;
 
-  const { portalNode, portalSubtree } = useFloatingPortalNode({
+  const { portalNode, portalNodeId, portalSubtree } = useFloatingPortalNode({
     container,
     ref: forwardedRef,
     componentProps,
@@ -261,7 +262,7 @@ export const FloatingPortal = React.forwardRef(function FloatingPortal(
           />
         )}
         {shouldRenderGuards && portalNode && (
-          <span aria-owns={portalNode.id} style={ownerVisuallyHidden} />
+          <span aria-owns={portalNodeId} style={ownerVisuallyHidden} />
         )}
         {portalNode && ReactDOM.createPortal(children, portalNode)}
         {shouldRenderGuards && portalNode && (

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -63,13 +63,13 @@ export interface UseFloatingPortalNodeProps {
 }
 
 export interface UseFloatingPortalNodeResult {
-  portalNode: HTMLElement | null;
+  node: HTMLElement | null;
   /**
    * The `id` attribute of the portal node. On React 17 it is `undefined` until the `useId`
    * polyfill assigns it in an effect after the node has been created.
    */
-  portalNodeId: string | undefined;
-  portalSubtree: React.ReactPortal | null;
+  nodeId: string | undefined;
+  subtree: React.ReactPortal | null;
 }
 
 export function useFloatingPortalNode(
@@ -147,13 +147,13 @@ export function useFloatingPortalNode(
       : null;
 
   return {
-    portalNode,
+    node: portalNode,
     // `id` and `render` props can override or remove the generated ID. Use the exact
     // rendered value so `aria-owns` never points at an ID absent from the DOM.
-    portalNodeId: React.isValidElement<{ id?: string | undefined }>(portalElement)
+    nodeId: React.isValidElement<{ id?: string | undefined }>(portalElement)
       ? portalElement.props.id
       : undefined,
-    portalSubtree,
+    subtree: portalSubtree,
   };
 }
 
@@ -172,7 +172,11 @@ export const FloatingPortal = React.forwardRef(function FloatingPortal(
 ) {
   const { render, className, style, children, container, ...elementProps } = componentProps;
 
-  const { portalNode, portalNodeId, portalSubtree } = useFloatingPortalNode({
+  const {
+    node: portalNode,
+    nodeId: portalNodeId,
+    subtree: portalSubtree,
+  } = useFloatingPortalNode({
     container,
     ref: forwardedRef,
     componentProps,

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.tsx
@@ -150,7 +150,9 @@ export function useFloatingPortalNode(
     portalNode,
     // `id` and `render` props can override or remove the generated ID. Use the exact
     // rendered value so `aria-owns` never points at an ID absent from the DOM.
-    portalNodeId: (portalElement as React.ReactElement<{ id?: string | undefined }>).props.id,
+    portalNodeId: React.isValidElement<{ id?: string | undefined }>(portalElement)
+      ? portalElement.props.id
+      : undefined,
     portalSubtree,
   };
 }

--- a/packages/react/src/utils/FloatingPortalLite.tsx
+++ b/packages/react/src/utils/FloatingPortalLite.tsx
@@ -21,7 +21,7 @@ export const FloatingPortalLite = React.forwardRef(function FloatingPortalLite(
 ) {
   const { children, container, className, render, style, ...elementProps } = componentProps;
 
-  const { portalNode, portalSubtree } = useFloatingPortalNode({
+  const { node: portalNode, subtree: portalSubtree } = useFloatingPortalNode({
     container,
     ref: forwardedRef,
     componentProps,


### PR DESCRIPTION
In React 17, opening a popup for the first time skips the `.Popup` enter transition (`data-starting-style` is missing at mount) and lets the `.Positioner` slide in from the viewport origin. The subtree only misbehaves on the first open after mount; reopening works.

The root cause is in `useFloatingPortalNode`: it waits for `useId` before resolving the portal container. On React 17 the `useId` polyfill assigns the id in a passive effect, and after a discrete input Chromium can paint before that flush runs, so the entire popup subtree mounts one task late — after the one-frame `starting` guard has already ended. (Reopening works because scheduling new React work force-flushes the pending passive effects synchronously.) The wait dates back to floating-ui/floating-ui#2778, when portal nodes were created imperatively and needed the id upfront to dedupe; the portal element is rendered by React now, so the guard is obsolete. Removing it lets the subtree mount within the opening task, and the portal div's `id` attribute simply fills in once the polyfill resolves. `aria-owns` now reads the id from React state instead of the DOM node so it stays in sync on React 17.

Verified with a React 17.0.2 Chromium repro (first and subsequent opens mount with `data-starting-style` and run the enter transition) and with the full popup-family suites on React 19. Note that the positioner's initial position can still race the `starting` guard on React 17 in unlucky frames — consumers who transition `transform` on the Positioner should scope it away from the initial open; the deterministic fix for that requires store-subscription changes that aren't worth the bytes for React 17's share.

Demo: https://stackblitz.com/edit/jpqdbqiv-tyrzftjr

Closes #5187

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
