### PR TITLE
[toast] Add group option for stacking toasts in multiple positions

### DIFF
--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -1753,6 +1753,7 @@ Generates toast notifications.
   - Examples
     - Anchored toasts
     - Custom position
+    - Multiple positions
     - Undo action
     - Promise
     - Custom
@@ -1779,7 +1780,7 @@ Generates toast notifications.
 - Exports:
   - Toast - Root
     - Props: className, render, style, swipeDirection, toast
-    - Data Attributes: data-ending-style, data-expanded, data-limited, data-starting-style, data-swipe-direction, data-swiping, data-type
+    - Data Attributes: data-ending-style, data-expanded, data-group, data-limited, data-starting-style, data-swipe-direction, data-swiping, data-type
     - CSS Variables: --toast-height, --toast-index, --toast-offset-y, --toast-swipe-movement-x, --toast-swipe-movement-y
   - Toast - Provider
     - Props: children, limit, timeout, toastManager

--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -220,12 +220,62 @@ import { DemoToastAnchored } from './demos/anchored';
 
 The position of the toasts is controlled by your own CSS.
 To change the toasts' position, you can modify the `.Viewport` and `.Root` styles.
-A more general component could accept a `data-position` attribute, which the CSS handles for each variation.
 The following shows a top-center position:
 
 import { DemoToastPosition } from './demos/position';
 
 <DemoToastPosition />
+
+### Multiple positions
+
+To render independently stacked toasts in multiple screen positions, assign each toast to a `group`.
+Toasts with the same group share stacking indices and offsets, and `<Toast.Root>` exposes the group as a `data-group` attribute for positioning with CSS.
+Toasts without a group share the default stack.
+
+```tsx title="Adding grouped toasts"
+toastManager.add({
+  title: 'Settings saved',
+  group: 'top-right',
+});
+
+toastManager.add({
+  title: 'Message sent',
+  group: 'bottom-left',
+});
+```
+
+Render every group in the same provider and viewport:
+
+```tsx title="Rendering grouped toasts"
+function Toasts() {
+  const { toasts } = Toast.useToastManager();
+
+  return toasts.map((toast) => (
+    <Toast.Root key={toast.id} toast={toast} className="Toast">
+      {/* ... */}
+    </Toast.Root>
+  ));
+}
+```
+
+```css title="Positioning grouped toasts"
+.Toast {
+  position: absolute;
+}
+
+.Toast[data-group='top-right'] {
+  top: 0;
+  right: 0;
+}
+
+.Toast[data-group='bottom-left'] {
+  bottom: 0;
+  left: 0;
+}
+```
+
+The provider's `limit` applies independently to each group.
+Hover or focus expansion and timeout pausing remain shared by all groups in the viewport.
 
 ### Undo action
 

--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -275,6 +275,7 @@ function Toasts() {
 ```
 
 The provider's `limit` applies independently to each group.
+Each `<Toast.Root>` also sets the `--toast-frontmost-height` CSS variable to the height of its own group's frontmost toast, so styles that size collapsed toasts with it collapse each group independently.
 Hover or focus expansion and timeout pausing remain shared by all groups in the viewport.
 
 ### Undo action

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -24,6 +24,7 @@ Renders a `<div>` element.
 | Attribute            | Type                                  | Description                                                              |
 | :------------------- | :------------------------------------ | :----------------------------------------------------------------------- |
 | data-expanded        | `boolean`                             | Present when the toast is expanded in the viewport.                      |
+| data-group           | `string`                              | The named stack the toast belongs to.                                    |
 | data-limited         | `boolean`                             | Present when the toast was limited because the toast limit was exceeded. |
 | data-swipe-direction | `'up' \| 'down' \| 'left' \| 'right'` | The direction the toast was swiped.                                      |
 | data-swiping         | `boolean`                             | Present when the toast is being swiped.                                  |
@@ -57,6 +58,8 @@ type ToastRootState = {
   limited: boolean;
   /** The type of the toast. */
   type: string | undefined;
+  /** The named stack the toast belongs to. */
+  group: string | undefined;
   /** Whether the toast is being swiped. */
   swiping: boolean;
   /** The direction the toast is being swiped. */
@@ -94,6 +97,14 @@ type ToastRootToastObject<Data extends {} = any> = {
    * @default 'low'
    */
   priority?: 'low' | 'high';
+  /**
+   * The named stack the toast belongs to. Toasts with the same group stack
+   * together: stacking indices and offsets are computed per group, letting a
+   * single provider render toasts in multiple screen positions within one
+   * viewport. The value is exposed as the `data-group` attribute on
+   * `Toast.Root` for anchoring each stack with CSS.
+   */
+  group?: string;
   /** The transition status of the toast. */
   transitionStatus?: 'starting' | 'ending';
   /** A counter that increments whenever the toast is updated or upserted. */
@@ -124,12 +135,12 @@ Provides a context for creating and managing toasts.
 
 **Provider Props:**
 
-| Prop         | Type              | Default | Description                                                                                                                                                                                                                              |
-| :----------- | :---------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| limit        | `number`          | `3`     | The maximum number of toasts that can be displayed at once.&#xA;When the limit is exceeded, the oldest toasts are marked as `limited` (via the `data-limited`&#xA;attribute) rather than removed, so they can be hidden or animated out. |
-| toastManager | `ToastManager`    | -       | A global manager for toasts to use outside of a React component.                                                                                                                                                                         |
-| timeout      | `number`          | `5000`  | The default amount of time (in ms) before a toast is auto dismissed.&#xA;A value of `0` will prevent the toast from being dismissed automatically.                                                                                       |
-| children     | `React.ReactNode` | -       | -                                                                                                                                                                                                                                        |
+| Prop         | Type              | Default | Description                                                                                                                                                                                                                                                                                           |
+| :----------- | :---------------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| limit        | `number`          | `3`     | The maximum number of toasts that can be displayed at once in each group&#xA;(toasts without a `group` share one stack).&#xA;When the limit is exceeded, the oldest toasts are marked as `limited` (via the `data-limited`&#xA;attribute) rather than removed, so they can be hidden or animated out. |
+| toastManager | `ToastManager`    | -       | A global manager for toasts to use outside of a React component.                                                                                                                                                                                                                                      |
+| timeout      | `number`          | `5000`  | The default amount of time (in ms) before a toast is auto dismissed.&#xA;A value of `0` will prevent the toast from being dismissed automatically.                                                                                                                                                    |
+| children     | `React.ReactNode` | -       | -                                                                                                                                                                                                                                                                                                     |
 
 ### Provider.Props
 
@@ -553,6 +564,14 @@ type ToastObject<Data extends {}> = {
    * @default 'low'
    */
   priority?: 'low' | 'high';
+  /**
+   * The named stack the toast belongs to. Toasts with the same group stack
+   * together: stacking indices and offsets are computed per group, letting a
+   * single provider render toasts in multiple screen positions within one
+   * viewport. The value is exposed as the `data-group` attribute on
+   * `Toast.Root` for anchoring each stack with CSS.
+   */
+  group?: string;
   /** The transition status of the toast. */
   transitionStatus?: 'starting' | 'ending';
   /** A counter that increments whenever the toast is updated or upserted. */
@@ -623,6 +642,14 @@ type ToastManagerAddOptions<Data extends {}> = {
    * @default 'low'
    */
   priority?: 'low' | 'high';
+  /**
+   * The named stack the toast belongs to. Toasts with the same group stack
+   * together: stacking indices and offsets are computed per group, letting a
+   * single provider render toasts in multiple screen positions within one
+   * viewport. The value is exposed as the `data-group` attribute on
+   * `Toast.Root` for anchoring each stack with CSS.
+   */
+  group?: string;
   /** The transition status of the toast. */
   transitionStatus?: 'starting' | 'ending';
   /** Callback function to be called when the toast is closed. */
@@ -845,6 +872,14 @@ type ToastManagerUpdateOptions<Data extends {}> = {
    * @default 'low'
    */
   priority?: 'low' | 'high';
+  /**
+   * The named stack the toast belongs to. Toasts with the same group stack
+   * together: stacking indices and offsets are computed per group, letting a
+   * single provider render toasts in multiple screen positions within one
+   * viewport. The value is exposed as the `data-group` attribute on
+   * `Toast.Root` for anchoring each stack with CSS.
+   */
+  group?: string;
   /** Callback function to be called when the toast is closed. */
   onClose?: () => void;
   /** Callback function to be called when the toast is removed from the list after any animations are complete when closed. */

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -495,9 +495,9 @@ Renders a `<div>` element.
 
 **Viewport CSS Variables:**
 
-| Variable                   | Type     | Description                                  |
-| :------------------------- | :------- | :------------------------------------------- |
-| `--toast-frontmost-height` | `number` | Indicates the height of the frontmost toast. |
+| Variable                   | Type     | Description                                                                                                                               |
+| :------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--toast-frontmost-height` | `number` | Indicates the height of the frontmost toast.&#xA;Each `Toast.Root` shadows this value with the height of its own group's frontmost toast. |
 
 ### Viewport.Props
 

--- a/docs/src/app/(private)/experiments/toast-positions.module.css
+++ b/docs/src/app/(private)/experiments/toast-positions.module.css
@@ -1,0 +1,192 @@
+.viewport {
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.root {
+  --dir: -1;
+  --gap: 0.75rem;
+  --peek: 0.75rem;
+  --scale: calc(max(0, 1 - (var(--toast-index) * 0.1)));
+  --shrink: calc(1 - var(--scale));
+  --height: var(--toast-frontmost-height, var(--toast-height));
+  --offset-y: calc(
+    (var(--toast-offset-y) + (var(--toast-index) * var(--gap))) * var(--dir) +
+      var(--toast-swipe-movement-y)
+  );
+  position: absolute;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  box-sizing: border-box;
+  width: 20rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+  transform-origin: bottom center;
+  pointer-events: auto;
+  -webkit-user-select: none;
+  user-select: none;
+  transition:
+    transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.5s,
+    height 0.15s;
+  cursor: default;
+  z-index: calc(1000 - var(--toast-index));
+  height: var(--height);
+  transform: translateX(var(--toast-swipe-movement-x))
+    translateY(
+      calc(
+        var(--toast-swipe-movement-y) +
+          ((var(--toast-index) * var(--peek)) + (var(--shrink) * var(--height))) * var(--dir)
+      )
+    )
+    scale(var(--scale));
+
+  @media (prefers-color-scheme: dark) {
+    border: 1px solid white;
+    background-color: oklch(14.5% 0 0deg);
+    color: white;
+    box-shadow: none;
+  }
+
+  &[data-expanded] {
+    transform: translateX(var(--toast-swipe-movement-x)) translateY(var(--offset-y));
+    height: var(--toast-height);
+  }
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    transform: translateY(calc(var(--dir) * -150%));
+  }
+
+  &[data-limited] {
+    opacity: 0;
+  }
+
+  &[data-ending-style] {
+    opacity: 0;
+
+    &[data-swipe-direction='up'] {
+      transform: translateY(calc(var(--toast-swipe-movement-y) - 150%));
+    }
+    &[data-swipe-direction='left'] {
+      transform: translateX(calc(var(--toast-swipe-movement-x) - 150%)) translateY(var(--offset-y));
+    }
+    &[data-swipe-direction='right'] {
+      transform: translateX(calc(var(--toast-swipe-movement-x) + 150%)) translateY(var(--offset-y));
+    }
+    &[data-swipe-direction='down'] {
+      transform: translateY(calc(var(--toast-swipe-movement-y) + 150%));
+    }
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    width: 100%;
+    left: 0;
+    height: calc(var(--gap) + 1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid oklch(14.5% 0 0deg);
+    outline-offset: -1px;
+
+    @media (prefers-color-scheme: dark) {
+      outline-color: white;
+    }
+  }
+}
+
+.root[data-group='bottom-left'] {
+  right: auto;
+  left: 1.5rem;
+}
+
+.root[data-group='top-right'] {
+  --dir: 1;
+  bottom: auto;
+  top: 1.5rem;
+  transform-origin: top center;
+
+  &::after {
+    top: auto;
+    bottom: 100%;
+  }
+}
+
+.content {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  height: 100%;
+  padding: 0.75rem;
+  overflow: hidden;
+  transition: opacity 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+
+  &[data-behind] {
+    opacity: 0;
+  }
+
+  &[data-expanded] {
+    opacity: 1;
+  }
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.title {
+  font-weight: 700;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  margin: 0;
+}
+
+.description {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  margin: 0;
+}
+
+.close,
+.button {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  height: 2rem;
+  padding: 0 0.75rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 0;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1;
+  white-space: nowrap;
+
+  @media (prefers-color-scheme: dark) {
+    border: 1px solid white;
+    background-color: oklch(14.5% 0 0deg);
+    color: white;
+  }
+}
+
+.buttons {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 2rem;
+}

--- a/docs/src/app/(private)/experiments/toast-positions.tsx
+++ b/docs/src/app/(private)/experiments/toast-positions.tsx
@@ -1,0 +1,82 @@
+'use client';
+import * as React from 'react';
+import { Toast } from '@base-ui/react/toast';
+import styles from './toast-positions.module.css';
+
+const SWIPE_DIRECTIONS: Record<string, ('up' | 'down' | 'left' | 'right')[]> = {
+  'top-right': ['up', 'right'],
+  'bottom-right': ['down', 'right'],
+  'bottom-left': ['down', 'left'],
+};
+
+const POSITIONS = Object.keys(SWIPE_DIRECTIONS);
+
+export default function Page() {
+  return (
+    <Toast.Provider>
+      <Toast.Viewport className={styles.viewport}>
+        <Toasts />
+      </Toast.Viewport>
+      <Buttons />
+    </Toast.Provider>
+  );
+}
+
+function Buttons() {
+  const toastManager = Toast.useToastManager();
+  const countRef = React.useRef(0);
+
+  function add(group: string) {
+    countRef.current += 1;
+    toastManager.add({
+      group,
+      title: `Toast ${countRef.current}`,
+      description: `Anchored to ${group}`,
+    });
+  }
+
+  return (
+    <div className={styles.buttons}>
+      <h1>Toast: multiple positions, one provider, one viewport</h1>
+      {POSITIONS.map((position) => (
+        <button
+          key={position}
+          className={styles.button}
+          type="button"
+          onClick={() => add(position)}
+        >
+          Add toast at {position}
+        </button>
+      ))}
+      <button
+        className={styles.button}
+        type="button"
+        onClick={() => add(POSITIONS[Math.floor(Math.random() * POSITIONS.length)])}
+      >
+        Add toast at random position
+      </button>
+    </div>
+  );
+}
+
+function Toasts() {
+  const { toasts } = Toast.useToastManager();
+  return toasts.map((toast) => (
+    <Toast.Root
+      key={toast.id}
+      toast={toast}
+      className={styles.root}
+      swipeDirection={SWIPE_DIRECTIONS[toast.group ?? 'bottom-right']}
+    >
+      <Toast.Content className={styles.content}>
+        <div className={styles.text}>
+          <Toast.Title className={styles.title} />
+          <Toast.Description className={styles.description} />
+        </div>
+        <Toast.Close className={styles.close} aria-label="Close">
+          ×
+        </Toast.Close>
+      </Toast.Content>
+    </Toast.Root>
+  ));
+}

--- a/packages/react/src/toast/enumSync.test.tsx
+++ b/packages/react/src/toast/enumSync.test.tsx
@@ -26,6 +26,11 @@ describe('Toast enum sync', () => {
     expect(Object.keys(emitted!)[0]).toBe(ToastRootDataAttributes.swipeDirection);
   });
 
+  it('names the group attribute per ToastRootDataAttributes', () => {
+    const emitted = toastRootStateAttributesMapping.group!('top-right');
+    expect(Object.keys(emitted!)[0]).toBe(ToastRootDataAttributes.group);
+  });
+
   it('names the root CSS variables per ToastRootCssVars', async () => {
     const { user } = await render(
       <Toast.Provider>

--- a/packages/react/src/toast/enumSync.test.tsx
+++ b/packages/react/src/toast/enumSync.test.tsx
@@ -91,6 +91,13 @@ describe('Toast enum sync', () => {
             .style.getPropertyValue(ToastViewportCssVars.frontmostHeight),
         ).not.toBe(''),
       );
+
+      // The root shadows the viewport variable with its group-local value,
+      // which for a single toast is its own measured height.
+      const root = screen.getByTestId('root');
+      expect(root.style.getPropertyValue(ToastViewportCssVars.frontmostHeight)).toBe(
+        root.style.getPropertyValue(ToastRootCssVars.height),
+      );
     },
   );
 });

--- a/packages/react/src/toast/positioner/ToastPositioner.tsx
+++ b/packages/react/src/toast/positioner/ToastPositioner.tsx
@@ -56,7 +56,7 @@ export const ToastPositioner = React.forwardRef(function ToastPositioner(
 
   const [positionerElement, setPositionerElement] = React.useState<HTMLDivElement | null>(null);
 
-  const domIndex = store.useState('toastIndex', toast.id);
+  const stackIndex = store.useState('toastStackIndex', toast.id);
   const visibleIndex = store.useState('toastVisibleIndex', toast.id);
 
   const anchor = isElement(anchorProp) ? anchorProp : null;
@@ -97,7 +97,7 @@ export const ToastPositioner = React.forwardRef(function ToastPositioner(
   const element = usePositioner(componentProps, state, {
     styles: {
       ...positioning.positionerStyles,
-      ['--toast-index' as string]: toast.transitionStatus === 'ending' ? domIndex : visibleIndex,
+      ['--toast-index' as string]: toast.transitionStatus === 'ending' ? stackIndex : visibleIndex,
     },
     transitionStatus: toast.transitionStatus,
     props: elementProps,

--- a/packages/react/src/toast/provider/ToastProvider.tsx
+++ b/packages/react/src/toast/provider/ToastProvider.tsx
@@ -76,7 +76,8 @@ export interface ToastProviderProps {
    */
   timeout?: number | undefined;
   /**
-   * The maximum number of toasts that can be displayed at once.
+   * The maximum number of toasts that can be displayed at once in each group
+   * (toasts without a `group` share one stack).
    * When the limit is exceeded, the oldest toasts are marked as `limited` (via the `data-limited`
    * attribute) rather than removed, so they can be hidden or animated out.
    * @default 3

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -87,6 +87,55 @@ describe('<Toast.Root />', () => {
     },
   }));
 
+  it('exposes the group and computes stacking indices per group', async () => {
+    function AddButtons() {
+      const { add } = Toast.useToastManager();
+      return (
+        <React.Fragment>
+          <button type="button" onClick={() => add({ title: 'top toast', group: 'top' })}>
+            add top
+          </button>
+          <button type="button" onClick={() => add({ title: 'bottom toast' })}>
+            add bottom
+          </button>
+        </React.Fragment>
+      );
+    }
+
+    function GroupList() {
+      return Toast.useToastManager().toasts.map((toastItem) => (
+        <Toast.Root key={toastItem.id} toast={toastItem} data-testid={toastItem.group ?? 'default'}>
+          <Toast.Title />
+        </Toast.Root>
+      ));
+    }
+
+    const { user } = await render(
+      <Toast.Provider>
+        <Toast.Viewport>
+          <GroupList />
+        </Toast.Viewport>
+        <AddButtons />
+      </Toast.Provider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'add top' }));
+    await user.click(screen.getByRole('button', { name: 'add top' }));
+    await user.click(screen.getByRole('button', { name: 'add bottom' }));
+
+    const [newestTop, oldestTop] = screen.getAllByTestId('top');
+    const defaultToast = screen.getByTestId('default');
+
+    expect(newestTop).toHaveAttribute('data-group', 'top');
+    expect(oldestTop).toHaveAttribute('data-group', 'top');
+    expect(defaultToast).not.toHaveAttribute('data-group');
+
+    // Each group stacks independently: both frontmost toasts have index 0.
+    expect(newestTop.style.getPropertyValue('--toast-index')).toBe('0');
+    expect(oldestTop.style.getPropertyValue('--toast-index')).toBe('1');
+    expect(defaultToast.style.getPropertyValue('--toast-index')).toBe('0');
+  });
+
   it('keeps dynamic title and description ids synchronized with mounted label parts', async () => {
     function App() {
       const [mode, setMode] = React.useState<'fallback' | 'explicit' | 'none' | 'restored'>(

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -27,6 +27,9 @@ export const toastRootStateAttributesMapping: StateAttributesMapping<ToastRootSt
   swipeDirection(value) {
     return value ? { 'data-swipe-direction': value } : null;
   },
+  group(value) {
+    return value ? { 'data-group': value } : null;
+  },
 };
 
 const SWIPE_THRESHOLD = 40;
@@ -93,9 +96,10 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
   const activePointerIdRef = React.useRef<number | null>(null);
   const dragAbortControllerRef = React.useRef<AbortController | null>(null);
 
-  const domIndex = store.useState('toastIndex', toast.id);
+  const stackIndex = store.useState('toastStackIndex', toast.id);
   const visibleIndex = store.useState('toastVisibleIndex', toast.id);
   const offsetY = store.useState('toastOffsetY', toast.id);
+  const frontmostHeight = store.useState('toastFrontmostHeight', toast.id);
   const focused = store.useState('focused');
   const expanded = store.useState('expanded');
 
@@ -471,9 +475,14 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     inert: inertValue(toast.limited),
     style: {
       ...getDragStyles(),
-      ['--toast-index' as string]: toast.transitionStatus === 'ending' ? domIndex : visibleIndex,
+      ['--toast-index' as string]: toast.transitionStatus === 'ending' ? stackIndex : visibleIndex,
       ['--toast-offset-y' as string]: `${offsetY}px`,
       ['--toast-height' as string]: toast.height ? `${toast.height}px` : undefined,
+      // Shadows the viewport-level variable so each group collapses to the
+      // height of its own frontmost toast. `initial` (rather than omitting the
+      // variable) keeps a group without a measured height from inheriting
+      // another group's value through the viewport.
+      ['--toast-frontmost-height' as string]: frontmostHeight ? `${frontmostHeight}px` : 'initial',
     },
   };
 
@@ -494,6 +503,7 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
     expanded,
     limited: toast.limited || false,
     type: toast.type,
+    group: toast.group,
     swiping: isSwiping,
     swipeDirection: currentSwipeDirection,
   };
@@ -527,6 +537,10 @@ export interface ToastRootState {
    * The type of the toast.
    */
   type: string | undefined;
+  /**
+   * The named stack the toast belongs to.
+   */
+  group: string | undefined;
   /**
    * Whether the toast is being swiped.
    */

--- a/packages/react/src/toast/root/ToastRootDataAttributes.ts
+++ b/packages/react/src/toast/root/ToastRootDataAttributes.ts
@@ -17,6 +17,11 @@ export enum ToastRootDataAttributes {
    */
   type = 'data-type',
   /**
+   * The named stack the toast belongs to.
+   * @type {string}
+   */
+  group = 'data-group',
+  /**
    * Present when the toast is being swiped.
    * @type {boolean}
    */

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -64,6 +64,92 @@ describe('ToastStore', () => {
     expectToastMetadataToMatchToasts(store);
   });
 
+  it('computes stacking metadata per group', () => {
+    // Ordered newest-first, matching how `addToast` prepends. Two toasts in the
+    // `top` group interleaved with two in the default (unnamed) group.
+    const store = createStore([
+      { id: 'd', height: 10, group: 'top' },
+      { id: 'c', height: 20 },
+      { id: 'b', height: 30, group: 'top' },
+      { id: 'a', height: 40 },
+    ]);
+
+    // The default group ignores the `top` toasts entirely.
+    expect(selectors.toastVisibleIndex(store.state, 'c')).toBe(0);
+    expect(selectors.toastVisibleIndex(store.state, 'a')).toBe(1);
+    expect(selectors.toastOffsetY(store.state, 'c')).toBe(0);
+    expect(selectors.toastOffsetY(store.state, 'a')).toBe(20);
+    expect(selectors.toastFrontmostHeight(store.state, 'a')).toBe(20);
+
+    // ...and vice versa.
+    expect(selectors.toastVisibleIndex(store.state, 'd')).toBe(0);
+    expect(selectors.toastVisibleIndex(store.state, 'b')).toBe(1);
+    expect(selectors.toastOffsetY(store.state, 'd')).toBe(0);
+    expect(selectors.toastOffsetY(store.state, 'b')).toBe(10);
+    expect(selectors.toastFrontmostHeight(store.state, 'b')).toBe(10);
+
+    // DOM indices stay global; stack indices are per group.
+    expect(selectors.toastIndex(store.state, 'b')).toBe(2);
+    expect(selectors.toastStackIndex(store.state, 'b')).toBe(1);
+    expect(selectors.toastIndex(store.state, 'a')).toBe(3);
+    expect(selectors.toastStackIndex(store.state, 'a')).toBe(1);
+
+    // An ending toast keeps holding space in its own group only.
+    store.closeToast('d');
+    expect(selectors.toastVisibleIndex(store.state, 'd')).toBe(-1);
+    expect(selectors.toastVisibleIndex(store.state, 'b')).toBe(0);
+    expect(selectors.toastVisibleIndex(store.state, 'c')).toBe(0);
+    expect(selectors.toastVisibleIndex(store.state, 'a')).toBe(1);
+  });
+
+  it('measures the frontmost height from the newest toast that is not ending', () => {
+    const store = createStore([
+      { id: 'b', height: 10, group: 'top' },
+      { id: 'a', height: 30, group: 'top' },
+    ]);
+
+    // Closing the frontmost toast zeroes its height; the toast behind it is now
+    // the one collapsed stacks should size against.
+    store.closeToast('b');
+    expect(selectors.toastFrontmostHeight(store.state, 'a')).toBe(30);
+    expect(selectors.toastFrontmostHeight(store.state, 'b')).toBe(30);
+  });
+
+  it('applies the limit per group', () => {
+    const store = createStore([
+      { id: 'f', group: 'top' },
+      { id: 'e' },
+      { id: 'd', group: 'top' },
+      { id: 'c' },
+      { id: 'b', group: 'top' },
+      { id: 'a' },
+    ]);
+
+    store.syncProviderProps(0, 2);
+    expect(selectors.toast(store.state, 'f')?.limited).toBe(false);
+    expect(selectors.toast(store.state, 'd')?.limited).toBe(false);
+    expect(selectors.toast(store.state, 'b')?.limited).toBe(true);
+    expect(selectors.toast(store.state, 'e')?.limited).toBe(false);
+    expect(selectors.toast(store.state, 'c')?.limited).toBe(false);
+    expect(selectors.toast(store.state, 'a')?.limited).toBe(true);
+  });
+
+  it('recomputes limited flags when a toast moves between groups', () => {
+    const store = createStore([{ id: 'b', group: 'top' }, { id: 'a' }]);
+    store.syncProviderProps(0, 1);
+    expect(selectors.toast(store.state, 'b')?.limited).toBe(false);
+    expect(selectors.toast(store.state, 'a')?.limited).toBe(false);
+
+    // Moving `b` into the default group exceeds its limit of 1.
+    store.updateToast('b', { group: undefined });
+    expect(selectors.toast(store.state, 'b')?.limited).toBe(false);
+    expect(selectors.toast(store.state, 'a')?.limited).toBe(true);
+
+    // Moving it back frees the slot again.
+    store.updateToast('b', { group: 'top' });
+    expect(selectors.toast(store.state, 'a')?.limited).toBe(false);
+  });
+
   it('ignores height recalculations while a toast is transitioning out', () => {
     const store = createStore([{ id: 'a', height: 40 }]);
 

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -109,10 +109,25 @@ describe('ToastStore', () => {
     ]);
 
     // Closing the frontmost toast zeroes its height; the toast behind it is now
-    // the one collapsed stacks should size against.
+    // the one collapsed stacks should size against. The ending toast itself
+    // sees its own zeroed height so it exits at its natural height instead of
+    // resizing to the next toast's.
     store.closeToast('b');
     expect(selectors.toastFrontmostHeight(store.state, 'a')).toBe(30);
-    expect(selectors.toastFrontmostHeight(store.state, 'b')).toBe(30);
+    expect(selectors.toastFrontmostHeight(store.state, 'b')).toBe(0);
+  });
+
+  it('sizes a non-frontmost ending toast against the group frontmost toast', () => {
+    const store = createStore([
+      { id: 'c', height: 20, group: 'top' },
+      { id: 'b', height: 10, group: 'top' },
+      { id: 'a', height: 30, group: 'top' },
+    ]);
+
+    store.closeToast('b');
+    expect(selectors.toastFrontmostHeight(store.state, 'b')).toBe(20);
+    expect(selectors.toastFrontmostHeight(store.state, 'a')).toBe(20);
+    expect(selectors.toastFrontmostHeight(store.state, 'c')).toBe(20);
   });
 
   it('applies the limit per group', () => {

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -37,30 +37,61 @@ export type State = {
 type ToastMetadata = {
   value: StoredToast;
   domIndex: number;
+  stackIndex: number;
   visibleIndex: number;
   offsetY: number;
+  frontmostHeight: number;
 };
 
 type InitialState = Omit<State, 'toastMetadata'>;
 
+type StackCounters = {
+  stackIndex: number;
+  visibleIndex: number;
+  offsetY: number;
+};
+
+// Stacking indices and offsets are computed per group so a single provider
+// can render toasts in multiple screen positions within one viewport. Toasts
+// without a `group` all share the same (default) stack.
 function createToastMetadata(toasts: StoredToast[]) {
   const metadata = new Map<string, ToastMetadata>();
-  let visibleIndex = 0;
-  let offsetY = 0;
+  const stacks = new Map<string, StackCounters>();
+
+  // The frontmost toast of each group is the newest one that isn't animating
+  // out: ending toasts have their height forced to 0, and the toast behind them
+  // is already the one collapsed stacks should size against.
+  const frontmostHeights = new Map<string, number>();
+  for (const toast of toasts) {
+    const group = toast.group ?? '';
+    if (!frontmostHeights.has(group) && toast.transitionStatus !== 'ending') {
+      frontmostHeights.set(group, toast.height || 0);
+    }
+  }
 
   toasts.forEach((toast, toastIndex) => {
+    const group = toast.group ?? '';
+    let stack = stacks.get(group);
+    if (!stack) {
+      stack = { stackIndex: 0, visibleIndex: 0, offsetY: 0 };
+      stacks.set(group, stack);
+    }
+
     const isEnding = toast.transitionStatus === 'ending';
     metadata.set(toast.id, {
       value: toast,
       domIndex: toastIndex,
-      visibleIndex: isEnding ? -1 : visibleIndex,
-      offsetY,
+      stackIndex: stack.stackIndex,
+      visibleIndex: isEnding ? -1 : stack.visibleIndex,
+      offsetY: stack.offsetY,
+      frontmostHeight: frontmostHeights.get(group) ?? 0,
     });
 
-    offsetY += toast.height || 0;
+    stack.stackIndex += 1;
+    stack.offsetY += toast.height || 0;
 
     if (!isEnding) {
-      visibleIndex += 1;
+      stack.visibleIndex += 1;
     }
   });
 
@@ -68,17 +99,19 @@ function createToastMetadata(toasts: StoredToast[]) {
 }
 
 // Marks the active (non-ending) toasts beyond `limit` as limited. Callers pass
-// toasts in newest-first order, so the newest `limit` toasts stay visible and
-// the rest are flagged. Returns the same toast reference when its `limited`
-// flag is unchanged to avoid unnecessary re-renders.
+// toasts in newest-first order, so the newest `limit` toasts of each group
+// stay visible and the rest are flagged. Returns the same toast reference
+// when its `limited` flag is unchanged to avoid unnecessary re-renders.
 function applyLimited(toasts: StoredToast[], limit: number): StoredToast[] {
-  let activeIndex = 0;
+  const activeCounts = new Map<string, number>();
   return toasts.map((toast) => {
     if (toast.transitionStatus === 'ending') {
       return toast;
     }
+    const group = toast.group ?? '';
+    const activeIndex = activeCounts.get(group) ?? 0;
+    activeCounts.set(group, activeIndex + 1);
     const limited = activeIndex >= limit;
-    activeIndex += 1;
     return toast.limited === limited ? toast : { ...toast, limited };
   });
 }
@@ -88,8 +121,11 @@ export const selectors = {
   isEmpty: (state: State) => state.toasts.length === 0,
   toast: (state: State, id: string) => state.toastMetadata.get(id)?.value,
   toastIndex: (state: State, id: string) => state.toastMetadata.get(id)?.domIndex ?? -1,
+  toastStackIndex: (state: State, id: string) => state.toastMetadata.get(id)?.stackIndex ?? -1,
   toastOffsetY: (state: State, id: string) => state.toastMetadata.get(id)?.offsetY ?? 0,
   toastVisibleIndex: (state: State, id: string) => state.toastMetadata.get(id)?.visibleIndex ?? -1,
+  toastFrontmostHeight: (state: State, id: string) =>
+    state.toastMetadata.get(id)?.frontmostHeight ?? 0,
   focused: (state: State) => state.focused,
   expanded: (state: State) => state.hovering || state.focused,
   expandedOrOutOfFocus: (state: State) => state.hovering || state.focused || !state.isWindowFocused,
@@ -233,7 +269,11 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       }),
     };
 
-    this.setToasts(toasts.map((toast) => (toast.id === id ? nextToast : toast)));
+    const newToasts = toasts.map((toast) => (toast.id === id ? nextToast : toast));
+    // Moving a toast between groups changes which toasts fall outside each
+    // group's limit, so the `limited` flags must be recomputed.
+    const groupChanged = Object.hasOwn(updates, 'group') && prevToast.group !== nextToast.group;
+    this.setToasts(groupChanged ? applyLimited(newToasts, this.state.limit) : newToasts);
 
     const nextTimeout = nextToast.timeout ?? timeout;
     const prevTimeout = prevToast.timeout ?? timeout;

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -60,10 +60,18 @@ function createToastMetadata(toasts: StoredToast[]) {
 
   // The frontmost toast of each group is the newest one that isn't animating
   // out: ending toasts have their height forced to 0, and the toast behind them
-  // is already the one collapsed stacks should size against.
+  // is already the one collapsed stacks should size against. Ending toasts
+  // instead size against the group's newest toast including ending ones — a
+  // dismissed frontmost toast then sees its own zeroed height (rendered as
+  // `initial`) and exits at its natural height rather than resizing to the
+  // next toast's.
   const frontmostHeights = new Map<string, number>();
+  const newestHeights = new Map<string, number>();
   for (const toast of toasts) {
     const group = toast.group ?? '';
+    if (!newestHeights.has(group)) {
+      newestHeights.set(group, toast.height || 0);
+    }
     if (!frontmostHeights.has(group) && toast.transitionStatus !== 'ending') {
       frontmostHeights.set(group, toast.height || 0);
     }
@@ -84,7 +92,7 @@ function createToastMetadata(toasts: StoredToast[]) {
       stackIndex: stack.stackIndex,
       visibleIndex: isEnding ? -1 : stack.visibleIndex,
       offsetY: stack.offsetY,
-      frontmostHeight: frontmostHeights.get(group) ?? 0,
+      frontmostHeight: (isEnding ? newestHeights : frontmostHeights).get(group) ?? 0,
     });
 
     stack.stackIndex += 1;
@@ -514,18 +522,28 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
 
     const toasts = selectors.toasts(this.state);
     const currentIndex = selectors.toastIndex(this.state, toastId);
+    const currentGroup = toasts[currentIndex]?.group ?? '';
 
-    const scan = (from: number, step: number) => {
+    const scan = (from: number, step: number, sameGroup: boolean) => {
       for (let index = from; index >= 0 && index < toasts.length; index += step) {
-        if (toasts[index].transitionStatus !== 'ending') {
-          return toasts[index];
+        const candidate = toasts[index];
+        if (
+          candidate.transitionStatus !== 'ending' &&
+          (!sameGroup || (candidate.group ?? '') === currentGroup)
+        ) {
+          return candidate;
         }
       }
       return null;
     };
 
     // Try to find the next toast that isn't animating out, then fall back to the previous one.
-    const nextToast = scan(currentIndex + 1, 1) ?? scan(currentIndex - 1, -1);
+    // Prefer toasts in the same group so focus stays in the same screen position.
+    const nextToast =
+      scan(currentIndex + 1, 1, true) ??
+      scan(currentIndex - 1, -1, true) ??
+      scan(currentIndex + 1, 1, false) ??
+      scan(currentIndex - 1, -1, false);
 
     if (nextToast) {
       nextToast.ref?.current?.focus();

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -59,6 +59,14 @@ export interface ToastObject<Data extends object> {
    */
   priority?: 'low' | 'high' | undefined;
   /**
+   * The named stack the toast belongs to. Toasts with the same group stack
+   * together: stacking indices and offsets are computed per group, letting a
+   * single provider render toasts in multiple screen positions within one
+   * viewport. The value is exposed as the `data-group` attribute on
+   * `Toast.Root` for anchoring each stack with CSS.
+   */
+  group?: string | undefined;
+  /**
    * The transition status of the toast.
    */
   transitionStatus?: 'starting' | 'ending' | undefined;

--- a/packages/react/src/toast/viewport/ToastViewport.test.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.test.tsx
@@ -1076,6 +1076,48 @@ describe('<Toast.Viewport />', () => {
       expect(oldest).toHaveFocus();
     });
 
+    it.skipIf(!isJSDOM)('prefers a toast in the same group when handing off focus', async () => {
+      const manager = Toast.createToastManager();
+
+      await renderFakeTimers(
+        <Toast.Provider toastManager={manager} timeout={0}>
+          <Toast.Viewport data-testid="viewport">
+            <List />
+          </Toast.Viewport>
+          <Button />
+        </Toast.Provider>,
+      );
+
+      const button = screen.getByRole('button', { name: 'add' });
+      await act(async () => button.focus());
+
+      await act(async () => {
+        manager.add({ id: 'corner-old', title: 'corner old', group: 'top-right' });
+      });
+      await act(async () => {
+        manager.add({ id: 'other', title: 'other' });
+      });
+      await act(async () => {
+        manager.add({ id: 'corner-new', title: 'corner new', group: 'top-right' });
+      });
+
+      const [cornerNew, other, cornerOld] = screen.getAllByTestId('root');
+      expect(other).toHaveTextContent('other');
+
+      fireEvent.keyDown(button, { key: 'F6' });
+      const viewport = screen.getByTestId('viewport');
+      const guard = document.querySelector('[data-base-ui-focus-guard]') as HTMLElement;
+      fireEvent.focus(guard, { relatedTarget: viewport });
+
+      expect(cornerNew).toHaveFocus();
+
+      // Dismissing the focused toast hands focus to the remaining toast in the
+      // same group (same screen position), not the nearer toast in another group.
+      await act(async () => manager.close('corner-new'));
+
+      expect(cornerOld).toHaveFocus();
+    });
+
     it.skipIf(!isJSDOM)('leaves focus alone when it is outside the viewport', async () => {
       const manager = Toast.createToastManager();
 

--- a/packages/react/src/toast/viewport/ToastViewportCssVars.ts
+++ b/packages/react/src/toast/viewport/ToastViewportCssVars.ts
@@ -1,6 +1,7 @@
 export enum ToastViewportCssVars {
   /**
    * Indicates the height of the frontmost toast.
+   * Each `Toast.Root` shadows this value with the height of its own group's frontmost toast.
    * @type {number}
    */
   frontmostHeight = '--toast-frontmost-height',


### PR DESCRIPTION
Adds a `group` option so one toast manager, provider, and viewport can render multiple independently stacked positions. Previously, each position needed its own `Toast.createToastManager`, provider, and viewport.

This is orthogonal to using a global manager to avoid `useToastManager` subscriptions: one `Toast.createToastManager` can still dispatch every toast, while `group` selects its stack.

https://deploy-preview-5310--base-ui.netlify.app/experiments/toast-positions

## Changes

- Computes stacking indices, offsets, frontmost height, and `limit` per group.
- Exposes `data-group` on `Toast.Root` for CSS positioning.
- Adds coverage and documentation for grouped toast positions.
