### PR TITLE
[all components] Fix stale focused field state

### DIFF
--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -1469,6 +1469,47 @@ describe('<Checkbox.Root />', () => {
       expect(button).not.toHaveAttribute('data-focused');
     });
 
+    describe('[data-focused] without a blur event', () => {
+      function Checkboxes(props: { firstMounted?: boolean; firstDisabled?: boolean }) {
+        const { firstMounted = true, firstDisabled = false } = props;
+        return (
+          <Field.Root data-testid="root">
+            {firstMounted && <Checkbox.Root data-testid="first" disabled={firstDisabled} />}
+          </Field.Root>
+        );
+      }
+
+      it('is removed when the focused checkbox becomes disabled', async () => {
+        const { setProps } = await render(<Checkboxes />);
+
+        const button = screen.getByTestId('first');
+        act(() => {
+          button.focus();
+        });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstDisabled: true });
+
+        expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+        expect(button).not.toHaveAttribute('data-focused');
+      });
+
+      it('is removed when the focused checkbox unmounts', async () => {
+        const { setProps } = await render(<Checkboxes />);
+
+        act(() => {
+          screen.getByTestId('first').focus();
+        });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstMounted: false });
+
+        expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+      });
+    });
+
     it('[data-invalid]', async () => {
       await render(
         <Field.Root invalid>

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -304,9 +304,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
         'aria-labelledby': ariaLabelledBy,
         [PARENT_CHECKBOX as string]: parent ? '' : undefined,
         onFocus() {
-          if (!disabled) {
-            setFocused(true);
-          }
+          setFocused(true);
         },
         onBlur() {
           const inputEl = inputRef.current;

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -20,6 +20,7 @@ import { mergeProps } from '../../merge-props';
 import { useButton } from '../../internals/use-button/useButton';
 import type { FieldRootState } from '../../field/root/FieldRoot';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
+import { useSetFieldFocused } from '../../internals/field-root-context/useSetFieldFocused';
 import { useRegisterFieldControl } from '../../internals/field-register-control/useRegisterFieldControl';
 import { useFieldItemContext } from '../../field/item/FieldItemContext';
 import { useFormContext } from '../../internals/form-context/FormContext';
@@ -76,7 +77,6 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     name: fieldName,
     setDirty,
     setFilled,
-    setFocused,
     setTouched,
     state: fieldState,
     validationMode,
@@ -94,6 +94,8 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     rootDisabled || fieldItemContext.disabled || groupContext?.disabled || disabledProp;
   const name = fieldName ?? nameProp;
   const value = valueProp ?? name;
+
+  const setFocused = useSetFieldFocused(disabled);
 
   const id = useBaseUiId();
 

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -13,6 +13,7 @@ import {
   FieldRootContext,
   useFieldRootContext,
 } from '../../internals/field-root-context/FieldRootContext';
+import { useSetFieldFocused } from '../../internals/field-root-context/useSetFieldFocused';
 import { DEFAULT_FIELD_STATE_ATTRIBUTES } from '../../internals/field-constants/constants';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
 import { useComboboxChipsContext } from '../chips/ComboboxChipsContext';
@@ -54,7 +55,6 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
     state: fieldState,
     disabled: fieldDisabled,
     setTouched,
-    setFocused,
     validationMode,
     validation,
   } = useFieldRootContext();
@@ -88,6 +88,8 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
   const popupSide = usePopupSide(store);
   const disabled = fieldDisabled || comboboxDisabled || disabledProp;
   const listEmpty = useListEmpty();
+
+  const setFocused = useSetFieldFocused(disabled);
 
   const isInsidePopup = hasPositionerParent || inline;
   const focusManagerModal = !isInsidePopup || modal;

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -11751,6 +11751,92 @@ describe('<Combobox.Root />', () => {
       expect(trigger).not.toHaveAttribute('data-focused');
     });
 
+    describe('[data-focused] without a blur event', () => {
+      function Comboboxes(props: { firstMounted?: boolean; firstDisabled?: boolean }) {
+        const { firstMounted = true, firstDisabled = false } = props;
+        return (
+          <Field.Root data-testid="field">
+            {firstMounted && (
+              <Combobox.Root disabled={firstDisabled}>
+                <Combobox.Input data-testid="first" />
+              </Combobox.Root>
+            )}
+          </Field.Root>
+        );
+      }
+
+      it('is removed when the focused input becomes disabled', async () => {
+        const { setProps } = await render(<Comboboxes />);
+
+        const input = screen.getByTestId('first');
+        act(() => {
+          input.focus();
+        });
+
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstDisabled: true });
+
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+        expect(input).not.toHaveAttribute('data-focused');
+      });
+
+      it('is removed when the focused input unmounts', async () => {
+        const { setProps } = await render(<Comboboxes />);
+
+        act(() => {
+          screen.getByTestId('first').focus();
+        });
+
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstMounted: false });
+
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+      });
+
+      function Triggers(props: { disabled?: boolean; mounted?: boolean }) {
+        const { disabled = false, mounted = true } = props;
+        return (
+          <Field.Root data-testid="field">
+            <Combobox.Root disabled={disabled}>
+              {mounted && <Combobox.Trigger data-testid="trigger" />}
+            </Combobox.Root>
+          </Field.Root>
+        );
+      }
+
+      it('is removed when the focused trigger becomes disabled', async () => {
+        const { setProps } = await render(<Triggers />);
+
+        const trigger = screen.getByTestId('trigger');
+        act(() => {
+          trigger.focus();
+        });
+
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ disabled: true });
+
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+        expect(trigger).not.toHaveAttribute('data-focused');
+      });
+
+      it('is removed when the focused trigger unmounts', async () => {
+        const { setProps } = await render(<Triggers />);
+
+        act(() => {
+          screen.getByTestId('trigger').focus();
+        });
+
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ mounted: false });
+
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+      });
+    });
+
     it('does not mark as touched when focus moves into the popup', async () => {
       const validateSpy = vi.fn(() => 'error');
 

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -13,6 +13,7 @@ import {
 } from '../root/ComboboxRootContext';
 import { triggerStateAttributesMapping } from '../utils/stateAttributesMapping';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
+import { useSetFieldFocused } from '../../internals/field-root-context/useSetFieldFocused';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
 import { stopEvent, contains, getTarget } from '../../floating-ui-react/utils';
 import { isMouseWithinBounds } from '../../utils/getPseudoElementBounds';
@@ -50,7 +51,6 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
     state: fieldState,
     disabled: fieldDisabled,
     setTouched,
-    setFocused,
     validationMode,
     validation,
   } = useFieldRootContext();
@@ -82,6 +82,8 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
   const disabled = fieldDisabled || comboboxDisabled || disabledProp;
   const listEmpty = useListEmpty();
   const popupSide = usePopupSide(store);
+
+  const setFocused = useSetFieldFocused(disabled);
 
   useLabelableId({ id: inputInsidePopup ? idProp : undefined });
   const id = inputInsidePopup ? (idProp ?? rootId) : idProp;

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -527,6 +527,97 @@ describe('<Field.Control />', () => {
     expect(screen.getByText('Required')).toBeInTheDocument();
   });
 
+  describe('[data-focused]', () => {
+    function Controls(props: { firstMounted?: boolean; firstDisabled?: boolean }) {
+      const { firstMounted = true, firstDisabled = false } = props;
+      return (
+        <Field.Root data-testid="root">
+          <Field.Label data-testid="label">Name</Field.Label>
+          {firstMounted && <Field.Control data-testid="first" disabled={firstDisabled} />}
+        </Field.Root>
+      );
+    }
+
+    it('is removed when the focused control becomes disabled', async () => {
+      const { setProps } = await render(<Controls />);
+
+      const control = screen.getByTestId('first');
+      act(() => {
+        control.focus();
+      });
+
+      expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+      expect(control).toHaveAttribute('data-focused', '');
+
+      await setProps({ firstDisabled: true });
+
+      expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+      expect(control).not.toHaveAttribute('data-focused');
+      expect(screen.getByTestId('label')).not.toHaveAttribute('data-focused');
+    });
+
+    it('is removed when the field root becomes disabled', async () => {
+      function TestCase(props: { disabled?: boolean }) {
+        const { disabled = false } = props;
+        return (
+          <Field.Root data-testid="root" disabled={disabled}>
+            <Field.Control data-testid="control" />
+          </Field.Root>
+        );
+      }
+
+      const { setProps } = await render(<TestCase />);
+
+      act(() => {
+        screen.getByTestId('control').focus();
+      });
+      expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+      await setProps({ disabled: true });
+
+      expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+    });
+
+    it('can be re-acquired after the control is re-enabled', async () => {
+      const { setProps } = await render(<Controls />);
+
+      const control = screen.getByTestId('first');
+      act(() => {
+        control.focus();
+      });
+      expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+      await setProps({ firstDisabled: true });
+      expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+
+      await setProps({ firstDisabled: false });
+      expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+
+      // jsdom leaves a disabled control as the active element, so blur first to make the
+      // refocus fire a real focus event.
+      act(() => {
+        control.blur();
+        control.focus();
+      });
+      expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+    });
+
+    it('is removed when the focused control unmounts', async () => {
+      const { setProps } = await render(<Controls />);
+
+      act(() => {
+        screen.getByTestId('first').focus();
+      });
+
+      expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+      await setProps({ firstMounted: false });
+
+      expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+      expect(screen.getByTestId('label')).not.toHaveAttribute('data-focused');
+    });
+  });
+
   it.skipIf(isJSDOM)('should sync focused state when autoFocus is used with SSR', async () => {
     vi.spyOn(console, 'error')
       .mockName('console.error')

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -7,6 +7,7 @@ import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useTimeout } from '@base-ui/utils/useTimeout';
 import { type FieldRootState } from '../root/FieldRoot';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
+import { useSetFieldFocused } from '../../internals/field-root-context/useSetFieldFocused';
 import { useRegisterFieldControl } from '../../internals/field-register-control/useRegisterFieldControl';
 import { useFormContext } from '../../internals/form-context/FormContext';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
@@ -55,7 +56,6 @@ export const FieldControl = React.forwardRef(function FieldControl(
     setTouched,
     setDirty,
     validityData,
-    setFocused,
     setFilled,
     validationMode,
     validation,
@@ -64,6 +64,8 @@ export const FieldControl = React.forwardRef(function FieldControl(
 
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
+
+  const setFocused = useSetFieldFocused(disabled);
 
   const state: FieldControlState = {
     ...fieldState,

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -51,6 +51,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
   const [dirtyState, setDirtyUnwrapped] = React.useState(false);
   const [filled, setFilled] = React.useState(false);
   const [focused, setFocused] = React.useState(false);
+  const focusOwnerRef = React.useRef<unknown>(undefined);
 
   const dirty = dirtyProp ?? dirtyState;
   const touched = touchedProp ?? touchedState;
@@ -160,6 +161,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
       setDirty,
       setFilled,
       setFocused,
+      focusOwnerRef,
       validationMode,
       shouldValidateOnChange,
       state,

--- a/packages/react/src/internals/field-root-context/FieldRootContext.ts
+++ b/packages/react/src/internals/field-root-context/FieldRootContext.ts
@@ -19,6 +19,11 @@ export interface FieldRootContext {
   setDirty: React.Dispatch<React.SetStateAction<boolean>>;
   setFilled: React.Dispatch<React.SetStateAction<boolean>>;
   setFocused: React.Dispatch<React.SetStateAction<boolean>>;
+  /**
+   * Identifies the control the focused state belongs to, so that disabling or unmounting a
+   * different control in the same field can't clear it. Written through `useSetFieldFocused`.
+   */
+  focusOwnerRef: React.RefObject<unknown>;
   validationMode: Form.ValidationMode;
   shouldValidateOnChange: () => boolean;
   state: FieldRootState;
@@ -45,6 +50,7 @@ export const DEFAULT_FIELD_ROOT_CONTEXT: FieldRootContext = {
   setDirty: NOOP,
   setFilled: NOOP,
   setFocused: NOOP,
+  focusOwnerRef: { current: undefined },
   validationMode: 'onSubmit',
   shouldValidateOnChange: () => false,
   state: DEFAULT_FIELD_ROOT_STATE,

--- a/packages/react/src/internals/field-root-context/useSetFieldFocused.ts
+++ b/packages/react/src/internals/field-root-context/useSetFieldFocused.ts
@@ -18,6 +18,12 @@ export function useSetFieldFocused(
   const { setFocused, focusOwnerRef } = useFieldRootContext();
 
   const setFieldFocused = useStableCallback((focused: boolean) => {
+    // A disabled target can still be focused (`aria-disabled` elements stay programmatically
+    // focusable), but must not publish the field's focused styling.
+    if (focused && disabled) {
+      return;
+    }
+
     if (!focused && focusOwnerRef.current !== setFieldFocused) {
       return;
     }

--- a/packages/react/src/internals/field-root-context/useSetFieldFocused.ts
+++ b/packages/react/src/internals/field-root-context/useSetFieldFocused.ts
@@ -1,0 +1,35 @@
+'use client';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import { useFieldRootContext } from './FieldRootContext';
+
+/**
+ * Returns the field's `setFocused`, recording which control the focused state belongs to.
+ *
+ * Disabling or unmounting a focused control moves focus away without firing `blur`, so the focused
+ * state would otherwise stay latched. A field can have several focus targets, so a control only
+ * clears the shared state when focus last landed on itself. The stable callback doubles as that
+ * identity.
+ */
+export function useSetFieldFocused(
+  disabled: boolean | undefined,
+  onFocusedChange?: ((focused: boolean) => void) | undefined,
+) {
+  const { setFocused, focusOwnerRef } = useFieldRootContext();
+
+  const setFieldFocused = useStableCallback((focused: boolean) => {
+    if (!focused && focusOwnerRef.current !== setFieldFocused) {
+      return;
+    }
+
+    focusOwnerRef.current = focused ? setFieldFocused : undefined;
+    onFocusedChange?.(focused);
+    setFocused(focused);
+  });
+
+  // Re-run the cleanup when `disabled` changes so a focused control releases the field even when
+  // the browser does not fire `blur`.
+  useIsoLayoutEffect(() => () => setFieldFocused(false), [disabled, setFieldFocused]);
+
+  return setFieldFocused;
+}

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -7,6 +7,7 @@ import { formatNumber } from '@base-ui/utils/formatNumber';
 import { useNumberFieldRootContext } from '../root/NumberFieldRootContext';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
+import { useSetFieldFocused } from '../../internals/field-root-context/useSetFieldFocused';
 import { useRegisterFieldControl } from '../../internals/field-register-control/useRegisterFieldControl';
 import { useFormContext } from '../../internals/form-context/FormContext';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
@@ -78,9 +79,11 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
   const { disabled, readOnly, required, value, inputValue } = state;
 
   const { clearErrors } = useFormContext();
-  const { validationMode, setTouched, setFocused, invalid, shouldValidateOnChange, validation } =
+  const { validationMode, setTouched, invalid, shouldValidateOnChange, validation } =
     useFieldRootContext();
   const { labelId } = useLabelableContext();
+
+  const setFocused = useSetFieldFocused(disabled);
 
   const blockRevalidationRef = React.useRef(false);
   const pendingCaretRef = React.useRef<number | null>(null);

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -2007,6 +2007,51 @@ describe('<NumberField />', () => {
       expect(input).toHaveAttribute('data-focused', '');
     });
 
+    describe('[data-focused] without a blur event', () => {
+      function NumberFields(props: { firstMounted?: boolean; firstDisabled?: boolean }) {
+        const { firstMounted = true, firstDisabled = false } = props;
+        return (
+          <Field.Root data-testid="root">
+            {firstMounted && (
+              <NumberFieldBase.Root disabled={firstDisabled}>
+                <NumberFieldBase.Input data-testid="first" />
+              </NumberFieldBase.Root>
+            )}
+          </Field.Root>
+        );
+      }
+
+      it('is removed when the focused input becomes disabled', async () => {
+        const { setProps } = await render(<NumberFields />);
+
+        const input = screen.getByTestId('first');
+        act(() => {
+          input.focus();
+        });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstDisabled: true });
+
+        expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+        expect(input).not.toHaveAttribute('data-focused');
+      });
+
+      it('is removed when the focused input unmounts', async () => {
+        const { setProps } = await render(<NumberFields />);
+
+        act(() => {
+          screen.getByTestId('first').focus();
+        });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstMounted: false });
+
+        expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+      });
+    });
+
     it('prop: validate', async () => {
       await render(
         <Field.Root validationMode="onBlur" validate={() => 'error'}>

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -6,6 +6,7 @@ import { stopEvent } from '../../floating-ui-react/utils';
 import { useCompositeListItem } from '../../internals/composite/list/useCompositeListItem';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useDirection } from '../../internals/direction-context/DirectionContext';
+import { useSetFieldFocused } from '../../internals/field-root-context/useSetFieldFocused';
 import { useRenderElement } from '../../internals/useRenderElement';
 import {
   createChangeEventDetails,
@@ -56,6 +57,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
     readOnly,
     required,
     normalizeValue,
+    setFocused: setRootFocused,
     setValue,
     state,
     validationType,
@@ -64,6 +66,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
 
   const { ref: listItemRef, index } = useCompositeListItem({ guess: true });
   const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const setFocused = useSetFieldFocused(disabled, setRootFocused);
   const direction = useDirection();
 
   const slotValue = value[index] ?? '';
@@ -121,6 +124,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
         return;
       }
 
+      setFocused(true);
       handleInputFocus(index, event);
     },
     onBlur(event) {
@@ -128,6 +132,8 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
         return;
       }
 
+      // Focus moving to a sibling slot stays inside the root; `handleInputBlur` clears the
+      // focused state only when focus leaves the root, so slot-to-slot moves don't churn it.
       handleInputBlur(event);
     },
     onChange(event) {

--- a/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
@@ -1524,6 +1524,11 @@ describe('<OTPField.Root />', () => {
     });
 
     it('is kept when a previously focused slot unmounts after focus moves to a sibling', async () => {
+      // `inputCount` trails `length` by a render, so shrinking both at once warns about a
+      // mismatch that never reaches the DOM. Silencing it keeps the test from passing only on
+      // CI's retry, where `warn`'s dedupe swallows the message it failed on the first time.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
       function TestCase(props: { firstMounted?: boolean }) {
         const { firstMounted = true } = props;
         return (
@@ -1537,25 +1542,29 @@ describe('<OTPField.Root />', () => {
         );
       }
 
-      const { setProps } = await render(<TestCase />);
-      const [first, second] = screen.getAllByRole<HTMLInputElement>('textbox');
+      try {
+        const { setProps } = await render(<TestCase />);
+        const [first, second] = screen.getAllByRole<HTMLInputElement>('textbox');
 
-      await act(async () => {
-        first.focus();
-      });
-      await act(async () => {
-        second.focus();
-      });
+        await act(async () => {
+          first.focus();
+        });
+        await act(async () => {
+          second.focus();
+        });
 
-      expect(second).toHaveFocus();
-      expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
-      expect(screen.getByTestId('otp')).toHaveAttribute('data-focused', '');
+        expect(second).toHaveFocus();
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+        expect(screen.getByTestId('otp')).toHaveAttribute('data-focused', '');
 
-      await setProps({ firstMounted: false });
+        await setProps({ firstMounted: false });
 
-      expect(second).toHaveFocus();
-      expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
-      expect(screen.getByTestId('otp')).toHaveAttribute('data-focused', '');
+        expect(second).toHaveFocus();
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+        expect(screen.getByTestId('otp')).toHaveAttribute('data-focused', '');
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it('is removed when the focused slot unmounts but its field remains', async () => {

--- a/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
@@ -1483,6 +1483,119 @@ describe('<OTPField.Root />', () => {
     });
   });
 
+  describe('[data-focused] without a blur event', () => {
+    function Fields(props: { firstMounted?: boolean; firstDisabled?: boolean }) {
+      const { firstMounted = true, firstDisabled = false } = props;
+      return (
+        <Field.Root data-testid="field">
+          {firstMounted && <OTPField data-testid="first" disabled={firstDisabled} />}
+        </Field.Root>
+      );
+    }
+
+    it('is removed when the focused field becomes disabled', async () => {
+      const { setProps } = await render(<Fields />);
+
+      await act(async () => {
+        screen.getAllByRole<HTMLInputElement>('textbox')[0].focus();
+      });
+
+      expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+      expect(screen.getByTestId('first')).toHaveAttribute('data-focused', '');
+
+      await setProps({ firstDisabled: true });
+
+      expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+      expect(screen.getByTestId('first')).not.toHaveAttribute('data-focused');
+    });
+
+    it('is removed when the focused field unmounts', async () => {
+      const { setProps } = await render(<Fields />);
+
+      await act(async () => {
+        screen.getAllByRole<HTMLInputElement>('textbox')[0].focus();
+      });
+
+      expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+      await setProps({ firstMounted: false });
+
+      expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+    });
+
+    it('is kept when a previously focused slot unmounts after focus moves to a sibling', async () => {
+      function TestCase(props: { firstMounted?: boolean }) {
+        const { firstMounted = true } = props;
+        return (
+          <Field.Root data-testid="field">
+            <OTPFieldBase.Root length={firstMounted ? 3 : 2} defaultValue="1" data-testid="otp">
+              {firstMounted && <OTPFieldBase.Input key="first" />}
+              <OTPFieldBase.Input key="second" />
+              <OTPFieldBase.Input key="third" />
+            </OTPFieldBase.Root>
+          </Field.Root>
+        );
+      }
+
+      const { setProps } = await render(<TestCase />);
+      const [first, second] = screen.getAllByRole<HTMLInputElement>('textbox');
+
+      await act(async () => {
+        first.focus();
+      });
+      await act(async () => {
+        second.focus();
+      });
+
+      expect(second).toHaveFocus();
+      expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+      expect(screen.getByTestId('otp')).toHaveAttribute('data-focused', '');
+
+      await setProps({ firstMounted: false });
+
+      expect(second).toHaveFocus();
+      expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+      expect(screen.getByTestId('otp')).toHaveAttribute('data-focused', '');
+    });
+
+    it('is removed when the focused slot unmounts but its field remains', async () => {
+      // Unmounting one slot leaves `length` out of sync with the rendered inputs, which is
+      // irrelevant to what this test asserts. `warn` dedupes on the message, so `length={3}`
+      // keeps this silenced warning from consuming the messages other tests assert.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      function TestCase(props: { firstMounted?: boolean }) {
+        const { firstMounted = true } = props;
+        return (
+          <Field.Root data-testid="field">
+            <OTPFieldBase.Root length={3} data-testid="otp">
+              {firstMounted && <OTPFieldBase.Input />}
+              <OTPFieldBase.Input />
+              <OTPFieldBase.Input />
+            </OTPFieldBase.Root>
+          </Field.Root>
+        );
+      }
+
+      try {
+        const { setProps } = await render(<TestCase />);
+
+        await act(async () => {
+          screen.getAllByRole<HTMLInputElement>('textbox')[0].focus();
+        });
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+        expect(screen.getByTestId('otp')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstMounted: false });
+
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+        expect(screen.getByTestId('otp')).not.toHaveAttribute('data-focused');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
   it('updates standalone filled and focused state on the root', async () => {
     await render(
       <OTPFieldBase.Root data-testid="root" length={OTP_LENGTH}>

--- a/packages/react/src/otp-field/root/OTPFieldRoot.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.tsx
@@ -83,7 +83,7 @@ export const OTPFieldRoot = React.forwardRef(function OTPFieldRoot(
     state: fieldState,
     validation,
     validationMode,
-    setFocused,
+    setFocused: setFieldFocused,
     setTouched,
   } = useFieldRootContext();
   const { clearErrors } = useFormContext();
@@ -277,8 +277,6 @@ export const OTPFieldRoot = React.forwardRef(function OTPFieldRoot(
       }
 
       setFocusedIndex(index);
-      setFocusedState(true);
-      setFocused(true);
       event.currentTarget.select();
     },
   );
@@ -290,7 +288,7 @@ export const OTPFieldRoot = React.forwardRef(function OTPFieldRoot(
 
     setTouched(true);
     setFocusedState(false);
-    setFocused(false);
+    setFieldFocused(false);
 
     if (validationMode === 'onBlur') {
       validation.commit(valueRef.current);
@@ -345,6 +343,7 @@ export const OTPFieldRoot = React.forwardRef(function OTPFieldRoot(
       required,
       normalizeValue,
       setValue,
+      setFocused: setFocusedState,
       state,
       validationType,
       value,
@@ -370,6 +369,7 @@ export const OTPFieldRoot = React.forwardRef(function OTPFieldRoot(
       required,
       normalizeValue,
       setValue,
+      setFocusedState,
       state,
       validationType,
       value,

--- a/packages/react/src/otp-field/root/OTPFieldRootContext.ts
+++ b/packages/react/src/otp-field/root/OTPFieldRootContext.ts
@@ -23,6 +23,7 @@ export interface OTPFieldRootContext {
   readOnly: boolean;
   required: boolean;
   normalizeValue: ((value: string) => string) | undefined;
+  setFocused: React.Dispatch<React.SetStateAction<boolean>>;
   setValue: (value: string, details: OTPFieldRoot.ChangeEventDetails) => string | null;
   state: OTPFieldRootState;
   validationType: OTPFieldRoot.ValidationType;

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1042,6 +1042,111 @@ describe('<RadioGroup />', () => {
 
         expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
       });
+
+      it('is not acquired when focus lands on a disabled radio', async () => {
+        await render(
+          <Field.Root data-testid="field">
+            <RadioGroup>
+              <Radio.Root value="a" disabled data-testid="disabled-radio" />
+              <Radio.Root value="b" />
+            </RadioGroup>
+          </Field.Root>,
+        );
+
+        act(() => {
+          screen.getByTestId('disabled-radio').focus();
+        });
+
+        expect(screen.getByTestId('disabled-radio')).toHaveFocus();
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+      });
+
+      it('is not reacquired when a radio disabled while focused is refocused', async () => {
+        function TestCase(props: { firstDisabled?: boolean }) {
+          const { firstDisabled = false } = props;
+          return (
+            <Field.Root data-testid="field">
+              <RadioGroup>
+                <Radio.Root value="a" disabled={firstDisabled} data-testid="first-radio" />
+                <Radio.Root value="b" />
+              </RadioGroup>
+            </Field.Root>
+          );
+        }
+
+        const { setProps } = await render(<TestCase />);
+        const first = screen.getByTestId('first-radio');
+
+        act(() => {
+          first.focus();
+        });
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstDisabled: true });
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+
+        act(() => {
+          first.blur();
+        });
+        act(() => {
+          first.focus();
+        });
+
+        expect(first).toHaveFocus();
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+      });
+
+      it('is not acquired when a radio inherits disabled from Field.Item', async () => {
+        await render(
+          <Field.Root data-testid="field">
+            <RadioGroup>
+              <Field.Item disabled>
+                <Radio.Root value="a" data-testid="disabled-radio" />
+              </Field.Item>
+              <Field.Item>
+                <Radio.Root value="b" />
+              </Field.Item>
+            </RadioGroup>
+          </Field.Root>,
+        );
+
+        act(() => {
+          screen.getByTestId('disabled-radio').focus();
+        });
+
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+      });
+
+      it('is reacquired when an arrow key moves focus from a disabled radio to an enabled sibling', async () => {
+        function TestCase(props: { firstDisabled?: boolean }) {
+          const { firstDisabled = false } = props;
+          return (
+            <Field.Root data-testid="field">
+              <RadioGroup>
+                <Radio.Root value="a" disabled={firstDisabled} data-testid="first-radio" />
+                <Radio.Root value="b" data-testid="second-radio" />
+              </RadioGroup>
+            </Field.Root>
+          );
+        }
+
+        const { setProps, user } = await render(<TestCase />);
+        const first = screen.getByTestId('first-radio');
+        const second = screen.getByTestId('second-radio');
+
+        act(() => {
+          first.focus();
+        });
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstDisabled: true });
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+
+        await user.keyboard('{ArrowDown}');
+
+        expect(second).toHaveFocus();
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+      });
     });
 
     describe('Field.Root', () => {

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -943,6 +943,107 @@ describe('<RadioGroup />', () => {
       expect(input).toHaveAttribute('name', 'test');
     });
 
+    describe('[data-focused] without a blur event', () => {
+      function Groups(props: { firstMounted?: boolean; firstDisabled?: boolean }) {
+        const { firstMounted = true, firstDisabled = false } = props;
+        return (
+          <Field.Root data-testid="field">
+            {firstMounted && (
+              <RadioGroup data-testid="first" disabled={firstDisabled}>
+                <Radio.Root value="a" data-testid="first-radio" />
+              </RadioGroup>
+            )}
+          </Field.Root>
+        );
+      }
+
+      it('is removed when the focused group becomes disabled', async () => {
+        const { setProps } = await render(<Groups />);
+
+        act(() => {
+          screen.getByTestId('first-radio').focus();
+        });
+
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstDisabled: true });
+
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+      });
+
+      it('is removed when the focused group unmounts', async () => {
+        const { setProps } = await render(<Groups />);
+
+        act(() => {
+          screen.getByTestId('first-radio').focus();
+        });
+
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstMounted: false });
+
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+      });
+
+      it('is kept when a previously focused radio unmounts after focus moves to a sibling', async () => {
+        function TestCase(props: { firstMounted?: boolean }) {
+          const { firstMounted = true } = props;
+          return (
+            <Field.Root data-testid="field">
+              <RadioGroup>
+                {firstMounted && <Radio.Root key="first" value="a" data-testid="first-radio" />}
+                <Radio.Root key="second" value="b" data-testid="second-radio" />
+              </RadioGroup>
+            </Field.Root>
+          );
+        }
+
+        const { setProps } = await render(<TestCase />);
+        const first = screen.getByTestId('first-radio');
+        const second = screen.getByTestId('second-radio');
+
+        act(() => {
+          first.focus();
+        });
+        act(() => {
+          second.focus();
+        });
+
+        expect(second).toHaveFocus();
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstMounted: false });
+
+        expect(second).toHaveFocus();
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+      });
+
+      it('is removed when the focused radio unmounts but its group remains', async () => {
+        function TestCase(props: { firstMounted?: boolean }) {
+          const { firstMounted = true } = props;
+          return (
+            <Field.Root data-testid="field">
+              <RadioGroup>
+                {firstMounted && <Radio.Root value="a" data-testid="first-radio" />}
+                <Radio.Root value="b" />
+              </RadioGroup>
+            </Field.Root>
+          );
+        }
+
+        const { setProps } = await render(<TestCase />);
+
+        act(() => {
+          screen.getByTestId('first-radio').focus();
+        });
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstMounted: false });
+
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+      });
+    });
+
     describe('Field.Root', () => {
       it('should receive disabled prop from Field.Root', async () => {
         await render(

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -233,9 +233,6 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     'aria-disabled': disabled || undefined,
     'aria-readonly': readOnly || undefined,
     'aria-labelledby': ariaLabelledby,
-    onFocus() {
-      setFocused(true);
-    },
     onBlur(event) {
       if (!contains(event.currentTarget, event.relatedTarget)) {
         setFieldTouched(true);
@@ -249,7 +246,6 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     onKeyDownCapture(event) {
       if (event.key.startsWith('Arrow')) {
         setTouched(true);
-        setFocused(true);
       }
     },
   };

--- a/packages/react/src/radio/root/RadioRoot.test.tsx
+++ b/packages/react/src/radio/root/RadioRoot.test.tsx
@@ -2,7 +2,8 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Radio } from '@base-ui/react/radio';
 import { RadioGroup } from '@base-ui/react/radio-group';
-import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { Field } from '@base-ui/react/field';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { describeConformance, createRenderer } from '#test-utils';
 
 describe('<Radio.Root />', () => {
@@ -240,6 +241,39 @@ describe('<Radio.Root />', () => {
       const radio = screen.getByTestId('radio');
       expect(radio).not.toHaveAttribute('disabled');
       expect(radio).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('does not acquire the field focused state when focused programmatically', async () => {
+      await render(
+        <Field.Root data-testid="field">
+          <Radio.Root value="a" disabled data-testid="radio" />
+        </Field.Root>,
+      );
+
+      const radio = screen.getByTestId('radio');
+
+      act(() => {
+        radio.focus();
+      });
+
+      expect(radio).toHaveFocus();
+      expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+    });
+  });
+
+  describe('prop: readOnly', () => {
+    it('acquires the field focused state on focus', async () => {
+      await render(
+        <Field.Root data-testid="field">
+          <Radio.Root value="a" readOnly data-testid="radio" />
+        </Field.Root>,
+      );
+
+      act(() => {
+        screen.getByTestId('radio').focus();
+      });
+
+      expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
     });
   });
 });

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -17,6 +17,7 @@ import { ACTIVE_COMPOSITE_ITEM } from '../../internals/composite/constants';
 import { CompositeItem } from '../../internals/composite/item/CompositeItem';
 import type { FieldRootState } from '../../field/root/FieldRoot';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
+import { useSetFieldFocused } from '../../internals/field-root-context/useSetFieldFocused';
 import { useFieldItemContext } from '../../field/item/FieldItemContext';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
 import { useAriaLabelledBy } from '../../internals/labelable-provider/useAriaLabelledBy';
@@ -76,6 +77,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
   const { labelId, getDescriptionProps } = useLabelableContext();
 
   const disabled = fieldDisabled || fieldItemContext.disabled || disabledGroup || disabledProp;
+  const setFieldFocused = useSetFieldFocused(disabled);
   const readOnly = readOnlyGroup || readOnlyProp;
   const required = requiredGroup || requiredProp;
   const form = formGroup;
@@ -151,6 +153,8 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
       dispatchClickWithModifiers(input, event);
     },
     onFocus(event) {
+      setFieldFocused(true);
+
       if (event.defaultPrevented || disabled || readOnly || !touched) {
         return;
       }
@@ -158,6 +162,13 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
       inputRef.current?.click();
 
       setTouched(false);
+    },
+    onBlur() {
+      // A grouped radio's exit is cleared by the group's `contains`-guarded blur handler, so
+      // radio-to-radio moves inside the group don't churn the focused state.
+      if (!groupContext) {
+        setFieldFocused(false);
+      }
     },
   };
 

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -3805,6 +3805,51 @@ describe('<Select.Root />', () => {
       expect(trigger).not.toHaveAttribute('data-focused');
     });
 
+    describe('[data-focused] without a blur event', () => {
+      function Selects(props: { firstMounted?: boolean; firstDisabled?: boolean }) {
+        const { firstMounted = true, firstDisabled = false } = props;
+        return (
+          <Field.Root data-testid="field">
+            {firstMounted && (
+              <Select.Root disabled={firstDisabled}>
+                <Select.Trigger data-testid="first" />
+              </Select.Root>
+            )}
+          </Field.Root>
+        );
+      }
+
+      it('is removed when the focused trigger becomes disabled', async () => {
+        const { setProps } = await render(<Selects />);
+
+        const trigger = screen.getByTestId('first');
+        act(() => {
+          trigger.focus();
+        });
+
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstDisabled: true });
+
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+        expect(trigger).not.toHaveAttribute('data-focused');
+      });
+
+      it('is removed when the focused trigger unmounts', async () => {
+        const { setProps } = await render(<Selects />);
+
+        act(() => {
+          screen.getByTestId('first').focus();
+        });
+
+        expect(screen.getByTestId('field')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstMounted: false });
+
+        expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+      });
+    });
+
     it('does not mark as touched when focus moves into the popup', async () => {
       const validateSpy = vi.fn(() => 'error');
 

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -6,6 +6,7 @@ import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { useSelectRootContext, useSelectRootPropsContext } from '../root/SelectRootContext';
 import { BaseUIComponentProps, HTMLProps, NativeButtonProps } from '../../internals/types';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
+import { useSetFieldFocused } from '../../internals/field-root-context/useSetFieldFocused';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
 import { pressableTriggerOpenStateMapping } from '../../utils/popupStateMapping';
 import { fieldValidityMapping } from '../../internals/field-constants/constants';
@@ -55,7 +56,6 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
 
   const {
     setTouched,
-    setFocused,
     validationMode,
     validation,
     state: fieldState,
@@ -65,6 +65,8 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const store = useSelectRootContext();
   const { readOnly, required, disabled: selectDisabled } = useSelectRootPropsContext();
   const disabled = fieldDisabled || selectDisabled || disabledProp;
+
+  const setFocused = useSetFieldFocused(disabled);
 
   const open = store.useState('open');
   const mounted = store.useState('mounted');

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -3156,6 +3156,93 @@ describe('<Slider.Root />', () => {
       expect(root).not.toHaveAttribute('data-focused');
     });
 
+    describe('[data-focused] without a blur event', () => {
+      function Thumbs(props: {
+        firstMounted?: boolean;
+        firstDisabled?: boolean;
+        rangeValue?: boolean;
+      }) {
+        const { firstMounted = true, firstDisabled = false, rangeValue = false } = props;
+        return (
+          <Field.Root data-testid="root">
+            <Slider.Root defaultValue={rangeValue ? [20, 40] : 20}>
+              <Slider.Control>
+                {firstMounted && <Slider.Thumb disabled={firstDisabled} />}
+                {rangeValue && <Slider.Thumb />}
+              </Slider.Control>
+            </Slider.Root>
+          </Field.Root>
+        );
+      }
+
+      it('is removed when the focused thumb becomes disabled', async () => {
+        const { setProps } = await render(<Thumbs />);
+
+        act(() => {
+          screen.getByRole('slider').focus();
+        });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstDisabled: true });
+
+        expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+      });
+
+      it('is removed when the focused thumb unmounts', async () => {
+        const { setProps } = await render(<Thumbs />);
+
+        act(() => {
+          screen.getByRole('slider').focus();
+        });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstMounted: false });
+
+        expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+      });
+
+      // A thumb's `blur` deliberately does nothing when focus moves to a sibling thumb, so a thumb
+      // that once held focus must not assume it still owns the field's focused state.
+      it('is kept when focus moved to a sibling before the first thumb is disabled', async () => {
+        const { setProps } = await render(<Thumbs rangeValue />);
+
+        const [first, second] = screen.getAllByRole('slider');
+
+        act(() => {
+          first.focus();
+        });
+        act(() => {
+          second.focus();
+        });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstDisabled: true });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+      });
+
+      it('is kept when a sibling thumb is disabled or unmounted', async () => {
+        const { setProps } = await render(<Thumbs rangeValue />);
+
+        act(() => {
+          screen.getAllByRole('slider')[1].focus();
+        });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstDisabled: true });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstMounted: false });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+      });
+    });
+
     describe('prop: validate', () => {
       it('validationMode=onSubmit', async () => {
         await render(

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -29,6 +29,7 @@ import { useCompositeListItem } from '../../internals/composite/list/useComposit
 import { useDirection } from '../../internals/direction-context/DirectionContext';
 import { PrehydrationScript } from '../../internals/PrehydrationScript';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
+import { useSetFieldFocused } from '../../internals/field-root-context/useSetFieldFocused';
 import { contains } from '../../floating-ui-react/utils';
 import { matchesFocusVisible } from '../../floating-ui-react/utils/element';
 import { useLabelableId } from '../../internals/labelable-provider/useLabelableId';
@@ -149,7 +150,9 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
   const vertical = orientation === 'vertical';
   const rtl = direction === 'rtl';
 
-  const { setTouched, setFocused, validationMode } = useFieldRootContext();
+  const { setTouched, validationMode } = useFieldRootContext();
+
+  const setFocused = useSetFieldFocused(disabled);
 
   const thumbRef = React.useRef<HTMLElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -1055,6 +1055,48 @@ describe('<Switch.Root />', () => {
       expect(button).not.toHaveAttribute('data-focused');
     });
 
+    describe('[data-focused] without a blur event', () => {
+      function Switches(props: { firstMounted?: boolean; firstDisabled?: boolean }) {
+        const { firstMounted = true, firstDisabled = false } = props;
+        return (
+          <Field.Root data-testid="root">
+            {firstMounted && <Switch.Root data-testid="first" disabled={firstDisabled} />}
+          </Field.Root>
+        );
+      }
+
+      it('is removed when the focused switch becomes disabled', async () => {
+        const { setProps } = await render(<Switches />);
+
+        const button = screen.getByTestId('first');
+        act(() => {
+          button.focus();
+        });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+        expect(button).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstDisabled: true });
+
+        expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+        expect(button).not.toHaveAttribute('data-focused');
+      });
+
+      it('is removed when the focused switch unmounts', async () => {
+        const { setProps } = await render(<Switches />);
+
+        act(() => {
+          screen.getByTestId('first').focus();
+        });
+
+        expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
+
+        await setProps({ firstMounted: false });
+
+        expect(screen.getByTestId('root')).not.toHaveAttribute('data-focused');
+      });
+    });
+
     it('prop: validationMode=onSubmit', async () => {
       await render(
         <Form>

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -125,9 +125,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     'aria-required': required || undefined,
     'aria-labelledby': ariaLabelledBy,
     onFocus() {
-      if (!disabled) {
-        setFocused(true);
-      }
+      setFocused(true);
     },
     onBlur() {
       const element = inputRef.current;

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -14,6 +14,7 @@ import { stateAttributesMapping } from '../stateAttributesMapping';
 import { dispatchClickWithModifiers } from '../../utils/dispatchClickWithModifiers';
 import type { FieldRootState } from '../../field/root/FieldRoot';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
+import { useSetFieldFocused } from '../../internals/field-root-context/useSetFieldFocused';
 import { useRegisterFieldControl } from '../../internals/field-register-control/useRegisterFieldControl';
 import { useFormContext } from '../../internals/form-context/FormContext';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
@@ -62,7 +63,6 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
     setDirty,
     validityData,
     setFilled,
-    setFocused,
     validationMode,
     disabled: fieldDisabled,
     name: fieldName,
@@ -72,6 +72,8 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
 
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
+
+  const setFocused = useSetFieldFocused(disabled);
 
   const inputRef = React.useRef<HTMLInputElement>(null);
   const handleInputRef = useMergedRefs(inputRef, externalInputRef, validation.inputRef);


### PR DESCRIPTION
Fixes #3987

Disabling or unmounting a focused control can move focus away without firing `blur`, leaving `data-focused` stuck on `Field.Root`, its label, and the control. This is reproducible in Chromium for both native inputs and buttons.

`useSetFieldFocused` records which focus target owns the field state and releases it when that target becomes disabled or unmounts. Ownership prevents cleanup from an old target from clearing focus that has moved to another target, which is required for components with multiple inherent focus targets such as Slider, Radio Group, and OTP Field.

The cleanup is attached to every field-aware focus target: `Field.Control`, `Switch.Root`, `Checkbox.Root`, `NumberField.Input`, `Radio.Root`, `OTPField.Input`, `Slider.Thumb`, `Select.Trigger`, and both `Combobox.Input` and `Combobox.Trigger`.

The PR intentionally stays focused on this lifecycle bug. Filled-state remount handling is already covered on `master`, and uncommon compositions with multiple independent controls under one `Field.Root` are left unsupported rather than adding runtime coordination.
