### PR TITLE
[popover] Fix detached trigger store migration

### DIFF
--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.test.tsx
@@ -15,6 +15,8 @@ import {
   type DrawerProviderContext,
   useDrawerProviderContext,
 } from '../provider/DrawerProviderContext';
+import { useDialogRootContext } from '../../dialog/root/DialogRootContext';
+import type { DialogStore } from '../../dialog/store/DialogStore';
 
 const useIdMockState = vi.hoisted(() => ({ returnUndefined: false }));
 const eventUtilsMockState = vi.hoisted(() => ({ forceVirtualClick: false }));
@@ -261,6 +263,11 @@ async function swipeLeft(
   options?: SwipeOptions,
 ) {
   return swipe(element, { x: startX, y: 10 }, { x: endX, y: 10 }, options);
+}
+
+function StoreProbe({ storeRef }: { storeRef: { current: DialogStore<unknown> | null } }) {
+  storeRef.current = useDialogRootContext();
+  return null;
 }
 
 describe('<Drawer.SwipeArea />', () => {
@@ -821,6 +828,65 @@ describe('<Drawer.SwipeArea />', () => {
     } finally {
       useIdMockState.returnUndefined = false;
     }
+  });
+
+  it('registers the swipe area once a generated id becomes available', async () => {
+    useIdMockState.returnUndefined = true;
+    const storeRef: { current: DialogStore<unknown> | null } = { current: null };
+
+    function App() {
+      const [, forceRender] = React.useReducer((count: number) => count + 1, 0);
+
+      React.useEffect(() => {
+        // React 17's `useId` fallback resolves the id in an effect after the first commit.
+        useIdMockState.returnUndefined = false;
+        forceRender();
+      }, []);
+
+      return (
+        <Drawer.Root>
+          <StoreProbe storeRef={storeRef} />
+          <Drawer.SwipeArea data-testid="swipe-area" />
+        </Drawer.Root>
+      );
+    }
+
+    try {
+      await render(<App />);
+
+      const swipeArea = screen.getByTestId('swipe-area');
+      await waitFor(() => {
+        expect(swipeArea).toHaveAttribute('id');
+      });
+
+      expect(storeRef.current!.context.triggerElements.getById(swipeArea.id)).toBe(swipeArea);
+    } finally {
+      useIdMockState.returnUndefined = false;
+    }
+  });
+
+  it('follows a swipe area id change', async () => {
+    const storeRef: { current: DialogStore<unknown> | null } = { current: null };
+
+    function App({ id }: { id: string }) {
+      return (
+        <Drawer.Root>
+          <StoreProbe storeRef={storeRef} />
+          <Drawer.SwipeArea data-testid="swipe-area" id={id} />
+        </Drawer.Root>
+      );
+    }
+
+    const { setProps } = await render(<App id="first" />);
+
+    const swipeArea = screen.getByTestId('swipe-area');
+    expect(storeRef.current!.context.triggerElements.getById('first')).toBe(swipeArea);
+
+    await setProps({ id: 'second' });
+
+    expect(storeRef.current!.context.triggerElements.getById('first')).toBeUndefined();
+    expect(storeRef.current!.context.triggerElements.getById('second')).toBe(swipeArea);
+    expect(storeRef.current!.context.triggerElements.size).toBe(1);
   });
 
   it('opens the drawer when swiped with touch events', async () => {

--- a/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
+++ b/packages/react/src/drawer/swipe-area/DrawerSwipeArea.tsx
@@ -112,6 +112,14 @@ export const DrawerSwipeArea = React.forwardRef(function DrawerSwipeArea(
   const swipeAreaId = useBaseUiId(componentProps.id);
   const registerTrigger = useTriggerRegistration(swipeAreaId, store);
 
+  // `registerTrigger` is stable, so the ref does not re-fire when the id changes: re-register the
+  // rendered element here instead. On React 17 the id also starts out `undefined`, so this is what
+  // registers the swipe area at all.
+  useIsoLayoutEffect(() => {
+    registerTrigger(swipeAreaRef.current);
+    return () => registerTrigger(null);
+  }, [registerTrigger, swipeAreaId, store]);
+
   const open = store.useState('open');
 
   const resetDragDelta = useStableCallback(() => {

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
@@ -4,6 +4,8 @@ import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Menu } from '@base-ui/react/menu';
 import { SafeReact } from '@base-ui/utils/safeReact';
+import { useMenuRootContext } from '../root/MenuRootContext';
+import type { MenuStore } from '../store/MenuStore';
 
 type TextDirection = 'ltr' | 'rtl';
 const hasCaptureOwnerStack = typeof SafeReact.captureOwnerStack === 'function';
@@ -43,6 +45,50 @@ describe('<Menu.SubmenuTrigger />', () => {
       );
     },
   }));
+
+  it('follows a submenu trigger id change', async () => {
+    const storeRef: { current: MenuStore<unknown> | null } = { current: null };
+
+    function StoreProbe() {
+      storeRef.current = useMenuRootContext().store;
+      return null;
+    }
+
+    function App({ id }: { id: string }) {
+      return (
+        <Menu.Root open>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.SubmenuRoot>
+                  <StoreProbe />
+                  <Menu.SubmenuTrigger id={id}>More</Menu.SubmenuTrigger>
+                  <Menu.Portal>
+                    <Menu.Positioner>
+                      <Menu.Popup>
+                        <Menu.Item>Monthly</Menu.Item>
+                      </Menu.Popup>
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.SubmenuRoot>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
+      );
+    }
+
+    const { setProps } = await render(<App id="first" />);
+
+    const submenuTrigger = screen.getByText('More');
+    expect(storeRef.current!.context.triggerElements.getById('first')).toBe(submenuTrigger);
+
+    await setProps({ id: 'second' });
+
+    expect(storeRef.current!.context.triggerElements.getById('first')).toBeUndefined();
+    expect(storeRef.current!.context.triggerElements.getById('second')).toBe(submenuTrigger);
+    expect(storeRef.current!.context.triggerElements.size).toBe(1);
+  });
 
   it('throws when rendered outside Menu.SubmenuRoot', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -63,7 +63,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
   const baseRegisterTrigger = useTriggerRegistration(thisTriggerId, store);
   const registerTrigger = React.useCallback(
     (element: Element | null) => {
-      const cleanup = baseRegisterTrigger(element);
+      baseRegisterTrigger(element);
 
       if (element !== null && store.select('open') && store.select('activeTriggerId') == null) {
         store.update({
@@ -72,8 +72,6 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
           closeDelay,
         });
       }
-
-      return cleanup;
     },
     [baseRegisterTrigger, closeDelay, store, thisTriggerId],
   );

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -5,6 +5,8 @@ import { warn } from '@base-ui/utils/warn';
 import { SafeReact } from '@base-ui/utils/safeReact';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { platform } from '@base-ui/utils/platform';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { safePolygon, useClick, useHoverReferenceInteraction } from '../../floating-ui-react';
 import { BaseUIComponentProps, NonNativeButtonProps } from '../../internals/types';
 import { useMenuRootContext } from '../root/MenuRootContext';
@@ -61,20 +63,19 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
   const popupId = store.useState('triggerPopupId', thisTriggerId);
 
   const baseRegisterTrigger = useTriggerRegistration(thisTriggerId, store);
-  const registerTrigger = React.useCallback(
-    (element: Element | null) => {
-      baseRegisterTrigger(element);
+  // Stable, so the merged ref on the rendered element keeps its identity for the trigger's whole
+  // lifetime; the latest `closeDelay` is read when it runs.
+  const registerTrigger = useStableCallback((element: Element | null) => {
+    baseRegisterTrigger(element);
 
-      if (element !== null && store.select('open') && store.select('activeTriggerId') == null) {
-        store.update({
-          activeTriggerId: thisTriggerId ?? null,
-          activeTriggerElement: element,
-          closeDelay,
-        });
-      }
-    },
-    [baseRegisterTrigger, closeDelay, store, thisTriggerId],
-  );
+    if (element !== null && store.select('open') && store.select('activeTriggerId') == null) {
+      store.update({
+        activeTriggerId: thisTriggerId ?? null,
+        activeTriggerElement: element,
+        closeDelay,
+      });
+    }
+  });
 
   const triggerElementRef = React.useRef<HTMLElement | null>(null);
   const handleTriggerElementRef = React.useCallback(
@@ -84,6 +85,14 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
     },
     [store],
   );
+
+  // A stable ref does not re-fire when the id changes, so register the rendered element here
+  // instead. On React 17 the id also starts out `undefined`, so this is what registers the trigger
+  // at all.
+  useIsoLayoutEffect(() => {
+    registerTrigger(triggerElementRef.current);
+    return () => registerTrigger(null);
+  }, [registerTrigger, thisTriggerId, store]);
 
   store.useSyncedValue('closeDelay', closeDelay);
 

--- a/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
@@ -144,7 +144,7 @@ describe('<Popover.Root />', () => {
 
     const swappedTrigger = screen.getByRole('button', { name: 'Trigger' });
     // Guards the setup: without a real host swap the rest of the test proves nothing.
-    expect(swappedTrigger).not.to.equal(initialTrigger);
+    expect(swappedTrigger).not.toBe(initialTrigger);
     expect(initialTrigger.isConnected).toBe(false);
     expect(fallbackStore.context.triggerElements.size).toBe(0);
     expect(handle.store.context.triggerElements.getById('trigger')).toBe(swappedTrigger);
@@ -159,6 +159,41 @@ describe('<Popover.Root />', () => {
       expect(screen.getByTestId('popup')).toBeVisible();
     });
     expect(handle.store.state.activeTriggerElement).toBe(swappedTrigger);
+  });
+
+  it('does not detach the consumer ref when the handle attaches to a root', async () => {
+    const handle = Popover.createHandle();
+    const refCalls: (Element | null)[] = [];
+
+    await render(
+      <React.Fragment>
+        <Popover.Trigger
+          handle={handle}
+          id="trigger"
+          ref={(element: HTMLElement | null) => {
+            refCalls.push(element);
+          }}
+        >
+          Trigger
+        </Popover.Trigger>
+        <Popover.Root handle={handle}>
+          <Popover.Portal>
+            <Popover.Positioner>
+              <Popover.Popup>Content</Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>
+      </React.Fragment>,
+      // Strict Mode replays the ref on its own, which would mask a migration-driven detach.
+      { strict: false },
+    );
+
+    expect(handle.store.context.triggerElements.getById('trigger')).toBe(
+      screen.getByRole('button', { name: 'Trigger' }),
+    );
+    // Migrating from the fallback store to the root's store must not churn the merged ref, which
+    // would hand the consumer a spurious `null` and back.
+    expect(refCalls).toEqual([screen.getByRole('button', { name: 'Trigger' })]);
   });
 
   describe.skipIf(isJSDOM)('handle-backed root ownership', () => {

--- a/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
@@ -13,12 +13,14 @@ describe('<Popover.Root />', () => {
 
   const { render, clock } = createRenderer();
 
+  // Stands in for ref mergers like `@rc-component/util`'s `useComposeRef`, which retain the
+  // callback they were first given.
   const StaleRefButton = React.forwardRef<
     HTMLButtonElement,
-    React.ComponentPropsWithoutRef<'button'>
-  >(function StaleRefButton(props, forwardedRef) {
+    React.ComponentPropsWithoutRef<'button'> & { nodeKey?: string }
+  >(function StaleRefButton({ nodeKey, ...props }, forwardedRef) {
     const staleRef = React.useRef(forwardedRef).current;
-    return <button {...props} ref={staleRef} />;
+    return <button key={nodeKey} {...props} ref={staleRef} />;
   });
 
   it('opens by trigger from a descendant layout effect on initial mount', async () => {
@@ -67,6 +69,9 @@ describe('<Popover.Root />', () => {
             payload={payload}
             openOnHover
             delay={0}
+            // Forces the handoff path: without a close delay the popup just closes and reopens,
+            // which works even when the trigger is registered on the wrong store.
+            closeDelay={100}
             render={<StaleRefButton />}
           >
             Trigger {payload}
@@ -96,6 +101,64 @@ describe('<Popover.Root />', () => {
     await waitFor(() => {
       expect(screen.getByTestId('popup')).toHaveTextContent('2');
     });
+  });
+
+  it('keeps registration on the attached store when a stale-ref component swaps its host node', async () => {
+    const handle = Popover.createHandle<number>();
+    const fallbackStore = handle.store;
+
+    function App() {
+      const [nodeKey, setNodeKey] = React.useState('a');
+      return (
+        <React.Fragment>
+          <button type="button" onClick={() => setNodeKey('b')}>
+            Swap node
+          </button>
+          <Popover.Trigger
+            handle={handle}
+            id="trigger"
+            payload={1}
+            render={<StaleRefButton nodeKey={nodeKey} />}
+          >
+            Trigger
+          </Popover.Trigger>
+          <Popover.Root handle={handle}>
+            <Popover.Portal>
+              <Popover.Positioner>
+                <Popover.Popup data-testid="popup">Content</Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          </Popover.Root>
+        </React.Fragment>
+      );
+    }
+
+    const { user } = await render(<App />);
+
+    const initialTrigger = screen.getByRole('button', { name: 'Trigger' });
+    expect(fallbackStore.context.triggerElements.size).toBe(0);
+    expect(handle.store.context.triggerElements.getById('trigger')).toBe(initialTrigger);
+
+    // Replacing the host node re-fires the retained ref callback after the migration.
+    await user.click(screen.getByRole('button', { name: 'Swap node' }));
+
+    const swappedTrigger = screen.getByRole('button', { name: 'Trigger' });
+    // Guards the setup: without a real host swap the rest of the test proves nothing.
+    expect(swappedTrigger).not.to.equal(initialTrigger);
+    expect(initialTrigger.isConnected).toBe(false);
+    expect(fallbackStore.context.triggerElements.size).toBe(0);
+    expect(handle.store.context.triggerElements.getById('trigger')).toBe(swappedTrigger);
+
+    // `open()` searches attached stores first, so a registration left on the wrong store would
+    // anchor the popup to the removed node.
+    await act(async () => {
+      handle.open('trigger');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('popup')).toBeVisible();
+    });
+    expect(handle.store.state.activeTriggerElement).toBe(swappedTrigger);
   });
 
   describe.skipIf(isJSDOM)('handle-backed root ownership', () => {

--- a/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
@@ -13,6 +13,14 @@ describe('<Popover.Root />', () => {
 
   const { render, clock } = createRenderer();
 
+  const StaleRefButton = React.forwardRef<
+    HTMLButtonElement,
+    React.ComponentPropsWithoutRef<'button'>
+  >(function StaleRefButton(props, forwardedRef) {
+    const staleRef = React.useRef(forwardedRef).current;
+    return <button {...props} ref={staleRef} />;
+  });
+
   it('opens by trigger from a descendant layout effect on initial mount', async () => {
     const handle = Popover.createHandle();
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -43,6 +51,51 @@ describe('<Popover.Root />', () => {
       'aria-expanded',
       'true',
     );
+  });
+
+  it('hands off hover between detached triggers when the rendered component retains a stale ref', async () => {
+    const handle = Popover.createHandle<number>();
+    const fallbackStore = handle.store;
+
+    const { user } = await render(
+      <React.Fragment>
+        {[1, 2].map((payload) => (
+          <Popover.Trigger
+            key={payload}
+            handle={handle}
+            id={`trigger-${payload}`}
+            payload={payload}
+            openOnHover
+            delay={0}
+            render={<StaleRefButton />}
+          >
+            Trigger {payload}
+          </Popover.Trigger>
+        ))}
+        <Popover.Root handle={handle}>
+          {({ payload }) => (
+            <Popover.Portal>
+              <Popover.Positioner>
+                <Popover.Popup data-testid="popup">{payload}</Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          )}
+        </Popover.Root>
+      </React.Fragment>,
+    );
+
+    expect(fallbackStore.context.triggerElements.size).toBe(0);
+    expect(handle.store.context.triggerElements.size).toBe(2);
+
+    await user.hover(screen.getByRole('button', { name: 'Trigger 1' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('popup')).toHaveTextContent('1');
+    });
+
+    await user.hover(screen.getByRole('button', { name: 'Trigger 2' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('popup')).toHaveTextContent('2');
+    });
   });
 
   describe.skipIf(isJSDOM)('handle-backed root ownership', () => {

--- a/packages/react/src/utils/popups/popupHandle.ts
+++ b/packages/react/src/utils/popups/popupHandle.ts
@@ -144,8 +144,8 @@ export class BasePopupHandle<
 
   /**
    * Points the handle at a root's store and notifies subscribers so detached triggers re-render and
-   * re-register into it (their registration ref re-fires on the store-pointer change). Returns a
-   * cleanup function that detaches the store again.
+   * re-register into it (their registration effect migrates them when the store pointer changes).
+   * Returns a cleanup function that detaches the store again.
    * @internal
    */
   attachStore(newStore: Store) {

--- a/packages/react/src/utils/popups/popupStoreUtils.test.tsx
+++ b/packages/react/src/utils/popups/popupStoreUtils.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import * as React from 'react';
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { flushMicrotasks } from '@mui/internal-test-utils';
 import { ReactStore } from '@base-ui/utils/store';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
@@ -316,6 +316,64 @@ describe('useTriggerRegistration', () => {
 
     unmount();
     expect(second.context.triggerElements.getById('trigger')).toBeUndefined();
+  });
+
+  describe('callers that pass the callback straight into a ref', () => {
+    // Mirrors `Drawer.SwipeArea`: the callback is merged into the rendered element's ref, and the
+    // migration effect is what re-registers it when the id changes.
+    function RefOnlyTrigger({ id, store }: { id: string | undefined; store: TestStore }) {
+      const register = useTriggerRegistration(id, store);
+      const elementRef = React.useRef<HTMLButtonElement | null>(null);
+
+      useIsoLayoutEffect(() => {
+        register(elementRef.current);
+        return () => register(null);
+      }, [register, id, store]);
+
+      const handleRef = React.useCallback(
+        (element: HTMLButtonElement | null) => {
+          elementRef.current = element;
+          register(element);
+        },
+        [register],
+      );
+
+      return <button type="button" data-testid="trigger" ref={handleRef} />;
+    }
+
+    it('registers once the id resolves after the first commit', () => {
+      const store = createStore();
+
+      const { rerender } = render(<RefOnlyTrigger id={undefined} store={store} />);
+      const element = screen.getByTestId('trigger');
+
+      expect(store.context.triggerElements.size).toBe(0);
+
+      // React 17's `useId` fallback returns `undefined` on the first render and a real id after an
+      // effect commits.
+      rerender(<RefOnlyTrigger id="trigger" store={store} />);
+
+      expect(store.context.triggerElements.getById('trigger')).toBe(element);
+      expect(store.context.triggerElements.size).toBe(1);
+    });
+
+    it('follows an id change', () => {
+      const store = createStore();
+
+      const { rerender, unmount } = render(<RefOnlyTrigger id="first" store={store} />);
+      const element = screen.getByTestId('trigger');
+
+      expect(store.context.triggerElements.getById('first')).toBe(element);
+
+      rerender(<RefOnlyTrigger id="second" store={store} />);
+
+      expect(store.context.triggerElements.getById('first')).toBeUndefined();
+      expect(store.context.triggerElements.getById('second')).toBe(element);
+      expect(store.context.triggerElements.size).toBe(1);
+
+      unmount();
+      expect(store.context.triggerElements.size).toBe(0);
+    });
   });
 
   it('keeps triggerCount reactive while the popup is open', () => {

--- a/packages/react/src/utils/popups/popupStoreUtils.test.tsx
+++ b/packages/react/src/utils/popups/popupStoreUtils.test.tsx
@@ -67,6 +67,7 @@ function TestTrigger({
 }) {
   const register = useTriggerRegistration(id, store);
 
+  // `register` is stable, so the caller owns migration by keying this effect on `[store, id]`.
   useIsoLayoutEffect(() => {
     for (let i = 0; i < repeat; i += 1) {
       register(element);
@@ -74,7 +75,7 @@ function TestTrigger({
     return () => {
       register(null);
     };
-  }, [register, repeat, element]);
+  }, [register, repeat, element, store, id]);
 
   return null;
 }
@@ -272,6 +273,49 @@ describe('useTriggerRegistration', () => {
     expect(store.context.triggerElements.hasElement(element)).toBe(false);
     expect(store.state.triggerCount).toBe(0);
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('returns a stable callback that unregisters from the store it registered in', () => {
+    const first = createStore();
+    const second = createStore();
+    const element = document.createElement('button');
+    let registerRef: ((element: Element | null) => void) | null = null;
+
+    function Probe({ store }: { store: ReturnType<typeof createStore> }) {
+      const register = useTriggerRegistration('trigger', store);
+      registerRef = register;
+
+      useIsoLayoutEffect(() => {
+        register(element);
+        return () => register(null);
+      }, [register, store]);
+
+      return null;
+    }
+
+    const { rerender, unmount } = render(<Probe store={first} />);
+    const initialRegister = registerRef as unknown as (element: Element | null) => void;
+
+    expect(first.context.triggerElements.getById('trigger')).toBe(element);
+
+    rerender(<Probe store={second} />);
+
+    expect(registerRef).toBe(initialRegister);
+    expect(first.context.triggerElements.getById('trigger')).toBeUndefined();
+    expect(second.context.triggerElements.getById('trigger')).toBe(element);
+
+    // A retained callback from before the migration must still act on the current store.
+    const replacement = document.createElement('button');
+    act(() => {
+      initialRegister(null);
+      initialRegister(replacement);
+    });
+
+    expect(first.context.triggerElements.getById('trigger')).toBeUndefined();
+    expect(second.context.triggerElements.getById('trigger')).toBe(replacement);
+
+    unmount();
+    expect(second.context.triggerElements.getById('trigger')).toBeUndefined();
   });
 
   it('keeps triggerCount reactive while the popup is open', () => {

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -348,7 +348,7 @@ export function useTriggerDataForwarding<
   });
 
   // Intentionally not stable. Its identity follows `[store, id]` so ordinary ref handling migrates
-  // the trigger. The layout effect below also synchronizes downstream ref mergers that retain it.
+  // the trigger.
   const registerTrigger = React.useCallback(
     (element: Element | null) => {
       baseRegisterTrigger(element);
@@ -359,6 +359,8 @@ export function useTriggerDataForwarding<
     [baseRegisterTrigger, applyTriggerData],
   );
 
+  // A downstream ref merger may retain a stale callback when `registerTrigger` changes.
+  // Synchronize from the retained element so store and id migrations still complete.
   useIsoLayoutEffect(() => {
     registerTrigger(triggerElementRef.current);
     return () => registerTrigger(null);

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -134,7 +134,9 @@ function syncTriggerCount(store: PopupTriggerDataStore<PopupStoreState<unknown>>
  * unregistering targets the store the element was actually registered in.
  *
  * Since the callback never changes, the caller must re-run it from a layout effect keyed on
- * `[store, id]` to migrate an already-registered element.
+ * `[store, id]` to migrate an already-registered element. That effect is also what registers the
+ * element in the first place when `id` only resolves after the first commit (React 17's `useId`
+ * fallback), because the register call made while the id is still `undefined` does nothing.
  *
  * @param id Id of the trigger.
  * @param store The Store instance where the trigger should be registered.

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -119,57 +119,65 @@ export function PopupHandleAttachment<Store>({
   return null;
 }
 
+function syncTriggerCount(store: PopupTriggerDataStore<PopupStoreState<unknown>>) {
+  const triggerCount = store.context.triggerElements.size;
+  if (store.select('open') && store.state.triggerCount !== triggerCount) {
+    store.set('triggerCount', triggerCount);
+  }
+}
+
 /**
- * Returns a callback ref that registers/unregisters the trigger element in the store.
+ * Returns a stable callback ref that registers/unregisters the trigger element in the store.
  *
+ * Stable so a downstream ref merger that retains the callback it was first given still reaches the
+ * trigger's current store. The registration is tracked as a `(store, id, element)` triple, so
+ * unregistering targets the store the element was actually registered in.
+ *
+ * Since the callback never changes, the caller must re-run it from a layout effect keyed on
+ * `[store, id]` to migrate an already-registered element.
+ *
+ * @param id Id of the trigger.
  * @param store The Store instance where the trigger should be registered.
  */
 export function useTriggerRegistration<State extends PopupStoreState<unknown>>(
   id: string | undefined,
   store: PopupTriggerDataStore<State>,
 ) {
-  // Keep track of the currently registered element to unregister it on unmount or id change.
-  const registeredElementIdRef = React.useRef<string | null>(null);
-  const registeredElementRef = React.useRef<Element | null>(null);
+  const registrationRef = React.useRef<{
+    store: PopupTriggerDataStore<State>;
+    id: string;
+    element: Element;
+  } | null>(null);
 
-  return React.useCallback(
-    (element: Element | null) => {
-      if (id === undefined) {
+  return useStableCallback((element: Element | null) => {
+    const registration = registrationRef.current;
+
+    if (registration !== null) {
+      if (
+        registration.element === element &&
+        registration.store === store &&
+        registration.id === id
+      ) {
+        // Already registered where it belongs, so the caller's migration effect is free on mount.
         return;
       }
 
-      let shouldSyncTriggerCount = false;
-
-      if (registeredElementIdRef.current !== null) {
-        const registeredId = registeredElementIdRef.current;
-        const registeredElement = registeredElementRef.current;
-        const currentElement = store.context.triggerElements.getById(registeredId);
-
-        if (registeredElement && currentElement === registeredElement) {
-          store.context.triggerElements.delete(registeredId);
-          shouldSyncTriggerCount = true;
-        }
-
-        registeredElementIdRef.current = null;
-        registeredElementRef.current = null;
+      registrationRef.current = null;
+      const registeredStore = registration.store;
+      if (
+        registeredStore.context.triggerElements.getById(registration.id) === registration.element
+      ) {
+        registeredStore.context.triggerElements.delete(registration.id);
+        syncTriggerCount(registeredStore);
       }
+    }
 
-      if (element !== null) {
-        registeredElementIdRef.current = id;
-        registeredElementRef.current = element;
-        store.context.triggerElements.add(id, element);
-        shouldSyncTriggerCount = true;
-      }
-
-      if (shouldSyncTriggerCount) {
-        const triggerCount = store.context.triggerElements.size;
-        if (store.select('open') && store.state.triggerCount !== triggerCount) {
-          store.set('triggerCount', triggerCount);
-        }
-      }
-    },
-    [store, id],
-  );
+    if (element !== null && id !== undefined) {
+      registrationRef.current = { store, id, element };
+      store.context.triggerElements.add(id, element);
+      syncTriggerCount(store);
+    }
+  });
 }
 
 type PopupOpenState = Pick<
@@ -347,24 +355,21 @@ export function useTriggerDataForwarding<
     }
   });
 
-  // Intentionally not stable. Its identity follows `[store, id]` so ordinary ref handling migrates
-  // the trigger.
-  const registerTrigger = React.useCallback(
-    (element: Element | null) => {
-      baseRegisterTrigger(element);
-      if (element) {
-        applyTriggerData(element);
-      }
-    },
-    [baseRegisterTrigger, applyTriggerData],
-  );
+  // Stable, so the merged ref on the rendered element keeps its identity for the trigger's whole
+  // lifetime.
+  const registerTrigger = useStableCallback((element: Element | null) => {
+    baseRegisterTrigger(element);
+    if (element) {
+      applyTriggerData(element);
+    }
+  });
 
-  // A downstream ref merger may retain a stale callback when `registerTrigger` changes.
-  // Synchronize from the retained element so store and id migrations still complete.
+  // A stable ref does not re-fire on a store or id change, so migrate here instead: unregister from
+  // the previous store, then register the element the trigger still renders into the current one.
   useIsoLayoutEffect(() => {
     registerTrigger(triggerElementRef.current);
     return () => registerTrigger(null);
-  }, [registerTrigger, triggerElementRef]);
+  }, [registerTrigger, triggerElementRef, store, triggerId]);
 
   useIsoLayoutEffect(() => {
     if (isMountedByThisTrigger) {

--- a/packages/react/src/utils/popups/popupStoreUtils.ts
+++ b/packages/react/src/utils/popups/popupStoreUtils.ts
@@ -347,11 +347,8 @@ export function useTriggerDataForwarding<
     }
   });
 
-  // Intentionally NOT stable. Its identity is derived from `baseRegisterTrigger`, which is keyed on
-  // `[store, id]`, so when a handle-backed trigger's store pointer swaps the merged ref re-fires —
-  // unregistering from the previous store and registering into the new one. This lets a detached
-  // trigger follow its handle's currently-attached store across attach/detach/remount. (A stable
-  // callback would keep its identity and never re-fire on a store swap.)
+  // Intentionally not stable. Its identity follows `[store, id]` so ordinary ref handling migrates
+  // the trigger. The layout effect below also synchronizes downstream ref mergers that retain it.
   const registerTrigger = React.useCallback(
     (element: Element | null) => {
       baseRegisterTrigger(element);
@@ -361,6 +358,11 @@ export function useTriggerDataForwarding<
     },
     [baseRegisterTrigger, applyTriggerData],
   );
+
+  useIsoLayoutEffect(() => {
+    registerTrigger(triggerElementRef.current);
+    return () => registerTrigger(null);
+  }, [registerTrigger, triggerElementRef]);
 
   useIsoLayoutEffect(() => {
     if (isMountedByThisTrigger) {


### PR DESCRIPTION
Fixes #5416

(Cause: https://github.com/mui/base-ui/pull/5149)

Base UI 1.7 changed a detached trigger's registration ref when its handle moved between the fallback and Root stores. A ref-merging component that retains the callback it was first given never calls the new one, so the trigger stays registered on the fallback store. Hover handoff resolves the destination trigger through the attached store's trigger map, finds nothing, and closes the popup instead of switching to the new trigger.

## Changes

- Make the trigger registration callback stable, so a retained downstream callback still reaches the trigger's current store.
- Track the active registration as a `(store, id, element)` triple, so unregistering targets the store the element was registered in rather than whichever store the caller captured.
- Move migration between stores into a layout effect keyed on `[store, id]`, since a stable ref no longer re-fires on those changes.
- Skip a register call that would re-register the same element under the same store and id.

## Notes

A stable ref also fixes a second failure with the same precondition. Once a merger has retained the callback from before the trigger migrated, replacing the rendered host node re-invokes that callback. It closes over the previous store, so the live node returns to the fallback store while the attached store keeps the disconnected one. `handle.open(triggerId)` searches attached stores first, so the popup then anchors to a removed element. A component that merges refs correctly, or does not merge at all, was never affected.

Consumers' own refs are no longer detached and reattached when a trigger's handle moves between stores.

## Tests

- Hover handoff across detached triggers whose rendered component retains a stale ref. A non-zero `closeDelay` is what forces the handoff path: without it the popup closes and reopens, which passes even when the trigger is registered on the wrong store.
- Host node replacement after a fallback-to-Root migration, asserting store contents and that `handle.open()` anchors to the live node.
- A `useTriggerRegistration` unit test covering callback stability and unregistering from the correct store.
