### PR TITLE
[combobox] Fill inline input on selection

### DIFF
--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -1341,6 +1341,47 @@ describe('<Autocomplete.Root />', () => {
       expect(submitCount).toBe(1);
     });
 
+    it.each(['pointer', 'Enter'])(
+      'submits the selected value from an inline list with %s',
+      async (interaction) => {
+        let submitValue: string | null = null;
+
+        const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+          event.preventDefault();
+          submitValue = new FormData(event.currentTarget).get('q') as string;
+        };
+
+        const { user } = await render(
+          <form onSubmit={handleSubmit}>
+            <Field.Root name="q">
+              <Autocomplete.Root items={['alpha', 'alpine']} inline open submitOnItemClick>
+                <Autocomplete.Input />
+                <Autocomplete.List>
+                  {(item) => (
+                    <Autocomplete.Item key={item} value={item}>
+                      {item}
+                    </Autocomplete.Item>
+                  )}
+                </Autocomplete.List>
+              </Autocomplete.Root>
+            </Field.Root>
+          </form>,
+        );
+
+        const input = screen.getByRole<HTMLInputElement>('combobox');
+        await user.type(input, 'al');
+
+        if (interaction === 'pointer') {
+          await user.click(screen.getByRole('option', { name: 'alpha' }));
+        } else {
+          await user.keyboard('{ArrowDown}{Enter}');
+        }
+
+        expect(submitValue).toBe('alpha');
+        expect(input).toHaveValue('alpha');
+      },
+    );
+
     it.skipIf(isJSDOM)(
       'when true, clicking with pointer submits an associated external form when `form` is provided',
       async () => {

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -3,10 +3,12 @@ import * as React from 'react';
 import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, isJSDOM } from '#test-utils';
 import { Autocomplete } from '@base-ui/react/autocomplete';
+import { Dialog } from '@base-ui/react/dialog';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
 import { Input } from '@base-ui/react/input';
 import { Switch } from '@base-ui/react/switch';
+import { REASONS } from '../../internals/reasons';
 
 describe('<Autocomplete.Root />', () => {
   beforeEach(() => {
@@ -1372,6 +1374,64 @@ describe('<Autocomplete.Root />', () => {
 
       expect(submitValue).toBe('alpha');
       expect(input).toHaveValue('alpha');
+    });
+
+    it('commits and submits the selected value when an inline dialog closes', async () => {
+      let submitValue: string | null = null;
+      const onValueChange = vi.fn();
+
+      function Test() {
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <React.Fragment>
+            <form
+              id="search-form"
+              onSubmit={(event) => {
+                event.preventDefault();
+                submitValue = new FormData(event.currentTarget).get('q') as string;
+              }}
+            />
+            <Autocomplete.Root
+              items={['alpha', 'alpine']}
+              name="q"
+              form="search-form"
+              inline
+              open={open}
+              onOpenChange={setOpen}
+              onValueChange={onValueChange}
+              submitOnItemClick
+            >
+              <Dialog.Root open={open} onOpenChange={setOpen}>
+                <Dialog.Portal keepMounted>
+                  <Dialog.Popup>
+                    <Autocomplete.Input />
+                    <Autocomplete.List>
+                      {(item) => (
+                        <Autocomplete.Item key={item} value={item}>
+                          {item}
+                        </Autocomplete.Item>
+                      )}
+                    </Autocomplete.List>
+                  </Dialog.Popup>
+                </Dialog.Portal>
+              </Dialog.Root>
+            </Autocomplete.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<Test />);
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      await user.type(input, 'al');
+      onValueChange.mockClear();
+      await user.click(screen.getByRole('option', { name: 'alpha' }));
+
+      expect(onValueChange).toHaveBeenCalledWith(
+        'alpha',
+        expect.objectContaining({ reason: REASONS.itemPress }),
+      );
+      expect(submitValue).toBe('alpha');
     });
 
     it.skipIf(isJSDOM)(

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -1341,46 +1341,38 @@ describe('<Autocomplete.Root />', () => {
       expect(submitCount).toBe(1);
     });
 
-    it.each(['pointer', 'Enter'])(
-      'submits the selected value from an inline list with %s',
-      async (interaction) => {
-        let submitValue: string | null = null;
+    it('submits the selected value from an inline list', async () => {
+      let submitValue: string | null = null;
 
-        const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
-          event.preventDefault();
-          submitValue = new FormData(event.currentTarget).get('q') as string;
-        };
+      const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+        event.preventDefault();
+        submitValue = new FormData(event.currentTarget).get('q') as string;
+      };
 
-        const { user } = await render(
-          <form onSubmit={handleSubmit}>
-            <Field.Root name="q">
-              <Autocomplete.Root items={['alpha', 'alpine']} inline open submitOnItemClick>
-                <Autocomplete.Input />
-                <Autocomplete.List>
-                  {(item) => (
-                    <Autocomplete.Item key={item} value={item}>
-                      {item}
-                    </Autocomplete.Item>
-                  )}
-                </Autocomplete.List>
-              </Autocomplete.Root>
-            </Field.Root>
-          </form>,
-        );
+      const { user } = await render(
+        <form onSubmit={handleSubmit}>
+          <Field.Root name="q">
+            <Autocomplete.Root items={['alpha', 'alpine']} inline open submitOnItemClick>
+              <Autocomplete.Input />
+              <Autocomplete.List>
+                {(item) => (
+                  <Autocomplete.Item key={item} value={item}>
+                    {item}
+                  </Autocomplete.Item>
+                )}
+              </Autocomplete.List>
+            </Autocomplete.Root>
+          </Field.Root>
+        </form>,
+      );
 
-        const input = screen.getByRole<HTMLInputElement>('combobox');
-        await user.type(input, 'al');
+      const input = screen.getByRole<HTMLInputElement>('combobox');
+      await user.type(input, 'al');
+      await user.click(screen.getByRole('option', { name: 'alpha' }));
 
-        if (interaction === 'pointer') {
-          await user.click(screen.getByRole('option', { name: 'alpha' }));
-        } else {
-          await user.keyboard('{ArrowDown}{Enter}');
-        }
-
-        expect(submitValue).toBe('alpha');
-        expect(input).toHaveValue('alpha');
-      },
-    );
+      expect(submitValue).toBe('alpha');
+      expect(input).toHaveValue('alpha');
+    });
 
     it.skipIf(isJSDOM)(
       'when true, clicking with pointer submits an associated external form when `form` is provided',

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -4,6 +4,7 @@ import { useControlled } from '@base-ui/utils/useControlled';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useOnFirstRender } from '@base-ui/utils/useOnFirstRender';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import { useAnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
@@ -144,6 +145,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
   const [queryChangedAfterOpen, setQueryChangedAfterOpen] = React.useState(false);
   const [closeQuery, setCloseQuery] = React.useState<string | null>(null);
+  const inlineSelectionFrame = useAnimationFrame();
 
   const listRef = React.useRef<Array<HTMLElement | null>>([]);
   const labelsRef = React.useRef<Array<string | null>>([]);
@@ -701,7 +703,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
       const shouldFillInput =
         (selectionMode === 'none' && popupRef.current && fillInputOnItemPress) ||
-        (single && (!store.state.inputInsidePopup || store.state.inline));
+        (single && !store.state.inputInsidePopup);
 
       if (shouldFillInput) {
         setInputValue(
@@ -763,6 +765,28 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
         }
 
         setOpen(false, eventDetails);
+
+        if (inline) {
+          // Fill the input when a value is selected but the combobox does not close.
+          const fillInput = () => {
+            setInputValue(
+              stringifyAsLabel(itemValue, itemToStringLabel),
+              createChangeEventDetails(eventDetails.reason, eventDetails.event),
+            );
+          };
+
+          if (eventDetails.isCanceled) {
+            // The selection was accepted, but closing was prevented.
+            fillInput();
+          } else {
+            // Check the controlled state after React flushes.
+            inlineSelectionFrame.request(() => {
+              if (store.state.open) {
+                fillInput();
+              }
+            });
+          }
+        }
       }
     },
   );

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -768,8 +768,8 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
           eventDetails.isCanceled || (openProp === true && props.onOpenChange === undefined);
         const inputInsideDialog = store.state.inputElement?.closest('[role="dialog"]') != null;
 
-        if (inline && (!inputInsideDialog || closeWasPrevented)) {
-          // Fill the input unless it is inside a dialog that closes on selection.
+        if (inline && (!single || !inputInsideDialog || closeWasPrevented)) {
+          // Fill the Autocomplete value, or the Combobox input unless its dialog closes.
           setInputValue(
             stringifyAsLabel(itemValue, itemToStringLabel),
             createChangeEventDetails(eventDetails.reason, eventDetails.event),

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -766,9 +766,10 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
         const closeWasPrevented =
           eventDetails.isCanceled || (openProp === true && props.onOpenChange === undefined);
+        const inputInsideDialog = store.state.inputElement?.closest('[role="dialog"]') != null;
 
-        if (inline && closeWasPrevented) {
-          // Fill the input when a value is selected but the combobox does not close.
+        if (inline && (!inputInsideDialog || closeWasPrevented)) {
+          // Fill the input unless it is inside a dialog that closes on selection.
           setInputValue(
             stringifyAsLabel(itemValue, itemToStringLabel),
             createChangeEventDetails(eventDetails.reason, eventDetails.event),

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -531,6 +531,10 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
   const setInputValue = useStableCallback(
     (next: string, eventDetails: AriaCombobox.ChangeEventDetails) => {
+      if (eventDetails.reason === REASONS.inputChange) {
+        inlineSelectionFrame.cancel();
+      }
+
       hadInputClearRef.current = eventDetails.reason === REASONS.inputClear;
 
       props.onInputValueChange?.(next, eventDetails);

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -701,7 +701,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
       const shouldFillInput =
         (selectionMode === 'none' && popupRef.current && fillInputOnItemPress) ||
-        (single && !store.state.inputInsidePopup);
+        (single && (!store.state.inputInsidePopup || store.state.inline));
 
       if (shouldFillInput) {
         setInputValue(

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -4,7 +4,6 @@ import { useControlled } from '@base-ui/utils/useControlled';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useOnFirstRender } from '@base-ui/utils/useOnFirstRender';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { useAnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
@@ -145,7 +144,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
   const [queryChangedAfterOpen, setQueryChangedAfterOpen] = React.useState(false);
   const [closeQuery, setCloseQuery] = React.useState<string | null>(null);
-  const inlineSelectionFrame = useAnimationFrame();
 
   const listRef = React.useRef<Array<HTMLElement | null>>([]);
   const labelsRef = React.useRef<Array<string | null>>([]);
@@ -531,10 +529,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
   const setInputValue = useStableCallback(
     (next: string, eventDetails: AriaCombobox.ChangeEventDetails) => {
-      if (eventDetails.reason === REASONS.inputChange) {
-        inlineSelectionFrame.cancel();
-      }
-
       hadInputClearRef.current = eventDetails.reason === REASONS.inputClear;
 
       props.onInputValueChange?.(next, eventDetails);
@@ -770,26 +764,15 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
 
         setOpen(false, eventDetails);
 
-        if (inline) {
-          // Fill the input when a value is selected but the combobox does not close.
-          const fillInput = () => {
-            setInputValue(
-              stringifyAsLabel(itemValue, itemToStringLabel),
-              createChangeEventDetails(eventDetails.reason, eventDetails.event),
-            );
-          };
+        const closeWasPrevented =
+          eventDetails.isCanceled || (openProp === true && props.onOpenChange === undefined);
 
-          if (eventDetails.isCanceled) {
-            // The selection was accepted, but closing was prevented.
-            fillInput();
-          } else {
-            // Check the controlled state after React flushes.
-            inlineSelectionFrame.request(() => {
-              if (store.state.open) {
-                fillInput();
-              }
-            });
-          }
+        if (inline && closeWasPrevented) {
+          // Fill the input when a value is selected but the combobox does not close.
+          setInputValue(
+            stringifyAsLabel(itemValue, itemToStringLabel),
+            createChangeEventDetails(eventDetails.reason, eventDetails.event),
+          );
         }
       }
     },

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -8742,6 +8742,10 @@ describe('<Combobox.Root />', () => {
       });
 
       it('does not fill the filter input when the dialog closes', async () => {
+        if (reactMajor <= 18) {
+          ignoreActWarnings();
+        }
+
         const onInputValueChange = vi.fn();
         const { user } = await render(
           <DialogSingleCombobox onInputValueChange={onInputValueChange} />,

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -3301,6 +3301,26 @@ describe('<Combobox.Root />', () => {
       expect(input).toHaveValue('Ba');
     });
 
+    it('fills the input with the selected item when rendered inline', async () => {
+      const { user } = await render(
+        <Combobox.Root inline open items={['Apple', 'Banana']}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.List>
+            {(item) => (
+              <Combobox.Item key={item} value={item}>
+                {item}
+              </Combobox.Item>
+            )}
+          </Combobox.List>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(screen.getByRole('option', { name: 'Banana' }));
+
+      expect(input).toHaveValue('Banana');
+    });
+
     it('bubbles Escape key when list is empty and popup hidden with CSS', async () => {
       const onOuterKeyDown = vi.fn();
 

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -3318,7 +3318,9 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByTestId('input');
       await user.click(screen.getByRole('option', { name: 'Banana' }));
 
-      expect(input).toHaveValue('Banana');
+      await waitFor(() => {
+        expect(input).toHaveValue('Banana');
+      });
     });
 
     it('bubbles Escape key when list is empty and popup hidden with CSS', async () => {
@@ -8549,12 +8551,24 @@ describe('<Combobox.Root />', () => {
       );
     }
 
-    function DialogSingleCombobox({ defaultOpen = true }: { defaultOpen?: boolean }) {
+    function DialogSingleCombobox({
+      defaultOpen = true,
+      onInputValueChange,
+    }: {
+      defaultOpen?: boolean;
+      onInputValueChange?: Combobox.Root.Props<string>['onInputValueChange'];
+    }) {
       const [open, setOpen] = React.useState(defaultOpen);
       const inputId = React.useId();
 
       return (
-        <Combobox.Root items={fruits} open={open} onOpenChange={setOpen} inline>
+        <Combobox.Root
+          items={fruits}
+          open={open}
+          onOpenChange={setOpen}
+          onInputValueChange={onInputValueChange}
+          inline
+        >
           <Dialog.Root open={open} onOpenChange={setOpen}>
             <Dialog.Trigger data-testid="dialog-trigger">
               <Combobox.Value>
@@ -8725,6 +8739,27 @@ describe('<Combobox.Root />', () => {
         await waitFor(() => {
           expect(trigger).toHaveTextContent('Apple');
         });
+      });
+
+      it('does not fill the filter input when the dialog closes', async () => {
+        const onInputValueChange = vi.fn();
+        const { user } = await render(
+          <DialogSingleCombobox onInputValueChange={onInputValueChange} />,
+        );
+
+        const input = await screen.findByTestId('dialog-input');
+        await user.type(input, 'ap');
+        await user.click(screen.getByRole('option', { name: 'Apple' }));
+        expect(input).not.toHaveValue('Apple');
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog', { name: 'Fruit chooser' })).toBe(null);
+        });
+
+        expect(onInputValueChange.mock.calls).not.toContainEqual([
+          'Apple',
+          expect.objectContaining({ reason: REASONS.itemPress }),
+        ]);
       });
 
       it('clears the filter input when re-opening after a selection', async () => {

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -3323,20 +3323,51 @@ describe('<Combobox.Root />', () => {
 
     it('fills the inline input when closing is canceled', async () => {
       const { user } = await render(
-        <Combobox.Root
-          inline
-          open
-          onOpenChange={(nextOpen, eventDetails) => {
-            if (!nextOpen) {
-              eventDetails.cancel();
-            }
-          }}
-        >
-          <Combobox.Input data-testid="input" />
-          <Combobox.List>
-            <Combobox.Item value="Banana">Banana</Combobox.Item>
-          </Combobox.List>
-        </Combobox.Root>,
+        <Dialog.Root open>
+          <Dialog.Portal>
+            <Dialog.Popup>
+              <Combobox.Root
+                inline
+                open
+                onOpenChange={(nextOpen, eventDetails) => {
+                  if (!nextOpen) {
+                    eventDetails.cancel();
+                  }
+                }}
+              >
+                <Combobox.Input data-testid="input" />
+                <Combobox.List>
+                  <Combobox.Item value="Banana">Banana</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Root>
+            </Dialog.Popup>
+          </Dialog.Portal>
+        </Dialog.Root>,
+      );
+
+      await user.click(screen.getByRole('option', { name: 'Banana' }));
+
+      expect(screen.getByTestId('input')).toHaveValue('Banana');
+    });
+
+    it('fills the inline input inside a persistent dialog', async () => {
+      const { user } = await render(
+        <Dialog.Root open>
+          <Dialog.Portal>
+            <Dialog.Popup>
+              <Combobox.Root inline open items={['Apple', 'Banana']}>
+                <Combobox.Input data-testid="input" />
+                <Combobox.List>
+                  {(item) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Root>
+            </Dialog.Popup>
+          </Dialog.Portal>
+        </Dialog.Root>,
       );
 
       await user.click(screen.getByRole('option', { name: 'Banana' }));

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -3318,9 +3318,30 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByTestId('input');
       await user.click(screen.getByRole('option', { name: 'Banana' }));
 
-      await waitFor(() => {
-        expect(input).toHaveValue('Banana');
-      });
+      expect(input).toHaveValue('Banana');
+    });
+
+    it('fills the inline input when closing is canceled', async () => {
+      const { user } = await render(
+        <Combobox.Root
+          inline
+          open
+          onOpenChange={(nextOpen, eventDetails) => {
+            if (!nextOpen) {
+              eventDetails.cancel();
+            }
+          }}
+        >
+          <Combobox.Input data-testid="input" />
+          <Combobox.List>
+            <Combobox.Item value="Banana">Banana</Combobox.Item>
+          </Combobox.List>
+        </Combobox.Root>,
+      );
+
+      await user.click(screen.getByRole('option', { name: 'Banana' }));
+
+      expect(screen.getByTestId('input')).toHaveValue('Banana');
     });
 
     it('bubbles Escape key when list is empty and popup hidden with CSS', async () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR fixes `inline` Combobox inputs not displaying the selected item's value.

Inline inputs share popup lifecycle behavior, which caused selection-to-input synchronization to be skipped. 
The input now updates after selecting an item while preserving the existing input-inside-popup behavior.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
