### PR TITLE
[menu] Propagate disabled state to items

### DIFF
--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
@@ -31,7 +31,7 @@ export const MenuCheckboxItem = React.forwardRef(function MenuCheckboxItem(
     id: idProp,
     label,
     nativeButton = false,
-    disabled = false,
+    disabled: disabledProp = false,
     closeOnClick = false,
     checked: checkedProp,
     defaultChecked,
@@ -45,6 +45,8 @@ export const MenuCheckboxItem = React.forwardRef(function MenuCheckboxItem(
   const id = useBaseUiId(idProp);
 
   const { store } = useMenuRootContext();
+  const rootDisabled = store.useState('disabled');
+  const disabled = disabledProp || rootDisabled;
   const highlighted = store.useState('isActive', listItem.index);
   const itemProps = store.useState('itemProps');
 

--- a/packages/react/src/menu/item/MenuItem.tsx
+++ b/packages/react/src/menu/item/MenuItem.tsx
@@ -24,7 +24,7 @@ export const MenuItem = React.forwardRef(function MenuItem(
     id: idProp,
     label,
     nativeButton = false,
-    disabled = false,
+    disabled: disabledProp = false,
     closeOnClick = true,
     style,
     ...elementProps
@@ -35,6 +35,8 @@ export const MenuItem = React.forwardRef(function MenuItem(
   const id = useBaseUiId(idProp);
 
   const { store } = useMenuRootContext();
+  const rootDisabled = store.useState('disabled');
+  const disabled = disabledProp || rootDisabled;
   const highlighted = store.useState('isActive', listItem.index);
   const itemProps = store.useState('itemProps');
 

--- a/packages/react/src/menu/item/useMenuItem.ts
+++ b/packages/react/src/menu/item/useMenuItem.ts
@@ -14,7 +14,7 @@ export const REGULAR_ITEM = {
 export function useMenuItem(params: UseMenuItemParameters): UseMenuItemReturnValue {
   const {
     closeOnClick,
-    disabled: disabledProp,
+    disabled,
     highlighted,
     id,
     store,
@@ -23,9 +23,6 @@ export function useMenuItem(params: UseMenuItemParameters): UseMenuItemReturnVal
     itemMetadata,
     nodeId,
   } = params;
-
-  const rootDisabled = store.useState('disabled');
-  const disabled = disabledProp || rootDisabled;
 
   const itemRef = React.useRef<HTMLElement | null>(null);
 

--- a/packages/react/src/menu/radio-item/MenuRadioItem.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.tsx
@@ -51,7 +51,8 @@ export const MenuRadioItem = React.forwardRef(function MenuRadioItem(
     disabled: groupDisabled,
   } = useMenuRadioGroupContext();
 
-  const disabled = groupDisabled || disabledProp;
+  const rootDisabled = store.useState('disabled');
+  const disabled = disabledProp || groupDisabled || rootDisabled;
   const checked = selectedValue === value;
 
   const { getItemProps, itemRef } = useMenuItem({

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -2822,6 +2822,31 @@ describe('<Menu.Root />', () => {
   });
 
   describe('prop: disabled', () => {
+    it('marks items as disabled when controlled open', async () => {
+      await render(
+        <TestMenuContents
+          rootProps={{ open: true, disabled: true }}
+          popupProps={{
+            children: (
+              <React.Fragment>
+                <Menu.Item data-testid="item">Item</Menu.Item>
+                <Menu.CheckboxItem data-testid="checkbox-item">Checkbox item</Menu.CheckboxItem>
+                <Menu.RadioGroup>
+                  <Menu.RadioItem data-testid="radio-item" value="radio">
+                    Radio item
+                  </Menu.RadioItem>
+                </Menu.RadioGroup>
+              </React.Fragment>
+            ),
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('item')).toHaveAttribute('data-disabled');
+      expect(screen.getByTestId('checkbox-item')).toHaveAttribute('data-disabled');
+      expect(screen.getByTestId('radio-item')).toHaveAttribute('data-disabled');
+    });
+
     it('does not highlight items with text navigation when controlled open', async () => {
       const { user } = await render(
         <TestMenuContents


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR fixes menu items not exposing their effective disabled state when a controlled-open `Menu.Root` is disabled.

Previously, the root disabled state was applied only inside `useMenuItem`, so interactions were prevented, but items did not receive `data-disabled` and their render state reported `disabled: false`.

Instead of resolving the final disabled state in the hook, this PR resolves it in `Menu.Item`, `Menu.CheckboxItem`, and `Menu.RadioItem`. 

The disabled-state logic in `useMenuItem` is removed because it is no longer needed and could easily cause interaction behavior and render state to become inconsistent again.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
