### PR TITLE
[all components] Avoid unused popup handle attachments

### DIFF
--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -546,6 +546,69 @@ describe('<Dialog.Root />', () => {
       });
     });
 
+    it('attaches and detaches a handle when the prop toggles on a live root', async () => {
+      const handle = Dialog.createHandle();
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      function App() {
+        const [attached, setAttached] = React.useState(false);
+
+        return (
+          <React.Fragment>
+            <Dialog.Trigger handle={handle} id="trigger">
+              Trigger
+            </Dialog.Trigger>
+            <button type="button" onClick={() => setAttached((value) => !value)}>
+              Toggle handle
+            </button>
+            <Dialog.Root
+              handle={attached ? handle : undefined}
+              modal={false}
+              disablePointerDismissal
+            >
+              <Dialog.Portal>
+                <Dialog.Popup>Dialog Content</Dialog.Popup>
+              </Dialog.Portal>
+            </Dialog.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      act(() => handle.open('trigger'));
+      expect(handle.isOpen).toBe(false);
+      expect(screen.queryByRole('dialog')).toBe(null);
+
+      await user.click(screen.getByRole('button', { name: 'Toggle handle' }));
+      act(() => handle.open('trigger'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Dialog Content')).toBeVisible();
+      });
+      expect(trigger.getAttribute('aria-controls')).toBe(
+        screen.getByRole('dialog').getAttribute('id'),
+      );
+
+      act(() => handle.close());
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).toBe(null);
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Toggle handle' }));
+      act(() => handle.open('trigger'));
+      expect(handle.isOpen).toBe(false);
+      expect(screen.queryByRole('dialog')).toBe(null);
+
+      const detachedWarnings = consoleWarn.mock.calls.filter(
+        ([message]) =>
+          typeof message === 'string' && message.includes('no root using this handle is mounted'),
+      );
+      consoleWarn.mockRestore();
+      expect(detachedWarnings).toHaveLength(2);
+    });
+
     it('registers a detached trigger declared after the root', async () => {
       const handle = Dialog.createHandle();
 

--- a/packages/react/src/dialog/root/useRenderDialogRoot.tsx
+++ b/packages/react/src/dialog/root/useRenderDialogRoot.tsx
@@ -90,7 +90,7 @@ export function useRenderDialogRoot<Payload>(
 
   return (
     <DialogRootContext.Provider value={store as DialogStore<unknown>}>
-      <PopupHandleAttachment handle={handle} store={store} />
+      {handle && <PopupHandleAttachment handle={handle} store={store} />}
       {shouldRenderInteractions && (
         <DialogInteractions
           store={store}

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -536,7 +536,7 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
 
   const content = (
     <MenuRootContext.Provider value={context as MenuRootContext}>
-      <PopupHandleAttachment handle={handle} store={store} />
+      {handle && <PopupHandleAttachment handle={handle} store={store} />}
       {typeof children === 'function' ? children({ payload }) : children}
     </MenuRootContext.Provider>
   );

--- a/packages/react/src/popover/root/PopoverRoot.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.tsx
@@ -79,7 +79,7 @@ function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Pay
 
   return (
     <PopoverRootContext.Provider value={store as PopoverRootContext<unknown>}>
-      <PopupHandleAttachment handle={handle} store={store} />
+      {handle && <PopupHandleAttachment handle={handle} store={store} />}
       {shouldRenderInteractions && <PopoverInteractions store={store} modal={modal} />}
       {typeof children === 'function' ? children({ payload }) : children}
     </PopoverRootContext.Provider>

--- a/packages/react/src/preview-card/root/PreviewCardRoot.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.tsx
@@ -84,7 +84,7 @@ function PreviewCardRootComponent<Payload>(props: PreviewCardRoot.Props<Payload>
 
   return (
     <PreviewCardRootContext.Provider value={store as PreviewCardRootContext}>
-      <PopupHandleAttachment handle={handle} store={store} />
+      {handle && <PopupHandleAttachment handle={handle} store={store} />}
       {shouldRenderInteractions && <PreviewCardInteractions store={store} />}
       {typeof children === 'function' ? children({ payload }) : children}
     </PreviewCardRootContext.Provider>

--- a/packages/react/src/tooltip/root/TooltipRoot.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.tsx
@@ -137,7 +137,7 @@ export const TooltipRoot = fastComponent(function TooltipRoot<Payload>(
 
   return (
     <TooltipRootContext.Provider value={store as TooltipRootContext}>
-      <PopupHandleAttachment handle={handle} store={store} />
+      {handle && <PopupHandleAttachment handle={handle} store={store} />}
       {shouldRenderInteractions && (
         <TooltipInteractions store={store} disabled={disabled} trackCursorAxis={trackCursorAxis} />
       )}

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -98,19 +98,18 @@ export function usePopupRootStore<
  * effects. This lets descendants call the handle during the Root's initial commit without attaching
  * during render, which would leak suspended or abandoned stores. Store subscribers are notified by
  * `attachStore` in this ordinary layout phase, where React permits synchronous updates.
+ *
+ * Popup Roots must render this component only when a handle is present so handle-less Roots avoid
+ * mounting an extra fiber and layout effect.
  */
 export function PopupHandleAttachment<Store>({
   handle,
   store,
 }: {
-  handle: PopupRootStoreHandle<Store> | undefined;
+  handle: PopupRootStoreHandle<Store>;
   store: Store;
 }) {
   useIsoLayoutEffect(() => {
-    if (!handle) {
-      return undefined;
-    }
-
     return handle.attachStore(store);
   }, [handle, store]);
 


### PR DESCRIPTION
Popup roots without a handle still mounted a null attachment component and ran its layout effect. This introduced a mount performance regression in the common no-handle path. Limit the attachment to handle-backed roots so regular popup mounts avoid that extra work while preserving handle lifecycle ordering.

## Changes

- Render popup handle attachments only when a handle is provided.
- Preserve attachment ordering for handle-backed roots.

## Benchmarks

300 closed roots in Chromium with React 19.2.5. Values are the median of three runs after warmup, with 20 measured iterations per run.

| Benchmark | Current master | This PR | Change |
| --- | ---: | ---: | ---: |
| Menu mount | 22.14 ms | 21.53 ms | -2.8% |
| Popover mount | 16.08 ms | 15.01 ms | -6.7% |
| Dialog mount | 13.36 ms | 12.51 ms | -6.3% |
| Tooltip mount | 13.81 ms | 12.22 ms | -11.5% |

Menu's run ranges overlap, so its improvement is inconclusive. The other three benchmarks had non-overlapping ranges.