### PR TITLE
[menu] Open submenus on Android TalkBack press

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useClick.ts
+++ b/packages/react/src/floating-ui-react/hooks/useClick.ts
@@ -5,7 +5,7 @@ import { useTimeout } from '@base-ui/utils/useTimeout';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import type { ElementProps, FloatingContext, FloatingRootContext } from '../types';
 import { getTarget, isTypeableElement } from '../utils/element';
-import { isMouseLikePointerType } from '../utils/event';
+import { isMouseLikePointerType, isVirtualPointerEvent } from '../utils/event';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 
@@ -74,7 +74,7 @@ export function useClick(
 
   const dataRef = store.context.dataRef;
 
-  const pointerTypeRef = React.useRef<'mouse' | 'pen' | 'touch'>(undefined);
+  const pointerTypeRef = React.useRef<'mouse' | 'pen' | 'touch' | 'virtual'>(undefined);
   const frame = useAnimationFrame();
   const touchOpenTimeout = useTimeout();
 
@@ -83,7 +83,7 @@ export function useClick(
       nextOpen: boolean,
       nativeEvent: MouseEvent,
       target: HTMLElement,
-      pointerType: 'mouse' | 'pen' | 'touch' | undefined,
+      pointerType: 'mouse' | 'pen' | 'touch' | 'virtual' | undefined,
     ) {
       const details = createChangeEventDetails(reason, nativeEvent, target);
 
@@ -130,7 +130,15 @@ export function useClick(
 
     return {
       onPointerDown(event) {
-        pointerTypeRef.current = event.pointerType;
+        // Screen reader activations (Android TalkBack, desktop screen readers) report a
+        // mouse-like `pointerType`, but `ignoreMouse` must not drop them: hover logic cannot
+        // open for a virtual press since there is no real pointer movement to wait for.
+        // Virtual `touch` presses (iOS VoiceOver) keep their type so `touchOpenDelay` applies.
+        pointerTypeRef.current =
+          isMouseLikePointerType(event.pointerType, true) &&
+          isVirtualPointerEvent(event.nativeEvent)
+            ? 'virtual'
+            : event.pointerType;
       },
       onMouseDown(event) {
         const pointerType = pointerTypeRef.current;

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.talkBack.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.talkBack.test.tsx
@@ -46,9 +46,7 @@ function Test(props: { submenuTriggerProps?: React.ComponentProps<typeof Menu.Su
   );
 }
 
-// TalkBack in Chrome activates elements with a synthetic mouse press: a zero-pressure 1x1
-// `pointerdown` followed by `mousedown` and a `detail: 0` click.
-function fireTalkBackPress(element: Element) {
+function fireTalkBackMouseDown(element: Element) {
   fireEvent.pointerDown(element, {
     pointerType: 'mouse',
     width: 1,
@@ -57,6 +55,12 @@ function fireTalkBackPress(element: Element) {
     detail: 0,
   });
   fireEvent.mouseDown(element, { detail: 0 });
+}
+
+// TalkBack in Chrome activates elements with a synthetic mouse press: a zero-pressure 1x1
+// `pointerdown` followed by `mousedown` and a `detail: 0` click.
+function fireTalkBackPress(element: Element) {
+  fireTalkBackMouseDown(element);
   fireEvent.click(element, { detail: 0 });
 }
 
@@ -94,16 +98,13 @@ describe.skipIf(isJSDOM)('<Menu.SubmenuTrigger /> with TalkBack', () => {
     await user.click(screen.getByRole('button', { name: 'Open menu' }));
     const submenuTrigger = await screen.findByTestId('submenu-trigger');
 
-    fireTalkBackPress(submenuTrigger);
+    fireTalkBackMouseDown(submenuTrigger);
 
     await screen.findByTestId('submenu');
 
     // The trailing click must not toggle the freshly opened submenu closed.
-    await act(async () => {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 50);
-      });
-    });
+    fireEvent.click(submenuTrigger, { detail: 0 });
+    await waitForFrames();
 
     expect(screen.queryByTestId('submenu')).not.toBe(null);
   });

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.talkBack.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.talkBack.test.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import { act, fireEvent, screen } from '@mui/internal-test-utils';
+import { vi, describe, it, expect } from 'vitest';
+import { createRenderer, isJSDOM } from '#test-utils';
+import { Menu } from '@base-ui/react/menu';
+
+// Kept in a separate file so the module mock doesn't leak into `MenuSubmenuTrigger.test.tsx`.
+// `isVirtualPointerEvent` only recognizes the TalkBack press shape when the platform reports
+// Android, which desktop Chromium does not.
+vi.mock('@base-ui/utils/platform', async () => {
+  const actual =
+    await vi.importActual<typeof import('@base-ui/utils/platform')>('@base-ui/utils/platform');
+
+  return {
+    platform: {
+      ...actual.platform,
+      os: { ...actual.platform.os, android: true },
+    },
+  };
+});
+
+function Test(props: { submenuTriggerProps?: React.ComponentProps<typeof Menu.SubmenuTrigger> }) {
+  return (
+    <Menu.Root>
+      <Menu.Trigger>Open menu</Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner>
+          <Menu.Popup>
+            <Menu.SubmenuRoot>
+              <Menu.SubmenuTrigger data-testid="submenu-trigger" {...props.submenuTriggerProps}>
+                More
+              </Menu.SubmenuTrigger>
+              <Menu.Portal>
+                <Menu.Positioner>
+                  <Menu.Popup data-testid="submenu">
+                    <Menu.Item>Alpha</Menu.Item>
+                    <Menu.Item>Beta</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.SubmenuRoot>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}
+
+// TalkBack in Chrome activates elements with a synthetic mouse press: a zero-pressure 1x1
+// `pointerdown` followed by `mousedown` and a `detail: 0` click.
+function fireTalkBackPress(element: Element) {
+  fireEvent.pointerDown(element, {
+    pointerType: 'mouse',
+    width: 1,
+    height: 1,
+    pressure: 0,
+    detail: 0,
+  });
+  fireEvent.mouseDown(element, { detail: 0 });
+  fireEvent.click(element, { detail: 0 });
+}
+
+async function waitForFrames(count = 2) {
+  for (let i = 0; i < count; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        }),
+    );
+  }
+}
+
+// `isVirtualPointerEvent` returns `false` under jsdom, so the virtual press cannot be detected there.
+describe.skipIf(isJSDOM)('<Menu.SubmenuTrigger /> with TalkBack', () => {
+  const { render } = createRenderer();
+
+  it('opens the submenu on a TalkBack press with the default `openOnHover`', async () => {
+    const { user } = await render(<Test />);
+
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    const submenuTrigger = await screen.findByTestId('submenu-trigger');
+
+    fireTalkBackPress(submenuTrigger);
+
+    // The mousedown open path defers through a rAF.
+    await screen.findByTestId('submenu');
+  });
+
+  it('keeps the submenu open on a TalkBack press with `openOnHover={false}`', async () => {
+    const { user } = await render(<Test submenuTriggerProps={{ openOnHover: false }} />);
+
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    const submenuTrigger = await screen.findByTestId('submenu-trigger');
+
+    fireTalkBackPress(submenuTrigger);
+
+    await screen.findByTestId('submenu');
+
+    // The trailing click must not toggle the freshly opened submenu closed.
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+    });
+
+    expect(screen.queryByTestId('submenu')).not.toBe(null);
+  });
+
+  it('ignores an ordinary mouse press with the default `openOnHover`', async () => {
+    const { user } = await render(<Test />);
+
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    const submenuTrigger = await screen.findByTestId('submenu-trigger');
+
+    // A real pressed mouse reports non-zero pressure, so it is not a virtual press.
+    fireEvent.pointerDown(submenuTrigger, {
+      pointerType: 'mouse',
+      width: 1,
+      height: 1,
+      pressure: 0.5,
+      detail: 0,
+    });
+    fireEvent.mouseDown(submenuTrigger);
+    fireEvent.click(submenuTrigger, { detail: 1 });
+
+    await waitForFrames();
+
+    expect(screen.queryByTestId('submenu')).toBe(null);
+  });
+});


### PR DESCRIPTION
A TalkBack double-tap on `Menu.SubmenuTrigger` with the default `openOnHover` does nothing. TalkBack activates elements with a virtual mouse press (1×1, zero-pressure `pointerdown` with `pointerType: 'mouse'`, then `mousedown` and a `detail: 0` click), so `useClick` latches `mouse` and `ignoreMouse` swallows the whole press — and the hover path can't rescue it since opening is gated on real mouse movement (`allowMouseEnter`).

`useClick` now latches `'virtual'` as the pointer type when a mouse-like `pointerdown` matches `isVirtualPointerEvent`. The value isn't mouse-like, so `ignoreMouse` lets the press open on `mousedown`, while remaining truthy so the existing guard still swallows the trailing click (no immediate re-toggle when `openOnHover={false}`). Virtual `touch` presses (iOS VoiceOver) keep their type so `touchOpenDelay` still applies.

The tests live in a separate file because `isVirtualPointerEvent` only recognizes the TalkBack shape when the platform reports Android, so the file mocks `@base-ui/utils/platform` without leaking into sibling suites.
