### PR TITLE
[toolbar] Prevent IME text entry while disabled

### DIFF
--- a/packages/react/src/toolbar/input/ToolbarInput.test.tsx
+++ b/packages/react/src/toolbar/input/ToolbarInput.test.tsx
@@ -49,6 +49,40 @@ describe('<Toolbar.Input />', () => {
 
       expect(screen.getByTestId('input')).toBe(screen.getByRole('textbox'));
     });
+
+    it('is read-only while disabled', async () => {
+      function TestInput({ disabled }: { disabled: boolean }) {
+        return (
+          <Toolbar.Root>
+            <Toolbar.Input data-testid="input" disabled={disabled} />
+          </Toolbar.Root>
+        );
+      }
+
+      const { setProps } = await render(<TestInput disabled />);
+      const input = screen.getByTestId('input');
+
+      // The input stays editable while disabled because it receives `aria-disabled`
+      // rather than the native `disabled` attribute, so that it remains focusable.
+      // Canceling `keydown` is not enough to reject text: an IME commits composed text
+      // through a channel a canceled `keydown` never reaches. `readOnly` is what
+      // actually prevents text entry.
+      expect(input).not.toHaveAttribute('disabled');
+      expect(input).toHaveAttribute('readonly');
+
+      await setProps({ disabled: false });
+      expect(input).not.toHaveAttribute('readonly');
+    });
+
+    it('keeps an explicit readOnly prop when not disabled', async () => {
+      await render(
+        <Toolbar.Root>
+          <Toolbar.Input data-testid="input" readOnly />
+        </Toolbar.Root>,
+      );
+
+      expect(screen.getByTestId('input')).toHaveAttribute('readonly');
+    });
   });
 
   describe('pointer interactions', () => {
@@ -193,6 +227,27 @@ describe('<Toolbar.Input />', () => {
   });
 
   describe.skipIf(isJSDOM)('disabled', () => {
+    it('does not accept typed text when disabled', async () => {
+      const { user } = await render(
+        <Toolbar.Root>
+          <Toolbar.Button data-testid="button" />
+          <Toolbar.Input disabled />
+        </Toolbar.Root>,
+      );
+
+      const button = screen.getByTestId('button');
+      const input = screen.getByRole('textbox');
+
+      await user.keyboard('[Tab]');
+      expect(button).toHaveFocus();
+
+      await user.keyboard(`[${ARROW_RIGHT}]`);
+      expect(input).toHaveFocus();
+
+      await user.keyboard('abc');
+      expect(input).toHaveValue('');
+    });
+
     it('does not trap keyboard focus when disabled', async () => {
       const { user } = await render(
         <div>

--- a/packages/react/src/toolbar/input/ToolbarInput.tsx
+++ b/packages/react/src/toolbar/input/ToolbarInput.tsx
@@ -70,7 +70,16 @@ export const ToolbarInput = React.forwardRef(function ToolbarInput(
       metadata={itemMetadata}
       state={state}
       refs={[forwardedRef]}
-      props={[defaultProps, elementProps, focusableWhenDisabledProps]}
+      props={[
+        defaultProps,
+        elementProps,
+        focusableWhenDisabledProps,
+        // `useFocusableWhenDisabled` only cancels `keydown`, but an IME commits composed
+        // text through a channel that a canceled `keydown` never reaches. Since the input
+        // stays editable (it receives `aria-disabled`, never the native `disabled`
+        // attribute, so it remains focusable), it must be made read-only to reject text.
+        disabled ? { readOnly: true } : {},
+      ]}
     />
   );
 });


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #5366

## Problem

A disabled `Toolbar.Input` still accepts text entered through an IME (Korean, Japanese, Chinese, …). Latin typing is correctly blocked; composing text with an IME writes into the input as if it were enabled.

`useFocusableWhenDisabled` blocks text entry solely by canceling `keydown`:

https://github.com/mui/base-ui/blob/master/packages/react/src/utils/useFocusableWhenDisabled.ts#L22-L24

`Toolbar.Input` passes `focusableWhenDisabled` (default `true`) and `isNativeButton: false`, so the native `disabled` attribute is never applied — only `aria-disabled` — which keeps the element focusable. The existing test asserts exactly this (`expect(input).not.toHaveAttribute('disabled')`). `ToolbarInput` itself only cancels `onClick` and `onPointerDown`. So that single `preventDefault` is the **only** thing preventing text entry, and it is not enough: an IME commits composed text through a channel a canceled `keydown` never reaches.

Worth stressing: `preventDefault` is not failing to run. I measured it firing, and it correctly blocks both ordinary typing and text carried on the key event itself. Only the composition → commit path gets through.

### Measurements

Chromium over CDP: `Input.dispatchKeyEvent` (virtual keycode 229, as a real IME emits) then `Input.imeSetComposition` + `Input.insertText`. Each variant is a bare `<input>`; `prevented` reproduces the hook's handler verbatim.

| variant                          | IME (compose after canceled keydown) | text on key event | ordinary typing |
| -------------------------------- | ------------------------------------ | ----------------- | --------------- |
| control (no handler)             | `한`                                 | `한`              | `abc`           |
| **prevented (current behavior)** | **`한` ← bug**                       | `''`              | `''`            |
| native `disabled` attribute      | `''`                                 | `''`              | `''`            |
| **`readOnly` (this PR)**         | `''`                                 | `''`              | `''`            |

The `control` row confirms the simulation is faithful.

## Fix

Mark the input `readOnly` while disabled. It rejects text from every input method while keeping the element focusable, so `focusableWhenDisabled` behavior (tabbing away, roving focus) is preserved. The native `disabled` attribute also blocks IME but removes focusability, defeating the purpose of the hook.

It is scoped to `ToolbarInput` rather than the shared hook: `useFocusableWhenDisabled` has only two consumers (`ToolbarInput` and `useButton`), and `isNativeButton: false` is used only by `ToolbarInput` — it is the sole text-entry consumer. Applying `readOnly` in the hook would leak the attribute onto buttons and links.

It is appended after `elementProps` so it wins while disabled, and it is `{}` when enabled so an explicit `readOnly` prop is never clobbered (covered by a test).

As a side effect this also closes context-menu paste, drag-and-drop, and autofill, which currently bypass the disabled state through the same gap.

`readOnly` is ignored by checkboxes, so `Toolbar.Input type="checkbox"` keeps relying on the existing `onClick`/`onPointerDown` handling — not an IME concern, and the existing test for it still passes.

## Tests

Added to `ToolbarInput.test.tsx`:

1. **`is read-only while disabled`** — the regression test. I verified it goes **red** without the fix and green with it. Also asserts the attribute is dropped when re-enabled.
2. **`keeps an explicit readOnly prop when not disabled`** — guards the prop-merge order.
3. **`does not accept typed text when disabled`** — worth flagging honestly: **this one passes without the fix too**, because canceling `keydown` already blocks ordinary typing. It is not a guard for this bug; it fills a separate gap, since the file previously had no `keyDown`/`preventDefault`/`composition` assertions at all, so "typing is blocked while disabled" was untested in general.

On the seam: a real IME cannot be driven from the Vitest browser harness, so no test asserts the user-visible symptom directly. Synthetic `compositionstart`/`compositionend` events would pass regardless of `readOnly` and would be a fake test, so I did not add one. Test 1 locks down the mechanism that blocks IME instead. Happy to add the standalone CDP script somewhere if you'd like the symptom covered.

## Relationship to #4968

#4968 states: _"Removed the redundant `stopEvent` keydown handler from `Toolbar.Input`… `useFocusableWhenDisabled` already prevents text entry."_ This PR contradicts that premise for IME input, so it partly revisits that decision. Flagging it explicitly rather than burying it.

Note the fix is not a `keyCode === 229` guard. The existing `event.which === 229` guards in `NumberFieldInput`, `ComboboxInput`, and `useListNavigation` exist to _avoid interfering_ with IME composition — the opposite of what is needed here. Adding one makes no difference to this bug; the composition commit path still writes to the input.

## Verification

- `ToolbarInput` — 30 tests pass in Chromium, 23 pass / 7 skipped in jsdom.
- Whole `src/toolbar` suite — 159 pass / 1 skipped in Chromium.
- Prettier clean.

Not verified: Safari and Firefox. Worth a look, given `NumberFieldInput` notes that `isComposing` is broken in Safari (webkit bug 165004). I also did not hand-test with a real OS IME — the measurements above are CDP-driven, using Chromium's IME bridge.
