### PR TITLE
[all components] Fix stale popup close modality

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -5,6 +5,8 @@ import { test, vi, expect } from 'vitest';
 
 /* eslint-disable react/jsx-fragments */
 import userEvent from '@testing-library/user-event';
+import type { InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import {
   flushMicrotasks,
   act,
@@ -1466,6 +1468,8 @@ describe('FloatingFocusManager', () => {
       });
 
       test('resets keyboard close modality between keep-mounted open sessions', async () => {
+        const finalFocus = vi.fn((_closeType: InteractionType) => true);
+
         function App() {
           const [isOpen, setIsOpen] = React.useState(false);
 
@@ -1481,9 +1485,10 @@ describe('FloatingFocusManager', () => {
           return (
             <>
               <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
+              <button data-testid="controlled-open" onClick={() => setIsOpen(true)} />
               <button data-testid="controlled-close" onClick={() => setIsOpen(false)} />
               <FloatingPortal>
-                <FloatingFocusManager context={context} disabled={!isOpen}>
+                <FloatingFocusManager context={context} disabled={!isOpen} returnFocus={finalFocus}>
                   <div ref={refs.setFloating} {...getFloatingProps()}>
                     <button data-testid="child" />
                   </div>
@@ -1511,6 +1516,7 @@ describe('FloatingFocusManager', () => {
               focusVisible: true,
             });
           });
+          expect(finalFocus).toHaveBeenLastCalledWith('keyboard');
 
           focusSpy.mockClear();
 
@@ -1527,6 +1533,88 @@ describe('FloatingFocusManager', () => {
           expect(focusSpy).not.toHaveBeenCalledWith(
             expect.objectContaining({ focusVisible: true }),
           );
+          expect(finalFocus).toHaveBeenLastCalledWith('');
+
+          focusSpy.mockClear();
+          finalFocus.mockClear();
+
+          fireEvent.click(screen.getByTestId('controlled-open'));
+          await waitFor(() => {
+            expect(screen.getByTestId('child')).toHaveFocus();
+          });
+
+          fireEvent.click(screen.getByTestId('controlled-close'));
+
+          await waitFor(() => {
+            expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+          });
+          expect(focusSpy).not.toHaveBeenCalledWith(
+            expect.objectContaining({ focusVisible: true }),
+          );
+          expect(finalFocus).toHaveBeenCalledWith('');
+        } finally {
+          focusSpy.mockRestore();
+        }
+      });
+
+      test('preserves keyboard close modality when reopening before focus restoration', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+          const [reopenOnClose, setReopenOnClose] = React.useState(false);
+
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          const click = useClick(context);
+          const dismiss = useDismiss(context);
+          const { getReferenceProps, getFloatingProps } = useTestInteractions([click, dismiss]);
+
+          useIsoLayoutEffect(() => {
+            if (!isOpen && reopenOnClose) {
+              setReopenOnClose(false);
+              setIsOpen(true);
+            }
+          }, [isOpen, reopenOnClose]);
+
+          return (
+            <>
+              <span data-testid="open-state">{String(isOpen)}</span>
+              <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
+              <button data-testid="reopen-on-close" onClick={() => setReopenOnClose(true)} />
+              <FloatingPortal>
+                <FloatingFocusManager context={context} disabled={!isOpen}>
+                  <div ref={refs.setFloating} {...getFloatingProps()}>
+                    <button data-testid="child" />
+                  </div>
+                </FloatingFocusManager>
+              </FloatingPortal>
+            </>
+          );
+        }
+
+        render(<App />);
+
+        const reference = screen.getByTestId('reference');
+        const focusSpy = vi.spyOn(reference, 'focus');
+
+        try {
+          await userEvent.click(reference);
+          await waitFor(() => {
+            expect(screen.getByTestId('child')).toHaveFocus();
+          });
+
+          fireEvent.click(screen.getByTestId('reopen-on-close'));
+          await userEvent.keyboard('{Escape}');
+
+          await waitFor(() => {
+            expect(focusSpy).toHaveBeenCalledWith({
+              preventScroll: true,
+              focusVisible: true,
+            });
+          });
+          expect(screen.getByTestId('open-state')).toHaveTextContent('true');
         } finally {
           focusSpy.mockRestore();
         }

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -1465,6 +1465,73 @@ describe('FloatingFocusManager', () => {
         expect(screen.getByTestId('reference')).toHaveFocus();
       });
 
+      test('resets keyboard close modality between keep-mounted open sessions', async () => {
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          const click = useClick(context);
+          const dismiss = useDismiss(context);
+          const { getReferenceProps, getFloatingProps } = useTestInteractions([click, dismiss]);
+
+          return (
+            <>
+              <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
+              <button data-testid="controlled-close" onClick={() => setIsOpen(false)} />
+              <FloatingPortal>
+                <FloatingFocusManager context={context} disabled={!isOpen}>
+                  <div ref={refs.setFloating} {...getFloatingProps()}>
+                    <button data-testid="child" />
+                  </div>
+                </FloatingFocusManager>
+              </FloatingPortal>
+            </>
+          );
+        }
+
+        render(<App />);
+
+        const reference = screen.getByTestId('reference');
+        const focusSpy = vi.spyOn(reference, 'focus');
+
+        try {
+          await userEvent.click(reference);
+          await waitFor(() => {
+            expect(screen.getByTestId('child')).toHaveFocus();
+          });
+
+          await userEvent.keyboard('{Escape}');
+          await waitFor(() => {
+            expect(focusSpy).toHaveBeenCalledWith({
+              preventScroll: true,
+              focusVisible: true,
+            });
+          });
+
+          focusSpy.mockClear();
+
+          await userEvent.click(reference);
+          await waitFor(() => {
+            expect(screen.getByTestId('child')).toHaveFocus();
+          });
+
+          fireEvent.click(screen.getByTestId('controlled-close'));
+
+          await waitFor(() => {
+            expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+          });
+          expect(focusSpy).not.toHaveBeenCalledWith(
+            expect.objectContaining({ focusVisible: true }),
+          );
+        } finally {
+          focusSpy.mockRestore();
+        }
+      });
+
       test('clears outside pointer state between keep-mounted open sessions', async () => {
         let readInsideReactTree = () => false;
 

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -1467,7 +1467,7 @@ describe('FloatingFocusManager', () => {
         expect(screen.getByTestId('reference')).toHaveFocus();
       });
 
-      test('resets keyboard close modality between keep-mounted open sessions', async () => {
+      test('resets close modality between keep-mounted open sessions', async () => {
         const finalFocus = vi.fn((_closeType: InteractionType) => true);
 
         function App() {
@@ -1543,6 +1543,7 @@ describe('FloatingFocusManager', () => {
             expect(screen.getByTestId('child')).toHaveFocus();
           });
 
+          fireEvent.pointerDown(reference, { pointerType: 'mouse' });
           fireEvent.click(screen.getByTestId('controlled-close'));
 
           await waitFor(() => {
@@ -1552,6 +1553,24 @@ describe('FloatingFocusManager', () => {
             expect.objectContaining({ focusVisible: true }),
           );
           expect(finalFocus).toHaveBeenCalledWith('');
+
+          focusSpy.mockClear();
+          finalFocus.mockClear();
+
+          fireEvent.click(screen.getByTestId('controlled-open'));
+          await waitFor(() => {
+            expect(screen.getByTestId('child')).toHaveFocus();
+          });
+
+          fireEvent.click(reference, { detail: 0 });
+
+          await waitFor(() => {
+            expect(focusSpy).toHaveBeenCalledWith({
+              preventScroll: true,
+              focusVisible: true,
+            });
+          });
+          expect(finalFocus).toHaveBeenCalledWith('keyboard');
         } finally {
           focusSpy.mockRestore();
         }

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -668,6 +668,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
     }
 
     closeTypeRef.current = '';
+    lastInteractionTypeRef.current = '';
 
     const doc = ownerDocument(floatingFocusElement);
     const previouslyFocusedElement = activeElement(doc);

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -314,6 +314,12 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
   const isInsidePortal = portalContext != null;
   const floatingFocusElement = getFloatingFocusElement(floating);
 
+  useIsoLayoutEffect(() => {
+    if (open) {
+      closeTypeRef.current = '';
+    }
+  }, [open]);
+
   const getTabbableContent = useStableCallback(
     (container: Element | null = floatingFocusElement) => {
       return container ? tabbable(container) : [];

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -314,12 +314,6 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
   const isInsidePortal = portalContext != null;
   const floatingFocusElement = getFloatingFocusElement(floating);
 
-  useIsoLayoutEffect(() => {
-    if (open) {
-      closeTypeRef.current = '';
-    }
-  }, [open]);
-
   const getTabbableContent = useStableCallback(
     (container: Element | null = floatingFocusElement) => {
       return container ? tabbable(container) : [];
@@ -673,6 +667,8 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
       return;
     }
 
+    closeTypeRef.current = '';
+
     const doc = ownerDocument(floatingFocusElement);
     const previouslyFocusedElement = activeElement(doc);
 
@@ -809,11 +805,11 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
 
     events.on('openchange', onOpenChangeLocal);
 
-    function getReturnElement() {
+    function getReturnElement(closeType: InteractionType) {
       const returnFocusValueOrFn = returnFocusRef.current;
       let resolvedReturnFocusValue =
         typeof returnFocusValueOrFn === 'function'
-          ? returnFocusValueOrFn(closeTypeRef.current)
+          ? returnFocusValueOrFn(closeType)
           : returnFocusValueOrFn;
 
       // `null` should fallback to default behavior in case of an empty ref.
@@ -861,7 +857,8 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
 
       // eslint-disable-next-line react-hooks/exhaustive-deps
       const returnFocusValueOrFn = returnFocusRef.current;
-      const returnElement = getReturnElement();
+      const closeType = closeTypeRef.current;
+      const returnElement = getReturnElement(closeType);
 
       queueMicrotask(() => {
         // `returnElement` if it is tabbable, otherwise its first tabbable child,
@@ -881,7 +878,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
             : true)
         ) {
           const focusOptions: FocusOptions = { preventScroll: true };
-          if (closeTypeRef.current === 'keyboard') {
+          if (closeType === 'keyboard') {
             focusOptions.focusVisible = true;
           }
           tabbableReturnElement.focus(focusOptions);


### PR DESCRIPTION
This fixes a post-v1.6.0 regression found by an AI audit of `v1.6.0..master`. A kept-mounted controlled popup could reuse keyboard close modality from an earlier session, causing focus-visible restoration after a later controlled close.

## Changes

- Reset close modality when each popup session opens and snapshot it for queued focus restoration.
- Cover pointer and controlled reopen sessions, including reopening before focus restoration completes.