### PR TITLE
[drawer] Fix Shadow DOM swipe gestures

### DIFF
--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -248,6 +248,69 @@ describe('<Drawer.Viewport />', () => {
     }
   });
 
+  it('uses shadow-root hit testing for touch swipe targets', async () => {
+    const host = document.body.appendChild(document.createElement('div'));
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    const originalDocumentElementFromPoint = document.elementFromPoint;
+    const originalShadowElementFromPoint = shadowRoot.elementFromPoint;
+
+    try {
+      await render(
+        <Drawer.Root open>
+          <Drawer.Portal container={shadowRoot}>
+            <Drawer.Backdrop data-testid="backdrop" />
+            <Drawer.Viewport>
+              <Drawer.Popup>
+                <div data-testid="target">Target</div>
+                <div data-base-ui-swipe-ignore data-testid="ignored">
+                  Ignore
+                </div>
+              </Drawer.Popup>
+            </Drawer.Viewport>
+          </Drawer.Portal>
+        </Drawer.Root>,
+      );
+
+      const target = shadowRoot.querySelector<HTMLElement>('[data-testid="target"]');
+      const ignored = shadowRoot.querySelector<HTMLElement>('[data-testid="ignored"]');
+      const backdrop = shadowRoot.querySelector<HTMLElement>('[data-testid="backdrop"]');
+      expect(target).not.toBeNull();
+      expect(ignored).not.toBeNull();
+      expect(backdrop).not.toBeNull();
+      if (!target || !ignored || !backdrop) {
+        return;
+      }
+
+      document.elementFromPoint = () => host;
+      shadowRoot.elementFromPoint = () => ignored;
+
+      fireEvent.touchStart(ignored, {
+        touches: [createTouch(ignored, { clientX: 0, clientY: 0 })],
+      });
+
+      await flushMicrotasks();
+
+      expect(backdrop).not.toHaveAttribute('data-swiping');
+
+      fireEvent.touchEnd(ignored, {
+        changedTouches: [createTouch(ignored, { clientX: 0, clientY: 0 })],
+      });
+      shadowRoot.elementFromPoint = () => target;
+
+      fireEvent.touchStart(target, {
+        touches: [createTouch(target, { clientX: 0, clientY: 0 })],
+      });
+
+      await flushMicrotasks();
+
+      expect(backdrop).toHaveAttribute('data-swiping', '');
+    } finally {
+      document.elementFromPoint = originalDocumentElementFromPoint;
+      shadowRoot.elementFromPoint = originalShadowElementFromPoint;
+      host.remove();
+    }
+  });
+
   it('clears the backdrop data-swiping attribute when the drawer unmounts mid-swipe', async () => {
     const { unmount } = await render(
       <Drawer.Root open>

--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -314,6 +314,58 @@ describe('<Drawer.Viewport />', () => {
     }
   });
 
+  it.skipIf(isJSDOM)('starts a swipe inside a shadow root using real hit testing', async () => {
+    const host = document.body.appendChild(document.createElement('div'));
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+
+    try {
+      await render(
+        <Drawer.Root open swipeDirection="down">
+          <Drawer.Portal container={shadowRoot}>
+            <Drawer.Backdrop data-testid="backdrop" />
+            <Drawer.Viewport>
+              <Drawer.Popup
+                data-testid="popup"
+                style={{ position: 'fixed', top: 0, left: 0, width: 200, height: 200 }}
+              >
+                Content
+              </Drawer.Popup>
+            </Drawer.Viewport>
+          </Drawer.Portal>
+        </Drawer.Root>,
+      );
+
+      const popup = shadowRoot.querySelector<HTMLElement>('[data-testid="popup"]');
+      const backdrop = shadowRoot.querySelector<HTMLElement>('[data-testid="backdrop"]');
+      expect(popup).not.toBeNull();
+      expect(backdrop).not.toBeNull();
+      if (!popup || !backdrop) {
+        return;
+      }
+
+      // No `elementFromPoint` stubbing: a real document hit test retargets the popup content to
+      // the shadow host, which fails the `contains()` check in the swipe `canStart` guard, so
+      // this only engages when the hit test runs against the shadow root.
+      fireEvent.touchStart(popup, {
+        touches: [createTouch(popup, { clientX: 100, clientY: 100 })],
+      });
+
+      fireEvent.touchMove(popup, {
+        touches: [createTouch(popup, { clientX: 100, clientY: 125 })],
+      });
+
+      await waitFor(() => {
+        expect(backdrop).toHaveAttribute('data-swiping', '');
+      });
+
+      fireEvent.touchEnd(popup, {
+        changedTouches: [createTouch(popup, { clientX: 100, clientY: 125 })],
+      });
+    } finally {
+      host.remove();
+    }
+  });
+
   it('clears the backdrop data-swiping attribute when the drawer unmounts mid-swipe', async () => {
     const { unmount } = await render(
       <Drawer.Root open>

--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -281,7 +281,10 @@ describe('<Drawer.Viewport />', () => {
         return;
       }
 
-      document.elementFromPoint = () => host;
+      // Returning an in-popup element from the document hit test would start the swipe if the
+      // shadow root were not consulted, so this pins the shadow-root lookup rather than the
+      // `contains()` rejection that a retargeted host would also trigger.
+      document.elementFromPoint = () => target;
       shadowRoot.elementFromPoint = () => ignored;
 
       fireEvent.touchStart(ignored, {

--- a/packages/react/src/drawer/viewport/DrawerViewport.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.tsx
@@ -354,7 +354,7 @@ export const DrawerViewport = React.forwardRef(function DrawerViewport(
       }
 
       const doc = popupElement.ownerDocument;
-      const elementAtPoint = getElementAtPoint(doc, position.x, position.y);
+      const elementAtPoint = getElementAtPoint(popupElement.getRootNode(), position.x, position.y);
       if (!elementAtPoint || !contains(popupElement, elementAtPoint)) {
         return false;
       }
@@ -870,8 +870,11 @@ export const DrawerViewport = React.forwardRef(function DrawerViewport(
             return;
           }
 
-          const doc = ownerDocument(event.currentTarget);
-          const elementAtPoint = getElementAtPoint(doc, event.clientX, event.clientY);
+          const elementAtPoint = getElementAtPoint(
+            event.currentTarget.getRootNode(),
+            event.clientX,
+            event.clientY,
+          );
           if (isSwipeIgnoredTarget(elementAtPoint) || isDrawerContentTarget(elementAtPoint)) {
             return;
           }
@@ -923,9 +926,12 @@ export const DrawerViewport = React.forwardRef(function DrawerViewport(
             return;
           }
 
-          const doc = ownerDocument(event.currentTarget);
-          const elementAtPoint = getElementAtPoint(doc, touch.clientX, touch.clientY);
           const rootElement = event.currentTarget;
+          const elementAtPoint = getElementAtPoint(
+            rootElement.getRootNode(),
+            touch.clientX,
+            touch.clientY,
+          );
           const eventTarget = getTarget(event.nativeEvent);
           const target = isElement(eventTarget) ? eventTarget : rootElement;
           if (!contains(rootElement, target)) {

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.test.tsx
@@ -1072,6 +1072,70 @@ describe('<Drawer.VirtualKeyboardProvider />', () => {
     },
   );
 
+  it.skipIf(isJSDOM)(
+    'resolves the lift point through the shadow root when the drawer renders in one',
+    async () => {
+      const host = document.body.appendChild(document.createElement('div'));
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+      const originalDocumentElementFromPoint = document.elementFromPoint;
+      const originalShadowElementFromPoint = shadowRoot.elementFromPoint;
+      let focusSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+      try {
+        await render(
+          <Drawer.Root open modal={false}>
+            <Drawer.VirtualKeyboardProvider>
+              <Drawer.Portal container={shadowRoot}>
+                <Drawer.Viewport>
+                  <Drawer.Popup>
+                    <input data-testid="input" type="text" />
+                    <button data-testid="button" type="button">
+                      Action
+                    </button>
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.VirtualKeyboardProvider>
+          </Drawer.Root>,
+        );
+
+        const input = shadowRoot.querySelector<HTMLInputElement>('[data-testid="input"]');
+        const button = shadowRoot.querySelector<HTMLButtonElement>('[data-testid="button"]');
+        expect(input).not.toBeNull();
+        expect(button).not.toBeNull();
+        if (!input || !button) {
+          return;
+        }
+
+        focusSpy = vi.spyOn(input, 'focus');
+        // A real document hit test retargets shadow content to the host, so only the shadow
+        // root sees the button under the lift point. Resolving against the document would miss
+        // it and fall back to focusing the touchstart input.
+        document.elementFromPoint = () => host;
+        shadowRoot.elementFromPoint = () => button;
+
+        fireEvent.touchStart(input, {
+          touches: [createTouch(input, { clientX: 0, clientY: 0 })],
+        });
+
+        const touchEnd = createNativeTouchEnd(input, { clientX: 5, clientY: 5 });
+
+        await act(async () => {
+          input.dispatchEvent(touchEnd);
+          await flushMicrotasks();
+        });
+
+        expect(touchEnd.defaultPrevented).toBe(false);
+        expect(focusSpy).not.toHaveBeenCalled();
+      } finally {
+        document.elementFromPoint = originalDocumentElementFromPoint;
+        shadowRoot.elementFromPoint = originalShadowElementFromPoint;
+        host.remove();
+        focusSpy?.mockRestore();
+      }
+    },
+  );
+
   it.skipIf(isJSDOM)('preserves native taps on disabled inputs', async () => {
     await render(
       <Drawer.Root open modal={false}>

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
@@ -568,10 +568,10 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
     }
 
     const touch = event.changedTouches[0] ?? event.touches[0];
-    const doc = ownerDocument(event.currentTarget);
+    const root = event.currentTarget.getRootNode();
     const nativeEventTarget = getTarget(event.nativeEvent);
     const pointTarget = touch
-      ? resolveKeyboardTouchTargetFromPoint(doc, touch.clientX, touch.clientY)
+      ? resolveKeyboardTouchTargetFromPoint(root, touch.clientX, touch.clientY)
       : null;
 
     // The lift point landed on another interactive/label element; let its native tap
@@ -726,11 +726,11 @@ function getContentEditableHost(element: HTMLElement): HTMLElement {
 }
 
 function resolveKeyboardTouchTargetFromPoint(
-  doc: Document,
+  root: Node,
   clientX: number,
   clientY: number,
 ): KeyboardTouchTarget | typeof KEYBOARD_TAP_BLOCKED | null {
-  const exactTarget = getElementAtPoint(doc, clientX, clientY);
+  const exactTarget = getElementAtPoint(root, clientX, clientY);
   if (isHTMLElement(exactTarget)) {
     const exactKeyboardTarget = resolveKeyboardInputTarget(exactTarget);
     if (exactKeyboardTarget) {
@@ -758,7 +758,7 @@ function resolveKeyboardTouchTargetFromPoint(
     [-INPUT_TAP_HIT_SLOP, 0],
   ]) {
     const keyboardTarget = resolveKeyboardInputTarget(
-      getElementAtPoint(doc, clientX + offsetX, clientY + offsetY),
+      getElementAtPoint(root, clientX + offsetX, clientY + offsetY),
     );
 
     if (keyboardTarget) {

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
@@ -568,7 +568,7 @@ export function DrawerVirtualKeyboardProvider(props: DrawerVirtualKeyboardProvid
     }
 
     const touch = event.changedTouches[0] ?? event.touches[0];
-    const root = event.currentTarget.getRootNode();
+    const root = rootElement.getRootNode();
     const nativeEventTarget = getTarget(event.nativeEvent);
     const pointTarget = touch
       ? resolveKeyboardTouchTargetFromPoint(root, touch.clientX, touch.clientY)

--- a/packages/react/src/utils/getElementAtPoint.ts
+++ b/packages/react/src/utils/getElementAtPoint.ts
@@ -1,5 +1,8 @@
 type ElementFromPointRoot = Node & Partial<Pick<Document, 'elementFromPoint'>>;
 
+// `Document.elementFromPoint` retargets shadow content to the shadow host, which then fails
+// `contains()` checks against a popup inside that shadow root, so callers pass `getRootNode()`
+// (a document or a shadow root) rather than `ownerDocument()`.
 export function getElementAtPoint(
   root: ElementFromPointRoot | null | undefined,
   x: number,

--- a/packages/react/src/utils/getElementAtPoint.ts
+++ b/packages/react/src/utils/getElementAtPoint.ts
@@ -1,3 +1,9 @@
-export function getElementAtPoint(doc: Document | null | undefined, x: number, y: number) {
-  return typeof doc?.elementFromPoint === 'function' ? doc.elementFromPoint(x, y) : null;
+type ElementFromPointRoot = Node & Partial<Pick<Document, 'elementFromPoint'>>;
+
+export function getElementAtPoint(
+  root: ElementFromPointRoot | null | undefined,
+  x: number,
+  y: number,
+) {
+  return typeof root?.elementFromPoint === 'function' ? root.elementFromPoint(x, y) : null;
 }

--- a/packages/react/src/utils/useSwipeDismiss.ts
+++ b/packages/react/src/utils/useSwipeDismiss.ts
@@ -346,8 +346,8 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
   }
 
   function getTargetAtPoint(position: { x: number; y: number }, nativeEvent: Event) {
-    const doc = ownerDocument(elementRef.current);
-    const elementAtPoint = getElementAtPoint(doc, position.x, position.y);
+    const root = elementRef.current?.getRootNode();
+    const elementAtPoint = getElementAtPoint(root, position.x, position.y);
     const target = elementAtPoint ?? getTarget(nativeEvent);
     return target as HTMLElement | null;
   }


### PR DESCRIPTION
Fixes #5359

## Changes

- Use the drawer's document or shadow root when hit-testing swipe targets.
- Preserve ignored-target and scroll-arbitration behavior inside shadow roots.