### PR TITLE
[composite] Prevent update loops from unstable refs

### DIFF
--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { act, screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer } from '#test-utils';
+import { createRenderer, mergeRefs } from '#test-utils';
 import { CompositeList } from './CompositeList';
 import { useCompositeListItem } from './useCompositeListItem';
 
@@ -196,31 +196,57 @@ describe('<CompositeList />', () => {
       expect(elementsRef.current[1]).toBe(screen.getByTestId('explicit'));
     });
 
-    it('populates a replacement element registry when the items are unchanged', async () => {
+    it('syncs replacement refs without publishing an unchanged map', async () => {
       const firstElementsRef = {
         current: [] as Array<HTMLElement | null>,
       };
       const secondElementsRef = {
         current: [null, null] as Array<HTMLElement | null>,
       };
+      const firstLabelsRef = {
+        current: [] as Array<string | null>,
+      };
+      const secondLabelsRef = {
+        current: [null, null] as Array<string | null>,
+      };
+      const onMapChange = vi.fn();
+
+      function UnstableRefItem() {
+        const internalRef = React.useRef<HTMLElement | null>(null);
+        const { ref } = useCompositeListItem({ label: 'item' });
+
+        return <div ref={mergeRefs(ref, internalRef)} data-testid="item" />;
+      }
 
       function App() {
         const [useSecondRef, setUseSecondRef] = React.useState(false);
         return (
-          <CompositeList elementsRef={useSecondRef ? secondElementsRef : firstElementsRef}>
+          <CompositeList
+            elementsRef={useSecondRef ? secondElementsRef : firstElementsRef}
+            labelsRef={useSecondRef ? secondLabelsRef : firstLabelsRef}
+            onMapChange={onMapChange}
+          >
             <button type="button" onClick={() => setUseSecondRef(true)}>
               Replace ref
             </button>
-            <Item label="item" />
+            <UnstableRefItem />
           </CompositeList>
         );
       }
 
       const { user } = await render(<App />);
-      expect(firstElementsRef.current).toEqual([screen.getByTestId('item')]);
+      const item = screen.getByTestId('item');
+      expect(firstElementsRef.current).toEqual([item]);
+      expect(firstLabelsRef.current).toEqual(['item']);
+      onMapChange.mockClear();
 
       await user.click(screen.getByRole('button', { name: 'Replace ref' }));
-      expect(secondElementsRef.current).toEqual([screen.getByTestId('item')]);
+
+      expect(firstElementsRef.current).toEqual([]);
+      expect(firstLabelsRef.current).toEqual([]);
+      expect(secondElementsRef.current).toEqual([item]);
+      expect(secondLabelsRef.current).toEqual(['item']);
+      expect(onMapChange).not.toHaveBeenCalled();
     });
 
     it('registers a replacement render target', async () => {
@@ -442,6 +468,27 @@ describe('<CompositeList />', () => {
       });
       expect(refCalls).toEqual([tracked, null, tracked, null, tracked]);
       expect(elementsRef.current).toEqual([tracked]);
+    });
+
+    it('resolves an automatic index when the equivalent explicit index is removed', async () => {
+      const elementsRef = {
+        current: [] as Array<HTMLElement | null>,
+      };
+
+      function App(props: { index?: number }) {
+        return (
+          <CompositeList elementsRef={elementsRef}>
+            <Item label="indexed" index={props.index} />
+          </CompositeList>
+        );
+      }
+
+      const { setProps } = await render(<App index={0} />, { strict: false });
+      await setProps({ index: undefined });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('indexed')).toHaveAttribute('data-index', '0');
+      });
     });
 
     it('does not detach item refs when an index shifts', async () => {

--- a/packages/react/src/internals/composite/list/CompositeList.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.tsx
@@ -141,6 +141,8 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
 
   const flush = useStableCallback(() => {
     const [items, automaticNodes] = getCompositeListSnapshot(map);
+    const nextMap = syncRefs(items);
+
     const previousItems = itemsRef.current;
     const changed =
       previousItems.length !== items.length ||
@@ -149,10 +151,10 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
         return (
           item.index !== previousItem.index ||
           item.element !== previousItem.element ||
+          item.registration.index !== previousItem.registration.index ||
           item.registration.metadata !== previousItem.registration.metadata
         );
       });
-    const nextMap = syncRefs(items);
 
     observe(automaticNodes);
     itemsRef.current = items;

--- a/packages/react/src/internals/composite/list/CompositeList.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.tsx
@@ -30,7 +30,7 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
   const map = useRefWithInit(createMap<Metadata>).current;
   const nextIndexRef = React.useRef(0);
   const isDirtyRef = React.useRef(true);
-  const itemsRef = React.useRef<readonly CompositeListItem<Metadata>[]>([]);
+  const itemsRef = React.useRef<readonly CompositeListItem<Metadata>[] | null>(null);
   const mutationObserverRef = React.useRef<MutationObserver | null>(null);
 
   // Item effects can run without their parent rendering. Schedule one synchronous
@@ -145,6 +145,7 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
 
     const previousItems = itemsRef.current;
     const changed =
+      !previousItems ||
       previousItems.length !== items.length ||
       items.some((item, index) => {
         const previousItem = previousItems[index];
@@ -171,7 +172,7 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
   useIsoLayoutEffect(() => {
     // Re-copy the last committed snapshot when the ref objects change or Strict Mode replays
     // effects without reattaching callback refs.
-    if (!isDirtyRef.current) {
+    if (!isDirtyRef.current && itemsRef.current) {
       syncRefs(itemsRef.current);
     }
 

--- a/packages/react/src/internals/composite/list/CompositeList.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.tsx
@@ -141,11 +141,26 @@ export function CompositeList<Metadata>(props: CompositeList.Props<Metadata>) {
 
   const flush = useStableCallback(() => {
     const [items, automaticNodes] = getCompositeListSnapshot(map);
+    const previousItems = itemsRef.current;
+    const changed =
+      previousItems.length !== items.length ||
+      items.some((item, index) => {
+        const previousItem = previousItems[index];
+        return (
+          item.index !== previousItem.index ||
+          item.element !== previousItem.element ||
+          item.registration.metadata !== previousItem.registration.metadata
+        );
+      });
     const nextMap = syncRefs(items);
 
     observe(automaticNodes);
     itemsRef.current = items;
     isDirtyRef.current = false;
+
+    if (!changed) {
+      return;
+    }
 
     listeners.forEach((listener) => listener(nextMap));
     onMapChange(nextMap);

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -3,11 +3,21 @@ import * as React from 'react';
 import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Slider } from '@base-ui/react/slider';
 import { Field } from '@base-ui/react/field';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { createRenderer, describeConformance, isJSDOM, mergeRefs } from '#test-utils';
 import { platform } from '@base-ui/utils/platform';
 import { createTouches, getHorizontalSliderRect } from '../utils/test-utils';
 
 const isWebKit = platform.engine.webkit;
+
+const UnstableRefThumb = React.forwardRef(function UnstableRefThumb(
+  props: React.ComponentPropsWithoutRef<'div'>,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
+) {
+  const internalRef = React.useRef<HTMLDivElement>(null);
+
+  // Deliberately recreate the merged host ref on every render.
+  return <div {...props} ref={mergeRefs(forwardedRef, internalRef)} />;
+});
 
 describe('<Slider.Thumb />', () => {
   const { render, renderToString } = createRenderer();
@@ -18,6 +28,18 @@ describe('<Slider.Thumb />', () => {
     },
     refInstanceof: window.HTMLDivElement,
   }));
+
+  it('settles when the rendered component recreates its merged ref', async () => {
+    await render(
+      <Slider.Root defaultValue={50}>
+        <Slider.Control>
+          <Slider.Thumb render={<UnstableRefThumb />} />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    expect(screen.getByRole('slider')).toBeInTheDocument();
+  });
 
   describe('ARIA attributes', () => {
     ['aria-label', 'aria-labelledby', 'aria-describedby', 'aria-valuetext'].forEach((attr) => {

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -1031,6 +1031,40 @@ describe('<Tabs.Root />', () => {
       expect(screen.getByRole('tabpanel', { hidden: true })).toHaveAttribute('hidden');
     });
 
+    it('calls onValueChange with null when a populated tab list is replaced by an empty one', async () => {
+      const handleChange = vi.fn();
+
+      function TestComponent({ empty }: { empty: boolean }) {
+        return (
+          <Tabs.Root defaultValue={0} onValueChange={handleChange}>
+            <Tabs.List key={empty ? 'empty' : 'populated'}>
+              {!empty && <Tabs.Tab value={0}>Tab 0</Tabs.Tab>}
+            </Tabs.List>
+            <Tabs.Panel value={0} keepMounted>
+              Panel 0
+            </Tabs.Panel>
+          </Tabs.Root>
+        );
+      }
+
+      const { setProps } = await render(<TestComponent empty={false} />);
+
+      expect(screen.getByRole('tabpanel')).not.toHaveAttribute('hidden');
+
+      await setProps({ empty: true });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledWith(
+          null,
+          expect.objectContaining({ reason: 'missing' }),
+        );
+      });
+
+      const panel = screen.getByRole('tabpanel', { hidden: true });
+      expect(panel).toHaveAttribute('hidden');
+      expect(panel).not.toHaveAttribute('aria-labelledby');
+    });
+
     it('calls onValueChange when an explicit defaultValue points at a tab that is never present', async () => {
       const handleChange = vi.fn();
 

--- a/packages/react/src/tabs/tab/TabsTab.test.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.test.tsx
@@ -83,11 +83,18 @@ describe('<Tabs.Tab />', () => {
             >
               Overview
             </Tabs.Tab>
+            <Tabs.Tab
+              nativeButton={false}
+              render={<UnstableRefTab href="#details" />}
+              value="details"
+            >
+              Details
+            </Tabs.Tab>
           </Tabs.List>
         </Tabs.Root>,
       );
 
-      expect(screen.getByRole('tab')).toHaveAttribute('href', '#overview');
+      expect(screen.getAllByRole('tab').map((tab) => tab.tabIndex)).toEqual([0, -1]);
     });
   });
 

--- a/packages/react/src/tabs/tab/TabsTab.test.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.test.tsx
@@ -1,8 +1,19 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
+import { Link, MemoryRouter } from 'react-router';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import { Tabs } from '@base-ui/react/tabs';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { createRenderer, describeConformance, isJSDOM, mergeRefs } from '#test-utils';
+
+const UnstableRefTab = React.forwardRef(function UnstableRefTab(
+  props: React.ComponentPropsWithoutRef<'a'>,
+  forwardedRef: React.ForwardedRef<HTMLAnchorElement>,
+) {
+  const internalRef = React.useRef<HTMLAnchorElement>(null);
+
+  // Deliberately recreate the merged host ref on every render.
+  return <a {...props} ref={mergeRefs(forwardedRef, internalRef)} />;
+});
 
 describe('<Tabs.Tab />', () => {
   const { render } = createRenderer();
@@ -43,6 +54,40 @@ describe('<Tabs.Tab />', () => {
 
       expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
       expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('renders a react-router Link', async () => {
+      await render(
+        <MemoryRouter>
+          <Tabs.Root defaultValue="overview">
+            <Tabs.List>
+              <Tabs.Tab nativeButton={false} render={<Link to="/overview" />} value="overview">
+                Overview
+              </Tabs.Tab>
+            </Tabs.List>
+          </Tabs.Root>
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByRole('tab')).toHaveAttribute('href', '/overview');
+    });
+
+    it('settles when the rendered component recreates its merged ref', async () => {
+      await render(
+        <Tabs.Root defaultValue="overview">
+          <Tabs.List>
+            <Tabs.Tab
+              nativeButton={false}
+              render={<UnstableRefTab href="#overview" />}
+              value="overview"
+            >
+              Overview
+            </Tabs.Tab>
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      expect(screen.getByRole('tab')).toHaveAttribute('href', '#overview');
     });
   });
 

--- a/packages/react/test/index.ts
+++ b/packages/react/test/index.ts
@@ -3,6 +3,7 @@ export { advanceReactClock } from './advanceReactClock';
 export { createRenderer } from './createRenderer';
 export { describeConformance } from './describeConformance';
 export { enterWithMouse, moveMouse } from './pointer';
+export { mergeRefs } from './mergeRefs';
 export { popupConformanceTests } from './popupConformanceTests';
 export { resetBrowserPointer } from './resetBrowserPointer';
 export { useTestInteractions } from './useTestInteractions';

--- a/packages/react/test/mergeRefs.ts
+++ b/packages/react/test/mergeRefs.ts
@@ -1,0 +1,13 @@
+import type * as React from 'react';
+
+export function mergeRefs<T>(...refs: React.Ref<T>[]) {
+  return (value: T | null) => {
+    refs.forEach((ref) => {
+      if (typeof ref === 'function') {
+        ref(value);
+      } else if (ref) {
+        ref.current = value;
+      }
+    });
+  };
+}


### PR DESCRIPTION
Fixes #5432

Cause: [#5256](https://github.com/mui/base-ui/pull/5256)

React Router's `Link` recreates its merged host ref on every render. React then detaches and reattaches the same DOM node, causing `CompositeList` to publish an equivalent map. Tabs and Slider feed that notification back into rendering, so the ref churn never settles and eventually reaches React's maximum update depth.

## Changes

- Notify CompositeList subscribers only when the ordered elements, indexes, or metadata change.
- Continue synchronizing refs and observation during equivalent ref churn.
- Cover the reported React Router case and add framework-independent unstable-ref regressions for Tabs and Slider.

## Performance

The worst case is an unchanged dirty list where the comparison scans every item. Synthetic median timings compare the added scan with the existing ref/map rebuild:

| Items | Existing rebuild | Added scan | Relative cost |
| ---: | ---: | ---: | ---: |
| 1,000 | 0.0209 ms | 0.0018 ms | 8.5% |
| 10,000 | 0.381 ms | 0.0285 ms | 7.5% |
| 100,000 | 4.83 ms | 0.265 ms | 5.5% |

Stable refs do not dirty the list, and the comparison retains no additional map or per-item state.
