### PR TITLE
[slider] Fix post-v1.6 regressions

### DIFF
--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -114,6 +114,34 @@ describe('<Slider.Thumb />', () => {
       expect(handleKeyDown).toHaveBeenCalledTimes(1);
       expect(slider).toHaveAttribute('aria-valuenow', '50');
     });
+
+    it('does not commit NaN when more thumbs are rendered than values', async () => {
+      const onValueChange = vi.fn();
+      const onValueCommitted = vi.fn();
+
+      await render(
+        <Slider.Root
+          defaultValue={[10, 20]}
+          onValueChange={onValueChange}
+          onValueCommitted={onValueCommitted}
+        >
+          <Slider.Control>
+            <Slider.Thumb />
+            <Slider.Thumb />
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>,
+      );
+
+      const extraThumb = screen.getAllByRole('slider')[2];
+      await act(async () => {
+        extraThumb.focus();
+      });
+      fireEvent.keyDown(extraThumb, { key: 'ArrowRight' });
+
+      expect(onValueChange).not.toHaveBeenCalled();
+      expect(onValueCommitted).not.toHaveBeenCalled();
+    });
   });
 
   // AT (e.g. Android Talkback) may use increase/decrease actions to interact
@@ -283,6 +311,49 @@ describe('<Slider.Thumb />', () => {
           expect(validateSpy).toHaveBeenCalledTimes(1);
         });
       });
+
+      it.skipIf(isJSDOM)(
+        'commits field validation when focus moves from a thumb to an arbitrary Control child',
+        async () => {
+          const validateSpy = vi.fn(() => null);
+          const { user } = await render(
+            <React.Fragment>
+              <Field.Root validationMode="onBlur" validate={validateSpy} data-testid="field">
+                <Slider.Root defaultValue={[20, 50]}>
+                  <Slider.Control>
+                    <Slider.Thumb index={0} />
+                    <Slider.Thumb index={1} />
+                    <button type="button">Help</button>
+                  </Slider.Control>
+                </Slider.Root>
+              </Field.Root>
+              <button type="button">Outside</button>
+            </React.Fragment>,
+          );
+
+          const [thumb0, thumb1] = screen.getAllByRole('slider');
+
+          await user.keyboard('[Tab]');
+          expect(thumb0).toHaveFocus();
+          validateSpy.mockClear();
+
+          await user.keyboard('[Tab]');
+          expect(thumb1).toHaveFocus();
+          expect(validateSpy).not.toHaveBeenCalled();
+
+          await user.keyboard('[Tab]');
+          expect(screen.getByRole('button', { name: 'Help' })).toHaveFocus();
+          await waitFor(() => {
+            expect(validateSpy).toHaveBeenCalledTimes(1);
+          });
+          expect(screen.getByTestId('field')).toHaveAttribute('data-touched');
+          expect(screen.getByTestId('field')).not.toHaveAttribute('data-focused');
+
+          await user.keyboard('[Tab]');
+          expect(screen.getByRole('button', { name: 'Outside' })).toHaveFocus();
+          expect(validateSpy).toHaveBeenCalledTimes(1);
+        },
+      );
     });
 
     describe('change', () => {

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -138,6 +138,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
     setIndicatorPosition,
     state,
     step,
+    thumbRefs,
     values: sliderValues,
   } = useSliderRootContext();
 
@@ -348,7 +349,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
 
         // Keep field-level blur logic from running while focus moves to another thumb
         // of the same slider, so validation doesn't commit mid-interaction.
-        if (contains(controlRef.current, event.relatedTarget)) {
+        if (thumbRefs.current.some((thumb) => contains(thumb, event.relatedTarget))) {
           return;
         }
 

--- a/packages/react/src/slider/utils/validateMinimumDistance.ts
+++ b/packages/react/src/slider/utils/validateMinimumDistance.ts
@@ -9,7 +9,7 @@ export function validateMinimumDistance(
 
   const minDistance = step * minStepsBetweenValues;
   for (let i = 0; i < values.length - 1; i += 1) {
-    if (Math.abs(values[i] - values[i + 1]) < minDistance) {
+    if (!(Math.abs(values[i] - values[i + 1]) >= minDistance)) {
       return false;
     }
   }


### PR DESCRIPTION
These post-v1.6.0 regressions were found by an AI audit of `v1.6.0..master` and trace back to #5222.

## Changes

- Limit field blur suppression to focus moves between registered Slider thumbs.
- Reject invalid minimum-distance comparisons before they can commit `NaN`.

## Original findings addressed

- Slider field validation stayed focused and untouched when focus moved to an arbitrary focusable child inside `Slider.Control`.
- A keyboard step on a thumb without a corresponding value could commit `NaN`.