### PR TITLE
[typescript] Preserve published internals types

### DIFF
--- a/packages/react/src/internals/composite/item/CompositeItem.tsx
+++ b/packages/react/src/internals/composite/item/CompositeItem.tsx
@@ -6,9 +6,6 @@ import { useCompositeItem } from './useCompositeItem';
 import type { BaseUIComponentProps } from '../../types';
 import { StateAttributesMapping } from '../../getStateAttributesProps';
 
-/**
- * @internal
- */
 export function CompositeItem<Metadata, State extends Record<string, any>>(
   componentProps: CompositeItem.Props<Metadata, State>,
 ) {

--- a/packages/react/src/internals/composite/list/CompositeList.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.tsx
@@ -18,7 +18,6 @@ interface CompositeListItem<Metadata> {
 
 /**
  * Provides context for a list of items in a composite component.
- * @internal
  */
 export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
   const { children, elementsRef, labelsRef, onMapChange: onMapChangeProp } = props;

--- a/packages/react/src/internals/composite/root/CompositeRoot.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.tsx
@@ -11,9 +11,6 @@ import type { CompositeGridNavigator } from './gridNavigation';
 import { useDirection } from '../../direction-context/DirectionContext';
 import { StateAttributesMapping } from '../../getStateAttributesProps';
 
-/**
- * @internal
- */
 export function CompositeRoot<Metadata extends {}, State extends Record<string, any>>(
   componentProps: CompositeRoot.Props<Metadata, State>,
 ) {

--- a/packages/react/src/internals/csp-context/CSPContext.tsx
+++ b/packages/react/src/internals/csp-context/CSPContext.tsx
@@ -6,18 +6,12 @@ export interface CSPContextValue {
   disableStyleElements?: boolean | undefined;
 }
 
-/**
- * @internal
- */
 export const CSPContext = React.createContext<CSPContextValue | undefined>(undefined);
 
 const DEFAULT_CSP_CONTEXT_VALUE: CSPContextValue = {
   disableStyleElements: false,
 };
 
-/**
- * @internal
- */
 export function useCSPContext(): CSPContextValue {
   return React.useContext(CSPContext) ?? DEFAULT_CSP_CONTEXT_VALUE;
 }

--- a/packages/react/src/internals/direction-context/DirectionContext.tsx
+++ b/packages/react/src/internals/direction-context/DirectionContext.tsx
@@ -7,9 +7,6 @@ export type DirectionContext = {
   direction: TextDirection;
 };
 
-/**
- * @internal
- */
 export const DirectionContext = React.createContext<DirectionContext | undefined>(undefined);
 
 export function useDirection() {

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -6,9 +6,6 @@ import { HTMLProps } from '../types';
 import { useBaseUiId } from '../useBaseUiId';
 import { LabelableContext, useLabelableContext } from './LabelableContext';
 
-/**
- * @internal
- */
 export const LabelableProvider: React.FC<LabelableProvider.Props> = function LabelableProvider(
   props,
 ) {

--- a/packages/react/src/internals/labelable-provider/useAriaLabelledBy.ts
+++ b/packages/react/src/internals/labelable-provider/useAriaLabelledBy.ts
@@ -3,9 +3,6 @@ import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useBaseUiId } from '../useBaseUiId';
 
-/**
- * @internal
- */
 export function useAriaLabelledBy(
   explicitAriaLabelledBy: string | undefined,
   labelId: string | undefined,


### PR DESCRIPTION
## Overview

Enabling `stripInternal` in #5165 removed declarations for runtime values that remain exported from published `internals/*` entrypoints. This left the shipped types self-inconsistent and caused downstream TypeScript builds to fail.

This is a post-v1.6.0 regression identified by an AI audit of `v1.6.0..master`.

## Changes

- Preserve declarations for the runtime values deliberately exposed by the composite, direction context, labelable provider, and CSP context internals entrypoints.
- Keep `stripInternal` enabled for declarations that are not part of published entrypoints.