### PR TITLE
[checkbox group] Fix stale child disabled state during parent clicks

### DIFF
--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.test.tsx
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.test.tsx
@@ -1,6 +1,7 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { CheckboxGroup } from '@base-ui/react/checkbox-group';
 import { Checkbox } from '@base-ui/react/checkbox';
 
@@ -421,5 +422,169 @@ describe('useCheckboxGroupParent', () => {
     fireEvent.click(parent);
     expect(checkboxA).toHaveAttribute('aria-checked', 'true');
     expect(checkboxB).toHaveAttribute('aria-checked', 'false');
+  });
+
+  describe('child disabled state registration', () => {
+    it('reads fresh disabled state when the parent is clicked right after the change commits', () => {
+      function App() {
+        const [disabled, setDisabled] = React.useState(false);
+        const parentRef = React.useRef<HTMLElement>(null);
+
+        useIsoLayoutEffect(() => {
+          if (disabled) {
+            parentRef.current?.click();
+          }
+        }, [disabled]);
+
+        return (
+          <div>
+            <CheckboxGroup defaultValue={[]} allValues={allValues}>
+              <Checkbox.Root parent data-testid="parent" ref={parentRef} />
+              <Checkbox.Root value="a" disabled={disabled} data-testid="checkboxA" />
+              <Checkbox.Root value="b" />
+              <Checkbox.Root value="c" />
+            </CheckboxGroup>
+            <button onClick={() => setDisabled(true)}>Disable</button>
+          </div>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.click(screen.getByText('Disable'));
+
+      expect(screen.getByTestId('checkboxA')).toHaveAttribute('aria-checked', 'false');
+      expect(screen.getByTestId('parent')).toHaveAttribute('aria-checked', 'mixed');
+    });
+
+    it('keeps a replacement child registration when the replaced child unmounts later', () => {
+      function App() {
+        const [phase, setPhase] = React.useState(0);
+        return (
+          <div>
+            <CheckboxGroup defaultValue={[]} allValues={allValues}>
+              <Checkbox.Root parent data-testid="parent" />
+              {phase < 2 && <Checkbox.Root key="old" value="a" />}
+              {phase >= 1 && <Checkbox.Root key="new" value="a" disabled data-testid="new-a" />}
+              <Checkbox.Root value="b" />
+              <Checkbox.Root value="c" />
+            </CheckboxGroup>
+            <button onClick={() => setPhase((prev) => prev + 1)}>Advance</button>
+          </div>
+        );
+      }
+
+      render(<App />);
+
+      const advance = screen.getByText('Advance');
+      // Mount the disabled replacement alongside the old child, then unmount
+      // the old child in a later commit so its cleanup runs after the
+      // replacement registered.
+      fireEvent.click(advance);
+      fireEvent.click(advance);
+
+      const parent = screen.getByTestId('parent');
+      fireEvent.click(parent);
+
+      expect(screen.getByTestId('new-a')).toHaveAttribute('aria-checked', 'false');
+      expect(parent).toHaveAttribute('aria-checked', 'mixed');
+    });
+
+    it('tracks a child that is re-enabled after being disabled', () => {
+      function App() {
+        const [disabled, setDisabled] = React.useState(true);
+        return (
+          <div>
+            <CheckboxGroup defaultValue={[]} allValues={allValues}>
+              <Checkbox.Root parent data-testid="parent" />
+              <Checkbox.Root value="a" disabled={disabled} data-testid="checkboxA" />
+              <Checkbox.Root value="b" />
+              <Checkbox.Root value="c" />
+            </CheckboxGroup>
+            <button onClick={() => setDisabled(false)}>Enable</button>
+          </div>
+        );
+      }
+
+      render(<App />);
+
+      const parent = screen.getByTestId('parent');
+
+      fireEvent.click(parent);
+      expect(screen.getByTestId('checkboxA')).toHaveAttribute('aria-checked', 'false');
+      expect(parent).toHaveAttribute('aria-checked', 'mixed');
+
+      fireEvent.click(screen.getByText('Enable'));
+      fireEvent.click(parent);
+
+      expect(screen.getByTestId('checkboxA')).toHaveAttribute('aria-checked', 'true');
+      expect(parent).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves the registration when a child value changes', () => {
+      function App() {
+        const [checkboxValue, setCheckboxValue] = React.useState('a');
+        return (
+          <div>
+            <CheckboxGroup defaultValue={[]} allValues={allValues}>
+              <Checkbox.Root parent data-testid="parent" />
+              <Checkbox.Root value={checkboxValue} disabled data-testid="movable" />
+              <Checkbox.Root value="b" data-testid="b" />
+            </CheckboxGroup>
+            <button onClick={() => setCheckboxValue('c')}>Move</button>
+          </div>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.click(screen.getByText('Move'));
+
+      const parent = screen.getByTestId('parent');
+      fireEvent.click(parent);
+
+      // "a" no longer has a disabled registration, while "c" does.
+      expect(screen.getByTestId('movable')).toHaveAttribute('aria-checked', 'false');
+      expect(screen.getByTestId('b')).toHaveAttribute('aria-checked', 'true');
+      expect(parent).toHaveAttribute('aria-checked', 'mixed');
+    });
+
+    it('clears the registration on unmount and restores it on remount', () => {
+      function App() {
+        const [value, setValue] = React.useState<string[]>([]);
+        const [mounted, setMounted] = React.useState(true);
+        return (
+          <div>
+            <CheckboxGroup value={value} onValueChange={setValue} allValues={allValues}>
+              <Checkbox.Root parent data-testid="parent" />
+              {mounted && <Checkbox.Root value="a" disabled data-testid="checkboxA" />}
+              <Checkbox.Root value="b" />
+              <Checkbox.Root value="c" />
+            </CheckboxGroup>
+            <button onClick={() => setMounted((prev) => !prev)}>Toggle</button>
+            <button onClick={() => setValue([])}>Reset</button>
+          </div>
+        );
+      }
+
+      render(<App />);
+
+      const parent = screen.getByTestId('parent');
+      const toggle = screen.getByText('Toggle');
+
+      fireEvent.click(toggle);
+      fireEvent.click(parent);
+
+      // The unmounted child no longer registers as disabled.
+      expect(parent).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(screen.getByText('Reset'));
+      fireEvent.click(toggle);
+      fireEvent.click(parent);
+
+      // The remounted child registers as disabled again.
+      expect(screen.getByTestId('checkboxA')).toHaveAttribute('aria-checked', 'false');
+      expect(parent).toHaveAttribute('aria-checked', 'mixed');
+    });
   });
 });

--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
@@ -12,7 +12,7 @@ export function useCheckboxGroupParent(
   const { allValues = EMPTY_ARRAY as string[], value, onValueChange: onValueChangeProp } = params;
 
   const uncontrolledStateRef = React.useRef(value);
-  const disabledStatesRef = React.useRef(new Map<string, boolean>());
+  const disabledStatesRef = React.useRef(new Map<string, CheckboxGroupChildDisabledState>());
 
   const [status, setStatus] = React.useState<'on' | 'off' | 'mixed'>('mixed');
 
@@ -35,13 +35,13 @@ export function useCheckboxGroupParent(
 
         // None except the disabled ones that are checked, which can't be changed.
         const none = allValues.filter(
-          (v) => disabledStatesRef.current.get(v) && uncontrolledState.includes(v),
+          (v) => disabledStatesRef.current.get(v)?.disabled && uncontrolledState.includes(v),
         );
         // "All" that are valid:
         // - any that aren't disabled
         // - disabled ones that are checked
         const all = allValues.filter(
-          (v) => !disabledStatesRef.current.get(v) || uncontrolledState.includes(v),
+          (v) => !disabledStatesRef.current.get(v)?.disabled || uncontrolledState.includes(v),
         );
 
         const allOnOrOff =
@@ -110,6 +110,15 @@ export function useCheckboxGroupParent(
   );
 }
 
+export interface CheckboxGroupChildDisabledState {
+  /**
+   * Identifies the checkbox that owns the registration so that a stale cleanup
+   * from an unmounting checkbox cannot clear a newer registration for the same value.
+   */
+  owner: symbol;
+  disabled: boolean;
+}
+
 export interface UseCheckboxGroupParentParameters {
   allValues?: string[] | undefined;
   value: string[];
@@ -123,7 +132,7 @@ export interface UseCheckboxGroupParentParameters {
 
 export interface UseCheckboxGroupParentReturnValue {
   id: string | undefined;
-  disabledStatesRef: React.RefObject<Map<string, boolean>>;
+  disabledStatesRef: React.RefObject<Map<string, CheckboxGroupChildDisabledState>>;
   getParentProps: () => {
     id: string | undefined;
     indeterminate: boolean;

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -289,18 +289,25 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     (props) => validation.getValidationProps(disabled, props),
   );
 
-  React.useEffect(() => {
-    if (!parentContext || value === undefined) {
+  // Register in the layout phase so a parent checkbox handling a click in the
+  // same task as this commit reads fresh disabled state.
+  const disabledStatesRef = parentContext?.disabledStatesRef;
+  useIsoLayoutEffect(() => {
+    if (!disabledStatesRef || value === undefined) {
       return undefined;
     }
 
-    const disabledStates = parentContext.disabledStatesRef.current;
-    disabledStates.set(value, disabled);
+    const owner = controlSourceRef.current;
+    const disabledStates = disabledStatesRef.current;
+    disabledStates.set(value, { owner, disabled });
 
     return () => {
-      disabledStates.delete(value);
+      // A newer checkbox may have registered the same value; it owns the entry.
+      if (disabledStates.get(value)?.owner === owner) {
+        disabledStates.delete(value);
+      }
     };
-  }, [parentContext, disabled, value]);
+  }, [disabledStatesRef, disabled, value, controlSourceRef]);
 
   const state: CheckboxRootState = React.useMemo(
     () => ({


### PR DESCRIPTION
`CheckboxRoot` published each child's `disabled` state into the group parent's `disabledStatesRef` map from a passive effect, while the parent checkbox's `onCheckedChange` reads that map synchronously during a click. Since React 18 no longer flushes passive effects before same-task discrete events, a parent click handled after a commit but before its passive effects flush (for example, a mousedown handler disabling a child followed by the click of the same gesture) computes the group value from stale metadata and checks a disabled checkbox. Separately, an older child's unconditional `delete` cleanup could wipe a newer same-value child's registration when the old one unmounted in a later commit than its replacement mounted.

Registration now runs in a layout effect so it is fresh by the time any post-commit event handler runs, and each entry records its owner (the existing per-instance `controlSourceRef` symbol) so cleanup only removes an entry the checkbox still owns; setup remains last-writer-wins. The effect depends on the stable `disabledStatesRef` rather than the identity-churning parent context, so ordinary group value changes no longer re-run it while reparenting still re-registers.

Each safeguard is pinned by a regression test that fails if it is reverted independently: restoring passive timing fails the post-commit parent click test, and removing the owner guard fails the replacement-registration test.
