### PR TITLE
[test] Stabilize popup interaction tests

### DIFF
--- a/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
@@ -138,17 +138,11 @@ describe('<Popover.Trigger />', () => {
       fireEvent.click(trigger, { detail: 1 });
     }
 
-    function hoverTrigger(trigger: HTMLElement) {
-      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
-      fireEvent.mouseEnter(trigger);
-      fireEvent.mouseMove(trigger);
-    }
-
     // A touch tap leaves the pointer parked wherever the cursor happens to be, so hover must stay
     // disarmed until the popover is reopened by some other means. Otherwise a stray hover over a
     // sibling trigger silently swaps the content the user just tapped for.
     it('keeps ownership on the tapped trigger when a sibling trigger is hovered', async () => {
-      await render(<MultiTriggerPopover />);
+      const { user } = await render(<MultiTriggerPopover />);
 
       const one = screen.getByRole('button', { name: 'One' });
       const two = screen.getByRole('button', { name: 'Two' });
@@ -158,7 +152,7 @@ describe('<Popover.Trigger />', () => {
 
       expect(screen.getByTestId('content')).toHaveTextContent('One');
 
-      hoverTrigger(two);
+      await user.hover(two);
       await flushMicrotasks();
 
       expect(screen.getByTestId('content')).toHaveTextContent('One');
@@ -168,7 +162,7 @@ describe('<Popover.Trigger />', () => {
     // The same hover must still take over when the popover was opened with a mouse, so the guard
     // above can't be a blanket disable.
     it('hands ownership to a hovered sibling trigger when opened by mouse', async () => {
-      await render(<MultiTriggerPopover />);
+      const { user } = await render(<MultiTriggerPopover />);
 
       const one = screen.getByRole('button', { name: 'One' });
       const two = screen.getByRole('button', { name: 'Two' });
@@ -178,7 +172,7 @@ describe('<Popover.Trigger />', () => {
 
       expect(screen.getByTestId('content')).toHaveTextContent('One');
 
-      hoverTrigger(two);
+      await user.hover(two);
       await flushMicrotasks();
 
       expect(screen.getByTestId('content')).toHaveTextContent('Two');

--- a/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
+++ b/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
@@ -1,6 +1,6 @@
 import { expect } from 'vitest';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { screen, fireEvent, flushMicrotasks } from '@mui/internal-test-utils';
+import { act, screen, fireEvent, flushMicrotasks } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';
 import { OPEN_DELAY } from '../utils/constants';
 
@@ -209,15 +209,18 @@ describe('<Tooltip.Provider />', () => {
 
       fireEvent.mouseEnter(first);
       fireEvent.mouseMove(first);
-      clock.tick(100);
-      await flushMicrotasks();
+      await act(async () => {
+        clock.tick(100);
+      });
 
       expect(screen.queryByText('Content One')).not.toBe(null);
 
       fireEvent.mouseLeave(first);
       fireEvent.mouseEnter(second);
       fireEvent.mouseMove(second);
-      await flushMicrotasks();
+      await act(async () => {
+        clock.tick(0);
+      });
 
       expect(screen.queryByText('Content Two')).not.toBe(null);
       expect(screen.queryByText('Content One')).toBe(null);


### PR DESCRIPTION
## Changes

- Await the full sibling-hover interaction in the Popover touch ownership tests.
- Advance Tooltip provider fake timers inside React `act()` boundaries.