### PR TITLE
[select] Stabilize scroll arrow cleanup test

### DIFF
--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -1950,7 +1950,12 @@ describe('<Select.Root />', () => {
         });
 
         await user.click(screen.getByRole('combobox'));
-        await act(async () => actionsRef.current.unmount());
+        await act(async () => {
+          await new Promise((resolve) => {
+            requestAnimationFrame(resolve);
+          });
+          actionsRef.current.unmount();
+        });
 
         await waitFor(() => {
           expect(upArrow).not.toHaveAttribute('data-visible');


### PR DESCRIPTION
## Changes

- Wait for the queued scroll-arrow frame before manually unmounting Select.
- Stabilize the cleanup assertion in React 18 Strict Mode.