### PR TITLE
[field] Preserve custom validity set outside the field

### DIFF
--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -598,6 +598,36 @@ describe('<CheckboxGroup />', () => {
       expect(httpInput?.validity.customError).toBe(false);
     });
 
+    it('keeps a custom validity message set outside the field on a registered input when submitting', async () => {
+      const onFormSubmit = vi.fn();
+      const { user } = render(
+        <Form onFormSubmit={onFormSubmit}>
+          <Field.Root name="protocols">
+            <CheckboxGroup defaultValue={[]}>
+              <Field.Item>
+                <Checkbox.Root value="http" data-testid="cb-http" />
+              </Field.Item>
+              <Field.Item>
+                <Checkbox.Root value="https" data-testid="cb-https" />
+              </Field.Item>
+            </CheckboxGroup>
+            <Field.Error data-testid="error" />
+          </Field.Root>
+          <button type="submit">submit</button>
+        </Form>,
+      );
+
+      // The hidden inputs only carry their `value` attribute while checked, so select by position.
+      const httpInput = document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')[0];
+      httpInput.setCustomValidity('external error');
+
+      await user.click(screen.getByText('submit'));
+
+      expect(onFormSubmit).not.toHaveBeenCalled();
+      expect(httpInput.validationMessage).toBe('external error');
+      expect(screen.getByTestId('error')).toHaveTextContent('external error');
+    });
+
     it('prop: validationMode=onSubmit', async () => {
       const validateSpy = vi.fn((value) => {
         const v = value as string[];

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -1017,6 +1017,42 @@ describe('<Field.Root />', () => {
       expect(screen.getByTestId('error')).toHaveTextContent('external error');
     });
 
+    it('does not restore a message the outside code withdrew while its own error was displayed', async () => {
+      let shouldFail = false;
+      await render(
+        <Field.Root
+          name="field"
+          validationMode="onChange"
+          validate={() => (shouldFail ? 'own error' : null)}
+        >
+          <Field.Control />
+          <Field.Error data-testid="error" />
+        </Field.Root>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      control.setCustomValidity('external error');
+
+      shouldFail = true;
+      fireEvent.change(control, { target: { value: 'a' } });
+      expect(control.validationMessage).toBe('own error');
+
+      // The outside code withdraws its condition while the field's own error still applies. Both
+      // messages share one slot, so the own error is reinstalled on the next commit.
+      control.setCustomValidity('');
+      fireEvent.change(control, { target: { value: 'ab' } });
+      expect(control.validationMessage).toBe('own error');
+
+      // Nothing is left to restore: the withdrawn message must not come back with the field valid.
+      shouldFail = false;
+      fireEvent.change(control, { target: { value: 'abc' } });
+
+      expect(control.validationMessage).toBe('');
+      expect(control).not.toHaveAttribute('data-invalid');
+      expect(screen.queryByTestId('error')).toBe(null);
+    });
+
     it('keeps a message set outside the field on another input of the group', async () => {
       let shouldFail = true;
       await render(
@@ -1053,6 +1089,76 @@ describe('<Field.Root />', () => {
       expect(first.validationMessage).toBe('');
       expect(second.validationMessage).toBe('external error');
       expect(screen.getByTestId('error')).toHaveTextContent('external error');
+    });
+
+    it('keeps a message set outside the field on another input of the group when revalidating on change', async () => {
+      const handleValidity = vi.fn();
+      await render(
+        <Field.Root name="field" validationMode="onBlur" validate={() => 'own error'}>
+          <CheckboxGroup>
+            <Field.Item>
+              <Checkbox.Root value="a" data-testid="a" />
+            </Field.Item>
+            <Field.Item>
+              <Checkbox.Root value="b" data-testid="b" />
+            </Field.Item>
+          </CheckboxGroup>
+          <Field.Error data-testid="error" />
+          <Field.Validity>{handleValidity}</Field.Validity>
+        </Field.Root>,
+      );
+
+      const [first, second] = Array.from(
+        document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+      );
+
+      fireEvent.blur(screen.getByTestId('a'));
+      expect(first.validationMessage).toBe('own error');
+
+      second.setCustomValidity('external error');
+
+      // Change revalidation drops the field's own error until the next blur, but the group is still
+      // invalid through the other input.
+      fireEvent.click(screen.getByTestId('b'));
+
+      expect(first.validationMessage).toBe('');
+      expect(second.validationMessage).toBe('external error');
+      expect(screen.getByTestId('error')).toHaveTextContent('external error');
+      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
+      expect(handleValidity.mock.lastCall?.[0].validity.valid).toBe(false);
+    });
+
+    it('keeps other native errors deferred while a message set outside the field survives', async () => {
+      const handleValidity = vi.fn();
+      await render(
+        <Field.Root name="field" validationMode="onBlur">
+          <Field.Control type="email" required />
+          <Field.Error match="typeMismatch" data-testid="type-mismatch">
+            invalid email
+          </Field.Error>
+          <Field.Validity>{handleValidity}</Field.Validity>
+        </Field.Root>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      // The field only publishes `valueMissing` once dirtied.
+      fireEvent.focus(control);
+      fireEvent.change(control, { target: { value: 'a' } });
+      fireEvent.change(control, { target: { value: '' } });
+      fireEvent.blur(control);
+      expect(control).toHaveAttribute('data-invalid', '');
+
+      control.setCustomValidity('external error');
+
+      fireEvent.change(control, { target: { value: 'abc' } });
+
+      // Native errors other than the resolved `valueMissing` one wait for the blur or submit
+      // boundary, whether or not an outside message keeps the field invalid in the meantime.
+      expect(screen.queryByTestId('type-mismatch')).toBe(null);
+      expect(handleValidity.mock.lastCall?.[0].validity.typeMismatch).toBe(false);
+      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
+      expect(handleValidity.mock.lastCall?.[0].validity.valid).toBe(false);
     });
 
     it('clears a multi-line message it set itself', async () => {

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -827,6 +827,83 @@ describe('<Field.Root />', () => {
     });
   });
 
+  describe('external custom validity', () => {
+    // A control can own a validity condition that no native constraint expresses (for example a
+    // date field whose sections spell out February 30th) and surface it with `setCustomValidity`.
+    // Revalidation must not silently drop it, since the field would then report itself as valid.
+    function ExternallyInvalidControl({ message }: { message: string }) {
+      const ref = React.useRef<HTMLInputElement | null>(null);
+
+      React.useEffect(() => {
+        ref.current?.setCustomValidity(message);
+      }, [message]);
+
+      return <Field.Control ref={ref} />;
+    }
+
+    it('keeps a message set outside the field when submitting', async () => {
+      const onFormSubmit = vi.fn();
+      await render(
+        <Form onFormSubmit={onFormSubmit}>
+          <Field.Root name="field">
+            <ExternallyInvalidControl message="external error" />
+            <Field.Error data-testid="error" />
+          </Field.Root>
+          <button type="submit">submit</button>
+        </Form>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      fireEvent.click(screen.getByText('submit'));
+
+      expect(onFormSubmit).not.toHaveBeenCalled();
+      expect(control.validationMessage).toBe('external error');
+      expect(screen.getByTestId('error')).toHaveTextContent('external error');
+    });
+
+    it('keeps a message set outside the field when revalidating on change', async () => {
+      await render(
+        <Field.Root name="field" validationMode="onChange">
+          <ExternallyInvalidControl message="external error" />
+          <Field.Error data-testid="error" />
+        </Field.Root>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      fireEvent.change(control, { target: { value: 'text' } });
+
+      expect(control.validationMessage).toBe('external error');
+      expect(control).toHaveAttribute('data-invalid', '');
+    });
+
+    it('clears the message it set itself', async () => {
+      let shouldFail = true;
+      await render(
+        <Field.Root
+          name="field"
+          validationMode="onChange"
+          validate={() => (shouldFail ? 'error' : null)}
+        >
+          <Field.Control />
+          <Field.Error data-testid="error" />
+        </Field.Root>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      fireEvent.change(control, { target: { value: 'a' } });
+      expect(control.validationMessage).toBe('error');
+
+      shouldFail = false;
+      fireEvent.change(control, { target: { value: 'ab' } });
+
+      expect(control.validationMessage).toBe('');
+      expect(screen.queryByTestId('error')).toBe(null);
+    });
+  });
+
   describe('prop: validationMode', () => {
     describe('onSubmit', () => {
       it('should validate the field on submit', async () => {

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -1091,6 +1091,54 @@ describe('<Field.Root />', () => {
       expect(screen.getByTestId('error')).toHaveTextContent('external error');
     });
 
+    it('uses the latest representative input after async validation', async () => {
+      let resolveValidation: (result: string | null) => void = () => {};
+      const validate = vi.fn(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveValidation = resolve;
+          }),
+      );
+      const handleValidity = vi.fn();
+
+      await render(
+        <Field.Root name="field" validationMode="onChange" validate={validate}>
+          <CheckboxGroup>
+            <Field.Item>
+              <Checkbox.Root value="a" data-testid="a" />
+            </Field.Item>
+            <Field.Item>
+              <Checkbox.Root value="b" data-testid="b" />
+            </Field.Item>
+          </CheckboxGroup>
+          <Field.Error data-testid="error" />
+          <Field.Validity>{handleValidity}</Field.Validity>
+        </Field.Root>,
+      );
+
+      const [, second] = Array.from(
+        document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+      );
+
+      fireEvent.click(screen.getByTestId('a'));
+      expect(validate).toHaveBeenCalledTimes(1);
+
+      // The validator is still pending, so make another input the group's representative before it
+      // resolves. The post-await validity snapshot must come from this input, not the one that
+      // represented the group when validation started.
+      second.setCustomValidity('external error');
+
+      await act(async () => {
+        resolveValidation(null);
+        await flushMicrotasks();
+      });
+
+      expect(second.validationMessage).toBe('external error');
+      expect(screen.getByTestId('error')).toHaveTextContent('external error');
+      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
+      expect(handleValidity.mock.lastCall?.[0].validity.valid).toBe(false);
+    });
+
     it('keeps a message set outside the field on another input of the group when revalidating on change', async () => {
       const handleValidity = vi.fn();
       await render(

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -828,9 +828,8 @@ describe('<Field.Root />', () => {
   });
 
   describe('external custom validity', () => {
-    // A control can own a validity condition that no native constraint expresses (for example a
-    // date field whose sections spell out February 30th) and surface it with `setCustomValidity`.
-    // Revalidation must not silently drop it, since the field would then report itself as valid.
+    // Simulates a control that surfaces its own validity condition through `setCustomValidity`,
+    // as a custom date field would for an invalid date.
     function ExternallyInvalidControl({ message }: { message: string }) {
       const ref = React.useRef<HTMLInputElement | null>(null);
 
@@ -895,7 +894,7 @@ describe('<Field.Root />', () => {
 
       const control = screen.getByRole<HTMLInputElement>('textbox');
 
-      // Dirty the field, then blur it empty so the `valueMissing` error is published.
+      // The field only publishes `valueMissing` once dirtied.
       fireEvent.focus(control);
       fireEvent.change(control, { target: { value: 'a' } });
       fireEvent.change(control, { target: { value: '' } });
@@ -904,8 +903,6 @@ describe('<Field.Root />', () => {
 
       control.setCustomValidity('external error');
 
-      // Filling the required value revalidates on change; the field must surface the external
-      // message instead of flashing valid or keeping the stale required error.
       fireEvent.change(control, { target: { value: 'text' } });
 
       expect(control.validationMessage).toBe('external error');
@@ -933,7 +930,6 @@ describe('<Field.Root />', () => {
       fireEvent.change(control, { target: { value: 'a' } });
       expect(control.validationMessage).toBe('own error');
 
-      // Other code replaces the field's own message; the field no longer owns what is displayed.
       control.setCustomValidity('external error');
 
       shouldFail = false;

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -863,10 +863,12 @@ describe('<Field.Root />', () => {
     });
 
     it('keeps a message set outside the field when revalidating on change', async () => {
+      const handleValidity = vi.fn();
       await render(
         <Field.Root name="field" validationMode="onChange">
           <ExternallyInvalidControl message="external error" />
           <Field.Error data-testid="error" />
+          <Field.Validity>{handleValidity}</Field.Validity>
         </Field.Root>,
       );
 
@@ -876,6 +878,92 @@ describe('<Field.Root />', () => {
 
       expect(control.validationMessage).toBe('external error');
       expect(control).toHaveAttribute('data-invalid', '');
+      expect(screen.getByTestId('error')).toHaveTextContent('external error');
+      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
+      expect(handleValidity.mock.lastCall?.[0].validity.valid).toBe(false);
+    });
+
+    it('surfaces a message set outside the field when a missing required value is filled in', async () => {
+      const handleValidity = vi.fn();
+      await render(
+        <Field.Root name="field" validationMode="onBlur">
+          <Field.Control required />
+          <Field.Error data-testid="error" />
+          <Field.Validity>{handleValidity}</Field.Validity>
+        </Field.Root>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      // Dirty the field, then blur it empty so the `valueMissing` error is published.
+      fireEvent.focus(control);
+      fireEvent.change(control, { target: { value: 'a' } });
+      fireEvent.change(control, { target: { value: '' } });
+      fireEvent.blur(control);
+      expect(control).toHaveAttribute('data-invalid', '');
+
+      control.setCustomValidity('external error');
+
+      // Filling the required value revalidates on change; the field must surface the external
+      // message instead of flashing valid or keeping the stale required error.
+      fireEvent.change(control, { target: { value: 'text' } });
+
+      expect(control.validationMessage).toBe('external error');
+      expect(control).toHaveAttribute('data-invalid', '');
+      expect(screen.getByTestId('error')).toHaveTextContent('external error');
+      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
+      expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(false);
+    });
+
+    it('keeps a message that overwrote the one it set itself', async () => {
+      let shouldFail = true;
+      await render(
+        <Field.Root
+          name="field"
+          validationMode="onChange"
+          validate={() => (shouldFail ? 'own error' : null)}
+        >
+          <Field.Control />
+          <Field.Error data-testid="error" />
+        </Field.Root>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      fireEvent.change(control, { target: { value: 'a' } });
+      expect(control.validationMessage).toBe('own error');
+
+      // Other code replaces the field's own message; the field no longer owns what is displayed.
+      control.setCustomValidity('external error');
+
+      shouldFail = false;
+      fireEvent.change(control, { target: { value: 'ab' } });
+
+      expect(control.validationMessage).toBe('external error');
+      expect(control).toHaveAttribute('data-invalid', '');
+      expect(screen.getByTestId('error')).toHaveTextContent('external error');
+    });
+
+    it('returns to valid once the outside code withdraws its message', async () => {
+      await render(
+        <Field.Root name="field" validationMode="onChange">
+          <Field.Control />
+          <Field.Error data-testid="error" />
+        </Field.Root>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      control.setCustomValidity('external error');
+      fireEvent.change(control, { target: { value: 'a' } });
+      expect(screen.getByTestId('error')).toHaveTextContent('external error');
+
+      control.setCustomValidity('');
+      fireEvent.change(control, { target: { value: 'ab' } });
+
+      expect(control.validationMessage).toBe('');
+      expect(control).not.toHaveAttribute('data-invalid');
+      expect(screen.queryByTestId('error')).toBe(null);
     });
 
     it('clears the message it set itself', async () => {
@@ -895,6 +983,31 @@ describe('<Field.Root />', () => {
 
       fireEvent.change(control, { target: { value: 'a' } });
       expect(control.validationMessage).toBe('error');
+
+      shouldFail = false;
+      fireEvent.change(control, { target: { value: 'ab' } });
+
+      expect(control.validationMessage).toBe('');
+      expect(screen.queryByTestId('error')).toBe(null);
+    });
+
+    it('clears a multi-line message it set itself', async () => {
+      let shouldFail = true;
+      await render(
+        <Field.Root
+          name="field"
+          validationMode="onChange"
+          validate={() => (shouldFail ? ['error one', 'error two'] : null)}
+        >
+          <Field.Control />
+          <Field.Error data-testid="error" />
+        </Field.Root>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      fireEvent.change(control, { target: { value: 'a' } });
+      expect(control.validationMessage).toBe('error one\nerror two');
 
       shouldFail = false;
       fireEvent.change(control, { target: { value: 'ab' } });

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -987,6 +987,74 @@ describe('<Field.Root />', () => {
       expect(screen.queryByTestId('error')).toBe(null);
     });
 
+    it('restores a message its own error overwrote', async () => {
+      let shouldFail = false;
+      await render(
+        <Field.Root
+          name="field"
+          validationMode="onChange"
+          validate={() => (shouldFail ? 'own error' : null)}
+        >
+          <Field.Control />
+          <Field.Error data-testid="error" />
+        </Field.Root>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      control.setCustomValidity('external error');
+
+      shouldFail = true;
+      fireEvent.change(control, { target: { value: 'a' } });
+      expect(control.validationMessage).toBe('own error');
+
+      // The external condition still applies once the field's own error is resolved.
+      shouldFail = false;
+      fireEvent.change(control, { target: { value: 'ab' } });
+
+      expect(control.validationMessage).toBe('external error');
+      expect(control).toHaveAttribute('data-invalid', '');
+      expect(screen.getByTestId('error')).toHaveTextContent('external error');
+    });
+
+    it('keeps a message set outside the field on another input of the group', async () => {
+      let shouldFail = true;
+      await render(
+        <Field.Root
+          name="field"
+          validationMode="onChange"
+          validate={() => (shouldFail ? 'own error' : null)}
+        >
+          <CheckboxGroup>
+            <Field.Item>
+              <Checkbox.Root value="a" data-testid="a" />
+            </Field.Item>
+            <Field.Item>
+              <Checkbox.Root value="b" data-testid="b" />
+            </Field.Item>
+          </CheckboxGroup>
+          <Field.Error data-testid="error" />
+        </Field.Root>,
+      );
+
+      const [first, second] = Array.from(
+        document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+      );
+
+      fireEvent.click(screen.getByTestId('a'));
+      expect(first.validationMessage).toBe('own error');
+
+      second.setCustomValidity('external error');
+
+      // The field's own error resolves, but the group is still invalid through the other input.
+      shouldFail = false;
+      fireEvent.click(screen.getByTestId('b'));
+
+      expect(first.validationMessage).toBe('');
+      expect(second.validationMessage).toBe('external error');
+      expect(screen.getByTestId('error')).toHaveTextContent('external error');
+    });
+
     it('clears a multi-line message it set itself', async () => {
       let shouldFail = true;
       await render(
@@ -1004,6 +1072,32 @@ describe('<Field.Root />', () => {
 
       fireEvent.change(control, { target: { value: 'a' } });
       expect(control.validationMessage).toBe('error one\nerror two');
+
+      shouldFail = false;
+      fireEvent.change(control, { target: { value: 'ab' } });
+
+      expect(control.validationMessage).toBe('');
+      expect(screen.queryByTestId('error')).toBe(null);
+    });
+
+    it('clears a message it set itself with CRLF line breaks', async () => {
+      // Chromium reports `\r\n` back as `\n`, so ownership has to survive that normalization.
+      let shouldFail = true;
+      await render(
+        <Field.Root
+          name="field"
+          validationMode="onChange"
+          validate={() => (shouldFail ? 'error one\r\nerror two' : null)}
+        >
+          <Field.Control />
+          <Field.Error data-testid="error" />
+        </Field.Root>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      fireEvent.change(control, { target: { value: 'a' } });
+      expect(control.validity.customError).toBe(true);
 
       shouldFail = false;
       fireEvent.change(control, { target: { value: 'ab' } });

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -72,27 +72,60 @@ function findRepresentativeInput(
  */
 const ownedCustomValidity = new WeakMap<HTMLInputElement, string>();
 
+/**
+ * Messages set by other code that an owned message overwrote. Restoring one when the owned message
+ * is cleared keeps a condition this hook doesn't know about from disappearing behind a validator
+ * error that has since been resolved.
+ */
+const displacedCustomValidity = new WeakMap<HTMLInputElement, string>();
+
+/**
+ * Browsers normalize line breaks in custom validity messages — Chromium reports `\r\n` and `\r` as
+ * `\n` — so ownership has to be matched on normalized text. Comparing raw text would read a
+ * multi-line owned message back as foreign and strand it on the control.
+ */
+function normalizeValidationMessage(message: string) {
+  return message.replace(/\r\n?/g, '\n');
+}
+
+function hasOwnCustomValidity(element: HTMLInputElement) {
+  const ownMessage = ownedCustomValidity.get(element);
+  if (ownMessage === undefined) {
+    return false;
+  }
+  // Elements barred from constraint validation (disabled ones, for example) report an empty
+  // `validationMessage`, so there is nothing to compare and the recorded message stands.
+  return (
+    !element.willValidate || normalizeValidationMessage(element.validationMessage) === ownMessage
+  );
+}
+
 function setOwnCustomValidity(element: HTMLInputElement, message: string) {
+  if (element.willValidate && element.validity.customError && !hasOwnCustomValidity(element)) {
+    displacedCustomValidity.set(element, element.validationMessage);
+  }
+
   element.setCustomValidity(message);
-  ownedCustomValidity.set(element, message);
+  ownedCustomValidity.set(element, normalizeValidationMessage(message));
 }
 
 function clearOwnCustomValidity(element: HTMLInputElement) {
-  const ownMessage = ownedCustomValidity.get(element);
-  if (ownMessage === undefined) {
+  if (!ownedCustomValidity.has(element)) {
     return;
   }
 
-  // Another message replaced the owned one, so it is no longer this hook's to clear. Elements
-  // barred from constraint validation (disabled ones, for example) report an empty
-  // `validationMessage`, so the comparison is skipped there and the clear proceeds.
-  if (element.willValidate && element.validationMessage !== ownMessage) {
+  if (!hasOwnCustomValidity(element)) {
+    // Another message replaced the owned one, so it is no longer this hook's to clear — and it
+    // superseded whatever that owned message had displaced.
     ownedCustomValidity.delete(element);
+    displacedCustomValidity.delete(element);
     return;
   }
 
-  element.setCustomValidity('');
+  // Hand the control back to the message the owned one overwrote, if there was one.
+  element.setCustomValidity(displacedCustomValidity.get(element) ?? '');
   ownedCustomValidity.delete(element);
+  displacedCustomValidity.delete(element);
 }
 
 function clearCustomValidity(element: HTMLInputElement | null, inputs: RegisteredInputs) {
@@ -190,10 +223,13 @@ export function useFieldValidation(
     // A field can own several inputs (such as a checkbox or radio group), but only the last-mounted
     // one wins the shared `inputRef`. Validate against the registry instead so every input counts;
     // `inputRef` is the fallback only when no inputs are registered.
-    const element =
-      registeredInputs.size > 0
+    function resolveRepresentativeInput() {
+      return registeredInputs.size > 0
         ? findRepresentativeInput(registeredInputs, elementRef.current)
         : inputRef.current;
+    }
+
+    const element = resolveRepresentativeInput();
     // A field with no eligible input has no native constraint, but its custom validator still
     // applies to the logical value at the configured validation boundary.
 
@@ -336,18 +372,20 @@ export function useFieldValidation(
       } else if (isValidatingOnChange) {
         // The validate function returned no errors, so clear the custom validity this hook set.
         clearCustomValidity(element, registeredInputs);
-        // A message set outside of this hook survives the clear above and may even have appeared
-        // while an async `validate` was pending, after `nextState` was snapshotted, so read the
-        // remaining custom error off the element and re-derive `valid` with it.
-        nextState.customError = element?.validity.customError ?? false;
-        if (nextState.customError) {
-          nextState.valid = false;
-        }
 
-        if (element && element.validationMessage) {
-          defaultValidationMessage = element.validationMessage;
-          validationErrors = [element.validationMessage];
-        } else if ((!element || element.validity.valid) && !nextState.valid) {
+        // Clearing can hand representative status to another registered input that kept a message
+        // of its own, and an awaited `validate` may have let the DOM move on since `nextState` was
+        // snapshotted, so resolve the representative again and read the state off it.
+        const currentElement = resolveRepresentativeInput();
+        Object.assign(
+          nextState,
+          currentElement ? getState(currentElement) : { ...DEFAULT_VALIDITY_STATE, valid: true },
+        );
+
+        if (currentElement && currentElement.validationMessage) {
+          defaultValidationMessage = currentElement.validationMessage;
+          validationErrors = [currentElement.validationMessage];
+        } else if ((!currentElement || currentElement.validity.valid) && !nextState.valid) {
           nextState.valid = true;
         }
       }

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -69,6 +69,8 @@ function findRepresentativeInput(
  * by other code. Components can own a validity condition that no native constraint expresses (for
  * example a date field whose sections spell out February 30th) and surface it through
  * `setCustomValidity`, and the field must not silently drop it while revalidating.
+ * Ownership is tracked by message equality: a message set by other code that is identical to the
+ * currently owned one is indistinguishable from it and is cleared as owned.
  */
 const ownedCustomValidity = new WeakMap<HTMLInputElement, string>();
 
@@ -84,8 +86,12 @@ function clearOwnCustomValidity(element: HTMLInputElement) {
   }
 
   // `validationMessage` is empty on elements barred from constraint validation (disabled ones, for
-  // example), so the message can only be compared when the element is able to report it.
+  // example), so the message can only be compared when the element is able to report it. On a
+  // barred element the clear proceeds unchecked: a message that overwrote this hook's own one
+  // while the element was barred cannot be told apart and is knowingly wiped.
   if (element.willValidate && element.validationMessage !== ownMessage) {
+    // The message was overwritten by other code, so it is no longer this hook's to clear.
+    ownedCustomValidity.delete(element);
     return;
   }
 
@@ -173,15 +179,7 @@ export function useFieldValidation(
       });
     }
 
-    function publishAllValid(input: HTMLInputElement | null, externalInvalid?: boolean) {
-      clearCustomValidity(input, registeredInputs);
-
-      if (input?.validity.customError) {
-        // A custom validity message set outside of this hook survived the clear, so the field is
-        // still invalid. Leave the published validity untouched instead of claiming validity.
-        return false;
-      }
-
+    function publishAllValid(externalInvalid?: boolean) {
       const nextValidityData = {
         value,
         state: { ...DEFAULT_VALIDITY_STATE, valid: true },
@@ -191,7 +189,6 @@ export function useFieldValidation(
       };
       updateRegisteredFieldValidity(nextValidityData, externalInvalid);
       setValidityData(nextValidityData);
-      return true;
     }
 
     // A field can own several inputs (such as a checkbox or radio group), but only the last-mounted
@@ -212,13 +209,30 @@ export function useFieldValidation(
       const currentNativeValidity = element.validity;
 
       if (!currentNativeValidity.valueMissing) {
-        // The 'valueMissing' (required) condition has been resolved by the user typing.
-        // Temporarily mark the field as valid for this onChange event.
-        // Other native errors (e.g., typeMismatch) will be caught by full validation on blur or submit.
-        // The required value is now present; ignore stale external invalid state for this pass.
-        if (publishAllValid(element, false)) {
+        clearCustomValidity(element, registeredInputs);
+
+        if (!element.validity.customError) {
+          // The 'valueMissing' (required) condition has been resolved by the user typing.
+          // Temporarily mark the field as valid for this onChange event.
+          // Other native errors (e.g., typeMismatch) will be caught by full validation on blur or submit.
+          // The required value is now present; ignore stale external invalid state for this pass.
+          publishAllValid(false);
           return;
         }
+
+        // A custom validity message set outside of this hook survived the clear, so the field is
+        // still invalid. Publish the element's actual state so the just-resolved `valueMissing`
+        // error is not left on display.
+        const nextValidityData = {
+          value,
+          state: getState(element),
+          error: element.validationMessage,
+          errors: [element.validationMessage],
+          initialValue: validityData.initialValue,
+        };
+        updateRegisteredFieldValidity(nextValidityData, false);
+        setValidityData(nextValidityData);
+        return;
       }
 
       // Avoid surfacing another error during change revalidation while the required value is
@@ -325,12 +339,17 @@ export function useFieldValidation(
           }
         }
       } else if (isValidatingOnChange) {
-        // validate function returned no errors, if validating on change
-        // we need to clear the custom validity state
+        // The validate function returned no errors while validating on change, so clear the
+        // custom validity state this hook set on a previous commit.
         clearCustomValidity(element, registeredInputs);
         // A custom validity message set outside of this hook survives the clear above, so read the
         // remaining state off the element instead of assuming there is no custom error left.
         nextState.customError = element?.validity.customError ?? false;
+        if (nextState.customError) {
+          // The message may have appeared while an async `validate` was pending, after `nextState`
+          // was snapshotted, so `valid` must be re-derived alongside `customError`.
+          nextState.valid = false;
+        }
 
         if (element && element.validationMessage) {
           defaultValidationMessage = element.validationMessage;

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -101,8 +101,18 @@ function hasOwnCustomValidity(element: HTMLInputElement) {
 }
 
 function setOwnCustomValidity(element: HTMLInputElement, message: string) {
-  if (element.willValidate && element.validity.customError && !hasOwnCustomValidity(element)) {
-    displacedCustomValidity.set(element, element.validationMessage);
+  // Elements barred from constraint validation (disabled ones, for example) report an empty
+  // `validationMessage`, so a message set on them by other code can neither be recognized nor
+  // remembered, and installing an owned message overwrites it without a record.
+  if (element.willValidate) {
+    if (!element.validity.customError) {
+      // Nothing is set on the control, so whatever an owned message had displaced was withdrawn in
+      // the meantime — clearing a custom validity wipes the single slot both messages share. Drop
+      // the stale record so it can't be restored as a condition that no longer applies.
+      displacedCustomValidity.delete(element);
+    } else if (!hasOwnCustomValidity(element)) {
+      displacedCustomValidity.set(element, element.validationMessage);
+    }
   }
 
   element.setCustomValidity(message);
@@ -243,7 +253,11 @@ export function useFieldValidation(
       if (!currentNativeValidity.valueMissing) {
         clearCustomValidity(element, registeredInputs);
 
-        if (!element.validity.customError) {
+        // Clearing an owned message can hand representative status to another registered input that
+        // kept a message of its own, so resolve it again before reading the remaining state.
+        const currentElement = resolveRepresentativeInput() ?? element;
+
+        if (!currentElement.validity.customError) {
           // The 'valueMissing' (required) condition has been resolved by the user typing.
           // Temporarily mark the field as valid for this onChange event.
           // Other native errors (e.g., typeMismatch) will be caught by full validation on blur or submit.
@@ -253,12 +267,13 @@ export function useFieldValidation(
         }
 
         // A message set outside of this hook survived the clear, so the field is still invalid.
-        // Publish the element's actual state so the resolved `valueMissing` error doesn't linger.
+        // Publish that surviving error alone: the resolved `valueMissing` one must not linger, and
+        // co-occurring native errors stay deferred to the blur or submit boundary as above.
         const nextValidityData = {
           value,
-          state: getState(element),
-          error: element.validationMessage,
-          errors: [element.validationMessage],
+          state: { ...DEFAULT_VALIDITY_STATE, valid: false, customError: true },
+          error: currentElement.validationMessage,
+          errors: [currentElement.validationMessage],
           initialValue: validityData.initialValue,
         };
         updateRegisteredFieldValidity(nextValidityData, false);
@@ -385,8 +400,6 @@ export function useFieldValidation(
         if (currentElement && currentElement.validationMessage) {
           defaultValidationMessage = currentElement.validationMessage;
           validationErrors = [currentElement.validationMessage];
-        } else if ((!currentElement || currentElement.validity.valid) && !nextState.valid) {
-          nextState.valid = true;
         }
       }
     }

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -65,12 +65,10 @@ function findRepresentativeInput(
 }
 
 /**
- * Custom validity messages this hook set itself, so that clearing them doesn't wipe a message set
- * by other code. Components can own a validity condition that no native constraint expresses (for
- * example a date field whose sections spell out February 30th) and surface it through
- * `setCustomValidity`, and the field must not silently drop it while revalidating.
- * Ownership is tracked by message equality: a message set by other code that is identical to the
- * currently owned one is indistinguishable from it and is cleared as owned.
+ * Custom validity messages this hook set itself. Clearing only these keeps messages set by other
+ * code (for example a date field surfacing an invalid date through `setCustomValidity`) intact
+ * across revalidation. Ownership is matched by message text, so an identical foreign message is
+ * indistinguishable from an owned one.
  */
 const ownedCustomValidity = new WeakMap<HTMLInputElement, string>();
 
@@ -85,12 +83,10 @@ function clearOwnCustomValidity(element: HTMLInputElement) {
     return;
   }
 
-  // `validationMessage` is empty on elements barred from constraint validation (disabled ones, for
-  // example), so the message can only be compared when the element is able to report it. On a
-  // barred element the clear proceeds unchecked: a message that overwrote this hook's own one
-  // while the element was barred cannot be told apart and is knowingly wiped.
+  // Another message replaced the owned one, so it is no longer this hook's to clear. Elements
+  // barred from constraint validation (disabled ones, for example) report an empty
+  // `validationMessage`, so the comparison is skipped there and the clear proceeds.
   if (element.willValidate && element.validationMessage !== ownMessage) {
-    // The message was overwritten by other code, so it is no longer this hook's to clear.
     ownedCustomValidity.delete(element);
     return;
   }
@@ -220,9 +216,8 @@ export function useFieldValidation(
           return;
         }
 
-        // A custom validity message set outside of this hook survived the clear, so the field is
-        // still invalid. Publish the element's actual state so the just-resolved `valueMissing`
-        // error is not left on display.
+        // A message set outside of this hook survived the clear, so the field is still invalid.
+        // Publish the element's actual state so the resolved `valueMissing` error doesn't linger.
         const nextValidityData = {
           value,
           state: getState(element),
@@ -339,15 +334,13 @@ export function useFieldValidation(
           }
         }
       } else if (isValidatingOnChange) {
-        // The validate function returned no errors while validating on change, so clear the
-        // custom validity state this hook set on a previous commit.
+        // The validate function returned no errors, so clear the custom validity this hook set.
         clearCustomValidity(element, registeredInputs);
-        // A custom validity message set outside of this hook survives the clear above, so read the
-        // remaining state off the element instead of assuming there is no custom error left.
+        // A message set outside of this hook survives the clear above and may even have appeared
+        // while an async `validate` was pending, after `nextState` was snapshotted, so read the
+        // remaining custom error off the element and re-derive `valid` with it.
         nextState.customError = element?.validity.customError ?? false;
         if (nextState.customError) {
-          // The message may have appeared while an async `validate` was pending, after `nextState`
-          // was snapshotted, so `valid` must be re-derived alongside `customError`.
           nextState.valid = false;
         }
 

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -64,11 +64,42 @@ function findRepresentativeInput(
   return fallback;
 }
 
+/**
+ * Custom validity messages this hook set itself, so that clearing them doesn't wipe a message set
+ * by other code. Components can own a validity condition that no native constraint expresses (for
+ * example a date field whose sections spell out February 30th) and surface it through
+ * `setCustomValidity`, and the field must not silently drop it while revalidating.
+ */
+const ownedCustomValidity = new WeakMap<HTMLInputElement, string>();
+
+function setOwnCustomValidity(element: HTMLInputElement, message: string) {
+  element.setCustomValidity(message);
+  ownedCustomValidity.set(element, message);
+}
+
+function clearOwnCustomValidity(element: HTMLInputElement) {
+  const ownMessage = ownedCustomValidity.get(element);
+  if (ownMessage === undefined) {
+    return;
+  }
+
+  // `validationMessage` is empty on elements barred from constraint validation (disabled ones, for
+  // example), so the message can only be compared when the element is able to report it.
+  if (element.willValidate && element.validationMessage !== ownMessage) {
+    return;
+  }
+
+  element.setCustomValidity('');
+  ownedCustomValidity.delete(element);
+}
+
 function clearCustomValidity(element: HTMLInputElement | null, inputs: RegisteredInputs) {
   for (const input of inputs.keys()) {
-    input.setCustomValidity('');
+    clearOwnCustomValidity(input);
   }
-  element?.setCustomValidity('');
+  if (element) {
+    clearOwnCustomValidity(element);
+  }
 }
 
 export function useFieldValidation(
@@ -143,6 +174,14 @@ export function useFieldValidation(
     }
 
     function publishAllValid(input: HTMLInputElement | null, externalInvalid?: boolean) {
+      clearCustomValidity(input, registeredInputs);
+
+      if (input?.validity.customError) {
+        // A custom validity message set outside of this hook survived the clear, so the field is
+        // still invalid. Leave the published validity untouched instead of claiming validity.
+        return false;
+      }
+
       const nextValidityData = {
         value,
         state: { ...DEFAULT_VALIDITY_STATE, valid: true },
@@ -150,9 +189,9 @@ export function useFieldValidation(
         errors: [],
         initialValue: validityData.initialValue,
       };
-      clearCustomValidity(input, registeredInputs);
       updateRegisteredFieldValidity(nextValidityData, externalInvalid);
       setValidityData(nextValidityData);
+      return true;
     }
 
     // A field can own several inputs (such as a checkbox or radio group), but only the last-mounted
@@ -177,8 +216,9 @@ export function useFieldValidation(
         // Temporarily mark the field as valid for this onChange event.
         // Other native errors (e.g., typeMismatch) will be caught by full validation on blur or submit.
         // The required value is now present; ignore stale external invalid state for this pass.
-        publishAllValid(element, false);
-        return;
+        if (publishAllValid(element, false)) {
+          return;
+        }
       }
 
       // Avoid surfacing another error during change revalidation while the required value is
@@ -275,16 +315,22 @@ export function useFieldValidation(
 
         if (Array.isArray(result)) {
           validationErrors = result;
-          element?.setCustomValidity(result.join('\n'));
+          if (element) {
+            setOwnCustomValidity(element, result.join('\n'));
+          }
         } else if (result) {
           validationErrors = [result];
-          element?.setCustomValidity(result);
+          if (element) {
+            setOwnCustomValidity(element, result);
+          }
         }
       } else if (isValidatingOnChange) {
         // validate function returned no errors, if validating on change
         // we need to clear the custom validity state
         clearCustomValidity(element, registeredInputs);
-        nextState.customError = false;
+        // A custom validity message set outside of this hook survives the clear above, so read the
+        // remaining state off the element instead of assuming there is no custom error left.
+        nextState.customError = element?.validity.customError ?? false;
 
         if (element && element.validationMessage) {
           defaultValidationMessage = element.validationMessage;


### PR DESCRIPTION
A control can own a validity condition that no native constraint expresses — a date field whose sections spell out February 30th, a range field whose bounds are reversed — and the natural way to surface it is `setCustomValidity` on the control's input. Today the field throws that away.

`Form`'s submit handler sets `submitAttemptedRef` *before* calling `field.validate()` on each field, so `shouldValidateOnChange()` is already `true` for the submit pass itself. That pass takes the `validate`-branch in `useFieldValidation.commit()`, which calls `clearCustomValidity()` on every input — indiscriminately, including messages the field never set — forces `customError` to `false`, and then recomputes the field as valid from `element.validity`. Since `Form` renders `noValidate`, the published `validityData` is the only thing gating submission, so the form submits an invalid value and the `<Field.Error>` disappears.

The same clear runs on every subsequent change commit (`submitAttemptedRef` is never reset), so once a form has been submitted the message can't come back.

## Changes

- Track the custom validity messages this hook sets in a module-level `WeakMap` and clear only those. The message comparison is skipped when `!element.willValidate`, because elements barred from constraint validation report `validationMessage === ''` — that case is exercised by the existing `CheckboxGroup` disabled-input test.
- Read `nextState.customError` back off `element.validity` instead of assuming the clear removed it.
- Make `publishAllValid` bail when a foreign custom error survives the clear, so the on-change revalidation path can't publish an all-valid state over a message it doesn't own either.

Messages the field sets itself (from the `validate` prop) are cleared exactly as before.

## Testing

Three tests in `FieldRoot.test.tsx`. The two "keeps a message set outside the field" tests fail on `master`; "clears the message it set itself" passes both before and after, as a guard against over-fixing.

Verified end to end against Base UI Plus' `DateField`, which surfaces its invalid-date state this way: with this change and no Plus-side edits, entering February 30th blocks `<Form>` submission and keeps the error visible, in both jsdom and Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)