### PR TITLE
[test] Stabilize combobox popup reopen tests

### DIFF
--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -158,9 +158,9 @@ describe('<Autocomplete.Root />', () => {
       await user.click(trigger);
 
       expect(await screen.findByTestId('input')).toHaveValue('al');
-      expect(screen.getByRole('option', { name: 'alpha' })).not.toBe(null);
-      expect(screen.getByRole('option', { name: 'alpine' })).not.toBe(null);
-      expect(screen.queryByRole('option', { name: 'beta' })).toBe(null);
+      expect(await screen.findByRole('option', { name: 'alpha' })).not.toBe(null);
+      expect(await screen.findByRole('option', { name: 'alpine' })).not.toBe(null);
+      await waitFor(() => expect(screen.queryByRole('option', { name: 'beta' })).toBe(null));
 
       await user.keyboard('{Escape}');
       await waitFor(() => expect(screen.queryByRole('dialog')).toBe(null));

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -306,7 +306,7 @@ describe('<Combobox.Root />', () => {
       const reopenedInput = await screen.findByTestId('input');
       expect(reopenedInput).toHaveValue('');
 
-      const banana = screen.getByRole('option', { name: 'Banana' });
+      const banana = await screen.findByRole('option', { name: 'Banana' });
       expect(banana).toHaveAttribute('aria-selected', 'true');
       await waitFor(() => expect(banana).toHaveAttribute('data-highlighted'));
     });
@@ -352,11 +352,11 @@ describe('<Combobox.Root />', () => {
       await user.click(trigger);
 
       expect(await screen.findByTestId('input')).toHaveValue('');
-      expect(screen.getByRole('option', { name: 'Apple' })).toHaveAttribute(
+      expect(await screen.findByRole('option', { name: 'Apple' })).toHaveAttribute(
         'aria-selected',
         'true',
       );
-      expect(screen.getByRole('option', { name: 'Banana' })).not.toBe(null);
+      expect(await screen.findByRole('option', { name: 'Banana' })).not.toBe(null);
     });
 
     it('keeps filtering responsive when the selection close is canceled', async () => {


### PR DESCRIPTION
## Changes

- Wait for Autocomplete popup options to mount before checking filtered results.
- Wait for Combobox popup options to mount after reopening.