### PR TITLE
[ci] Adopt the new Claude review workflow (mui-public#1745)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   claude-review:
-    uses: mui/mui-public/.github/workflows/claude-review.yml@81d083b050545e4cb5149d84c5b3e8cd7eb79fe6 # master
+    uses: mui/mui-public/.github/workflows/claude-review.yml@2087162a4d04c984a95b54c4f6f268cf3fbc7714 # master
     permissions:
       contents: read # read the repo (checkout + git diff)
       id-token: write # mint the GitHub OIDC token exchanged for a Claude token via WIF

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,11 +13,10 @@ permissions: {}
 
 jobs:
   claude-review:
-    uses: mui/mui-public/.github/workflows/claude-review.yml@7b036a9626688a966e67a55030c8ad9e28698691 # master
+    uses: mui/mui-public/.github/workflows/claude-review.yml@81d083b050545e4cb5149d84c5b3e8cd7eb79fe6 # master
     permissions:
       contents: read # read the repo (checkout + git diff)
       id-token: write # mint the GitHub OIDC token exchanged for a Claude token via WIF
-      issues: write # requested by the called workflow; the trigger comment lives on the issues side
-      pull-requests: write # `gh pr comment` posts the review through the GraphQL `addComment` mutation on the PR node
+      pull-requests: write # the reusable workflow posts the review comment (commenting on a PR needs pull-requests: write)
     with:
       review-skill: base-ui-review


### PR DESCRIPTION
Brings in the new Claude review setup from mui/mui-public#1745: the reusable workflow posts the review itself and the agent has no GitHub write access. Repins to the latest mui-public master and sets `pull-requests: write` (the workflow needs write on the PR to post), dropping the now-unneeded `issues: write`.