### PR TITLE
[ci] Bump Claude review footer fix

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   claude-review:
-    uses: mui/mui-public/.github/workflows/claude-review.yml@2087162a4d04c984a95b54c4f6f268cf3fbc7714 # master
+    uses: mui/mui-public/.github/workflows/claude-review.yml@6a01f9caec47cef7ab805248de15934b70745d59 # master
     permissions:
       contents: read # read the repo (checkout + git diff)
       id-token: write # mint the GitHub OIDC token exchanged for a Claude token via WIF


### PR DESCRIPTION
Pins the shared review workflow to [mui/mui-public#1749](https://github.com/mui/mui-public/pull/1749) so Base UI can test the prompt-only attribution fix before [mui/mui-public#1760](https://github.com/mui/mui-public/pull/1760) changes the footer formatting.

## Changes

- Updated the reusable Claude review workflow pin to the [mui/mui-public#1749](https://github.com/mui/mui-public/pull/1749) merge commit.