### PR TITLE
[number-field] Enhance paste handling to strip trailing invalid characters

### DIFF
--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -89,20 +89,6 @@ describe('<NumberField.Input />', () => {
     expect(input).toHaveValue('123');
   });
 
-  it('strips trailing invalid characters from a partially-numeric paste', async () => {
-    const onValueChange = vi.fn();
-    await render(<NumberField onValueChange={onValueChange} />);
-    const input = screen.getByRole('textbox') as HTMLInputElement;
-
-    await act(async () => input.focus());
-    input.select();
-    pasteText(input, '12abc');
-
-    expect(input).toHaveValue('12');
-    expect(onValueChange.mock.lastCall?.[0]).toBe(12);
-    expect(onValueChange.mock.lastCall?.[1].reason).toBe(REASONS.inputPaste);
-  });
-
   it('should increment on keydown ArrowUp', async () => {
     await render(
       <NumberField.Root defaultValue={0}>

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -89,6 +89,20 @@ describe('<NumberField.Input />', () => {
     expect(input).toHaveValue('123');
   });
 
+  it('strips trailing invalid characters from a partially-numeric paste', async () => {
+    const onValueChange = vi.fn();
+    await render(<NumberField onValueChange={onValueChange} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+
+    await act(async () => input.focus());
+    input.select();
+    pasteText(input, '12abc');
+
+    expect(input).toHaveValue('12');
+    expect(onValueChange.mock.lastCall?.[0]).toBe(12);
+    expect(onValueChange.mock.lastCall?.[1].reason).toBe(REASONS.inputPaste);
+  });
+
   it('should increment on keydown ArrowUp', async () => {
     await render(
       <NumberField.Root defaultValue={0}>

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -440,6 +440,22 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
         return;
       }
 
+      // Keep only the characters the typed path would accept, so pasting "12abc" yields "12"
+      // instead of displaying the trailing invalid characters (parseNumber salvages a leading
+      // number via parseFloat, so a null check alone wouldn't catch them).
+      const allowedNonNumericKeys = getAllowedNonNumericKeys();
+      const validCharacterString = Array.from(pastedData)
+        .filter(
+          (ch) =>
+            isNumeralChar(ch) ||
+            ANY_MINUS_DETECT_RE.test(ch) ||
+            allowedNonNumericKeys.has(ch) ||
+            // Bidi/format controls are stripped by `parseNumber`; don't let them reject the string
+            // (RTL locales insert them around exponent/currency signs, e.g. scientific notation).
+            FORMAT_CONTROL_DETECT_RE.test(ch),
+        )
+        .join('');
+      pastedData = validCharacterString;
       // Prevent `onChange` from being called.
       event.preventDefault();
 

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -2407,6 +2407,20 @@ describe('<NumberField />', () => {
       expect(onValueChange).not.toHaveBeenCalled();
     });
 
+    it('strips trailing invalid characters from a partially-numeric paste', async () => {
+      const onValueChange = vi.fn();
+      await render(<NumberField onValueChange={onValueChange} />);
+      const input = screen.getByRole('textbox') as HTMLInputElement;
+
+      await act(async () => input.focus());
+      input.select();
+      pasteText(input, '12abc');
+
+      expect(input).toHaveValue('12');
+      expect(onValueChange.mock.lastCall?.[0]).toBe(12);
+      expect(onValueChange.mock.lastCall?.[1].reason).toBe(REASONS.inputPaste);
+    });
+
     it('parses Persian digits and separators via change events', async () => {
       const onValueChange = vi.fn();
       function App() {


### PR DESCRIPTION
Issue reproduction steps

1. open https://base-ui.com/react/components/number-field
2. paste string `12abc`
3. Notice entire string get's accepted and onclick of `+` button, count rightly increases to `13`
