### PR TITLE
[drawer] Fix click-only outside dismissal after swipe

### DIFF
--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -33,6 +33,7 @@ type SwipeInput = 'pointer' | 'touch';
 type SwipeOptions = {
   beforeRelease?: (() => Promise<unknown>) | (() => unknown);
   input?: SwipeInput;
+  pointerType?: 'mouse' | 'pen';
   timeStepMs?: number;
   startTimeMs?: number;
 };
@@ -69,7 +70,13 @@ function dispatchTouchPointerEvent(
 async function swipe(element: HTMLElement, start: Point, end: Point, options: SwipeOptions = {}) {
   const stepX = start.x + (end.x === start.x ? 0 : Math.sign(end.x - start.x));
   const stepY = start.y + (end.y === start.y ? 0 : Math.sign(end.y - start.y));
-  const { beforeRelease, input = 'pointer', timeStepMs, startTimeMs = 0 } = options;
+  const {
+    beforeRelease,
+    input = 'pointer',
+    pointerType = 'mouse',
+    timeStepMs,
+    startTimeMs = 0,
+  } = options;
   const useTimeStamp = input === 'pointer' && typeof timeStepMs === 'number';
   let timeStamp = startTimeMs;
 
@@ -135,7 +142,7 @@ async function swipe(element: HTMLElement, start: Point, end: Point, options: Sw
     pointerId: 1,
     clientX: start.x,
     clientY: start.y,
-    pointerType: 'mouse',
+    pointerType,
     ...(useTimeStamp ? { timeStamp } : null),
   });
 
@@ -150,7 +157,7 @@ async function swipe(element: HTMLElement, start: Point, end: Point, options: Sw
     clientX: stepX,
     clientY: stepY,
     buttons: 1,
-    pointerType: 'mouse',
+    pointerType,
     ...(useTimeStamp ? { timeStamp } : null),
   });
 
@@ -165,7 +172,7 @@ async function swipe(element: HTMLElement, start: Point, end: Point, options: Sw
     clientX: end.x,
     clientY: end.y,
     buttons: 1,
-    pointerType: 'mouse',
+    pointerType,
     ...(useTimeStamp ? { timeStamp } : null),
   });
 
@@ -184,7 +191,7 @@ async function swipe(element: HTMLElement, start: Point, end: Point, options: Sw
     pointerId: 1,
     clientX: end.x,
     clientY: end.y,
-    pointerType: 'mouse',
+    pointerType,
     ...(useTimeStamp ? { timeStamp } : null),
   });
 
@@ -827,40 +834,73 @@ describe('<Drawer.SwipeArea />', () => {
     expect(swipeArea).toHaveAttribute('data-closed', '');
   });
 
-  it('does not dismiss from the click synthesized by the swipe-open pointerup', async () => {
-    // Dragging past the popup releases the pointer outside it, so the gesture's own pointerup
-    // synthesizes a `click` over the backdrop. That click (which has no fresh pointerdown) must not
-    // be read as an outside press and dismiss the drawer that was just opened — even when it lands a
-    // macrotask later, after a timer-based re-enable would have fired.
-    await render(
-      <Drawer.Root>
-        <Drawer.SwipeArea data-testid="swipe-area" />
-        <Drawer.Portal>
-          <Drawer.Viewport>
-            <Drawer.Popup data-testid="popup">Drawer</Drawer.Popup>
-          </Drawer.Viewport>
-        </Drawer.Portal>
-      </Drawer.Root>,
+  it.each([
+    { input: 'pointer' as const, pointerType: 'mouse' as const },
+    { input: 'pointer' as const, pointerType: 'pen' as const },
+    { input: 'touch' as const, pointerType: 'mouse' as const },
+  ])(
+    'does not dismiss from the $pointerType/$input click synthesized by the swipe-open release',
+    async ({ input, pointerType }) => {
+      // Dragging past the popup releases the pointer outside it, so the gesture's own pointerup
+      // synthesizes a `click` over the backdrop. That click (which has no fresh pointerdown) must not
+      // be read as an outside press and dismiss the drawer that was just opened.
+      await render(
+        <Drawer.Root>
+          <Drawer.SwipeArea data-testid="swipe-area" />
+          <Drawer.Portal>
+            <Drawer.Viewport>
+              <Drawer.Popup data-testid="popup">Drawer</Drawer.Popup>
+            </Drawer.Viewport>
+          </Drawer.Portal>
+        </Drawer.Root>,
+      );
+
+      const swipeArea = screen.getByTestId('swipe-area');
+
+      await swipeUp(swipeArea, 120, 40, { input, pointerType });
+
+      expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+
+      // Trailing synthesized click with no preceding fresh pointerdown.
+      fireEvent.click(document.body, { detail: 1 });
+
+      await act(async () => {
+        await nextMacrotask();
+      });
+
+      expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+    },
+  );
+
+  it.skipIf(isJSDOM)('allows a later click-only activation to dismiss after a swipe', async () => {
+    const { user } = await render(
+      <React.Fragment>
+        <button type="button">Outside</button>
+        <Drawer.Root modal={false}>
+          <Drawer.SwipeArea data-testid="swipe-area" />
+          <Drawer.Portal>
+            <Drawer.Viewport>
+              <Drawer.Popup data-testid="popup" initialFocus={false}>
+                Drawer
+              </Drawer.Popup>
+            </Drawer.Viewport>
+          </Drawer.Portal>
+        </Drawer.Root>
+      </React.Fragment>,
     );
 
-    const swipeArea = screen.getByTestId('swipe-area');
+    const outside = screen.getByRole('button', { name: 'Outside' });
+    outside.focus();
 
-    await swipeUp(swipeArea, 120, 40);
-
+    await swipeUp(screen.getByTestId('swipe-area'), 120, 40);
     expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+    expect(outside).toHaveFocus();
 
-    await act(async () => {
-      await nextMacrotask();
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('popup')).toBe(null);
     });
-
-    // Trailing synthesized click with no preceding fresh pointerdown.
-    fireEvent.click(document.body);
-
-    await act(async () => {
-      await nextMacrotask();
-    });
-
-    expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
   });
 
   it('re-enables outside press dismissal after an interrupted swipe-open gesture', async () => {

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -934,7 +934,8 @@ describe('<Drawer.SwipeArea />', () => {
     async ({ input, pointerType }) => {
       // Dragging past the popup releases the pointer outside it, so the gesture's own pointerup
       // synthesizes a `click` over the backdrop. That click (which has no fresh pointerdown) must not
-      // be read as an outside press and dismiss the drawer that was just opened.
+      // be read as an outside press and dismiss the drawer that was just opened — even when it lands
+      // a macrotask later, after a timer-based re-enable would have fired.
       await render(
         <Drawer.Root>
           <Drawer.SwipeArea data-testid="swipe-area" />
@@ -952,6 +953,10 @@ describe('<Drawer.SwipeArea />', () => {
 
       expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
 
+      await act(async () => {
+        await nextMacrotask();
+      });
+
       // Trailing synthesized click with no preceding fresh pointerdown.
       const releaseClick = new MouseEvent('click', { bubbles: true, detail: 1 });
       Object.defineProperty(releaseClick, 'pointerType', { value: pointerType });
@@ -962,75 +967,6 @@ describe('<Drawer.SwipeArea />', () => {
       });
 
       expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
-    },
-  );
-
-  it.skipIf(isJSDOM)(
-    'does not dismiss from the trusted click synthesized by a real mouse swipe release',
-    async () => {
-      // Unlike `fireEvent`, a trusted dispatch performs a microtask checkpoint between listeners,
-      // so this is the only shape that exercises the real ordering between the release guard
-      // (document capture) and floating-ui's outside-press check (target phase).
-      ignoreActWarnings();
-      const { userEvent: user } = await import('vitest/browser');
-      const { render: vbrRender, cleanup } = await import('vitest-browser-react');
-
-      try {
-        await vbrRender(
-          <div>
-            <div
-              data-testid="release-target"
-              style={{ position: 'fixed', top: 0, left: 0, width: '100%', height: 100 }}
-            />
-            <Drawer.Root>
-              <Drawer.SwipeArea
-                data-testid="swipe-area"
-                style={{ position: 'fixed', bottom: 0, left: 0, width: '100%', height: 40 }}
-              />
-              <Drawer.Portal>
-                <Drawer.Viewport>
-                  <Drawer.Popup
-                    data-testid="popup"
-                    style={{ position: 'fixed', bottom: 0, left: 0, width: '100%', height: 150 }}
-                  >
-                    Drawer
-                  </Drawer.Popup>
-                </Drawer.Viewport>
-              </Drawer.Portal>
-            </Drawer.Root>
-          </div>,
-        );
-
-        // Drag the swipe area past the popup's size and release outside it. The swipe area holds
-        // pointer capture, so the gesture's trusted synthesized `click` retargets to the swipe
-        // area itself — this pins that a real mouse swipe never self-dismisses, whichever element
-        // the click resolves to.
-        await user.dragAndDrop(
-          screen.getByTestId('swipe-area'),
-          screen.getByTestId('release-target'),
-        );
-
-        await waitFor(() => {
-          expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
-        });
-
-        await act(async () => {
-          await nextMacrotask();
-        });
-
-        expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
-
-        // A deliberate outside press afterwards must dismiss, proving the guard was restored.
-        // `force` skips Playwright's actionability check: the drawer's internal backdrop
-        // intercepts the click, which is exactly the outside press being tested.
-        await user.click(screen.getByTestId('release-target'), { force: true });
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('popup')).toBe(null);
-        });
-      } finally {
-        await cleanup();
-      }
     },
   );
 

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -2,7 +2,14 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 import * as React from 'react';
 import { Drawer } from '@base-ui/react/drawer';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
+import {
+  act,
+  fireEvent,
+  flushMicrotasks,
+  ignoreActWarnings,
+  screen,
+  waitFor,
+} from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import {
   type DrawerProviderContext,
@@ -46,6 +53,7 @@ type SwipeInput = 'pointer' | 'touch';
 type SwipeOptions = {
   beforeRelease?: (() => Promise<unknown>) | (() => unknown);
   input?: SwipeInput;
+  // Applies only to `input: 'pointer'`; the `touch` branch always dispatches touch events.
   pointerType?: 'mouse' | 'pen' | 'touch';
   timeStepMs?: number;
   startTimeMs?: number;
@@ -661,6 +669,70 @@ describe('<Drawer.SwipeArea />', () => {
     }
   });
 
+  it('keeps the drawer open when the release click follows a mid-gesture disable', async () => {
+    function TestCase({ disabled }: { disabled: boolean }) {
+      return (
+        <Drawer.Root>
+          <Drawer.SwipeArea data-testid="swipe-area" disabled={disabled} />
+          <Drawer.Portal>
+            <Drawer.Viewport>
+              <Drawer.Popup data-testid="popup">Drawer</Drawer.Popup>
+            </Drawer.Viewport>
+          </Drawer.Portal>
+        </Drawer.Root>
+      );
+    }
+
+    const { setProps } = await render(<TestCase disabled={false} />);
+    const swipeArea = screen.getByTestId('swipe-area');
+
+    fireEvent.pointerDown(swipeArea, {
+      button: 0,
+      buttons: 1,
+      pointerId: 1,
+      clientX: 0,
+      clientY: 100,
+      pointerType: 'mouse',
+    });
+    fireEvent.pointerMove(swipeArea, {
+      buttons: 1,
+      pointerId: 1,
+      clientX: 0,
+      clientY: 99,
+      pointerType: 'mouse',
+    });
+    fireEvent.pointerMove(swipeArea, {
+      buttons: 1,
+      pointerId: 1,
+      clientX: 0,
+      clientY: 40,
+      pointerType: 'mouse',
+    });
+    await flushMicrotasks();
+    expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+
+    await setProps({ disabled: true });
+
+    // The pointer is still down when `disabled` flips, so the gesture's eventual release
+    // synthesizes a click with no fresh `pointerdown`. It must not dismiss the drawer the
+    // gesture just opened.
+    const releaseClick = new MouseEvent('click', { bubbles: true, detail: 1 });
+    Object.defineProperty(releaseClick, 'pointerType', { value: 'mouse' });
+    fireEvent(document.body, releaseClick);
+
+    await act(async () => {
+      await nextMacrotask();
+    });
+
+    expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+
+    pressOutside();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('popup')).toBe(null);
+    });
+  });
+
   it('does not prevent a non-cancelable pointer start', async () => {
     await render(
       <Drawer.Root>
@@ -890,6 +962,146 @@ describe('<Drawer.SwipeArea />', () => {
       });
 
       expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    'does not dismiss from the trusted click synthesized by a real mouse swipe release',
+    async () => {
+      // Unlike `fireEvent`, a trusted dispatch performs a microtask checkpoint between listeners,
+      // so this is the only shape that exercises the real ordering between the release guard
+      // (document capture) and floating-ui's outside-press check (target phase).
+      ignoreActWarnings();
+      const { userEvent: user } = await import('vitest/browser');
+      const { render: vbrRender, cleanup } = await import('vitest-browser-react');
+
+      try {
+        await vbrRender(
+          <div>
+            <div
+              data-testid="release-target"
+              style={{ position: 'fixed', top: 0, left: 0, width: '100%', height: 100 }}
+            />
+            <Drawer.Root>
+              <Drawer.SwipeArea
+                data-testid="swipe-area"
+                style={{ position: 'fixed', bottom: 0, left: 0, width: '100%', height: 40 }}
+              />
+              <Drawer.Portal>
+                <Drawer.Viewport>
+                  <Drawer.Popup
+                    data-testid="popup"
+                    style={{ position: 'fixed', bottom: 0, left: 0, width: '100%', height: 150 }}
+                  >
+                    Drawer
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.Root>
+          </div>,
+        );
+
+        // Drag the swipe area past the popup's size and release outside it. The swipe area holds
+        // pointer capture, so the gesture's trusted synthesized `click` retargets to the swipe
+        // area itself — this pins that a real mouse swipe never self-dismisses, whichever element
+        // the click resolves to.
+        await user.dragAndDrop(
+          screen.getByTestId('swipe-area'),
+          screen.getByTestId('release-target'),
+        );
+
+        await waitFor(() => {
+          expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+        });
+
+        await act(async () => {
+          await nextMacrotask();
+        });
+
+        expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+
+        // A deliberate outside press afterwards must dismiss, proving the guard was restored.
+        // `force` skips Playwright's actionability check: the drawer's internal backdrop
+        // intercepts the click, which is exactly the outside press being tested.
+        await user.click(screen.getByTestId('release-target'), { force: true });
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('popup')).toBe(null);
+        });
+      } finally {
+        await cleanup();
+      }
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    'suppresses a trusted release click that arrives without a preceding pointerdown',
+    async () => {
+      // A trusted dispatch performs a microtask checkpoint after each listener, so only trusted
+      // input exercises the real ordering between the release guard (document capture) and
+      // floating-ui's outside-press check (target phase). Browsers deliver the gesture's trailing
+      // click without a fresh `pointerdown` (e.g. a touch flick within tap slop); trusted
+      // low-level input cannot produce that shape directly, so the `pointerdown` is stopped at
+      // the window — ahead of document capture — and only the trusted `click` flows through.
+      ignoreActWarnings();
+      const { userEvent: user } = await import('vitest/browser');
+      const { render: vbrRender, cleanup } = await import('vitest-browser-react');
+
+      const stopPointerDown = (event: Event) => event.stopPropagation();
+
+      try {
+        await vbrRender(
+          <div>
+            <div
+              data-testid="outside-target"
+              style={{ position: 'fixed', top: 0, left: 0, width: '100%', height: 100 }}
+            />
+            <Drawer.Root>
+              <Drawer.SwipeArea
+                data-testid="swipe-area"
+                style={{ position: 'fixed', bottom: 0, left: 0, width: '100%', height: 40 }}
+              />
+              <Drawer.Portal>
+                <Drawer.Viewport>
+                  <Drawer.Popup
+                    data-testid="popup"
+                    style={{ position: 'fixed', bottom: 0, left: 0, width: '100%', height: 150 }}
+                  >
+                    Drawer
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.Root>
+          </div>,
+        );
+
+        // Synthetic swipe: opens the drawer and arms the release guard without synthesizing the
+        // trailing click (`fireEvent` does not), leaving the guard waiting for it.
+        await swipeUp(screen.getByTestId('swipe-area'), 120, 40);
+        expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+
+        window.addEventListener('pointerdown', stopPointerDown, true);
+        // `force` skips Playwright's actionability check; the drawer's internal backdrop
+        // intercepts the click, which is exactly where a release click would land.
+        await user.click(screen.getByTestId('outside-target'), { force: true });
+        window.removeEventListener('pointerdown', stopPointerDown, true);
+
+        await act(async () => {
+          await nextMacrotask();
+        });
+
+        expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+
+        // The guard is consumed and restored, so a deliberate outside press now dismisses.
+        await user.click(screen.getByTestId('outside-target'), { force: true });
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('popup')).toBe(null);
+        });
+      } finally {
+        window.removeEventListener('pointerdown', stopPointerDown, true);
+        await cleanup();
+      }
     },
   );
 

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '../provider/DrawerProviderContext';
 
 const useIdMockState = vi.hoisted(() => ({ returnUndefined: false }));
+const eventUtilsMockState = vi.hoisted(() => ({ forceVirtualClick: false }));
 
 vi.mock('@base-ui/utils/useId', async () => {
   const actual =
@@ -19,6 +20,18 @@ vi.mock('@base-ui/utils/useId', async () => {
     useId(...args: Parameters<typeof actual.useId>) {
       const id = actual.useId(...args);
       return useIdMockState.returnUndefined ? undefined : id;
+    },
+  };
+});
+
+vi.mock('../../floating-ui-react/utils/event', async () => {
+  const actual = await vi.importActual<typeof import('../../floating-ui-react/utils/event')>(
+    '../../floating-ui-react/utils/event',
+  );
+  return {
+    ...actual,
+    isVirtualClick(...args: Parameters<typeof actual.isVirtualClick>) {
+      return eventUtilsMockState.forceVirtualClick || actual.isVirtualClick(...args);
     },
   };
 });
@@ -33,7 +46,7 @@ type SwipeInput = 'pointer' | 'touch';
 type SwipeOptions = {
   beforeRelease?: (() => Promise<unknown>) | (() => unknown);
   input?: SwipeInput;
-  pointerType?: 'mouse' | 'pen';
+  pointerType?: 'mouse' | 'pen' | 'touch';
   timeStepMs?: number;
   startTimeMs?: number;
 };
@@ -637,6 +650,12 @@ describe('<Drawer.SwipeArea />', () => {
       expect(cleanupPhases.at(-1)).toBe(true);
       expect(screen.getByTestId('popup')).not.toHaveAttribute('data-swiping');
       expect(swipeArea).toHaveAttribute('data-disabled', '');
+
+      pressOutside();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('popup')).toBe(null);
+      });
     } finally {
       providerContext!.visualStateStore.set = originalSetVisualState;
     }
@@ -837,7 +856,7 @@ describe('<Drawer.SwipeArea />', () => {
   it.each([
     { input: 'pointer' as const, pointerType: 'mouse' as const },
     { input: 'pointer' as const, pointerType: 'pen' as const },
-    { input: 'touch' as const, pointerType: 'mouse' as const },
+    { input: 'touch' as const, pointerType: 'touch' as const },
   ])(
     'does not dismiss from the $pointerType/$input click synthesized by the swipe-open release',
     async ({ input, pointerType }) => {
@@ -862,7 +881,9 @@ describe('<Drawer.SwipeArea />', () => {
       expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
 
       // Trailing synthesized click with no preceding fresh pointerdown.
-      fireEvent.click(document.body, { detail: 1 });
+      const releaseClick = new MouseEvent('click', { bubbles: true, detail: 1 });
+      Object.defineProperty(releaseClick, 'pointerType', { value: pointerType });
+      fireEvent(document.body, releaseClick);
 
       await act(async () => {
         await nextMacrotask();
@@ -897,6 +918,40 @@ describe('<Drawer.SwipeArea />', () => {
     expect(outside).toHaveFocus();
 
     await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('popup')).toBe(null);
+    });
+  });
+
+  it('allows a later pointerless virtual click to dismiss when the release has no click', async () => {
+    await render(
+      <React.Fragment>
+        <button type="button">Outside</button>
+        <Drawer.Root modal={false}>
+          <Drawer.SwipeArea data-testid="swipe-area" />
+          <Drawer.Portal>
+            <Drawer.Viewport>
+              <Drawer.Popup data-testid="popup" initialFocus={false}>
+                Drawer
+              </Drawer.Popup>
+            </Drawer.Viewport>
+          </Drawer.Portal>
+        </Drawer.Root>
+      </React.Fragment>,
+    );
+
+    await swipeUp(screen.getByTestId('swipe-area'), 120, 40, { input: 'touch' });
+    expect(screen.getByTestId('popup')).toHaveAttribute('data-open', '');
+
+    eventUtilsMockState.forceVirtualClick = true;
+    try {
+      const virtualClick = new MouseEvent('click', { bubbles: true, detail: 1 });
+      Object.defineProperty(virtualClick, 'pointerType', { value: '' });
+      fireEvent(screen.getByRole('button', { name: 'Outside' }), virtualClick);
+    } finally {
+      eventUtilsMockState.forceVirtualClick = false;
+    }
 
     await waitFor(() => {
       expect(screen.queryByTestId('popup')).toBe(null);

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
@@ -127,29 +127,36 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
     store.context.outsidePressEnabledRef.current = false;
   }
 
-  function enableDismissAfterRelease() {
+  function enableDismissAfterRelease(event?: PointerEvent | TouchEvent) {
     releaseGuardCleanupRef.current();
+    store.context.outsidePressEnabledRef.current = true;
+
+    if (!event) {
+      return;
+    }
 
     const doc = ownerDocument(swipeAreaRef.current);
 
-    function restore() {
+    function handleReleaseEvent(clickEvent?: MouseEvent) {
       releaseGuardCleanupRef.current = NOOP;
-      doc.removeEventListener('pointerdown', restore, true);
-      store.context.outsidePressEnabledRef.current = true;
+      doc.removeEventListener('click', handleReleaseEvent, true);
+      doc.removeEventListener('pointerdown', handleReleaseEvent, true);
+
+      // A fresh physical interaction starts with `pointerdown`, while keyboard and assistive
+      // technology clicks have zero detail. Only the trailing release click reaches this branch.
+      if (clickEvent?.type !== 'click' || clickEvent.detail === 0) {
+        return;
+      }
+
+      store.context.outsidePressEnabledRef.current = false;
+      queueMicrotask(() => {
+        store.context.outsidePressEnabledRef.current = true;
+      });
     }
 
-    // The pointerup that ends a swipe-open gesture synthesizes a `click`. When the drag released
-    // outside the popup (e.g. it was dragged past the popup's size), that click would be treated as
-    // an outside press and immediately dismiss the drawer that was just opened. Keep outside-press
-    // dismissal disabled until the next *fresh* pointer interaction: the synthesized click has no
-    // pointerdown of its own, so it is ignored, while a deliberate outside press always starts with
-    // a pointerdown and re-enables dismissal in time to close the drawer. This is deterministic,
-    // unlike re-enabling on a timer that can race the synthesized click and dismiss at random.
-    //
-    // `restore` runs in document capture, ahead of floating-ui's own outside-press check (which
-    // happens on the event target, after capture), so the triggering press still dismisses.
-    releaseGuardCleanupRef.current = restore;
-    doc.addEventListener('pointerdown', restore, true);
+    releaseGuardCleanupRef.current = handleReleaseEvent;
+    doc.addEventListener('click', handleReleaseEvent, true);
+    doc.addEventListener('pointerdown', handleReleaseEvent, true);
   }
 
   function getPopupSize(popupElement: HTMLElement) {
@@ -299,9 +306,9 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
     setSwipeActive(false);
   }
 
-  function finishSwipeInteraction() {
+  function finishSwipeInteraction(event?: PointerEvent | TouchEvent) {
     resetSwipeInteractionState();
-    enableDismissAfterRelease();
+    enableDismissAfterRelease(event);
     resetDragDelta();
     clearSwipeStyles();
   }
@@ -372,7 +379,7 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
         closeDrawer(event);
       }
 
-      finishSwipeInteraction();
+      finishSwipeInteraction(event);
 
       return false;
     },

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
@@ -128,36 +128,38 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
     store.context.outsidePressEnabledRef.current = false;
   }
 
-  const enableDismissAfterRelease = useStableCallback((event?: PointerEvent | TouchEvent) => {
+  const enableDismissAfterRelease = useStableCallback(() => {
     releaseGuardCleanupRef.current();
-    store.context.outsidePressEnabledRef.current = true;
-
-    if (!event) {
-      return;
-    }
 
     const doc = ownerDocument(swipeAreaRef.current);
 
-    function handleReleaseEvent(clickEvent?: MouseEvent) {
-      releaseGuardCleanupRef.current = NOOP;
-      doc.removeEventListener('click', handleReleaseEvent, true);
-      doc.removeEventListener('pointerdown', handleReleaseEvent, true);
-
-      // A fresh physical interaction starts with `pointerdown`. Only the trailing physical release
-      // click should temporarily keep outside press dismissal disabled.
-      if (clickEvent?.type !== 'click' || clickEvent.detail === 0 || isVirtualClick(clickEvent)) {
+    function restore(event?: MouseEvent) {
+      // The gesture's trailing release click is the one physical click with no `pointerdown` of
+      // its own. Ignore it and keep waiting, so it cannot dismiss the drawer it just opened,
+      // while a click-only activation (keyboard or assistive tech) still re-enables in time.
+      if (event?.type === 'click' && event.detail !== 0 && !isVirtualClick(event)) {
         return;
       }
 
-      store.context.outsidePressEnabledRef.current = false;
-      queueMicrotask(() => {
-        store.context.outsidePressEnabledRef.current = true;
-      });
+      releaseGuardCleanupRef.current = NOOP;
+      doc.removeEventListener('pointerdown', restore, true);
+      doc.removeEventListener('click', restore, true);
+      store.context.outsidePressEnabledRef.current = true;
     }
 
-    releaseGuardCleanupRef.current = handleReleaseEvent;
-    doc.addEventListener('click', handleReleaseEvent, true);
-    doc.addEventListener('pointerdown', handleReleaseEvent, true);
+    // The pointerup that ends a swipe-open gesture synthesizes a `click`. When the drag released
+    // outside the popup (e.g. it was dragged past the popup's size), that click would be treated as
+    // an outside press and immediately dismiss the drawer that was just opened. Keep outside-press
+    // dismissal disabled until the next interaction that isn't that release click: a deliberate
+    // outside press starts with a `pointerdown`, and a click-only activation (keyboard or
+    // assistive tech) is distinguishable from a physical release. This is deterministic, unlike
+    // re-enabling on a timer that can race the synthesized click and dismiss at random.
+    //
+    // `restore` runs in document capture, ahead of floating-ui's own outside-press check (which
+    // happens on the event target, after capture), so the triggering press still dismisses.
+    releaseGuardCleanupRef.current = restore;
+    doc.addEventListener('pointerdown', restore, true);
+    doc.addEventListener('click', restore, true);
   });
 
   function getPopupSize(popupElement: HTMLElement) {
@@ -307,9 +309,9 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
     setSwipeActive(false);
   }
 
-  function finishSwipeInteraction(event?: PointerEvent | TouchEvent) {
+  function finishSwipeInteraction() {
     resetSwipeInteractionState();
-    enableDismissAfterRelease(event);
+    enableDismissAfterRelease();
     resetDragDelta();
     clearSwipeStyles();
   }
@@ -380,7 +382,7 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
         closeDrawer(event);
       }
 
-      finishSwipeInteraction(event);
+      finishSwipeInteraction();
 
       return false;
     },

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
@@ -23,6 +23,7 @@ import { useDrawerRootContext, type DrawerSwipeDirection } from '../root/DrawerR
 import { useBaseUiId } from '../../internals/useBaseUiId';
 import { useTriggerRegistration } from '../../utils/popups';
 import { useDrawerProviderContext } from '../provider/DrawerProviderContext';
+import { isVirtualClick } from '../../floating-ui-react/utils/event';
 import { DrawerSwipeAreaDataAttributes } from './DrawerSwipeAreaDataAttributes';
 
 const DEFAULT_SWIPE_OPEN_RATIO = 0.5;
@@ -127,7 +128,7 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
     store.context.outsidePressEnabledRef.current = false;
   }
 
-  function enableDismissAfterRelease(event?: PointerEvent | TouchEvent) {
+  const enableDismissAfterRelease = useStableCallback((event?: PointerEvent | TouchEvent) => {
     releaseGuardCleanupRef.current();
     store.context.outsidePressEnabledRef.current = true;
 
@@ -142,9 +143,9 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
       doc.removeEventListener('click', handleReleaseEvent, true);
       doc.removeEventListener('pointerdown', handleReleaseEvent, true);
 
-      // A fresh physical interaction starts with `pointerdown`, while keyboard and assistive
-      // technology clicks have zero detail. Only the trailing release click reaches this branch.
-      if (clickEvent?.type !== 'click' || clickEvent.detail === 0) {
+      // A fresh physical interaction starts with `pointerdown`. Only the trailing physical release
+      // click should temporarily keep outside press dismissal disabled.
+      if (clickEvent?.type !== 'click' || clickEvent.detail === 0 || isVirtualClick(clickEvent)) {
         return;
       }
 
@@ -157,7 +158,7 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
     releaseGuardCleanupRef.current = handleReleaseEvent;
     doc.addEventListener('click', handleReleaseEvent, true);
     doc.addEventListener('pointerdown', handleReleaseEvent, true);
-  }
+  });
 
   function getPopupSize(popupElement: HTMLElement) {
     const isHorizontal = dismissDirection === 'left' || dismissDirection === 'right';
@@ -401,12 +402,22 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
 
   useIsoLayoutEffect(() => {
     if (!enabled) {
+      if (swipeActive) {
+        enableDismissAfterRelease();
+      }
       resetSwipe();
       resetDragDelta();
       clearSwipeStyles();
       resetSwipeInteractionState();
     }
-  }, [clearSwipeStyles, enabled, resetDragDelta, resetSwipe]);
+  }, [
+    clearSwipeStyles,
+    enableDismissAfterRelease,
+    enabled,
+    resetDragDelta,
+    resetSwipe,
+    swipeActive,
+  ]);
 
   React.useEffect(() => {
     return () => {


### PR DESCRIPTION
Opening a non-modal Drawer by swipe could leave outside press dismissal disabled until another pointerdown. This is a post-v1.6.0 regression found by an AI audit of `v1.6.0..master`.

## Changes

- Suppressed only the synthesized click from the swipe release, then restored outside press dismissal without waiting for another pointer interaction.
- Added Chromium coverage for mouse, pen, and touch release clicks and later click-only keyboard dismissal.