### PR TITLE
[menu] Fix submenu spuriously closing as sibling before node ids are registered

### DIFF
--- a/packages/react/src/menu/positioner/MenuPositioner.test.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.test.tsx
@@ -178,6 +178,48 @@ describe('<Menu.Positioner />', () => {
     expect(onSubmenuOpenChange.mock.lastCall?.[1].reason).toBe('sibling-open');
   });
 
+  it('does not close a kept-mounted default-open submenu as a sibling when its parent opens', async () => {
+    const onSubmenuOpenChange = vi.fn();
+    let openParent = () => {};
+
+    function Test() {
+      const [open, setOpen] = React.useState(false);
+      openParent = () => setOpen(true);
+
+      return (
+        <Menu.Root open={open}>
+          <Menu.Trigger>Open</Menu.Trigger>
+          <Menu.Portal keepMounted>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.SubmenuRoot defaultOpen onOpenChange={onSubmenuOpenChange}>
+                  <Menu.SubmenuTrigger>More</Menu.SubmenuTrigger>
+                  <Menu.Portal keepMounted>
+                    <Menu.Positioner>
+                      <Menu.Popup data-testid="submenu-popup" />
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.SubmenuRoot>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
+      );
+    }
+
+    await render(<Test />);
+
+    await act(async () => {
+      openParent();
+    });
+    await flushMicrotasks();
+
+    const siblingClose = onSubmenuOpenChange.mock.calls.find(
+      (call) => call[0] === false && call[1].reason === 'sibling-open',
+    );
+    expect(siblingClose).toBe(undefined);
+  });
+
   describe.skipIf(isJSDOM)('prop: anchor', () => {
     it('should be placed near the specified element when a ref is passed', async () => {
       function TestComponent() {

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -143,6 +143,9 @@ export const MenuPositioner = React.forwardRef(function MenuPositioner(
         }
         if (
           details.nodeId !== floatingNodeId &&
+          // Both ids must be registered; before registration both sides can be
+          // null, which would spuriously match unrelated menus as siblings.
+          details.parentNodeId != null &&
           details.parentNodeId === store.select('floatingParentNodeId')
         ) {
           store.setOpen(false, createChangeEventDetails(REASONS.siblingOpen));


### PR DESCRIPTION
`MenuPositioner`'s `menuopenchange` sibling check compares `details.parentNodeId` with the menu's own `floatingParentNodeId` using strict equality. Both ids can still be `null` before floating node registration — a root menu's node id only reaches the store while it is open — so the comparison matches spuriously. Concretely, a `defaultOpen` kept-mounted submenu under a closed kept-mounted parent closes itself with reason `sibling-open` the moment its parent opens, because the parent's open emit fires as `{ parentNodeId: null }` before ids are registered.

The fix guards the comparison so a menu is only treated as a sibling when `details.parentNodeId` is non-null (strict equality then implies the store side is non-null too). There is no legitimate null–null sibling case: standalone roots each create their own floating tree, and registered submenus always have a non-null parent id.

Adds a regression test that asserts the submenu receives no `sibling-open` close when its parent opens; it asserts on the close reason rather than open state, since focus-out closes in jsdom could otherwise mask the result. Verified failing before the fix.
