### PR TITLE
[docs] Add Formisch to forms handbook

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@base-ui/react": "workspace:*",
     "@base-ui/utils": "workspace:*",
+    "@formisch/react": "^1.0.0-rc.0",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@mui/internal-docs-infra": "0.12.1-canary.35",
@@ -53,6 +54,7 @@
     "remark-typography": "0.7.3",
     "scroll-into-view-if-needed": "3.1.0",
     "server-only": "^0.0.1",
+    "valibot": "^1.4.1",
     "unist-util-visit-parents": "^6.0.2"
   },
   "devDependencies": {

--- a/docs/src/app/(docs)/react/handbook/forms/demos/formisch/index.ts
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/formisch/index.ts
@@ -1,0 +1,4 @@
+import { createDemoWithVariants } from 'docs/src/utils/createDemo';
+import Tailwind from './tailwind';
+
+export const DemoFormisch = createDemoWithVariants(import.meta.url, { Tailwind });

--- a/docs/src/app/(docs)/react/handbook/forms/demos/formisch/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/formisch/tailwind/index.tsx
@@ -1,0 +1,501 @@
+'use client';
+import * as React from 'react';
+import type { SubmitHandler } from '@formisch/react';
+import { Field as FormischField, Form as FormischForm, useForm } from '@formisch/react';
+import * as v from 'valibot';
+import { Button } from '../../components/button';
+import { CheckboxGroup } from '../../components/checkbox-group';
+import { RadioGroup } from '../../components/radio-group';
+import { ToastProvider, useToastManager } from '../../components/toast';
+import * as Autocomplete from '../../components/autocomplete';
+import * as Checkbox from '../../components/checkbox';
+import * as Combobox from '../../components/combobox';
+import * as Field from '../../components/field';
+import * as Fieldset from '../../components/fieldset';
+import * as NumberField from '../../components/number-field';
+import * as Radio from '../../components/radio';
+import * as Select from '../../components/select';
+import * as Slider from '../../components/slider';
+import * as Switch from '../../components/switch';
+
+const FormSchema = v.object({
+  serverName: v.pipe(
+    v.string(),
+    v.nonEmpty('This is a required field.'),
+    v.minLength(3, 'At least 3 characters.'),
+  ),
+  region: v.pipe(
+    v.nullable(v.string()),
+    v.check((value) => value !== null, 'This is a required field.'),
+  ),
+  containerImage: v.pipe(v.string(), v.nonEmpty('This is a required field.')),
+  serverType: v.pipe(
+    v.nullable(v.string()),
+    v.check((value) => value !== null, 'This is a required field.'),
+  ),
+  numOfInstances: v.pipe(
+    v.nullable(v.number()),
+    v.check((value) => value !== null, 'This is a required field.'),
+  ),
+  scalingThreshold: v.array(v.number()),
+  storageType: v.picklist(['ssd', 'hdd']),
+  restartOnFailure: v.boolean(),
+  allowedNetworkProtocols: v.array(v.string()),
+});
+
+function Formisch() {
+  const toastManager = useToastManager();
+
+  const form = useForm({
+    schema: FormSchema,
+    initialInput: {
+      serverName: '',
+      region: null,
+      containerImage: '',
+      serverType: null,
+      numOfInstances: null,
+      scalingThreshold: [0.2, 0.8],
+      storageType: 'ssd',
+      restartOnFailure: true,
+      allowedNetworkProtocols: [],
+    },
+  });
+
+  const submitForm: SubmitHandler<typeof FormSchema> = (output) => {
+    toastManager.add({
+      title: 'Form submitted',
+      description: 'The form contains these values:',
+      data: output,
+    });
+  };
+
+  return (
+    <FormischForm
+      of={form}
+      onSubmit={submitForm}
+      aria-label="Launch new cloud server"
+      className="flex w-full max-w-3xs flex-col gap-5 sm:max-w-[20rem]"
+    >
+      <FormischField of={form} path={['serverName']}>
+        {(field) => (
+          <Field.Root
+            name={field.props.name}
+            invalid={field.errors !== null}
+            dirty={field.isDirty}
+            touched={field.isTouched}
+          >
+            <Field.Label>Server name</Field.Label>
+            <Field.Control
+              value={field.input}
+              onValueChange={field.onChange}
+              onBlur={field.props.onBlur}
+              placeholder="e.g. api-server-01"
+            />
+            <Field.Description>Must be 3 or more characters long</Field.Description>
+            <Field.Error match={field.errors !== null}>{field.errors?.[0]}</Field.Error>
+          </Field.Root>
+        )}
+      </FormischField>
+
+      <FormischField of={form} path={['region']}>
+        {(field) => (
+          <Field.Root
+            name={field.props.name}
+            invalid={field.errors !== null}
+            dirty={field.isDirty}
+            touched={field.isTouched}
+          >
+            <Combobox.Root items={REGIONS} value={field.input} onValueChange={field.onChange}>
+              <div className="relative text-sm leading-5 font-bold text-neutral-950 dark:text-white">
+                <Field.Label className="mb-1 block">Region</Field.Label>
+                <Combobox.InputGroup>
+                  <Combobox.Input placeholder="e.g. eu-central-1" onBlur={field.props.onBlur} />
+                  <div className="absolute right-0 bottom-0 inline-flex h-full items-center justify-center text-neutral-500 dark:text-neutral-400">
+                    <Combobox.Clear />
+                    <Combobox.Trigger>
+                      <Combobox.CaretDownIcon />
+                    </Combobox.Trigger>
+                  </div>
+                </Combobox.InputGroup>
+              </div>
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.Empty>No matches</Combobox.Empty>
+                    <Combobox.List>
+                      {(region: string) => {
+                        return (
+                          <Combobox.Item key={region} value={region}>
+                            <Combobox.ItemIndicator>
+                              <CheckIcon />
+                            </Combobox.ItemIndicator>
+                            <span className="col-start-2">{region}</span>
+                          </Combobox.Item>
+                        );
+                      }}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+            <Field.Error match={field.errors !== null}>{field.errors?.[0]}</Field.Error>
+          </Field.Root>
+        )}
+      </FormischField>
+
+      <FormischField of={form} path={['containerImage']}>
+        {(field) => (
+          <Field.Root
+            name={field.props.name}
+            invalid={field.errors !== null}
+            dirty={field.isDirty}
+            touched={field.isTouched}
+          >
+            <Autocomplete.Root
+              items={IMAGES}
+              mode="both"
+              itemToStringValue={(itemValue: Image) => itemValue.url}
+              value={field.input}
+              onValueChange={field.onChange}
+            >
+              <Field.Label>Container image</Field.Label>
+              <Autocomplete.Input
+                placeholder="e.g. docker.io/library/node:latest"
+                onBlur={field.props.onBlur}
+              />
+              <Field.Description>Enter a registry URL with optional tags</Field.Description>
+              <Autocomplete.Portal>
+                <Autocomplete.Positioner>
+                  <Autocomplete.Popup>
+                    <Autocomplete.List>
+                      {(image: Image) => {
+                        return (
+                          <Autocomplete.Item key={image.url} value={image}>
+                            <span>{image.name}</span>
+                            <span className="font-mono whitespace-nowrap text-xs opacity-80">
+                              {image.url}
+                            </span>
+                          </Autocomplete.Item>
+                        );
+                      }}
+                    </Autocomplete.List>
+                  </Autocomplete.Popup>
+                </Autocomplete.Positioner>
+              </Autocomplete.Portal>
+            </Autocomplete.Root>
+            <Field.Error match={field.errors !== null}>{field.errors?.[0]}</Field.Error>
+          </Field.Root>
+        )}
+      </FormischField>
+
+      <FormischField of={form} path={['serverType']}>
+        {(field) => (
+          <Field.Root
+            name={field.props.name}
+            invalid={field.errors !== null}
+            dirty={field.isDirty}
+            touched={field.isTouched}
+          >
+            <Select.Root items={SERVER_TYPES} value={field.input} onValueChange={field.onChange}>
+              <div className="w-fit space-y-1">
+                <Select.Label>Server type</Select.Label>
+                <Select.Trigger className="w-48">
+                  <Select.Value />
+                  <Select.Icon>
+                    <CaretUpDownIcon />
+                  </Select.Icon>
+                </Select.Trigger>
+              </div>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup>
+                    <Select.ScrollUpArrow />
+                    <Select.List>
+                      {SERVER_TYPES.map(({ label, value }) => {
+                        return (
+                          <Select.Item key={value} value={value}>
+                            <Select.ItemIndicator>
+                              <CheckIcon />
+                            </Select.ItemIndicator>
+                            <Select.ItemText>{label}</Select.ItemText>
+                          </Select.Item>
+                        );
+                      })}
+                    </Select.List>
+                    <Select.ScrollDownArrow />
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+            <Field.Error match={field.errors !== null}>{field.errors?.[0]}</Field.Error>
+          </Field.Root>
+        )}
+      </FormischField>
+
+      <FormischField of={form} path={['numOfInstances']}>
+        {(field) => (
+          <Field.Root
+            name={field.props.name}
+            invalid={field.errors !== null}
+            dirty={field.isDirty}
+            touched={field.isTouched}
+          >
+            <NumberField.Root value={field.input} onValueChange={field.onChange} min={1} max={64}>
+              <Field.Label>Number of instances</Field.Label>
+              <NumberField.Group>
+                <NumberField.Decrement>
+                  <MinusIcon />
+                </NumberField.Decrement>
+                <NumberField.Input onBlur={field.props.onBlur} />
+                <NumberField.Increment>
+                  <PlusIcon />
+                </NumberField.Increment>
+              </NumberField.Group>
+            </NumberField.Root>
+            <Field.Error match={field.errors !== null}>{field.errors?.[0]}</Field.Error>
+          </Field.Root>
+        )}
+      </FormischField>
+
+      <FormischField of={form} path={['scalingThreshold']}>
+        {(field) => (
+          <Field.Root
+            name={field.props.name}
+            invalid={field.errors !== null}
+            dirty={field.isDirty}
+            touched={field.isTouched}
+          >
+            <Fieldset.Root
+              render={
+                <Slider.Root
+                  value={field.input}
+                  onValueChange={field.onChange}
+                  onValueCommitted={field.onChange}
+                  thumbAlignment="edge"
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  format={{
+                    style: 'percent',
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 0,
+                  }}
+                  className="w-full gap-y-2"
+                />
+              }
+            >
+              <Fieldset.Legend>Scaling threshold</Fieldset.Legend>
+              <Slider.Value className="col-start-2 text-end" />
+              <Slider.Control>
+                <Slider.Track>
+                  <Slider.Indicator />
+                  <Slider.Thumb
+                    index={0}
+                    aria-label="Minimum threshold"
+                    onBlur={field.props.onBlur}
+                  />
+                  <Slider.Thumb
+                    index={1}
+                    aria-label="Maximum threshold"
+                    onBlur={field.props.onBlur}
+                  />
+                </Slider.Track>
+              </Slider.Control>
+            </Fieldset.Root>
+            <Field.Error match={field.errors !== null}>{field.errors?.[0]}</Field.Error>
+          </Field.Root>
+        )}
+      </FormischField>
+
+      <FormischField of={form} path={['storageType']}>
+        {(field) => (
+          <Field.Root
+            name={field.props.name}
+            invalid={field.errors !== null}
+            dirty={field.isDirty}
+            touched={field.isTouched}
+          >
+            <Fieldset.Root
+              render={
+                <RadioGroup value={field.input} onValueChange={field.onChange} className="gap-4" />
+              }
+            >
+              <Fieldset.Legend className="-mt-px">Storage type</Fieldset.Legend>
+              {['ssd', 'hdd'].map((radioValue) => (
+                <Field.Item key={radioValue}>
+                  <Field.Label className="uppercase">
+                    <Radio.Root value={radioValue}>
+                      <Radio.Indicator />
+                    </Radio.Root>
+                    {radioValue}
+                  </Field.Label>
+                </Field.Item>
+              ))}
+            </Fieldset.Root>
+            <Field.Error match={field.errors !== null}>{field.errors?.[0]}</Field.Error>
+          </Field.Root>
+        )}
+      </FormischField>
+
+      <FormischField of={form} path={['restartOnFailure']}>
+        {(field) => (
+          <Field.Root
+            name={field.props.name}
+            invalid={field.errors !== null}
+            dirty={field.isDirty}
+            touched={field.isTouched}
+          >
+            <Field.Label className="gap-2">
+              Restart on failure
+              <Switch.Root checked={field.input} onCheckedChange={field.onChange}>
+                <Switch.Thumb />
+              </Switch.Root>
+            </Field.Label>
+          </Field.Root>
+        )}
+      </FormischField>
+
+      <FormischField of={form} path={['allowedNetworkProtocols']}>
+        {(field) => (
+          <Field.Root
+            name={field.props.name}
+            invalid={field.errors !== null}
+            dirty={field.isDirty}
+            touched={field.isTouched}
+          >
+            <Fieldset.Root
+              render={<CheckboxGroup value={field.input} onValueChange={field.onChange} />}
+            >
+              <Fieldset.Legend className="mb-2">Allowed network protocols</Fieldset.Legend>
+              <div className="flex gap-4">
+                {['http', 'https', 'ssh'].map((checkboxValue) => {
+                  return (
+                    <Field.Item key={checkboxValue}>
+                      <Field.Label className="uppercase">
+                        <Checkbox.Root value={checkboxValue}>
+                          <Checkbox.Indicator>
+                            <CheckIcon />
+                          </Checkbox.Indicator>
+                        </Checkbox.Root>
+                        {checkboxValue}
+                      </Field.Label>
+                    </Field.Item>
+                  );
+                })}
+              </div>
+            </Fieldset.Root>
+            <Field.Error match={field.errors !== null}>{field.errors?.[0]}</Field.Error>
+          </Field.Root>
+        )}
+      </FormischField>
+
+      <Button type="submit" className="mt-3">
+        Launch server
+      </Button>
+    </FormischForm>
+  );
+}
+
+export default function App() {
+  return (
+    <ToastProvider>
+      <Formisch />
+    </ToastProvider>
+  );
+}
+
+function CaretUpDownIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M11 10H5l3 3.5zm0-4H5l3-3.5z" />
+    </svg>
+  );
+}
+
+function CheckIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="m2.5 8.5 4 4 7-9" />
+    </svg>
+  );
+}
+
+function PlusIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="round"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M1.5 8h13M8 14.5v-13" />
+    </svg>
+  );
+}
+
+function MinusIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="round"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M1.5 8h13" />
+    </svg>
+  );
+}
+
+function cartesian<T extends string[][]>(...arrays: T): string[][] {
+  return arrays.reduce<string[][]>(
+    (acc, curr) => acc.flatMap((a) => curr.map((b) => [...a, b])),
+    [[]],
+  );
+}
+
+const REGIONS = cartesian(['us', 'eu', 'ap'], ['central', 'east', 'west'], ['1', '2', '3']).map(
+  (part) => part.join('-'),
+);
+
+interface Image {
+  url: string;
+  name: string;
+}
+/* prettier-ignore */
+const IMAGES: Image[] = ['nginx:1.29-alpine', 'node:22-slim', 'postgres:18', 'redis:8.2.2-alpine'].map((name) => ({
+  url: `docker.io/library/${name}`,
+  name,
+}));
+
+const SERVER_TYPES = [
+  { label: 'Select server type', value: null },
+  ...cartesian(['t', 'm'], ['1', '2'], ['small', 'medium', 'large']).map((part) => {
+    const value = part.join('.').replace('.', '');
+    return { label: value, value };
+  }),
+];

--- a/docs/src/app/(docs)/react/handbook/forms/demos/formisch/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/handbook/forms/demos/formisch/tailwind/index.tsx
@@ -199,7 +199,10 @@ function Formisch() {
             <Select.Root items={SERVER_TYPES} value={field.input} onValueChange={field.onChange}>
               <div className="w-fit space-y-1">
                 <Select.Label>Server type</Select.Label>
-                <Select.Trigger className="w-48">
+                <Select.Trigger
+                  className="w-48"
+                  onBlur={field.props.onBlur as React.FocusEventHandler}
+                >
                   <Select.Value />
                   <Select.Icon>
                     <CaretUpDownIcon />
@@ -324,7 +327,10 @@ function Formisch() {
               {['ssd', 'hdd'].map((radioValue) => (
                 <Field.Item key={radioValue}>
                   <Field.Label className="uppercase">
-                    <Radio.Root value={radioValue}>
+                    <Radio.Root
+                      value={radioValue}
+                      onBlur={field.props.onBlur as React.FocusEventHandler}
+                    >
                       <Radio.Indicator />
                     </Radio.Root>
                     {radioValue}
@@ -347,7 +353,11 @@ function Formisch() {
           >
             <Field.Label className="gap-2">
               Restart on failure
-              <Switch.Root checked={field.input} onCheckedChange={field.onChange}>
+              <Switch.Root
+                checked={field.input}
+                onCheckedChange={field.onChange}
+                onBlur={field.props.onBlur as React.FocusEventHandler}
+              >
                 <Switch.Thumb />
               </Switch.Root>
             </Field.Label>
@@ -372,7 +382,10 @@ function Formisch() {
                   return (
                     <Field.Item key={checkboxValue}>
                       <Field.Label className="uppercase">
-                        <Checkbox.Root value={checkboxValue}>
+                        <Checkbox.Root
+                          value={checkboxValue}
+                          onBlur={field.props.onBlur as React.FocusEventHandler}
+                        >
                           <Checkbox.Indicator>
                             <CheckIcon />
                           </Checkbox.Indicator>

--- a/docs/src/app/(docs)/react/handbook/forms/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/forms/page.mdx
@@ -717,7 +717,7 @@ const form = useForm({
 
 ## Formisch
 
-[Formisch](https://formisch.dev) is a schema-based, headless form library that can be integrated with Base UI. It validates with a [Valibot](https://valibot.dev) schema and infers the types of all field values and paths directly from it.
+[Formisch](https://formisch.dev) is a schema-based, headless form library that can be integrated with Base UI. It validates with a [Valibot](https://valibot.dev) schema and infers the types of all field values and paths directly from it.
 
 import { DemoFormisch } from './demos/formisch';
 
@@ -750,7 +750,7 @@ const form = useForm({
 
 ### Integrate components
 
-Use the `<Field>` component from Formisch to integrate with Base UI components, forwarding the field store provided by its render prop to the appropriate part. Since Base UI also exports a `Field` component, import the Formisch one under an alias:
+Use the `<Field>` component from Formisch to integrate with Base UI components, forwarding the field store provided by its render prop to the appropriate part. Since Base UI also exports a `Field` component, import the Formisch one under an alias:
 
 ```tsx title="Integrating Formisch with Base UI components"
 import { Field as FormischField, useForm } from '@formisch/react'; {/* @highlight-text "FormischField" */}
@@ -793,7 +793,7 @@ const form = useForm(/* schema, initialInput */);
 </FormischField>
 ```
 
-The Base UI `<Form>` component is not needed when using Formisch, as Formisch ships its own `<Form>` component that wraps a native `<form>` element.
+The Base UI `<Form>` component is not needed when using Formisch, as Formisch ships its own `<Form>` component that wraps a native `<form>` element.
 
 ### Form validation
 

--- a/docs/src/app/(docs)/react/handbook/forms/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/forms/page.mdx
@@ -829,20 +829,14 @@ import type { SubmitHandler } from '@formisch/react';
 
 const form = useForm(/* schema, initialInput */);
 
-{
-  /* @highlight-start */
-}
+// @highlight-start
 const submitForm: SubmitHandler<typeof FormSchema> = async (output) => {
   /* prettier-ignore */
   await fetch(/* POST the validated `output` to an external API */);
 };
-{
-  /* @highlight-end */
-}
+// @highlight-end
 
-{
-  /* @highlight-text "submitForm" */
-}
+// @highlight-text "submitForm"
 <Form of={form} onSubmit={submitForm}>
   {/* form fields */}
   <button type="submit">Submit</button>

--- a/docs/src/app/(docs)/react/handbook/forms/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/forms/page.mdx
@@ -3,7 +3,7 @@
 <Subtitle>A guide to building forms with Base UI components.</Subtitle>
 <Meta name="description" content="A guide to building forms with Base UI components." />
 
-Base UI form control components extend the native [constraint validation API](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api) so you can build forms for collecting user input or providing control over an interface. They also integrate seamlessly with third-party libraries like [React Hook Form](#react-hook-form) and [TanStack Form](#tanstack-form).
+Base UI form control components extend the native [constraint validation API](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api) so you can build forms for collecting user input or providing control over an interface. They also integrate seamlessly with third-party libraries like [React Hook Form](#react-hook-form), [TanStack Form](#tanstack-form), and [Formisch](#formisch).
 
 import { DemoBaseUIForm } from './demos/hero';
 
@@ -715,6 +715,140 @@ const form = useForm({
 </form>;
 ```
 
+## Formisch
+
+[Formisch](https://formisch.dev) is a schema-based, headless form library that can be integrated with Base UI. It validates with a [Valibot](https://valibot.dev) schema and infers the types of all field values and paths directly from it.
+
+import { DemoFormisch } from './demos/formisch';
+
+<DemoFormisch />
+
+### Initialize the form
+
+Create a form instance with the `useForm` hook, passing your Valibot schema and the initial value of each field in the `initialInput` parameter. The schema is the single source of truth for validation and types — there is no resolver step:
+
+```tsx title="Initialize a form instance"
+import { useForm } from '@formisch/react';
+import * as v from 'valibot';
+
+const FormSchema = v.object({
+  username: v.pipe(v.string(), v.minLength(3, 'At least 3 characters.')),
+  email: v.pipe(v.string(), v.email('Invalid email address.')),
+});
+
+{/* @highlight-start */}
+/* useForm returns the store of the form */
+const form = useForm({
+{/* @highlight-end */}
+  schema: FormSchema,
+  initialInput: {
+    username: '',
+    email: '',
+  },
+});
+```
+
+### Integrate components
+
+Use the `<Field>` component from Formisch to integrate with Base UI components, forwarding the field store provided by its render prop to the appropriate part. Since Base UI also exports a `Field` component, import the Formisch one under an alias:
+
+```tsx title="Integrating Formisch with Base UI components"
+import { Field as FormischField, useForm } from '@formisch/react'; {/* @highlight-text "FormischField" */}
+import { Field } from '@base-ui/react/field';
+
+const form = useForm(/* schema, initialInput */);
+
+{/* @highlight-start */}
+<FormischField
+  of={form}
+  path={['username']}
+  {/* @highlight-end */}
+>
+  {(field) => (
+    <Field.Root
+      {/* @highlight-start */}
+      name={field.props.name} {/* @highlight-text "field.props.name" */}
+      invalid={field.errors !== null} {/* @highlight-text "field.errors" */}
+      dirty={field.isDirty} {/* @highlight-text "isDirty" */}
+      touched={field.isTouched} {/* @highlight-text "isTouched" */}
+      {/* @highlight-end */}
+    >
+      <Field.Label>Username</Field.Label>
+      <Field.Control
+        {/* @highlight-start */}
+        value={field.input} {/* @highlight-text "field.input" */}
+        onValueChange={field.onChange} {/* @highlight-text "field.onChange" */}
+        onBlur={field.props.onBlur} {/* @highlight-text "onBlur" */}
+        {/* @highlight-end */}
+        placeholder="e.g. alice132"
+      />
+
+      {/* @highlight-start */}
+      <Field.Error match={field.errors !== null}> {/* @highlight-text "field.errors" */}
+      {/* @highlight-end */}
+        {field.errors?.[0]}
+      </Field.Error>
+    </Field.Root>
+  )}
+</FormischField>
+```
+
+The Base UI `<Form>` component is not needed when using Formisch, as Formisch ships its own `<Form>` component that wraps a native `<form>` element.
+
+### Form validation
+
+Validation is defined entirely by the Valibot schema passed to `useForm`. Use the `validate` and `revalidate` parameters to configure when the first validation and subsequent revalidations are performed:
+
+```tsx title="Configuring validation modes"
+import { useForm } from '@formisch/react';
+import * as v from 'valibot';
+
+const FormSchema = v.object({
+  username: v.pipe(v.string(), v.minLength(3, 'At least 3 characters.')),
+  email: v.pipe(v.string(), v.email('Invalid email address.')),
+});
+
+const form = useForm({
+  schema: FormSchema,
+  {/* @highlight-start */}
+  validate: 'submit', {/* @highlight-text "validate" */}
+  revalidate: 'input', {/* @highlight-text "revalidate" */}
+  {/* @highlight-end */}
+});
+```
+
+This validates all fields when the first submission is attempted, and revalidates any invalid fields when their values change again. This behavior is the default.
+
+### Submitting data
+
+Pass a submit handler to the `onSubmit` prop of Formisch's `<Form>` component. It is only called when validation succeeds, and receives the validated values typed according to the output of your schema:
+
+```tsx title="Form submission handler"
+import { Form, useForm } from '@formisch/react';
+import type { SubmitHandler } from '@formisch/react';
+
+const form = useForm(/* schema, initialInput */);
+
+{
+  /* @highlight-start */
+}
+const submitForm: SubmitHandler<typeof FormSchema> = async (output) => {
+  /* prettier-ignore */
+  await fetch(/* POST the validated `output` to an external API */);
+};
+{
+  /* @highlight-end */
+}
+
+{
+  /* @highlight-text "submitForm" */
+}
+<Form of={form} onSubmit={submitForm}>
+  {/* form fields */}
+  <button type="submit">Submit</button>
+</Form>;
+```
+
 export const metadata = {
   keywords: [
     'Base UI Forms',
@@ -722,6 +856,7 @@ export const metadata = {
     'Field Validation Handbook',
     'React Hook Form Integration',
     'TanStack Form Guide',
+    'Formisch Integration',
     'Constraint Validation API',
     'Handbook Forms',
     'Form State',

--- a/docs/src/app/(docs)/react/handbook/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/page.mdx
@@ -104,7 +104,7 @@ A guide to building forms with Base UI components.
 
 <summary>Outline</summary>
 
-- Keywords: Base UI Forms, React Accessible Forms, Field Validation Handbook, React Hook Form Integration, TanStack Form Guide, Constraint Validation API, Handbook Forms, Form State, Form Library, Form Handling, Input Validation, Error Messages, Form Submission, Accessible Forms, ARIA Forms
+- Keywords: Base UI Forms, React Accessible Forms, Field Validation Handbook, React Hook Form Integration, TanStack Form Guide, Formisch Integration, Constraint Validation API, Handbook Forms, Form State, Form Library, Form Handling, Input Validation, Error Messages, Form Submission, Accessible Forms, ARIA Forms
 - Sections:
   - Naming form controls
     - Input controls
@@ -128,6 +128,11 @@ A guide to building forms with Base UI components.
     - Integrate components
     - Form validation
     - Field validation
+    - Submitting data
+  - Formisch
+    - Initialize the form
+    - Integrate components
+    - Form validation
     - Submitting data
 
 </details>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       '@base-ui/utils':
         specifier: workspace:*
         version: link:../packages/utils/build
+      '@formisch/react':
+        specifier: ^1.0.0-rc.0
+        version: 1.0.0-rc.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))
       '@mdx-js/loader':
         specifier: ^3.1.1
         version: 3.1.1(supports-color@10.2.2)(webpack@5.109.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)(uglify-js@3.19.3))
@@ -281,6 +284,9 @@ importers:
       unist-util-visit-parents:
         specifier: ^6.0.2
         version: 6.0.2
+      valibot:
+        specifier: ^1.4.1
+        version: 1.4.2(typescript@6.0.3)
     devDependencies:
       '@mdx-js/mdx':
         specifier: 3.1.1
@@ -1618,6 +1624,17 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@formisch/react@1.0.0-rc.0':
+    resolution: {integrity: sha512-KLYvwpg1MGubT3JutG/3S+iy7zktkDoLmI1Gl991ZKkKMTttyZBJC+gQet5UwOLTB7XDiuxQ3AaTQqs1o34a4w==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      typescript: '>=5'
+      valibot: ^1.4.1
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@gar/promise-retry@1.0.3':
     resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
@@ -9357,6 +9374,14 @@ packages:
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -10947,6 +10972,14 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
 
   '@floating-ui/utils@0.2.12': {}
+
+  '@formisch/react@1.0.0-rc.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))':
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      valibot: 1.4.2(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@gar/promise-retry@1.0.3': {}
 
@@ -20350,6 +20383,10 @@ snapshots:
       is-generator-function: 1.1.2
       is-typed-array: 1.1.15
       which-typed-array: 1.1.20
+
+  valibot@1.4.2(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   validate-npm-package-license@3.0.4:
     dependencies:


### PR DESCRIPTION
Closes https://github.com/mui/base-ui/issues/4064

Adds a [Formisch](https://formisch.dev/) section to the forms handbook, alongside the existing React Hook Form and TanStack Form sections, including a port of the same interactive demo. Formisch is a schema-based, headless form library I maintain. It validates with a Valibot schema and infers all types from it.

Opening this as a draft as proposed in #5396.