### PR TITLE
[docs] Overhaul grays

### DIFF
--- a/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
+++ b/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
@@ -20,7 +20,7 @@ import { Accordion } from '@base-ui/react/accordion';
 
 export default function ExampleAccordion() {
   return (
-    <Accordion.Root className="flex w-full max-w-80 flex-col border border-neutral-950 text-neutral-950 dark:border-white dark:text-white">
+    <Accordion.Root className="flex w-full max-w-80 flex-col border border-neutral-950 bg-white text-neutral-950 dark:border-white dark:bg-neutral-950 dark:text-white">
       <Accordion.Item>
         <Accordion.Header>
           <Accordion.Trigger className="group flex w-full items-center justify-between gap-4 bg-transparent px-3 py-2 text-left text-sm font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-neutral-950 dark:focus-visible:outline-white dark:text-white dark:hover:not-data-disabled:bg-neutral-800">
@@ -99,10 +99,12 @@ This example shows how to implement the component using CSS Modules.
   width: 100%;
   flex-direction: column;
   border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
   color: oklch(14.5% 0 0deg);
 
   @media (prefers-color-scheme: dark) {
     border: 1px solid white;
+    background-color: oklch(14.5% 0 0deg);
     color: white;
   }
 }
@@ -307,7 +309,7 @@ export default function ExampleAccordion() {
   return (
     <Accordion.Root
       multiple
-      className="flex w-full max-w-80 flex-col border border-neutral-950 text-neutral-950 dark:border-white dark:text-white"
+      className="flex w-full max-w-80 flex-col border border-neutral-950 bg-white text-neutral-950 dark:border-white dark:bg-neutral-950 dark:text-white"
     >
       <Accordion.Item>
         <Accordion.Header>
@@ -387,10 +389,12 @@ This example shows how to implement the component using CSS Modules.
   width: 100%;
   flex-direction: column;
   border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
   color: oklch(14.5% 0 0deg);
 
   @media (prefers-color-scheme: dark) {
     border: 1px solid white;
+    background-color: oklch(14.5% 0 0deg);
     color: white;
   }
 }

--- a/docs/src/app/(docs)/layout.css
+++ b/docs/src/app/(docs)/layout.css
@@ -10,8 +10,8 @@
     min-width: 320px;
     line-height: 1.5;
     /* It's also the iOS footer overscroll background */
-    background-color: var(--color-content);
-    color: var(--color-foreground);
+    background-color: var(--canvas);
+    color: var(--gray-t3);
   }
 }
 
@@ -46,7 +46,6 @@
     display: flex;
     flex-grow: 1;
     flex-direction: column;
-    background-color: var(--color-content);
   }
 
   .ContentLayoutRoot {

--- a/docs/src/app/(docs)/layout.tsx
+++ b/docs/src/app/(docs)/layout.tsx
@@ -171,14 +171,14 @@ export const viewport: Viewport = {
   initialScale: 1,
   width: 'device-width',
   themeColor: [
-    // Safari header background: match the page background (--color-content)
+    // Safari header background: match the page background (--canvas)
     {
       media: '(prefers-color-scheme: light)',
       color: 'white',
     },
     {
       media: '(prefers-color-scheme: dark)',
-      color: 'black',
+      color: 'oklch(21% 0 0deg)',
     },
   ],
 };

--- a/docs/src/app/(docs)/react/components/accordion/demos/_index.module.css
+++ b/docs/src/app/(docs)/react/components/accordion/demos/_index.module.css
@@ -5,10 +5,12 @@
   width: 100%;
   flex-direction: column;
   border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
   color: oklch(14.5% 0 0deg);
 
   @media (prefers-color-scheme: dark) {
     border: 1px solid white;
+    background-color: oklch(14.5% 0 0deg);
     color: white;
   }
 }

--- a/docs/src/app/(docs)/react/components/accordion/demos/hero/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/accordion/demos/hero/tailwind/index.tsx
@@ -3,7 +3,7 @@ import { Accordion } from '@base-ui/react/accordion';
 
 export default function ExampleAccordion() {
   return (
-    <Accordion.Root className="flex w-full max-w-80 flex-col border border-neutral-950 text-neutral-950 dark:border-white dark:text-white">
+    <Accordion.Root className="flex w-full max-w-80 flex-col border border-neutral-950 bg-white text-neutral-950 dark:border-white dark:bg-neutral-950 dark:text-white">
       <Accordion.Item>
         <Accordion.Header>
           <Accordion.Trigger className="group flex w-full items-center justify-between gap-4 bg-transparent px-3 py-2 text-left text-sm font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-neutral-950 dark:focus-visible:outline-white dark:text-white dark:hover:not-data-disabled:bg-neutral-800">

--- a/docs/src/app/(docs)/react/components/accordion/demos/multiple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/accordion/demos/multiple/tailwind/index.tsx
@@ -5,7 +5,7 @@ export default function ExampleAccordion() {
   return (
     <Accordion.Root
       multiple
-      className="flex w-full max-w-80 flex-col border border-neutral-950 text-neutral-950 dark:border-white dark:text-white"
+      className="flex w-full max-w-80 flex-col border border-neutral-950 bg-white text-neutral-950 dark:border-white dark:bg-neutral-950 dark:text-white"
     >
       <Accordion.Item>
         <Accordion.Header>

--- a/docs/src/app/(private)/docs-theme/page.module.css
+++ b/docs/src/app/(private)/docs-theme/page.module.css
@@ -1,6 +1,7 @@
 .page {
   padding: var(--space-40);
-  color: var(--gray-t2);
+  background-color: var(--canvas);
+  color: var(--gray-t3);
   font-family: var(--font-sans);
 }
 
@@ -44,7 +45,7 @@
 
 .colorMatrixGrid {
   display: grid;
-  grid-template-columns: 7rem repeat(9, 6.5rem);
+  grid-template-columns: 7rem repeat(12, 6.5rem);
   row-gap: 2px;
   align-items: start;
   width: max-content;
@@ -66,7 +67,7 @@
 }
 
 .colorMatrixHeaderCell {
-  color: var(--gray-p2);
+  color: var(--gray-p4);
   font-family: var(--font-mono);
   font-size: var(--font-size-13);
   text-transform: lowercase;
@@ -88,7 +89,7 @@
 }
 
 .swatch:hover {
-  outline: 2px solid var(--gray-t2);
+  outline: 2px solid var(--gray-t3);
 }
 
 .swatchTokenName {
@@ -115,7 +116,7 @@
   }
 }
 
-/* Tune blackA readability (auto color can be too faint on near-white alpha steps) */
+/* Tune alpha-step readability (auto color can be too faint on near-white alpha steps) */
 .colorMatrixRowAlpha > .colorMatrixCell {
   background-color: var(--gray-s1);
   background-image:
@@ -131,17 +132,17 @@
     -6px 0;
 }
 
-.colorMatrixRowAlpha > .colorMatrixCell:nth-child(-n + 6) .swatchTokenName {
+.colorMatrixRowAlpha > .colorMatrixCell:nth-child(-n + 5) .swatchTokenName {
   color: black;
 }
 
-.colorMatrixRowAlpha > .colorMatrixCell:nth-child(7) .swatchTokenName {
+.colorMatrixRowAlpha > .colorMatrixCell:nth-child(6) .swatchTokenName {
   color: white;
 }
 
 @media (prefers-color-scheme: dark) {
-  .colorMatrixRowAlpha > .colorMatrixCell:nth-child(-n + 6) .swatchTokenName,
-  .colorMatrixRowAlpha > .colorMatrixCell:nth-child(7) .swatchTokenName {
+  .colorMatrixRowAlpha > .colorMatrixCell:nth-child(-n + 5) .swatchTokenName,
+  .colorMatrixRowAlpha > .colorMatrixCell:nth-child(6) .swatchTokenName {
     color: white;
   }
 }
@@ -158,7 +159,7 @@
   gap: var(--space-24);
 }
 
-.shadowGrid {
+.surfaceGrid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(7.5rem, 1fr));
   gap: var(--space-24);
@@ -166,8 +167,17 @@
 
 .typeCard,
 .radiusCard,
-.shadowCard {
+.surfaceCard {
   border-radius: var(--radius-5);
+}
+
+/* Outlined so `canvas` stays visible where it matches the page background. */
+.surfaceSwatch {
+  height: 3rem;
+  margin-top: var(--space-12);
+  border-radius: var(--radius-4);
+  outline: 1px solid var(--gray-c3);
+  outline-offset: -1px;
 }
 
 .typeSample {
@@ -209,12 +219,12 @@
 .spaceBar {
   min-width: 1px;
   height: 0.75rem;
-  background: var(--gray-t2);
+  background: var(--gray-t3);
 }
 
 .radiusShape {
   margin-top: var(--space-12);
-  background: var(--gray-t2);
+  background: var(--gray-t3);
 }
 
 .radiusShapeSquare {
@@ -225,18 +235,6 @@
 .radiusShapePill {
   width: 6rem;
   height: 4rem;
-}
-
-.shadowSurface {
-  height: 5rem;
-  margin-top: var(--space-12);
-  border-radius: var(--radius-4);
-  background: var(--gray-s1);
-
-  /* Hack to make the surface visible in dark mode since there are no shadows in dark mode */
-  @media (prefers-color-scheme: dark) {
-    background: var(--gray-s2);
-  }
 }
 
 @media (max-width: 48rem) {

--- a/docs/src/app/(private)/docs-theme/page.tsx
+++ b/docs/src/app/(private)/docs-theme/page.tsx
@@ -5,12 +5,27 @@ import 'docs/src/css/index.css';
 
 import styles from './page.module.css';
 
-const coreScaleSteps = ['s1', 's2', 'c1', 'c2', 'c3', 'p1', 'p2', 't1', 't2'] as const;
-const coreColorRows = ['gray', 'indigo'] as const;
-const accentColorRows = ['poppy', 'blue', 'green', 'orange', 'pink', 'grape', 'lime'] as const;
-const alphaColorRows = ['blackA'] as const;
-const alphaScaleSteps = ['1', '2', '3', '4', '5', '6'] as const;
+const coreScaleSteps = [
+  's1',
+  's2',
+  'c1',
+  'c2',
+  'c3',
+  'p1',
+  'p2',
+  'p3',
+  'p4',
+  't1',
+  't2',
+  't3',
+] as const;
+const coreColorRows = ['gray'] as const;
+const accentColorRows = ['poppy', 'green'] as const;
+const alphaColorRows = ['gray'] as const;
+const alphaScaleSteps = ['a1', 'a2', 'a3', 'a4', 'a5'] as const;
 const allCoreRows = [...coreColorRows, ...accentColorRows];
+
+const surfaceTokens = ['canvas', 'surface', 'panel'] as const;
 
 const typefaces = [
   { token: 'font-sans', sample: 'Die Grotesk A for UI copy' },
@@ -27,7 +42,6 @@ const fontWeights = [
 const fontSizeScale = ['12', '14', '15', '16', '18', '21', '24', '36', '42'] as const;
 const spaceScale = ['4', '8', '12', '16', '20', '24', '28', '32', '40', '48'] as const;
 const radiusScale = ['2', '3', '4', '6', '8', '12', '16', 'pill', 'circle'] as const;
-const shadows = ['1', '2', '3', '4', '5'] as const;
 
 export default function ThemePage() {
   return (
@@ -118,6 +132,20 @@ export default function ThemePage() {
             ))}
           </div>
         </div>
+
+        <div className={styles.colorMatrixSection}>
+          <div className={styles.surfaceGrid}>
+            {surfaceTokens.map((token) => (
+              <article key={token} className={styles.surfaceCard}>
+                <p className={styles.tokenName}>--{token}</p>
+                <div
+                  className={styles.surfaceSwatch}
+                  style={{ backgroundColor: `var(--${token})` }}
+                />
+              </article>
+            ))}
+          </div>
+        </div>
       </section>
 
       <section className={styles.section}>
@@ -188,20 +216,6 @@ export default function ThemePage() {
                 style={{
                   borderRadius: `var(--radius-${step})`,
                 }}
-              />
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className={styles.section}>
-        <div className={styles.shadowGrid}>
-          {shadows.map((step) => (
-            <article key={step} className={styles.shadowCard}>
-              <p className={styles.tokenName}>--shadow-{step}</p>
-              <div
-                className={styles.shadowSurface}
-                style={{ boxShadow: `var(--shadow-${step})` }}
               />
             </article>
           ))}

--- a/docs/src/app/(website)/css/components/Accordion.css
+++ b/docs/src/app/(website)/css/components/Accordion.css
@@ -1,11 +1,11 @@
 @layer components {
   .AccordionWebsiteRoot {
-    border-top: 1px solid var(--gray-t2);
+    border-top: 1px solid var(--gray-t3);
   }
 
   .AccordionWebsiteItem {
     box-sizing: border-box;
-    border-bottom: 1px solid var(--gray-t2);
+    border-bottom: 1px solid var(--gray-t3);
   }
 
   .AccordionWebsiteHeader {

--- a/docs/src/app/(website)/css/components/Body.css
+++ b/docs/src/app/(website)/css/components/Body.css
@@ -2,7 +2,7 @@
   .Body {
     box-sizing: border-box;
     margin: 0;
-    color: var(--gray-t2);
-    background-color: var(--gray-s1);
+    color: var(--gray-t3);
+    background-color: var(--canvas);
   }
 }

--- a/docs/src/app/(website)/css/components/List.css
+++ b/docs/src/app/(website)/css/components/List.css
@@ -7,7 +7,7 @@
   }
 
   .ListItem {
-    border-bottom: 1px solid var(--gray-t2);
+    border-bottom: 1px solid var(--gray-t3);
     padding-block-start: 12px;
     padding-block-end: 12px;
   }

--- a/docs/src/app/(website)/css/components/Separator.css
+++ b/docs/src/app/(website)/css/components/Separator.css
@@ -3,6 +3,6 @@
     box-sizing: border-box;
     height: 1px;
     width: 32px;
-    background-color: var(--gray-s2);
+    background-color: var(--gray-c1);
   }
 }

--- a/docs/src/app/(website)/layout.tsx
+++ b/docs/src/app/(website)/layout.tsx
@@ -161,11 +161,11 @@ export const viewport: Viewport = {
     // Mobile Safari header background (match the page content)
     {
       media: '(prefers-color-scheme: light)',
-      color: '#FFF',
+      color: 'white',
     },
     {
       media: '(prefers-color-scheme: dark)',
-      color: 'hsl(0deg 0% 6%)',
+      color: 'oklch(21% 0 0deg)',
     },
   ],
 };

--- a/docs/src/app/(website)/page.tsx
+++ b/docs/src/app/(website)/page.tsx
@@ -167,7 +167,7 @@ export default function Homepage() {
           <ul
             className="List"
             aria-label="team members"
-            style={{ borderTop: '1px solid var(--gray-t2)' }}
+            style={{ borderTop: '1px solid var(--gray-t3)' }}
           >
             <li className="ListItem bui-d-g bui-gtc-2 bui-g-8 bp3:bui-g-9">
               <span className="Text sz-2">Colm Tuite</span>
@@ -461,11 +461,11 @@ export const viewport: Viewport = {
     // Mobile Safari header background (match the page content)
     {
       media: '(prefers-color-scheme: light)',
-      color: '#FFF',
+      color: 'white',
     },
     {
       media: '(prefers-color-scheme: dark)',
-      color: '#000',
+      color: 'oklch(21% 0 0deg)',
     },
   ],
 };

--- a/docs/src/components/Accordion.css
+++ b/docs/src/components/Accordion.css
@@ -1,27 +1,19 @@
 @layer components {
   .AccordionRoot {
-    --color-trigger-hover: hsl(0deg 0 99);
-    --color-open-trigger-shadow: var(--gray-c3);
-
-    @media (prefers-color-scheme: dark) {
-      --color-trigger-hover: hsl(0deg 0 9);
-      --color-open-trigger-shadow: hsl(0deg 0 5);
-    }
-
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
     justify-content: center;
     color: var(--gray-t1);
 
-    border: 1px solid var(--color-border);
+    border: 1px solid var(--gray-c3);
     border-collapse: separate;
     border-radius: var(--radius-12);
   }
 
   .AccordionHeaderRow {
     border-radius: calc(var(--radius-12) - 1px) calc(var(--radius-12) - 1px) 0 0;
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--gray-c3);
     background-color: var(--gray-s2);
     background-clip: padding-box;
   }
@@ -29,7 +21,7 @@
   .AccordionHeaderCell {
     font-size: var(--font-size-14);
     font-weight: var(--font-weight-400);
-    color: var(--color-foreground);
+    color: var(--gray-t3);
   }
 
   .AccordionHeaderCellInner {
@@ -47,7 +39,7 @@
   }
 
   .AccordionItem:not(:last-child) {
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--gray-c3);
   }
 
   .AccordionTrigger {
@@ -64,7 +56,7 @@
     border: none;
     outline: none;
     text-align: left;
-    background-color: var(--color-content);
+    background-color: var(--panel);
 
     /* remove default disclosure triangle  */
     &::-webkit-details-marker {
@@ -74,7 +66,7 @@
 
     @media (hover: hover) {
       &:hover {
-        background-color: var(--color-trigger-hover);
+        background-color: var(--gray-c1);
         cursor: default;
       }
     }
@@ -94,14 +86,14 @@
         inset: 0;
         z-index: 1;
         border-radius: inherit;
-        outline: 2px solid var(--gray-t2);
+        outline: 2px solid var(--gray-t3);
         outline-offset: -2px;
       }
     }
 
     [open] & {
       box-shadow:
-        0 2px 4px -3px var(--color-open-trigger-shadow),
+        0 2px 4px -3px color-mix(in oklch, var(--panel), black 7%),
         inset 0 -1px 1px transparent;
     }
 
@@ -126,7 +118,7 @@
     box-sizing: border-box;
     height: auto;
     overflow: hidden;
-    color: var(--color-foreground);
+    color: var(--gray-t3);
     font-size: 1rem;
     line-height: 1.5rem;
   }
@@ -160,7 +152,7 @@
         inset: 0;
         z-index: 1;
         /* The cell clips its own overflow, so the ring must sit fully inside it. */
-        outline: 2px solid var(--gray-t2);
+        outline: 2px solid var(--gray-t3);
         outline-offset: -2px;
       }
     }
@@ -188,8 +180,9 @@
       }
 
       @media (hover: hover) {
+        /* Fade into the hovered row's fill so the overlay is invisible. */
         .AccordionTrigger:hover &::after {
-          background-image: linear-gradient(to right, transparent, var(--color-trigger-hover));
+          background-image: linear-gradient(to right, transparent, var(--gray-c1));
         }
       }
     }

--- a/docs/src/components/Accordion.tsx
+++ b/docs/src/components/Accordion.tsx
@@ -103,7 +103,7 @@ export function Scrollable({
   children,
   className,
   tag: Tag = 'span',
-  gradientColor = 'var(--color-content)',
+  gradientColor = 'var(--panel)',
   ...props
 }: React.ComponentProps<'span'> & {
   gradientColor?: string;

--- a/docs/src/components/CodeBlock/CodeBlock.css
+++ b/docs/src/components/CodeBlock/CodeBlock.css
@@ -4,9 +4,9 @@
 @layer components {
   .CodeBlockRoot {
     align-self: stretch;
-    background-color: var(--color-content);
-    border: 1px solid var(--color-border);
+    border: 1px solid var(--gray-c3);
     border-radius: var(--radius-12);
+    background-color: var(--canvas);
 
     & code .frame {
       padding-left: 0.75rem;
@@ -29,7 +29,7 @@
     line-height: 1;
     background-color: var(--gray-s2);
     background-clip: padding-box;
-    color: var(--gray-t2);
+    color: var(--gray-t3);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -40,7 +40,7 @@
     gap: 1rem;
     border-top-left-radius: calc(var(--radius-12) - 1px);
     border-top-right-radius: calc(var(--radius-12) - 1px);
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--gray-c3);
 
     /* Scroll */
     overflow: auto hidden;
@@ -53,7 +53,7 @@
     /* Scroll containers may be focusable */
     &:focus-visible {
       position: relative;
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -1px;
       z-index: 1;
     }
@@ -62,7 +62,7 @@
   .CodeBlockPanelTitle {
     font-size: var(--font-size-14);
     line-height: 1.25rem;
-    color: var(--gray-t2);
+    color: var(--gray-t3);
     font-weight: var(--font-weight-400);
   }
 
@@ -85,7 +85,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: 0;
     }
   }
@@ -99,7 +99,7 @@
     font-size: 0.8125rem; /* 13px */
     line-height: 1.25rem; /* 20px */
     cursor: text;
-    color: var(--color-foreground);
+    color: var(--gray-t3);
     outline: 0;
 
     display: flex;

--- a/docs/src/components/Demo/Demo.css
+++ b/docs/src/components/Demo/Demo.css
@@ -6,8 +6,9 @@
 @layer components {
   .DemoRoot {
     --demo-radius: var(--radius-12);
-    border: 1px solid var(--color-border);
+    border: 1px solid var(--gray-c3);
     border-radius: var(--demo-radius);
+    background-color: var(--canvas);
     margin-bottom: var(--space-24);
   }
 
@@ -20,7 +21,6 @@
   .DemoPlayground {
     position: relative;
 
-    background-color: var(--color-content);
     border-top-left-radius: calc(var(--demo-radius) - 1px);
     border-top-right-radius: calc(var(--demo-radius) - 1px);
 
@@ -31,7 +31,7 @@
 
     /* Scroll containers may be focusable */
     &:focus-visible {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -1px;
       z-index: 1;
     }
@@ -58,7 +58,10 @@
     font-size: var(--font-size-13);
     line-height: 1.25rem;
     white-space: nowrap;
-    color: var(--gray-t2);
+    color: var(--gray-t3);
+    /* Recedes behind the active tab and code block, which share `gray-s1` so
+       the tab reads as fused with its code. */
+    background-color: var(--gray-s2);
     background-clip: padding-box;
     display: flex;
     align-items: end;
@@ -75,8 +78,8 @@
       inset: 0;
       z-index: 0;
       background-image:
-        linear-gradient(var(--color-border), var(--color-border)),
-        linear-gradient(var(--color-border), var(--color-border));
+        linear-gradient(var(--gray-c3), var(--gray-c3)),
+        linear-gradient(var(--gray-c3), var(--gray-c3));
       background-position:
         0 0,
         0 100%;
@@ -109,7 +112,7 @@
     position: absolute;
     inset: 0;
     z-index: 2;
-    outline: 2px solid var(--gray-t2);
+    outline: 2px solid var(--gray-t3);
     outline-offset: -2px;
     pointer-events: none;
   }
@@ -230,7 +233,7 @@
           content: '';
           position: absolute;
           inset: 1px -1px;
-          background-color: var(--gray-s2);
+          background-color: var(--gray-c1);
           background-clip: padding-box;
           pointer-events: none;
         }
@@ -246,7 +249,7 @@
         inset: 1px -1px;
         background-color: var(--gray-s1);
         background-clip: padding-box;
-        border-inline: 1px solid var(--color-border);
+        border-inline: 1px solid var(--gray-c3);
         pointer-events: none;
       }
 
@@ -259,11 +262,16 @@
         content: '';
         position: absolute;
         bottom: 0;
-        left: 0;
-        width: 100%;
+        inset-inline: 0;
         height: 1px;
         background-color: var(--gray-s1);
         pointer-events: none;
+      }
+
+      /* Without a start border the fill bleeds 1px further, so the bridge has
+         to reach just as far or a 1px notch of the separator shows through. */
+      &:first-child::after {
+        inset-inline-start: -1px;
       }
     }
 
@@ -274,7 +282,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -2px;
 
       &::after {
@@ -419,7 +427,7 @@
     flex-shrink: 0;
     border: none;
     padding: 0 0 0.75rem;
-    color: var(--color-foreground);
+    color: var(--gray-t3);
     background: transparent;
     font-family: inherit;
     font-size: var(--font-size-13);
@@ -438,7 +446,7 @@
     }
 
     &:focus-visible .DemoCollapseButtonVisual {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -1px;
     }
 
@@ -484,10 +492,10 @@
       z-index: -1;
       inset: 1px;
       border-radius: var(--radius-pill);
-      background: var(--color-content);
+      background: var(--gray-s1);
       pointer-events: none;
       box-shadow:
-        inset 0 0 0 1px white,
+        inset 0 0 0 1px var(--gray-s1),
         0 1px 2px hsl(0deg 0% 0% / 5%),
         0 2px 8px -1px hsl(0deg 0% 0% / 6%),
         0 4px 16px -4px hsl(0deg 0% 0% / 5%);

--- a/docs/src/components/DescriptionList.css
+++ b/docs/src/components/DescriptionList.css
@@ -23,7 +23,7 @@
     font-size: var(--font-size-14);
     line-height: 1.25rem;
     font-weight: var(--font-weight-700);
-    color: var(--color-foreground);
+    color: var(--gray-t3);
     white-space: nowrap;
     word-break: keep-all;
     position: relative;
@@ -40,7 +40,7 @@
     &.separator {
       &::before {
         content: '';
-        box-shadow: inset 0 1px 0 0 var(--color-border);
+        box-shadow: inset 0 1px 0 0 var(--gray-c3);
         position: absolute;
         top: 0;
         inset-inline: 0.75rem 1rem;
@@ -59,7 +59,7 @@
     font-size: var(--font-size-14);
     line-height: 1.25rem;
 
-    color: var(--color-foreground);
+    color: var(--gray-t3);
     grid-column: span 2;
 
     & p {

--- a/docs/src/components/GhostButton.css
+++ b/docs/src/components/GhostButton.css
@@ -4,7 +4,7 @@
 @layer components {
   .GhostButton {
     font-size: var(--font-size-13);
-    color: var(--gray-t2);
+    color: var(--gray-t3);
     cursor: default;
     position: relative;
     z-index: 0;
@@ -27,7 +27,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -1px;
     }
 
@@ -39,7 +39,7 @@
       }
 
       &[data-pressed] {
-        background-color: var(--gray-c1);
+        background-color: var(--gray-c2);
       }
     }
   }

--- a/docs/src/components/Header.css
+++ b/docs/src/components/Header.css
@@ -23,7 +23,7 @@
     position: fixed;
     top: 0;
     inset-inline: 0;
-    background: var(--color-content);
+    background: var(--canvas);
     z-index: 2;
 
     @media (--show-side-nav) {
@@ -56,12 +56,12 @@
     margin: -0.25rem -0.5rem;
 
     &:active {
-      color: var(--gray-p1);
+      color: var(--gray-p3);
     }
 
     &:focus-visible {
       border-radius: var(--radius-6);
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -1px;
     }
   }

--- a/docs/src/components/HeadingLink.css
+++ b/docs/src/components/HeadingLink.css
@@ -14,7 +14,7 @@
         --focus-h-padding: 0.5rem;
         content: '';
         z-index: 1;
-        outline: 2px solid var(--gray-t2);
+        outline: 2px solid var(--gray-t3);
         outline-offset: -2px;
         position: absolute;
         top: calc(0px - var(--focus-v-padding));

--- a/docs/src/components/InstallationBlock/InstallationBlock.css
+++ b/docs/src/components/InstallationBlock/InstallationBlock.css
@@ -58,8 +58,8 @@
     }
 
     &[data-active] {
-      border-color: var(--color-border);
-      background-color: var(--color-content);
+      border-color: var(--gray-c3);
+      background-color: var(--canvas);
 
       &::after {
         content: '';
@@ -68,7 +68,7 @@
         left: 0;
         width: 100%;
         height: 1px;
-        background-color: var(--color-content);
+        background-color: var(--canvas);
         pointer-events: none;
       }
 
@@ -80,7 +80,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -2px;
 
       &::after {
@@ -90,7 +90,7 @@
   }
 
   .InstallationBlockTabPanel {
-    border-top: 1px solid var(--color-border);
+    border-top: 1px solid var(--gray-c3);
     /* Match the card's inner corner so the focus ring rounds to follow the
        card's rounded bottom corners. */
     border-bottom-left-radius: calc(var(--radius-12) - 1px);
@@ -99,7 +99,7 @@
     outline: 0;
 
     &:focus-visible {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -2px;
       position: relative;
       z-index: 1;

--- a/docs/src/components/Kbd/Kbd.css
+++ b/docs/src/components/Kbd/Kbd.css
@@ -38,13 +38,13 @@
 
     @media (prefers-color-scheme: dark) {
       text-shadow: #fff8 0 0 1px;
-      color: var(--gray-t2);
-      background-color: var(--color-content);
+      color: var(--gray-t3);
+      background-color: var(--gray-s1);
       box-shadow:
         inset 0 round(-0.1em, 1px) black,
         inset 0 round(-0.05em, 1px) round(0.75em, 1px) var(--gray-c1),
-        0 0 0 round(0.075em, 1px) var(--gray-p1),
-        inset 0 round(0.05em, 1px) var(--gray-p2);
+        0 0 0 round(0.075em, 1px) var(--gray-p3),
+        inset 0 round(0.05em, 1px) var(--gray-p4);
     }
   }
 }

--- a/docs/src/components/Link.css
+++ b/docs/src/components/Link.css
@@ -14,7 +14,7 @@
     text-underline-offset: 4px;
 
     &:active {
-      background-color: var(--gray-t2);
+      background-color: var(--gray-t3);
       color: var(--gray-s1);
     }
 
@@ -25,13 +25,13 @@
 
     /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
     &:has(code):active {
-      color: var(--color-background);
+      color: var(--gray-s1);
       background-color: var(--color-blue);
     }
 
     /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
     &:has(code):active * {
-      color: var(--color-background) !important;
+      color: var(--gray-s1) !important;
     }
 
     &:focus-visible {

--- a/docs/src/components/Menu.css
+++ b/docs/src/components/Menu.css
@@ -13,7 +13,7 @@
     max-width: var(--available-width);
     max-height: var(--available-height);
     border-radius: var(--radius-8);
-    background-color: var(--color-popup);
+    background-color: var(--surface);
     overflow: hidden;
     cursor: default;
     -webkit-user-select: none;
@@ -25,12 +25,12 @@
 
     @media (prefers-color-scheme: light) {
       box-shadow:
-        0 0 1px var(--blackA-4),
-        0 0.5px 1px var(--blackA-3),
-        0 1px 3px var(--blackA-1),
-        0 2px 4px -1px var(--blackA-1),
-        0 4px 12px -2px var(--blackA-1),
-        0 4px 16px -4px var(--blackA-1);
+        0 0 1px var(--gray-a4),
+        0 0.5px 1px var(--gray-a3),
+        0 1px 3px var(--gray-a1),
+        0 2px 4px -1px var(--gray-a1),
+        0 4px 12px -2px var(--gray-a1),
+        0 4px 16px -4px var(--gray-a1);
     }
 
     @media (prefers-color-scheme: dark) {
@@ -49,16 +49,13 @@
     line-height: 1;
     white-space: nowrap;
     z-index: 0;
-    color: var(--gray-t2);
+    color: var(--gray-t3);
     text-decoration: none;
 
     &[data-highlighted] {
       position: relative;
-      color: white;
-
-      @media (prefers-color-scheme: dark) {
-        color: black;
-      }
+      /* Ink and its contrast; both invert per mode, so no override is needed. */
+      color: var(--gray-s1);
 
       &::before {
         content: '';
@@ -67,11 +64,7 @@
         inset-block: 0;
         z-index: -1;
         border-radius: var(--radius-4);
-        background-color: var(--gray-t2);
-
-        @media (prefers-color-scheme: dark) {
-          background-color: white;
-        }
+        background-color: var(--gray-t3);
       }
     }
 
@@ -85,6 +78,6 @@
     height: 1px;
     margin-block: 0.25rem;
     margin-inline: 0.25rem;
-    background-color: var(--color-border);
+    background-color: var(--gray-c3);
   }
 }

--- a/docs/src/components/MobileNav.css
+++ b/docs/src/components/MobileNav.css
@@ -68,19 +68,20 @@
     margin-bottom: calc(-1 * var(--mobile-nav-bleed));
     border-top-left-radius: var(--radius-36); /* Mimic iOS bottom sheets */
     border-top-right-radius: var(--radius-36); /* Mimic iOS bottom sheets */
-    background-color: var(--color-popup);
-    color: var(--gray-t2);
+    background-color: var(--surface);
+    color: var(--gray-t3);
     outline: 0;
     touch-action: none;
+    /* Alpha ring stays crisp over the dimmed backdrop; opaque c3 would read lighter than it */
     box-shadow:
       0 10px 64px -10px rgb(36 40 52 / 20%),
-      0 0.25px 0 1px var(--color-border);
+      0 0.25px 0 1px var(--gray-a2);
     transform: translateY(var(--drawer-swipe-movement-y));
     transition: transform 340ms cubic-bezier(0.32, 0.72, 0, 1);
     will-change: transform;
 
     @media (prefers-color-scheme: dark) {
-      box-shadow: 0 0 0 1px var(--color-border);
+      box-shadow: 0 0 0 1px var(--gray-c3);
     }
 
     &[data-swiping] {
@@ -128,7 +129,7 @@
     width: 3.5rem; /* 56px to mimic iOS */
     height: 0.3125rem; /* 5px to mimic iOS */
     border-radius: var(--radius-pill);
-    background-color: var(--color-border);
+    background-color: var(--gray-c3);
   }
 
   .MobileNavSearchInputRoot {
@@ -143,7 +144,7 @@
     transform: translateY(-50%);
     width: var(--space-16);
     height: var(--space-16);
-    color: var(--gray-t1);
+    color: var(--gray-p3);
     pointer-events: none;
   }
 
@@ -159,12 +160,12 @@
     padding-left: var(--space-36);
     padding-right: var(--space-32);
     font: inherit;
-    color: var(--gray-t2);
+    color: var(--gray-t3);
     outline: 0;
   }
 
   .MobileNavSearchInput::placeholder {
-    color: var(--gray-t1);
+    color: var(--gray-p3);
   }
 
   .MobileNavClearSearch {
@@ -179,7 +180,7 @@
     width: var(--space-24);
     height: var(--space-24);
     border-radius: 100%;
-    color: var(--gray-t2);
+    color: var(--gray-t3);
     outline: 0;
 
     > svg {
@@ -196,12 +197,12 @@
 
     @media not (hover: hover) {
       &:active {
-        background-color: var(--gray-c2);
+        background-color: var(--gray-c3);
       }
     }
 
     &:focus-visible {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -1px;
     }
   }
@@ -262,7 +263,7 @@
     );
 
     &:focus-visible {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -2px;
     }
   }
@@ -305,7 +306,7 @@
       /* Visible thumb width */
       width: var(--space-4);
       border-radius: var(--radius-4);
-      background-color: var(--gray-p2);
+      background-color: var(--gray-p4);
     }
   }
 
@@ -345,13 +346,13 @@
     align-items: center;
     height: var(--mobile-nav-item-height);
     padding-inline: var(--mobile-nav-item-padding-x);
-    color: var(--gray-t2);
+    color: var(--gray-t3);
     outline: 0;
   }
 
   .MobileNavLink:focus-visible,
   .MobileNavSearchOption:focus-visible {
-    outline: 2px solid var(--gray-t2);
+    outline: 2px solid var(--gray-t3);
     outline-offset: -2px;
   }
 
@@ -360,7 +361,7 @@
       text-decoration: underline;
       text-underline-offset: 3px;
       text-decoration-thickness: 1px;
-      text-decoration-color: var(--gray-t2);
+      text-decoration-color: var(--gray-t3);
     }
   }
 
@@ -453,7 +454,7 @@
     margin-inline: var(--space-4);
     vertical-align: middle;
     flex-shrink: 0;
-    color: var(--gray-t1);
+    color: var(--gray-p3);
   }
 
   .MobileNavSearchScore {

--- a/docs/src/components/Popup.css
+++ b/docs/src/components/Popup.css
@@ -6,18 +6,21 @@
     max-width: var(--available-width, none);
     max-height: var(--available-height, none);
     border-radius: var(--radius-6);
-    background-color: var(--color-popup);
-    box-shadow:
-      0 1px 3px 0 var(--blackA-1),
-      0 2px 4px -1px var(--blackA-1),
-      0 4px 12px -2px var(--blackA-1),
-      0 4px 16px -4px var(--blackA-1),
-      0 8px 24px -4px var(--blackA-1),
-      0 12px 48px -4px var(--blackA-1);
-    outline: 1px solid var(--blackA-3);
+    background-color: var(--surface);
+    outline: 1px solid var(--gray-a3);
+
+    @media (prefers-color-scheme: light) {
+      box-shadow:
+        0 1px 3px 0 var(--gray-a1),
+        0 2px 4px -1px var(--gray-a1),
+        0 4px 12px -2px var(--gray-a1),
+        0 4px 16px -4px var(--gray-a1),
+        0 8px 24px -4px var(--gray-a1),
+        0 12px 48px -4px var(--gray-a1);
+    }
 
     @media (prefers-color-scheme: dark) {
-      /* Use stronger outline in dark mode because the shadow isn't really visible */
+      /* Use a stronger opaque outline in dark mode because there is no shadow */
       outline-color: var(--gray-c3);
       outline-offset: -1px;
     }

--- a/docs/src/components/QuickNav/QuickNav.css
+++ b/docs/src/components/QuickNav/QuickNav.css
@@ -61,7 +61,7 @@
     outline: 0;
 
     &:focus-visible {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -2px;
     }
   }
@@ -98,7 +98,7 @@
       /* Visible thumb width */
       width: var(--quick-nav-scrollbar-thumb-width);
       border-radius: var(--radius-4);
-      background-color: var(--gray-p2);
+      background-color: var(--gray-p4);
     }
   }
 
@@ -121,7 +121,7 @@
 
     &:focus-visible {
       z-index: 1;
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -2px;
     }
 
@@ -130,7 +130,7 @@
         text-decoration: underline;
         text-underline-offset: 2px;
         text-decoration-thickness: 1px;
-        text-decoration-color: var(--gray-p1);
+        text-decoration-color: var(--gray-p3);
       }
     }
   }

--- a/docs/src/components/ReferenceTable/ReferenceTable.css
+++ b/docs/src/components/ReferenceTable/ReferenceTable.css
@@ -309,7 +309,7 @@
   }
 
   .MethodParamSep {
-    color: var(--gray-p1);
+    color: var(--gray-p3);
   }
 
   .MethodParamDesc {
@@ -342,7 +342,7 @@
     font-size: var(--font-size-14);
     line-height: 1.25rem;
     font-weight: var(--font-weight-400);
-    color: var(--gray-p1);
+    color: var(--gray-p3);
   }
 
   .AdditionalTypeBackLink[data-hidden='true'] {
@@ -350,17 +350,7 @@
   }
 
   .AdditionalTypeBackLink:hover {
-    color: var(--gray-t2);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .AdditionalTypeBackLink {
-      color: var(--gray-p2);
-    }
-
-    .AdditionalTypeBackLink:hover {
-      color: var(--gray-c2);
-    }
+    color: var(--gray-t3);
   }
 
   .AdditionalTypeReExport {
@@ -389,13 +379,7 @@
     font-size: var(--font-size-16);
     line-height: 1.5rem;
     font-weight: var(--font-weight-700);
-    color: var(--gray-t2);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .ReferenceSectionHeading {
-      color: white;
-    }
+    color: var(--gray-t3);
   }
 
   .ReferenceSectionSubtext {
@@ -403,12 +387,6 @@
     font-size: var(--font-size-14);
     line-height: 1.25rem;
     color: var(--gray-t1);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .ReferenceSectionSubtext {
-      color: var(--gray-p2);
-    }
   }
 
   .ReferenceBlockSpaced {

--- a/docs/src/components/ReleaseTimeline/ReleaseTimeline.css
+++ b/docs/src/components/ReleaseTimeline/ReleaseTimeline.css
@@ -43,8 +43,8 @@
       background: linear-gradient(
         to bottom,
         transparent,
-        var(--color-border) 2.5rem,
-        var(--color-border) calc(100% - 2.5rem),
+        var(--gray-c3) 2.5rem,
+        var(--gray-c3) calc(100% - 2.5rem),
         transparent
       );
     }
@@ -76,9 +76,14 @@
       width: var(--dot-size);
       height: var(--dot-size);
       border-radius: 50%;
-      background: var(--color-content);
-      border: 1px solid var(--gray-c3);
-      box-shadow: 0 0 0 4px var(--color-content);
+      background: var(--canvas);
+      border: 1px solid var(--gray-a3);
+      box-shadow: 0 0 0 4px var(--canvas);
+
+      @media (prefers-color-scheme: dark) {
+        /* Use the opaque border step in dark mode for a stronger dot edge */
+        border-color: var(--gray-c3);
+      }
       transform: translateX(-50%);
       z-index: 1;
     }
@@ -91,7 +96,7 @@
       top: var(--dot-y);
       width: calc(var(--column-gap) / 2 - var(--dot-size) / 2);
       height: 1px;
-      background: var(--color-border);
+      background: var(--gray-c3);
     }
 
     .TimelineItem:nth-child(even)::after {
@@ -110,11 +115,11 @@
     flex-direction: column;
     align-items: start;
     gap: 0.75rem;
-    background-color: var(--color-border);
+    background-color: var(--gray-c3);
     border-radius: var(--radius-8);
     padding: 1.25rem;
     font-size: var(--font-size-15);
-    color: var(--color-foreground);
+    color: var(--gray-t3);
     line-height: 1.375rem;
   }
 
@@ -126,7 +131,7 @@
 
   .TimelineCard::before {
     inset: 1px;
-    background-color: var(--color-content);
+    background-color: var(--panel);
     border-radius: calc(var(--radius-8) - 1px);
     z-index: -1;
   }
@@ -134,10 +139,14 @@
   .TimelineCard::after {
     inset: 1px;
     border-radius: calc(var(--radius-8) - 1px);
-    box-shadow:
-      0 1px 3px 0 var(--color-border),
-      0 1px 2px -1px var(--color-border);
     z-index: -1;
+
+    /* Light only: the alpha steps flip to white in dark mode and would glow */
+    @media (prefers-color-scheme: light) {
+      box-shadow:
+        0 1px 3px 0 var(--gray-a2),
+        0 1px 2px -1px var(--gray-a2);
+    }
   }
 
   .TimelineCardHeader {
@@ -160,7 +169,7 @@
     font-size: var(--font-size-18);
     line-height: 1.75rem;
     font-weight: var(--font-weight-700);
-    color: var(--color-foreground);
+    color: var(--gray-t3);
   }
 
   .TimelineVersionLink {
@@ -179,7 +188,7 @@
 
     &:focus-visible {
       border-radius: 0.125rem;
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       text-decoration-line: none;
     }
   }

--- a/docs/src/components/ScrollArea.css
+++ b/docs/src/components/ScrollArea.css
@@ -8,7 +8,7 @@
     /* Scroll containers may be focusable */
     &:focus-visible {
       position: relative;
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -1px;
       z-index: 1;
     }
@@ -55,7 +55,7 @@
       &::before {
         height: 0.25rem;
         inset-inline: 0;
-        background-color: var(--gray-c2);
+        background-color: var(--gray-p4);
       }
     }
 
@@ -67,7 +67,7 @@
       &::before {
         width: 0.25rem;
         inset-block: 0;
-        background-color: var(--gray-c2);
+        background-color: var(--gray-p4);
       }
     }
   }
@@ -75,7 +75,7 @@
   .ScrollAreaThumb {
     position: relative;
     border-radius: inherit;
-    background-color: var(--gray-p2);
+    background-color: var(--gray-p4);
 
     &[data-orientation='horizontal'] {
       height: 0.25rem;

--- a/docs/src/components/Search/Search.css
+++ b/docs/src/components/Search/Search.css
@@ -24,7 +24,7 @@
       /* Visible thumb width */
       width: 0.25rem;
       border-radius: var(--radius-4);
-      background-color: var(--gray-p2);
+      background-color: var(--gray-p4);
     }
   }
 
@@ -41,7 +41,7 @@
   }
 
   .SearchBreadcrumbSeparator {
-    color: var(--gray-c3);
+    color: var(--gray-p3);
   }
 
   .SearchScore {
@@ -73,7 +73,7 @@
     transform: translateY(-50%);
     width: 1rem;
     height: 1rem;
-    color: var(--gray-p1);
+    color: var(--gray-p3);
     pointer-events: none;
   }
 
@@ -87,12 +87,12 @@
     background: transparent;
     font-size: var(--font-size-16);
     font-weight: var(--font-weight-400);
-    color: var(--gray-t2);
+    color: var(--gray-t3);
     outline: 0;
   }
 
   .SearchInput::placeholder {
-    color: var(--gray-p1);
+    color: var(--gray-p3);
   }
 
   .SearchGroup {
@@ -124,7 +124,7 @@
     font-size: 0.9375rem;
     font-weight: var(--font-weight-400);
     line-height: 1;
-    color: var(--gray-t2);
+    color: var(--gray-t3);
     cursor: default;
     -webkit-user-select: none;
     user-select: none;
@@ -178,20 +178,30 @@
     max-height: min(29.5rem, calc(100vh - 6rem));
     width: min(34rem, calc(100vw - 2rem));
     border-radius: 1rem;
-    background: var(--gray-s1);
-    color: var(--gray-t2);
-    outline: 1px solid var(--color-border);
-    box-shadow:
-      0 0.5px 1px hsl(0deg 0% 0% / 12%),
-      0 1px 3px -1px hsl(0deg 0% 0% / 4%),
-      0 2px 4px -1px hsl(0deg 0% 0% / 4%),
-      0 4px 8px -2px hsl(0deg 0% 0% / 4%),
-      0 12px 14px -4px hsl(0deg 0% 0% / 4%),
-      0 24px 64px -8px hsl(0deg 0% 0% / 4%),
-      0 40px 48px -32px hsl(0deg 0% 0% / 4%);
+    background: var(--surface);
+    color: var(--gray-t3);
+    /* Alpha outline stays crisp over the dimmed backdrop; opaque c3 would read lighter than it */
+    outline: 1px solid var(--gray-a2);
     transition:
       transform 150ms ease,
       opacity 150ms ease;
+
+    /* Light only: the alpha steps flip to white in dark mode and would glow */
+    @media (prefers-color-scheme: light) {
+      box-shadow:
+        0 0.5px 1px var(--gray-a3),
+        0 1px 3px -1px var(--gray-a1),
+        0 2px 4px -1px var(--gray-a1),
+        0 4px 8px -2px var(--gray-a1),
+        0 12px 14px -4px var(--gray-a1),
+        0 24px 64px -8px var(--gray-a1),
+        0 40px 48px -32px var(--gray-a1);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      /* Use the opaque border step in dark mode for a stronger edge */
+      outline-color: var(--gray-c3);
+    }
   }
 
   .SearchPopup[data-starting-style] {
@@ -199,16 +209,9 @@
     opacity: 0;
   }
 
-  @media (prefers-color-scheme: dark) {
-    .SearchPopup {
-      background: oklch(20% 0.5% 264deg);
-      outline-color: hsl(0deg 0% 100% / 25%);
-    }
-  }
-
   .SearchHead {
     flex-shrink: 0;
-    border-bottom: 1px solid var(--gray-c1);
+    border-bottom: 1px solid var(--gray-c3);
     border-radius: 1rem 1rem 0 0;
   }
 
@@ -227,7 +230,7 @@
 
     /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
     &:has(.SearchScrollAreaViewport:focus-visible) {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -1px;
     }
   }
@@ -248,12 +251,12 @@
   }
 
   .SearchFooter {
-    border-top: 1px solid var(--gray-c1);
+    border-top: 1px solid var(--gray-c3);
     padding: 0.5rem 0.5rem 0.5rem 1rem;
     display: flex;
     font-size: var(--font-size-13);
     line-height: 1;
-    color: var(--gray-p1);
+    color: var(--gray-p3);
   }
 
   .SearchFooterHint {

--- a/docs/src/components/SearchTrigger.css
+++ b/docs/src/components/SearchTrigger.css
@@ -18,7 +18,7 @@
     line-height: 1.375rem;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    color: var(--gray-t2);
+    color: var(--gray-t3);
     text-align: left;
     white-space: nowrap;
     border-radius: var(--radius-8);

--- a/docs/src/components/Select.css
+++ b/docs/src/components/Select.css
@@ -13,7 +13,7 @@
     max-width: var(--available-width);
     max-height: var(--available-height);
     border-radius: var(--radius-8);
-    background-color: var(--color-popup);
+    background-color: var(--surface);
     overflow: hidden;
     cursor: default;
     -webkit-user-select: none;
@@ -25,12 +25,12 @@
 
     @media (prefers-color-scheme: light) {
       box-shadow:
-        0 0 1px var(--blackA-4),
-        0 0.5px 1px var(--blackA-3),
-        0 1px 3px var(--blackA-1),
-        0 2px 4px -1px var(--blackA-1),
-        0 4px 12px -2px var(--blackA-1),
-        0 4px 16px -4px var(--blackA-1);
+        0 0 1px var(--gray-a4),
+        0 0.5px 1px var(--gray-a3),
+        0 1px 3px var(--gray-a1),
+        0 2px 4px -1px var(--gray-a1),
+        0 4px 12px -2px var(--gray-a1),
+        0 4px 16px -4px var(--gray-a1);
     }
 
     @media (prefers-color-scheme: dark) {
@@ -53,11 +53,8 @@
 
     &[data-highlighted] {
       position: relative;
-      color: white;
-
-      @media (prefers-color-scheme: dark) {
-        color: black;
-      }
+      /* Ink and its contrast; both invert per mode, so no override is needed. */
+      color: var(--gray-s1);
 
       &::before {
         content: '';
@@ -66,11 +63,7 @@
         inset-block: 0;
         z-index: -1;
         border-radius: var(--radius-4);
-        background-color: var(--gray-t2);
-
-        @media (prefers-color-scheme: dark) {
-          background-color: white;
-        }
+        background-color: var(--gray-t3);
       }
     }
 

--- a/docs/src/components/SideNav.css
+++ b/docs/src/components/SideNav.css
@@ -64,7 +64,7 @@
       inset: 0 -2px;
       pointer-events: none;
       position: absolute;
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -2px;
     }
   }
@@ -101,7 +101,7 @@
       /* Visible thumb width */
       width: var(--side-nav-scrollbar-thumb-width);
       border-radius: var(--radius-4);
-      background-color: var(--gray-p2);
+      background-color: var(--gray-p4);
     }
   }
 
@@ -119,7 +119,7 @@
   .SideNavSeparator {
     margin-block: 1rem;
     border: none;
-    border-top: 1px solid var(--color-border);
+    border-top: 1px solid var(--gray-c3);
     width: var(--space-32);
   }
 
@@ -146,7 +146,7 @@
         text-decoration: underline;
         text-underline-offset: 2px;
         text-decoration-thickness: 1px;
-        text-decoration-color: var(--gray-t2);
+        text-decoration-color: var(--gray-t3);
       }
     }
 
@@ -154,8 +154,8 @@
       border: none;
       padding-block: var(--side-nav-item-padding-y);
       padding-inline: var(--side-nav-link-padding-x);
-      background-color: var(--gray-s2);
-      outline: 1px solid var(--gray-c2);
+      background-color: var(--gray-c1);
+      outline: 1px solid var(--gray-c3);
       outline-offset: -1px;
       font-weight: var(--font-weight-400);
       word-spacing: -0.005em;
@@ -164,7 +164,7 @@
 
     &:focus-visible {
       z-index: 1;
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       /* Fully inset (>= outline width) so the ring isn't clipped by the
          scroll viewport's overflow where the pill bleeds to its edge */
       outline-offset: -2px;

--- a/docs/src/components/SkipNav.css
+++ b/docs/src/components/SkipNav.css
@@ -27,13 +27,13 @@
       justify-content: center;
       align-items: center;
       padding-inline: 12px;
-      background-color: var(--color-background);
+      background-color: var(--surface);
       color: var(--color-blue);
       text-decoration: underline;
       text-underline-offset: 2px;
       text-decoration-thickness: 1px;
       text-decoration-color: color-mix(in oklab, var(--color-blue), transparent);
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: -2px;
       border-radius: var(--radius-4);
     }

--- a/docs/src/components/Subtitle/Subtitle.css
+++ b/docs/src/components/Subtitle/Subtitle.css
@@ -43,11 +43,11 @@
     gap: 0.5em;
     padding: 0.5em;
     margin-inline: -0.5em;
-    color: var(--color-foreground);
+    color: var(--gray-t3);
   }
 
   .SubtitleLink:focus-visible .SubtitleLinkText {
-    outline: 2px solid var(--gray-t2);
+    outline: 2px solid var(--gray-t3);
     outline-offset: -2px;
     border-radius: var(--radius-4);
   }

--- a/docs/src/components/Table.css
+++ b/docs/src/components/Table.css
@@ -3,9 +3,10 @@
     font-size: var(--font-size-14);
     line-height: 1.25rem;
     color: var(--gray-t1);
-    border: 1px solid var(--color-border);
+    border: 1px solid var(--gray-c3);
     border-collapse: separate;
     border-radius: var(--radius-12);
+    background-color: var(--panel);
     white-space: nowrap;
     overflow: hidden;
   }
@@ -28,10 +29,10 @@
   .TableColumnHeader {
     text-align: initial;
     font-weight: var(--font-weight-400);
-    color: var(--color-foreground);
-    background-color: var(--gray-s2);
+    color: var(--gray-t3);
+    background-color: var(--panel);
     background-clip: padding-box;
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--gray-c3);
   }
 
   .TableCell {
@@ -39,7 +40,7 @@
     font-weight: var(--font-weight-400);
 
     :not(:last-child) > & {
-      border-bottom: 1px solid var(--color-border);
+      border-bottom: 1px solid var(--gray-c3);
     }
 
     &[data-scrollable] {
@@ -54,7 +55,7 @@
         bottom: 1px;
         right: -1px; /* Browsers may miss half a pixel due to subpixel table cell widths */
         width: 1.25rem;
-        background-image: linear-gradient(to right, transparent, var(--color-content));
+        background-image: linear-gradient(to right, transparent, var(--panel));
         animation: table-cell-overscroll-overlay 500ms;
       }
 

--- a/docs/src/components/TypeRef/TypeRef.css
+++ b/docs/src/components/TypeRef/TypeRef.css
@@ -20,7 +20,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid var(--gray-t2);
+      outline: 2px solid var(--gray-t3);
       outline-offset: 2px;
     }
   }
@@ -58,11 +58,11 @@
   }
 
   .TypeRefArrowFill {
-    fill: var(--color-popup);
+    fill: var(--surface);
   }
 
   .TypeRefArrowStroke {
-    fill: var(--blackA-3);
+    fill: var(--gray-a3);
   }
 
   .TypeRefArrowStrokeDark {

--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -118,66 +118,44 @@
 @layer theme {
   :root {
     /* Colors */
-    --gray-s1: hsl(0deg 0% 99%);
-    --gray-s2: hsl(0deg 0% 97.5%);
-    --gray-c1: hsl(0deg 0% 95.25%);
-    --gray-c2: hsl(0deg 0% 94%);
-    --gray-c3: hsl(0deg 0% 88%);
-    --gray-p1: hsl(0deg 0% 55%);
-    --gray-p2: hsl(0deg 0% 51%);
-    --gray-t1: hsl(0deg 0% 46.4%);
-    --gray-t2: hsl(0deg 0% 18%);
-
-    --indigo-s1: hsl(204deg 100% 98.75%);
-    --indigo-s2: hsl(198deg 100% 97.5%);
-    --indigo-c1: hsl(204deg 100% 95%);
-    --indigo-c2: hsl(205deg 100% 93.5%);
-    --indigo-c3: hsl(206deg 100% 92.5%);
-    --indigo-p1: hsl(214deg 98% 50%);
-    --indigo-p2: hsl(207deg 96% 48%);
-    --indigo-t1: hsl(221deg 74% 51%);
-    --indigo-t2: hsl(221deg 74% 19.8%);
-
-    --blackA-1: hsl(0deg 0% 0% / 4%);
-    --blackA-2: hsl(0deg 0% 0% / 8%);
-    --blackA-3: hsl(0deg 0% 0% / 12%);
-    --blackA-4: hsl(0deg 0% 0% / 16%);
-    --blackA-5: hsl(0deg 0% 0% / 24%);
-    --blackA-6: hsl(0deg 0% 0% / 64%);
-
-    --whiteA-1: hsl(0deg 0% 100% / 4%);
-    --whiteA-2: hsl(0deg 0% 100% / 8%);
-    --whiteA-3: hsl(0deg 0% 100% / 12%);
-    --whiteA-4: hsl(0deg 0% 100% / 16%);
-    --whiteA-5: hsl(0deg 0% 100% / 24%);
-    --whiteA-6: hsl(0deg 0% 100% / 64%);
+    --gray-s1: oklch(99% 0 0deg);
+    --gray-s2: oklch(97.5% 0 0deg);
+    --gray-c1: oklch(95.25% 0 0deg);
+    --gray-c2: oklch(93.5% 0 0deg);
+    --gray-c3: oklch(92.25% 0 0deg);
+    --gray-p1: oklch(73% 0 0deg);
+    --gray-p2: oklch(67% 0 0deg);
+    --gray-p3: oklch(64% 0 0deg);
+    --gray-p4: oklch(62.5% 0 0deg);
+    --gray-t1: oklch(61% 0 0deg);
+    --gray-t2: oklch(53% 0 0deg);
+    --gray-t3: oklch(30% 0 0deg);
+    --gray-a1: oklch(0% 0 0deg / 0.04);
+    --gray-a2: oklch(0% 0 0deg / 0.08);
+    --gray-a3: oklch(0% 0 0deg / 0.12);
+    --gray-a4: oklch(0% 0 0deg / 0.24);
+    --gray-a5: oklch(0% 0 0deg / 0.6);
 
     --poppy-t1: hsl(10deg 86% 48%);
-    --blue-t1: hsl(211deg 100% 49%);
     --green-t1: hsl(156deg 81% 29%);
-    --orange-t1: hsl(14deg 96% 52.5%);
-    --pink-t1: hsl(316deg 84% 51%);
-    --grape-t1: hsl(276deg 66% 54%);
-    --lime-t1: hsl(91deg 64% 38.75%);
 
     /* Legacy colors */
     --color-blue: oklch(45% 50% 264deg);
     --color-red: oklch(50% 55% 31deg);
 
     /* Functional colors */
-    --color-content: white;
-    --color-background: var(--gray-s2);
-    --color-foreground: var(--gray-t2);
-    --color-border: var(--blackA-2);
-    --color-popup: white;
-    --color-gridline: var(--gray-c3);
-    --color-selection: hsl(0deg 0% 92%);
+    /* `canvas` is the page plane. `panel` shares it because embedded containers
+       are defined by their borders, while `surface` floats above it. */
+    --canvas: white;
+    --surface: white;
+    --panel: white;
+    --color-selection: var(--gray-c2);
     --color-line-highlight: hsl(205deg 100% 96%);
     --color-line-highlight-strong: hsl(205deg 100% 90%);
     --color-line-highlight-strong-mark: hsl(205deg 100% 80%);
 
-    /* Syntax highlighting */
-    --color-gray: var(--gray-t1);
+    /* Syntax highlighting (pinned literals so code colors stay independent of the UI gray scale) */
+    --color-gray: hsl(0deg 0% 46.4%);
     --color-navy: oklch(31% 25% 264deg);
     --color-green: oklch(46% 30% 150deg);
     --color-violet: oklch(40% 60% 300deg);
@@ -226,21 +204,6 @@
     --radius-pill: 9999px;
     --radius-circle: 50%;
 
-    /* Shadow */
-    --shadow-1:
-      0 1px 1px 0 var(--blackA-1), 0 2px 1px -1px var(--blackA-1), 0 1px 3px 0 var(--blackA-1);
-    --shadow-2:
-      0 1px 1px 0 var(--blackA-1), 0 1px 3px -1px var(--blackA-1), 0 4px 8px -2px var(--blackA-1);
-    --shadow-3:
-      0 1px 1px 0 var(--blackA-1), 0 2px 6px -1px var(--blackA-1), 0 6px 12px -3px var(--blackA-1),
-      0 8px 16px -4px var(--blackA-1);
-    --shadow-4:
-      0 1px 1px 0 var(--blackA-1), 0 2px 4px -1px var(--blackA-1), 0 4px 8px -2px var(--blackA-1),
-      0 12px 32px -6px var(--blackA-3), 0 20px 48px -10px var(--blackA-1);
-    --shadow-5:
-      0 10px 32px var(--blackA-5), 0 1px 1px var(--blackA-1), 0 4px 6px var(--blackA-2),
-      0 1px 1px var(--blackA-2), 0 24px 68px var(--blackA-4);
-
     /* Breakpoints (use custom-media.css where possible) */
     --breakpoint-max-layout-width: 89rem; /* 1424px - this is a 1440px device minus 16px scrollbar */
 
@@ -259,59 +222,44 @@
 
   @media (prefers-color-scheme: dark) {
     :root {
-      --gray-s1: hsl(0deg 0% 7.5%);
-      --gray-s2: hsl(0deg 0% 10%);
-      --gray-c1: hsl(0deg 0% 13%);
-      --gray-c2: hsl(0deg 0% 16%);
-      --gray-c3: hsl(0deg 0% 32%);
-      --gray-p1: hsl(0deg 0% 60%);
-      --gray-p2: hsl(0deg 0% 64%);
-      --gray-t1: hsl(0deg 0% 70%);
-      --gray-t2: hsl(0deg 0% 90%);
-
-      --indigo-s1: hsl(223deg 38% 10%);
-      --indigo-s2: hsl(223deg 42% 12%);
-      --indigo-c1: hsl(222deg 50% 16%);
-      --indigo-c2: hsl(221deg 56% 20%);
-      --indigo-c3: hsl(220deg 62% 24%);
-      --indigo-p1: hsl(214deg 94% 60%);
-      --indigo-p2: hsl(207deg 96% 64%);
-      --indigo-t1: hsl(214deg 93% 66%);
-      --indigo-t2: hsl(210deg 100% 86%);
+      --gray-s1: oklch(23% 0 0deg);
+      --gray-s2: oklch(25% 0 0deg);
+      --gray-c1: oklch(30% 0 0deg);
+      --gray-c2: oklch(34% 0 0deg);
+      --gray-c3: oklch(37% 0 0deg);
+      --gray-p1: oklch(73% 0 0deg);
+      --gray-p2: oklch(67% 0 0deg);
+      --gray-p3: oklch(64% 0 0deg);
+      --gray-p4: oklch(62.5% 0 0deg);
+      --gray-t1: oklch(75% 0 0deg);
+      --gray-t2: oklch(80% 0 0deg);
+      --gray-t3: oklch(93% 0 0deg);
+      --gray-a1: oklch(100% 0 0deg / 0.077);
+      --gray-a2: oklch(100% 0 0deg / 0.171);
+      --gray-a3: oklch(100% 0 0deg / 0.232);
+      --gray-a4: oklch(100% 0 0deg / 0.338);
+      --gray-a5: oklch(100% 0 0deg / 0.641);
 
       --poppy-t1: hsl(10deg 96% 63%);
-      --blue-t1: hsl(210deg 98% 66%);
       --green-t1: hsl(156deg 68% 54%);
-      --orange-t1: hsl(26deg 98% 63%);
-      --pink-t1: hsl(316deg 86% 68%);
-      --grape-t1: hsl(276deg 86% 70%);
-      --lime-t1: hsl(91deg 72% 56%);
 
       --color-blue: oklch(69% 50% 264deg);
       --color-red: oklch(80% 55% 31deg);
 
       /* Functional colors */
-      --color-content: black;
-      --color-background: black;
-      --color-border: var(--whiteA-5);
-      --color-popup: var(--gray-s1);
-      --color-gridline: var(--gray-c1);
-      --color-selection: hsl(0deg 0% 18%);
+      --canvas: oklch(21% 0 0deg);
+      --surface: var(--gray-s2);
+      --panel: var(--gray-s2);
+      --color-selection: var(--gray-c3);
       --color-line-highlight: hsl(205deg 45% 12%);
       --color-line-highlight-strong: hsl(205deg 55% 16%);
       --color-line-highlight-strong-mark: hsl(205deg 65% 20%);
 
       /* Syntax highlighting */
+      --color-gray: hsl(0deg 0% 70%);
       --color-green: oklch(75% 25% 150deg);
       --color-navy: oklch(85% 25% 264deg);
       --color-violet: oklch(80% 60% 280deg);
-
-      /* Shadow */
-      --shadow-1: transparent;
-      --shadow-2: transparent;
-      --shadow-3: transparent;
-      --shadow-4: transparent;
-      --shadow-5: transparent;
     }
   }
 
@@ -326,40 +274,19 @@
     --gray-c3: initial;
     --gray-p1: initial;
     --gray-p2: initial;
+    --gray-p3: initial;
+    --gray-p4: initial;
     --gray-t1: initial;
     --gray-t2: initial;
-
-    --indigo-s1: initial;
-    --indigo-s2: initial;
-    --indigo-c1: initial;
-    --indigo-c2: initial;
-    --indigo-c3: initial;
-    --indigo-p1: initial;
-    --indigo-p2: initial;
-    --indigo-t1: initial;
-    --indigo-t2: initial;
-
-    --blackA-1: initial;
-    --blackA-2: initial;
-    --blackA-3: initial;
-    --blackA-4: initial;
-    --blackA-5: initial;
-    --blackA-6: initial;
-
-    --whiteA-1: initial;
-    --whiteA-2: initial;
-    --whiteA-3: initial;
-    --whiteA-4: initial;
-    --whiteA-5: initial;
-    --whiteA-6: initial;
+    --gray-t3: initial;
+    --gray-a1: initial;
+    --gray-a2: initial;
+    --gray-a3: initial;
+    --gray-a4: initial;
+    --gray-a5: initial;
 
     --poppy-t1: initial;
-    --blue-t1: initial;
     --green-t1: initial;
-    --orange-t1: initial;
-    --pink-t1: initial;
-    --grape-t1: initial;
-    --lime-t1: initial;
 
     --radius-2: initial;
     --radius-3: initial;
@@ -385,13 +312,9 @@
     --space-40: initial;
     --space-48: initial;
 
-    --color-content: initial;
-    --color-background: initial;
-    --color-foreground: initial;
-    --color-border: initial;
-    --color-popup: initial;
-    --color-gridline: initial;
-    --color-highlight: initial;
+    --canvas: initial;
+    --surface: initial;
+    --panel: initial;
     --color-line-highlight: initial;
     --color-line-highlight-strong: initial;
     --color-line-highlight-strong-mark: initial;
@@ -400,12 +323,6 @@
     --color-navy: initial;
     --color-green: initial;
     --color-violet: initial;
-
-    --shadow-1: initial;
-    --shadow-2: initial;
-    --shadow-3: initial;
-    --shadow-4: initial;
-    --shadow-5: initial;
 
     --font-size-13: initial;
     --font-size-14: initial;

--- a/docs/src/css/syntax.css
+++ b/docs/src/css/syntax.css
@@ -19,15 +19,16 @@
     --color-prettylights-syntax-sublimelinter-gutter-mark: var(--color-gray);
 
     /* Invalid/error states */
+    /* Text colors pinned so code colors stay independent of the UI theme */
     --color-prettylights-syntax-invalid-illegal-bg: var(--color-red);
-    --color-prettylights-syntax-invalid-illegal-text: var(--color-content);
+    --color-prettylights-syntax-invalid-illegal-text: white;
     --color-prettylights-syntax-carriage-return-bg: var(--color-red);
-    --color-prettylights-syntax-carriage-return-text: var(--color-content);
+    --color-prettylights-syntax-carriage-return-text: white;
 
     /* Markup/markdown (unused in code demos but included for completeness) */
     --color-prettylights-syntax-markup-heading: var(--color-blue);
-    --color-prettylights-syntax-markup-bold: var(--color-foreground);
-    --color-prettylights-syntax-markup-italic: var(--color-foreground);
+    --color-prettylights-syntax-markup-bold: var(--gray-t3);
+    --color-prettylights-syntax-markup-italic: var(--gray-t3);
     --color-prettylights-syntax-markup-list: var(--color-red);
     --color-prettylights-syntax-markup-changed-bg: transparent;
     --color-prettylights-syntax-markup-changed-text: var(--color-red);
@@ -47,13 +48,20 @@
     --color-docs-infra-syntax-attr-value: var(--color-navy);
     --color-docs-infra-syntax-attr-equals: var(--color-red);
     --color-docs-infra-syntax-data-attr: var(--color-blue);
-    --color-docs-infra-syntax-css-property: var(--color-foreground);
+    --color-docs-infra-syntax-css-property: var(--gray-t3);
     --color-docs-infra-syntax-css-value: var(--color-blue);
     --color-docs-infra-syntax-this: var(--color-red);
     --color-docs-infra-syntax-builtin-type: var(--color-blue);
     --color-docs-infra-syntax-jsx: var(--color-blue);
     --color-docs-infra-syntax-html-tag: var(--color-green);
     --color-docs-infra-syntax-jsx-tag: var(--color-blue);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --color-prettylights-syntax-invalid-illegal-text: black;
+      --color-prettylights-syntax-carriage-return-text: black;
+    }
   }
 }
 

--- a/test/e2e/index.html
+++ b/test/e2e/index.html
@@ -9,8 +9,8 @@
         color-scheme: light dark;
       }
       body {
-        background-color: var(--color-background, white);
-        color: var(--color-foreground, black);
+        background-color: var(--canvas, white);
+        color: var(--gray-t3, black);
       }
     </style>
   </head>

--- a/test/regressions/index.html
+++ b/test/regressions/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="initial-scale=1, width=device-width" />
     <style>
       body {
-        background-color: white;
+        background-color: var(--canvas, white);
         font-family: 'Die Grotesk A', system-ui, sans-serif;
       }
     </style>


### PR DESCRIPTION
Preview: https://deploy-preview-5329--base-ui.netlify.app/

## What changed

Replaces the docs-site gray system (HSL scale + separate `blackA`/`whiteA` scales) with one oklch token set, across the docs, home, careers, and 404 pages. Demos, experiments, and syntax highlighting are untouched, apart from one accordion demo noted below.

**Scale** — `s1..s2` surfaces, `c1..c3` fills and borders, `p1..p4` dim ramp, `t1..t3` text ramp, `a1..a5` alpha.

**Alpha is mode-aware**: black in light, white in dark. Blurred shadows are gated to light mode, where white alpha would glow instead of shade; dark elevation comes from rings and surface steps.

**Functional tokens** replace `--color-content`/`--color-background`/`--color-foreground`/`--color-border` with three planes: `--canvas` (the page), `--surface` (floats above it), `--panel` (embedded containers, defined by their borders).

**Conventions this settles**

- `c1` hover, `c2` pressed — applied to ghost buttons, accordion triggers, demo tabs, search options, and the mobile nav.
- `c3` for borders and separators. Alpha (`a2`/`a3`) only where an outline composites over a dimmed backdrop — search dialog, mobile drawer, popups — since an opaque step reads *lighter* than the scrim there.

**Removals** — the indigo scale, five unconsumed accent steps, `--gray-contrast`, and `--shadow-1..5`: 62 declarations with no `var()` reference anywhere. The shadow ramp was never consumed in any commit (recover from `86c467bd4`). `--gray-contrast` is redundant because `s1` over `t3` already inverts per mode.

## Notes for review

- **One demo change**: the accordion demos gain the `white`/`neutral-950` fill that 108 of 113 demo stylesheets already use. Its transparent interior read as deliberate against the old pure-black dark playground, but as a missing background against the new canvas.
- **Contrast** (WCAG, light): `t3` 13.6:1, `t2` 5.3:1, `t1` 3.79:1 — the muted tier is intentionally below AA, per the source palette — and placeholders ~3.4:1. Dark passes throughout: text ≥8:1, placeholders ~5:1.
- The private `/docs-theme` page has been updated.
