### PR TITLE
[menubar] Make touch-click cooldown test deterministic with fake timers

### DIFF
--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -52,18 +52,30 @@ describe('<Menubar />', () => {
     await screen.findByTestId('file-menu');
 
     const editTrigger = screen.getByTestId('edit-trigger');
-    await act(async () => {
-      editTrigger.focus();
-    });
-    await screen.findByTestId('edit-menu');
 
-    fireEvent(
-      editTrigger,
-      new PointerEvent('click', { bubbles: true, cancelable: true, pointerType: 'touch' }),
-    );
-    expect(screen.queryByTestId('edit-menu')).not.toBe(null);
+    // The focus-open below starts a 300ms wall-clock cooldown during which touch clicks
+    // are ignored. Freeze timers so the cooldown cannot expire before the first click
+    // on a loaded machine, and advance past its expiry explicitly.
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        editTrigger.focus();
+      });
+      screen.getByTestId('edit-menu');
 
-    await wait(310);
+      fireEvent(
+        editTrigger,
+        new PointerEvent('click', { bubbles: true, cancelable: true, pointerType: 'touch' }),
+      );
+      expect(screen.queryByTestId('edit-menu')).not.toBe(null);
+
+      await act(async () => {
+        vi.advanceTimersByTime(310);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
     fireEvent(
       editTrigger,
       new PointerEvent('click', { bubbles: true, cancelable: true, pointerType: 'touch' }),


### PR DESCRIPTION
Fixes a pre-existing, load-sensitive flake in `Menubar.test.tsx` noticed during the review of #5378: the "ignores a delayed touch click immediately after focus opens another menu" test failed in 2 of 3 full jsdom runs on a loaded machine, while passing in isolation.

## The race

Focusing the edit trigger opens its menu with reason `trigger-focus`, which starts a **300ms wall-clock cooldown** (`allowTouchToCloseTimeout` in `MenuRoot.tsx`) during which touch clicks must not close the menu. The test then fired an "immediate" touch click and asserted the menu stayed open — but that click isn't actually immediate: instrumentation shows the `act(focus)` flush alone consumes ~51ms and `findByTestId` another ~6–13ms, i.e. 62–146ms of the 300ms budget even on a fast, idle machine. Under full-suite load, a scheduler stall or GC pause pushes the gap past 300ms; the cooldown expires, the touch click closes the menu, and the assertion fails with `expected null not to be null`.

Injecting a 310ms stall between the focus-open and the first click reproduced the exact failure signature deterministically.

## The fix

- Enable `vi.useFakeTimers()` **before** the focus that starts the cooldown, so no wall-clock time can elapse before the first touch click regardless of machine load.
- Replace the fixed `wait(310)` with `vi.advanceTimersByTime(310)` inside `act` to expire the cooldown explicitly.
- Restore real timers in a `finally` before the closing click and its `waitFor`, following the existing fake-timer pattern used elsewhere in the repo.

## Verification

- The fixed test passes with the same injected 310ms wall-clock stall that previously guaranteed failure.
- Full `Menubar.test.tsx` file: 3/3 repeat runs green; full jsdom suite green (328 files / 7465 tests).
- `eslint` and `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)