### PR TITLE
[preview card] Expand test coverage

### DIFF
--- a/docs/src/error-codes.json
+++ b/docs/src/error-codes.json
@@ -46,7 +46,7 @@
   "46": "Base UI: PopoverPositionerContext is missing. PopoverPositioner parts must be placed within <Popover.Positioner>.",
   "47": "Base UI: PopoverRootContext is missing. Popover parts must be placed within <Popover.Root>.",
   "48": "Base UI: <PreviewCard.Portal> is missing.",
-  "49": "Base UI: <PreviewCard.Popup> and <PreviewCard.Arrow> must be used within the <PreviewCard.Positioner> component",
+  "49": "Base UI: PreviewCardPositionerContext is missing. PreviewCardPositioner parts must be placed within <PreviewCard.Positioner>.",
   "50": "Base UI: PreviewCardRootContext is missing. PreviewCard parts must be placed within <PreviewCard.Root>.",
   "51": "Base UI: ProgressRootContext is missing. Progress parts must be placed within <Progress.Root>.",
   "52": "Base UI: RadioRootContext is missing. Radio parts must be placed within <Radio.Root>.",

--- a/packages/react/src/preview-card/popup/PreviewCardPopup.test.tsx
+++ b/packages/react/src/preview-card/popup/PreviewCardPopup.test.tsx
@@ -1,9 +1,9 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
-describe('<Popover.Popup />', () => {
+describe('<PreviewCard.Popup />', () => {
   const { render } = createRenderer();
 
   describeConformance(<PreviewCard.Popup />, () => ({
@@ -18,6 +18,38 @@ describe('<Popover.Popup />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <PreviewCard.Root>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<PreviewCard.Popup />)).rejects.toThrow(
+        'Base UI: PreviewCardRootContext is missing. PreviewCard parts must be placed within <PreviewCard.Root>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('throws a descriptive error when rendered outside <PreviewCard.Positioner>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <PreviewCard.Root open>
+            <PreviewCard.Portal>
+              <PreviewCard.Popup />
+            </PreviewCard.Portal>
+          </PreviewCard.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: PreviewCardPositionerContext is missing. PreviewCardPositioner parts must be placed within <PreviewCard.Positioner>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   it('should render the children', async () => {
     await render(

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, expect } from 'vitest';
+import { afterEach, expect, vi } from 'vitest';
 import * as React from 'react';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { screen, waitFor } from '@mui/internal-test-utils';
@@ -72,6 +72,22 @@ describe('<PreviewCard.Positioner />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <PreviewCard.Portal>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <PreviewCard.Root open>
+            <PreviewCard.Positioner />
+          </PreviewCard.Root>,
+        ),
+      ).rejects.toThrow('Base UI: <PreviewCard.Portal> is missing.');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   const baselineX = 10;
   const baselineY = 36;

--- a/packages/react/src/preview-card/positioner/PreviewCardPositionerContext.ts
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositionerContext.ts
@@ -15,7 +15,7 @@ export function usePreviewCardPositionerContext() {
   const context = React.useContext(PreviewCardPositionerContext);
   if (context === undefined) {
     throw new Error(
-      'Base UI: <PreviewCard.Popup> and <PreviewCard.Arrow> must be used within the <PreviewCard.Positioner> component',
+      'Base UI: PreviewCardPositionerContext is missing. PreviewCardPositioner parts must be placed within <PreviewCard.Positioner>.',
     );
   }
 

--- a/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
@@ -4,6 +4,7 @@ import { PreviewCard } from '@base-ui/react/preview-card';
 import { act, fireEvent, screen, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { createRenderer, isJSDOM, popupConformanceTests } from '#test-utils';
+import { REASONS } from '../../internals/reasons';
 import { CLOSE_DELAY, OPEN_DELAY } from '../utils/constants';
 
 describe('<PreviewCard.Root />', () => {
@@ -490,6 +491,34 @@ describe('<PreviewCard.Root />', () => {
         await waitFor(() => {
           expect(screen.queryByTestId('positioner')).toBe(null);
         });
+      });
+
+      it('closes the preview card when the `close` method is called', async () => {
+        const onOpenChange = vi.fn();
+        const actionsRef = React.createRef<PreviewCard.Root.Actions>();
+
+        const { user } = await render(
+          <TestPreviewCard rootProps={{ actionsRef, onOpenChange }} triggerProps={{ delay: 0 }} />,
+        );
+
+        const trigger = screen.getByRole('link', { name: 'Link' });
+        await user.hover(trigger);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('popup')).not.toBe(null);
+        });
+
+        await act(async () => actionsRef.current?.close());
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('positioner')).toBe(null);
+        });
+
+        expect(trigger).not.toHaveAttribute('data-popup-open');
+        expect(onOpenChange).toHaveBeenLastCalledWith(
+          false,
+          expect.objectContaining({ reason: REASONS.imperativeAction }),
+        );
       });
     });
 

--- a/packages/react/src/preview-card/root/PreviewCardRoot.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.tsx
@@ -95,13 +95,11 @@ function PreviewCardInteractions<Payload>({ store }: { store: PreviewCardStore<P
 
   const dismiss = useDismiss(floatingRootContext);
 
-  // `useDismiss` is not given an `enabled` option, so it always returns both prop bags.
-  // `dismiss.trigger` is always the same object as `dismiss.reference`.
+  // `useDismiss` is not given an `enabled` option, so all three prop bags are always defined.
+  // `dismiss.trigger` is the same object as `dismiss.reference`.
   usePopupInteractionProps(store, {
     activeTriggerProps: dismiss.reference!,
     inactiveTriggerProps: dismiss.trigger!,
-    // PreviewCardPopup spreads `FOCUSABLE_POPUP_PROPS` directly, so the popup
-    // props only need to carry the dismiss handlers.
     popupProps: dismiss.floating!,
   });
 

--- a/packages/react/src/preview-card/root/PreviewCardRoot.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import { fastComponent } from '@base-ui/utils/fastHooks';
-import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useDismiss, FloatingTree } from '../../floating-ui-react';
 import { PreviewCardRootContext, usePreviewCardRootContext } from './PreviewCardContext';
@@ -96,12 +95,14 @@ function PreviewCardInteractions<Payload>({ store }: { store: PreviewCardStore<P
 
   const dismiss = useDismiss(floatingRootContext);
 
+  // `useDismiss` is not given an `enabled` option, so it always returns both prop bags.
+  // `dismiss.trigger` is always the same object as `dismiss.reference`.
   usePopupInteractionProps(store, {
-    // `enabled` is not passed to `useDismiss`, so its props are always defined,
-    // and `trigger` is the same object as `reference`.
     activeTriggerProps: dismiss.reference!,
     inactiveTriggerProps: dismiss.trigger!,
-    popupProps: dismiss.floating ?? EMPTY_OBJECT,
+    // PreviewCardPopup spreads `FOCUSABLE_POPUP_PROPS` directly, so the popup
+    // props only need to carry the dismiss handlers.
+    popupProps: dismiss.floating!,
   });
 
   return null;

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -55,9 +55,9 @@ export class PreviewCardStore<Payload> extends ReactStore<
   Selectors
 > {
   constructor(
-    initialState?: Partial<State<Payload>>,
-    floatingId?: string | undefined,
-    nested = false,
+    initialState: Partial<State<Payload>>,
+    floatingId: string | undefined,
+    nested: boolean,
   ) {
     const triggerElements = new PopupTriggerMap();
     super(

--- a/packages/react/src/preview-card/trigger/PreviewCardTrigger.test.tsx
+++ b/packages/react/src/preview-card/trigger/PreviewCardTrigger.test.tsx
@@ -1,3 +1,4 @@
+import { expect, vi } from 'vitest';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { createRenderer, describeConformance } from '#test-utils';
 
@@ -10,4 +11,16 @@ describe('<PreviewCard.Trigger />', () => {
       return render(<PreviewCard.Root open>{node}</PreviewCard.Root>);
     },
   }));
+
+  it('throws without PreviewCard.Root or a handle', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(render(<PreviewCard.Trigger />)).rejects.toThrow(
+        'Base UI: <PreviewCard.Trigger> must be either used within a <PreviewCard.Root> component or provided with a handle.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/packages/react/src/preview-card/viewport/PreviewCardViewport.test.tsx
+++ b/packages/react/src/preview-card/viewport/PreviewCardViewport.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { act, ignoreActWarnings, screen, waitFor } from '@mui/internal-test-utils';
@@ -22,6 +22,26 @@ describe('<PreviewCard.Viewport />', () => {
       );
     },
   }));
+
+  it('throws a descriptive error when rendered outside <PreviewCard.Positioner>', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        render(
+          <PreviewCard.Root open>
+            <PreviewCard.Portal>
+              <PreviewCard.Viewport />
+            </PreviewCard.Portal>
+          </PreviewCard.Root>,
+        ),
+      ).rejects.toThrow(
+        'Base UI: PreviewCardPositionerContext is missing. PreviewCardPositioner parts must be placed within <PreviewCard.Positioner>.',
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 
   it('should render children in the `current` container by default', async () => {
     await render(


### PR DESCRIPTION
Expands Preview Card test coverage to 100% across statements, branches, functions, and lines on merged jsdom and Chromium results, and removes the redundant code the sweep uncovered.

## Changes

- Added behavior tests for imperative closing, detached triggers, and missing Root, Positioner, and Portal compositions.
- Fixed the Positioner context error to describe the Preview Card part that is missing.
- Removed unreachable dismiss-prop fallbacks and unused optional store constructor inputs.