### PR TITLE
[release] v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ _Aug 3, 2026_
 - Fix rendered trigger ID ownership (#5110) by @atomiks
 - Prevent unwanted flip with capped scrollable content (#5120) by @atomiks
 - Fix `collisionPadding` off-by-one on the biased side (#5143) by @atomiks
-- Reduce Dialog and Popover bundle size (#5193) by @atomiks
 - Reduce shared popup bundle size (#5192) by @atomiks
 - Mount popup subtrees synchronously when opening in React 17 (#5309) by @atomiks
 - Fix auto-resize origin for left-anchored popups (#5370) by @sai6855
@@ -98,6 +97,7 @@ _Aug 3, 2026_
 - Fix touch outside-press dismissal without a backdrop (#5096) by @atomiks
 - Make `<Dialog.Root>` own the store (#5109) by @michaldudak
 - Fix scroll lock handoff with external overlays (#4665) by @atomiks
+- Reduce bundle size (#5193) by @atomiks
 
 ### Drawer
 
@@ -158,6 +158,7 @@ _Aug 3, 2026_
 ### Popover
 
 - Make `<Popover.Root>` own the store (#5149) by @michaldudak
+- Reduce bundle size (#5193) by @atomiks
 
 ### Preview Card
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,235 @@
 # Versions
 
+## v1.7.0
+
+<!-- generated comparing v1.6.0...1a2ca3c9f8a39bd8c0dda939a7a23b72da226124 -->
+
+_Aug 3, 2026_
+
+### General changes
+
+- Restore visible focus after keyboard close in Safari and Firefox (#5093) by @lyzno1
+- Type `render` callback props based on the rendered element (#5104) by @atomiks
+- Reduce popup bundle size (#5233) by @atomiks
+- Reduce selector bundle size (#5250) by @atomiks
+- Keep unpositioned popups at the viewport origin (#5299) by @flaviendelangle
+- Correct layout and passive effect timing (#5337) by @atomiks
+- Remove redundant lifecycle synchronization (#5341) by @atomiks
+- Prevent stale cleanup from clearing registered part IDs (#5340) by @atomiks
+- Avoid unused popup handle work during mount (#5394) by @atomiks
+- Complete popup unmounting after a canceled exit transition (#5401) by @atomiks
+- Export `useAnchorPositioning` and `getDisabledMountTransitionStyles` (#5298) by @DiegoAndai
+- Fix rendered trigger ID ownership (#5110) by @atomiks
+- Prevent unwanted flip with capped scrollable content (#5120) by @atomiks
+- Fix `collisionPadding` off-by-one on the biased side (#5143) by @atomiks
+- Reduce Dialog and Popover bundle size (#5193) by @atomiks
+- Reduce shared popup bundle size (#5192) by @atomiks
+- Mount popup subtrees synchronously when opening in React 17 (#5309) by @atomiks
+- Fix auto-resize origin for left-anchored popups (#5370) by @sai6855
+- Avoid redundant re-renders during lazy flipping (#5372) by @mdm317
+- Strip implementation-only types from published `.d.ts` files (#5165) by @michaldudak
+- Fix `usePreviousValue` equality comparison (#5264) by @lyzno1
+
+### Accordion
+
+- Remove the implicit `dir` attribute from `<Accordion.Root>` (#5117) by @chuganzy
+
+### Alert Dialog
+
+- Make `<AlertDialog.Root>` own the store (#5109) by @michaldudak
+
+### Autocomplete
+
+- Respect locale when filtering (#5195) by @atomiks
+- Add `input-press` to change event details (#5356) by @chuganzy
+- Add `cancel-open` to change event details (#5376) by @chuganzy
+- Reset list scroll position on filter (#5231) by @atomiks
+- Remove dead code and deduplicate handlers (#5194) by @atomiks
+
+### Avatar
+
+- Show `<Avatar.Fallback>` immediately when `delay={0}` (#5147) by @chuganzy
+
+### Button
+
+- Fix keyboard click handling for custom elements (#4838) by @atomiks
+
+### Checkbox
+
+- Remove redundant validation input ref (#5188) by @nami8824
+- Stop internal input clicks from reaching ancestors (#5176) by @atomiks
+- Reduce bundle size (#5223) by @atomiks
+
+### Checkbox Group
+
+- Focus invalid checkbox (#5216) by @atomiks
+- Align form values with native submission (#5218) by @atomiks
+- Reduce bundle size (#5223) by @atomiks
+
+### Combobox
+
+- Add `input-press` to change event details (#5356) by @chuganzy
+- Add `cancel-open` to change event details (#5376) by @chuganzy
+- Stop filtering grouped items after limit (#5086) by @lyzno1
+- Remove leaky value registry (#5198) by @atomiks
+- Set initial highlight in inline combobox (#5230) by @atomiks
+- Return highlight to selected item on query clear (#5232) by @atomiks
+- Expose `expanded` state for inline comboboxes (#5332) by @sarthakmalik0810
+- Keep portalled popup content open (#5334) by @obeattie
+- Reset list scroll position on filter (#5231) by @atomiks
+- Fix hovered item stealing highlight when the list scrolls in Safari (#5265) by @arikchakma
+- Inherit the disabled state from `<Combobox.Root>` in `<Combobox.Item>` (#5365) by @chuganzy
+- Widen trigger slip-out release tolerance (#5159) by @atomiks
+- Remove dead code and deduplicate handlers (#5194) by @atomiks
+
+### Composite
+
+- Export `CompositeListContext` and `useCompositeListContext` from `/internals` (#5138) by @flaviendelangle
+- Fix nested list reorder detection (#5156) by @jjenzz
+- Always skip natively disabled items during list navigation (#5185) by @atomiks
+- Fix scroll alignment for RTL direction in `scrollIntoViewIfNeeded` (#5234) by @sai6855
+- Simplify keyboard bookkeeping (#5249) by @atomiks
+- Publish an atomic item registry (#5256) by @atomiks
+
+### Dialog
+
+- Fix touch outside-press dismissal without a backdrop (#5096) by @atomiks
+- Make `<Dialog.Root>` own the store (#5109) by @michaldudak
+- Fix scroll lock handoff with external overlays (#4665) by @atomiks
+
+### Drawer
+
+- Make `<Drawer.Root>` own the store (#5109) by @michaldudak
+- Fix unreliable swipe-to-open gestures (#5105) by @atomiks
+- Fix popup flashing fully open for a frame on swipe area re-grab (#5112) by @atomiks
+- Deduplicate swipe math to reduce bundle size (#5181) by @atomiks
+- Fix scroll handling when focus moves while the virtual keyboard is open (#5179) by @atomiks
+- Fix cross-axis scroll blocked on iOS below the touchmove slop (#5257) by @atomiks
+- Fix snap point jump when pinned pointer moves leave the drag offset unchanged (#5308) by @atomiks
+- Fix Shadow DOM swipe gestures (#5360) by @atomiks
+
+### Field
+
+- Keep invalid state on disabled fields (#5116) by @atomiks
+- Reduce bundle size (#5225) by @atomiks
+- Fix `data-dirty` tracking for null-valued controls (#5290) by @sai6855
+
+### Fieldset
+
+- Reduce bundle size (#5225) by @atomiks
+
+### Form
+
+- Reduce bundle size (#5225) by @atomiks
+- Focus the first invalid field in document order (#5287) by @atomiks
+
+### Menu
+
+- Ignore pinch-zoom shifting (#4485) by @atomiks
+- Cancel stale submenu hover-open when Chrome drops mouseleave (#5153) by @atomiks
+- Fix exit animation not running on uncheck of item (#5252) by @sai6855
+- Fix duplicate `onOpenChange` calls when closing a submenu (#5178) by @atomiks
+- Fix VoiceOver announcement when opening a submenu (#5342) by @atomiks
+- Propagate disabled state to items (#5363) by @chuganzy
+- Open submenus on Android TalkBack press (#5384) by @atomiks
+- Make `<Menu.Root>` own the store (#5149) by @michaldudak
+- Widen trigger slip-out release tolerance (#5159) by @atomiks
+
+### Meter
+
+- Reduce bundle size (#5224) by @atomiks
+
+### Navigation Menu
+
+- Fix frozen menu when the open trigger unmounts (#5240) by @DreierF
+- Ignore pinch-zoom shifting (#4485) by @atomiks
+
+### Number Field
+
+- Fix keyboard editing with multi-character format symbols (#5111) by @atomiks
+- Reduce bundle size (#5220) by @atomiks
+
+### OTP Field
+
+- Keep focus on the invalid field when `autoSubmit` is blocked (#5089) by @lyzno1
+
+### Popover
+
+- Make `<Popover.Root>` own the store (#5149) by @michaldudak
+
+### Preview Card
+
+- Make `<PreviewCard.Root>` own the store (#5149) by @michaldudak
+
+### Progress
+
+- Fix custom `min`/`max` semantics to match the indicator (#5095) by @atomiks
+- Reduce bundle size (#5224) by @atomiks
+
+### Radio Group
+
+- Remove unnecessary ARIA attributes from `<Radio.Root>` (#5213) by @sai6855
+- Stop internal input clicks from reaching ancestors (#5176) by @atomiks
+- Align form values with native submission (#5238) by @atomiks
+- Reduce bundle size (#5223) by @atomiks
+
+### Scroll Area
+
+- Fix thumb-drag divide-by-zero and per-scroll re-render (#5099) by @atomiks
+- Fix scrollbar visibility during touch scrolling on iOS (#5157) by @atomiks
+- Add WebKit overscroll feedback to `<ScrollArea.Thumb>` (#5145) by @atomiks
+- Reduce bundle size (#5217) by @atomiks
+- Prevent scroll snapping while dragging the thumb (#5259) by @atomiks
+- End thumb drag when the primary button is no longer held (#5374) by @atomiks
+
+### Select
+
+- Fix hovered item stealing highlight when the list scrolls in Safari (#5265) by @arikchakma
+- Inherit the disabled state from `<Select.Root>` in `<Select.Item>` (#5365) by @chuganzy
+- Widen trigger slip-out release tolerance (#5159) by @atomiks
+- Do not force-mount the popup on programmatic value changes (#5119) by @atomiks
+- Remove dead code and deduplicate handlers (#5194) by @atomiks
+
+### Slider
+
+- Fix assorted issues (#5097) by @atomiks
+- Reduce bundle size (#5222) by @atomiks
+- Exclude the prehydration script from client bundles (#5003) by @michaldudak
+
+### Switch
+
+- Stop internal input clicks from reaching ancestors (#5176) by @atomiks
+- Reduce bundle size (#5223) by @atomiks
+
+### Tabs
+
+- Position pre-hydration indicator inside streamed Suspense (#5171) by @brijeshb42
+- Exclude the prehydration script from client bundles (#5003) by @michaldudak
+- Reduce bundle size (#5221) by @atomiks
+
+### Toast
+
+- Fix remaining toast timer calculation (#5261) by @sai6855
+- Reduce bundle size (#5219) by @atomiks
+- Render content passed through the `render` prop in `<Toast.Title>`, `<Toast.Description>`, and `<Toast.Action>` (#5210) by @m2na7
+- Fix re-adding a closing toast (#5258) by @atomiks
+- Fix swipe direction locking for two-axis swipes (#5295) by @sai6855
+- Fix `<Toast.Provider>` prop effect ordering (#5338) by @atomiks
+
+### Toggle Group
+
+- Reduce bundle size (#5224) by @atomiks
+
+### Toolbar
+
+- Reduce bundle size (#5221) by @atomiks
+
+### Tooltip
+
+- Make `<Tooltip.Root>` own the store (#5149) by @michaldudak
+
+All contributors of this release in alphabetical order: @arikchakma, @atomiks, @bernardobelchior, @brijeshb42, @chuganzy, @DiegoAndai, @DreierF, @flaviendelangle, @jjenzz, @lyzno1, @m2na7, @mdm317, @michaldudak, @nami8824, @obeattie, @sai6855, @sarthakmalik0810
+
 ## v1.6.0
 
 _Jun 18, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,12 @@ _Aug 4, 2026_
 - Restore visible focus after keyboard close in Safari and Firefox (#5093) by @lyzno1
 - Type `render` callback props based on the rendered element (#5104) by @atomiks
 - Reduce popup bundle size (#5233) by @atomiks
-- Reduce selector bundle size (#5250) by @atomiks
+- Reduce store bundle size (#5250) by @atomiks
 - Keep unpositioned popups at the viewport origin (#5299) by @flaviendelangle
 - Correct layout and passive effect timing (#5337) by @atomiks
 - Remove redundant lifecycle synchronization (#5341) by @atomiks
 - Prevent stale cleanup from clearing registered part IDs (#5340) by @atomiks
 - Complete popup unmounting after a canceled exit transition (#5401) by @atomiks
-- Export `useAnchorPositioning` and `getDisabledMountTransitionStyles` (#5298) by @DiegoAndai
 - Fix rendered trigger ID ownership (#5110) by @atomiks
 - Prevent unwanted flip with capped scrollable content (#5120) by @atomiks
 - Fix `collisionPadding` off-by-one on the biased side (#5143) by @atomiks
@@ -34,7 +33,7 @@ _Aug 4, 2026_
 
 ### Alert Dialog
 
-- Make `<AlertDialog.Root>` own the store (#5109) by @michaldudak
+- Prevent `<AlertDialog.Root>` from reopening after remounting with a reused handle (#5109) by @michaldudak
 
 ### Autocomplete
 
@@ -84,23 +83,21 @@ _Aug 4, 2026_
 
 ### Composite
 
-- Export `CompositeListContext` and `useCompositeListContext` from `/internals` (#5138) by @flaviendelangle
 - Fix nested list reorder detection (#5156) by @jjenzz
 - Always skip natively disabled items during list navigation (#5185) by @atomiks
 - Fix scroll alignment for RTL direction in `scrollIntoViewIfNeeded` (#5234) by @sai6855
 - Simplify keyboard bookkeeping (#5249) by @atomiks
-- Publish an atomic item registry (#5256) by @atomiks
 
 ### Dialog
 
 - Fix touch outside-press dismissal without a backdrop (#5096) by @atomiks
-- Make `<Dialog.Root>` own the store (#5109) by @michaldudak
+- Prevent `<Dialog.Root>` from reopening after remounting with a reused handle (#5109) by @michaldudak
 - Fix scroll lock handoff with external overlays (#4665) by @atomiks
 - Reduce bundle size (#5193) by @atomiks
 
 ### Drawer
 
-- Make `<Drawer.Root>` own the store (#5109) by @michaldudak
+- Prevent `<Drawer.Root>` from reopening after remounting with a reused handle (#5109) by @michaldudak
 - Fix unreliable swipe-to-open gestures (#5105) by @atomiks
 - Fix popup flashing fully open for a frame on swipe area re-grab (#5112) by @atomiks
 - Deduplicate swipe math to reduce bundle size (#5181) by @atomiks
@@ -133,7 +130,7 @@ _Aug 4, 2026_
 - Fix VoiceOver announcement when opening a submenu (#5342) by @atomiks
 - Propagate disabled state to items (#5363) by @chuganzy
 - Open submenus on Android TalkBack press (#5384) by @atomiks
-- Make `<Menu.Root>` own the store (#5149) by @michaldudak
+- Prevent `<Menu.Root>` from reopening after remounting with a reused handle (#5149) by @michaldudak
 - Widen trigger slip-out release tolerance (#5159) by @atomiks
 
 ### Meter
@@ -157,12 +154,12 @@ _Aug 4, 2026_
 
 ### Popover
 
-- Make `<Popover.Root>` own the store (#5149) by @michaldudak
+- Prevent `<Popover.Root>` from reopening after remounting with a reused handle (#5149) by @michaldudak
 - Reduce bundle size (#5193) by @atomiks
 
 ### Preview Card
 
-- Make `<PreviewCard.Root>` own the store (#5149) by @michaldudak
+- Prevent `<PreviewCard.Root>` from reopening after remounting with a reused handle (#5149) by @michaldudak
 
 ### Progress
 
@@ -230,7 +227,7 @@ _Aug 4, 2026_
 
 ### Tooltip
 
-- Make `<Tooltip.Root>` own the store (#5149) by @michaldudak
+- Prevent `<Tooltip.Root>` from reopening after remounting with a reused handle (#5149) by @michaldudak
 
 All contributors of this release in alphabetical order: @arikchakma, @atomiks, @bernardobelchior, @brijeshb42, @chuganzy, @DiegoAndai, @DreierF, @flaviendelangle, @jjenzz, @lyzno1, @m2na7, @mdm317, @michaldudak, @nami8824, @obeattie, @sai6855, @sarthakmalik0810
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ _Aug 3, 2026_
 - Add `cancel-open` to change event details (#5376) by @chuganzy
 - Reset list scroll position on filter (#5231) by @atomiks
 - Remove dead code and deduplicate handlers (#5194) by @atomiks
+- Fix listbox separator semantics (#5399) by @sarthakmalik0810
 
 ### Avatar
 
@@ -81,6 +82,7 @@ _Aug 3, 2026_
 - Inherit the disabled state from `<Combobox.Root>` in `<Combobox.Item>` (#5365) by @chuganzy
 - Widen trigger slip-out release tolerance (#5159) by @atomiks
 - Remove dead code and deduplicate handlers (#5194) by @atomiks
+- Fix listbox separator semantics (#5399) by @sarthakmalik0810
 
 ### Composite
 
@@ -189,6 +191,7 @@ _Aug 3, 2026_
 - Widen trigger slip-out release tolerance (#5159) by @atomiks
 - Do not force-mount the popup on programmatic value changes (#5119) by @atomiks
 - Remove dead code and deduplicate handlers (#5194) by @atomiks
+- Fix listbox separator semantics (#5399) by @sarthakmalik0810
 
 ### Slider
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## v1.7.0
 
-<!-- generated comparing v1.6.0...9222cdac2509af9ecf80c413516830e5f707c5fd -->
-
 _Aug 4, 2026_
 
 ### General changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v1.7.0
 
-<!-- generated comparing v1.6.0...1a2ca3c9f8a39bd8c0dda939a7a23b72da226124 -->
+<!-- generated comparing v1.6.0...9222cdac2509af9ecf80c413516830e5f707c5fd -->
 
-_Aug 3, 2026_
+_Aug 4, 2026_
 
 ### General changes
 
@@ -138,6 +138,7 @@ _Aug 3, 2026_
 
 ### Meter
 
+- Format clamped values (#5409) by @atomiks
 - Reduce bundle size (#5224) by @atomiks
 
 ### Navigation Menu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ _Aug 3, 2026_
 - Correct layout and passive effect timing (#5337) by @atomiks
 - Remove redundant lifecycle synchronization (#5341) by @atomiks
 - Prevent stale cleanup from clearing registered part IDs (#5340) by @atomiks
-- Avoid unused popup handle work during mount (#5394) by @atomiks
 - Complete popup unmounting after a canceled exit transition (#5401) by @atomiks
 - Export `useAnchorPositioning` and `getDisabledMountTransitionStyles` (#5298) by @DiegoAndai
 - Fix rendered trigger ID ownership (#5110) by @atomiks

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -23,7 +23,7 @@
 - Meter - ([Outline](#meter), [Contents](./meter/page.mdx))
 - Navigation Menu - ([Outline](#navigation-menu), [Contents](./navigation-menu/page.mdx))
 - Number Field - ([Outline](#number-field), [Contents](./number-field/page.mdx))
-- OTP Field [New] - ([Outline](#otp-field), [Contents](./otp-field/page.mdx))
+- OTP Field - ([Outline](#otp-field), [Contents](./otp-field/page.mdx))
 - Popover - ([Outline](#popover), [Contents](./popover/page.mdx))
 - Preview Card - ([Outline](#preview-card), [Contents](./preview-card/page.mdx))
 - Progress - ([Outline](#progress), [Contents](./progress/page.mdx))

--- a/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
+++ b/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
@@ -13,7 +13,6 @@
 - Correct layout and passive effect timing ([#5337](https://github.com/mui/base-ui/pull/5337))
 - Remove redundant lifecycle synchronization ([#5341](https://github.com/mui/base-ui/pull/5341))
 - Prevent stale cleanup from clearing registered part IDs ([#5340](https://github.com/mui/base-ui/pull/5340))
-- Avoid unused popup handle work during mount ([#5394](https://github.com/mui/base-ui/pull/5394))
 - Complete popup unmounting after a canceled exit transition ([#5401](https://github.com/mui/base-ui/pull/5401))
 - Export `useAnchorPositioning` and `getDisabledMountTransitionStyles` ([#5298](https://github.com/mui/base-ui/pull/5298))
 - Fix rendered trigger ID ownership ([#5110](https://github.com/mui/base-ui/pull/5110))

--- a/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
+++ b/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
@@ -1,0 +1,226 @@
+# v1.7.0
+
+<Subtitle>Aug 3, 2026</Subtitle>
+<Meta name="description" content="v1.7.0 release notes. Aug 3, 2026." />
+
+## General changes
+
+- Restore visible focus after keyboard close in Safari and Firefox ([#5093](https://github.com/mui/base-ui/pull/5093))
+- Type `render` callback props based on the rendered element ([#5104](https://github.com/mui/base-ui/pull/5104))
+- Reduce popup bundle size ([#5233](https://github.com/mui/base-ui/pull/5233))
+- Reduce selector bundle size ([#5250](https://github.com/mui/base-ui/pull/5250))
+- Keep unpositioned popups at the viewport origin ([#5299](https://github.com/mui/base-ui/pull/5299))
+- Correct layout and passive effect timing ([#5337](https://github.com/mui/base-ui/pull/5337))
+- Remove redundant lifecycle synchronization ([#5341](https://github.com/mui/base-ui/pull/5341))
+- Prevent stale cleanup from clearing registered part IDs ([#5340](https://github.com/mui/base-ui/pull/5340))
+- Avoid unused popup handle work during mount ([#5394](https://github.com/mui/base-ui/pull/5394))
+- Complete popup unmounting after a canceled exit transition ([#5401](https://github.com/mui/base-ui/pull/5401))
+- Export `useAnchorPositioning` and `getDisabledMountTransitionStyles` ([#5298](https://github.com/mui/base-ui/pull/5298))
+- Fix rendered trigger ID ownership ([#5110](https://github.com/mui/base-ui/pull/5110))
+- Prevent unwanted flip with capped scrollable content ([#5120](https://github.com/mui/base-ui/pull/5120))
+- Fix `collisionPadding` off-by-one on the biased side ([#5143](https://github.com/mui/base-ui/pull/5143))
+- Reduce Dialog and Popover bundle size ([#5193](https://github.com/mui/base-ui/pull/5193))
+- Reduce shared popup bundle size ([#5192](https://github.com/mui/base-ui/pull/5192))
+- Mount popup subtrees synchronously when opening in React 17 ([#5309](https://github.com/mui/base-ui/pull/5309))
+- Fix auto-resize origin for left-anchored popups ([#5370](https://github.com/mui/base-ui/pull/5370))
+- Avoid redundant re-renders during lazy flipping ([#5372](https://github.com/mui/base-ui/pull/5372))
+- Strip implementation-only types from published `.d.ts` files ([#5165](https://github.com/mui/base-ui/pull/5165))
+- Fix `usePreviousValue` equality comparison ([#5264](https://github.com/mui/base-ui/pull/5264))
+
+## Accordion
+
+- Remove the implicit `dir` attribute from `<Accordion.Root>` ([#5117](https://github.com/mui/base-ui/pull/5117))
+
+## Alert Dialog
+
+- Make `<AlertDialog.Root>` own the store ([#5109](https://github.com/mui/base-ui/pull/5109))
+
+## Autocomplete
+
+- Respect locale when filtering ([#5195](https://github.com/mui/base-ui/pull/5195))
+- Add `input-press` to change event details ([#5356](https://github.com/mui/base-ui/pull/5356))
+- Add `cancel-open` to change event details ([#5376](https://github.com/mui/base-ui/pull/5376))
+- Reset list scroll position on filter ([#5231](https://github.com/mui/base-ui/pull/5231))
+- Remove dead code and deduplicate handlers ([#5194](https://github.com/mui/base-ui/pull/5194))
+
+## Avatar
+
+- Show `<Avatar.Fallback>` immediately when `delay={0}` ([#5147](https://github.com/mui/base-ui/pull/5147))
+
+## Button
+
+- Fix keyboard click handling for custom elements ([#4838](https://github.com/mui/base-ui/pull/4838))
+
+## Checkbox
+
+- Remove redundant validation input ref ([#5188](https://github.com/mui/base-ui/pull/5188))
+- Stop internal input clicks from reaching ancestors ([#5176](https://github.com/mui/base-ui/pull/5176))
+- Reduce bundle size ([#5223](https://github.com/mui/base-ui/pull/5223))
+
+## Checkbox Group
+
+- Focus invalid checkbox ([#5216](https://github.com/mui/base-ui/pull/5216))
+- Align form values with native submission ([#5218](https://github.com/mui/base-ui/pull/5218))
+- Reduce bundle size ([#5223](https://github.com/mui/base-ui/pull/5223))
+
+## Combobox
+
+- Add `input-press` to change event details ([#5356](https://github.com/mui/base-ui/pull/5356))
+- Add `cancel-open` to change event details ([#5376](https://github.com/mui/base-ui/pull/5376))
+- Stop filtering grouped items after limit ([#5086](https://github.com/mui/base-ui/pull/5086))
+- Remove leaky value registry ([#5198](https://github.com/mui/base-ui/pull/5198))
+- Set initial highlight in inline combobox ([#5230](https://github.com/mui/base-ui/pull/5230))
+- Return highlight to selected item on query clear ([#5232](https://github.com/mui/base-ui/pull/5232))
+- Expose `expanded` state for inline comboboxes ([#5332](https://github.com/mui/base-ui/pull/5332))
+- Keep portalled popup content open ([#5334](https://github.com/mui/base-ui/pull/5334))
+- Reset list scroll position on filter ([#5231](https://github.com/mui/base-ui/pull/5231))
+- Fix hovered item stealing highlight when the list scrolls in Safari ([#5265](https://github.com/mui/base-ui/pull/5265))
+- Inherit the disabled state from `<Combobox.Root>` in `<Combobox.Item>` ([#5365](https://github.com/mui/base-ui/pull/5365))
+- Widen trigger slip-out release tolerance ([#5159](https://github.com/mui/base-ui/pull/5159))
+- Remove dead code and deduplicate handlers ([#5194](https://github.com/mui/base-ui/pull/5194))
+
+## Composite
+
+- Export `CompositeListContext` and `useCompositeListContext` from `/internals` ([#5138](https://github.com/mui/base-ui/pull/5138))
+- Fix nested list reorder detection ([#5156](https://github.com/mui/base-ui/pull/5156))
+- Always skip natively disabled items during list navigation ([#5185](https://github.com/mui/base-ui/pull/5185))
+- Fix scroll alignment for RTL direction in `scrollIntoViewIfNeeded` ([#5234](https://github.com/mui/base-ui/pull/5234))
+- Simplify keyboard bookkeeping ([#5249](https://github.com/mui/base-ui/pull/5249))
+- Publish an atomic item registry ([#5256](https://github.com/mui/base-ui/pull/5256))
+
+## Dialog
+
+- Fix touch outside-press dismissal without a backdrop ([#5096](https://github.com/mui/base-ui/pull/5096))
+- Make `<Dialog.Root>` own the store ([#5109](https://github.com/mui/base-ui/pull/5109))
+- Fix scroll lock handoff with external overlays ([#4665](https://github.com/mui/base-ui/pull/4665))
+
+## Drawer
+
+- Make `<Drawer.Root>` own the store ([#5109](https://github.com/mui/base-ui/pull/5109))
+- Fix unreliable swipe-to-open gestures ([#5105](https://github.com/mui/base-ui/pull/5105))
+- Fix popup flashing fully open for a frame on swipe area re-grab ([#5112](https://github.com/mui/base-ui/pull/5112))
+- Deduplicate swipe math to reduce bundle size ([#5181](https://github.com/mui/base-ui/pull/5181))
+- Fix scroll handling when focus moves while the virtual keyboard is open ([#5179](https://github.com/mui/base-ui/pull/5179))
+- Fix cross-axis scroll blocked on iOS below the touchmove slop ([#5257](https://github.com/mui/base-ui/pull/5257))
+- Fix snap point jump when pinned pointer moves leave the drag offset unchanged ([#5308](https://github.com/mui/base-ui/pull/5308))
+- Fix Shadow DOM swipe gestures ([#5360](https://github.com/mui/base-ui/pull/5360))
+
+## Field
+
+- Keep invalid state on disabled fields ([#5116](https://github.com/mui/base-ui/pull/5116))
+- Reduce bundle size ([#5225](https://github.com/mui/base-ui/pull/5225))
+- Fix `data-dirty` tracking for null-valued controls ([#5290](https://github.com/mui/base-ui/pull/5290))
+
+## Fieldset
+
+- Reduce bundle size ([#5225](https://github.com/mui/base-ui/pull/5225))
+
+## Form
+
+- Reduce bundle size ([#5225](https://github.com/mui/base-ui/pull/5225))
+- Focus the first invalid field in document order ([#5287](https://github.com/mui/base-ui/pull/5287))
+
+## Menu
+
+- Ignore pinch-zoom shifting ([#4485](https://github.com/mui/base-ui/pull/4485))
+- Cancel stale submenu hover-open when Chrome drops mouseleave ([#5153](https://github.com/mui/base-ui/pull/5153))
+- Fix exit animation not running on uncheck of item ([#5252](https://github.com/mui/base-ui/pull/5252))
+- Fix duplicate `onOpenChange` calls when closing a submenu ([#5178](https://github.com/mui/base-ui/pull/5178))
+- Fix VoiceOver announcement when opening a submenu ([#5342](https://github.com/mui/base-ui/pull/5342))
+- Propagate disabled state to items ([#5363](https://github.com/mui/base-ui/pull/5363))
+- Open submenus on Android TalkBack press ([#5384](https://github.com/mui/base-ui/pull/5384))
+- Make `<Menu.Root>` own the store ([#5149](https://github.com/mui/base-ui/pull/5149))
+- Widen trigger slip-out release tolerance ([#5159](https://github.com/mui/base-ui/pull/5159))
+
+## Meter
+
+- Reduce bundle size ([#5224](https://github.com/mui/base-ui/pull/5224))
+
+## Navigation Menu
+
+- Fix frozen menu when the open trigger unmounts ([#5240](https://github.com/mui/base-ui/pull/5240))
+- Ignore pinch-zoom shifting ([#4485](https://github.com/mui/base-ui/pull/4485))
+
+## Number Field
+
+- Fix keyboard editing with multi-character format symbols ([#5111](https://github.com/mui/base-ui/pull/5111))
+- Reduce bundle size ([#5220](https://github.com/mui/base-ui/pull/5220))
+
+## OTP Field
+
+- Keep focus on the invalid field when `autoSubmit` is blocked ([#5089](https://github.com/mui/base-ui/pull/5089))
+
+## Popover
+
+- Make `<Popover.Root>` own the store ([#5149](https://github.com/mui/base-ui/pull/5149))
+
+## Preview Card
+
+- Make `<PreviewCard.Root>` own the store ([#5149](https://github.com/mui/base-ui/pull/5149))
+
+## Progress
+
+- Fix custom `min`/`max` semantics to match the indicator ([#5095](https://github.com/mui/base-ui/pull/5095))
+- Reduce bundle size ([#5224](https://github.com/mui/base-ui/pull/5224))
+
+## Radio Group
+
+- Remove unnecessary ARIA attributes from `<Radio.Root>` ([#5213](https://github.com/mui/base-ui/pull/5213))
+- Stop internal input clicks from reaching ancestors ([#5176](https://github.com/mui/base-ui/pull/5176))
+- Align form values with native submission ([#5238](https://github.com/mui/base-ui/pull/5238))
+- Reduce bundle size ([#5223](https://github.com/mui/base-ui/pull/5223))
+
+## Scroll Area
+
+- Fix thumb-drag divide-by-zero and per-scroll re-render ([#5099](https://github.com/mui/base-ui/pull/5099))
+- Fix scrollbar visibility during touch scrolling on iOS ([#5157](https://github.com/mui/base-ui/pull/5157))
+- Add WebKit overscroll feedback to `<ScrollArea.Thumb>` ([#5145](https://github.com/mui/base-ui/pull/5145))
+- Reduce bundle size ([#5217](https://github.com/mui/base-ui/pull/5217))
+- Prevent scroll snapping while dragging the thumb ([#5259](https://github.com/mui/base-ui/pull/5259))
+- End thumb drag when the primary button is no longer held ([#5374](https://github.com/mui/base-ui/pull/5374))
+
+## Select
+
+- Fix hovered item stealing highlight when the list scrolls in Safari ([#5265](https://github.com/mui/base-ui/pull/5265))
+- Inherit the disabled state from `<Select.Root>` in `<Select.Item>` ([#5365](https://github.com/mui/base-ui/pull/5365))
+- Widen trigger slip-out release tolerance ([#5159](https://github.com/mui/base-ui/pull/5159))
+- Do not force-mount the popup on programmatic value changes ([#5119](https://github.com/mui/base-ui/pull/5119))
+- Remove dead code and deduplicate handlers ([#5194](https://github.com/mui/base-ui/pull/5194))
+
+## Slider
+
+- Fix assorted issues ([#5097](https://github.com/mui/base-ui/pull/5097))
+- Reduce bundle size ([#5222](https://github.com/mui/base-ui/pull/5222))
+- Exclude the prehydration script from client bundles ([#5003](https://github.com/mui/base-ui/pull/5003))
+
+## Switch
+
+- Stop internal input clicks from reaching ancestors ([#5176](https://github.com/mui/base-ui/pull/5176))
+- Reduce bundle size ([#5223](https://github.com/mui/base-ui/pull/5223))
+
+## Tabs
+
+- Position pre-hydration indicator inside streamed Suspense ([#5171](https://github.com/mui/base-ui/pull/5171))
+- Exclude the prehydration script from client bundles ([#5003](https://github.com/mui/base-ui/pull/5003))
+- Reduce bundle size ([#5221](https://github.com/mui/base-ui/pull/5221))
+
+## Toast
+
+- Fix remaining toast timer calculation ([#5261](https://github.com/mui/base-ui/pull/5261))
+- Reduce bundle size ([#5219](https://github.com/mui/base-ui/pull/5219))
+- Render content passed through the `render` prop in `<Toast.Title>`, `<Toast.Description>`, and `<Toast.Action>` ([#5210](https://github.com/mui/base-ui/pull/5210))
+- Fix re-adding a closing toast ([#5258](https://github.com/mui/base-ui/pull/5258))
+- Fix swipe direction locking for two-axis swipes ([#5295](https://github.com/mui/base-ui/pull/5295))
+- Fix `<Toast.Provider>` prop effect ordering ([#5338](https://github.com/mui/base-ui/pull/5338))
+
+## Toggle Group
+
+- Reduce bundle size ([#5224](https://github.com/mui/base-ui/pull/5224))
+
+## Toolbar
+
+- Reduce bundle size ([#5221](https://github.com/mui/base-ui/pull/5221))
+
+## Tooltip
+
+- Make `<Tooltip.Root>` own the store ([#5149](https://github.com/mui/base-ui/pull/5149))

--- a/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
+++ b/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
@@ -19,7 +19,6 @@
 - Fix rendered trigger ID ownership ([#5110](https://github.com/mui/base-ui/pull/5110))
 - Prevent unwanted flip with capped scrollable content ([#5120](https://github.com/mui/base-ui/pull/5120))
 - Fix `collisionPadding` off-by-one on the biased side ([#5143](https://github.com/mui/base-ui/pull/5143))
-- Reduce Dialog and Popover bundle size ([#5193](https://github.com/mui/base-ui/pull/5193))
 - Reduce shared popup bundle size ([#5192](https://github.com/mui/base-ui/pull/5192))
 - Mount popup subtrees synchronously when opening in React 17 ([#5309](https://github.com/mui/base-ui/pull/5309))
 - Fix auto-resize origin for left-anchored popups ([#5370](https://github.com/mui/base-ui/pull/5370))
@@ -95,6 +94,7 @@
 - Fix touch outside-press dismissal without a backdrop ([#5096](https://github.com/mui/base-ui/pull/5096))
 - Make `<Dialog.Root>` own the store ([#5109](https://github.com/mui/base-ui/pull/5109))
 - Fix scroll lock handoff with external overlays ([#4665](https://github.com/mui/base-ui/pull/4665))
+- Reduce bundle size ([#5193](https://github.com/mui/base-ui/pull/5193))
 
 ## Drawer
 
@@ -155,6 +155,7 @@
 ## Popover
 
 - Make `<Popover.Root>` own the store ([#5149](https://github.com/mui/base-ui/pull/5149))
+- Reduce bundle size ([#5193](https://github.com/mui/base-ui/pull/5193))
 
 ## Preview Card
 

--- a/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
+++ b/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
@@ -1,7 +1,7 @@
 # v1.7.0
 
-<Subtitle>Aug 3, 2026</Subtitle>
-<Meta name="description" content="v1.7.0 release notes. Aug 3, 2026." />
+<Subtitle>Aug 4, 2026</Subtitle>
+<Meta name="description" content="v1.7.0 release notes. Aug 4, 2026." />
 
 ## General changes
 
@@ -135,6 +135,7 @@
 
 ## Meter
 
+- Format clamped values ([#5409](https://github.com/mui/base-ui/pull/5409))
 - Reduce bundle size ([#5224](https://github.com/mui/base-ui/pull/5224))
 
 ## Navigation Menu

--- a/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
+++ b/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
@@ -42,6 +42,7 @@
 - Add `cancel-open` to change event details ([#5376](https://github.com/mui/base-ui/pull/5376))
 - Reset list scroll position on filter ([#5231](https://github.com/mui/base-ui/pull/5231))
 - Remove dead code and deduplicate handlers ([#5194](https://github.com/mui/base-ui/pull/5194))
+- Fix listbox separator semantics ([#5399](https://github.com/mui/base-ui/pull/5399))
 
 ## Avatar
 
@@ -78,6 +79,7 @@
 - Inherit the disabled state from `<Combobox.Root>` in `<Combobox.Item>` ([#5365](https://github.com/mui/base-ui/pull/5365))
 - Widen trigger slip-out release tolerance ([#5159](https://github.com/mui/base-ui/pull/5159))
 - Remove dead code and deduplicate handlers ([#5194](https://github.com/mui/base-ui/pull/5194))
+- Fix listbox separator semantics ([#5399](https://github.com/mui/base-ui/pull/5399))
 
 ## Composite
 
@@ -186,6 +188,7 @@
 - Widen trigger slip-out release tolerance ([#5159](https://github.com/mui/base-ui/pull/5159))
 - Do not force-mount the popup on programmatic value changes ([#5119](https://github.com/mui/base-ui/pull/5119))
 - Remove dead code and deduplicate handlers ([#5194](https://github.com/mui/base-ui/pull/5194))
+- Fix listbox separator semantics ([#5399](https://github.com/mui/base-ui/pull/5399))
 
 ## Slider
 

--- a/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
+++ b/docs/src/app/(docs)/react/overview/releases/v1-7-0/page.mdx
@@ -8,13 +8,12 @@
 - Restore visible focus after keyboard close in Safari and Firefox ([#5093](https://github.com/mui/base-ui/pull/5093))
 - Type `render` callback props based on the rendered element ([#5104](https://github.com/mui/base-ui/pull/5104))
 - Reduce popup bundle size ([#5233](https://github.com/mui/base-ui/pull/5233))
-- Reduce selector bundle size ([#5250](https://github.com/mui/base-ui/pull/5250))
+- Reduce store bundle size ([#5250](https://github.com/mui/base-ui/pull/5250))
 - Keep unpositioned popups at the viewport origin ([#5299](https://github.com/mui/base-ui/pull/5299))
 - Correct layout and passive effect timing ([#5337](https://github.com/mui/base-ui/pull/5337))
 - Remove redundant lifecycle synchronization ([#5341](https://github.com/mui/base-ui/pull/5341))
 - Prevent stale cleanup from clearing registered part IDs ([#5340](https://github.com/mui/base-ui/pull/5340))
 - Complete popup unmounting after a canceled exit transition ([#5401](https://github.com/mui/base-ui/pull/5401))
-- Export `useAnchorPositioning` and `getDisabledMountTransitionStyles` ([#5298](https://github.com/mui/base-ui/pull/5298))
 - Fix rendered trigger ID ownership ([#5110](https://github.com/mui/base-ui/pull/5110))
 - Prevent unwanted flip with capped scrollable content ([#5120](https://github.com/mui/base-ui/pull/5120))
 - Fix `collisionPadding` off-by-one on the biased side ([#5143](https://github.com/mui/base-ui/pull/5143))
@@ -31,7 +30,7 @@
 
 ## Alert Dialog
 
-- Make `<AlertDialog.Root>` own the store ([#5109](https://github.com/mui/base-ui/pull/5109))
+- Prevent `<AlertDialog.Root>` from reopening after remounting with a reused handle ([#5109](https://github.com/mui/base-ui/pull/5109))
 
 ## Autocomplete
 
@@ -81,23 +80,21 @@
 
 ## Composite
 
-- Export `CompositeListContext` and `useCompositeListContext` from `/internals` ([#5138](https://github.com/mui/base-ui/pull/5138))
 - Fix nested list reorder detection ([#5156](https://github.com/mui/base-ui/pull/5156))
 - Always skip natively disabled items during list navigation ([#5185](https://github.com/mui/base-ui/pull/5185))
 - Fix scroll alignment for RTL direction in `scrollIntoViewIfNeeded` ([#5234](https://github.com/mui/base-ui/pull/5234))
 - Simplify keyboard bookkeeping ([#5249](https://github.com/mui/base-ui/pull/5249))
-- Publish an atomic item registry ([#5256](https://github.com/mui/base-ui/pull/5256))
 
 ## Dialog
 
 - Fix touch outside-press dismissal without a backdrop ([#5096](https://github.com/mui/base-ui/pull/5096))
-- Make `<Dialog.Root>` own the store ([#5109](https://github.com/mui/base-ui/pull/5109))
+- Prevent `<Dialog.Root>` from reopening after remounting with a reused handle ([#5109](https://github.com/mui/base-ui/pull/5109))
 - Fix scroll lock handoff with external overlays ([#4665](https://github.com/mui/base-ui/pull/4665))
 - Reduce bundle size ([#5193](https://github.com/mui/base-ui/pull/5193))
 
 ## Drawer
 
-- Make `<Drawer.Root>` own the store ([#5109](https://github.com/mui/base-ui/pull/5109))
+- Prevent `<Drawer.Root>` from reopening after remounting with a reused handle ([#5109](https://github.com/mui/base-ui/pull/5109))
 - Fix unreliable swipe-to-open gestures ([#5105](https://github.com/mui/base-ui/pull/5105))
 - Fix popup flashing fully open for a frame on swipe area re-grab ([#5112](https://github.com/mui/base-ui/pull/5112))
 - Deduplicate swipe math to reduce bundle size ([#5181](https://github.com/mui/base-ui/pull/5181))
@@ -130,7 +127,7 @@
 - Fix VoiceOver announcement when opening a submenu ([#5342](https://github.com/mui/base-ui/pull/5342))
 - Propagate disabled state to items ([#5363](https://github.com/mui/base-ui/pull/5363))
 - Open submenus on Android TalkBack press ([#5384](https://github.com/mui/base-ui/pull/5384))
-- Make `<Menu.Root>` own the store ([#5149](https://github.com/mui/base-ui/pull/5149))
+- Prevent `<Menu.Root>` from reopening after remounting with a reused handle ([#5149](https://github.com/mui/base-ui/pull/5149))
 - Widen trigger slip-out release tolerance ([#5159](https://github.com/mui/base-ui/pull/5159))
 
 ## Meter
@@ -154,12 +151,12 @@
 
 ## Popover
 
-- Make `<Popover.Root>` own the store ([#5149](https://github.com/mui/base-ui/pull/5149))
+- Prevent `<Popover.Root>` from reopening after remounting with a reused handle ([#5149](https://github.com/mui/base-ui/pull/5149))
 - Reduce bundle size ([#5193](https://github.com/mui/base-ui/pull/5193))
 
 ## Preview Card
 
-- Make `<PreviewCard.Root>` own the store ([#5149](https://github.com/mui/base-ui/pull/5149))
+- Prevent `<PreviewCard.Root>` from reopening after remounting with a reused handle ([#5149](https://github.com/mui/base-ui/pull/5149))
 
 ## Progress
 
@@ -227,4 +224,4 @@
 
 ## Tooltip
 
-- Make `<Tooltip.Root>` own the store ([#5149](https://github.com/mui/base-ui/pull/5149))
+- Prevent `<Tooltip.Root>` from reopening after remounting with a reused handle ([#5149](https://github.com/mui/base-ui/pull/5149))

--- a/docs/src/data/releases.ts
+++ b/docs/src/data/releases.ts
@@ -9,6 +9,16 @@ export interface Release {
 export const releases: Release[] = [
   {
     latest: true,
+    version: 'v1.7.0',
+    versionSlug: 'v1-7-0',
+    date: '2026-08-03',
+    highlights: [
+      '`<ScrollArea.Thumb>` adds overscroll feedback on WebKit.',
+      'Reduce bundle size and improve performance across components.',
+      'Many accessibility and bug fixes.',
+    ],
+  },
+  {
     version: 'v1.6.0',
     versionSlug: 'v1-6-0',
     date: '2026-06-18',

--- a/docs/src/data/releases.ts
+++ b/docs/src/data/releases.ts
@@ -11,7 +11,7 @@ export const releases: Release[] = [
     latest: true,
     version: 'v1.7.0',
     versionSlug: 'v1-7-0',
-    date: '2026-08-03',
+    date: '2026-08-04',
     highlights: [
       '`<ScrollArea.Thumb>` adds overscroll feedback on WebKit.',
       'Reduce bundle size and improve performance across components.',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@base-ui/monorepo",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@base-ui/react",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": "MUI Team",
   "description": "Base UI is a library of headless ('unstyled') React components and low-level hooks. You gain complete control over your app's CSS and accessibility features.",
   "license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@base-ui/utils",
-  "version": "0.4.0",
+  "version": "0.3.2",
   "author": "MUI Team",
   "description": "A collection of React utility functions for Base UI.",
   "license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@base-ui/utils",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "MUI Team",
   "description": "A collection of React utility functions for Base UI.",
   "license": "MIT",


### PR DESCRIPTION
Preview: https://deploy-preview-5404--base-ui.netlify.app/react/overview/releases

## Changes

- Bump `@base-ui/react` to 1.7.0 and `@base-ui/utils` to 0.3.2.
- Add the v1.7.0 changelog and release documentation.

## Performance benchmark

(This should be done via [`/benchmark`](https://github.com/mui/base-ui/pull/5403) on release PRs in the future)

Compared fresh builds of v1.6.0 (`b34551d64`) and master (`7cc0eef3a`) using the full Chromium benchmark suite. After discarded warm-ups, two runs per revision were measured in ABBA order. Values are the mean React duration across both runs; lower is better.

| Benchmark | v1.6.0 | 1.7.0 (master) | Change | Renders |
| --- | ---: | ---: | ---: | ---: |
| Slider mount | 34.63 ms | 20.11 ms | **−41.9%** | 3 → 2 |
| Tabs mount | 43.72 ms | 33.75 ms | **−22.8%** | 4 → 3 |
| Combobox narrow typing | 9.28 ms | 7.60 ms | **−18.1%** | 17 → 15 |
| Select open | 10.66 ms | 9.10 ms | **−14.6%** | 14 |
| Combobox typing | 7.79 ms | 6.69 ms | **−14.1%** | 11 |
| Select mount | 27.15 ms | 23.43 ms | −13.7% | 3 |
| Mixed surface mount | 18.44 ms | 16.67 ms | **−9.6%** | 5 |
| Menu open | 18.64 ms | 17.12 ms | −8.2% | 12 |
| Popover mount | 16.38 ms | 15.13 ms | −7.6% | 1 |
| Dialog mount | 12.49 ms | 12.03 ms | −3.6% | 1 |
| Menu mount | 23.38 ms | 22.69 ms | −2.9% | 2 |
| Tooltip mount | 13.09 ms | 12.86 ms | −1.8% | 1 |
| Scroll Area mount | 21.12 ms | 21.12 ms | 0.0% | 3 |
| Checkbox mount | 17.47 ms | 17.96 ms | +2.8% | 1 |

Across the 14 shared benchmarks, master was 12.0% faster by geometric mean. No shared benchmark regressed by more than 5%, and paint time improved or remained neutral in every case.
