### PR TITLE
[popups] Fix quadratic dev-mode trigger registration check

### DIFF
--- a/packages/react/src/utils/popups/popupTriggerMap.test.ts
+++ b/packages/react/src/utils/popups/popupTriggerMap.test.ts
@@ -70,6 +70,45 @@ describe('PopupTriggerMap', () => {
     }
   });
 
+  it('allows re-registering an element under a new id after it was deleted', () => {
+    const map = new PopupTriggerMap();
+    const button = document.createElement('button');
+
+    map.add('first', button);
+    map.delete('first');
+
+    expect(() => map.add('second', button)).not.toThrow();
+    expect(map.getById('second')).toBe(button);
+    expect(map.size).toBe(1);
+  });
+
+  it('allows an element evicted by id reuse to register under a new id', () => {
+    const map = new PopupTriggerMap();
+    const first = document.createElement('button');
+    const second = document.createElement('button');
+
+    map.add('trigger', first);
+    // `first` is no longer registered under `trigger`, so it may claim another id.
+    map.add('trigger', second);
+
+    expect(() => map.add('other', first)).not.toThrow();
+    expect(map.getById('other')).toBe(first);
+    expect(map.getById('trigger')).toBe(second);
+    expect(map.size).toBe(2);
+  });
+
+  it('still throws when a re-added element is registered under a second id', () => {
+    const map = new PopupTriggerMap();
+    const button = document.createElement('button');
+
+    map.add('first', button);
+    map.add('first', button);
+
+    expect(() => map.add('second', button)).toThrow(
+      'Base UI: A trigger element cannot be registered under multiple IDs in PopupTriggerMap.',
+    );
+  });
+
   it.skipIf(!isJSDOM)(
     'does not throw in production when the same element is registered under multiple ids',
     () => {

--- a/packages/react/src/utils/popups/popupTriggerMap.test.ts
+++ b/packages/react/src/utils/popups/popupTriggerMap.test.ts
@@ -82,6 +82,20 @@ describe('PopupTriggerMap', () => {
     expect(map.size).toBe(1);
   });
 
+  it('keeps an unrelated element claim when another id is deleted', () => {
+    const map = new PopupTriggerMap();
+    const first = document.createElement('button');
+    const second = document.createElement('button');
+
+    map.add('first', first);
+    map.add('second', second);
+    map.delete('second');
+
+    expect(() => map.add('other', first)).toThrow(
+      'Base UI: A trigger element cannot be registered under multiple IDs in PopupTriggerMap.',
+    );
+  });
+
   it('allows an element evicted by id reuse to register under a new id', () => {
     const map = new PopupTriggerMap();
     const first = document.createElement('button');

--- a/packages/react/src/utils/popups/popupTriggerMap.ts
+++ b/packages/react/src/utils/popups/popupTriggerMap.ts
@@ -22,8 +22,8 @@ function getDevElementIds(map: PopupTriggerMap) {
 /**
  * Data structure to keep track of popup trigger elements by their IDs.
  *
- * Element lookups iterate the id map; trigger counts are single digits, so linear
- * scans on event-frequency paths are cheaper than maintaining a parallel Set.
+ * Element lookups iterate the id map rather than maintaining a parallel Set. Registration is O(1),
+ * while `hasElement` and `hasMatchingElement` are linear in the number of triggers.
  */
 export class PopupTriggerMap {
   private idMap: Map<string, Element>;

--- a/packages/react/src/utils/popups/popupTriggerMap.ts
+++ b/packages/react/src/utils/popups/popupTriggerMap.ts
@@ -2,12 +2,15 @@
  * Development-only reverse index of element to registered id, keyed by the owning map.
  *
  * Registration would otherwise have to scan every entry to detect an element claimed by two ids,
- * making the mount of many triggers sharing one handle quadratic. Kept module-scoped and read only
- * from `process.env.NODE_ENV` guards so production builds drop it along with the checks.
+ * making the mount of many triggers sharing one handle quadratic. Kept module-scoped, lazily
+ * initialized, and read only from `process.env.NODE_ENV` guards so production builds drop it along
+ * with the checks.
  */
-const devElementIdsByMap = new WeakMap<PopupTriggerMap, WeakMap<Element, string>>();
+let devElementIdsByMap: WeakMap<PopupTriggerMap, WeakMap<Element, string>> | undefined;
 
 function getDevElementIds(map: PopupTriggerMap) {
+  devElementIdsByMap ??= new WeakMap();
+
   let elementIds = devElementIdsByMap.get(map);
   if (!elementIds) {
     elementIds = new WeakMap();
@@ -67,7 +70,7 @@ export class PopupTriggerMap {
     if (process.env.NODE_ENV !== 'production') {
       const element = this.idMap.get(id);
       if (element !== undefined) {
-        devElementIdsByMap.get(this)?.delete(element);
+        devElementIdsByMap?.get(this)?.delete(element);
       }
     }
 

--- a/packages/react/src/utils/popups/popupTriggerMap.ts
+++ b/packages/react/src/utils/popups/popupTriggerMap.ts
@@ -1,4 +1,22 @@
 /**
+ * Development-only reverse index of element to registered id, keyed by the owning map.
+ *
+ * Registration would otherwise have to scan every entry to detect an element claimed by two ids,
+ * making the mount of many triggers sharing one handle quadratic. Kept module-scoped and read only
+ * from `process.env.NODE_ENV` guards so production builds drop it along with the checks.
+ */
+const devElementIdsByMap = new WeakMap<PopupTriggerMap, WeakMap<Element, string>>();
+
+function getDevElementIds(map: PopupTriggerMap) {
+  let elementIds = devElementIdsByMap.get(map);
+  if (!elementIds) {
+    elementIds = new WeakMap();
+    devElementIdsByMap.set(map, elementIds);
+  }
+  return elementIds;
+}
+
+/**
  * Data structure to keep track of popup trigger elements by their IDs.
  *
  * Element lookups iterate the id map; trigger counts are single digits, so linear
@@ -18,15 +36,25 @@ export class PopupTriggerMap {
    */
   public add(id: string, element: Element) {
     if (process.env.NODE_ENV !== 'production') {
-      for (const [existingId, existingElement] of this.idMap) {
-        if (existingElement === element && existingId !== id) {
-          // TODO: fix mui/no-guarded-throw
-          // eslint-disable-next-line mui/no-guarded-throw
-          throw new Error(
-            'Base UI: A trigger element cannot be registered under multiple IDs in PopupTriggerMap.',
-          );
-        }
+      const elementIds = getDevElementIds(this);
+
+      const existingId = elementIds.get(element);
+      if (existingId !== undefined && existingId !== id) {
+        // TODO: fix mui/no-guarded-throw
+        // eslint-disable-next-line mui/no-guarded-throw
+        throw new Error(
+          'Base UI: A trigger element cannot be registered under multiple IDs in PopupTriggerMap.',
+        );
       }
+
+      // Reusing an id for a different element evicts the previous one, so it must lose its claim
+      // on the id or a later registration under a different id would be reported as a duplicate.
+      const previousElement = this.idMap.get(id);
+      if (previousElement !== undefined && previousElement !== element) {
+        elementIds.delete(previousElement);
+      }
+
+      elementIds.set(element, id);
     }
 
     this.idMap.set(id, element);
@@ -36,6 +64,13 @@ export class PopupTriggerMap {
    * Removes the trigger element with the given ID.
    */
   public delete(id: string) {
+    if (process.env.NODE_ENV !== 'production') {
+      const element = this.idMap.get(id);
+      if (element !== undefined) {
+        devElementIdsByMap.get(this)?.delete(element);
+      }
+    }
+
     this.idMap.delete(id);
   }
 


### PR DESCRIPTION
**Development-only, and unreleased.** The affected code sits inside a `process.env.NODE_ENV !== 'production'` guard, so production bundles never ran it and their behaviour, size, and performance are unchanged. The slowdown was introduced after v1.6.0 by #5193; there has been no release since, so no published version is affected.

In development, `PopupTriggerMap.add` scans every entry on each registration to assert that an element isn't claimed by two IDs. That makes mounting many triggers which share one handle quadratic — roughly 2.2 ms for 1,000 triggers and 37 ms for 5,000, about double under StrictMode. It was O(1) until the parallel element `Set` was removed.

The assertion now reads a development-only element-to-ID index instead of scanning, restoring O(1) registration. That index is module-scoped and read only from `process.env.NODE_ENV` guards, so minifiers drop it along with the assertion rather than reinstating the production bytes #5193 reclaimed. Deleting an ID, and reusing an ID for a different element, both release the previous element's claim, which keeps the check exactly as strict as the scan. `hasElement` keeps its linear scan.
