### PR TITLE
[all components] Fix canceled exit unmount

### DIFF
--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -68,7 +68,7 @@ export function useCollapsiblePanel(
   const mergedPanelRef = useMergedRefs(externalRef, panelRef);
   const latestOpenRef = useValueAsRef(open);
   // Only used to handle panel close
-  const runOnceCloseAnimationsFinish = useAnimationsFinished(panelRef, false, false);
+  const runOnceCloseAnimationsFinish = useAnimationsFinished(panelRef);
 
   const hidden = !open && !mounted;
   const panelTransitionStatus = forcePanelIdle ? 'idle' : transitionStatus;

--- a/packages/react/src/internals/useAnimationsFinished.test.tsx
+++ b/packages/react/src/internals/useAnimationsFinished.test.tsx
@@ -25,6 +25,28 @@ function createAnimation() {
   };
 }
 
+interface TestProps {
+  getAnimations: () => Animation[];
+  onFinished: () => void;
+}
+
+function Test({ getAnimations, onFinished }: TestProps) {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const runOnceAnimationsFinish = useAnimationsFinished(ref);
+
+  useIsoLayoutEffect(() => {
+    if (ref.current) {
+      ref.current.getAnimations = getAnimations;
+    }
+  }, [getAnimations]);
+
+  React.useEffect(() => {
+    runOnceAnimationsFinish(onFinished);
+  }, [onFinished, runOnceAnimationsFinish]);
+
+  return <div ref={ref} />;
+}
+
 describe('useAnimationsFinished', () => {
   const { render } = createRenderer();
 
@@ -38,28 +60,16 @@ describe('useAnimationsFinished', () => {
     let animations: Animation[] = [initialAnimation.animation];
     let getAnimationsCallCount = 0;
 
-    function Test() {
-      const ref = React.useRef<HTMLDivElement>(null);
-      const runOnceAnimationsFinish = useAnimationsFinished(ref);
-
-      useIsoLayoutEffect(() => {
-        if (ref.current) {
-          ref.current.getAnimations = () => {
+    try {
+      await render(
+        <Test
+          getAnimations={() => {
             getAnimationsCallCount += 1;
             return animations;
-          };
-        }
-      }, []);
-
-      React.useEffect(() => {
-        runOnceAnimationsFinish(onFinished);
-      }, [runOnceAnimationsFinish]);
-
-      return <div ref={ref} />;
-    }
-
-    try {
-      await render(<Test />);
+          }}
+          onFinished={onFinished}
+        />,
+      );
 
       await waitFor(() => {
         expect(getAnimationsCallCount).toBeGreaterThan(0);
@@ -78,6 +88,43 @@ describe('useAnimationsFinished', () => {
 
       await act(async () => {
         replacementAnimation.finish();
+        await flushMicrotasks();
+      });
+
+      expect(onFinished).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
+    }
+  });
+
+  it('finishes when a canceled animation has no replacement', async () => {
+    const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+    const initialAnimation = createAnimation();
+    const onFinished = vi.fn();
+    let animations: Animation[] = [initialAnimation.animation];
+    let getAnimationsCallCount = 0;
+
+    try {
+      await render(
+        <Test
+          getAnimations={() => {
+            getAnimationsCallCount += 1;
+            return animations;
+          }}
+          onFinished={onFinished}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(getAnimationsCallCount).toBeGreaterThan(0);
+      });
+
+      animations = [];
+
+      await act(async () => {
+        initialAnimation.cancel();
         await flushMicrotasks();
       });
 

--- a/packages/react/src/internals/useAnimationsFinished.test.tsx
+++ b/packages/react/src/internals/useAnimationsFinished.test.tsx
@@ -1,0 +1,89 @@
+import { expect, vi } from 'vitest';
+import * as React from 'react';
+import { act, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { createRenderer } from '#test-utils';
+import { useAnimationsFinished } from './useAnimationsFinished';
+
+function createAnimation() {
+  let resolveFinished!: () => void;
+  let rejectFinished!: () => void;
+
+  const finished = new Promise<void>((resolve, reject) => {
+    resolveFinished = resolve;
+    rejectFinished = reject;
+  });
+
+  return {
+    animation: {
+      finished,
+      pending: false,
+      playState: 'running',
+    } as unknown as Animation,
+    finish: resolveFinished,
+    cancel: rejectFinished,
+  };
+}
+
+describe('useAnimationsFinished', () => {
+  const { render } = createRenderer();
+
+  it('waits for a replacement animation after an animation is canceled', async () => {
+    const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+    const initialAnimation = createAnimation();
+    const replacementAnimation = createAnimation();
+    const onFinished = vi.fn();
+    let animations: Animation[] = [initialAnimation.animation];
+    let getAnimationsCallCount = 0;
+
+    function Test() {
+      const ref = React.useRef<HTMLDivElement>(null);
+      const runOnceAnimationsFinish = useAnimationsFinished(ref);
+
+      useIsoLayoutEffect(() => {
+        if (ref.current) {
+          ref.current.getAnimations = () => {
+            getAnimationsCallCount += 1;
+            return animations;
+          };
+        }
+      }, []);
+
+      React.useEffect(() => {
+        runOnceAnimationsFinish(onFinished);
+      }, [runOnceAnimationsFinish]);
+
+      return <div ref={ref} />;
+    }
+
+    try {
+      await render(<Test />);
+
+      await waitFor(() => {
+        expect(getAnimationsCallCount).toBeGreaterThan(0);
+      });
+
+      animations = [replacementAnimation.animation];
+
+      await act(async () => {
+        initialAnimation.cancel();
+        await flushMicrotasks();
+      });
+
+      expect(onFinished).not.toHaveBeenCalled();
+
+      animations = [];
+
+      await act(async () => {
+        replacementAnimation.finish();
+        await flushMicrotasks();
+      });
+
+      expect(onFinished).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
+    }
+  });
+});

--- a/packages/react/src/internals/useAnimationsFinished.ts
+++ b/packages/react/src/internals/useAnimationsFinished.ts
@@ -7,16 +7,14 @@ import { resolveRef } from '../utils/resolveRef';
 
 /**
  * Executes a function once all animations have finished on the provided element.
+ * If an animation is canceled, waits for any replacement animations before executing.
  * @param elementOrRef - The element to watch for animations.
  * @param waitForStartingStyleRemoved - Whether to wait for [data-starting-style] to be removed before checking for animations.
- * @param treatAbortedAsFinished - Whether to treat aborted animations as finished. If `false`, and there are aborted animations,
- *   the function will check again if any new animations have started and wait for them to finish.
  * @returns A function that takes a callback to execute once all animations have finished, and an optional AbortSignal to abort the callback
  */
 export function useAnimationsFinished(
   elementOrRef: React.RefObject<HTMLElement | null> | HTMLElement | null,
   waitForStartingStyleRemoved = false,
-  treatAbortedAsFinished = true,
 ) {
   const frame = useAnimationFrame();
 
@@ -70,11 +68,6 @@ export function useAnimationsFinished(
           },
           () => {
             if (signal?.aborted) {
-              return;
-            }
-
-            if (treatAbortedAsFinished) {
-              done();
               return;
             }
 

--- a/packages/react/src/internals/useAnimationsFinished.ts
+++ b/packages/react/src/internals/useAnimationsFinished.ts
@@ -41,11 +41,6 @@ export function useAnimationsFinished(
       const resolvedElement = element;
 
       const done = () => {
-        // Ignore a stale completion after the ref moves to a replacement element.
-        if (resolveRef(elementOrRef) !== resolvedElement) {
-          return;
-        }
-
         // Synchronously flush the unmounting of the component so that the browser doesn't
         // paint: https://github.com/mui/base-ui/issues/979
         ReactDOM.flushSync(fnToExecute);

--- a/packages/react/src/internals/useAnimationsFinished.ts
+++ b/packages/react/src/internals/useAnimationsFinished.ts
@@ -57,13 +57,13 @@ export function useAnimationsFinished(
       }
 
       function exec() {
-        Promise.all(resolvedElement.getAnimations().map((animation) => animation.finished))
-          .then(() => {
+        Promise.all(resolvedElement.getAnimations().map((animation) => animation.finished)).then(
+          () => {
             if (!signal?.aborted) {
               done();
             }
-          })
-          .catch(() => {
+          },
+          () => {
             if (signal?.aborted) {
               return;
             }
@@ -87,7 +87,8 @@ export function useAnimationsFinished(
             }
 
             done();
-          });
+          },
+        );
       }
 
       if (waitForStartingStyleRemoved) {

--- a/packages/react/src/internals/useAnimationsFinished.ts
+++ b/packages/react/src/internals/useAnimationsFinished.ts
@@ -43,6 +43,11 @@ export function useAnimationsFinished(
       const resolvedElement = element;
 
       const done = () => {
+        // Ignore a stale completion after the ref moves to a replacement element.
+        if (resolveRef(elementOrRef) !== resolvedElement) {
+          return;
+        }
+
         // Synchronously flush the unmounting of the component so that the browser doesn't
         // paint: https://github.com/mui/base-ui/issues/979
         ReactDOM.flushSync(fnToExecute);

--- a/packages/react/src/internals/useAnimationsFinished.ts
+++ b/packages/react/src/internals/useAnimationsFinished.ts
@@ -64,18 +64,18 @@ export function useAnimationsFinished(
             }
           })
           .catch(() => {
+            if (signal?.aborted) {
+              return;
+            }
+
             if (treatAbortedAsFinished) {
-              if (!signal?.aborted) {
-                done();
-              }
+              done();
               return;
             }
 
             const currentAnimations = resolvedElement.getAnimations();
 
             if (
-              !signal?.aborted &&
-              currentAnimations.length > 0 &&
               currentAnimations.some(
                 (animation) => animation.pending || animation.playState !== 'finished',
               )
@@ -83,7 +83,10 @@ export function useAnimationsFinished(
               // Sometimes animations can be aborted because a property they depend on changes while the animation plays.
               // In such cases, we need to re-check if any new animations have started.
               exec();
+              return;
             }
+
+            done();
           });
       }
 

--- a/packages/react/src/internals/useOpenChangeComplete.tsx
+++ b/packages/react/src/internals/useOpenChangeComplete.tsx
@@ -10,7 +10,7 @@ export function useOpenChangeComplete(parameters: UseOpenChangeCompleteParameter
   const { enabled = true, open, ref, onComplete: onCompleteParam } = parameters;
 
   const onComplete = useStableCallback(onCompleteParam);
-  const runOnceAnimationsFinish = useAnimationsFinished(ref, open, false);
+  const runOnceAnimationsFinish = useAnimationsFinished(ref, open);
 
   React.useEffect(() => {
     if (!enabled) {

--- a/packages/react/src/menu/positioner/MenuPositioner.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.tsx
@@ -78,7 +78,7 @@ export const MenuPositioner = React.forwardRef(function MenuPositioner(
   const domReference = floatingRootContext.useState('domReferenceElement');
 
   const previousTriggerRef = React.useRef<Element | null>(null);
-  const runOnceAnimationsFinish = useAnimationsFinished(positionerElement, false, false);
+  const runOnceAnimationsFinish = useAnimationsFinished(positionerElement);
 
   let anchor = anchorProp;
   let sideOffset = sideOffsetProp;

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -130,7 +130,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
   const hoverFloatingElement = positionerElement || viewportElement;
   const hoverInteractionsEnabled = (hoverFloatingElement != null || value == null) && !disabled;
 
-  const runOnceAnimationsFinish = useAnimationsFinished(popupElement, false, false);
+  const runOnceAnimationsFinish = useAnimationsFinished(popupElement);
 
   const handleTriggerElement = React.useCallback((element: HTMLElement | null) => {
     triggerElementRef.current = element;

--- a/packages/react/src/popover/positioner/PopoverPositioner.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.tsx
@@ -69,7 +69,7 @@ export const PopoverPositioner = React.forwardRef(function PopoverPositioner(
 
   const prevTriggerElementRef = React.useRef<Element | null>(null);
 
-  const runOnceAnimationsFinish = useAnimationsFinished(positionerElement, false, false);
+  const runOnceAnimationsFinish = useAnimationsFinished(positionerElement);
 
   const positioning = useAnchorPositioning({
     anchor,

--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -677,6 +677,62 @@ describe('<Tooltip.Root />', () => {
         });
       });
 
+      it('unmounts an exiting tooltip when another tooltip opens', async () => {
+        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+        const style = `
+          .tooltip[data-ending-style] {
+            transition: opacity 10s;
+            opacity: 0;
+          }
+
+          .tooltip[data-instant] {
+            transition: none;
+          }
+        `;
+
+        const { user } = await render(
+          <Tooltip.Provider timeout={30000}>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            {['First', 'Second'].map((name, index) => (
+              <Tooltip.Root key={name}>
+                <Tooltip.Trigger data-testid={`trigger-${index + 1}`} delay={0}>
+                  {name}
+                </Tooltip.Trigger>
+                <Tooltip.Portal>
+                  <Tooltip.Positioner>
+                    <Tooltip.Popup className="tooltip" data-testid={`popup-${index + 1}`}>
+                      {name} tooltip
+                    </Tooltip.Popup>
+                  </Tooltip.Positioner>
+                </Tooltip.Portal>
+              </Tooltip.Root>
+            ))}
+          </Tooltip.Provider>,
+        );
+
+        const firstTrigger = screen.getByTestId('trigger-1');
+        const secondTrigger = screen.getByTestId('trigger-2');
+
+        await user.hover(firstTrigger);
+
+        const firstPopup = await screen.findByTestId('popup-1');
+
+        await user.unhover(firstTrigger);
+
+        await waitFor(() => {
+          expect(firstPopup.getAnimations().length).toBe(1);
+        });
+
+        await user.hover(secondTrigger);
+        await screen.findByTestId('popup-2');
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('popup-1')).toBe(null);
+        });
+      });
+
       it('inline opacity: 0 is removed before user CSS transitions run', async () => {
         globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
 

--- a/packages/react/src/tooltip/viewport/TooltipViewport.test.tsx
+++ b/packages/react/src/tooltip/viewport/TooltipViewport.test.tsx
@@ -234,7 +234,7 @@ describe('<Tooltip.Viewport />', () => {
       expect(await screen.findByText('Content 1')).toBeVisible();
     });
 
-    it('should handle rapid trigger changes', async () => {
+    it('keeps the latest transition active during rapid trigger changes', async () => {
       ignoreActWarnings();
       function TestComponent() {
         return (
@@ -242,10 +242,10 @@ describe('<Tooltip.Viewport />', () => {
             <style>
               {`
               [data-transitioning] [data-previous] {
-                animation: slide-out 0.2s ease-out forwards;
+                animation: slide-out 10s ease-out forwards;
               }
               [data-transitioning] [data-current] {
-                animation: slide-in 0.2s ease-out forwards;
+                animation: slide-in 10s ease-out forwards;
               }
               @keyframes slide-out {
                 from { transform: translateX(0); opacity: 1; }
@@ -272,7 +272,9 @@ describe('<Tooltip.Viewport />', () => {
                   <Tooltip.Portal>
                     <Tooltip.Positioner>
                       <Tooltip.Popup>
-                        <Tooltip.Viewport>Content {payload as number}</Tooltip.Viewport>
+                        <Tooltip.Viewport data-testid="viewport">
+                          Content {payload as number}
+                        </Tooltip.Viewport>
                       </Tooltip.Popup>
                     </Tooltip.Positioner>
                   </Tooltip.Portal>
@@ -293,14 +295,21 @@ describe('<Tooltip.Viewport />', () => {
       await act(async () => trigger1.focus());
       await waitSingleFrame();
       await act(async () => trigger2.focus());
+
+      await waitFor(() => {
+        const currentContainer = screen.getByText('Content 2').closest('[data-current]');
+        expect(currentContainer?.getAnimations().length).toBe(1);
+      });
+      // Allow `useAnimationsFinished` to begin waiting before replacing the current container.
       await waitSingleFrame();
+
       await act(async () => trigger3.focus());
       await waitSingleFrame();
-      await act(async () => trigger1.focus());
 
-      await waitFor(async () => {
-        expect(await screen.findByText('Content 1')).toBeVisible();
-      });
+      const currentContainer = screen.getByText('Content 3').closest('[data-current]');
+      expect(currentContainer?.getAnimations().length).toBe(1);
+      expect(screen.getByTestId('viewport')).toHaveAttribute('data-transitioning');
+      expect(document.querySelector('[data-previous]')).toHaveTextContent('Content 2');
     });
 
     it.each([

--- a/packages/react/src/tooltip/viewport/TooltipViewport.test.tsx
+++ b/packages/react/src/tooltip/viewport/TooltipViewport.test.tsx
@@ -312,6 +312,159 @@ describe('<Tooltip.Viewport />', () => {
       expect(document.querySelector('[data-previous]')).toHaveTextContent('Content 2');
     });
 
+    it('cleans up the transition when a lagging payload remounts the current container', async () => {
+      ignoreActWarnings();
+
+      let setPayload2: ((value: string | undefined) => void) | undefined;
+
+      function TestComponent() {
+        const [payload2, setPayload2State] = React.useState<string | undefined>(undefined);
+        setPayload2 = setPayload2State;
+
+        return (
+          <div>
+            <style>
+              {`
+              [data-transitioning] [data-current] {
+                transition: transform 10s linear, opacity 10s linear;
+              }
+              [data-transitioning] [data-current][data-starting-style] {
+                transform: translateX(30%);
+                opacity: 0;
+              }
+              [data-transitioning] [data-previous] {
+                transition: transform 10s linear, opacity 10s linear;
+              }
+              [data-transitioning] [data-previous][data-ending-style] {
+                transform: translateX(-30%);
+                opacity: 0;
+              }
+            `}
+            </style>
+            <Tooltip.Root>
+              {({ payload }) => (
+                <React.Fragment>
+                  <Tooltip.Trigger
+                    delay={0}
+                    data-testid="trigger1"
+                    style={{
+                      position: 'absolute',
+                      top: '10px',
+                      left: '10px',
+                      width: '100px',
+                      height: '50px',
+                    }}
+                  >
+                    Trigger 1
+                  </Tooltip.Trigger>
+                  <Tooltip.Trigger
+                    payload={payload2}
+                    delay={0}
+                    data-testid="trigger2"
+                    style={{
+                      position: 'absolute',
+                      top: '100px',
+                      left: '200px',
+                      width: '100px',
+                      height: '50px',
+                    }}
+                  >
+                    Trigger 2
+                  </Tooltip.Trigger>
+                  <Tooltip.Portal>
+                    <Tooltip.Positioner>
+                      <Tooltip.Popup>
+                        <Tooltip.Viewport data-testid="viewport">
+                          Content {String(payload)}
+                        </Tooltip.Viewport>
+                      </Tooltip.Popup>
+                    </Tooltip.Positioner>
+                  </Tooltip.Portal>
+                </React.Fragment>
+              )}
+            </Tooltip.Root>
+          </div>
+        );
+      }
+
+      await render(<TestComponent />);
+
+      const trigger1 = screen.getByTestId('trigger1');
+      const trigger2 = screen.getByTestId('trigger2');
+
+      await waitSingleFrame();
+      await act(async () => trigger1.focus());
+
+      await waitFor(() => {
+        expect(document.querySelector('[data-current]')).not.toBe(null);
+      });
+
+      await waitSingleFrame();
+      await act(async () => trigger2.focus());
+
+      // The morph is in progress: the previous snapshot exists and both containers
+      // are running their (long) transitions.
+      await waitFor(() => {
+        expect(document.querySelector('[data-previous]')).not.toBe(null);
+      });
+      await waitFor(() => {
+        expect(
+          document.querySelector('[data-previous]')?.getAnimations().length,
+        ).toBeGreaterThanOrEqual(1);
+      });
+      await waitFor(() => {
+        expect(
+          document.querySelector('[data-current]')?.getAnimations().length,
+        ).toBeGreaterThanOrEqual(1);
+      });
+
+      // Allow `useAnimationsFinished` to begin waiting before the container is replaced.
+      await waitSingleFrame();
+      await waitSingleFrame();
+
+      const containerBeforePayload = document.querySelector('[data-current]');
+
+      // The payload for the already-active trigger arrives a render later, which
+      // bumps the content key and remounts the current container mid-morph.
+      await act(async () => {
+        setPayload2?.('ready');
+      });
+
+      await waitFor(() => {
+        expect(document.querySelector('[data-current]')).not.toBe(containerBeforePayload);
+      });
+
+      // The remounted container must restart its entry transition, otherwise the
+      // cleanup watcher finds nothing to await and truncates the exit transition.
+      await waitFor(() => {
+        expect(
+          document.querySelector('[data-current]')?.getAnimations().length,
+        ).toBeGreaterThanOrEqual(1);
+      });
+
+      // The previous container's exit transition is still running, so it must not
+      // have been torn down in the frames right after the remount.
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      await waitSingleFrame();
+      expect(document.querySelector('[data-previous]')).not.toBe(null);
+
+      // Finish the live animations so the cleanup watcher can settle.
+      await waitFor(async () => {
+        await act(async () => {
+          document.querySelectorAll('[data-previous], [data-current]').forEach((el) => {
+            el.getAnimations().forEach((animation) => animation.finish());
+          });
+        });
+        expect(document.querySelector('[data-previous]')).toBe(null);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('viewport')).not.toHaveAttribute('data-transitioning');
+      });
+    });
+
     it.each([
       {
         name: 'should calculate "right down" direction',

--- a/packages/react/src/utils/usePopupAutoResize.ts
+++ b/packages/react/src/utils/usePopupAutoResize.ts
@@ -24,7 +24,7 @@ export function usePopupAutoResize(parameters: UsePopupAutoResizeParameters) {
     direction,
   } = parameters;
 
-  const runOnceAnimationsFinish = useAnimationsFinished(popupElement, true, false);
+  const runOnceAnimationsFinish = useAnimationsFinished(popupElement, true);
 
   const animationFrame = useAnimationFrame();
 

--- a/packages/react/src/utils/usePopupViewport.tsx
+++ b/packages/react/src/utils/usePopupViewport.tsx
@@ -169,23 +169,16 @@ export function usePopupViewport(parameters: UsePopupViewportParameters): UsePop
       const offset = calculateRelativePosition(previousActiveTrigger, activeTrigger);
       setNewTriggerOffset(offset);
 
-      cleanupFrame.request(() => {
-        ReactDOM.flushSync(() => {
-          setShowStartingStyleAttribute(false);
-        });
-        armViewportCleanup();
-      });
-
       lastHandledTriggerRef.current = activeTrigger;
     }
-  }, [activeTrigger, previousActiveTrigger, previousContentNode, armViewportCleanup, cleanupFrame]);
+  }, [activeTrigger, previousActiveTrigger]);
 
-  // The current container can remount mid-transition when a lagging payload bumps
-  // `currentContentKey`. The remount discards the running entry animation (and with
-  // transition-style CSS the replacement mounts at final styles with no animation at
-  // all), so re-run the starting-style choreography and re-arm the cleanup watcher —
-  // otherwise the watcher either strands or fires before the previous container's
-  // exit animation finishes.
+  // Arm cleanup after a trigger change, and re-arm it if the current container remounts
+  // mid-transition when a lagging payload bumps `currentContentKey`. The remount discards
+  // the running entry animation (and with transition-style CSS the replacement mounts at
+  // final styles with no animation at all), so re-run the starting-style choreography —
+  // otherwise the watcher either strands or fires before the previous container's exit
+  // animation finishes.
   useIsoLayoutEffect(() => {
     if (previousContentNode == null) {
       return;

--- a/packages/react/src/utils/usePopupViewport.tsx
+++ b/packages/react/src/utils/usePopupViewport.tsx
@@ -96,7 +96,7 @@ export function usePopupViewport(parameters: UsePopupViewportParameters): UsePop
   const currentContainerRef = React.useRef<HTMLDivElement>(null);
   const previousContainerRef = React.useRef<HTMLDivElement>(null);
 
-  const onAnimationsFinished = useAnimationsFinished(currentContainerRef, true, false);
+  const onAnimationsFinished = useAnimationsFinished(currentContainerRef, true);
   const cleanupFrame = useAnimationFrame();
 
   const [previousContentDimensions, setPreviousContentDimensions] = React.useState<{

--- a/packages/react/src/utils/usePopupViewport.tsx
+++ b/packages/react/src/utils/usePopupViewport.tsx
@@ -98,6 +98,7 @@ export function usePopupViewport(parameters: UsePopupViewportParameters): UsePop
 
   const onAnimationsFinished = useAnimationsFinished(currentContainerRef, true);
   const cleanupFrame = useAnimationFrame();
+  const cleanupControllerRef = React.useRef<AbortController | null>(null);
 
   const [previousContentDimensions, setPreviousContentDimensions] = React.useState<{
     width: number;
@@ -131,6 +132,17 @@ export function usePopupViewport(parameters: UsePopupViewportParameters): UsePop
     }
   });
 
+  const armViewportCleanup = useStableCallback(() => {
+    cleanupControllerRef.current?.abort();
+    const controller = new AbortController();
+    cleanupControllerRef.current = controller;
+    onAnimationsFinished(() => {
+      setPreviousContentNode(null);
+      setPreviousContentDimensions(null);
+      capturedNodeRef.current = null;
+    }, controller.signal);
+  });
+
   const lastHandledTriggerRef = React.useRef<Element | null>(null);
 
   useIsoLayoutEffect(() => {
@@ -161,22 +173,38 @@ export function usePopupViewport(parameters: UsePopupViewportParameters): UsePop
         ReactDOM.flushSync(() => {
           setShowStartingStyleAttribute(false);
         });
-        onAnimationsFinished(() => {
-          setPreviousContentNode(null);
-          setPreviousContentDimensions(null);
-          capturedNodeRef.current = null;
-        });
+        armViewportCleanup();
       });
 
       lastHandledTriggerRef.current = activeTrigger;
     }
-  }, [
-    activeTrigger,
-    previousActiveTrigger,
-    previousContentNode,
-    onAnimationsFinished,
-    cleanupFrame,
-  ]);
+  }, [activeTrigger, previousActiveTrigger, previousContentNode, armViewportCleanup, cleanupFrame]);
+
+  // The current container can remount mid-transition when a lagging payload bumps
+  // `currentContentKey`. The remount discards the running entry animation (and with
+  // transition-style CSS the replacement mounts at final styles with no animation at
+  // all), so re-run the starting-style choreography and re-arm the cleanup watcher —
+  // otherwise the watcher either strands or fires before the previous container's
+  // exit animation finishes.
+  useIsoLayoutEffect(() => {
+    if (previousContentNode == null) {
+      return;
+    }
+
+    // Abort the stale watcher synchronously. The remount cancels the old container's
+    // animations, and the resulting promise rejection would otherwise run the cleanup
+    // in a microtask before the re-armed watcher below is in place.
+    cleanupControllerRef.current?.abort();
+
+    setShowStartingStyleAttribute(true);
+
+    cleanupFrame.request(() => {
+      ReactDOM.flushSync(() => {
+        setShowStartingStyleAttribute(false);
+      });
+      armViewportCleanup();
+    });
+  }, [currentContentKey, previousContentNode, armViewportCleanup, cleanupFrame]);
 
   // Capture a clone of the current content DOM subtree when not transitioning.
   // We can't store previous React nodes as they may be stateful; instead we capture DOM clones for visual continuity.


### PR DESCRIPTION
Fixes #5395

## Changes

- Finish exit cleanup when a canceled animation has no replacement animation.
- Add coverage for switching between animated tooltips across a trigger gap.