### PR TITLE
[utils] Enforce store state key/value types

### DIFF
--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -509,10 +509,18 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       selectedIndex?: number | null | undefined;
       type?: AriaCombobox.HighlightEventReason | undefined;
     }) => {
-      const { activeIndex = store.state.activeIndex, selectedIndex = store.state.selectedIndex } =
-        options;
+      const indexUpdates: Partial<Pick<StoreState, 'activeIndex' | 'selectedIndex'>> = {};
 
-      store.update({ activeIndex, selectedIndex });
+      if (options.activeIndex !== undefined) {
+        indexUpdates.activeIndex = options.activeIndex;
+      }
+
+      if (options.selectedIndex !== undefined) {
+        indexUpdates.selectedIndex = options.selectedIndex;
+      }
+
+      // Every populated key is assigned its corresponding state value above.
+      store.update(indexUpdates as Pick<StoreState, 'activeIndex' | 'selectedIndex'>);
 
       const activeIndexOption = options.activeIndex;
       if (activeIndexOption === undefined) {

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -509,10 +509,17 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       selectedIndex?: number | null | undefined;
       type?: AriaCombobox.HighlightEventReason | undefined;
     }) => {
-      store.update({
-        ...(options.activeIndex !== undefined && { activeIndex: options.activeIndex }),
-        ...(options.selectedIndex !== undefined && { selectedIndex: options.selectedIndex }),
-      } as Pick<StoreState, 'activeIndex' | 'selectedIndex'>);
+      const update = {} as Pick<StoreState, 'activeIndex' | 'selectedIndex'>;
+
+      if (options.activeIndex !== undefined) {
+        update.activeIndex = options.activeIndex;
+      }
+
+      if (options.selectedIndex !== undefined) {
+        update.selectedIndex = options.selectedIndex;
+      }
+
+      store.update(update);
 
       const activeIndexOption = options.activeIndex;
       if (activeIndexOption === undefined) {

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -509,7 +509,11 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       selectedIndex?: number | null | undefined;
       type?: AriaCombobox.HighlightEventReason | undefined;
     }) => {
-      store.update(options);
+      const { activeIndex = store.state.activeIndex, selectedIndex = store.state.selectedIndex } =
+        options;
+
+      store.update({ activeIndex, selectedIndex });
+
       const activeIndexOption = options.activeIndex;
       if (activeIndexOption === undefined) {
         return;

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -509,18 +509,17 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       selectedIndex?: number | null | undefined;
       type?: AriaCombobox.HighlightEventReason | undefined;
     }) => {
-      const indexUpdates: Partial<Pick<StoreState, 'activeIndex' | 'selectedIndex'>> = {};
+      const updates = {};
 
       if (options.activeIndex !== undefined) {
-        indexUpdates.activeIndex = options.activeIndex;
+        (updates as Pick<StoreState, 'activeIndex'>).activeIndex = options.activeIndex;
       }
 
       if (options.selectedIndex !== undefined) {
-        indexUpdates.selectedIndex = options.selectedIndex;
+        (updates as Pick<StoreState, 'selectedIndex'>).selectedIndex = options.selectedIndex;
       }
 
-      // Every populated key is assigned its corresponding state value above.
-      store.update(indexUpdates as Pick<StoreState, 'activeIndex' | 'selectedIndex'>);
+      store.update(updates);
 
       const activeIndexOption = options.activeIndex;
       if (activeIndexOption === undefined) {

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -509,17 +509,10 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none'>(
       selectedIndex?: number | null | undefined;
       type?: AriaCombobox.HighlightEventReason | undefined;
     }) => {
-      const updates = {};
-
-      if (options.activeIndex !== undefined) {
-        (updates as Pick<StoreState, 'activeIndex'>).activeIndex = options.activeIndex;
-      }
-
-      if (options.selectedIndex !== undefined) {
-        (updates as Pick<StoreState, 'selectedIndex'>).selectedIndex = options.selectedIndex;
-      }
-
-      store.update(updates);
+      store.update({
+        ...(options.activeIndex !== undefined && { activeIndex: options.activeIndex }),
+        ...(options.selectedIndex !== undefined && { selectedIndex: options.selectedIndex }),
+      } as Pick<StoreState, 'activeIndex' | 'selectedIndex'>);
 
       const activeIndexOption = options.activeIndex;
       if (activeIndexOption === undefined) {

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -10,7 +10,7 @@ import {
   PopupTriggerDataStore,
   PopupStoreState,
   PopupTriggerMap,
-  getPopupOpenState,
+  createPopupOpenState,
 } from '../../utils/popups';
 
 export type State<Payload> = PopupStoreState<Payload> & {
@@ -93,7 +93,7 @@ export class DialogStore<Payload> extends ReactStore<
 
     this.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);
 
-    this.update(getPopupOpenState(this.state, nextOpen, eventDetails.trigger));
+    this.update(createPopupOpenState(this.state, nextOpen, eventDetails.trigger));
   };
 }
 

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -10,7 +10,7 @@ import {
   PopupTriggerDataStore,
   PopupStoreState,
   PopupTriggerMap,
-  setPopupOpenState,
+  getPopupOpenState,
 } from '../../utils/popups';
 
 export type State<Payload> = PopupStoreState<Payload> & {
@@ -93,13 +93,7 @@ export class DialogStore<Payload> extends ReactStore<
 
     this.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);
 
-    const updatedState: Partial<State<Payload>> = {
-      open: nextOpen,
-    };
-
-    setPopupOpenState(updatedState, nextOpen, eventDetails.trigger);
-
-    this.update(updatedState);
+    this.update(getPopupOpenState(this.state, nextOpen, eventDetails.trigger));
   };
 }
 

--- a/packages/react/src/floating-ui-react/hooks/useFloatingRootContext.ts
+++ b/packages/react/src/floating-ui-react/hooks/useFloatingRootContext.ts
@@ -56,18 +56,21 @@ export function useFloatingRootContext(options: UseFloatingRootContextOptions): 
   ).current;
 
   useIsoLayoutEffect(() => {
-    store.update({
-      open,
-      floatingId,
-      ...(elements.floating !== undefined && { floatingElement: elements.floating }),
-      ...(elements.reference !== undefined && {
-        referenceElement: elements.reference,
-        domReferenceElement: isElement(elements.reference) ? elements.reference : null,
-      }),
-    } as Pick<
+    const valuesToSync = { open, floatingId } as Pick<
       State,
       'open' | 'floatingId' | 'referenceElement' | 'domReferenceElement' | 'floatingElement'
-    >);
+    >;
+
+    if (elements.reference !== undefined) {
+      valuesToSync.referenceElement = elements.reference;
+      valuesToSync.domReferenceElement = isElement(elements.reference) ? elements.reference : null;
+    }
+
+    if (elements.floating !== undefined) {
+      valuesToSync.floatingElement = elements.floating;
+    }
+
+    store.update(valuesToSync);
   }, [open, floatingId, elements.reference, elements.floating, store]);
 
   store.context.onOpenChange = onOpenChange;

--- a/packages/react/src/floating-ui-react/hooks/useFloatingRootContext.ts
+++ b/packages/react/src/floating-ui-react/hooks/useFloatingRootContext.ts
@@ -6,7 +6,7 @@ import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { PopupTriggerMap } from '../../utils/popups';
 import type { BaseUIChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { useFloatingParentNodeId } from '../components/FloatingTree';
-import { FloatingRootStore, type FloatingRootState } from '../components/FloatingRootStore';
+import { FloatingRootStore } from '../components/FloatingRootStore';
 import type { ReferenceType } from '../types';
 
 export interface UseFloatingRootContextOptions {
@@ -22,6 +22,8 @@ export interface UseFloatingRootContextOptions {
 
 export function useFloatingRootContext(options: UseFloatingRootContextOptions): FloatingRootStore {
   const { open = false, onOpenChange, elements = {} } = options;
+  const reference = elements.reference;
+  const floating = elements.floating;
 
   const floatingId = useId();
   const nested = useFloatingParentNodeId() != null;
@@ -43,8 +45,8 @@ export function useFloatingRootContext(options: UseFloatingRootContextOptions): 
         open,
         transitionStatus: undefined,
         onOpenChange,
-        referenceElement: elements.reference ?? null,
-        floatingElement: elements.floating ?? null,
+        referenceElement: reference ?? null,
+        floatingElement: floating ?? null,
         triggerElements: new PopupTriggerMap(),
         floatingId,
         syncOnly: false,
@@ -53,28 +55,25 @@ export function useFloatingRootContext(options: UseFloatingRootContextOptions): 
   ).current;
 
   useIsoLayoutEffect(() => {
-    const valuesToSync: Writeable<Partial<FloatingRootState>> = {
+    const referenceElement = reference === undefined ? store.state.referenceElement : reference;
+    const floatingElement = floating === undefined ? store.state.floatingElement : floating;
+    let domReferenceElement = store.state.domReferenceElement;
+
+    if (reference !== undefined) {
+      domReferenceElement = isElement(referenceElement) ? referenceElement : null;
+    }
+
+    store.update({
       open,
       floatingId,
-    };
-
-    // Only sync elements that are defined to avoid overwriting existing ones
-    if (elements.reference !== undefined) {
-      valuesToSync.referenceElement = elements.reference;
-      valuesToSync.domReferenceElement = isElement(elements.reference) ? elements.reference : null;
-    }
-
-    if (elements.floating !== undefined) {
-      valuesToSync.floatingElement = elements.floating;
-    }
-
-    store.update(valuesToSync);
-  }, [open, floatingId, elements.reference, elements.floating, store]);
+      referenceElement,
+      domReferenceElement,
+      floatingElement,
+    });
+  }, [open, floatingId, reference, floating, store]);
 
   store.context.onOpenChange = onOpenChange;
   store.context.nested = nested;
 
   return store;
 }
-
-type Writeable<T> = { -readonly [P in keyof T]: T[P] };

--- a/packages/react/src/floating-ui-react/hooks/useFloatingRootContext.ts
+++ b/packages/react/src/floating-ui-react/hooks/useFloatingRootContext.ts
@@ -56,21 +56,18 @@ export function useFloatingRootContext(options: UseFloatingRootContextOptions): 
   ).current;
 
   useIsoLayoutEffect(() => {
-    const valuesToSync = {};
-
-    // Only sync elements that are defined to avoid overwriting existing ones
-    if (elements.reference !== undefined) {
-      const domReferenceElement = isElement(elements.reference) ? elements.reference : null;
-      (valuesToSync as Pick<State, 'referenceElement'>).referenceElement = elements.reference;
-      (valuesToSync as Pick<State, 'domReferenceElement'>).domReferenceElement =
-        domReferenceElement;
-    }
-
-    if (elements.floating !== undefined) {
-      (valuesToSync as Pick<State, 'floatingElement'>).floatingElement = elements.floating;
-    }
-
-    store.update({ open, floatingId, ...valuesToSync });
+    store.update({
+      open,
+      floatingId,
+      ...(elements.floating !== undefined && { floatingElement: elements.floating }),
+      ...(elements.reference !== undefined && {
+        referenceElement: elements.reference,
+        domReferenceElement: isElement(elements.reference) ? elements.reference : null,
+      }),
+    } as Pick<
+      State,
+      'open' | 'floatingId' | 'referenceElement' | 'domReferenceElement' | 'floatingElement'
+    >);
   }, [open, floatingId, elements.reference, elements.floating, store]);
 
   store.context.onOpenChange = onOpenChange;

--- a/packages/react/src/floating-ui-react/hooks/useFloatingRootContext.ts
+++ b/packages/react/src/floating-ui-react/hooks/useFloatingRootContext.ts
@@ -6,7 +6,7 @@ import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { PopupTriggerMap } from '../../utils/popups';
 import type { BaseUIChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { useFloatingParentNodeId } from '../components/FloatingTree';
-import { FloatingRootStore } from '../components/FloatingRootStore';
+import { FloatingRootStore, type FloatingRootState } from '../components/FloatingRootStore';
 import type { ReferenceType } from '../types';
 
 export interface UseFloatingRootContextOptions {
@@ -22,8 +22,6 @@ export interface UseFloatingRootContextOptions {
 
 export function useFloatingRootContext(options: UseFloatingRootContextOptions): FloatingRootStore {
   const { open = false, onOpenChange, elements = {} } = options;
-  const reference = elements.reference;
-  const floating = elements.floating;
 
   const floatingId = useId();
   const nested = useFloatingParentNodeId() != null;
@@ -45,8 +43,8 @@ export function useFloatingRootContext(options: UseFloatingRootContextOptions): 
         open,
         transitionStatus: undefined,
         onOpenChange,
-        referenceElement: reference ?? null,
-        floatingElement: floating ?? null,
+        referenceElement: elements.reference ?? null,
+        floatingElement: elements.floating ?? null,
         triggerElements: new PopupTriggerMap(),
         floatingId,
         syncOnly: false,
@@ -55,25 +53,29 @@ export function useFloatingRootContext(options: UseFloatingRootContextOptions): 
   ).current;
 
   useIsoLayoutEffect(() => {
-    const referenceElement = reference === undefined ? store.state.referenceElement : reference;
-    const floatingElement = floating === undefined ? store.state.floatingElement : floating;
-    let domReferenceElement = store.state.domReferenceElement;
-
-    if (reference !== undefined) {
-      domReferenceElement = isElement(referenceElement) ? referenceElement : null;
-    }
-
-    store.update({
+    const valuesToSync: Writeable<Partial<FloatingRootState>> = {
       open,
       floatingId,
-      referenceElement,
-      domReferenceElement,
-      floatingElement,
-    });
-  }, [open, floatingId, reference, floating, store]);
+    };
+
+    // Only sync elements that are defined to avoid overwriting existing ones
+    if (elements.reference !== undefined) {
+      valuesToSync.referenceElement = elements.reference;
+      valuesToSync.domReferenceElement = isElement(elements.reference) ? elements.reference : null;
+    }
+
+    if (elements.floating !== undefined) {
+      valuesToSync.floatingElement = elements.floating;
+    }
+
+    // Every populated key is assigned its corresponding state value above.
+    store.update(valuesToSync as Pick<FloatingRootState, keyof FloatingRootState>);
+  }, [open, floatingId, elements.reference, elements.floating, store]);
 
   store.context.onOpenChange = onOpenChange;
   store.context.nested = nested;
 
   return store;
 }
+
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };

--- a/packages/react/src/floating-ui-react/hooks/useFloatingRootContext.ts
+++ b/packages/react/src/floating-ui-react/hooks/useFloatingRootContext.ts
@@ -6,7 +6,10 @@ import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { PopupTriggerMap } from '../../utils/popups';
 import type { BaseUIChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { useFloatingParentNodeId } from '../components/FloatingTree';
-import { FloatingRootStore, type FloatingRootState } from '../components/FloatingRootStore';
+import {
+  FloatingRootStore,
+  type FloatingRootState as State,
+} from '../components/FloatingRootStore';
 import type { ReferenceType } from '../types';
 
 export interface UseFloatingRootContextOptions {
@@ -53,23 +56,21 @@ export function useFloatingRootContext(options: UseFloatingRootContextOptions): 
   ).current;
 
   useIsoLayoutEffect(() => {
-    const valuesToSync: Writeable<Partial<FloatingRootState>> = {
-      open,
-      floatingId,
-    };
+    const valuesToSync = {};
 
     // Only sync elements that are defined to avoid overwriting existing ones
     if (elements.reference !== undefined) {
-      valuesToSync.referenceElement = elements.reference;
-      valuesToSync.domReferenceElement = isElement(elements.reference) ? elements.reference : null;
+      const domReferenceElement = isElement(elements.reference) ? elements.reference : null;
+      (valuesToSync as Pick<State, 'referenceElement'>).referenceElement = elements.reference;
+      (valuesToSync as Pick<State, 'domReferenceElement'>).domReferenceElement =
+        domReferenceElement;
     }
 
     if (elements.floating !== undefined) {
-      valuesToSync.floatingElement = elements.floating;
+      (valuesToSync as Pick<State, 'floatingElement'>).floatingElement = elements.floating;
     }
 
-    // Every populated key is assigned its corresponding state value above.
-    store.update(valuesToSync as Pick<FloatingRootState, keyof FloatingRootState>);
+    store.update({ open, floatingId, ...valuesToSync });
   }, [open, floatingId, elements.reference, elements.floating, store]);
 
   store.context.onOpenChange = onOpenChange;
@@ -77,5 +78,3 @@ export function useFloatingRootContext(options: UseFloatingRootContextOptions): 
 
   return store;
 }
-
-type Writeable<T> = { -readonly [P in keyof T]: T[P] };

--- a/packages/react/src/floating-ui-react/hooks/useSyncedFloatingRootContext.ts
+++ b/packages/react/src/floating-ui-react/hooks/useSyncedFloatingRootContext.ts
@@ -1,18 +1,26 @@
 'use client';
 import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { ReactStore } from '@base-ui/utils/store';
+import type { ReactStore } from '@base-ui/utils/store';
 import { isElement } from '@floating-ui/utils/dom';
 import { BaseUIChangeEventDetails } from '../../types';
 import { PopupStoreContext, PopupStoreSelectors, PopupStoreState } from '../../utils/popups';
 import { FloatingRootState, FloatingRootStore } from '../components/FloatingRootStore';
 
+/**
+ * Narrowed to the store members this hook uses so consumers do not need to provide
+ * unrelated store capabilities.
+ */
+export type SyncedFloatingRootContextStore<State extends PopupStoreState<unknown>> = Pick<
+  ReactStore<Readonly<State>, PopupStoreContext<never>, PopupStoreSelectors>,
+  'context' | 'state' | 'useState' | 'useSyncedValue'
+>;
+
 export interface UseSyncedFloatingRootContextOptions<
   State extends PopupStoreState<unknown>,
-  ContextEventDetails extends BaseUIChangeEventDetails<string>,
   OpenChangeEventDetails extends BaseUIChangeEventDetails<string>,
 > {
-  popupStore: ReactStore<State, PopupStoreContext<ContextEventDetails>, PopupStoreSelectors>;
+  popupStore: SyncedFloatingRootContextStore<State>;
   /**
    * Whether the Popup element is passed to Floating UI as the floating element instead of the default Positioner.
    */
@@ -29,11 +37,8 @@ export interface UseSyncedFloatingRootContextOptions<
  */
 export function useSyncedFloatingRootContext<
   State extends PopupStoreState<unknown>,
-  ContextEventDetails extends BaseUIChangeEventDetails<string>,
   OpenChangeEventDetails extends BaseUIChangeEventDetails<string>,
->(
-  options: UseSyncedFloatingRootContextOptions<State, ContextEventDetails, OpenChangeEventDetails>,
-): FloatingRootStore {
+>(options: UseSyncedFloatingRootContextOptions<State, OpenChangeEventDetails>): FloatingRootStore {
   const {
     popupStore,
     treatPopupAsFloatingElement = false,
@@ -75,23 +80,19 @@ export function useSyncedFloatingRootContext<
   popupStore.useSyncedValue('floatingId', floatingId as State['floatingId']);
 
   useIsoLayoutEffect(() => {
-    const valuesToSync: Partial<FloatingRootState> = {
-      open,
-      floatingId,
-      referenceElement,
-      floatingElement,
-    };
+    const valuesToSync = {};
 
     if (isElement(referenceElement)) {
-      valuesToSync.domReferenceElement = referenceElement;
+      (valuesToSync as Pick<FloatingRootState, 'domReferenceElement'>).domReferenceElement =
+        referenceElement;
     }
 
     if (store.state.positionReference === store.state.referenceElement) {
-      valuesToSync.positionReference = referenceElement;
+      (valuesToSync as Pick<FloatingRootState, 'positionReference'>).positionReference =
+        referenceElement;
     }
 
-    // Every populated key is assigned its corresponding state value above.
-    store.update(valuesToSync as Pick<FloatingRootState, keyof FloatingRootState>);
+    store.update({ open, floatingId, referenceElement, floatingElement, ...valuesToSync });
   }, [open, floatingId, referenceElement, floatingElement, store]);
 
   // Keep non-reactive context values fresh for interactions that call `store.setOpen`.

--- a/packages/react/src/floating-ui-react/hooks/useSyncedFloatingRootContext.ts
+++ b/packages/react/src/floating-ui-react/hooks/useSyncedFloatingRootContext.ts
@@ -5,7 +5,7 @@ import { ReactStore } from '@base-ui/utils/store';
 import { isElement } from '@floating-ui/utils/dom';
 import { BaseUIChangeEventDetails } from '../../types';
 import { PopupStoreContext, PopupStoreSelectors, PopupStoreState } from '../../utils/popups';
-import { FloatingRootState, FloatingRootStore } from '../components/FloatingRootStore';
+import { FloatingRootStore } from '../components/FloatingRootStore';
 
 export interface UseSyncedFloatingRootContextOptions<
   State extends PopupStoreState<unknown>,
@@ -75,22 +75,22 @@ export function useSyncedFloatingRootContext<
   popupStore.useSyncedValue('floatingId', floatingId as State['floatingId']);
 
   useIsoLayoutEffect(() => {
-    const valuesToSync: Partial<FloatingRootState> = {
+    const previousReferenceElement = store.state.referenceElement;
+    const positionReference =
+      store.state.positionReference === previousReferenceElement
+        ? referenceElement
+        : store.state.positionReference;
+
+    store.update({
       open,
       floatingId,
       referenceElement,
       floatingElement,
-    };
-
-    if (isElement(referenceElement)) {
-      valuesToSync.domReferenceElement = referenceElement;
-    }
-
-    if (store.state.positionReference === store.state.referenceElement) {
-      valuesToSync.positionReference = referenceElement;
-    }
-
-    store.update(valuesToSync);
+      domReferenceElement: isElement(referenceElement)
+        ? referenceElement
+        : store.state.domReferenceElement,
+      positionReference,
+    });
   }, [open, floatingId, referenceElement, floatingElement, store]);
 
   // Keep non-reactive context values fresh for interactions that call `store.setOpen`.

--- a/packages/react/src/floating-ui-react/hooks/useSyncedFloatingRootContext.ts
+++ b/packages/react/src/floating-ui-react/hooks/useSyncedFloatingRootContext.ts
@@ -5,7 +5,7 @@ import { ReactStore } from '@base-ui/utils/store';
 import { isElement } from '@floating-ui/utils/dom';
 import { BaseUIChangeEventDetails } from '../../types';
 import { PopupStoreContext, PopupStoreSelectors, PopupStoreState } from '../../utils/popups';
-import { FloatingRootStore } from '../components/FloatingRootStore';
+import { FloatingRootState, FloatingRootStore } from '../components/FloatingRootStore';
 
 export interface UseSyncedFloatingRootContextOptions<
   State extends PopupStoreState<unknown>,
@@ -75,22 +75,23 @@ export function useSyncedFloatingRootContext<
   popupStore.useSyncedValue('floatingId', floatingId as State['floatingId']);
 
   useIsoLayoutEffect(() => {
-    const previousReferenceElement = store.state.referenceElement;
-    const positionReference =
-      store.state.positionReference === previousReferenceElement
-        ? referenceElement
-        : store.state.positionReference;
-
-    store.update({
+    const valuesToSync: Partial<FloatingRootState> = {
       open,
       floatingId,
       referenceElement,
       floatingElement,
-      domReferenceElement: isElement(referenceElement)
-        ? referenceElement
-        : store.state.domReferenceElement,
-      positionReference,
-    });
+    };
+
+    if (isElement(referenceElement)) {
+      valuesToSync.domReferenceElement = referenceElement;
+    }
+
+    if (store.state.positionReference === store.state.referenceElement) {
+      valuesToSync.positionReference = referenceElement;
+    }
+
+    // Every populated key is assigned its corresponding state value above.
+    store.update(valuesToSync as Pick<FloatingRootState, keyof FloatingRootState>);
   }, [open, floatingId, referenceElement, floatingElement, store]);
 
   // Keep non-reactive context values fresh for interactions that call `store.setOpen`.

--- a/packages/react/src/floating-ui-react/hooks/useSyncedFloatingRootContext.ts
+++ b/packages/react/src/floating-ui-react/hooks/useSyncedFloatingRootContext.ts
@@ -80,15 +80,11 @@ export function useSyncedFloatingRootContext<
   popupStore.useSyncedValue('floatingId', floatingId as State['floatingId']);
 
   useIsoLayoutEffect(() => {
-    store.update({
+    const valuesToSync = {
       open,
       floatingId,
       referenceElement,
       floatingElement,
-      ...(isElement(referenceElement) && { domReferenceElement: referenceElement }),
-      ...(store.state.positionReference === store.state.referenceElement && {
-        positionReference: referenceElement,
-      }),
     } as Pick<
       FloatingRootState,
       | 'open'
@@ -97,7 +93,17 @@ export function useSyncedFloatingRootContext<
       | 'floatingElement'
       | 'domReferenceElement'
       | 'positionReference'
-    >);
+    >;
+
+    if (isElement(referenceElement)) {
+      valuesToSync.domReferenceElement = referenceElement;
+    }
+
+    if (store.state.positionReference === store.state.referenceElement) {
+      valuesToSync.positionReference = referenceElement;
+    }
+
+    store.update(valuesToSync);
   }, [open, floatingId, referenceElement, floatingElement, store]);
 
   // Keep non-reactive context values fresh for interactions that call `store.setOpen`.

--- a/packages/react/src/floating-ui-react/hooks/useSyncedFloatingRootContext.ts
+++ b/packages/react/src/floating-ui-react/hooks/useSyncedFloatingRootContext.ts
@@ -80,19 +80,24 @@ export function useSyncedFloatingRootContext<
   popupStore.useSyncedValue('floatingId', floatingId as State['floatingId']);
 
   useIsoLayoutEffect(() => {
-    const valuesToSync = {};
-
-    if (isElement(referenceElement)) {
-      (valuesToSync as Pick<FloatingRootState, 'domReferenceElement'>).domReferenceElement =
-        referenceElement;
-    }
-
-    if (store.state.positionReference === store.state.referenceElement) {
-      (valuesToSync as Pick<FloatingRootState, 'positionReference'>).positionReference =
-        referenceElement;
-    }
-
-    store.update({ open, floatingId, referenceElement, floatingElement, ...valuesToSync });
+    store.update({
+      open,
+      floatingId,
+      referenceElement,
+      floatingElement,
+      ...(isElement(referenceElement) && { domReferenceElement: referenceElement }),
+      ...(store.state.positionReference === store.state.referenceElement && {
+        positionReference: referenceElement,
+      }),
+    } as Pick<
+      FloatingRootState,
+      | 'open'
+      | 'floatingId'
+      | 'referenceElement'
+      | 'floatingElement'
+      | 'domReferenceElement'
+      | 'positionReference'
+    >);
   }, [open, floatingId, referenceElement, floatingElement, store]);
 
   // Keep non-reactive context values fresh for interactions that call `store.setOpen`.

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -37,7 +37,7 @@ import {
   attachPreventUnmountOnClose,
   FOCUSABLE_POPUP_PROPS,
   PayloadChildRenderFunction,
-  setPopupOpenState,
+  getPopupOpenState,
   PopupHandleAttachment,
   useImplicitActiveTrigger,
   useOpenStateTransitions,
@@ -162,11 +162,13 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
   }
 
   const { openMethod, triggerProps: interactionTypeProps } = useOpenInteractionType(open);
+  const modal =
+    parent.type === undefined || parent.type === 'context-menu' ? (modalProp ?? true) : false;
 
   store.useSyncedValues({
     disabled: disabledProp,
     highlightItemOnHover,
-    modal: parent.type === undefined ? modalProp : undefined,
+    modal,
     openMethod,
     rootId,
   });
@@ -301,20 +303,16 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
         (nativeEvent as MouseEvent).detail === 0;
       const isDismissClose = !nextOpen && (reason === REASONS.escapeKey || reason == null);
 
-      const updatedState: Partial<MenuStoreState<Payload>> = {
-        open: nextOpen,
-        openChangeReason: reason,
-      };
       openEventRef.current = eventDetails.event;
 
-      setPopupOpenState(
-        updatedState,
+      const popupOpenState = getPopupOpenState(
+        store.state,
         nextOpen,
         eventDetails.trigger,
         shouldPreventUnmountOnClose(),
       );
 
-      store.update(updatedState);
+      store.update({ ...popupOpenState, openChangeReason: reason });
 
       if (
         parent.type === 'menubar' &&

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -37,7 +37,7 @@ import {
   attachPreventUnmountOnClose,
   FOCUSABLE_POPUP_PROPS,
   PayloadChildRenderFunction,
-  getPopupOpenState,
+  createPopupOpenState,
   PopupHandleAttachment,
   useImplicitActiveTrigger,
   useOpenStateTransitions,
@@ -303,14 +303,17 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
 
       openEventRef.current = eventDetails.event;
 
-      const popupOpenState = getPopupOpenState(
+      const popupOpenState = createPopupOpenState(
         store.state,
         nextOpen,
         eventDetails.trigger,
         shouldPreventUnmountOnClose(),
-      );
+      ) as ReturnType<typeof createPopupOpenState> & {
+        openChangeReason: MenuRoot.ChangeEventReason;
+      };
 
-      store.update({ ...popupOpenState, openChangeReason: reason });
+      popupOpenState.openChangeReason = reason;
+      store.update(popupOpenState);
 
       if (
         parent.type === 'menubar' &&

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -162,13 +162,11 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
   }
 
   const { openMethod, triggerProps: interactionTypeProps } = useOpenInteractionType(open);
-  const modal =
-    parent.type === undefined || parent.type === 'context-menu' ? (modalProp ?? true) : false;
 
   store.useSyncedValues({
     disabled: disabledProp,
     highlightItemOnHover,
-    modal,
+    modal: parent.type === undefined ? modalProp : undefined,
     openMethod,
     rootId,
   });

--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -18,7 +18,7 @@ import {
 
 export type State<Payload> = PopupStoreState<Payload> & {
   disabled: boolean;
-  modal: boolean;
+  modal: boolean | undefined;
   openMethod: InteractionType | null;
   allowMouseEnter: boolean;
   highlightItemOnHover: boolean;

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -67,7 +67,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
 
       if (element !== null && store.select('open') && store.select('activeTriggerId') == null) {
         store.update({
-          activeTriggerId: thisTriggerId ?? store.state.activeTriggerId,
+          activeTriggerId: thisTriggerId ?? null,
           activeTriggerElement: element,
           closeDelay,
         });

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -67,7 +67,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
 
       if (element !== null && store.select('open') && store.select('activeTriggerId') == null) {
         store.update({
-          activeTriggerId: thisTriggerId,
+          activeTriggerId: thisTriggerId ?? store.state.activeTriggerId,
           activeTriggerElement: element,
           closeDelay,
         });

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -16,7 +16,7 @@ import {
   PopupStoreState,
   PopupTriggerMap,
   type PopupTriggerStoreKeys,
-  setPopupOpenState,
+  getPopupOpenState,
 } from '../../utils/popups';
 import { PATIENT_CLICK_THRESHOLD } from '../../internals/constants';
 import type { AdaptiveOriginMiddleware } from '../../utils/adaptiveOriginConstants';
@@ -130,19 +130,17 @@ export class PopoverStore<Payload> extends ReactStore<
     this.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);
 
     const changeState = () => {
-      const updatedState: Partial<State<Payload>> = {
-        open: nextOpen,
-        openChangeReason: eventDetails.reason,
-      };
-
-      setPopupOpenState(
-        updatedState,
+      const popupOpenState = getPopupOpenState(
+        this.state,
         nextOpen,
         eventDetails.trigger,
         shouldPreventUnmountOnClose(),
       );
 
-      this.update(updatedState);
+      this.update({
+        ...popupOpenState,
+        openChangeReason: eventDetails.reason,
+      });
     };
 
     if (isHover) {

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -16,7 +16,7 @@ import {
   PopupStoreState,
   PopupTriggerMap,
   type PopupTriggerStoreKeys,
-  getPopupOpenState,
+  createPopupOpenState,
 } from '../../utils/popups';
 import { PATIENT_CLICK_THRESHOLD } from '../../internals/constants';
 import type { AdaptiveOriginMiddleware } from '../../utils/adaptiveOriginConstants';
@@ -130,17 +130,17 @@ export class PopoverStore<Payload> extends ReactStore<
     this.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);
 
     const changeState = () => {
-      const popupOpenState = getPopupOpenState(
+      const popupOpenState = createPopupOpenState(
         this.state,
         nextOpen,
         eventDetails.trigger,
         shouldPreventUnmountOnClose(),
-      );
+      ) as ReturnType<typeof createPopupOpenState> & {
+        openChangeReason: PopoverRoot.ChangeEventReason;
+      };
 
-      this.update({
-        ...popupOpenState,
-        openChangeReason: eventDetails.reason,
-      });
+      popupOpenState.openChangeReason = eventDetails.reason;
+      this.update(popupOpenState);
     };
 
     if (isHover) {

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -72,33 +72,28 @@ export class PreviewCardStore<Payload> extends ReactStore<
   ) => {
     const { inlineRectCoordsRef } = this.context;
 
-    applyPopupOpenChange<State<Payload>, PreviewCardRoot.ChangeEventDetails>(
-      this,
-      nextOpen,
-      eventDetails as PreviewCardRoot.ChangeEventDetails,
-      {
-        onBeforeDispatch() {
-          // Capture the hovered inline-rect coordinates so the card anchors to the
-          // exact point on the link that was hovered.
-          const event = eventDetails.event;
-          if (
-            nextOpen &&
-            eventDetails.reason === REASONS.triggerHover &&
-            eventDetails.trigger &&
-            'clientX' in event &&
-            'clientY' in event &&
-            inlineRectCoordsRef.current?.element !== eventDetails.trigger
-          ) {
-            updateInlineRectCoords(
-              inlineRectCoordsRef,
-              eventDetails.trigger,
-              event.clientX,
-              event.clientY,
-            );
-          }
-        },
+    applyPopupOpenChange(this, nextOpen, eventDetails as PreviewCardRoot.ChangeEventDetails, {
+      onBeforeDispatch() {
+        // Capture the hovered inline-rect coordinates so the card anchors to the
+        // exact point on the link that was hovered.
+        const event = eventDetails.event;
+        if (
+          nextOpen &&
+          eventDetails.reason === REASONS.triggerHover &&
+          eventDetails.trigger &&
+          'clientX' in event &&
+          'clientY' in event &&
+          inlineRectCoordsRef.current?.element !== eventDetails.trigger
+        ) {
+          updateInlineRectCoords(
+            inlineRectCoordsRef,
+            eventDetails.trigger,
+            event.clientX,
+            event.clientY,
+          );
+        }
       },
-    );
+    });
   };
 }
 

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -123,20 +123,15 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       return;
     }
 
-    const updates: Pick<State, 'timeout' | 'limit'> &
-      Partial<Pick<State, 'toasts' | 'toastMetadata'>> = {
-      timeout,
-      limit,
-    };
+    const updates = {};
 
     if (limitChanged) {
       const newToasts = applyLimited(this.state.toasts, limit);
-      updates.toasts = newToasts;
-      updates.toastMetadata = createToastMetadata(newToasts);
+      (updates as Pick<State, 'toasts'>).toasts = newToasts;
+      (updates as Pick<State, 'toastMetadata'>).toastMetadata = createToastMetadata(newToasts);
     }
 
-    // Every populated key is assigned its corresponding state value above.
-    this.update(updates as Pick<State, 'timeout' | 'limit' | 'toasts' | 'toastMetadata'>);
+    this.update({ timeout, limit, ...updates });
   }
 
   disposeEffect = () => {
@@ -448,19 +443,18 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
   }
 
   private setToasts(newToasts: StoredToast[], clearInteraction: boolean = newToasts.length === 0) {
-    const toastUpdates: Pick<State, 'toasts' | 'toastMetadata'> &
-      Partial<Pick<State, 'hovering' | 'focused'>> = {
-      toasts: newToasts,
-      toastMetadata: createToastMetadata(newToasts),
-    };
+    const toastUpdates = {};
 
     if (clearInteraction) {
-      toastUpdates.hovering = false;
-      toastUpdates.focused = false;
+      (toastUpdates as Pick<State, 'hovering'>).hovering = false;
+      (toastUpdates as Pick<State, 'focused'>).focused = false;
     }
 
-    // Every populated key is assigned its corresponding state value above.
-    this.update(toastUpdates as Pick<State, 'toasts' | 'toastMetadata' | 'hovering' | 'focused'>);
+    this.update({
+      toasts: newToasts,
+      toastMetadata: createToastMetadata(newToasts),
+      ...toastUpdates,
+    });
   }
 
   private handleFocusManagement(toastId: string | undefined) {

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -123,16 +123,18 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       return;
     }
 
-    const newToasts = limitChanged ? applyLimited(this.state.toasts, limit) : undefined;
+    const updates = { timeout, limit } as Pick<
+      State,
+      'timeout' | 'limit' | 'toasts' | 'toastMetadata'
+    >;
 
-    this.update({
-      timeout,
-      limit,
-      ...(newToasts !== undefined && {
-        toasts: newToasts,
-        toastMetadata: createToastMetadata(newToasts),
-      }),
-    } as Pick<State, 'timeout' | 'limit' | 'toasts' | 'toastMetadata'>);
+    if (limitChanged) {
+      const newToasts = applyLimited(this.state.toasts, limit);
+      updates.toasts = newToasts;
+      updates.toastMetadata = createToastMetadata(newToasts);
+    }
+
+    this.update(updates);
   }
 
   disposeEffect = () => {
@@ -444,11 +446,17 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
   }
 
   private setToasts(newToasts: StoredToast[], clearInteraction: boolean = newToasts.length === 0) {
-    this.update({
+    const updates = {
       toasts: newToasts,
       toastMetadata: createToastMetadata(newToasts),
-      ...(clearInteraction && { hovering: false, focused: false }),
-    } as Pick<State, 'toasts' | 'toastMetadata' | 'hovering' | 'focused'>);
+    } as Pick<State, 'toasts' | 'toastMetadata' | 'hovering' | 'focused'>;
+
+    if (clearInteraction) {
+      updates.hovering = false;
+      updates.focused = false;
+    }
+
+    this.update(updates);
   }
 
   private handleFocusManagement(toastId: string | undefined) {

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -123,18 +123,14 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       return;
     }
 
-    const updates: Partial<State> = {
-      timeout,
-      limit,
-    };
-
     if (limitChanged) {
-      const newToasts = applyLimited(this.state.toasts, limit);
-      updates.toasts = newToasts;
-      updates.toastMetadata = createToastMetadata(newToasts);
+      const toasts = applyLimited(this.state.toasts, limit);
+      const toastMetadata = createToastMetadata(toasts);
+      this.update({ timeout, limit, toasts, toastMetadata });
+      return;
     }
 
-    this.update(updates);
+    this.update({ timeout, limit });
   }
 
   disposeEffect = () => {
@@ -446,15 +442,17 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
   }
 
   private setToasts(newToasts: StoredToast[], clearInteraction: boolean = newToasts.length === 0) {
-    const updates: Partial<State> = {
+    const toastUpdates = {
       toasts: newToasts,
       toastMetadata: createToastMetadata(newToasts),
     };
+
     if (clearInteraction) {
-      updates.hovering = false;
-      updates.focused = false;
+      this.update({ ...toastUpdates, hovering: false, focused: false });
+      return;
     }
-    this.update(updates);
+
+    this.update(toastUpdates);
   }
 
   private handleFocusManagement(toastId: string | undefined) {

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -123,14 +123,20 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       return;
     }
 
+    const updates: Pick<State, 'timeout' | 'limit'> &
+      Partial<Pick<State, 'toasts' | 'toastMetadata'>> = {
+      timeout,
+      limit,
+    };
+
     if (limitChanged) {
-      const toasts = applyLimited(this.state.toasts, limit);
-      const toastMetadata = createToastMetadata(toasts);
-      this.update({ timeout, limit, toasts, toastMetadata });
-      return;
+      const newToasts = applyLimited(this.state.toasts, limit);
+      updates.toasts = newToasts;
+      updates.toastMetadata = createToastMetadata(newToasts);
     }
 
-    this.update({ timeout, limit });
+    // Every populated key is assigned its corresponding state value above.
+    this.update(updates as Pick<State, 'timeout' | 'limit' | 'toasts' | 'toastMetadata'>);
   }
 
   disposeEffect = () => {
@@ -442,17 +448,19 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
   }
 
   private setToasts(newToasts: StoredToast[], clearInteraction: boolean = newToasts.length === 0) {
-    const toastUpdates = {
+    const toastUpdates: Pick<State, 'toasts' | 'toastMetadata'> &
+      Partial<Pick<State, 'hovering' | 'focused'>> = {
       toasts: newToasts,
       toastMetadata: createToastMetadata(newToasts),
     };
 
     if (clearInteraction) {
-      this.update({ ...toastUpdates, hovering: false, focused: false });
-      return;
+      toastUpdates.hovering = false;
+      toastUpdates.focused = false;
     }
 
-    this.update(toastUpdates);
+    // Every populated key is assigned its corresponding state value above.
+    this.update(toastUpdates as Pick<State, 'toasts' | 'toastMetadata' | 'hovering' | 'focused'>);
   }
 
   private handleFocusManagement(toastId: string | undefined) {

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -123,15 +123,16 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       return;
     }
 
-    const updates = {};
+    const newToasts = limitChanged ? applyLimited(this.state.toasts, limit) : undefined;
 
-    if (limitChanged) {
-      const newToasts = applyLimited(this.state.toasts, limit);
-      (updates as Pick<State, 'toasts'>).toasts = newToasts;
-      (updates as Pick<State, 'toastMetadata'>).toastMetadata = createToastMetadata(newToasts);
-    }
-
-    this.update({ timeout, limit, ...updates });
+    this.update({
+      timeout,
+      limit,
+      ...(newToasts !== undefined && {
+        toasts: newToasts,
+        toastMetadata: createToastMetadata(newToasts),
+      }),
+    } as Pick<State, 'timeout' | 'limit' | 'toasts' | 'toastMetadata'>);
   }
 
   disposeEffect = () => {
@@ -443,18 +444,11 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
   }
 
   private setToasts(newToasts: StoredToast[], clearInteraction: boolean = newToasts.length === 0) {
-    const toastUpdates = {};
-
-    if (clearInteraction) {
-      (toastUpdates as Pick<State, 'hovering'>).hovering = false;
-      (toastUpdates as Pick<State, 'focused'>).focused = false;
-    }
-
     this.update({
       toasts: newToasts,
       toastMetadata: createToastMetadata(newToasts),
-      ...toastUpdates,
-    });
+      ...(clearInteraction && { hovering: false, focused: false }),
+    } as Pick<State, 'toasts' | 'toastMetadata' | 'hovering' | 'focused'>);
   }
 
   private handleFocusManagement(toastId: string | undefined) {

--- a/packages/react/src/tooltip/root/TooltipRoot.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.tsx
@@ -18,7 +18,7 @@ import {
   type PayloadChildRenderFunction,
 } from '../../utils/popups';
 import { mergeProps } from '../../merge-props';
-import { TooltipStore } from '../store/TooltipStore';
+import { TooltipStore, type State as TooltipStoreState } from '../store/TooltipStore';
 import { type TooltipHandle } from '../store/TooltipHandle';
 import { REASONS } from '../../internals/reasons';
 
@@ -90,7 +90,9 @@ export const TooltipRoot = fastComponent(function TooltipRoot<Payload>(
   // 2) Closing because another tooltip opened (reason === 'none')
   // Otherwise, allow the animation to play. In particular, do not disable animations
   // during the 'ending' phase unless it's due to a sibling opening.
-  const previousInstantTypeRef = React.useRef<string | undefined | null>(null);
+  const previousInstantTypeRef = React.useRef<TooltipStoreState<Payload>['instantType'] | null>(
+    null,
+  );
 
   useIsoLayoutEffect(() => {
     if (openState && disabled) {

--- a/packages/react/src/tooltip/store/TooltipStore.ts
+++ b/packages/react/src/tooltip/store/TooltipStore.ts
@@ -83,12 +83,9 @@ export class TooltipStore<Payload> extends ReactStore<
     nextOpen: boolean,
     eventDetails: Omit<TooltipRoot.ChangeEventDetails, 'preventUnmountOnClose'>,
   ) => {
-    applyPopupOpenChange<State<Payload>, TooltipRoot.ChangeEventDetails>(
-      this,
-      nextOpen,
-      eventDetails as TooltipRoot.ChangeEventDetails,
-      { extraState: { openChangeReason: eventDetails.reason } },
-    );
+    applyPopupOpenChange(this, nextOpen, eventDetails as TooltipRoot.ChangeEventDetails, {
+      extraState: { openChangeReason: eventDetails.reason },
+    });
   };
 
   // Used by trigger clicks to clear a delayed hover open without reporting a public open-state change.

--- a/packages/react/src/utils/NullStore.ts
+++ b/packages/react/src/utils/NullStore.ts
@@ -18,9 +18,9 @@ export class NullStore<
   // inert even if a future base-class change stops routing a mutator through `setState`.
   setState(_newState: State) {}
 
-  update(_changes: Partial<State>) {}
+  update<const Key extends keyof State>(_changes: Pick<State, Key>) {}
 
-  set<T>(_key: keyof State, _value: T) {}
+  set<Key extends keyof State>(_key: Key, _value: State[Key]) {}
 
   notifyAll() {}
 }

--- a/packages/react/src/utils/popups/popupStoreUtils.spec.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.spec.ts
@@ -1,6 +1,7 @@
 import type { ReactStore } from '@base-ui/utils/store';
 import type { HTMLProps } from '../../internals/types';
-import { usePopupInteractionProps } from './popupStoreUtils';
+import type { BaseUIChangeEventDetails } from '../../types';
+import { applyPopupOpenChange, usePopupInteractionProps } from './popupStoreUtils';
 import type { PopupStoreContext, PopupStoreState, popupStoreSelectors } from './store';
 
 type TestState = PopupStoreState<unknown> & {
@@ -9,7 +10,20 @@ type TestState = PopupStoreState<unknown> & {
 
 type TestStore = ReactStore<TestState, PopupStoreContext<never>, typeof popupStoreSelectors>;
 
-function useTypeTests(store: TestStore, props: HTMLProps) {
+type OpenChangeDetails = BaseUIChangeEventDetails<string> & { preventUnmountOnClose(): void };
+
+type OpenChangeStore = {
+  readonly context: Pick<PopupStoreContext<OpenChangeDetails>, 'onOpenChange'>;
+  readonly state: TestState;
+  update<const Key extends keyof TestState>(state: Pick<TestState, Key>): void;
+};
+
+function useTypeTests(
+  store: TestStore,
+  openChangeStore: OpenChangeStore,
+  details: OpenChangeDetails,
+  props: HTMLProps,
+) {
   usePopupInteractionProps(store, {
     activeTriggerProps: props,
     inactiveTriggerProps: props,
@@ -23,6 +37,36 @@ function useTypeTests(store: TestStore, props: HTMLProps) {
     popupProps: props,
     // @ts-expect-error The store requires a defined item prop bag.
     itemProps: undefined,
+  });
+
+  // @ts-expect-error All three common popup prop bags are required.
+  usePopupInteractionProps(store, {
+    activeTriggerProps: props,
+    inactiveTriggerProps: props,
+    itemProps: props,
+  });
+
+  usePopupInteractionProps(store, {
+    activeTriggerProps: props,
+    inactiveTriggerProps: props,
+    popupProps: props,
+    // @ts-expect-error Additional store fields must use their declared value type.
+    itemProps: 'invalid',
+  });
+
+  applyPopupOpenChange(openChangeStore, true, details, {
+    // @ts-expect-error Extra state cannot contain unknown keys.
+    extraState: { unknownKey: 1 },
+  });
+
+  applyPopupOpenChange(openChangeStore, true, details, {
+    // @ts-expect-error A required extra-state field cannot explicitly be undefined.
+    extraState: { itemProps: undefined },
+  });
+
+  applyPopupOpenChange(openChangeStore, true, details, {
+    // @ts-expect-error Extra-state values must match their corresponding state fields.
+    extraState: { itemProps: 'invalid' },
   });
 }
 

--- a/packages/react/src/utils/popups/popupStoreUtils.spec.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.spec.ts
@@ -1,0 +1,29 @@
+import type { ReactStore } from '@base-ui/utils/store';
+import type { HTMLProps } from '../../internals/types';
+import { usePopupInteractionProps } from './popupStoreUtils';
+import type { PopupStoreContext, PopupStoreState, popupStoreSelectors } from './store';
+
+type TestState = PopupStoreState<unknown> & {
+  itemProps: HTMLProps;
+};
+
+type TestStore = ReactStore<TestState, PopupStoreContext<never>, typeof popupStoreSelectors>;
+
+function useTypeTests(store: TestStore, props: HTMLProps) {
+  usePopupInteractionProps(store, {
+    activeTriggerProps: props,
+    inactiveTriggerProps: props,
+    popupProps: props,
+    itemProps: props,
+  });
+
+  usePopupInteractionProps(store, {
+    activeTriggerProps: props,
+    inactiveTriggerProps: props,
+    popupProps: props,
+    // @ts-expect-error The store requires a defined item prop bag.
+    itemProps: undefined,
+  });
+}
+
+void useTypeTests;

--- a/packages/react/src/utils/popups/popupStoreUtils.test.tsx
+++ b/packages/react/src/utils/popups/popupStoreUtils.test.tsx
@@ -580,8 +580,8 @@ describe('useTriggerRegistration', () => {
 
     expect(store.state.activeTriggerId).toBe('registered-1');
 
-    // A handoff to the second trigger updates the active id from its DOM id (as `setPopupOpenState`
-    // does), without changing `open` or `triggerCount`.
+    // A handoff to the second trigger updates the active id from its DOM id (as
+    // `getPopupOpenState` does), without changing `open` or `triggerCount`.
     act(() => {
       store.update({ activeTriggerId: 'dom-id-2', activeTriggerElement: second });
     });
@@ -733,10 +733,14 @@ describe('applyPopupOpenChange', () => {
 
   function createOpenChangeStore() {
     const order: string[] = [];
-    const { floatingRootContext } = createInitialPopupStoreState(new PopupTriggerMap());
+    const state: OpenChangeState = {
+      ...createInitialPopupStoreState(new PopupTriggerMap()),
+      instantType: undefined,
+      openChangeReason: undefined,
+    };
 
     const dispatchOpenChange = vi
-      .spyOn(floatingRootContext, 'dispatchOpenChange')
+      .spyOn(state.floatingRootContext, 'dispatchOpenChange')
       .mockImplementation(() => {
         order.push('dispatchOpenChange');
       });
@@ -749,8 +753,10 @@ describe('applyPopupOpenChange', () => {
 
     const store = {
       context: { onOpenChange },
-      state: { floatingRootContext },
-      update,
+      state,
+      update<Key extends keyof OpenChangeState>(changes: Pick<OpenChangeState, Key>) {
+        update(changes);
+      },
     };
 
     return { store, order, onOpenChange, dispatchOpenChange, update };
@@ -767,7 +773,7 @@ describe('applyPopupOpenChange', () => {
       order.push('onBeforeDispatch');
     });
 
-    applyPopupOpenChange<OpenChangeState, BaseUIChangeEventDetails<string>>(store, true, details, {
+    applyPopupOpenChange(store, true, details, {
       onBeforeDispatch,
     });
 
@@ -784,12 +790,7 @@ describe('applyPopupOpenChange', () => {
     });
     const onBeforeDispatch = vi.fn();
 
-    applyPopupOpenChange<OpenChangeState, BaseUIChangeEventDetails<string>>(
-      store,
-      true,
-      createDetails(REASONS.triggerPress),
-      { onBeforeDispatch },
-    );
+    applyPopupOpenChange(store, true, createDetails(REASONS.triggerPress), { onBeforeDispatch });
 
     expect(onOpenChange).toHaveBeenCalledTimes(1);
     expect(onBeforeDispatch).not.toHaveBeenCalled();
@@ -800,15 +801,10 @@ describe('applyPopupOpenChange', () => {
   it('merges extraState into the update with `open` always reflecting nextOpen', () => {
     const { store, update } = createOpenChangeStore();
 
-    applyPopupOpenChange<OpenChangeState, BaseUIChangeEventDetails<string>>(
-      store,
-      true,
-      createDetails(REASONS.triggerFocus),
-      {
-        // `open: false` here must be overridden by `nextOpen` (true).
-        extraState: { open: false, openChangeReason: REASONS.triggerFocus },
-      },
-    );
+    applyPopupOpenChange(store, true, createDetails(REASONS.triggerFocus), {
+      // `open: false` here must be overridden by `nextOpen` (true).
+      extraState: { open: false, openChangeReason: REASONS.triggerFocus },
+    });
 
     const updatedState = update.mock.calls[0][0];
     expect(updatedState.open).toBe(true);
@@ -817,45 +813,25 @@ describe('applyPopupOpenChange', () => {
 
   it('maps the change reason to instantType', () => {
     const focusStore = createOpenChangeStore();
-    applyPopupOpenChange<OpenChangeState, BaseUIChangeEventDetails<string>>(
-      focusStore.store,
-      true,
-      createDetails(REASONS.triggerFocus),
-    );
+    applyPopupOpenChange(focusStore.store, true, createDetails(REASONS.triggerFocus));
     expect(focusStore.update.mock.calls[0][0].instantType).toBe('focus');
 
     const pressStore = createOpenChangeStore();
-    applyPopupOpenChange<OpenChangeState, BaseUIChangeEventDetails<string>>(
-      pressStore.store,
-      false,
-      createDetails(REASONS.triggerPress),
-    );
+    applyPopupOpenChange(pressStore.store, false, createDetails(REASONS.triggerPress));
     expect(pressStore.update.mock.calls[0][0].instantType).toBe('dismiss');
 
     const escapeStore = createOpenChangeStore();
-    applyPopupOpenChange<OpenChangeState, BaseUIChangeEventDetails<string>>(
-      escapeStore.store,
-      false,
-      createDetails(REASONS.escapeKey),
-    );
+    applyPopupOpenChange(escapeStore.store, false, createDetails(REASONS.escapeKey));
     expect(escapeStore.update.mock.calls[0][0].instantType).toBe('dismiss');
 
     const hoverStore = createOpenChangeStore();
-    applyPopupOpenChange<OpenChangeState, BaseUIChangeEventDetails<string>>(
-      hoverStore.store,
-      true,
-      createDetails(REASONS.triggerHover),
-    );
+    applyPopupOpenChange(hoverStore.store, true, createDetails(REASONS.triggerHover));
     const hoverState = hoverStore.update.mock.calls[0][0];
     expect('instantType' in hoverState).toBe(true);
     expect(hoverState.instantType).toBeUndefined();
 
     const noneStore = createOpenChangeStore();
-    applyPopupOpenChange<OpenChangeState, BaseUIChangeEventDetails<string>>(
-      noneStore.store,
-      true,
-      createDetails(REASONS.none),
-    );
+    applyPopupOpenChange(noneStore.store, true, createDetails(REASONS.none));
     expect('instantType' in noneStore.update.mock.calls[0][0]).toBe(false);
   });
 });

--- a/packages/react/src/utils/popups/popupStoreUtils.test.tsx
+++ b/packages/react/src/utils/popups/popupStoreUtils.test.tsx
@@ -754,9 +754,7 @@ describe('applyPopupOpenChange', () => {
     const store = {
       context: { onOpenChange },
       state,
-      update<Key extends keyof OpenChangeState>(changes: Pick<OpenChangeState, Key>) {
-        update(changes);
-      },
+      update,
     };
 
     return { store, order, onOpenChange, dispatchOpenChange, update };

--- a/packages/react/src/utils/popups/popupStoreUtils.test.tsx
+++ b/packages/react/src/utils/popups/popupStoreUtils.test.tsx
@@ -7,7 +7,7 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import {
   applyPopupOpenChange,
   createInitialPopupStoreState,
-  getPopupOpenState,
+  createPopupOpenState,
   PopupStoreContext,
   PopupStoreState,
   PopupStoreSelectors,
@@ -727,30 +727,30 @@ describe('usePopupInteractionProps', () => {
 
 describe('getPopupOpenState', () => {
   it('clears a previous unmount-prevention request when opening', () => {
-    const state = createInitialPopupStoreState();
+    const state = createInitialPopupStoreState(new PopupTriggerMap());
     state.preventUnmountingOnClose = true;
 
-    const nextState = getPopupOpenState(state, true, undefined);
+    const nextState = createPopupOpenState(state, true, undefined);
 
     expect(nextState.preventUnmountingOnClose).toBe(false);
     expect(state.preventUnmountingOnClose).toBe(true);
   });
 
   it('sets the unmount-prevention request when closing', () => {
-    const state = createInitialPopupStoreState();
+    const state = createInitialPopupStoreState(new PopupTriggerMap());
 
-    const nextState = getPopupOpenState(state, false, undefined, true);
+    const nextState = createPopupOpenState(state, false, undefined, true);
 
     expect(nextState.preventUnmountingOnClose).toBe(true);
   });
 
   it('preserves the active trigger when closing without a trigger', () => {
-    const state = createInitialPopupStoreState();
+    const state = createInitialPopupStoreState(new PopupTriggerMap());
     const trigger = document.createElement('button');
     state.activeTriggerId = 'trigger-id';
     state.activeTriggerElement = trigger;
 
-    const nextState = getPopupOpenState(state, false, undefined);
+    const nextState = createPopupOpenState(state, false, undefined);
 
     expect(nextState.activeTriggerId).toBe('trigger-id');
     expect(nextState.activeTriggerElement).toBe(trigger);

--- a/packages/react/src/utils/popups/popupStoreUtils.test.tsx
+++ b/packages/react/src/utils/popups/popupStoreUtils.test.tsx
@@ -7,6 +7,7 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import {
   applyPopupOpenChange,
   createInitialPopupStoreState,
+  getPopupOpenState,
   PopupStoreContext,
   PopupStoreState,
   PopupStoreSelectors,
@@ -724,6 +725,38 @@ describe('usePopupInteractionProps', () => {
   });
 });
 
+describe('getPopupOpenState', () => {
+  it('clears a previous unmount-prevention request when opening', () => {
+    const state = createInitialPopupStoreState();
+    state.preventUnmountingOnClose = true;
+
+    const nextState = getPopupOpenState(state, true, undefined);
+
+    expect(nextState.preventUnmountingOnClose).toBe(false);
+    expect(state.preventUnmountingOnClose).toBe(true);
+  });
+
+  it('sets the unmount-prevention request when closing', () => {
+    const state = createInitialPopupStoreState();
+
+    const nextState = getPopupOpenState(state, false, undefined, true);
+
+    expect(nextState.preventUnmountingOnClose).toBe(true);
+  });
+
+  it('preserves the active trigger when closing without a trigger', () => {
+    const state = createInitialPopupStoreState();
+    const trigger = document.createElement('button');
+    state.activeTriggerId = 'trigger-id';
+    state.activeTriggerElement = trigger;
+
+    const nextState = getPopupOpenState(state, false, undefined);
+
+    expect(nextState.activeTriggerId).toBe('trigger-id');
+    expect(nextState.activeTriggerElement).toBe(trigger);
+  });
+});
+
 describe('applyPopupOpenChange', () => {
   type OpenChangeState = PopupStoreState<unknown> & {
     instantType?: 'delay' | 'dismiss' | 'focus' | undefined;
@@ -747,9 +780,11 @@ describe('applyPopupOpenChange', () => {
     const onOpenChange = vi.fn((_open: boolean, _details: BaseUIChangeEventDetails<string>) => {
       order.push('onOpenChange');
     });
-    const update = vi.fn((_state: Partial<OpenChangeState>) => {
-      order.push('update');
-    });
+    const update = vi.fn(
+      <const Key extends keyof OpenChangeState>(_state: Pick<OpenChangeState, Key>) => {
+        order.push('update');
+      },
+    );
 
     const store = {
       context: { onOpenChange },

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -177,7 +177,7 @@ type PopupOpenState = Pick<
   'open' | 'preventUnmountingOnClose' | 'activeTriggerId' | 'activeTriggerElement'
 >;
 
-export function getPopupOpenState(
+export function createPopupOpenState(
   state: PopupOpenState,
   open: boolean,
   trigger: Element | undefined,
@@ -266,24 +266,27 @@ export function applyPopupOpenChange<
   store.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);
 
   const changeState = () => {
-    const popupOpenState = getPopupOpenState(
+    const popupOpenState = createPopupOpenState(
       store.state,
       nextOpen,
       eventDetails.trigger,
       shouldPreventUnmountOnClose(),
     );
 
-    const baseState = { ...options.extraState, ...popupOpenState };
+    const updatedState = { ...options.extraState, ...popupOpenState } as Pick<
+      State,
+      keyof PopupOpenState | ExtraKey | 'instantType'
+    >;
 
     if (isFocusOpen) {
-      store.update({ ...baseState, instantType: 'focus' });
+      updatedState.instantType = 'focus';
     } else if (isDismissClose) {
-      store.update({ ...baseState, instantType: 'dismiss' });
+      updatedState.instantType = 'dismiss';
     } else if (isHover) {
-      store.update({ ...baseState, instantType: undefined });
-    } else {
-      store.update(baseState);
+      updatedState.instantType = undefined;
     }
+
+    store.update(updatedState);
   };
 
   if (isHover) {
@@ -430,9 +433,14 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
     }
 
     const triggerCount = store.context.triggerElements.size;
-    const shouldUpdateTriggerCount = store.state.triggerCount !== triggerCount;
-    let nextActiveTriggerId: string | null | undefined;
-    let nextActiveTriggerElement: Element | null | undefined;
+    const stateUpdates = {} as Pick<
+      State,
+      'triggerCount' | 'activeTriggerId' | 'activeTriggerElement'
+    >;
+
+    if (store.state.triggerCount !== triggerCount) {
+      stateUpdates.triggerCount = triggerCount;
+    }
 
     const currentActiveTriggerId = store.select('activeTriggerId');
     let lostActiveTriggerId: string | null = null;
@@ -442,14 +450,14 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       if (!activeTriggerElement) {
         for (const [triggerId, triggerElement] of store.context.triggerElements.entries()) {
           if (triggerElement === store.state.activeTriggerElement) {
-            nextActiveTriggerId = triggerId;
-            nextActiveTriggerElement = triggerElement;
+            stateUpdates.activeTriggerId = triggerId;
+            stateUpdates.activeTriggerElement = triggerElement;
             resolvedActiveTriggerIdRef.current = triggerId;
             break;
           }
         }
 
-        if (nextActiveTriggerId === undefined) {
+        if (stateUpdates.activeTriggerId === undefined) {
           if (resolvedActiveTriggerIdRef.current === currentActiveTriggerId) {
             lostActiveTriggerId = currentActiveTriggerId;
           } else {
@@ -459,7 +467,7 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       } else {
         resolvedActiveTriggerIdRef.current = currentActiveTriggerId;
         if (activeTriggerElement !== store.state.activeTriggerElement) {
-          nextActiveTriggerElement = activeTriggerElement;
+          stateUpdates.activeTriggerElement = activeTriggerElement;
         }
       }
     } else {
@@ -470,24 +478,18 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       const iteratorResult = store.context.triggerElements.entries().next();
       if (!iteratorResult.done) {
         const [implicitTriggerId, implicitTriggerElement] = iteratorResult.value;
-        nextActiveTriggerId = implicitTriggerId;
-        nextActiveTriggerElement = implicitTriggerElement;
+        stateUpdates.activeTriggerId = implicitTriggerId;
+        stateUpdates.activeTriggerElement = implicitTriggerElement;
         resolvedActiveTriggerIdRef.current = implicitTriggerId;
       }
     }
 
     if (
-      shouldUpdateTriggerCount ||
-      nextActiveTriggerId !== undefined ||
-      nextActiveTriggerElement !== undefined
+      stateUpdates.triggerCount !== undefined ||
+      stateUpdates.activeTriggerId !== undefined ||
+      stateUpdates.activeTriggerElement !== undefined
     ) {
-      store.update({
-        ...(shouldUpdateTriggerCount && { triggerCount }),
-        ...(nextActiveTriggerId !== undefined && { activeTriggerId: nextActiveTriggerId }),
-        ...(nextActiveTriggerElement !== undefined && {
-          activeTriggerElement: nextActiveTriggerElement,
-        }),
-      } as Pick<Readonly<State>, 'triggerCount' | 'activeTriggerId' | 'activeTriggerElement'>);
+      store.update(stateUpdates);
     }
 
     if (lostActiveTriggerId) {

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -480,17 +480,8 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       stateUpdates.activeTriggerId !== undefined ||
       stateUpdates.activeTriggerElement !== undefined
     ) {
-      store.update({
-        triggerCount: stateUpdates.triggerCount ?? store.state.triggerCount,
-        activeTriggerId:
-          stateUpdates.activeTriggerId === undefined
-            ? store.state.activeTriggerId
-            : stateUpdates.activeTriggerId,
-        activeTriggerElement:
-          stateUpdates.activeTriggerElement === undefined
-            ? store.state.activeTriggerElement
-            : stateUpdates.activeTriggerElement,
-      });
+      // Every populated key is assigned its corresponding state value above.
+      store.update(stateUpdates as Pick<State, keyof PopupStoreState<unknown>>);
     }
 
     if (lostActiveTriggerId) {

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -169,27 +169,42 @@ export function useTriggerRegistration<State extends PopupStoreState<unknown>>(
   );
 }
 
-export function setPopupOpenState(
-  state: Partial<PopupStoreState<unknown>>,
+type PopupOpenState = Pick<
+  PopupStoreState<unknown>,
+  'open' | 'preventUnmountingOnClose' | 'activeTriggerId' | 'activeTriggerElement'
+>;
+
+export function getPopupOpenState(
+  state: PopupOpenState,
   open: boolean,
   trigger: Element | undefined,
   preventUnmountOnClose = false,
-) {
+): PopupOpenState {
+  let preventUnmountingOnClose = state.preventUnmountingOnClose;
   if (open) {
     // Opening starts a new close cycle, so clear any previous request to keep the popup mounted.
-    state.preventUnmountingOnClose = false;
+    preventUnmountingOnClose = false;
   } else if (preventUnmountOnClose) {
-    state.preventUnmountingOnClose = true;
+    preventUnmountingOnClose = true;
   }
 
   const triggerId = trigger?.id ?? null;
+  let activeTriggerId = state.activeTriggerId;
+  let activeTriggerElement = state.activeTriggerElement;
 
   // If a popup is closing, the `trigger` may be undefined.
   // We want to keep the previous value so that exit animations are played and focus is returned correctly.
   if (triggerId || open) {
-    state.activeTriggerId = triggerId;
-    state.activeTriggerElement = trigger ?? null;
+    activeTriggerId = triggerId;
+    activeTriggerElement = trigger ?? null;
   }
+
+  return {
+    open,
+    preventUnmountingOnClose,
+    activeTriggerId,
+    activeTriggerElement,
+  };
 }
 
 export function attachPreventUnmountOnClose(eventDetails: { preventUnmountOnClose(): void }) {
@@ -215,17 +230,18 @@ export function applyPopupOpenChange<
     instantType?: 'delay' | 'dismiss' | 'focus' | undefined;
   },
   EventDetails extends BaseUIChangeEventDetails<string>,
+  ExtraKey extends keyof State = never,
 >(
   store: {
     readonly context: Pick<PopupStoreContext<EventDetails>, 'onOpenChange'>;
-    readonly state: Pick<PopupStoreState<unknown>, 'floatingRootContext'>;
-    update(state: Partial<State>): void;
+    readonly state: State;
+    update<const Key extends keyof State>(state: Pick<State, Key>): void;
   },
   nextOpen: boolean,
   eventDetails: EventDetails & { preventUnmountOnClose(): void },
   options: {
     onBeforeDispatch?: (() => void) | undefined;
-    extraState?: Partial<State> | undefined;
+    extraState?: Pick<State, ExtraKey> | undefined;
   } = {},
 ): void {
   const reason = eventDetails.reason;
@@ -247,22 +263,22 @@ export function applyPopupOpenChange<
   store.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);
 
   const changeState = () => {
-    // Spread `extraState` first so `open` always reflects `nextOpen`, keeping it in
-    // sync with the value already passed to `dispatchOpenChange`/`setPopupOpenState`.
-    const updatedState: Partial<PopupStoreState<unknown>> & {
-      instantType?: 'delay' | 'dismiss' | 'focus' | undefined;
-    } = { ...options.extraState, open: nextOpen };
+    const popupOpenState = getPopupOpenState(
+      store.state,
+      nextOpen,
+      eventDetails.trigger,
+      shouldPreventUnmountOnClose(),
+    );
 
     if (isFocusOpen) {
-      updatedState.instantType = 'focus';
+      store.update({ ...options.extraState, ...popupOpenState, instantType: 'focus' });
     } else if (isDismissClose) {
-      updatedState.instantType = 'dismiss';
+      store.update({ ...options.extraState, ...popupOpenState, instantType: 'dismiss' });
     } else if (isHover) {
-      updatedState.instantType = undefined;
+      store.update({ ...options.extraState, ...popupOpenState, instantType: undefined });
+    } else {
+      store.update({ ...options.extraState, ...popupOpenState });
     }
-
-    setPopupOpenState(updatedState, nextOpen, eventDetails.trigger, shouldPreventUnmountOnClose());
-    store.update(updatedState as Partial<State>);
   };
 
   if (isHover) {
@@ -281,16 +297,21 @@ export function applyPopupOpenChange<
  * @param store The Store instance managing the popup state.
  * @param stateUpdates An object with state updates to apply when the trigger is active.
  */
-export function useTriggerDataForwarding<State extends PopupStoreState<unknown>>(
+export function useTriggerDataForwarding<
+  State extends PopupStoreState<unknown>,
+  const Key extends keyof Omit<State, 'activeTriggerId' | 'activeTriggerElement'>,
+>(
   triggerId: string | undefined,
   triggerElementRef: React.RefObject<Element | null>,
   store: PopupTriggerDataStore<State>,
-  stateUpdates: Omit<Partial<State>, 'activeTriggerId' | 'activeTriggerElement'>,
+  stateUpdates: Pick<State, Key>,
 ) {
   const isMountedByThisTrigger = store.useState('isMountedByTrigger', triggerId);
 
   const baseRegisterTrigger = useTriggerRegistration(triggerId, store);
 
+  // `stateUpdates` is key/value checked at this hook's boundary. TypeScript does not preserve that
+  // generic `Pick` relationship after object spreads, so the merged state objects are asserted below.
   // Applies trigger-owned state (active-trigger ownership and payload) when the trigger registers.
   // Stable so payload/`stateUpdates` changes do not change the ref identity (which would needlessly
   // churn registration); it reads the latest closure values when invoked.
@@ -299,10 +320,11 @@ export function useTriggerDataForwarding<State extends PopupStoreState<unknown>>
     const activeTriggerId = store.select('activeTriggerId');
 
     if (activeTriggerId === triggerId) {
-      store.update({
+      const changes = {
         activeTriggerElement: element,
         ...(open ? stateUpdates : null),
-      } as Partial<State>);
+      } as Pick<Readonly<State>, Key | 'activeTriggerElement'>;
+      store.update(changes);
       return;
     }
 
@@ -310,11 +332,12 @@ export function useTriggerDataForwarding<State extends PopupStoreState<unknown>>
       // If a popup is already open, a detached trigger can mount before any active trigger
       // has been established. Claim the first registered trigger so trigger-owned focus
       // management and ARIA relationships work.
-      store.update({
-        activeTriggerId: triggerId,
+      const changes = {
+        activeTriggerId: triggerId ?? null,
         activeTriggerElement: element,
         ...stateUpdates,
-      } as Partial<State>);
+      } as Pick<Readonly<State>, Key | 'activeTriggerId' | 'activeTriggerElement'>;
+      store.update(changes);
     }
   });
 
@@ -335,10 +358,11 @@ export function useTriggerDataForwarding<State extends PopupStoreState<unknown>>
 
   useIsoLayoutEffect(() => {
     if (isMountedByThisTrigger) {
-      store.update({
+      const changes = {
         activeTriggerElement: triggerElementRef.current,
         ...stateUpdates,
-      } as Partial<State>);
+      } as Pick<Readonly<State>, Key | 'activeTriggerElement'>;
+      store.update(changes);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMountedByThisTrigger, store, triggerElementRef, ...Object.values(stateUpdates)]);
@@ -456,7 +480,17 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       stateUpdates.activeTriggerId !== undefined ||
       stateUpdates.activeTriggerElement !== undefined
     ) {
-      store.update(stateUpdates as Partial<State>);
+      store.update({
+        triggerCount: stateUpdates.triggerCount ?? store.state.triggerCount,
+        activeTriggerId:
+          stateUpdates.activeTriggerId === undefined
+            ? store.state.activeTriggerId
+            : stateUpdates.activeTriggerId,
+        activeTriggerElement:
+          stateUpdates.activeTriggerElement === undefined
+            ? store.state.activeTriggerElement
+            : stateUpdates.activeTriggerElement,
+      });
     }
 
     if (lostActiveTriggerId) {
@@ -476,7 +510,7 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
               store.update({
                 activeTriggerId: null,
                 activeTriggerElement: null,
-              } as Partial<State>);
+              });
             }
           }
         });
@@ -518,7 +552,7 @@ export function useOpenStateTransitions<State extends PopupStoreState<unknown>>(
     mounted,
     transitionStatus,
     preventUnmountingOnClose: syncedPreventUnmountingOnClose,
-  } as Partial<State>);
+  });
 
   const forceUnmount = useStableCallback(() => {
     setMounted(false);
@@ -527,7 +561,7 @@ export function useOpenStateTransitions<State extends PopupStoreState<unknown>>(
       activeTriggerElement: null,
       mounted: false,
       preventUnmountingOnClose: false,
-    } as Partial<State>);
+    });
     onUnmount?.();
     store.context.onOpenChangeComplete?.(false);
   });
@@ -546,10 +580,14 @@ export function useOpenStateTransitions<State extends PopupStoreState<unknown>>(
   return { forceUnmount, transitionStatus };
 }
 
-export function usePopupInteractionProps<State extends PopupStoreState<unknown>>(
+type PopupInteractionPropKey = 'activeTriggerProps' | 'inactiveTriggerProps' | 'popupProps';
+
+export function usePopupInteractionProps<
+  State extends PopupStoreState<unknown>,
+  const Key extends keyof State,
+>(
   store: ReactStore<State, PopupStoreContext<never>, typeof popupStoreSelectors>,
-  statePart: Partial<State> &
-    Pick<State, 'activeTriggerProps' | 'inactiveTriggerProps' | 'popupProps'>,
+  statePart: Pick<State, Key | PopupInteractionPropKey>,
 ) {
   store.useSyncedValues(statePart);
 
@@ -559,7 +597,7 @@ export function usePopupInteractionProps<State extends PopupStoreState<unknown>>
         activeTriggerProps: EMPTY_OBJECT,
         inactiveTriggerProps: EMPTY_OBJECT,
         popupProps: EMPTY_OBJECT,
-      } as Partial<State>);
+      });
     },
     [store],
   );

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -266,7 +266,6 @@ export function applyPopupOpenChange<
   store.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);
 
   const changeState = () => {
-    const updatedState = {};
     const popupOpenState = getPopupOpenState(
       store.state,
       nextOpen,
@@ -274,15 +273,17 @@ export function applyPopupOpenChange<
       shouldPreventUnmountOnClose(),
     );
 
-    if (isFocusOpen) {
-      (updatedState as Pick<State, 'instantType'>).instantType = 'focus';
-    } else if (isDismissClose) {
-      (updatedState as Pick<State, 'instantType'>).instantType = 'dismiss';
-    } else if (isHover) {
-      (updatedState as Pick<State, 'instantType'>).instantType = undefined;
-    }
+    const baseState = { ...options.extraState, ...popupOpenState };
 
-    store.update({ ...options.extraState, ...popupOpenState, ...updatedState });
+    if (isFocusOpen) {
+      store.update({ ...baseState, instantType: 'focus' });
+    } else if (isDismissClose) {
+      store.update({ ...baseState, instantType: 'dismiss' });
+    } else if (isHover) {
+      store.update({ ...baseState, instantType: undefined });
+    } else {
+      store.update(baseState);
+    }
   };
 
   if (isHover) {
@@ -314,8 +315,6 @@ export function useTriggerDataForwarding<
 
   const baseRegisterTrigger = useTriggerRegistration(triggerId, store);
 
-  // `stateUpdates` is key/value checked at this hook's boundary. TypeScript does not preserve that
-  // generic `Pick` relationship after object spreads, so the merged state objects are asserted below.
   // Applies trigger-owned state (active-trigger ownership and payload) when the trigger registers.
   // Stable so payload/`stateUpdates` changes do not change the ref identity (which would needlessly
   // churn registration); it reads the latest closure values when invoked.
@@ -431,11 +430,9 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
     }
 
     const triggerCount = store.context.triggerElements.size;
-    const updates = {};
-
-    if (store.state.triggerCount !== triggerCount) {
-      (updates as Pick<State, 'triggerCount'>).triggerCount = triggerCount;
-    }
+    const shouldUpdateTriggerCount = store.state.triggerCount !== triggerCount;
+    let nextActiveTriggerId: string | null | undefined;
+    let nextActiveTriggerElement: Element | null | undefined;
 
     const currentActiveTriggerId = store.select('activeTriggerId');
     let lostActiveTriggerId: string | null = null;
@@ -445,14 +442,14 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       if (!activeTriggerElement) {
         for (const [triggerId, triggerElement] of store.context.triggerElements.entries()) {
           if (triggerElement === store.state.activeTriggerElement) {
-            (updates as Pick<State, 'activeTriggerId'>).activeTriggerId = triggerId;
-            (updates as Pick<State, 'activeTriggerElement'>).activeTriggerElement = triggerElement;
+            nextActiveTriggerId = triggerId;
+            nextActiveTriggerElement = triggerElement;
             resolvedActiveTriggerIdRef.current = triggerId;
             break;
           }
         }
 
-        if (!('activeTriggerId' in updates)) {
+        if (nextActiveTriggerId === undefined) {
           if (resolvedActiveTriggerIdRef.current === currentActiveTriggerId) {
             lostActiveTriggerId = currentActiveTriggerId;
           } else {
@@ -462,8 +459,7 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       } else {
         resolvedActiveTriggerIdRef.current = currentActiveTriggerId;
         if (activeTriggerElement !== store.state.activeTriggerElement) {
-          (updates as Pick<State, 'activeTriggerElement'>).activeTriggerElement =
-            activeTriggerElement;
+          nextActiveTriggerElement = activeTriggerElement;
         }
       }
     } else {
@@ -474,15 +470,24 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       const iteratorResult = store.context.triggerElements.entries().next();
       if (!iteratorResult.done) {
         const [implicitTriggerId, implicitTriggerElement] = iteratorResult.value;
-        (updates as Pick<State, 'activeTriggerId'>).activeTriggerId = implicitTriggerId;
-        (updates as Pick<State, 'activeTriggerElement'>).activeTriggerElement =
-          implicitTriggerElement;
+        nextActiveTriggerId = implicitTriggerId;
+        nextActiveTriggerElement = implicitTriggerElement;
         resolvedActiveTriggerIdRef.current = implicitTriggerId;
       }
     }
 
-    if (Object.keys(updates).length > 0) {
-      store.update(updates);
+    if (
+      shouldUpdateTriggerCount ||
+      nextActiveTriggerId !== undefined ||
+      nextActiveTriggerElement !== undefined
+    ) {
+      store.update({
+        ...(shouldUpdateTriggerCount && { triggerCount }),
+        ...(nextActiveTriggerId !== undefined && { activeTriggerId: nextActiveTriggerId }),
+        ...(nextActiveTriggerElement !== undefined && {
+          activeTriggerElement: nextActiveTriggerElement,
+        }),
+      } as Pick<Readonly<State>, 'triggerCount' | 'activeTriggerId' | 'activeTriggerElement'>);
     }
 
     if (lostActiveTriggerId) {

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -10,7 +10,10 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { FOCUSABLE_ATTRIBUTE } from '../../floating-ui-react/utils/constants';
 import { useFloatingParentNodeId } from '../../floating-ui-react/components/FloatingTree';
-import { useSyncedFloatingRootContext } from '../../floating-ui-react/hooks/useSyncedFloatingRootContext';
+import {
+  useSyncedFloatingRootContext,
+  type SyncedFloatingRootContextStore,
+} from '../../floating-ui-react/hooks/useSyncedFloatingRootContext';
 import { useTransitionStatus } from '../../internals/useTransitionStatus';
 import { useOpenChangeComplete } from '../../internals/useOpenChangeComplete';
 import type { HTMLProps } from '../../internals/types';
@@ -23,7 +26,6 @@ import {
   PopupStoreState,
   PopupStoreContext,
   popupStoreSelectors,
-  PopupStoreSelectors,
   PopupTriggerDataStore,
 } from './store';
 
@@ -45,9 +47,10 @@ export function createDefaultInitialFocus(popupRef: React.RefObject<HTMLElement 
 type PopupStoreWithOpen<
   State extends PopupStoreState<unknown>,
   SetOpenEventDetails extends BaseUIChangeEventDetails<string>,
-> = ReactStore<State, PopupStoreContext<never>, PopupStoreSelectors> & {
-  setOpen(open: boolean, eventDetails: SetOpenEventDetails): void;
-};
+> = PopupTriggerDataStore<State> &
+  Pick<SyncedFloatingRootContextStore<State>, 'useSyncedValue'> & {
+    setOpen(open: boolean, eventDetails: SetOpenEventDetails): void;
+  };
 
 /**
  * The subset of a popup handle that a Root needs to bind its store to. Both the real handle classes
@@ -263,6 +266,7 @@ export function applyPopupOpenChange<
   store.state.floatingRootContext.dispatchOpenChange(nextOpen, eventDetails);
 
   const changeState = () => {
+    const updatedState = {};
     const popupOpenState = getPopupOpenState(
       store.state,
       nextOpen,
@@ -271,14 +275,14 @@ export function applyPopupOpenChange<
     );
 
     if (isFocusOpen) {
-      store.update({ ...options.extraState, ...popupOpenState, instantType: 'focus' });
+      (updatedState as Pick<State, 'instantType'>).instantType = 'focus';
     } else if (isDismissClose) {
-      store.update({ ...options.extraState, ...popupOpenState, instantType: 'dismiss' });
+      (updatedState as Pick<State, 'instantType'>).instantType = 'dismiss';
     } else if (isHover) {
-      store.update({ ...options.extraState, ...popupOpenState, instantType: undefined });
-    } else {
-      store.update({ ...options.extraState, ...popupOpenState });
+      (updatedState as Pick<State, 'instantType'>).instantType = undefined;
     }
+
+    store.update({ ...options.extraState, ...popupOpenState, ...updatedState });
   };
 
   if (isHover) {
@@ -427,10 +431,10 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
     }
 
     const triggerCount = store.context.triggerElements.size;
-    const stateUpdates: Partial<PopupStoreState<unknown>> = {};
+    const updates = {};
 
     if (store.state.triggerCount !== triggerCount) {
-      stateUpdates.triggerCount = triggerCount;
+      (updates as Pick<State, 'triggerCount'>).triggerCount = triggerCount;
     }
 
     const currentActiveTriggerId = store.select('activeTriggerId');
@@ -441,14 +445,14 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       if (!activeTriggerElement) {
         for (const [triggerId, triggerElement] of store.context.triggerElements.entries()) {
           if (triggerElement === store.state.activeTriggerElement) {
-            stateUpdates.activeTriggerId = triggerId;
-            stateUpdates.activeTriggerElement = triggerElement;
+            (updates as Pick<State, 'activeTriggerId'>).activeTriggerId = triggerId;
+            (updates as Pick<State, 'activeTriggerElement'>).activeTriggerElement = triggerElement;
             resolvedActiveTriggerIdRef.current = triggerId;
             break;
           }
         }
 
-        if (stateUpdates.activeTriggerId === undefined) {
+        if (!('activeTriggerId' in updates)) {
           if (resolvedActiveTriggerIdRef.current === currentActiveTriggerId) {
             lostActiveTriggerId = currentActiveTriggerId;
           } else {
@@ -458,7 +462,8 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       } else {
         resolvedActiveTriggerIdRef.current = currentActiveTriggerId;
         if (activeTriggerElement !== store.state.activeTriggerElement) {
-          stateUpdates.activeTriggerElement = activeTriggerElement;
+          (updates as Pick<State, 'activeTriggerElement'>).activeTriggerElement =
+            activeTriggerElement;
         }
       }
     } else {
@@ -469,19 +474,15 @@ export function useImplicitActiveTrigger<State extends PopupStoreState<unknown>>
       const iteratorResult = store.context.triggerElements.entries().next();
       if (!iteratorResult.done) {
         const [implicitTriggerId, implicitTriggerElement] = iteratorResult.value;
-        stateUpdates.activeTriggerId = implicitTriggerId;
-        stateUpdates.activeTriggerElement = implicitTriggerElement;
+        (updates as Pick<State, 'activeTriggerId'>).activeTriggerId = implicitTriggerId;
+        (updates as Pick<State, 'activeTriggerElement'>).activeTriggerElement =
+          implicitTriggerElement;
         resolvedActiveTriggerIdRef.current = implicitTriggerId;
       }
     }
 
-    if (
-      stateUpdates.triggerCount !== undefined ||
-      stateUpdates.activeTriggerId !== undefined ||
-      stateUpdates.activeTriggerElement !== undefined
-    ) {
-      // Every populated key is assigned its corresponding state value above.
-      store.update(stateUpdates as Pick<State, keyof PopupStoreState<unknown>>);
+    if (Object.keys(updates).length > 0) {
+      store.update(updates);
     }
 
     if (lostActiveTriggerId) {

--- a/packages/utils/src/store/ReactStore.spec.ts
+++ b/packages/utils/src/store/ReactStore.spec.ts
@@ -24,6 +24,34 @@ const store = new ReactStore<TestState, Record<string, never>, typeof selectors>
   selectors,
 );
 
+store.set('text', 'next');
+store.set('count', undefined);
+store.update({ text: 'next' });
+store.update({ count: undefined });
+store.useSyncedValue('text', 'next');
+store.useSyncedValues({ text: 'next' });
+store.useControlledProp('text', 'next');
+
+const setText = store.useStateSetter('text');
+setText('next');
+
+// @ts-expect-error `text` only accepts strings.
+store.set('text', 1);
+// @ts-expect-error `text` does not accept undefined.
+store.set('text', undefined);
+// @ts-expect-error Store values must match their corresponding keys.
+store.update({ text: undefined });
+// @ts-expect-error Store updates cannot contain unknown keys.
+store.update({ unknown: true });
+// @ts-expect-error Synced values must match their corresponding keys.
+store.useSyncedValue('text', 1);
+// @ts-expect-error Synced values cannot explicitly be undefined unless the state field allows it.
+store.useSyncedValues({ text: undefined });
+// @ts-expect-error Controlled values must match their corresponding keys.
+store.useControlledProp('text', 1);
+// @ts-expect-error State setters only accept the selected field's value type.
+setText(1);
+
 const count = store.select('count');
 expectType<number | undefined, typeof count>(count);
 

--- a/packages/utils/src/store/ReactStore.test.tsx
+++ b/packages/utils/src/store/ReactStore.test.tsx
@@ -127,7 +127,7 @@ describe('ReactStore', () => {
   it('useProps applies multiple keys from a props object', () => {
     let store!: ReactStore<TestState>;
 
-    function Test({ props }: { props: Partial<TestState> }) {
+    function Test({ props }: { props: TestState }) {
       store = useStableStore<TestState>({ value: 0, label: '' });
       store.useSyncedValues(props);
       return null;
@@ -146,7 +146,7 @@ describe('ReactStore', () => {
     let store!: ReactStore<TestState>;
     let updateSpy!: MockInstance;
 
-    function Test({ props }: { props: Partial<TestState> }) {
+    function Test({ props }: { props: TestState }) {
       store = useStableStore<TestState>({ value: 0, label: '' });
 
       if (!updateSpy) {
@@ -178,6 +178,8 @@ describe('ReactStore', () => {
   it('warns if useSyncedValues keys change between renders', () => {
     function Test({ props }: { props: Partial<TestState> }) {
       const store = useStableStore<TestState>({ value: 0, label: '' });
+      // This intentionally violates the stable-key contract to verify the development warning.
+      // @ts-expect-error A broad partial can explicitly contain undefined state values.
       store.useSyncedValues(props);
       return null;
     }
@@ -262,9 +264,10 @@ describe('ReactStore', () => {
 
   it('supports nested stores as state values', async () => {
     type ParentState = { count: number };
-    type ChildState = { count: number; parent?: ReactStore<ParentState> };
-
     const parentSelectors = { count: (state: ParentState) => state.count };
+    type ParentStore = ReactStore<ParentState, Record<string, never>, typeof parentSelectors>;
+    type ChildState = { count: number; parent?: ParentStore };
+
     const childSelectors = {
       count: (state: ChildState) => state.parent?.state.count ?? state.count,
       parent: (state: ChildState) => state.parent,
@@ -286,8 +289,8 @@ describe('ReactStore', () => {
 
     let unsubscribeParentHandler: () => void;
     const onParentUpdated = (
-      newParent: ReactStore<ParentState> | undefined,
-      _: ReactStore<ParentState> | undefined,
+      newParent: ParentStore | undefined,
+      _: ParentStore | undefined,
       store: ReactStore<ChildState, any, any>,
     ) => {
       if (!newParent) {

--- a/packages/utils/src/store/ReactStore.ts
+++ b/packages/utils/src/store/ReactStore.ts
@@ -79,9 +79,13 @@ export class ReactStore<
 
   /**
    * Synchronizes multiple external values into the store.
+   * Each value must match its state key. Pass an exact known subset rather than a broad
+   * `Partial<State>`, which may contain `undefined` for required state fields.
    *
    * Note that the while the values in `state` are updated immediately, the values returned
    * by `useState` are updated before the next render (similarly to React's `useState`).
+   *
+   * @param statePart An exact subset of state fields to synchronize. Unknown keys are not accepted.
    */
   public useSyncedValues<const Key extends keyof State>(statePart: Pick<State, Key>) {
     // eslint-disable-next-line consistent-this

--- a/packages/utils/src/store/ReactStore.ts
+++ b/packages/utils/src/store/ReactStore.ts
@@ -42,10 +42,7 @@ export class ReactStore<
    * Note that the while the value in `state` is updated immediately, the value returned
    * by `useState` is updated before the next render (similarly to React's `useState`).
    */
-  useSyncedValue<Key extends keyof State, Value extends State[Key]>(
-    key: keyof State,
-    value: Value,
-  ) {
+  useSyncedValue<Key extends keyof State>(key: Key, value: State[Key]) {
     React.useDebugValue(key);
     // eslint-disable-next-line consistent-this
     const store = this;
@@ -86,7 +83,7 @@ export class ReactStore<
    * Note that the while the values in `state` are updated immediately, the values returned
    * by `useState` are updated before the next render (similarly to React's `useState`).
    */
-  public useSyncedValues(statePart: Partial<State>) {
+  public useSyncedValues<const Key extends keyof State>(statePart: Pick<State, Key>) {
     // eslint-disable-next-line consistent-this
     const store = this;
     if (process.env.NODE_ENV !== 'production') {
@@ -116,10 +113,7 @@ export class ReactStore<
    * Registers a controllable prop pair (`controlled`, `defaultValue`) for a specific key. If `controlled`
    * is non-undefined, the store's state at `key` is updated to match `controlled`.
    */
-  useControlledProp<Key extends keyof State, Value extends State[Key]>(
-    key: keyof State,
-    controlled: Value | undefined,
-  ): void {
+  useControlledProp<Key extends keyof State>(key: Key, controlled: State[Key] | undefined): void {
     React.useDebugValue(key);
     // eslint-disable-next-line consistent-this
     const store = this;
@@ -202,10 +196,10 @@ export class ReactStore<
    *
    * @param key Key of the state to set.
    */
-  useStateSetter<const Key extends keyof State, Value extends State[Key]>(key: keyof State) {
-    const ref = React.useRef<(v: Value) => void>(undefined as any);
+  useStateSetter<const Key extends keyof State>(key: Key) {
+    const ref = React.useRef<(value: State[Key]) => void>(undefined as any);
     if (ref.current === undefined) {
-      ref.current = (value: Value) => {
+      ref.current = (value: State[Key]) => {
         this.set(key, value);
       };
     }

--- a/packages/utils/src/store/Store.ts
+++ b/packages/utils/src/store/Store.ts
@@ -74,6 +74,8 @@ export class Store<State> {
 
   /**
    * Merges the provided changes into the current state and notifies listeners if there are changes.
+   * Each value must match its state key. Pass an exact known subset rather than a broad
+   * `Partial<State>`, which may contain `undefined` for required state fields.
    *
    * @param changes An object containing the changes to apply to the current state.
    */

--- a/packages/utils/src/store/Store.ts
+++ b/packages/utils/src/store/Store.ts
@@ -77,7 +77,7 @@ export class Store<State> {
    *
    * @param changes An object containing the changes to apply to the current state.
    */
-  update(changes: Partial<State>) {
+  update<const Key extends keyof State>(changes: Pick<State, Key>) {
     for (const key in changes) {
       if (!Object.is(this.state[key], changes[key])) {
         this.setState({ ...this.state, ...changes });
@@ -92,7 +92,7 @@ export class Store<State> {
    * @param key The key in the store's state to update.
    * @param value The new value to set for the specified key.
    */
-  set<T>(key: keyof State, value: T) {
+  set<Key extends keyof State>(key: Key, value: State[Key]) {
     if (!Object.is(this.state[key], value)) {
       this.setState({ ...this.state, [key]: value });
     }


### PR DESCRIPTION
> [!Tip]
> Easier to review with [hidden whitespace changes](https://github.com/mui/base-ui/pull/5423/changes?w=1)

Fixes #5422

## Summary

- Tie store mutation keys directly to their corresponding state value types.
- Propagate the same guarantee through React store synchronization and setter helpers.
- Tighten popup interaction state syncing and replace broad `Partial<State>` accumulators with exact batched updates.
- Fix invalid call sites exposed by the stricter types and add compile-time regressions.

## Root cause

`Store.set` and several `ReactStore` helpers accepted `keyof State` independently from the generic value type. TypeScript could therefore infer the value without checking it against the selected key. `Store.update` and `useSyncedValues` accepted `Partial<State>`, which allows explicitly assigning `undefined` to required fields when `exactOptionalPropertyTypes` is disabled.

Those signatures let the runtime store violate its declared state shape while selectors and component code continued to trust that shape.

Reproduction: https://stackblitz.com/edit/vitejs-vite-ghcgqkny

## Changes

- `Store.set` now accepts `State[Key]`, and `Store.update` accepts an inferred `Pick<State, Key>`.
- React store synchronization, controlled-prop, and setter helpers preserve the same key/value relationship.
- `usePopupInteractionProps` requires the common popup prop bags while validating component-specific state fields.
- Narrow floating-root synchronization to the popup-store capabilities it actually uses, preserving concrete state inference for specialized stores such as Tooltip.
- Popup, floating, and toast update paths now form exact updates while preserving batching and omitted-value behavior.
- Invalid call sites uncovered by the new types were corrected, including preventing Combobox event `type` metadata from being [merged into store state](https://github.com/mui/base-ui/pull/5423/changes#diff-30162b665077add067eff43f55765445b8292160513621f81fc186b6af941616R514-R525).
- Type-only tests cover wrong values, unknown keys, explicit `undefined`, state setters, popup interaction props, and popup open-change extra state.
- Direct tests cover the popup open-state branches that preserve active trigger data and control deferred unmounting.

## Impact

This is a breaking type change for `@base-ui/utils` consumers that pass a broad `Partial<State>` variable to `Store.update` or `ReactStore.useSyncedValues`. Existing valid object literals and exact known subsets continue to infer normally.

To migrate, represent broad partials as an exact known subset before writing them to the store. This prevents explicit `undefined` or unknown values from entering required state fields.

Store constructor initial-state parameters that still accept `Partial<State>` are deliberately out of scope for this PR and can be tightened separately.

## Validation

- `pnpm typescript`
- `pnpm eslint`
- `pnpm prettier`
- `pnpm test:jsdom ReactStore --no-watch`
- `pnpm test:jsdom popupStoreUtils --no-watch`
- `pnpm test:jsdom toast/store --no-watch`
- `pnpm test:jsdom ComboboxRootContext --no-watch`
- Focused jsdom suites for Combobox, Menu/Submenu, Tooltip, Preview Card, Popover, Dialog, Toast, and floating root synchronization
