### PR TITLE
[scroll area] Expand test coverage

### DIFF
--- a/packages/react/src/scroll-area/content/ScrollAreaContent.test.tsx
+++ b/packages/react/src/scroll-area/content/ScrollAreaContent.test.tsx
@@ -1,5 +1,8 @@
+import * as React from 'react';
+import { expect, vi } from 'vitest';
 import { ScrollArea } from '@base-ui/react/scroll-area';
-import { createRenderer } from '#test-utils';
+import { createRenderer, isJSDOM } from '#test-utils';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { describeConformance } from '../../../test/describeConformance';
 
 describe('<ScrollArea.Content />', () => {
@@ -15,4 +18,60 @@ describe('<ScrollArea.Content />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <ScrollArea.Viewport>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <ScrollArea.Root>
+            <ScrollArea.Content />
+          </ScrollArea.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: ScrollAreaViewportContext missing. ScrollAreaViewport parts must be placed within <ScrollArea.Viewport>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it.skipIf(isJSDOM)('recomputes overflow when observed content resizes', async () => {
+    const renderArea = (contentHeight: number) => (
+      <ScrollArea.Root data-testid="root" style={{ width: 100, height: 100 }}>
+        <ScrollArea.Viewport style={{ width: '100%', height: '100%' }}>
+          <ScrollArea.Content data-testid="content" style={{ height: contentHeight }} />
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
+    );
+
+    const { rerender } = await render(renderArea(50));
+    const root = screen.getByTestId('root');
+
+    await waitFor(() => expect(root).not.toHaveAttribute('data-has-overflow-y'));
+
+    await rerender(renderArea(1000));
+
+    await waitFor(() => expect(root).toHaveAttribute('data-has-overflow-y'));
+  });
+
+  it('supports a custom content renderer that does not forward its ref', async () => {
+    function ContentWithoutRef({ ref: ignoredRef, ...props }: React.ComponentPropsWithRef<'div'>) {
+      return <div {...props} />;
+    }
+
+    await render(
+      <ScrollArea.Root>
+        <ScrollArea.Viewport>
+          <ScrollArea.Content
+            data-testid="content"
+            render={<ContentWithoutRef data-testid="content" />}
+          />
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>,
+    );
+
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+  });
 });

--- a/packages/react/src/scroll-area/content/ScrollAreaContent.test.tsx
+++ b/packages/react/src/scroll-area/content/ScrollAreaContent.test.tsx
@@ -64,10 +64,7 @@ describe('<ScrollArea.Content />', () => {
     await render(
       <ScrollArea.Root>
         <ScrollArea.Viewport>
-          <ScrollArea.Content
-            data-testid="content"
-            render={<ContentWithoutRef data-testid="content" />}
-          />
+          <ScrollArea.Content data-testid="content" render={<ContentWithoutRef />} />
         </ScrollArea.Viewport>
       </ScrollArea.Root>,
     );

--- a/packages/react/src/scroll-area/content/ScrollAreaContent.test.tsx
+++ b/packages/react/src/scroll-area/content/ScrollAreaContent.test.tsx
@@ -57,9 +57,12 @@ describe('<ScrollArea.Content />', () => {
   });
 
   it('supports a custom content renderer that does not forward its ref', async () => {
-    function ContentWithoutRef({ ref: ignoredRef, ...props }: React.ComponentPropsWithRef<'div'>) {
+    const ContentWithoutRef = React.forwardRef<
+      HTMLDivElement,
+      React.ComponentPropsWithoutRef<'div'>
+    >(function ContentWithoutRef(props, _ref) {
       return <div {...props} />;
-    }
+    });
 
     await render(
       <ScrollArea.Root>

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -1,4 +1,5 @@
-import { expect } from 'vitest';
+import * as React from 'react';
+import { expect, vi } from 'vitest';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { screen, fireEvent, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
@@ -14,6 +15,28 @@ describe('<ScrollArea.Scrollbar />', () => {
       return render(<ScrollArea.Root>{node}</ScrollArea.Root>);
     },
   }));
+
+  it('supports a custom scrollbar renderer that does not forward its ref', async () => {
+    function ScrollbarWithoutRef({
+      ref: ignoredRef,
+      ...props
+    }: React.ComponentPropsWithRef<'div'>) {
+      return <div {...props} />;
+    }
+
+    await render(
+      <ScrollArea.Root>
+        <ScrollArea.Viewport />
+        <ScrollArea.Scrollbar
+          data-testid="scrollbar"
+          keepMounted
+          render={<ScrollbarWithoutRef />}
+        />
+      </ScrollArea.Root>,
+    );
+
+    expect(screen.getByTestId('scrollbar')).toBeInTheDocument();
+  });
 
   describe('data-scrolling attribute', () => {
     const { render: renderWithClock, clock } = createRenderer();
@@ -79,6 +102,50 @@ describe('<ScrollArea.Scrollbar />', () => {
   });
 
   describe('data-hovering attribute', () => {
+    it('detects a viewport that is already hovered on mount', async () => {
+      const originalMatches = Element.prototype.matches;
+      const matchesSpy = vi.spyOn(Element.prototype, 'matches').mockImplementation(function matches(
+        this: Element,
+        selector: string,
+      ) {
+        if (selector === ':hover' && (this as HTMLElement).dataset.testid === 'viewport') {
+          return true;
+        }
+        return originalMatches.call(this, selector);
+      });
+
+      try {
+        await render(
+          <ScrollArea.Root>
+            <ScrollArea.Viewport data-testid="viewport" />
+            <ScrollArea.Scrollbar data-testid="scrollbar" keepMounted />
+          </ScrollArea.Root>,
+        );
+
+        await waitFor(() =>
+          expect(screen.getByTestId('scrollbar')).toHaveAttribute('data-hovering'),
+        );
+      } finally {
+        matchesSpy.mockRestore();
+      }
+    });
+
+    it('does not enter hover state for touch pointers', async () => {
+      await render(
+        <ScrollArea.Root>
+          <ScrollArea.Viewport data-testid="viewport" />
+          <ScrollArea.Scrollbar data-testid="scrollbar" keepMounted />
+        </ScrollArea.Root>,
+      );
+
+      const viewport = screen.getByTestId('viewport');
+      const scrollbar = screen.getByTestId('scrollbar');
+
+      fireEvent.pointerEnter(viewport, { pointerType: 'touch' });
+
+      expect(scrollbar).not.toHaveAttribute('data-hovering');
+    });
+
     it('adds [data-hovering] when the synthetic pointer target differs from the native path', async () => {
       await render(
         <ScrollArea.Root data-testid="root" style={{ width: 200, height: 200 }}>
@@ -124,6 +191,64 @@ describe('<ScrollArea.Scrollbar />', () => {
   });
 
   describe('track pointer down', () => {
+    it('ignores non-primary pointer presses', async () => {
+      await render(
+        <ScrollArea.Root>
+          <ScrollArea.Viewport data-testid="viewport" style={{ scrollSnapType: 'y mandatory' }} />
+          <ScrollArea.Scrollbar data-testid="scrollbar" keepMounted>
+            <ScrollArea.Thumb />
+          </ScrollArea.Scrollbar>
+        </ScrollArea.Root>,
+      );
+
+      const viewport = screen.getByTestId('viewport');
+      fireEvent.pointerDown(screen.getByTestId('scrollbar'), {
+        button: 2,
+        clientY: 100,
+        pointerId: 1,
+      });
+
+      expect(viewport.scrollTop).toBe(0);
+      expect(viewport.style.scrollSnapType).toBe('y mandatory');
+    });
+
+    it('handles a track press when no viewport is mounted', async () => {
+      await render(
+        <ScrollArea.Root>
+          <ScrollArea.Scrollbar data-testid="scrollbar" keepMounted>
+            <ScrollArea.Thumb />
+          </ScrollArea.Scrollbar>
+        </ScrollArea.Root>,
+      );
+
+      expect(() =>
+        fireEvent.pointerDown(screen.getByTestId('scrollbar'), {
+          button: 0,
+          clientY: 100,
+          pointerId: 1,
+        }),
+      ).not.toThrow();
+    });
+
+    it('does not start a track gesture without a thumb', async () => {
+      await render(
+        <ScrollArea.Root>
+          <ScrollArea.Viewport data-testid="viewport" style={{ scrollSnapType: 'y mandatory' }} />
+          <ScrollArea.Scrollbar data-testid="scrollbar" keepMounted />
+        </ScrollArea.Root>,
+      );
+
+      const viewport = screen.getByTestId('viewport');
+      fireEvent.pointerDown(screen.getByTestId('scrollbar'), {
+        button: 0,
+        clientY: 100,
+        pointerId: 1,
+      });
+
+      expect(viewport.scrollTop).toBe(0);
+      expect(viewport.style.scrollSnapType).toBe('y mandatory');
+    });
+
     it('ignores thumb clicks when the native path differs from the synthetic target', async () => {
       await render(
         <ScrollArea.Root style={{ width: 200, height: 200 }}>
@@ -666,6 +791,17 @@ describe('<ScrollArea.Scrollbar />', () => {
       });
 
       expect(fireEvent.wheel(scrollbar, { deltaY: 0 })).toBe(true);
+      expect(viewport.scrollTop).toBe(400);
+      expect(scrollbar).not.toHaveAttribute('data-scrolling');
+    });
+
+    it('does not intercept browser zoom gestures', async () => {
+      const { viewport, scrollbar } = await renderWheelTest({
+        orientation: 'vertical',
+        scrollTop: 400,
+      });
+
+      expect(fireEvent.wheel(scrollbar, { ctrlKey: true, deltaY: 50 })).toBe(true);
       expect(viewport.scrollTop).toBe(400);
       expect(scrollbar).not.toHaveAttribute('data-scrolling');
     });

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -221,13 +221,10 @@ describe('<ScrollArea.Scrollbar />', () => {
         </ScrollArea.Root>,
       );
 
-      expect(() =>
-        fireEvent.pointerDown(screen.getByTestId('scrollbar'), {
-          button: 0,
-          clientY: 100,
-          pointerId: 1,
-        }),
-      ).not.toThrow();
+      const scrollbar = screen.getByTestId('scrollbar');
+      fireEvent.pointerDown(scrollbar, { button: 0, clientY: 100, pointerId: 1 });
+
+      expect(scrollbar).not.toHaveAttribute('data-scrolling');
     });
 
     it('does not start a track gesture without a thumb', async () => {

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -17,12 +17,12 @@ describe('<ScrollArea.Scrollbar />', () => {
   }));
 
   it('supports a custom scrollbar renderer that does not forward its ref', async () => {
-    function ScrollbarWithoutRef({
-      ref: ignoredRef,
-      ...props
-    }: React.ComponentPropsWithRef<'div'>) {
+    const ScrollbarWithoutRef = React.forwardRef<
+      HTMLDivElement,
+      React.ComponentPropsWithoutRef<'div'>
+    >(function ScrollbarWithoutRef(props, _ref) {
       return <div {...props} />;
-    }
+    });
 
     await render(
       <ScrollArea.Root>

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
@@ -77,7 +77,7 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
     }
 
     function handleWheel(event: WheelEvent) {
-      if (!viewportEl || !scrollbarEl || event.ctrlKey) {
+      if (!viewportEl || event.ctrlKey) {
         return;
       }
 
@@ -138,52 +138,46 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
 
       const scrollbarEl = vertical ? scrollbarYRef.current : scrollbarXRef.current;
 
-      if (thumbEl && scrollbarEl) {
-        const axis = vertical ? 'y' : 'x';
-        const thumbOffset = getOffset(thumbEl, 'margin', axis);
-        const scrollbarOffset = getOffset(scrollbarEl, 'padding', axis);
-        const thumbSizePx = vertical ? thumbEl.offsetHeight : thumbEl.offsetWidth;
-        const trackRect = scrollbarEl.getBoundingClientRect();
-        const clickPosition = vertical
-          ? event.clientY - trackRect.top - thumbSizePx / 2 - scrollbarOffset + thumbOffset / 2
-          : event.clientX - trackRect.left - thumbSizePx / 2 - scrollbarOffset + thumbOffset / 2;
+      if (!thumbEl || !scrollbarEl) {
+        return;
+      }
 
-        const scrollableSize = vertical ? viewportEl.scrollHeight : viewportEl.scrollWidth;
-        const viewportSize = vertical ? viewportEl.clientHeight : viewportEl.clientWidth;
-        const trackSize = vertical ? scrollbarEl.offsetHeight : scrollbarEl.offsetWidth;
+      const axis = vertical ? 'y' : 'x';
+      const thumbOffset = getOffset(thumbEl, 'margin', axis);
+      const scrollbarOffset = getOffset(scrollbarEl, 'padding', axis);
+      const thumbSizePx = vertical ? thumbEl.offsetHeight : thumbEl.offsetWidth;
+      const trackRect = scrollbarEl.getBoundingClientRect();
+      const clickPosition = vertical
+        ? event.clientY - trackRect.top - thumbSizePx / 2 - scrollbarOffset + thumbOffset / 2
+        : event.clientX - trackRect.left - thumbSizePx / 2 - scrollbarOffset + thumbOffset / 2;
 
-        const maxThumbOffset = trackSize - thumbSizePx - scrollbarOffset - thumbOffset;
-        // A short or heavily padded track can drive `maxThumbOffset` to zero or
-        // negative once the thumb hits its `MIN_THUMB_SIZE` floor. Dividing by it
-        // would yield a non-finite (`Infinity`/`NaN`) or inverted scroll position.
-        if (maxThumbOffset <= 0) {
-          return;
-        }
+      const scrollableSize = vertical ? viewportEl.scrollHeight : viewportEl.scrollWidth;
+      const viewportSize = vertical ? viewportEl.clientHeight : viewportEl.clientWidth;
+      const trackSize = vertical ? scrollbarEl.offsetHeight : scrollbarEl.offsetWidth;
 
-        const scrollRatio = clickPosition / maxThumbOffset;
-        const maxScrollDistance = scrollableSize - viewportSize;
+      const maxThumbOffset = trackSize - thumbSizePx - scrollbarOffset - thumbOffset;
+      // A short or heavily padded track can drive `maxThumbOffset` to zero or
+      // negative once the thumb hits its `MIN_THUMB_SIZE` floor. Dividing by it
+      // would yield a non-finite (`Infinity`/`NaN`) or inverted scroll position.
+      if (maxThumbOffset <= 0) {
+        return;
+      }
 
-        // Disable snapping before the jump-to-click assignment, or the
-        // assigned position quantizes to the nearest snap point and the thumb
-        // stays offset from the pointer for the whole drag. `handlePointerDown`
-        // below re-runs this as a guarded no-op for the thumb-drag path.
-        disableViewportSnap();
+      const scrollRatio = clickPosition / maxThumbOffset;
+      const maxScrollDistance = scrollableSize - viewportSize;
 
-        if (vertical) {
-          viewportEl.scrollTop = scrollRatio * maxScrollDistance;
-        } else if (direction === 'rtl') {
-          // In RTL, invert the scroll direction
-          let newScrollLeft = (1 - scrollRatio) * maxScrollDistance;
+      // Disable snapping before the jump-to-click assignment, or the
+      // assigned position quantizes to the nearest snap point and the thumb
+      // stays offset from the pointer for the whole drag. `handlePointerDown`
+      // below re-runs this as a guarded no-op for the thumb-drag path.
+      disableViewportSnap();
 
-          // Adjust for browsers that use negative scrollLeft in RTL
-          if (viewportEl.scrollLeft <= 0) {
-            newScrollLeft = -newScrollLeft;
-          }
-
-          viewportEl.scrollLeft = newScrollLeft;
-        } else {
-          viewportEl.scrollLeft = scrollRatio * maxScrollDistance;
-        }
+      if (vertical) {
+        viewportEl.scrollTop = scrollRatio * maxScrollDistance;
+      } else if (direction === 'rtl') {
+        viewportEl.scrollLeft = -(1 - scrollRatio) * maxScrollDistance;
+      } else {
+        viewportEl.scrollLeft = scrollRatio * maxScrollDistance;
       }
 
       handleScroll({ x: viewportEl.scrollLeft, y: viewportEl.scrollTop });

--- a/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
+++ b/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { expect, vi } from 'vitest';
 import { createRenderer, isJSDOM } from '#test-utils';
 import { ScrollArea } from '@base-ui/react/scroll-area';
@@ -19,6 +21,130 @@ describe('<ScrollArea.Thumb />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <ScrollArea.Scrollbar>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <ScrollArea.Root>
+            <ScrollArea.Thumb />
+          </ScrollArea.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: ScrollAreaScrollbarContext is missing. ScrollAreaScrollbar parts must be placed within <ScrollArea.Scrollbar>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('handles a thumb gesture when no viewport is mounted', async () => {
+    await render(
+      <ScrollArea.Root>
+        <ScrollArea.Scrollbar keepMounted>
+          <ScrollArea.Thumb data-testid="thumb" />
+        </ScrollArea.Scrollbar>
+      </ScrollArea.Root>,
+    );
+
+    const thumb = screen.getByTestId('thumb');
+    Object.defineProperties(thumb, {
+      setPointerCapture: {
+        configurable: true,
+        value: () => {},
+      },
+      hasPointerCapture: {
+        configurable: true,
+        value: () => false,
+      },
+    });
+
+    fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
+    expect(() => fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1 })).not.toThrow();
+    expect(() => fireEvent.pointerUp(thumb, { pointerId: 1 })).not.toThrow();
+  });
+
+  it('handles the scrollbar unmounting from a user pointer-move callback', async () => {
+    function App() {
+      const [mounted, setMounted] = React.useState(true);
+
+      return (
+        <ScrollArea.Root>
+          <ScrollArea.Viewport data-testid="viewport" />
+          {mounted && (
+            <ScrollArea.Scrollbar keepMounted data-testid="scrollbar">
+              <ScrollArea.Thumb
+                data-testid="thumb"
+                onPointerMove={() => {
+                  ReactDOM.flushSync(() => setMounted(false));
+                }}
+              />
+            </ScrollArea.Scrollbar>
+          )}
+        </ScrollArea.Root>
+      );
+    }
+
+    await render(<App />);
+
+    const viewport = screen.getByTestId('viewport');
+    const thumb = screen.getByTestId('thumb');
+    Object.defineProperty(thumb, 'setPointerCapture', {
+      configurable: true,
+      value: () => {},
+    });
+
+    fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
+    expect(() => fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1 })).not.toThrow();
+
+    expect(screen.queryByTestId('scrollbar')).toBe(null);
+    expect(viewport.scrollTop).toBe(0);
+  });
+
+  it('handles the viewport unmounting from a user pointer-up callback', async () => {
+    function App() {
+      const [mounted, setMounted] = React.useState(true);
+
+      return (
+        <ScrollArea.Root>
+          {mounted && (
+            <ScrollArea.Viewport data-testid="viewport" style={{ scrollSnapType: 'y mandatory' }} />
+          )}
+          <ScrollArea.Scrollbar keepMounted>
+            <ScrollArea.Thumb
+              data-testid="thumb"
+              onPointerUp={() => {
+                ReactDOM.flushSync(() => setMounted(false));
+              }}
+            />
+          </ScrollArea.Scrollbar>
+        </ScrollArea.Root>
+      );
+    }
+
+    await render(<App />);
+
+    const viewport = screen.getByTestId('viewport');
+    const thumb = screen.getByTestId('thumb');
+    Object.defineProperties(thumb, {
+      setPointerCapture: {
+        configurable: true,
+        value: () => {},
+      },
+      hasPointerCapture: {
+        configurable: true,
+        value: () => false,
+      },
+    });
+
+    fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
+    expect(viewport.style.scrollSnapType).toBe('none');
+
+    expect(() => fireEvent.pointerUp(thumb, { pointerId: 1 })).not.toThrow();
+    expect(screen.queryByTestId('viewport')).toBe(null);
+  });
 
   describe.skipIf(isJSDOM)('horizontal dragging', () => {
     async function renderHorizontal(direction: 'ltr' | 'rtl') {
@@ -310,6 +436,23 @@ describe('<ScrollArea.Thumb />', () => {
 
       fireEvent.pointerUp(thumb, { pointerId: 1 });
       expect(viewport.style.scrollSnapType).toBe('y mandatory');
+    });
+
+    it('ignores non-primary pointer presses', async () => {
+      await renderWithSnap();
+
+      const viewport = screen.getByTestId('viewport');
+      const thumb = screen.getByTestId('thumb');
+      const setPointerCapture = vi.fn();
+      Object.defineProperty(thumb, 'setPointerCapture', {
+        configurable: true,
+        value: setPointerCapture,
+      });
+
+      fireEvent.pointerDown(thumb, { button: 2, clientY: 0, pointerId: 1 });
+
+      expect(viewport.style.scrollSnapType).toBe('y mandatory');
+      expect(setPointerCapture).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
+++ b/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
@@ -62,8 +62,14 @@ describe('<ScrollArea.Thumb />', () => {
     });
 
     fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
-    expect(() => fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1 })).not.toThrow();
-    expect(() => fireEvent.pointerUp(thumb, { pointerId: 1 })).not.toThrow();
+    fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1 });
+
+    // Without a viewport there is nothing to scroll, so the drag never consumes the move.
+    expect(thumb).not.toHaveAttribute('data-scrolling');
+    expect(thumb.style.transform).toBe('');
+
+    fireEvent.pointerUp(thumb, { pointerId: 1 });
+    expect(thumb).not.toHaveAttribute('data-scrolling');
   });
 
   it('handles the scrollbar unmounting from a user pointer-move callback', async () => {

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.test.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.test.tsx
@@ -1,8 +1,10 @@
-import { expect } from 'vitest';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { expect, vi } from 'vitest';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { createRenderer, isJSDOM, describeConformance } from '#test-utils';
-import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { SCROLL_TIMEOUT } from '../constants';
 
 describe('<ScrollArea.Viewport />', () => {
@@ -14,6 +16,120 @@ describe('<ScrollArea.Viewport />', () => {
       return render(<ScrollArea.Root>{node}</ScrollArea.Root>);
     },
   }));
+
+  it('handles a user scroll callback unmounting the viewport', async () => {
+    function App() {
+      const [mounted, setMounted] = React.useState(true);
+
+      return (
+        <ScrollArea.Root>
+          {mounted && (
+            <ScrollArea.Viewport
+              data-testid="viewport"
+              onScroll={() => {
+                ReactDOM.flushSync(() => setMounted(false));
+              }}
+            />
+          )}
+        </ScrollArea.Root>
+      );
+    }
+
+    await render(<App />);
+
+    expect(() => fireEvent.scroll(screen.getByTestId('viewport'))).not.toThrow();
+    expect(screen.queryByTestId('viewport')).toBe(null);
+  });
+
+  describe.skipIf(isJSDOM)('subtree animations', () => {
+    it('recomputes overflow after a subtree animation finishes', async () => {
+      let scrollWidth = 100;
+      let resolveAnimation: () => void = () => {};
+      const finished = new Promise<void>((resolve) => {
+        resolveAnimation = resolve;
+      });
+      const getAnimations = vi.fn(() => [{ finished }] as unknown as Animation[]);
+
+      await render(
+        <ScrollArea.Root data-testid="root">
+          <ScrollArea.Viewport
+            ref={(node) => {
+              if (node) {
+                Object.defineProperties(node, {
+                  clientHeight: { configurable: true, value: 100 },
+                  clientWidth: { configurable: true, value: 100 },
+                  scrollHeight: { configurable: true, value: 100 },
+                  scrollWidth: { configurable: true, get: () => scrollWidth },
+                  getAnimations: { configurable: true, value: getAnimations },
+                });
+              }
+            }}
+          />
+          <ScrollArea.Scrollbar orientation="horizontal" keepMounted>
+            <ScrollArea.Thumb />
+          </ScrollArea.Scrollbar>
+        </ScrollArea.Root>,
+      );
+
+      const root = screen.getByTestId('root');
+      await waitFor(() => expect(getAnimations).toHaveBeenCalled());
+      expect(root).not.toHaveAttribute('data-has-overflow-x');
+
+      scrollWidth = 1000;
+      await act(async () => {
+        resolveAnimation();
+        await finished;
+      });
+
+      await waitFor(() => expect(root).toHaveAttribute('data-has-overflow-x'));
+    });
+
+    it('ignores an animation finishing after its viewport unmounts', async () => {
+      let resolveAnimation: () => void = () => {};
+      const finished = new Promise<void>((resolve) => {
+        resolveAnimation = resolve;
+      });
+      const getAnimations = vi.fn(() => [{ finished }] as unknown as Animation[]);
+
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+
+        return (
+          <React.Fragment>
+            <button type="button" onClick={() => setMounted(false)}>
+              unmount
+            </button>
+            <ScrollArea.Root>
+              {mounted && (
+                <ScrollArea.Viewport
+                  data-testid="viewport"
+                  ref={(node) => {
+                    if (node) {
+                      Object.defineProperty(node, 'getAnimations', {
+                        configurable: true,
+                        value: getAnimations,
+                      });
+                    }
+                  }}
+                />
+              )}
+            </ScrollArea.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+      await waitFor(() => expect(getAnimations).toHaveBeenCalled());
+
+      await user.click(screen.getByRole('button', { name: 'unmount' }));
+      expect(screen.queryByTestId('viewport')).toBe(null);
+
+      await act(async () => {
+        resolveAnimation();
+        await finished;
+      });
+    });
+  });
 
   describe('data-scrolling attribute', () => {
     const { render: renderWithClock, clock } = createRenderer();
@@ -367,5 +483,17 @@ describe('<ScrollArea.Viewport />', () => {
         0,
       );
     });
+  });
+
+  it('throws a descriptive error when rendered outside <ScrollArea.Root>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<ScrollArea.Viewport />)).rejects.toThrow(
+        'Base UI: ScrollAreaRootContext is missing. ScrollArea parts must be placed within <ScrollArea.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -340,9 +340,12 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
         return;
       }
 
-      void Promise.allSettled(animations.map((animation) => animation.finished)).then(
-        computeThumbPosition,
-      );
+      // `allSettled` never rejects, but `computeThumbPosition` can still run against a
+      // torn-down tree once the animations resolve. Swallow instead of leaking an unhandled
+      // rejection; `void` alone would only silence the floating-promise lint.
+      Promise.allSettled(animations.map((animation) => animation.finished))
+        .then(computeThumbPosition)
+        .catch(() => {});
     });
 
     return () => {

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.tsx
@@ -278,12 +278,8 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
   });
 
   useIsoLayoutEffect(() => {
-    if (!viewportRef.current) {
-      return;
-    }
-
     removeCSSVariableInheritance();
-  }, [viewportRef]);
+  }, []);
 
   useIsoLayoutEffect(() => {
     // Wait for scrollbar and thumb refs after hidden-state toggles, refresh math on direction
@@ -344,9 +340,9 @@ export const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(
         return;
       }
 
-      Promise.allSettled(animations.map((animation) => animation.finished))
-        .then(computeThumbPosition)
-        .catch(() => {});
+      void Promise.allSettled(animations.map((animation) => animation.finished)).then(
+        computeThumbPosition,
+      );
     });
 
     return () => {


### PR DESCRIPTION
Expands Scroll Area test coverage to 100% across statements, branches, functions, and lines on merged jsdom and Chromium results, and removes the redundant code the sweep uncovered.

## Changes

- Added behavior tests for content resizing, subtree animations, hover and touch pointers, track and wheel gestures, lifecycle unmounts, missing compositions, and custom renderers.
- Prevented track presses without a thumb from starting a gesture or disabling scroll snapping.
- Removed redundant scrollbar and ref guards, the obsolete positive RTL scroll offset fallback, and the animation rejection catch.