### PR TITLE
[field] Fix required validity after custom error

### DIFF
--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -182,6 +182,18 @@ export function useFieldValidation(
         return;
       }
 
+      // A stale custom error can coexist with valueMissing, but defer any other native errors.
+      for (const key of validityKeys) {
+        if (
+          key !== 'valid' &&
+          key !== 'valueMissing' &&
+          key !== 'customError' &&
+          currentNativeValidity[key]
+        ) {
+          return;
+        }
+      }
+
       // Value is still missing: publish the current native state so valueMissing and the changed
       // value are observable immediately. Full custom validation still waits for its boundary.
     }

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -182,17 +182,8 @@ export function useFieldValidation(
         return;
       }
 
-      // Avoid surfacing another error during change revalidation while the required value is
-      // still missing. The full validity state is published at the configured blur or submit
-      // boundary instead.
-      for (const key of validityKeys) {
-        if (key !== 'valid' && key !== 'valueMissing' && currentNativeValidity[key]) {
-          return;
-        }
-      }
-
-      // Value is still missing and it is the only native error: fall through to the main
-      // validation logic below.
+      // Value is still missing: publish the current native state so valueMissing and the changed
+      // value are observable immediately. Full custom validation still waits for its boundary.
     }
 
     function getState(el: HTMLInputElement) {

--- a/packages/react/src/field/validity/FieldValidity.test.tsx
+++ b/packages/react/src/field/validity/FieldValidity.test.tsx
@@ -2,6 +2,7 @@ import { expect, vi } from 'vitest';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
+import { isJSDOM } from '#test-utils';
 
 describe('<Field.Validity />', () => {
   const { render } = createRenderer();
@@ -61,6 +62,46 @@ describe('<Field.Validity />', () => {
       expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(true);
       expect(screen.getByText('Required')).toBeVisible();
     });
+  });
+
+  it.skipIf(isJSDOM)('defers badInput during required change revalidation', async () => {
+    const { userEvent } = await import('vitest/browser');
+    const user = userEvent.setup();
+    const handleValidity = vi.fn();
+
+    await render(
+      <Field.Root validationMode="onBlur" validate={() => 'custom error'}>
+        <Field.Control type="number" required />
+        <Field.Error match="valueMissing">Required</Field.Error>
+        <Field.Error match="badInput">Invalid number</Field.Error>
+        <Field.Validity>{handleValidity}</Field.Validity>
+      </Field.Root>,
+    );
+
+    const input = screen.getByRole<HTMLInputElement>('spinbutton');
+
+    await act(async () => {
+      await user.click(input);
+      await user.keyboard('1');
+      await user.tab();
+    });
+
+    expect(handleValidity.mock.lastCall?.[0].value).toBe('1');
+    expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
+
+    await act(async () => {
+      await user.click(input);
+      await user.keyboard('{Control>}a{/Control}');
+      await user.keyboard('e');
+    });
+
+    expect(input.validity.valueMissing).toBe(true);
+    expect(input.validity.badInput).toBe(true);
+    expect(handleValidity.mock.lastCall?.[0].value).toBe('1');
+    expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(false);
+    expect(handleValidity.mock.lastCall?.[0].validity.badInput).toBe(false);
+    expect(screen.queryByText('Required')).toBe(null);
+    expect(screen.queryByText('Invalid number')).toBe(null);
   });
 
   describe('validationMode=onSubmit', () => {

--- a/packages/react/src/field/validity/FieldValidity.test.tsx
+++ b/packages/react/src/field/validity/FieldValidity.test.tsx
@@ -9,13 +9,11 @@ describe('<Field.Validity />', () => {
   ['onBlur', 'onSubmit'].forEach((validationMode) => {
     it(`surfaces valueMissing immediately after a stale custom error in ${validationMode} mode`, () => {
       const handleValidity = vi.fn();
+      const validate = vi.fn(() => 'custom error');
 
       render(
         <Form>
-          <Field.Root
-            validationMode={validationMode as 'onBlur' | 'onSubmit'}
-            validate={() => 'custom error'}
-          >
+          <Field.Root validationMode={validationMode as 'onBlur' | 'onSubmit'} validate={validate}>
             <Field.Control required />
             <Field.Error match="valueMissing">Required</Field.Error>
             <Field.Validity>{handleValidity}</Field.Validity>
@@ -41,9 +39,22 @@ describe('<Field.Validity />', () => {
       expect(handleValidity.mock.lastCall?.[0].value).toBe('invalid');
       expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
       expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(false);
+      expect(validate).toHaveBeenCalledTimes(1);
 
       fireEvent.focus(input);
       fireEvent.change(input, { target: { value: '' } });
+
+      expect(handleValidity.mock.lastCall?.[0].value).toBe('');
+      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
+      expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(true);
+      expect(screen.getByText('Required')).toBeVisible();
+      expect(validate).toHaveBeenCalledTimes(1);
+
+      if (validationMode === 'onBlur') {
+        fireEvent.blur(input);
+      } else {
+        fireEvent.click(screen.getByText('submit'));
+      }
 
       expect(handleValidity.mock.lastCall?.[0].value).toBe('');
       expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);

--- a/packages/react/src/field/validity/FieldValidity.test.tsx
+++ b/packages/react/src/field/validity/FieldValidity.test.tsx
@@ -7,7 +7,7 @@ describe('<Field.Validity />', () => {
   const { render } = createRenderer();
 
   ['onBlur', 'onSubmit'].forEach((validationMode) => {
-    it(`defers a required field's stale custom error until the ${validationMode} boundary`, () => {
+    it(`surfaces valueMissing immediately after a stale custom error in ${validationMode} mode`, () => {
       const handleValidity = vi.fn();
 
       render(
@@ -17,6 +17,7 @@ describe('<Field.Validity />', () => {
             validate={() => 'custom error'}
           >
             <Field.Control required />
+            <Field.Error match="valueMissing">Required</Field.Error>
             <Field.Validity>{handleValidity}</Field.Validity>
           </Field.Root>
           <button type="submit">submit</button>
@@ -44,18 +45,10 @@ describe('<Field.Validity />', () => {
       fireEvent.focus(input);
       fireEvent.change(input, { target: { value: '' } });
 
-      expect(handleValidity.mock.lastCall?.[0].value).toBe('invalid');
-      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
-      expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(false);
-
-      if (validationMode === 'onBlur') {
-        fireEvent.blur(input);
-      } else {
-        fireEvent.click(screen.getByText('submit'));
-      }
-
       expect(handleValidity.mock.lastCall?.[0].value).toBe('');
+      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
       expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(true);
+      expect(screen.getByText('Required')).toBeVisible();
     });
   });
 

--- a/packages/react/src/field/validity/FieldValidity.test.tsx
+++ b/packages/react/src/field/validity/FieldValidity.test.tsx
@@ -80,20 +80,12 @@ describe('<Field.Validity />', () => {
 
     const input = screen.getByRole<HTMLInputElement>('spinbutton');
 
-    await act(async () => {
-      await user.click(input);
-      await user.keyboard('1');
-      await user.tab();
-    });
+    await act(() => user.type(input, '1[Tab]'));
 
     expect(handleValidity.mock.lastCall?.[0].value).toBe('1');
     expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(true);
 
-    await act(async () => {
-      await user.click(input);
-      await user.keyboard('{Control>}a{/Control}');
-      await user.keyboard('e');
-    });
+    await act(() => user.type(input, '{Control>}a{/Control}e'));
 
     expect(input.validity.valueMissing).toBe(true);
     expect(input.validity.badInput).toBe(true);


### PR DESCRIPTION
This fixes a post-v1.6.0 regression found by an AI audit of `v1.6.0..master`. #5225 made a previously dead change-revalidation guard live, leaving Field.Validity on stale state after custom validation had set `customError` and a required field was then cleared.

## Changes

- Restore immediate `valueMissing` publication on change while custom validation remains deferred to its configured boundary.
- Add focused coverage for clearing a required field after a custom error.