### PR TITLE
[internal] Use predefined change reasons

### DIFF
--- a/packages/react/src/combobox/chip-remove/ComboboxChipRemove.tsx
+++ b/packages/react/src/combobox/chip-remove/ComboboxChipRemove.tsx
@@ -68,7 +68,7 @@ export const ComboboxChipRemove = React.forwardRef(function ComboboxChipRemove(
     if (removedIndex !== -1 && activeIndex === removedIndex) {
       store.state.setIndices({
         activeIndex: null,
-        type: store.state.keyboardActiveRef.current ? 'keyboard' : 'pointer',
+        type: store.state.keyboardActiveRef.current ? REASONS.keyboard : REASONS.pointer,
       });
     }
   }

--- a/packages/react/src/combobox/chip/ComboboxChip.tsx
+++ b/packages/react/src/combobox/chip/ComboboxChip.tsx
@@ -60,7 +60,11 @@ export const ComboboxChip = React.forwardRef(function ComboboxChip(
 
       stopEvent(event);
 
-      store.state.setIndices({ activeIndex: null, selectedIndex: null, type: 'keyboard' });
+      store.state.setIndices({
+        activeIndex: null,
+        selectedIndex: null,
+        type: REASONS.keyboard,
+      });
       store.state.setSelectedValue(
         selectedValue.filter((_: any, i: number) => i !== index),
         createChangeEventDetails(REASONS.none, event.nativeEvent),

--- a/packages/react/src/combobox/clear/ComboboxClear.tsx
+++ b/packages/react/src/combobox/clear/ComboboxClear.tsx
@@ -103,7 +103,7 @@ export const ComboboxClear = React.forwardRef(function ComboboxClear(
             return;
           }
 
-          const type = store.state.keyboardActiveRef.current ? 'keyboard' : 'pointer';
+          const type = store.state.keyboardActiveRef.current ? REASONS.keyboard : REASONS.pointer;
 
           store.state.setInputValue(
             '',

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -125,7 +125,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
     store.state.setIndices({
       activeIndex: null,
       selectedIndex: null,
-      type: store.state.keyboardActiveRef.current ? 'keyboard' : 'pointer',
+      type: store.state.keyboardActiveRef.current ? REASONS.keyboard : REASONS.pointer,
     });
   }
 

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -509,7 +509,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
     (options: {
       activeIndex?: number | null | undefined;
       selectedIndex?: number | null | undefined;
-      type?: 'none' | 'keyboard' | 'pointer' | undefined;
+      type?: AriaCombobox.HighlightEventReason | undefined;
     }) => {
       store.update(options);
       const activeIndexOption = options.activeIndex;
@@ -517,7 +517,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         return;
       }
 
-      const type: AriaCombobox.HighlightEventReason = options.type || 'none';
+      const type: AriaCombobox.HighlightEventReason = options.type || REASONS.none;
 
       if (activeIndexOption === null) {
         emitHighlight(undefined, -1, type);
@@ -616,7 +616,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       // with CSS. In this case, allow the Escape key to bubble to close a parent popup
       // if there are no items to show.
       if (
-        eventDetails.reason === 'escape-key' &&
+        eventDetails.reason === REASONS.escapeKey &&
         hasItems &&
         flatFilteredItems.length === 0 &&
         !emptyRef.current
@@ -1198,7 +1198,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       } else {
         setIndices({
           activeIndex: nextActiveIndex,
-          type: keyboardActiveRef.current ? 'keyboard' : 'pointer',
+          type: keyboardActiveRef.current ? REASONS.keyboard : REASONS.pointer,
         });
       }
     },
@@ -1760,7 +1760,10 @@ export namespace AriaCombobox {
     unmount: () => void;
   }
 
-  export type HighlightEventReason = 'keyboard' | 'pointer' | 'none';
+  export type HighlightEventReason =
+    | typeof REASONS.keyboard
+    | typeof REASONS.pointer
+    | typeof REASONS.none;
   export type HighlightEventDetails = BaseUIGenericEventDetails<
     HighlightEventReason,
     { index: number }

--- a/packages/react/src/combobox/store.ts
+++ b/packages/react/src/combobox/store.ts
@@ -66,7 +66,7 @@ export type State = {
   setIndices: (indices: {
     activeIndex?: number | null | undefined;
     selectedIndex?: number | null | undefined;
-    type?: 'keyboard' | 'pointer' | 'none' | undefined;
+    type?: AriaCombobox.HighlightEventReason | undefined;
   }) => void;
   forceMount: () => void;
   handleSelection: (event: MouseEvent | PointerEvent | KeyboardEvent, itemValue: any) => void;

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -113,7 +113,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
     onMatch(index) {
       const nextSelectedValue = store.state.valuesRef.current[index];
       if (nextSelectedValue !== undefined) {
-        store.state.setSelectedValue(nextSelectedValue, createChangeEventDetails('none'));
+        store.state.setSelectedValue(nextSelectedValue, createChangeEventDetails(REASONS.none));
       }
     },
   });
@@ -230,7 +230,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
               return;
             }
 
-            store.state.setOpen(false, createChangeEventDetails('cancel-open', mouseEvent));
+            store.state.setOpen(false, createChangeEventDetails(REASONS.cancelOpen, mouseEvent));
           }
 
           if (inputInsidePopup) {

--- a/packages/react/src/menu/trigger/MenuTrigger.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.tsx
@@ -359,7 +359,7 @@ function useStickIfOpen(open: boolean, openReason: string | null) {
   const stickIfOpenTimeout = useTimeout();
   const [stickIfOpen, setStickIfOpen] = React.useState(false);
   useIsoLayoutEffect(() => {
-    if (open && openReason === 'trigger-hover') {
+    if (open && openReason === REASONS.triggerHover) {
       // Only allow "patient" clicks to close the menu if it's open.
       // If they clicked within 500ms of the menu opening, keep it open.
       setStickIfOpen(true);

--- a/packages/react/src/menubar/Menubar.tsx
+++ b/packages/react/src/menubar/Menubar.tsx
@@ -14,6 +14,7 @@ import { useBaseUiId } from '../internals/useBaseUiId';
 import { MenuOpenEventDetails } from '../menu/utils/types';
 import { StateAttributesMapping } from '../internals/getStateAttributesProps';
 import { MenubarDataAttributes } from './MenubarDataAttributes';
+import { REASONS } from '../internals/reasons';
 
 const menubarStateAttributesMapping: StateAttributesMapping<MenubarState> = {
   hasSubmenuOpen(value) {
@@ -109,7 +110,10 @@ function MenubarContent(props: React.PropsWithChildren<{}>) {
         if (!rootContext.hasSubmenuOpen) {
           rootContext.setHasSubmenuOpen(true);
         }
-      } else if (details.reason !== 'sibling-open' && details.reason !== 'list-navigation') {
+      } else if (
+        details.reason !== REASONS.siblingOpen &&
+        details.reason !== REASONS.listNavigation
+      ) {
         rootContext.setHasSubmenuOpen(false);
       }
     }

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -368,7 +368,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
         const changed = incrementValue(amount, {
           direction: event.deltaY > 0 ? -1 : 1,
           event,
-          reason: 'wheel',
+          reason: REASONS.wheel,
         });
         if (changed) {
           onValueCommitted(

--- a/packages/react/src/number-field/utils/types.ts
+++ b/packages/react/src/number-field/utils/types.ts
@@ -1,11 +1,13 @@
+import { REASONS } from '../../internals/reasons';
+
 export type Direction = -1 | 1;
 
 export type DirectionalChangeReason =
-  | 'increment-press'
-  | 'decrement-press'
-  | 'wheel'
-  | 'scrub'
-  | 'keyboard';
+  | typeof REASONS.incrementPress
+  | typeof REASONS.decrementPress
+  | typeof REASONS.wheel
+  | typeof REASONS.scrub
+  | typeof REASONS.keyboard;
 
 export interface ChangeEventCustomProperties {
   direction?: Direction | undefined;

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -378,7 +378,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
       if (open) {
         store.set('activeIndex', index);
       } else {
-        setValue(valuesRef.current[index], createChangeEventDetails('none'));
+        setValue(valuesRef.current[index], createChangeEventDetails(REASONS.none));
       }
     },
     onTyping(typing) {

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -132,7 +132,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   const pressedThumbIndexRef = React.useRef(-1);
   // The values when the current drag interaction started.
   const pressedValuesRef = React.useRef<readonly number[] | null>(null);
-  const lastChangeReasonRef = React.useRef<SliderRoot.ChangeEventReason>('none');
+  const lastChangeReasonRef = React.useRef<SliderRoot.ChangeEventReason>(REASONS.none);
 
   // We can't use the :active browser pseudo-classes.
   // - The active state isn't triggered when clicking on the rail.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This is a very tiny PR to replace hardcoded change-reason strings with predefined `REASONS` constants for better consistency.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
