### PR TITLE
[code-infra] Grant Claude review pull-requests: write

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,10 +17,7 @@ jobs:
     permissions:
       contents: read # read the repo (checkout + git diff)
       id-token: write # mint the GitHub OIDC token exchanged for a Claude token via WIF
-      issues: write # requested by the called workflow; the trigger comment itself lives on the issues side
-      # `gh pr comment` posts through the GraphQL `addComment` mutation on the PR node, not
-      # POST /issues/{n}/comments, so `issues: write` does not cover it: with `read` here the
-      # mutation 403s and the run ends green having posted nothing. See cli/cli#8374.
-      pull-requests: write
+      issues: write # requested by the called workflow; the trigger comment lives on the issues side
+      pull-requests: write # `gh pr comment` posts the review through the GraphQL `addComment` mutation on the PR node
     with:
       review-skill: base-ui-review

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,11 +13,14 @@ permissions: {}
 
 jobs:
   claude-review:
-    uses: mui/mui-public/.github/workflows/claude-review.yml@909caa6fc5ecd4b9324f7b53e4845f52764b1867 # master
+    uses: mui/mui-public/.github/workflows/claude-review.yml@7b036a9626688a966e67a55030c8ad9e28698691 # master
     permissions:
       contents: read # read the repo (checkout + git diff)
       id-token: write # mint the GitHub OIDC token exchanged for a Claude token via WIF
-      issues: write # post the top-level PR comment (a PR comment goes through the issues API)
-      pull-requests: read # read PR metadata (gh pr view --json baseRefName); the review posts --comment only, no inline comments
+      issues: write # requested by the called workflow; the trigger comment itself lives on the issues side
+      # `gh pr comment` posts through the GraphQL `addComment` mutation on the PR node, not
+      # POST /issues/{n}/comments, so `issues: write` does not cover it: with `read` here the
+      # mutation 403s and the run ends green having posted nothing. See cli/cli#8374.
+      pull-requests: write
     with:
       review-skill: base-ui-review


### PR DESCRIPTION
The review posts its comment with `gh pr comment`, which goes through the GraphQL `addComment` mutation on the PR node rather than `POST /issues/{n}/comments`. That needs `pull-requests: write` — `issues: write` doesn't cover it, so with `read` the mutation 403s and the run finishes green having posted nothing ([run 30492713068](https://github.com/mui/base-ui/actions/runs/30492713068) on #5362 did exactly that).

Also bumps the pin to the mui-public revert (mui/mui-public#1744), which restores the same scope in the reusable workflow.