### PR TITLE
[popups] Avoid redundant re-renders with lazy flip

### DIFF
--- a/packages/react/src/internals/useAnchorPositioning.ts
+++ b/packages/react/src/internals/useAnchorPositioning.ts
@@ -559,10 +559,10 @@ export function useAnchorPositioningWithHook(
   // and flips back lazily, not eagerly. Ideal for filtered lists that change
   // the size of the popup dynamically to avoid unwanted flipping when typing.
   useIsoLayoutEffect(() => {
-    if (lazyFlip && mounted && isPositioned) {
+    if (lazyFlip && mounted && isPositioned && renderedSide !== side) {
       setMountSide(renderedSide);
     }
-  }, [lazyFlip, mounted, isPositioned, renderedSide]);
+  }, [lazyFlip, mounted, isPositioned, renderedSide, side]);
 
   const arrowStyles = React.useMemo(
     () => ({


### PR DESCRIPTION
This change reduces re-renders in components that use lazy flipping. 
You can verify this behavior using the Profiler in React DevTools.

 - /react/components/combobox
    - commit 11 => 10 
 - /react/components/menu
   - commit same 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
