### PR TITLE
[popups] Handle Escape during deferred opens

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useClick.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useClick.test.tsx
@@ -124,6 +124,31 @@ describe.skipIf(!isJSDOM)('useClick', () => {
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
   });
 
+  test('cancels a pending mousedown open when Escape is pressed', async () => {
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameCallbacks.push(callback);
+      return frameCallbacks.length;
+    });
+    const onOpenChange = vi.fn();
+
+    render(<App event="mousedown" onOpenChange={onOpenChange} />);
+
+    const button = screen.getByRole('button');
+
+    fireEvent.pointerDown(button, { pointerType: 'mouse' });
+    fireEvent.mouseDown(button);
+    act(() => button.focus());
+    fireEvent.keyDown(button, { key: 'Escape' });
+
+    await act(async () => {
+      frameCallbacks.forEach((callback) => callback(0));
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
   test('closes from the mousedown event path', async () => {
     render(<App event="mousedown" initialOpen />);
 
@@ -174,6 +199,27 @@ describe.skipIf(!isJSDOM)('useClick', () => {
     });
 
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  test('cancels a delayed touch open when Escape is pressed', async () => {
+    vi.useFakeTimers();
+    const onOpenChange = vi.fn();
+
+    render(<App touchOpenDelay={100} onOpenChange={onOpenChange} />);
+
+    const button = screen.getByRole('button');
+
+    fireEvent.pointerDown(button, { pointerType: 'touch' });
+    fireEvent.click(button);
+    act(() => button.focus());
+    fireEvent.keyDown(button, { key: 'Escape' });
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
   test('delays touch opening from the deferred mousedown event path', async () => {

--- a/packages/react/src/floating-ui-react/hooks/useClick.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useClick.test.tsx
@@ -2,7 +2,7 @@ import { vi, expect } from 'vitest';
 import { act, fireEvent, flushMicrotasks, render, screen } from '@mui/internal-test-utils';
 import * as React from 'react';
 import { isJSDOM, useTestInteractions } from '#test-utils';
-import { useClick, useFloating, useHover } from '../index';
+import { useClick, useDismiss, useFloating, useHover } from '../index';
 import { REASONS } from '../../internals/reasons';
 import type { UseFloatingOptions } from '../types';
 import type { UseClickProps } from './useClick';
@@ -31,6 +31,22 @@ function App({
   return (
     <React.Fragment>
       <Reference data-testid="reference" {...getReferenceProps({ ref: refs.setReference })} />
+      {open && <div role="tooltip" {...getFloatingProps({ ref: refs.setFloating })} />}
+    </React.Fragment>
+  );
+}
+
+function DismissApp(props: UseClickProps) {
+  const [open, setOpen] = React.useState(false);
+  const { refs, context } = useFloating({ open, onOpenChange: setOpen });
+  const { getReferenceProps, getFloatingProps } = useTestInteractions([
+    useClick(context, props),
+    useDismiss(context),
+  ]);
+
+  return (
+    <React.Fragment>
+      <button {...getReferenceProps({ ref: refs.setReference })} />
       {open && <div role="tooltip" {...getFloatingProps({ ref: refs.setFloating })} />}
     </React.Fragment>
   );
@@ -149,6 +165,29 @@ describe.skipIf(!isJSDOM)('useClick', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
+  test('closes when Escape is pressed after the deferred mousedown open runs', async () => {
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameCallbacks.push(callback);
+      return frameCallbacks.length;
+    });
+
+    render(<DismissApp event="mousedown" />);
+
+    const button = screen.getByRole('button');
+
+    fireEvent.pointerDown(button, { pointerType: 'mouse' });
+    fireEvent.mouseDown(button);
+
+    await act(async () => {
+      frameCallbacks.forEach((callback) => callback(0));
+      // Keep Escape in the same batch as the pending open to exercise the pre-commit window.
+      button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
   test('closes from the mousedown event path', async () => {
     render(<App event="mousedown" initialOpen />);
 
@@ -219,6 +258,24 @@ describe.skipIf(!isJSDOM)('useClick', () => {
     });
 
     expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  test('closes when Escape is pressed after the delayed touch open runs', async () => {
+    vi.useFakeTimers();
+
+    render(<DismissApp touchOpenDelay={100} />);
+
+    const button = screen.getByRole('button');
+
+    fireEvent.pointerDown(button, { pointerType: 'touch' });
+    fireEvent.click(button);
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+      button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 

--- a/packages/react/src/floating-ui-react/hooks/useClick.ts
+++ b/packages/react/src/floating-ui-react/hooks/useClick.ts
@@ -213,8 +213,13 @@ export function useClick(
           pointerType,
         );
       },
-      onKeyDown() {
+      onKeyDown(event) {
         pointerTypeRef.current = undefined;
+
+        if (event.key === 'Escape') {
+          frame.cancel();
+          touchOpenTimeout.clear();
+        }
       },
     };
   }, [

--- a/packages/react/src/floating-ui-react/hooks/useClick.ts
+++ b/packages/react/src/floating-ui-react/hooks/useClick.ts
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { useAnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import { useTimeout } from '@base-ui/utils/useTimeout';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
@@ -84,15 +85,18 @@ export function useClick(
       nativeEvent: MouseEvent,
       target: HTMLElement,
       pointerType: 'mouse' | 'pen' | 'touch' | 'virtual' | undefined,
+      synchronous = false,
     ) {
       const details = createChangeEventDetails(reason, nativeEvent, target);
+      const setOpen = () => store.setOpen(nextOpen, details);
 
+      // Preserve discrete-event ordering after deferring work so later input sees the new state.
       if (nextOpen && pointerType === 'touch' && touchOpenDelay > 0) {
-        touchOpenTimeout.start(touchOpenDelay, () => {
-          store.setOpen(true, details);
-        });
+        touchOpenTimeout.start(touchOpenDelay, () => ReactDOM.flushSync(setOpen));
+      } else if (synchronous) {
+        ReactDOM.flushSync(setOpen);
       } else {
-        store.setOpen(nextOpen, details);
+        setOpen();
       }
     }
 
@@ -177,7 +181,7 @@ export function useClick(
         // Wait until focus is set on the element. This is an alternative to
         // `event.preventDefault()` to avoid :focus-visible from appearing when using a pointer.
         frame.request(() => {
-          setOpenWithTouchDelay(nextOpen, nativeEvent, eventCurrentTarget, pointerType);
+          setOpenWithTouchDelay(nextOpen, nativeEvent, eventCurrentTarget, pointerType, true);
         });
       },
       onClick(event) {


### PR DESCRIPTION
Addresses the reproducible stuck-open Select state reported in #5358. The separate development-build renderer spin remains unverified and is not covered here.

Pointer-driven opens defer work so focus can settle. Escape can arrive either before that work runs or after it requests an open but before React commits the new state.

## Changes

- Cancel pending animation-frame and delayed-touch opens when Escape arrives first.
- Commit deferred state changes synchronously so subsequent input observes the updated open state.
- Cover both event orderings for mouse and touch in the shared `useClick` tests.