### PR TITLE
[code-infra] Remove obsolete trust policy exclusion

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,19 +21,9 @@ minimumReleaseAgeExclude:
   - '@mui/internal-*'
 trustPolicy: no-downgrade
 # Skip trust-policy checks for packages published more than 365 days ago.
-# Some widely-used legacy packages (notably semver@6.x — pulled in by @babel/core@7.x — plus
-# reselect@5.1.1 and parts of @octokit/*) dropped provenance attestation for specific releases,
-# triggering false-positive trust-downgrade errors. Packages that old have had ample time for
-# community review; supply-chain risk is most relevant within a shorter window.
-# TODO: drop once @babel/core stops depending on semver@^6.3.1 (no 6.x semver release has
-# provenance), and the other legacy packages restore provenance.
+# Several widely-used legacy packages in the current dependency tree have releases that dropped
+# provenance attestation, triggering false-positive trust-downgrade errors. Packages that old have
+# had ample time for community review; supply-chain risk is most relevant within a shorter window.
+# TODO: drop once the dependency tree no longer contains @octokit/endpoint@9.0.6, semver@5.7.2,
+# semver@6.3.1, or undici-types@6.21.0.
 trustPolicyIgnoreAfter: 525600
-# nanoid@3.3.14 (a transitive dep of postcss@8.5.15) shipped without trust evidence after an
-# earlier release published via staged publish, so pnpm rejects it as a trust downgrade. The
-# default jobs install from the frozen lockfile (pinned to nanoid@3.3.12) and are unaffected,
-# but the React 18 jobs re-resolve the tree without a frozen lockfile and pull this version.
-# The independent minimumReleaseAge gate still applies to it. nanoid restored provenance in
-# 3.3.15, so once that ages in the resolver moves past 3.3.14 and this exclude becomes inert.
-# TODO: drop once the resolved nanoid is >= 3.3.15.
-trustPolicyExclude:
-  - 'nanoid@3.3.14'


### PR DESCRIPTION
## Summary

- remove the obsolete `nanoid@3.3.14` trust-policy exclusion introduced in https://github.com/mui/base-ui/pull/5113
- update the remaining trust-policy TODO to name the dependency versions that still require the age cutoff

## Why

The current lockfile resolves `nanoid` to `3.3.12`, and a fresh resolution no longer encounters the provenance downgrade from `3.3.14`. Keeping the package-specific exclusion therefore weakens the policy without affecting current installs.

The broader `trustPolicyIgnoreAfter` setting is still required. Removing it currently rejects `@octokit/endpoint@9.0.6`, `semver@5.7.2`, `semver@6.3.1`, and `undici-types@6.21.0`, so this change retains the cutoff and makes its follow-up condition explicit.
