### PR TITLE
[scroll-area] Prevent scrollbars from stealing focus

### DIFF
--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -459,14 +459,22 @@ describe('<ScrollArea.Scrollbar />', () => {
       );
     }
 
-    it('cancels the press on the track so focus stays on the active element', async () => {
-      await renderScrollbarWithThumb();
+    // Native scrollbars keep focus for every button, not just the primary one.
+    it.each([
+      { name: 'primary', button: 0 },
+      { name: 'middle', button: 1 },
+      { name: 'secondary', button: 2 },
+    ])(
+      'cancels a $name press on the track so focus stays on the active element',
+      async ({ button }) => {
+        await renderScrollbarWithThumb();
 
-      const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 });
-      screen.getByTestId('scrollbar').dispatchEvent(event);
+        const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button });
+        screen.getByTestId('scrollbar').dispatchEvent(event);
 
-      expect(event.defaultPrevented).toBe(true);
-    });
+        expect(event.defaultPrevented).toBe(true);
+      },
+    );
 
     it('cancels the press on the thumb so focus stays on the active element', async () => {
       await renderScrollbarWithThumb();
@@ -475,15 +483,6 @@ describe('<ScrollArea.Scrollbar />', () => {
       screen.getByTestId('thumb').dispatchEvent(event);
 
       expect(event.defaultPrevented).toBe(true);
-    });
-
-    it('leaves non-primary presses alone', async () => {
-      await renderScrollbarWithThumb();
-
-      const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 1 });
-      screen.getByTestId('scrollbar').dispatchEvent(event);
-
-      expect(event.defaultPrevented).toBe(false);
     });
   });
 

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -445,6 +445,48 @@ describe('<ScrollArea.Scrollbar />', () => {
     });
   });
 
+  // jsdom doesn't implement the focus side of a mouse press, so these assert the
+  // cancellation that suppresses it rather than the resulting `activeElement`.
+  describe('track mouse down', () => {
+    async function renderScrollbarWithThumb() {
+      await render(
+        <ScrollArea.Root>
+          <ScrollArea.Viewport data-testid="viewport" />
+          <ScrollArea.Scrollbar data-testid="scrollbar" keepMounted>
+            <ScrollArea.Thumb data-testid="thumb" />
+          </ScrollArea.Scrollbar>
+        </ScrollArea.Root>,
+      );
+    }
+
+    it('cancels the press on the track so focus stays on the active element', async () => {
+      await renderScrollbarWithThumb();
+
+      const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 });
+      screen.getByTestId('scrollbar').dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('cancels the press on the thumb so focus stays on the active element', async () => {
+      await renderScrollbarWithThumb();
+
+      const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 });
+      screen.getByTestId('thumb').dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('leaves non-primary presses alone', async () => {
+      await renderScrollbarWithThumb();
+
+      const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 1 });
+      screen.getByTestId('scrollbar').dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(false);
+    });
+  });
+
   // The vertical/horizontal track-click branches were consolidated into one
   // axis-parameterized path. `getOffset` reads logical margins/paddings that jsdom
   // doesn't compute, so exercise the merged branch against real layout here to pin

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
@@ -184,6 +184,16 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
 
       handlePointerDown(event);
     },
+    // Native scrollbars don't move focus when pressed. Handled here rather than on
+    // the thumb so the bubbled press covers both the track and the thumb. Limited to
+    // the primary button so middle-click autoscroll keeps its default behavior.
+    onMouseDown(event) {
+      if (event.button !== 0) {
+        return;
+      }
+
+      event.preventDefault();
+    },
     onPointerUp: handlePointerUp,
     // Mirror `onPointerUp` so a browser-cancelled gesture on the track (no thumb
     // child captures the pointer) still clears the drag state.

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
@@ -184,14 +184,9 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
 
       handlePointerDown(event);
     },
-    // Native scrollbars don't move focus when pressed. Handled here rather than on
-    // the thumb so the bubbled press covers both the track and the thumb. Limited to
-    // the primary button so middle-click autoscroll keeps its default behavior.
+    // Native scrollbars don't move focus when pressed, whichever button is used.
+    // Handled here rather than on the thumb so the bubbled press covers both.
     onMouseDown(event) {
-      if (event.button !== 0) {
-        return;
-      }
-
       event.preventDefault();
     },
     onPointerUp: handlePointerUp,


### PR DESCRIPTION
Closes #5415

Pressing a scrollbar track or thumb ran the default mousedown behavior, which
blurs the currently active element. Native scrollbars leave focus where it is.

Cancels the primary-button press on `ScrollArea.Scrollbar`, following the
existing precedent in `ComboboxClear`. The handler sits on the track rather
than the thumb so the bubbled press covers both.

Two things worth a maintainer's opinion:

- **Primary button only.** Cancelling a middle-click mousedown would also
  suppress Chrome's autoscroll, which seemed out of scope for this issue.
  Happy to make it unconditional if you'd prefer scrollbars never move focus.
- **`ScrollArea.Corner` has the same behavior** but is a sibling element, so
  it isn't covered here. Left out to keep this scoped to the issue title —
  can fold it in if wanted.

This doesn't address the second half of the thread (non-nested popovers
closing on scrollbar press) — that's an outside-press concern that
`preventDefault` doesn't solve, and there's already a userland workaround via
`eventDetails.event.target`.

### Testing

Three tests in `ScrollAreaScrollbar.test.tsx` covering track press, thumb
press, and the non-primary-button case. They assert `defaultPrevented` rather
than `activeElement` because jsdom doesn't implement focus-on-mousedown — a
focus assertion would pass with the fix removed. Verified the tests fail
against the unpatched component.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
