### PR TITLE
[code-infra] Bump Claude review pin to pull-requests: read fix

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   claude-review:
-    uses: mui/mui-public/.github/workflows/claude-review.yml@d7a721986aed46adb128a9b200b12729c7a55378 # master
+    uses: mui/mui-public/.github/workflows/claude-review.yml@909caa6fc5ecd4b9324f7b53e4845f52764b1867 # master
     permissions:
       contents: read # read the repo (checkout + git diff)
       id-token: write # mint the GitHub OIDC token exchanged for a Claude token via WIF


### PR DESCRIPTION
Bumps the mui-public reusable claude-review pin to master `909caa6` (mui/mui-public#1738), which drops the review job to `pull-requests: read`. The old pin requested `pull-requests: write`, which exceeded this caller's `read` grant and failed reusable-workflow validation.