### PR TITLE
[tooltip] Respect trigger delay with zero provider delay

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingDelayGroup.tsx
@@ -17,7 +17,7 @@ interface ContextValue {
   delayRef: React.RefObject<Delay>;
   initialDelayRef: React.RefObject<Delay>;
   timeout: Timeout;
-  currentIdRef: React.RefObject<any>;
+  currentIdRef: React.RefObject<string | null | undefined>;
   currentContextRef: React.RefObject<{
     onOpenChange: (open: boolean, eventDetails: BaseUIChangeEventDetails<any>) => void;
     setIsInstantPhase: (value: boolean) => void;
@@ -114,6 +114,10 @@ interface UseDelayGroupOptions {
 }
 
 interface UseDelayGroupReturn {
+  /**
+   * The id of the floating element keeping the delay group active.
+   */
+  activeIdRef: React.RefObject<string | null | undefined>;
   /**
    * The delay reference object.
    */
@@ -267,10 +271,11 @@ export function useDelayGroup(
 
   return React.useMemo(
     () => ({
+      activeIdRef: currentIdRef,
       hasProvider,
       delayRef,
       isInstantPhase,
     }),
-    [hasProvider, delayRef, isInstantPhase],
+    [currentIdRef, hasProvider, delayRef, isInstantPhase],
   );
 }

--- a/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
+++ b/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
@@ -194,12 +194,20 @@ describe('<Tooltip.Provider />', () => {
   describe('prop: timeout', () => {
     clock.withFakeTimers();
 
-    function TwoTooltips({ timeout }: { timeout: number }) {
+    function TwoTooltips({
+      timeout,
+      providerDelay = 100,
+      triggerDelay,
+    }: {
+      timeout: number;
+      providerDelay?: number;
+      triggerDelay?: number;
+    }) {
       return (
-        <Tooltip.Provider delay={100} timeout={timeout}>
+        <Tooltip.Provider delay={providerDelay} timeout={timeout}>
           {['One', 'Two'].map((name) => (
             <Tooltip.Root key={name}>
-              <Tooltip.Trigger>{name}</Tooltip.Trigger>
+              <Tooltip.Trigger delay={triggerDelay}>{name}</Tooltip.Trigger>
               <Tooltip.Portal>
                 <Tooltip.Positioner>
                   <Tooltip.Popup>{`Content ${name}`}</Tooltip.Popup>
@@ -232,6 +240,46 @@ describe('<Tooltip.Provider />', () => {
 
       expect(screen.queryByText('Content Two')).not.toBe(null);
       expect(screen.queryByText('Content One')).toBe(null);
+    });
+
+    it('respects a trigger delay over delay=0 outside the instant phase', async () => {
+      await render(<TwoTooltips timeout={400} providerDelay={0} triggerDelay={100} />);
+
+      const first = screen.getByRole('button', { name: 'One' });
+      const second = screen.getByRole('button', { name: 'Two' });
+
+      fireEvent.mouseEnter(first);
+      fireEvent.mouseMove(first);
+      await flushMicrotasks();
+
+      await tick(99);
+      expect(screen.queryByText('Content One')).toBe(null);
+
+      await tick(1);
+      expect(screen.queryByText('Content One')).not.toBe(null);
+
+      fireEvent.mouseLeave(first);
+      fireEvent.mouseEnter(second);
+      fireEvent.mouseMove(second);
+      await flushMicrotasks();
+      await tick(0);
+
+      expect(screen.queryByText('Content Two')).not.toBe(null);
+      expect(screen.queryByText('Content One')).toBe(null);
+
+      fireEvent.mouseLeave(second);
+      await flushMicrotasks();
+      await tick(400);
+
+      fireEvent.mouseEnter(first);
+      fireEvent.mouseMove(first);
+      await flushMicrotasks();
+
+      await tick(99);
+      expect(screen.queryByText('Content One')).toBe(null);
+
+      await tick(1);
+      expect(screen.queryByText('Content One')).not.toBe(null);
     });
 
     it('requires the full delay again once the timeout elapses', async () => {

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -103,7 +103,6 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
 
   const triggerElementRef = React.useRef<Element | null>(null);
 
-  const delayWithDefault = delay ?? OPEN_DELAY;
   const closeDelayWithDefault = closeDelay ?? 0;
 
   const { registerTrigger, isMountedByThisTrigger } = useTriggerDataForwarding(
@@ -140,10 +139,11 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
   const pointerTypeRef = React.useRef<string | undefined>(undefined);
 
   function getOpenDelay() {
-    if (!hasProvider) {
-      return delayWithDefault;
+    // Adjacent tooltips open instantly while the group is active.
+    if (hasProvider && activeIdRef.current != null) {
+      return 0;
     }
-    return activeIdRef.current == null ? (delay ?? providerDelay ?? OPEN_DELAY) : 0;
+    return delay ?? providerDelay ?? OPEN_DELAY;
   }
 
   function isEnabledNestedTriggerTarget(target: Element | null) {

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -118,9 +118,12 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
   );
 
   const providerDelay = useTooltipProviderContext();
-  const { delayRef, isInstantPhase, hasProvider } = useDelayGroup(floatingRootContext, {
-    open: isOpenedByThisTrigger,
-  });
+  const { activeIdRef, delayRef, isInstantPhase, hasProvider } = useDelayGroup(
+    floatingRootContext,
+    {
+      open: isOpenedByThisTrigger,
+    },
+  );
   const hoverInteraction = useHoverInteractionSharedState(floatingRootContext);
 
   store.useSyncedValue('isInstantPhase', isInstantPhase);
@@ -140,7 +143,7 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
     if (!hasProvider) {
       return delayWithDefault;
     }
-    return getDelay(delayRef.current, 'open') === 0 ? 0 : (delay ?? providerDelay ?? OPEN_DELAY);
+    return activeIdRef.current == null ? (delay ?? providerDelay ?? OPEN_DELAY) : 0;
   }
 
   function isEnabledNestedTriggerTarget(target: Element | null) {


### PR DESCRIPTION
shadcn/ui sets `<Tooltip.Provider delay={0}>` by default. In that configuration, a non-zero `<Tooltip.Trigger delay>` was ignored because the provider's configured zero delay was indistinguishable from the delay group's temporary instant phase.

## Changes

- Use the group's existing active tooltip ID to decide when opening should be instant, allowing the trigger delay to override the provider delay before the group becomes active.
- Preserve instant adjacent tooltip opens while the group is active and restore the trigger delay after the timeout.
- Add regression coverage for the zero provider delay and per-trigger delay combination.

Related: shadcn-ui/ui#9617
