### PR TITLE
[popups] Don't scroll the page when moving focus into the popup

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -1881,6 +1881,50 @@ describe('FloatingFocusManager', () => {
     });
   });
 
+  describe('prop: initialFocus', () => {
+    test.skipIf(isJSDOM)('does not scroll the page when focus moves into the popup', async () => {
+      function App() {
+        const [open, setOpen] = React.useState(false);
+        const { refs, context } = useFloating({
+          open,
+          onOpenChange: setOpen,
+        });
+
+        const click = useClick(context);
+        const { getReferenceProps, getFloatingProps } = useTestInteractions([click]);
+
+        return (
+          <React.Fragment>
+            <button ref={refs.setReference} {...getReferenceProps()} data-testid="reference" />
+            {/* Makes the document scrollable so the portaled popup, appended to the end of
+                `<body>`, sits below the fold. */}
+            <div style={{ height: '150vh' }} />
+            <FloatingPortal>
+              {open && (
+                <FloatingFocusManager context={context}>
+                  <div ref={refs.setFloating} {...getFloatingProps()} data-testid="floating">
+                    <button data-testid="one">one</button>
+                  </div>
+                </FloatingFocusManager>
+              )}
+            </FloatingPortal>
+          </React.Fragment>
+        );
+      }
+
+      render(<App />);
+
+      await userEvent.click(screen.getByTestId('reference'));
+      await flushMicrotasks();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('one')).toHaveFocus();
+      });
+
+      expect(window.scrollY).toBe(0);
+    });
+  });
+
   describe('prop: restoreFocus', () => {
     function App({ restoreFocus = true }: { restoreFocus?: boolean }) {
       const [isOpen, setIsOpen] = React.useState(false);

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -713,7 +713,10 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
 
       // enqueueFocus returns a rAF-cancel function; we intentionally don't cancel this focus.
       void enqueueFocus(elToFocus, {
-        preventScroll: elToFocus === floatingFocusElement,
+        // Scrolling the focused element into view would move the page out from under the
+        // user. A portaled popup sits at the end of `<body>`, so focusing anything inside
+        // it scrolls the document down to that point. Return focus already opts out below.
+        preventScroll: true,
         shouldFocus() {
           // This focus is queued on the next animation frame. If the floating element has closed
           // before it runs — e.g. tabbing out of a kept-mounted popup — don't pull focus back


### PR DESCRIPTION
`FloatingFocusManager` passes `preventScroll` only when the initial focus target
is the popup element itself:

    preventScroll: elToFocus === floatingFocusElement

When the popup has a focusable child, focus goes to that child and the browser
scrolls it into view. Portaled popups are appended to the end of `<body>`, so
the page jumps down on open.

Return focus already passes `preventScroll: true` unconditionally.

The test opens a portaled popup on a scrollable page: 487px of scroll on master,
0 with the change. Chromium only, since jsdom doesn't scroll on focus.

Reported in #4520.
