### PR TITLE
[code-infra] base-ui-review: add a `--comment <path>` mode

### DIFF
--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -397,6 +397,8 @@ If any check fails, rewrite the output before sending.
 Always close review with `---` horizontal rule, blank line, then
 `🤖 Review generated with {Claude Code | Codex}`. Use **Claude Code** when this
 skill executed by Claude Code harness, **Codex** when executed by Codex harness.
+Exception: in `--comment=<path>` mode, omit this footer — whoever publishes the file
+owns the closing line, and a footer here would stack a second rule under theirs.
 
 ## Posting to GitHub (--comment)
 
@@ -415,7 +417,7 @@ comment mode:
   GitHub write access). The `=` is required: a bare token after `--comment` is a review
   target, never a path. This is the one comment mode with no GitHub PR requirement — the
   file is the whole deliverable, so finish by reporting the path rather than a comment
-  URL, and never fall back to posting.
+  URL, never fall back to posting, and omit the closing footer (see [Output](#output)).
 
 For `--comment inline`, include same severity marker in each inline comment
 body. Use latest PR head `commit_id`, `path`, `line`, `side`, post via

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -359,10 +359,6 @@ see.}
 ## Verdict
 
 **{Request changes | Approve after nits | Approve}** - {one clause on the deciding factor}.
-
----
-
-🤖 Review generated with {Claude Code | Codex}
 ````
 
 Same per-finding shape for Tests, Simplifications, Docs. For Tests,
@@ -381,7 +377,7 @@ related issues under one finding when they share same root cause.
 
 If nothing survives verification, omit all category headings and counts. Return
 `# PR review`, `No findings.`, a brief note of residual test gaps or risk,
-`## Verdict` with **Approve**, and the `🤖 Review generated with ...` footer.
+and `## Verdict` with **Approve**.
 
 ### Final output preflight
 
@@ -394,11 +390,6 @@ Treat the output format as a hard contract. Before sending:
 
 If any check fails, rewrite the output before sending.
 
-Always close review with `---` horizontal rule, blank line, then
-`🤖 Review generated with {Claude Code | Codex}`. Use **Claude Code** when this
-skill executed by Claude Code harness, **Codex** when executed by Codex harness.
-Exception: in `--comment=<path>` mode, omit this footer — whoever publishes the file
-owns the closing line, and a footer here would stack a second rule under theirs.
 
 ## Posting to GitHub (--comment)
 
@@ -412,12 +403,19 @@ comment mode:
 - `--comment inline` — post inline comments for findings mapping to PR diff
   lines, include all non-diff findings in top-level fallback comment.
 - `--comment=<path>` — do not touch GitHub at all: write the Markdown review to
-  `<path>`, exactly the body `--comment` would have posted. For callers that publish
+  `<path>`. For callers that publish
   the review themselves (a CI job holding the token, so the review session needs no
   GitHub write access). The `=` is required: a bare token after `--comment` is a review
   target, never a path. This is the one comment mode with no GitHub PR requirement — the
   file is the whole deliverable, so finish by reporting the path rather than a comment
   URL, and never fall back to posting.
+
+Attribution belongs to whoever posts, not to the review body. When this skill posts —
+`--comment`, or the top-level fallback comment for `--comment inline` — close that comment
+with a `---` horizontal rule, blank line, then `🤖 Review generated with {Claude Code |
+Codex}`: **Claude Code** under the Claude Code harness, **Codex** under Codex. In
+`--comment=<path>` mode the caller publishes the file and owns that line, so the file holds
+the review alone.
 
 For `--comment inline`, include same severity marker in each inline comment
 body. Use latest PR head `commit_id`, `path`, `line`, `side`, post via

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base-ui-review
-description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, --comment <path> to write the review to that file instead of posting, or --fix to apply findings.'
 ---
 
 # Base UI Review
@@ -9,7 +9,7 @@ Review current diff. Find **regressions and correctness bugs** first. Also find
 **cleanup** (reuse / simplification / efficiency). Default effort: `medium`. See
 [Effort levels](#effort-levels) for depth and subagent fan-out.
 
-Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment [inline]] [<target>]`
+Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment [inline|<path>]] [<target>]`
 
 `medium` = **precision**. Every finding actionable. `high`, `xhigh`, `max` =
 **recall**. Missed bug ships. Keep uncertain findings when mechanism is real;
@@ -409,6 +409,13 @@ comment mode:
   `gh pr comment`.
 - `--comment inline` — post inline comments for findings mapping to PR diff
   lines, include all non-diff findings in top-level fallback comment.
+- `--comment <path>` — do not touch GitHub at all: write the Markdown review to
+  `<path>`, exactly the body `--comment` would have posted. For callers that publish
+  the review themselves (a CI job holding the token, so the review session needs no
+  GitHub write access). `inline` is reserved for the mode above; any other value is a
+  path. This is the one comment mode with no GitHub PR requirement — the file is the
+  whole deliverable, so finish by reporting the path rather than a comment URL, and
+  never fall back to posting.
 
 For `--comment inline`, include same severity marker in each inline comment
 body. Use latest PR head `commit_id`, `path`, `line`, `side`, post via

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -417,7 +417,7 @@ comment mode:
   GitHub write access). The `=` is required: a bare token after `--comment` is a review
   target, never a path. This is the one comment mode with no GitHub PR requirement — the
   file is the whole deliverable, so finish by reporting the path rather than a comment
-  URL, never fall back to posting, and omit the closing footer (see [Output](#output)).
+  URL, and never fall back to posting.
 
 For `--comment inline`, include same severity marker in each inline comment
 body. Use latest PR head `commit_id`, `path`, `line`, `side`, post via

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base-ui-review
-description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, --comment <path> to write the review to that file instead of posting, or --fix to apply findings.'
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, --comment=<path> to write the review to that file instead of posting, or --fix to apply findings.'
 ---
 
 # Base UI Review
@@ -9,7 +9,7 @@ Review current diff. Find **regressions and correctness bugs** first. Also find
 **cleanup** (reuse / simplification / efficiency). Default effort: `medium`. See
 [Effort levels](#effort-levels) for depth and subagent fan-out.
 
-Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment [inline|<path>]] [<target>]`
+Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment [inline] | --comment=<path>] [<target>]`
 
 `medium` = **precision**. Every finding actionable. `high`, `xhigh`, `max` =
 **recall**. Missed bug ships. Keep uncertain findings when mechanism is real;
@@ -409,13 +409,13 @@ comment mode:
   `gh pr comment`.
 - `--comment inline` — post inline comments for findings mapping to PR diff
   lines, include all non-diff findings in top-level fallback comment.
-- `--comment <path>` — do not touch GitHub at all: write the Markdown review to
+- `--comment=<path>` — do not touch GitHub at all: write the Markdown review to
   `<path>`, exactly the body `--comment` would have posted. For callers that publish
   the review themselves (a CI job holding the token, so the review session needs no
-  GitHub write access). `inline` is reserved for the mode above; any other value is a
-  path. This is the one comment mode with no GitHub PR requirement — the file is the
-  whole deliverable, so finish by reporting the path rather than a comment URL, and
-  never fall back to posting.
+  GitHub write access). The `=` is required: a bare token after `--comment` is a review
+  target, never a path. This is the one comment mode with no GitHub PR requirement — the
+  file is the whole deliverable, so finish by reporting the path rather than a comment
+  URL, and never fall back to posting.
 
 For `--comment inline`, include same severity marker in each inline comment
 body. Use latest PR head `commit_id`, `path`, `line`, `side`, post via

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -386,10 +386,9 @@ Treat the output format as a hard contract. Before sending:
 - Use `# PR review`; start the summary with concrete risk, not target/base filler.
 - Use exact `## {Category} ({count})` headings for non-empty categories only.
 - Print each finding exactly once and verify every category count.
-- Use a separate `## Verdict` heading and the required closing footer.
+- Use a separate `## Verdict` heading.
 
 If any check fails, rewrite the output before sending.
-
 
 ## Posting to GitHub (--comment)
 

--- a/.claude/skills/base-ui-review/SKILL.md
+++ b/.claude/skills/base-ui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base-ui-review
-description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, --comment <path> to write the review to that file instead of posting, or --fix to apply findings.'
 ---
 
 # Base UI Review
@@ -9,5 +9,5 @@ This is the Claude Code entrypoint for the shared repo skill.
 
 Before reviewing, read `.agents/skills/base-ui-review/SKILL.md` completely and
 follow that canonical workflow. Pass through any user arguments such as `low`,
-`medium`, `high`, `xhigh`, `max`, `--comment`, `--comment inline`, `--fix`, or a
+`medium`, `high`, `xhigh`, `max`, `--comment`, `--comment inline`, `--comment <path>`, `--fix`, or a
 review target.

--- a/.claude/skills/base-ui-review/SKILL.md
+++ b/.claude/skills/base-ui-review/SKILL.md
@@ -8,6 +8,4 @@ description: 'Review the current diff for regressions, correctness bugs, tests, 
 This is the Claude Code entrypoint for the shared repo skill.
 
 Before reviewing, read `.agents/skills/base-ui-review/SKILL.md` completely and
-follow that canonical workflow. Pass through any user arguments such as `low`,
-`medium`, `high`, `xhigh`, `max`, `--comment`, `--comment inline`, `--comment=<path>`, `--fix`, or a
-review target.
+follow that canonical workflow. Pass through any user arguments verbatim.

--- a/.claude/skills/base-ui-review/SKILL.md
+++ b/.claude/skills/base-ui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base-ui-review
-description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, --comment <path> to write the review to that file instead of posting, or --fix to apply findings.'
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, --comment=<path> to write the review to that file instead of posting, or --fix to apply findings.'
 ---
 
 # Base UI Review
@@ -9,5 +9,5 @@ This is the Claude Code entrypoint for the shared repo skill.
 
 Before reviewing, read `.agents/skills/base-ui-review/SKILL.md` completely and
 follow that canonical workflow. Pass through any user arguments such as `low`,
-`medium`, `high`, `xhigh`, `max`, `--comment`, `--comment inline`, `--comment <path>`, `--fix`, or a
+`medium`, `high`, `xhigh`, `max`, `--comment`, `--comment inline`, `--comment=<path>`, `--fix`, or a
 review target.


### PR DESCRIPTION
Writes the Markdown review to the given path instead of posting it, for callers that publish the review themselves — a CI job holding the token, so the review session needs no GitHub write access at all. `inline` stays reserved; any other value is a path.

Mirrors the same addition to `pr-review` in mui/mui-public#1745, which invokes this skill with `--comment ./pr-review-comment.md`.