### PR TITLE
[progress] Fix clamped value formatting

### DIFF
--- a/packages/react/src/progress/root/ProgressRoot.test.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.test.tsx
@@ -177,6 +177,41 @@ describe('<Progress.Root />', () => {
       expect(screen.getByTestId('indicator').style.width).toBe('0%');
     });
 
+    it.each([
+      { value: 50, expectedValue: 40 },
+      { value: 10, expectedValue: 20 },
+    ])(
+      'formats the clamped value $expectedValue when a custom-formatted value $value is outside the range',
+      async ({ value, expectedValue }) => {
+        const format: Intl.NumberFormatOptions = {
+          style: 'currency',
+          currency: 'USD',
+        };
+        const expected = new Intl.NumberFormat(undefined, format).format(expectedValue);
+        const getAriaValueText = vi.fn((formattedValue: string, rawValue: number | null) => {
+          return `${formattedValue} (raw: ${rawValue})`;
+        });
+
+        await render(
+          <Progress.Root
+            min={20}
+            max={40}
+            value={value}
+            format={format}
+            getAriaValueText={getAriaValueText}
+          >
+            <Progress.Value data-testid="value" />
+          </Progress.Root>,
+        );
+
+        const progressbar = screen.getByRole('progressbar');
+        expect(progressbar).toHaveAttribute('aria-valuenow', String(expectedValue));
+        expect(screen.getByTestId('value')).toHaveTextContent(expected);
+        expect(getAriaValueText).toHaveBeenLastCalledWith(expected, value);
+        expect(progressbar).toHaveAttribute('aria-valuetext', `${expected} (raw: ${value})`);
+      },
+    );
+
     it('reports complete when the value reaches or exceeds max', async () => {
       await render(
         <Progress.Root min={0} max={40} value={45}>

--- a/packages/react/src/progress/root/ProgressRoot.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.tsx
@@ -54,7 +54,7 @@ export const ProgressRoot = React.forwardRef(function ProgressRoot(
     // Without an explicit `format`, the value is displayed as its position within the range so the
     // text stays in sync with the indicator fill.
     formattedValue = format
-      ? formatNumber(value, locale, format)
+      ? formatNumber(clampedValue, locale, format)
       : formatNumber(percentageValue / 100, locale, { style: 'percent' });
     defaultAriaValueText = formattedValue;
   }


### PR DESCRIPTION
This is a post-v1.6.0 regression found by an AI audit of `v1.6.0..master`.

## Changes

- Format custom Progress text from the clamped value used by `aria-valuenow` and the indicator.
- Keep the raw value passed to `getAriaValueText` unchanged.
- Cover values above `max` and below `min`.
