### PR TITLE
[temporal] Remove `TemporalAdapter.parse`

### DIFF
--- a/packages/react/src/internals/temporal-adapter-date-fns/TemporalAdapterDateFns.ts
+++ b/packages/react/src/internals/temporal-adapter-date-fns/TemporalAdapterDateFns.ts
@@ -40,7 +40,7 @@ import { isSameYear } from 'date-fns/isSameYear';
 import { isSameMonth } from 'date-fns/isSameMonth';
 import { isValid } from 'date-fns/isValid';
 import { isWithinInterval } from 'date-fns/isWithinInterval';
-import { Locale as DateFnsLocale } from 'date-fns/locale';
+import { Locale as DateFnsLocale, LocaleDayPeriod, LocaleWidth, MatchFn } from 'date-fns/locale';
 import { enUS } from 'date-fns/locale/en-US';
 import { setDate } from 'date-fns/setDate';
 import { setHours } from 'date-fns/setHours';
@@ -62,6 +62,7 @@ import {
   DateBuilderReturnType,
   TemporalTimezone,
   TemporalAdapter,
+  TemporalAdapterLetterMatch,
 } from '../temporal';
 
 const FORMATS: TemporalAdapterFormats = {
@@ -96,6 +97,33 @@ declare module '@base-ui/react/internals/temporal' {
   interface TemporalSupportedObjectLookup {
     'date-fns': Date;
   }
+}
+
+/**
+ * Widths a locale can match a letter date part with, loosest first.
+ * Trying all of them is what lets a value be read in a spelling the field does not itself render:
+ * the abbreviated month in a field showing the full one, or, in the locales that inflect month
+ * names, the nominative form in a field showing the genitive one.
+ */
+const LETTER_MATCH_WIDTHS: LocaleWidth[] = ['wide', 'abbreviated', 'short', 'narrow'];
+
+/**
+ * The day periods that mean the second half of the day. The others (`am`, `midnight`, `night`
+ * and `morning`) mean the first half.
+ */
+const PM_DAY_PERIODS: LocaleDayPeriod[] = ['pm', 'noon', 'afternoon', 'evening'];
+
+function matchLetterDatePart<TValue>(match: MatchFn<TValue>, value: string) {
+  for (const width of LETTER_MATCH_WIDTHS) {
+    const result = match(value, { width });
+    // The value is `undefined` when the string matches the width's pattern but none of the
+    // patterns telling the individual values apart.
+    if (result != null && result.value != null) {
+      return result;
+    }
+  }
+
+  return null;
 }
 
 export class TemporalAdapterDateFns implements TemporalAdapter {
@@ -211,6 +239,25 @@ export class TemporalAdapterDateFns implements TemporalAdapter {
 
   public formatByString = (value: Date, format: string) => {
     return dateFnsFormat(value, format, { locale: this.locale });
+  };
+
+  public matchMonth = (value: string): TemporalAdapterLetterMatch | null => {
+    const match = matchLetterDatePart(this.locale.match.month, value);
+    return match == null ? null : { index: match.value, rest: match.rest };
+  };
+
+  public matchWeekDay = (value: string): TemporalAdapterLetterMatch | null => {
+    const match = matchLetterDatePart(this.locale.match.day, value);
+    return match == null ? null : { index: match.value, rest: match.rest };
+  };
+
+  public matchMeridiem = (value: string): TemporalAdapterLetterMatch | null => {
+    const match = matchLetterDatePart(this.locale.match.dayPeriod, value);
+    if (match == null) {
+      return null;
+    }
+
+    return { index: PM_DAY_PERIODS.includes(match.value) ? 1 : 0, rest: match.rest };
   };
 
   public isEqual = (value: Date | null, comparing: Date | null) => {

--- a/packages/react/src/internals/temporal-adapter-date-fns/TemporalAdapterDateFns.ts
+++ b/packages/react/src/internals/temporal-adapter-date-fns/TemporalAdapterDateFns.ts
@@ -42,7 +42,6 @@ import { isValid } from 'date-fns/isValid';
 import { isWithinInterval } from 'date-fns/isWithinInterval';
 import { Locale as DateFnsLocale } from 'date-fns/locale';
 import { enUS } from 'date-fns/locale/en-US';
-import { parse } from 'date-fns/parse';
 import { setDate } from 'date-fns/setDate';
 import { setHours } from 'date-fns/setHours';
 import { setMilliseconds } from 'date-fns/setMilliseconds';
@@ -162,29 +161,6 @@ export class TemporalAdapterDateFns implements TemporalAdapter {
       isDateOnly ? date.getUTCMilliseconds() : date.getMilliseconds(),
       timezone,
     ) as unknown as R;
-  };
-
-  public parse = (value: string, format: string, timezone: TemporalTimezone): Date => {
-    const date = parse(value, format, new Date(), {
-      locale: this.locale,
-    });
-
-    if (timezone === 'system' || timezone === 'default') {
-      return date;
-    }
-
-    // `new TZDate(value, timezone)` returns a date with the same timestamp `new Date(value)` would return,
-    // whereas we want to create that represents the string in the given timezone.
-    return new TZDate(
-      date.getFullYear(),
-      date.getMonth(),
-      date.getDate(),
-      date.getHours(),
-      date.getMinutes(),
-      date.getSeconds(),
-      date.getMilliseconds(),
-      timezone,
-    );
   };
 
   public getTimezone = (value: Date): string => {

--- a/packages/react/src/internals/temporal-adapter-luxon/TemporalAdapterLuxon.ts
+++ b/packages/react/src/internals/temporal-adapter-luxon/TemporalAdapterLuxon.ts
@@ -9,6 +9,7 @@ import {
   DateBuilderReturnType,
   TemporalTimezone,
   TemporalAdapter,
+  TemporalAdapterLetterMatch,
 } from '../temporal';
 
 const FORMATS: TemporalAdapterFormats = {
@@ -47,6 +48,43 @@ const FORMATS: TemporalAdapterFormats = {
 //   }
 // }
 
+/**
+ * The lengths Luxon can render a letter date part with.
+ * Both the stand-alone and the formatting lists are collected, so a value can be read in a
+ * spelling the field does not itself render — which matters in the locales that inflect month
+ * and week day names.
+ */
+const LETTER_LENGTHS = ['long', 'short', 'narrow'] as const;
+
+interface LetterDatePartOption {
+  text: string;
+  index: number;
+}
+
+function buildLetterDatePartOptions(lists: string[][]): LetterDatePartOption[] {
+  const options: LetterDatePartOption[] = [];
+  for (const list of lists) {
+    list.forEach((text, index) => {
+      if (text !== '') {
+        options.push({ text: text.toLowerCase(), index });
+      }
+    });
+  }
+
+  // Longest first so that an option prefixing another one cannot shadow it.
+  return options.sort((a, b) => b.text.length - a.text.length);
+}
+
+/**
+ * Reads one of `options` at the beginning of `value`, ignoring case.
+ */
+function matchLetterDatePart(options: LetterDatePartOption[], value: string) {
+  const lowerCaseValue = value.toLowerCase();
+  const option = options.find((candidate) => lowerCaseValue.startsWith(candidate.text));
+
+  return option == null ? null : { index: option.index, rest: value.slice(option.text.length) };
+}
+
 export class TemporalAdapterLuxon implements TemporalAdapter {
   public isTimezoneCompatible = true;
 
@@ -57,6 +95,12 @@ export class TemporalAdapterLuxon implements TemporalAdapter {
   public formats: TemporalAdapterFormats = FORMATS;
 
   public escapedCharacters = { start: "'", end: "'" };
+
+  private monthOptions: LetterDatePartOption[] | null = null;
+
+  private weekDayOptions: LetterDatePartOption[] | null = null;
+
+  private meridiemOptions: LetterDatePartOption[] | null = null;
 
   constructor({ locale }: TemporalAdapterLuxon.ConstructorParameters = {}) {
     this.locale = locale ?? 'en-US';
@@ -126,6 +170,35 @@ export class TemporalAdapterLuxon implements TemporalAdapter {
 
   public formatByString = (value: DateTime, format: string) => {
     return value.setLocale(this.locale).toFormat(format);
+  };
+
+  public matchMonth = (value: string): TemporalAdapterLetterMatch | null => {
+    this.monthOptions ??= buildLetterDatePartOptions(
+      LETTER_LENGTHS.flatMap((length) => [
+        Info.months(length, { locale: this.locale }),
+        Info.monthsFormat(length, { locale: this.locale }),
+      ]),
+    );
+
+    return matchLetterDatePart(this.monthOptions, value);
+  };
+
+  public matchWeekDay = (value: string): TemporalAdapterLetterMatch | null => {
+    // Luxon starts its week day lists on Monday, the interface indexes them from Sunday.
+    this.weekDayOptions ??= buildLetterDatePartOptions(
+      LETTER_LENGTHS.flatMap((length) => [
+        Info.weekdays(length, { locale: this.locale }),
+        Info.weekdaysFormat(length, { locale: this.locale }),
+      ]),
+    ).map((option) => ({ ...option, index: (option.index + 1) % 7 }));
+
+    return matchLetterDatePart(this.weekDayOptions, value);
+  };
+
+  public matchMeridiem = (value: string): TemporalAdapterLetterMatch | null => {
+    this.meridiemOptions ??= buildLetterDatePartOptions([Info.meridiems({ locale: this.locale })]);
+
+    return matchLetterDatePart(this.meridiemOptions, value);
   };
 
   public isEqual = (value: DateTime | null, comparing: DateTime | null) => {

--- a/packages/react/src/internals/temporal-adapter-luxon/TemporalAdapterLuxon.ts
+++ b/packages/react/src/internals/temporal-adapter-luxon/TemporalAdapterLuxon.ts
@@ -87,10 +87,6 @@ export class TemporalAdapterLuxon implements TemporalAdapter {
     return DateTime.fromISO(value, { locale: this.locale, zone: timezone });
   };
 
-  public parse = (value: string, format: string, timezone: TemporalTimezone): DateTime => {
-    return DateTime.fromFormat(value, format, { locale: this.locale, zone: timezone });
-  };
-
   public getTimezone = (value: DateTime): string => {
     // When using the system zone, we want to return "system", not something like "Europe/Paris"
     if (value.zone.type === 'system') {

--- a/packages/react/src/internals/temporal/temporal-adapter.ts
+++ b/packages/react/src/internals/temporal/temporal-adapter.ts
@@ -113,10 +113,6 @@ export interface TemporalAdapter {
    */
   date<T extends string | null>(value: T, timezone: TemporalTimezone): DateBuilderReturnType<T>;
   /**
-   * Parses a date from a string in the given format.
-   */
-  parse(value: string, format: string, timezone: TemporalTimezone): TemporalSupportedObject;
-  /**
    * Creates a date in the date library format for the current time.
    */
   now(timezone: TemporalTimezone): TemporalSupportedObject;

--- a/packages/react/src/internals/temporal/temporal-adapter.ts
+++ b/packages/react/src/internals/temporal/temporal-adapter.ts
@@ -97,6 +97,23 @@ export type DateBuilderReturnType<T extends string | null> = [T] extends [null]
   ? null
   : TemporalSupportedObject;
 
+/**
+ * A letter date part read at the beginning of a string.
+ * Reading only a prefix lets the caller keep parsing what follows, which is what makes it safe
+ * to accept the loosest spellings a locale knows: a spelling that matches too much leaves a rest
+ * the caller then fails on.
+ */
+export interface TemporalAdapterLetterMatch {
+  /**
+   * Index of the value that was read.
+   */
+  index: number;
+  /**
+   * What is left of the string once the value has been read.
+   */
+  rest: string;
+}
+
 export interface TemporalAdapter {
   isTimezoneCompatible: boolean;
   formats: TemporalAdapterFormats;
@@ -144,6 +161,21 @@ export interface TemporalAdapter {
    * Formats a date using a format of the date library.
    */
   formatByString(value: TemporalSupportedObject, formatString: string): string;
+  /**
+   * Reads the month name written at the beginning of a string.
+   * The index is 0-based, 0 - January, 11 - December.
+   */
+  matchMonth(value: string): TemporalAdapterLetterMatch | null;
+  /**
+   * Reads the week day name written at the beginning of a string.
+   * The index is 0-based and always starts on Sunday, whichever day the locale starts its week on.
+   */
+  matchWeekDay(value: string): TemporalAdapterLetterMatch | null;
+  /**
+   * Reads the meridiem written at the beginning of a string.
+   * The index is 0 for AM and 1 for PM.
+   */
+  matchMeridiem(value: string): TemporalAdapterLetterMatch | null;
   /**
    * Checks if the two dates are equal (which means they represent the same timestamp).
    */

--- a/packages/react/test/describeGregorianAdapter/testComputations.ts
+++ b/packages/react/test/describeGregorianAdapter/testComputations.ts
@@ -101,22 +101,6 @@ export const testComputations: DescribeGregorianAdapterTestSuite = ({
     });
   });
 
-  describe('Method: date', () => {
-    it('should parse custom strings', () => {
-      // RFC5545 format: YYYYMMDDTHHmmssZ
-      const f = adapter.formats;
-      const dateFormat = `${f.yearPadded}${f.monthPadded}${f.dayOfMonthPadded}`;
-      const dateTimeSeparator = `${adapter.escapedCharacters.start}T${adapter.escapedCharacters.end}`;
-      const timeFormat = `${f.hours24hPadded}${f.minutesPadded}${f.secondsPadded}`;
-      const timezoneSuffix = `${adapter.escapedCharacters.start}Z${adapter.escapedCharacters.end}`;
-      const format = `${dateFormat}${dateTimeSeparator}${timeFormat}${timezoneSuffix}`;
-
-      expect(adapter.parse('20181030T114400Z', format, 'default')).toEqualDateTime(
-        '2018-10-30T11:44:00.000Z',
-      );
-    });
-  });
-
   describe('Method: now', () => {
     test.skipIf(adapterTZ.lib !== 'dayjs')('should support system timezone', () => {
       if (adapter.isTimezoneCompatible) {

--- a/packages/react/test/describeGregorianAdapter/testLocalization.ts
+++ b/packages/react/test/describeGregorianAdapter/testLocalization.ts
@@ -1,7 +1,7 @@
 import { expect } from 'vitest';
 import { DescribeGregorianAdapterTestSuite } from './describeGregorianAdapter.types';
 
-export const testLocalization: DescribeGregorianAdapterTestSuite = ({ adapter }) => {
+export const testLocalization: DescribeGregorianAdapterTestSuite = ({ adapter, adapterFr }) => {
   it('Method: getCurrentLocaleCode', () => {
     // TODO: When adding the moment adapter
     // if (adapter.lib === 'moment') {
@@ -10,5 +10,63 @@ export const testLocalization: DescribeGregorianAdapterTestSuite = ({ adapter })
 
     // Returns the default locale
     expect(adapter.getCurrentLocaleCode()).toMatch(/en/);
+  });
+
+  describe('Method: matchMonth', () => {
+    it('should read the full month name and return what follows it', () => {
+      expect(adapter.matchMonth('March 15, 2024')).toEqual({ index: 2, rest: ' 15, 2024' });
+    });
+
+    it('should read the abbreviated month name', () => {
+      expect(adapter.matchMonth('Mar 15, 2024')).toEqual({ index: 2, rest: ' 15, 2024' });
+    });
+
+    it('should ignore the case', () => {
+      expect(adapter.matchMonth('MARCH 15, 2024')).toEqual({ index: 2, rest: ' 15, 2024' });
+      expect(adapter.matchMonth('march 15, 2024')).toEqual({ index: 2, rest: ' 15, 2024' });
+    });
+
+    it('should return null when the value does not start with a month name', () => {
+      expect(adapter.matchMonth('xyz 15, 2024')).toBe(null);
+    });
+
+    it('should use the locale of the adapter', () => {
+      expect(adapterFr.matchMonth('mars 15')).toEqual({ index: 2, rest: ' 15' });
+      expect(adapterFr.matchMonth('Mars 15')).toEqual({ index: 2, rest: ' 15' });
+    });
+  });
+
+  describe('Method: matchWeekDay', () => {
+    it('should index the week days from Sunday', () => {
+      expect(adapter.matchWeekDay('Sunday 15')).toEqual({ index: 0, rest: ' 15' });
+      expect(adapter.matchWeekDay('Friday 15')).toEqual({ index: 5, rest: ' 15' });
+    });
+
+    it('should read the abbreviated week day name', () => {
+      expect(adapter.matchWeekDay('Fri 15')).toEqual({ index: 5, rest: ' 15' });
+    });
+
+    it('should return null when the value does not start with a week day name', () => {
+      expect(adapter.matchWeekDay('xyz 15')).toBe(null);
+    });
+
+    it('should use the locale of the adapter', () => {
+      expect(adapterFr.matchWeekDay('vendredi 15')).toEqual({ index: 5, rest: ' 15' });
+    });
+  });
+
+  describe('Method: matchMeridiem', () => {
+    it('should return 0 for AM and 1 for PM', () => {
+      expect(adapter.matchMeridiem('AM 15')).toEqual({ index: 0, rest: ' 15' });
+      expect(adapter.matchMeridiem('PM 15')).toEqual({ index: 1, rest: ' 15' });
+    });
+
+    it('should ignore the case', () => {
+      expect(adapter.matchMeridiem('pm')).toEqual({ index: 1, rest: '' });
+    });
+
+    it('should return null when the value does not start with a meridiem', () => {
+      expect(adapter.matchMeridiem('xyz')).toBe(null);
+    });
   });
 };


### PR DESCRIPTION
Removes `parse` from `TemporalAdapter` and from both adapters, and replaces it with three much
narrower methods that read a single letter date part.

## Why

`parse` is by far the most expensive method an adapter has to implement. Measured on the exact
import set of `TemporalAdapterDateFns`:

| | minified | gzipped |
| --- | --- | --- |
| Adapter deps with `parse` | 50.0 kB | 12.1 kB |
| Adapter deps without `parse` | 29.6 kB | 8.3 kB |
| **Saved** | **20.4 kB (-41%)** | **3.8 kB (-31%)** |

Luxon pays the equivalent cost for `DateTime.fromFormat`, which pulls in its token parser.

Nothing in this repository calls `parse` — the only consumer was the Base UI Plus date field, and
it no longer needs it: https://github.com/mui/base-ui-plus/pull/136 replaces it with per-date-part
application built on the setters the adapters already expose (`setYear`, `setMonth`, `setDate`, …).
That turns out to be a better fit anyway, since the field always knows which date part each
character belongs to and never needed a general-purpose string parser.

## What the field still needs: reading letter date parts

The field can enumerate what a token renders and match against that, which is enough to read back
its own output. It is not enough to read what a user *pastes*, because that is often a spelling the
field never renders:

| pasted into a `MMMM d, yyyy` field | `parse` | enumeration alone |
| --- | --- | --- |
| fr `janv. 15, 2024` | ✅ | ❌ |
| de `Jan. 15, 2024` | ✅ | ❌ |
| ru `15 январь 2024` (nominative into a genitive format) | ✅ | ❌ |
| uk `січень`, cs `leden`, pl `styczeń` | ✅ | ❌ |

The Slavic row is the one that matters most: in ru/uk/cs/pl the wide `MMMM` is genitive (`января`)
while every other UI shows the nominative (`январь`), so anything a user copies from elsewhere is in
the form the field would refuse.

That tolerance data already ships — it is `matchMonthPatterns` / `parseMonthPatterns` in each
date-fns locale file, hand-authored per locale, and attached to the exported locale object whether
or not you call it. Only the parser machinery was worth removing.

## Changes

- `TemporalAdapter.parse` removed from the interface.
- `TemporalAdapterDateFns.parse` removed, along with the `date-fns/parse` import.
- `TemporalAdapterLuxon.parse` removed.
- `TemporalAdapter.matchMonth`, `matchWeekDay` and `matchMeridiem` added, along with the
  `TemporalAdapterLetterMatch` result type. Each reads one value at the beginning of a string and
  returns its index plus the rest of the string.
- The date-fns adapter implements them over `locale.match`, trying the widths loosest first.
- The Luxon adapter implements them by enumerating `Info.months` / `Info.weekdays` /
  `Info.meridiems` in both their stand-alone and formatting variants, cached per adapter instance.
- The `describeGregorianAdapter` conformance test for `parse` removed (it was the only test of the
  method; it also sat under a mislabelled `describe('Method: date')`), and twelve tests added for
  the new matchers.

### Why a prefix matcher

`match` returns `{ value, rest }`, and the width fallback chain always eventually succeeds because
the narrow patterns are single letters — `fr` `"fevrier 15"` matches the narrow `f` and leaves
`"evrier 15"` behind. That is safe only because the caller keeps parsing and fails on the leftover,
which is exactly how `parse` behaved (it returns Invalid Date for that input). Returning `rest` puts
the same contract in the interface rather than hiding it.

Indexing is absolute so callers do not have to know the locale's conventions: months are 0-based
from January, week days 0-based from Sunday whichever day the locale starts its week on, and
meridiems are 0 for AM and 1 for PM.

## Merge order

This depends on https://github.com/mui/base-ui-plus/pull/136 landing first, since Base UI Plus
master still calls `adapter.parse` until then. The matchers are additive, so Base UI Plus can adopt
them in a follow-up once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
