### PR TITLE
[popups] Improve trigger mount performance

### DIFF
--- a/packages/react/src/dialog/root/DialogRoot.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { fastComponent } from '@base-ui/utils/fastHooks';
 import type { BaseUIChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 import { DialogHandle } from '../store/DialogHandle';
@@ -12,9 +13,11 @@ import { useRenderDialogRoot } from './useRenderDialogRoot';
  *
  * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
  */
-export function DialogRoot<Payload>(props: DialogRoot.Props<Payload>) {
+export const DialogRoot = fastComponent(function DialogRoot<Payload>(
+  props: DialogRoot.Props<Payload>,
+) {
   return useRenderDialogRoot('dialog', props);
-}
+});
 
 export interface DialogRootState {}
 

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -4,7 +4,6 @@ import { type InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import { type DialogRoot } from '../root/DialogRoot';
 import { NullStore } from '../../utils/NullStore';
 import {
-  createPopupFloatingRootContext,
   createInitialPopupStoreState,
   PopupStoreContext,
   popupStoreSelectors,
@@ -126,9 +125,7 @@ function createInitialState<Payload>(
   nested = false,
 ): State<Payload> {
   const state: State<Payload> = {
-    ...createInitialPopupStoreState<Payload>(
-      createPopupFloatingRootContext(triggerElements, floatingId, nested),
-    ),
+    ...createInitialPopupStoreState<Payload>(triggerElements, floatingId, nested),
     modal: true,
     disablePointerDismissal: false,
     viewportElement: null,

--- a/packages/react/src/dialog/store/DialogStore.ts
+++ b/packages/react/src/dialog/store/DialogStore.ts
@@ -126,7 +126,9 @@ function createInitialState<Payload>(
   nested = false,
 ): State<Payload> {
   const state: State<Payload> = {
-    ...createInitialPopupStoreState<Payload>(),
+    ...createInitialPopupStoreState<Payload>(
+      createPopupFloatingRootContext(triggerElements, floatingId, nested),
+    ),
     modal: true,
     disablePointerDismissal: false,
     viewportElement: null,
@@ -139,8 +141,6 @@ function createInitialState<Payload>(
     role: 'dialog',
     ...initialState,
   };
-
-  state.floatingRootContext = createPopupFloatingRootContext(triggerElements, floatingId, nested);
 
   return state;
 }

--- a/packages/react/src/dialog/trigger/DialogTrigger.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { fastComponentRef } from '@base-ui/utils/fastHooks';
 import { useDialogRootContext } from '../root/DialogRootContext';
 import { useButton } from '../../internals/use-button/useButton';
 import { useRenderElement } from '../../internals/useRenderElement';
@@ -18,7 +19,7 @@ import { useOpenMethodTriggerProps } from '../../utils/useOpenInteractionType';
  *
  * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
  */
-export const DialogTrigger = React.forwardRef(function DialogTrigger(
+export const DialogTrigger = fastComponentRef(function DialogTrigger(
   componentProps: DialogTrigger.Props,
   forwardedRef: React.ForwardedRef<HTMLButtonElement>,
 ) {

--- a/packages/react/src/menu/root/MenuRoot.tsx
+++ b/packages/react/src/menu/root/MenuRoot.tsx
@@ -105,24 +105,33 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     };
   }, [contextMenuContext, parentMenuRootContext, menubarContext, isSubmenu]);
 
-  const store = useMenuRootStore<Payload>({
-    open: defaultOpen,
-    openProp,
-    activeTriggerId: defaultTriggerIdProp,
-    triggerIdProp,
-    parent: parentFromContext,
-  });
+  const rootId = useId();
+  const floatingId = useId();
+  const floatingParentNodeIdFromContext = useFloatingParentNodeId();
+
+  const store = useMenuRootStore<Payload>(
+    {
+      open: defaultOpen,
+      openProp,
+      activeTriggerId: defaultTriggerIdProp,
+      triggerIdProp,
+      parent: parentFromContext,
+      disabled: disabledProp,
+      highlightItemOnHover,
+      modal: parentFromContext.type === undefined ? modalProp : undefined,
+      rootId,
+    },
+    floatingId,
+    floatingParentNodeIdFromContext != null,
+  );
 
   store.useControlledProp('openProp', openProp);
   store.useControlledProp('triggerIdProp', triggerIdProp);
 
   store.useContextCallback('onOpenChangeComplete', onOpenChangeComplete);
 
-  const rootId = useId();
-  const floatingId = useId();
   const floatingTreeRoot = store.useState('floatingTreeRoot');
   const floatingNodeIdFromContext = useFloatingNodeId(floatingTreeRoot);
-  const floatingParentNodeIdFromContext = useFloatingParentNodeId();
 
   const open = store.useState('open');
   const activeTriggerElement = store.useState('activeTriggerElement');
@@ -326,6 +335,7 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
 
   const floatingRootContext = useSyncedFloatingRootContext({
     popupStore: store,
+    floatingRootContext: store.state.floatingRootContext,
     floatingId,
     nested: floatingParentNodeIdFromContext != null,
     onOpenChange: setOpen,
@@ -472,6 +482,13 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
     return mergedProps;
   }, [listNavigation.trigger, dismiss.trigger, interactionTypeProps]);
 
+  // The initial render has no store subscribers yet. Seed these props before triggers render so
+  // the synchronization effect below doesn't make every trigger render twice in the first commit.
+  useRefWithInit(() => {
+    store.update({ inactiveTriggerProps });
+    return null;
+  });
+
   const popupProps = React.useMemo(
     () =>
       mergeProps(
@@ -549,13 +566,19 @@ export const MenuRoot = fastComponent(function MenuRoot<Payload>(props: MenuRoot
   return content;
 });
 
-function useMenuRootStore<Payload>(initialState: Partial<MenuStoreState<Payload>>) {
+function useMenuRootStore<Payload>(
+  initialState: Partial<MenuStoreState<Payload>>,
+  floatingId: string | undefined,
+  nested: boolean,
+) {
   // The store is owned by this Root instance and created exactly once. It is not tied to the handle:
   // the handle attaches to it, so swapping the handle re-attaches rather than recreating state.
   // Default values are only initial values; controlled values and root state are synced after creation.
   // Unlike other popups, Menu wires its floating root context separately (it relays open changes
   // through an event).
-  const store = useRefWithInit(() => new MenuStore<Payload>(initialState)).current;
+  const store = useRefWithInit(
+    () => new MenuStore<Payload>(initialState, floatingId, nested),
+  ).current;
 
   return store;
 }

--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -6,9 +6,11 @@ import { MenuParent, MenuRoot } from '../root/MenuRoot';
 import { FloatingTreeStore } from '../../floating-ui-react/components/FloatingTreeStore';
 import { HTMLProps } from '../../internals/types';
 import { NullStore } from '../../utils/NullStore';
+import { getEmptyRootContext } from '../../floating-ui-react/utils/getEmptyRootContext';
 import type { AdaptiveOriginMiddleware } from '../../utils/adaptiveOriginConstants';
 import {
   createInitialPopupStoreState,
+  createPopupFloatingRootContext,
   PopupStoreContext,
   popupStoreSelectors,
   PopupStoreState,
@@ -112,8 +114,21 @@ type Selectors = typeof selectors;
 export type MenuHandleStore<Payload> = Pick<MenuStore<Payload>, PopupTriggerStoreKeys | 'setOpen'>;
 
 export class MenuStore<Payload> extends ReactStore<Readonly<State<Payload>>, Context, Selectors> {
-  constructor(initialState?: Partial<State<Payload>>) {
-    super({ ...createInitialState(), ...initialState }, createInitialContext(), selectors);
+  constructor(
+    initialState?: Partial<State<Payload>>,
+    floatingId?: string | undefined,
+    nested = false,
+  ) {
+    const triggerElements = new PopupTriggerMap();
+    const state = {
+      ...createInitialState<Payload>(
+        createPopupFloatingRootContext(triggerElements, floatingId, nested),
+      ),
+      floatingId,
+      ...initialState,
+    };
+
+    super(state, createInitialContext(triggerElements), selectors);
 
     // Set up propagation of state from parent menu if applicable.
     this.unsubscribeParentListener = this.observe('parent', (parent) => {
@@ -159,6 +174,10 @@ export class MenuStore<Payload> extends ReactStore<Readonly<State<Payload>>, Con
     this.state.floatingRootContext.context.events.emit('setOpen', { open, eventDetails });
   }
 
+  initializeInactiveTriggerProps(inactiveTriggerProps: HTMLProps) {
+    this.state = { ...this.state, inactiveTriggerProps };
+  }
+
   private unsubscribeParentListener: (() => void) | null = null;
 }
 
@@ -178,7 +197,7 @@ export function createNullMenuStore<Payload>(): MenuHandleStore<Payload> {
   return Object.assign(store, { setOpen: NOOP });
 }
 
-function createInitialContext(): Context {
+function createInitialContext(triggerElements = new PopupTriggerMap()): Context {
   return {
     positionerRef: React.createRef<HTMLElement | null>(),
     popupRef: React.createRef<HTMLElement | null>(),
@@ -189,13 +208,13 @@ function createInitialContext(): Context {
     triggerFocusTargetRef: React.createRef<HTMLElement>(),
     beforeContentFocusGuardRef: React.createRef<HTMLElement>(),
     onOpenChangeComplete: undefined,
-    triggerElements: new PopupTriggerMap(),
+    triggerElements,
   };
 }
 
-function createInitialState<Payload>(): State<Payload> {
+function createInitialState<Payload>(floatingRootContext = getEmptyRootContext()): State<Payload> {
   return {
-    ...createInitialPopupStoreState(),
+    ...createInitialPopupStoreState<Payload>(floatingRootContext),
     disabled: false,
     modal: true,
     openMethod: null,

--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -6,11 +6,9 @@ import { MenuParent, MenuRoot } from '../root/MenuRoot';
 import { FloatingTreeStore } from '../../floating-ui-react/components/FloatingTreeStore';
 import { HTMLProps } from '../../internals/types';
 import { NullStore } from '../../utils/NullStore';
-import { getEmptyRootContext } from '../../floating-ui-react/utils/getEmptyRootContext';
 import type { AdaptiveOriginMiddleware } from '../../utils/adaptiveOriginConstants';
 import {
   createInitialPopupStoreState,
-  createPopupFloatingRootContext,
   PopupStoreContext,
   popupStoreSelectors,
   PopupStoreState,
@@ -120,13 +118,7 @@ export class MenuStore<Payload> extends ReactStore<Readonly<State<Payload>>, Con
     nested = false,
   ) {
     const triggerElements = new PopupTriggerMap();
-    const state = {
-      ...createInitialState<Payload>(
-        createPopupFloatingRootContext(triggerElements, floatingId, nested),
-      ),
-      floatingId,
-      ...initialState,
-    };
+    const state = createInitialState<Payload>(triggerElements, floatingId, nested, initialState);
 
     super(state, createInitialContext(triggerElements), selectors);
 
@@ -189,15 +181,16 @@ export class MenuStore<Payload> extends ReactStore<Readonly<State<Payload>>, Con
  * `setOpen` without it ever taking effect while detached.
  */
 export function createNullMenuStore<Payload>(): MenuHandleStore<Payload> {
+  const triggerElements = new PopupTriggerMap();
   const store = new NullStore<Readonly<State<Payload>>, Context, Selectors>(
-    Object.freeze(createInitialState<Payload>()),
-    Object.freeze(createInitialContext()),
+    Object.freeze(createInitialState<Payload>(triggerElements)),
+    Object.freeze(createInitialContext(triggerElements)),
     selectors,
   );
   return Object.assign(store, { setOpen: NOOP });
 }
 
-function createInitialContext(triggerElements = new PopupTriggerMap()): Context {
+function createInitialContext(triggerElements: PopupTriggerMap): Context {
   return {
     positionerRef: React.createRef<HTMLElement | null>(),
     popupRef: React.createRef<HTMLElement | null>(),
@@ -212,9 +205,14 @@ function createInitialContext(triggerElements = new PopupTriggerMap()): Context 
   };
 }
 
-function createInitialState<Payload>(floatingRootContext = getEmptyRootContext()): State<Payload> {
+function createInitialState<Payload>(
+  triggerElements: PopupTriggerMap,
+  floatingId?: string | undefined,
+  nested = false,
+  initialState?: Partial<State<Payload>>,
+): State<Payload> {
   return {
-    ...createInitialPopupStoreState<Payload>(floatingRootContext),
+    ...createInitialPopupStoreState<Payload>(triggerElements, floatingId, nested),
     disabled: false,
     modal: true,
     openMethod: null,
@@ -235,5 +233,6 @@ function createInitialState<Payload>(floatingRootContext = getEmptyRootContext()
     keyboardEventRelay: undefined,
     closeDelay: 0,
     adaptiveOrigin: undefined,
+    ...initialState,
   };
 }

--- a/packages/react/src/menu/store/MenuStore.ts
+++ b/packages/react/src/menu/store/MenuStore.ts
@@ -166,10 +166,6 @@ export class MenuStore<Payload> extends ReactStore<Readonly<State<Payload>>, Con
     this.state.floatingRootContext.context.events.emit('setOpen', { open, eventDetails });
   }
 
-  initializeInactiveTriggerProps(inactiveTriggerProps: HTMLProps) {
-    this.state = { ...this.state, inactiveTriggerProps };
-  }
-
   private unsubscribeParentListener: (() => void) | null = null;
 }
 

--- a/packages/react/src/popover/root/PopoverRoot.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { fastComponent } from '@base-ui/utils/fastHooks';
 import { useDismiss, FloatingTree } from '../../floating-ui-react';
 import { PopoverRootContext, usePopoverRootContext } from './PopoverRootContext';
 import { PopoverStore, type State as PopoverStoreState } from '../store/PopoverStore';
@@ -19,7 +20,11 @@ import {
   type PayloadChildRenderFunction,
 } from '../../utils/popups';
 
-function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Payload> }) {
+const PopoverRootComponent = fastComponent(function PopoverRootComponent<Payload>({
+  props,
+}: {
+  props: PopoverRoot.Props<Payload>;
+}) {
   const {
     children,
     open: openProp,
@@ -84,7 +89,7 @@ function PopoverRootComponent<Payload>({ props }: { props: PopoverRoot.Props<Pay
       {typeof children === 'function' ? children({ payload }) : children}
     </PopoverRootContext.Provider>
   );
-}
+});
 
 /**
  * Groups all parts of the popover.

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -10,7 +10,6 @@ import { REASONS } from '../../internals/reasons';
 import { NullStore } from '../../utils/NullStore';
 import {
   attachPreventUnmountOnClose,
-  createPopupFloatingRootContext,
   createInitialPopupStoreState,
   PopupStoreContext,
   popupStoreSelectors,
@@ -196,9 +195,7 @@ function createInitialState<Payload>(
   nested = false,
 ): State<Payload> {
   const state: State<Payload> = {
-    ...createInitialPopupStoreState<Payload>(
-      createPopupFloatingRootContext(triggerElements, floatingId, nested),
-    ),
+    ...createInitialPopupStoreState<Payload>(triggerElements, floatingId, nested),
     disabled: false,
     modal: false,
     focusManagerModal: false,

--- a/packages/react/src/popover/store/PopoverStore.ts
+++ b/packages/react/src/popover/store/PopoverStore.ts
@@ -196,7 +196,9 @@ function createInitialState<Payload>(
   nested = false,
 ): State<Payload> {
   const state: State<Payload> = {
-    ...createInitialPopupStoreState<Payload>(),
+    ...createInitialPopupStoreState<Payload>(
+      createPopupFloatingRootContext(triggerElements, floatingId, nested),
+    ),
     disabled: false,
     modal: false,
     focusManagerModal: false,
@@ -215,8 +217,6 @@ function createInitialState<Payload>(
   if (state.open && initialState?.mounted === undefined) {
     state.mounted = true;
   }
-
-  state.floatingRootContext = createPopupFloatingRootContext(triggerElements, floatingId, nested);
 
   return state;
 }

--- a/packages/react/src/popover/trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { fastComponentRef } from '@base-ui/utils/fastHooks';
 import { usePopoverRootContext } from '../root/PopoverRootContext';
 import { useButton } from '../../internals/use-button/useButton';
 import type { BaseUIComponentProps, NativeButtonProps } from '../../internals/types';
@@ -26,7 +27,7 @@ import { useOpenMethodTriggerProps } from '../../utils/useOpenInteractionType';
  *
  * Documentation: [Base UI Popover](https://base-ui.com/react/components/popover)
  */
-export const PopoverTrigger = React.forwardRef(function PopoverTrigger(
+export const PopoverTrigger = fastComponentRef(function PopoverTrigger(
   componentProps: PopoverTrigger.Props,
   forwardedRef: React.ForwardedRef<HTMLElement>,
 ) {

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -125,14 +125,14 @@ function createInitialState<Payload>(
   nested = false,
 ): State<Payload> {
   const state: State<Payload> = {
-    ...createInitialPopupStoreState<Payload>(),
+    ...createInitialPopupStoreState<Payload>(
+      createPopupFloatingRootContext(triggerElements, floatingId, nested),
+    ),
     instantType: undefined,
     adaptiveOrigin: undefined,
     closeDelay: CLOSE_DELAY,
     ...initialState,
   };
-
-  state.floatingRootContext = createPopupFloatingRootContext(triggerElements, floatingId, nested);
 
   return state;
 }

--- a/packages/react/src/preview-card/store/PreviewCardStore.ts
+++ b/packages/react/src/preview-card/store/PreviewCardStore.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { ReactStore } from '@base-ui/utils/store';
 import {
   applyPopupOpenChange,
-  createPopupFloatingRootContext,
   createInitialPopupStoreState,
   InlineRectCoords,
   PopupStoreContext,
@@ -125,9 +124,7 @@ function createInitialState<Payload>(
   nested = false,
 ): State<Payload> {
   const state: State<Payload> = {
-    ...createInitialPopupStoreState<Payload>(
-      createPopupFloatingRootContext(triggerElements, floatingId, nested),
-    ),
+    ...createInitialPopupStoreState<Payload>(triggerElements, floatingId, nested),
     instantType: undefined,
     adaptiveOrigin: undefined,
     closeDelay: CLOSE_DELAY,

--- a/packages/react/src/tooltip/store/TooltipStore.ts
+++ b/packages/react/src/tooltip/store/TooltipStore.ts
@@ -126,7 +126,9 @@ function createInitialState<Payload>(
   nested = false,
 ): State<Payload> {
   const state: State<Payload> = {
-    ...createInitialPopupStoreState<Payload>(),
+    ...createInitialPopupStoreState<Payload>(
+      createPopupFloatingRootContext(triggerElements, floatingId, nested),
+    ),
     disabled: false,
     instantType: undefined,
     isInstantPhase: false,
@@ -138,8 +140,6 @@ function createInitialState<Payload>(
     adaptiveOrigin: undefined,
     ...initialState,
   };
-
-  state.floatingRootContext = createPopupFloatingRootContext(triggerElements, floatingId, nested);
 
   return state;
 }

--- a/packages/react/src/tooltip/store/TooltipStore.ts
+++ b/packages/react/src/tooltip/store/TooltipStore.ts
@@ -8,7 +8,6 @@ import { NullStore } from '../../utils/NullStore';
 import type { AdaptiveOriginMiddleware } from '../../utils/adaptiveOriginConstants';
 import {
   applyPopupOpenChange,
-  createPopupFloatingRootContext,
   createInitialPopupStoreState,
   PopupStoreContext,
   popupStoreSelectors,
@@ -126,9 +125,7 @@ function createInitialState<Payload>(
   nested = false,
 ): State<Payload> {
   const state: State<Payload> = {
-    ...createInitialPopupStoreState<Payload>(
-      createPopupFloatingRootContext(triggerElements, floatingId, nested),
-    ),
+    ...createInitialPopupStoreState<Payload>(triggerElements, floatingId, nested),
     disabled: false,
     instantType: undefined,
     isInstantPhase: false,

--- a/packages/react/src/utils/popups/popupStoreUtils.test.tsx
+++ b/packages/react/src/utils/popups/popupStoreUtils.test.tsx
@@ -18,7 +18,6 @@ import {
   useTriggerRegistration,
 } from './';
 import { useSyncedFloatingRootContext } from '../../floating-ui-react';
-import { getEmptyRootContext } from '../../floating-ui-react/utils/getEmptyRootContext';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 import type { BaseUIChangeEventDetails } from '../../types';
@@ -32,14 +31,15 @@ type TestStore = ReactStore<
 };
 
 function createStore() {
+  const triggerElements = new PopupTriggerMap();
   const store = new ReactStore<
     PopupStoreState<unknown>,
     PopupStoreContext<unknown>,
     PopupStoreSelectors
   >(
-    createInitialPopupStoreState(getEmptyRootContext()),
+    createInitialPopupStoreState(triggerElements),
     {
-      triggerElements: new PopupTriggerMap(),
+      triggerElements,
       popupRef: React.createRef<HTMLElement | null>(),
       onOpenChangeComplete: undefined,
     },
@@ -733,7 +733,7 @@ describe('applyPopupOpenChange', () => {
 
   function createOpenChangeStore() {
     const order: string[] = [];
-    const { floatingRootContext } = createInitialPopupStoreState(getEmptyRootContext());
+    const { floatingRootContext } = createInitialPopupStoreState(new PopupTriggerMap());
 
     const dispatchOpenChange = vi
       .spyOn(floatingRootContext, 'dispatchOpenChange')

--- a/packages/react/src/utils/popups/popupStoreUtils.test.tsx
+++ b/packages/react/src/utils/popups/popupStoreUtils.test.tsx
@@ -18,6 +18,7 @@ import {
   useTriggerRegistration,
 } from './';
 import { useSyncedFloatingRootContext } from '../../floating-ui-react';
+import { getEmptyRootContext } from '../../floating-ui-react/utils/getEmptyRootContext';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 import type { BaseUIChangeEventDetails } from '../../types';
@@ -36,7 +37,7 @@ function createStore() {
     PopupStoreContext<unknown>,
     PopupStoreSelectors
   >(
-    createInitialPopupStoreState(),
+    createInitialPopupStoreState(getEmptyRootContext()),
     {
       triggerElements: new PopupTriggerMap(),
       popupRef: React.createRef<HTMLElement | null>(),
@@ -732,7 +733,7 @@ describe('applyPopupOpenChange', () => {
 
   function createOpenChangeStore() {
     const order: string[] = [];
-    const { floatingRootContext } = createInitialPopupStoreState();
+    const { floatingRootContext } = createInitialPopupStoreState(getEmptyRootContext());
 
     const dispatchOpenChange = vi
       .spyOn(floatingRootContext, 'dispatchOpenChange')

--- a/packages/react/src/utils/popups/store.test.ts
+++ b/packages/react/src/utils/popups/store.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { createInitialPopupStoreState, popupStoreSelectors, type PopupStoreState } from './store';
+import { getEmptyRootContext } from '../../floating-ui-react/utils/getEmptyRootContext';
 
 function createState(state: Partial<PopupStoreState<unknown>>) {
   return {
-    ...createInitialPopupStoreState(),
+    ...createInitialPopupStoreState(getEmptyRootContext()),
     activeTriggerId: 'trigger',
     ...state,
   };

--- a/packages/react/src/utils/popups/store.test.ts
+++ b/packages/react/src/utils/popups/store.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { createInitialPopupStoreState, popupStoreSelectors, type PopupStoreState } from './store';
-import { getEmptyRootContext } from '../../floating-ui-react/utils/getEmptyRootContext';
+import { PopupTriggerMap } from './popupTriggerMap';
 
 function createState(state: Partial<PopupStoreState<unknown>>) {
   return {
-    ...createInitialPopupStoreState(getEmptyRootContext()),
+    ...createInitialPopupStoreState(new PopupTriggerMap()),
     activeTriggerId: 'trigger',
     ...state,
   };

--- a/packages/react/src/utils/popups/store.ts
+++ b/packages/react/src/utils/popups/store.ts
@@ -81,15 +81,27 @@ export type PopupStoreState<Payload> = {
 };
 
 export function createInitialPopupStoreState<Payload>(
-  floatingRootContext: FloatingRootContext,
+  triggerElements: PopupTriggerMap,
+  floatingId?: string | undefined,
+  nested = false,
 ): PopupStoreState<Payload> {
   return {
     open: false,
     openProp: undefined,
     mounted: false,
     transitionStatus: undefined,
-    floatingRootContext,
-    floatingId: undefined,
+    floatingRootContext: new FloatingRootStore({
+      open: false,
+      transitionStatus: undefined,
+      floatingElement: null,
+      referenceElement: null,
+      triggerElements,
+      floatingId,
+      syncOnly: true,
+      nested,
+      onOpenChange: undefined,
+    }),
+    floatingId,
     triggerCount: 0,
     preventUnmountingOnClose: false,
     payload: undefined,
@@ -102,24 +114,6 @@ export function createInitialPopupStoreState<Payload>(
     inactiveTriggerProps: EMPTY_OBJECT as HTMLProps,
     popupProps: EMPTY_OBJECT as HTMLProps,
   };
-}
-
-export function createPopupFloatingRootContext(
-  triggerElements: PopupTriggerMap,
-  floatingId?: string | undefined,
-  nested = false,
-) {
-  return new FloatingRootStore({
-    open: false,
-    transitionStatus: undefined,
-    floatingElement: null,
-    referenceElement: null,
-    triggerElements,
-    floatingId,
-    syncOnly: true,
-    nested,
-    onOpenChange: undefined,
-  });
 }
 
 export type PopupStoreContext<ChangeEventDetails> = {

--- a/packages/react/src/utils/popups/store.ts
+++ b/packages/react/src/utils/popups/store.ts
@@ -2,7 +2,6 @@ import type { ReactStore } from '@base-ui/utils/store';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { FloatingRootContext } from '../../floating-ui-react';
 import { FloatingRootStore } from '../../floating-ui-react/components/FloatingRootStore';
-import { getEmptyRootContext } from '../../floating-ui-react/utils/getEmptyRootContext';
 import { TransitionStatus } from '../../internals/useTransitionStatus';
 import { PopupTriggerMap } from './popupTriggerMap';
 import { HTMLProps } from '../../internals/types';
@@ -81,13 +80,15 @@ export type PopupStoreState<Payload> = {
   popupProps: HTMLProps;
 };
 
-export function createInitialPopupStoreState<Payload>(): PopupStoreState<Payload> {
+export function createInitialPopupStoreState<Payload>(
+  floatingRootContext: FloatingRootContext,
+): PopupStoreState<Payload> {
   return {
     open: false,
     openProp: undefined,
     mounted: false,
     transitionStatus: undefined,
-    floatingRootContext: getEmptyRootContext(),
+    floatingRootContext,
     floatingId: undefined,
     triggerCount: 0,
     preventUnmountingOnClose: false,

--- a/test/performance/tests/menu.bench.tsx
+++ b/test/performance/tests/menu.bench.tsx
@@ -4,51 +4,8 @@ import { benchmark, ElementTiming } from '@mui/internal-benchmark';
 import { createRows, MountList } from './shared';
 
 const menuRows = createRows(300, 'Menu');
-const multiTriggerMenuRows = createRows(100, 'Menu');
-const menuTriggers = createRows(20, 'Menu trigger');
 const menuItems = createRows(5, 'Menu item');
-const smallMenuItems = createRows(10, 'Menu item');
 const largeMenuItems = createRows(500, 'Menu item');
-const firstOpenTimingNameRef = { current: 'menu-first-open' };
-const subsequentOpenTimingNameRef = { current: 'menu-first-open' };
-
-function waitForRemoval(element: Element) {
-  if (!element.isConnected) {
-    return Promise.resolve();
-  }
-
-  return new Promise<void>((resolve) => {
-    const observer = new MutationObserver(() => {
-      if (!element.isConnected) {
-        observer.disconnect();
-        resolve();
-      }
-    });
-    observer.observe(document, { childList: true, subtree: true });
-  });
-}
-
-function waitForElement(selector: string) {
-  const element = document.querySelector(selector);
-  if (element) {
-    return Promise.resolve(element);
-  }
-
-  return new Promise<Element>((resolve) => {
-    const observer = new MutationObserver(() => {
-      const nextElement = document.querySelector(selector);
-      if (nextElement) {
-        observer.disconnect();
-        resolve(nextElement);
-      }
-    });
-    observer.observe(document, { childList: true, subtree: true });
-  });
-}
-
-function PhaseElementTiming({ timingNameRef }: { timingNameRef: { current: string } }) {
-  return <ElementTiming name={timingNameRef.current} />;
-}
 
 function MenuMountList() {
   return (
@@ -68,40 +25,6 @@ function MenuMountList() {
         </Menu.Root>
       )}
     </MountList>
-  );
-}
-
-function MultiTriggerMenuMountList() {
-  return (
-    <MountList rows={multiTriggerMenuRows}>
-      {(row) => (
-        <Menu.Root key={row.id}>
-          {menuTriggers.map((trigger) => (
-            <Menu.Trigger key={trigger.id}>{trigger.label}</Menu.Trigger>
-          ))}
-        </Menu.Root>
-      )}
-    </MountList>
-  );
-}
-
-function SmallMenu({ timingNameRef }: { timingNameRef: { current: string } }) {
-  return (
-    <Menu.Root>
-      <Menu.Trigger aria-label="Open small menu benchmark">Open menu</Menu.Trigger>
-      <Menu.Portal>
-        <Menu.Positioner sideOffset={8} positionMethod="fixed">
-          <Menu.Popup>
-            <div data-benchmark="small-menu-open-content">
-              <PhaseElementTiming timingNameRef={timingNameRef} />
-            </div>
-            {smallMenuItems.map((item) => (
-              <Menu.Item key={item.id}>{item.label}</Menu.Item>
-            ))}
-          </Menu.Popup>
-        </Menu.Positioner>
-      </Menu.Portal>
-    </Menu.Root>
   );
 }
 
@@ -126,61 +49,6 @@ function LargeMenu() {
 }
 
 benchmark('Menu mount (300 instances)', () => <MenuMountList />);
-benchmark('Menu mount (100 roots, 20 triggers each)', () => <MultiTriggerMenuMountList />);
-
-benchmark(
-  'Menu first open (10 items)',
-  () => <SmallMenu timingNameRef={firstOpenTimingNameRef} />,
-  async ({ waitForElementTiming }) => {
-    const trigger = document.querySelector<HTMLElement>('[aria-label="Open small menu benchmark"]');
-
-    if (trigger == null) {
-      throw new Error('Missing small menu benchmark trigger');
-    }
-
-    trigger.click();
-    await waitForElementTiming('menu-first-open');
-  },
-);
-
-benchmark(
-  'Menu subsequent open (10 items)',
-  () => {
-    subsequentOpenTimingNameRef.current = 'menu-first-open';
-    return <SmallMenu timingNameRef={subsequentOpenTimingNameRef} />;
-  },
-  async ({ waitForElementTiming, resumeReactRecording }) => {
-    const trigger = document.querySelector<HTMLElement>('[aria-label="Open small menu benchmark"]');
-
-    if (trigger == null) {
-      throw new Error('Missing small menu benchmark trigger');
-    }
-
-    trigger.click();
-    await waitForElementTiming('menu-first-open');
-
-    const popupContent = document.querySelector('[data-benchmark="small-menu-open-content"]');
-    if (popupContent == null) {
-      throw new Error('Missing small menu benchmark popup');
-    }
-
-    trigger.click();
-    await waitForRemoval(popupContent);
-
-    subsequentOpenTimingNameRef.current = 'menu-subsequent-open';
-    resumeReactRecording();
-    trigger.click();
-    const nextPopupContent = await waitForElement('[data-benchmark="small-menu-open-content"]');
-    const timingName = nextPopupContent
-      .querySelector('[elementtiming]')
-      ?.getAttribute('elementtiming');
-    if (timingName !== 'menu-subsequent-open') {
-      throw new Error(`Expected subsequent-open marker, found ${timingName}`);
-    }
-    await waitForElementTiming('menu-subsequent-open');
-  },
-  { reactRecordingPaused: true },
-);
 
 benchmark(
   'Menu open (500 items)',

--- a/test/performance/tests/menu.bench.tsx
+++ b/test/performance/tests/menu.bench.tsx
@@ -4,8 +4,51 @@ import { benchmark, ElementTiming } from '@mui/internal-benchmark';
 import { createRows, MountList } from './shared';
 
 const menuRows = createRows(300, 'Menu');
+const multiTriggerMenuRows = createRows(100, 'Menu');
+const menuTriggers = createRows(20, 'Menu trigger');
 const menuItems = createRows(5, 'Menu item');
+const smallMenuItems = createRows(10, 'Menu item');
 const largeMenuItems = createRows(500, 'Menu item');
+const firstOpenTimingNameRef = { current: 'menu-first-open' };
+const subsequentOpenTimingNameRef = { current: 'menu-first-open' };
+
+function waitForRemoval(element: Element) {
+  if (!element.isConnected) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve) => {
+    const observer = new MutationObserver(() => {
+      if (!element.isConnected) {
+        observer.disconnect();
+        resolve();
+      }
+    });
+    observer.observe(document, { childList: true, subtree: true });
+  });
+}
+
+function waitForElement(selector: string) {
+  const element = document.querySelector(selector);
+  if (element) {
+    return Promise.resolve(element);
+  }
+
+  return new Promise<Element>((resolve) => {
+    const observer = new MutationObserver(() => {
+      const nextElement = document.querySelector(selector);
+      if (nextElement) {
+        observer.disconnect();
+        resolve(nextElement);
+      }
+    });
+    observer.observe(document, { childList: true, subtree: true });
+  });
+}
+
+function PhaseElementTiming({ timingNameRef }: { timingNameRef: { current: string } }) {
+  return <ElementTiming name={timingNameRef.current} />;
+}
 
 function MenuMountList() {
   return (
@@ -25,6 +68,40 @@ function MenuMountList() {
         </Menu.Root>
       )}
     </MountList>
+  );
+}
+
+function MultiTriggerMenuMountList() {
+  return (
+    <MountList rows={multiTriggerMenuRows}>
+      {(row) => (
+        <Menu.Root key={row.id}>
+          {menuTriggers.map((trigger) => (
+            <Menu.Trigger key={trigger.id}>{trigger.label}</Menu.Trigger>
+          ))}
+        </Menu.Root>
+      )}
+    </MountList>
+  );
+}
+
+function SmallMenu({ timingNameRef }: { timingNameRef: { current: string } }) {
+  return (
+    <Menu.Root>
+      <Menu.Trigger aria-label="Open small menu benchmark">Open menu</Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner sideOffset={8} positionMethod="fixed">
+          <Menu.Popup>
+            <div data-benchmark="small-menu-open-content">
+              <PhaseElementTiming timingNameRef={timingNameRef} />
+            </div>
+            {smallMenuItems.map((item) => (
+              <Menu.Item key={item.id}>{item.label}</Menu.Item>
+            ))}
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
   );
 }
 
@@ -49,6 +126,61 @@ function LargeMenu() {
 }
 
 benchmark('Menu mount (300 instances)', () => <MenuMountList />);
+benchmark('Menu mount (100 roots, 20 triggers each)', () => <MultiTriggerMenuMountList />);
+
+benchmark(
+  'Menu first open (10 items)',
+  () => <SmallMenu timingNameRef={firstOpenTimingNameRef} />,
+  async ({ waitForElementTiming }) => {
+    const trigger = document.querySelector<HTMLElement>('[aria-label="Open small menu benchmark"]');
+
+    if (trigger == null) {
+      throw new Error('Missing small menu benchmark trigger');
+    }
+
+    trigger.click();
+    await waitForElementTiming('menu-first-open');
+  },
+);
+
+benchmark(
+  'Menu subsequent open (10 items)',
+  () => {
+    subsequentOpenTimingNameRef.current = 'menu-first-open';
+    return <SmallMenu timingNameRef={subsequentOpenTimingNameRef} />;
+  },
+  async ({ waitForElementTiming, resumeReactRecording }) => {
+    const trigger = document.querySelector<HTMLElement>('[aria-label="Open small menu benchmark"]');
+
+    if (trigger == null) {
+      throw new Error('Missing small menu benchmark trigger');
+    }
+
+    trigger.click();
+    await waitForElementTiming('menu-first-open');
+
+    const popupContent = document.querySelector('[data-benchmark="small-menu-open-content"]');
+    if (popupContent == null) {
+      throw new Error('Missing small menu benchmark popup');
+    }
+
+    trigger.click();
+    await waitForRemoval(popupContent);
+
+    subsequentOpenTimingNameRef.current = 'menu-subsequent-open';
+    resumeReactRecording();
+    trigger.click();
+    const nextPopupContent = await waitForElement('[data-benchmark="small-menu-open-content"]');
+    const timingName = nextPopupContent
+      .querySelector('[elementtiming]')
+      ?.getAttribute('elementtiming');
+    if (timingName !== 'menu-subsequent-open') {
+      throw new Error(`Expected subsequent-open marker, found ${timingName}`);
+    }
+    await waitForElementTiming('menu-subsequent-open');
+  },
+  { reactRecordingPaused: true },
+);
 
 benchmark(
   'Menu open (500 items)',


### PR DESCRIPTION
This PR reduces the work needed to mount closed popup roots and triggers.

## Changes

- Initializes each popup's real floating context directly instead of creating and replacing an unused context.
- Seeds Menu's initial inactive-trigger props before triggers subscribe, avoiding a second render after mount.
- Batches store subscriptions in Dialog and Popover roots and triggers.
- Keeps Menu dismissal and typeahead interactions mounted normally, so the mount improvement does not move their initialization cost to first open.

## Performance

| Scenario | Fixture | Base UI 1.7.0 | This PR | Improvement |
|---|---:|---:|---:|---:|
| Menu closed mount | 300 roots, 1 trigger each | 22.4 ms | 16.4 ms | **26.9%** |
| Menu closed mount | 100 roots, 20 triggers each | 72.5 ms | 42.6 ms | **41.2%** |
| Menu first open | 1 trigger, 10 items | 2.0 ms | 1.7 ms | **14.4%** |
| Menu subsequent open | 1 trigger, 10 items | 2.2 ms | 1.5 ms | **30.6%** |
| Popover closed mount | 500 triggers | 21.3 ms | 16.5 ms | **22.4%** |
| Dialog closed mount | 500 triggers | 15.6 ms | 13.2 ms | **15.4%** |

Menu results are React render totals from the repository's production benchmark harness. Base UI 1.7.0 is averaged across two runs and this PR across three runs. Popover and Dialog results use the standalone production harness and average two reverse-order fresh-browser runs per version. Every run uses 20 measured iterations with outlier filtering.
