### PR TITLE
[autocomplete][combobox] Add `input-press` to change event details

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/types.md
+++ b/docs/src/app/(docs)/react/components/autocomplete/types.md
@@ -69,6 +69,7 @@ type AutocompleteRootActions = { unmount: () => void };
 ```typescript
 type AutocompleteRootChangeEventReason =
   | 'trigger-press'
+  | 'input-press'
   | 'outside-press'
   | 'item-press'
   | 'close-press'
@@ -88,6 +89,7 @@ type AutocompleteRootChangeEventReason =
 type AutocompleteRootChangeEventDetails = (
   | { reason: 'none'; event: Event }
   | { reason: 'trigger-press'; event: MouseEvent | PointerEvent | TouchEvent | KeyboardEvent }
+  | { reason: 'input-press'; event: MouseEvent | PointerEvent | TouchEvent | KeyboardEvent }
   | { reason: 'outside-press'; event: MouseEvent | PointerEvent | TouchEvent }
   | { reason: 'item-press'; event: MouseEvent | PointerEvent | KeyboardEvent }
   | { reason: 'close-press'; event: MouseEvent | PointerEvent | KeyboardEvent }

--- a/docs/src/app/(docs)/react/components/combobox/types.md
+++ b/docs/src/app/(docs)/react/components/combobox/types.md
@@ -77,6 +77,7 @@ type ComboboxRootActions = { unmount: () => void };
 ```typescript
 type ComboboxRootChangeEventReason =
   | 'trigger-press'
+  | 'input-press'
   | 'outside-press'
   | 'item-press'
   | 'close-press'
@@ -96,6 +97,7 @@ type ComboboxRootChangeEventReason =
 type ComboboxRootChangeEventDetails = (
   | { reason: 'none'; event: Event }
   | { reason: 'trigger-press'; event: MouseEvent | PointerEvent | TouchEvent | KeyboardEvent }
+  | { reason: 'input-press'; event: MouseEvent | PointerEvent | TouchEvent | KeyboardEvent }
   | { reason: 'outside-press'; event: MouseEvent | PointerEvent | TouchEvent }
   | { reason: 'item-press'; event: MouseEvent | PointerEvent | KeyboardEvent }
   | { reason: 'close-press'; event: MouseEvent | PointerEvent | KeyboardEvent }

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -1768,6 +1768,7 @@ export namespace AriaCombobox {
 
   export type ChangeEventReason =
     | typeof REASONS.triggerPress
+    | typeof REASONS.inputPress
     | typeof REASONS.outsidePress
     | typeof REASONS.itemPress
     | typeof REASONS.closePress

--- a/packages/react/src/combobox/root/ComboboxRoot.spec.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.spec.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
+import { expectType } from '#test-utils';
 import { mergeProps } from '../../merge-props';
+import { REASONS } from '../../internals/reasons';
 
 const objectItems = [
   { value: 'a', label: 'apple' },
@@ -210,6 +212,16 @@ function App() {
   onValueChange={(value) => {
     // @ts-expect-error
     value.length;
+  }}
+/>;
+
+<Combobox.Root
+  onOpenChange={(_open, details) => {
+    if (details.reason === REASONS.inputPress) {
+      expectType<MouseEvent | PointerEvent | TouchEvent | KeyboardEvent, typeof details.event>(
+        details.event,
+      );
+    }
   }}
 />;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR adds `input-press` to the public Combobox change event type. 

Although widening a public discriminated union would normally be considered a breaking change, `input-press` has already been emitted at runtime since #4015, so this change aims to align the type definition with the existing behavior.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
