### PR TITLE
[ci] Bump Claude review footer metadata

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   claude-review:
-    uses: mui/mui-public/.github/workflows/claude-review.yml@6a01f9caec47cef7ab805248de15934b70745d59 # master
+    uses: mui/mui-public/.github/workflows/claude-review.yml@d934a6de99c7a164f090dc7935206f903f66a066 # master
     permissions:
       contents: read # read the repo (checkout + git diff)
       id-token: write # mint the GitHub OIDC token exchanged for a Claude token via WIF


### PR DESCRIPTION
Pins the shared review workflow to [mui/mui-public#1760](https://github.com/mui/mui-public/pull/1760) so the review footer reports the model and reasoning effort, and names the skill's level "review depth" rather than "effort".

## Changes

- Updated the reusable Claude review workflow pin to the [mui/mui-public#1760](https://github.com/mui/mui-public/pull/1760) merge commit.
