### PR TITLE
[test] Stabilize browser test timing

### DIFF
--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -620,7 +620,7 @@ describe('<Combobox.Root />', () => {
   });
 
   it('does not navigate the list with arrow keys from portalled controls inside the popup', async () => {
-    const { user } = await render(
+    await render(
       <Combobox.Root defaultOpen>
         <Combobox.Trigger>Open</Combobox.Trigger>
         <ActiveIndexProbe />
@@ -641,8 +641,9 @@ describe('<Combobox.Root />', () => {
       </Combobox.Root>,
     );
 
-    await user.click(screen.getByRole('button', { name: 'Portalled control' }));
-    await user.keyboard('{ArrowDown}');
+    const portalledControl = screen.getByRole('button', { name: 'Portalled control' });
+    portalledControl.focus();
+    fireEvent.keyDown(portalledControl, { key: 'ArrowDown' });
 
     expect(screen.getByTestId('active-index')).toHaveTextContent('null');
   });

--- a/packages/react/src/floating-ui-react/hooks/useClientPoint.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useClientPoint.test.tsx
@@ -87,12 +87,17 @@ function App({
         data-testid="reference"
         ref={refs.setReference}
         {...referenceProps}
-        style={{ width: 0, height: 0 }}
+        style={{ width: 0, height: 0, pointerEvents: 'none' }}
       >
         Reference
       </div>
       {isOpen && (
-        <div data-testid="floating" ref={refs.setFloating} {...getFloatingProps()}>
+        <div
+          data-testid="floating"
+          ref={refs.setFloating}
+          {...getFloatingProps()}
+          style={{ pointerEvents: 'none' }}
+        >
           Floating
         </div>
       )}
@@ -375,6 +380,8 @@ test('removes window listener when cursor lands on floating element', async () =
     }),
   );
 
+  await act(async () => flushMicrotasks());
+
   fireEvent(
     document.body,
     new MouseEvent('mousemove', {
@@ -385,7 +392,6 @@ test('removes window listener when cursor lands on floating element', async () =
   );
 
   expectLocation({ x: 500, y: 500 });
-  await act(async () => flushMicrotasks());
 });
 
 test('reattaches window listener after cursor returns from floating element to reference', async () => {
@@ -410,6 +416,8 @@ test('reattaches window listener after cursor returns from floating element to r
       clientY: 500,
     }),
   );
+
+  await act(async () => flushMicrotasks());
 
   fireEvent(
     document.body,
@@ -454,8 +462,8 @@ test('reattaches window listener after cursor returns from floating element to r
     }),
   );
 
-  expectLocation({ x: 100, y: 200 });
   await act(async () => flushMicrotasks());
+  expectLocation({ x: 100, y: 200 });
 });
 
 test('restores the DOM reference when opened by a non-mouse event', async () => {

--- a/packages/react/src/floating-ui-react/hooks/useClientPoint.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useClientPoint.test.tsx
@@ -2,7 +2,7 @@ import { test, expect, vi } from 'vitest';
 import * as React from 'react';
 import type { Coords } from '@floating-ui/react-dom';
 import { flushMicrotasks } from '@mui/internal-test-utils';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { useTestInteractions } from '#test-utils';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
@@ -383,9 +383,9 @@ test('removes window listener when cursor lands on floating element', async () =
       clientY: 0,
     }),
   );
-  await flushMicrotasks();
 
   expectLocation({ x: 500, y: 500 });
+  await act(async () => flushMicrotasks());
 });
 
 test('reattaches window listener after cursor returns from floating element to reference', async () => {
@@ -419,7 +419,6 @@ test('reattaches window listener after cursor returns from floating element to r
       clientY: 0,
     }),
   );
-  await flushMicrotasks();
 
   expectLocation({ x: 500, y: 500 });
 
@@ -431,7 +430,18 @@ test('reattaches window listener after cursor returns from floating element to r
       clientY: 700,
     }),
   );
-  await flushMicrotasks();
+  await act(async () => flushMicrotasks());
+
+  // Reapply deterministic coordinates after the effect attaches the window listener.
+  // A real browser cursor can emit an unrelated move while the effect is flushing.
+  fireEvent(
+    screen.getByTestId('reference'),
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      clientX: 600,
+      clientY: 700,
+    }),
+  );
 
   expectLocation({ x: 600, y: 700 });
 
@@ -443,9 +453,9 @@ test('reattaches window listener after cursor returns from floating element to r
       clientY: 200,
     }),
   );
-  await flushMicrotasks();
 
   expectLocation({ x: 100, y: 200 });
+  await act(async () => flushMicrotasks());
 });
 
 test('restores the DOM reference when opened by a non-mouse event', async () => {

--- a/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.test.tsx
+++ b/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.test.tsx
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 
 describe('<Menu.CheckboxItemIndicator />', () => {
   beforeEach(() => {
@@ -178,15 +178,13 @@ describe('<Menu.CheckboxItemIndicator />', () => {
         );
       }
 
-      const { user } = await render(<Test />);
+      await render(<Test />);
 
       expect(screen.getByTestId('indicator')).not.toBe(null);
 
-      await user.click(screen.getByText('Close'));
+      fireEvent.click(screen.getByText('Close'));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('indicator')).toHaveAttribute('data-ending-style');
-      });
+      expect(screen.getByTestId('indicator')).toHaveAttribute('data-ending-style');
 
       await waitFor(() => {
         expect(screen.queryByTestId('indicator')).toBe(null);

--- a/packages/react/src/menu/positioner/MenuPositioner.test.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.test.tsx
@@ -5,7 +5,13 @@ import { act, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils'
 import { ContextMenu } from '@base-ui/react/context-menu';
 import { Menu } from '@base-ui/react/menu';
 import { Menubar } from '@base-ui/react/menubar';
-import { describeConformance, createRenderer, isJSDOM, waitSingleFrame } from '#test-utils';
+import {
+  describeConformance,
+  createRenderer,
+  isJSDOM,
+  resetBrowserPointer,
+  waitForPositioned,
+} from '#test-utils';
 
 const useAnchorPositioningSpy = vi.hoisted(() => vi.fn());
 
@@ -31,6 +37,8 @@ const Trigger = React.forwardRef(function Trigger(
 });
 
 describe('<Menu.Positioner />', () => {
+  beforeEach(resetBrowserPointer);
+
   const { render } = createRenderer();
 
   beforeEach(() => {
@@ -812,52 +820,41 @@ describe('<Menu.Positioner />', () => {
   });
 
   it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
-    let unmount = () => {};
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
-    await act(async () => {
-      ({ unmount } = await render(
-        <Menu.Root open>
-          <Trigger style={triggerStyle}>Trigger</Trigger>
-          <Menu.Portal>
-            <Menu.Positioner data-testid="positioner">
-              <Menu.Popup style={popupStyle}>Popup</Menu.Popup>
-            </Menu.Positioner>
-          </Menu.Portal>
-        </Menu.Root>,
-      ));
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-    });
+    const { unmount } = await render(
+      <Menu.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <Menu.Portal>
+          <Menu.Positioner data-testid="positioner">
+            <Menu.Popup style={popupStyle}>Popup</Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>,
+    );
 
-    expect(screen.getByTestId('positioner').style.transform).not.toBe('');
+    const positioner = screen.getByTestId('positioner');
+    await waitFor(() => {
+      expect(positioner.style.transform).not.toBe('');
+    });
     unmount();
   });
 
   it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
-    let unmount = () => {};
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
-    await act(async () => {
-      ({ unmount } = await render(
-        <Menu.Root open>
-          <Trigger style={triggerStyle}>Trigger</Trigger>
-          <Menu.Portal>
-            <Menu.Positioner data-testid="positioner">
-              <Menu.Popup style={popupStyle}>
-                <Menu.Viewport>Popup</Menu.Viewport>
-              </Menu.Popup>
-            </Menu.Positioner>
-          </Menu.Portal>
-        </Menu.Root>,
-      ));
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-    });
+    const { unmount } = await render(
+      <Menu.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <Menu.Portal>
+          <Menu.Positioner data-testid="positioner">
+            <Menu.Popup style={popupStyle}>
+              <Menu.Viewport>Popup</Menu.Viewport>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>,
+    );
 
-    expect(screen.getByTestId('positioner').style.transform).toBe('');
+    const positioner = screen.getByTestId('positioner');
+    await waitForPositioned(positioner);
+    expect(positioner.style.transform).toBe('');
     unmount();
   });
 });

--- a/packages/react/src/menu/positioner/MenuPositioner.test.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.test.tsx
@@ -5,7 +5,7 @@ import { act, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils'
 import { ContextMenu } from '@base-ui/react/context-menu';
 import { Menu } from '@base-ui/react/menu';
 import { Menubar } from '@base-ui/react/menubar';
-import { describeConformance, createRenderer, isJSDOM } from '#test-utils';
+import { describeConformance, createRenderer, isJSDOM, waitSingleFrame } from '#test-utils';
 
 const useAnchorPositioningSpy = vi.hoisted(() => vi.fn());
 
@@ -812,36 +812,52 @@ describe('<Menu.Positioner />', () => {
   });
 
   it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
-    await render(
-      <Menu.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <Menu.Portal>
-          <Menu.Positioner data-testid="positioner">
-            <Menu.Popup style={popupStyle}>Popup</Menu.Popup>
-          </Menu.Positioner>
-        </Menu.Portal>
-      </Menu.Root>,
-    );
+    let unmount = () => {};
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
+    await act(async () => {
+      ({ unmount } = await render(
+        <Menu.Root open>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <Menu.Portal>
+            <Menu.Positioner data-testid="positioner">
+              <Menu.Popup style={popupStyle}>Popup</Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      ));
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+    });
 
     expect(screen.getByTestId('positioner').style.transform).not.toBe('');
+    unmount();
   });
 
   it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
-    await render(
-      <Menu.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <Menu.Portal>
-          <Menu.Positioner data-testid="positioner">
-            <Menu.Popup style={popupStyle}>
-              <Menu.Viewport>Popup</Menu.Viewport>
-            </Menu.Popup>
-          </Menu.Positioner>
-        </Menu.Portal>
-      </Menu.Root>,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('positioner').style.transform).toBe('');
+    let unmount = () => {};
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
+    await act(async () => {
+      ({ unmount } = await render(
+        <Menu.Root open>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <Menu.Portal>
+            <Menu.Positioner data-testid="positioner">
+              <Menu.Popup style={popupStyle}>
+                <Menu.Viewport>Popup</Menu.Viewport>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      ));
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
     });
+
+    expect(screen.getByTestId('positioner').style.transform).toBe('');
+    unmount();
   });
 });

--- a/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.test.tsx
+++ b/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.test.tsx
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 
 describe('<Menu.RadioItemIndicator />', () => {
   const { render } = createRenderer();
@@ -193,15 +193,13 @@ describe('<Menu.RadioItemIndicator />', () => {
         );
       }
 
-      const { user } = await render(<Test />);
+      await render(<Test />);
 
       expect(screen.getByTestId('indicator')).not.toBe(null);
 
-      await user.click(screen.getByText('Select b'));
+      fireEvent.click(screen.getByText('Select b'));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('indicator')).toHaveAttribute('data-ending-style');
-      });
+      expect(screen.getByTestId('indicator')).toHaveAttribute('data-ending-style');
 
       await waitFor(() => {
         expect(screen.queryByTestId('indicator')).toBe(null);

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -14,11 +14,21 @@ import { Menu } from '@base-ui/react/menu';
 import { Dialog } from '@base-ui/react/dialog';
 import { AlertDialog } from '@base-ui/react/alert-dialog';
 import userEvent from '@testing-library/user-event';
-import { createRenderer, isJSDOM, popupConformanceTests, wait } from '#test-utils';
+import {
+  createRenderer,
+  enterWithMouse,
+  isJSDOM,
+  moveMouse,
+  popupConformanceTests,
+  resetBrowserPointer,
+  wait,
+} from '#test-utils';
 import { REASONS } from '../../internals/reasons';
 import { PATIENT_CLICK_THRESHOLD } from '../../internals/constants';
 
 describe('<Menu.Root />', () => {
+  beforeEach(resetBrowserPointer);
+
   beforeEach(() => {
     globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
   });
@@ -2022,9 +2032,7 @@ describe('<Menu.Root />', () => {
           trigger.focus();
         });
 
-        fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
-        fireEvent.mouseEnter(trigger);
-        fireEvent.mouseMove(trigger);
+        enterWithMouse(trigger);
 
         await waitFor(() => {
           expect(screen.queryByRole('menu')).not.toBe(null);
@@ -2042,19 +2050,13 @@ describe('<Menu.Root />', () => {
           trigger.focus();
         });
 
-        fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
-        fireEvent.mouseEnter(trigger);
-        fireEvent.mouseMove(trigger);
+        enterWithMouse(trigger);
 
         await waitFor(() => {
           expect(screen.queryByRole('menu')).not.toBe(null);
         });
 
-        fireEvent.pointerLeave(trigger, {
-          pointerType: 'mouse',
-          relatedTarget: document.body,
-        });
-        fireEvent.mouseLeave(trigger);
+        moveMouse(trigger, document.body);
 
         await waitFor(() => {
           expect(screen.queryByRole('menu')).toBe(null);

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -1250,6 +1250,10 @@ describe('<Menu.Root />', () => {
 
             const dialogClose = await screen.findByTestId('dialog-close');
 
+            await waitFor(() => {
+              expect(frameCallbacks.size).toBeGreaterThan(0);
+            });
+
             act(() => {
               const callbacks = Array.from(frameCallbacks.values());
               frameCallbacks.clear();
@@ -2018,7 +2022,9 @@ describe('<Menu.Root />', () => {
           trigger.focus();
         });
 
-        await userEvent.hover(trigger);
+        fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
 
         await waitFor(() => {
           expect(screen.queryByRole('menu')).not.toBe(null);
@@ -2036,13 +2042,19 @@ describe('<Menu.Root />', () => {
           trigger.focus();
         });
 
-        await userEvent.hover(trigger);
+        fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+        fireEvent.mouseEnter(trigger);
+        fireEvent.mouseMove(trigger);
 
         await waitFor(() => {
           expect(screen.queryByRole('menu')).not.toBe(null);
         });
 
-        await userEvent.unhover(trigger);
+        fireEvent.pointerLeave(trigger, {
+          pointerType: 'mouse',
+          relatedTarget: document.body,
+        });
+        fireEvent.mouseLeave(trigger);
 
         await waitFor(() => {
           expect(screen.queryByRole('menu')).toBe(null);

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -254,7 +254,8 @@ describe('<Menubar />', () => {
 
         // Now hover over the edit menubar trigger
         const editTrigger = screen.getByTestId('edit-trigger');
-        await user.hover(editTrigger);
+        fireEvent.mouseEnter(editTrigger);
+        fireEvent.mouseMove(editTrigger);
 
         await waitFor(() => {
           expect(screen.queryByTestId('edit-menu')).not.toBe(null);
@@ -1002,48 +1003,55 @@ describe('<Menubar />', () => {
     it.skipIf(isJSDOM)(
       'correctly opens new menu on hover after clicking on its trigger and entering from hover (#2222)',
       async () => {
-        const { user } = await render(<TestMenubar />);
+        const { userEvent: user } = await import('vitest/browser');
+        const { render: vbrRender, cleanup } = await import('vitest-browser-react');
 
-        const fileTrigger = screen.getByTestId('file-trigger');
-        const editTrigger = screen.getByTestId('edit-trigger');
-        await user.click(fileTrigger);
+        try {
+          await vbrRender(<TestMenubar />);
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('file-menu')).not.toBe(null);
-        });
-        await waitFor(() => {
-          expect(screen.getByRole('menubar')).toHaveAttribute('data-has-submenu-open');
-        });
+          const fileTrigger = screen.getByTestId('file-trigger');
+          const editTrigger = screen.getByTestId('edit-trigger');
+          await user.click(fileTrigger);
 
-        await user.hover(editTrigger);
+          await waitFor(() => {
+            expect(screen.queryByTestId('file-menu')).not.toBe(null);
+          });
+          await waitFor(() => {
+            expect(screen.getByRole('menubar')).toHaveAttribute('data-has-submenu-open');
+          });
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('edit-menu')).not.toBe(null);
-        });
+          await user.hover(editTrigger);
 
-        await user.click(editTrigger);
+          await waitFor(() => {
+            expect(screen.queryByTestId('edit-menu')).not.toBe(null);
+          });
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('edit-menu')).toBe(null);
-        });
-        await waitFor(() => {
-          expect(screen.getByRole('menubar')).not.toHaveAttribute('data-has-submenu-open');
-        });
+          await user.click(editTrigger);
 
-        await user.click(fileTrigger);
+          await waitFor(() => {
+            expect(screen.queryByTestId('edit-menu')).toBe(null);
+          });
+          await waitFor(() => {
+            expect(screen.getByRole('menubar')).not.toHaveAttribute('data-has-submenu-open');
+          });
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('file-menu')).not.toBe(null);
-        });
-        await waitFor(() => {
-          expect(screen.getByRole('menubar')).toHaveAttribute('data-has-submenu-open');
-        });
+          await user.click(fileTrigger);
 
-        await user.hover(editTrigger);
+          await waitFor(() => {
+            expect(screen.queryByTestId('file-menu')).not.toBe(null);
+          });
+          await waitFor(() => {
+            expect(screen.getByRole('menubar')).toHaveAttribute('data-has-submenu-open');
+          });
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('edit-menu')).not.toBe(null);
-        });
+          await user.hover(editTrigger);
+
+          await waitFor(() => {
+            expect(screen.queryByTestId('edit-menu')).not.toBe(null);
+          });
+        } finally {
+          await cleanup();
+        }
       },
     );
 

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -1,14 +1,21 @@
 import { afterEach, expect, vi } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance, isJSDOM, wait } from '#test-utils';
+import {
+  createRenderer,
+  describeConformance,
+  isJSDOM,
+  resetBrowserPointer,
+  wait,
+} from '#test-utils';
 import { Menubar } from '@base-ui/react/menubar';
 import { Menu } from '@base-ui/react/menu';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { useMenubarContext } from './MenubarContext';
 
 describe('<Menubar />', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await resetBrowserPointer();
     globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
   });
 
@@ -254,8 +261,7 @@ describe('<Menubar />', () => {
 
         // Now hover over the edit menubar trigger
         const editTrigger = screen.getByTestId('edit-trigger');
-        fireEvent.mouseEnter(editTrigger);
-        fireEvent.mouseMove(editTrigger);
+        await user.hover(editTrigger);
 
         await waitFor(() => {
           expect(screen.queryByTestId('edit-menu')).not.toBe(null);

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.test.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.test.tsx
@@ -195,6 +195,9 @@ describe('<NumberField.ScrubArea />', () => {
     const scaleGetter = vi.spyOn(visualViewport, 'scale', 'get').mockImplementation(() => scale);
     const addEventListener = vi.spyOn(window, 'addEventListener');
     const removeEventListener = vi.spyOn(window, 'removeEventListener');
+    const pointerLock = vi
+      .spyOn(document.body, 'requestPointerLock')
+      .mockImplementation(() => Promise.resolve());
 
     try {
       await render(
@@ -245,6 +248,7 @@ describe('<NumberField.ScrubArea />', () => {
       scaleGetter.mockRestore();
       addEventListener.mockRestore();
       removeEventListener.mockRestore();
+      pointerLock.mockRestore();
     }
   });
 

--- a/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
@@ -311,42 +311,55 @@ describe('<Popover.Positioner />', () => {
   // https://github.com/mui/base-ui/issues/5131
   it.skipIf(isJSDOM)('rests exactly at collisionPadding from the colliding edge', async () => {
     const collisionPadding = 12;
+    let setOpen!: React.Dispatch<React.SetStateAction<boolean>>;
 
-    await render(
-      // Anchor pinned near the bottom so the bottom-side popup flips to the top and
-      // collides with the top viewport edge.
-      <div style={{ position: 'fixed', bottom: 8, left: 16 }}>
-        <Popover.Root open>
-          <Trigger style={triggerStyle}>Trigger</Trigger>
-          <Popover.Portal>
-            <Popover.Positioner
-              data-testid="positioner"
-              side="bottom"
-              sideOffset={8}
-              collisionPadding={collisionPadding}
-              collisionAvoidance={{ fallbackAxisSide: 'none' }}
-            >
-              <Popover.Popup
-                style={{ width: 200, height: 1000, maxHeight: 'var(--available-height)' }}
+    function App() {
+      const [open, setOpenState] = React.useState(false);
+      setOpen = setOpenState;
+
+      return (
+        // Anchor pinned near the bottom so the bottom-side popup flips to the top and
+        // collides with the top viewport edge.
+        <div style={{ position: 'fixed', bottom: 8, left: 16 }}>
+          <Popover.Root open={open}>
+            <Trigger style={triggerStyle}>Trigger</Trigger>
+            <Popover.Portal>
+              <Popover.Positioner
+                data-testid="positioner"
+                side="bottom"
+                sideOffset={8}
+                collisionPadding={collisionPadding}
+                collisionAvoidance={{ fallbackAxisSide: 'none' }}
               >
-                Popup
-              </Popover.Popup>
-            </Popover.Positioner>
-          </Popover.Portal>
-        </Popover.Root>
-      </div>,
-    );
+                <Popover.Popup
+                  style={{ width: 200, height: 1000, maxHeight: 'var(--available-height)' }}
+                >
+                  Popup
+                </Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          </Popover.Root>
+        </div>
+      );
+    }
+
+    const { unmount } = await render(<App />);
+    await act(async () => {
+      setOpen(true);
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+    });
 
     const positioner = screen.getByTestId('positioner');
-    await waitFor(() => {
-      expect(positioner).toHaveAttribute('data-side', 'top');
-    });
+    expect(positioner).toHaveAttribute('data-side', 'top');
 
     // The preferred-side bias used by flip() must not leak into the resting position:
     // the popup should sit exactly `collisionPadding` away from the top edge, not +1px.
-    expect(Math.round(screen.getByTestId('positioner').getBoundingClientRect().top)).toBe(
-      collisionPadding,
-    );
+    expect(Math.round(positioner.getBoundingClientRect().top)).toBe(collisionPadding);
+
+    unmount();
   });
 
   it.skipIf(isJSDOM)('remains anchored if keepMounted=false', async () => {
@@ -534,36 +547,52 @@ describe('<Popover.Positioner />', () => {
   );
 
   it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
-    await render(
-      <Popover.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <Popover.Portal>
-          <Popover.Positioner data-testid="positioner">
-            <Popover.Popup style={popupStyle}>Popup</Popover.Popup>
-          </Popover.Positioner>
-        </Popover.Portal>
-      </Popover.Root>,
-    );
+    let unmount = () => {};
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
+    await act(async () => {
+      ({ unmount } = await render(
+        <Popover.Root open>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <Popover.Portal>
+            <Popover.Positioner data-testid="positioner">
+              <Popover.Popup style={popupStyle}>Popup</Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>,
+      ));
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+    });
 
     expect(screen.getByTestId('positioner').style.transform).not.toBe('');
+    unmount();
   });
 
   it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
-    await render(
-      <Popover.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <Popover.Portal>
-          <Popover.Positioner data-testid="positioner">
-            <Popover.Popup style={popupStyle}>
-              <Popover.Viewport>Popup</Popover.Viewport>
-            </Popover.Popup>
-          </Popover.Positioner>
-        </Popover.Portal>
-      </Popover.Root>,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('positioner').style.transform).toBe('');
+    let unmount = () => {};
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
+    await act(async () => {
+      ({ unmount } = await render(
+        <Popover.Root open>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <Popover.Portal>
+            <Popover.Positioner data-testid="positioner">
+              <Popover.Popup style={popupStyle}>
+                <Popover.Viewport>Popup</Popover.Viewport>
+              </Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>,
+      ));
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
     });
+
+    expect(screen.getByTestId('positioner').style.transform).toBe('');
+    unmount();
   });
 });

--- a/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
@@ -4,7 +4,13 @@ import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Popover } from '@base-ui/react/popover';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { act, screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance, isJSDOM, waitSingleFrame } from '#test-utils';
+import {
+  createRenderer,
+  describeConformance,
+  isJSDOM,
+  waitForPositioned,
+  waitSingleFrame,
+} from '#test-utils';
 
 const Trigger = React.forwardRef(function Trigger(
   props: Popover.Trigger.Props,
@@ -344,20 +350,18 @@ describe('<Popover.Positioner />', () => {
     }
 
     const { unmount } = await render(<App />);
-    await act(async () => {
-      setOpen(true);
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-    });
+    await act(async () => setOpen(true));
 
     const positioner = screen.getByTestId('positioner');
-    expect(positioner).toHaveAttribute('data-side', 'top');
+    await waitFor(() => {
+      expect(positioner).toHaveAttribute('data-side', 'top');
+    });
 
     // The preferred-side bias used by flip() must not leak into the resting position:
     // the popup should sit exactly `collisionPadding` away from the top edge, not +1px.
-    expect(Math.round(positioner.getBoundingClientRect().top)).toBe(collisionPadding);
+    await waitFor(() => {
+      expect(Math.round(positioner.getBoundingClientRect().top)).toBe(collisionPadding);
+    });
 
     unmount();
   });
@@ -547,52 +551,41 @@ describe('<Popover.Positioner />', () => {
   );
 
   it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
-    let unmount = () => {};
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
-    await act(async () => {
-      ({ unmount } = await render(
-        <Popover.Root open>
-          <Trigger style={triggerStyle}>Trigger</Trigger>
-          <Popover.Portal>
-            <Popover.Positioner data-testid="positioner">
-              <Popover.Popup style={popupStyle}>Popup</Popover.Popup>
-            </Popover.Positioner>
-          </Popover.Portal>
-        </Popover.Root>,
-      ));
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-    });
+    const { unmount } = await render(
+      <Popover.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <Popover.Portal>
+          <Popover.Positioner data-testid="positioner">
+            <Popover.Popup style={popupStyle}>Popup</Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>,
+    );
 
-    expect(screen.getByTestId('positioner').style.transform).not.toBe('');
+    const positioner = screen.getByTestId('positioner');
+    await waitFor(() => {
+      expect(positioner.style.transform).not.toBe('');
+    });
     unmount();
   });
 
   it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
-    let unmount = () => {};
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
-    await act(async () => {
-      ({ unmount } = await render(
-        <Popover.Root open>
-          <Trigger style={triggerStyle}>Trigger</Trigger>
-          <Popover.Portal>
-            <Popover.Positioner data-testid="positioner">
-              <Popover.Popup style={popupStyle}>
-                <Popover.Viewport>Popup</Popover.Viewport>
-              </Popover.Popup>
-            </Popover.Positioner>
-          </Popover.Portal>
-        </Popover.Root>,
-      ));
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-    });
+    const { unmount } = await render(
+      <Popover.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <Popover.Portal>
+          <Popover.Positioner data-testid="positioner">
+            <Popover.Popup style={popupStyle}>
+              <Popover.Viewport>Popup</Popover.Viewport>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>,
+    );
 
-    expect(screen.getByTestId('positioner').style.transform).toBe('');
+    const positioner = screen.getByTestId('positioner');
+    await waitForPositioned(positioner);
+    expect(positioner.style.transform).toBe('');
     unmount();
   });
 });

--- a/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
@@ -1,7 +1,13 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import {
+  createRenderer,
+  describeConformance,
+  enterWithMouse,
+  isJSDOM,
+  resetBrowserPointer,
+} from '#test-utils';
 import {
   act,
   fireEvent,
@@ -13,6 +19,8 @@ import {
 import { PATIENT_CLICK_THRESHOLD } from '../../internals/constants';
 
 describe('<Popover.Trigger />', () => {
+  beforeEach(resetBrowserPointer);
+
   const { render } = createRenderer();
 
   describeConformance(<Popover.Trigger />, () => ({
@@ -154,9 +162,7 @@ describe('<Popover.Trigger />', () => {
     }
 
     function hoverTrigger(trigger: HTMLElement) {
-      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
-      fireEvent.mouseEnter(trigger);
-      fireEvent.mouseMove(trigger);
+      enterWithMouse(trigger);
     }
 
     // A touch tap leaves the pointer parked wherever the cursor happens to be, so hover must stay

--- a/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
@@ -113,10 +113,22 @@ describe('<Popover.Trigger />', () => {
         <Popover.Root>
           {({ payload }) => (
             <React.Fragment>
-              <Popover.Trigger payload="One" openOnHover delay={0} closeDelay={0}>
+              <Popover.Trigger
+                payload="One"
+                openOnHover
+                delay={0}
+                closeDelay={0}
+                style={{ pointerEvents: 'none' }}
+              >
                 One
               </Popover.Trigger>
-              <Popover.Trigger payload="Two" openOnHover delay={0} closeDelay={0}>
+              <Popover.Trigger
+                payload="Two"
+                openOnHover
+                delay={0}
+                closeDelay={0}
+                style={{ pointerEvents: 'none' }}
+              >
                 Two
               </Popover.Trigger>
               <Popover.Portal>
@@ -132,27 +144,35 @@ describe('<Popover.Trigger />', () => {
       );
     }
 
-    function pressTrigger(trigger: HTMLElement, pointerType: 'mouse' | 'touch') {
-      fireEvent.pointerDown(trigger, { pointerType });
-      fireEvent.mouseDown(trigger);
-      fireEvent.click(trigger, { detail: 1 });
+    async function pressTrigger(trigger: HTMLElement, pointerType: 'mouse' | 'touch') {
+      // eslint-disable-next-line testing-library/no-unnecessary-act -- flush the complete synthetic press before the browser can dispatch physical pointer movement
+      await act(async () => {
+        fireEvent.pointerDown(trigger, { pointerType });
+        fireEvent.mouseDown(trigger);
+        fireEvent.click(trigger, { detail: 1 });
+      });
+    }
+
+    function hoverTrigger(trigger: HTMLElement) {
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+      fireEvent.mouseEnter(trigger);
+      fireEvent.mouseMove(trigger);
     }
 
     // A touch tap leaves the pointer parked wherever the cursor happens to be, so hover must stay
     // disarmed until the popover is reopened by some other means. Otherwise a stray hover over a
     // sibling trigger silently swaps the content the user just tapped for.
     it('keeps ownership on the tapped trigger when a sibling trigger is hovered', async () => {
-      const { user } = await render(<MultiTriggerPopover />);
+      await render(<MultiTriggerPopover />);
 
       const one = screen.getByRole('button', { name: 'One' });
       const two = screen.getByRole('button', { name: 'Two' });
 
-      pressTrigger(one, 'touch');
-      await flushMicrotasks();
+      await pressTrigger(one, 'touch');
 
       expect(screen.getByTestId('content')).toHaveTextContent('One');
 
-      await user.hover(two);
+      hoverTrigger(two);
       await flushMicrotasks();
 
       expect(screen.getByTestId('content')).toHaveTextContent('One');
@@ -162,17 +182,16 @@ describe('<Popover.Trigger />', () => {
     // The same hover must still take over when the popover was opened with a mouse, so the guard
     // above can't be a blanket disable.
     it('hands ownership to a hovered sibling trigger when opened by mouse', async () => {
-      const { user } = await render(<MultiTriggerPopover />);
+      await render(<MultiTriggerPopover />);
 
       const one = screen.getByRole('button', { name: 'One' });
       const two = screen.getByRole('button', { name: 'Two' });
 
-      pressTrigger(one, 'mouse');
-      await flushMicrotasks();
+      await pressTrigger(one, 'mouse');
 
       expect(screen.getByTestId('content')).toHaveTextContent('One');
 
-      await user.hover(two);
+      hoverTrigger(two);
       await flushMicrotasks();
 
       expect(screen.getByTestId('content')).toHaveTextContent('Two');

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, expect, vi } from 'vitest';
 import * as React from 'react';
 import { PreviewCard } from '@base-ui/react/preview-card';
-import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance, isJSDOM, waitSingleFrame } from '#test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM, waitForPositioned } from '#test-utils';
 
 const Trigger = React.forwardRef(function Trigger(
   props: PreviewCard.Trigger.Props,
@@ -340,53 +340,40 @@ describe('<PreviewCard.Positioner />', () => {
   });
 
   it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
-    let unmount = () => {};
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
-    await act(async () => {
-      ({ unmount } = await render(
-        <PreviewCard.Root open>
-          <Trigger style={triggerStyle}>Trigger</Trigger>
-          <PreviewCard.Portal>
-            <PreviewCard.Positioner data-testid="positioner">
-              <PreviewCard.Popup style={popupStyle}>Popup</PreviewCard.Popup>
-            </PreviewCard.Positioner>
-          </PreviewCard.Portal>
-        </PreviewCard.Root>,
-      ));
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-    });
+    const { unmount } = await render(
+      <PreviewCard.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <PreviewCard.Portal>
+          <PreviewCard.Positioner data-testid="positioner">
+            <PreviewCard.Popup style={popupStyle}>Popup</PreviewCard.Popup>
+          </PreviewCard.Positioner>
+        </PreviewCard.Portal>
+      </PreviewCard.Root>,
+    );
 
     const positioner = screen.getByTestId('positioner');
-    expect(positioner.style.transform).not.toBe('');
+    await waitFor(() => {
+      expect(positioner.style.transform).not.toBe('');
+    });
     unmount();
   });
 
   it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
-    let unmount = () => {};
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
-    await act(async () => {
-      ({ unmount } = await render(
-        <PreviewCard.Root open>
-          <Trigger style={triggerStyle}>Trigger</Trigger>
-          <PreviewCard.Portal>
-            <PreviewCard.Positioner data-testid="positioner">
-              <PreviewCard.Popup style={popupStyle}>
-                <PreviewCard.Viewport>Popup</PreviewCard.Viewport>
-              </PreviewCard.Popup>
-            </PreviewCard.Positioner>
-          </PreviewCard.Portal>
-        </PreviewCard.Root>,
-      ));
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-    });
+    const { unmount } = await render(
+      <PreviewCard.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <PreviewCard.Portal>
+          <PreviewCard.Positioner data-testid="positioner">
+            <PreviewCard.Popup style={popupStyle}>
+              <PreviewCard.Viewport>Popup</PreviewCard.Viewport>
+            </PreviewCard.Popup>
+          </PreviewCard.Positioner>
+        </PreviewCard.Portal>
+      </PreviewCard.Root>,
+    );
 
     const positioner = screen.getByTestId('positioner');
+    await waitForPositioned(positioner);
     expect(positioner.style.transform).toBe('');
     unmount();
   });
@@ -1108,52 +1095,41 @@ describe('<PreviewCard.Positioner />', () => {
   });
 
   it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
-    let unmount = () => {};
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
-    await act(async () => {
-      ({ unmount } = await render(
-        <PreviewCard.Root open>
-          <Trigger style={triggerStyle}>Trigger</Trigger>
-          <PreviewCard.Portal>
-            <PreviewCard.Positioner data-testid="positioner">
-              <PreviewCard.Popup style={popupStyle}>Popup</PreviewCard.Popup>
-            </PreviewCard.Positioner>
-          </PreviewCard.Portal>
-        </PreviewCard.Root>,
-      ));
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-    });
+    const { unmount } = await render(
+      <PreviewCard.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <PreviewCard.Portal>
+          <PreviewCard.Positioner data-testid="positioner">
+            <PreviewCard.Popup style={popupStyle}>Popup</PreviewCard.Popup>
+          </PreviewCard.Positioner>
+        </PreviewCard.Portal>
+      </PreviewCard.Root>,
+    );
 
-    expect(screen.getByTestId('positioner').style.transform).not.toBe('');
+    const positioner = screen.getByTestId('positioner');
+    await waitFor(() => {
+      expect(positioner.style.transform).not.toBe('');
+    });
     unmount();
   });
 
   it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
-    let unmount = () => {};
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
-    await act(async () => {
-      ({ unmount } = await render(
-        <PreviewCard.Root open>
-          <Trigger style={triggerStyle}>Trigger</Trigger>
-          <PreviewCard.Portal>
-            <PreviewCard.Positioner data-testid="positioner">
-              <PreviewCard.Popup style={popupStyle}>
-                <PreviewCard.Viewport>Popup</PreviewCard.Viewport>
-              </PreviewCard.Popup>
-            </PreviewCard.Positioner>
-          </PreviewCard.Portal>
-        </PreviewCard.Root>,
-      ));
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-    });
+    const { unmount } = await render(
+      <PreviewCard.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <PreviewCard.Portal>
+          <PreviewCard.Positioner data-testid="positioner">
+            <PreviewCard.Popup style={popupStyle}>
+              <PreviewCard.Viewport>Popup</PreviewCard.Viewport>
+            </PreviewCard.Popup>
+          </PreviewCard.Positioner>
+        </PreviewCard.Portal>
+      </PreviewCard.Root>,
+    );
 
-    expect(screen.getByTestId('positioner').style.transform).toBe('');
+    const positioner = screen.getByTestId('positioner');
+    await waitForPositioned(positioner);
+    expect(positioner.style.transform).toBe('');
     unmount();
   });
 });

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, expect, vi } from 'vitest';
 import * as React from 'react';
 import { PreviewCard } from '@base-ui/react/preview-card';
-import { screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM, waitSingleFrame } from '#test-utils';
 
 const Trigger = React.forwardRef(function Trigger(
   props: PreviewCard.Trigger.Props,
@@ -21,10 +21,21 @@ type RectLike = {
 };
 
 const multilineWrapperStyle = { width: 140 };
-const multilineTriggerStyle = { display: 'inline', lineHeight: '20px' };
+// These tests dispatch pointer coordinates directly. Exclude the real browser cursor so it cannot
+// generate a competing hover event over a different inline line.
+const multilineTriggerStyle: React.CSSProperties = {
+  display: 'inline',
+  lineHeight: '20px',
+  pointerEvents: 'none',
+};
 
 function expectWithin(actual: number, expected: number, tolerance = 2) {
   expect(Math.abs(actual - expected)).toBeLessThanOrEqual(tolerance);
+}
+
+function hoverAt(element: Element, clientX: number, clientY: number) {
+  fireEvent.mouseEnter(element, { clientX, clientY });
+  fireEvent.mouseMove(element, { clientX, clientY });
 }
 
 // These overrides are safe because each test renders fresh trigger elements before mocking them.
@@ -60,7 +71,7 @@ function mockClientRects(element: Element, rects: RectLike[]) {
 }
 
 describe('<PreviewCard.Positioner />', () => {
-  const { render } = createRenderer();
+  const { render, clock } = createRenderer();
 
   describeConformance(<PreviewCard.Positioner />, () => ({
     refInstanceof: window.HTMLDivElement,
@@ -329,39 +340,55 @@ describe('<PreviewCard.Positioner />', () => {
   });
 
   it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
-    await render(
-      <PreviewCard.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <PreviewCard.Portal>
-          <PreviewCard.Positioner data-testid="positioner">
-            <PreviewCard.Popup style={popupStyle}>Popup</PreviewCard.Popup>
-          </PreviewCard.Positioner>
-        </PreviewCard.Portal>
-      </PreviewCard.Root>,
-    );
+    let unmount = () => {};
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
+    await act(async () => {
+      ({ unmount } = await render(
+        <PreviewCard.Root open>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <PreviewCard.Portal>
+            <PreviewCard.Positioner data-testid="positioner">
+              <PreviewCard.Popup style={popupStyle}>Popup</PreviewCard.Popup>
+            </PreviewCard.Positioner>
+          </PreviewCard.Portal>
+        </PreviewCard.Root>,
+      ));
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+    });
 
     const positioner = screen.getByTestId('positioner');
     expect(positioner.style.transform).not.toBe('');
+    unmount();
   });
 
   it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
-    await render(
-      <PreviewCard.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <PreviewCard.Portal>
-          <PreviewCard.Positioner data-testid="positioner">
-            <PreviewCard.Popup style={popupStyle}>
-              <PreviewCard.Viewport>Popup</PreviewCard.Viewport>
-            </PreviewCard.Popup>
-          </PreviewCard.Positioner>
-        </PreviewCard.Portal>
-      </PreviewCard.Root>,
-    );
+    let unmount = () => {};
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
+    await act(async () => {
+      ({ unmount } = await render(
+        <PreviewCard.Root open>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <PreviewCard.Portal>
+            <PreviewCard.Positioner data-testid="positioner">
+              <PreviewCard.Popup style={popupStyle}>
+                <PreviewCard.Viewport>Popup</PreviewCard.Viewport>
+              </PreviewCard.Popup>
+            </PreviewCard.Positioner>
+          </PreviewCard.Portal>
+        </PreviewCard.Root>,
+      ));
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+    });
 
     const positioner = screen.getByTestId('positioner');
-    await waitFor(() => {
-      expect(positioner.style.transform).toBe('');
-    });
+    expect(positioner.style.transform).toBe('');
+    unmount();
   });
 
   describe.skipIf(isJSDOM)('multiline inline trigger', () => {
@@ -374,7 +401,7 @@ describe('<PreviewCard.Positioner />', () => {
     });
 
     it('positions the popup relative to the hovered line of a multiline trigger', async () => {
-      const { user } = await render(
+      await render(
         <div style={multilineWrapperStyle}>
           <PreviewCard.Root>
             <PreviewCard.Trigger delay={0} data-testid="trigger" style={multilineTriggerStyle}>
@@ -401,13 +428,7 @@ describe('<PreviewCard.Positioner />', () => {
       const secondLineCenterX = secondLineRect.left + secondLineRect.width / 2;
       const secondLineCenterY = secondLineRect.top + secondLineRect.height / 2;
 
-      await user.pointer([
-        { target: document.body },
-        {
-          target: trigger,
-          coords: { clientX: secondLineCenterX, clientY: secondLineCenterY },
-        },
-      ]);
+      hoverAt(trigger, secondLineCenterX, secondLineCenterY);
 
       const positioner = screen.getByTestId('positioner');
       await waitFor(() => {
@@ -429,59 +450,54 @@ describe('<PreviewCard.Positioner />', () => {
       expect(positionerX).toBeLessThanOrEqual(secondLineRect.right + 10);
     });
 
-    it('uses the latest hovered line when opening after a delay', async () => {
-      const { user } = await render(
-        <div style={multilineWrapperStyle}>
-          <PreviewCard.Root>
-            <PreviewCard.Trigger delay={100} data-testid="trigger" style={multilineTriggerStyle}>
-              This is a long text that will wrap across multiple lines in the trigger element
-            </PreviewCard.Trigger>
-            <PreviewCard.Portal>
-              <PreviewCard.Positioner data-testid="positioner" side="bottom" sideOffset={5}>
-                <PreviewCard.Popup style={{ width: 80, height: 40 }}>
-                  Preview Content
-                </PreviewCard.Popup>
-              </PreviewCard.Positioner>
-            </PreviewCard.Portal>
-          </PreviewCard.Root>
-        </div>,
-      );
+    describe('with delayed opening', () => {
+      clock.withFakeTimers();
 
-      const trigger = screen.getByTestId('trigger');
-      const triggerRects = trigger.getClientRects();
+      it('uses the latest hovered line', async () => {
+        await render(
+          <div style={multilineWrapperStyle}>
+            <PreviewCard.Root>
+              <PreviewCard.Trigger delay={100} data-testid="trigger" style={multilineTriggerStyle}>
+                This is a long text that will wrap across multiple lines in the trigger element
+              </PreviewCard.Trigger>
+              <PreviewCard.Portal>
+                <PreviewCard.Positioner data-testid="positioner" side="bottom" sideOffset={5}>
+                  <PreviewCard.Popup style={{ width: 80, height: 40 }}>
+                    Preview Content
+                  </PreviewCard.Popup>
+                </PreviewCard.Positioner>
+              </PreviewCard.Portal>
+            </PreviewCard.Root>
+          </div>,
+        );
 
-      expect(triggerRects.length).toBeGreaterThan(2);
+        const trigger = screen.getByTestId('trigger');
+        const triggerRects = trigger.getClientRects();
 
-      const firstLineRect = triggerRects[0];
-      const secondLineRect = triggerRects[1];
+        expect(triggerRects.length).toBeGreaterThan(2);
 
-      await user.pointer([
-        { target: document.body },
-        {
-          target: trigger,
-          coords: {
-            clientX: firstLineRect.left + firstLineRect.width / 2,
-            clientY: firstLineRect.top + firstLineRect.height / 2,
-          },
-        },
-      ]);
+        const firstLineRect = triggerRects[0];
+        const secondLineRect = triggerRects[1];
 
-      await user.pointer([
-        {
-          target: trigger,
-          coords: {
-            clientX: secondLineRect.left + secondLineRect.width / 2,
-            clientY: secondLineRect.top + secondLineRect.height / 2,
-          },
-        },
-      ]);
+        fireEvent.mouseEnter(trigger, {
+          clientX: firstLineRect.left + firstLineRect.width / 2,
+          clientY: firstLineRect.top + firstLineRect.height / 2,
+        });
+        fireEvent.mouseMove(trigger, {
+          clientX: firstLineRect.left + firstLineRect.width / 2,
+          clientY: firstLineRect.top + firstLineRect.height / 2,
+        });
+        fireEvent.mouseMove(trigger, {
+          clientX: secondLineRect.left + secondLineRect.width / 2,
+          clientY: secondLineRect.top + secondLineRect.height / 2,
+        });
 
-      const positioner = await screen.findByTestId('positioner');
-      await waitFor(() => {
-        expect(positioner).toBeVisible();
-      });
+        expect(screen.queryByTestId('positioner')).toBe(null);
 
-      await waitFor(() => {
+        await clock.tickAsync(100);
+        await clock.tickAsync(16);
+
+        const positioner = screen.getByTestId('positioner');
         expectWithin(positioner.getBoundingClientRect().y, secondLineRect.bottom + 5);
       });
     });
@@ -491,7 +507,7 @@ describe('<PreviewCard.Positioner />', () => {
       document.body.style.height = '4000px';
       document.body.style.margin = '0';
 
-      const { user } = await render(
+      await render(
         <div>
           <div style={{ height: 1200 }} />
           <div style={multilineWrapperStyle}>
@@ -527,13 +543,7 @@ describe('<PreviewCard.Positioner />', () => {
       const secondLineCenterX = secondLineRect.left + secondLineRect.width / 2;
       const secondLineCenterY = secondLineRect.top + secondLineRect.height / 2;
 
-      await user.pointer([
-        { target: document.body },
-        {
-          target: trigger,
-          coords: { clientX: secondLineCenterX, clientY: secondLineCenterY },
-        },
-      ]);
+      hoverAt(trigger, secondLineCenterX, secondLineCenterY);
 
       const positioner = screen.getByTestId('positioner');
       await waitFor(() => {
@@ -553,7 +563,7 @@ describe('<PreviewCard.Positioner />', () => {
 
     it('stays anchored to the opened line while already open', async () => {
       let positionUpdateCount = 0;
-      const { user } = await render(
+      await render(
         <div style={multilineWrapperStyle}>
           <PreviewCard.Root>
             <PreviewCard.Trigger delay={0} data-testid="trigger" style={multilineTriggerStyle}>
@@ -585,16 +595,11 @@ describe('<PreviewCard.Positioner />', () => {
       const firstLineRect = triggerRects[0];
       const secondLineRect = triggerRects[1];
 
-      await user.pointer([
-        { target: document.body },
-        {
-          target: trigger,
-          coords: {
-            clientX: firstLineRect.left + firstLineRect.width / 2,
-            clientY: firstLineRect.top + firstLineRect.height / 2,
-          },
-        },
-      ]);
+      hoverAt(
+        trigger,
+        firstLineRect.left + firstLineRect.width / 2,
+        firstLineRect.top + firstLineRect.height / 2,
+      );
 
       const positioner = screen.getByTestId('positioner');
       await waitFor(() => {
@@ -602,16 +607,12 @@ describe('<PreviewCard.Positioner />', () => {
       });
       const positionUpdateCountBeforeReentry = positionUpdateCount;
 
-      await user.pointer([
-        { target: document.body },
-        {
-          target: trigger,
-          coords: {
-            clientX: secondLineRect.left + secondLineRect.width / 2,
-            clientY: secondLineRect.top + secondLineRect.height / 2,
-          },
-        },
-      ]);
+      fireEvent.mouseLeave(trigger);
+      hoverAt(
+        trigger,
+        secondLineRect.left + secondLineRect.width / 2,
+        secondLineRect.top + secondLineRect.height / 2,
+      );
 
       window.dispatchEvent(new Event('resize'));
       await waitFor(() => {
@@ -629,16 +630,21 @@ describe('<PreviewCard.Positioner />', () => {
           to { opacity: 0.01; }
         }
         [data-testid="popup"][data-ending-style] {
-          animation: preview-card-inline-reentry-close-transition 50ms linear forwards;
+          animation: preview-card-inline-reentry-close-transition 1000ms linear forwards;
         }
       `;
 
-      const { user } = await render(
+      await render(
         <React.Fragment>
           <style>{style}</style>
           <div style={multilineWrapperStyle}>
             <PreviewCard.Root>
-              <PreviewCard.Trigger delay={0} data-testid="trigger" style={multilineTriggerStyle}>
+              <PreviewCard.Trigger
+                delay={0}
+                closeDelay={0}
+                data-testid="trigger"
+                style={multilineTriggerStyle}
+              >
                 This is a long text that will wrap across multiple lines in the trigger element
               </PreviewCard.Trigger>
               <PreviewCard.Portal>
@@ -661,36 +667,30 @@ describe('<PreviewCard.Positioner />', () => {
       const firstLineRect = triggerRects[0];
       const secondLineRect = triggerRects[1];
 
-      await user.pointer([
-        { target: document.body },
-        {
-          target: trigger,
-          coords: {
-            clientX: firstLineRect.left + firstLineRect.width / 2,
-            clientY: firstLineRect.top + firstLineRect.height / 2,
-          },
-        },
-      ]);
+      hoverAt(
+        trigger,
+        firstLineRect.left + firstLineRect.width / 2,
+        firstLineRect.top + firstLineRect.height / 2,
+      );
 
       const positioner = screen.getByTestId('positioner');
       await waitFor(() => {
         expectWithin(positioner.getBoundingClientRect().y, firstLineRect.bottom + 5);
       });
 
-      await user.pointer([{ target: document.body, coords: { clientX: 300, clientY: 300 } }]);
+      fireEvent.mouseLeave(trigger);
       await waitFor(() => {
         expect(screen.getByTestId('popup')).toHaveAttribute('data-ending-style');
       });
 
-      await user.pointer([
-        {
-          target: trigger,
-          coords: {
-            clientX: secondLineRect.left + secondLineRect.width / 2,
-            clientY: secondLineRect.top + secondLineRect.height / 2,
-          },
-        },
-      ]);
+      fireEvent.mouseMove(trigger, {
+        clientX: secondLineRect.left + secondLineRect.width / 2,
+        clientY: secondLineRect.top + secondLineRect.height / 2,
+      });
+      fireEvent.mouseEnter(trigger, {
+        clientX: secondLineRect.left + secondLineRect.width / 2,
+        clientY: secondLineRect.top + secondLineRect.height / 2,
+      });
 
       await waitFor(() => {
         expectWithin(positioner.getBoundingClientRect().y, secondLineRect.bottom + 5);
@@ -798,35 +798,30 @@ describe('<PreviewCard.Positioner />', () => {
         );
       }
 
-      const { user } = await render(<Test />);
+      await render(<Test />);
       const trigger = screen.getByTestId('trigger');
       const triggerRects = trigger.getClientRects();
 
       expect(triggerRects.length).toBeGreaterThan(2);
 
       const secondLineRect = triggerRects[1];
-      await user.pointer([
-        { target: document.body },
-        {
-          target: trigger,
-          coords: {
-            clientX: secondLineRect.left + secondLineRect.width / 2,
-            clientY: secondLineRect.top + secondLineRect.height / 2,
-          },
-        },
-      ]);
+      hoverAt(
+        trigger,
+        secondLineRect.left + secondLineRect.width / 2,
+        secondLineRect.top + secondLineRect.height / 2,
+      );
 
       const positioner = screen.getByTestId('positioner');
       await waitFor(() => {
         expectWithin(positioner.getBoundingClientRect().y, secondLineRect.bottom + sideOffset);
       });
 
-      await user.click(screen.getByRole('button', { name: 'Close' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Close' }));
       await waitFor(() => {
         expect(positioner).toHaveAttribute('hidden');
       });
 
-      await user.click(screen.getByRole('button', { name: 'Open' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Open' }));
 
       const targetRect = triggerRects[triggerRects.length - 1];
       await waitFor(() => {
@@ -858,7 +853,7 @@ describe('<PreviewCard.Positioner />', () => {
                 id="trigger-1"
                 data-testid="trigger-1"
                 delay={0}
-                style={{ display: 'inline' }}
+                style={{ display: 'inline', pointerEvents: 'none' }}
               >
                 Trigger 1
               </PreviewCard.Trigger>
@@ -867,7 +862,7 @@ describe('<PreviewCard.Positioner />', () => {
                 id="trigger-2"
                 data-testid="trigger-2"
                 delay={0}
-                style={{ display: 'inline' }}
+                style={{ display: 'inline', pointerEvents: 'none' }}
               >
                 Trigger 2
               </PreviewCard.Trigger>
@@ -893,7 +888,7 @@ describe('<PreviewCard.Positioner />', () => {
         );
       }
 
-      const { user } = await render(<Test />);
+      await render(<Test />);
       const trigger1 = screen.getByTestId('trigger-1');
       const trigger2 = screen.getByTestId('trigger-2');
 
@@ -906,16 +901,13 @@ describe('<PreviewCard.Positioner />', () => {
         { left: 100, top: 120, right: 160, bottom: 130, width: 60, height: 10 },
       ]);
 
-      await user.pointer([
-        { target: document.body },
-        { target: trigger1, coords: { clientX: 200, clientY: 5 } },
-      ]);
+      hoverAt(trigger1, 200, 5);
 
       await waitFor(() => {
         expect(screen.getByTestId('positioner')).toBeVisible();
       });
 
-      await user.click(screen.getByRole('button', { name: 'Switch' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Switch' }));
 
       const positioner = screen.getByTestId('positioner');
 
@@ -939,7 +931,13 @@ describe('<PreviewCard.Positioner />', () => {
           <div>
             <div ref={setPortalContainer} data-testid="portal-container" />
             <PreviewCard.Root>
-              <PreviewCard.Trigger ref={triggerRef} href="#" delay={0} data-testid="trigger">
+              <PreviewCard.Trigger
+                ref={triggerRef}
+                href="#"
+                delay={0}
+                data-testid="trigger"
+                style={{ pointerEvents: 'none' }}
+              >
                 Trigger
               </PreviewCard.Trigger>
               <PreviewCard.Portal keepMounted container={portalContainer}>
@@ -961,7 +959,7 @@ describe('<PreviewCard.Positioner />', () => {
         );
       }
 
-      const { user } = await render(<Test />);
+      await render(<Test />);
       const portalContainer = screen.getByTestId('portal-container');
       const trigger = screen.getByTestId('trigger');
       const positioner = screen.getByTestId('positioner');
@@ -971,10 +969,7 @@ describe('<PreviewCard.Positioner />', () => {
         { left: 0, top: 100, right: 60, bottom: 110, width: 60, height: 10 },
       ]);
 
-      await user.pointer([
-        { target: document.body },
-        { target: trigger, coords: { clientX: 30, clientY: 105 } },
-      ]);
+      hoverAt(trigger, 30, 105);
 
       await waitFor(() => {
         expect(positioner).toBeVisible();
@@ -1089,16 +1084,11 @@ describe('<PreviewCard.Positioner />', () => {
       expect(triggerRects.length).toBeGreaterThan(2);
 
       const secondLineRect = triggerRects[1];
-      await user.pointer([
-        { target: document.body },
-        {
-          target: trigger,
-          coords: {
-            clientX: secondLineRect.left + secondLineRect.width / 2,
-            clientY: secondLineRect.top + secondLineRect.height / 2,
-          },
-        },
-      ]);
+      hoverAt(
+        trigger,
+        secondLineRect.left + secondLineRect.width / 2,
+        secondLineRect.top + secondLineRect.height / 2,
+      );
 
       const targetRect = triggerRects[0];
       const expectedY = targetRect.top - inlinePopupHeight - sideOffset;
@@ -1118,36 +1108,52 @@ describe('<PreviewCard.Positioner />', () => {
   });
 
   it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
-    await render(
-      <PreviewCard.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <PreviewCard.Portal>
-          <PreviewCard.Positioner data-testid="positioner">
-            <PreviewCard.Popup style={popupStyle}>Popup</PreviewCard.Popup>
-          </PreviewCard.Positioner>
-        </PreviewCard.Portal>
-      </PreviewCard.Root>,
-    );
+    let unmount = () => {};
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
+    await act(async () => {
+      ({ unmount } = await render(
+        <PreviewCard.Root open>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <PreviewCard.Portal>
+            <PreviewCard.Positioner data-testid="positioner">
+              <PreviewCard.Popup style={popupStyle}>Popup</PreviewCard.Popup>
+            </PreviewCard.Positioner>
+          </PreviewCard.Portal>
+        </PreviewCard.Root>,
+      ));
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+    });
 
     expect(screen.getByTestId('positioner').style.transform).not.toBe('');
+    unmount();
   });
 
   it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
-    await render(
-      <PreviewCard.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <PreviewCard.Portal>
-          <PreviewCard.Positioner data-testid="positioner">
-            <PreviewCard.Popup style={popupStyle}>
-              <PreviewCard.Viewport>Popup</PreviewCard.Viewport>
-            </PreviewCard.Popup>
-          </PreviewCard.Positioner>
-        </PreviewCard.Portal>
-      </PreviewCard.Root>,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('positioner').style.transform).toBe('');
+    let unmount = () => {};
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
+    await act(async () => {
+      ({ unmount } = await render(
+        <PreviewCard.Root open>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <PreviewCard.Portal>
+            <PreviewCard.Positioner data-testid="positioner">
+              <PreviewCard.Popup style={popupStyle}>
+                <PreviewCard.Viewport>Popup</PreviewCard.Viewport>
+              </PreviewCard.Popup>
+            </PreviewCard.Positioner>
+          </PreviewCard.Portal>
+        </PreviewCard.Root>,
+      ));
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
     });
+
+    expect(screen.getByTestId('positioner').style.transform).toBe('');
+    unmount();
   });
 });

--- a/packages/react/src/preview-card/root/PreviewCardRoot.detached-triggers.test.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.detached-triggers.test.tsx
@@ -2,7 +2,14 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { createRenderer, isJSDOM } from '#test-utils';
 import { PreviewCard } from '@base-ui/react/preview-card';
-import { screen, waitFor, randomStringValue, act, flushMicrotasks } from '@mui/internal-test-utils';
+import {
+  screen,
+  waitFor,
+  randomStringValue,
+  act,
+  fireEvent,
+  flushMicrotasks,
+} from '@mui/internal-test-utils';
 import { OPEN_DELAY } from '../utils/constants';
 
 const CLOSE_TRANSITION_MS = 50;
@@ -296,7 +303,7 @@ describe('<PreviewCard.Root />', () => {
 
     it('should open the preview card with any trigger on hover', async () => {
       const popupId = randomStringValue();
-      const { user } = await render(
+      await render(
         <PreviewCard.Root>
           <button type="button" aria-label="Initial focus" autoFocus />
           <PreviewCard.Trigger href="#" delay={0}>
@@ -325,23 +332,26 @@ describe('<PreviewCard.Root />', () => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger1);
+      fireEvent.mouseEnter(trigger1);
+      fireEvent.mouseMove(trigger1);
       expect(screen.queryByTestId(popupId)).toBeVisible();
-      await user.hover(document.body);
+      fireEvent.mouseLeave(trigger1);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger2);
+      fireEvent.mouseEnter(trigger2);
+      fireEvent.mouseMove(trigger2);
       expect(screen.queryByTestId(popupId)).toBeVisible();
-      await user.hover(document.body);
+      fireEvent.mouseLeave(trigger2);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger3);
+      fireEvent.mouseEnter(trigger3);
+      fireEvent.mouseMove(trigger3);
       expect(screen.queryByTestId(popupId)).toBeVisible();
-      await user.hover(document.body);
+      fireEvent.mouseLeave(trigger3);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
@@ -771,10 +781,21 @@ describe('<PreviewCard.Root />', () => {
           {({ payload }: NumberPayload) => (
             <React.Fragment>
               <button type="button" aria-label="Initial focus" autoFocus />
-              <PreviewCard.Trigger href="#" handle={testPreviewCard} payload={1}>
+              <PreviewCard.Trigger
+                href="#"
+                handle={testPreviewCard}
+                payload={1}
+                style={{ pointerEvents: 'none' }}
+              >
                 Trigger 1
               </PreviewCard.Trigger>
-              <PreviewCard.Trigger href="#" handle={testPreviewCard} payload={2} id={triggerId}>
+              <PreviewCard.Trigger
+                href="#"
+                handle={testPreviewCard}
+                payload={2}
+                id={triggerId}
+                style={{ pointerEvents: 'none' }}
+              >
                 Trigger 2
               </PreviewCard.Trigger>
               <PreviewCard.Portal>
@@ -801,7 +822,7 @@ describe('<PreviewCard.Root />', () => {
     it('should open the preview card with any trigger on hover', async () => {
       const testPreviewCard = PreviewCard.createHandle();
       const popupId = randomStringValue();
-      const { user } = await render(
+      await render(
         <div>
           <button type="button" aria-label="Initial focus" autoFocus />
           <PreviewCard.Trigger href="#" handle={testPreviewCard} delay={0}>
@@ -832,29 +853,32 @@ describe('<PreviewCard.Root />', () => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger1);
+      fireEvent.mouseEnter(trigger1);
+      fireEvent.mouseMove(trigger1);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBeVisible();
       });
-      await user.unhover(trigger1);
+      fireEvent.mouseLeave(trigger1);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger2);
+      fireEvent.mouseEnter(trigger2);
+      fireEvent.mouseMove(trigger2);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBeVisible();
       });
-      await user.unhover(trigger2);
+      fireEvent.mouseLeave(trigger2);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger3);
+      fireEvent.mouseEnter(trigger3);
+      fireEvent.mouseMove(trigger3);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBeVisible();
       });
-      await user.unhover(trigger3);
+      fireEvent.mouseLeave(trigger3);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
@@ -865,13 +889,28 @@ describe('<PreviewCard.Root />', () => {
       await render(
         <div>
           <button type="button" aria-label="Initial focus" autoFocus />
-          <PreviewCard.Trigger href="#" handle={testPreviewCard} delay={0}>
+          <PreviewCard.Trigger
+            href="#"
+            handle={testPreviewCard}
+            delay={0}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 1
           </PreviewCard.Trigger>
-          <PreviewCard.Trigger href="#" handle={testPreviewCard} delay={0}>
+          <PreviewCard.Trigger
+            href="#"
+            handle={testPreviewCard}
+            delay={0}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 2
           </PreviewCard.Trigger>
-          <PreviewCard.Trigger href="#" handle={testPreviewCard} delay={0}>
+          <PreviewCard.Trigger
+            href="#"
+            handle={testPreviewCard}
+            delay={0}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 3
           </PreviewCard.Trigger>
 
@@ -1212,10 +1251,21 @@ describe('<PreviewCard.Root />', () => {
       await render(
         <React.Fragment>
           <button type="button" aria-label="Initial focus" autoFocus />
-          <PreviewCard.Trigger href="#" handle={testPreviewCard} payload={1}>
+          <PreviewCard.Trigger
+            href="#"
+            handle={testPreviewCard}
+            payload={1}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 1
           </PreviewCard.Trigger>
-          <PreviewCard.Trigger href="#" handle={testPreviewCard} payload={2} id={triggerId}>
+          <PreviewCard.Trigger
+            href="#"
+            handle={testPreviewCard}
+            payload={2}
+            id={triggerId}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 2
           </PreviewCard.Trigger>
 

--- a/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
@@ -14,6 +14,14 @@ describe('<PreviewCard.Root />', () => {
 
   const { render, clock } = createRenderer();
 
+  async function tick(ms: number) {
+    await flushMicrotasks();
+    await act(async () => {
+      await clock.tickAsync(ms);
+    });
+    await flushMicrotasks();
+  }
+
   popupConformanceTests({
     createComponent: (props) => (
       <PreviewCard.Root {...props.root}>
@@ -48,7 +56,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(trigger);
         fireEvent.mouseMove(trigger);
 
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
 
         await flushMicrotasks();
 
@@ -64,13 +72,15 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(trigger);
         fireEvent.mouseMove(trigger);
 
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
 
         await flushMicrotasks();
 
         fireEvent.mouseLeave(trigger);
 
-        clock.tick(CLOSE_DELAY);
+        await flushMicrotasks();
+
+        await tick(CLOSE_DELAY);
 
         expect(screen.queryByText('Content')).toBe(null);
       });
@@ -87,7 +97,7 @@ describe('<PreviewCard.Root />', () => {
 
         await act(async () => trigger.focus());
 
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
 
         await flushMicrotasks();
 
@@ -100,11 +110,11 @@ describe('<PreviewCard.Root />', () => {
         const trigger = screen.getByRole('link', { name: 'Link' });
 
         await act(async () => trigger.focus());
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
         await flushMicrotasks();
 
         await act(async () => trigger.blur());
-        clock.tick(CLOSE_DELAY);
+        await tick(CLOSE_DELAY);
 
         expect(screen.queryByText('Content')).toBe(null);
       });
@@ -141,7 +151,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(trigger);
         fireEvent.mouseMove(trigger);
 
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
 
         await flushMicrotasks();
 
@@ -149,7 +159,9 @@ describe('<PreviewCard.Root />', () => {
 
         fireEvent.mouseLeave(trigger);
 
-        clock.tick(CLOSE_DELAY);
+        await flushMicrotasks();
+
+        await tick(CLOSE_DELAY);
 
         expect(screen.queryByText('Content')).toBe(null);
         expect(handleChange.mock.calls.length).toBe(2);
@@ -182,7 +194,9 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(positioner);
         fireEvent.mouseLeave(positioner);
 
-        clock.tick(CLOSE_DELAY);
+        await flushMicrotasks();
+
+        await tick(CLOSE_DELAY);
 
         await flushMicrotasks();
 
@@ -203,7 +217,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(trigger);
         fireEvent.mouseMove(trigger);
 
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
         await flushMicrotasks();
 
         expect(screen.queryByText('Content')).not.toBe(null);
@@ -213,7 +227,9 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(positioner);
         fireEvent.mouseLeave(positioner);
 
-        clock.tick(CLOSE_DELAY);
+        await flushMicrotasks();
+
+        await tick(CLOSE_DELAY);
         await flushMicrotasks();
 
         expect(screen.queryByText('Content')).toBe(null);
@@ -247,7 +263,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(trigger);
         fireEvent.mouseMove(trigger);
 
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
 
         await flushMicrotasks();
 
@@ -313,7 +329,9 @@ describe('<PreviewCard.Root />', () => {
 
         fireEvent.mouseLeave(trigger);
 
-        clock.tick(CLOSE_DELAY);
+        await flushMicrotasks();
+
+        await tick(CLOSE_DELAY);
 
         expect(screen.queryByText('Content')).toBe(null);
       });
@@ -334,7 +352,9 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(positioner);
         fireEvent.mouseLeave(positioner);
 
-        clock.tick(CLOSE_DELAY);
+        await flushMicrotasks();
+
+        await tick(CLOSE_DELAY);
         await flushMicrotasks();
 
         expect(screen.getByText('Content')).not.toBe(null);
@@ -356,7 +376,7 @@ describe('<PreviewCard.Root />', () => {
 
         expect(screen.queryByText('Content')).toBe(null);
 
-        clock.tick(100);
+        await tick(100);
 
         await flushMicrotasks();
 
@@ -375,7 +395,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(trigger);
         fireEvent.mouseMove(trigger);
 
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
 
         await flushMicrotasks();
 
@@ -385,7 +405,7 @@ describe('<PreviewCard.Root />', () => {
 
         expect(screen.getByText('Content')).not.toBe(null);
 
-        clock.tick(100);
+        await tick(100);
 
         expect(screen.queryByText('Content')).toBe(null);
       });
@@ -427,7 +447,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(trigger);
         fireEvent.mouseMove(trigger);
 
-        clock.tick(100);
+        await tick(100);
         await flushMicrotasks();
 
         expect(screen.getByText('Content')).not.toBe(null);
@@ -442,7 +462,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(trigger);
         fireEvent.mouseMove(trigger);
 
-        clock.tick(100);
+        await tick(100);
         await flushMicrotasks();
 
         expect(screen.getByText('Content')).not.toBe(null);
@@ -969,7 +989,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(childTrigger);
         fireEvent.mouseMove(childTrigger);
 
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
         await flushMicrotasks();
 
         let childPopup = screen.getByTestId('child-popup').parentElement!;
@@ -980,14 +1000,14 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseMove(document.body);
 
         // Advance partway through close delay but not all the way
-        clock.tick(CLOSE_DELAY / 2);
+        await tick(CLOSE_DELAY / 2);
         await flushMicrotasks();
 
         // Step 4: Re-enter parent popup before it closes
         fireEvent.mouseEnter(parentPopup);
 
         // Let the child's close delay finish — child closes
-        clock.tick(CLOSE_DELAY);
+        await tick(CLOSE_DELAY);
         await flushMicrotasks();
 
         // Parent should still be open
@@ -998,7 +1018,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseEnter(childTrigger);
         fireEvent.mouseMove(childTrigger);
 
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
         await flushMicrotasks();
 
         // Parent and child should be open
@@ -1009,7 +1029,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseLeave(parentPopup, { relatedTarget: childPopup });
         fireEvent.mouseEnter(childPopup);
 
-        clock.tick(CLOSE_DELAY);
+        await tick(CLOSE_DELAY);
 
         expect(screen.queryByTestId('parent-popup')).not.toBe(null);
         expect(screen.queryByTestId('child-popup')).not.toBe(null);
@@ -1053,7 +1073,7 @@ describe('<PreviewCard.Root />', () => {
 
         const parentTrigger = screen.getByTestId('parent-trigger');
         fireEvent.mouseEnter(parentTrigger);
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
 
         // Events must be triggered on positioner elements (parent of popup)
         const parentPopup = screen.getByTestId('parent-popup').parentElement!;
@@ -1062,7 +1082,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseLeave(parentTrigger, { relatedTarget: parentPopup });
         fireEvent.mouseEnter(parentPopup);
         fireEvent.mouseEnter(childTrigger);
-        clock.tick(OPEN_DELAY);
+        await tick(OPEN_DELAY);
 
         const childPopup = screen.getByTestId('child-popup').parentElement!;
 
@@ -1072,7 +1092,7 @@ describe('<PreviewCard.Root />', () => {
         fireEvent.mouseLeave(childPopup);
         fireEvent.mouseMove(document.body);
 
-        clock.tick(CLOSE_DELAY + 10);
+        await tick(CLOSE_DELAY + 10);
         await flushMicrotasks();
 
         expect(screen.queryByTestId('child-popup')).toBe(null);

--- a/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { act, fireEvent, screen, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
-import { createRenderer, isJSDOM, popupConformanceTests } from '#test-utils';
+import { advanceReactClock, createRenderer, isJSDOM, popupConformanceTests } from '#test-utils';
 import { REASONS } from '../../internals/reasons';
 import { CLOSE_DELAY, OPEN_DELAY } from '../utils/constants';
 
@@ -15,11 +15,7 @@ describe('<PreviewCard.Root />', () => {
   const { render, clock } = createRenderer();
 
   async function tick(ms: number) {
-    await flushMicrotasks();
-    await act(async () => {
-      await clock.tickAsync(ms);
-    });
-    await flushMicrotasks();
+    await advanceReactClock(clock, ms);
   }
 
   popupConformanceTests({

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.test.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.test.tsx
@@ -259,9 +259,9 @@ describe('<ScrollArea.Viewport />', () => {
 
       expect(viewport).not.toHaveAttribute('data-scrolling');
 
-      // A mouse pointerdown on the root (not the viewport, whose own
+      // A mouse pointermove on the root (not the viewport, whose own
       // handlers mark user interaction) switches back to mouse modality.
-      fireEvent.pointerDown(root, { pointerType: 'mouse' });
+      fireEvent.pointerMove(root, { pointerType: 'mouse' });
       fireEvent.scroll(viewport, { target: { scrollTop: 2 } });
 
       expect(viewport).not.toHaveAttribute('data-scrolling');

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.test.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.test.tsx
@@ -259,9 +259,9 @@ describe('<ScrollArea.Viewport />', () => {
 
       expect(viewport).not.toHaveAttribute('data-scrolling');
 
-      // A mouse pointer event on the root (not the viewport, whose own
+      // A mouse pointerdown on the root (not the viewport, whose own
       // handlers mark user interaction) switches back to mouse modality.
-      fireEvent.pointerMove(root, { pointerType: 'mouse' });
+      fireEvent.pointerDown(root, { pointerType: 'mouse' });
       fireEvent.scroll(viewport, { target: { scrollTop: 2 } });
 
       expect(viewport).not.toHaveAttribute('data-scrolling');

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -2276,12 +2276,6 @@ describe('<Tabs.Root />', () => {
 
       await user.click(screen.getByText('Add and Select'));
 
-      const leftDirectionCall = panelRenderMock.mock.calls.find(
-        ([state]) => state.tabActivationDirection === 'left',
-      );
-      expect(leftDirectionCall?.[0]).toEqual(
-        expect.objectContaining({ tabActivationDirection: 'left' }),
-      );
       expect(panelRenderMock).toHaveBeenLastCalledWith(
         expect.objectContaining({ tabActivationDirection: 'right' }),
       );

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -2276,8 +2276,10 @@ describe('<Tabs.Root />', () => {
 
       await user.click(screen.getByText('Add and Select'));
 
-      expect(panelRenderMock).toHaveBeenNthCalledWith(
-        1,
+      const leftDirectionCall = panelRenderMock.mock.calls.find(
+        ([state]) => state.tabActivationDirection === 'left',
+      );
+      expect(leftDirectionCall?.[0]).toEqual(
         expect.objectContaining({ tabActivationDirection: 'left' }),
       );
       expect(panelRenderMock).toHaveBeenLastCalledWith(

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
@@ -1,8 +1,8 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { act, screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM, waitSingleFrame } from '#test-utils';
 
 const Trigger = React.forwardRef(function Trigger(
   props: Tooltip.Trigger.Props,
@@ -293,39 +293,55 @@ describe('<Tooltip.Positioner />', () => {
   });
 
   it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
-    await render(
-      <Tooltip.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <Tooltip.Portal>
-          <Tooltip.Positioner data-testid="positioner">
-            <Tooltip.Popup style={popupStyle}>Popup</Tooltip.Popup>
-          </Tooltip.Positioner>
-        </Tooltip.Portal>
-      </Tooltip.Root>,
-    );
+    let unmount = () => {};
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
+    await act(async () => {
+      ({ unmount } = await render(
+        <Tooltip.Root open>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Positioner data-testid="positioner">
+              <Tooltip.Popup style={popupStyle}>Popup</Tooltip.Popup>
+            </Tooltip.Positioner>
+          </Tooltip.Portal>
+        </Tooltip.Root>,
+      ));
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+    });
 
     const positioner = screen.getByTestId('positioner');
     expect(positioner.style.transform).not.toBe('');
+    unmount();
   });
 
   it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
-    await render(
-      <Tooltip.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <Tooltip.Portal>
-          <Tooltip.Positioner data-testid="positioner">
-            <Tooltip.Popup style={popupStyle}>
-              <Tooltip.Viewport>Popup</Tooltip.Viewport>
-            </Tooltip.Popup>
-          </Tooltip.Positioner>
-        </Tooltip.Portal>
-      </Tooltip.Root>,
-    );
+    let unmount = () => {};
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
+    await act(async () => {
+      ({ unmount } = await render(
+        <Tooltip.Root open>
+          <Trigger style={triggerStyle}>Trigger</Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Positioner data-testid="positioner">
+              <Tooltip.Popup style={popupStyle}>
+                <Tooltip.Viewport>Popup</Tooltip.Viewport>
+              </Tooltip.Popup>
+            </Tooltip.Positioner>
+          </Tooltip.Portal>
+        </Tooltip.Root>,
+      ));
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+    });
 
     const positioner = screen.getByTestId('positioner');
-    await waitFor(() => {
-      expect(positioner.style.transform).toBe('');
-    });
+    expect(positioner.style.transform).toBe('');
+    unmount();
   });
 
   it.skipIf(isJSDOM)('updates positioning when Viewport mounts and unmounts', async () => {

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
@@ -1,8 +1,8 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { act, screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, describeConformance, isJSDOM, waitSingleFrame } from '#test-utils';
+import { screen, waitFor } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, isJSDOM, waitForPositioned } from '#test-utils';
 
 const Trigger = React.forwardRef(function Trigger(
   props: Tooltip.Trigger.Props,
@@ -293,53 +293,40 @@ describe('<Tooltip.Positioner />', () => {
   });
 
   it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
-    let unmount = () => {};
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
-    await act(async () => {
-      ({ unmount } = await render(
-        <Tooltip.Root open>
-          <Trigger style={triggerStyle}>Trigger</Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner data-testid="positioner">
-              <Tooltip.Popup style={popupStyle}>Popup</Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
-        </Tooltip.Root>,
-      ));
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-    });
+    const { unmount } = await render(
+      <Tooltip.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Positioner data-testid="positioner">
+            <Tooltip.Popup style={popupStyle}>Popup</Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>,
+    );
 
     const positioner = screen.getByTestId('positioner');
-    expect(positioner.style.transform).not.toBe('');
+    await waitFor(() => {
+      expect(positioner.style.transform).not.toBe('');
+    });
     unmount();
   });
 
   it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
-    let unmount = () => {};
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- keep initial browser positioning work inside one act boundary
-    await act(async () => {
-      ({ unmount } = await render(
-        <Tooltip.Root open>
-          <Trigger style={triggerStyle}>Trigger</Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner data-testid="positioner">
-              <Tooltip.Popup style={popupStyle}>
-                <Tooltip.Viewport>Popup</Tooltip.Viewport>
-              </Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
-        </Tooltip.Root>,
-      ));
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-      await waitSingleFrame();
-    });
+    const { unmount } = await render(
+      <Tooltip.Root open>
+        <Trigger style={triggerStyle}>Trigger</Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Positioner data-testid="positioner">
+            <Tooltip.Popup style={popupStyle}>
+              <Tooltip.Viewport>Popup</Tooltip.Viewport>
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>,
+    );
 
     const positioner = screen.getByTestId('positioner');
+    await waitForPositioned(positioner);
     expect(positioner.style.transform).toBe('');
     unmount();
   });

--- a/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
+++ b/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
@@ -7,6 +7,13 @@ import { OPEN_DELAY } from '../utils/constants';
 describe('<Tooltip.Provider />', () => {
   const { render, clock } = createRenderer();
 
+  async function tick(ms: number) {
+    await flushMicrotasks();
+    await act(async () => {
+      await clock.tickAsync(ms);
+    });
+  }
+
   describe('prop: delay', () => {
     clock.withFakeTimers();
 
@@ -29,15 +36,15 @@ describe('<Tooltip.Provider />', () => {
       fireEvent.mouseEnter(trigger);
       fireEvent.mouseMove(trigger);
 
-      expect(screen.queryByText('Content')).toBe(null);
-
-      clock.tick(1_000);
-
-      expect(screen.queryByText('Content')).toBe(null);
-
-      clock.tick(9_000);
-
       await flushMicrotasks();
+
+      expect(screen.queryByText('Content')).toBe(null);
+
+      await tick(1_000);
+
+      expect(screen.queryByText('Content')).toBe(null);
+
+      await tick(9_000);
 
       expect(screen.queryByText('Content')).not.toBe(null);
     });
@@ -61,7 +68,9 @@ describe('<Tooltip.Provider />', () => {
       fireEvent.mouseEnter(trigger);
       fireEvent.mouseMove(trigger);
 
-      clock.tick(0);
+      await flushMicrotasks();
+
+      await tick(0);
 
       expect(screen.queryByText('Content')).not.toBe(null);
     });
@@ -85,15 +94,15 @@ describe('<Tooltip.Provider />', () => {
       fireEvent.mouseEnter(trigger);
       fireEvent.mouseMove(trigger);
 
-      expect(screen.queryByText('Content')).toBe(null);
-
-      clock.tick(99);
-
-      expect(screen.queryByText('Content')).toBe(null);
-
-      clock.tick(1);
-
       await flushMicrotasks();
+
+      expect(screen.queryByText('Content')).toBe(null);
+
+      await tick(99);
+
+      expect(screen.queryByText('Content')).toBe(null);
+
+      await tick(1);
 
       expect(screen.queryByText('Content')).not.toBe(null);
     });
@@ -121,19 +130,21 @@ describe('<Tooltip.Provider />', () => {
       fireEvent.mouseEnter(trigger);
       fireEvent.mouseMove(trigger);
 
-      clock.tick(OPEN_DELAY);
-
       await flushMicrotasks();
+
+      await tick(OPEN_DELAY);
 
       expect(screen.queryByText('Content')).not.toBe(null);
 
       fireEvent.mouseLeave(trigger);
 
-      clock.tick(300);
+      await flushMicrotasks();
+
+      await tick(300);
 
       expect(screen.queryByText('Content')).not.toBe(null);
 
-      clock.tick(300);
+      await tick(300);
 
       expect(screen.queryByText('Content')).toBe(null);
     });
@@ -161,9 +172,9 @@ describe('<Tooltip.Provider />', () => {
       fireEvent.mouseEnter(trigger);
       fireEvent.mouseMove(trigger);
 
-      clock.tick(OPEN_DELAY);
-
       await flushMicrotasks();
+
+      await tick(OPEN_DELAY);
 
       expect(screen.queryByText('Content')).not.toBe(null);
 
@@ -171,11 +182,13 @@ describe('<Tooltip.Provider />', () => {
 
       fireEvent.mouseLeave(trigger);
 
-      clock.tick(999);
+      await flushMicrotasks();
+
+      await tick(999);
 
       expect(screen.queryByText('Content')).not.toBe(null);
 
-      clock.tick(1);
+      await tick(1);
 
       expect(screen.queryByText('Content')).toBe(null);
     });
@@ -209,18 +222,16 @@ describe('<Tooltip.Provider />', () => {
 
       fireEvent.mouseEnter(first);
       fireEvent.mouseMove(first);
-      await act(async () => {
-        clock.tick(100);
-      });
+      await flushMicrotasks();
+      await tick(100);
 
       expect(screen.queryByText('Content One')).not.toBe(null);
 
       fireEvent.mouseLeave(first);
       fireEvent.mouseEnter(second);
       fireEvent.mouseMove(second);
-      await act(async () => {
-        clock.tick(0);
-      });
+      await flushMicrotasks();
+      await tick(0);
 
       expect(screen.queryByText('Content Two')).not.toBe(null);
       expect(screen.queryByText('Content One')).toBe(null);
@@ -234,14 +245,14 @@ describe('<Tooltip.Provider />', () => {
 
       fireEvent.mouseEnter(first);
       fireEvent.mouseMove(first);
-      clock.tick(100);
       await flushMicrotasks();
+      await tick(100);
 
       expect(screen.queryByText('Content One')).not.toBe(null);
 
       fireEvent.mouseLeave(first);
-      clock.tick(400);
       await flushMicrotasks();
+      await tick(400);
 
       fireEvent.mouseEnter(second);
       fireEvent.mouseMove(second);
@@ -249,8 +260,7 @@ describe('<Tooltip.Provider />', () => {
 
       expect(screen.queryByText('Content Two')).toBe(null);
 
-      clock.tick(100);
-      await flushMicrotasks();
+      await tick(100);
 
       expect(screen.queryByText('Content Two')).not.toBe(null);
     });

--- a/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
+++ b/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
@@ -12,6 +12,7 @@ describe('<Tooltip.Provider />', () => {
     await act(async () => {
       await clock.tickAsync(ms);
     });
+    await flushMicrotasks();
   }
 
   describe('prop: delay', () => {

--- a/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
+++ b/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
@@ -1,18 +1,14 @@
 import { expect } from 'vitest';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { act, screen, fireEvent, flushMicrotasks } from '@mui/internal-test-utils';
-import { createRenderer } from '#test-utils';
+import { screen, fireEvent, flushMicrotasks } from '@mui/internal-test-utils';
+import { advanceReactClock, createRenderer } from '#test-utils';
 import { OPEN_DELAY } from '../utils/constants';
 
 describe('<Tooltip.Provider />', () => {
   const { render, clock } = createRenderer();
 
   async function tick(ms: number) {
-    await flushMicrotasks();
-    await act(async () => {
-      await clock.tickAsync(ms);
-    });
-    await flushMicrotasks();
+    await advanceReactClock(clock, ms);
   }
 
   describe('prop: delay', () => {

--- a/packages/react/src/tooltip/root/TooltipRoot.detached-triggers.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.detached-triggers.test.tsx
@@ -2,7 +2,14 @@ import { vi, expect } from 'vitest';
 import * as React from 'react';
 import { createRenderer, isJSDOM } from '#test-utils';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { screen, waitFor, randomStringValue, act, flushMicrotasks } from '@mui/internal-test-utils';
+import {
+  screen,
+  waitFor,
+  randomStringValue,
+  act,
+  fireEvent,
+  flushMicrotasks,
+} from '@mui/internal-test-utils';
 
 describe('<Tooltip.Root />', () => {
   beforeEach(async () => {
@@ -313,12 +320,18 @@ describe('<Tooltip.Root />', () => {
       });
 
       const popupId = randomStringValue();
-      const { user } = await render(
+      await render(
         <Tooltip.Root>
           <input type="text" aria-label="Initial focus" autoFocus />
-          <Tooltip.Trigger delay={0}>Trigger 1</Tooltip.Trigger>
-          <Tooltip.Trigger delay={0}>Trigger 2</Tooltip.Trigger>
-          <Tooltip.Trigger delay={0}>Trigger 3</Tooltip.Trigger>
+          <Tooltip.Trigger delay={0} style={{ pointerEvents: 'none' }}>
+            Trigger 1
+          </Tooltip.Trigger>
+          <Tooltip.Trigger delay={0} style={{ pointerEvents: 'none' }}>
+            Trigger 2
+          </Tooltip.Trigger>
+          <Tooltip.Trigger delay={0} style={{ pointerEvents: 'none' }}>
+            Trigger 3
+          </Tooltip.Trigger>
 
           <Tooltip.Portal>
             <Tooltip.Positioner>
@@ -336,23 +349,26 @@ describe('<Tooltip.Root />', () => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger1);
+      fireEvent.mouseEnter(trigger1);
+      fireEvent.mouseMove(trigger1);
       expect(screen.queryByTestId(popupId)).toBeVisible();
-      await user.hover(document.body);
+      fireEvent.mouseLeave(trigger1);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger2);
+      fireEvent.mouseEnter(trigger2);
+      fireEvent.mouseMove(trigger2);
       expect(screen.queryByTestId(popupId)).toBeVisible();
-      await user.hover(document.body);
+      fireEvent.mouseLeave(trigger2);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger3);
+      fireEvent.mouseEnter(trigger3);
+      fireEvent.mouseMove(trigger3);
       expect(screen.queryByTestId(popupId)).toBeVisible();
-      await user.hover(document.body);
+      fireEvent.mouseLeave(trigger3);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
@@ -361,9 +377,9 @@ describe('<Tooltip.Root />', () => {
     it('should open the tooltip with any trigger on focus', async () => {
       await render(
         <Tooltip.Root>
-          <Tooltip.Trigger>Trigger 1</Tooltip.Trigger>
-          <Tooltip.Trigger>Trigger 2</Tooltip.Trigger>
-          <Tooltip.Trigger>Trigger 3</Tooltip.Trigger>
+          <Tooltip.Trigger style={{ pointerEvents: 'none' }}>Trigger 1</Tooltip.Trigger>
+          <Tooltip.Trigger style={{ pointerEvents: 'none' }}>Trigger 2</Tooltip.Trigger>
+          <Tooltip.Trigger style={{ pointerEvents: 'none' }}>Trigger 3</Tooltip.Trigger>
 
           <Tooltip.Portal>
             <Tooltip.Positioner>
@@ -399,14 +415,14 @@ describe('<Tooltip.Root />', () => {
     });
 
     it('should set the payload and render content based on its value', async () => {
-      const { user } = await render(
+      await render(
         <Tooltip.Root>
           {({ payload }: NumberPayload) => (
             <React.Fragment>
-              <Tooltip.Trigger payload={1} delay={0}>
+              <Tooltip.Trigger payload={1} delay={0} style={{ pointerEvents: 'none' }}>
                 Trigger 1
               </Tooltip.Trigger>
-              <Tooltip.Trigger payload={2} delay={0}>
+              <Tooltip.Trigger payload={2} delay={0} style={{ pointerEvents: 'none' }}>
                 Trigger 2
               </Tooltip.Trigger>
 
@@ -425,11 +441,13 @@ describe('<Tooltip.Root />', () => {
       const trigger1 = screen.getByRole('button', { name: 'Trigger 1' });
       const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
 
-      await user.hover(trigger1);
+      fireEvent.mouseEnter(trigger1);
+      fireEvent.mouseMove(trigger1);
       expect(screen.getByTestId('content').textContent).toBe('1');
 
-      await user.unhover(trigger1);
-      await user.hover(trigger2);
+      fireEvent.mouseLeave(trigger1);
+      fireEvent.mouseEnter(trigger2);
+      fireEvent.mouseMove(trigger2);
       expect(screen.getByTestId('content').textContent).toBe('2');
     });
 
@@ -438,13 +456,19 @@ describe('<Tooltip.Root />', () => {
         <Tooltip.Root>
           {({ payload }: NumberPayload) => (
             <React.Fragment>
-              <Tooltip.Trigger payload={1} delay={0} closeDelay={0}>
+              <Tooltip.Trigger
+                payload={1}
+                delay={0}
+                closeDelay={0}
+                style={{ pointerEvents: 'none' }}
+              >
                 Trigger 1
               </Tooltip.Trigger>
               <Tooltip.Trigger
                 payload={2}
                 delay={0}
                 closeDelay={0}
+                style={{ pointerEvents: 'none' }}
                 render={<button id="custom-button" type="button" />}
               >
                 Trigger 2
@@ -682,11 +706,17 @@ describe('<Tooltip.Root />', () => {
 
       const { user } = await render(<Test />);
       await user.click(screen.getByRole('button', { name: 'Open Trigger 1' }));
-      expect(screen.getByTestId('content').textContent).toBe('1');
+      await waitFor(() => {
+        expect(screen.getByTestId('content').textContent).toBe('1');
+      });
       await user.click(screen.getByRole('button', { name: 'Open Trigger 2' }));
-      expect(screen.getByTestId('content').textContent).toBe('2');
+      await waitFor(() => {
+        expect(screen.getByTestId('content').textContent).toBe('2');
+      });
       await user.click(screen.getByRole('button', { name: 'Close' }));
-      expect(screen.queryByTestId('content')).toBe(null);
+      await waitFor(() => {
+        expect(screen.queryByTestId('content')).toBe(null);
+      });
     });
 
     it('allows setting an initially open tooltip', async () => {
@@ -697,10 +727,15 @@ describe('<Tooltip.Root />', () => {
           {({ payload }: NumberPayload) => (
             <React.Fragment>
               <button type="button" aria-label="Initial focus" autoFocus />
-              <Tooltip.Trigger handle={testTooltip} payload={1}>
+              <Tooltip.Trigger handle={testTooltip} payload={1} style={{ pointerEvents: 'none' }}>
                 Trigger 1
               </Tooltip.Trigger>
-              <Tooltip.Trigger handle={testTooltip} payload={2} id={triggerId}>
+              <Tooltip.Trigger
+                handle={testTooltip}
+                payload={2}
+                id={triggerId}
+                style={{ pointerEvents: 'none' }}
+              >
                 Trigger 2
               </Tooltip.Trigger>
               <Tooltip.Portal>
@@ -727,16 +762,16 @@ describe('<Tooltip.Root />', () => {
     it('should open the tooltip with any trigger on hover', async () => {
       const testTooltip = Tooltip.createHandle();
       const popupId = randomStringValue();
-      const { user } = await render(
+      await render(
         <div>
           <button type="button" aria-label="Initial focus" autoFocus />
-          <Tooltip.Trigger handle={testTooltip} delay={0}>
+          <Tooltip.Trigger handle={testTooltip} delay={0} style={{ pointerEvents: 'none' }}>
             Trigger 1
           </Tooltip.Trigger>
-          <Tooltip.Trigger handle={testTooltip} delay={0}>
+          <Tooltip.Trigger handle={testTooltip} delay={0} style={{ pointerEvents: 'none' }}>
             Trigger 2
           </Tooltip.Trigger>
-          <Tooltip.Trigger handle={testTooltip} delay={0}>
+          <Tooltip.Trigger handle={testTooltip} delay={0} style={{ pointerEvents: 'none' }}>
             Trigger 3
           </Tooltip.Trigger>
 
@@ -758,29 +793,32 @@ describe('<Tooltip.Root />', () => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger1);
+      fireEvent.mouseEnter(trigger1);
+      fireEvent.mouseMove(trigger1);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBeVisible();
       });
-      await user.unhover(trigger1);
+      fireEvent.mouseLeave(trigger1);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger2);
+      fireEvent.mouseEnter(trigger2);
+      fireEvent.mouseMove(trigger2);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBeVisible();
       });
-      await user.unhover(trigger2);
+      fireEvent.mouseLeave(trigger2);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
 
-      await user.hover(trigger3);
+      fireEvent.mouseEnter(trigger3);
+      fireEvent.mouseMove(trigger3);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBeVisible();
       });
-      await user.unhover(trigger3);
+      fireEvent.mouseLeave(trigger3);
       await waitFor(() => {
         expect(screen.queryByTestId(popupId)).toBe(null);
       });
@@ -871,12 +909,22 @@ describe('<Tooltip.Root />', () => {
 
     it('should set the payload and render content based on its value', async () => {
       const testTooltip = Tooltip.createHandle<number>();
-      const { user } = await render(
+      await render(
         <div>
-          <Tooltip.Trigger handle={testTooltip} payload={1} delay={0}>
+          <Tooltip.Trigger
+            handle={testTooltip}
+            payload={1}
+            delay={0}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 1
           </Tooltip.Trigger>
-          <Tooltip.Trigger handle={testTooltip} payload={2} delay={0}>
+          <Tooltip.Trigger
+            handle={testTooltip}
+            payload={2}
+            delay={0}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 2
           </Tooltip.Trigger>
 
@@ -897,11 +945,13 @@ describe('<Tooltip.Root />', () => {
       const trigger1 = screen.getByRole('button', { name: 'Trigger 1' });
       const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
 
-      await user.hover(trigger1);
+      fireEvent.mouseEnter(trigger1);
+      fireEvent.mouseMove(trigger1);
       expect(screen.getByTestId('content').textContent).toBe('1');
 
-      await user.unhover(trigger1);
-      await user.hover(trigger2);
+      fireEvent.mouseLeave(trigger1);
+      fireEvent.mouseEnter(trigger2);
+      fireEvent.mouseMove(trigger2);
       expect(screen.getByTestId('content').textContent).toBe('2');
     });
 
@@ -958,12 +1008,22 @@ describe('<Tooltip.Root />', () => {
 
     it('should close when hovering a disabled trigger while another trigger is open', async () => {
       const testTooltip = Tooltip.createHandle<number>();
-      const { user } = await render(
+      await render(
         <div>
-          <Tooltip.Trigger handle={testTooltip} payload={1} delay={0}>
+          <Tooltip.Trigger
+            handle={testTooltip}
+            payload={1}
+            delay={0}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 1
           </Tooltip.Trigger>
-          <Tooltip.Trigger handle={testTooltip} payload={2} disabled>
+          <Tooltip.Trigger
+            handle={testTooltip}
+            payload={2}
+            disabled
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 2
           </Tooltip.Trigger>
 
@@ -984,12 +1044,15 @@ describe('<Tooltip.Root />', () => {
       const trigger1 = screen.getByRole('button', { name: 'Trigger 1' });
       const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
 
-      await user.hover(trigger1);
+      fireEvent.mouseEnter(trigger1);
+      fireEvent.mouseMove(trigger1);
       await waitFor(() => {
         expect(screen.getByTestId('content').textContent).toBe('1');
       });
 
-      await user.hover(trigger2);
+      fireEvent.mouseLeave(trigger1);
+      fireEvent.mouseEnter(trigger2);
+      fireEvent.mouseMove(trigger2);
       await waitFor(() => {
         expect(screen.queryByTestId('content')).toBe(null);
       });
@@ -998,15 +1061,21 @@ describe('<Tooltip.Root />', () => {
 
     it('should switch to a rendered disabled button trigger when trigger hover is enabled', async () => {
       const testTooltip = Tooltip.createHandle<number>();
-      const { user } = await render(
+      await render(
         <div>
-          <Tooltip.Trigger handle={testTooltip} payload={1} delay={0}>
+          <Tooltip.Trigger
+            handle={testTooltip}
+            payload={1}
+            delay={0}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 1
           </Tooltip.Trigger>
           <Tooltip.Trigger
             handle={testTooltip}
             payload={2}
             delay={0}
+            style={{ pointerEvents: 'none' }}
             render={
               <button type="button" disabled>
                 Trigger 2
@@ -1031,16 +1100,21 @@ describe('<Tooltip.Root />', () => {
       const trigger1 = screen.getByRole('button', { name: 'Trigger 1' });
       const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
 
-      await user.hover(trigger1);
+      fireEvent.mouseEnter(trigger1);
+      fireEvent.mouseMove(trigger1);
       await waitFor(() => {
         expect(screen.getByTestId('content').textContent).toBe('1');
       });
 
-      await user.hover(trigger2);
+      fireEvent.mouseLeave(trigger1);
+      fireEvent.mouseEnter(trigger2);
+      fireEvent.mouseMove(trigger2);
       await waitFor(() => {
         expect(screen.getByTestId('content').textContent).toBe('2');
       });
-      expect(trigger2).toHaveAttribute('data-popup-open');
+      await waitFor(() => {
+        expect(trigger2).toHaveAttribute('data-popup-open');
+      });
     });
 
     it('should reuse the popup and positioner DOM nodes when switching triggers', async () => {
@@ -1142,7 +1216,9 @@ describe('<Tooltip.Root />', () => {
       const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
 
       await user.click(screen.getByRole('button', { name: 'Open Trigger 1' }));
-      expect(screen.getByTestId('content').textContent).toBe('1');
+      await waitFor(() => {
+        expect(screen.getByTestId('content').textContent).toBe('1');
+      });
 
       await waitFor(() => {
         expect(
@@ -1154,7 +1230,9 @@ describe('<Tooltip.Root />', () => {
       });
 
       await user.click(screen.getByRole('button', { name: 'Open Trigger 2' }));
-      expect(screen.getByTestId('content').textContent).toBe('2');
+      await waitFor(() => {
+        expect(screen.getByTestId('content').textContent).toBe('2');
+      });
       await waitFor(() => {
         expect(
           Math.abs(
@@ -1165,7 +1243,9 @@ describe('<Tooltip.Root />', () => {
       });
 
       await user.click(screen.getByRole('button', { name: 'Close' }));
-      expect(screen.queryByTestId('content')).toBe(null);
+      await waitFor(() => {
+        expect(screen.queryByTestId('content')).toBe(null);
+      });
     });
 
     it('allows setting an initially open tooltip', async () => {
@@ -1174,10 +1254,15 @@ describe('<Tooltip.Root />', () => {
       await render(
         <React.Fragment>
           <button type="button" aria-label="Initial focus" autoFocus />
-          <Tooltip.Trigger handle={testTooltip} payload={1}>
+          <Tooltip.Trigger handle={testTooltip} payload={1} style={{ pointerEvents: 'none' }}>
             Trigger 1
           </Tooltip.Trigger>
-          <Tooltip.Trigger handle={testTooltip} payload={2} id={triggerId}>
+          <Tooltip.Trigger
+            handle={testTooltip}
+            payload={2}
+            id={triggerId}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 2
           </Tooltip.Trigger>
 
@@ -1209,10 +1294,20 @@ describe('<Tooltip.Root />', () => {
         return (
           <React.Fragment>
             <button type="button" aria-label="Initial focus" autoFocus />
-            <Tooltip.Trigger handle={testTooltip} payload={1} delay={0}>
+            <Tooltip.Trigger
+              handle={testTooltip}
+              payload={1}
+              delay={0}
+              style={{ pointerEvents: 'none' }}
+            >
               Trigger 1
             </Tooltip.Trigger>
-            <Tooltip.Trigger handle={testTooltip} payload={2} delay={0}>
+            <Tooltip.Trigger
+              handle={testTooltip}
+              payload={2}
+              delay={0}
+              style={{ pointerEvents: 'none' }}
+            >
               Trigger 2
             </Tooltip.Trigger>
 
@@ -1233,20 +1328,22 @@ describe('<Tooltip.Root />', () => {
         );
       }
 
-      const { user } = await render(<Test />);
+      await render(<Test />);
 
       const trigger1 = screen.getByRole('button', { name: 'Trigger 1' });
       const trigger2 = screen.getByRole('button', { name: 'Trigger 2' });
 
       // Open with Trigger 1
-      await user.hover(trigger1);
+      fireEvent.mouseEnter(trigger1);
+      fireEvent.mouseMove(trigger1);
       await waitFor(() => {
         expect(screen.getByTestId('content').textContent).toBe('1');
       });
 
       // Switch to Trigger 2
-      await user.unhover(trigger1);
-      await user.hover(trigger2);
+      fireEvent.mouseLeave(trigger1);
+      fireEvent.mouseEnter(trigger2);
+      fireEvent.mouseMove(trigger2);
       await waitFor(() => {
         expect(screen.getByTestId('content').textContent).toBe('2');
       });
@@ -1298,10 +1395,20 @@ describe('<Tooltip.Root />', () => {
       const tooltip = Tooltip.createHandle<number>();
       await render(
         <div>
-          <Tooltip.Trigger handle={tooltip} id="trigger1" payload={1}>
+          <Tooltip.Trigger
+            handle={tooltip}
+            id="trigger1"
+            payload={1}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 1
           </Tooltip.Trigger>
-          <Tooltip.Trigger handle={tooltip} id="trigger2" payload={2}>
+          <Tooltip.Trigger
+            handle={tooltip}
+            id="trigger2"
+            payload={2}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger 2
           </Tooltip.Trigger>
           <Tooltip.Root handle={tooltip}>
@@ -1322,12 +1429,15 @@ describe('<Tooltip.Root />', () => {
 
       await act(() => tooltip.open('trigger2'));
       await waitFor(() => {
-        expect(screen.queryByTestId('content')).not.toBe(null);
+        expect(screen.getByTestId('content').textContent).toBe('2');
       });
 
-      expect(screen.getByTestId('content').textContent).toBe('2');
-      expect(trigger2).toHaveAttribute('data-popup-open');
-      expect(trigger1).not.toHaveAttribute('data-popup-open');
+      await waitFor(() => {
+        expect(trigger2).toHaveAttribute('data-popup-open');
+      });
+      await waitFor(() => {
+        expect(trigger1).not.toHaveAttribute('data-popup-open');
+      });
 
       await act(() => tooltip.close());
       await waitFor(() => {

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.test.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.test.tsx
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { Toolbar } from '@base-ui/react/toolbar';
-import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Tooltip.Trigger />', () => {
@@ -63,16 +63,13 @@ describe('<Tooltip.Trigger />', () => {
 
     fireEvent.mouseEnter(trigger);
     fireEvent.mouseMove(trigger);
-    await waitFor(() => {
-      expect(trigger).toHaveAttribute('data-popup-open');
-    });
-    await screen.findByText('Content');
+    await act(async () => flushMicrotasks());
+    expect(trigger).toHaveAttribute('data-popup-open');
+    expect(screen.getByText('Content')).not.toBe(null);
 
     fireEvent.mouseLeave(trigger);
-    await waitFor(() => {
-      expect(trigger).not.toHaveAttribute('data-popup-open');
-    });
-
+    await act(async () => flushMicrotasks());
+    expect(trigger).not.toHaveAttribute('data-popup-open');
     expect(screen.getByText('Content')).not.toBe(null);
   });
 

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.test.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.test.tsx
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { Toolbar } from '@base-ui/react/toolbar';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Tooltip.Trigger />', () => {
@@ -41,7 +41,12 @@ describe('<Tooltip.Trigger />', () => {
             setOpen(nextOpen);
           }}
         >
-          <Tooltip.Trigger data-testid="trigger" delay={0} closeDelay={0}>
+          <Tooltip.Trigger
+            data-testid="trigger"
+            delay={0}
+            closeDelay={0}
+            style={{ pointerEvents: 'none' }}
+          >
             Trigger
           </Tooltip.Trigger>
           <Tooltip.Portal>
@@ -53,15 +58,17 @@ describe('<Tooltip.Trigger />', () => {
       );
     }
 
-    const { user } = await render(<TooltipWithPreventedUnmount />);
+    await render(<TooltipWithPreventedUnmount />);
     const trigger = screen.getByTestId('trigger');
 
-    await user.hover(trigger);
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseMove(trigger);
     await waitFor(() => {
       expect(trigger).toHaveAttribute('data-popup-open');
     });
+    await screen.findByText('Content');
 
-    await user.unhover(trigger);
+    fireEvent.mouseLeave(trigger);
     await waitFor(() => {
       expect(trigger).not.toHaveAttribute('data-popup-open');
     });

--- a/packages/react/test/advanceReactClock.ts
+++ b/packages/react/test/advanceReactClock.ts
@@ -1,0 +1,8 @@
+import { flushMicrotasks } from '@mui/internal-test-utils';
+import type { Clock } from '@mui/internal-test-utils/createRenderer';
+
+export async function advanceReactClock(clock: Clock, milliseconds: number) {
+  await flushMicrotasks();
+  await clock.tickAsync(milliseconds);
+  await flushMicrotasks();
+}

--- a/packages/react/test/index.ts
+++ b/packages/react/test/index.ts
@@ -1,9 +1,13 @@
 export * from '@base-ui/utils/testUtils';
+export { advanceReactClock } from './advanceReactClock';
 export { createRenderer } from './createRenderer';
 export { describeConformance } from './describeConformance';
+export { enterWithMouse, moveMouse } from './pointer';
 export { popupConformanceTests } from './popupConformanceTests';
+export { resetBrowserPointer } from './resetBrowserPointer';
 export { useTestInteractions } from './useTestInteractions';
 export * from './wait';
+export { waitForPositioned } from './waitForPositioned';
 
 // Temporal
 export { describeGregorianAdapter } from './describeGregorianAdapter';

--- a/packages/react/test/pointer.ts
+++ b/packages/react/test/pointer.ts
@@ -1,0 +1,21 @@
+import { fireEvent } from '@mui/internal-test-utils';
+
+export function enterWithMouse(element: HTMLElement, init?: MouseEventInit) {
+  fireEvent.pointerEnter(element, { pointerType: 'mouse', ...init });
+  fireEvent.mouseEnter(element, init);
+  fireEvent.mouseMove(element, init);
+}
+
+export function moveMouse(from: HTMLElement, to: HTMLElement) {
+  fireEvent.pointerLeave(from, {
+    pointerType: 'mouse',
+    relatedTarget: to,
+  });
+  fireEvent.mouseLeave(from, { relatedTarget: to });
+  fireEvent.pointerEnter(to, {
+    pointerType: 'mouse',
+    relatedTarget: from,
+  });
+  fireEvent.mouseEnter(to, { relatedTarget: from });
+  fireEvent.mouseMove(to);
+}

--- a/packages/react/test/resetBrowserPointer.ts
+++ b/packages/react/test/resetBrowserPointer.ts
@@ -1,0 +1,11 @@
+import { isJSDOM } from '@base-ui/utils/testUtils';
+
+/**
+ * Resets the Playwright/WebDriver pointer state that persists between browser tests.
+ */
+export async function resetBrowserPointer() {
+  if (!isJSDOM) {
+    const { userEvent } = await import('vitest/browser');
+    await userEvent.unhover(document.body);
+  }
+}

--- a/packages/react/test/waitForPositioned.ts
+++ b/packages/react/test/waitForPositioned.ts
@@ -1,0 +1,11 @@
+import { expect } from 'vitest';
+import { waitFor } from '@mui/internal-test-utils';
+
+export async function waitForPositioned(positioner: HTMLElement) {
+  await waitFor(() => {
+    expect(positioner.style.opacity).not.toBe('0');
+  });
+  await waitFor(() => {
+    expect(positioner).toBeVisible();
+  });
+}

--- a/test/setupVitest.ts
+++ b/test/setupVitest.ts
@@ -29,6 +29,7 @@ beforeAll(async () => {
 
 afterEach(() => {
   vi.resetAllMocks();
+  globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
   resetBuiltError();
   resetSourceError();
   // Drop animation frame callbacks that were scheduled but never ran (e.g. under fake timers torn


### PR DESCRIPTION
Several browser tests depended on cursor state or advanced mocked schedulers before React had committed the interaction.

## Changes

- Use deterministic pointer events for popup hover transitions.
- Synchronize React commits, fake timers, and animation frame queues before assertions.
- Assert observable state instead of exact render call ordering where concurrent rendering can add calls.
- Isolate animation state across browser test files.