### PR TITLE
[accordion][collapsible] Expand test coverage

### DIFF
--- a/packages/react/src/accordion/header/AccordionHeader.test.tsx
+++ b/packages/react/src/accordion/header/AccordionHeader.test.tsx
@@ -1,8 +1,15 @@
+import { expect } from 'vitest';
 import { Accordion } from '@base-ui/react/accordion';
 import { describeConformance, createRenderer } from '#test-utils';
 
 describe('<Accordion.Header />', () => {
   const { render } = createRenderer();
+
+  it('throws when rendered outside an Accordion.Item', async () => {
+    await expect(render(<Accordion.Header />)).rejects.toThrow(
+      'Base UI: AccordionItemContext is missing. Accordion parts must be placed within <Accordion.Item>.',
+    );
+  });
 
   describeConformance(<Accordion.Header />, () => ({
     render: (node) =>

--- a/packages/react/src/accordion/header/AccordionHeader.test.tsx
+++ b/packages/react/src/accordion/header/AccordionHeader.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { Accordion } from '@base-ui/react/accordion';
 import { describeConformance, createRenderer } from '#test-utils';
 
@@ -6,9 +6,15 @@ describe('<Accordion.Header />', () => {
   const { render } = createRenderer();
 
   it('throws when rendered outside an Accordion.Item', async () => {
-    await expect(render(<Accordion.Header />)).rejects.toThrow(
-      'Base UI: AccordionItemContext is missing. Accordion parts must be placed within <Accordion.Item>.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Accordion.Header />)).rejects.toThrow(
+        'Base UI: AccordionItemContext is missing. Accordion parts must be placed within <Accordion.Item>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   describeConformance(<Accordion.Header />, () => ({

--- a/packages/react/src/accordion/item/AccordionItem.test.tsx
+++ b/packages/react/src/accordion/item/AccordionItem.test.tsx
@@ -6,6 +6,12 @@ import { describeConformance, createRenderer, isJSDOM } from '#test-utils';
 describe('<Accordion.Item />', () => {
   const { render } = createRenderer();
 
+  it('throws when rendered outside an Accordion.Root', async () => {
+    await expect(render(<Accordion.Item />)).rejects.toThrow(
+      'Base UI: AccordionRootContext is missing. Accordion parts must be placed within <Accordion.Root>.',
+    );
+  });
+
   describeConformance(<Accordion.Item />, () => ({
     render: (node) => {
       return render(<Accordion.Root>{node}</Accordion.Root>);

--- a/packages/react/src/accordion/item/AccordionItem.test.tsx
+++ b/packages/react/src/accordion/item/AccordionItem.test.tsx
@@ -7,9 +7,15 @@ describe('<Accordion.Item />', () => {
   const { render } = createRenderer();
 
   it('throws when rendered outside an Accordion.Root', async () => {
-    await expect(render(<Accordion.Item />)).rejects.toThrow(
-      'Base UI: AccordionRootContext is missing. Accordion parts must be placed within <Accordion.Root>.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<Accordion.Item />)).rejects.toThrow(
+        'Base UI: AccordionRootContext is missing. Accordion parts must be placed within <Accordion.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   describeConformance(<Accordion.Item />, () => ({

--- a/packages/react/src/accordion/item/AccordionItem.tsx
+++ b/packages/react/src/accordion/item/AccordionItem.tsx
@@ -55,19 +55,7 @@ export const AccordionItem = React.forwardRef(function AccordionItem(
 
   const disabled = disabledProp || contextDisabled;
 
-  const isOpen = React.useMemo(() => {
-    if (!openValues) {
-      return false;
-    }
-
-    for (let i = 0; i < openValues.length; i += 1) {
-      if (openValues[i] === value) {
-        return true;
-      }
-    }
-
-    return false;
-  }, [openValues, value]);
+  const isOpen = openValues.indexOf(value) !== -1;
 
   const onOpenChange = useStableCallback(
     (nextOpen: boolean, eventDetails: CollapsibleRoot.ChangeEventDetails) => {

--- a/packages/react/src/accordion/item/stateAttributesMapping.ts
+++ b/packages/react/src/accordion/item/stateAttributesMapping.ts
@@ -6,9 +6,7 @@ import { AccordionItemDataAttributes } from './AccordionItemDataAttributes';
 
 export const accordionStateAttributesMapping: StateAttributesMapping<AccordionItemState> = {
   ...baseMapping,
-  index: (value) => {
-    return Number.isInteger(value) ? { [AccordionItemDataAttributes.index]: String(value) } : null;
-  },
+  index: (value) => ({ [AccordionItemDataAttributes.index]: String(value) }),
   ...transitionStatusMapping,
   value: () => null,
 };

--- a/packages/react/src/accordion/panel/AccordionPanel.test.tsx
+++ b/packages/react/src/accordion/panel/AccordionPanel.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { reactMajor, screen, waitFor } from '@mui/internal-test-utils';
 import * as React from 'react';
 import { Accordion } from '@base-ui/react/accordion';
@@ -27,6 +27,29 @@ describe('<Accordion.Panel />', () => {
       ),
     refInstanceof: window.HTMLDivElement,
   }));
+
+  it('warns when a panel enables hiddenUntilFound and disables keepMounted', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await render(
+        <Accordion.Root>
+          <Accordion.Item>
+            <Accordion.Panel hiddenUntilFound keepMounted={false}>
+              {PANEL_CONTENT}
+            </Accordion.Panel>
+          </Accordion.Item>
+        </Accordion.Root>,
+      );
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Base UI: The `keepMounted={false}` prop on an `Accordion.Panel` is ignored when `hiddenUntilFound` is enabled on the panel or root, since the panel must remain mounted while closed.',
+      );
+      expect(screen.getByText(PANEL_CONTENT).getAttribute('hidden')).toBe('until-found');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 
   describe('server-side rendering', () => {
     it('suppresses the initial keyframe animation from inline styles when rendered open', async () => {

--- a/packages/react/src/accordion/panel/AccordionPanel.tsx
+++ b/packages/react/src/accordion/panel/AccordionPanel.tsx
@@ -52,6 +52,7 @@ export const AccordionPanel = React.forwardRef(function AccordionPanel(
   const hiddenUntilFound = hiddenUntilFoundProp ?? contextHiddenUntilFound;
   const keepMounted = keepMountedProp ?? contextKeepMounted;
 
+  /* istanbul ignore else -- `process.env.NODE_ENV` is a build-time constant under test */
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {

--- a/packages/react/src/accordion/root/AccordionRoot.test.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.test.tsx
@@ -16,6 +16,27 @@ describe('<Accordion.Root />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
+  it('warns when hiddenUntilFound overrides keepMounted={false}', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await render(
+        <Accordion.Root hiddenUntilFound keepMounted={false}>
+          <Accordion.Item>
+            <Accordion.Panel>Panel</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion.Root>,
+      );
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Base UI: The `keepMounted={false}` prop on `Accordion.Root` is ignored when `hiddenUntilFound` is enabled, since panels must remain mounted while closed.',
+      );
+      expect(screen.getByText('Panel').getAttribute('hidden')).toBe('until-found');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   describe('ARIA attributes', () => {
     it('renders correct ARIA attributes', async () => {
       await render(
@@ -558,6 +579,32 @@ describe('<Accordion.Root />', () => {
       expect(onValueChange.mock.calls.length).toBe(1);
     });
 
+    it('onValueChange cancel() prevents closing while uncontrolled', async () => {
+      const onValueChange = vi.fn((_value, eventDetails) => {
+        eventDetails.cancel();
+      });
+
+      await render(
+        <Accordion.Root defaultValue={[0]} onValueChange={onValueChange}>
+          <Accordion.Item value={0}>
+            <Accordion.Header>
+              <Accordion.Trigger>Trigger 1</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Panel>{PANEL_CONTENT_1}</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion.Root>,
+      );
+
+      const trigger = screen.getByRole('button');
+
+      fireEvent.click(trigger);
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByText(PANEL_CONTENT_1)).toHaveAttribute('data-open');
+      expect(onValueChange).toHaveBeenCalledOnce();
+      expect(onValueChange.mock.lastCall?.[0]).toEqual([]);
+    });
+
     it('onOpenChange cancel() prevents onValueChange while controlled', async () => {
       const onValueChange = vi.fn();
 
@@ -709,6 +756,13 @@ describe('<Accordion.Root />', () => {
       expect(screen.queryByText(PANEL_CONTENT_1)).toHaveAttribute('data-open');
       expect(screen.queryByText(PANEL_CONTENT_2)).toHaveAttribute('data-open');
       expect(trigger1).toHaveAttribute('data-panel-open');
+      expect(trigger2).toHaveAttribute('data-panel-open');
+
+      await user.pointer({ keys: '[MouseLeft]', target: trigger1 });
+
+      expect(screen.queryByText(PANEL_CONTENT_1)).toBe(null);
+      expect(screen.getByText(PANEL_CONTENT_2)).toHaveAttribute('data-open');
+      expect(trigger1).not.toHaveAttribute('data-panel-open');
       expect(trigger2).toHaveAttribute('data-panel-open');
     });
 

--- a/packages/react/src/accordion/root/AccordionRoot.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.tsx
@@ -40,6 +40,7 @@ export const AccordionRoot = React.forwardRef(function AccordionRoot<Value = any
     ...elementProps
   } = componentProps;
 
+  /* istanbul ignore else -- `process.env.NODE_ENV` is a build-time constant under test */
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -51,6 +51,27 @@ describe('<Collapsible.Panel />', () => {
     },
   }));
 
+  it('warns when hiddenUntilFound overrides keepMounted={false}', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await render(
+        <Collapsible.Root>
+          <Collapsible.Panel hiddenUntilFound keepMounted={false}>
+            {PANEL_CONTENT}
+          </Collapsible.Panel>
+        </Collapsible.Root>,
+      );
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Base UI: The `keepMounted={false}` prop on `Collapsible.Panel` is ignored when `hiddenUntilFound` is enabled, since the panel must remain mounted while closed.',
+      );
+      expect(screen.getByText(PANEL_CONTENT).getAttribute('hidden')).toBe('until-found');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   describe('prop: keepMounted', () => {
     it('does not unmount the panel when true', async () => {
       function App() {
@@ -214,6 +235,193 @@ describe('<Collapsible.Panel />', () => {
         expect(panel.style.getPropertyValue('--collapsible-panel-height')).toMatch(/px$/);
       });
     });
+
+    it('unmounts a zero-size panel without waiting for unrelated transitions', async () => {
+      await render(
+        <React.Fragment>
+          <style>{`
+            .zero-size-panel {
+              overflow: hidden;
+              width: 0;
+              height: 0;
+              opacity: 1;
+              transition: opacity 10s linear;
+            }
+
+            .zero-size-panel[data-ending-style] {
+              opacity: 0;
+            }
+          `}</style>
+
+          <Collapsible.Root defaultOpen>
+            <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+            <Collapsible.Panel className="zero-size-panel" data-testid="panel" />
+          </Collapsible.Root>
+        </React.Fragment>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      expect(screen.getByTestId('panel')).toHaveAttribute('data-open');
+
+      fireEvent.click(trigger);
+      await act(async () => {
+        await waitForAnimationFrame();
+      });
+
+      expect(screen.queryByTestId('panel')).toBe(null);
+    });
+
+    it('supports removing the rendered panel as it closes', async () => {
+      const onOpenChange = vi.fn();
+
+      function RemovablePanel({
+        open,
+        ...props
+      }: React.ComponentPropsWithRef<'div'> & { open: boolean }) {
+        return open ? <div {...props} /> : null;
+      }
+
+      const { user } = await render(
+        <Collapsible.Root defaultOpen onOpenChange={onOpenChange}>
+          <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+          <Collapsible.Panel
+            render={(props, state) => <RemovablePanel {...props} open={state.open} />}
+            style={{ transition: 'height 100ms linear' }}
+          >
+            {PANEL_CONTENT}
+          </Collapsible.Panel>
+        </Collapsible.Root>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      expect(screen.getByText(PANEL_CONTENT)).toHaveAttribute('data-open');
+
+      await user.click(trigger);
+      await act(async () => {
+        await waitForAnimationFrame();
+      });
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByText(PANEL_CONTENT)).toBe(null);
+      expect(onOpenChange).toHaveBeenCalledWith(false, expect.anything());
+    });
+
+    it('preserves inline alignment styles while measuring an opening panel', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        await render(
+          <React.Fragment>
+            <style>{`
+              @keyframes panel-fade-in {
+                from {
+                  opacity: 0;
+                }
+
+                to {
+                  opacity: 1;
+                }
+              }
+
+              .mixed-motion-panel {
+                height: var(--collapsible-panel-height);
+                transition: height 100ms linear;
+                animation: panel-fade-in 100ms linear;
+              }
+
+              .mixed-motion-panel[data-starting-style] {
+                height: 0;
+              }
+            `}</style>
+
+            <Collapsible.Root>
+              <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+              <Collapsible.Panel
+                className="mixed-motion-panel"
+                data-testid="panel"
+                keepMounted
+                style={{ justifyContent: 'center' }}
+              >
+                {PANEL_CONTENT}
+              </Collapsible.Panel>
+            </Collapsible.Root>
+          </React.Fragment>,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Trigger' });
+        const panel = screen.getByTestId('panel');
+
+        fireEvent.click(trigger);
+
+        expect(panel).toHaveAttribute('data-starting-style');
+        expect(panel.style.getPropertyValue('justify-content')).toBe('initial');
+        expect(panel.style.getPropertyPriority('justify-content')).toBe('important');
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Base UI: CSS transitions and CSS animations both detected on Collapsible or Accordion panel. Only one of either animation type should be used.',
+        );
+
+        await act(async () => {
+          await waitForAnimationFrame();
+        });
+
+        expect(panel.style.justifyContent).toBe('center');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('keeps exit transitions working after a close is interrupted by reopening', async () => {
+      const { user } = await render(
+        <React.Fragment>
+          <style>{`
+            .interruptible-panel {
+              overflow: hidden;
+              height: var(--collapsible-panel-height);
+              transition: height 100ms linear;
+            }
+
+            .interruptible-panel[data-starting-style],
+            .interruptible-panel[data-ending-style] {
+              height: 0;
+            }
+          `}</style>
+
+          <Collapsible.Root defaultOpen>
+            <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+            <Collapsible.Panel className="interruptible-panel" data-testid="panel">
+              {PANEL_CONTENT}
+            </Collapsible.Panel>
+          </Collapsible.Root>
+        </React.Fragment>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      const panel = screen.getByTestId('panel');
+
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(panel).toHaveAttribute('data-ending-style');
+      });
+
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(panel).toHaveAttribute('data-open');
+      });
+      await waitFor(() => {
+        expect(panel).not.toHaveAttribute('data-starting-style');
+      });
+
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(panel).toHaveAttribute('data-ending-style');
+      });
+      expect(screen.getByTestId('panel')).toBe(panel);
+    });
   });
 
   describe.skipIf(isJSDOM)('CSS animations', () => {
@@ -313,6 +521,51 @@ describe('<Collapsible.Panel />', () => {
 
       await waitFor(() => {
         expect(panel).toHaveAttribute('data-open');
+        expect(panel.getAnimations().length).toBe(1);
+      });
+    });
+
+    it('restores measured dimensions before applying a closing keyframe animation', async () => {
+      const { user } = await render(
+        <React.Fragment>
+          <style>{`
+            @keyframes panel-slide-up {
+              from {
+                height: var(--collapsible-panel-height);
+              }
+
+              to {
+                height: 0;
+              }
+            }
+
+            .closing-animation-panel[data-closed] {
+              overflow: hidden;
+              animation: panel-slide-up 100ms linear;
+            }
+          `}</style>
+
+          <Collapsible.Root defaultOpen>
+            <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+            <Collapsible.Panel className="closing-animation-panel" data-testid="panel">
+              {PANEL_CONTENT}
+            </Collapsible.Panel>
+          </Collapsible.Root>
+        </React.Fragment>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      const panel = screen.getByTestId('panel');
+
+      await waitFor(() => {
+        expect(panel.style.getPropertyValue('--collapsible-panel-height')).toBe('auto');
+      });
+
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(panel).toHaveAttribute('data-ending-style');
+        expect(panel.style.getPropertyValue('--collapsible-panel-height')).toMatch(/px$/);
         expect(panel.getAnimations().length).toBe(1);
       });
     });

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -9,6 +9,7 @@ import {
   waitFor,
 } from '@mui/internal-test-utils';
 import { Collapsible } from '@base-ui/react/collapsible';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { REASONS } from '../../internals/reasons';
 
@@ -158,6 +159,53 @@ describe('<Collapsible.Panel />', () => {
         expect(panel).not.toHaveAttribute('data-ending-style');
       },
     );
+  });
+
+  it('unmounts a panel that mounts after the close has already entered the ending phase', async () => {
+    const renderedStatuses: Array<Collapsible.Panel.State['transitionStatus']> = [];
+
+    function PanelThatMountsDuringEnding({
+      open,
+      transitionStatus,
+      ...props
+    }: React.ComponentPropsWithRef<'div'> & {
+      open: boolean;
+      transitionStatus: Collapsible.Panel.State['transitionStatus'];
+    }) {
+      renderedStatuses.push(transitionStatus);
+
+      if (!open && transitionStatus !== 'ending') {
+        return null;
+      }
+
+      return <div {...props} />;
+    }
+
+    await render(
+      <Collapsible.Root defaultOpen>
+        <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+        <Collapsible.Panel
+          render={(props, state) => (
+            <PanelThatMountsDuringEnding
+              {...props}
+              open={state.open}
+              transitionStatus={state.transitionStatus}
+            />
+          )}
+        >
+          {PANEL_CONTENT}
+        </Collapsible.Panel>
+      </Collapsible.Root>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+
+    await act(async () => {
+      await waitForAnimationFrame();
+    });
+
+    expect(renderedStatuses).toContain('ending');
+    expect(screen.queryByText(PANEL_CONTENT)).toBe(null);
   });
 
   describe.skipIf(isJSDOM)('CSS transitions', () => {
@@ -421,6 +469,135 @@ describe('<Collapsible.Panel />', () => {
         expect(panel).toHaveAttribute('data-ending-style');
       });
       expect(screen.getByTestId('panel')).toBe(panel);
+    });
+
+    it('keeps the measured size when an open animation finishes during a close commit', async () => {
+      const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+      const abortSpy = vi.spyOn(AbortController.prototype, 'abort').mockImplementation(() => {});
+      let animationStarted = false;
+      const animation = new Animation(new KeyframeEffect(null, [], 10_000), document.timeline);
+      animation.play();
+
+      function ResolveAnimationOnClose({ open }: { open: boolean }) {
+        useIsoLayoutEffect(() => {
+          if (!open && animationStarted) {
+            animation.finish();
+          }
+        }, [open]);
+
+        return null;
+      }
+
+      const setPanelRef = (node: HTMLDivElement | null) => {
+        if (node) {
+          node.getAnimations = () => {
+            if (node.hasAttribute('data-open')) {
+              animationStarted = true;
+              return [animation];
+            }
+
+            return [];
+          };
+        }
+      };
+
+      try {
+        await render(
+          <Collapsible.Root defaultOpen>
+            <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+            <Collapsible.Panel
+              ref={setPanelRef}
+              keepMounted
+              render={(props, state) => (
+                <div {...props}>
+                  <ResolveAnimationOnClose open={state.open} />
+                  {props.children}
+                </div>
+              )}
+              style={{ transition: 'height 10s linear' }}
+            >
+              {PANEL_CONTENT}
+            </Collapsible.Panel>
+          </Collapsible.Root>,
+        );
+
+        const panel = screen.getByText(PANEL_CONTENT);
+
+        await act(async () => {
+          await waitForAnimationFrame();
+        });
+        expect(animationStarted).toBe(true);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+        await flushMicrotasks();
+
+        expect(panel.style.getPropertyValue('--collapsible-panel-height')).toMatch(/px$/);
+      } finally {
+        animation.cancel();
+        abortSpy.mockRestore();
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
+      }
+    });
+
+    it('does not restart the entrance transition when a close animation finishes after reopening', async () => {
+      const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+      const abortSpy = vi.spyOn(AbortController.prototype, 'abort').mockImplementation(() => {});
+      let closeAnimationStarted = false;
+      const closeAnimation = new Animation(new KeyframeEffect(null, [], 10_000), document.timeline);
+      closeAnimation.play();
+
+      const setPanelRef = (node: HTMLDivElement | null) => {
+        if (node) {
+          node.getAnimations = () => {
+            if (node.hasAttribute('data-ending-style')) {
+              closeAnimationStarted = true;
+              return [closeAnimation];
+            }
+
+            return [];
+          };
+        }
+      };
+
+      try {
+        await render(
+          <Collapsible.Root defaultOpen>
+            <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+            <Collapsible.Panel ref={setPanelRef} style={{ transition: 'height 10s linear' }}>
+              {PANEL_CONTENT}
+            </Collapsible.Panel>
+          </Collapsible.Root>,
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Trigger' });
+        const panel = screen.getByText(PANEL_CONTENT);
+
+        fireEvent.click(trigger);
+        await waitFor(() => {
+          expect(closeAnimationStarted).toBe(true);
+        });
+
+        fireEvent.click(trigger);
+        await waitFor(() => {
+          expect(panel).toHaveAttribute('data-open');
+        });
+        await waitFor(() => {
+          expect(panel).not.toHaveAttribute('data-starting-style');
+        });
+
+        closeAnimation.finish();
+        await flushMicrotasks();
+
+        expect(panel).toHaveAttribute('data-open');
+        expect(panel).not.toHaveAttribute('data-starting-style');
+        expect(screen.getByText(PANEL_CONTENT)).toBe(panel);
+      } finally {
+        closeAnimation.cancel();
+        abortSpy.mockRestore();
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
+      }
     });
   });
 

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -322,12 +322,12 @@ describe('<Collapsible.Panel />', () => {
     it('supports removing the rendered panel as it closes', async () => {
       const onOpenChange = vi.fn();
 
-      function RemovablePanel({
-        open,
-        ...props
-      }: React.ComponentPropsWithRef<'div'> & { open: boolean }) {
-        return open ? <div {...props} /> : null;
-      }
+      const RemovablePanel = React.forwardRef<
+        HTMLDivElement,
+        React.ComponentPropsWithoutRef<'div'> & { open: boolean }
+      >(function RemovablePanel({ open, ...props }, ref) {
+        return open ? <div {...props} ref={ref} /> : null;
+      });
 
       const { user } = await render(
         <Collapsible.Root defaultOpen onOpenChange={onOpenChange}>

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -164,22 +164,21 @@ describe('<Collapsible.Panel />', () => {
   it('unmounts a panel that mounts after the close has already entered the ending phase', async () => {
     const renderedStatuses: Array<Collapsible.Panel.State['transitionStatus']> = [];
 
-    function PanelThatMountsDuringEnding({
-      open,
-      transitionStatus,
-      ...props
-    }: React.ComponentPropsWithRef<'div'> & {
-      open: boolean;
-      transitionStatus: Collapsible.Panel.State['transitionStatus'];
-    }) {
+    const PanelThatMountsDuringEnding = React.forwardRef<
+      HTMLDivElement,
+      React.ComponentPropsWithoutRef<'div'> & {
+        open: boolean;
+        transitionStatus: Collapsible.Panel.State['transitionStatus'];
+      }
+    >(function PanelThatMountsDuringEnding({ open, transitionStatus, ...props }, ref) {
       renderedStatuses.push(transitionStatus);
 
       if (!open && transitionStatus !== 'ending') {
         return null;
       }
 
-      return <div {...props} />;
-    }
+      return <div {...props} ref={ref} />;
+    });
 
     await render(
       <Collapsible.Root defaultOpen>

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.tsx
@@ -32,6 +32,7 @@ export const CollapsiblePanel = React.forwardRef(function CollapsiblePanel(
     ...elementProps
   } = componentProps;
 
+  /* istanbul ignore else -- `process.env.NODE_ENV` is a build-time constant under test */
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {

--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -5,7 +5,6 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { AnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { warn } from '@base-ui/utils/warn';
 import { ownerWindow } from '@base-ui/utils/owner';
 import { HTMLProps } from '../../internals/types';
@@ -66,10 +65,6 @@ export function useCollapsiblePanel(
   const pendingTemporaryStyleRestoreRef = React.useRef<(() => void) | null>(null);
 
   const mergedPanelRef = useMergedRefs(externalRef, panelRef);
-  const latestStateRef = useValueAsRef({
-    mounted,
-    open,
-  });
   // Only used to handle panel close
   const runOnceCloseAnimationsFinish = useAnimationsFinished(panelRef, false, false);
 
@@ -206,25 +201,21 @@ export function useCollapsiblePanel(
         return restoreLayoutStyles;
       }
 
-      if (animationType === 'css-animation') {
-        setDimensions(getDimensions(panel));
+      setDimensions(getDimensions(panel));
 
-        if (!skipNextOpen) {
-          const restoreAnimationName = setTemporaryStyle(panel, 'animation-name', 'none');
-          restoreAnimationName();
-
-          return undefined;
-        }
-
-        const restoreAnimationName = setTemporaryStyle(panel, 'animation-name', 'none');
-        const restoreAnimationDuration = setTemporaryStyle(panel, 'animation-duration', '0s');
-
+      const restoreAnimationName = setTemporaryStyle(panel, 'animation-name', 'none');
+      if (!skipNextOpen) {
         restoreAnimationName();
-        setPendingTemporaryStyleRestore(restoreAnimationDuration);
-        setForcePanelIdle(true);
-
         return undefined;
       }
+
+      const restoreAnimationDuration = setTemporaryStyle(panel, 'animation-duration', '0s');
+
+      restoreAnimationName();
+      setPendingTemporaryStyleRestore(restoreAnimationDuration);
+      setForcePanelIdle(true);
+
+      return undefined;
     }
 
     // Capture the current size as soon as close is requested, before the
@@ -248,13 +239,8 @@ export function useCollapsiblePanel(
       return undefined;
     }
 
-    if (animationType === 'none') {
-      setMounted(false);
-      return undefined;
-    }
-
     const nextDimensions = getDimensions(panel);
-    const hasMeasuredSize = (nextDimensions.height ?? 0) > 0 || (nextDimensions.width ?? 0) > 0;
+    const hasMeasuredSize = nextDimensions.height > 0 || nextDimensions.width > 0;
 
     if (!hasMeasuredSize) {
       setMounted(false);
@@ -285,10 +271,6 @@ export function useCollapsiblePanel(
     open: true,
     ref: panelRef,
     onComplete() {
-      if (!open) {
-        return;
-      }
-
       setDimensions(EMPTY_DIMENSIONS, false);
     },
   });
@@ -313,18 +295,12 @@ export function useCollapsiblePanel(
     let endingStyleFrame = -1;
 
     function handleComplete() {
-      if (latestStateRef.current.open) {
-        return;
-      }
-
       setMounted(false);
       setDimensions(EMPTY_DIMENSIONS, false);
     }
 
     endingStyleFrame = AnimationFrame.request(() => {
-      if (!abortController.signal.aborted) {
-        runOnceCloseAnimationsFinish(handleComplete, abortController.signal);
-      }
+      runOnceCloseAnimationsFinish(handleComplete, abortController.signal);
     });
 
     return () => {
@@ -332,7 +308,6 @@ export function useCollapsiblePanel(
       abortController.abort();
     };
   }, [
-    latestStateRef,
     mounted,
     open,
     panelTransitionStatus,
@@ -398,7 +373,7 @@ export function useCollapsiblePanel(
   };
 }
 
-function getDimensions(element: HTMLElement): Dimensions {
+function getDimensions(element: HTMLElement) {
   return {
     height: element.scrollHeight,
     width: element.scrollWidth,
@@ -407,7 +382,7 @@ function getDimensions(element: HTMLElement): Dimensions {
 
 function getAnimationType(
   element: HTMLElement,
-  hasSuppressedMountAnimation: boolean = false,
+  hasSuppressedMountAnimation: boolean,
 ): AnimationType {
   const panelStyles = ownerWindow(element).getComputedStyle(element);
   const hasAnimation =
@@ -420,6 +395,7 @@ function getAnimationType(
   const hasTransition = hasNonZeroDuration(panelStyles.transitionDuration);
 
   if (hasAnimation && hasTransition) {
+    /* istanbul ignore else -- `process.env.NODE_ENV` is a build-time constant under test */
     if (process.env.NODE_ENV !== 'production') {
       warn(
         'CSS transitions and CSS animations both detected on Collapsible or Accordion panel.',

--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -5,6 +5,7 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { AnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { warn } from '@base-ui/utils/warn';
 import { ownerWindow } from '@base-ui/utils/owner';
 import { HTMLProps } from '../../internals/types';
@@ -65,6 +66,7 @@ export function useCollapsiblePanel(
   const pendingTemporaryStyleRestoreRef = React.useRef<(() => void) | null>(null);
 
   const mergedPanelRef = useMergedRefs(externalRef, panelRef);
+  const latestOpenRef = useValueAsRef(open);
   // Only used to handle panel close
   const runOnceCloseAnimationsFinish = useAnimationsFinished(panelRef, false, false);
 
@@ -239,6 +241,14 @@ export function useCollapsiblePanel(
       return undefined;
     }
 
+    // Reachable when `transitionStatus` already flipped to `ending` before this effect ran, so
+    // the close branch above was skipped. Without motion there is nothing to wait for, so unmount
+    // here instead of deferring to the animation-finished path below.
+    if (animationType === 'none') {
+      setMounted(false);
+      return undefined;
+    }
+
     const nextDimensions = getDimensions(panel);
     const hasMeasuredSize = nextDimensions.height > 0 || nextDimensions.width > 0;
 
@@ -271,6 +281,15 @@ export function useCollapsiblePanel(
     open: true,
     ref: panelRef,
     onComplete() {
+      // `useOpenChangeComplete` only aborts from its effect cleanup, which React runs in the
+      // post-paint passive flush. An animation's `finished` microtask can resolve after the render
+      // that set `open` to `false` but before that cleanup, so re-check the latest value here.
+      // Clearing the measured size in that window would make the close transition start from
+      // `height: 0` instead of the expanded pixel height.
+      if (!open) {
+        return;
+      }
+
       setDimensions(EMPTY_DIMENSIONS, false);
     },
   });
@@ -295,6 +314,13 @@ export function useCollapsiblePanel(
     let endingStyleFrame = -1;
 
     function handleComplete() {
+      // Same post-paint race as the `useOpenChangeComplete` callback above, except `open` is
+      // captured by this effect's closure and always `false` here, so read the latest value from
+      // a ref. Unmounting a panel that has already reopened would drop it from the DOM.
+      if (latestOpenRef.current) {
+        return;
+      }
+
       setMounted(false);
       setDimensions(EMPTY_DIMENSIONS, false);
     }
@@ -308,6 +334,7 @@ export function useCollapsiblePanel(
       abortController.abort();
     };
   }, [
+    latestOpenRef,
     mounted,
     open,
     panelTransitionStatus,

--- a/packages/react/src/collapsible/trigger/CollapsibleTrigger.test.tsx
+++ b/packages/react/src/collapsible/trigger/CollapsibleTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { Collapsible } from '@base-ui/react/collapsible';
 import { describeConformance } from '../../../test/describeConformance';
@@ -7,9 +7,15 @@ describe('<Collapsible.Trigger />', () => {
   const { render } = createRenderer();
 
   it('throws when rendered outside a Collapsible.Root', () => {
-    expect(() => render(<Collapsible.Trigger />)).toThrow(
-      'Base UI: CollapsibleRootContext is missing. Collapsible parts must be placed within <Collapsible.Root>.',
-    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      expect(() => render(<Collapsible.Trigger />)).toThrow(
+        'Base UI: CollapsibleRootContext is missing. Collapsible parts must be placed within <Collapsible.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   describeConformance(<Collapsible.Trigger />, () => ({

--- a/packages/react/src/collapsible/trigger/CollapsibleTrigger.test.tsx
+++ b/packages/react/src/collapsible/trigger/CollapsibleTrigger.test.tsx
@@ -6,6 +6,12 @@ import { describeConformance } from '../../../test/describeConformance';
 describe('<Collapsible.Trigger />', () => {
   const { render } = createRenderer();
 
+  it('throws when rendered outside a Collapsible.Root', () => {
+    expect(() => render(<Collapsible.Trigger />)).toThrow(
+      'Base UI: CollapsibleRootContext is missing. Collapsible parts must be placed within <Collapsible.Root>.',
+    );
+  });
+
   describeConformance(<Collapsible.Trigger />, () => ({
     refInstanceof: window.HTMLButtonElement,
     testComponentPropWith: 'button',


### PR DESCRIPTION
Expands Accordion and Collapsible test coverage to 100% across statements, branches, functions, and lines on merged jsdom and Chromium results, and removes the redundant code the sweep uncovered.

## Changes

- Added behavior tests for canceled closes, multiple-item state, hidden-until-found composition, zero-size panels, custom render removal, and transition and keyframe lifecycles.
- Covered missing-context errors, mixed transition and animation warnings, interrupted closes, and inline style restoration.
- Removed redundant item lookup, state-attribute, and panel animation branches.