### PR TITLE
[meter] Format clamped values

### DIFF
--- a/packages/react/src/meter/root/MeterRoot.test.tsx
+++ b/packages/react/src/meter/root/MeterRoot.test.tsx
@@ -253,9 +253,12 @@ describe('<Meter.Root />', () => {
         currency: 'USD',
       };
       const expectedValue = new Intl.NumberFormat(undefined, format).format(100);
+      const getAriaValueText = vi.fn(
+        (formattedValue: string, rawValue: number) => `${formattedValue} (raw: ${rawValue})`,
+      );
 
       await render(
-        <Meter.Root value={150} format={format}>
+        <Meter.Root value={150} format={format} getAriaValueText={getAriaValueText}>
           <Meter.Value data-testid="value" />
           <Meter.Track>
             <Meter.Indicator data-testid="indicator" />
@@ -266,7 +269,8 @@ describe('<Meter.Root />', () => {
       const meter = screen.getByRole('meter');
       expect(screen.getByTestId('value').textContent).toBe(expectedValue);
       expect(meter).toHaveAttribute('aria-valuenow', '100');
-      expect(meter).toHaveAttribute('aria-valuetext', expectedValue);
+      expect(getAriaValueText).toHaveBeenLastCalledWith(expectedValue, 150);
+      expect(meter).toHaveAttribute('aria-valuetext', `${expectedValue} (raw: 150)`);
       expect(screen.getByTestId('indicator').style.width).toBe('100%');
     });
   });

--- a/packages/react/src/meter/root/MeterRoot.test.tsx
+++ b/packages/react/src/meter/root/MeterRoot.test.tsx
@@ -247,12 +247,12 @@ describe('<Meter.Root />', () => {
       expect(meter).toHaveAttribute('aria-valuetext', formatValue(30));
     });
 
-    it('formats the raw value while clamping range attributes and indicator width', async () => {
+    it('formats the clamped value while clamping range attributes and indicator width', async () => {
       const format: Intl.NumberFormatOptions = {
         style: 'currency',
         currency: 'USD',
       };
-      const expectedValue = new Intl.NumberFormat(undefined, format).format(150);
+      const expectedValue = new Intl.NumberFormat(undefined, format).format(100);
 
       await render(
         <Meter.Root value={150} format={format}>

--- a/packages/react/src/meter/root/MeterRoot.tsx
+++ b/packages/react/src/meter/root/MeterRoot.tsx
@@ -39,8 +39,8 @@ export const MeterRoot = React.forwardRef(function MeterRoot(
   const percentageValue = clamp(Number.isNaN(rawPercentage) ? 0 : rawPercentage, 0, 100);
   const clampedValue = clamp(Number.isNaN(valueProp) ? min : valueProp, min, max);
 
-  // Without an explicit `format`, the value is displayed as its position within the range so the
-  // text stays in sync with the indicator fill for any `min`/`max` (not just the default 0–100).
+  // Format the clamped value so visible and accessible text stay in sync with `aria-valuenow` and
+  // the indicator fill. The raw value remains available as the second `getAriaValueText` argument.
   const formattedValue = format
     ? formatNumber(clampedValue, locale, format)
     : formatNumber(percentageValue / 100, locale, { style: 'percent' });

--- a/packages/react/src/meter/root/MeterRoot.tsx
+++ b/packages/react/src/meter/root/MeterRoot.tsx
@@ -42,7 +42,7 @@ export const MeterRoot = React.forwardRef(function MeterRoot(
   // Without an explicit `format`, the value is displayed as its position within the range so the
   // text stays in sync with the indicator fill for any `min`/`max` (not just the default 0–100).
   const formattedValue = format
-    ? formatNumber(valueProp, locale, format)
+    ? formatNumber(clampedValue, locale, format)
     : formatNumber(percentageValue / 100, locale, { style: 'percent' });
 
   let ariaValuetext = formattedValue;

--- a/packages/react/src/progress/root/ProgressRoot.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.tsx
@@ -51,8 +51,8 @@ export const ProgressRoot = React.forwardRef(function ProgressRoot(
     percentageValue = clamp(Number.isNaN(rawPercentage) ? 0 : rawPercentage, 0, 100);
     clampedValue = clamp(value, min, max);
     status = clampedValue === max ? 'complete' : 'progressing';
-    // Without an explicit `format`, the value is displayed as its position within the range so the
-    // text stays in sync with the indicator fill.
+    // Format the clamped value so visible and accessible text stay in sync with `aria-valuenow` and
+    // the indicator fill. The raw value remains available as the second `getAriaValueText` argument.
     formattedValue = format
       ? formatNumber(clampedValue, locale, format)
       : formatNumber(percentageValue / 100, locale, { style: 'percent' });


### PR DESCRIPTION
Meter formatted explicit values from the raw value even when the indicator and ARIA range value were clamped. This could make a full meter display and announce a value above its maximum.

## Changes

- Format visible and accessible Meter values from the clamped range value.
- Keep the raw value available to `getAriaValueText` and cover the callback contract.
- Clarify the shared Meter and Progress formatting invariant.
