### PR TITLE
[menu] Fix VoiceOver announcement when opening a submenu

### DIFF
--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -16,6 +16,7 @@ import { useRenderElement } from '../../internals/useRenderElement';
 import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 import { useTriggerRegistration } from '../../utils/popups';
 import { useMenuSubmenuRootContext } from '../submenu-root/MenuSubmenuRootContext';
+import { REASONS } from '../../internals/reasons';
 
 const VOICE_OVER_EXPANDED_PROPS = { 'aria-expanded': undefined };
 
@@ -166,6 +167,14 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
 
   const state: MenuSubmenuTriggerState = { disabled, highlighted, open };
 
+  const openMethod = store.useState('openMethod');
+  const lastOpenChangeReason = store.useState('lastOpenChangeReason');
+  // Arrow keys open the submenu through list navigation without dispatching a click, so
+  // `openMethod` stays null there; Enter and Space do dispatch one and report `keyboard`.
+  const openedByKeyboard =
+    lastOpenChangeReason === REASONS.listNavigation || openMethod === 'keyboard';
+  const shouldOmitExpanded = open && openedByKeyboard && platform.screenReader.voiceOver;
+
   const element = useRenderElement('div', componentProps, {
     state,
     stateAttributesMapping: triggerOpenStateMapping,
@@ -179,7 +188,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
       // moves to a moment later, so the first item is never announced. Dropping the state while
       // the submenu is open avoids the announcement without claiming the submenu is collapsed;
       // `aria-haspopup` still conveys that the item opens a submenu.
-      open && platform.screenReader.voiceOver ? VOICE_OVER_EXPANDED_PROPS : undefined,
+      shouldOmitExpanded ? VOICE_OVER_EXPANDED_PROPS : undefined,
       {
         'aria-controls': popupId,
         tabIndex: open || highlighted ? 0 : -1,

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -4,6 +4,7 @@ import { isElementDisabled } from '@base-ui/utils/isElementDisabled';
 import { warn } from '@base-ui/utils/warn';
 import { SafeReact } from '@base-ui/utils/safeReact';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
+import { platform } from '@base-ui/utils/platform';
 import { safePolygon, useClick, useHoverReferenceInteraction } from '../../floating-ui-react';
 import { BaseUIComponentProps, NonNativeButtonProps } from '../../internals/types';
 import { useMenuRootContext } from '../root/MenuRootContext';
@@ -15,6 +16,8 @@ import { useRenderElement } from '../../internals/useRenderElement';
 import { useMenuPositionerContext } from '../positioner/MenuPositionerContext';
 import { useTriggerRegistration } from '../../utils/popups';
 import { useMenuSubmenuRootContext } from '../submenu-root/MenuSubmenuRootContext';
+
+const VOICE_OVER_EXPANDED_PROPS = { 'aria-expanded': undefined };
 
 /**
  * A menu item that opens a submenu.
@@ -171,6 +174,12 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
       hoverProps,
       rootTriggerProps,
       itemProps,
+      // Opening a submenu changes the trigger's expanded state while the trigger still holds
+      // focus, and VoiceOver announces that state change instead of the submenu item that focus
+      // moves to a moment later, so the first item is never announced. Dropping the state while
+      // the submenu is open avoids the announcement without claiming the submenu is collapsed;
+      // `aria-haspopup` still conveys that the item opens a submenu.
+      open && platform.screenReader.voiceOver ? VOICE_OVER_EXPANDED_PROPS : undefined,
       {
         'aria-controls': popupId,
         tabIndex: open || highlighted ? 0 : -1,

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.voiceOver.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.voiceOver.test.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { screen } from '@mui/internal-test-utils';
+import { vi, describe, it, expect } from 'vitest';
+import { createRenderer } from '#test-utils';
+import { Menu } from '@base-ui/react/menu';
+
+// Kept in a separate file so the module mock doesn't leak into `MenuSubmenuTrigger.test.tsx`.
+vi.mock('@base-ui/utils/platform', async () => {
+  const actual =
+    await vi.importActual<typeof import('@base-ui/utils/platform')>('@base-ui/utils/platform');
+
+  return {
+    platform: {
+      ...actual.platform,
+      screenReader: { ...actual.platform.screenReader, voiceOver: true },
+    },
+  };
+});
+
+describe('<Menu.SubmenuTrigger /> with VoiceOver', () => {
+  const { render } = createRenderer();
+
+  it('does not expose the expanded state while the submenu is open', async () => {
+    const { user } = await render(
+      <Menu.Root open>
+        <Menu.Trigger>Open menu</Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner>
+            <Menu.Popup>
+              <Menu.SubmenuRoot>
+                <Menu.SubmenuTrigger>More</Menu.SubmenuTrigger>
+                <Menu.Portal>
+                  <Menu.Positioner>
+                    <Menu.Popup data-testid="submenu">
+                      <Menu.Item>Alpha</Menu.Item>
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.SubmenuRoot>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>,
+    );
+
+    const submenuTrigger = screen.getByText('More');
+    expect(submenuTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(submenuTrigger);
+    await screen.findByTestId('submenu');
+
+    expect(submenuTrigger).not.toHaveAttribute('aria-expanded');
+    // The submenu is still discoverable through `aria-haspopup`.
+    expect(submenuTrigger).toHaveAttribute('aria-haspopup', 'menu');
+  });
+});

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.voiceOver.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.voiceOver.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { screen } from '@mui/internal-test-utils';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { vi, describe, it, expect } from 'vitest';
 import { createRenderer } from '#test-utils';
 import { Menu } from '@base-ui/react/menu';
@@ -17,40 +17,91 @@ vi.mock('@base-ui/utils/platform', async () => {
   };
 });
 
+function Test() {
+  return (
+    <Menu.Root>
+      <Menu.Trigger>Open menu</Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner>
+          <Menu.Popup>
+            <Menu.SubmenuRoot>
+              <Menu.SubmenuTrigger>More</Menu.SubmenuTrigger>
+              <Menu.Portal>
+                <Menu.Positioner>
+                  <Menu.Popup data-testid="submenu">
+                    <Menu.Item>Alpha</Menu.Item>
+                    <Menu.Item>Beta</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.SubmenuRoot>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}
+
 describe('<Menu.SubmenuTrigger /> with VoiceOver', () => {
   const { render } = createRenderer();
 
-  it('does not expose the expanded state while the submenu is open', async () => {
-    const { user } = await render(
-      <Menu.Root open>
-        <Menu.Trigger>Open menu</Menu.Trigger>
-        <Menu.Portal>
-          <Menu.Positioner>
-            <Menu.Popup>
-              <Menu.SubmenuRoot>
-                <Menu.SubmenuTrigger>More</Menu.SubmenuTrigger>
-                <Menu.Portal>
-                  <Menu.Positioner>
-                    <Menu.Popup data-testid="submenu">
-                      <Menu.Item>Alpha</Menu.Item>
-                    </Menu.Popup>
-                  </Menu.Positioner>
-                </Menu.Portal>
-              </Menu.SubmenuRoot>
-            </Menu.Popup>
-          </Menu.Positioner>
-        </Menu.Portal>
-      </Menu.Root>,
-    );
+  it('omits the expanded state when the submenu is opened with ArrowRight', async () => {
+    const { user } = await render(<Test />);
 
-    const submenuTrigger = screen.getByText('More');
+    await user.keyboard('[Tab]');
+    await user.keyboard('[Enter]');
+
+    const submenuTrigger = await screen.findByRole('menuitem', { name: 'More' });
+    await waitFor(() => {
+      expect(submenuTrigger).toHaveFocus();
+    });
     expect(submenuTrigger).toHaveAttribute('aria-expanded', 'false');
 
-    await user.click(submenuTrigger);
+    await user.keyboard('[ArrowRight]');
+
     await screen.findByTestId('submenu');
+    // Focus moves into the submenu; this is the announcement VoiceOver must not talk over.
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'Alpha' })).toHaveFocus();
+    });
 
     expect(submenuTrigger).not.toHaveAttribute('aria-expanded');
     // The submenu is still discoverable through `aria-haspopup`.
     expect(submenuTrigger).toHaveAttribute('aria-haspopup', 'menu');
+  });
+
+  it('omits the expanded state when the submenu is opened with Enter', async () => {
+    const { user } = await render(<Test />);
+
+    await user.keyboard('[Tab]');
+    await user.keyboard('[Enter]');
+
+    const submenuTrigger = await screen.findByRole('menuitem', { name: 'More' });
+    await waitFor(() => {
+      expect(submenuTrigger).toHaveFocus();
+    });
+
+    await user.keyboard('[Enter]');
+
+    await screen.findByTestId('submenu');
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'Alpha' })).toHaveFocus();
+    });
+
+    expect(submenuTrigger).not.toHaveAttribute('aria-expanded');
+  });
+
+  it('keeps the expanded state when the submenu is opened with a pointer', async () => {
+    const { user } = await render(<Test />);
+
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    const submenuTrigger = await screen.findByRole('menuitem', { name: 'More' });
+    await user.click(submenuTrigger);
+
+    await screen.findByTestId('submenu');
+
+    // Focus stays on the trigger, so there is no item announcement to talk over.
+    expect(submenuTrigger).toHaveAttribute('aria-expanded', 'true');
   });
 });


### PR DESCRIPTION
VoiceOver doesn't announce the first submenu item when a submenu is opened — it announces the trigger again instead, including its freshly changed expanded state. Opening the submenu flips `aria-expanded` to `true` while the trigger still holds focus, and VoiceOver announces that state change over the item that focus moves to a moment later.

This PR makes it so the submenu trigger now omits `aria-expanded` while its submenu is open on Apple platforms. `aria-haspopup="menu"` and `aria-controls` are untouched, and `aria-expanded="false"` is still exposed while closed, so the only thing given up is the expanded state at the moment focus is already inside the submenu. Omitting the state rather than reporting `false` means nothing incorrect is exposed, which is why this doesn't need to be narrowed to keyboard opens.

Alternative to #5067, which fixes the same bug by also dropping the popup's `aria-labelledby` and the trigger's `aria-controls` and deferring initial focus by a frame. Testing each edge in isolation with VoiceOver, `aria-labelledby` and `aria-controls` turned out to be irrelevant and `aria-expanded` alone load-bearing, so the util files, `openEvent` plumbing, and the `useListNavigation` deferral aren't needed.

Since focus moves into the submenu when it opens, the only time users can tell if `aria-expanded="true"` is applied is if they move  focus back to the submenu trigger, which is not a common navigation pattern. And even then, it doesn't say it's `collapsed` incorrectly, it just lacks `expanded`. This trade-off appears worth it.

<img width="1224" height="812" alt="Screenshot 2026-07-27 at 10 12 41 am" src="https://github.com/user-attachments/assets/e34da56a-e2fb-48c0-babf-b4a8852b607d" />


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
