### PR TITLE
[autocomplete][combobox] Add cancel-open to change event details

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/types.md
+++ b/docs/src/app/(docs)/react/components/autocomplete/types.md
@@ -80,6 +80,7 @@ type AutocompleteRootChangeEventReason =
   | 'input-clear'
   | 'clear-press'
   | 'chip-remove-press'
+  | 'cancel-open'
   | 'none';
 ```
 
@@ -100,6 +101,7 @@ type AutocompleteRootChangeEventDetails = (
   | { reason: 'input-clear'; event: Event | FocusEvent | InputEvent }
   | { reason: 'clear-press'; event: MouseEvent | PointerEvent | KeyboardEvent }
   | { reason: 'chip-remove-press'; event: MouseEvent | PointerEvent | KeyboardEvent }
+  | { reason: 'cancel-open'; event: MouseEvent }
 ) & {
   /** Cancels Base UI from handling the event. */
   cancel: () => void;

--- a/docs/src/app/(docs)/react/components/combobox/types.md
+++ b/docs/src/app/(docs)/react/components/combobox/types.md
@@ -88,6 +88,7 @@ type ComboboxRootChangeEventReason =
   | 'input-clear'
   | 'clear-press'
   | 'chip-remove-press'
+  | 'cancel-open'
   | 'none';
 ```
 
@@ -108,6 +109,7 @@ type ComboboxRootChangeEventDetails = (
   | { reason: 'input-clear'; event: Event | FocusEvent | InputEvent }
   | { reason: 'clear-press'; event: MouseEvent | PointerEvent | KeyboardEvent }
   | { reason: 'chip-remove-press'; event: MouseEvent | PointerEvent | KeyboardEvent }
+  | { reason: 'cancel-open'; event: MouseEvent }
 ) & {
   /** Cancels Base UI from handling the event. */
   cancel: () => void;

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -1782,6 +1782,7 @@ export namespace AriaCombobox {
     | typeof REASONS.inputClear
     | typeof REASONS.clearPress
     | typeof REASONS.chipRemovePress
+    | typeof REASONS.cancelOpen
     | typeof REASONS.none;
   export type ChangeEventDetails = BaseUIChangeEventDetails<ChangeEventReason>;
 }

--- a/packages/react/src/combobox/root/ComboboxRoot.spec.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.spec.tsx
@@ -222,6 +222,9 @@ function App() {
         details.event,
       );
     }
+    if (details.reason === REASONS.cancelOpen) {
+      expectType<MouseEvent, typeof details.event>(details.event);
+    }
   }}
 />;
 

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
@@ -654,8 +654,10 @@ describe('<Combobox.Trigger />', () => {
 
   describe('cancel-open', () => {
     it('closes the popup when mouseup occurs outside the trigger bounds', async () => {
+      const onOpenChange = vi.fn();
+
       await render(
-        <Combobox.Root>
+        <Combobox.Root onOpenChange={onOpenChange}>
           <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
           <Combobox.Portal>
             <Combobox.Positioner>
@@ -680,6 +682,8 @@ describe('<Combobox.Trigger />', () => {
       await waitFor(() => {
         expect(screen.queryByRole('listbox')).toBe(null);
       });
+      expect(onOpenChange.mock.lastCall?.[0]).toBe(false);
+      expect(onOpenChange.mock.lastCall?.[1].reason).toBe(REASONS.cancelOpen);
     });
 
     it('keeps the popup open when mouseup remains near the trigger bounds', async () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR adds `cancel-open` to the public Autocomplete and Combobox change event types. 

Similar to the `input-press` omission fixed in #5356, `cancel-open` has been emitted at runtime since drag-to-select support was introduced in #3167, but was missing from the shared change event type.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
