### PR TITLE
[scroll area] End thumb drag when the primary button is no longer held

### DIFF
--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
@@ -68,7 +68,7 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
   const thumbXRef = React.useRef<HTMLDivElement | null>(null);
   const cornerRef = React.useRef<HTMLDivElement | null>(null);
 
-  const thumbDraggingRef = React.useRef(false);
+  const activePointerIdRef = React.useRef<number | null>(null);
   const startYRef = React.useRef(0);
   const startXRef = React.useRef(0);
   const startScrollTopRef = React.useRef(0);
@@ -117,11 +117,11 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
   });
 
   const handlePointerDown = useStableCallback((event: React.PointerEvent) => {
-    if (event.button !== 0) {
+    if (event.button !== 0 || activePointerIdRef.current !== null) {
       return;
     }
 
-    thumbDraggingRef.current = true;
+    activePointerIdRef.current = event.pointerId;
     startYRef.current = event.clientY;
     startXRef.current = event.clientX;
     // Literal instead of `ScrollAreaScrollbarDataAttributes.orientation`: referencing an
@@ -144,7 +144,11 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
   });
 
   const handlePointerUp = useStableCallback((event: React.PointerEvent) => {
-    thumbDraggingRef.current = false;
+    if (event.pointerId !== activePointerIdRef.current) {
+      return;
+    }
+
+    activePointerIdRef.current = null;
 
     if (savedSnapTypeRef.current !== null) {
       if (viewportRef.current) {
@@ -163,7 +167,7 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
   });
 
   const handlePointerMove = useStableCallback((event: React.PointerEvent) => {
-    if (!thumbDraggingRef.current) {
+    if (event.pointerId !== activePointerIdRef.current) {
       return;
     }
 

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
@@ -117,8 +117,20 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
   });
 
   const handlePointerDown = useStableCallback((event: React.PointerEvent) => {
-    if (event.button !== 0 || activePointerIdRef.current !== null) {
+    if (event.button !== 0) {
       return;
+    }
+
+    if (activePointerIdRef.current !== null) {
+      const activeThumb =
+        currentOrientationRef.current === 'vertical' ? thumbYRef.current : thumbXRef.current;
+      // A live drag holds capture for the active pointer — ignore other pointers.
+      // No capture means the release went missing entirely (silent capture drop
+      // with an id that never reappears, e.g. a lost touch contact), so let the
+      // new pointer take over the latch instead of leaving dragging dead.
+      if (activeThumb?.hasPointerCapture(activePointerIdRef.current)) {
+        return;
+      }
     }
 
     activePointerIdRef.current = event.pointerId;

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
@@ -161,6 +161,10 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
     }
 
     activePointerIdRef.current = null;
+    // Clear the drag's scrolling state immediately rather than waiting for the
+    // `SCROLL_TIMEOUT` timer armed by the last drag move, so every release path
+    // (real, `pointercancel`, or the missed-release fallback) behaves the same.
+    (currentOrientationRef.current === 'vertical' ? setScrollingY : setScrollingX)(false);
 
     if (savedSnapTypeRef.current !== null) {
       if (viewportRef.current) {
@@ -297,9 +301,7 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
       touchModality,
       cornerRef,
       scrollingX,
-      setScrollingX,
       scrollingY,
-      setScrollingY,
       hovering,
       setHovering,
       viewportRef,

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.tsx
@@ -143,8 +143,37 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
     thumb?.setPointerCapture(event.pointerId);
   });
 
+  const handlePointerUp = useStableCallback((event: React.PointerEvent) => {
+    thumbDraggingRef.current = false;
+
+    if (savedSnapTypeRef.current !== null) {
+      if (viewportRef.current) {
+        viewportRef.current.style.scrollSnapType = savedSnapTypeRef.current;
+      }
+      savedSnapTypeRef.current = null;
+    }
+
+    const thumb =
+      currentOrientationRef.current === 'vertical' ? thumbYRef.current : thumbXRef.current;
+    // `pointercancel` releases capture implicitly, so guard against releasing a
+    // capture we no longer hold (which would throw).
+    if (thumb?.hasPointerCapture(event.pointerId)) {
+      thumb.releasePointerCapture(event.pointerId);
+    }
+  });
+
   const handlePointerMove = useStableCallback((event: React.PointerEvent) => {
     if (!thumbDraggingRef.current) {
+      return;
+    }
+
+    // The release can go missing entirely (e.g. the browser drops pointer
+    // capture while the scrollbar is hidden mid-drag), leaving the drag
+    // latched so a buttonless hover over the thumb scrolls the viewport.
+    // Treat a move without the primary button held (`buttons` bit 1 unset)
+    // as the missed release.
+    if (event.buttons % 2 === 0) {
+      handlePointerUp(event);
       return;
     }
 
@@ -185,25 +214,6 @@ export const ScrollAreaRoot = React.forwardRef(function ScrollAreaRoot(
     event.preventDefault();
 
     startScrolling(vertical);
-  });
-
-  const handlePointerUp = useStableCallback((event: React.PointerEvent) => {
-    thumbDraggingRef.current = false;
-
-    if (savedSnapTypeRef.current !== null) {
-      if (viewportRef.current) {
-        viewportRef.current.style.scrollSnapType = savedSnapTypeRef.current;
-      }
-      savedSnapTypeRef.current = null;
-    }
-
-    const thumb =
-      currentOrientationRef.current === 'vertical' ? thumbYRef.current : thumbXRef.current;
-    // `pointercancel` releases capture implicitly, so guard against releasing a
-    // capture we no longer hold (which would throw).
-    if (thumb?.hasPointerCapture(event.pointerId)) {
-      thumb.releasePointerCapture(event.pointerId);
-    }
   });
 
   function handleTouchModalityChange(event: React.PointerEvent) {

--- a/packages/react/src/scroll-area/root/ScrollAreaRootContext.ts
+++ b/packages/react/src/scroll-area/root/ScrollAreaRootContext.ts
@@ -19,9 +19,7 @@ export interface ScrollAreaRootContext {
   hovering: boolean;
   setHovering: React.Dispatch<React.SetStateAction<boolean>>;
   scrollingX: boolean;
-  setScrollingX: React.Dispatch<React.SetStateAction<boolean>>;
   scrollingY: boolean;
-  setScrollingY: React.Dispatch<React.SetStateAction<boolean>>;
   viewportRef: React.RefObject<HTMLDivElement | null>;
   scrollbarYRef: React.RefObject<HTMLDivElement | null>;
   thumbYRef: React.RefObject<HTMLDivElement | null>;

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -439,7 +439,7 @@ describe('<ScrollArea.Scrollbar />', () => {
       const scrollTopAfterTrackPress = viewport.scrollTop;
 
       fireEvent.pointerCancel(verticalScrollbar, { pointerId: 1 });
-      fireEvent.pointerMove(thumb, { clientY: 180, pointerId: 1 });
+      fireEvent.pointerMove(thumb, { clientY: 180, pointerId: 1, buttons: 1 });
 
       expect(viewport.scrollTop).toBe(scrollTopAfterTrackPress);
     });
@@ -612,7 +612,7 @@ describe('<ScrollArea.Scrollbar />', () => {
       // Park the scroll mid-range so an erroneous jump to an edge is detectable.
       viewport.scrollTop = 400;
       fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
-      fireEvent.pointerMove(thumb, { clientY: 5, pointerId: 1 });
+      fireEvent.pointerMove(thumb, { clientY: 5, pointerId: 1, buttons: 1 });
 
       expect(viewport.scrollTop).toBe(400);
     });
@@ -622,7 +622,7 @@ describe('<ScrollArea.Scrollbar />', () => {
 
       viewport.scrollTop = 400;
       fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
-      fireEvent.pointerMove(thumb, { clientY: 5, pointerId: 1 });
+      fireEvent.pointerMove(thumb, { clientY: 5, pointerId: 1, buttons: 1 });
 
       expect(viewport.scrollTop).toBe(400);
     });

--- a/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
+++ b/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
@@ -355,12 +355,16 @@ describe('<ScrollArea.Thumb />', () => {
       fireEvent.pointerMove(thumb, { clientY: 60, pointerId: 1, buttons: 1 });
       expect(viewport.scrollTop).toBeGreaterThan(scrolled);
       const continuedScroll = viewport.scrollTop;
+      expect(thumb).toHaveAttribute('data-scrolling');
 
       // The release never arrived (e.g. pointer capture was lost mid-drag), so
-      // the first buttonless move must end the drag rather than scroll.
+      // the first buttonless move must end the drag rather than scroll. It must
+      // clear the scrolling state immediately like a real release, not leave it
+      // lingering until the scroll timeout fires.
       fireEvent.pointerMove(thumb, { clientY: 100, pointerId: 1, buttons: 0 });
       expect(viewport.scrollTop).toBe(continuedScroll);
       expect(viewport.style.scrollSnapType).toBe('y mandatory');
+      expect(thumb).not.toHaveAttribute('data-scrolling');
 
       fireEvent.pointerMove(thumb, { clientY: 140, pointerId: 1, buttons: 0 });
       expect(viewport.scrollTop).toBe(continuedScroll);

--- a/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
+++ b/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
@@ -439,16 +439,32 @@ describe('<ScrollArea.Thumb />', () => {
 
   describe('scroll snap', () => {
     function defineThumbPointerCapture(thumb: HTMLElement) {
+      let capturedId: number | null = null;
       Object.defineProperties(thumb, {
         setPointerCapture: {
           configurable: true,
-          value: () => {},
+          value: (pointerId: number) => {
+            capturedId = pointerId;
+          },
         },
         hasPointerCapture: {
           configurable: true,
-          value: () => false,
+          value: (pointerId: number) => pointerId === capturedId,
+        },
+        releasePointerCapture: {
+          configurable: true,
+          value: (pointerId: number) => {
+            if (pointerId === capturedId) {
+              capturedId = null;
+            }
+          },
         },
       });
+      return {
+        dropCapture() {
+          capturedId = null;
+        },
+      };
     }
 
     function renderWithSnap() {
@@ -510,6 +526,26 @@ describe('<ScrollArea.Thumb />', () => {
       expect(viewport.style.scrollSnapType).toBe('none');
 
       fireEvent.pointerUp(thumb, { pointerId: 1 });
+      expect(viewport.style.scrollSnapType).toBe('y mandatory');
+    });
+
+    it('lets a new pointer take over when capture was silently dropped', async () => {
+      await renderWithSnap();
+
+      const viewport = screen.getByTestId('viewport');
+      const thumb = screen.getByTestId('thumb');
+      const capture = defineThumbPointerCapture(thumb);
+
+      fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
+      expect(viewport.style.scrollSnapType).toBe('none');
+
+      // The browser dropped capture without delivering `pointerup` or
+      // `pointercancel`, and the contact's id never reappears (e.g. a lost
+      // touch), so a new pointer must be able to take over the latched drag.
+      capture.dropCapture();
+
+      fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 2 });
+      fireEvent.pointerUp(thumb, { pointerId: 2 });
       expect(viewport.style.scrollSnapType).toBe('y mandatory');
     });
 

--- a/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
+++ b/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
@@ -308,7 +308,10 @@ describe('<ScrollArea.Thumb />', () => {
     async () => {
       await render(
         <ScrollArea.Root style={{ width: 200, height: 200 }}>
-          <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
+          <ScrollArea.Viewport
+            data-testid="viewport"
+            style={{ width: '100%', height: '100%', scrollSnapType: 'y mandatory' }}
+          >
             <div style={{ width: 200, height: 1000 }} />
           </ScrollArea.Viewport>
           <ScrollArea.Scrollbar
@@ -338,17 +341,29 @@ describe('<ScrollArea.Thumb />', () => {
       });
 
       fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
+      expect(viewport.style.scrollSnapType).toBe('none');
+
       fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1, buttons: 1 });
       expect(viewport.scrollTop).toBeGreaterThan(0);
       const scrolled = viewport.scrollTop;
 
+      // A different pointer hovering over the thumb must not end the active drag.
+      fireEvent.pointerMove(thumb, { clientY: 60, pointerId: 2, buttons: 0 });
+      expect(viewport.scrollTop).toBe(scrolled);
+      expect(viewport.style.scrollSnapType).toBe('none');
+
+      fireEvent.pointerMove(thumb, { clientY: 60, pointerId: 1, buttons: 1 });
+      expect(viewport.scrollTop).toBeGreaterThan(scrolled);
+      const continuedScroll = viewport.scrollTop;
+
       // The release never arrived (e.g. pointer capture was lost mid-drag), so
       // the first buttonless move must end the drag rather than scroll.
-      fireEvent.pointerMove(thumb, { clientY: 60, pointerId: 1, buttons: 0 });
-      expect(viewport.scrollTop).toBe(scrolled);
-
       fireEvent.pointerMove(thumb, { clientY: 100, pointerId: 1, buttons: 0 });
-      expect(viewport.scrollTop).toBe(scrolled);
+      expect(viewport.scrollTop).toBe(continuedScroll);
+      expect(viewport.style.scrollSnapType).toBe('y mandatory');
+
+      fireEvent.pointerMove(thumb, { clientY: 140, pointerId: 1, buttons: 0 });
+      expect(viewport.scrollTop).toBe(continuedScroll);
     },
   );
 
@@ -480,7 +495,7 @@ describe('<ScrollArea.Thumb />', () => {
       expect(viewport.style.scrollSnapType).toBe('y mandatory');
     });
 
-    it('keeps the saved scroll snap value when a second pointer starts mid-drag', async () => {
+    it('ignores a second pointer while a drag is active', async () => {
       await renderWithSnap();
 
       const viewport = screen.getByTestId('viewport');
@@ -489,6 +504,9 @@ describe('<ScrollArea.Thumb />', () => {
 
       fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
       fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 2 });
+      expect(viewport.style.scrollSnapType).toBe('none');
+
+      fireEvent.pointerUp(thumb, { pointerId: 2 });
       expect(viewport.style.scrollSnapType).toBe('none');
 
       fireEvent.pointerUp(thumb, { pointerId: 1 });

--- a/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
+++ b/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
@@ -62,7 +62,7 @@ describe('<ScrollArea.Thumb />', () => {
     });
 
     fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
-    fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1 });
+    fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1, buttons: 1 });
 
     // Without a viewport there is nothing to scroll, so the drag never consumes the move.
     expect(thumb).not.toHaveAttribute('data-scrolling');
@@ -103,7 +103,9 @@ describe('<ScrollArea.Thumb />', () => {
     });
 
     fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
-    expect(() => fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1 })).not.toThrow();
+    expect(() =>
+      fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1, buttons: 1 }),
+    ).not.toThrow();
 
     expect(screen.queryByTestId('scrollbar')).toBe(null);
     expect(viewport.scrollTop).toBe(0);
@@ -292,7 +294,7 @@ describe('<ScrollArea.Thumb />', () => {
     });
 
     fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
-    fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1 });
+    fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1, buttons: 1 });
 
     await waitFor(() => expect(scrollbar).toHaveAttribute('data-scrolling'));
 
@@ -300,6 +302,55 @@ describe('<ScrollArea.Thumb />', () => {
 
     await waitFor(() => expect(scrollbar).not.toHaveAttribute('data-scrolling'));
   });
+
+  it.skipIf(isJSDOM)(
+    'ends a drag whose release was missed instead of scrolling on hover',
+    async () => {
+      await render(
+        <ScrollArea.Root style={{ width: 200, height: 200 }}>
+          <ScrollArea.Viewport data-testid="viewport" style={{ width: '100%', height: '100%' }}>
+            <div style={{ width: 200, height: 1000 }} />
+          </ScrollArea.Viewport>
+          <ScrollArea.Scrollbar
+            orientation="vertical"
+            keepMounted
+            style={{ width: 10, height: 200 }}
+          >
+            <ScrollArea.Thumb data-testid="thumb" />
+          </ScrollArea.Scrollbar>
+        </ScrollArea.Root>,
+      );
+
+      const viewport = screen.getByTestId('viewport');
+      const thumb = screen.getByTestId('thumb');
+      await waitFor(() => expect(thumb.offsetHeight).toBeGreaterThan(0));
+
+      // The missed-release scenario means no capture is ever in effect.
+      Object.defineProperties(thumb, {
+        setPointerCapture: {
+          configurable: true,
+          value: () => {},
+        },
+        hasPointerCapture: {
+          configurable: true,
+          value: () => false,
+        },
+      });
+
+      fireEvent.pointerDown(thumb, { button: 0, clientY: 0, pointerId: 1 });
+      fireEvent.pointerMove(thumb, { clientY: 20, pointerId: 1, buttons: 1 });
+      expect(viewport.scrollTop).toBeGreaterThan(0);
+      const scrolled = viewport.scrollTop;
+
+      // The release never arrived (e.g. pointer capture was lost mid-drag), so
+      // the first buttonless move must end the drag rather than scroll.
+      fireEvent.pointerMove(thumb, { clientY: 60, pointerId: 1, buttons: 0 });
+      expect(viewport.scrollTop).toBe(scrolled);
+
+      fireEvent.pointerMove(thumb, { clientY: 100, pointerId: 1, buttons: 0 });
+      expect(viewport.scrollTop).toBe(scrolled);
+    },
+  );
 
   it('clears horizontal scrolling state on pointer cancel', async () => {
     await render(
@@ -362,7 +413,7 @@ describe('<ScrollArea.Thumb />', () => {
     });
 
     fireEvent.pointerDown(thumb, { button: 0, clientX: 0, pointerId: 1 });
-    fireEvent.pointerMove(thumb, { clientX: 20, pointerId: 1 });
+    fireEvent.pointerMove(thumb, { clientX: 20, pointerId: 1, buttons: 1 });
 
     await waitFor(() => expect(scrollbar).toHaveAttribute('data-scrolling'));
 

--- a/packages/react/src/scroll-area/thumb/ScrollAreaThumb.tsx
+++ b/packages/react/src/scroll-area/thumb/ScrollAreaThumb.tsx
@@ -23,8 +23,6 @@ export const ScrollAreaThumb = React.forwardRef(function ScrollAreaThumb(
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
-    setScrollingX,
-    setScrollingY,
     scrollingX,
     scrollingY,
     hasMeasuredScrollbar,
@@ -38,11 +36,6 @@ export const ScrollAreaThumb = React.forwardRef(function ScrollAreaThumb(
     orientation,
   };
 
-  function endDrag(event: React.PointerEvent) {
-    (vertical ? setScrollingY : setScrollingX)(false);
-    handlePointerUp(event);
-  }
-
   const element = useRenderElement('div', componentProps, {
     ref: [forwardedRef, vertical ? thumbYRef : thumbXRef],
     state,
@@ -50,8 +43,8 @@ export const ScrollAreaThumb = React.forwardRef(function ScrollAreaThumb(
       {
         onPointerDown: handlePointerDown,
         onPointerMove: handlePointerMove,
-        onPointerUp: endDrag,
-        onPointerCancel: endDrag,
+        onPointerUp: handlePointerUp,
+        onPointerCancel: handlePointerUp,
         style: {
           visibility: hasMeasuredScrollbar ? undefined : 'hidden',
           ...(vertical


### PR DESCRIPTION
Fixes #5371

Dragging the thumb latches an internal drag flag that only a `pointerup`/`pointercancel` reaching the thumb or scrollbar clears. When pointer capture is lost mid-drag, the release is delivered to whatever element is under the cursor instead, so the flag survives the gesture and the next buttonless hover over the thumb drags it along with the cursor (the drag's scroll-snap disable also leaks).

`handlePointerMove` now treats a move without the primary button held as the missed release and runs the full `pointerup` cleanup. This mirrors the existing defense in `useSwipeDismiss`, which ends the gesture on `buttons: 0` moves with the same "the gesture is over even if no pointerup reached us" reasoning, and the equivalent guard in `SliderControl`; nothing in the codebase relies on `lostpointercapture` for this. `buttons % 2` follows the `hasPrimaryMouseButton` idiom since `no-bitwise` is enforced.

The regression test is Chromium-only because the drag math reads logical properties through `getComputedStyle`, which jsdom reports as empty strings. Existing raw `fireEvent.pointerMove` drag simulations now pass `buttons: 1`, matching real held-button moves.
