### PR TITLE
[all components] Fix labelable id registration and non-native label focus

### DIFF
--- a/docs/src/app/(docs)/react/components/slider/types.md
+++ b/docs/src/app/(docs)/react/components/slider/types.md
@@ -595,7 +595,7 @@ type SliderRootChangeEventCustomProperties = {
 ### ThumbMetadata
 
 ```typescript
-type ThumbMetadata = { inputId: string | null | undefined };
+type ThumbMetadata = { inputId: string | undefined };
 ```
 
 ## External Types

--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
+import { createRenderer, screen, fireEvent, waitFor } from '@mui/internal-test-utils';
 import { CheckboxGroup } from '@base-ui/react/checkbox-group';
 import { Checkbox } from '@base-ui/react/checkbox';
 import { Field } from '@base-ui/react/field';
@@ -10,7 +10,7 @@ import { Form } from '@base-ui/react/form';
 import { describeConformance, isJSDOM } from '#test-utils';
 
 describe('<CheckboxGroup />', () => {
-  const { render } = createRenderer();
+  const { render, renderToString } = createRenderer();
 
   describeConformance(<CheckboxGroup />, () => ({
     inheritComponent: 'div',
@@ -825,6 +825,85 @@ describe('<CheckboxGroup />', () => {
   });
 
   describe('Field.Label', () => {
+    it.each([
+      { nativeButton: false, parent: false },
+      { nativeButton: true, parent: false },
+      { nativeButton: false, parent: true },
+      { nativeButton: true, parent: true },
+    ])(
+      'associates a group-derived Checkbox id during SSR (nativeButton=$nativeButton, parent=$parent)',
+      ({ nativeButton, parent }) => {
+        renderToString(
+          <Field.Root name="apple">
+            <CheckboxGroup allValues={['fuji']}>
+              <Field.Item>
+                <Field.Label data-testid="label">Fuji</Field.Label>
+                <Checkbox.Root
+                  parent={parent}
+                  value={parent ? undefined : 'fuji'}
+                  nativeButton={nativeButton}
+                  render={nativeButton ? <button /> : undefined}
+                />
+              </Field.Item>
+            </CheckboxGroup>
+          </Field.Root>,
+        );
+
+        const control = nativeButton
+          ? screen.getByRole('checkbox')
+          : document.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+        expect(control.id).not.toBe('');
+        expect(screen.getByTestId('label')).toHaveAttribute('for', control.id);
+      },
+    );
+
+    it.each([false, true])(
+      'preserves parent aria-controls during SSR (nativeButton=%s)',
+      async (nativeButton) => {
+        const { hydrate } = renderToString(
+          <Field.Root name="apple">
+            <CheckboxGroup allValues={['fuji']}>
+              <Field.Item>
+                <Field.Label data-testid="label">All</Field.Label>
+                <Checkbox.Root
+                  parent
+                  data-testid="parent"
+                  nativeButton={nativeButton}
+                  render={nativeButton ? <button /> : undefined}
+                />
+              </Field.Item>
+              <Field.Item>
+                <Field.Label data-testid="label">Fuji</Field.Label>
+                <Checkbox.Root
+                  value="fuji"
+                  nativeButton={nativeButton}
+                  render={nativeButton ? <button /> : undefined}
+                />
+              </Field.Item>
+            </CheckboxGroup>
+          </Field.Root>,
+        );
+
+        const controls = screen.getAllByRole('checkbox', { hidden: true });
+        const controlledId = screen.getByTestId('parent').getAttribute('aria-controls')!;
+        expect(controls).toContain(document.getElementById(controlledId));
+        expect(document.querySelectorAll(`[id="${controlledId}"]`)).toHaveLength(1);
+
+        screen.getAllByTestId('label').forEach((label) => {
+          expect(controls).toContain(document.getElementById(label.getAttribute('for')!));
+        });
+
+        hydrate();
+
+        await waitFor(() => {
+          expect(document.querySelectorAll(`[id="${controlledId}"]`)).toHaveLength(1);
+        });
+        expect(screen.getAllByRole('checkbox', { hidden: true })).toContain(
+          document.getElementById(controlledId),
+        );
+      },
+    );
+
     it('implicit association', async () => {
       const changeSpy = vi.fn();
       render(

--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -825,6 +825,73 @@ describe('<CheckboxGroup />', () => {
   });
 
   describe('Field.Label', () => {
+    it.each([false, true])(
+      'keeps checkbox ids unique when the group shares one Field.Root (nativeButton=%s)',
+      async (nativeButton) => {
+        await render(
+          <Field.Root name="apples">
+            <Field.Label>Apples</Field.Label>
+            <CheckboxGroup allValues={['fuji', 'gala']}>
+              <Checkbox.Root
+                parent
+                data-testid="parent"
+                nativeButton={nativeButton}
+                render={nativeButton ? <button /> : undefined}
+              />
+              <Checkbox.Root
+                value="fuji"
+                nativeButton={nativeButton}
+                render={nativeButton ? <button /> : undefined}
+              />
+              <Checkbox.Root
+                value="gala"
+                nativeButton={nativeButton}
+                render={nativeButton ? <button /> : undefined}
+              />
+            </CheckboxGroup>
+          </Field.Root>,
+        );
+
+        const ids = Array.from(document.querySelectorAll('[id]'), (element) => element.id);
+        expect(new Set(ids).size).toBe(ids.length);
+
+        const controlledIds = screen
+          .getByTestId('parent')
+          .getAttribute('aria-controls')!
+          .split(' ');
+        controlledIds.forEach((controlledId) => {
+          expect(document.querySelectorAll(`[id="${controlledId}"]`)).toHaveLength(1);
+        });
+      },
+    );
+
+    it('gives each checkbox in a shared Field.Root its own accessible name', async () => {
+      await render(
+        <Field.Root name="apples">
+          <CheckboxGroup allValues={['fuji', 'gala']}>
+            <label>
+              <Checkbox.Root parent data-testid="parent" />
+              All
+            </label>
+            <label>
+              <Checkbox.Root value="fuji" data-testid="fuji" />
+              Fuji
+            </label>
+            <label>
+              <Checkbox.Root value="gala" data-testid="gala" />
+              Gala
+            </label>
+          </CheckboxGroup>
+        </Field.Root>,
+      );
+
+      ['All', 'Fuji', 'Gala'].forEach((name, index) => {
+        const testId = ['parent', 'fuji', 'gala'][index];
+        const labelId = screen.getByTestId(testId).getAttribute('aria-labelledby')!;
+        expect(document.getElementById(labelId)).toHaveTextContent(name);
+      });
+    });
+
     it.each([
       { nativeButton: false, parent: false },
       { nativeButton: true, parent: false },

--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
@@ -29,7 +29,9 @@ export function useCheckboxGroupParent(
       checked,
       // TODO: custom `id` on child checkboxes breaks this
       // https://github.com/mui/base-ui/issues/2691
-      'aria-controls': allValues.map((v) => `${id}-${v}`).join(' '),
+      // Children can't derive their ids before the React 17 fallback id is assigned, so pointing
+      // at them during that window would reference elements that don't exist.
+      'aria-controls': id === undefined ? undefined : allValues.map((v) => `${id}-${v}`).join(' '),
       onCheckedChange(_, eventDetails) {
         const uncontrolledState = uncontrolledStateRef.current;
 
@@ -128,7 +130,7 @@ export interface UseCheckboxGroupParentReturnValue {
     id: string | undefined;
     indeterminate: boolean;
     checked: boolean;
-    'aria-controls': string;
+    'aria-controls': string | undefined;
     onCheckedChange: (
       checked: boolean,
       eventDetails: BaseUIChangeEventDetails<BaseUIEventReasons['none']>,

--- a/packages/react/src/checkbox/root/CheckboxRoot.react17.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.react17.test.tsx
@@ -1,0 +1,103 @@
+import { vi } from 'vitest';
+import * as React from 'react';
+import { Checkbox } from '@base-ui/react/checkbox';
+import { CheckboxGroup } from '@base-ui/react/checkbox-group';
+import { Field } from '@base-ui/react/field';
+import { screen } from '@mui/internal-test-utils';
+import { createRenderer } from '#test-utils';
+
+vi.mock('@base-ui/utils/safeReact', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@base-ui/utils/safeReact')>();
+
+  return {
+    SafeReact: {
+      ...original.SafeReact,
+      captureOwnerStack: undefined,
+      useId: undefined,
+    },
+  };
+});
+
+describe('<Checkbox.Root /> with the React 17 id fallback', () => {
+  const { render, renderToString } = createRenderer();
+
+  function TestCase(props: {
+    checkboxId?: string | undefined;
+    checkboxKey?: React.Key | undefined;
+    nativeButton: boolean;
+  }) {
+    const { checkboxId, checkboxKey, nativeButton } = props;
+
+    return (
+      <Field.Root>
+        <Field.Label data-testid="label">Label</Field.Label>
+        <Checkbox.Root
+          key={checkboxKey}
+          id={checkboxId}
+          nativeButton={nativeButton}
+          render={nativeButton ? <button /> : undefined}
+        />
+      </Field.Root>
+    );
+  }
+
+  function getLabelControl(nativeButton: boolean) {
+    return nativeButton
+      ? screen.getByRole('checkbox')
+      : document.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+  }
+
+  it.each([false, true])(
+    'drops an explicit id when the prop is removed (nativeButton=%s)',
+    async (nativeButton) => {
+      const { rerender } = await render(
+        <TestCase checkboxId="explicit" nativeButton={nativeButton} />,
+      );
+
+      await rerender(<TestCase nativeButton={nativeButton} />);
+
+      const control = getLabelControl(nativeButton);
+      expect(control.id).not.toBe('');
+      expect(control).not.toHaveAttribute('id', 'explicit');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', control.id);
+    },
+  );
+
+  it.each([false, true])(
+    'does not reuse an unmounted Checkbox id for a keyed id-less Checkbox (nativeButton=%s)',
+    async (nativeButton) => {
+      const { rerender } = await render(
+        <TestCase checkboxKey="explicit" checkboxId="explicit" nativeButton={nativeButton} />,
+      );
+
+      await rerender(<TestCase checkboxKey="generated" nativeButton={nativeButton} />);
+
+      const control = getLabelControl(nativeButton);
+      expect(control.id).not.toBe('');
+      expect(control).not.toHaveAttribute('id', 'explicit');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', control.id);
+    },
+  );
+
+  it.each([false, true])(
+    'does not stringify an unavailable group id during SSR (nativeButton=%s)',
+    (nativeButton) => {
+      renderToString(
+        <Field.Root name="apple">
+          <CheckboxGroup allValues={['fuji']}>
+            <Field.Item>
+              <Field.Label>Fuji</Field.Label>
+              <Checkbox.Root
+                value="fuji"
+                nativeButton={nativeButton}
+                render={nativeButton ? <button /> : undefined}
+              />
+            </Field.Item>
+          </CheckboxGroup>
+        </Field.Root>,
+      );
+
+      expect(getLabelControl(nativeButton)).not.toHaveAttribute('id', 'undefined-fuji');
+    },
+  );
+});

--- a/packages/react/src/checkbox/root/CheckboxRoot.react17.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.react17.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Checkbox } from '@base-ui/react/checkbox';
 import { CheckboxGroup } from '@base-ui/react/checkbox-group';
@@ -98,6 +98,35 @@ describe('<Checkbox.Root /> with the React 17 id fallback', () => {
       );
 
       expect(getLabelControl(nativeButton)).not.toHaveAttribute('id', 'undefined-fuji');
+    },
+  );
+
+  it.each([false, true])(
+    'omits parent aria-controls while the group id is unavailable (nativeButton=%s)',
+    (nativeButton) => {
+      renderToString(
+        <Field.Root name="apple">
+          <CheckboxGroup allValues={['fuji', 'gala']}>
+            <Field.Item>
+              <Checkbox.Root
+                parent
+                data-testid="parent"
+                nativeButton={nativeButton}
+                render={nativeButton ? <button /> : undefined}
+              />
+            </Field.Item>
+            <Field.Item>
+              <Checkbox.Root
+                value="fuji"
+                nativeButton={nativeButton}
+                render={nativeButton ? <button /> : undefined}
+              />
+            </Field.Item>
+          </CheckboxGroup>
+        </Field.Root>,
+      );
+
+      expect(screen.getByTestId('parent')).not.toHaveAttribute('aria-controls');
     },
   );
 });

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -102,14 +102,26 @@ describe('<Checkbox.Root />', () => {
       },
     );
 
+    // An explicit `id` only reaches the DOM once registration runs, so the server markup carries
+    // the provider's generated id on both the label and the control instead.
     it.each([false, true])(
-      'associates an explicit id with Field.Label during SSR (nativeButton=%s)',
-      (nativeButton) => {
-        renderToString(<TestCase checkboxId="explicit" nativeButton={nativeButton} />);
+      'defers an explicit id until hydration but keeps Field.Label associated during SSR (nativeButton=%s)',
+      async (nativeButton) => {
+        const { hydrate } = renderToString(
+          <TestCase checkboxId="explicit" nativeButton={nativeButton} />,
+        );
 
         const control = getLabelControl(nativeButton);
         expect(control.id).not.toBe('');
+        expect(control).not.toHaveAttribute('id', 'explicit');
         expect(screen.getByTestId('label')).toHaveAttribute('for', control.id);
+
+        hydrate();
+
+        await waitFor(() => {
+          expect(getLabelControl(nativeButton)).toHaveAttribute('id', 'explicit');
+        });
+        expect(screen.getByTestId('label')).toHaveAttribute('for', 'explicit');
       },
     );
   });

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -8,7 +8,7 @@ import { Form } from '@base-ui/react/form';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Checkbox.Root />', () => {
-  const { render } = createRenderer();
+  const { render, renderToString } = createRenderer();
 
   describeConformance(<Checkbox.Root />, () => ({
     refInstanceof: window.HTMLSpanElement,
@@ -33,6 +33,85 @@ describe('<Checkbox.Root />', () => {
       const { container } = await render(<Checkbox.Root role="switch" />);
       expect(container.firstElementChild as HTMLElement).toHaveAttribute('role', 'switch');
     });
+  });
+
+  describe('id', () => {
+    function TestCase(props: {
+      checkboxId?: string | undefined;
+      checkboxKey?: React.Key | undefined;
+      nativeButton: boolean;
+    }) {
+      const { checkboxId, checkboxKey, nativeButton } = props;
+
+      return (
+        <Field.Root>
+          <Field.Label data-testid="label">Label</Field.Label>
+          <Checkbox.Root
+            key={checkboxKey}
+            id={checkboxId}
+            nativeButton={nativeButton}
+            render={nativeButton ? <button /> : undefined}
+          />
+        </Field.Root>
+      );
+    }
+
+    function getLabelControl(nativeButton: boolean) {
+      return nativeButton
+        ? screen.getByRole('checkbox')
+        : document.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    }
+
+    it.each([false, true])(
+      'drops an explicit id when the prop is removed (nativeButton=%s)',
+      async (nativeButton) => {
+        const { rerender } = await render(
+          <TestCase checkboxId="explicit" nativeButton={nativeButton} />,
+        );
+
+        const label = screen.getByTestId('label');
+        expect(getLabelControl(nativeButton)).toHaveAttribute('id', 'explicit');
+        expect(label).toHaveAttribute('for', 'explicit');
+
+        await rerender(<TestCase nativeButton={nativeButton} />);
+
+        const control = getLabelControl(nativeButton);
+        expect(control.id).not.toBe('');
+        expect(control).not.toHaveAttribute('id', 'explicit');
+        expect(label).toHaveAttribute('for', control.id);
+      },
+    );
+
+    it.each([false, true])(
+      'does not reuse an unmounted Checkbox id for a keyed id-less Checkbox (nativeButton=%s)',
+      async (nativeButton) => {
+        const { rerender } = await render(
+          <TestCase checkboxKey="explicit" checkboxId="explicit" nativeButton={nativeButton} />,
+        );
+
+        const label = screen.getByTestId('label');
+        expect(getLabelControl(nativeButton)).toHaveAttribute('id', 'explicit');
+        expect(label).toHaveAttribute('for', 'explicit');
+
+        await rerender(<TestCase checkboxKey="generated" nativeButton={nativeButton} />);
+
+        const control = getLabelControl(nativeButton);
+        expect(control.id).not.toBe('');
+        expect(control).not.toHaveAttribute('id', 'explicit');
+        expect(label).toHaveAttribute('for', control.id);
+      },
+    );
+
+    it.each([false, true])(
+      'associates an explicit id with Field.Label during SSR (nativeButton=%s)',
+      (nativeButton) => {
+        renderToString(<TestCase checkboxId="explicit" nativeButton={nativeButton} />);
+
+        const control = getLabelControl(nativeButton);
+        expect(control.id).not.toBe('');
+        expect(screen.getByTestId('label')).toHaveAttribute('for', control.id);
+      },
+    );
   });
 
   describe('prop: onClick', () => {

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -4,11 +4,9 @@ import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { useControlled } from '@base-ui/utils/useControlled';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
-import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import { ownerWindow } from '@base-ui/utils/owner';
 import { getDefaultFormSubmitter } from '@base-ui/utils/getDefaultFormSubmitter';
-import { NOOP } from '../../internals/noop';
 import { getCheckboxStateAttributesMapping } from '../utils/getCheckboxStateAttributesMapping';
 import { dispatchClickWithModifiers } from '../../utils/dispatchClickWithModifiers';
 import { useRenderElement } from '../../internals/useRenderElement';
@@ -27,6 +25,7 @@ import { useFieldItemContext } from '../../field/item/FieldItemContext';
 import { useFormContext } from '../../internals/form-context/FormContext';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
 import { useAriaLabelledBy } from '../../internals/labelable-provider/useAriaLabelledBy';
+import { useLabelableId } from '../../internals/labelable-provider/useLabelableId';
 import { useCheckboxGroupContext } from '../../checkbox-group/CheckboxGroupContext';
 import { CheckboxRootContext } from './CheckboxRootContext';
 import {
@@ -85,7 +84,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     validation: localValidation,
   } = useFieldRootContext();
   const fieldItemContext = useFieldItemContext();
-  const { labelId, controlId, registerControlId, getDescriptionProps } = useLabelableContext();
+  const { labelId, getDescriptionProps } = useLabelableContext();
 
   const groupContext = useCheckboxGroupContext();
   const parentContext = groupContext?.allValues === undefined ? undefined : groupContext.parent;
@@ -98,17 +97,20 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
 
   const id = useBaseUiId();
 
-  const generatedInputId = useBaseUiId();
-  let inputId = idProp || controlId;
+  const groupInputId =
+    isGroupedWithParent && !parent && value !== undefined && parentContext.id !== undefined
+      ? `${parentContext.id}-${value}`
+      : undefined;
+  let inputIdToRegister = idProp || undefined;
   if (isGroupedWithParent) {
     if (parent) {
-      inputId = generatedInputId;
-    } else if (value !== undefined) {
-      inputId = `${parentContext.id}-${value}`;
-    } else {
-      inputId ||= generatedInputId;
+      inputIdToRegister = nativeButton ? parentContext.id : undefined;
+    } else if (groupInputId !== undefined) {
+      inputIdToRegister = groupInputId;
     }
   }
+  const inputId = useLabelableId({ id: inputIdToRegister });
+  const pendingGroupInputId = groupInputId !== inputId ? groupInputId : undefined;
 
   let groupProps: Partial<Omit<CheckboxRoot.Props, 'className'>> = {};
   if (isGroupedWithParent) {
@@ -119,18 +121,20 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     }
   }
 
+  const groupId = groupProps.id;
   const {
     checked: groupChecked = checkedProp,
     indeterminate: groupIndeterminate = indeterminate,
     onCheckedChange: groupOnChange,
     ...otherGroupProps
   } = groupProps;
+  if (nativeButton) {
+    delete otherGroupProps.id;
+  }
 
   const groupValue = groupContext?.value;
 
   const controlRef = React.useRef<HTMLButtonElement>(null);
-  const controlSourceRef = useRefWithInit(() => Symbol());
-  const hasRegisteredRef = React.useRef(false);
 
   const { getButtonProps, buttonRef } = useButton({
     disabled,
@@ -153,31 +157,6 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
   const computedIndeterminate = isGroupedWithParent
     ? groupIndeterminate || indeterminate
     : indeterminate;
-
-  // can't use useLabelableId because of optional groupContext and/or parent
-  useIsoLayoutEffect(() => {
-    if (registerControlId === NOOP) {
-      return undefined;
-    }
-
-    hasRegisteredRef.current = true;
-    registerControlId(controlSourceRef.current, inputId);
-
-    return undefined;
-  }, [inputId, registerControlId, controlSourceRef]);
-
-  React.useEffect(() => {
-    const controlSource = controlSourceRef.current;
-
-    return () => {
-      if (!hasRegisteredRef.current || registerControlId === NOOP) {
-        return;
-      }
-
-      hasRegisteredRef.current = false;
-      registerControlId(controlSource, undefined);
-    };
-  }, [registerControlId, controlSourceRef]);
 
   useRegisterFieldControl(controlRef, id, checked, undefined, !groupContext && !disabled, nameProp);
 
@@ -228,7 +207,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
       name: parent ? undefined : name,
       // Set `id` to stop Chrome warning about an unassociated input.
       // When using a native button, the `id` is applied to the button instead.
-      id: nativeButton ? undefined : (inputId ?? undefined),
+      id: nativeButton ? pendingGroupInputId : (inputId ?? undefined),
       required,
       ref: mergedInputRef,
       style: name ? visuallyHiddenInput : visuallyHidden,
@@ -321,7 +300,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     ref: [buttonRef, controlRef, forwardedRef],
     props: [
       {
-        id: nativeButton ? (inputId ?? undefined) : id,
+        id: nativeButton ? (inputId ?? undefined) : (pendingGroupInputId ?? groupId ?? id),
         role: 'checkbox',
         'aria-checked': computedIndeterminate ? 'mixed' : computedChecked,
         'aria-readonly': readOnly || undefined,

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -101,15 +101,29 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     isGroupedWithParent && !parent && value !== undefined && parentContext.id !== undefined
       ? `${parentContext.id}-${value}`
       : undefined;
+
   let inputIdToRegister = idProp || undefined;
   if (isGroupedWithParent) {
     if (parent) {
-      inputIdToRegister = nativeButton ? parentContext.id : undefined;
+      // The group id belongs to the button, so a hidden input needs an id of its own.
+      inputIdToRegister = nativeButton ? parentContext.id : id;
     } else if (groupInputId !== undefined) {
       inputIdToRegister = groupInputId;
     }
   }
-  const inputId = useLabelableId({ id: inputIdToRegister });
+
+  const registeredInputId = useLabelableId({ id: inputIdToRegister });
+
+  // The provider hands the same selected id to every control it wraps, and a `CheckboxGroup` can
+  // put several checkboxes in one `Field.Root`. Once registration has run, render the id this
+  // checkbox registered so siblings don't collapse onto the selected one.
+  const [ownInputId, setOwnInputId] = React.useState<string | undefined>();
+
+  useIsoLayoutEffect(() => {
+    setOwnInputId(inputIdToRegister);
+  }, [inputIdToRegister]);
+
+  const inputId = ownInputId ?? registeredInputId;
   const pendingGroupInputId = groupInputId !== inputId ? groupInputId : undefined;
 
   let groupProps: Partial<Omit<CheckboxRoot.Props, 'className'>> = {};
@@ -121,7 +135,6 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     }
   }
 
-  const groupId = groupProps.id;
   const {
     checked: groupChecked = checkedProp,
     indeterminate: groupIndeterminate = indeterminate,
@@ -300,7 +313,7 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     ref: [buttonRef, controlRef, forwardedRef],
     props: [
       {
-        id: nativeButton ? (inputId ?? undefined) : (pendingGroupInputId ?? groupId ?? id),
+        id: nativeButton ? (inputId ?? undefined) : (pendingGroupInputId ?? id),
         role: 'checkbox',
         'aria-checked': computedIndeterminate ? 'mixed' : computedChecked,
         'aria-readonly': readOnly || undefined,

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -9460,6 +9460,38 @@ describe('<Combobox.Root />', () => {
       expect(screen.getByTestId('label')).toHaveAttribute('for', 'root-id');
     });
 
+    it('falls back to the root id when a trigger mounted with an explicit id loses it', async () => {
+      function Test({ triggerId }: { triggerId?: string | undefined }) {
+        return (
+          <Field.Root>
+            <Field.Label data-testid="label">Search</Field.Label>
+            <Combobox.Root id="root-id">
+              <Combobox.Trigger data-testid="trigger" id={triggerId}>
+                Open
+              </Combobox.Trigger>
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.Input />
+                    <Combobox.List />
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          </Field.Root>
+        );
+      }
+
+      const { setProps } = await render(<Test triggerId="trigger-id" />);
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'trigger-id');
+
+      await setProps({ triggerId: undefined });
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'root-id');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'root-id');
+    });
+
     it('keeps Field.Label associated with an outside input when the trigger has an explicit id', async () => {
       await render(
         <Field.Root>

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -9423,6 +9423,43 @@ describe('<Combobox.Root />', () => {
       /* eslint-enable testing-library/no-wait-for-multiple-assertions */
     });
 
+    it('updates Field.Label when an inside-popup trigger receives an explicit id', async () => {
+      function Test({ triggerId }: { triggerId?: string | undefined }) {
+        return (
+          <Field.Root>
+            <Field.Label data-testid="label">Search</Field.Label>
+            <Combobox.Root id="root-id">
+              <Combobox.Trigger data-testid="trigger" id={triggerId}>
+                Open
+              </Combobox.Trigger>
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.Input />
+                    <Combobox.List />
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          </Field.Root>
+        );
+      }
+
+      const { setProps } = await render(<Test />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'root-id');
+
+      await setProps({ triggerId: 'trigger-id' });
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'trigger-id');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'trigger-id');
+
+      await setProps({ triggerId: undefined });
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'root-id');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'root-id');
+    });
+
     it('does not apply validation ARIA attributes to input inside popup', async () => {
       const { user } = await render(
         <Field.Root invalid>

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -9460,6 +9460,30 @@ describe('<Combobox.Root />', () => {
       expect(screen.getByTestId('label')).toHaveAttribute('for', 'root-id');
     });
 
+    it('keeps Field.Label associated with an outside input when the trigger has an explicit id', async () => {
+      await render(
+        <Field.Root>
+          <Field.Label data-testid="label">Search</Field.Label>
+          <Combobox.Root id="root-id">
+            <Combobox.Input data-testid="input" />
+            <Combobox.Trigger id="trigger-id">Open</Combobox.Trigger>
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <Combobox.List />
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>
+        </Field.Root>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('input')).toHaveAttribute('id', 'root-id');
+      });
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'root-id');
+    });
+
     it('does not apply validation ARIA attributes to input inside popup', async () => {
       const { user } = await render(
         <Field.Root invalid>

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -85,7 +85,10 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
   const listEmpty = useListEmpty();
   const popupSide = usePopupSide(store);
 
-  useLabelableId({ id: inputInsidePopup ? idProp : undefined });
+  useLabelableId({
+    id: inputInsidePopup ? idProp : undefined,
+    preferId: inputInsidePopup && idProp != null,
+  });
   const id = inputInsidePopup ? (idProp ?? rootId) : idProp;
   const ariaLabelledBy = resolveAriaLabelledBy(fieldLabelId, comboboxLabelId);
 

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -85,9 +85,11 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
   const listEmpty = useListEmpty();
   const popupSide = usePopupSide(store);
 
+  // Without an explicit `id` the trigger renders the root's id, so it must unregister rather than
+  // fall back to a generated one.
   useLabelableId({
     id: idProp,
-    enabled: inputInsidePopup,
+    enabled: inputInsidePopup && idProp != null,
     preferId: idProp != null,
   });
   const id = inputInsidePopup ? (idProp ?? rootId) : idProp;

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -86,8 +86,9 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
   const popupSide = usePopupSide(store);
 
   useLabelableId({
-    id: inputInsidePopup ? idProp : undefined,
-    preferId: inputInsidePopup && idProp != null,
+    id: idProp,
+    enabled: inputInsidePopup,
+    preferId: idProp != null,
   });
   const id = inputInsidePopup ? (idProp ?? rootId) : idProp;
   const ariaLabelledBy = resolveAriaLabelledBy(fieldLabelId, comboboxLabelId);

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -143,7 +143,7 @@ describe('<Field.Control />', () => {
       expect(screen.getByText('Label')).toHaveAttribute('for', control.id);
     });
 
-    it('applies the explicit id on the first client render', () => {
+    it('applies the explicit id after registration', () => {
       renderNonStrict(
         <Field.Root>
           <Field.Control id="explicit" />
@@ -200,6 +200,7 @@ describe('<Field.Control />', () => {
 
       const control = screen.getByRole('textbox');
       expect(control.id).not.toBe('');
+      expect(control.id).not.toBe('custom');
       expect(screen.getByTestId('label')).toHaveAttribute('for', control.id);
 
       await user.click(screen.getByTestId('label'));

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -178,27 +178,33 @@ describe('<Field.Control />', () => {
       expect(screen.getByTestId('label')).toHaveAttribute('for', 'b');
     });
 
-    it('clears the label association when the control unmounts', () => {
+    it('keeps the label associated when an explicit id control is replaced by one without an id', async () => {
       function App() {
-        const [mounted, setMounted] = React.useState(true);
+        const [explicit, setExplicit] = React.useState(true);
         return (
           <React.Fragment>
             <Field.Root>
               <Field.Label data-testid="label">Label</Field.Label>
-              {mounted && <Field.Control id="a" />}
+              {explicit ? <Field.Control key="a" id="custom" /> : <Field.Control key="b" />}
             </Field.Root>
-            <button onClick={() => setMounted(false)}>unmount</button>
+            <button onClick={() => setExplicit(false)}>swap</button>
           </React.Fragment>
         );
       }
 
-      renderNonStrict(<App />);
+      const { user } = await renderNonStrict(<App />);
 
-      expect(screen.getByTestId('label')).toHaveAttribute('for', 'a');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'custom');
 
       fireEvent.click(screen.getByRole('button'));
 
-      expect(screen.getByTestId('label')).not.toHaveAttribute('for');
+      const control = screen.getByRole('textbox');
+      expect(control.id).not.toBe('');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', control.id);
+
+      await user.click(screen.getByTestId('label'));
+
+      expect(control).toHaveFocus();
     });
   });
 });

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -1,4 +1,5 @@
 import { expect, vi } from 'vitest';
+import * as React from 'react';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
@@ -126,5 +127,78 @@ describe('<Field.Control />', () => {
     expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
     expect(control).toHaveAttribute('data-focused', '');
     expect(screen.getByText('Name')).toHaveAttribute('data-focused', '');
+  });
+
+  describe('id', () => {
+    it('associates the label with the control when server-side rendering', () => {
+      renderToString(
+        <Field.Root>
+          <Field.Label>Label</Field.Label>
+          <Field.Control id="custom-id" />
+        </Field.Root>,
+      );
+
+      const control = screen.getByRole('textbox');
+      expect(control.id).not.toBe('');
+      expect(screen.getByText('Label')).toHaveAttribute('for', control.id);
+    });
+
+    it('applies the explicit id on the first client render', () => {
+      renderNonStrict(
+        <Field.Root>
+          <Field.Control id="explicit" />
+        </Field.Root>,
+      );
+
+      expect(screen.getByRole('textbox')).toHaveAttribute('id', 'explicit');
+    });
+
+    it('updates the label association when the control is swapped', () => {
+      function App() {
+        const [controlKey, setControlKey] = React.useState('a');
+        return (
+          <React.Fragment>
+            <Field.Root>
+              <Field.Label data-testid="label">Label</Field.Label>
+              <Field.Control key={controlKey} id={controlKey} />
+            </Field.Root>
+            <button onClick={() => setControlKey('b')}>swap</button>
+          </React.Fragment>
+        );
+      }
+
+      renderNonStrict(<App />);
+
+      expect(screen.getByRole('textbox')).toHaveAttribute('id', 'a');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'a');
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(screen.getByRole('textbox')).toHaveAttribute('id', 'b');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'b');
+    });
+
+    it('clears the label association when the control unmounts', () => {
+      function App() {
+        const [mounted, setMounted] = React.useState(true);
+        return (
+          <React.Fragment>
+            <Field.Root>
+              <Field.Label data-testid="label">Label</Field.Label>
+              {mounted && <Field.Control id="a" />}
+            </Field.Root>
+            <button onClick={() => setMounted(false)}>unmount</button>
+          </React.Fragment>
+        );
+      }
+
+      renderNonStrict(<App />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'a');
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(screen.getByTestId('label')).not.toHaveAttribute('for');
+    });
   });
 });

--- a/packages/react/src/field/label/FieldLabel.test.tsx
+++ b/packages/react/src/field/label/FieldLabel.test.tsx
@@ -1,11 +1,12 @@
 import { expect } from 'vitest';
 import * as React from 'react';
 import { Field } from '@base-ui/react/field';
-import { screen } from '@mui/internal-test-utils';
+import { act, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Field.Label />', () => {
   const { render } = createRenderer();
+  const { render: renderNonStrict } = createRenderer({ strict: false });
 
   describeConformance(<Field.Label />, () => ({
     refInstanceof: window.HTMLLabelElement,
@@ -43,6 +44,88 @@ describe('<Field.Label />', () => {
 
     await user.click(label);
     expect(control).toHaveFocus();
+  });
+
+  it('when nativeLabel={false}, clicking focuses a control inside a shadow root', async () => {
+    const host = document.body.appendChild(document.createElement('div'));
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    const container = shadowRoot.appendChild(document.createElement('div'));
+
+    try {
+      const { user } = await render(
+        <Field.Root>
+          <Field.Control id="shadow-control" />
+          <Field.Label nativeLabel={false} render={<span />} data-testid="label">
+            Label
+          </Field.Label>
+        </Field.Root>,
+        { container },
+      );
+
+      const label = shadowRoot.querySelector<HTMLElement>('[data-testid="label"]');
+      const control = shadowRoot.getElementById('shadow-control');
+      expect(label).not.toBe(null);
+      expect(control).not.toBe(null);
+
+      await user.click(label!);
+
+      expect(shadowRoot.activeElement).toBe(control);
+    } finally {
+      await act(async () => {
+        host.remove();
+      });
+    }
+  });
+
+  it('when nativeLabel={false}, clicking a nested button focuses the button', async () => {
+    const { user } = await render(
+      <Field.Root>
+        <Field.Control data-testid="control" />
+        <Field.Label nativeLabel={false} render={<div />}>
+          <button type="button">inner</button>
+        </Field.Label>
+      </Field.Root>,
+    );
+
+    const button = screen.getByRole('button');
+
+    await user.click(button);
+
+    expect(button).toHaveFocus();
+    expect(screen.getByTestId('control')).not.toHaveFocus();
+  });
+
+  describe('control selection', () => {
+    function Fields(props: { first?: boolean; second?: boolean }) {
+      const { first = true, second = true } = props;
+      return (
+        <Field.Root>
+          {first && <Field.Control id="a" />}
+          {second && <Field.Control id="b" />}
+          <Field.Label data-testid="label">Label</Field.Label>
+        </Field.Root>
+      );
+    }
+
+    it('keeps the selected control id when another control unmounts', async () => {
+      const { rerender } = await renderNonStrict(<Fields />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'a');
+
+      await rerender(<Fields second={false} />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'a');
+    });
+
+    it('falls over to the remaining control when the selected one unmounts', async () => {
+      const { rerender } = await renderNonStrict(<Fields />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'a');
+
+      await rerender(<Fields first={false} />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'b');
+    });
   });
 
   it('reflects the disabled state from Field.Item', async () => {

--- a/packages/react/src/field/label/FieldLabel.test.tsx
+++ b/packages/react/src/field/label/FieldLabel.test.tsx
@@ -95,6 +95,24 @@ describe('<Field.Label />', () => {
     expect(screen.getByTestId('control')).not.toHaveFocus();
   });
 
+  it('when nativeLabel={false}, clicking a nested link focuses the link', async () => {
+    const { user } = await render(
+      <Field.Root>
+        <Field.Control data-testid="control" />
+        <Field.Label nativeLabel={false} render={<div />}>
+          <a href="#anchor">inner</a>
+        </Field.Label>
+      </Field.Root>,
+    );
+
+    const link = screen.getByRole('link');
+
+    await user.click(link);
+
+    expect(link).toHaveFocus();
+    expect(screen.getByTestId('control')).not.toHaveFocus();
+  });
+
   describe('control selection', () => {
     function Fields(props: { first?: boolean; second?: boolean }) {
       const { first = true, second = true } = props;

--- a/packages/react/src/field/label/FieldLabel.test.tsx
+++ b/packages/react/src/field/label/FieldLabel.test.tsx
@@ -113,6 +113,23 @@ describe('<Field.Label />', () => {
     expect(screen.getByTestId('control')).not.toHaveFocus();
   });
 
+  it('when nativeLabel={false}, clicking focuses the control inside a focusable ancestor', async () => {
+    const { user } = await render(
+      <div tabIndex={0}>
+        <Field.Root>
+          <Field.Control data-testid="control" />
+          <Field.Label nativeLabel={false} render={<span />} data-testid="label">
+            Label
+          </Field.Label>
+        </Field.Root>
+      </div>,
+    );
+
+    await user.click(screen.getByTestId('label'));
+
+    expect(screen.getByTestId('control')).toHaveFocus();
+  });
+
   describe('control selection', () => {
     function Fields(props: { first?: boolean; second?: boolean }) {
       const { first = true, second = true } = props;

--- a/packages/react/src/field/label/FieldLabel.test.tsx
+++ b/packages/react/src/field/label/FieldLabel.test.tsx
@@ -1,5 +1,6 @@
 import { expect } from 'vitest';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { Field } from '@base-ui/react/field';
 import { act, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';
@@ -110,6 +111,25 @@ describe('<Field.Label />', () => {
     await user.click(link);
 
     expect(link).toHaveFocus();
+    expect(screen.getByTestId('control')).not.toHaveFocus();
+  });
+
+  it('when nativeLabel={false}, clicking a portaled button focuses the button', async () => {
+    const { user } = await render(
+      <Field.Root>
+        <Field.Control data-testid="control" />
+        <Field.Label nativeLabel={false} render={<div />}>
+          Label
+          {ReactDOM.createPortal(<button type="button">inner</button>, document.body)}
+        </Field.Label>
+      </Field.Root>,
+    );
+
+    const button = screen.getByRole('button');
+
+    await user.click(button);
+
+    expect(button).toHaveFocus();
     expect(screen.getByTestId('control')).not.toHaveFocus();
   });
 

--- a/packages/react/src/field/root/FieldRoot.react17.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.react17.test.tsx
@@ -20,6 +20,25 @@ vi.mock('@base-ui/utils/safeReact', async (importOriginal) => {
 describe('<Field.Root /> with the React 17 id fallback', () => {
   const { render } = createRenderer();
 
+  it('associates an id-less control after the fallback id is assigned', async () => {
+    const { user } = await render(
+      <Field.Root>
+        <Field.Label data-testid="label">Label</Field.Label>
+        <Field.Control />
+      </Field.Root>,
+    );
+
+    const label = screen.getByTestId('label');
+    const control = screen.getByRole('textbox');
+
+    expect(control.id).not.toBe('');
+    expect(label).toHaveAttribute('for', control.id);
+
+    await user.click(label);
+
+    expect(control).toHaveFocus();
+  });
+
   it('allows mount-time imperative validation before the fallback id is assigned', async () => {
     function TestCase() {
       const actionsRef = React.useRef<Field.Root.Actions>(null);

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -19,7 +19,6 @@ import {
   waitFor,
 } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { LabelableProvider } from '../../internals/labelable-provider';
 
 describe('<Field.Root />', () => {
   const { render, renderToString } = createRenderer();
@@ -84,23 +83,6 @@ describe('<Field.Root />', () => {
     await waitFor(() => {
       expect(label).toHaveAttribute('for', 'control-b');
     });
-  });
-
-  it('preserves null initial control ids', async () => {
-    await render(
-      <Field.Root>
-        <LabelableProvider controlId={null}>
-          <Field.Label>Label</Field.Label>
-          <Field.Control data-testid="control" />
-        </LabelableProvider>
-      </Field.Root>,
-    );
-
-    const label = screen.getByText('Label');
-    const control = screen.getByTestId('control');
-
-    expect(label).not.toHaveAttribute('for');
-    expect(control.getAttribute('id')).not.toBe(null);
   });
 
   it('updates label associations when the control id changes', async () => {

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -281,7 +281,7 @@ describe('<Field.Root />', () => {
   );
 
   it.skipIf(reactMajor < 19)(
-    'does not loop when a control is unmounted and remounted',
+    'preserves label association without looping when a control is unmounted and remounted',
     async () => {
       const errorSpy = vi
         .spyOn(console, 'error')
@@ -303,12 +303,10 @@ describe('<Field.Root />', () => {
           return (
             <React.Fragment>
               <Field.Root>
-                <Field.Label nativeLabel={false} render={<div />}>
-                  Label
-                </Field.Label>
+                <Field.Label data-testid="label">Label</Field.Label>
                 <Activity mode={showSelect ? 'visible' : 'hidden'}>
                   <Select.Root>
-                    <Select.Trigger>
+                    <Select.Trigger data-testid="trigger">
                       <Select.Value placeholder="Select a model" />
                     </Select.Trigger>
                     <Select.Portal>
@@ -334,10 +332,17 @@ describe('<Field.Root />', () => {
         await renderStrict(<TestCase />);
 
         const checkbox = screen.getByRole('checkbox');
+        const label = screen.getByTestId('label');
+
+        expect(label).toHaveAttribute('for', screen.getByTestId('trigger').id);
 
         fireEvent.click(checkbox);
+
+        expect(label).toHaveAttribute('for', screen.getByTestId('trigger').id);
+
         fireEvent.click(checkbox);
 
+        expect(label).toHaveAttribute('for', screen.getByTestId('trigger').id);
         expect(errorSpy.mock.calls.length).toBe(0);
       } finally {
         errorSpy.mockRestore();

--- a/packages/react/src/floating-ui-react/utils/constants.ts
+++ b/packages/react/src/floating-ui-react/utils/constants.ts
@@ -4,6 +4,7 @@ export const SELECTED_KEY = 'selected';
 export const TYPEABLE_SELECTOR =
   "input:not([type='hidden']):not([disabled])," +
   "[contenteditable]:not([contenteditable='false']),textarea:not([disabled])";
+export const INTERACTIVE_SELECTOR = `button,a[href],[role="button"],select,[tabindex]:not([tabindex="-1"]),${TYPEABLE_SELECTOR}`;
 export const ARROW_LEFT = 'ArrowLeft';
 export const ARROW_RIGHT = 'ArrowRight';
 export const ARROW_UP = 'ArrowUp';

--- a/packages/react/src/floating-ui-react/utils/element.ts
+++ b/packages/react/src/floating-ui-react/utils/element.ts
@@ -1,6 +1,6 @@
 import { isElement, isHTMLElement } from '@floating-ui/utils/dom';
 import { platform } from '@base-ui/utils/platform';
-import { FOCUSABLE_ATTRIBUTE, TYPEABLE_SELECTOR } from './constants';
+import { FOCUSABLE_ATTRIBUTE, INTERACTIVE_SELECTOR, TYPEABLE_SELECTOR } from './constants';
 import { type PopupTriggerMap } from '../../utils/popups';
 import { activeElement, contains, getTarget } from '../../internals/shadowDom';
 
@@ -52,11 +52,7 @@ export function isTypeableElement(element: unknown): boolean {
 }
 
 export function isInteractiveElement(element: Element | null) {
-  return (
-    element?.closest(
-      `button,a[href],[role="button"],select,[tabindex]:not([tabindex="-1"]),${TYPEABLE_SELECTOR}`,
-    ) != null
-  );
+  return element?.closest(INTERACTIVE_SELECTOR) != null;
 }
 
 export function isTypeableCombobox(element: Element | null) {

--- a/packages/react/src/internals/labelable-provider/LabelableContext.ts
+++ b/packages/react/src/internals/labelable-provider/LabelableContext.ts
@@ -6,10 +6,9 @@ import { HTMLProps } from '../types';
 export interface LabelableContext {
   /**
    * The `id` of the labelable element.
-   * When `null` the association is implicit.
    */
-  controlId: string | null | undefined;
-  registerControlId: (source: symbol, id: string | null | undefined) => void;
+  controlId: string | undefined;
+  registerControlId: (source: symbol, id: string | undefined, preferId?: boolean) => void;
   /**
    * The `id` of the label.
    */

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -10,23 +10,19 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
   props,
 ) {
   const defaultId = useBaseUiId();
-  const initialControlId = props.controlId === undefined ? defaultId : props.controlId;
-
-  const [controlIdState, setControlIdState] = React.useState<string | null | undefined>(
-    initialControlId,
-  );
-  const [labelId, setLabelId] = React.useState<string | undefined>(props.labelId);
+  const [controlIdState, setControlIdState] = React.useState<string | undefined>(defaultId);
+  const [labelId, setLabelId] = React.useState<string | undefined>();
   const [messageIds, setMessageIds] = React.useState<string[]>([]);
 
   // `undefined` only survives until the React 17 fallback id is assigned.
-  const controlId = controlIdState === undefined ? initialControlId : controlIdState;
+  const controlId = controlIdState ?? defaultId;
 
-  const registrationsRef = useRefWithInit(() => new Map<symbol, string | null>());
+  const registrationsRef = useRefWithInit(() => new Map<symbol, string>());
 
   const { messageIds: parentMessageIds } = useLabelableContext();
 
   const registerControlId = useStableCallback(
-    (source: symbol, nextId: string | null | undefined) => {
+    (source: symbol, nextId: string | undefined, preferId = false) => {
       const registrations = registrationsRef.current;
 
       if (nextId === undefined) {
@@ -40,13 +36,18 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
       // Keep the previously selected id while it is still registered so rapid
       // unmount/remount cycles (e.g. React Activity) don't churn the selection.
       setControlIdState((prev) => {
+        // An explicit control-part id must supersede a root id registered for the same control.
+        if (nextId !== undefined && preferId) {
+          return nextId;
+        }
+
         // Controls rendered without an explicit `id` never register, so fall back to this
         // provider's own id to keep them associated with the label.
         if (registrations.size === 0) {
-          return initialControlId;
+          return defaultId;
         }
 
-        let nextControlId: string | null | undefined;
+        let nextControlId: string | undefined;
 
         for (const id of registrations.values()) {
           if (id === prev) {
@@ -107,8 +108,6 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
 export interface LabelableProviderState {}
 
 export interface LabelableProviderProps {
-  controlId?: string | null | undefined;
-  labelId?: string | undefined;
   children?: React.ReactNode;
 }
 

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -49,7 +49,7 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
         let nextControlId: string | null | undefined;
 
         for (const id of registrations.values()) {
-          if (prev !== undefined && id === prev) {
+          if (id === prev) {
             return prev;
           }
 

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -27,20 +27,24 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
       const registrations = registrationsRef.current;
 
       if (nextId === undefined) {
-        registrations.delete(source);
-        return;
-      }
+        const registeredId = registrations.get(source);
 
-      registrations.set(source, nextId);
-
-      // Only flush when registering, not when unregistering.
-      // This prevents loops during rapid unmount/remount cycles (e.g. React Activity).
-      // The next registration will pick up the correct state.
-      setControlIdState((prev) => {
-        if (registrations.size === 0) {
-          return undefined;
+        if (!registrations.delete(source)) {
+          return;
         }
 
+        // Controls without their own id adopt this provider's generated id. Keep it when the
+        // last one unregisters so a remount (e.g. React Activity) re-registering it can't loop.
+        if (registrations.size === 0 && registeredId === initialControlId) {
+          return;
+        }
+      } else {
+        registrations.set(source, nextId);
+      }
+
+      // Keep the previously selected id while it is still registered so rapid
+      // unmount/remount cycles (e.g. React Activity) don't churn the selection.
+      setControlIdState((prev) => {
         let nextControlId: string | null | undefined;
 
         for (const id of registrations.values()) {

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -18,6 +18,7 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
   const [labelId, setLabelId] = React.useState<string | undefined>(props.labelId);
   const [messageIds, setMessageIds] = React.useState<string[]>([]);
 
+  // `undefined` only survives until the React 17 fallback id is assigned.
   const controlId = controlIdState === undefined ? initialControlId : controlIdState;
 
   const registrationsRef = useRefWithInit(() => new Map<symbol, string | null>());

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -26,9 +26,7 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
       const registrations = registrationsRef.current;
 
       if (nextId === undefined) {
-        if (!registrations.delete(source)) {
-          return;
-        }
+        registrations.delete(source);
       } else {
         registrations.set(source, nextId);
       }

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -12,11 +12,13 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
   const defaultId = useBaseUiId();
   const initialControlId = props.controlId === undefined ? defaultId : props.controlId;
 
-  const [controlId, setControlIdState] = React.useState<string | null | undefined>(
+  const [controlIdState, setControlIdState] = React.useState<string | null | undefined>(
     initialControlId,
   );
   const [labelId, setLabelId] = React.useState<string | undefined>(props.labelId);
   const [messageIds, setMessageIds] = React.useState<string[]>([]);
+
+  const controlId = controlIdState === undefined ? initialControlId : controlIdState;
 
   const registrationsRef = useRefWithInit(() => new Map<symbol, string | null>());
 

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -27,15 +27,7 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
       const registrations = registrationsRef.current;
 
       if (nextId === undefined) {
-        const registeredId = registrations.get(source);
-
         if (!registrations.delete(source)) {
-          return;
-        }
-
-        // Controls without their own id adopt this provider's generated id. Keep it when the
-        // last one unregisters so a remount (e.g. React Activity) re-registering it can't loop.
-        if (registrations.size === 0 && registeredId === initialControlId) {
           return;
         }
       } else {
@@ -45,6 +37,12 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
       // Keep the previously selected id while it is still registered so rapid
       // unmount/remount cycles (e.g. React Activity) don't churn the selection.
       setControlIdState((prev) => {
+        // Controls rendered without an explicit `id` never register, so fall back to this
+        // provider's own id to keep them associated with the label.
+        if (registrations.size === 0) {
+          return initialControlId;
+        }
+
         let nextControlId: string | null | undefined;
 
         for (const id of registrations.values()) {

--- a/packages/react/src/internals/labelable-provider/useAriaLabelledBy.ts
+++ b/packages/react/src/internals/labelable-provider/useAriaLabelledBy.ts
@@ -11,6 +11,7 @@ export function useAriaLabelledBy(
   labelSourceId?: string,
 ) {
   const [fallbackAriaLabelledBy, setFallbackAriaLabelledBy] = React.useState<string | undefined>();
+  const assignedLabelIdRef = React.useRef<string | undefined>(undefined);
 
   const generatedLabelId = useBaseUiId(labelSourceId ? `${labelSourceId}-label` : undefined);
   const ariaLabelledBy = explicitAriaLabelledBy ?? labelId ?? fallbackAriaLabelledBy;
@@ -23,7 +24,11 @@ export function useAriaLabelledBy(
     const nextAriaLabelledBy =
       explicitAriaLabelledBy || labelId || !enableFallback
         ? undefined
-        : getAriaLabelledBy(labelSourceRef.current, generatedLabelId);
+        : getAriaLabelledBy(labelSourceRef.current, generatedLabelId, assignedLabelIdRef.current);
+
+    if (nextAriaLabelledBy === generatedLabelId) {
+      assignedLabelIdRef.current = generatedLabelId;
+    }
 
     if (fallbackAriaLabelledBy !== nextAriaLabelledBy) {
       setFallbackAriaLabelledBy(nextAriaLabelledBy);
@@ -33,13 +38,19 @@ export function useAriaLabelledBy(
   return ariaLabelledBy;
 }
 
-function getAriaLabelledBy(labelSource?: LabelSource | null, generatedLabelId?: string) {
+function getAriaLabelledBy(
+  labelSource: LabelSource | null | undefined,
+  generatedLabelId: string | undefined,
+  assignedLabelId: string | undefined,
+) {
   const label = findAssociatedLabel(labelSource);
   if (!label) {
     return undefined;
   }
 
-  if (!label.id && generatedLabelId) {
+  // The control id can settle a commit after mount, so refresh an id this hook assigned itself.
+  // Leaving the first one in place would let two controls keep the same label id.
+  if (generatedLabelId && (!label.id || label.id === assignedLabelId)) {
     label.id = generatedLabelId;
   }
 

--- a/packages/react/src/internals/labelable-provider/useLabel.ts
+++ b/packages/react/src/internals/labelable-provider/useLabel.ts
@@ -7,6 +7,11 @@ import { getTarget } from '../../floating-ui-react/utils';
 import { useRegisteredLabelId } from '../../utils/useRegisteredLabelId';
 import { useLabelableContext } from './LabelableContext';
 
+function isInteractiveTarget(event: React.SyntheticEvent) {
+  const target = getTarget(event.nativeEvent) as HTMLElement | null;
+  return target?.closest('button,input,select,textarea') != null;
+}
+
 export function useLabel(params: UseLabelParameters = {}): UseLabelReturnValue {
   const {
     id: idProp,
@@ -37,15 +42,17 @@ export function useLabel(params: UseLabelParameters = {}): UseLabelReturnValue {
       return;
     }
 
-    const controlElement = ownerDocument(event.currentTarget).getElementById(resolvedControlId);
+    const rootNode = event.currentTarget.getRootNode() as Document | ShadowRoot;
+    const controlElement =
+      rootNode.getElementById?.(resolvedControlId) ??
+      ownerDocument(event.currentTarget).getElementById(resolvedControlId);
     if (isHTMLElement(controlElement)) {
       focusElementWithVisible(controlElement);
     }
   }
 
   function handleInteraction(event: React.MouseEvent) {
-    const target = getTarget(event.nativeEvent) as HTMLElement | null;
-    if (target?.closest('button,input,select,textarea')) {
+    if (isInteractiveTarget(event)) {
       return;
     }
 
@@ -71,7 +78,9 @@ export function useLabel(params: UseLabelParameters = {}): UseLabelReturnValue {
         id,
         onClick: handleInteraction,
         onPointerDown(event: React.PointerEvent) {
-          event.preventDefault();
+          if (!isInteractiveTarget(event)) {
+            event.preventDefault();
+          }
         },
       };
 }

--- a/packages/react/src/internals/labelable-provider/useLabel.ts
+++ b/packages/react/src/internals/labelable-provider/useLabel.ts
@@ -3,12 +3,20 @@ import * as React from 'react';
 import { isHTMLElement } from '@floating-ui/utils/dom';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { getTarget, isInteractiveElement } from '../../floating-ui-react/utils';
+import { INTERACTIVE_SELECTOR } from '../../floating-ui-react/utils/constants';
+import { contains, getTarget } from '../shadowDom';
 import { useRegisteredLabelId } from '../../utils/useRegisteredLabelId';
 import { useLabelableContext } from './LabelableContext';
 
-function isInteractiveTarget(event: React.SyntheticEvent) {
-  return isInteractiveElement(getTarget(event.nativeEvent) as Element | null);
+/**
+ * Whether the event originated from interactive content nested inside the label.
+ * `closest()` keeps walking past the label, so matches outside it must be rejected:
+ * the label itself may sit inside a link, a scroll viewport, or anything else focusable.
+ */
+function isInteractiveTarget(event: React.SyntheticEvent<Element>) {
+  const target = getTarget(event.nativeEvent) as Element | null;
+  const match = target?.closest(INTERACTIVE_SELECTOR);
+  return match != null && match !== event.currentTarget && contains(event.currentTarget, match);
 }
 
 export function useLabel(params: UseLabelParameters = {}): UseLabelReturnValue {

--- a/packages/react/src/internals/labelable-provider/useLabel.ts
+++ b/packages/react/src/internals/labelable-provider/useLabel.ts
@@ -102,7 +102,7 @@ export interface UseLabelParameters {
   /**
    * Control id used when no labelable context control id exists.
    */
-  fallbackControlId?: string | null | undefined;
+  fallbackControlId?: string | undefined;
   /**
    * Whether the rendered element is a native `<label>`.
    * @default false
@@ -116,9 +116,7 @@ export interface UseLabelParameters {
    * Custom focus handler for non-native labels.
    * If omitted, focus behavior targets the resolved control id.
    */
-  focusControl?:
-    | ((event: React.MouseEvent, controlId: string | null | undefined) => void)
-    | undefined;
+  focusControl?: ((event: React.MouseEvent, controlId: string | undefined) => void) | undefined;
 }
 
 export type UseLabelReturnValue = React.HTMLAttributes<any> & React.LabelHTMLAttributes<any>;

--- a/packages/react/src/internals/labelable-provider/useLabel.ts
+++ b/packages/react/src/internals/labelable-provider/useLabel.ts
@@ -3,13 +3,12 @@ import * as React from 'react';
 import { isHTMLElement } from '@floating-ui/utils/dom';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { getTarget } from '../../floating-ui-react/utils';
+import { getTarget, isInteractiveElement } from '../../floating-ui-react/utils';
 import { useRegisteredLabelId } from '../../utils/useRegisteredLabelId';
 import { useLabelableContext } from './LabelableContext';
 
 function isInteractiveTarget(event: React.SyntheticEvent) {
-  const target = getTarget(event.nativeEvent) as HTMLElement | null;
-  return target?.closest('button,input,select,textarea') != null;
+  return isInteractiveElement(getTarget(event.nativeEvent) as Element | null);
 }
 
 export function useLabel(params: UseLabelParameters = {}): UseLabelReturnValue {

--- a/packages/react/src/internals/labelable-provider/useLabel.ts
+++ b/packages/react/src/internals/labelable-provider/useLabel.ts
@@ -19,6 +19,14 @@ function isInteractiveTarget(event: React.SyntheticEvent<Element>) {
   return match != null && match !== event.currentTarget && contains(event.currentTarget, match);
 }
 
+export function getControlElement(labelElement: Element, controlId: string) {
+  // `getElementById` on the owner document cannot see into shadow roots.
+  const rootNode = labelElement.getRootNode() as Document | ShadowRoot;
+  return (
+    rootNode.getElementById?.(controlId) ?? ownerDocument(labelElement).getElementById(controlId)
+  );
+}
+
 export function useLabel(params: UseLabelParameters = {}): UseLabelReturnValue {
   const {
     id: idProp,
@@ -49,10 +57,7 @@ export function useLabel(params: UseLabelParameters = {}): UseLabelReturnValue {
       return;
     }
 
-    const rootNode = event.currentTarget.getRootNode() as Document | ShadowRoot;
-    const controlElement =
-      rootNode.getElementById?.(resolvedControlId) ??
-      ownerDocument(event.currentTarget).getElementById(resolvedControlId);
+    const controlElement = getControlElement(event.currentTarget, resolvedControlId);
     if (isHTMLElement(controlElement)) {
       focusElementWithVisible(controlElement);
     }

--- a/packages/react/src/internals/labelable-provider/useLabel.ts
+++ b/packages/react/src/internals/labelable-provider/useLabel.ts
@@ -10,13 +10,13 @@ import { useLabelableContext } from './LabelableContext';
 
 /**
  * Whether the event originated from interactive content nested inside the label.
- * `closest()` keeps walking past the label, so matches outside it must be rejected:
- * the label itself may sit inside a link, a scroll viewport, or anything else focusable.
+ * `closest()` keeps walking past the label, so interactive ancestors must be rejected.
+ * Portaled descendants remain valid because their events bubble through the label in React.
  */
 function isInteractiveTarget(event: React.SyntheticEvent<Element>) {
   const target = getTarget(event.nativeEvent) as Element | null;
   const match = target?.closest(INTERACTIVE_SELECTOR);
-  return match != null && match !== event.currentTarget && contains(event.currentTarget, match);
+  return match != null && !contains(match, event.currentTarget);
 }
 
 export function getControlElement(labelElement: Element, controlId: string) {

--- a/packages/react/src/internals/labelable-provider/useLabelableId.ts
+++ b/packages/react/src/internals/labelable-provider/useLabelableId.ts
@@ -79,6 +79,9 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
     return unregisterControlId;
   }, [unregisterControlId]);
 
+  // Don't let an explicit `id` preempt the selected id: during SSR the label renders
+  // `htmlFor` from the provider's pre-registration state, and preempting it here would
+  // desynchronize the pair until hydration.
   return controlId ?? defaultId;
 }
 

--- a/packages/react/src/internals/labelable-provider/useLabelableId.ts
+++ b/packages/react/src/internals/labelable-provider/useLabelableId.ts
@@ -8,7 +8,7 @@ import { useBaseUiId } from '../useBaseUiId';
 import { useLabelableContext } from './LabelableContext';
 
 export function useLabelableId(params: UseLabelableIdParameters = {}) {
-  const { id } = params;
+  const { id, preferId = false } = params;
 
   const { controlId, registerControlId } = useLabelableContext();
 
@@ -49,10 +49,10 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
     }
 
     hasRegisteredRef.current = true;
-    registerControlId(controlSourceRef.current, nextId);
+    registerControlId(controlSourceRef.current, nextId, preferId);
 
     return undefined;
-  }, [id, registerControlId, defaultId, controlSourceRef, unregisterControlId]);
+  }, [id, registerControlId, defaultId, preferId, controlSourceRef, unregisterControlId]);
 
   React.useEffect(() => {
     return unregisterControlId;
@@ -66,6 +66,11 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
 
 export interface UseLabelableIdParameters {
   id?: string | undefined;
+  /**
+   * Whether the registered id should replace the currently selected id.
+   * @default false
+   */
+  preferId?: boolean | undefined;
 }
 
 export type UseLabelableIdReturnValue = string;

--- a/packages/react/src/internals/labelable-provider/useLabelableId.ts
+++ b/packages/react/src/internals/labelable-provider/useLabelableId.ts
@@ -8,7 +8,7 @@ import { useBaseUiId } from '../useBaseUiId';
 import { useLabelableContext } from './LabelableContext';
 
 export function useLabelableId(params: UseLabelableIdParameters = {}) {
-  const { id, preferId = false } = params;
+  const { id, enabled = true, preferId = false } = params;
 
   const { controlId, registerControlId } = useLabelableContext();
 
@@ -32,6 +32,12 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
       return undefined;
     }
 
+    if (!enabled) {
+      hadExplicitIdRef.current = false;
+      unregisterControlId();
+      return undefined;
+    }
+
     let nextId: string | undefined;
 
     if (id != null) {
@@ -52,7 +58,7 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
     registerControlId(controlSourceRef.current, nextId, preferId);
 
     return undefined;
-  }, [id, registerControlId, defaultId, preferId, controlSourceRef, unregisterControlId]);
+  }, [id, enabled, registerControlId, defaultId, preferId, controlSourceRef, unregisterControlId]);
 
   React.useEffect(() => {
     return unregisterControlId;
@@ -66,6 +72,11 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
 
 export interface UseLabelableIdParameters {
   id?: string | undefined;
+  /**
+   * Whether the control owns the label association.
+   * @default true
+   */
+  enabled?: boolean | undefined;
   /**
    * Whether the registered id should replace the currently selected id.
    * @default false

--- a/packages/react/src/internals/labelable-provider/useLabelableId.ts
+++ b/packages/react/src/internals/labelable-provider/useLabelableId.ts
@@ -3,19 +3,16 @@ import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
-import { isElement } from '@floating-ui/utils/dom';
 import { NOOP } from '../noop';
 import { useBaseUiId } from '../useBaseUiId';
 import { useLabelableContext } from './LabelableContext';
 
 export function useLabelableId(params: UseLabelableIdParameters = {}) {
-  const { id, implicit = false, controlRef } = params;
+  const { id } = params;
 
   const { controlId, registerControlId } = useLabelableContext();
 
   const defaultId = useBaseUiId(id);
-
-  const controlIdForEffect = implicit ? controlId : undefined;
 
   const controlSourceRef = useRefWithInit(() => Symbol());
   const hasRegisteredRef = React.useRef(false);
@@ -35,26 +32,17 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
       return undefined;
     }
 
-    let nextId: string | null | undefined;
+    let nextId: string | undefined;
 
-    if (implicit) {
-      const elem = controlRef?.current;
-
-      if (isElement(elem) && elem.closest('label') != null) {
-        nextId = id ?? null;
-      } else {
-        nextId = controlIdForEffect ?? defaultId;
-      }
-    } else if (id != null) {
+    if (id != null) {
       hadExplicitIdRef.current = true;
       nextId = id;
     } else if (hadExplicitIdRef.current) {
       nextId = defaultId;
-    } else {
-      unregisterControlId();
-      return undefined;
     }
 
+    // Either the control never had an explicit `id`, or the React 17 fallback id
+    // has not been assigned yet. Neither is worth registering.
     if (nextId === undefined) {
       unregisterControlId();
       return undefined;
@@ -64,16 +52,7 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
     registerControlId(controlSourceRef.current, nextId);
 
     return undefined;
-  }, [
-    id,
-    controlRef,
-    controlIdForEffect,
-    registerControlId,
-    implicit,
-    defaultId,
-    controlSourceRef,
-    unregisterControlId,
-  ]);
+  }, [id, registerControlId, defaultId, controlSourceRef, unregisterControlId]);
 
   React.useEffect(() => {
     return unregisterControlId;
@@ -87,15 +66,6 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
 
 export interface UseLabelableIdParameters {
   id?: string | undefined;
-  /**
-   * Whether implicit labelling is supported.
-   * @default false
-   */
-  implicit?: boolean | undefined;
-  /**
-   * A ref to an element that can be implicitly labelled.
-   */
-  controlRef?: React.RefObject<HTMLElement | null> | undefined;
 }
 
 export type UseLabelableIdReturnValue = string;

--- a/packages/react/src/internals/labelable-provider/useLabelableId.ts
+++ b/packages/react/src/internals/labelable-provider/useLabelableId.ts
@@ -12,7 +12,7 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
 
   const { controlId, registerControlId } = useLabelableContext();
 
-  const defaultId = useBaseUiId(id);
+  const defaultId = useBaseUiId();
 
   const controlSourceRef = useRefWithInit(() => Symbol());
   const hasRegisteredRef = React.useRef(false);
@@ -64,10 +64,10 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
     return unregisterControlId;
   }, [unregisterControlId]);
 
-  // Don't let an explicit `id` preempt the selected id: during SSR the label renders
-  // `htmlFor` from the provider's pre-registration state, and preempting it here would
-  // desynchronize the pair until hydration.
-  return controlId ?? defaultId;
+  // Don't let an explicit `id` preempt the provider's selected id: during SSR the label
+  // renders `htmlFor` from the provider's pre-registration state, and preempting it here
+  // would desynchronize the pair until hydration.
+  return controlId ?? id ?? defaultId;
 }
 
 export interface UseLabelableIdParameters {

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -113,11 +113,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
   }, [checked, disabled, registerInputRef]);
 
   const id = useBaseUiId();
-  const inputId = useLabelableId({
-    id: idProp,
-    implicit: false,
-    controlRef: radioRef,
-  });
+  const inputId = useLabelableId({ id: idProp });
   const hiddenInputId = nativeButton ? undefined : inputId;
   const ariaLabelledBy = useAriaLabelledBy(
     ariaLabelledByProp,

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -22,6 +22,7 @@ describe('<Select.Root />', () => {
   });
 
   const { render, renderToString } = createRenderer();
+  const { render: renderNonStrict } = createRenderer({ strict: false });
 
   describe('conformance', () => {
     beforeEach(() => {
@@ -2949,6 +2950,22 @@ describe('<Select.Root />', () => {
   });
 
   describe('with Field.Root parent', () => {
+    it('applies the root id to the trigger', async () => {
+      await renderNonStrict(
+        <Field.Root>
+          <Field.Label data-testid="label">Label</Field.Label>
+          <Select.Root id="test-id">
+            <Select.Trigger data-testid="trigger">
+              <Select.Value />
+            </Select.Trigger>
+          </Select.Root>
+        </Field.Root>,
+      );
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'test-id');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'test-id');
+    });
+
     it('should receive disabled prop from Field.Root', async () => {
       await render(
         <Field.Root disabled>

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -22,7 +22,6 @@ describe('<Select.Root />', () => {
   });
 
   const { render, renderToString } = createRenderer();
-  const { render: renderNonStrict } = createRenderer({ strict: false });
 
   describe('conformance', () => {
     beforeEach(() => {
@@ -2951,7 +2950,7 @@ describe('<Select.Root />', () => {
 
   describe('with Field.Root parent', () => {
     it('applies the root id to the trigger', async () => {
-      await renderNonStrict(
+      await render(
         <Field.Root>
           <Field.Label data-testid="label">Label</Field.Label>
           <Select.Root id="test-id">
@@ -2964,6 +2963,65 @@ describe('<Select.Root />', () => {
 
       expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'test-id');
       expect(screen.getByTestId('label')).toHaveAttribute('for', 'test-id');
+    });
+
+    it('updates the label association when the trigger id changes', async () => {
+      function Test({ triggerId }: { triggerId?: string | undefined }) {
+        return (
+          <Field.Root>
+            <Field.Label data-testid="label">Label</Field.Label>
+            <Select.Root id="root-id">
+              <Select.Trigger id={triggerId} data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+            </Select.Root>
+          </Field.Root>
+        );
+      }
+
+      const { setProps } = await render(<Test />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'root-id');
+
+      await setProps({ triggerId: 'trigger-id' });
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'trigger-id');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'trigger-id');
+
+      await setProps({ triggerId: undefined });
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'root-id');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'root-id');
+    });
+
+    it('restores an explicit trigger id after remounting the trigger', async () => {
+      function Test({ showTrigger }: { showTrigger: boolean }) {
+        return (
+          <Field.Root>
+            <Field.Label data-testid="label">Label</Field.Label>
+            <Select.Root id="root-id">
+              {showTrigger && (
+                <Select.Trigger id="trigger-id" data-testid="trigger">
+                  <Select.Value />
+                </Select.Trigger>
+              )}
+            </Select.Root>
+          </Field.Root>
+        );
+      }
+
+      const { setProps } = await render(<Test showTrigger />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'trigger-id');
+
+      await setProps({ showTrigger: false });
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'root-id');
+
+      await setProps({ showTrigger: true });
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'trigger-id');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'trigger-id');
     });
 
     it('should receive disabled prop from Field.Root', async () => {

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -2994,6 +2994,30 @@ describe('<Select.Root />', () => {
       expect(screen.getByTestId('label')).toHaveAttribute('for', 'root-id');
     });
 
+    it('falls back to the root id when a trigger mounted with an explicit id loses it', async () => {
+      function Test({ triggerId }: { triggerId?: string | undefined }) {
+        return (
+          <Field.Root>
+            <Field.Label data-testid="label">Label</Field.Label>
+            <Select.Root id="root-id">
+              <Select.Trigger id={triggerId} data-testid="trigger">
+                <Select.Value />
+              </Select.Trigger>
+            </Select.Root>
+          </Field.Root>
+        );
+      }
+
+      const { setProps } = await render(<Test triggerId="trigger-id" />);
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'trigger-id');
+
+      await setProps({ triggerId: undefined });
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'root-id');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'root-id');
+    });
+
     it('restores an explicit trigger id after remounting the trigger', async () => {
       function Test({ showTrigger }: { showTrigger: boolean }) {
         return (

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -89,7 +89,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const id = idProp ?? rootId;
   const ariaLabelledBy = resolveAriaLabelledBy(fieldLabelId, selectLabelId);
 
-  useLabelableId({ id: idProp });
+  useLabelableId({ id: idProp, preferId: idProp != null });
 
   const positionerRef = useValueAsRef(positionerElement);
 

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -89,7 +89,9 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const id = idProp ?? rootId;
   const ariaLabelledBy = resolveAriaLabelledBy(fieldLabelId, selectLabelId);
 
-  useLabelableId({ id: idProp, preferId: idProp != null });
+  // Without an explicit `id` the trigger renders the root's id, so it must unregister rather than
+  // fall back to a generated one.
+  useLabelableId({ id: idProp, enabled: idProp != null, preferId: idProp != null });
 
   const positionerRef = useValueAsRef(positionerElement);
 

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -89,7 +89,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const id = idProp ?? rootId;
   const ariaLabelledBy = resolveAriaLabelledBy(fieldLabelId, selectLabelId);
 
-  useLabelableId({ id });
+  useLabelableId({ id: idProp });
 
   const positionerRef = useValueAsRef(positionerElement);
 

--- a/packages/react/src/slider/label/SliderLabel.tsx
+++ b/packages/react/src/slider/label/SliderLabel.tsx
@@ -29,7 +29,7 @@ export const SliderLabel = React.forwardRef(function SliderLabel(
 
   const { state, setLabelId, controlRef, rootLabelId } = useSliderRootContext();
 
-  function focusControl(event: React.MouseEvent, controlId: string | null | undefined) {
+  function focusControl(event: React.MouseEvent, controlId: string | undefined) {
     if (controlId) {
       const controlElement = getControlElement(event.currentTarget, controlId);
       if (isHTMLElement(controlElement)) {

--- a/packages/react/src/slider/label/SliderLabel.tsx
+++ b/packages/react/src/slider/label/SliderLabel.tsx
@@ -1,8 +1,11 @@
 'use client';
 import * as React from 'react';
 import { isHTMLElement } from '@floating-ui/utils/dom';
-import { ownerDocument } from '@base-ui/utils/owner';
-import { focusElementWithVisible, useLabel } from '../../internals/labelable-provider/useLabel';
+import {
+  focusElementWithVisible,
+  getControlElement,
+  useLabel,
+} from '../../internals/labelable-provider/useLabel';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
 import type { SliderRoot } from '../root/SliderRoot';
@@ -28,7 +31,7 @@ export const SliderLabel = React.forwardRef(function SliderLabel(
 
   function focusControl(event: React.MouseEvent, controlId: string | null | undefined) {
     if (controlId) {
-      const controlElement = ownerDocument(event.currentTarget).getElementById(controlId);
+      const controlElement = getControlElement(event.currentTarget, controlId);
       if (isHTMLElement(controlElement)) {
         focusElementWithVisible(controlElement);
         return;

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -80,11 +80,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
 
   const id = useBaseUiId();
 
-  const controlId = useLabelableId({
-    id: idProp,
-    implicit: false,
-    controlRef: switchRef,
-  });
+  const controlId = useLabelableId({ id: idProp });
   const hiddenInputId = nativeButton ? undefined : controlId;
 
   const [checked, setCheckedState] = useControlled({


### PR DESCRIPTION
Fixes four classes of bugs in the shared `labelable-provider` internals used by Field, Checkbox, Radio, Switch, Select, Combobox, Number Field, OTP Field, and Slider.

## Changes

- **Control swaps latched the old id (production only).** Registration runs in a layout effect, but unregistration was a passive cleanup that never flushed state. Replacing `<Field.Control id="a" />` with `<Field.Control id="b" />` kept the rendered id and the label `htmlFor` at `a`. StrictMode's simulated remount hides the bug, so the regression tests render with `strict: false`. The provider now recomputes the selected id on unregister. When the last registration goes away it falls back to its own generated id, which is what lets a control without an `id` take over from one that had an explicit `id`.
- **Non-native labels could not focus controls inside shadow roots.** Click-to-focus used `ownerDocument(...).getElementById`, which cannot see into shadow roots. The lookup now starts from `currentTarget.getRootNode()` and falls back to the owner document. It lives in `getControlElement`, which `Slider.Label` shares.
- **Non-native labels blocked focus of nested interactive elements.** `pointerdown` called `preventDefault()` unconditionally, so a button inside the label activated on click but never received focus. Both handlers now skip interactive content nested inside the label, using the shared `INTERACTIVE_SELECTOR`. The match is rejected when it sits outside the label, so a label inside a link, a scroll viewport, or any other focusable container keeps working.
- **Checkbox maintained a separate labelable-id ownership path.** Removing an explicit id or replacing the Checkbox with a keyed id-less instance could retain the previous id. During SSR, explicit and CheckboxGroup-derived ids could also leave `Field.Label` targeting a different node than the visible or hidden control. Checkbox now delegates registration to the shared hook, keeps the React 17 fallback independent from the explicit override, and preserves group-derived aliases so parent `aria-controls` remains valid. Regression coverage includes native and non-native controls, `Field.Item`/CheckboxGroup compositions, SSR hydration, and React 17.

## Notes

The Checkbox failures reproduce at the exact pre-PR base (`5322c6d7c`) as well as the earlier PR head, so they are pre-existing bugs rather than regressions introduced by this PR.

The unregister flush skips one case: the last unregistering source had adopted the provider's own generated id. `Select.Trigger` registers an id it adopts from the provider through the Select store, one commit behind, and clearing the selection there loops forever (the existing "preserves label association without looping when a control is unmounted and remounted" Activity test catches it). Skipping the flush there matches the old behavior exactly, so that path cannot regress. Explicit ids still clear and fall over to the remaining registration.

Server rendering still ignores an explicit `id` on the control: the provider seeds its own generated id, and registration only runs in an effect. Label and control agree on that generated id, so the association itself is correct, but an outside `<label for>`, an `#id` CSS rule, or a fragment link that targets the explicit id will not match until hydration. Making the explicit id available to the provider during render needs a different design, so it is left out of this PR. React 17 also cannot generate the provider id during SSR, so its label association is established during hydration; group-derived ids no longer serialize an `undefined-` prefix in the interim.
