### PR TITLE
[combobox][select] Inherit root disabled state in items

### DIFF
--- a/packages/react/src/combobox/item/ComboboxItem.test.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.test.tsx
@@ -159,6 +159,36 @@ describe('<Combobox.Item />', () => {
     expect(input).toHaveValue('');
   });
 
+  it('inherits the disabled state from the root', async () => {
+    const handleClick = vi.fn();
+
+    const { user } = await render(
+      <Combobox.Root defaultOpen disabled>
+        <Combobox.Input data-testid="input" />
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                <Combobox.Item value="one" onClick={handleClick}>
+                  one
+                </Combobox.Item>
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    const item = screen.getByRole('option', { name: 'one' });
+    expect(item).toHaveAttribute('data-disabled');
+
+    await user.click(item);
+    await flushMicrotasks();
+
+    expect(handleClick).not.toHaveBeenCalled();
+    expect(screen.getByTestId('input')).toHaveValue('');
+  });
+
   it('Enter selects highlighted item', async () => {
     const { user } = await render(
       <Combobox.Root>

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -41,7 +41,7 @@ function ComboboxItemInner(props: ComboboxItemInnerProps) {
     style,
     value: itemValue = null,
     index: indexProp,
-    disabled = false,
+    disabled: disabledProp = false,
     nativeButton = false,
     ...elementProps
   } = componentProps;
@@ -58,9 +58,11 @@ function ComboboxItemInner(props: ComboboxItemInnerProps) {
   const hasItems = useComboboxHasItemsContext();
 
   const selectionMode = useStore(store, selectors.selectionMode);
+  const rootDisabled = useStore(store, selectors.disabled);
   const readOnly = useStore(store, selectors.readOnly);
   const isItemEqualToValue = useStore(store, selectors.isItemEqualToValue);
 
+  const disabled = rootDisabled || disabledProp;
   const selectable = selectionMode !== 'none';
   const index = indexProp ?? indexFromFilter ?? listItem.index;
   const hasRegistered = index !== -1;

--- a/packages/react/src/select/item/SelectItem.test.tsx
+++ b/packages/react/src/select/item/SelectItem.test.tsx
@@ -268,6 +268,35 @@ describe('<Select.Item />', () => {
     expect(screen.getByTestId('value').textContent).toBe('');
   });
 
+  it('inherits the disabled state from the root', async () => {
+    const handleClick = vi.fn();
+
+    const { user } = await render(
+      <Select.Root open disabled>
+        <Select.Trigger>
+          <Select.Value data-testid="value" />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="one" onClick={handleClick}>
+                one
+              </Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const item = screen.getByRole('option', { name: 'one' });
+    expect(item).toHaveAttribute('data-disabled');
+
+    await user.click(item);
+
+    expect(handleClick).not.toHaveBeenCalled();
+    expect(screen.getByTestId('value').textContent).toBe('');
+  });
+
   it('should call onClick exactly once for a regular click', async () => {
     const handleClick = vi.fn();
 

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -36,7 +36,7 @@ export const SelectItem = React.memo(
       style,
       value: itemValue = null,
       label,
-      disabled = false,
+      disabled: disabledProp = false,
       nativeButton = false,
       ...elementProps
     } = componentProps;
@@ -62,6 +62,7 @@ export const SelectItem = React.memo(
       readOnly,
     } = useSelectRootContext();
 
+    const disabled = selectDisabled || disabledProp;
     const highlighted = useStore(store, selectors.isActive, listItem.index);
     const open = useStore(store, selectors.open);
     const selected = useStore(store, selectors.isSelected, itemValue);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR fixes `Combobox.Item` and `Select.Item` not inheriting the disabled state from their root components.

[Related discussion](https://github.com/mui/base-ui/pull/5363#issuecomment-5112483189)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
