### PR TITLE
[form] Include portaled group values in Form submission

### DIFF
--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -1107,7 +1107,7 @@ describe('<CheckboxGroup />', () => {
       expect(handleSubmit.mock.lastCall?.[0]).toEqual({ fruits: ['apple'] });
     });
 
-    it('omits a context-portaled checkbox without native form association', () => {
+    it('includes a context-portaled checkbox without native form association', () => {
       const handleSubmit = vi.fn();
       const portalContainer = document.createElement('div');
       document.body.append(portalContainer);
@@ -1125,7 +1125,35 @@ describe('<CheckboxGroup />', () => {
 
       fireEvent.click(screen.getByText('Submit'));
 
-      expect(handleSubmit.mock.lastCall?.[0]).toEqual({ fruits: [] });
+      // Field registration is context-driven, so a portaled checkbox with no explicit `form`
+      // association still projects its value into `onFormSubmit`, like other field controls.
+      expect(handleSubmit.mock.lastCall?.[0]).toEqual({ fruits: ['apple'] });
+      portalContainer.remove();
+    });
+
+    it('includes a group fully portaled outside the form element', () => {
+      const handleSubmit = vi.fn();
+      const portalContainer = document.createElement('div');
+      document.body.append(portalContainer);
+
+      render(
+        <Form onFormSubmit={handleSubmit}>
+          {ReactDOM.createPortal(
+            <Field.Root name="fruits">
+              <CheckboxGroup defaultValue={['apple', 'banana']}>
+                <Checkbox.Root value="apple" />
+                <Checkbox.Root value="banana" disabled />
+              </CheckboxGroup>
+            </Field.Root>,
+            portalContainer,
+          )}
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      fireEvent.click(screen.getByText('Submit'));
+
+      expect(handleSubmit.mock.lastCall?.[0]).toEqual({ fruits: ['apple'] });
       portalContainer.remove();
     });
 

--- a/packages/react/src/checkbox-group/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.tsx
@@ -7,6 +7,7 @@ import { useBaseUiId } from '../internals/useBaseUiId';
 import { useRenderElement } from '../internals/useRenderElement';
 import { CheckboxGroupContext } from './CheckboxGroupContext';
 import type { FieldRootState } from '../field/root/FieldRoot';
+import { isEligibleInput } from '../field/root/useFieldValidation';
 import { useFieldRootContext } from '../internals/field-root-context/FieldRootContext';
 import { useRegisterFieldControl } from '../internals/field-register-control/useRegisterFieldControl';
 import { useLabelableContext } from '../internals/labelable-provider/LabelableContext';
@@ -107,8 +108,7 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
       if (
         registration.value !== undefined &&
         input.checked &&
-        !input.matches(':disabled') &&
-        input.form === formElement
+        isEligibleInput(input, formElement)
       ) {
         successfulValues.add(registration.value);
       }

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -25,9 +25,9 @@ export type RegisteredInputs = Map<HTMLInputElement, RegisteredInput>;
 /**
  * Whether an input participates in the surrounding Base UI Form. Inputs that are effectively
  * disabled, or whose `form` attribute explicitly associates them with another form, are excluded.
- * DOM position is not considered: field registration is context-driven, so portaled inputs
- * (for example inside a dialog) still belong to the form, for both validation and the values
- * projected into `onFormSubmit`.
+ * DOM position only matters when it associates the input with a different form. Otherwise, field
+ * registration is context-driven, so portaled inputs (for example inside a dialog) still belong to
+ * the form for both validation and values projected into `onFormSubmit`.
  */
 export function isEligibleInput(input: HTMLInputElement, formElement: HTMLFormElement | null) {
   if (input.matches(':disabled')) {

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -26,9 +26,10 @@ export type RegisteredInputs = Map<HTMLInputElement, RegisteredInput>;
  * Whether an input participates in the surrounding Base UI Form. Inputs that are effectively
  * disabled, or whose `form` attribute explicitly associates them with another form, are excluded.
  * DOM position is not considered: field registration is context-driven, so portaled inputs
- * (for example inside a dialog) still belong to the form.
+ * (for example inside a dialog) still belong to the form, for both validation and the values
+ * projected into `onFormSubmit`.
  */
-function isEligibleInput(input: HTMLInputElement, formElement: HTMLFormElement | null) {
+export function isEligibleInput(input: HTMLInputElement, formElement: HTMLFormElement | null) {
   if (input.matches(':disabled')) {
     return false;
   }

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1683,7 +1683,7 @@ describe('<RadioGroup />', () => {
     });
 
     it.skipIf(isJSDOM)(
-      'omits a context-portaled radio without native form association',
+      'includes a context-portaled radio without native form association in onFormSubmit',
       async () => {
         const handleSubmit = vi.fn();
         const portalContainer = document.createElement('div');
@@ -1701,16 +1701,43 @@ describe('<RadioGroup />', () => {
         );
 
         const form = screen.getByTestId('form') as HTMLFormElement;
-        // The radio is portaled out of the form with no `form` association, so its value is not
-        // submitted, matching native successful-control semantics.
+        // Native submission omits the portaled radio since it has no DOM form association.
         expect(new FormData(form).getAll('choice')).toEqual([]);
 
         fireEvent.click(screen.getByText('Submit'));
 
-        expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: null });
+        // Field registration is context-driven, so the portaled radio still projects its value
+        // into `onFormSubmit`, like other field controls.
+        expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: 'a' });
         portalContainer.remove();
       },
     );
+
+    it('includes a group fully portaled outside the form element in onFormSubmit', async () => {
+      const handleSubmit = vi.fn();
+      const portalContainer = document.createElement('div');
+      document.body.append(portalContainer);
+
+      await renderFakeTimers(
+        <Form onFormSubmit={handleSubmit}>
+          {ReactDOM.createPortal(
+            <Field.Root name="choice">
+              <RadioGroup defaultValue="a">
+                <Radio.Root value="a" />
+                <Radio.Root value="b" />
+              </RadioGroup>
+            </Field.Root>,
+            portalContainer,
+          )}
+          <button type="submit">Submit</button>
+        </Form>,
+      );
+
+      fireEvent.click(screen.getByText('Submit'));
+
+      expect(handleSubmit.mock.calls[0][0]).toEqual({ choice: 'a' });
+      portalContainer.remove();
+    });
 
     it.skipIf(isJSDOM)(
       'submits null when the selected radio in a required group is disabled, matching native validity',

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -11,6 +11,7 @@ import { useFieldRootContext } from '../internals/field-root-context/FieldRootCo
 import { useRegisterFieldControl } from '../internals/field-register-control/useRegisterFieldControl';
 import { fieldValidityMapping } from '../internals/field-constants/constants';
 import type { FieldRootState } from '../field/root/FieldRoot';
+import { isEligibleInput } from '../field/root/useFieldValidation';
 import { useFieldsetRootContext } from '../fieldset/root/FieldsetRootContext';
 import { useFormContext } from '../internals/form-context/FormContext';
 import { useLabelableContext } from '../internals/labelable-provider/LabelableContext';
@@ -162,7 +163,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     }
 
     for (const input of validation.registeredInputs.keys()) {
-      if (input.checked && !input.matches(':disabled') && input.form === formElement) {
+      if (input.checked && isEligibleInput(input, formElement)) {
         return checkedValue ?? null;
       }
     }


### PR DESCRIPTION
(Undoing a post-1.6.0 change, marked internal)

Portaled Checkbox/Radio groups (for example inside a popover or dialog while `Form` wraps the page) satisfy `required` validation but were silently missing from `onFormSubmit` values: `getFormValue` gated each hidden input on `input.form === formElement`, while field membership everywhere else is context-driven.

Both `getFormValue` implementations now share the `isEligibleInput` predicate from `useFieldValidation`, so an input unassociated due to portaling still projects its value. The `:disabled` exclusion and the explicit `form`-attribute opt-out are unchanged.